### PR TITLE
refactor: harden livescan watcher

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,6 @@
     "@codesesh/core": "workspace:*",
     "@hono/node-server": "^1.14.0",
     "better-sqlite3": "^11.10.0",
-    "chokidar": "^4.0.3",
     "citty": "^0.1.6",
     "consola": "^3.4.2",
     "hono": "^4.7.4",

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -55,6 +55,45 @@ vi.mock("@codesesh/core", async (importOriginal) => {
 import { LiveScanStore, resolveAgentWatchTargets, type SessionsUpdatedEvent } from "./live-scan.js";
 import { appLogger } from "./logging.js";
 
+let restoreRuntime: (() => void) | null = null;
+
+function stubProcessRuntime(platform: NodeJS.Platform, nodeVersion: string): void {
+  restoreRuntime?.();
+  const originalPlatform = process.platform;
+  const originalNodeVersion = process.versions.node;
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  Object.defineProperty(process.versions, "node", { configurable: true, value: nodeVersion });
+  restoreRuntime = () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+    Object.defineProperty(process.versions, "node", {
+      configurable: true,
+      value: originalNodeVersion,
+    });
+  };
+}
+
+function registerMockWatcher(
+  path: string,
+  options: { recursive?: boolean },
+  listener: (eventType: string, filename: string | Buffer | null) => void,
+) {
+  const watcher = {
+    path,
+    options,
+    listener,
+    on: vi.fn(),
+    close: vi.fn(async () => undefined),
+  };
+  fsWatch.watchers.push(watcher);
+  return {
+    on: watcher.on,
+    close: watcher.close,
+  };
+}
+
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
     id,
@@ -108,20 +147,7 @@ describe("LiveScanStore", () => {
         path: string,
         options: { recursive?: boolean },
         listener: (eventType: string, filename: string | Buffer | null) => void,
-      ) => {
-        const watcher = {
-          path,
-          options,
-          listener,
-          on: vi.fn(),
-          close: vi.fn(async () => undefined),
-        };
-        fsWatch.watchers.push(watcher);
-        return {
-          on: watcher.on,
-          close: watcher.close,
-        };
-      },
+      ) => registerMockWatcher(path, options, listener),
     );
     core.getCursorDataPath.mockReturnValue("/tmp/cursor");
     core.resolveProviderRoots.mockReturnValue({
@@ -134,6 +160,8 @@ describe("LiveScanStore", () => {
   });
 
   afterEach(() => {
+    restoreRuntime?.();
+    restoreRuntime = null;
     vi.useRealTimers();
   });
 
@@ -256,6 +284,7 @@ describe("LiveScanStore", () => {
 
   it("uses native recursive watch and waits for appended files to stabilize", async () => {
     vi.useFakeTimers();
+    stubProcessRuntime("darwin", "18.0.0");
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-watch-"));
     const codexRoot = join(tempDir, "codex");
     const sessionsDir = join(codexRoot, "sessions");
@@ -310,6 +339,53 @@ describe("LiveScanStore", () => {
         newSessions: 1,
       }),
     ]);
+
+    await store.shutdown();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses non-recursive directory watches on Node 18 Linux", async () => {
+    vi.useFakeTimers();
+    stubProcessRuntime("linux", "18.19.0");
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-watch-fallback-"));
+    const codexRoot = join(tempDir, "codex");
+    const sessionsDir = join(codexRoot, "sessions");
+    const dayDir = join(sessionsDir, "2026", "05", "10");
+    const sessionFile = join(dayDir, "new.jsonl");
+    mkdirSync(dayDir, { recursive: true });
+    core.resolveProviderRoots.mockReturnValue({
+      claudeRoot: join(tempDir, "claude"),
+      codexRoot,
+      kimiRoot: join(tempDir, "kimi"),
+      opencodeRoot: join(tempDir, "opencode"),
+    });
+
+    const codex = makeAgent("codex", {
+      scan: vi.fn(() => [makeSession("new")]),
+    });
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [],
+      byAgent: { codex: [] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore(true, { agents: ["codex"] });
+    await store.initialize();
+
+    expect(fsWatch.watchers.some((watcher) => watcher.options.recursive)).toBe(false);
+    expect(fsWatch.watchers.map((watcher) => watcher.path)).toEqual(
+      expect.arrayContaining([codexRoot, sessionsDir, dayDir]),
+    );
+
+    writeFileSync(sessionFile, "complete");
+    const dayWatcher = fsWatch.watchers.find((watcher) => watcher.path === dayDir);
+    expect(dayWatcher).toBeDefined();
+    dayWatcher!.listener("rename", "new.jsonl");
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(codex.scan).toHaveBeenCalledTimes(1);
 
     await store.shutdown();
     rmSync(tempDir, { recursive: true, force: true });

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1,6 +1,19 @@
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionHead } from "@codesesh/core";
+
+const fsWatch = vi.hoisted(() => ({
+  watch: vi.fn(),
+  watchers: [] as Array<{
+    path: string;
+    options: { recursive?: boolean };
+    listener: (eventType: string, filename: string | Buffer | null) => void;
+    on: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  }>,
+}));
 
 const core = vi.hoisted(() => ({
   createRegisteredAgents: vi.fn(),
@@ -17,6 +30,14 @@ const core = vi.hoisted(() => ({
   syncSessionSearchIndex: vi.fn(),
 }));
 
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    watch: fsWatch.watch,
+  };
+});
+
 vi.mock("@codesesh/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core")>();
   return {
@@ -31,16 +52,8 @@ vi.mock("@codesesh/core", async (importOriginal) => {
   };
 });
 
-vi.mock("chokidar", () => ({
-  default: {
-    watch: vi.fn(() => ({
-      on: vi.fn(),
-      close: vi.fn(async () => undefined),
-    })),
-  },
-}));
-
-import { LiveScanStore, resolveAgentWatchTargets } from "./live-scan.js";
+import { LiveScanStore, resolveAgentWatchTargets, type SessionsUpdatedEvent } from "./live-scan.js";
+import { appLogger } from "./logging.js";
 
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
@@ -89,7 +102,39 @@ function makeAgent(name: string, overrides: Record<string, unknown> = {}) {
 describe("LiveScanStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fsWatch.watchers.length = 0;
+    fsWatch.watch.mockImplementation(
+      (
+        path: string,
+        options: { recursive?: boolean },
+        listener: (eventType: string, filename: string | Buffer | null) => void,
+      ) => {
+        const watcher = {
+          path,
+          options,
+          listener,
+          on: vi.fn(),
+          close: vi.fn(async () => undefined),
+        };
+        fsWatch.watchers.push(watcher);
+        return {
+          on: watcher.on,
+          close: watcher.close,
+        };
+      },
+    );
+    core.getCursorDataPath.mockReturnValue("/tmp/cursor");
+    core.resolveProviderRoots.mockReturnValue({
+      claudeRoot: "/tmp/claude",
+      codexRoot: "/tmp/codex",
+      kimiRoot: "/tmp/kimi",
+      opencodeRoot: "/tmp/opencode",
+    });
     core.filterSessions.mockImplementation((sessions: SessionHead[]) => sessions);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("initializes a sorted snapshot for allowed registered agents", async () => {
@@ -123,6 +168,7 @@ describe("LiveScanStore", () => {
   });
 
   it("emits refresh events and persists changed agent sessions", async () => {
+    vi.useFakeTimers();
     const previous = makeSession("session", { title: "old", time_updated: 1000 });
     const updated = makeSession("session", { title: "new", time_updated: 2000 });
     const added = makeSession("added", { time_updated: 1500 });
@@ -147,6 +193,7 @@ describe("LiveScanStore", () => {
     store.subscribe((event) => events.push(event));
     await store.initialize();
     await (store as any).runRefresh("codex");
+    await vi.advanceTimersByTimeAsync(250);
 
     expect(codex.checkForChanges).toHaveBeenCalledWith(expect.any(Number), [previous]);
     expect(codex.incrementalScan).toHaveBeenCalledWith(previous ? [previous] : [], [
@@ -206,17 +253,185 @@ describe("LiveScanStore", () => {
     ]);
     expect(store.getSnapshot().sessions).toEqual([]);
   });
+
+  it("uses native recursive watch and waits for appended files to stabilize", async () => {
+    vi.useFakeTimers();
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-watch-"));
+    const codexRoot = join(tempDir, "codex");
+    const sessionsDir = join(codexRoot, "sessions");
+    const sessionFile = join(sessionsDir, "new.jsonl");
+    mkdirSync(sessionsDir, { recursive: true });
+    core.resolveProviderRoots.mockReturnValue({
+      claudeRoot: join(tempDir, "claude"),
+      codexRoot,
+      kimiRoot: join(tempDir, "kimi"),
+      opencodeRoot: join(tempDir, "opencode"),
+    });
+
+    const newSession = makeSession("new");
+    const codex = makeAgent("codex", {
+      scan: vi.fn(() => [newSession]),
+    });
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [],
+      byAgent: { codex: [] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore(true, { agents: ["codex"] });
+    const events: SessionsUpdatedEvent[] = [];
+    store.subscribe((event) => events.push(event));
+
+    await store.initialize();
+    expect(fsWatch.watchers).toEqual([
+      expect.objectContaining({
+        path: codexRoot,
+        options: { recursive: true },
+      }),
+    ]);
+
+    writeFileSync(sessionFile, "partial");
+    fsWatch.watchers[0]!.listener("change", join("sessions", "new.jsonl"));
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(150);
+
+    appendFileSync(sessionFile, "\ncomplete");
+    fsWatch.watchers[0]!.listener("change", join("sessions", "new.jsonl"));
+    await Promise.resolve();
+    expect(codex.scan).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(codex.scan).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([
+      expect.objectContaining({
+        changedAgents: ["codex"],
+        newSessions: 1,
+      }),
+    ]);
+
+    await store.shutdown();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("logs refresh failures and handles later watch events", async () => {
+    vi.useFakeTimers();
+    const logError = vi.spyOn(appLogger, "error").mockImplementation(() => undefined);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-watch-error-"));
+    const codexRoot = join(tempDir, "codex");
+    const sessionsDir = join(codexRoot, "sessions");
+    const sessionFile = join(sessionsDir, "new.jsonl");
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(sessionFile, "session");
+    core.resolveProviderRoots.mockReturnValue({
+      claudeRoot: join(tempDir, "claude"),
+      codexRoot,
+      kimiRoot: join(tempDir, "kimi"),
+      opencodeRoot: join(tempDir, "opencode"),
+    });
+
+    const codex = makeAgent("codex", {
+      scan: vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error("bad file");
+        })
+        .mockImplementationOnce(() => [makeSession("new")]),
+    });
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [],
+      byAgent: { codex: [] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore(true, { agents: ["codex"] });
+    await store.initialize();
+
+    fsWatch.watchers[0]!.listener("change", join("sessions", "new.jsonl"));
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    appendFileSync(sessionFile, "\nretry");
+    fsWatch.watchers[0]!.listener("change", join("sessions", "new.jsonl"));
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(codex.scan).toHaveBeenCalledTimes(2);
+    expect(logError).toHaveBeenCalledWith(
+      "scan.refresh.error",
+      expect.objectContaining({ agent: "codex", error: expect.any(Error) }),
+    );
+
+    await store.shutdown();
+    rmSync(tempDir, { recursive: true, force: true });
+    consoleError.mockRestore();
+    logError.mockRestore();
+  });
+
+  it("merges new session events inside a short window", async () => {
+    vi.useFakeTimers();
+    const existingCodex = makeSession("codex-old");
+    const existingKimi = makeSession("kimi-old");
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["codex-new"],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [existingCodex, makeSession("codex-new")]),
+    });
+    const kimi = makeAgent("kimi", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["kimi-new"],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [existingKimi, makeSession("kimi-new")]),
+    });
+    core.createRegisteredAgents.mockReturnValue([codex, kimi]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [existingCodex, existingKimi],
+      byAgent: { codex: [existingCodex], kimi: [existingKimi] },
+      agents: [codex, kimi],
+    });
+
+    const store = new LiveScanStore(false);
+    const events: SessionsUpdatedEvent[] = [];
+    store.subscribe((event) => events.push(event));
+    await store.initialize();
+    await (store as any).runRefresh("codex");
+    await (store as any).runRefresh("kimi");
+
+    expect(events).toEqual([]);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        changedAgents: ["codex", "kimi"],
+        newSessions: 2,
+        updatedSessions: 0,
+        removedSessions: 0,
+        totalSessions: 4,
+      }),
+    ]);
+  });
 });
 
 describe("resolveAgentWatchTargets", () => {
   it("resolves cursor and opencode watch targets", () => {
     expect(resolveAgentWatchTargets("cursor")).toEqual([
-      { path: join("/tmp/cursor", "globalStorage", "state.vscdb") },
-      { path: join("/tmp/cursor", "workspaceStorage"), depth: 2 },
+      {
+        root: "/tmp/cursor",
+        path: join("/tmp/cursor", "globalStorage", "state.vscdb"),
+      },
+      { root: "/tmp/cursor", path: join("/tmp/cursor", "workspaceStorage") },
     ]);
     expect(resolveAgentWatchTargets("opencode")).toEqual([
-      { path: join("/tmp/opencode", "opencode.db") },
-      { path: "data/opencode/opencode.db" },
+      { root: "/tmp/opencode", path: join("/tmp/opencode", "opencode.db") },
+      { root: "data/opencode", path: "data/opencode/opencode.db" },
     ]);
     expect(resolveAgentWatchTargets("unknown")).toEqual([]);
   });

--- a/packages/cli/src/live-scan.test.ts
+++ b/packages/cli/src/live-scan.test.ts
@@ -11,7 +11,7 @@ describe("resolveAgentWatchTargets", () => {
     vi.stubEnv("CODEX_HOME", "/tmp/codex-home");
 
     expect(resolveAgentWatchTargets("codex")).toEqual([
-      { path: join("/tmp/codex-home", "sessions"), depth: 4 },
+      { root: "/tmp/codex-home", path: join("/tmp/codex-home", "sessions") },
     ]);
   });
 
@@ -19,8 +19,8 @@ describe("resolveAgentWatchTargets", () => {
     vi.stubEnv("CLAUDE_CONFIG_DIR", "/tmp/claude-home");
 
     expect(resolveAgentWatchTargets("claudecode")).toEqual([
-      { path: join("/tmp/claude-home", "projects"), depth: 2 },
-      { path: "data/claudecode", depth: 2 },
+      { root: "/tmp/claude-home", path: join("/tmp/claude-home", "projects") },
+      { path: "data/claudecode" },
     ]);
   });
 });

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync, watch, type FSWatcher } from "node:fs";
+import { existsSync, readdirSync, statSync, watch, type FSWatcher } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   createRegisteredAgents,
@@ -156,6 +156,30 @@ function getWatchRoot(path: string): string {
   return stat.isDirectory() ? path : dirname(path);
 }
 
+function isRecursiveWatchSupported(
+  platform = process.platform,
+  nodeVersion = process.versions.node,
+): boolean {
+  if (platform === "darwin" || platform === "win32") {
+    return true;
+  }
+  if (platform !== "linux" && platform !== "aix" && platform !== "ibmi") {
+    return false;
+  }
+
+  const [major = 0, minor = 0] = nodeVersion.split(".").map((part) => Number(part));
+  return major > 19 || (major === 19 && minor >= 1);
+}
+
+function isRecursiveWatchUnavailable(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ERR_FEATURE_UNAVAILABLE_ON_PLATFORM"
+  );
+}
+
 function isSameOrChildPath(parentPath: string, childPath: string): boolean {
   const path = relative(parentPath, childPath);
   return path === "" || (!path.startsWith("..") && !isAbsolute(path));
@@ -178,6 +202,26 @@ function mergeEvents(
     totalSessions: next.totalSessions,
     timestamp: next.timestamp,
   };
+}
+
+function mergeScopes(target: WatchScope[], scopes: WatchScope[]): void {
+  for (const scope of scopes) {
+    if (
+      !target.some(
+        (item) => item.agentName === scope.agentName && item.targetPath === scope.targetPath,
+      )
+    ) {
+      target.push(scope);
+    }
+  }
+}
+
+function resolveWatchEventPath(watchPath: string, filename: string | Buffer | null): string {
+  const filenameText = filename?.toString();
+  if (!filenameText) {
+    return watchPath;
+  }
+  return isAbsolute(filenameText) ? filenameText : join(watchPath, filenameText);
 }
 
 export function resolveAgentWatchTargets(agentName: string): WatchTarget[] {
@@ -227,6 +271,7 @@ export class LiveScanStore {
   private refreshInFlight = new Set<string>();
   private pendingRefreshes = new Set<string>();
   private watchers: FSWatcher[] = [];
+  private fallbackWatchScopes = new Map<string, WatchScope[]>();
   private stablePaths = new Map<string, StablePathState>();
   private pendingEvent: SessionsUpdatedEvent | null = null;
   private pendingEventTimer: NodeJS.Timeout | null = null;
@@ -309,6 +354,7 @@ export class LiveScanStore {
 
     await Promise.all(this.watchers.map((watcher) => watcher.close()));
     this.watchers = [];
+    this.fallbackWatchScopes.clear();
   }
 
   private emit(event: SessionsUpdatedEvent): void {
@@ -435,40 +481,105 @@ export class LiveScanStore {
         })),
       });
 
