### PR TITLE
fix(core): cache smart refresh failed to detect new sessions

### DIFF
--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -105,6 +105,10 @@ async function scanAgentSmart(
         agent.setSessionMetaMap(metaMap);
       }
 
+      // 命中缓存时也要确保 agent 的 basePath 等状态已初始化
+      // 否则后台增量刷新会因为 basePath 为 null 而失效
+      agent.isAvailable();
+
       // 通知缓存已加载
       onProgress?.({
         agent: agent.name,


### PR DESCRIPTION
## Summary

修复缓存模式下新增会话无法被后台增量扫描发现的问题。

## Root Cause

在 `scanAgentSmart` 中，命中缓存时**没有调用 `agent.isAvailable()`**。而 ClaudeCode / Codex / Kimi 等 Agent 的 `isAvailable()` 负责初始化 `this.basePath`。

这导致后台智能刷新时：
- `checkForChanges` 因为 `basePath === null` 直接返回 `hasChanges: false`
- `incrementalScan` 从未被执行
- 新增会话文件永远无法被检测和加入缓存

## Fix

在命中缓存后、启动后台增量刷新前，先调用 `agent.isAvailable()` 确保 Agent 状态已初始化。

Fixes [XING-164](https://linear.app/xingkaixin/issue/XING-164)

🤖 Generated with [Claude Code](https://claude.com/claude-code)