### PR TITLE
feat: bidirectional session rename via cc-native custom-title (Claude Code)

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -615,6 +615,51 @@ describe("handlePatchSession", () => {
     expect(calls[0]?.[1]?.length).toBe(200);
   });
 
+  it("preserves scanner-enriched fields (project_identity, smart_tags) on rename", async () => {
+    // setSessionAlias() returns a bare SessionHead from parseSessionHead() —
+    // it doesn't carry scanner-enriched fields. handlePatchSession must merge
+    // per-field instead of replacing, otherwise project/tag-filtered endpoints
+    // would temporarily drop or misclassify the renamed session until the
+    // next chokidar-triggered rescan.
+    const enrichedExisting = makeSession("s1", {
+      title: "Old",
+      project_identity: { id: "proj-abc", path_root: "/home/user/project" } as any,
+      smart_tags: [{ tag: "refactor", confidence: 0.9 } as any],
+      smart_tags_source_updated_at: 1700000000,
+    });
+    const agent = makeRenameAgent((id, alias) =>
+      // Bare SessionHead — no project_identity / smart_tags.
+      makeSession(id, { title: alias ?? "" }),
+    );
+
+    const scanResult = makeScanResult({
+      agents: [agent],
+      byAgent: { claudecode: [enrichedExisting] },
+      sessions: [enrichedExisting],
+    });
+    const scanSource: ScanResultSource = { getSnapshot: () => scanResult };
+
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "s1" },
+      body: { title: "Renamed" },
+    });
+    await handlePatchSession(c, scanSource);
+
+    const inAgent = scanResult.byAgent.claudecode?.find((s) => s.id === "s1");
+    const inFlat = scanResult.sessions.find((s) => s.id === "s1");
+    expect(inAgent?.title).toBe("Renamed");
+    expect(inFlat?.title).toBe("Renamed");
+    // Enriched fields preserved through the merge.
+    expect(inAgent?.project_identity).toEqual({ id: "proj-abc", path_root: "/home/user/project" });
+    expect(inAgent?.smart_tags).toEqual([{ tag: "refactor", confidence: 0.9 }]);
+    expect(inAgent?.smart_tags_source_updated_at).toBe(1700000000);
+    expect(inFlat?.project_identity).toEqual({ id: "proj-abc", path_root: "/home/user/project" });
+
+    // Response body also reflects the merged record (not the bare one).
+    const lastCall = (c.json as any).mock.calls.at(-1);
+    expect(lastCall?.[0].session.smart_tags).toEqual([{ tag: "refactor", confidence: 0.9 }]);
+  });
+
   it("forwards null titles to clear the alias", async () => {
     const calls: Array<[string, string | null]> = [];
     const agent = makeRenameAgent((id, alias) => {

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -6,6 +6,7 @@ import {
   handleGetProjects,
   handleGetSessions,
   handleGetSessionData,
+  handlePatchSession,
   type ScanResultSource,
 } from "../handlers.js";
 import type { ScanResult, SessionHead, SessionData } from "@codesesh/core";
@@ -35,6 +36,8 @@ function makeMockContext(
   overrides: {
     query?: Record<string, string>;
     param?: Record<string, string>;
+    body?: unknown;
+    bodyError?: boolean;
   } = {},
 ) {
   const jsonFn = vi.fn().mockReturnValue({ status: 200 });
@@ -42,6 +45,10 @@ function makeMockContext(
     req: {
       query: (key: string) => overrides.query?.[key] ?? "",
       param: (key: string) => overrides.param?.[key] ?? "",
+      json: () =>
+        overrides.bodyError
+          ? Promise.reject(new Error("Invalid JSON"))
+          : Promise.resolve(overrides.body),
     },
     json: jsonFn,
   } as any;
@@ -509,5 +516,116 @@ describe("handleGetSessionData", () => {
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
     await handleGetSessionData(c, makeScanSource({ agents: [agent] }));
     expect(c.json).toHaveBeenCalledWith({ error: "DB not found" }, 500);
+  });
+});
+
+describe("handlePatchSession", () => {
+  function makeRenameAgent(impl?: (id: string, alias: string | null) => SessionHead | null) {
+    const agent = new MockAgent();
+    (agent as any).setSessionAlias =
+      impl ?? ((id: string, alias: string | null) => makeSession(id, { title: alias ?? "" }));
+    return agent;
+  }
+
+  it("rejects unknown agents", async () => {
+    const c = makeMockContext({
+      param: { agent: "unknown", id: "s1" },
+      body: { title: "Foo" },
+    });
+    await handlePatchSession(c, makeScanSource());
+    expect(c.json).toHaveBeenCalledWith({ error: "Unknown agent: unknown" }, 404);
+  });
+
+  it("rejects agents that do not implement setSessionAlias", async () => {
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "s1" },
+      body: { title: "Foo" },
+    });
+    await handlePatchSession(c, makeScanSource());
+    expect(c.json).toHaveBeenCalledWith(
+      { error: "Agent does not support rename: claudecode" },
+      400,
+    );
+  });
+
+  it("rejects payloads missing the title field", async () => {
+    const agent = makeRenameAgent();
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "s1" },
+      body: {},
+    });
+    await handlePatchSession(c, makeScanSource({ agents: [agent] }));
+    expect(c.json).toHaveBeenCalledWith({ error: "Missing title in request body" }, 400);
+  });
+
+  it("rejects non-string non-null titles", async () => {
+    const agent = makeRenameAgent();
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "s1" },
+      body: { title: 42 },
+    });
+    await handlePatchSession(c, makeScanSource({ agents: [agent] }));
+    expect(c.json).toHaveBeenCalledWith({ error: "Title must be a string or null" }, 400);
+  });
+
+  it("returns 404 when agent reports session not found", async () => {
+    const agent = makeRenameAgent(() => null);
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "missing" },
+      body: { title: "anything" },
+    });
+    await handlePatchSession(c, makeScanSource({ agents: [agent] }));
+    expect(c.json).toHaveBeenCalledWith({ error: "Session not found: missing" }, 404);
+  });
+
+  it("returns updated session and patches the in-memory snapshot", async () => {
+    const calls: Array<[string, string | null]> = [];
+    const agent = makeRenameAgent((id, alias) => {
+      calls.push([id, alias]);
+      return makeSession(id, { title: alias ?? "" });
+    });
+
+    const scanResult = makeScanResult({ agents: [agent] });
+    const scanSource: ScanResultSource = { getSnapshot: () => scanResult };
+
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "s1" },
+      body: { title: "Renamed" },
+    });
+    await handlePatchSession(c, scanSource);
+
+    expect(calls).toEqual([["s1", "Renamed"]]);
+    const lastCall = (c.json as any).mock.calls.at(-1);
+    expect(lastCall?.[0].session.title).toBe("Renamed");
+    expect(scanResult.byAgent.claudecode?.find((s) => s.id === "s1")?.title).toBe("Renamed");
+    expect(scanResult.sessions.find((s) => s.id === "s1")?.title).toBe("Renamed");
+  });
+
+  it("trims overly long titles to 200 chars before persisting", async () => {
+    const calls: Array<[string, string | null]> = [];
+    const agent = makeRenameAgent((id, alias) => {
+      calls.push([id, alias]);
+      return makeSession(id, { title: alias ?? "" });
+    });
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "s1" },
+      body: { title: "x".repeat(500) },
+    });
+    await handlePatchSession(c, makeScanSource({ agents: [agent] }));
+    expect(calls[0]?.[1]?.length).toBe(200);
+  });
+
+  it("forwards null titles to clear the alias", async () => {
+    const calls: Array<[string, string | null]> = [];
+    const agent = makeRenameAgent((id, alias) => {
+      calls.push([id, alias]);
+      return makeSession(id, { title: "Default Title" });
+    });
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "s1" },
+      body: { title: null },
+    });
+    await handlePatchSession(c, makeScanSource({ agents: [agent] }));
+    expect(calls).toEqual([["s1", null]]);
   });
 });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -324,6 +324,66 @@ export async function handlePostClientLog(c: Context) {
   return c.json({ ok: true });
 }
 