-      try {
-        const watcher = watch(rootPath, { recursive: true }, (eventType, filename) => {
-          queueMicrotask(() => {
-            try {
-              this.handleWatchEvent(rootPath, scopes, eventType, filename);
-            } catch (error) {
-              this.reportWatchError("watch.event.error", { root: rootPath, error });
+      if (isRecursiveWatchSupported()) {
+        const started = this.watchDirectory(rootPath, scopes, true);
+        if (started) {
+          continue;
+        }
+      }
+
+      this.watchDirectoryTree(rootPath, scopes);
+    }
+  }
+
+  private watchDirectory(path: string, scopes: WatchScope[], recursive: boolean): boolean {
+    try {
+      const watcher = watch(path, { recursive }, (eventType, filename) => {
+        queueMicrotask(() => {
+          try {
+            const activeScopes = recursive
+              ? scopes
+              : (this.fallbackWatchScopes.get(path) ?? scopes);
+            this.handleWatchEvent(path, activeScopes, eventType, filename);
+            if (!recursive) {
+              this.watchNewDirectories(path, filename, activeScopes);
             }
-          });
+          } catch (error) {
+            this.reportWatchError("watch.event.error", { path, recursive, error });
+          }
         });
+      });
 
-        watcher.on("error", (error) => {
-          this.reportWatchError("watch.error", { root: rootPath, agents, error });
-        });
+      watcher.on("error", (error) => {
+        this.reportWatchError("watch.error", { path, recursive, error });
+      });
 
-        this.watchers.push(watcher);
+      this.watchers.push(watcher);
+      return true;
+    } catch (error) {
+      if (recursive && isRecursiveWatchUnavailable(error)) {
+        appLogger.warn("watch.recursive_unavailable", { path, error });
+        return false;
+      }
+
+      this.reportWatchError("watch.start.error", { path, recursive, error });
+      return false;
+    }
+  }
+
+  private watchDirectoryTree(rootPath: string, scopes: WatchScope[]): void {
+    const pending = [rootPath];
+
+    while (pending.length > 0) {
+      const dirPath = pending.pop()!;
+      this.watchFallbackDirectory(dirPath, scopes);
+
+      try {
+        for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+          if (entry.isDirectory()) {
+            pending.push(join(dirPath, entry.name));
+          }
+        }
       } catch (error) {
-        this.reportWatchError("watch.start.error", { root: rootPath, agents, error });
+        this.reportWatchError("watch.scan.error", { path: dirPath, error });
       }
     }
   }
 
+  private watchFallbackDirectory(path: string, scopes: WatchScope[]): void {
+    const existingScopes = this.fallbackWatchScopes.get(path);
+    if (existingScopes) {
+      mergeScopes(existingScopes, scopes);
+      return;
+    }
+
+    const storedScopes = [...scopes];
+    this.fallbackWatchScopes.set(path, storedScopes);
+    if (!this.watchDirectory(path, storedScopes, false)) {
+      this.fallbackWatchScopes.delete(path);
+    }
+  }
+
+  private watchNewDirectories(
+    watchPath: string,
+    filename: string | Buffer | null,
+    scopes: WatchScope[],
+  ): void {
+    const path = resolveWatchEventPath(watchPath, filename);
+    try {
+      if (statSync(path).isDirectory()) {
+        this.watchDirectoryTree(path, scopes);
+      }
+    } catch {}
+  }
+
   private handleWatchEvent(
-    rootPath: string,
+    watchPath: string,
     scopes: WatchScope[],
     eventType: string,
     filename: string | Buffer | null,
   ): void {
-    const filenameText = filename?.toString();
-    const changedPath = filenameText
-      ? isAbsolute(filenameText)
-        ? filenameText
-        : join(rootPath, filenameText)
-      : rootPath;
+    const changedPath = resolveWatchEventPath(watchPath, filename);
     const agentNames = new Set(
       scopes
         .filter((scope) => isRelatedPath(changedPath, scope.targetPath))

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -1,6 +1,5 @@
-import { existsSync } from "node:fs";
-import { dirname, isAbsolute, join } from "node:path";
-import chokidar, { type FSWatcher } from "chokidar";
+import { existsSync, statSync, watch, type FSWatcher } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import {
   createRegisteredAgents,
   filterSessions,
@@ -31,8 +30,28 @@ type StoreListener = (event: SessionsUpdatedEvent) => void;
 
 interface WatchTarget {
   path: string;
-  depth?: number;
+  root?: string;
 }
+
+interface WatchScope {
+  agentName: string;
+  targetPath: string;
+}
+
+interface StablePathState {
+  path: string;
+  agentNames: Set<string>;
+  lastMtimeMs: number | null;
+  lastSize: number | null;
+  stableSince: number;
+  timer: NodeJS.Timeout | null;
+}
+
+const REFRESH_DEBOUNCE_MS = 200;
+const PENDING_REFRESH_DELAY_MS = 100;
+const WRITE_STABILITY_THRESHOLD_MS = 250;
+const WRITE_STABILITY_POLL_MS = 100;
+const NEW_SESSION_EVENT_WINDOW_MS = 250;
 
 function sortSessions(sessions: SessionHead[]): SessionHead[] {
   return [...sessions].sort(
@@ -110,12 +129,16 @@ function buildUpdateEvent(
   };
 }
 
+function toAbsolutePath(path: string): string {
+  return isAbsolute(path) ? path : resolve(path);
+}
+
 function closestWatchablePath(targetPath: string): string | null {
   if (!isAbsolute(targetPath) && !existsSync(targetPath)) {
     return null;
   }
 
-  let current = targetPath;
+  let current = toAbsolutePath(targetPath);
 
   while (!existsSync(current)) {
     const parent = dirname(current);
@@ -128,6 +151,35 @@ function closestWatchablePath(targetPath: string): string | null {
   return current;
 }
 
+function getWatchRoot(path: string): string {
+  const stat = statSync(path);
+  return stat.isDirectory() ? path : dirname(path);
+}
+
+function isSameOrChildPath(parentPath: string, childPath: string): boolean {
+  const path = relative(parentPath, childPath);
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+function isRelatedPath(changedPath: string, targetPath: string): boolean {
+  return isSameOrChildPath(targetPath, changedPath) || isSameOrChildPath(changedPath, targetPath);
+}
+
+function mergeEvents(
+  previous: SessionsUpdatedEvent,
+  next: SessionsUpdatedEvent,
+): SessionsUpdatedEvent {
+  return {
+    type: "sessions-updated",
+    changedAgents: Array.from(new Set([...previous.changedAgents, ...next.changedAgents])),
+    newSessions: previous.newSessions + next.newSessions,
+    updatedSessions: previous.updatedSessions + next.updatedSessions,
+    removedSessions: previous.removedSessions + next.removedSessions,
+    totalSessions: next.totalSessions,
+    timestamp: next.timestamp,
+  };
+}
+
 export function resolveAgentWatchTargets(agentName: string): WatchTarget[] {
   const roots = resolveProviderRoots();
   const cursorDataPath = getCursorDataPath();
@@ -135,27 +187,30 @@ export function resolveAgentWatchTargets(agentName: string): WatchTarget[] {
   switch (agentName) {
     case "claudecode":
       return [
-        { path: join(roots.claudeRoot, "projects"), depth: 2 },
-        { path: "data/claudecode", depth: 2 },
+        { root: roots.claudeRoot, path: join(roots.claudeRoot, "projects") },
+        { path: "data/claudecode" },
       ];
     case "codex":
-      return [{ path: join(roots.codexRoot, "sessions"), depth: 4 }];
+      return [{ root: roots.codexRoot, path: join(roots.codexRoot, "sessions") }];
     case "cursor":
       return cursorDataPath
         ? [
-            { path: join(cursorDataPath, "globalStorage", "state.vscdb") },
-            { path: join(cursorDataPath, "workspaceStorage"), depth: 2 },
+            {
+              root: cursorDataPath,
+              path: join(cursorDataPath, "globalStorage", "state.vscdb"),
+            },
+            { root: cursorDataPath, path: join(cursorDataPath, "workspaceStorage") },
           ]
         : [];
     case "kimi":
       return [
-        { path: join(roots.kimiRoot, "sessions"), depth: 2 },
-        { path: "data/kimi", depth: 2 },
+        { root: roots.kimiRoot, path: join(roots.kimiRoot, "sessions") },
+        { path: "data/kimi" },
       ];
     case "opencode":
       return [
-        { path: join(roots.opencodeRoot, "opencode.db") },
-        { path: "data/opencode/opencode.db" },
+        { root: roots.opencodeRoot, path: join(roots.opencodeRoot, "opencode.db") },
+        { root: "data/opencode", path: "data/opencode/opencode.db" },
       ];
     default:
       return [];
@@ -172,6 +227,9 @@ export class LiveScanStore {
   private refreshInFlight = new Set<string>();
   private pendingRefreshes = new Set<string>();
   private watchers: FSWatcher[] = [];
+  private stablePaths = new Map<string, StablePathState>();
+  private pendingEvent: SessionsUpdatedEvent | null = null;
+  private pendingEventTimer: NodeJS.Timeout | null = null;
 
   constructor(
     private readonly watchEnabled = true,
@@ -236,14 +294,52 @@ export class LiveScanStore {
     }
     this.refreshTimers.clear();
 
+    for (const state of this.stablePaths.values()) {
+      if (state.timer) {
+        clearTimeout(state.timer);
+      }
+    }
+    this.stablePaths.clear();
+
+    if (this.pendingEventTimer) {
+      clearTimeout(this.pendingEventTimer);
+      this.pendingEventTimer = null;
+    }
+    this.pendingEvent = null;
+
     await Promise.all(this.watchers.map((watcher) => watcher.close()));
     this.watchers = [];
   }
 
   private emit(event: SessionsUpdatedEvent): void {
+    if (this.pendingEvent || event.newSessions > 0) {
+      this.queueEvent(event);
+      return;
+    }
+
+    this.emitNow(event);
+  }
+
+  private emitNow(event: SessionsUpdatedEvent): void {
     for (const listener of this.listeners) {
       listener(event);
     }
+  }
+
+  private queueEvent(event: SessionsUpdatedEvent): void {
+    this.pendingEvent = this.pendingEvent ? mergeEvents(this.pendingEvent, event) : event;
+    if (this.pendingEventTimer) {
+      return;
+    }
+
+    this.pendingEventTimer = setTimeout(() => {
+      const pending = this.pendingEvent;
+      this.pendingEvent = null;
+      this.pendingEventTimer = null;
+      if (pending) {
+        this.emitNow(pending);
+      }
+    }, NEW_SESSION_EVENT_WINDOW_MS);
   }
 
   private rebuildSessions(): void {
@@ -296,60 +392,169 @@ export class LiveScanStore {
   }
 
   private startWatching(): void {
+    const scopesByRoot = new Map<string, WatchScope[]>();
+
     for (const agent of this.agents) {
-      const rawTargets = resolveAgentWatchTargets(agent.name);
-      const watchTargets = rawTargets
-        .map((target) => {
-          const watchPath = closestWatchablePath(target.path);
-          return watchPath ? { ...target, path: watchPath } : null;
-        })
-        .filter((target): target is WatchTarget => target !== null)
-        .filter(
-          (target, index, items) =>
-            items.findIndex((item) => item.path === target.path && item.depth === target.depth) ===
-            index,
-        );
+      const watchTargets = resolveAgentWatchTargets(agent.name);
 
       if (watchTargets.length === 0) {
         appLogger.debug("watch.skip", { agent: agent.name });
         continue;
       }
 
+      for (const target of watchTargets) {
+        const watchRootPath = closestWatchablePath(target.root ?? target.path);
+        if (!watchRootPath) continue;
+
+        let rootPath: string;
+        try {
+          rootPath = getWatchRoot(watchRootPath);
+        } catch (error) {
+          this.reportWatchError("watch.resolve.error", { path: watchRootPath, error });
+          continue;
+        }
+        const targetPath = toAbsolutePath(target.path);
+        const scopes = scopesByRoot.get(rootPath) ?? [];
+        if (
+          !scopes.some((scope) => scope.agentName === agent.name && scope.targetPath === targetPath)
+        ) {
+          scopes.push({ agentName: agent.name, targetPath });
+        }
+        scopesByRoot.set(rootPath, scopes);
+      }
+    }
+
+    for (const [rootPath, scopes] of scopesByRoot.entries()) {
+      const agents = Array.from(new Set(scopes.map((scope) => scope.agentName)));
       appLogger.info("watch.start", {
-        agent: agent.name,
-        targets: watchTargets.map((target) => ({
-          path: target.path,
-          depth: target.depth ?? 0,
+        root: rootPath,
+        agents,
+        targets: scopes.map((scope) => ({
+          agent: scope.agentName,
+          path: scope.targetPath,
         })),
       });
-      const watcher = chokidar.watch(
-        watchTargets.map((target) => target.path),
-        {
-          ignoreInitial: true,
-          awaitWriteFinish: {
-            stabilityThreshold: 250,
-            pollInterval: 100,
-          },
-          depth: watchTargets.reduce(
-            (maxDepth, target) => Math.max(maxDepth, target.depth ?? 0),
-            0,
-          ),
-        },
-      );
 
-      watcher.on("all", () => {
-        this.scheduleRefresh(agent.name);
-      });
-      watcher.on("error", (error) => {
-        appLogger.error("watch.error", { agent: agent.name, error });
-        console.error(`[${agent.name}] File watcher failed:`, error);
-      });
+      try {
+        const watcher = watch(rootPath, { recursive: true }, (eventType, filename) => {
+          queueMicrotask(() => {
+            try {
+              this.handleWatchEvent(rootPath, scopes, eventType, filename);
+            } catch (error) {
+              this.reportWatchError("watch.event.error", { root: rootPath, error });
+            }
+          });
+        });
 
-      this.watchers.push(watcher);
+        watcher.on("error", (error) => {
+          this.reportWatchError("watch.error", { root: rootPath, agents, error });
+        });
+
+        this.watchers.push(watcher);
+      } catch (error) {
+        this.reportWatchError("watch.start.error", { root: rootPath, agents, error });
+      }
     }
   }
 
-  private scheduleRefresh(agentName: string, delayMs = 200): void {
+  private handleWatchEvent(
+    rootPath: string,
+    scopes: WatchScope[],
+    eventType: string,
+    filename: string | Buffer | null,
+  ): void {
+    const filenameText = filename?.toString();
+    const changedPath = filenameText
+      ? isAbsolute(filenameText)
+        ? filenameText
+        : join(rootPath, filenameText)
+      : rootPath;
+    const agentNames = new Set(
+      scopes
+        .filter((scope) => isRelatedPath(changedPath, scope.targetPath))
+        .map((scope) => scope.agentName),
+    );
+
+    if (agentNames.size === 0) {
+      return;
+    }
+
+    appLogger.debug("watch.event", {
+      event: eventType,
+      path: changedPath,
+      agents: Array.from(agentNames),
+    });
+    this.waitForStablePath(changedPath, agentNames);
+  }
+
+  private waitForStablePath(path: string, agentNames: Set<string>): void {
+    const existing = this.stablePaths.get(path);
+    if (existing) {
+      for (const agentName of agentNames) {
+        existing.agentNames.add(agentName);
+      }
+      return;
+    }
+
+    const state: StablePathState = {
+      path,
+      agentNames: new Set(agentNames),
+      lastMtimeMs: null,
+      lastSize: null,
+      stableSince: Date.now(),
+      timer: null,
+    };
+    this.stablePaths.set(path, state);
+    this.pollStablePath(path);
+  }
+
+  private pollStablePath(path: string): void {
+    const state = this.stablePaths.get(path);
+    if (!state) {
+      return;
+    }
+
+    let size: number;
+    let mtimeMs: number;
+    try {
+      const stat = statSync(path);
+      size = stat.size;
+      mtimeMs = stat.mtimeMs;
+    } catch {
+      this.stablePaths.delete(path);
+      this.scheduleRefreshForAgents(state.agentNames);
+      return;
+    }
+
+    const now = Date.now();
+    const unchanged = state.lastSize === size && state.lastMtimeMs === mtimeMs;
+    if (!unchanged) {
+      state.lastSize = size;
+      state.lastMtimeMs = mtimeMs;
+      state.stableSince = now;
+    }
+
+    if (unchanged && now - state.stableSince >= WRITE_STABILITY_THRESHOLD_MS) {
+      this.stablePaths.delete(path);
+      this.scheduleRefreshForAgents(state.agentNames);
+      return;
+    }
+
+    state.timer = setTimeout(() => this.pollStablePath(path), WRITE_STABILITY_POLL_MS);
+  }
+
+  private scheduleRefreshForAgents(agentNames: Set<string>): void {
+    for (const agentName of agentNames) {
+      this.scheduleRefresh(agentName);
+    }
+  }
+
+  private reportWatchError(event: string, data: Record<string, unknown>): void {
+    appLogger.error(event, data);
+    console.error("[watch] File watcher failed:", data.error);
+  }
+
+  private scheduleRefresh(agentName: string, delayMs = REFRESH_DEBOUNCE_MS): void {
     appLogger.debug("scan.refresh.schedule", { agent: agentName, delay_ms: delayMs });
     const existing = this.refreshTimers.get(agentName);
     if (existing) {
@@ -375,11 +580,14 @@ export class LiveScanStore {
 
     try {
       await this.runRefresh(agentName);
+    } catch (error) {
+      appLogger.error("scan.refresh.error", { agent: agentName, error });
+      console.error(`[${agentName}] Session refresh failed:`, error);
     } finally {
       this.refreshInFlight.delete(agentName);
 
       if (this.pendingRefreshes.delete(agentName)) {
-        this.scheduleRefresh(agentName, 100);
+        this.scheduleRefresh(agentName, PENDING_REFRESH_DELAY_MS);
       }
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,9 +175,6 @@ importers:
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
-      chokidar:
-        specifier: ^4.0.3
-        version: 4.0.3
       citty:
         specifier: ^0.1.6
         version: 0.1.6


### PR DESCRIPTION
## What changed

- Replaced the LiveScan chokidar watcher with grouped native `fs.watch(..., { recursive: true })` roots.
- Added `size + mtime` stability polling before scheduling incremental refreshes.
- Added watcher/refresh error logging so later watch events continue to process.
- Coalesced short-window new-session SSE notifications into one merged event.
- Removed the direct `chokidar` dependency from the CLI package.

## Why

RD-331 calls for reducing watcher dependency surface while keeping appended session files and batched new sessions stable under live scanning.

## Validation

- `pnpm --filter codesesh format:check`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh test`
- `pnpm --filter codesesh build`

