### PR TITLE
feat: Add SQLite migrations and backups

### DIFF
--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -1,6 +1,7 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearCache,
@@ -71,6 +72,62 @@ function makeSessionData(id: string, text: string): SessionData {
   };
 }
 
+function createLegacyCacheTables(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE cache_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    CREATE TABLE agent_cache (
+      agent_name TEXT PRIMARY KEY,
+      timestamp INTEGER NOT NULL
+    );
+
+    CREATE TABLE cached_sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      session_json TEXT NOT NULL,
+      meta_json TEXT,
+      PRIMARY KEY (agent_name, session_id)
+    );
+  `);
+}
+
+function createLegacyCachedSessionDb(version: number, session = makeSession("legacy")): void {
+  mkdirSync(getCacheDir(), { recursive: true });
+  const db = new Database(getCachePath());
+  try {
+    createLegacyCacheTables(db);
+    db.prepare("INSERT INTO cache_meta(key, value) VALUES ('version', ?)").run(String(version));
+    db.prepare("INSERT INTO agent_cache(agent_name, timestamp) VALUES (?, ?)").run(
+      "claudecode",
+      now,
+    );
+    db.prepare(
+      `
+        INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json)
+        VALUES (?, ?, ?, ?)
+      `,
+    ).run("claudecode", session.id, JSON.stringify(session), null);
+  } finally {
+    db.close();
+  }
+}
+
+function getUserVersion(dbPath: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return Number(db.pragma("user_version", { simple: true }));
+  } finally {
+    db.close();
+  }
+}
+
+function getMigrationBackups(): string[] {
+  return readdirSync(getCacheDir()).filter((name) => name.endsWith(".cache-migration.bak"));
+}
+
 beforeEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   dateNowSpy.mockReturnValue(now);
@@ -126,6 +183,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
+    expect(getUserVersion(getCachePath())).toBe(6);
   });
 
   it("overwrites cached rows for the same agent", () => {
@@ -186,6 +244,62 @@ describe("saveCachedSessions", () => {
         lastActivity: now,
       },
     ]);
+  });
+
+  it("migrates legacy sqlite cache rows to the current schema", () => {
+    createLegacyCachedSessionDb(3);
+
+    const result = loadCachedSessions("claudecode");
+
+    expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
+    expect(getUserVersion(getCachePath())).toBe(6);
+    expect(listCachedProjectGroups()).toEqual([
+      {
+        identityKind: "path",
+        identityKey: "/tmp/project",
+        displayName: "project",
+        sources: ["claudecode"],
+        sessionCount: 1,
+        lastActivity: now,
+      },
+    ]);
+  });
+
+  it("backs up populated cache before destructive migration", () => {
+    createLegacyCachedSessionDb(2);
+
+    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
+      "legacy",
+    ]);
+
+    const backups = getMigrationBackups();
+    expect(backups).toHaveLength(1);
+
+    const backupName = backups[0];
+    expect(backupName).toBeDefined();
+    const backupDb = new Database(join(getCacheDir(), backupName as string), { readonly: true });
+    try {
+      const row = backupDb.prepare("SELECT COUNT(*) AS value FROM cached_sessions").get() as {
+        value?: number;
+      };
+      expect(Number(row.value ?? 0)).toBe(1);
+    } finally {
+      backupDb.close();
+    }
+  });
+
+  it("skips destructive migration backup when cache tables are empty", () => {
+    mkdirSync(getCacheDir(), { recursive: true });
+    const db = new Database(getCachePath());
+    try {
+      createLegacyCacheTables(db);
+      db.prepare("INSERT INTO cache_meta(key, value) VALUES ('version', '2')").run();
+    } finally {
+      db.close();
+    }
+
+    expect(loadCachedSessions("claudecode")).toBeNull();
+    expect(getMigrationBackups()).toEqual([]);
   });
 });
 
@@ -251,5 +365,75 @@ describe("searchSessions", () => {
     const filteredResults = searchSessions("alpha OR beta", { agent: "cursor" });
     expect(filteredResults).toHaveLength(1);
     expect(filteredResults[0]?.agentName).toBe("cursor");
+  });
+
+  it("rebuilds an empty FTS index when content rows exist", () => {
+    mkdirSync(getCacheDir(), { recursive: true });
+    const db = new Database(getCachePath());
+    try {
+      createLegacyCacheTables(db);
+      db.prepare("INSERT INTO cache_meta(key, value) VALUES ('version', '4')").run();
+      db.exec(`
+        CREATE TABLE session_documents (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          agent_name TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          slug TEXT NOT NULL,
+          title TEXT NOT NULL,
+          directory TEXT NOT NULL,
+          time_created INTEGER NOT NULL,
+          time_updated INTEGER,
+          activity_time INTEGER NOT NULL,
+          content_text TEXT NOT NULL,
+          content_hash TEXT NOT NULL,
+          indexed_at INTEGER NOT NULL,
+          UNIQUE(agent_name, session_id)
+        );
+
+        CREATE VIRTUAL TABLE session_documents_fts USING fts5(
+          title,
+          content_text,
+          content='session_documents',
+          content_rowid='id'
+        );
+      `);
+      db.prepare(
+        `
+          INSERT INTO session_documents(
+            agent_name,
+            session_id,
+            slug,
+            title,
+            directory,
+            time_created,
+            time_updated,
+            activity_time,
+            content_text,
+            content_hash,
+            indexed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      ).run(
+        "claudecode",
+        "fts-empty",
+        "claudecode/fts-empty",
+        "FTS Empty",
+        "/tmp/project",
+        now,
+        now,
+        now,
+        "orphan index content",
+        "old",
+        now,
+      );
+    } finally {
+      db.close();
+    }
+
+    const results = searchSessions("orphan");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.session.id).toBe("fts-empty");
+    expect(results[0]?.snippet).toContain("<mark>orphan</mark>");
   });
 });

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -12,9 +12,18 @@ import type {
   SessionHead,
 } from "../types/index.js";
 import { buildProjectGroups, computeIdentity, realFs } from "../projects/index.js";
