### PR TITLE
Fix agent model and token stats

### DIFF
--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -69,6 +69,10 @@ function parseTimestampMs(data: Record<string, unknown>): number {
   }
 }
 
+function extractModelName(raw: unknown): string | null {
+  return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+}
+
 // ---------------------------------------------------------------------------
 // Title helpers
 // ---------------------------------------------------------------------------
@@ -435,16 +439,22 @@ export class CodexAgent extends BaseAgent {
     let currentAssistantIndex: number | null = null;
     let latestAssistantTextIndex: number | null = null;
     let pendingPlan: MessagePart | null = null;
+    let activeModel: string | null = meta.model;
 
     // Token-count dedup state (matches codeburn strategy)
     let prevCumulativeTotal = 0;
     let prevInput = 0;
-    let prevCached = 0;
     let prevOutput = 0;
     let prevReasoning = 0;
 
     for (const record of parseJsonlLines(content)) {
       try {
+        const recordType = String(record["type"] ?? "");
+        if (recordType === "turn_context") {
+          const payload = (record["payload"] ?? {}) as Record<string, unknown>;
+          activeModel = extractModelName(payload["model"]) ?? activeModel;
+        }
+
         const result = this.convertRecord(
           record,
           messages,
@@ -458,8 +468,14 @@ export class CodexAgent extends BaseAgent {
         latestAssistantTextIndex = result.latestAssistantTextIndex;
         pendingPlan = result.pendingPlan;
 
+        if (currentAssistantIndex !== null && activeModel) {
+          const message = messages[currentAssistantIndex];
+          if (message?.role === "assistant" && !message.model) {
+            message.model = activeModel;
+          }
+        }
+
         // Process Codex token_count events
-        const recordType = String(record["type"] ?? "");
         if (recordType === "event_msg") {
           const payload = (record["payload"] ?? {}) as Record<string, unknown>;
           if (String(payload["type"] ?? "") === "token_count") {
@@ -474,31 +490,27 @@ export class CodexAgent extends BaseAgent {
 
               const lastUsage = info?.["last_token_usage"] as Record<string, unknown> | undefined;
               let inputTokens = 0;
-              let cachedInputTokens = 0;
               let outputTokens = 0;
               let reasoningTokens = 0;
 
               if (lastUsage) {
                 inputTokens = Number(lastUsage["input_tokens"] ?? 0);
-                cachedInputTokens = Number(lastUsage["cached_input_tokens"] ?? 0);
                 outputTokens = Number(lastUsage["output_tokens"] ?? 0);
                 reasoningTokens = Number(lastUsage["reasoning_output_tokens"] ?? 0);
               } else if (cumulativeTotal > 0 && totalUsage) {
                 inputTokens = Number(totalUsage["input_tokens"] ?? 0) - prevInput;
-                cachedInputTokens = Number(totalUsage["cached_input_tokens"] ?? 0) - prevCached;
                 outputTokens = Number(totalUsage["output_tokens"] ?? 0) - prevOutput;
                 reasoningTokens =
                   Number(totalUsage["reasoning_output_tokens"] ?? 0) - prevReasoning;
 
                 prevInput = Number(totalUsage["input_tokens"] ?? 0);
-                prevCached = Number(totalUsage["cached_input_tokens"] ?? 0);
                 prevOutput = Number(totalUsage["output_tokens"] ?? 0);
                 prevReasoning = Number(totalUsage["reasoning_output_tokens"] ?? 0);
               }
 
-              const uncachedInput = Math.max(0, inputTokens - cachedInputTokens);
-              if (uncachedInput || outputTokens || reasoningTokens) {
-                totalInputTokens += uncachedInput;
+              const totalInput = Math.max(0, inputTokens);
+              if (totalInput || outputTokens || reasoningTokens) {
+                totalInputTokens += totalInput;
                 totalOutputTokens += outputTokens + reasoningTokens;
 
                 // Bind to the most recent assistant message without tokens
@@ -506,7 +518,7 @@ export class CodexAgent extends BaseAgent {
                   const msg = messages[i]!;
                   if (msg.role === "assistant" && !msg.tokens) {
                     msg.tokens = {
-                      input: uncachedInput,
+                      input: totalInput,
                       output: outputTokens + reasoningTokens,
                     };
                     break;
@@ -635,7 +647,6 @@ export class CodexAgent extends BaseAgent {
 
     let scanPrevCumulativeTotal = 0;
     let scanPrevInput = 0;
-    let scanPrevCached = 0;
     let scanPrevOutput = 0;
     let scanPrevReasoning = 0;
 
@@ -645,7 +656,11 @@ export class CodexAgent extends BaseAgent {
       try {
         const data = JSON.parse(line);
         const recordType = String(data["type"] ?? "");
-        if (recordType === "session_meta") {
+        if (recordType === "session_meta" || recordType === "turn_context") {
+          const payload = (data["payload"] ?? {}) as Record<string, unknown>;
+          if (!model) {
+            model = extractModelName(payload["model"]);
+          }
           const p = (data["payload"] ?? {}) as Record<string, unknown>;
           const ts = parseTimestampMs(p);
           if (ts > updatedAt) updatedAt = ts;
@@ -678,30 +693,26 @@ export class CodexAgent extends BaseAgent {
 
               const lastUsage = info?.["last_token_usage"] as Record<string, unknown> | undefined;
               let inputTokens = 0;
-              let cachedInputTokens = 0;
               let outputTokens = 0;
               let reasoningTokens = 0;
 
               if (lastUsage) {
                 inputTokens = Number(lastUsage["input_tokens"] ?? 0);
-                cachedInputTokens = Number(lastUsage["cached_input_tokens"] ?? 0);
                 outputTokens = Number(lastUsage["output_tokens"] ?? 0);
                 reasoningTokens = Number(lastUsage["reasoning_output_tokens"] ?? 0);
               } else if (cumulativeTotal > 0 && totalUsage) {
                 inputTokens = Number(totalUsage["input_tokens"] ?? 0) - scanPrevInput;
-                cachedInputTokens = Number(totalUsage["cached_input_tokens"] ?? 0) - scanPrevCached;
                 outputTokens = Number(totalUsage["output_tokens"] ?? 0) - scanPrevOutput;
                 reasoningTokens =
                   Number(totalUsage["reasoning_output_tokens"] ?? 0) - scanPrevReasoning;
 
                 scanPrevInput = Number(totalUsage["input_tokens"] ?? 0);
-                scanPrevCached = Number(totalUsage["cached_input_tokens"] ?? 0);
                 scanPrevOutput = Number(totalUsage["output_tokens"] ?? 0);
                 scanPrevReasoning = Number(totalUsage["reasoning_output_tokens"] ?? 0);
               }
 
-              const uncachedInput = Math.max(0, inputTokens - cachedInputTokens);
-              totalInputTokens += uncachedInput;
+              const totalInput = Math.max(0, inputTokens);
+              totalInputTokens += totalInput;
               totalOutputTokens += outputTokens + reasoningTokens;
             }
           }

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -390,7 +390,12 @@ export class CursorAgent extends BaseAgent {
           const updatedAt = composer.updatedAt ?? createdAt;
 
           // Load actual messages to filter out empty composers
-          const messages = this.loadMessagesFromBubbles(db, composerId, sessionId);
+          const messages = this.loadMessagesFromBubbles(
+            db,
+            composerId,
+            sessionId,
+            composer.modelConfig?.modelName ?? composer.model ?? null,
+          );
           const hasSubagents =
             Array.isArray(composer.subagentInfos) && composer.subagentInfos.length > 0;
           if (messages.length === 0 && !hasSubagents) {
@@ -537,7 +542,12 @@ export class CursorAgent extends BaseAgent {
       const updatedAt = composer.updatedAt ?? createdAt;
 
       // Load messages from bubbles (like agent-dump does)
-      const messages = this.loadMessagesFromBubbles(db, composerId, resolvedSessionId);
+      const messages = this.loadMessagesFromBubbles(
+        db,
+        composerId,
+        resolvedSessionId,
+        composer.modelConfig?.modelName ?? composer.model ?? null,
+      );
 
       // Aggregate stats
       let totalInputTokens = 0;
@@ -689,6 +699,7 @@ export class CursorAgent extends BaseAgent {
     db: SQLiteDatabase,
     composerId: string,
     _sessionId: string,
+    initialModelName: string | null,
   ): Message[] {
     const messages: Message[] = [];
 
@@ -697,7 +708,7 @@ export class CursorAgent extends BaseAgent {
         .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE ? ORDER BY rowid ASC")
         .all(`bubbleId:${composerId}:%`) as Array<{ key: string; value: string }>;
 
-      let activeModelName: string | null = null;
+      let activeModelName: string | null = initialModelName;
       let messageIndex = 0;
 
       for (const row of rows) {
@@ -719,7 +730,7 @@ export class CursorAgent extends BaseAgent {
           }
 
           // Track model from user turn
-          if (role === "user" && bubble.modelInfo?.modelName) {
+          if (bubble.modelInfo?.modelName) {
             activeModelName = bubble.modelInfo.modelName;
           }
 
@@ -754,7 +765,7 @@ export class CursorAgent extends BaseAgent {
             time_created: timestampMs,
             time_completed: null,
             mode: role === "assistant" && parts.some((p) => p.type === "tool") ? "tool" : null,
-            model: activeModelName,
+            model: bubble.modelInfo?.modelName ?? activeModelName,
             provider: null,
             tokens: { input: inputTokens, output: outputTokens },
             cost: 0,

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -235,6 +235,7 @@ export class KimiAgent extends BaseAgent {
         if (!meta) continue;
 
         this.sessionMetaMap.set(meta.id, meta);
+        const stats = this.extractStats(meta.sourcePath);
         heads.push({
           id: meta.id,
           slug: `kimi/${meta.id}`,
@@ -242,12 +243,7 @@ export class KimiAgent extends BaseAgent {
           directory: meta.cwd,
           time_created: meta.createdAt,
           time_updated: meta.createdAt,
-          stats: {
-            message_count: 0,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cost: 0,
-          },
+          stats,
         });
       } catch {
         // skip
@@ -319,6 +315,7 @@ export class KimiAgent extends BaseAgent {
 
         if (changedIds.includes(meta.id)) {
           this.sessionMetaMap.set(meta.id, meta);
+          const stats = this.extractStats(meta.sourcePath);
           sessionMap.set(meta.id, {
             id: meta.id,
             slug: `kimi/${meta.id}`,
@@ -326,12 +323,7 @@ export class KimiAgent extends BaseAgent {
             directory: meta.cwd,
             time_created: meta.createdAt,
             time_updated: meta.createdAt,
-            stats: {
-              message_count: 0,
-              total_input_tokens: 0,
-              total_output_tokens: 0,
-              total_cost: 0,
-            },
+            stats,
           });
         }
       } catch {

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -4,7 +4,7 @@ import { BaseAgent } from "./base.js";
 import type { SessionCacheMeta, ChangeCheckResult } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
-import { openDbReadOnly, isSqliteAvailable } from "../utils/sqlite.js";
+import { openDbReadOnly, isSqliteAvailable, type SQLiteDatabase } from "../utils/sqlite.js";
 
 export class OpenCodeAgent extends BaseAgent {
   readonly name = "opencode";
@@ -75,6 +75,7 @@ export class OpenCodeAgent extends BaseAgent {
         const timeUpdated = Number(row.time_updated ?? timeCreated);
         const slug = `opencode/${id}`;
         const directory = String(row.directory ?? "");
+        const stats = hasMessageTable ? this.readSessionStats(db, id) : null;
 
         heads.push({
           id,
@@ -84,10 +85,10 @@ export class OpenCodeAgent extends BaseAgent {
           time_created: timeCreated,
           time_updated: timeUpdated,
           stats: {
-            message_count: Number(row.message_count ?? 0),
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cost: 0,
+            message_count: stats?.message_count ?? Number(row.message_count ?? 0),
+            total_input_tokens: stats?.total_input_tokens ?? 0,
+            total_output_tokens: stats?.total_output_tokens ?? 0,
+            total_cost: stats?.total_cost ?? 0,
           },
         });
 
@@ -152,6 +153,40 @@ export class OpenCodeAgent extends BaseAgent {
   incrementalScan(_cachedSessions: SessionHead[], _changedIds: string[]): SessionHead[] {
     // 对于 OpenCode，直接重新执行完整扫描
     return this.scan();
+  }
+
+  private readSessionStats(
+    db: SQLiteDatabase,
+    sessionId: string,
+  ): SessionHead["stats"] | null {
+    try {
+      const rows = db
+        .prepare("SELECT data FROM message WHERE session_id = ? ORDER BY time_created ASC")
+        .all(sessionId) as Array<{ data?: string }>;
+
+      let totalCost = 0;
+      let totalInputTokens = 0;
+      let totalOutputTokens = 0;
+
+      for (const row of rows) {
+        const msgData = JSON.parse(String(row.data ?? "{}")) as Record<string, unknown>;
+        const cost = Number(msgData.cost ?? 0);
+        const tokens = msgData.tokens as Record<string, unknown> | undefined;
+
+        totalCost += cost;
+        totalInputTokens += Number(tokens?.input ?? 0);
+        totalOutputTokens += Number(tokens?.output ?? 0);
+      }
+
+      return {
+        message_count: rows.length,
+        total_input_tokens: totalInputTokens,
+        total_output_tokens: totalOutputTokens,
+        total_cost: totalCost,
+      };
+    } catch {
+      return null;
+    }
   }
 
   getSessionData(sessionId: string): SessionData {

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -155,10 +155,7 @@ export class OpenCodeAgent extends BaseAgent {
     return this.scan();
   }
 
-  private readSessionStats(
-    db: SQLiteDatabase,
-    sessionId: string,
-  ): SessionHead["stats"] | null {
+  private readSessionStats(db: SQLiteDatabase, sessionId: string): SessionHead["stats"] | null {
     try {
       const rows = db
         .prepare("SELECT data FROM message WHERE session_id = ? ORDER BY time_created ASC")


### PR DESCRIPTION
## Summary
- Restore Codex model propagation from `turn_context` and keep assistant message models populated.
- Count Codex input tokens from the raw usage totals so session totals match the source events.
- Populate Cursor message models from composer-level metadata and bubble-level model info.
- Fill Kimi and OpenCode session stats during scan instead of returning empty token totals.

## Testing
- `pnpm -C packages/core lint`
- `pnpm -C packages/core test`
- `pnpm -C packages/core build`