### PR TITLE
Add live session monitoring and incremental refresh

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,12 +4,7 @@ import { useEffect, useEffectEvent, useMemo, useState, type ReactNode } from "re
 import { Link, useLocation } from "react-router-dom";
 import { ModelConfig } from "./config";
 import type { AgentInfo, SessionHead, SessionData, SessionsUpdatedEvent } from "./lib/api";
-import {
-  fetchAgents,
-  fetchSessions,
-  fetchSessionData,
-  subscribeSessionUpdates,
-} from "./lib/api";
+import { fetchAgents, fetchSessions, fetchSessionData, subscribeSessionUpdates } from "./lib/api";
 import { SessionDetail } from "./components/SessionDetail";
 import { SessionDetailSkeleton } from "./components/SessionDetailSkeleton";
 import {
@@ -206,7 +201,10 @@ export default function App() {
 
       if (viewState.mode === "session") {
         try {
-          const data = await fetchSessionData(viewState.activeAgentKey, viewState.activeSessionSlug);
+          const data = await fetchSessionData(
+            viewState.activeAgentKey,
+            viewState.activeSessionSlug,
+          );
           setSession(data);
           setSessionError(null);
         } catch {
@@ -255,7 +253,7 @@ export default function App() {
     });
 
     return unsubscribe;
-  }, [syncLiveUpdate]);
+  }, []);
 
   useEffect(() => {
     if (!liveNotice) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,15 @@
 declare const __APP_VERSION__: string;
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useEffectEvent, useMemo, useState, type ReactNode } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { ModelConfig } from "./config";
-import type { AgentInfo, SessionHead, SessionData } from "./lib/api";
-import { fetchAgents, fetchSessions, fetchSessionData } from "./lib/api";
+import type { AgentInfo, SessionHead, SessionData, SessionsUpdatedEvent } from "./lib/api";
+import {
+  fetchAgents,
+  fetchSessions,
+  fetchSessionData,
+  subscribeSessionUpdates,
+} from "./lib/api";
 import { SessionDetail } from "./components/SessionDetail";
 import { SessionDetailSkeleton } from "./components/SessionDetailSkeleton";
 import {
@@ -97,6 +102,7 @@ export default function App() {
   const [session, setSession] = useState<SessionData | null>(null);
   const [sessionLoading, setSessionLoading] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
+  const [liveNotice, setLiveNotice] = useState<string | null>(null);
 
   // Load agents and sessions
   useEffect(() => {
@@ -192,6 +198,33 @@ export default function App() {
       ? `${viewState.activeAgentKey}/${viewState.activeSessionSlug}`
       : "";
 
+  const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
+    try {
+      const [agentList, sessionList] = await Promise.all([fetchAgents(), fetchSessions()]);
+      setAgents(agentList);
+      setSessions(sessionList.sessions);
+
+      if (viewState.mode === "session") {
+        try {
+          const data = await fetchSessionData(viewState.activeAgentKey, viewState.activeSessionSlug);
+          setSession(data);
+          setSessionError(null);
+        } catch {
+          setSession(null);
+          setSessionError("Session not found");
+        }
+      }
+
+      if (event.newSessions > 0) {
+        setLiveNotice(`发现 ${event.newSessions} 个新会话，列表已自动刷新`);
+      } else if (event.updatedSessions > 0) {
+        setLiveNotice("会话内容已同步");
+      }
+    } catch (err) {
+      console.error("Failed to sync live session update:", err);
+    }
+  });
+
   // Load session detail
   useEffect(() => {
     if (viewState.mode !== "session") {
@@ -215,6 +248,28 @@ export default function App() {
     })();
     return () => ac.abort();
   }, [sessionFetchKey, viewState.activeAgentKey, viewState.activeSessionSlug, viewState.mode]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeSessionUpdates((event) => {
+      void syncLiveUpdate(event);
+    });
+
+    return unsubscribe;
+  }, [syncLiveUpdate]);
+
+  useEffect(() => {
+    if (!liveNotice) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setLiveNotice(null);
+    }, 3500);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [liveNotice]);
 
   // Build landing data
   const landingSessions = useMemo<LandingSession[]>(() => {
@@ -463,6 +518,11 @@ export default function App() {
               <p className="console-mono mt-1 text-xs text-[var(--console-muted)]">
                 {headerSubtitle}
               </p>
+              {liveNotice ? (
+                <p className="console-mono mt-2 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-text)]">
+                  {liveNotice}
+                </p>
+              ) : null}
             </div>
           </section>
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -89,6 +89,16 @@ export interface SessionData {
   messages: Message[];
 }
 
+export interface SessionsUpdatedEvent {
+  type: "sessions-updated";
+  changedAgents: string[];
+  newSessions: number;
+  updatedSessions: number;
+  removedSessions: number;
+  totalSessions: number;
+  timestamp: number;
+}
+
 export async function fetchAgents(): Promise<AgentInfo[]> {
   const res = await fetch("/api/agents");
   if (!res.ok) throw new Error("Failed to fetch agents");
@@ -107,4 +117,26 @@ export async function fetchSessionData(agent: string, sessionId: string): Promis
   const res = await fetch(`/api/sessions/${agent}/${sessionId}`);
   if (!res.ok) throw new Error("Failed to fetch session data");
   return res.json();
+}
+
+export function subscribeSessionUpdates(
+  onUpdate: (event: SessionsUpdatedEvent) => void,
+): () => void {
+  const source = new EventSource("/api/events");
+
+  source.addEventListener("sessions-updated", (event) => {
+    try {
+      onUpdate(JSON.parse(event.data) as SessionsUpdatedEvent);
+    } catch (error) {
+      console.error("Failed to parse session update event:", error);
+    }
+  });
+
+  source.onerror = () => {
+    console.error("Session update stream disconnected");
+  };
+
+  return () => {
+    source.close();
+  };
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@codesesh/core": "workspace:*",
     "@hono/node-server": "^1.14.0",
+    "chokidar": "^5.0.0",
     "citty": "^0.1.6",
     "consola": "^3.4.2",
     "hono": "^4.7.4",

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
-import { handleGetAgents, handleGetSessions, handleGetSessionData } from "../handlers.js";
+import {
+  handleGetAgents,
+  handleGetSessions,
+  handleGetSessionData,
+  type ScanResultSource,
+} from "../handlers.js";
 import type { ScanResult, SessionHead, SessionData } from "@codesesh/core";
 import { BaseAgent } from "@codesesh/core";
 
@@ -73,13 +78,21 @@ function makeScanResult(overrides?: Partial<ScanResult>): ScanResult {
   };
 }
 
+function makeScanSource(overrides?: Partial<ScanResult>): ScanResultSource {
+  const result = makeScanResult(overrides);
+  return {
+    getSnapshot() {
+      return result;
+    },
+  };
+}
+
 // --- Tests ---
 
 describe("handleGetAgents", () => {
   it("returns agent info list", () => {
     const c = makeMockContext();
-    const result = makeScanResult();
-    handleGetAgents(c, result);
+    handleGetAgents(c, makeScanSource());
     expect(c.json).toHaveBeenCalled();
     const response = c.json.mock.calls[0]![0];
     expect(Array.isArray(response)).toBe(true);
@@ -89,24 +102,21 @@ describe("handleGetAgents", () => {
 describe("handleGetSessions", () => {
   it("returns all sessions without filters", () => {
     const c = makeMockContext();
-    const result = makeScanResult();
-    handleGetSessions(c, result);
+    handleGetSessions(c, makeScanSource());
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(2);
   });
 
   it("filters by agent", () => {
     const c = makeMockContext({ query: { agent: "claudecode" } });
-    const result = makeScanResult();
-    handleGetSessions(c, result);
+    handleGetSessions(c, makeScanSource());
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(2);
   });
 
   it("falls back to all sessions when agent not found in byAgent", () => {
     const c = makeMockContext({ query: { agent: "nonexistent" } });
-    const result = makeScanResult();
-    handleGetSessions(c, result);
+    handleGetSessions(c, makeScanSource());
     const response = c.json.mock.calls[0]![0];
     // Falls back to scanResult.sessions
     expect(response.sessions).toHaveLength(2);
@@ -114,8 +124,7 @@ describe("handleGetSessions", () => {
 
   it("filters by q (title search)", () => {
     const c = makeMockContext({ query: { q: "s1" } });
-    const result = makeScanResult();
-    handleGetSessions(c, result);
+    handleGetSessions(c, makeScanSource());
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(1);
     expect(response.sessions[0].id).toBe("s1");
@@ -123,22 +132,23 @@ describe("handleGetSessions", () => {
 
   it("filters by cwd (substring match)", () => {
     const c = makeMockContext({ query: { cwd: "project" } });
-    const result = makeScanResult();
-    handleGetSessions(c, result);
+    handleGetSessions(c, makeScanSource());
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(2);
   });
 
   it("filters by from date", () => {
     const c = makeMockContext({ query: { from: "2024-01-01" } });
-    const result = makeScanResult({
+    handleGetSessions(
+      c,
+      makeScanSource({
       sessions: [
         makeSession("old", { time_created: new Date("2023-01-01").getTime() }),
         makeSession("new", { time_created: new Date("2025-01-01").getTime() }),
       ],
       byAgent: {},
-    });
-    handleGetSessions(c, result);
+      }),
+    );
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(1);
     expect(response.sessions[0].id).toBe("new");
@@ -146,8 +156,7 @@ describe("handleGetSessions", () => {
 
   it("ignores invalid from date", () => {
     const c = makeMockContext({ query: { from: "not-a-date" } });
-    const result = makeScanResult();
-    handleGetSessions(c, result);
+    handleGetSessions(c, makeScanSource());
     const response = c.json.mock.calls[0]![0];
     // Invalid date → filter not applied
     expect(response.sessions).toHaveLength(2);
@@ -157,8 +166,7 @@ describe("handleGetSessions", () => {
 describe("handleGetSessionData", () => {
   it("returns session data for valid agent and id", async () => {
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-    const result = makeScanResult();
-    await handleGetSessionData(c, result);
+    await handleGetSessionData(c, makeScanSource());
     expect(c.json).toHaveBeenCalled();
     const response = c.json.mock.calls[0]![0];
     expect(response.title).toBe("Test Session");
@@ -166,15 +174,13 @@ describe("handleGetSessionData", () => {
 
   it("returns 400 when session ID is missing", async () => {
     const c = makeMockContext({ param: { agent: "claudecode", id: "" } });
-    const result = makeScanResult();
-    await handleGetSessionData(c, result);
+    await handleGetSessionData(c, makeScanSource());
     expect(c.json).toHaveBeenCalledWith({ error: "Missing session ID" }, 400);
   });
 
   it("returns 404 for unknown agent", async () => {
     const c = makeMockContext({ param: { agent: "unknown", id: "s1" } });
-    const result = makeScanResult();
-    await handleGetSessionData(c, result);
+    await handleGetSessionData(c, makeScanSource());
     expect(c.json).toHaveBeenCalledWith({ error: "Unknown agent: unknown" }, 404);
   });
 
@@ -184,8 +190,7 @@ describe("handleGetSessionData", () => {
       throw new Error("DB not found");
     };
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-    const result = makeScanResult({ agents: [agent] });
-    await handleGetSessionData(c, result);
+    await handleGetSessionData(c, makeScanSource({ agents: [agent] }));
     expect(c.json).toHaveBeenCalledWith({ error: "DB not found" }, 500);
   });
 });

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -142,11 +142,11 @@ describe("handleGetSessions", () => {
     handleGetSessions(
       c,
       makeScanSource({
-      sessions: [
-        makeSession("old", { time_created: new Date("2023-01-01").getTime() }),
-        makeSession("new", { time_created: new Date("2025-01-01").getTime() }),
-      ],
-      byAgent: {},
+        sessions: [
+          makeSession("old", { time_created: new Date("2023-01-01").getTime() }),
+          makeSession("new", { time_created: new Date("2025-01-01").getTime() }),
+        ],
+        byAgent: {},
       }),
     );
     const response = c.json.mock.calls[0]![0];

--- a/packages/cli/src/api/__tests__/routes.test.ts
+++ b/packages/cli/src/api/__tests__/routes.test.ts
@@ -1,15 +1,20 @@
 import { describe, it, expect } from "vitest";
 import { createApiRoutes } from "../routes.js";
 import type { ScanResult } from "@codesesh/core";
+import type { ScanResultSource } from "../handlers.js";
 
 describe("createApiRoutes", () => {
   it("returns a Hono instance with route handlers", () => {
-    const scanResult = {
-      sessions: [],
-      byAgent: {},
-      agents: [],
-    } as unknown as ScanResult;
-    const app = createApiRoutes(scanResult);
+    const scanSource: ScanResultSource = {
+      getSnapshot() {
+        return {
+          sessions: [],
+          byAgent: {},
+          agents: [],
+        } as unknown as ScanResult;
+      },
+    };
+    const app = createApiRoutes(scanSource);
     expect(app).toBeDefined();
     expect(app.fetch).toBeDefined();
   });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -2,16 +2,21 @@ import type { Context } from "hono";
 import type { ScanResult, SessionData, SessionHead } from "@codesesh/core";
 import { getAgentInfoMap } from "@codesesh/core";
 
-export function handleGetAgents(c: Context, scanResult: ScanResult) {
-  const counts: Record<string, number> = {};
-  for (const agent of scanResult.agents) {
-    counts[agent.name] = scanResult.byAgent[agent.name]?.length ?? 0;
-  }
+export interface ScanResultSource {
+  getSnapshot(): ScanResult;
+}
+
+export function handleGetAgents(c: Context, scanSource: ScanResultSource) {
+  const scanResult = scanSource.getSnapshot();
+  const counts = Object.fromEntries(
+    Object.entries(scanResult.byAgent).map(([agentName, sessions]) => [agentName, sessions.length]),
+  );
   const info = getAgentInfoMap(counts);
   return c.json(info);
 }
 
-export function handleGetSessions(c: Context, scanResult: ScanResult) {
+export function handleGetSessions(c: Context, scanSource: ScanResultSource) {
+  const scanResult = scanSource.getSnapshot();
   const agent = c.req.query("agent");
   const q = c.req.query("q")?.toLowerCase();
   const cwd = c.req.query("cwd")?.toLowerCase();
@@ -52,7 +57,8 @@ export function handleGetSessions(c: Context, scanResult: ScanResult) {
   return c.json({ sessions });
 }
 
-export async function handleGetSessionData(c: Context, scanResult: ScanResult) {
+export async function handleGetSessionData(c: Context, scanSource: ScanResultSource) {
+  const scanResult = scanSource.getSnapshot();
   const agentName = c.req.param("agent");
   const sessionId = c.req.param("id");
 

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -1,13 +1,64 @@
 import { Hono } from "hono";
-import type { ScanResult } from "@codesesh/core";
-import { handleGetAgents, handleGetSessions, handleGetSessionData } from "./handlers.js";
+import {
+  handleGetAgents,
+  handleGetSessions,
+  handleGetSessionData,
+  type ScanResultSource,
+} from "./handlers.js";
+import type { LiveScanStore } from "../live-scan.js";
 
-export function createApiRoutes(scanResult: ScanResult): Hono {
+function createSseResponse(store: LiveScanStore, signal: AbortSignal): Response {
+  const encoder = new TextEncoder();
+
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        const write = (event: string, data: unknown) => {
+          controller.enqueue(encoder.encode(`event: ${event}\n`));
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+        };
+
+        write("connected", { timestamp: Date.now() });
+
+        const unsubscribe = store.subscribe((event) => {
+          write(event.type, event);
+        });
+
+        const heartbeat = setInterval(() => {
+          controller.enqueue(encoder.encode(": keepalive\n\n"));
+        }, 15000);
+
+        const close = () => {
+          clearInterval(heartbeat);
+          unsubscribe();
+          controller.close();
+        };
+
+        signal.addEventListener("abort", close, { once: true });
+      },
+      cancel() {
+        return;
+      },
+    }),
+    {
+      headers: {
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream",
+      },
+    },
+  );
+}
+
+export function createApiRoutes(scanSource: ScanResultSource, store?: LiveScanStore): Hono {
   const api = new Hono();
 
-  api.get("/agents", (c) => handleGetAgents(c, scanResult));
-  api.get("/sessions", (c) => handleGetSessions(c, scanResult));
-  api.get("/sessions/:agent/:id", (c) => handleGetSessionData(c, scanResult));
+  api.get("/agents", (c) => handleGetAgents(c, scanSource));
+  api.get("/sessions", (c) => handleGetSessions(c, scanSource));
+  api.get("/sessions/:agent/:id", (c) => handleGetSessionData(c, scanSource));
+  if (store) {
+    api.get("/events", (c) => createSseResponse(store, c.req.raw.signal));
+  }
 
   return api;
 }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,7 +1,8 @@
 import { defineCommand } from "citty";
 import { createServer } from "../server.js";
 import { printScanResults } from "../output.js";
-import { scanSessions, createRegisteredAgents } from "@codesesh/core";
+import { createRegisteredAgents } from "@codesesh/core";
+import { LiveScanStore } from "../live-scan.js";
 
 export const serveCommand = defineCommand({
   meta: {
@@ -41,9 +42,11 @@ export const serveCommand = defineCommand({
     const port = parseInt(args.port as string, 10) || 4321;
     const noOpen = args["no-open"] as boolean;
     const jsonOnly = args.json as boolean;
+    const store = new LiveScanStore(!jsonOnly);
 
-    // Scan sessions
-    const result = scanSessions();
+    await store.initialize();
+    const result = store.getSnapshot();
+
     const agents = createRegisteredAgents();
 
     if (jsonOnly) {
@@ -68,7 +71,7 @@ export const serveCommand = defineCommand({
     printScanResults(agents, result);
 
     // Start server
-    const { url } = await createServer(port, result);
+    const { url } = await createServer(port, store);
 
     if (!noOpen) {
       const open = (await import("open")).default;

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -1,0 +1,304 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import chokidar, { type FSWatcher } from "chokidar";
+import {
+  createRegisteredAgents,
+  getCursorDataPath,
+  resolveProviderRoots,
+  scanSessions,
+  type BaseAgent,
+  type ScanResult,
+  type SessionHead,
+} from "@codesesh/core";
+
+export interface SessionsUpdatedEvent {
+  type: "sessions-updated";
+  changedAgents: string[];
+  newSessions: number;
+  updatedSessions: number;
+  removedSessions: number;
+  totalSessions: number;
+  timestamp: number;
+}
+
+type StoreListener = (event: SessionsUpdatedEvent) => void;
+
+function sortSessions(sessions: SessionHead[]): SessionHead[] {
+  return [...sessions].sort(
+    (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
+  );
+}
+
+function sessionSignature(session: SessionHead): string {
+  return JSON.stringify([
+    session.title,
+    session.directory,
+    session.time_created,
+    session.time_updated ?? session.time_created,
+    session.stats.message_count,
+    session.stats.total_input_tokens,
+    session.stats.total_output_tokens,
+    session.stats.total_cost,
+    session.stats.total_tokens ?? 0,
+  ]);
+}
+
+function buildUpdateEvent(
+  agentName: string,
+  previousSessions: SessionHead[],
+  nextSessions: SessionHead[],
+): SessionsUpdatedEvent | null {
+  const previousMap = new Map(previousSessions.map((session) => [session.id, session]));
+  const nextMap = new Map(nextSessions.map((session) => [session.id, session]));
+
+  let newSessions = 0;
+  let updatedSessions = 0;
+  let removedSessions = 0;
+
+  for (const [id, session] of nextMap.entries()) {
+    const previous = previousMap.get(id);
+    if (!previous) {
+      newSessions += 1;
+      continue;
+    }
+    if (sessionSignature(previous) !== sessionSignature(session)) {
+      updatedSessions += 1;
+    }
+  }
+
+  for (const id of previousMap.keys()) {
+    if (!nextMap.has(id)) {
+      removedSessions += 1;
+    }
+  }
+
+  if (newSessions === 0 && updatedSessions === 0 && removedSessions === 0) {
+    return null;
+  }
+
+  return {
+    type: "sessions-updated",
+    changedAgents: [agentName],
+    newSessions,
+    updatedSessions,
+    removedSessions,
+    totalSessions: nextSessions.length,
+    timestamp: Date.now(),
+  };
+}
+
+function closestWatchablePath(targetPath: string): string {
+  let current = targetPath;
+
+  while (!existsSync(current)) {
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  return current;
+}
+
+function resolveAgentWatchPaths(agentName: string): string[] {
+  const roots = resolveProviderRoots();
+  const cursorDataPath = getCursorDataPath();
+
+  switch (agentName) {
+    case "claudecode":
+      return [join(roots.claudeRoot, "projects"), "data/claudecode"];
+    case "codex":
+      return [join(roots.codexRoot, "sessions")];
+    case "cursor":
+      return cursorDataPath
+        ? [
+            join(cursorDataPath, "globalStorage", "state.vscdb"),
+            join(cursorDataPath, "workspaceStorage"),
+          ]
+        : [];
+    case "kimi":
+      return [join(roots.kimiRoot, "sessions"), "data/kimi"];
+    case "opencode":
+      return [join(roots.opencodeRoot, "opencode.db"), "data/opencode/opencode.db"];
+    default:
+      return [];
+  }
+}
+
+export class LiveScanStore {
+  private agents: BaseAgent[] = [];
+  private byAgent: Record<string, SessionHead[]> = {};
+  private sessions: SessionHead[] = [];
+  private listeners = new Set<StoreListener>();
+  private refreshTimers = new Map<string, NodeJS.Timeout>();
+  private refreshTimestamps = new Map<string, number>();
+  private refreshInFlight = new Set<string>();
+  private pendingRefreshes = new Set<string>();
+  private watchers: FSWatcher[] = [];
+
+  constructor(private readonly watchEnabled = true) {}
+
+  async initialize(): Promise<void> {
+    const initialResult = await scanSessions({
+      useCache: true,
+      smartRefresh: false,
+    });
+    const knownAgents = createRegisteredAgents();
+    const agentMap = new Map<string, BaseAgent>();
+
+    for (const agent of initialResult.agents) {
+      agentMap.set(agent.name, agent);
+    }
+    for (const agent of knownAgents) {
+      if (!agentMap.has(agent.name)) {
+        agentMap.set(agent.name, agent);
+      }
+    }
+
+    this.agents = [...agentMap.values()];
+
+    for (const agent of this.agents) {
+      this.byAgent[agent.name] = sortSessions(initialResult.byAgent[agent.name] ?? []);
+      this.refreshTimestamps.set(agent.name, Date.now());
+    }
+
+    this.rebuildSessions();
+    if (this.watchEnabled) {
+      this.startWatching();
+    }
+  }
+
+  getSnapshot(): ScanResult {
+    return {
+      sessions: this.sessions,
+      byAgent: this.byAgent,
+      agents: this.agents,
+    };
+  }
+
+  subscribe(listener: StoreListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async shutdown(): Promise<void> {
+    for (const timer of this.refreshTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.refreshTimers.clear();
+
+    await Promise.all(this.watchers.map((watcher) => watcher.close()));
+    this.watchers = [];
+  }
+
+  private emit(event: SessionsUpdatedEvent): void {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  private rebuildSessions(): void {
+    this.sessions = sortSessions(Object.values(this.byAgent).flat());
+  }
+
+  private startWatching(): void {
+    for (const agent of this.agents) {
+      const rawPaths = resolveAgentWatchPaths(agent.name);
+      const watchPaths = [...new Set(rawPaths.map(closestWatchablePath))];
+
+      if (watchPaths.length === 0) {
+        continue;
+      }
+
+      const watcher = chokidar.watch(watchPaths, {
+        ignoreInitial: true,
+        awaitWriteFinish: {
+          stabilityThreshold: 250,
+          pollInterval: 100,
+        },
+      });
+
+      watcher.on("all", () => {
+        this.scheduleRefresh(agent.name);
+      });
+
+      this.watchers.push(watcher);
+    }
+  }
+
+  private scheduleRefresh(agentName: string, delayMs = 200): void {
+    const existing = this.refreshTimers.get(agentName);
+    if (existing) {
+      clearTimeout(existing);
+    }
+
+    const timer = setTimeout(() => {
+      this.refreshTimers.delete(agentName);
+      void this.refreshAgent(agentName);
+    }, delayMs);
+
+    this.refreshTimers.set(agentName, timer);
+  }
+
+  private async refreshAgent(agentName: string): Promise<void> {
+    if (this.refreshInFlight.has(agentName)) {
+      this.pendingRefreshes.add(agentName);
+      return;
+    }
+
+    this.refreshInFlight.add(agentName);
+
+    try {
+      await this.runRefresh(agentName);
+    } finally {
+      this.refreshInFlight.delete(agentName);
+
+      if (this.pendingRefreshes.delete(agentName)) {
+        this.scheduleRefresh(agentName, 100);
+      }
+    }
+  }
+
+  private async runRefresh(agentName: string): Promise<void> {
+    const agent = this.agents.find((item) => item.name === agentName);
+    if (!agent) {
+      return;
+    }
+
+    const previousSessions = this.byAgent[agentName] ?? [];
+    let nextSessions = previousSessions;
+
+    if (!agent.isAvailable()) {
+      nextSessions = [];
+      this.refreshTimestamps.set(agentName, Date.now());
+    } else if (previousSessions.length > 0 && agent.checkForChanges && agent.incrementalScan) {
+      const checkResult = await Promise.resolve(
+        agent.checkForChanges(this.refreshTimestamps.get(agentName) ?? 0, previousSessions),
+      );
+
+      this.refreshTimestamps.set(agentName, checkResult.timestamp);
+      if (!checkResult.hasChanges) {
+        return;
+      }
+
+      nextSessions = await Promise.resolve(
+        agent.incrementalScan(previousSessions, checkResult.changedIds ?? []),
+      );
+    } else {
+      nextSessions = await Promise.resolve(agent.scan());
+      this.refreshTimestamps.set(agentName, Date.now());
+    }
+
+    const event = buildUpdateEvent(agentName, previousSessions, nextSessions);
+    this.byAgent[agentName] = sortSessions(nextSessions);
+    this.rebuildSessions();
+
+    if (event) {
+      event.totalSessions = this.sessions.length;
+      this.emit(event);
+    }
+  }
+}

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -5,8 +5,8 @@ import { logger } from "hono/logger";
 import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ScanResult } from "@codesesh/core";
 import { createApiRoutes } from "./api/routes.js";
+import { LiveScanStore } from "./live-scan.js";
 
 function findWebDistPath(): string | null {
   const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -28,14 +28,14 @@ function findWebDistPath(): string | null {
 
 export async function createServer(
   port: number,
-  scanResult: ScanResult,
+  store: LiveScanStore,
 ): Promise<{ url: string; shutdown: () => void }> {
   const app = new Hono();
 
   app.use("*", logger());
 
   // API routes
-  app.route("/api", createApiRoutes(scanResult));
+  app.route("/api", createApiRoutes(store, store));
 
   // Serve static files from web dist (if available)
   const webDistPath = findWebDistPath();
@@ -51,6 +51,9 @@ export async function createServer(
 
   return {
     url,
-    shutdown: () => server.close(),
+    shutdown: () => {
+      server.close();
+      void store.shutdown();
+    },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.14.0
         version: 1.19.14(hono@4.12.12)
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       citty:
         specifier: ^0.1.6
         version: 0.1.6
@@ -1374,6 +1377,10 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -2149,6 +2156,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   refractor@5.0.0:
     resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
@@ -3403,6 +3414,10 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4:
     optional: true
 
@@ -4359,6 +4374,8 @@ snapshots:
     optional: true
 
   readdirp@4.1.2: {}
+
+  readdirp@5.0.0: {}
 
   refractor@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Add file watching for agent session sources and refresh scans incrementally on change
- Expose a server-sent events stream so the web UI updates sessions and open details automatically
- Show a lightweight notice when new or updated sessions arrive

## Testing
- `pnpm --filter codesesh test`
- `pnpm --filter @codesesh/web build`
- `pnpm --filter codesesh build`