### PR TITLE
feat: add SQLite cache and full-text search

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,12 +1,19 @@
 declare const __APP_VERSION__: string;
 
-import { useEffect, useEffectEvent, useMemo, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { Link, useLocation } from "react-router-dom";
 import { ModelConfig } from "./config";
 import type {
   AgentInfo,
   AppConfig,
   DashboardData,
+  SearchResult,
   SessionHead,
   SessionData,
   SessionsUpdatedEvent,
@@ -15,6 +22,7 @@ import {
   fetchAgents,
   fetchConfig,
   fetchDashboard,
+  fetchSearchResults,
   fetchSessions,
   fetchSessionData,
   subscribeSessionUpdates,
@@ -121,6 +129,17 @@ function formatRelativeTime(timestamp?: number) {
   return `${days}d ago`;
 }
 
+function toSafeSnippetHtml(snippet: string): string {
+  return snippet
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("&lt;mark&gt;", "<mark>")
+    .replaceAll("&lt;/mark&gt;", "</mark>");
+}
+
 interface BreadcrumbItem {
   label: string;
   to?: string;
@@ -138,6 +157,10 @@ export default function App() {
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
   const [appConfig, setAppConfig] = useState<AppConfig | null>(null);
+  const [draftSearchQuery, setDraftSearchQuery] = useState("");
+  const [activeSearchQuery, setActiveSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
 
   // Load config + agents + sessions + dashboard (all share the same app-level window)
   useEffect(() => {
@@ -169,11 +192,25 @@ export default function App() {
 
   const location = useLocation();
   const validAgentKeys = useMemo(() => new Set(agents.map((a) => a.name.toLowerCase())), [agents]);
+  const agentNameMap = useMemo(
+    () => new Map(agents.map((agent) => [agent.name.toLowerCase(), agent.displayName])),
+    [agents],
+  );
+  const isSearchMode = activeSearchQuery.length > 0;
 
   const viewState = useMemo(
     () => parseViewState(location.pathname, validAgentKeys),
     [location.pathname, validAgentKeys],
   );
+  const detailHighlightQuery =
+    isSearchMode
+      ? activeSearchQuery
+      : typeof location.state === "object" &&
+          location.state !== null &&
+          "searchQuery" in location.state &&
+          typeof location.state.searchQuery === "string"
+        ? location.state.searchQuery
+        : "";
 
   const sessionsByAgent = useMemo(() => {
     const grouped: Record<string, SessionHead[]> = {};
@@ -245,17 +282,24 @@ export default function App() {
 
   const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
     try {
-      const [agentList, sessionList, dashboardData] = await Promise.all([
+      const [agentList, sessionList, dashboardData, searchData] = await Promise.all([
         fetchAgents(),
         fetchSessions(),
         fetchDashboard(appConfig?.window.days).catch((err) => {
           console.error("Failed to refresh dashboard:", err);
           return null;
         }),
+        activeSearchQuery
+          ? fetchSearchResults(activeSearchQuery).catch((err) => {
+              console.error("Failed to refresh search results:", err);
+              return { results: [] };
+            })
+          : Promise.resolve<{ results: SearchResult[] } | null>(null),
       ]);
       setAgents(agentList);
       setSessions(sessionList.sessions);
       if (dashboardData) setDashboard(dashboardData);
+      if (searchData) setSearchResults(searchData.results);
 
       if (viewState.mode === "session") {
         try {
@@ -280,6 +324,36 @@ export default function App() {
       console.error("Failed to sync live session update:", err);
     }
   });
+
+  useEffect(() => {
+    if (!activeSearchQuery) {
+      setSearchResults([]);
+      setSearchLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setSearchLoading(true);
+
+    void fetchSearchResults(activeSearchQuery)
+      .then((data) => {
+        if (cancelled) return;
+        setSearchResults(data.results);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("Failed to load search results:", err);
+        setSearchResults([]);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setSearchLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSearchQuery]);
 
   // Load session detail
   useEffect(() => {
@@ -360,10 +434,20 @@ export default function App() {
   let headerTitle = "CodeSesh";
   let headerSubtitle = "Select an agent to browse sessions";
   if (viewState.mode === "root") {
-    headerTitle = "Dashboard";
-    headerSubtitle = dashboard
-      ? `${dashboard.totals.sessions.toLocaleString("en-US")} total sessions across ${dashboard.perAgent.length} agents`
-      : "Aggregated view across all agents";
+    headerTitle = isSearchMode ? "Search" : "Dashboard";
+    headerSubtitle = isSearchMode
+      ? searchLoading
+        ? `Searching for "${activeSearchQuery}"`
+        : `${searchResults.length} matches for "${activeSearchQuery}"`
+      : dashboard
+        ? `${dashboard.totals.sessions.toLocaleString("en-US")} total sessions across ${dashboard.perAgent.length} agents`
+        : "Aggregated view across all agents";
+  }
+  if (isSearchMode && viewState.mode !== "root") {
+    headerTitle = "Search";
+    headerSubtitle = searchLoading
+      ? `Searching for "${activeSearchQuery}"`
+      : `${searchResults.length} matches for "${activeSearchQuery}"`;
   }
   if (viewState.mode === "agent" && activeAgentKey) {
     headerTitle = activeAgent?.displayName ?? activeAgentKey;
@@ -389,6 +473,10 @@ export default function App() {
   }
 
   const breadcrumbItems = useMemo<BreadcrumbItem[]>(() => {
+    if (isSearchMode) {
+      return [{ label: "Search" }];
+    }
+
     const dashboardCrumb: BreadcrumbItem = {
       label: "Dashboard",
       to: viewState.mode === "root" ? undefined : "/",
@@ -425,12 +513,22 @@ export default function App() {
     }
 
     return [dashboardCrumb, { label: "Invalid Route" }];
-  }, [activeAgent, activeAgentKey, session?.title, viewState]);
+  }, [activeAgent, activeAgentKey, isSearchMode, session?.title, viewState]);
 
   // Content
   let content: ReactNode;
   if (loading) {
     content = <SessionDetailSkeleton />;
+  } else if (isSearchMode) {
+    content = (
+      <SearchResultsPanel
+        query={activeSearchQuery}
+        loading={searchLoading}
+        results={searchResults}
+        agentNameMap={agentNameMap}
+        onOpenResult={() => setActiveSearchQuery("")}
+      />
+    );
   } else if (error) {
     content = (
       <div className="mx-auto max-w-4xl rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6 text-sm text-[var(--console-error)]">
@@ -467,7 +565,7 @@ export default function App() {
         />
       );
     } else {
-      content = <SessionDetail session={session} />;
+      content = <SessionDetail session={session} highlightQuery={detailHighlightQuery} />;
     }
   } else if (viewState.mode === "missingAgent") {
     content = (
@@ -482,17 +580,43 @@ export default function App() {
     content = <div className="text-sm text-[var(--console-muted)]">Invalid route.</div>;
   }
 
+  function runSearch() {
+    setActiveSearchQuery(draftSearchQuery.trim());
+  }
+
   return (
     <div className="console-ui h-screen overflow-hidden bg-[var(--console-bg)] text-[var(--console-text)]">
       <header className="h-14 shrink-0 border-b border-[var(--console-border)] bg-white/85 backdrop-blur-sm">
-        <div className="flex h-full items-center justify-between px-4">
+        <div className="grid h-full grid-cols-[auto_1fr_auto] items-center gap-4 px-4">
           <Link to="/" className="flex items-center gap-2 text-[var(--console-text)]">
             <img src="/logo.svg?v=3" alt="CodeSesh" className="h-6 w-6 rounded-sm" />
             <span className="console-mono text-sm font-semibold uppercase tracking-[0.05em]">
               CodeSesh
             </span>
           </Link>
-          <div className="flex items-center gap-3">
+          <form
+            className="mx-auto flex w-full max-w-[560px] items-center justify-center gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              runSearch();
+            }}
+          >
+            <label className="flex min-w-0 flex-1 items-center rounded-sm border border-[var(--console-border)] bg-white px-2 py-1">
+              <input
+                value={draftSearchQuery}
+                onChange={(event) => setDraftSearchQuery(event.target.value)}
+                placeholder="Search sessions"
+                className="console-mono w-full min-w-0 bg-transparent text-xs text-[var(--console-text)] outline-none placeholder:text-[var(--console-muted)]"
+              />
+            </label>
+            <button
+              type="submit"
+              className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-white"
+            >
+              Search
+            </button>
+          </form>
+          <div className="flex items-center justify-end gap-3">
             {formatWindowLabel(appConfig) ? (
               <span
                 className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-2 py-1 text-xs text-[var(--console-text)]"
@@ -685,6 +809,88 @@ export default function App() {
           </section>
         </main>
       </div>
+    </div>
+  );
+}
+
+function SearchResultsPanel({
+  query,
+  loading,
+  results,
+  agentNameMap,
+  onOpenResult,
+}: {
+  query: string;
+  loading: boolean;
+  results: SearchResult[];
+  agentNameMap: Map<string, string>;
+  onOpenResult: () => void;
+}) {
+  if (loading) {
+    return (
+      <div className="grid gap-3">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={index}
+            className="animate-pulse rounded-sm border border-[var(--console-border)] bg-white/80 p-4"
+          >
+            <div className="h-3 w-32 rounded bg-[var(--console-surface-muted)]" />
+            <div className="mt-3 h-4 w-2/3 rounded bg-[var(--console-surface-muted)]" />
+            <div className="mt-2 h-3 w-full rounded bg-[var(--console-surface-muted)]" />
+            <div className="mt-1 h-3 w-5/6 rounded bg-[var(--console-surface-muted)]" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <div className="rounded-sm border border-[var(--console-border)] bg-white/80 p-6">
+        <h2 className="console-mono text-sm font-semibold text-[var(--console-text)]">
+          No matches
+        </h2>
+        <p className="console-mono mt-2 text-xs text-[var(--console-muted)]">
+          Query: {query}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      {results.map((result) => {
+        const agentKey = result.agentName.toLowerCase();
+        const agentLabel = agentNameMap.get(agentKey) ?? result.agentName;
+
+        return (
+          <Link
+            key={`${result.agentName}/${result.session.id}`}
+            to={`/${agentKey}/${result.session.id}`}
+            state={{ searchQuery: query }}
+            onClick={onOpenResult}
+            className="rounded-sm border border-[var(--console-border)] bg-white/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-white"
+          >
+            <div className="flex items-center gap-2">
+              <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-1.5 py-0.5 text-[10px] uppercase text-[var(--console-muted)]">
+                {agentLabel}
+              </span>
+              <span className="console-mono text-[11px] text-[var(--console-muted)]">
+                {result.session.directory}
+              </span>
+            </div>
+            <h2 className="console-mono mt-3 text-sm font-semibold text-[var(--console-text)]">
+              {result.session.title}
+            </h2>
+            <p
+              className="console-mono mt-2 text-xs leading-6 text-[var(--console-muted)] [&_mark]:bg-[var(--console-accent)] [&_mark]:px-0.5 [&_mark]:text-white"
+              dangerouslySetInnerHTML={{
+                __html: toSafeSnippetHtml(result.snippet || result.session.title),
+              }}
+            />
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,12 +1,6 @@
 declare const __APP_VERSION__: string;
 
-import {
-  useEffect,
-  useEffectEvent,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react";
+import { useEffect, useEffectEvent, useMemo, useState, type ReactNode } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { ModelConfig } from "./config";
 import type {
@@ -202,15 +196,14 @@ export default function App() {
     () => parseViewState(location.pathname, validAgentKeys),
     [location.pathname, validAgentKeys],
   );
-  const detailHighlightQuery =
-    isSearchMode
-      ? activeSearchQuery
-      : typeof location.state === "object" &&
-          location.state !== null &&
-          "searchQuery" in location.state &&
-          typeof location.state.searchQuery === "string"
-        ? location.state.searchQuery
-        : "";
+  const detailHighlightQuery = isSearchMode
+    ? activeSearchQuery
+    : typeof location.state === "object" &&
+        location.state !== null &&
+        "searchQuery" in location.state &&
+        typeof location.state.searchQuery === "string"
+      ? location.state.searchQuery
+      : "";
 
   const sessionsByAgent = useMemo(() => {
     const grouped: Record<string, SessionHead[]> = {};
@@ -850,9 +843,7 @@ function SearchResultsPanel({
         <h2 className="console-mono text-sm font-semibold text-[var(--console-text)]">
           No matches
         </h2>
-        <p className="console-mono mt-2 text-xs text-[var(--console-muted)]">
-          Query: {query}
-        </p>
+        <p className="console-mono mt-2 text-xs text-[var(--console-muted)]">Query: {query}</p>
       </div>
     );
   }

--- a/apps/web/src/components/MarkdownContent.tsx
+++ b/apps/web/src/components/MarkdownContent.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 
@@ -7,8 +8,85 @@ const markdownComponents: Components = {
 
 interface MarkdownContentProps {
   text: string;
+  highlightQuery?: string;
 }
 
-export function MarkdownContent({ text }: MarkdownContentProps) {
-  return <ReactMarkdown components={markdownComponents}>{text}</ReactMarkdown>;
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildHighlightPattern(query?: string): RegExp | null {
+  const normalized = query?.trim();
+  if (!normalized) return null;
+
+  const terms = Array.from(
+    new Set(
+      (normalized.match(/"[^"]+"|\S+/g) ?? [])
+        .map((term) => term.replace(/^"|"$/g, "").trim())
+        .filter(Boolean)
+        .filter((term) => !/^OR$/i.test(term)),
+    ),
+  );
+
+  if (terms.length === 0) return null;
+  return new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
+}
+
+export function MarkdownContent({ text, highlightQuery }: MarkdownContentProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const highlightPattern = useMemo(() => buildHighlightPattern(highlightQuery), [highlightQuery]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !highlightPattern) {
+      return;
+    }
+
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+    const textNodes: Text[] = [];
+
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      if (!(node instanceof Text)) continue;
+      const parent = node.parentElement;
+      if (!parent) continue;
+      if (parent.closest("mark, pre, code")) continue;
+      if (!node.textContent?.trim()) continue;
+      textNodes.push(node);
+    }
+
+    for (const node of textNodes) {
+      const source = node.textContent ?? "";
+      highlightPattern.lastIndex = 0;
+      if (!highlightPattern.test(source)) continue;
+
+      const fragment = document.createDocumentFragment();
+      let lastIndex = 0;
+      highlightPattern.lastIndex = 0;
+
+      for (const match of source.matchAll(highlightPattern)) {
+        const start = match.index ?? 0;
+        const matched = match[0] ?? "";
+        if (start > lastIndex) {
+          fragment.append(source.slice(lastIndex, start));
+        }
+        const mark = document.createElement("mark");
+        mark.textContent = matched;
+        fragment.append(mark);
+        lastIndex = start + matched.length;
+      }
+
+      if (lastIndex < source.length) {
+        fragment.append(source.slice(lastIndex));
+      }
+
+      node.parentNode?.replaceChild(fragment, node);
+    }
+  }, [highlightPattern, text]);
+
+  return (
+    <div ref={containerRef}>
+      <ReactMarkdown components={markdownComponents}>{text}</ReactMarkdown>
+    </div>
+  );
 }

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -61,6 +61,7 @@ import type { DiffBlock, DiffLineItem, ToolOutputContent } from "./tool-output/t
 
 interface SessionDetailProps {
   session: SessionData;
+  highlightQuery?: string;
 }
 
 type ToolStatus = "running" | "completed" | "error";
@@ -117,8 +118,41 @@ const TOOL_STATUS_META: Record<
 // Small helpers
 // ---------------------------------------------------------------------------
 
-function MessageMarkdown({ text }: { text: string }) {
-  return <MarkdownContent text={text} />;
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildHighlightPattern(query?: string): RegExp | null {
+  const normalized = query?.trim();
+  if (!normalized) return null;
+  const terms = Array.from(
+    new Set(
+      (normalized.match(/"[^"]+"|\S+/g) ?? [])
+        .map((term) => term.replace(/^"|"$/g, "").trim())
+        .filter(Boolean)
+        .filter((term) => !/^OR$/i.test(term)),
+    ),
+  );
+  if (terms.length === 0) return null;
+  return new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
+}
+
+function renderHighlightedText(text: string, query?: string) {
+  const pattern = buildHighlightPattern(query);
+  if (!pattern) return text;
+
+  const parts = text.split(pattern);
+  return parts.map((part, index) =>
+    part.match(pattern) ? (
+      <mark key={`${part}-${index}`}>{part}</mark>
+    ) : (
+      <span key={`${part}-${index}`}>{part}</span>
+    ),
+  );
+}
+
+function MessageMarkdown({ text, highlightQuery }: { text: string; highlightQuery?: string }) {
+  return <MarkdownContent text={text} highlightQuery={highlightQuery} />;
 }
 
 function toDisplayText(value: unknown) {
@@ -1151,7 +1185,7 @@ function formatMessageTime(rawTime: number | string) {
 // SessionDetail (main export)
 // ---------------------------------------------------------------------------
 
-export function SessionDetail({ session }: SessionDetailProps) {
+export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
   const sessionSlug = session.slug || "";
   const sessionAgentKey =
     sessionSlug.split("/")[0] || ModelConfig.getDefaultAgentKey() || "claudecode";
@@ -1213,6 +1247,7 @@ export function SessionDetail({ session }: SessionDetailProps) {
                 blocks={blocks}
                 formatTokens={formatTokens}
                 sessionAgentKey={sessionAgentKey}
+                highlightQuery={highlightQuery}
               />
             ))
           ) : (
@@ -1366,11 +1401,13 @@ function MessageItem({
   blocks,
   formatTokens: fmtTokens,
   sessionAgentKey,
+  highlightQuery,
 }: {
   msg: Message;
   blocks?: MessageBlock[];
   formatTokens: (n: number) => string;
   sessionAgentKey: string;
+  highlightQuery?: string;
 }) {
   const isUser = msg.role === "user";
   const isAbortMessage = isCodexTurnAbortedMessage(msg, sessionAgentKey);
@@ -1431,14 +1468,19 @@ function MessageItem({
           ) : (
             renderedBlocks.map((block, index) => {
               if (block.type === "reasoning") {
-                return <ReasoningSection key={index} parts={block.parts} />;
+                return <ReasoningSection key={index} parts={block.parts} highlightQuery={highlightQuery} />;
               }
               if (block.type === "plan") {
-                return <PlansSection key={index} parts={block.parts} />;
+                return <PlansSection key={index} parts={block.parts} highlightQuery={highlightQuery} />;
               }
               if (block.type === "tool") {
                 return (
-                  <ToolsSection key={index} parts={block.parts} sessionAgentKey={sessionAgentKey} />
+                  <ToolsSection
+                    key={index}
+                    parts={block.parts}
+                    sessionAgentKey={sessionAgentKey}
+                    highlightQuery={highlightQuery}
+                  />
                 );
               }
               return (
@@ -1448,7 +1490,11 @@ function MessageItem({
                 >
                   <div className="console-markdown text-sm leading-relaxed text-[var(--console-text)]">
                     {block.parts.map((part, partIndex) => (
-                      <MessageMarkdown key={partIndex} text={extractMessageText(part.text)} />
+                      <MessageMarkdown
+                        key={partIndex}
+                        text={extractMessageText(part.text)}
+                        highlightQuery={highlightQuery}
+                      />
                     ))}
                   </div>
                 </div>
@@ -1509,7 +1555,7 @@ function AbortToolItem() {
   );
 }
 
-function ReasoningSection({ parts }: { parts: MessagePart[] }) {
+function ReasoningSection({ parts, highlightQuery }: { parts: MessagePart[]; highlightQuery?: string }) {
   const [expanded, setExpanded] = useState(false);
   const fullText = parts
     .map((p) => extractMessageText(p.text))
@@ -1533,7 +1579,7 @@ function ReasoningSection({ parts }: { parts: MessagePart[] }) {
       {expanded && (
         <div className="border-t border-dashed border-[var(--console-thinking-border)] px-4 py-3">
           <div className="console-mono whitespace-pre-wrap text-xs leading-relaxed text-[var(--console-muted)]">
-            {fullText}
+            {renderHighlightedText(fullText, highlightQuery)}
           </div>
         </div>
       )}
@@ -1544,32 +1590,39 @@ function ReasoningSection({ parts }: { parts: MessagePart[] }) {
 function ToolsSection({
   parts,
   sessionAgentKey,
+  highlightQuery,
 }: {
   parts: MessagePart[];
   sessionAgentKey: string;
+  highlightQuery?: string;
 }) {
   return (
     <div className="space-y-2">
       <div className="space-y-2">
         {parts.map((tool, i) => (
-          <ToolItem key={i} tool={tool} sessionAgentKey={sessionAgentKey} />
+          <ToolItem
+            key={i}
+            tool={tool}
+            sessionAgentKey={sessionAgentKey}
+            highlightQuery={highlightQuery}
+          />
         ))}
       </div>
     </div>
   );
 }
 
-function PlansSection({ parts }: { parts: MessagePart[] }) {
+function PlansSection({ parts, highlightQuery }: { parts: MessagePart[]; highlightQuery?: string }) {
   return (
     <div className="space-y-2">
       {parts.map((plan, i) => (
-        <PlanItem key={i} part={plan} />
+        <PlanItem key={i} part={plan} highlightQuery={highlightQuery} />
       ))}
     </div>
   );
 }
 
-function PlanItem({ part }: { part: MessagePart }) {
+function PlanItem({ part, highlightQuery }: { part: MessagePart; highlightQuery?: string }) {
   const [expanded, setExpanded] = useState(false);
   const display = buildCodexPlanDisplay(part);
   const statusMeta =
@@ -1632,7 +1685,7 @@ function PlanItem({ part }: { part: MessagePart }) {
           </div>
           <div className="p-4">
             <div className="console-markdown text-sm leading-relaxed text-[var(--console-text)]">
-              <MessageMarkdown text={display.contentMarkdown} />
+              <MessageMarkdown text={display.contentMarkdown} highlightQuery={highlightQuery} />
             </div>
           </div>
         </div>
@@ -1641,7 +1694,15 @@ function PlanItem({ part }: { part: MessagePart }) {
   );
 }
 
-function ToolItem({ tool, sessionAgentKey }: { tool: MessagePart; sessionAgentKey: string }) {
+function ToolItem({
+  tool,
+  sessionAgentKey,
+  highlightQuery,
+}: {
+  tool: MessagePart;
+  sessionAgentKey: string;
+  highlightQuery?: string;
+}) {
   const [expanded, setExpanded] = useState(false);
   const state = normalizeToolState(tool);
   const strategy = getToolDisplayStrategy(sessionAgentKey, tool, state);
@@ -1670,7 +1731,7 @@ function ToolItem({ tool, sessionAgentKey }: { tool: MessagePart; sessionAgentKe
                 </span>
                 {strategy.secondaryText ? (
                   <span className="console-mono mt-0.5 block whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-muted)]">
-                    {strategy.secondaryText}
+                    {renderHighlightedText(strategy.secondaryText, highlightQuery)}
                   </span>
                 ) : null}
               </span>
@@ -1691,7 +1752,7 @@ function ToolItem({ tool, sessionAgentKey }: { tool: MessagePart; sessionAgentKe
                 </span>
                 {strategy.secondaryText ? (
                   <span className="console-mono mt-0.5 block whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-muted)]">
-                    {strategy.secondaryText}
+                    {renderHighlightedText(strategy.secondaryText, highlightQuery)}
                   </span>
                 ) : null}
               </span>
@@ -1724,7 +1785,7 @@ function ToolItem({ tool, sessionAgentKey }: { tool: MessagePart; sessionAgentKe
                         {detail.label}
                       </span>
                       <span className="console-mono whitespace-pre-wrap break-all text-xs leading-relaxed text-[var(--console-text)]">
-                        {detail.value}
+                        {renderHighlightedText(detail.value, highlightQuery)}
                       </span>
                     </div>
                   ))}
@@ -1739,7 +1800,7 @@ function ToolItem({ tool, sessionAgentKey }: { tool: MessagePart; sessionAgentKe
                 Input Preview
               </span>
               <pre className="console-mono mt-1 max-h-[200px] overflow-x-auto whitespace-pre-wrap break-all text-xs leading-relaxed text-[var(--console-muted)]">
-                {state.inputText || "{}"}
+                {renderHighlightedText(state.inputText || "{}", highlightQuery)}
               </pre>
             </div>
           ) : null}

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -1468,10 +1468,18 @@ function MessageItem({
           ) : (
             renderedBlocks.map((block, index) => {
               if (block.type === "reasoning") {
-                return <ReasoningSection key={index} parts={block.parts} highlightQuery={highlightQuery} />;
+                return (
+                  <ReasoningSection
+                    key={index}
+                    parts={block.parts}
+                    highlightQuery={highlightQuery}
+                  />
+                );
               }
               if (block.type === "plan") {
-                return <PlansSection key={index} parts={block.parts} highlightQuery={highlightQuery} />;
+                return (
+                  <PlansSection key={index} parts={block.parts} highlightQuery={highlightQuery} />
+                );
               }
               if (block.type === "tool") {
                 return (
@@ -1555,7 +1563,13 @@ function AbortToolItem() {
   );
 }
 
-function ReasoningSection({ parts, highlightQuery }: { parts: MessagePart[]; highlightQuery?: string }) {
+function ReasoningSection({
+  parts,
+  highlightQuery,
+}: {
+  parts: MessagePart[];
+  highlightQuery?: string;
+}) {
   const [expanded, setExpanded] = useState(false);
   const fullText = parts
     .map((p) => extractMessageText(p.text))
@@ -1612,7 +1626,13 @@ function ToolsSection({
   );
 }
 
-function PlansSection({ parts, highlightQuery }: { parts: MessagePart[]; highlightQuery?: string }) {
+function PlansSection({
+  parts,
+  highlightQuery,
+}: {
+  parts: MessagePart[];
+  highlightQuery?: string;
+}) {
   return (
     <div className="space-y-2">
       {parts.map((plan, i) => (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -142,6 +142,12 @@ export interface AppConfig {
   };
 }
 
+export interface SearchResult {
+  agentName: string;
+  session: SessionHead;
+  snippet: string;
+}
+
 export async function fetchConfig(): Promise<AppConfig> {
   const res = await fetch("/api/config");
   if (!res.ok) throw new Error("Failed to fetch config");
@@ -174,6 +180,14 @@ export async function fetchDashboard(days?: number): Promise<DashboardData> {
   const suffix = params.toString();
   const res = await fetch(suffix ? `/api/dashboard?${suffix}` : "/api/dashboard");
   if (!res.ok) throw new Error("Failed to fetch dashboard");
+  return res.json();
+}
+
+export async function fetchSearchResults(query: string): Promise<{ results: SearchResult[] }> {
+  const params = new URLSearchParams();
+  params.set("q", query);
+  const res = await fetch(`/api/search?${params}`);
+  if (!res.ok) throw new Error("Failed to fetch search results");
   return res.json();
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,27 +60,12 @@
 │                          Cache Layer                           │
 │              packages/core/src/discovery/cache.ts               │
 │                                                                │
-│   缓存位置: ~/.cache/codesesh/scan-cache.json               │
-│   缓存格式: { version: 2, entries: { [agent]: CacheEntry } }  │
-│   缓存内容: sessions + meta + timestamp                       │
+│   存储位置: ~/.cache/codesesh/codesesh.db                     │
+│   存储内容: sessions cache + meta + FTS index                 │
 │   TTL: 7 天                                                    │
 └────────────────────────────────────────────────────────────────┘
 
-CacheEntry Structure:
-{
-  "claudecode": {
-    "sessions": [...],      // SessionHead[]
-    "meta": {               // SessionCacheMeta
-      "session-id": {
-        "id": "...",
-        "sourcePath": "...",
-        ...
-      }
-    },
-    "timestamp": 1776241234567,  // 用于变更检测
-    "version": 2
-  }
-}
+详细表结构和数据流见 [sqlite-storage.md](./sqlite-storage.md)。
 ```
 
 ## 性能对比

--- a/docs/scanning-and-caching.md
+++ b/docs/scanning-and-caching.md
@@ -4,6 +4,8 @@
 
 本文档详细说明 CodeSesh 的会话扫描、并行处理和缓存机制的设计理念与实现细节。
 
+SQLite 表结构和搜索索引数据流见 [sqlite-storage.md](./sqlite-storage.md)。
+
 ## 1. 整体架构
 
 ```
@@ -184,21 +186,17 @@ incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHea
 
 ### 3.3 缓存数据结构
 
-```typescript
-// 缓存版本 2
-interface CacheData {
-  version: 2;
-  entries: Record<string, CacheEntry>; // 按 Agent 分组
-  lastScanTime: number;
-}
+当前缓存后端已经切换为 SQLite，位置是 `~/.cache/codesesh/codesesh.db`。
 
-interface CacheEntry {
-  sessions: SessionHead[];           // 会话列表
-  meta: Record<string, SessionCacheMeta>; // 元数据（sourcePath 等）
-  timestamp: number;                 // 缓存时间戳（用于变更检测）
-  version: number;
-}
-```
+核心表：
+
+- `cache_meta`
+- `agent_cache`
+- `cached_sessions`
+- `session_documents`
+- `session_documents_fts`
+
+结构说明见 [sqlite-storage.md](./sqlite-storage.md)。
 
 ## 4. 数据一致性保证
 
@@ -339,16 +337,16 @@ fs.watch(sessionDir, (eventType, filename) => {
 });
 ```
 
-### 8.3 数据库存储
+### 8.3 SQLite 存储深化
 
 ```typescript
-// 将会话元数据存储在 SQLite 中
-const db = new Database('~/.cache/codesesh/cache.db');
+// 当前已经使用 SQLite 统一持久化缓存和搜索索引
+const db = new Database("~/.cache/codesesh/codesesh.db");
 
-// 优势：
-// - 更快的查询速度
-// - 支持复杂过滤
-// - 增量更新更高效
+// 后续可以继续深化：
+// - 将首次搜索的按需建索引改成后台预热
+// - 将更多过滤条件前移到 SQLite 查询层
+// - 让搜索索引覆盖更多结构化工具输出
 ```
 
 ## 9. 总结

--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -1,0 +1,244 @@
+# CodeSesh SQLite 存储说明
+
+## 概述
+
+CodeSesh 现在将会话缓存和全文搜索索引统一存储在同一个 SQLite 数据库：
+
+- 路径：`~/.cache/codesesh/codesesh.db`
+- 实现：`packages/core/src/discovery/cache.ts`
+- 目标：
+  - 启动时快速恢复 `SessionHead[]`
+  - 为 `getSessionData()` 恢复 `SessionCacheMeta`
+  - 为全文搜索提供 FTS5 索引
+  - 让缓存刷新和搜索索引共享同一条数据生命周期
+
+## 表结构
+
+### `cache_meta`
+
+用于保存数据库级元信息。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `key` | `TEXT PRIMARY KEY` | 元信息键 |
+| `value` | `TEXT NOT NULL` | 元信息值 |
+
+当前主要存储：
+
+- `version`：当前 schema 版本，来自 `CACHE_VERSION`
+
+### `agent_cache`
+
+按 Agent 记录缓存时间戳。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `agent_name` | `TEXT PRIMARY KEY` | agent 名称，如 `claudecode` |
+| `timestamp` | `INTEGER NOT NULL` | 最近一次成功写入缓存的时间戳 |
+
+用途：
+
+- `loadCachedSessions()` 用它判断某个 agent 的缓存是否存在
+- 同时用于 7 天 TTL 校验
+- `scanner.ts` 会把这个时间戳作为 `checkForChanges()` 的输入基准
+
+### `cached_sessions`
+
+保存会话列表页需要的轻量元数据和详情恢复所需 meta。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `agent_name` | `TEXT NOT NULL` | agent 名称 |
+| `session_id` | `TEXT NOT NULL` | 会话 ID |
+| `session_json` | `TEXT NOT NULL` | `SessionHead` 的 JSON 序列化 |
+| `meta_json` | `TEXT` | `SessionCacheMeta` 的 JSON 序列化 |
+
+主键：
+
+- `PRIMARY KEY (agent_name, session_id)`
+
+用途：
+
+- 启动时恢复会话列表
+- 恢复 `sessionMetaMap`
+- 为增量扫描提供上一次已知会话集合
+
+### `session_documents`
+
+保存全文搜索的规范化文档源表。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | `INTEGER PRIMARY KEY AUTOINCREMENT` | FTS 关联主键 |
+| `agent_name` | `TEXT NOT NULL` | agent 名称 |
+| `session_id` | `TEXT NOT NULL` | 会话 ID |
+| `slug` | `TEXT NOT NULL` | 会话 slug |
+| `title` | `TEXT NOT NULL` | 会话标题 |
+| `directory` | `TEXT NOT NULL` | 会话目录 |
+| `time_created` | `INTEGER NOT NULL` | 创建时间 |
+| `time_updated` | `INTEGER` | 更新时间 |
+| `activity_time` | `INTEGER NOT NULL` | 搜索排序和过滤用活动时间 |
+| `content_text` | `TEXT NOT NULL` | 从 `SessionData.messages` 提取的全文文本 |
+| `content_hash` | `TEXT NOT NULL` | 当前索引版本对应的内容签名 |
+| `indexed_at` | `INTEGER NOT NULL` | 最近一次建索引时间 |
+
+唯一约束：
+
+- `UNIQUE(agent_name, session_id)`
+
+用途：
+
+- 作为 FTS 外部内容表
+- 保存搜索结果展示所需字段
+- 用 `content_hash` 判断是否需要重建某条会话索引
+
+### `session_documents_fts`
+
+FTS5 虚表，挂在 `session_documents` 上。
+
+定义：
+
+```sql
+CREATE VIRTUAL TABLE session_documents_fts USING fts5(
+  title,
+  content_text,
+  content='session_documents',
+  content_rowid='id'
+);
+```
+
+索引字段：
+
+- `title`
+- `content_text`
+
+查询逻辑：
+
+- 使用 `MATCH` 执行全文检索
+- 使用 `bm25(session_documents_fts, 8.0, 1.0)` 排序
+- 使用 `snippet(...)` 生成高亮片段
+
+## 触发器
+
+`session_documents_fts` 通过 3 个触发器和 `session_documents` 保持同步：
+
+- `session_documents_ai`
+  插入 `session_documents` 时向 FTS 插入对应 row
+- `session_documents_ad`
+  删除 `session_documents` 时从 FTS 删除对应 row
+- `session_documents_au`
+  更新 `session_documents` 时先删旧索引，再插入新索引
+
+这套设计让业务代码只需要维护 `session_documents`，FTS 同步由 SQLite 完成。
+
+## 数据流
+
+### 1. 启动扫描
+
+```text
+CLI
+  -> scanSessions()
+  -> scanAgentSmart(agent)
+  -> loadCachedSessions(agent.name)
+  -> 从 agent_cache + cached_sessions 恢复 SessionHead[] 和 meta
+  -> 立即返回会话列表
+```
+
+关键点：
+
+- 启动路径只依赖 `cached_sessions`
+- 搜索索引不会阻塞基础列表恢复
+
+### 2. 完整扫描
+
+```text
+agent.scan()
+  -> heads: SessionHead[]
+  -> saveCachedSessions(agentName, heads, meta)
+  -> 覆盖 agent_cache
+  -> 覆盖 cached_sessions
+```
+
+关键点：
+
+- 这一步只写列表缓存
+- 还没有读取 `SessionData.messages`
+
+### 3. 搜索建索引
+
+```text
+/api/search?q=...
+  -> handleSearchSessions()
+  -> syncSessionSearchIndex(agentName, sessions, agent.getSessionData)
+  -> 对比 session_documents.content_hash
+  -> 只为缺失或变更的会话加载 SessionData
+  -> 写入 session_documents
+  -> 触发器同步 session_documents_fts
+  -> searchSessions()
+  -> 返回 snippet + session metadata
+```
+
+关键点：
+
+- 第一次搜索会按需补齐索引
+- 搜索索引构建和缓存恢复解耦
+- 只有发生变化的会话会重新读取全文内容
+
+### 4. 增量刷新
+
+```text
+LiveScanStore.refreshAgent()
+  -> agent.checkForChanges(...)
+  -> agent.incrementalScan(...)
+  -> saveCachedSessions(...)
+  -> syncSessionSearchIndex(...)
+```
+
+关键点：
+
+- 监听文件变化后，列表缓存和搜索索引一起更新
+- 搜索和列表共享同一份会话集合
+
+## 读写职责
+
+| 场景 | 读取表 | 写入表 |
+|------|--------|--------|
+| 启动恢复列表 | `agent_cache`, `cached_sessions` | 无 |
+| 保存扫描结果 | 无 | `agent_cache`, `cached_sessions` |
+| 构建搜索索引 | `session_documents` | `session_documents` |
+| 执行全文搜索 | `session_documents_fts`, `session_documents` | 无 |
+| 清空缓存 | 全部 | `agent_cache`, `cached_sessions`, `session_documents` |
+
+## 一致性策略
+
+### 列表缓存
+
+- 以 agent 为单位整体覆盖
+- `saveCachedSessions()` 在事务里先删旧数据，再写入新数据
+
+### 搜索索引
+
+- 以单会话为单位增量更新
+- `content_hash` 基于 `SessionHead` 核心字段生成
+- 如果 `SessionHead` 没变化，默认跳过全文重建
+
+### 详情内容
+
+- `getSessionData()` 仍然实时读取源文件或源数据库
+- SQLite 当前存的是搜索用规范化文本，不是详情页完整消息快照
+
+## 现阶段边界
+
+当前实现有两个明确边界：
+
+1. 首次搜索某个大库时，索引会按需建立，这次请求会更重
+2. `content_hash` 基于 `SessionHead`，如果底层消息内容变化但 head 未变化，索引刷新依赖增量扫描重新产出新的 head
+
+这两个边界都属于当前设计下的可接受权衡，因为启动速度和实现复杂度更重要。
+
+## 相关代码
+
+- `packages/core/src/discovery/cache.ts`
+- `packages/core/src/discovery/scanner.ts`
+- `packages/cli/src/api/handlers.ts`
+- `packages/cli/src/live-scan.ts`

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
 import type { ScanResult, SessionData, SessionHead } from "@codesesh/core";
-import { getAgentInfoMap } from "@codesesh/core";
+import { getAgentInfoMap, searchSessions, syncSessionSearchIndex } from "@codesesh/core";
 
 export interface ScanResultSource {
   getSnapshot(): ScanResult;
@@ -110,6 +110,40 @@ export function handleGetSessions(
   }
 
   return c.json({ sessions });
+}
+
+export function handleSearchSessions(
+  c: Context,
+  scanSource: ScanResultSource,
+  defaults: SessionListDefaults = {},
+) {
+  const query = c.req.query("q")?.trim() ?? "";
+  if (!query) {
+    return c.json({ results: [] });
+  }
+
+  const scanResult = scanSource.getSnapshot();
+  const agent = c.req.query("agent");
+  const cwd = c.req.query("cwd");
+  const from = parseDateParam(c.req.query("from"), defaults.from);
+  const to = parseDateParam(c.req.query("to"), defaults.to);
+
+  for (const indexedAgent of scanResult.agents) {
+    const sessions = scanResult.byAgent[indexedAgent.name] ?? [];
+    syncSessionSearchIndex(indexedAgent.name, sessions, (sessionId) =>
+      indexedAgent.getSessionData(sessionId),
+    );
+  }
+
+  const results = searchSessions(query, {
+    agent,
+    cwd,
+    from,
+    to,
+    limit: 50,
+  });
+
+  return c.json({ results });
 }
 
 export async function handleGetSessionData(c: Context, scanSource: ScanResultSource) {

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -3,6 +3,7 @@ import {
   handleGetAgents,
   handleGetConfig,
   handleGetDashboard,
+  handleSearchSessions,
   handleGetSessions,
   handleGetSessionData,
   type ScanResultSource,
@@ -74,6 +75,7 @@ export function createApiRoutes(
   api.get("/config", (c) => handleGetConfig(c, listDefaults));
   api.get("/agents", (c) => handleGetAgents(c, scanSource, listDefaults));
   api.get("/sessions", (c) => handleGetSessions(c, scanSource, listDefaults));
+  api.get("/search", (c) => handleSearchSessions(c, scanSource, listDefaults));
   api.get("/sessions/:agent/:id", (c) => handleGetSessionData(c, scanSource));
   api.get("/dashboard", (c) => handleGetDashboard(c, scanSource, listDefaults));
   if (store) {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -7,6 +7,7 @@ import {
   getCursorDataPath,
   resolveProviderRoots,
   scanSessions,
+  syncSessionSearchIndex,
   saveCachedSessions,
   type BaseAgent,
   type ScanResult,
@@ -369,6 +370,7 @@ export class LiveScanStore {
 
     nextSessions = this.applyFilters(nextSessions);
     saveCachedSessions(agentName, nextSessions, buildAgentCacheMeta(agent));
+    syncSessionSearchIndex(agentName, nextSessions, (sessionId) => agent.getSessionData(sessionId));
 
     const event = buildUpdateEvent(agentName, previousSessions, nextSessions);
     this.byAgent[agentName] = sortSessions(nextSessions);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "tsup": "^8.4.0",
     "typescript": "^5.9.3"
   },
-  "optionalDependencies": {
+  "dependencies": {
     "better-sqlite3": "^11.10.0"
   }
 }

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -6,10 +6,12 @@ import {
   clearCache,
   getCacheInfo,
   loadCachedSessions,
+  searchSessions,
   saveCachedSessions,
+  syncSessionSearchIndex,
   type SessionCacheMeta,
 } from "../cache.js";
-import type { SessionHead } from "../../types/index.js";
+import type { SessionData, SessionHead } from "../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
 
@@ -50,6 +52,21 @@ function makeSession(id: string): SessionHead {
       total_output_tokens: 0,
       total_cost: 0,
     },
+  };
+}
+
+function makeSessionData(id: string, text: string): SessionData {
+  const session = makeSession(id);
+  return {
+    ...session,
+    messages: [
+      {
+        id: `${id}-m1`,
+        role: "user",
+        time_created: now,
+        parts: [{ type: "text", text }],
+      },
+    ],
   };
 }
 
@@ -166,5 +183,41 @@ describe("getCacheInfo", () => {
     saveCachedSessions("agent2", [makeSession("c")]);
 
     expect(getCacheInfo()).toEqual({ lastScanTime: now, size: 3 });
+  });
+});
+
+describe("searchSessions", () => {
+  it("indexes session content and returns highlighted matches", () => {
+    const session = makeSession("s1");
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex("claudecode", [session], (sessionId) =>
+      makeSessionData(sessionId, "sqlite fts search is now enabled"),
+    );
+
+    const results = searchSessions("sqlite");
+    expect(results).toHaveLength(1);
+    expect(results[0]?.agentName).toBe("claudecode");
+    expect(results[0]?.session.id).toBe("s1");
+    expect(results[0]?.snippet).toContain("<mark>sqlite</mark>");
+  });
+
+  it("supports OR queries and agent filters", () => {
+    const alpha = makeSession("alpha");
+    const beta = makeSession("beta");
+    saveCachedSessions("claudecode", [alpha]);
+    saveCachedSessions("cursor", [beta]);
+    syncSessionSearchIndex("claudecode", [alpha], (sessionId) =>
+      makeSessionData(sessionId, "search alpha term"),
+    );
+    syncSessionSearchIndex("cursor", [beta], (sessionId) =>
+      makeSessionData(sessionId, "search beta term"),
+    );
+
+    const allResults = searchSessions("alpha OR beta");
+    expect(allResults).toHaveLength(2);
+
+    const filteredResults = searchSessions("alpha OR beta", { agent: "cursor" });
+    expect(filteredResults).toHaveLength(1);
+    expect(filteredResults[0]?.agentName).toBe("cursor");
   });
 });

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -1,41 +1,40 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-vi.mock("node:os", () => ({
-  homedir: vi.fn(() => "/home/testuser"),
-}));
-
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  return {
-    ...actual,
-    existsSync: vi.fn(() => false),
-    readFileSync: vi.fn(),
-    writeFileSync: vi.fn(),
-    mkdirSync: vi.fn(),
-  };
-});
-
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import {
-  loadCachedSessions,
-  saveCachedSessions,
   clearCache,
   getCacheInfo,
+  loadCachedSessions,
+  saveCachedSessions,
   type SessionCacheMeta,
 } from "../cache.js";
 import type { SessionHead } from "../../types/index.js";
 
-const mockedExistsSync = vi.mocked(existsSync);
-const mockedReadFileSync = vi.mocked(readFileSync);
-const mockedWriteFileSync = vi.mocked(writeFileSync);
-const mockedMkdirSync = vi.mocked(mkdirSync);
+const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => testHomeDir),
+  };
+});
 
 const now = Date.now();
-vi.spyOn(Date, "now").mockReturnValue(now);
+const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
+function getCacheDir(): string {
+  return join(testHomeDir, ".cache", "codesesh");
+}
+
+function getCachePath(): string {
+  return join(getCacheDir(), "codesesh.db");
+}
+
+function getLegacyCachePath(): string {
+  return join(getCacheDir(), "scan-cache.json");
+}
 
 function makeSession(id: string): SessionHead {
   return {
@@ -54,179 +53,118 @@ function makeSession(id: string): SessionHead {
   };
 }
 
+beforeEach(() => {
+  rmSync(getCacheDir(), { recursive: true, force: true });
+  dateNowSpy.mockReturnValue(now);
+});
+
+afterEach(() => {
+  rmSync(getCacheDir(), { recursive: true, force: true });
+});
+
 describe("loadCachedSessions", () => {
-  it("returns null when cache file does not exist", () => {
-    mockedExistsSync.mockReturnValue(false);
+  it("returns null when cache db does not exist", () => {
     expect(loadCachedSessions("claudecode")).toBeNull();
   });
 
-  it("returns null on invalid JSON", () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue("not json");
+  it("returns null when agent is not cached", () => {
+    saveCachedSessions("cursor", [makeSession("s1")]);
     expect(loadCachedSessions("claudecode")).toBeNull();
   });
 
-  it("returns null on version mismatch", () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue(
-      JSON.stringify({ version: 1, entries: {}, lastScanTime: now }),
-    );
+  it("returns null when cache is too old", () => {
+    saveCachedSessions("claudecode", [makeSession("s1")]);
+    dateNowSpy.mockReturnValue(now + 8 * 24 * 60 * 60 * 1000);
     expect(loadCachedSessions("claudecode")).toBeNull();
   });
 
-  it("returns null when agent not in cache", () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue(
-      JSON.stringify({ version: 2, entries: {}, lastScanTime: now }),
-    );
-    expect(loadCachedSessions("claudecode")).toBeNull();
-  });
-
-  it("returns null when cache is too old (>7 days)", () => {
-    const oldTimestamp = now - 8 * 24 * 60 * 60 * 1000;
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue(
-      JSON.stringify({
-        version: 2,
-        entries: {
-          claudecode: {
-            sessions: [makeSession("s1")],
-            meta: {},
-            timestamp: oldTimestamp,
-            version: 2,
-          },
-        },
-        lastScanTime: oldTimestamp,
-      }),
-    );
-    expect(loadCachedSessions("claudecode")).toBeNull();
-  });
-
-  it("returns cached sessions when valid", () => {
-    const session = makeSession("s1");
+  it("returns cached sessions and meta when valid", () => {
     const meta: Record<string, SessionCacheMeta> = {
-      s1: { id: "s1", sourcePath: "/path" },
+      s1: { id: "s1", sourcePath: "/path/to/source" },
     };
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue(
-      JSON.stringify({
-        version: 2,
-        entries: {
-          claudecode: { sessions: [session], meta, timestamp: now, version: 2 },
-        },
-        lastScanTime: now,
-      }),
-    );
+
+    saveCachedSessions("claudecode", [makeSession("s1")], meta);
+
     const result = loadCachedSessions("claudecode");
     expect(result).not.toBeNull();
-    expect(result!.sessions).toHaveLength(1);
-    expect(result!.sessions[0]!.id).toBe("s1");
-    expect(result?.meta.s1?.sourcePath).toBe("/path");
+    expect(result?.sessions).toHaveLength(1);
+    expect(result?.sessions[0]?.id).toBe("s1");
+    expect(result?.meta.s1?.sourcePath).toBe("/path/to/source");
+    expect(result?.timestamp).toBe(now);
+  });
+
+  it("preserves empty cached results", () => {
+    saveCachedSessions("claudecode", []);
+    const result = loadCachedSessions("claudecode");
+    expect(result).toEqual({
+      sessions: [],
+      meta: {},
+      timestamp: now,
+    });
   });
 });
 
 describe("saveCachedSessions", () => {
-  it("creates new cache when file does not exist", () => {
-    mockedExistsSync.mockReturnValue(false);
+  it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
-    expect(mockedMkdirSync).toHaveBeenCalled();
-    expect(mockedWriteFileSync).toHaveBeenCalled();
-    const written = JSON.parse(mockedWriteFileSync.mock.calls[0]![1] as string);
-    expect(written.version).toBe(2);
-    expect(written.entries.claudecode.sessions).toHaveLength(1);
+    expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
   });
 
-  it("resets cache when existing file has wrong version", () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue(
-      JSON.stringify({ version: 1, entries: { old: {} }, lastScanTime: 0 }),
-    );
-    saveCachedSessions("claudecode", [makeSession("s1")]);
-    const written = JSON.parse(mockedWriteFileSync.mock.calls[0]![1] as string);
-    // Old entries should be cleared
-    expect(Object.keys(written.entries)).toEqual(["claudecode"]);
-  });
-
-  it("overwrites existing entry for same agent", () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue(
-      JSON.stringify({
-        version: 2,
-        entries: {
-          other: { sessions: [], meta: {}, timestamp: now, version: 2 },
-          claudecode: {
-            sessions: [makeSession("old")],
-            meta: {},
-            timestamp: now - 1000,
-            version: 2,
-          },
-        },
-        lastScanTime: now - 1000,
-      }),
-    );
+  it("overwrites cached rows for the same agent", () => {
+    saveCachedSessions("claudecode", [makeSession("old")]);
     saveCachedSessions("claudecode", [makeSession("new")]);
-    const written = JSON.parse(mockedWriteFileSync.mock.calls[0]![1] as string);
-    expect(written.entries.claudecode.sessions[0].id).toBe("new");
-    // Other agent preserved
-    expect(written.entries.other).toBeDefined();
+
+    const result = loadCachedSessions("claudecode");
+    expect(result?.sessions.map((session) => session.id)).toEqual(["new"]);
   });
 
-  it("silently ignores write errors", () => {
-    mockedExistsSync.mockReturnValue(false);
-    mockedWriteFileSync.mockImplementation(() => {
-      throw new Error("Permission denied");
-    });
-    expect(() => saveCachedSessions("claudecode", [makeSession("s1")])).not.toThrow();
+  it("preserves other agents", () => {
+    saveCachedSessions("cursor", [makeSession("cursor-1")]);
+    saveCachedSessions("claudecode", [makeSession("claude-1")]);
+
+    expect(loadCachedSessions("cursor")?.sessions.map((session) => session.id)).toEqual([
+      "cursor-1",
+    ]);
+    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
+      "claude-1",
+    ]);
+  });
+
+  it("removes legacy json cache file after sqlite write", () => {
+    mkdirSync(getCacheDir(), { recursive: true });
+    writeFileSync(getLegacyCachePath(), JSON.stringify({ stale: true }), "utf-8");
+
+    saveCachedSessions("claudecode", [makeSession("s1")]);
+
+    expect(() => readFileSync(getLegacyCachePath(), "utf-8")).toThrow();
   });
 });
 
 describe("clearCache", () => {
-  it("writes empty entries when cache exists", () => {
-    mockedExistsSync.mockReturnValue(true);
+  it("clears sqlite rows", () => {
+    saveCachedSessions("claudecode", [makeSession("s1")]);
     clearCache();
-    const written = JSON.parse(mockedWriteFileSync.mock.calls[0]![1] as string);
-    expect(written.entries).toEqual({});
-    expect(written.lastScanTime).toBe(0);
+    expect(loadCachedSessions("claudecode")).toBeNull();
+    expect(getCacheInfo()).toEqual({ lastScanTime: null, size: 0 });
   });
 
-  it("does nothing when cache does not exist", () => {
-    mockedExistsSync.mockReturnValue(false);
+  it("removes legacy json cache file", () => {
+    mkdirSync(getCacheDir(), { recursive: true });
+    writeFileSync(getLegacyCachePath(), JSON.stringify({ stale: true }), "utf-8");
     clearCache();
-    expect(mockedWriteFileSync).not.toHaveBeenCalled();
+    expect(() => readFileSync(getLegacyCachePath(), "utf-8")).toThrow();
   });
 });
 
 describe("getCacheInfo", () => {
-  it("returns defaults when cache does not exist", () => {
-    mockedExistsSync.mockReturnValue(false);
+  it("returns defaults when cache db does not exist", () => {
     expect(getCacheInfo()).toEqual({ lastScanTime: null, size: 0 });
   });
 
-  it("returns info from valid cache", () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue(
-      JSON.stringify({
-        version: 2,
-        entries: {
-          agent1: {
-            sessions: [makeSession("a"), makeSession("b")],
-            meta: {},
-            timestamp: now,
-            version: 2,
-          },
-          agent2: { sessions: [makeSession("c")], meta: {}, timestamp: now, version: 2 },
-        },
-        lastScanTime: now,
-      }),
-    );
-    const info = getCacheInfo();
-    expect(info.lastScanTime).toBe(now);
-    expect(info.size).toBe(3);
-  });
+  it("returns aggregate info from sqlite cache", () => {
+    saveCachedSessions("agent1", [makeSession("a"), makeSession("b")]);
+    saveCachedSessions("agent2", [makeSession("c")]);
 
-  it("returns defaults on invalid JSON", () => {
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockReturnValue("bad json");
-    expect(getCacheInfo()).toEqual({ lastScanTime: null, size: 0 });
+    expect(getCacheInfo()).toEqual({ lastScanTime: now, size: 3 });
   });
 });

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -5,7 +5,7 @@
 import { existsSync, rmSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import type { SessionHead } from "../types/index.js";
+import type { SessionData, SessionHead } from "../types/index.js";
 import { openDb, type DatabaseRow } from "../utils/sqlite.js";
 
 const CACHE_VERSION = 3;
@@ -32,6 +32,36 @@ interface ScalarRow extends DatabaseRow {
 interface CacheRow extends DatabaseRow {
   session_json?: string;
   meta_json?: string | null;
+}
+
+interface IndexedSearchRow extends DatabaseRow {
+  session_id?: string;
+  content_hash?: string;
+}
+
+interface SearchResultRow extends DatabaseRow {
+  agent_name?: string;
+  session_id?: string;
+  slug?: string;
+  title?: string;
+  directory?: string;
+  time_created?: number;
+  time_updated?: number | null;
+  snippet?: string | null;
+}
+
+export interface SearchResult {
+  agentName: string;
+  session: SessionHead;
+  snippet: string;
+}
+
+export interface SearchOptions {
+  agent?: string;
+  cwd?: string;
+  from?: number;
+  to?: number;
+  limit?: number;
 }
 
 function getCacheDir(): string {
@@ -83,6 +113,46 @@ function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
       meta_json TEXT,
       PRIMARY KEY (agent_name, session_id)
     );
+
+    CREATE TABLE IF NOT EXISTS session_documents (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      slug TEXT NOT NULL,
+      title TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER,
+      activity_time INTEGER NOT NULL,
+      content_text TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      indexed_at INTEGER NOT NULL,
+      UNIQUE(agent_name, session_id)
+    );
+
+    CREATE VIRTUAL TABLE IF NOT EXISTS session_documents_fts USING fts5(
+      title,
+      content_text,
+      content='session_documents',
+      content_rowid='id'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS session_documents_ai AFTER INSERT ON session_documents BEGIN
+      INSERT INTO session_documents_fts(rowid, title, content_text)
+      VALUES (new.id, new.title, new.content_text);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS session_documents_ad AFTER DELETE ON session_documents BEGIN
+      INSERT INTO session_documents_fts(session_documents_fts, rowid, title, content_text)
+      VALUES ('delete', old.id, old.title, old.content_text);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS session_documents_au AFTER UPDATE ON session_documents BEGIN
+      INSERT INTO session_documents_fts(session_documents_fts, rowid, title, content_text)
+      VALUES ('delete', old.id, old.title, old.content_text);
+      INSERT INTO session_documents_fts(rowid, title, content_text)
+      VALUES (new.id, new.title, new.content_text);
+    END;
   `);
 
   const versionRow = db.prepare("SELECT value FROM cache_meta WHERE key = 'version'").get() as
@@ -97,10 +167,101 @@ function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
   db.exec(`
     DELETE FROM agent_cache;
     DELETE FROM cached_sessions;
+    DELETE FROM session_documents;
+    INSERT INTO session_documents_fts(session_documents_fts) VALUES ('rebuild');
     INSERT INTO cache_meta(key, value)
     VALUES ('version', '${CACHE_VERSION}')
     ON CONFLICT(key) DO UPDATE SET value = excluded.value;
   `);
+}
+
+function sessionContentHash(session: SessionHead): string {
+  return JSON.stringify([
+    session.slug,
+    session.title,
+    session.directory,
+    session.time_created,
+    session.time_updated ?? session.time_created,
+    session.stats.message_count,
+    session.stats.total_input_tokens,
+    session.stats.total_output_tokens,
+    session.stats.total_cost,
+    session.stats.total_tokens ?? 0,
+  ]);
+}
+
+function escapeFtsTerm(value: string): string {
+  return value.replaceAll('"', '""');
+}
+
+function toFtsQuery(input: string): string {
+  const tokens = input.match(/"[^"]+"|\S+/g) ?? [];
+  return tokens
+    .map((token) => {
+      if (/^OR$/i.test(token)) {
+        return "OR";
+      }
+      if (token.startsWith('"') && token.endsWith('"')) {
+        return `"${escapeFtsTerm(token.slice(1, -1))}"`;
+      }
+      return `"${escapeFtsTerm(token)}"`;
+    })
+    .join(" ");
+}
+
+function appendPlainText(value: unknown, chunks: string[]): void {
+  if (value == null) return;
+
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (normalized) {
+      chunks.push(normalized);
+    }
+    return;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    chunks.push(String(value));
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      appendPlainText(item, chunks);
+    }
+    return;
+  }
+
+  if (typeof value === "object") {
+    for (const nested of Object.values(value as Record<string, unknown>)) {
+      appendPlainText(nested, chunks);
+    }
+  }
+}
+
+function buildSessionContent(session: SessionData): string {
+  const chunks: string[] = [];
+
+  appendPlainText(session.title, chunks);
+
+  for (const message of session.messages) {
+    chunks.push(message.role);
+    appendPlainText(message.agent, chunks);
+    appendPlainText(message.model, chunks);
+
+    for (const part of message.parts) {
+      appendPlainText(part.type, chunks);
+      appendPlainText(part.title, chunks);
+      appendPlainText(part.nickname, chunks);
+      appendPlainText(part.tool, chunks);
+      appendPlainText(part.text, chunks);
+      appendPlainText(part.input, chunks);
+      appendPlainText(part.output, chunks);
+      appendPlainText(part.state, chunks);
+    }
+  }
+
+  return chunks.join("\n");
 }
 
 function deleteLegacyCacheFile(): void {
@@ -252,4 +413,173 @@ export function getCacheInfo(): { lastScanTime: number | null; size: number } {
   });
 
   return info ?? { lastScanTime: null, size: 0 };
+}
+
+export function syncSessionSearchIndex(
+  agentName: string,
+  sessions: SessionHead[],
+  loadSessionData: (sessionId: string) => SessionData,
+): void {
+  if (!hasCacheStorage()) {
+    return;
+  }
+
+  withCacheDb((db) => {
+    const existingRows = db
+      .prepare(
+        "SELECT session_id, content_hash FROM session_documents WHERE agent_name = ? ORDER BY id",
+      )
+      .all(agentName) as IndexedSearchRow[];
+    const existingMap = new Map(
+      existingRows.map((row) => [String(row.session_id), String(row.content_hash ?? "")]),
+    );
+    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+
+    const toDelete = existingRows
+      .map((row) => String(row.session_id))
+      .filter((sessionId) => !sessionMap.has(sessionId));
+    const toUpsert = sessions.filter(
+      (session) => existingMap.get(session.id) !== sessionContentHash(session),
+    );
+
+    const loaded = toUpsert
+      .map((session) => {
+        try {
+        const data = loadSessionData(session.id);
+        return {
+          session,
+          contentText: buildSessionContent(data),
+          contentHash: sessionContentHash(session),
+        };
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+    const deleteRow = db.prepare(
+      "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
+    );
+    const upsertRow = db.prepare(`
+      INSERT INTO session_documents(
+        agent_name,
+        session_id,
+        slug,
+        title,
+        directory,
+        time_created,
+        time_updated,
+        activity_time,
+        content_text,
+        content_hash,
+        indexed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(agent_name, session_id) DO UPDATE SET
+        slug = excluded.slug,
+        title = excluded.title,
+        directory = excluded.directory,
+        time_created = excluded.time_created,
+        time_updated = excluded.time_updated,
+        activity_time = excluded.activity_time,
+        content_text = excluded.content_text,
+        content_hash = excluded.content_hash,
+        indexed_at = excluded.indexed_at
+    `);
+
+    const write = db.transaction(() => {
+      for (const sessionId of toDelete) {
+        deleteRow.run(agentName, sessionId);
+      }
+
+      for (const entry of loaded) {
+        const activityTime = entry.session.time_updated ?? entry.session.time_created;
+        upsertRow.run(
+          agentName,
+          entry.session.id,
+          entry.session.slug,
+          entry.session.title,
+          entry.session.directory,
+          entry.session.time_created,
+          entry.session.time_updated ?? null,
+          activityTime,
+          entry.contentText,
+          entry.contentHash,
+          Date.now(),
+        );
+      }
+    });
+
+    write();
+  });
+}
+
+export function searchSessions(query: string, options: SearchOptions = {}): SearchResult[] {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery || !hasCacheStorage()) {
+    return [];
+  }
+
+  const ftsQuery = toFtsQuery(normalizedQuery);
+
+  const results = withCacheDb((db) => {
+    const rows = db
+      .prepare(
+        `
+          SELECT
+            d.agent_name,
+            d.session_id,
+            d.slug,
+            d.title,
+            d.directory,
+            d.time_created,
+            d.time_updated,
+            COALESCE(
+              NULLIF(snippet(session_documents_fts, 1, '<mark>', '</mark>', ' … ', 18), ''),
+              highlight(session_documents_fts, 0, '<mark>', '</mark>')
+            ) AS snippet
+          FROM session_documents_fts
+          JOIN session_documents d ON d.id = session_documents_fts.rowid
+          WHERE session_documents_fts MATCH ?
+            AND (? IS NULL OR d.agent_name = ?)
+            AND (? IS NULL OR LOWER(d.directory) LIKE ?)
+            AND (? IS NULL OR d.activity_time >= ?)
+            AND (? IS NULL OR d.activity_time <= ?)
+          ORDER BY bm25(session_documents_fts, 8.0, 1.0), d.activity_time DESC
+          LIMIT ?
+        `,
+      )
+      .all(
+        ftsQuery,
+        options.agent ?? null,
+        options.agent ?? null,
+        options.cwd?.toLowerCase() ?? null,
+        options.cwd ? `%${options.cwd.toLowerCase()}%` : null,
+        options.from ?? null,
+        options.from ?? null,
+        options.to ?? null,
+        options.to ?? null,
+        options.limit ?? 50,
+      ) as SearchResultRow[];
+
+    return rows.map((row) => ({
+      agentName: String(row.agent_name),
+      session: {
+        id: String(row.session_id),
+        slug: String(row.slug),
+        title: String(row.title),
+        directory: String(row.directory),
+        time_created: Number(row.time_created),
+        time_updated: row.time_updated == null ? undefined : Number(row.time_updated),
+        stats: {
+          message_count: 0,
+          total_input_tokens: 0,
+          total_output_tokens: 0,
+          total_cost: 0,
+        },
+      },
+      snippet: String(row.snippet ?? ""),
+    }));
+  });
+
+  return results ?? [];
 }

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -1,45 +1,22 @@
 /**
- * 扫描结果缓存 - 将扫描结果持久化到磁盘，加速后续启动
+ * 扫描结果缓存 - 使用 SQLite 持久化扫描结果，为后续 FTS 复用同一存储。
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, rmSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { SessionHead } from "../types/index.js";
+import { openDb, type DatabaseRow } from "../utils/sqlite.js";
 
-const CACHE_VERSION = 2; // Bumped version for metadata support
-const CACHE_FILENAME = "scan-cache.json";
+const CACHE_VERSION = 3;
+const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
+const CACHE_FILENAME = "codesesh.db";
+const LEGACY_CACHE_FILENAME = "scan-cache.json";
 
-// Session metadata needed for getSessionData
 export interface SessionCacheMeta {
   id: string;
   sourcePath: string;
-  // Additional fields per agent type
   [key: string]: unknown;
-}
-
-interface CacheEntry {
-  sessions: SessionHead[];
-  meta: Record<string, SessionCacheMeta>; // keyed by session id
-  timestamp: number;
-  version: number;
-}
-
-interface CacheData {
-  version: number;
-  entries: Record<string, CacheEntry>; // keyed by agent name
-  lastScanTime: number;
-}
-
-function getCachePath(): string {
-  return join(homedir(), ".cache", "codesesh", CACHE_FILENAME);
-}
-
-function ensureCacheDir(): void {
-  const cacheDir = join(homedir(), ".cache", "codesesh");
-  if (!existsSync(cacheDir)) {
-    mkdirSync(cacheDir, { recursive: true });
-  }
 }
 
 export interface CachedResult {
@@ -48,27 +25,141 @@ export interface CachedResult {
   timestamp: number;
 }
 
-export function loadCachedSessions(agentName: string): CachedResult | null {
+interface ScalarRow extends DatabaseRow {
+  value?: number;
+}
+
+interface CacheRow extends DatabaseRow {
+  session_json?: string;
+  meta_json?: string | null;
+}
+
+function getCacheDir(): string {
+  return join(homedir(), ".cache", "codesesh");
+}
+
+function getCachePath(): string {
+  return join(getCacheDir(), CACHE_FILENAME);
+}
+
+function getLegacyCachePath(): string {
+  return join(getCacheDir(), LEGACY_CACHE_FILENAME);
+}
+
+function hasCacheStorage(): boolean {
+  return existsSync(getCachePath());
+}
+
+function withCacheDb<T>(fn: (db: NonNullable<ReturnType<typeof openDb>>) => T): T | null {
+  const db = openDb(getCachePath());
+  if (!db) return null;
+
   try {
-    const cachePath = getCachePath();
-    if (!existsSync(cachePath)) return null;
-
-    const data = JSON.parse(readFileSync(cachePath, "utf-8")) as CacheData;
-
-    // Version check
-    if (data.version !== CACHE_VERSION) return null;
-
-    const entry = data.entries[agentName];
-    if (!entry) return null;
-
-    // Check if cache is too old (7 days)
-    const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
-    if (Date.now() - entry.timestamp > CACHE_TTL) return null;
-
-    return { sessions: entry.sessions, meta: entry.meta || {}, timestamp: entry.timestamp };
+    ensureSchema(db);
+    return fn(db);
   } catch {
     return null;
+  } finally {
+    db.close();
   }
+}
+
+function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cache_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS agent_cache (
+      agent_name TEXT PRIMARY KEY,
+      timestamp INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS cached_sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      session_json TEXT NOT NULL,
+      meta_json TEXT,
+      PRIMARY KEY (agent_name, session_id)
+    );
+  `);
+
+  const versionRow = db.prepare("SELECT value FROM cache_meta WHERE key = 'version'").get() as
+    | DatabaseRow
+    | undefined;
+  const version = Number(versionRow?.value ?? 0);
+
+  if (version === CACHE_VERSION) {
+    return;
+  }
+
+  db.exec(`
+    DELETE FROM agent_cache;
+    DELETE FROM cached_sessions;
+    INSERT INTO cache_meta(key, value)
+    VALUES ('version', '${CACHE_VERSION}')
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+  `);
+}
+
+function deleteLegacyCacheFile(): void {
+  const legacyPath = getLegacyCachePath();
+  if (!existsSync(legacyPath)) {
+    return;
+  }
+
+  try {
+    unlinkSync(legacyPath);
+  } catch {
+    // Ignore legacy cleanup errors
+  }
+}
+
+export function loadCachedSessions(agentName: string): CachedResult | null {
+  if (!hasCacheStorage()) {
+    return null;
+  }
+
+  return withCacheDb((db) => {
+    const timestampRow = db
+      .prepare("SELECT timestamp AS value FROM agent_cache WHERE agent_name = ?")
+      .get(agentName) as ScalarRow | undefined;
+    const timestamp = Number(timestampRow?.value ?? 0);
+
+    if (!timestamp || Date.now() - timestamp > CACHE_TTL) {
+      return null;
+    }
+
+    const rows = db
+      .prepare(
+        `
+          SELECT session_json, meta_json
+          FROM cached_sessions
+          WHERE agent_name = ?
+          ORDER BY rowid
+        `,
+      )
+      .all(agentName) as CacheRow[];
+
+    const sessions: SessionHead[] = [];
+    const meta: Record<string, SessionCacheMeta> = {};
+
+    for (const row of rows) {
+      if (!row.session_json) {
+        continue;
+      }
+
+      const session = JSON.parse(row.session_json) as SessionHead;
+      sessions.push(session);
+
+      if (row.meta_json) {
+        meta[session.id] = JSON.parse(row.meta_json) as SessionCacheMeta;
+      }
+    }
+
+    return { sessions, meta, timestamp };
+  });
 }
 
 export function saveCachedSessions(
@@ -76,69 +167,89 @@ export function saveCachedSessions(
   sessions: SessionHead[],
   meta: Record<string, SessionCacheMeta> = {},
 ): void {
-  try {
-    ensureCacheDir();
-    const cachePath = getCachePath();
+  withCacheDb((db) => {
+    const deleteAgent = db.prepare("DELETE FROM agent_cache WHERE agent_name = ?");
+    const deleteSessions = db.prepare("DELETE FROM cached_sessions WHERE agent_name = ?");
+    const upsertAgent = db.prepare(`
+      INSERT INTO agent_cache(agent_name, timestamp)
+      VALUES (?, ?)
+      ON CONFLICT(agent_name) DO UPDATE SET timestamp = excluded.timestamp
+    `);
+    const insertSession = db.prepare(`
+      INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json)
+      VALUES (?, ?, ?, ?)
+    `);
 
-    let data: CacheData;
-    if (existsSync(cachePath)) {
-      try {
-        data = JSON.parse(readFileSync(cachePath, "utf-8")) as CacheData;
-        if (data.version !== CACHE_VERSION) {
-          data = { version: CACHE_VERSION, entries: {}, lastScanTime: 0 };
-        }
-      } catch {
-        data = { version: CACHE_VERSION, entries: {}, lastScanTime: 0 };
+    const write = db.transaction(() => {
+      const timestamp = Date.now();
+      deleteAgent.run(agentName);
+      deleteSessions.run(agentName);
+      upsertAgent.run(agentName, timestamp);
+
+      for (const session of sessions) {
+        insertSession.run(
+          agentName,
+          session.id,
+          JSON.stringify(session),
+          meta[session.id] ? JSON.stringify(meta[session.id]) : null,
+        );
       }
-    } else {
-      data = { version: CACHE_VERSION, entries: {}, lastScanTime: 0 };
-    }
+    });
 
-    data.entries[agentName] = {
-      sessions,
-      meta,
-      timestamp: Date.now(),
-      version: CACHE_VERSION,
-    };
-    data.lastScanTime = Date.now();
-
-    writeFileSync(cachePath, JSON.stringify(data, null, 2), "utf-8");
-  } catch {
-    // Ignore cache write errors
-  }
+    write();
+    deleteLegacyCacheFile();
+  });
 }
 
 export function clearCache(): void {
-  try {
-    const cachePath = getCachePath();
-    if (existsSync(cachePath)) {
-      const data: CacheData = {
-        version: CACHE_VERSION,
-        entries: {},
-        lastScanTime: 0,
-      };
-      writeFileSync(cachePath, JSON.stringify(data, null, 2), "utf-8");
+  if (!hasCacheStorage()) {
+    deleteLegacyCacheFile();
+    return;
+  }
+
+  withCacheDb((db) => {
+    db.exec(`
+      DELETE FROM agent_cache;
+      DELETE FROM cached_sessions;
+    `);
+  });
+
+  deleteLegacyCacheFile();
+
+  const cachePath = getCachePath();
+  const walPath = `${cachePath}-wal`;
+  const shmPath = `${cachePath}-shm`;
+
+  for (const filePath of [walPath, shmPath]) {
+    if (!existsSync(filePath)) {
+      continue;
     }
-  } catch {
-    // Ignore errors
+    try {
+      rmSync(filePath, { force: true });
+    } catch {
+      // Ignore sidecar cleanup errors
+    }
   }
 }
 
 export function getCacheInfo(): { lastScanTime: number | null; size: number } {
-  try {
-    const cachePath = getCachePath();
-    if (!existsSync(cachePath)) {
-      return { lastScanTime: null, size: 0 };
-    }
-
-    const data = JSON.parse(readFileSync(cachePath, "utf-8")) as CacheData;
-    const size = Object.values(data.entries).reduce((sum, entry) => sum + entry.sessions.length, 0);
-
-    return {
-      lastScanTime: data.lastScanTime || null,
-      size,
-    };
-  } catch {
+  if (!hasCacheStorage()) {
     return { lastScanTime: null, size: 0 };
   }
+
+  const info = withCacheDb((db) => {
+    const timestampRow = db
+      .prepare("SELECT MAX(timestamp) AS value FROM agent_cache")
+      .get() as ScalarRow | undefined;
+    const sizeRow = db
+      .prepare("SELECT COUNT(*) AS value FROM cached_sessions")
+      .get() as ScalarRow | undefined;
+
+    const lastScanTime = Number(timestampRow?.value ?? 0) || null;
+    const size = Number(sizeRow?.value ?? 0);
+
+    return { lastScanTime, size };
+  });
+
+  return info ?? { lastScanTime: null, size: 0 };
 }

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -399,12 +399,12 @@ export function getCacheInfo(): { lastScanTime: number | null; size: number } {
   }
 
   const info = withCacheDb((db) => {
-    const timestampRow = db
-      .prepare("SELECT MAX(timestamp) AS value FROM agent_cache")
-      .get() as ScalarRow | undefined;
-    const sizeRow = db
-      .prepare("SELECT COUNT(*) AS value FROM cached_sessions")
-      .get() as ScalarRow | undefined;
+    const timestampRow = db.prepare("SELECT MAX(timestamp) AS value FROM agent_cache").get() as
+      | ScalarRow
+      | undefined;
+    const sizeRow = db.prepare("SELECT COUNT(*) AS value FROM cached_sessions").get() as
+      | ScalarRow
+      | undefined;
 
     const lastScanTime = Number(timestampRow?.value ?? 0) || null;
     const size = Number(sizeRow?.value ?? 0);
@@ -445,12 +445,12 @@ export function syncSessionSearchIndex(
     const loaded = toUpsert
       .map((session) => {
         try {
-        const data = loadSessionData(session.id);
-        return {
-          session,
-          contentText: buildSessionContent(data),
-          contentHash: sessionContentHash(session),
-        };
+          const data = loadSessionData(session.id);
+          return {
+            session,
+            contentText: buildSessionContent(data),
+            contentHash: sessionContentHash(session),
+          };
         } catch {
           return null;
         }

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -2,6 +2,13 @@ export { resolveProviderRoots, getCursorDataPath, firstExisting } from "./paths.
 export type { ProviderRoots } from "./paths.js";
 export { filterSessions, scanSessions, scanSessionsAsync } from "./scanner.js";
 export type { ScanResult, ScanOptions } from "./scanner.js";
-export { loadCachedSessions, saveCachedSessions, clearCache, getCacheInfo } from "./cache.js";
+export {
+  loadCachedSessions,
+  saveCachedSessions,
+  clearCache,
+  getCacheInfo,
+  searchSessions,
+  syncSessionSearchIndex,
+} from "./cache.js";
 export { perf } from "../utils/index.js";
 export type { PerfMarker } from "../utils/index.js";

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { parseJsonlLines, readJsonlFile } from "./jsonl.js";
 export { basenameTitle, resolveSessionTitle, normalizeTitleText } from "./title-fallback.js";
-export { openDbReadOnly, isSqliteAvailable } from "./sqlite.js";
+export { openDb, openDbReadOnly, isSqliteAvailable } from "./sqlite.js";
 export { perf, type PerfMarker } from "./perf.js";

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -2,18 +2,38 @@
  * SQLite helper — graceful degradation if better-sqlite3 is unavailable.
  */
 
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 import { createRequire } from "node:module";
 
-let DatabaseConstructor: ((path: string) => unknown) | null = null;
+interface SQLiteStatement {
+  all(...params: unknown[]): DatabaseRow[];
+  get(...params: unknown[]): DatabaseRow | undefined;
+  run(...params: unknown[]): unknown;
+}
+
+interface SQLiteTransaction {
+  (...params: unknown[]): unknown;
+}
+
+interface SQLitePragmaCapable {
+  pragma(sql: string): unknown;
+}
+
+type SQLiteDatabaseConstructor = (
+  path: string,
+  options?: { readonly?: boolean },
+) => SQLiteDatabase & SQLitePragmaCapable;
+
+let DatabaseConstructor: SQLiteDatabaseConstructor | null = null;
 
 try {
   const require = createRequire(import.meta.url);
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mod = require("better-sqlite3");
-  DatabaseConstructor =
-    typeof mod === "function"
-      ? mod
-      : ((mod as { default?: unknown }).default as typeof DatabaseConstructor);
+  DatabaseConstructor = (typeof mod === "function"
+    ? mod
+    : (mod as { default?: unknown }).default) as SQLiteDatabaseConstructor;
 } catch {
   // better-sqlite3 not installed — adapters that need SQLite will gracefully skip
 }
@@ -23,11 +43,9 @@ export interface DatabaseRow {
 }
 
 export interface SQLiteDatabase {
-  prepare(sql: string): {
-    all(...params: unknown[]): DatabaseRow[];
-    get(...params: unknown[]): DatabaseRow | undefined;
-    run(...params: unknown[]): void;
-  };
+  prepare(sql: string): SQLiteStatement;
+  exec(sql: string): void;
+  transaction<T extends SQLiteTransaction>(fn: T): T;
   close(): void;
 }
 
@@ -38,10 +56,21 @@ export interface SQLiteDatabase {
 export function openDbReadOnly(dbPath: string): SQLiteDatabase | null {
   if (!DatabaseConstructor) return null;
   try {
-    // better-sqlite3 constructor with readonly flag
-    const db = (
-      DatabaseConstructor as (path: string, options?: { readonly?: boolean }) => SQLiteDatabase
-    )(dbPath, { readonly: true });
+    const db = DatabaseConstructor(dbPath, { readonly: true });
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+export function openDb(dbPath: string): SQLiteDatabase | null {
+  if (!DatabaseConstructor) return null;
+  try {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    const db = DatabaseConstructor(dbPath);
+    db.pragma("journal_mode = WAL");
+    db.pragma("synchronous = NORMAL");
+    db.pragma("foreign_keys = ON");
     return db;
   } catch {
     return null;

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -31,9 +31,9 @@ try {
   const require = createRequire(import.meta.url);
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mod = require("better-sqlite3");
-  DatabaseConstructor = (typeof mod === "function"
-    ? mod
-    : (mod as { default?: unknown }).default) as SQLiteDatabaseConstructor;
+  DatabaseConstructor = (
+    typeof mod === "function" ? mod : (mod as { default?: unknown }).default
+  ) as SQLiteDatabaseConstructor;
 } catch {
   // better-sqlite3 not installed — adapters that need SQLite will gracefully skip
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,7 +193,7 @@ importers:
         version: 5.9.3
 
   packages/core:
-    optionalDependencies:
+    dependencies:
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0


### PR DESCRIPTION
## Summary
- migrate scan cache from JSON to SQLite and document the storage schema/data flow
- add SQLite FTS-backed session search API and keep the index in sync during live refresh
- add header search UI with button-triggered search and detail-page match highlighting

## Testing
- pnpm --filter @codesesh/core test
- pnpm --filter @codesesh/web build
- pnpm --filter codesesh build
