### PR TITLE
feat(core): unify agent parse cleanup

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -197,4 +197,82 @@ describe("ClaudeCodeAgent cache refresh", () => {
       parts: [{ type: "text", text: "detached output" }],
     });
   });
+
+  it("filters internal-only sessions", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-test-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, "internal-only.jsonl"),
+      [
+        JSON.stringify({
+          type: "progress",
+          timestamp: "2026-04-20T10:00:00Z",
+          message: { role: "", content: "" },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    expect(agent.scan()).toEqual([]);
+  });
+
+  it("cleans internal tag blocks from visible messages", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-test-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const sessionId = "tagged-session";
+
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, `${sessionId}.jsonl`),
+      [
+        JSON.stringify({
+          type: "user",
+          uuid: "user-1",
+          timestamp: "2026-04-20T10:00:00Z",
+          cwd: "/tmp/project",
+          message: {
+            role: "user",
+            content:
+              "Visible request\n<command-name>clear</command-name>\n<local-command-stdout>noise</local-command-stdout>",
+          },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          uuid: "assistant-1",
+          timestamp: "2026-04-20T10:00:01Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "Visible answer <system-reminder>hidden</system-reminder>",
+              },
+            ],
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    const [head] = agent.scan();
+    const data = agent.getSessionData(sessionId);
+
+    expect(head?.title).toBe("Visible request");
+    expect(data.messages[0]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible request" }),
+    ]);
+    expect(data.messages[1]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible answer" }),
+    ]);
+  });
 });

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -267,6 +267,148 @@ describe("CodexAgent cache refresh", () => {
     expect(head?.model_usage).toEqual({ "gpt-5.5": 120, "gpt-5.4": 50 });
   });
 
+  it("falls back to untitled when no title source is available", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    const sessionFile = join(
+      tempDir,
+      "rollout-2026-04-20T10-00-00-019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa.jsonl",
+    );
+
+    writeFileSync(
+      sessionFile,
+      [
+        '{"timestamp":"2026-04-20T10:00:00Z","type":"session_meta","payload":{}}',
+        '{"timestamp":"2026-04-20T10:01:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.sessionIndexCache = new Map();
+
+    const head = agent.parseSessionHead(sessionFile);
+
+    expect(head?.title).toBe("Untitled Session");
+  });
+
+  it("filters internal-only sessions", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionFile = join(
+      tempDir,
+      "rollout-2026-04-20T10-00-00-019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa.jsonl",
+    );
+
+    writeFileSync(
+      sessionFile,
+      [
+        '{"timestamp":"2026-04-20T10:00:00Z","type":"progress","payload":{"type":"progress"}}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+
+    expect(agent.scan()).toEqual([]);
+  });
+
+  it("cleans internal tag blocks from messages and tool output", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const sessionFile = join(tempDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:00Z",
+          type: "session_meta",
+          payload: { cwd: "/tmp/project" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:01Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [
+              { type: "input_text", text: "<environment_context>noise</environment_context>" },
+            ],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:02Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content:
+              "Visible request\n<command-name>clear</command-name>\n<local-command-stdout>noise</local-command-stdout>",
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:03Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "Visible answer <system-reminder>hidden</system-reminder>",
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:04Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            call_id: "call-1",
+            name: "exec_command",
+            arguments: '{"cmd":"pwd"}',
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:05Z",
+          type: "response_item",
+          payload: {
+            type: "function_call_output",
+            call_id: "call-1",
+            output: "Visible output\n<local-command-stdout>/tmp/project</local-command-stdout>",
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+
+    const [head] = agent.scan();
+    const data = agent.getSessionData(sessionId);
+    const toolPart = data.messages[1]?.parts.find((part) => part.type === "tool");
+
+    expect(head?.title).toBe("Visible request");
+    expect(data.messages[0]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible request" }),
+    ]);
+    expect(data.messages[1]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "Visible answer",
+    });
+    expect(toolPart).toMatchObject({
+      type: "tool",
+      tool: "bash",
+      state: {
+        output: [expect.objectContaining({ type: "text", text: "Visible output" })],
+      },
+    });
+  });
+
   it("parses messages, plans, tools, outputs, and token usage", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/__tests__/cursor-opencode.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-opencode.test.ts
@@ -1,0 +1,193 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { CursorAgent } from "../cursor.js";
+import { OpenCodeAgent } from "../opencode.js";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("SQLite-backed agent parse contracts", () => {
+  it("cleans Cursor messages and resolves title/tool names consistently", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "state.vscdb");
+    const db = new Database(dbPath);
+    try {
+      db.exec("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)");
+      db.prepare("INSERT INTO cursorDiskKV(key, value) VALUES (?, ?)").run(
+        "composerData:composer-1",
+        JSON.stringify({ composerId: "composer-1", createdAt: 1000, updatedAt: 2000 }),
+      );
+      db.prepare("INSERT INTO cursorDiskKV(key, value) VALUES (?, ?)").run(
+        "bubbleId:composer-1:1",
+        JSON.stringify({
+          type: 1,
+          text: "Visible request\n<command-name>clear</command-name>",
+        }),
+      );
+      db.prepare("INSERT INTO cursorDiskKV(key, value) VALUES (?, ?)").run(
+        "bubbleId:composer-1:2",
+        JSON.stringify({
+          type: 2,
+          text: "Visible answer <system-reminder>hidden</system-reminder>",
+          toolFormerData: {
+            name: "read_file_v2",
+            toolCallId: "call-1",
+            status: "completed",
+            result: '{"contents":"ok"}',
+          },
+        }),
+      );
+      db.prepare("INSERT INTO cursorDiskKV(key, value) VALUES (?, ?)").run(
+        "bubbleId:composer-1:3",
+        JSON.stringify({ type: 1, eventType: "progress", text: "noise" }),
+      );
+    } finally {
+      db.close();
+    }
+
+    const agent = new CursorAgent() as any;
+    agent.dbPath = dbPath;
+    agent.buildWorkspacePathMap = () => new Map([["composer-1", "/tmp/project"]]);
+
+    const [head] = agent.scan({ from: 0 });
+    const data = agent.getSessionData("composer-1");
+    const tool = data.messages[1]?.parts.find((part) => part.type === "tool");
+
+    expect(head?.title).toBe("Visible request");
+    expect(data.messages).toHaveLength(2);
+    expect(data.messages[0]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible request" }),
+    ]);
+    expect(data.messages[1]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "Visible answer",
+    });
+    expect(tool).toMatchObject({ type: "tool", tool: "read", title: "Tool: read" });
+  });
+
+  it("cleans OpenCode messages and filters empty/internal parts", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-opencode-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "opencode.db");
+    const db = new Database(dbPath);
+    try {
+      db.exec(`
+        CREATE TABLE session (
+          id TEXT PRIMARY KEY,
+          title TEXT,
+          time_created INTEGER,
+          time_updated INTEGER,
+          slug TEXT,
+          directory TEXT,
+          version TEXT,
+          summary_files TEXT
+        );
+        CREATE TABLE message (
+          id TEXT PRIMARY KEY,
+          session_id TEXT,
+          time_created INTEGER,
+          data TEXT
+        );
+        CREATE TABLE part (
+          id TEXT PRIMARY KEY,
+          message_id TEXT,
+          time_created INTEGER,
+          data TEXT
+        );
+      `);
+      db.prepare("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?, ?, ?)").run(
+        "session-1",
+        "",
+        1000,
+        2000,
+        "",
+        "/tmp/project",
+        null,
+        null,
+      );
+      db.prepare("INSERT INTO message VALUES (?, ?, ?, ?)").run(
+        "m1",
+        "session-1",
+        1000,
+        JSON.stringify({ role: "user" }),
+      );
+      db.prepare("INSERT INTO part VALUES (?, ?, ?, ?)").run(
+        "p1",
+        "m1",
+        1000,
+        JSON.stringify({
+          type: "text",
+          text: "Visible request\n<local-command-stdout>noise</local-command-stdout>",
+        }),
+      );
+      db.prepare("INSERT INTO message VALUES (?, ?, ?, ?)").run(
+        "m2",
+        "session-1",
+        1500,
+        JSON.stringify({ role: "assistant", type: "progress" }),
+      );
+      db.prepare("INSERT INTO part VALUES (?, ?, ?, ?)").run(
+        "p2",
+        "m2",
+        1500,
+        JSON.stringify({ type: "progress", text: "noise" }),
+      );
+      db.prepare("INSERT INTO message VALUES (?, ?, ?, ?)").run(
+        "m3",
+        "session-1",
+        2000,
+        JSON.stringify({ role: "assistant" }),
+      );
+      db.prepare("INSERT INTO part VALUES (?, ?, ?, ?)").run(
+        "p3",
+        "m3",
+        2000,
+        JSON.stringify({
+          type: "tool",
+          tool: "bash",
+          title: "Tool: bash",
+          state: {
+            output: [
+              {
+                type: "text",
+                text: "Visible output\n<local-command-stdout>noise</local-command-stdout>",
+              },
+            ],
+          },
+        }),
+      );
+    } finally {
+      db.close();
+    }
+
+    const agent = new OpenCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const [head] = agent.scan({ from: 0 });
+    const data = agent.getSessionData("session-1");
+    const tool = data.messages[1]?.parts[0];
+
+    expect(head?.title).toBe("Visible request");
+    expect(head?.stats.message_count).toBe(2);
+    expect(data.messages).toHaveLength(2);
+    expect(data.messages[0]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible request" }),
+    ]);
+    expect(tool).toMatchObject({
+      type: "tool",
+      state: {
+        output: [expect.objectContaining({ type: "text", text: "Visible output" })],
+      },
+    });
+  });
+});

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { CursorAgent } from "../cursor.js";
+
+let tempDirs: string[] = [];
+
+function createCursorDb(tempDir: string): string {
+  const dbPath = join(tempDir, "state.vscdb");
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+  db.close();
+  return dbPath;
+}
+
+function insertKv(dbPath: string, key: string, value: unknown): void {
+  const db = new Database(dbPath);
+  db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)").run(key, JSON.stringify(value));
+  db.close();
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("CursorAgent parsing", () => {
+  it("cleans internal tags and keeps normalized tool names", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createCursorDb(tempDir);
+
+    insertKv(dbPath, "bubbleId:composer-1:user", {
+      type: 1,
+      text: "Visible request\n<command-name>clear</command-name>",
+      createdAt: 1_000,
+    });
+    insertKv(dbPath, "bubbleId:composer-1:assistant", {
+      type: 2,
+      text: "Visible answer <system-reminder>hidden</system-reminder>",
+      createdAt: 2_000,
+      toolFormerData: {
+        name: "run_terminal_command_v2",
+        toolCallId: "call-1",
+        status: "completed",
+        result: "Visible output\n<local-command-stdout>noise</local-command-stdout>",
+      },
+    });
+
+    const agent = new CursorAgent() as any;
+    agent.dbPath = dbPath;
+    agent.composerCache.set("composer-1", {
+      id: "composer-1",
+      text: "Fallback title",
+      createdAt: 1_000,
+      updatedAt: 2_000,
+    });
+
+    const data = agent.getSessionData("composer-1");
+    const toolPart = data.messages[1]?.parts.find((part) => part.type === "tool");
+
+    expect(data.title).toBe("Visible request");
+    expect(data.messages[0]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible request" }),
+    ]);
+    expect(data.messages[1]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "Visible answer",
+    });
+    expect(toolPart).toMatchObject({
+      type: "tool",
+      tool: "bash",
+      state: {
+        output: "Visible output",
+      },
+    });
+  });
+
+  it("falls back to untitled when no title text is available", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createCursorDb(tempDir);
+
+    insertKv(dbPath, "bubbleId:composer-1:assistant", {
+      type: 2,
+      text: "Assistant only",
+      createdAt: 1_000,
+    });
+
+    const agent = new CursorAgent() as any;
+    agent.dbPath = dbPath;
+    agent.composerCache.set("composer-1", {
+      id: "composer-1",
+      createdAt: 1_000,
+      updatedAt: 1_000,
+    });
+
+    const data = agent.getSessionData("composer-1");
+
+    expect(data.title).toBe("Untitled Session");
+  });
+});

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -169,4 +169,75 @@ describe("KimiAgent cache refresh", () => {
       },
     });
   });
