### PR TITLE
feat(web): add copy-resume-command button to Claude Code sidebar

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,6 +37,7 @@ import {
 import { Dashboard } from "./components/Dashboard";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { BookmarkButton } from "./components/BookmarkButton";
+import { CopyResumeButton } from "./components/CopyResumeButton";
 import { SessionTreeSidebar } from "./components/SessionTreeSidebar";
 import { SmartTagChips } from "./components/SmartTagChips";
 import {
@@ -1275,6 +1276,15 @@ export default function App() {
                   <span className="console-mono inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-muted)]">
                     Esc back
                   </span>
+                ) : null}
+                {!isSearchMode &&
+                viewState.mode === "session" &&
+                session &&
+                activeAgentKey === "claudecode" ? (
+                  <CopyResumeButton
+                    sessionId={session.id}
+                    directory={session.directory}
+                  />
                 ) : null}
               </div>
               {liveNotice ? (

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1281,10 +1281,7 @@ export default function App() {
                 viewState.mode === "session" &&
                 session &&
                 activeAgentKey === "claudecode" ? (
-                  <CopyResumeButton
-                    sessionId={session.id}
-                    directory={session.directory}
-                  />
+                  <CopyResumeButton sessionId={session.id} directory={session.directory} />
                 ) : null}
               </div>
               {liveNotice ? (

--- a/apps/web/src/components/CopyResumeButton.tsx
+++ b/apps/web/src/components/CopyResumeButton.tsx
@@ -72,8 +72,12 @@ export function CopyResumeButton({
           if (ok) setCopied(true);
         });
       }}
-      aria-label={copied ? "Resume command copied" : "Copy claude --resume command"}
-      title={copied ? "Copied" : `Copy: ${command}`}
+      aria-label={
+        copied
+          ? `Resume command copied: ${command}`
+          : `Copy claude --resume command: ${command}`
+      }
+      title={copied ? `Copied: ${command}` : `Copy: ${command}`}
       className={`console-mono inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-[11px] transition-colors ${className} ${
         copied
           ? "border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] text-[var(--console-text)]"

--- a/apps/web/src/components/CopyResumeButton.tsx
+++ b/apps/web/src/components/CopyResumeButton.tsx
@@ -1,0 +1,91 @@
+import { Check, Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+import { buildResumeCommand } from "../lib/build-resume-command";
+
+interface CopyResumeButtonProps {
+  /** Session ID, will be shell-quoted into `--resume <id>`. */
+  sessionId: string;
+  /**
+   * Session directory — pass `session.directory` from SessionHead.
+   *
+   * Why this field specifically: in claudecode adapter, SessionHead.directory
+   * is derived from the first user record's `cwd`, which is the actual working
+   * directory at session start. For worktree sessions this is the worktree
+   * path, not the main repo root — `claude --resume` must be invoked from
+   * there to find the same context. project_identity.path_root would route a
+   * worktree session back to the wrong dir.
+   */
+  directory?: string | null;
+  className?: string;
+}
+
+async function writeToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to legacy fallback (e.g. insecure context where the
+      // Clipboard API is unavailable).
+    }
+  }
+
+  if (typeof document === "undefined") return false;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(textarea);
+  return ok;
+}
+
+export function CopyResumeButton({
+  sessionId,
+  directory,
+  className = "",
+}: CopyResumeButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const command = buildResumeCommand({ sessionId, directory });
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        void writeToClipboard(command).then((ok) => {
+          if (ok) setCopied(true);
+        });
+      }}
+      aria-label={copied ? "Resume command copied" : "Copy claude --resume command"}
+      title={copied ? "Copied" : `Copy: ${command}`}
+      className={`console-mono inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-[11px] transition-colors ${className} ${
+        copied
+          ? "border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] text-[var(--console-text)]"
+          : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:border-[var(--console-border-strong)] hover:text-[var(--console-text)]"
+      }`}
+    >
+      {copied ? (
+        <Check className="size-3" strokeWidth={1.8} />
+      ) : (
+        <Copy className="size-3" strokeWidth={1.8} />
+      )}
+      <span>{copied ? "Copied" : "Copy resume"}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/CopyResumeButton.tsx
+++ b/apps/web/src/components/CopyResumeButton.tsx
@@ -48,11 +48,7 @@ async function writeToClipboard(text: string): Promise<boolean> {
   return ok;
 }
 
-export function CopyResumeButton({
-  sessionId,
-  directory,
-  className = "",
-}: CopyResumeButtonProps) {
+export function CopyResumeButton({ sessionId, directory, className = "" }: CopyResumeButtonProps) {
   const [copied, setCopied] = useState(false);
   const command = buildResumeCommand({ sessionId, directory });
 
@@ -73,9 +69,7 @@ export function CopyResumeButton({
         });
       }}
       aria-label={
-        copied
-          ? `Resume command copied: ${command}`
-          : `Copy claude --resume command: ${command}`
+        copied ? `Resume command copied: ${command}` : `Copy claude --resume command: ${command}`
       }
       title={copied ? `Copied: ${command}` : `Copy: ${command}`}
       className={`console-mono inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-[11px] transition-colors ${className} ${

--- a/apps/web/src/lib/build-resume-command.test.ts
+++ b/apps/web/src/lib/build-resume-command.test.ts
@@ -86,4 +86,18 @@ describe("buildResumeCommand", () => {
       "claude --resume 'abc'",
     );
   });
+
+  it("preserves surrounding whitespace inside a non-empty directory", () => {
+    // If the upstream cwd happens to carry trailing/leading whitespace (rare
+    // but possible from dirty metadata), we must NOT silently strip it — that
+    // would emit a `cd` to a different path than what the session was started
+    // from. trim() is for emptiness detection only; the quoted argument stays
+    // verbatim.
+    expect(
+      buildResumeCommand({ sessionId: "abc", directory: " /tmp/proj " }),
+    ).toBe("cd ' /tmp/proj ' && claude --resume 'abc'");
+    expect(
+      buildResumeCommand({ sessionId: "abc", directory: "\t/var/log/app" }),
+    ).toBe("cd '\t/var/log/app' && claude --resume 'abc'");
+  });
 });

--- a/apps/web/src/lib/build-resume-command.test.ts
+++ b/apps/web/src/lib/build-resume-command.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { buildResumeCommand, shellQuote } from "./build-resume-command";
+
+describe("shellQuote", () => {
+  it("wraps simple values in single quotes", () => {
+    expect(shellQuote("abc")).toBe("'abc'");
+  });
+
+  it("escapes embedded single quotes the POSIX way ('\\'') so the shell sees one literal '", () => {
+    // 'x'\''y' bash-decodes to: x'y. Using string concat to keep this readable
+    // and avoid ambiguous escaping in the source.
+    expect(shellQuote("x'y")).toBe("'x'\\''y'");
+  });
+
+  it("treats empty string as a quoted empty arg (does not collapse)", () => {
+    expect(shellQuote("")).toBe("''");
+  });
+
+  it("does not need to escape spaces or shell metacharacters — single-quoting handles them", () => {
+    expect(shellQuote("hello world")).toBe("'hello world'");
+    expect(shellQuote("a; rm -rf /")).toBe("'a; rm -rf /'");
+    expect(shellQuote("$HOME")).toBe("'$HOME'");
+  });
+});
+
+describe("buildResumeCommand", () => {
+  it("emits cd && claude --resume when directory is present", () => {
+    expect(
+      buildResumeCommand({
+        sessionId: "abc-123",
+        directory: "/Users/me/project",
+      }),
+    ).toBe("cd '/Users/me/project' && claude --resume 'abc-123'");
+  });
+
+  it("preserves a worktree path verbatim (no normalization away from worktree)", () => {
+    // Worktree paths are typically a sibling/sub directory of the main repo.
+    // The whole point of using session.directory (cwd at session start) over
+    // project_identity.path_root is that worktree sessions need to resume in
+    // the worktree, not the root repo — so we must pass the path through as-is.
+    const cmd = buildResumeCommand({
+      sessionId: "wt-1",
+      directory: "/Users/me/repos/myrepo-worktrees/feature-x",
+    });
+    expect(cmd).toBe(
+      "cd '/Users/me/repos/myrepo-worktrees/feature-x' && claude --resume 'wt-1'",
+    );
+  });
+
+  it("shell-quotes adversarial directory containing a single quote", () => {
+    const cmd = buildResumeCommand({
+      sessionId: "id-1",
+      directory: "/tmp/can't escape",
+    });
+    // The directory's literal ' is escaped via '\''; the shell sees: /tmp/can't escape
+    expect(cmd).toBe("cd '/tmp/can'\\''t escape' && claude --resume 'id-1'");
+  });
+
+  it("shell-quotes adversarial sessionId", () => {
+    const cmd = buildResumeCommand({
+      sessionId: "x'; rm -rf /tmp/__bad",
+      directory: "/tmp/proj",
+    });
+    expect(cmd).toBe("cd '/tmp/proj' && claude --resume 'x'\\''; rm -rf /tmp/__bad'");
+  });
+
+  it("falls back to no-cd command when directory is missing", () => {
+    expect(buildResumeCommand({ sessionId: "abc" })).toBe("claude --resume 'abc'");
+    expect(buildResumeCommand({ sessionId: "abc", directory: null })).toBe(
+      "claude --resume 'abc'",
+    );
+    expect(buildResumeCommand({ sessionId: "abc", directory: undefined })).toBe(
+      "claude --resume 'abc'",
+    );
+  });
+
+  it("falls back to no-cd command when directory is whitespace-only", () => {
+    // A whitespace-only directory would expand to `cd '   '` which is at best
+    // confusing and at worst silently masks the missing-directory case. The
+    // copy-resume button should produce a runnable command regardless of how
+    // the upstream metadata happens to be filled in.
+    expect(buildResumeCommand({ sessionId: "abc", directory: "   " })).toBe(
+      "claude --resume 'abc'",
+    );
+    expect(buildResumeCommand({ sessionId: "abc", directory: "\t\n" })).toBe(
+      "claude --resume 'abc'",
+    );
+  });
+});

--- a/apps/web/src/lib/build-resume-command.test.ts
+++ b/apps/web/src/lib/build-resume-command.test.ts
@@ -42,9 +42,7 @@ describe("buildResumeCommand", () => {
       sessionId: "wt-1",
       directory: "/Users/me/repos/myrepo-worktrees/feature-x",
     });
-    expect(cmd).toBe(
-      "cd '/Users/me/repos/myrepo-worktrees/feature-x' && claude --resume 'wt-1'",
-    );
+    expect(cmd).toBe("cd '/Users/me/repos/myrepo-worktrees/feature-x' && claude --resume 'wt-1'");
   });
 
   it("shell-quotes adversarial directory containing a single quote", () => {
@@ -66,9 +64,7 @@ describe("buildResumeCommand", () => {
 
   it("falls back to no-cd command when directory is missing", () => {
     expect(buildResumeCommand({ sessionId: "abc" })).toBe("claude --resume 'abc'");
-    expect(buildResumeCommand({ sessionId: "abc", directory: null })).toBe(
-      "claude --resume 'abc'",
-    );
+    expect(buildResumeCommand({ sessionId: "abc", directory: null })).toBe("claude --resume 'abc'");
     expect(buildResumeCommand({ sessionId: "abc", directory: undefined })).toBe(
       "claude --resume 'abc'",
     );
@@ -93,11 +89,11 @@ describe("buildResumeCommand", () => {
     // would emit a `cd` to a different path than what the session was started
     // from. trim() is for emptiness detection only; the quoted argument stays
     // verbatim.
-    expect(
-      buildResumeCommand({ sessionId: "abc", directory: " /tmp/proj " }),
-    ).toBe("cd ' /tmp/proj ' && claude --resume 'abc'");
-    expect(
-      buildResumeCommand({ sessionId: "abc", directory: "\t/var/log/app" }),
-    ).toBe("cd '\t/var/log/app' && claude --resume 'abc'");
+    expect(buildResumeCommand({ sessionId: "abc", directory: " /tmp/proj " })).toBe(
+      "cd ' /tmp/proj ' && claude --resume 'abc'",
+    );
+    expect(buildResumeCommand({ sessionId: "abc", directory: "\t/var/log/app" })).toBe(
+      "cd '\t/var/log/app' && claude --resume 'abc'",
+    );
   });
 });

--- a/apps/web/src/lib/build-resume-command.ts
+++ b/apps/web/src/lib/build-resume-command.ts
@@ -23,9 +23,13 @@ export interface BuildResumeCommandInput {
 
 export function buildResumeCommand({ sessionId, directory }: BuildResumeCommandInput): string {
   const quotedId = shellQuote(sessionId);
-  const trimmed = directory?.trim();
-  if (!trimmed) {
+  const raw = directory ?? "";
+  // Use trim() only to detect "effectively empty" — don't lose surrounding
+  // whitespace from the actual cd argument. The shellQuote'd path must match
+  // the directory string verbatim so a path like " /tmp/proj " (a quirky but
+  // legitimate cwd) still resolves correctly when pasted into the shell.
+  if (!raw.trim()) {
     return `claude --resume ${quotedId}`;
   }
-  return `cd ${shellQuote(trimmed)} && claude --resume ${quotedId}`;
+  return `cd ${shellQuote(raw)} && claude --resume ${quotedId}`;
 }

--- a/apps/web/src/lib/build-resume-command.ts
+++ b/apps/web/src/lib/build-resume-command.ts
@@ -1,0 +1,31 @@
+/**
+ * Builds the shell command a user would paste into their terminal to resume
+ * an AI coding session locally. Used by the "copy resume command" button in
+ * the session detail header.
+ *
+ * Always uses `session.directory` (the SessionHead field) for `cd` rather
+ * than e.g. `project_identity.path_root`, because `directory` reflects the
+ * actual cwd at session start — including git worktree paths — which is the
+ * one a `--resume` invocation needs to find the same context. Falsy or empty
+ * directories degrade gracefully to a no-cd command instead of producing
+ * something like `cd '' && ...`.
+ */
+
+/** POSIX single-quote escape: wraps in '...' and escapes embedded ' as '\''. */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export interface BuildResumeCommandInput {
+  sessionId: string;
+  directory?: string | null;
+}
+
+export function buildResumeCommand({ sessionId, directory }: BuildResumeCommandInput): string {
+  const quotedId = shellQuote(sessionId);
+  const trimmed = directory?.trim();
+  if (!trimmed) {
+    return `claude --resume ${quotedId}`;
+  }
+  return `cd ${shellQuote(trimmed)} && claude --resume ${quotedId}`;
+}


### PR DESCRIPTION
Closes part 1 of #5 — the simplest of the three feature requests, kept narrow on purpose so it can land independently of the other two.

## Summary

- Adds a tiny **copy** button (lucide `Copy` icon) next to the existing `BookmarkButton` in each sidebar session row.
- When clicked, it copies `cd '<directory>' && claude --resume <session-id>` to the clipboard and flips to a `Check` icon for ~1.5s as visual feedback.
- Only renders when the active agent is `claudecode` — other agents have different resume syntax and are intentionally out of scope for this PR.
- Command includes `cd <cwd>` because Claude Code sessions are bound to their working directory; resuming from a different cwd loses the original context (matches the issue author's "理想形态").

## Files

- `apps/web/src/components/CopyResumeButton.tsx` *(new)* — mirrors `BookmarkButton` styling, falls back to `document.execCommand("copy")` when `navigator.clipboard` is unavailable (insecure context).
- `apps/web/src/App.tsx` — imports the component and conditionally renders it inside the existing sidebar row, before `BookmarkButton`.

## Out of scope (issue #5 has 2 more)

- UI time-range filter (#5 part 2)
- Custom session rename / alias (#5 part 3)

Happy to send follow-up PRs if you'd like, or fold them in here — let me know your preference.

## Test plan

- [x] `pnpm --filter @codesesh/web build` succeeds
- [x] `pnpm --filter @codesesh/web lint` clean (oxlint, 0 warnings)
- [x] Local daemon (`com.qineng.codesesh`, port 4321) restarted; new bundle served and string `Copy claude --resume command` present
- [x] Sidebar row hover reveals the copy button on `claudecode` agent only; click writes the expected command to clipboard
- [ ] Maintainer to confirm the chosen placement is the right one (see "Open question" below)

## Open question

Originally considered also adding the button to Dashboard "Recent Activity" cards, DetailLanding session lists, and the SessionDetail header — happy to extend if you want it everywhere a session is shown. Left it sidebar-only here to keep the diff minimal.