### PR TITLE
perf(search): optimize FTS bulk sync

### DIFF
--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -21,7 +21,7 @@ import {
   syncSessionSearchIndex,
   upsertBookmark,
 } from "@codesesh/core";
-import { appLogger } from "../logging.js";
+import { appLogger, logSearchIndexSync } from "../logging.js";
 
 export interface ScanResultSource {
   getSnapshot(): ScanResult;
@@ -242,9 +242,10 @@ export function handleSearchSessions(
 
   for (const indexedAgent of scanResult.agents) {
     const sessions = scanResult.byAgent[indexedAgent.name] ?? [];
-    syncSessionSearchIndex(indexedAgent.name, sessions, (sessionId) =>
+    const syncResult = syncSessionSearchIndex(indexedAgent.name, sessions, (sessionId) =>
       indexedAgent.getSessionData(sessionId),
     );
+    logSearchIndexSync("api.search", syncResult);
   }
 
   const results = searchSessions(query, {

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -249,6 +249,38 @@ describe("LiveScanStore", () => {
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["session", "added"]);
   });
 
+  it("marks search index sync as bulk when many paths are pending", async () => {
+    const previous = makeSession("session", { title: "old", time_updated: 1000 });
+    const updated = makeSession("session", { title: "new", time_updated: 2000 });
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["session"],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [updated]),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [previous],
+      byAgent: { codex: [previous] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    (store as any).pendingRefreshPathCounts.set("codex", 101);
+    await (store as any).runRefresh("codex");
+
+    expect(core.syncSessionSearchIndex).toHaveBeenLastCalledWith(
+      "codex",
+      [updated],
+      expect.any(Function),
+      { isBulk: true },
+    );
+  });
+
   it("removes sessions when an agent becomes unavailable", async () => {
     const previous = makeSession("session");
     const codex = makeAgent("codex", {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -14,7 +14,7 @@ import {
   type SessionCacheMeta,
   type SessionHead,
 } from "@codesesh/core";
-import { appLogger } from "./logging.js";
+import { appLogger, logSearchIndexSync } from "./logging.js";
 
 export interface SessionsUpdatedEvent {
   type: "sessions-updated";
@@ -52,6 +52,7 @@ const PENDING_REFRESH_DELAY_MS = 100;
 const WRITE_STABILITY_THRESHOLD_MS = 250;
 const WRITE_STABILITY_POLL_MS = 100;
 const NEW_SESSION_EVENT_WINDOW_MS = 250;
+const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 
 function sortSessions(sessions: SessionHead[]): SessionHead[] {
   return [...sessions].sort(
@@ -270,6 +271,7 @@ export class LiveScanStore {
   private refreshTimestamps = new Map<string, number>();
   private refreshInFlight = new Set<string>();
   private pendingRefreshes = new Set<string>();
+  private pendingRefreshPathCounts = new Map<string, number>();
   private watchers: FSWatcher[] = [];
   private fallbackWatchScopes = new Map<string, WatchScope[]>();
   private stablePaths = new Map<string, StablePathState>();
@@ -338,6 +340,7 @@ export class LiveScanStore {
       clearTimeout(timer);
     }
     this.refreshTimers.clear();
+    this.pendingRefreshPathCounts.clear();
 
     for (const state of this.stablePaths.values()) {
       if (state.timer) {
@@ -656,6 +659,10 @@ export class LiveScanStore {
 
   private scheduleRefreshForAgents(agentNames: Set<string>): void {
     for (const agentName of agentNames) {
+      this.pendingRefreshPathCounts.set(
+        agentName,
+        (this.pendingRefreshPathCounts.get(agentName) ?? 0) + 1,
+      );
       this.scheduleRefresh(agentName);
     }
   }
@@ -705,6 +712,8 @@ export class LiveScanStore {
 
   private async runRefresh(agentName: string): Promise<void> {
     const startedAt = performance.now();
+    const pendingPathCount = this.pendingRefreshPathCounts.get(agentName) ?? 0;
+    this.pendingRefreshPathCounts.delete(agentName);
     const agent = this.agents.find((item) => item.name === agentName);
     if (!agent) {
       appLogger.warn("scan.refresh.missing_agent", { agent: agentName });
@@ -743,7 +752,19 @@ export class LiveScanStore {
     if (!this.hasStartupWindow()) {
       saveCachedSessions(agentName, nextSessions, buildAgentCacheMeta(agent));
     }
-    syncSessionSearchIndex(agentName, nextSessions, (sessionId) => agent.getSessionData(sessionId));
+    const searchIndexOptions =
+      pendingPathCount >= SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD ? { isBulk: true } : undefined;
+    const syncResult = searchIndexOptions
+      ? syncSessionSearchIndex(
+          agentName,
+          nextSessions,
+          (sessionId) => agent.getSessionData(sessionId),
+          searchIndexOptions,
+        )
+      : syncSessionSearchIndex(agentName, nextSessions, (sessionId) =>
+          agent.getSessionData(sessionId),
+        );
+    logSearchIndexSync("scan.refresh", syncResult, { pending_paths: pendingPathCount });
 
     const event = buildUpdateEvent(agentName, previousSessions, nextSessions);
     this.byAgent[agentName] = sortSessions(nextSessions);
@@ -760,6 +781,12 @@ export class LiveScanStore {
       new_sessions: event?.newSessions ?? 0,
       updated_sessions: event?.updatedSessions ?? 0,
       removed_sessions: event?.removedSessions ?? 0,
+      pending_paths: pendingPathCount,
+      search_index_mode: syncResult?.mode,
+      search_index_rebuild_duration_ms:
+        syncResult?.rebuildDurationMs == null
+          ? undefined
+          : Math.round(syncResult.rebuildDurationMs),
     });
   }
 }

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { SearchIndexSyncResult } from "@codesesh/core";
 
 type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -159,3 +160,27 @@ export class AppLogger {
 }
 
 export const appLogger = new AppLogger();
+
+export function logSearchIndexSync(
+  context: string,
+  result: SearchIndexSyncResult | null,
+  data: Record<string, unknown> = {},
+): void {
+  if (!result || result.mode !== "bulk" || result.rebuildDurationMs == null) {
+    return;
+  }
+
+  appLogger.info("search_index.sync", {
+    context,
+    agent: result.agentName,
+    mode: result.mode,
+    sessions: result.sessions,
+    changed: result.changed,
+    deleted: result.deleted,
+    indexed: result.indexed,
+    skipped: result.skipped,
+    duration_ms: Math.round(result.durationMs),
+    rebuild_duration_ms: Math.round(result.rebuildDurationMs),
+    ...data,
+  });
+}

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -559,6 +559,64 @@ describe("searchSessions", () => {
     expect(searchSessions("instant")).toHaveLength(1);
   });
 
+  it("restores missing FTS triggers before incremental sync", () => {
+    const session = makeSession("trigger");
+    const updated = {
+      ...session,
+      title: "Updated trigger",
+      stats: { ...session.stats, message_count: 2 },
+    };
+
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex("claudecode", [session], (sessionId) =>
+      makeSessionData(sessionId, "old trigger content"),
+    );
+
+    const db = new Database(getCachePath());
+    try {
+      db.exec(`
+        DROP TRIGGER session_documents_ai;
+        DROP TRIGGER session_documents_ad;
+        DROP TRIGGER session_documents_au;
+      `);
+    } finally {
+      db.close();
+    }
+
+    saveCachedSessions("claudecode", [updated]);
+    syncSessionSearchIndex("claudecode", [updated], () => ({
+      ...updated,
+      messages: [
+        {
+          id: "trigger-m1",
+          role: "user",
+          time_created: now,
+          parts: [{ type: "text", text: "old trigger content" }],
+        },
+        {
+          id: "trigger-m2",
+          role: "assistant",
+          time_created: now + 1,
+          parts: [{ type: "text", text: "healed trigger content" }],
+        },
+      ],
+    }));
+
+    const triggerDb = new Database(getCachePath(), { readonly: true });
+    try {
+      const row = triggerDb
+        .prepare(
+          "SELECT COUNT(*) AS value FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'session_documents_%'",
+        )
+        .get() as { value?: number };
+      expect(row.value).toBe(3);
+    } finally {
+      triggerDb.close();
+    }
+
+    expect(searchSessions("healed")).toHaveLength(1);
+  });
+
   it("upserts normalized message rows for indexed sessions", () => {
     const session = {
       ...makeSession("s1"),

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -449,6 +449,116 @@ describe("searchSessions", () => {
     expect(results[0]?.snippet).toContain("<mark>sqlite</mark>");
   });
 
+  it("bulk sync rebuilds FTS for large initial indexes", () => {
+    const sessions = Array.from({ length: 101 }, (_, index) => {
+      const session = makeSession(`bulk-${index}`);
+      if (index === 42) {
+        return {
+          ...session,
+          directory: "/tmp/bulk-project",
+          project_identity: {
+            kind: "path" as const,
+            key: "/tmp/bulk-project",
+            displayName: "bulk-project",
+          },
+        };
+      }
+      if (index === 43) {
+        return {
+          ...session,
+          directory: "/tmp/other-project",
+          project_identity: {
+            kind: "path" as const,
+            key: "/tmp/other-project",
+            displayName: "other-project",
+          },
+        };
+      }
+      return session;
+    });
+    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+
+    saveCachedSessions("claudecode", sessions);
+    const result = syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
+      ...sessionMap.get(sessionId)!,
+      messages: [
+        {
+          id: `${sessionId}-m1`,
+          role: "user",
+          time_created: now,
+          parts: [
+            {
+              type: "text",
+              text:
+                sessionId === "bulk-42" || sessionId === "bulk-43"
+                  ? "bulk needle project filter"
+                  : `bulk filler ${sessionId}`,
+            },
+          ],
+        },
+      ],
+    }));
+
+    expect(result).toMatchObject({
+      mode: "bulk",
+      sessions: 101,
+      changed: 101,
+      deleted: 0,
+      indexed: 101,
+      skipped: 0,
+    });
+    expect(result?.rebuildDurationMs).toBeGreaterThanOrEqual(0);
+
+    const allResults = searchSessions("needle");
+    expect(allResults).toHaveLength(2);
+
+    const filteredResults = searchSessions("needle", { cwd: "/tmp/bulk-project" });
+    expect(filteredResults).toHaveLength(1);
+    expect(filteredResults[0]?.session.id).toBe("bulk-42");
+    expect(filteredResults[0]?.snippet).toContain("<mark>needle</mark>");
+  });
+
+  it("keeps small incremental updates searchable immediately", () => {
+    const session = makeSession("small");
+    const updated = {
+      ...session,
+      stats: { ...session.stats, message_count: 2 },
+    };
+
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex("claudecode", [session], (sessionId) =>
+      makeSessionData(sessionId, "old search content"),
+    );
+
+    saveCachedSessions("claudecode", [updated]);
+    const result = syncSessionSearchIndex("claudecode", [updated], () => ({
+      ...updated,
+      messages: [
+        {
+          id: "small-m1",
+          role: "user",
+          time_created: now,
+          parts: [{ type: "text", text: "old search content" }],
+        },
+        {
+          id: "small-m2",
+          role: "assistant",
+          time_created: now + 1,
+          parts: [{ type: "text", text: "instant incremental token" }],
+        },
+      ],
+    }));
+
+    expect(result).toMatchObject({
+      mode: "incremental",
+      changed: 1,
+      indexed: 1,
+      deleted: 0,
+    });
+    expect(result?.rebuildDurationMs).toBeUndefined();
+    expect(searchSessions("instant")).toHaveLength(1);
+  });
+
   it("upserts normalized message rows for indexed sessions", () => {
     const session = {
       ...makeSession("s1"),

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -29,6 +29,7 @@ const CACHE_SCHEMA_VERSION = 7;
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
+const SEARCH_INDEX_BULK_SYNC_THRESHOLD = 100;
 
 export interface SessionCacheMeta {
   id: string;
@@ -40,6 +41,23 @@ export interface CachedResult {
   sessions: SessionHead[];
   meta: Record<string, SessionCacheMeta>;
   timestamp: number;
+}
+
+export interface SearchIndexSyncOptions {
+  isBulk?: boolean;
+  bulkThreshold?: number;
+}
+
+export interface SearchIndexSyncResult {
+  agentName: string;
+  mode: "bulk" | "incremental";
+  sessions: number;
+  changed: number;
+  deleted: number;
+  indexed: number;
+  skipped: number;
+  durationMs: number;
+  rebuildDurationMs?: number;
 }
 
 interface ScalarRow extends DatabaseRow {
@@ -327,7 +345,13 @@ function createSearchTables(db: SQLiteDatabase): void {
       content='session_documents',
       content_rowid='id'
     );
+  `);
 
+  createSearchTriggers(db);
+}
+
+function createSearchTriggers(db: SQLiteDatabase): void {
+  db.exec(`
     CREATE TRIGGER IF NOT EXISTS session_documents_ai AFTER INSERT ON session_documents BEGIN
       INSERT INTO session_documents_fts(rowid, title, content_text)
       VALUES (new.id, new.title, new.content_text);
@@ -344,6 +368,14 @@ function createSearchTables(db: SQLiteDatabase): void {
       INSERT INTO session_documents_fts(rowid, title, content_text)
       VALUES (new.id, new.title, new.content_text);
     END;
+  `);
+}
+
+function dropSearchTriggers(db: SQLiteDatabase): void {
+  db.exec(`
+    DROP TRIGGER IF EXISTS session_documents_ai;
+    DROP TRIGGER IF EXISTS session_documents_ad;
+    DROP TRIGGER IF EXISTS session_documents_au;
   `);
 }
 
@@ -914,6 +946,15 @@ function rebuildSearchIndex(db: SQLiteDatabase): void {
   db.exec("INSERT INTO session_documents_fts(session_documents_fts) VALUES ('rebuild')");
 }
 
+function shouldBulkSyncSearchIndex(options: SearchIndexSyncOptions, changedCount: number): boolean {
+  if (options.isBulk != null) {
+    return options.isBulk;
+  }
+
+  const threshold = options.bulkThreshold ?? SEARCH_INDEX_BULK_SYNC_THRESHOLD;
+  return threshold > 0 && changedCount >= threshold;
+}
+
 function ensureFtsConsistency(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents_fts")) {
     createSearchTables(db);
@@ -1364,12 +1405,14 @@ export function syncSessionSearchIndex(
   agentName: string,
   sessions: SessionHead[],
   loadSessionData: (sessionId: string) => SessionData,
-): void {
+  options: SearchIndexSyncOptions = {},
+): SearchIndexSyncResult | null {
   if (!hasCacheStorage()) {
-    return;
+    return null;
   }
 
-  withCacheDb((db) => {
+  return withCacheDb((db) => {
+    const startedAt = performance.now();
     const existingRows = db
       .prepare(
         "SELECT session_id, content_hash FROM session_documents WHERE agent_name = ? ORDER BY id",
@@ -1397,6 +1440,8 @@ export function syncSessionSearchIndex(
         existingMap.get(session.id) !== sessionContentHash(session) ||
         messageCountMap.get(session.id) !== session.stats.message_count,
     );
+    const changedCount = toDelete.length + toUpsert.length;
+    const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
 
     const loaded = toUpsert
       .map((session) => {
@@ -1555,7 +1600,34 @@ export function syncSessionSearchIndex(
       }
     });
 
-    write();
+    let rebuildDurationMs: number | undefined;
+    const needsRebuild = isBulk && (toDelete.length > 0 || loaded.length > 0);
+
+    if (needsRebuild) {
+      dropSearchTriggers(db);
+      try {
+        write();
+        const rebuildStartedAt = performance.now();
+        rebuildSearchIndex(db);
+        rebuildDurationMs = performance.now() - rebuildStartedAt;
+      } finally {
+        createSearchTriggers(db);
+      }
+    } else {
+      write();
+    }
+
+    return {
+      agentName,
+      mode: isBulk ? "bulk" : "incremental",
+      sessions: sessions.length,
+      changed: toUpsert.length,
+      deleted: toDelete.length,
+      indexed: loaded.length,
+      skipped: toUpsert.length - loaded.length,
+      durationMs: performance.now() - startedAt,
+      rebuildDurationMs,
+    };
   });
 }
 

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -959,6 +959,7 @@ function ensureFtsConsistency(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents_fts")) {
     createSearchTables(db);
   }
+  createSearchTriggers(db);
 
   try {
     db.exec(
@@ -1539,7 +1540,7 @@ export function syncSessionSearchIndex(
         indexed_at = excluded.indexed_at
     `);
 
-    const write = db.transaction(() => {
+    const writeRows = () => {
       for (const sessionId of toDelete) {
         deleteRow.run(agentName, sessionId);
         deleteMessages.run(agentName, sessionId, 0);
@@ -1598,23 +1599,22 @@ export function syncSessionSearchIndex(
           Date.now(),
         );
       }
-    });
+    };
 
     let rebuildDurationMs: number | undefined;
     const needsRebuild = isBulk && (toDelete.length > 0 || loaded.length > 0);
 
     if (needsRebuild) {
-      dropSearchTriggers(db);
-      try {
-        write();
+      db.transaction(() => {
+        dropSearchTriggers(db);
+        writeRows();
         const rebuildStartedAt = performance.now();
         rebuildSearchIndex(db);
         rebuildDurationMs = performance.now() - rebuildStartedAt;
-      } finally {
         createSearchTriggers(db);
-      }
+      })();
     } else {
-      write();
+      db.transaction(writeRows)();
     }
 
     return {

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -11,5 +11,6 @@ export {
   searchSessions,
   syncSessionSearchIndex,
 } from "./cache.js";
+export type { SearchIndexSyncOptions, SearchIndexSyncResult } from "./cache.js";
 export { perf } from "../utils/index.js";
 export type { PerfMarker } from "../utils/index.js";


### PR DESCRIPTION
## What changed

- Add bulk FTS sync mode for large session index updates.
- Temporarily disable search document FTS triggers during bulk writes, then rebuild the FTS index once.
- Keep incremental sync behavior for small updates so new results remain immediately searchable.
- Log bulk rebuild duration for performance diagnosis.
- Add regression coverage for bulk rebuild search correctness and pending path bulk detection.

## Why

RD-333 identified write amplification from updating the FTS table session by session during first scans or large file change batches. Batch writing the backing documents and rebuilding FTS once reduces SQLite write cost while preserving the existing realtime path for normal refreshes.

## Validation

- `pn test`
- `pn exec turbo run test --force`
- `pn build`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter codesesh lint`
- `git diff --check`

Linear: RD-333