+
+  it("uses the first user message as fallback title", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    const sessionDir = createSessionDir(basePath, "fallback-title", "", 1_000);
+    writeFileSync(
+      join(sessionDir, "context.jsonl"),
+      JSON.stringify({ role: "user", content: "Fallback title" }) + "\n",
+    );
+
+    const agent = createAgent(basePath);
+    const [head] = agent.scan();
+
+    expect(head?.title).toBe("Fallback title");
+  });
+
+  it("falls back to untitled when no title text is available", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    const sessionDir = createSessionDir(basePath, "untitled", "", 1_000);
+    writeFileSync(
+      join(sessionDir, "context.jsonl"),
+      JSON.stringify({
+        role: "assistant",
+        content: [{ type: "text", text: "Assistant only" }],
+      }) + "\n",
+    );
+
+    const agent = createAgent(basePath);
+    const [head] = agent.scan();
+
+    expect(head?.title).toBe("Untitled Session");
+  });
+
+  it("cleans internal tag blocks from parsed messages", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    const sessionDir = createSessionDir(basePath, "tagged-context", "Context", 1_000);
+    writeFileSync(
+      join(sessionDir, "context.jsonl"),
+      [
+        JSON.stringify({
+          role: "user",
+          content:
+            "Visible request\n<command-name>clear</command-name>\n<local-command-stdout>noise</local-command-stdout>",
+        }),
+        JSON.stringify({
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Visible answer <system-reminder>hidden</system-reminder>",
+            },
+          ],
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const agent = createAgent(basePath);
+    agent.scan();
+
+    const data = agent.getSessionData("tagged-context");
+
+    expect(data.messages[0]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible request" }),
+    ]);
+    expect(data.messages[1]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible answer" }),
+    ]);
+  });
 });