+const ALIAS_TITLE_MAX_LENGTH = 200;
+
+export async function handlePatchSession(c: Context, scanSource: ScanResultSource) {
+  const agentName = c.req.param("agent");
+  const sessionId = c.req.param("id");
+
+  if (!sessionId) {
+    return c.json({ error: "Missing session ID" }, 400);
+  }
+
+  const scanResult = scanSource.getSnapshot();
+  const agent = scanResult.agents.find((a) => a.name === agentName);
+  if (!agent) {
+    return c.json({ error: `Unknown agent: ${agentName}` }, 404);
+  }
+
+  if (typeof agent.setSessionAlias !== "function") {
+    return c.json({ error: `Agent does not support rename: ${agentName}` }, 400);
+  }
+
+  const payload = await c.req.json().catch(() => null);
+  if (!isRecord(payload) || !("title" in payload)) {
+    return c.json({ error: "Missing title in request body" }, 400);
+  }
+
+  const rawTitle = payload.title;
+  let alias: string | null;
+  if (rawTitle === null) {
+    alias = null;
+  } else if (typeof rawTitle === "string") {
+    alias = rawTitle.slice(0, ALIAS_TITLE_MAX_LENGTH);
+  } else {
+    return c.json({ error: "Title must be a string or null" }, 400);
+  }
+
+  let updated: SessionHead | null;
+  try {
+    updated = agent.setSessionAlias(sessionId, alias);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to rename session";
+    return c.json({ error: message }, 500);
+  }
+
+  if (!updated) {
+    return c.json({ error: `Session not found: ${sessionId}` }, 404);
+  }
+
+  // Eagerly patch the in-memory snapshot so subsequent GETs see the new title
+  // before chokidar's debounced refresh fires.
+  const agentSessions = scanResult.byAgent[agentName];
+  if (agentSessions) {
+    const idx = agentSessions.findIndex((session) => session.id === sessionId);
+    if (idx >= 0) agentSessions[idx] = updated;
+  }
+  const flatIdx = scanResult.sessions.findIndex((session) => session.id === sessionId);
+  if (flatIdx >= 0) scanResult.sessions[flatIdx] = updated;
+
+  return c.json({ session: updated });
+}
+
 export function handleGetBookmarks(c: Context) {
   try {
     return c.json({ bookmarks: listBookmarks(), storageAvailable: true });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -373,15 +373,30 @@ export async function handlePatchSession(c: Context, scanSource: ScanResultSourc
 
   // Eagerly patch the in-memory snapshot so subsequent GETs see the new title
   // before chokidar's debounced refresh fires.
+  //
+  // setSessionAlias() returns a bare SessionHead from parseSessionHead() that
+  // does not carry scanner-enriched fields (project_identity, smart_tags,
+  // smart_tags_source_updated_at). Merge per-field instead of replacing so
+  // those fields survive a rename until the next chokidar-triggered rescan —
+  // otherwise project/tag-filtered endpoints would temporarily drop or
+  // misclassify the renamed session.
+  const mergeRename = (existing: SessionHead): SessionHead => ({
+    ...updated,
+    project_identity: updated.project_identity ?? existing.project_identity,
+    smart_tags: updated.smart_tags ?? existing.smart_tags,
+    smart_tags_source_updated_at:
+      updated.smart_tags_source_updated_at ?? existing.smart_tags_source_updated_at,
+  });
+
   const agentSessions = scanResult.byAgent[agentName];
   if (agentSessions) {
     const idx = agentSessions.findIndex((session) => session.id === sessionId);
-    if (idx >= 0) agentSessions[idx] = updated;
+    if (idx >= 0) agentSessions[idx] = mergeRename(agentSessions[idx]!);
   }
   const flatIdx = scanResult.sessions.findIndex((session) => session.id === sessionId);
-  if (flatIdx >= 0) scanResult.sessions[flatIdx] = updated;
+  if (flatIdx >= 0) scanResult.sessions[flatIdx] = mergeRename(scanResult.sessions[flatIdx]!);
 
-  return c.json({ session: updated });
+  return c.json({ session: agentSessions?.find((s) => s.id === sessionId) ?? updated });
 }
 
 export function handleGetBookmarks(c: Context) {

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -11,6 +11,7 @@ import {
   handleSearchSessions,
   handleGetSessions,
   handleGetSessionData,
+  handlePatchSession,
   handlePutBookmark,
   type ScanResultSource,
   type SessionListDefaults,
@@ -84,6 +85,7 @@ export function createApiRoutes(
   api.get("/sessions", (c) => handleGetSessions(c, scanSource, listDefaults));
   api.get("/search", (c) => handleSearchSessions(c, scanSource, listDefaults));
   api.get("/sessions/:agent/:id", (c) => handleGetSessionData(c, scanSource));
+  api.patch("/sessions/:agent/:id", (c) => handlePatchSession(c, scanSource));
   api.get("/dashboard", (c) => handleGetDashboard(c, scanSource, listDefaults));
   api.get("/bookmarks", (c) => handleGetBookmarks(c));
   api.put("/bookmarks", (c) => handlePutBookmark(c));

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -266,12 +266,60 @@ describe("ClaudeCodeAgent session alias (cc-native custom-title upsert)", () => 
 
     expect(head?.title).toBe("My Custom Title");
     const records = readJsonl();
+    // The prepended row carries a timestamp copied from the file's first
+    // existing record so parseSessionHead's time_created derivation doesn't
+    // fall back to file mtime (which would re-anchor on every rename).
     expect(records[0]).toEqual({
       type: "custom-title",
       customTitle: "My Custom Title",
       sessionId,
+      timestamp: "2026-04-25T00:00:00.000Z",
     });
     expect(records).toHaveLength(2);
+  });
+
+  it("preserves time_created across renames (no mtime drift)", () => {
+    // Regression for the case where a freshly-prepended custom-title row had
+    // no timestamp, causing parseSessionHead() to fall back to file mtime and
+    // silently drift the session's creation time forward on every rename.
+    const originalTs = "2026-03-01T00:00:00.000Z";
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          parentUuid: null,
+          type: "user",
+          message: { role: "user", content: "first prompt" },
+          timestamp: originalTs,
+          sessionId,
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { agent } = buildAgent();
+    // Force-set mtime far in the future so any mtime-fallback would be
+    // immediately visible as drift.
+    const futureMs = Date.parse("2099-01-01T00:00:00.000Z");
+    utimesSync(sessionFile, futureMs / 1000, futureMs / 1000);
+
+    const expectedMs = Date.parse(originalTs);
+
+    const firstHead = agent.setSessionAlias(sessionId, "First name");
+    expect(firstHead?.time_created).toBe(expectedMs);
+
+    // Re-rename: the first row is now our custom-title; the replace path must
+    // also preserve a timestamp so time_created still comes from the original
+    // user record, not from the (refreshed) file mtime.
+    utimesSync(sessionFile, futureMs / 1000 + 100, futureMs / 1000 + 100);
+    const secondHead = agent.setSessionAlias(sessionId, "Second name");
+    expect(secondHead?.time_created).toBe(expectedMs);
+
+    // Clearing falls back through the precedence chain — the first user row
+    // re-becomes lines[0], so its own timestamp drives time_created. Either
+    // way, no mtime drift.
+    const clearedHead = agent.setSessionAlias(sessionId, null);
+    expect(clearedHead?.time_created).toBe(expectedMs);
   });
 
   it("collapses cc's append-on-resume duplicates into a single fresh row", () => {

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ClaudeCodeAgent } from "../claudecode.js";
 import type { SessionHead } from "../../types/index.js";
 
@@ -196,5 +196,219 @@ describe("ClaudeCodeAgent cache refresh", () => {
       role: "tool",
       parts: [{ type: "text", text: "detached output" }],
     });
+  });
+});
+
+describe("ClaudeCodeAgent session alias (cc-native custom-title upsert)", () => {
+  let baseDir: string;
+  let projectDir: string;
+  let sessionFile: string;
+  const sessionId = "abcd-1234";
+
+  function readJsonl(): Array<Record<string, unknown>> {
+    return readFileSync(sessionFile, "utf-8")
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line));
+  }
+
+  function buildAgent(): { agent: ClaudeCodeAgent; raw: any } {
+    const agent = new ClaudeCodeAgent();
+    const raw = agent as any;
+    raw.basePath = baseDir;
+    raw.sessionsIndexCache = {};
+    raw.sessionMetaMap = new Map([
+      [
+        sessionId,
+        {
+          id: sessionId,
+          title: "Old",
+          sourcePath: sessionFile,
+          directory: "/tmp/project",
+          model: null,
+          messageCount: 1,
+          createdAt: 1000,
+          updatedAt: 1000,
+        },
+      ],
+    ]);
+    return { agent, raw };
+  }
+
+  beforeEach(() => {
+    baseDir = mkdtempSync(join(tmpdir(), "codesesh-claudecode-"));
+    projectDir = join(baseDir, "project");
+    mkdirSync(projectDir, { recursive: true });
+    sessionFile = join(projectDir, `${sessionId}.jsonl`);
+  });
+
+  afterEach(() => {
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it("prepends a custom-title record when none exists", () => {
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          parentUuid: null,
+          type: "user",
+          message: { role: "user", content: "hello world" },
+          timestamp: "2026-04-25T00:00:00.000Z",
+          sessionId,
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { agent } = buildAgent();
+    const head = agent.setSessionAlias(sessionId, "  My Custom Title  ");
+
+    expect(head?.title).toBe("My Custom Title");
+    const records = readJsonl();
+    expect(records[0]).toEqual({
+      type: "custom-title",
+      customTitle: "My Custom Title",
+      sessionId,
+    });
+    expect(records).toHaveLength(2);
+  });
+
+  it("collapses cc's append-on-resume duplicates into a single fresh row", () => {
+    // cc itself writes a new custom-title row on every resume, so a long-lived
+    // session may accumulate several of them. setSessionAlias should leave at
+    // most one row behind regardless of how many were there before.
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "custom-title", customTitle: "Old name 1", sessionId }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "first prompt" },
+          timestamp: "2026-04-25T00:00:00.000Z",
+          sessionId,
+        }),
+        JSON.stringify({ type: "custom-title", customTitle: "Old name 2", sessionId }),
+        JSON.stringify({ type: "custom-title", customTitle: "Old name 3", sessionId }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { agent } = buildAgent();
+    const head = agent.setSessionAlias(sessionId, "Fresh name");
+
+    expect(head?.title).toBe("Fresh name");
+    const records = readJsonl();
+    const titleRows = records.filter((r) => r["type"] === "custom-title");
+    expect(titleRows).toHaveLength(1);
+    expect(titleRows[0]?.["customTitle"]).toBe("Fresh name");
+    // user message preserved
+    expect(records.filter((r) => r["type"] === "user")).toHaveLength(1);
+  });
+
+  it("reads the LAST custom-title row when several exist (matches cc's /resume)", () => {
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "custom-title", customTitle: "First", sessionId }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "first prompt" },
+          timestamp: "2026-04-25T00:00:00.000Z",
+          sessionId,
+        }),
+        JSON.stringify({ type: "custom-title", customTitle: "Latest cc --name", sessionId }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { agent, raw } = buildAgent();
+    // No write, just observe parseSessionHead reading existing rows.
+    const head = raw.parseSessionHead(sessionFile, projectDir);
+    expect(head?.title).toBe("Latest cc --name");
+    // setSessionAlias (no-op clear when nothing) leaves both rows since we
+    // didn't ask to rewrite anything.
+    void agent;
+  });
+
+  it("prefers custom-title over hook-emitted summary on read", () => {
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "summary", summary: "Hook says X", source: "session-end-hook" }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "first prompt" },
+          timestamp: "2026-04-25T00:00:00.000Z",
+          sessionId,
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { agent } = buildAgent();
+    const head = agent.setSessionAlias(sessionId, "User override");
+    expect(head?.title).toBe("User override");
+
+    const records = readJsonl();
+    // The hook summary stays untouched — codesesh only owns custom-title rows.
+    expect(records.filter((r) => r["source"] === "session-end-hook")).toHaveLength(1);
+    expect(records.filter((r) => r["type"] === "custom-title")).toHaveLength(1);
+  });
+
+  it("removes custom-title rows when cleared and falls back to hook summary", () => {
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "summary", summary: "Hook says X", source: "session-end-hook" }),
+        JSON.stringify({ type: "custom-title", customTitle: "Old alias", sessionId }),
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "first prompt" },
+          timestamp: "2026-04-25T00:00:00.000Z",
+          sessionId,
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { agent } = buildAgent();
+    const head = agent.setSessionAlias(sessionId, "");
+    expect(head?.title).toBe("Hook says X");
+
+    const records = readJsonl();
+    expect(records.some((r) => r["type"] === "custom-title")).toBe(false);
+    // hook record + user message
+    expect(records).toHaveLength(2);
+  });
+
+  it("falls back to first user message when no metadata records remain", () => {
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "actual first prompt text" },
+          timestamp: "2026-04-25T00:00:00.000Z",
+          sessionId,
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { agent } = buildAgent();
+    const head = agent.setSessionAlias(sessionId, null);
+    // No alias was set, file should be untouched and parseSessionHead
+    // should derive the title from the first user message.
+    expect(head?.title).toBe("actual first prompt text");
+    const records = readJsonl();
+    expect(records).toHaveLength(1);
+  });
+
+  it("returns null for unknown sessions without touching the filesystem", () => {
+    writeFileSync(sessionFile, "", "utf-8");
+    const { agent } = buildAgent();
+    expect(agent.setSessionAlias("does-not-exist", "Whatever")).toBeNull();
+    expect(readFileSync(sessionFile, "utf-8")).toBe("");
   });
 });

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -322,6 +322,50 @@ describe("ClaudeCodeAgent session alias (cc-native custom-title upsert)", () => 
     expect(clearedHead?.time_created).toBe(expectedMs);
   });
 