-import { openDb, type DatabaseRow } from "../utils/sqlite.js";
+import {
+  columnExists,
+  getUserVersion,
+  openDb,
+  runSchemaMigrations,
+  setUserVersion,
+  tableExists,
+  type DatabaseRow,
+  type SQLiteDatabase,
+} from "../utils/sqlite.js";
 
-const CACHE_VERSION = 6;
+const CACHE_SCHEMA_VERSION = 6;
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
@@ -65,6 +74,17 @@ interface ProjectGroupRow extends DatabaseRow {
   last_activity?: number | null;
 }
 
+interface ProjectBackfillSessionRow extends DatabaseRow {
+  agent_name?: string;
+  session_id?: string;
+  session_json?: string;
+}
+
+interface ProjectBackfillDocumentRow extends DatabaseRow {
+  id?: number;
+  directory?: string;
+}
+
 export interface SearchResult {
   agentName: string;
   session: SessionHead;
@@ -95,12 +115,13 @@ function hasCacheStorage(): boolean {
   return existsSync(getCachePath());
 }
 
-function withCacheDb<T>(fn: (db: NonNullable<ReturnType<typeof openDb>>) => T): T | null {
-  const db = openDb(getCachePath());
+function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
+  const cachePath = getCachePath();
+  const db = openDb(cachePath);
   if (!db) return null;
 
   try {
-    ensureSchema(db);
+    ensureSchema(db, cachePath);
     return fn(db);
   } catch {
     return null;
@@ -109,7 +130,7 @@ function withCacheDb<T>(fn: (db: NonNullable<ReturnType<typeof openDb>>) => T): 
   }
 }
 
-function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
+function createCacheTables(db: SQLiteDatabase): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS cache_meta (
       key TEXT PRIMARY KEY,
@@ -128,7 +149,11 @@ function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
       meta_json TEXT,
       PRIMARY KEY (agent_name, session_id)
     );
+  `);
+}
 
+function createSearchTables(db: SQLiteDatabase): void {
+  db.exec(`
     CREATE TABLE IF NOT EXISTS session_documents (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       agent_name TEXT NOT NULL,
@@ -136,9 +161,6 @@ function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
       slug TEXT NOT NULL,
       title TEXT NOT NULL,
       directory TEXT NOT NULL,
-      project_identity_kind TEXT NOT NULL DEFAULT 'path',
-      project_identity_key TEXT NOT NULL DEFAULT '',
-      project_display_name TEXT NOT NULL DEFAULT '',
       time_created INTEGER NOT NULL,
       time_updated INTEGER,
       activity_time INTEGER NOT NULL,
@@ -147,31 +169,6 @@ function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
       indexed_at INTEGER NOT NULL,
       UNIQUE(agent_name, session_id)
     );
-
-    CREATE TABLE IF NOT EXISTS project_sessions (
-      agent_name TEXT NOT NULL,
-      session_id TEXT NOT NULL,
-      identity_kind TEXT NOT NULL,
-      identity_key TEXT NOT NULL,
-      display_name TEXT NOT NULL,
-      directory TEXT NOT NULL,
-      activity_time INTEGER NOT NULL,
-      PRIMARY KEY (agent_name, session_id)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_project_sessions_identity
-      ON project_sessions(identity_kind, identity_key);
-
-    CREATE VIEW IF NOT EXISTS project_groups_v AS
-      SELECT
-        identity_kind,
-        identity_key,
-        MIN(display_name) AS display_name,
-        GROUP_CONCAT(DISTINCT agent_name) AS sources_csv,
-        COUNT(*) AS session_count,
-        MAX(activity_time) AS last_activity
-      FROM project_sessions
-      GROUP BY identity_kind, identity_key;
 
     CREATE VIRTUAL TABLE IF NOT EXISTS session_documents_fts USING fts5(
       title,
@@ -197,39 +194,288 @@ function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
       VALUES (new.id, new.title, new.content_text);
     END;
   `);
+}
 
-  const sessionDocumentColumns = new Set(
-    (db.prepare("PRAGMA table_info(session_documents)").all() as DatabaseRow[]).map((row) =>
-      String(row.name),
-    ),
-  );
-  if (!sessionDocumentColumns.has("project_identity_kind")) {
-    db.exec(`
-      ALTER TABLE session_documents ADD COLUMN project_identity_kind TEXT NOT NULL DEFAULT 'path';
-      ALTER TABLE session_documents ADD COLUMN project_identity_key TEXT NOT NULL DEFAULT '';
-      ALTER TABLE session_documents ADD COLUMN project_display_name TEXT NOT NULL DEFAULT '';
-    `);
+function ensureProjectColumns(db: SQLiteDatabase): void {
+  if (!tableExists(db, "session_documents")) {
+    return;
+  }
+
+  if (!columnExists(db, "session_documents", "project_identity_kind")) {
+    db.exec(
+      "ALTER TABLE session_documents ADD COLUMN project_identity_kind TEXT NOT NULL DEFAULT 'path'",
+    );
+  }
+  if (!columnExists(db, "session_documents", "project_identity_key")) {
+    db.exec(
+      "ALTER TABLE session_documents ADD COLUMN project_identity_key TEXT NOT NULL DEFAULT ''",
+    );
+  }
+  if (!columnExists(db, "session_documents", "project_display_name")) {
+    db.exec(
+      "ALTER TABLE session_documents ADD COLUMN project_display_name TEXT NOT NULL DEFAULT ''",
+    );
+  }
+}
+
+function createProjectTables(db: SQLiteDatabase): void {
+  ensureProjectColumns(db);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS project_sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      identity_kind TEXT NOT NULL,
+      identity_key TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      activity_time INTEGER NOT NULL,
+      PRIMARY KEY (agent_name, session_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_project_sessions_identity
+      ON project_sessions(identity_kind, identity_key);
+
+    CREATE VIEW IF NOT EXISTS project_groups_v AS
+      SELECT
+        identity_kind,
+        identity_key,
+        MIN(display_name) AS display_name,
+        GROUP_CONCAT(DISTINCT agent_name) AS sources_csv,
+        COUNT(*) AS session_count,
+        MAX(activity_time) AS last_activity
+      FROM project_sessions
+      GROUP BY identity_kind, identity_key;
+  `);
+}
+
+function createLatestCacheSchema(db: SQLiteDatabase): void {
+  createCacheTables(db);
+  createSearchTables(db);
+  createProjectTables(db);
+}
+
+function recreateSearchIndexSchema(db: SQLiteDatabase): void {
+  db.exec(`
+    DROP TRIGGER IF EXISTS session_documents_ai;
+    DROP TRIGGER IF EXISTS session_documents_ad;
+    DROP TRIGGER IF EXISTS session_documents_au;
+    DROP TABLE IF EXISTS session_documents_fts;
+  `);
+  createSearchTables(db);
+  rebuildSearchIndex(db);
+}
+
+function readLegacyCacheVersion(db: SQLiteDatabase): number {
+  if (
+    !tableExists(db, "cache_meta") ||
+    !columnExists(db, "cache_meta", "key") ||
+    !columnExists(db, "cache_meta", "value")
+  ) {
+    return 0;
   }
 
   const versionRow = db.prepare("SELECT value FROM cache_meta WHERE key = 'version'").get() as
     | DatabaseRow
     | undefined;
-  const version = Number(versionRow?.value ?? 0);
+  return Number(versionRow?.value ?? 0);
+}
 
-  if (version === CACHE_VERSION) {
+function inferCacheSchemaVersion(db: SQLiteDatabase): number {
+  if (
+    tableExists(db, "project_sessions") ||
+    columnExists(db, "session_documents", "project_identity_key")
+  ) {
+    return 5;
+  }
+  if (tableExists(db, "session_documents")) {
+    return 4;
+  }
+  if (tableExists(db, "cached_sessions") || tableExists(db, "agent_cache")) {
+    return 3;
+  }
+  return 0;
+}
+
+function getCurrentCacheSchemaVersion(db: SQLiteDatabase): number {
+  const userVersion = getUserVersion(db);
+  if (userVersion > 0) {
+    return userVersion;
+  }
+
+  const legacyVersion = readLegacyCacheVersion(db);
+  return Math.max(legacyVersion, inferCacheSchemaVersion(db));
+}
+
+function hasAnyCacheSchema(db: SQLiteDatabase): boolean {
+  return [
+    "cache_meta",
+    "agent_cache",
+    "cached_sessions",
+    "session_documents",
+    "session_documents_fts",
+    "project_sessions",
+  ].some((table) => tableExists(db, table));
+}
+
+function backfillProjectSessions(db: SQLiteDatabase): void {
+  if (!tableExists(db, "cached_sessions") || !tableExists(db, "project_sessions")) {
     return;
   }
 
-  db.exec(`
-    DELETE FROM agent_cache;
-    DELETE FROM cached_sessions;
-    DELETE FROM session_documents;
-    DELETE FROM project_sessions;
-    INSERT INTO session_documents_fts(session_documents_fts) VALUES ('rebuild');
-    INSERT INTO cache_meta(key, value)
-    VALUES ('version', '${CACHE_VERSION}')
-    ON CONFLICT(key) DO UPDATE SET value = excluded.value;
+  const rows = db
+    .prepare("SELECT agent_name, session_id, session_json FROM cached_sessions")
+    .all() as ProjectBackfillSessionRow[];
+  const upsert = db.prepare(`
+    INSERT INTO project_sessions(
+      agent_name,
+      session_id,
+      identity_kind,
+      identity_key,
+      display_name,
+      directory,
+      activity_time
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(agent_name, session_id) DO UPDATE SET
+      identity_kind = excluded.identity_kind,
+      identity_key = excluded.identity_key,
+      display_name = excluded.display_name,
+      directory = excluded.directory,
+      activity_time = excluded.activity_time
   `);
+
+  for (const row of rows) {
+    if (!row.session_json || !row.agent_name || !row.session_id) {
+      continue;
+    }
+
+    try {
+      const session = JSON.parse(row.session_json) as SessionHead;
+      const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
+      upsert.run(
+        row.agent_name,
+        row.session_id,
+        identity.kind,
+        identity.key,
+        identity.displayName,
+        session.directory,
+        session.time_updated ?? session.time_created,
+      );
+    } catch {
+      continue;
+    }
+  }
+}
+
+function backfillSessionDocumentProjects(db: SQLiteDatabase): void {
+  if (
+    !tableExists(db, "session_documents") ||
+    !columnExists(db, "session_documents", "project_identity_key")
+  ) {
+    return;
+  }
+
+  const rows = db
+    .prepare("SELECT id, directory FROM session_documents")
+    .all() as ProjectBackfillDocumentRow[];
+  const update = db.prepare(`
+    UPDATE session_documents
+    SET
+      project_identity_kind = ?,
+      project_identity_key = ?,
+      project_display_name = ?
+    WHERE id = ?
+  `);
+
+  for (const row of rows) {
+    const identity = computeIdentity(String(row.directory ?? ""), realFs);
+    update.run(identity.kind, identity.key, identity.displayName, Number(row.id));
+  }
+}
+
+function migrateProjectIdentity(db: SQLiteDatabase): void {
+  createProjectTables(db);
+  backfillProjectSessions(db);
+  backfillSessionDocumentProjects(db);
+}
+
+function invalidateSearchContentHashes(db: SQLiteDatabase): void {
+  if (
+    tableExists(db, "session_documents") &&
+    columnExists(db, "session_documents", "content_hash")
+  ) {
+    db.exec("UPDATE session_documents SET content_hash = ''");
+  }
+}
+
+function rebuildSearchIndex(db: SQLiteDatabase): void {
+  if (!tableExists(db, "session_documents_fts")) {
+    return;
+  }
+  db.exec("INSERT INTO session_documents_fts(session_documents_fts) VALUES ('rebuild')");
+}
+
+function ensureFtsConsistency(db: SQLiteDatabase): void {
+  if (!tableExists(db, "session_documents_fts")) {
+    createSearchTables(db);
+  }
+
+  try {
+    db.exec(
+      "INSERT INTO session_documents_fts(session_documents_fts, rank) VALUES ('integrity-check', 1)",
+    );
+  } catch {
+    rebuildSearchIndex(db);
+  }
+}
+
+function setCacheSchemaVersion(db: SQLiteDatabase): void {
+  createCacheTables(db);
+  setUserVersion(db, CACHE_SCHEMA_VERSION);
+  db.prepare(
+    `
+      INSERT INTO cache_meta(key, value)
+      VALUES ('version', ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `,
+  ).run(String(CACHE_SCHEMA_VERSION));
+}
+
+function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
+  const currentVersion = getCurrentCacheSchemaVersion(db);
+  if (currentVersion === 0 && !hasAnyCacheSchema(db)) {
+    createLatestCacheSchema(db);
+    setCacheSchemaVersion(db);
+    return;
+  }
+
+  runSchemaMigrations(db, {
+    dbPath,
+    currentVersion,
+    targetVersion: CACHE_SCHEMA_VERSION,
+    backupLabel: "cache-migration",
+    backupTables: ["agent_cache", "cached_sessions", "session_documents", "project_sessions"],
+    migrations: [
+      { version: 3, migrate: createCacheTables },
+      { version: 4, migrate: createSearchTables },
+      { version: 5, migrate: migrateProjectIdentity },
+      {
+        version: 6,
+        destructive: true,
+        migrate(db) {
+          createLatestCacheSchema(db);
+          recreateSearchIndexSchema(db);
+          invalidateSearchContentHashes(db);
+        },
+      },
+    ],
+  });
+
+  createLatestCacheSchema(db);
+  ensureFtsConsistency(db);
+
+  if (getUserVersion(db) <= CACHE_SCHEMA_VERSION) {
+    setCacheSchemaVersion(db);
+  }
 }
 
 function sessionContentHash(session: SessionHead): string {

--- a/packages/core/src/state/__tests__/bookmarks.test.ts
+++ b/packages/core/src/state/__tests__/bookmarks.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   deleteBookmark,
@@ -26,6 +27,19 @@ const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
 
 function getStateDir(): string {
   return join(testHomeDir, ".local", "share", "codesesh");
+}
+
+function getStatePath(): string {
+  return join(getStateDir(), "state.db");
+}
+
+function getUserVersion(dbPath: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return Number(db.pragma("user_version", { simple: true }));
+  } finally {
+    db.close();
+  }
 }
 
 function makeBookmark(
@@ -67,6 +81,7 @@ describe("bookmarks state storage", () => {
         bookmarked_at: now,
       },
     ]);
+    expect(getUserVersion(getStatePath())).toBe(1);
   });
 
   it("preserves bookmarked_at when refreshing a snapshot", () => {
@@ -101,5 +116,25 @@ describe("bookmarks state storage", () => {
     upsertBookmark(makeBookmark());
     deleteBookmark("codex", "s1");
     expect(listBookmarks()).toEqual([]);
+  });
+
+  it("migrates legacy state metadata to user_version", () => {
+    upsertBookmark(makeBookmark());
+    const db = new Database(getStatePath());
+    try {
+      db.exec("PRAGMA user_version = 0");
+      db.prepare(
+        `
+          INSERT INTO state_meta(key, value)
+          VALUES ('version', '1')
+          ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        `,
+      ).run();
+    } finally {
+      db.close();
+    }
+
+    expect(listBookmarks()[0]?.sessionId).toBe("s1");
+    expect(getUserVersion(getStatePath())).toBe(1);
   });
 });

--- a/packages/core/src/state/bookmarks.ts
+++ b/packages/core/src/state/bookmarks.ts
@@ -1,10 +1,19 @@
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { SessionStats } from "../types/index.js";
-import { openDb, type DatabaseRow } from "../utils/sqlite.js";
+import {
+  columnExists,
+  getUserVersion,
+  openDb,
+  runSchemaMigrations,
+  setUserVersion,
+  tableExists,
+  type DatabaseRow,
+  type SQLiteDatabase,
+} from "../utils/sqlite.js";
 
 const BOOKMARK_DB_FILENAME = "state.db";
-const BOOKMARK_DB_VERSION = 1;
+const BOOKMARK_SCHEMA_VERSION = 1;
 
 export class BookmarkStorageUnavailableError extends Error {
   constructor() {
@@ -53,7 +62,7 @@ function getStateDbPath(): string {
   return join(getStateDir(), BOOKMARK_DB_FILENAME);
 }
 
-function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
+function createStateSchema(db: SQLiteDatabase): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS state_meta (
       key TEXT PRIMARY KEY,
@@ -73,30 +82,85 @@ function ensureSchema(db: NonNullable<ReturnType<typeof openDb>>): void {
       PRIMARY KEY (agent_name, session_id)
     );
   `);
+}
+
+function readLegacyStateVersion(db: SQLiteDatabase): number {
+  if (
+    !tableExists(db, "state_meta") ||
+    !columnExists(db, "state_meta", "key") ||
+    !columnExists(db, "state_meta", "value")
+  ) {
+    return 0;
+  }
 
   const row = db.prepare("SELECT value FROM state_meta WHERE key = 'version'").get() as
     | DatabaseRow
     | undefined;
-  const version = Number(row?.value ?? 0);
-  if (version === BOOKMARK_DB_VERSION) return;
+  return Number(row?.value ?? 0);
+}
 
+function getCurrentStateSchemaVersion(db: SQLiteDatabase): number {
+  const userVersion = getUserVersion(db);
+  if (userVersion > 0) {
+    return userVersion;
+  }
+
+  const legacyVersion = readLegacyStateVersion(db);
+  if (legacyVersion > 0) {
+    return legacyVersion;
+  }
+
+  return tableExists(db, "bookmarks") ? 1 : 0;
+}
+
+function hasAnyStateSchema(db: SQLiteDatabase): boolean {
+  return tableExists(db, "state_meta") || tableExists(db, "bookmarks");
+}
+
+function setStateSchemaVersion(db: SQLiteDatabase): void {
+  createStateSchema(db);
+  setUserVersion(db, BOOKMARK_SCHEMA_VERSION);
   db.prepare(
     `
       INSERT INTO state_meta(key, value)
       VALUES ('version', ?)
       ON CONFLICT(key) DO UPDATE SET value = excluded.value
     `,
-  ).run(String(BOOKMARK_DB_VERSION));
+  ).run(String(BOOKMARK_SCHEMA_VERSION));
 }
 
-function withStateDb<T>(fn: (db: NonNullable<ReturnType<typeof openDb>>) => T): T {
-  const db = openDb(getStateDbPath());
+function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
+  const currentVersion = getCurrentStateSchemaVersion(db);
+  if (currentVersion === 0 && !hasAnyStateSchema(db)) {
+    setStateSchemaVersion(db);
+    return;
+  }
+
+  runSchemaMigrations(db, {
+    dbPath,
+    currentVersion,
+    targetVersion: BOOKMARK_SCHEMA_VERSION,
+    backupLabel: "state-migration",
+    backupTables: ["bookmarks"],
+    migrations: [{ version: 1, migrate: createStateSchema }],
+  });
+
+  createStateSchema(db);
+
+  if (getUserVersion(db) <= BOOKMARK_SCHEMA_VERSION) {
+    setStateSchemaVersion(db);
+  }
+}
+
+function withStateDb<T>(fn: (db: SQLiteDatabase) => T): T {
+  const statePath = getStateDbPath();
+  const db = openDb(statePath);
   if (!db) {
     throw new BookmarkStorageUnavailableError();
   }
 
   try {
-    ensureSchema(db);
+    ensureSchema(db, statePath);
     return fn(db);
   } finally {
     db.close();

--- a/packages/core/src/utils/__tests__/sqlite.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite.test.ts
@@ -1,0 +1,21 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { backupDatabaseIfPopulated, type SQLiteDatabase } from "../sqlite.js";
+
+describe("sqlite migration helpers", () => {
+  it("skips backups for in-memory databases", () => {
+    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    try {
+      db.exec(`
+        CREATE TABLE rows (
+          id INTEGER PRIMARY KEY
+        );
+        INSERT INTO rows(id) VALUES (1);
+      `);
+
+      expect(backupDatabaseIfPopulated(db, ":memory:", "migration", ["rows"])).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -2,8 +2,8 @@
  * SQLite helper — graceful degradation if better-sqlite3 is unavailable.
  */
 
-import { mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { createRequire } from "node:module";
 
 interface SQLiteStatement {
@@ -47,6 +47,147 @@ export interface SQLiteDatabase {
   exec(sql: string): void;
   transaction<T extends SQLiteTransaction>(fn: T): T;
   close(): void;
+}
+
+export interface SchemaMigration {
+  version: number;
+  destructive?: boolean;
+  migrate(db: SQLiteDatabase): void;
+}
+
+export interface RunSchemaMigrationsOptions {
+  dbPath: string;
+  currentVersion: number;
+  targetVersion: number;
+  migrations: SchemaMigration[];
+  backupTables: string[];
+  backupLabel: string;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function quoteSqlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function isInMemoryPath(dbPath: string): boolean {
+  return (
+    dbPath === ":memory:" || dbPath.startsWith("file::memory:") || dbPath.includes("mode=memory")
+  );
+}
+
+export function getUserVersion(db: SQLiteDatabase): number {
+  const row = db.prepare("PRAGMA user_version").get() as DatabaseRow | undefined;
+  return Number(row?.user_version ?? 0);
+}
+
+export function setUserVersion(db: SQLiteDatabase, version: number): void {
+  db.exec(`PRAGMA user_version = ${Math.trunc(version)}`);
+}
+
+export function tableExists(db: SQLiteDatabase, tableName: string): boolean {
+  const row = db
+    .prepare(
+      `
+        SELECT 1 AS value
+        FROM sqlite_master
+        WHERE name = ? AND type IN ('table', 'view')
+        LIMIT 1
+      `,
+    )
+    .get(tableName) as DatabaseRow | undefined;
+  return row !== undefined;
+}
+
+export function columnExists(db: SQLiteDatabase, tableName: string, columnName: string): boolean {
+  if (!tableExists(db, tableName)) {
+    return false;
+  }
+
+  const rows = db.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all();
+  return rows.some((row) => String(row.name) === columnName);
+}
+
+export function tableHasRows(db: SQLiteDatabase, tableName: string): boolean {
+  if (!tableExists(db, tableName)) {
+    return false;
+  }
+
+  const row = db.prepare(`SELECT 1 AS value FROM ${quoteIdentifier(tableName)} LIMIT 1`).get() as
+    | DatabaseRow
+    | undefined;
+  return row !== undefined;
+}
+
+export function backupDatabase(db: SQLiteDatabase, dbPath: string, label: string): string | null {
+  if (isInMemoryPath(dbPath)) {
+    return null;
+  }
+
+  const timestamp = new Date(Date.now()).toISOString().replaceAll(":", "").replaceAll(".", "-");
+  let backupPath = join(dirname(dbPath), `${basename(dbPath)}.${timestamp}.${label}.bak`);
+  for (let counter = 1; existsSync(backupPath); counter += 1) {
+    backupPath = join(dirname(dbPath), `${basename(dbPath)}.${timestamp}.${label}.${counter}.bak`);
+  }
+  db.exec(`VACUUM INTO ${quoteSqlString(backupPath)}`);
+  return backupPath;
+}
+
+export function backupDatabaseIfPopulated(
+  db: SQLiteDatabase,
+  dbPath: string,
+  label: string,
+  tables: string[],
+): string | null {
+  if (!tables.some((table) => tableHasRows(db, table))) {
+    return null;
+  }
+
+  return backupDatabase(db, dbPath, label);
+}
+
+export function runSchemaMigrations(
+  db: SQLiteDatabase,
+  options: RunSchemaMigrationsOptions,
+): string[] {
+  const backups: string[] = [];
+  let currentVersion = options.currentVersion;
+
+  for (const migration of options.migrations) {
+    if (migration.version <= currentVersion) {
+      continue;
+    }
+    if (migration.version > options.targetVersion) {
+      break;
+    }
+
+    if (migration.destructive) {
+      const backupPath = backupDatabaseIfPopulated(
+        db,
+        options.dbPath,
+        options.backupLabel,
+        options.backupTables,
+      );
+      if (backupPath) {
+        backups.push(backupPath);
+      }
+    }
+
+    const apply = db.transaction(() => {
+      migration.migrate(db);
+      setUserVersion(db, migration.version);
+    });
+    apply();
+    currentVersion = migration.version;
+  }
+
+  if (currentVersion < options.targetVersion) {
+    setUserVersion(db, options.targetVersion);
+  }
+
+  return backups;
 }
 
 /**


### PR DESCRIPTION
## Summary
- 为 `codesesh.db` 和 `state.db` 引入 `PRAGMA user_version` 驱动的增量迁移
- 在破坏性迁移前自动执行 `VACUUM INTO` 备份，并跳过内存库与空表场景
- 为历史 schema 增加 `tableExists` / `columnExists` 守卫，保留旧数据并完成回填
- 补充旧版本 DB、FTS 重建和备份行为的 smoke tests

## Testing
- `pnpm --filter @codesesh/core test`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core build`
- `pnpm test`