--- a/packages/core/src/agents/__tests__/opencode.test.ts
+++ b/packages/core/src/agents/__tests__/opencode.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { OpenCodeAgent } from "../opencode.js";
+
+let tempDirs: string[] = [];
+
+function createOpenCodeDb(tempDir: string): string {
+  const dbPath = join(tempDir, "opencode.db");
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      time_created INTEGER,
+      time_updated INTEGER,
+      slug TEXT,
+      directory TEXT,
+      version TEXT,
+      summary_files TEXT
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      data TEXT,
+      time_created INTEGER
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT,
+      data TEXT,
+      time_created INTEGER
+    );
+  `);
+  db.close();
+  return dbPath;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("OpenCodeAgent parsing", () => {
+  it("keeps sessions when the message table is unavailable", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-opencode-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "opencode.db");
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY,
+        title TEXT,
+        time_created INTEGER,
+        time_updated INTEGER,
+        slug TEXT,
+        directory TEXT,
+        version TEXT,
+        summary_files TEXT
+      );
+    `);
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory) VALUES (?, ?, ?, ?, ?)",
+    ).run("legacy-session", "Legacy session", 1_000, 2_000, "/tmp/project");
+    db.close();
+
+    const agent = new OpenCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const [head] = agent.scan({ from: 0 });
+
+    expect(head).toMatchObject({
+      id: "legacy-session",
+      title: "Legacy session",
+      stats: { message_count: 0 },
+    });
+  });
+
+  it("cleans internal tags and filters empty messages", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-opencode-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createOpenCodeDb(tempDir);
+    const db = new Database(dbPath);
+
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory) VALUES (?, ?, ?, ?, ?)",
+    ).run("session-1", "", 1_000, 2_000, "/tmp/project");
+    db.prepare("INSERT INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+      "empty-message",
+      "session-1",
+      JSON.stringify({ role: "assistant" }),
+      1_000,
+    );
+    db.prepare("INSERT INTO part (id, message_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+      "step-part",
+      "empty-message",
+      JSON.stringify({ type: "step-start" }),
+      1_000,
+    );
+    db.prepare("INSERT INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+      "user-message",
+      "session-1",
+      JSON.stringify({ role: "user" }),
+      1_100,
+    );
+    db.prepare("INSERT INTO part (id, message_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+      "user-part",
+      "user-message",
+      JSON.stringify({
+        type: "text",
+        text: "Visible request\n<command-name>clear</command-name>",
+      }),
+      1_100,
+    );
+    db.prepare("INSERT INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+      "assistant-message",
+      "session-1",
+      JSON.stringify({ role: "assistant" }),
+      1_200,
+    );
+    db.prepare("INSERT INTO part (id, message_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+      "tool-part",
+      "assistant-message",
+      JSON.stringify({
+        type: "tool",
+        tool: "bash",
+        callID: "call-1",
+        title: "Tool: bash",
+        state: {
+          output: "Visible output\n<local-command-stdout>noise</local-command-stdout>",
+        },
+      }),
+      1_200,
+    );
+    db.close();
+
+    const agent = new OpenCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const data = agent.getSessionData("session-1");
+
+    expect(data.title).toBe("Visible request");
+    expect(data.messages).toHaveLength(2);
+    expect(data.messages[0]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Visible request" }),
+    ]);
+    expect(data.messages[1]?.parts[0]).toMatchObject({
+      type: "tool",
+      tool: "bash",
+      state: {
+        output: "Visible output",
+      },
+    });
+  });
+});

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,4 +1,22 @@
-import type { SessionHead, SessionData } from "../types/index.js";
+import type { SessionHead, SessionData, ParseSessionResult } from "../types/index.js";
+
+export type { ParseSessionResult };
+
+export function parsedSession<T>(session: T): ParseSessionResult<T> {
+  return { status: "parsed", data: session };
+}
+
+export function skippedSession<T>(reason: string): ParseSessionResult<T> {
+  return { status: "skipped", reason };
+}
+
+export function filteredSession<T>(reason: string): ParseSessionResult<T> {
+  return { status: "filtered", reason };
+}
+
+export function getParsedSession<T>(result: ParseSessionResult<T>): T | null {
+  return result.status === "parsed" ? result.data : null;
+}
 
 export interface SessionCacheMeta {
   id: string;

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -1,10 +1,20 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
-import { BaseAgent, matchesScanWindow } from "./base.js";
+import {
+  BaseAgent,
+  filteredSession,
+  getParsedSession,
+  matchesScanWindow,
+  parsedSession,
+  skippedSession,
+} from "./base.js";
+import type { ParseSessionResult } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
 import { parseJsonlLines } from "../utils/jsonl.js";
-import { resolveSessionTitle, basenameTitle } from "../utils/title-fallback.js";
+import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
+import { isInternalEventType } from "../utils/parse-cleanup.js";
+import { cleanInternalText, cleanParsedMessages } from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
@@ -30,12 +40,6 @@ function parseTimestampMs(data: Record<string, unknown>): number {
   } catch {
     return 0;
   }
-}
-
-function normalizeTitleText(text: string): string {
-  // First non-empty line, truncated
-  const line = text.split("\n").find((l) => l.trim());
-  return line?.trim().slice(0, 80) || "";
 }
 
 export class ClaudeCodeAgent extends BaseAgent {
@@ -88,7 +92,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           if (!matchesScanWindow(statSync(file).mtimeMs, options)) continue;
 
           const parseMarker = perf.start(`parseSessionHead:${basename(file)}`);
-          const head = this.parseSessionHead(file, projectDir);
+          const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
           perf.end(parseMarker);
 
           if (head) {
@@ -162,7 +166,9 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
     }
 
-    for (const msg of messages) {
+    const cleanedMessages = cleanParsedMessages(messages);
+
+    for (const msg of cleanedMessages) {
       totalCost += msg.cost ?? 0;
       totalInputTokens += msg.tokens?.input ?? 0;
       totalOutputTokens += msg.tokens?.output ?? 0;
@@ -179,7 +185,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       time_created: meta.createdAt,
       time_updated: meta.updatedAt,
       stats: {
-        message_count: messages.length,
+        message_count: cleanedMessages.length,
         total_input_tokens: totalInputTokens,
         total_output_tokens: totalOutputTokens,
         total_cost: totalCost,
@@ -187,7 +193,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         total_cache_read_tokens: totalCacheRead,
         total_cache_create_tokens: totalCacheCreate,
       },
-      messages,
+      messages: cleanedMessages,
     };
   }
 
@@ -271,7 +277,7 @@ export class ClaudeCodeAgent extends BaseAgent {
 
           // 只处理变更的会话
           if (changedIds.includes(sessionId)) {
-            const head = this.parseSessionHead(file, projectDir);
+            const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
             if (head) {
               sessionMap.set(head.id, head);
               this.sessionMetaMap.set(head.id, {
@@ -298,7 +304,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         try {
           const sessionId = basename(file, ".jsonl");
           if (!sessionMap.has(sessionId)) {
-            const head = this.parseSessionHead(file, projectDir);
+            const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
             if (head) {
               sessionMap.set(head.id, head);
               this.sessionMetaMap.set(head.id, {
@@ -374,10 +380,17 @@ export class ClaudeCodeAgent extends BaseAgent {
   }
 
   private parseSessionHead(filePath: string, projectDir: string): SessionHead | null {
+    return getParsedSession(this.parseSessionHeadResult(filePath, projectDir));
+  }
+
+  private parseSessionHeadResult(
+    filePath: string,
+    projectDir: string,
+  ): ParseSessionResult<SessionHead> {
     const content = readFileSync(filePath, "utf-8");
     const lines = content.split("\n").filter((l) => l.trim());
 
-    if (lines.length === 0) return null;
+    if (lines.length === 0) return skippedSession("empty file");
 
     const sessionId = basename(filePath, ".jsonl");
 
@@ -385,7 +398,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     try {
       firstRecord = JSON.parse(lines[0]!);
     } catch {
-      return null;
+      return skippedSession("malformed first record");
     }
 
     const createdAt = parseTimestampMs(firstRecord) || statSync(filePath).mtimeMs;
@@ -410,6 +423,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     for (const line of lines) {
       try {
         const data = JSON.parse(line);
+        if (isInternalEventType(data["type"])) continue;
         const ts = parseTimestampMs(data);
         if (ts > updatedAt) updatedAt = ts;
 
@@ -472,8 +486,9 @@ export class ClaudeCodeAgent extends BaseAgent {
     const title = resolveSessionTitle(explicitTitle, messageTitle, directoryTitle);
 
     const hasModelUsage = Object.keys(modelUsageMap).length > 0;
+    if (messageCount === 0) return filteredSession("no visible messages");
 
-    return {
+    return parsedSession({
       id: sessionId,
       slug: `claudecode/${sessionId}`,
       title,
@@ -490,13 +505,14 @@ export class ClaudeCodeAgent extends BaseAgent {
         total_cache_create_tokens: totalCacheCreateTokens,
       },
       model_usage: hasModelUsage ? modelUsageMap : undefined,
-    };
+    });
   }
 
   private extractTitle(lines: string[]): string | null {
     for (const line of lines.slice(0, 20)) {
       try {
         const data = JSON.parse(line);
+        if (isInternalEventType(data["type"])) continue;
         const msg = data["message"];
         if (!msg || typeof msg !== "object") continue;
         if ((msg as Record<string, unknown>)["role"] !== "user") continue;
@@ -505,14 +521,16 @@ export class ClaudeCodeAgent extends BaseAgent {
         if (!content) continue;
 
         if (typeof content === "string") {
-          return normalizeTitleText(content);
+          const title = normalizeTitleText(content);
+          if (title) return title;
         }
         if (Array.isArray(content)) {
           const texts = content
             .filter((item) => typeof item === "object" && item !== null && "text" in item)
             .map((item) => String((item as Record<string, unknown>)["text"] ?? ""))
             .join(" ");
-          return normalizeTitleText(texts);
+          const title = normalizeTitleText(texts);
+          if (title) return title;
         }
       } catch {
         // skip
@@ -534,6 +552,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     if (data["isMeta"] === true) return;
 
     const msgType = String(data["type"] ?? "");
+    if (isInternalEventType(msgType)) return;
 
     if (msgType === "assistant") {
       this.convertAssistantRecord(
@@ -582,8 +601,8 @@ export class ClaudeCodeAgent extends BaseAgent {
         const partType = String(part["type"] ?? "");
 
         if (partType === "thinking") {
-          const text = String(part["thinking"] ?? "");
-          if (text.trim()) {
+          const text = cleanInternalText(String(part["thinking"] ?? ""));
+          if (text) {
             currentAssistantIndex = this.appendAssistantReasoning(
               messages,
               { messageId: uuid, msg, timestampMs, text },
@@ -594,8 +613,8 @@ export class ClaudeCodeAgent extends BaseAgent {
         }
 
         if (partType === "text") {
-          const text = String(part["text"] ?? "");
-          if (text.trim()) {
+          const text = cleanInternalText(String(part["text"] ?? ""));
+          if (text) {
             currentAssistantIndex = this.appendAssistantText(
               messages,
               { messageId: uuid, msg, timestampMs, text },
@@ -910,7 +929,8 @@ export class ClaudeCodeAgent extends BaseAgent {
 
   private normalizeUserTextParts(content: unknown, timestampMs: number): MessagePart[] {
     if (typeof content === "string") {
-      return content.trim() ? [this.buildTextPart(content, timestampMs)] : [];
+      const text = cleanInternalText(content);
+      return text ? [this.buildTextPart(text, timestampMs)] : [];
     }
     if (!Array.isArray(content)) return [];
 
@@ -919,10 +939,11 @@ export class ClaudeCodeAgent extends BaseAgent {
       if (typeof item === "object" && item !== null) {
         const ci = item as Record<string, unknown>;
         if (ci["type"] === "tool_result") continue;
-        const text = String(ci["text"] ?? "");
-        if (text.trim()) parts.push(this.buildTextPart(text, timestampMs));
-      } else if (typeof item === "string" && item.trim()) {
-        parts.push(this.buildTextPart(item, timestampMs));
+        const text = cleanInternalText(String(ci["text"] ?? ""));
+        if (text) parts.push(this.buildTextPart(text, timestampMs));
+      } else if (typeof item === "string") {
+        const text = cleanInternalText(item);
+        if (text) parts.push(this.buildTextPart(text, timestampMs));
       }
     }
     return parts;
@@ -930,7 +951,8 @@ export class ClaudeCodeAgent extends BaseAgent {
 
   private normalizeClaudeToolOutput(content: unknown, timestampMs: number): MessagePart[] {
     if (typeof content === "string") {
-      return content.trim() ? [this.buildTextPart(content, timestampMs)] : [];
+      const text = cleanInternalText(content);
+      return text ? [this.buildTextPart(text, timestampMs)] : [];
     }
     if (content === null || content === undefined) return [];
 
@@ -943,16 +965,18 @@ export class ClaudeCodeAgent extends BaseAgent {
               (item as Record<string, unknown>)["content"] ??
               "",
           );
-          if (text.trim()) parts.push(this.buildTextPart(text, timestampMs));
-        } else if (typeof item === "string" && item.trim()) {
-          parts.push(this.buildTextPart(item, timestampMs));
+          const cleaned = cleanInternalText(text);
+          if (cleaned) parts.push(this.buildTextPart(cleaned, timestampMs));
+        } else if (typeof item === "string") {
+          const text = cleanInternalText(item);
+          if (text) parts.push(this.buildTextPart(text, timestampMs));
         }
       }
       return parts;
     }
 
-    const text = String(content);
-    return text.trim() ? [this.buildTextPart(text, timestampMs)] : [];
+    const text = cleanInternalText(String(content));
+    return text ? [this.buildTextPart(text, timestampMs)] : [];
   }
 
   // --- Tool backfill ---

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -8,11 +8,24 @@ import {
   statSync,
 } from "node:fs";
 import { join, basename } from "node:path";
-import { BaseAgent, matchesScanWindow } from "./base.js";
+import {
+  BaseAgent,
+  filteredSession,
+  getParsedSession,
+  matchesScanWindow,
+  parsedSession,
+  skippedSession,
+} from "./base.js";
+import type { ParseSessionResult } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
 import { parseJsonlLines } from "../utils/jsonl.js";
-import { resolveSessionTitle, basenameTitle } from "../utils/title-fallback.js";
+import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
+import {
+  cleanInternalText,
+  cleanParsedMessages,
+  isInternalEventType,
+} from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
 
@@ -87,15 +100,6 @@ function extractModelName(raw: unknown): string | null {
 function extractCachedInputTokens(usage: Record<string, unknown> | undefined): number {
   if (!usage) return 0;
   return Number(usage["cached_input_tokens"] ?? usage["cache_read_input_tokens"] ?? 0);
-}
-
-// ---------------------------------------------------------------------------
-// Title helpers
-// ---------------------------------------------------------------------------
-
-function normalizeTitleText(text: string): string {
-  const line = text.split("\n").find((l) => l.trim());
-  return line?.trim().slice(0, 80) || "";
 }
 
 // ---------------------------------------------------------------------------
@@ -301,7 +305,7 @@ export class CodexAgent extends BaseAgent {
     for (const file of files) {
       try {
         const parseMarker = perf.start(`parseSessionHead:${basename(file)}`);
-        const head = this.parseSessionHead(file, options);
+        const head = getParsedSession(this.parseSessionHeadResult(file, options));
         perf.end(parseMarker);
 
         if (head) {
@@ -591,6 +595,7 @@ export class CodexAgent extends BaseAgent {
     if (pendingPlan && currentAssistantIndex !== null) {
       messages[currentAssistantIndex]!.parts.push(pendingPlan);
     }
+    const cleanedMessages = cleanParsedMessages(messages);
 
     return {
       id: meta.id,
@@ -600,14 +605,14 @@ export class CodexAgent extends BaseAgent {
       time_created: meta.createdAt,
       time_updated: meta.updatedAt,
       stats: {
-        message_count: messages.length,
+        message_count: cleanedMessages.length,
         total_input_tokens: totalInputTokens,
         total_output_tokens: totalOutputTokens,
         total_cache_read_tokens: totalCacheReadTokens || undefined,
         total_cost: totalCost,
         cost_source: totalCost > 0 ? "estimated" : undefined,
       },
-      messages,
+      messages: cleanedMessages,
     };
   }
 
@@ -683,13 +688,20 @@ export class CodexAgent extends BaseAgent {
   }
 
   private parseSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {
+    return getParsedSession(this.parseSessionHeadResult(filePath, options));
+  }
+
+  private parseSessionHeadResult(
+    filePath: string,
+    options?: AgentScanOptions,
+  ): ParseSessionResult<SessionHead> {
     if (options?.fast) {
-      return this.parseFastSessionHead(filePath);
+      return this.parseFastSessionHeadResult(filePath);
     }
 
     const content = readFileSync(filePath, "utf-8");
     const lines = content.split("\n").filter((l) => l.trim());
-    if (lines.length === 0) return null;
+    if (lines.length === 0) return skippedSession("empty file");
 
     const sessionId = extractSessionId(filePath);
 
@@ -697,7 +709,7 @@ export class CodexAgent extends BaseAgent {
     try {
       firstRecord = JSON.parse(lines[0]!);
     } catch {
-      return null;
+      return skippedSession("malformed first record");
     }
 
     const payload = (firstRecord["payload"] ?? {}) as Record<string, unknown>;
@@ -731,17 +743,22 @@ export class CodexAgent extends BaseAgent {
 
     const COUNTED_TYPES = new Set(["message", "function_call", "function_call_output"]);
 
+    let hasNonInternalRecord = false;
+
     for (const line of lines) {
       try {
         const data = JSON.parse(line);
         const recordType = String(data["type"] ?? "");
+        const payload = (data["payload"] ?? {}) as Record<string, unknown>;
+        const payloadType = String(payload["type"] ?? "");
+        if (isInternalEventType(recordType) || isInternalEventType(payloadType)) continue;
+        hasNonInternalRecord = true;
         const recordTs =
           parseTimestampMs(data) ||
           parseTimestampMs((data["payload"] ?? {}) as Record<string, unknown>);
         if (recordTs > updatedAt) updatedAt = recordTs;
 
         if (recordType === "session_meta" || recordType === "turn_context") {
-          const payload = (data["payload"] ?? {}) as Record<string, unknown>;
           const nextModel = extractModelName(payload["model"]);
           if (nextModel) {
             activeModel = nextModel;
@@ -751,7 +768,7 @@ export class CodexAgent extends BaseAgent {
         }
 
         if (recordType === "response_item") {
-          const p = (data["payload"] ?? {}) as Record<string, unknown>;
+          const p = payload;
           const pType = String(p["type"] ?? "");
           if (COUNTED_TYPES.has(pType)) {
             messageCount++;
@@ -823,9 +840,11 @@ export class CodexAgent extends BaseAgent {
       }
     }
 
+    if (!hasNonInternalRecord) return filteredSession("internal events only");
+
     const directory = payload["cwd"] ? String(payload["cwd"]) : "";
 
-    return {
+    return parsedSession({
       id: sessionId,
       slug: `codex/${sessionId}`,
       title,
@@ -841,13 +860,17 @@ export class CodexAgent extends BaseAgent {
         cost_source: totalCost > 0 ? "estimated" : undefined,
       },
       model_usage: Object.keys(modelUsageMap).length > 0 ? modelUsageMap : undefined,
-    };
+    });
   }
 
   private parseFastSessionHead(filePath: string): SessionHead | null {
+    return getParsedSession(this.parseFastSessionHeadResult(filePath));
+  }
+
+  private parseFastSessionHeadResult(filePath: string): ParseSessionResult<SessionHead> {
     const prefix = this.readFilePrefix(filePath);
     const lines = prefix.split("\n").filter((l) => l.trim());
-    if (lines.length === 0) return null;
+    if (lines.length === 0) return skippedSession("empty file");
 
     const sessionId = extractSessionId(filePath);
 
@@ -855,7 +878,7 @@ export class CodexAgent extends BaseAgent {
     try {
       firstRecord = JSON.parse(lines[0]!);
     } catch {
-      return null;
+      return skippedSession("malformed first record");
     }
 
     const payload = (firstRecord["payload"] ?? {}) as Record<string, unknown>;
@@ -867,7 +890,7 @@ export class CodexAgent extends BaseAgent {
     const directoryTitle = basenameTitle(directory || null);
     const title = resolveSessionTitle(indexTitle, messageTitle, directoryTitle);
 
-    return {
+    return parsedSession({
       id: sessionId,
       slug: `codex/${sessionId}`,
       title,
@@ -880,37 +903,34 @@ export class CodexAgent extends BaseAgent {
         total_output_tokens: 0,
         total_cost: 0,
       },
-    };
+    });
   }
 
   private extractTitleFromLines(lines: string[]): string | null {
-    let userMessageCount = 0;
     for (const line of lines.slice(0, 20)) {
       try {
         const data = JSON.parse(line);
         const recordType = String(data["type"] ?? "");
-        if (recordType !== "response_item") continue;
+        if (recordType !== "response_item" || isInternalEventType(recordType)) continue;
 
         const payload = (data["payload"] ?? {}) as Record<string, unknown>;
         const pType = String(payload["type"] ?? "");
-        if (pType !== "message") continue;
+        if (pType !== "message" || isInternalEventType(pType)) continue;
         if (String(payload["role"] ?? "") !== "user") continue;
 
-        // Skip the first user message (context injection); use the second
-        userMessageCount++;
-        if (userMessageCount < 2) continue;
-
         const content = payload["content"];
+        let text: string | null = null;
         if (Array.isArray(content)) {
-          const texts = content
+          text = content
             .filter((item) => typeof item === "object" && item !== null && "text" in item)
             .map((item) => String((item as Record<string, unknown>)["text"] ?? ""))
             .join(" ");
-          return normalizeTitleText(texts);
+        } else if (typeof content === "string") {
+          text = content;
         }
-        if (typeof content === "string") {
-          return normalizeTitleText(content);
-        }
+        if (!text || isDeveloperLikeUserMessage(text)) continue;
+        const title = normalizeTitleText(text);
+        if (title) return title;
       } catch {
         // skip
       }
@@ -934,6 +954,9 @@ export class CodexAgent extends BaseAgent {
     pendingPlan: MessagePart | null;
   } {
     const recordType = String(data["type"] ?? "");
+    if (isInternalEventType(recordType)) {
+      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+    }
 
     // Skip non-response records
     if (recordType === "session_meta" || recordType === "event_msg") {
@@ -946,6 +969,9 @@ export class CodexAgent extends BaseAgent {
 
     const payload = (data["payload"] ?? {}) as Record<string, unknown>;
     const payloadType = String(payload["type"] ?? "");
+    if (isInternalEventType(payloadType)) {
+      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+    }
     const timestampMs = parseTimestampMs(data) || parseTimestampMs(payload);
 
     switch (payloadType) {
@@ -1059,7 +1085,7 @@ export class CodexAgent extends BaseAgent {
     }
 
     // Build text part (strip the proposed plan tags)
-    const displayText = fullText.replace(PROPOSED_PLAN_PATTERN, "").trim();
+    const displayText = cleanInternalText(fullText.replace(PROPOSED_PLAN_PATTERN, ""));
     if (!displayText) {
       return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
     }
@@ -1117,17 +1143,18 @@ export class CodexAgent extends BaseAgent {
           .join(" ")
       : String(content ?? "");
 
-    if (!text.trim()) {
+    const visibleText = cleanInternalText(text);
+    if (!visibleText) {
       return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
     }
 
     // Skip injected developer/system context messages
-    if (isDeveloperLikeUserMessage(text)) {
+    if (isDeveloperLikeUserMessage(visibleText)) {
       return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
     }
 
     // Check for plan approval
-    if (text.trimStart().startsWith(PLAN_APPROVAL_PREFIX)) {
+    if (visibleText.trimStart().startsWith(PLAN_APPROVAL_PREFIX)) {
       // Finalize pending plan by attaching it to current assistant
       if (pendingPlan && currentAssistantIndex !== null) {
         messages[currentAssistantIndex]!.parts.push(pendingPlan);
@@ -1140,7 +1167,7 @@ export class CodexAgent extends BaseAgent {
           messageId: "",
           role: "user",
           timestampMs,
-          parts: [{ type: "text", text: text.trim(), time_created: timestampMs }],
+          parts: [{ type: "text", text: visibleText, time_created: timestampMs }],
         }),
       );
 
@@ -1150,7 +1177,7 @@ export class CodexAgent extends BaseAgent {
     }
 
     // Check for subagent notification
-    const subagentMatch = text.match(SUBAGENT_NOTIFICATION_PATTERN);
+    const subagentMatch = visibleText.match(SUBAGENT_NOTIFICATION_PATTERN);
     if (subagentMatch) {
       try {
         const notifPayload = JSON.parse(subagentMatch[1]!) as Record<string, unknown>;
@@ -1191,7 +1218,7 @@ export class CodexAgent extends BaseAgent {
         messageId: "",
         role: "user",
         timestampMs,
-        parts: [{ type: "text", text: text.trim(), time_created: timestampMs }],
+        parts: [{ type: "text", text: visibleText, time_created: timestampMs }],
       }),
     );
 
@@ -1347,8 +1374,8 @@ export class CodexAgent extends BaseAgent {
     const location = pendingToolCalls.get(callId);
     if (!location) return;
 
-    const outputText = String(payload["output"] ?? "");
-    const outputParts: MessagePart[] = outputText.trim()
+    const outputText = cleanInternalText(String(payload["output"] ?? ""));
+    const outputParts: MessagePart[] = outputText
       ? [{ type: "text", text: outputText, time_created: timestampMs }]
       : [];
 
@@ -1449,8 +1476,8 @@ export class CodexAgent extends BaseAgent {
     const location = pendingToolCalls.get(callId);
     if (!location) return;
 
-    const outputText = String(payload["output"] ?? "");
-    const outputParts: MessagePart[] = outputText.trim()
+    const outputText = cleanInternalText(String(payload["output"] ?? ""));
+    const outputParts: MessagePart[] = outputText
       ? [{ type: "text", text: outputText, time_created: timestampMs }]
       : [];
 

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -1,10 +1,23 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, normalize } from "node:path";
-import { BaseAgent, matchesScanWindow } from "./base.js";
+import {
+  BaseAgent,
+  filteredSession,
+  getParsedSession,
+  matchesScanWindow,
+  parsedSession,
+} from "./base.js";
 import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { getCursorDataPath } from "../discovery/paths.js";
 import { openDbReadOnly, isSqliteAvailable, type SQLiteDatabase } from "../utils/sqlite.js";
+import { resolveSessionTitle } from "../utils/title-fallback.js";
+import { isInternalEventType } from "../utils/parse-cleanup.js";
+import {
+  cleanInternalText,
+  cleanParsedMessages,
+  firstUserMessageTitle,
+} from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
 
@@ -114,9 +127,8 @@ function normalizeToolOutputParts(output: unknown, timestampMs: number): Message
   if (output == null) return [];
 
   if (typeof output === "string") {
-    return output.trim()
-      ? [{ type: "text" as const, text: output, time_created: timestampMs }]
-      : [];
+    const text = cleanInternalText(output);
+    return text ? [{ type: "text" as const, text, time_created: timestampMs }] : [];
   }
 
   if (Array.isArray(output)) {
@@ -126,17 +138,19 @@ function normalizeToolOutputParts(output: unknown, timestampMs: number): Message
         const text = String(
           (item as Record<string, unknown>).text ?? (item as Record<string, unknown>).content ?? "",
         );
-        if (text.trim()) parts.push({ type: "text", text, time_created: timestampMs });
-      } else if (typeof item === "string" && item.trim()) {
-        parts.push({ type: "text", text: item, time_created: timestampMs });
+        const cleaned = cleanInternalText(text);
+        if (cleaned) parts.push({ type: "text", text: cleaned, time_created: timestampMs });
+      } else if (typeof item === "string") {
+        const text = cleanInternalText(item);
+        if (text) parts.push({ type: "text", text, time_created: timestampMs });
       }
     }
     return parts;
   }
 
   // For object output, stringify for readability
-  const text = String(output);
-  return text.trim() ? [{ type: "text", text, time_created: timestampMs }] : [];
+  const text = cleanInternalText(String(output));
+  return text ? [{ type: "text", text, time_created: timestampMs }] : [];
 }
 
 /** Extract a timestamp (in ms) from a chat message */
@@ -148,6 +162,10 @@ function extractTimestamp(msg: ChatMessage): number {
     return msg.timestamp;
   }
   return 0;
+}
+
+function isInternalBubble(bubble: BubbleData): boolean {
+  return ["eventType", "kind", "subtype", "name"].some((key) => isInternalEventType(bubble[key]));
 }
 
 /** Build a normalized tool state object from an action entry */
@@ -202,7 +220,7 @@ function buildToolPart(action: ActionEntry, timestampMs: number): MessagePart {
 /** Build a MessagePart for terminal command actions */
 function buildTerminalToolPart(action: ActionEntry, timestampMs: number): MessagePart {
   const command = String(action.input?.command ?? "");
-  const description = String(action.input?.commandDescription ?? "");
+  const description = cleanInternalText(String(action.input?.commandDescription ?? ""));
 
   return {
     type: "tool",
@@ -386,7 +404,8 @@ export class CursorAgent extends BaseAgent {
             composer.updatedAt ?? composer.lastUpdatedAt ?? composer.lastSendTime ?? createdAt;
           if (!matchesScanWindow(updatedAt, options)) continue;
 
-          const title = this.extractTitle(composer);
+          const fastTitle = this.extractTitle(composer);
+          const hasFastMessages = Array.isArray(composer.chatMessages);
           const fastMessageCount = composer.chatMessages?.length ?? 0;
           const hasSubagents =
             Array.isArray(composer.subagentInfos) && composer.subagentInfos.length > 0;
@@ -397,21 +416,27 @@ export class CursorAgent extends BaseAgent {
                 input: composer.inputTokenCount ?? 0,
                 output: composer.outputTokenCount ?? 0,
               }) ?? 0;
-            heads.push({
-              id: composerId,
-              slug: `cursor/${composerId}`,
-              title,
-              directory,
-              time_created: createdAt,
-              time_updated: updatedAt || undefined,
-              stats: {
-                message_count: fastMessageCount,
-                total_input_tokens: composer.inputTokenCount ?? 0,
-                total_output_tokens: composer.outputTokenCount ?? 0,
-                total_cost: totalCost,
-                cost_source: totalCost > 0 ? "estimated" : undefined,
-              },
-            });
+            const head = getParsedSession(
+              hasFastMessages && fastMessageCount === 0 && !hasSubagents
+                ? filteredSession<SessionHead>("no visible messages")
+                : parsedSession<SessionHead>({
+                    id: composerId,
+                    slug: `cursor/${composerId}`,
+                    title: fastTitle,
+                    directory,
+                    time_created: createdAt,
+                    time_updated: updatedAt || undefined,
+                    stats: {
+                      message_count: fastMessageCount,
+                      total_input_tokens: composer.inputTokenCount ?? 0,
+                      total_output_tokens: composer.outputTokenCount ?? 0,
+                      total_cost: totalCost,
+                      cost_source: totalCost > 0 ? "estimated" : undefined,
+                    },
+                  }),
+            );
+            if (!head) continue;
+            heads.push(head);
             this.composerCache.set(composerId, composer);
             this.sessionMetaMap.set(composerId, {
               id: composerId,
@@ -425,16 +450,22 @@ export class CursorAgent extends BaseAgent {
           const sessionId = requestId || composerId;
 
           // Load actual messages to filter out empty composers
-          const messages = this.loadMessagesFromBubbles(
-            db,
-            composerId,
-            sessionId,
-            composer.modelConfig?.modelName ?? composer.model ?? null,
+          const parsedMessages = cleanParsedMessages(
+            this.loadMessagesFromBubbles(
+              db,
+              composerId,
+              sessionId,
+              composer.modelConfig?.modelName ?? composer.model ?? null,
+            ),
           );
-          if (messages.length === 0 && !hasSubagents) {
-            continue; // Skip empty sessions
-          }
+          const messages = getParsedSession(
+            parsedMessages.length === 0 && !hasSubagents
+              ? filteredSession<Message[]>("no visible messages")
+              : parsedSession(parsedMessages),
+          );
+          if (!messages) continue;
           const messageCount = messages.length;
+          const title = this.extractTitle(composer, messages);
 
           const directory = workspacePathMap.get(composerId) ?? "";
 
@@ -585,7 +616,6 @@ export class CursorAgent extends BaseAgent {
       }
 
       const composerId = composer.id || composer.composerId || "";
-      const title = this.extractTitle(composer);
       const createdAt = composer.createdAt ?? 0;
       const updatedAt = composer.updatedAt ?? createdAt;
 
@@ -597,12 +627,17 @@ export class CursorAgent extends BaseAgent {
         composer.modelConfig?.modelName ?? composer.model ?? null,
       );
 
+      // Append subagent messages
+      this.appendSubagentMessages(db, composer, messages);
+      const cleanedMessages = cleanParsedMessages(messages);
+      const title = this.extractTitle(composer, cleanedMessages);
+
       // Aggregate stats
       let totalInputTokens = 0;
       let totalOutputTokens = 0;
       let totalCost = 0;
 
-      for (const msg of messages) {
+      for (const msg of cleanedMessages) {
         totalInputTokens += msg.tokens?.input ?? 0;
         totalOutputTokens += msg.tokens?.output ?? 0;
         totalCost += msg.cost ?? 0;
@@ -619,9 +654,6 @@ export class CursorAgent extends BaseAgent {
           }) ?? 0;
       }
 
-      // Append subagent messages
-      this.appendSubagentMessages(db, composer, messages);
-
       // Retrieve directory from cache (populated during scan) or build map on demand
       const cachedDir = this.composerCache.get(`__dir__${composerId}`);
       const directory =
@@ -637,13 +669,13 @@ export class CursorAgent extends BaseAgent {
         time_created: createdAt,
         time_updated: updatedAt || undefined,
         stats: {
-          message_count: messages.length,
+          message_count: cleanedMessages.length,
           total_input_tokens: totalInputTokens,
           total_output_tokens: totalOutputTokens,
           total_cost: totalCost,
           cost_source: totalCost > 0 ? "estimated" : undefined,
         },
-        messages,
+        messages: cleanedMessages,
       };
     } finally {
       db.close();
@@ -708,23 +740,10 @@ export class CursorAgent extends BaseAgent {
   }
 
   /** Extract title from composer (like agent-dump) */
-  private extractTitle(composer: ComposerData): string {
-    if (composer.name && typeof composer.name === "string" && composer.name.trim()) {
-      return composer.name.trim();
-    }
-    if (composer.title && typeof composer.title === "string" && composer.title.trim()) {
-      return composer.title.trim();
-    }
-    if (composer.text && typeof composer.text === "string" && composer.text.trim()) {
-      const firstLine = composer.text
-        .split("\n")
-        .find((l) => l.trim())
-        ?.trim()
-        .slice(0, 80);
-      if (firstLine) return firstLine;
-    }
-    const composerId = composer.composerId || composer.id || "";
-    return `Cursor Session ${composerId.slice(0, 8)}`;
+  private extractTitle(composer: ComposerData, messages: Message[] = []): string {
+    const explicit = composer.name || composer.title;
+    const messageTitle = firstUserMessageTitle(messages) ?? composer.text;
+    return resolveSessionTitle(explicit, messageTitle, null);
   }
 
   /** Count messages from bubbles */
@@ -772,6 +791,7 @@ export class CursorAgent extends BaseAgent {
       for (const row of rows) {
         try {
           const bubble = JSON.parse(row.value) as BubbleData;
+          if (isInternalBubble(bubble)) continue;
           const bubbleId = row.key.split(":").pop() || String(messageIndex);
 
           // Determine role: type 2 = assistant, otherwise user
@@ -800,7 +820,7 @@ export class CursorAgent extends BaseAgent {
           const parts: MessagePart[] = [];
 
           // Text content
-          const text = bubble.text?.trim();
+          const text = cleanInternalText(bubble.text ?? "");
           if (text) {
             parts.push({ type: "text", text, time_created: timestampMs });
           }
@@ -913,7 +933,7 @@ export class CursorAgent extends BaseAgent {
       type: "tool",
       tool: normalizedName,
       callID: toolData.toolCallId || "",
-      title: `Tool: ${toolName}`,
+      title: `Tool: ${normalizedName}`,
       state,
       time_created: timestampMs,
     };
@@ -968,13 +988,14 @@ export class CursorAgent extends BaseAgent {
         const timestampMs = extractTimestamp(chatMsg);
         const parts: MessagePart[] = [];
 
-        const text = chatMsg.text ?? "";
-        if (text.trim()) {
+        const text = cleanInternalText(chatMsg.text ?? "");
+        if (text) {
           parts.push({ type: "text", text, time_created: timestampMs });
         }
 
         if (role === "assistant" && Array.isArray(chatMsg.actions)) {
           for (const action of chatMsg.actions) {
+            if (isInternalEventType(action.type) || isInternalEventType(action.tool)) continue;
             const part = convertActionToPart(action as ActionEntry, timestampMs);
             if (part) parts.push(part);
           }

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,5 +1,7 @@
 export { BaseAgent } from "./base.js";
+export { filteredSession, getParsedSession, parsedSession, skippedSession } from "./base.js";
 export type { SessionCacheMeta, ChangeCheckResult } from "./base.js";
+export type { ParseSessionResult } from "../types/index.js";
 export {
   registerAgent,
   createRegisteredAgents,

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -1,10 +1,25 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
-import { BaseAgent, matchesScanWindow } from "./base.js";
+import {
+  BaseAgent,
+  getParsedSession,
+  matchesScanWindow,
+  parsedSession,
+  skippedSession,
+} from "./base.js";
+import type {
+  AgentScanOptions,
+  ChangeCheckResult,
+  ParseSessionResult,
+  SessionCacheMeta,
+} from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
 import { parseJsonlLines } from "../utils/jsonl.js";
+import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
+import { isInternalEventType } from "../utils/parse-cleanup.js";
+import { cleanInternalText, cleanParsedMessages } from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
 
@@ -22,8 +37,6 @@ const KIMI_IGNORED_TOOLS = new Set(["SetTodoList"]);
 function mapToolTitle(toolName: string): string {
   return KIMI_TOOL_TITLE_MAP[toolName] ?? toolName;
 }
-
-import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
 
 interface SessionMeta extends SessionCacheMeta {
   id: string;
@@ -54,41 +67,82 @@ function normalizeToolArguments(raw: unknown): unknown {
 
 function normalizeToolOutputParts(content: unknown, timestampMs: number): MessagePart[] {
   if (typeof content === "string") {
-    return content.trim()
-      ? [{ type: "text" as const, text: content, time_created: timestampMs }]
-      : [];
+    const text = cleanInternalText(content);
+    return text ? [{ type: "text" as const, text, time_created: timestampMs }] : [];
   }
   if (Array.isArray(content)) {
     const parts: MessagePart[] = [];
     for (const item of content) {
       if (typeof item === "object" && item !== null && "text" in item) {
         const text = String((item as Record<string, unknown>).text ?? "");
-        if (text.trim()) parts.push({ type: "text", text, time_created: timestampMs });
-      } else if (typeof item === "string" && item.trim()) {
-        parts.push({ type: "text", text: item, time_created: timestampMs });
+        const cleaned = cleanInternalText(text);
+        if (cleaned) parts.push({ type: "text", text: cleaned, time_created: timestampMs });
+      } else if (typeof item === "string") {
+        const text = cleanInternalText(item);
+        if (text) parts.push({ type: "text", text, time_created: timestampMs });
       }
     }
     return parts;
   }
   if (content == null) return [];
-  const text = String(content);
-  return text.trim() ? [{ type: "text", text, time_created: timestampMs }] : [];
+  const text = cleanInternalText(String(content));
+  return text ? [{ type: "text", text, time_created: timestampMs }] : [];
 }
 
 function normalizeWireToolOutputParts(returnValue: unknown, timestampMs: number): MessagePart[] {
   if (returnValue == null) return [];
   if (typeof returnValue === "string") {
-    return returnValue.trim()
-      ? [{ type: "text" as const, text: returnValue, time_created: timestampMs }]
-      : [];
+    const text = cleanInternalText(returnValue);
+    return text ? [{ type: "text" as const, text, time_created: timestampMs }] : [];
   }
   if (typeof returnValue === "object") {
-    return [
-      { type: "text", text: JSON.stringify(returnValue, null, 2), time_created: timestampMs },
-    ];
+    const text = cleanInternalText(JSON.stringify(returnValue, null, 2));
+    return text ? [{ type: "text", text, time_created: timestampMs }] : [];
   }
-  const text = String(returnValue);
-  return text.trim() ? [{ type: "text", text, time_created: timestampMs }] : [];
+  const text = cleanInternalText(String(returnValue));
+  return text ? [{ type: "text", text, time_created: timestampMs }] : [];
+}
+
+function kimiContentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  return content
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (typeof item === "object" && item !== null) {
+        const record = item as Record<string, unknown>;
+        return String(record.text ?? record.content ?? "");
+      }
+      return "";
+    })
+    .join(" ");
+}
+
+function extractFirstUserTitle(contextFile: string | null, wireFile: string | null): string | null {
+  if (contextFile && existsSync(contextFile)) {
+    const content = readFileSync(contextFile, "utf-8");
+    for (const record of parseJsonlLines(content)) {
+      if (record.role !== "user") continue;
+      const title = normalizeTitleText(kimiContentText(record.content));
+      if (title) return title;
+    }
+  }
+
+  if (wireFile && existsSync(wireFile)) {
+    const content = readFileSync(wireFile, "utf-8");
+    for (const record of parseJsonlLines(content)) {
+      const message = (record.message ?? {}) as Record<string, unknown>;
+      if (message.type !== "TurnBegin") continue;
+      const payload = (message.payload ?? {}) as Record<string, unknown>;
+      const userInput = payload.user_input;
+      if (!Array.isArray(userInput)) continue;
+      const title = normalizeTitleText(kimiContentText(userInput));
+      if (title) return title;
+    }
+  }
+
+  return null;
 }
 
 export class KimiAgent extends BaseAgent {
@@ -173,13 +227,19 @@ export class KimiAgent extends BaseAgent {
 
   /** Parse session directory, preferring state.json over metadata.json */
   private parseSessionDir(sessionDir: string): SessionMeta | null {
+    return getParsedSession(this.parseSessionDirResult(sessionDir));
+  }
+
+  private parseSessionDirResult(sessionDir: string): ParseSessionResult<SessionMeta> {
     try {
       const sessionId = basename(sessionDir);
       const projectHash = basename(dirname(sessionDir));
       const contextFile = join(sessionDir, "context.jsonl");
       const wireFile = join(sessionDir, "wire.jsonl");
 
-      if (!existsSync(contextFile) && !existsSync(wireFile)) return null;
+      if (!existsSync(contextFile) && !existsSync(wireFile)) {
+        return skippedSession("missing transcript");
+      }
 
       const statePath = join(sessionDir, "state.json");
       const metaPath = join(sessionDir, "metadata.json");
@@ -201,6 +261,9 @@ export class KimiAgent extends BaseAgent {
       }
 
       const cwd = this.projectMap.get(projectHash) || "";
+      const existingContextFile = existsSync(contextFile) ? contextFile : null;
+      const existingWireFile = existsSync(wireFile) ? wireFile : null;
+      const messageTitle = extractFirstUserTitle(existingContextFile, existingWireFile);
       const createdAt =
         wireMtime !== null
           ? wireMtime * 1000
@@ -208,18 +271,18 @@ export class KimiAgent extends BaseAgent {
             ? statSync(metaFile).mtimeMs
             : statSync(sessionDir).mtimeMs;
 
-      return {
+      return parsedSession({
         id: sessionId,
-        title: title || "Untitled Session",
+        title: resolveSessionTitle(title, messageTitle, null),
         sourcePath: sessionDir,
         cwd,
-        contextFile: existsSync(contextFile) ? contextFile : null,
-        wireFile: existsSync(wireFile) ? wireFile : null,
+        contextFile: existingContextFile,
+        wireFile: existingWireFile,
         createdAt,
         metaFile,
-      };
+      });
     } catch {
-      return null;
+      return skippedSession("malformed metadata");
     }
   }
 
@@ -236,7 +299,7 @@ export class KimiAgent extends BaseAgent {
     for (const dir of sessionDirs) {
       try {
         const parseMarker = perf.start(`parseSessionDir:${basename(dir)}`);
-        const meta = this.parseSessionDir(dir);
+        const meta = getParsedSession(this.parseSessionDirResult(dir));
         perf.end(parseMarker);
 
         if (!meta) continue;
@@ -279,7 +342,7 @@ export class KimiAgent extends BaseAgent {
     const currentIds = new Set<string>();
 
     for (const dir of this.listSessionDirs()) {
-      const meta = this.parseSessionDir(dir);
+      const meta = getParsedSession(this.parseSessionDirResult(dir));
       if (!meta) continue;
 
       currentIds.add(meta.id);
@@ -334,7 +397,7 @@ export class KimiAgent extends BaseAgent {
 
     for (const dir of this.listSessionDirs()) {
       try {
-        const meta = this.parseSessionDir(dir);
+        const meta = getParsedSession(this.parseSessionDirResult(dir));
         if (!meta) continue;
 
         if (changedIdSet.has(meta.id)) {
@@ -382,11 +445,11 @@ export class KimiAgent extends BaseAgent {
       seq++;
       try {
         const role = String(record.role ?? "");
-        if (role === "_checkpoint" || role === "_usage") continue;
+        if (role === "_checkpoint" || role === "_usage" || isInternalEventType(role)) continue;
 
         if (role === "user") {
-          const text = String(record.content ?? "");
-          if (text.trim()) {
+          const text = cleanInternalText(kimiContentText(record.content));
+          if (text) {
             messages.push(
               this.buildMessage({
                 messageId: `context-${seq}`,
@@ -461,6 +524,7 @@ export class KimiAgent extends BaseAgent {
       try {
         const message = (record.message ?? {}) as Record<string, unknown>;
         const msgType = String(message.type ?? "");
+        if (isInternalEventType(msgType)) continue;
         const payload = (message.payload ?? {}) as Record<string, unknown>;
         const timestamp = Number(record.timestamp ?? 0);
         const timestampMs = Number.isFinite(timestamp) ? Math.floor(timestamp * 1000) : 0;
@@ -490,8 +554,8 @@ export class KimiAgent extends BaseAgent {
         if (msgType === "TurnBegin") {
           const userInput = payload.user_input;
           if (Array.isArray(userInput) && userInput.length > 0) {
-            const text = String((userInput[0] as Record<string, unknown>)?.text ?? "");
-            if (text.trim()) {
+            const text = cleanInternalText(kimiContentText(userInput));
+            if (text) {
               messages.push(
                 this.buildMessage({
                   messageId: `wire-${seq}`,
@@ -516,13 +580,13 @@ export class KimiAgent extends BaseAgent {
           const assistant = messages[currentAssistantIndex]!;
           const partType = String(payload.type ?? "");
           if (partType === "think") {
-            const text = String(payload.think ?? "");
-            if (text.trim()) {
+            const text = cleanInternalText(String(payload.think ?? ""));
+            if (text) {
               assistant.parts.push({ type: "reasoning", text, time_created: timestampMs });
             }
           } else if (partType === "text") {
-            const text = String(payload.text ?? "");
-            if (text.trim()) {
+            const text = cleanInternalText(String(payload.text ?? ""));
+            if (text) {
               assistant.parts.push({ type: "text", text, time_created: timestampMs });
             }
           }
@@ -665,11 +729,11 @@ export class KimiAgent extends BaseAgent {
         const partType = String(ci.type ?? "");
 
         if (partType === "think") {
-          const text = String(ci.think ?? "");
-          if (text.trim()) parts.push({ type: "reasoning", text, time_created: fallbackTs });
+          const text = cleanInternalText(String(ci.think ?? ""));
+          if (text) parts.push({ type: "reasoning", text, time_created: fallbackTs });
         } else if (partType === "text") {
-          const text = String(ci.text ?? "");
-          if (text.trim()) parts.push({ type: "text", text, time_created: fallbackTs });
+          const text = cleanInternalText(String(ci.text ?? ""));
+          if (text) parts.push({ type: "text", text, time_created: fallbackTs });
         }
       }
     }
@@ -865,8 +929,9 @@ export class KimiAgent extends BaseAgent {
     messages: Message[],
     stats: SessionData["stats"],
   ): SessionData {
-    stats.message_count = messages.length;
-    const totalCost = messages.reduce((sum, message) => sum + (message.cost ?? 0), 0);
+    const cleanedMessages = cleanParsedMessages(messages);
+    stats.message_count = cleanedMessages.length;
+    const totalCost = cleanedMessages.reduce((sum, message) => sum + (message.cost ?? 0), 0);
     if (totalCost > 0) {
       stats.total_cost = Number(totalCost.toFixed(8));
       stats.cost_source = "estimated";
@@ -879,7 +944,7 @@ export class KimiAgent extends BaseAgent {
       time_created: meta.createdAt,
       time_updated: meta.createdAt,
       stats,
-      messages,
+      messages: cleanedMessages,
     };
   }
 }

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -1,11 +1,29 @@
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { BaseAgent } from "./base.js";
-import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
+import {
+  BaseAgent,
+  filteredSession,
+  getParsedSession,
+  parsedSession,
+  skippedSession,
+} from "./base.js";
+import type {
+  AgentScanOptions,
+  ChangeCheckResult,
+  ParseSessionResult,
+  SessionCacheMeta,
+} from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
 import { openDbReadOnly, isSqliteAvailable, type SQLiteDatabase } from "../utils/sqlite.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { resolveSessionTitle } from "../utils/title-fallback.js";
+import { isInternalEventType } from "../utils/parse-cleanup.js";
+import {
+  cleanInternalText,
+  cleanParsedMessages,
+  firstUserMessageTitle,
+} from "../utils/session-normalization.js";
 
 export class OpenCodeAgent extends BaseAgent {
   readonly name = "opencode";
@@ -36,9 +54,11 @@ export class OpenCodeAgent extends BaseAgent {
     try {
       const cutoffTime = options?.from ?? Date.now() - 3650 * 24 * 60 * 60 * 1000;
 
-      const hasMessageTable = db
-        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'message'")
-        .get();
+      const hasMessageTable = Boolean(
+        db
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'message'")
+          .get(),
+      );
 
       let rows: Record<string, unknown>[];
       if (hasMessageTable) {
@@ -70,34 +90,15 @@ export class OpenCodeAgent extends BaseAgent {
 
       const heads: SessionHead[] = [];
       for (const row of rows) {
-        const id = String(row.id ?? "");
-        const title = String(row.title ?? "").trim() || "Untitled";
-        const timeCreated = Number(row.time_created ?? 0);
-        const timeUpdated = Number(row.time_updated ?? timeCreated);
-        const slug = `opencode/${id}`;
-        const directory = String(row.directory ?? "");
-        const stats = hasMessageTable ? this.readSessionStats(db, id) : null;
+        const head = getParsedSession(this.parseSessionHeadRow(db, row, hasMessageTable));
+        if (!head) continue;
 
-        heads.push({
-          id,
-          slug,
-          title,
-          directory,
-          time_created: timeCreated,
-          time_updated: timeUpdated,
-          stats: {
-            message_count: stats?.message_count ?? Number(row.message_count ?? 0),
-            total_input_tokens: stats?.total_input_tokens ?? 0,
-            total_output_tokens: stats?.total_output_tokens ?? 0,
-            total_cost: stats?.total_cost ?? 0,
-            cost_source: stats?.cost_source,
-          },
-        });
+        heads.push(head);
 
         // Store session metadata for caching
         if (this.dbPath) {
-          this.sessionMetaMap.set(id, {
-            id,
+          this.sessionMetaMap.set(head.id, {
+            id: head.id,
             sourcePath: this.dbPath,
           });
         }
@@ -109,6 +110,38 @@ export class OpenCodeAgent extends BaseAgent {
     } finally {
       db.close();
     }
+  }
+
+  private parseSessionHeadRow(
+    db: SQLiteDatabase,
+    row: Record<string, unknown>,
+    hasMessageTable: boolean,
+  ): ParseSessionResult<SessionHead> {
+    const id = String(row.id ?? "");
+    if (!id) return skippedSession("missing session id");
+
+    const timeCreated = Number(row.time_created ?? 0);
+    const timeUpdated = Number(row.time_updated ?? timeCreated);
+    const stats = hasMessageTable ? this.readSessionStats(db, id) : null;
+    const messageCount = stats?.message_count ?? Number(row.message_count ?? 0);
+    if (hasMessageTable && messageCount === 0) return filteredSession("no visible messages");
+    const messageTitle = hasMessageTable ? this.readFirstUserTitle(db, id) : null;
+
+    return parsedSession({
+      id,
+      slug: `opencode/${id}`,
+      title: resolveSessionTitle(String(row.title ?? ""), messageTitle, null),
+      directory: String(row.directory ?? ""),
+      time_created: timeCreated,
+      time_updated: timeUpdated,
+      stats: {
+        message_count: messageCount,
+        total_input_tokens: stats?.total_input_tokens ?? 0,
+        total_output_tokens: stats?.total_output_tokens ?? 0,
+        total_cost: stats?.total_cost ?? 0,
+        cost_source: stats?.cost_source,
+      },
+    });
   }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
@@ -157,19 +190,86 @@ export class OpenCodeAgent extends BaseAgent {
     return this.scan();
   }
 
+  private readMessageParts(db: SQLiteDatabase, messageId: unknown): MessagePart[] {
+    const partRows = db
+      .prepare("SELECT * FROM part WHERE message_id = ? ORDER BY time_created ASC")
+      .all(messageId) as Record<string, unknown>[];
+    const parts: MessagePart[] = [];
+
+    for (const partRow of partRows) {
+      const partData = JSON.parse(String(partRow.data ?? "{}")) as Record<string, unknown>;
+      const partType = String(partData.type ?? "");
+      if (isInternalEventType(partType)) continue;
+
+      if (partType === "text" || partType === "reasoning") {
+        const text = cleanInternalText(String(partData.text ?? ""));
+        if (text) {
+          parts.push({
+            type: partType as "text" | "reasoning",
+            text,
+            time_created: Number(partRow.time_created ?? 0),
+          });
+        }
+      } else if (partType === "tool") {
+        parts.push({
+          type: "tool",
+          tool: String(partData.tool ?? ""),
+          callID: String(partData.callID ?? ""),
+          title: cleanInternalText(String(partData.title ?? "")),
+          state: (partData.state ?? {}) as MessagePart["state"],
+          time_created: Number(partRow.time_created ?? 0),
+        });
+      }
+    }
+
+    return parts;
+  }
+
+  private readFirstUserTitle(db: SQLiteDatabase, sessionId: string): string | null {
+    const rows = db
+      .prepare(
+        "SELECT id, data, time_created FROM message WHERE session_id = ? ORDER BY time_created ASC",
+      )
+      .all(sessionId) as Record<string, unknown>[];
+
+    for (const row of rows) {
+      const msgData = JSON.parse(String(row.data ?? "{}")) as Record<string, unknown>;
+      if (isInternalEventType(msgData.type)) continue;
+      if (String(msgData.role ?? "") !== "user") continue;
+      const parts = this.readMessageParts(db, row.id);
+      const title = firstUserMessageTitle([
+        {
+          id: String(row.id ?? ""),
+          role: "user",
+          agent: null,
+          time_created: Number(row.time_created ?? 0),
+          parts,
+        },
+      ]);
+      if (title) return title;
+    }
+
+    return null;
+  }
+
   private readSessionStats(db: SQLiteDatabase, sessionId: string): SessionHead["stats"] | null {
     try {
       const rows = db
-        .prepare("SELECT data FROM message WHERE session_id = ? ORDER BY time_created ASC")
-        .all(sessionId) as Array<{ data?: string }>;
+        .prepare("SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created ASC")
+        .all(sessionId) as Array<{ id?: unknown; data?: string }>;
 
       let totalCost = 0;
       let totalInputTokens = 0;
       let totalOutputTokens = 0;
       let hasEstimatedCost = false;
+      let messageCount = 0;
 
       for (const row of rows) {
         const msgData = JSON.parse(String(row.data ?? "{}")) as Record<string, unknown>;
+        if (isInternalEventType(msgData.type)) continue;
+        const parts = this.readMessageParts(db, row.id);
+        if (parts.length === 0) continue;
+
         const cost = Number(msgData.cost ?? 0);
         const tokens = msgData.tokens as Record<string, unknown> | undefined;
         const inputTokens = Number(tokens?.input ?? 0);
@@ -182,10 +282,11 @@ export class OpenCodeAgent extends BaseAgent {
         totalCost += cost || estimatedCost || 0;
         totalInputTokens += inputTokens;
         totalOutputTokens += outputTokens;
+        messageCount++;
       }
 
       return {
-        message_count: rows.length,
+        message_count: messageCount,
         total_input_tokens: totalInputTokens,
         total_output_tokens: totalOutputTokens,
         total_cost: totalCost,
@@ -220,7 +321,6 @@ export class OpenCodeAgent extends BaseAgent {
       }
 
       const id = String(sessionRow.id ?? sessionId);
-      const title = String(sessionRow.title ?? "Untitled");
       const slug = `opencode/${id}`;
       const directory = String(sessionRow.directory ?? "");
       const timeCreated = Number(sessionRow.time_created ?? 0);
@@ -239,8 +339,8 @@ export class OpenCodeAgent extends BaseAgent {
 
       for (const msgRow of msgRows) {
         const msgData = JSON.parse(String(msgRow.data ?? "{}")) as Record<string, unknown>;
+        if (isInternalEventType(msgData.type)) continue;
 
-        const parts: MessagePart[] = [];
         const cost = Number(msgData.cost ?? 0);
         const tokens = msgData.tokens as Record<string, unknown> | undefined;
         const inputTokens = Number(tokens?.input ?? 0);
@@ -250,38 +350,8 @@ export class OpenCodeAgent extends BaseAgent {
           cost > 0 ? null : estimateTokenCost(model, { input: inputTokens, output: outputTokens });
         const resolvedCost = cost || estimatedCost || 0;
 
-        if (estimatedCost !== null) hasEstimatedCost = true;
-        totalCost += resolvedCost;
-        totalInputTokens += inputTokens;
-        totalOutputTokens += outputTokens;
-
-        // Get parts for this message
-        const partRows = db
-          .prepare("SELECT * FROM part WHERE message_id = ? ORDER BY time_created ASC")
-          .all(msgRow.id) as Record<string, unknown>[];
-
-        for (const partRow of partRows) {
-          const partData = JSON.parse(String(partRow.data ?? "{}")) as Record<string, unknown>;
-          const partType = String(partData.type ?? "");
-
-          if (partType === "text" || partType === "reasoning") {
-            parts.push({
-              type: partType as "text" | "reasoning",
-              text: partData.text ?? "",
-              time_created: Number(partRow.time_created ?? 0),
-            });
-          } else if (partType === "tool") {
-            parts.push({
-              type: "tool",
-              tool: String(partData.tool ?? ""),
-              callID: String(partData.callID ?? ""),
-              title: String(partData.title ?? ""),
-              state: (partData.state ?? {}) as MessagePart["state"],
-              time_created: Number(partRow.time_created ?? 0),
-            });
-          }
-          // Skip step-start, step-finish parts
-        }
+        const parts = this.readMessageParts(db, msgRow.id);
+        if (parts.length === 0) continue;
 
         messages.push({
           id: String(msgRow.id ?? ""),
@@ -298,6 +368,19 @@ export class OpenCodeAgent extends BaseAgent {
         });
       }
 
+      const cleanedMessages = cleanParsedMessages(messages);
+      const title = resolveSessionTitle(
+        String(sessionRow.title ?? ""),
+        firstUserMessageTitle(cleanedMessages),
+        null,
+      );
+      for (const message of cleanedMessages) {
+        totalCost += message.cost ?? 0;
+        totalInputTokens += message.tokens?.input ?? 0;
+        totalOutputTokens += message.tokens?.output ?? 0;
+        if (message.cost_source === "estimated") hasEstimatedCost = true;
+      }
+
       return {
         id,
         title,
@@ -308,13 +391,13 @@ export class OpenCodeAgent extends BaseAgent {
         time_updated: timeUpdated,
         summary_files: sessionRow.summary_files ?? undefined,
         stats: {
-          message_count: messages.length,
+          message_count: cleanedMessages.length,
           total_input_tokens: totalInputTokens,
           total_output_tokens: totalOutputTokens,
           total_cost: totalCost,
           cost_source: totalCost > 0 ? (hasEstimatedCost ? "estimated" : "recorded") : undefined,
         },
-        messages,
+        messages: cleanedMessages,
       };
     } finally {
       db.close();

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -127,3 +127,8 @@ export interface SessionData {
   smart_tags?: SmartTag[];
   smart_tags_source_updated_at?: number;
 }
+
+export type ParseSessionResult<T> =
+  | { status: "parsed"; data: T }
+  | { status: "skipped"; reason?: string }
+  | { status: "filtered"; reason?: string };

--- a/packages/core/src/utils/__tests__/parse-cleanup.test.ts
+++ b/packages/core/src/utils/__tests__/parse-cleanup.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { cleanDisplayText, isInternalEventType } from "../parse-cleanup.js";
+
+describe("cleanDisplayText", () => {
+  it("removes internal control tag blocks", () => {
+    const text = [
+      "Visible before",
+      "<command-name>pwd</command-name>",
+      "<command-message>run local command</command-message>",
+      "<local-command-stdout>/tmp/project</local-command-stdout>",
+      "<system-reminder>hidden policy reminder</system-reminder>",
+      "Visible after",
+    ].join("\n");
+
+    expect(cleanDisplayText(text)).toBe("Visible before\nVisible after");
+  });
+
+  it("returns null when only internal tags remain", () => {
+    expect(cleanDisplayText("<command-name>clear</command-name>")).toBeNull();
+  });
+
+  it("preserves regular spacing and indentation", () => {
+    const text = "  const value =  1;\n\treturn value;\n| col  | value |";
+
+    expect(cleanDisplayText(text)).toBe(text);
+  });
+});
+
+describe("isInternalEventType", () => {
+  it("matches internal event aliases", () => {
+    expect(isInternalEventType("file-history snapshot")).toBe(true);
+    expect(isInternalEventType("queue_operation")).toBe(true);
+    expect(isInternalEventType("last prompt")).toBe(true);
+  });
+});

--- a/packages/core/src/utils/__tests__/title-fallback.test.ts
+++ b/packages/core/src/utils/__tests__/title-fallback.test.ts
@@ -93,4 +93,10 @@ describe("resolveSessionTitle", () => {
   it("normalizes whitespace in chosen candidate", () => {
     expect(resolveSessionTitle("  spaced  out  ", null, null)).toBe("spaced out");
   });
+
+  it("ignores internal command tags while resolving title", () => {
+    expect(resolveSessionTitle("<command-name>clear</command-name>", "Visible title", null)).toBe(
+      "Visible title",
+    );
+  });
 });

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,6 +1,18 @@
 export { parseJsonlLines, readJsonlFile } from "./jsonl.js";
 export { basenameTitle, resolveSessionTitle, normalizeTitleText } from "./title-fallback.js";
+export { cleanDisplayText, firstVisibleLine } from "./parse-cleanup.js";
 export { openDb, openDbReadOnly, isSqliteAvailable } from "./sqlite.js";
 export { perf, type PerfMarker } from "./perf.js";
 export { classifySessionTags, getSmartTagSourceTimestamp } from "./smart-tags.js";
 export { estimateTokenCost } from "./cost.js";
+export {
+  cleanInternalText,
+  cleanMessagePart,
+  cleanMessageParts,
+  cleanParsedMessage,
+  cleanParsedMessages,
+  filtered,
+  firstUserMessageTitle,
+  parsed,
+  skipped,
+} from "./session-normalization.js";

--- a/packages/core/src/utils/parse-cleanup.ts
+++ b/packages/core/src/utils/parse-cleanup.ts
@@ -1,0 +1,73 @@
+const INTERNAL_TAGS = [
+  "command-message",
+  "command-name",
+  "local-command-stdout",
+  "system-reminder",
+];
+
+const INTERNAL_EVENT_TYPES = new Set([
+  "progress",
+  "file history snapshot",
+  "file-history snapshot",
+  "file_history snapshot",
+  "queue operation",
+  "queue-operation",
+  "queue_operation",
+  "last prompt",
+  "last-prompt",
+  "last_prompt",
+]);
+
+function blockTagPattern(tag: string): RegExp {
+  return new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi");
+}
+
+function blockTagLinePattern(tag: string): RegExp {
+  return new RegExp(
+    `(^|\\r?\\n)[ \\t]*<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>[ \\t]*(?:\\r?\\n|$)`,
+    "gi",
+  );
+}
+
+function openBlockTagPattern(tag: string): RegExp {
+  return new RegExp(`\\n*<${tag}\\b[^>]*>[\\s\\S]*$`, "gi");
+}
+
+function looseTagPattern(tag: string): RegExp {
+  return new RegExp(`<\\/?${tag}\\b[^>]*>`, "gi");
+}
+
+export function isInternalEventType(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase().replace(/[_-]+/g, " ");
+  return INTERNAL_EVENT_TYPES.has(normalized);
+}
+
+export function cleanDisplayText(text: string): string | null {
+  let cleaned = text;
+
+  for (const tag of INTERNAL_TAGS) {
+    cleaned = cleaned.replace(blockTagLinePattern(tag), "$1");
+    cleaned = cleaned.replace(blockTagPattern(tag), "");
+    cleaned = cleaned.replace(openBlockTagPattern(tag), "");
+  }
+
+  for (const tag of INTERNAL_TAGS) {
+    cleaned = cleaned.replace(looseTagPattern(tag), "");
+  }
+
+  cleaned = cleaned.replace(/[ \t]+(?=\r?\n|$)/g, "").replace(/(?:\r?\n)+$/g, "");
+
+  return cleaned.trim() ? cleaned : null;
+}
+
+export function firstVisibleLine(text: string): string | null {
+  const cleaned = cleanDisplayText(text);
+  if (!cleaned) return null;
+  return (
+    cleaned
+      .split("\n")
+      .find((line) => line.trim())
+      ?.trim() ?? null
+  );
+}

--- a/packages/core/src/utils/session-normalization.ts
+++ b/packages/core/src/utils/session-normalization.ts
@@ -1,0 +1,99 @@
+import type { Message, MessagePart, ParseSessionResult } from "../types/index.js";
+import {
+  cleanDisplayText,
+  isInternalEventType as isRawInternalEventType,
+} from "./parse-cleanup.js";
+import { normalizeTitleText } from "./title-fallback.js";
+
+export function parsed<T>(data: T): ParseSessionResult<T> {
+  return { status: "parsed", data };
+}
+
+export function skipped<T = never>(reason?: string): ParseSessionResult<T> {
+  return reason ? { status: "skipped", reason } : { status: "skipped" };
+}
+
+export function filtered<T = never>(reason?: string): ParseSessionResult<T> {
+  return reason ? { status: "filtered", reason } : { status: "filtered" };
+}
+
+export function isInternalEventType(value: unknown): boolean {
+  return isRawInternalEventType(value);
+}
+
+export function cleanInternalText(text: string): string {
+  return cleanDisplayText(text) ?? "";
+}
+
+function cleanUnknown(value: unknown): unknown {
+  if (typeof value === "string") return cleanInternalText(value);
+  if (Array.isArray(value)) return value.map(cleanUnknown);
+  if (!value || typeof value !== "object") return value;
+
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    cleaned[key] = cleanUnknown(child);
+  }
+  return cleaned;
+}
+
+export function cleanMessagePart(part: MessagePart): MessagePart | null {
+  const next: MessagePart = { ...part };
+
+  if (typeof next.text === "string") {
+    next.text = cleanInternalText(next.text);
+    if (!next.text && (next.type === "text" || next.type === "reasoning" || next.type === "plan")) {
+      return null;
+    }
+  }
+
+  if (typeof next.title === "string") {
+    const title = cleanInternalText(next.title);
+    if (title) next.title = title;
+    else delete next.title;
+  }
+
+  if (next.input !== undefined) {
+    next.input = cleanUnknown(next.input);
+  }
+  if (next.output !== undefined) {
+    next.output = cleanUnknown(next.output);
+  }
+  if (next.state !== undefined) {
+    next.state = cleanUnknown(next.state) as MessagePart["state"];
+  }
+
+  return next;
+}
+
+export function cleanMessageParts(parts: MessagePart[]): MessagePart[] {
+  return parts.flatMap((part) => {
+    const cleaned = cleanMessagePart(part);
+    return cleaned ? [cleaned] : [];
+  });
+}
+
+export function cleanParsedMessage(message: Message): Message | null {
+  const parts = cleanMessageParts(message.parts);
+  if (parts.length === 0) return null;
+  return { ...message, parts };
+}
+
+export function cleanParsedMessages(messages: Message[]): Message[] {
+  return messages.flatMap((message) => {
+    const cleaned = cleanParsedMessage(message);
+    return cleaned ? [cleaned] : [];
+  });
+}
+
+export function firstUserMessageTitle(messages: Message[]): string | null {
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    for (const part of message.parts) {
+      if (part.type !== "text" || typeof part.text !== "string") continue;
+      const title = normalizeTitleText(cleanInternalText(part.text));
+      if (title) return title;
+    }
+  }
+  return null;
+}

--- a/packages/core/src/utils/title-fallback.ts
+++ b/packages/core/src/utils/title-fallback.ts
@@ -1,11 +1,18 @@
 import { basename } from "node:path";
+import { cleanDisplayText } from "./parse-cleanup.js";
 
 const TITLE_MAX_LENGTH = 100;
 const UNTITLED_SESSION = "Untitled Session";
 
 /** Normalize extracted title text for display. */
 export function normalizeTitleText(text: string): string | null {
-  const cleaned = text.replace(/\s+/g, " ").trim();
+  const visible =
+    cleanDisplayText(text)
+      ?.split("\n")
+      .find((line) => line.trim())
+      ?.trim() ?? null;
+  if (!visible) return null;
+  const cleaned = visible.replace(/\s+/g, " ").trim();
   if (!cleaned) return null;
   return cleaned.slice(0, TITLE_MAX_LENGTH);
 }


### PR DESCRIPTION
## What changed

- Added a unified `ParseSessionResult` contract for parsed, skipped, and filtered adapter results.
- Moved internal event and control-tag cleanup into the core parsing layer.
- Applied message cleanup, empty-message filtering, title fallback, and tool-name normalization across Claude Code, Codex, Cursor, Kimi, and OpenCode adapters.
- Added fixtures for internal event filtering, internal tag cleanup, title fallback, tool names, and SQLite-backed adapters.

## Why

RD-335 requires adapter outputs to provide stable, user-visible session data before UI and indexing consume it. This keeps internal agent noise out of downstream layers.

## Validation

- `pn test`
- `pnpm --filter @codesesh/core test -- --runInBand`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core build`