+  it("preserves time_created when row 0 is the sole timestamp source on re-rename", () => {
+    // Edge case (codex P1 follow-up): after a previous codesesh-written
+    // custom-title sits at row 0 with the only valid timestamp in the file,
+    // and cc has since append-on-resume'd another custom-title without a
+    // timestamp at the tail. The next setSessionAlias() would otherwise call
+    // findFallbackTimestamp(0), find no other row with a timestamp, and write
+    // a new row 0 without one — re-triggering the original mtime drift.
+    const originalTs = "2026-02-15T10:00:00.000Z";
+    writeFileSync(
+      sessionFile,
+      [
+        // Row 0: codesesh-written custom-title carrying the preserved timestamp.
+        JSON.stringify({
+          type: "custom-title",
+          customTitle: "First name",
+          sessionId,
+          timestamp: originalTs,
+        }),
+        // Row 1: cc-appended custom-title with NO timestamp (the realistic
+        // shape after a `claude --resume` against a renamed session).
+        JSON.stringify({ type: "custom-title", customTitle: "cc-appended", sessionId }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const futureMs = Date.parse("2099-06-01T00:00:00.000Z");
+    utimesSync(sessionFile, futureMs / 1000, futureMs / 1000);
+
+    const { agent } = buildAgent();
+    const head = agent.setSessionAlias(sessionId, "Second name");
+
+    expect(head?.time_created).toBe(Date.parse(originalTs));
+    const records = readJsonl();
+    // Cc's duplicate was collapsed; the surviving custom-title carries the
+    // preserved timestamp from the previous row 0.
+    expect(records).toHaveLength(1);
+    expect(records[0]).toEqual({
+      type: "custom-title",
+      customTitle: "Second name",
+      sessionId,
+      timestamp: originalTs,
+    });
+  });
+
   it("collapses cc's append-on-resume duplicates into a single fresh row", () => {
     // cc itself writes a new custom-title row on every resume, so a long-lived
     // session may accumulate several of them. setSessionAlias should leave at

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -78,4 +78,13 @@ export abstract class BaseAgent {
     cachedSessions: SessionHead[],
     changedIds: string[],
   ): Promise<SessionHead[]> | SessionHead[];
+
+  /**
+   * Persist a user-editable display title for the session.
+   * Implementations write back to the session's underlying storage so that
+   * subsequent scans pick the new title up. Pass `null` or an empty string
+   * to clear the alias and fall back to the auto-derived title.
+   * Returns the refreshed SessionHead, or `null` when the session is unknown.
+   */
+  setSessionAlias?(sessionId: string, alias: string | null): SessionHead | null;
 }

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -252,20 +252,51 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
     }
 
-    let mutated = false;
-    if (desired !== null) {
-      const newLine = JSON.stringify({
+    // Find a timestamp from the existing file to preserve when our row would
+    // become the file's first record. parseSessionHead() derives time_created
+    // from lines[0]'s timestamp and falls back to file mtime when missing —
+    // without this, a newly-prepended custom-title row would re-anchor the
+    // session's creation time to "now" on every rename and continue drifting
+    // with future writes. `skipIdx` lets us ignore an existing custom-title
+    // at row 0 (which itself may already lack a timestamp) when scanning.
+    const findFallbackTimestamp = (skipIdx: number): string | undefined => {
+      for (let i = 0; i < dataLines.length; i++) {
+        if (i === skipIdx) continue;
+        const candidate = dataLines[i];
+        if (!candidate || !candidate.trim()) continue;
+        try {
+          const parsed = JSON.parse(candidate);
+          const ts = parsed?.timestamp;
+          if (typeof ts === "string" && ts) return ts;
+        } catch {
+          // ignore
+        }
+      }
+      return undefined;
+    };
+    const buildCustomTitleRow = (preservedTimestamp?: string): string => {
+      const row: Record<string, unknown> = {
         type: CUSTOM_TITLE_TYPE,
         customTitle: desired,
         sessionId,
-      });
+      };
+      if (preservedTimestamp) row.timestamp = preservedTimestamp;
+      return JSON.stringify(row);
+    };
+
+    let mutated = false;
+    if (desired !== null) {
       if (customTitleIndices.length === 0) {
+        const newLine = buildCustomTitleRow(findFallbackTimestamp(-1));
         dataLines.unshift(newLine);
         mutated = true;
       } else {
         // Replace the first occurrence in place, drop the rest. Iterate from
         // the tail so splice indices stay valid.
         const [firstIdx, ...rest] = customTitleIndices;
+        const preserved =
+          firstIdx === 0 ? findFallbackTimestamp(0) : undefined;
+        const newLine = buildCustomTitleRow(preserved);
         if (dataLines[firstIdx!] !== newLine) {
           dataLines[firstIdx!] = newLine;
           mutated = true;

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -274,6 +274,23 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
       return undefined;
     };
+    // For replace-at-row-0: read the existing row's own timestamp as a last
+    // resort when no other record carries one. Otherwise — if a previous
+    // codesesh-written custom-title row at row 0 was the only timestamp source
+    // (e.g. cc appended a timestamp-less custom-title later) — we'd write a
+    // new row 0 without a timestamp and re-trigger the original P1 mtime drift.
+    const readRowTimestamp = (idx: number): string | undefined => {
+      const candidate = dataLines[idx];
+      if (!candidate || !candidate.trim()) return undefined;
+      try {
+        const parsed = JSON.parse(candidate);
+        const ts = parsed?.timestamp;
+        if (typeof ts === "string" && ts) return ts;
+      } catch {
+        // ignore
+      }
+      return undefined;
+    };
     const buildCustomTitleRow = (preservedTimestamp?: string): string => {
       const row: Record<string, unknown> = {
         type: CUSTOM_TITLE_TYPE,
@@ -295,7 +312,9 @@ export class ClaudeCodeAgent extends BaseAgent {
         // the tail so splice indices stay valid.
         const [firstIdx, ...rest] = customTitleIndices;
         const preserved =
-          firstIdx === 0 ? findFallbackTimestamp(0) : undefined;
+          firstIdx === 0
+            ? findFallbackTimestamp(0) ?? readRowTimestamp(0)
+            : undefined;
         const newLine = buildCustomTitleRow(preserved);
         if (dataLines[firstIdx!] !== newLine) {
           dataLines[firstIdx!] = newLine;

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -1,4 +1,12 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join, basename, dirname } from "node:path";
 import { BaseAgent, matchesScanWindow } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
@@ -10,6 +18,17 @@ import { estimateTokenCost } from "../utils/cost.js";
 import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
 
 const RECENT_SESSION_REVALIDATION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * cc itself writes `{type:"custom-title", customTitle, sessionId}` records
+ * when launched with `--name`. The picker, prompt box, and terminal title all
+ * read from this field, so codesesh round-trips through the same record to
+ * stay bidirectionally in sync with `claude --name`. cc appends a new row on
+ * every resume rather than upserting, so the *last* row wins on read; on
+ * write we replace any existing rows with a single fresh one.
+ */
+const CUSTOM_TITLE_TYPE = "custom-title";
+const ALIAS_TITLE_MAX_LENGTH = 200;
 
 interface SessionMeta extends SessionCacheMeta {
   id: string;
@@ -189,6 +208,118 @@ export class ClaudeCodeAgent extends BaseAgent {
       },
       messages,
     };
+  }
+
+  /**
+   * Persist a user-set display title onto the session jsonl by replacing all
+   * `{type:"custom-title"}` records with a single fresh one — the same field
+   * cc itself writes when launched with `--name`. Passing null or an empty
+   * string removes the records entirely, so the title falls back to whatever
+   * the auto-derivation chooses (sessions-index.json summary → first user
+   * message → directory name).
+   *
+   * cc appends a new custom-title row on every resume rather than upserting,
+   * so we collapse any existing rows into one to avoid unbounded growth.
+   *
+   * The write is atomic (temp file + rename) to avoid leaving a half-written
+   * jsonl that cc itself may try to resume from.
+   */
+  setSessionAlias(sessionId: string, alias: string | null): SessionHead | null {
+    const meta = this.sessionMetaMap.get(sessionId);
+    if (!meta) return null;
+    const filePath = meta.sourcePath;
+    if (!existsSync(filePath)) return null;
+
+    const projectDir = dirname(filePath);
+    const trimmed = (alias ?? "").trim().slice(0, ALIAS_TITLE_MAX_LENGTH);
+    const desired = trimmed.length > 0 ? trimmed : null;
+
+    const original = readFileSync(filePath, "utf-8");
+    const trailingNewline = original.endsWith("\n");
+    const dataLines = trailingNewline ? original.slice(0, -1).split("\n") : original.split("\n");
+
+    const customTitleIndices: number[] = [];
+    for (let i = 0; i < dataLines.length; i++) {
+      const line = dataLines[i];
+      if (!line || !line.trim()) continue;
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed?.type === CUSTOM_TITLE_TYPE) {
+          customTitleIndices.push(i);
+        }
+      } catch {
+        // ignore malformed lines
+      }
+    }
+
+    let mutated = false;
+    if (desired !== null) {
+      const newLine = JSON.stringify({
+        type: CUSTOM_TITLE_TYPE,
+        customTitle: desired,
+        sessionId,
+      });
+      if (customTitleIndices.length === 0) {
+        dataLines.unshift(newLine);
+        mutated = true;
+      } else {
+        // Replace the first occurrence in place, drop the rest. Iterate from
+        // the tail so splice indices stay valid.
+        const [firstIdx, ...rest] = customTitleIndices;
+        if (dataLines[firstIdx!] !== newLine) {
+          dataLines[firstIdx!] = newLine;
+          mutated = true;
+        }
+        for (const extra of rest.reverse()) {
+          dataLines.splice(extra, 1);
+          mutated = true;
+        }
+      }
+    } else if (customTitleIndices.length > 0) {
+      for (const idx of customTitleIndices.reverse()) {
+        dataLines.splice(idx, 1);
+      }
+      mutated = true;
+    }
+
+    if (mutated) {
+      const content =
+        dataLines.length > 0
+          ? dataLines.join("\n") + (trailingNewline || dataLines.length > 0 ? "\n" : "")
+          : "";
+      const tmpPath = `${filePath}.codesesh-alias.tmp`;
+      try {
+        writeFileSync(tmpPath, content, "utf-8");
+        renameSync(tmpPath, filePath);
+      } catch (error) {
+        try {
+          if (existsSync(tmpPath)) unlinkSync(tmpPath);
+        } catch {
+          // best-effort cleanup
+        }
+        throw error;
+      }
+    }
+
+    // sessions-index.json may still hold the previous summary; bust the cache
+    // entry for this project so the next parseSessionHead reload doesn't keep
+    // returning the stale value.
+    delete this.sessionsIndexCache[basename(projectDir)];
+
+    const head = this.parseSessionHead(filePath, projectDir);
+    if (head) {
+      this.sessionMetaMap.set(sessionId, {
+        id: head.id,
+        title: head.title,
+        sourcePath: filePath,
+        directory: head.directory,
+        model: meta.model,
+        messageCount: head.stats.message_count,
+        createdAt: head.time_created,
+        updatedAt: head.time_updated ?? head.time_created,
+      });
+    }
+    return head;
   }
 
   /**
@@ -393,7 +524,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     // Try to get title from sessions-index.json
     const index = this.loadSessionsIndex(projectDir);
     const indexEntry = index.get(sessionId);
-    const explicitTitle = indexEntry?.summary ? String(indexEntry.summary) : null;
+    const indexSummary = indexEntry?.summary ? String(indexEntry.summary) : null;
 
     // Extract lightweight metadata; cwd lives in user-type records, not the first line
     let updatedAt = createdAt;
@@ -405,6 +536,8 @@ export class ClaudeCodeAgent extends BaseAgent {
     let totalCacheReadTokens = 0;
     let totalCacheCreateTokens = 0;
     let totalCost = 0;
+    let customTitle: string | null = null;
+    let hookSummary: string | null = null;
     const modelUsageMap: Record<string, number> = {};
 
     for (const line of lines) {
@@ -415,6 +548,21 @@ export class ClaudeCodeAgent extends BaseAgent {
 
         if (!cwd && data["cwd"] && typeof data["cwd"] === "string") {
           cwd = data["cwd"];
+        }
+
+        if (data["type"] === CUSTOM_TITLE_TYPE && typeof data["customTitle"] === "string") {
+          // cc appends a fresh custom-title row on every resume, so let the
+          // last one win — that's what cc itself surfaces in /resume.
+          const titleText = data["customTitle"].trim();
+          if (titleText) customTitle = titleText;
+        } else if (data["type"] === "summary" && typeof data["summary"] === "string") {
+          const summaryText = data["summary"].trim();
+          if (summaryText && !hookSummary) {
+            // Prefer the first hook-emitted summary we encounter. cc only
+            // writes one of these per session-end so first === last in
+            // practice; pinning to the first keeps reads stable.
+            hookSummary = summaryText;
+          }
         }
 
         const msg = data["message"];
@@ -469,6 +617,11 @@ export class ClaudeCodeAgent extends BaseAgent {
     const messageTitle = this.extractTitle(lines);
     const directoryTitle = basenameTitle(directory) || basenameTitle(projectDir);
 
+    // Title precedence: cc-native custom-title (== `claude --name`) >
+    // sessions-index.json > hook-emitted summary > first user message >
+    // directory name. Using the cc-native field means renames done in
+    // codesesh appear in cc's /resume picker and vice versa.
+    const explicitTitle = customTitle ?? indexSummary ?? hookSummary ?? null;
     const title = resolveSessionTitle(explicitTitle, messageTitle, directoryTitle);
 
     const hasModelUsage = Object.keys(modelUsageMap).length > 0;


### PR DESCRIPTION
## Summary

Lets users rename a Claude Code session from either the detail header or any sidebar list item. Renames round-trip through cc's own `{type:"custom-title", customTitle, sessionId}` jsonl record — the exact field `claude --name` writes — so the alias is **bidirectional**: codesesh-side renames show up in cc's `/resume` picker / prompt box / terminal title, and `claude --name X` from the terminal shows up in codesesh on next scan.

- **core**: `ClaudeCodeAgent.setSessionAlias()` upserts a single `custom-title` row (atomic temp-file + rename), collapsing any duplicates cc accumulates from append-on-resume; `parseSessionHead()` now reads the *last* `custom-title` row (matching cc's own behavior). New title precedence: `custom-title` → `sessions-index.json` summary → `session-end-hook` summary → first user message → directory basename.
- **api**: `PATCH /api/sessions/:agent/:id` with body `{title: string | null}`. Empty/null clears the alias. Gated to agents that advertise `setSessionAlias` — only `claudecode` for this PR. The in-memory scan snapshot is patched in place so subsequent GETs don't have to wait for chokidar's debounced rescan.
- **web**: Pencil icon (a) next to the detail header title and (b) on every sidebar list item. Both swap the title for an inline input (Enter saves, Esc cancels, blur saves) and share a single handler that optimistically patches detail + sidebar state.

## Why cc-native `custom-title` instead of a codesesh-only field?

cc itself already writes `{type:"custom-title", customTitle, sessionId}` records into the jsonl when launched with `--name`, and reads them back for the `/resume` picker, prompt box, and terminal title. Using the same row makes the alias bidirectional with zero extra storage. An earlier draft used `{type:"summary", source:"codesesh-alias"}`; that worked but was a one-way private channel — cc had no way to see codesesh-set names and codesesh had no way to see `claude --name` names.

End-to-end verified that cc successfully `--resume`s a jsonl that codesesh wrote, and that cc's append-on-resume of the same custom-title is idempotent on the next scan.

## Scope: claudecode only

The other agents (cursor / kimi / codex / opencode) all use different storage formats and would each need bespoke write paths (codex has a native `summary` field, opencode is a SQLite UPDATE, etc.). Wiring those up after the UX is validated; for now the rename pencil only renders when the active agent is claudecode.

## Test plan

- [x] `pnpm test` — 132 tests pass (102 core + 30 cli)
  - core: prepends a custom-title row, collapses cc's append-on-resume duplicates into one, reads last row when several exist, prefers custom-title over hook summary, clear removes all custom-title rows and falls back, returns null for unknown sessions
  - api: 404 unknown agent, 400 unsupported agent / missing title / non-string title, 404 missing session, in-memory snapshot patched on success, 200-char clamp, null clears
- [x] `pnpm lint` clean
- [x] `pnpm --filter @codesesh/web build && pnpm --filter codesesh build` clean
- [x] CDP end-to-end self-check against the running daemon:
  - Detail header: pencil → input → type → Enter → header + sidebar + jsonl all updated; Esc cancels without round-trip
  - Sidebar item: pencil → input → Enter saves; Esc cancels
  - Re-rename: existing `custom-title` rows collapsed to a single row (no duplicates)
  - Clear (`title: null`) removes all `custom-title` rows; codesesh falls back through the precedence chain
  - cc resume against a codesesh-renamed session succeeds (`exit 0`) and cc's append-on-resume of the same name doesn't change codesesh's reading
  - Reverse direction: `claude --name X --resume` writes a custom-title row that codesesh reads on next scan
  - Bad payloads return 400; unknown agents return 400/404 as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)