### PR TITLE
Add structured global search

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,15 @@
 declare const __APP_VERSION__: string;
 
-import { useEffect, useEffectEvent, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { ModelConfig } from "./config";
 import type {
@@ -8,10 +17,13 @@ import type {
   AppConfig,
   BookmarkedSessionSnapshot,
   DashboardData,
+  FileActivityKind,
+  SearchRequestOptions,
   SearchResult,
   SessionHead,
   SessionData,
   SessionsUpdatedEvent,
+  SmartTag,
 } from "./lib/api";
 import {
   deleteBookmark,
@@ -39,7 +51,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { BookmarkButton } from "./components/BookmarkButton";
 import { CopyResumeButton } from "./components/CopyResumeButton";
 import { SessionTreeSidebar } from "./components/SessionTreeSidebar";
-import { SmartTagChips } from "./components/SmartTagChips";
+import { SMART_TAG_LABELS, SmartTagChips } from "./components/SmartTagChips";
 import {
   clearLegacyBookmarks,
   getSessionBookmarkKey,
@@ -127,6 +139,15 @@ function formatWindowLabel(config: AppConfig | null): string | null {
   return `${fromStr} → ${toStr}`;
 }
 
+function formatSearchSubtitle(query: string, loading: boolean, count: number) {
+  if (loading) return query ? `Searching for "${query}"` : "Loading recent sessions";
+  return query ? `${count} matches for "${query}"` : `${count} recent sessions`;
+}
+
+function getSessionAgentKey(session: SessionHead): string {
+  return session.slug.split("/")[0]?.toLowerCase() || "unknown";
+}
+
 function formatRelativeTime(timestamp?: number) {
   if (!timestamp) return "unknown";
   const diff = Date.now() - timestamp;
@@ -156,7 +177,64 @@ interface BreadcrumbItem {
   to?: string;
 }
 
+type CostRangeId = "paid" | "one_plus" | "ten_plus";
+
+interface SearchFilterState {
+  agent?: string;
+  projectKey?: string;
+  tag?: SmartTag;
+  tool?: string;
+  fileKind?: FileActivityKind;
+  costRange?: CostRangeId;
+}
+
+interface SearchProjectOption {
+  key: string;
+  label: string;
+  count: number;
+}
+
 const SHORTCUT_HINT_STORAGE_KEY = "codesesh.shortcuts-hint-dismissed";
+
+const SMART_TAG_OPTIONS: SmartTag[] = [
+  "bugfix",
+  "refactoring",
+  "feature-dev",
+  "testing",
+  "docs",
+  "git-ops",
+  "build-deploy",
+  "exploration",
+  "planning",
+];
+
+const SEARCH_TOOL_OPTIONS = ["apply_patch", "bash", "read", "edit", "grep"] as const;
+
+const FILE_ACTIVITY_OPTIONS: Array<{ kind: FileActivityKind; label: string }> = [
+  { kind: "read", label: "Read" },
+  { kind: "edit", label: "Edit" },
+  { kind: "write", label: "Write" },
+  { kind: "delete", label: "Delete" },
+];
+
+const COST_RANGE_OPTIONS: Array<{
+  id: CostRangeId;
+  label: string;
+  costMin: number;
+}> = [
+  { id: "paid", label: "Cost > $0", costMin: 0.000001 },
+  { id: "one_plus", label: "Cost >= $1", costMin: 1 },
+  { id: "ten_plus", label: "Cost >= $10", costMin: 10 },
+];
+
+const SEARCH_MATCH_LABELS: Record<SearchResult["matchType"], string> = {
+  recent: "Recent",
+  title: "Title",
+  user_message: "User message",
+  assistant_reply: "Assistant reply",
+  tool_output: "Tool output",
+  file_path: "File path",
+};
 
 const SHORTCUT_GROUPS = [
   {
@@ -170,6 +248,7 @@ const SHORTCUT_GROUPS = [
   {
     title: "Search",
     items: [
+      { keys: "Cmd/Ctrl K", description: "Open global search" },
       { keys: "/", description: "Focus the search box" },
       { keys: "Esc", description: "Exit search or close the current detail view" },
     ],
@@ -210,6 +289,8 @@ export default function App() {
   const [appConfig, setAppConfig] = useState<AppConfig | null>(null);
   const [draftSearchQuery, setDraftSearchQuery] = useState("");
   const [activeSearchQuery, setActiveSearchQuery] = useState("");
+  const [searchMode, setSearchMode] = useState(false);
+  const [searchFilters, setSearchFilters] = useState<SearchFilterState>({});
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [selectedSidebarSessionId, setSelectedSidebarSessionId] = useState<string | null>(null);
@@ -268,7 +349,7 @@ export default function App() {
     () => new Map(agents.map((agent) => [agent.name.toLowerCase(), agent.displayName])),
     [agents],
   );
-  const isSearchMode = activeSearchQuery.length > 0;
+  const isSearchMode = searchMode;
 
   const viewState = useMemo(
     () => parseViewState(location.pathname, validAgentKeys),
@@ -437,6 +518,41 @@ export default function App() {
     [bookmarks],
   );
 
+  const searchRequestOptions = useMemo<SearchRequestOptions>(() => {
+    const selectedCost = COST_RANGE_OPTIONS.find((option) => option.id === searchFilters.costRange);
+    return {
+      agent: searchFilters.agent,
+      projectKey: searchFilters.projectKey,
+      tag: searchFilters.tag,
+      tool: searchFilters.tool,
+      fileKind: searchFilters.fileKind,
+      costMin: selectedCost?.costMin,
+    };
+  }, [searchFilters]);
+  const usesServerSearch =
+    activeSearchQuery.trim().length > 0 || Boolean(searchFilters.tool || searchFilters.fileKind);
+  const recentSearchResults = useMemo<SearchResult[]>(() => {
+    const selectedCost = COST_RANGE_OPTIONS.find((option) => option.id === searchFilters.costRange);
+    return sessions
+      .filter((item) => {
+        if (searchFilters.agent && getSessionAgentKey(item) !== searchFilters.agent) return false;
+        if (searchFilters.projectKey && item.project_identity?.key !== searchFilters.projectKey) {
+          return false;
+        }
+        if (searchFilters.tag && !item.smart_tags?.includes(searchFilters.tag)) return false;
+        if (selectedCost && item.stats.total_cost < selectedCost.costMin) return false;
+        return true;
+      })
+      .toSorted((a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created))
+      .slice(0, 50)
+      .map((sessionItem) => ({
+        agentName: getSessionAgentKey(sessionItem),
+        session: sessionItem,
+        snippet: `Recent session · ${sessionItem.directory}`,
+        matchType: "recent" as const,
+      }));
+  }, [searchFilters, sessions]);
+
   // Stable key for session fetch
   const sessionFetchKey =
     viewState.mode === "session"
@@ -452,8 +568,8 @@ export default function App() {
           console.error("Failed to refresh dashboard:", err);
           return null;
         }),
-        activeSearchQuery
-          ? fetchSearchResults(activeSearchQuery).catch((err) => {
+        isSearchMode && usesServerSearch
+          ? fetchSearchResults(activeSearchQuery, searchRequestOptions).catch((err) => {
               console.error("Failed to refresh search results:", err);
               return { results: [] };
             })
@@ -489,8 +605,13 @@ export default function App() {
   });
 
   useEffect(() => {
-    if (!activeSearchQuery) {
+    if (!isSearchMode) {
       setSearchResults([]);
+      setSearchLoading(false);
+      return;
+    }
+    if (!usesServerSearch) {
+      setSearchResults(recentSearchResults);
       setSearchLoading(false);
       return;
     }
@@ -500,7 +621,7 @@ export default function App() {
     const startedAt = performance.now();
     logClientEvent("search.start", { query_length: activeSearchQuery.length });
 
-    void fetchSearchResults(activeSearchQuery)
+    void fetchSearchResults(activeSearchQuery, searchRequestOptions)
       .then((data) => {
         if (cancelled) return;
         setSearchResults(data.results);
@@ -526,7 +647,13 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [activeSearchQuery]);
+  }, [
+    activeSearchQuery,
+    isSearchMode,
+    recentSearchResults,
+    searchRequestOptions,
+    usesServerSearch,
+  ]);
 
   // Load session detail
   useEffect(() => {
@@ -664,15 +791,32 @@ export default function App() {
     [activeAgentKey, agents],
   );
 
+  const projectOptions = useMemo<SearchProjectOption[]>(() => {
+    const byKey = new Map<string, SearchProjectOption>();
+    for (const item of sessions) {
+      const identity = item.project_identity;
+      if (!identity?.key) continue;
+      const current = byKey.get(identity.key);
+      if (current) {
+        current.count += 1;
+      } else {
+        byKey.set(identity.key, {
+          key: identity.key,
+          label: identity.displayName || item.directory,
+          count: 1,
+        });
+      }
+    }
+    return [...byKey.values()].toSorted((a, b) => b.count - a.count).slice(0, 8);
+  }, [sessions]);
+
   // Header
   let headerTitle = "CodeSesh";
   let headerSubtitle: ReactNode = "Select an agent to browse sessions";
   if (viewState.mode === "root") {
     headerTitle = isSearchMode ? "Search" : "Dashboard";
     headerSubtitle = isSearchMode
-      ? searchLoading
-        ? `Searching for "${activeSearchQuery}"`
-        : `${searchResults.length} matches for "${activeSearchQuery}"`
+      ? formatSearchSubtitle(activeSearchQuery, searchLoading, searchResults.length)
       : dashboard
         ? `${dashboard.totals.sessions.toLocaleString("en-US")} total sessions across ${dashboard.perAgent.length} agents`
         : "Aggregated view across all agents";
@@ -708,9 +852,7 @@ export default function App() {
   }
   if (isSearchMode) {
     headerTitle = "Search";
-    headerSubtitle = searchLoading
-      ? `Searching for "${activeSearchQuery}"`
-      : `${searchResults.length} matches for "${activeSearchQuery}"`;
+    headerSubtitle = formatSearchSubtitle(activeSearchQuery, searchLoading, searchResults.length);
   }
 
   const breadcrumbItems = useMemo<BreadcrumbItem[]>(() => {
@@ -767,7 +909,14 @@ export default function App() {
         loading={searchLoading}
         results={searchResults}
         agentNameMap={agentNameMap}
-        onOpenResult={() => setActiveSearchQuery("")}
+        agents={agents}
+        projects={projectOptions}
+        filters={searchFilters}
+        onChangeFilters={setSearchFilters}
+        onOpenResult={() => {
+          setSearchMode(false);
+          setActiveSearchQuery("");
+        }}
         selectedIndex={selectedSearchIndex}
         registerResultRef={(key, node) => {
           if (node) searchResultRefs.current.set(key, node);
@@ -851,6 +1000,8 @@ export default function App() {
 
   function runSearch() {
     setActiveSearchQuery(draftSearchQuery.trim());
+    setSearchMode(true);
+    setSelectedSearchIndex(0);
   }
 
   function dismissShortcutHint() {
@@ -863,12 +1014,23 @@ export default function App() {
   }
 
   const handleGlobalKeydown = useEffectEvent((event: KeyboardEvent) => {
+    const key = event.key;
+    if ((event.metaKey || event.ctrlKey) && key.toLowerCase() === "k") {
+      event.preventDefault();
+      setSearchMode(true);
+      setSelectedSearchIndex(0);
+      window.setTimeout(() => {
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }, 0);
+      return;
+    }
+
     if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
     if (event.isComposing) return;
 
     const target = event.target;
     const inEditable = isEditableTarget(target);
-    const key = event.key;
 
     if (shortcutHelpOpen) {
       if (key === "Escape") {
@@ -896,6 +1058,7 @@ export default function App() {
     if (key === "/") {
       event.preventDefault();
       dismissShortcutHint();
+      setSearchMode(true);
       searchInputRef.current?.focus();
       searchInputRef.current?.select();
       return;
@@ -903,7 +1066,8 @@ export default function App() {
 
     if (key === "Escape") {
       event.preventDefault();
-      if (activeSearchQuery) {
+      if (isSearchMode) {
+        setSearchMode(false);
         setActiveSearchQuery("");
         setDraftSearchQuery("");
         return;
@@ -946,6 +1110,7 @@ export default function App() {
         if (!result) return;
         event.preventDefault();
         dismissShortcutHint();
+        setSearchMode(false);
         setActiveSearchQuery("");
         navigate(`/${result.agentName.toLowerCase()}/${result.session.id}`, {
           state: { searchQuery: activeSearchQuery },
@@ -1004,9 +1169,9 @@ export default function App() {
   }, []);
 
   return (
-    <div className="console-ui h-screen overflow-hidden bg-[var(--console-bg)] text-[var(--console-text)]">
-      <header className="h-14 shrink-0 border-b border-[var(--console-border)] bg-white/85 backdrop-blur-sm">
-        <div className="grid h-full grid-cols-[auto_1fr_auto] items-center gap-4 px-4">
+    <div className="console-ui flex h-screen flex-col overflow-hidden bg-[var(--console-bg)] text-[var(--console-text)]">
+      <header className="shrink-0 border-b border-[var(--console-border)] bg-white/85 backdrop-blur-sm">
+        <div className="grid min-h-14 grid-cols-[auto_1fr] items-center gap-3 px-4 py-2 sm:grid-cols-[auto_1fr_auto] sm:py-0">
           <Link to="/" className="flex items-center gap-2 text-[var(--console-text)]">
             <img src="/logo.svg?v=3" alt="CodeSesh" className="h-6 w-6 rounded-sm" />
             <span className="console-mono text-sm font-semibold uppercase tracking-[0.05em]">
@@ -1014,7 +1179,7 @@ export default function App() {
             </span>
           </Link>
           <form
-            className="mx-auto flex w-full max-w-[560px] items-center justify-center gap-2"
+            className="order-3 col-span-2 flex w-full items-center justify-center gap-2 sm:order-none sm:col-span-1 sm:mx-auto sm:max-w-[560px]"
             onSubmit={(event) => {
               event.preventDefault();
               runSearch();
@@ -1036,7 +1201,7 @@ export default function App() {
               Search
             </button>
           </form>
-          <div className="flex items-center justify-end gap-3">
+          <div className="flex items-center justify-end gap-2">
             <button
               type="button"
               onClick={() => {
@@ -1046,24 +1211,24 @@ export default function App() {
               className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface-muted)]"
               title="Show keyboard shortcuts"
             >
-              ? Shortcuts
+              ?<span className="hidden sm:inline"> Shortcuts</span>
             </button>
             {formatWindowLabel(appConfig) ? (
               <span
-                className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-2 py-1 text-xs text-[var(--console-text)]"
+                className="console-mono hidden rounded-sm border border-[var(--console-border)] bg-white px-2 py-1 text-xs text-[var(--console-text)] md:inline-flex"
                 title="Time window applied to agent counts, dashboard, and session list"
               >
                 {formatWindowLabel(appConfig)}
               </span>
             ) : null}
-            <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-muted)]">
+            <span className="console-mono hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-muted)] sm:inline-flex">
               v{__APP_VERSION__}
             </span>
           </div>
         </div>
       </header>
 
-      <div className="flex h-[calc(100vh-56px)] min-h-0">
+      <div className="flex min-h-0 flex-1">
         <aside className="hidden w-64 shrink-0 flex-col border-r border-[var(--console-border)] bg-[var(--console-sidebar-bg)] lg:flex">
           <div className="console-scrollbar flex-1 space-y-8 overflow-y-auto px-4 py-6">
             <section>
@@ -1363,6 +1528,10 @@ function SearchResultsPanel({
   loading,
   results,
   agentNameMap,
+  agents,
+  projects,
+  filters,
+  onChangeFilters,
   onOpenResult,
   selectedIndex,
   registerResultRef,
@@ -1371,41 +1540,63 @@ function SearchResultsPanel({
   loading: boolean;
   results: SearchResult[];
   agentNameMap: Map<string, string>;
+  agents: AgentInfo[];
+  projects: SearchProjectOption[];
+  filters: SearchFilterState;
+  onChangeFilters: Dispatch<SetStateAction<SearchFilterState>>;
   onOpenResult: () => void;
   selectedIndex: number;
   registerResultRef: (key: string, node: HTMLAnchorElement | null) => void;
 }) {
+  const filterBar = (
+    <SearchFilterBar
+      agents={agents}
+      projects={projects}
+      filters={filters}
+      onChangeFilters={onChangeFilters}
+    />
+  );
+
   if (loading) {
     return (
-      <div className="grid gap-3">
-        {Array.from({ length: 4 }).map((_, index) => (
-          <div
-            key={index}
-            className="animate-pulse rounded-sm border border-[var(--console-border)] bg-white/80 p-4"
-          >
-            <div className="h-3 w-32 rounded bg-[var(--console-surface-muted)]" />
-            <div className="mt-3 h-4 w-2/3 rounded bg-[var(--console-surface-muted)]" />
-            <div className="mt-2 h-3 w-full rounded bg-[var(--console-surface-muted)]" />
-            <div className="mt-1 h-3 w-5/6 rounded bg-[var(--console-surface-muted)]" />
-          </div>
-        ))}
+      <div className="flex flex-col gap-3">
+        {filterBar}
+        <div className="grid gap-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div
+              key={index}
+              className="animate-pulse rounded-sm border border-[var(--console-border)] bg-white/80 p-4"
+            >
+              <div className="h-3 w-32 rounded bg-[var(--console-surface-muted)]" />
+              <div className="mt-3 h-4 w-2/3 rounded bg-[var(--console-surface-muted)]" />
+              <div className="mt-2 h-3 w-full rounded bg-[var(--console-surface-muted)]" />
+              <div className="mt-1 h-3 w-5/6 rounded bg-[var(--console-surface-muted)]" />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }
 
   if (results.length === 0) {
     return (
-      <div className="rounded-sm border border-[var(--console-border)] bg-white/80 p-6">
-        <h2 className="console-mono text-sm font-semibold text-[var(--console-text)]">
-          No matches
-        </h2>
-        <p className="console-mono mt-2 text-xs text-[var(--console-muted)]">Query: {query}</p>
+      <div className="flex flex-col gap-3">
+        {filterBar}
+        <div className="rounded-sm border border-[var(--console-border)] bg-white/80 p-6">
+          <h2 className="console-mono text-sm font-semibold text-[var(--console-text)]">
+            {query ? "No matches" : "No recent sessions"}
+          </h2>
+          {query ? (
+            <p className="console-mono mt-2 text-xs text-[var(--console-muted)]">Query: {query}</p>
+          ) : null}
+        </div>
       </div>
     );
   }
 
   return (
     <div className="grid gap-3">
+      {filterBar}
       <div className="console-mono text-[11px] text-[var(--console-muted)]">
         Navigate j k · Open Enter · Exit Esc
       </div>
@@ -1431,6 +1622,9 @@ function SearchResultsPanel({
               <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-1.5 py-0.5 text-[10px] uppercase text-[var(--console-muted)]">
                 {agentLabel}
               </span>
+              <span className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5 text-[10px] uppercase text-[var(--console-muted)]">
+                {SEARCH_MATCH_LABELS[result.matchType]}
+              </span>
               <span className="console-mono text-[11px] text-[var(--console-muted)]">
                 {result.session.directory}
               </span>
@@ -1438,6 +1632,7 @@ function SearchResultsPanel({
             <h2 className="console-mono mt-3 text-sm font-semibold text-[var(--console-text)]">
               {result.session.title}
             </h2>
+            <SmartTagChips tags={result.session.smart_tags} className="mt-2" />
             <p
               className="console-mono mt-2 text-xs leading-6 text-[var(--console-muted)] [&_mark]:bg-[var(--console-accent)] [&_mark]:px-0.5 [&_mark]:text-white"
               dangerouslySetInnerHTML={{
@@ -1448,5 +1643,161 @@ function SearchResultsPanel({
         );
       })}
     </div>
+  );
+}
+
+function SearchFilterBar({
+  agents,
+  projects,
+  filters,
+  onChangeFilters,
+}: {
+  agents: AgentInfo[];
+  projects: SearchProjectOption[];
+  filters: SearchFilterState;
+  onChangeFilters: Dispatch<SetStateAction<SearchFilterState>>;
+}) {
+  const hasActiveFilters = Object.values(filters).some(Boolean);
+  const setFilter = <K extends keyof SearchFilterState>(key: K, value: SearchFilterState[K]) => {
+    onChangeFilters((current) => ({
+      ...current,
+      [key]: current[key] === value ? undefined : value,
+    }));
+  };
+
+  return (
+    <div className="rounded-sm border border-[var(--console-border)] bg-white/85 p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
+          Scope
+        </span>
+        <FilterChip
+          active={!filters.projectKey}
+          label="All"
+          onClick={() => onChangeFilters((current) => ({ ...current, projectKey: undefined }))}
+        />
+        {projects.map((project) => (
+          <FilterChip
+            key={project.key}
+            active={filters.projectKey === project.key}
+            label={`${project.label} · ${project.count}`}
+            onClick={() => setFilter("projectKey", project.key)}
+          />
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
+          Agent
+        </span>
+        <FilterChip
+          active={!filters.agent}
+          label="All Agents"
+          onClick={() => onChangeFilters((current) => ({ ...current, agent: undefined }))}
+        />
+        {agents.map((agent) => (
+          <FilterChip
+            key={agent.name}
+            active={filters.agent === agent.name}
+            label={agent.displayName}
+            onClick={() => setFilter("agent", agent.name)}
+          />
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
+          Tag
+        </span>
+        {SMART_TAG_OPTIONS.map((tag) => (
+          <FilterChip
+            key={tag}
+            active={filters.tag === tag}
+            label={SMART_TAG_LABELS[tag]}
+            onClick={() => setFilter("tag", tag)}
+          />
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
+          Signal
+        </span>
+        {SEARCH_TOOL_OPTIONS.map((tool) => (
+          <FilterChip
+            key={tool}
+            active={filters.tool === tool}
+            label={`tool:${tool}`}
+            onClick={() => setFilter("tool", tool)}
+          />
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
+          File Activity
+        </span>
+        {FILE_ACTIVITY_OPTIONS.map((option) => (
+          <FilterChip
+            key={option.kind}
+            active={filters.fileKind === option.kind}
+            label={option.label}
+            onClick={() => setFilter("fileKind", option.kind)}
+          />
+        ))}
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
+          Cost Range
+        </span>
+        <FilterChip
+          active={!filters.costRange}
+          label="Any Cost"
+          onClick={() => onChangeFilters((current) => ({ ...current, costRange: undefined }))}
+        />
+        {COST_RANGE_OPTIONS.map((option) => (
+          <FilterChip
+            key={option.id}
+            active={filters.costRange === option.id}
+            label={option.label}
+            onClick={() => setFilter("costRange", option.id)}
+          />
+        ))}
+        {hasActiveFilters ? (
+          <button
+            type="button"
+            onClick={() => onChangeFilters({})}
+            className="console-mono ml-auto rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[10px] text-[var(--console-muted)] transition-colors hover:bg-white"
+          >
+            Clear
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function FilterChip({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`console-mono rounded-sm border px-2 py-1 text-[10px] transition-colors ${
+        active
+          ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
+          : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-white"
+      }`}
+    >
+      {label}
+    </button>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -227,6 +227,17 @@ export interface SearchResult {
   agentName: string;
   session: SessionHead;
   snippet: string;
+  matchType: "recent" | "title" | "user_message" | "assistant_reply" | "tool_output" | "file_path";
+}
+
+export interface SearchRequestOptions {
+  agent?: string;
+  projectKey?: string;
+  tag?: SmartTag;
+  tool?: string;
+  fileKind?: FileActivityKind;
+  costMin?: number;
+  costMax?: number;
 }
 
 export interface BookmarkedSessionSnapshot {
@@ -294,9 +305,19 @@ export async function fetchDashboard(window?: AppConfig["window"]): Promise<Dash
   return res.json();
 }
 
-export async function fetchSearchResults(query: string): Promise<{ results: SearchResult[] }> {
+export async function fetchSearchResults(
+  query: string,
+  options: SearchRequestOptions = {},
+): Promise<{ results: SearchResult[] }> {
   const params = new URLSearchParams();
   params.set("q", query);
+  if (options.agent) params.set("agent", options.agent);
+  if (options.projectKey) params.set("projectKey", options.projectKey);
+  if (options.tag) params.set("tag", options.tag);
+  if (options.tool) params.set("tool", options.tool);
+  if (options.fileKind) params.set("fileActivity", options.fileKind);
+  if (options.costMin != null) params.set("costMin", String(options.costMin));
+  if (options.costMax != null) params.set("costMax", String(options.costMax));
   const res = await fetch(`/api/search?${params}`);
   if (!res.ok) throw new Error("Failed to fetch search results");
   return res.json();

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -6,6 +6,7 @@ import {
   handleGetProjects,
   handleGetSessions,
   handleGetSessionData,
+  handleSearchSessions,
   type ScanResultSource,
 } from "../handlers.js";
 import type { ScanResult, SessionHead, SessionData } from "@codesesh/core";
@@ -254,6 +255,55 @@ describe("handleGetSessions", () => {
     const response = c.json.mock.calls[0]![0];
     // Invalid date → filter not applied
     expect(response.sessions).toHaveLength(2);
+  });
+});
+
+describe("handleSearchSessions", () => {
+  it("returns recent sessions for empty query from the scan snapshot", () => {
+    const older = makeSession("older", {
+      time_created: 1000,
+      time_updated: 1000,
+    });
+    const newer = makeSession("newer", {
+      time_created: 2000,
+      time_updated: 2000,
+    });
+    const c = makeMockContext({ query: { q: "" } });
+    handleSearchSessions(
+      c,
+      makeScanSource({
+        sessions: [older, newer],
+        byAgent: { claudecode: [older, newer] },
+      }),
+    );
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.results.map((result: { session: SessionHead }) => result.session.id)).toEqual([
+      "newer",
+      "older",
+    ]);
+    expect(response.results[0].matchType).toBe("recent");
+  });
+
+  it("applies typed qualifiers on the recent-session path", () => {
+    const claude = makeSession("claude", { slug: "claudecode/claude" });
+    const codex = makeSession("codex", { slug: "codex/codex" });
+    const c = makeMockContext({ query: { q: "agent:codex" } });
+    handleSearchSessions(
+      c,
+      makeScanSource({
+        sessions: [claude, codex],
+        byAgent: {
+          claudecode: [claude],
+          codex: [codex],
+        },
+      }),
+    );
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].agentName).toBe("codex");
+    expect(response.results[0].session.id).toBe("codex");
   });
 });
 

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -220,8 +220,13 @@ function sanitizeClientLogData(value: unknown): Record<string, unknown> {
 }
 
 function sessionMatchesCostFilter(session: SessionHead, options: SearchOptions): boolean {
-  if (options.costMin != null && session.stats.total_cost < options.costMin) return false;
-  if (options.costMax != null && session.stats.total_cost > options.costMax) return false;
+  const cost = session.stats.total_cost;
+  if (options.costMin != null) {
+    if (options.costMinExclusive ? cost <= options.costMin : cost < options.costMin) return false;
+  }
+  if (options.costMax != null) {
+    if (options.costMaxExclusive ? cost >= options.costMax : cost > options.costMax) return false;
+  }
   return true;
 }
 
@@ -243,6 +248,8 @@ function mergeSearchOptions(options: SearchOptions, filters: SearchQueryFilters)
     fileKind: options.fileKind ?? filters.fileKind,
     costMin: options.costMin ?? filters.costMin,
     costMax: options.costMax ?? filters.costMax,
+    costMinExclusive: options.costMinExclusive ?? filters.costMinExclusive,
+    costMaxExclusive: options.costMaxExclusive ?? filters.costMaxExclusive,
   };
 }
 

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -18,15 +18,18 @@ import {
   listFileActivity,
   listCachedProjectGroups,
   listBookmarks,
+  parseSearchQuery,
   realFs,
   searchFileActivitySessions,
   searchSessions,
-  syncSessionSearchIndex,
   upsertBookmark,
   type FileActivityKind,
   type FileActivityResult,
+  type SearchMatchType,
+  type SearchOptions,
+  type SearchQueryFilters,
 } from "@codesesh/core";
-import { appLogger, logSearchIndexSync } from "../logging.js";
+import { appLogger } from "../logging.js";
 
 export interface ScanResultSource {
   getSnapshot(): ScanResult;
@@ -48,6 +51,7 @@ interface ApiSearchResult {
   agentName: string;
   session: SessionHead;
   snippet: string;
+  matchType: SearchMatchType;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -109,6 +113,67 @@ function parseDateParam(
   return Number.isNaN(ts) ? fallback : ts;
 }
 
+function parseNumberParam(value: string | undefined): number | undefined {
+  if (value == null || !value.trim()) return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function searchParams(c: Context): URLSearchParams {
+  return new URL(c.req.url ?? "http://localhost/", "http://localhost/").searchParams;
+}
+
+function queryValues(params: URLSearchParams, ...names: string[]): string[] {
+  return names.flatMap((name) =>
+    params
+      .getAll(name)
+      .flatMap((value) => value.split(","))
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+}
+
+function parseSmartTags(values: string[]): SmartTag[] | undefined {
+  const tags = values
+    .map((value) => value.toLowerCase())
+    .filter((value): value is SmartTag =>
+      [
+        "bugfix",
+        "refactoring",
+        "feature-dev",
+        "testing",
+        "docs",
+        "git-ops",
+        "build-deploy",
+        "exploration",
+        "planning",
+      ].includes(value),
+    );
+  return tags.length > 0 ? [...new Set(tags)] : undefined;
+}
+
+function parseSearchOptions(c: Context, defaults: SessionListDefaults): SearchOptions {
+  const params = searchParams(c);
+  const limitValue = parseNumberParam(params.get("limit") ?? undefined);
+  return {
+    agent: optionalQueryValue(params.get("agent") ?? undefined),
+    project: optionalQueryValue(params.get("project") ?? undefined),
+    projectKey: optionalQueryValue(params.get("projectKey") ?? undefined),
+    cwd: optionalQueryValue(params.get("cwd") ?? undefined),
+    tags: parseSmartTags(queryValues(params, "tag", "tags", "signal")),
+    tools: queryValues(params, "tool", "tools").map((tool) => tool.toLowerCase()),
+    file: optionalQueryValue(params.get("file") ?? params.get("path") ?? undefined),
+    fileKind: parseFileActivityKind(
+      optionalQueryValue(params.get("fileKind") ?? params.get("fileActivity") ?? undefined),
+    ),
+    costMin: parseNumberParam(params.get("costMin") ?? undefined),
+    costMax: parseNumberParam(params.get("costMax") ?? undefined),
+    from: parseDateParam(params.get("from") ?? undefined, defaults.from),
+    to: parseDateParam(params.get("to") ?? undefined, defaults.to),
+    limit: limitValue && limitValue > 0 ? Math.min(limitValue, 100) : 50,
+  };
+}
+
 function filterSessionsByWindow(
   sessions: SessionHead[],
   from: number | undefined,
@@ -154,103 +219,31 @@ function sanitizeClientLogData(value: unknown): Record<string, unknown> {
   );
 }
 
-function appendSearchText(value: unknown, chunks: string[]): void {
-  if (value == null) return;
-  if (typeof value === "string") {
-    if (value.trim()) chunks.push(value);
-    return;
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    chunks.push(String(value));
-    return;
-  }
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      appendSearchText(item, chunks);
-    }
-    return;
-  }
-  if (isRecord(value)) {
-    for (const item of Object.values(value)) {
-      appendSearchText(item, chunks);
-    }
-  }
+function sessionMatchesCostFilter(session: SessionHead, options: SearchOptions): boolean {
+  if (options.costMin != null && session.stats.total_cost < options.costMin) return false;
+  if (options.costMax != null && session.stats.total_cost > options.costMax) return false;
+  return true;
 }
 
-function parseFallbackSearchTerms(query: string): string[] {
-  return (query.match(/"[^"]+"|\S+/g) ?? [])
-    .map((term) => term.replace(/^"|"$/g, "").trim().toLowerCase())
-    .filter((term) => term && term !== "or");
+function mergeSearchLists<T>(left: T[] | undefined, right: T[] | undefined): T[] | undefined {
+  const values = [...(left ?? []), ...(right ?? [])];
+  return values.length > 0 ? [...new Set(values)] : undefined;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function buildFallbackSearchSnippet(text: string, terms: string[]): string {
-  const lower = text.toLowerCase();
-  const term = terms.find((item) => lower.includes(item)) ?? terms[0] ?? "";
-  if (!term) return text.slice(0, 160);
-
-  const index = lower.indexOf(term);
-  const start = Math.max(0, index - 80);
-  const end = Math.min(text.length, index + term.length + 80);
-  const snippet = text
-    .slice(start, end)
-    .replace(new RegExp(escapeRegExp(term), "gi"), (match) => `<mark>${match}</mark>`);
-  return `${start > 0 ? "… " : ""}${snippet}${end < text.length ? " …" : ""}`;
-}
-
-function matchesFallbackSearch(text: string, terms: string[]): boolean {
-  const lower = text.toLowerCase();
-  return terms.every((term) => lower.includes(term));
-}
-
-function fallbackSearchSessions(
-  scanResult: ScanResult,
-  query: string,
-  options: { agent?: string; cwd?: string; from?: number; to?: number; limit: number },
-): ApiSearchResult[] {
-  const terms = parseFallbackSearchTerms(query);
-  if (terms.length === 0) return [];
-
-  const agentEntries = options.agent
-    ? ([[options.agent, scanResult.byAgent[options.agent] ?? []]] as Array<[string, SessionHead[]]>)
-    : Object.entries(scanResult.byAgent);
-  const results: ApiSearchResult[] = [];
-
-  for (const [agentName, agentSessions] of agentEntries) {
-    const agent = scanResult.agents.find((item) => item.name === agentName);
-    if (!agent) continue;
-
-    let sessions = filterSessionsByActivityWindow(agentSessions, options.from, options.to);
-    if (options.cwd) {
-      sessions = sessions.filter((session) => matchesProjectScope(session, options.cwd!));
-    }
-
-    for (const session of sessions) {
-      const chunks = [session.title, session.directory];
-      try {
-        const data = agent.getSessionData(session.id);
-        appendSearchText(data.title, chunks);
-        appendSearchText(data.messages, chunks);
-      } catch {
-        continue;
-      }
-
-      const text = chunks.join("\n");
-      if (!matchesFallbackSearch(text, terms)) continue;
-
-      results.push({
-        agentName,
-        session,
-        snippet: buildFallbackSearchSnippet(text, terms),
-      });
-      if (results.length >= options.limit) return results;
-    }
-  }
-
-  return results;
+function mergeSearchOptions(options: SearchOptions, filters: SearchQueryFilters): SearchOptions {
+  return {
+    ...options,
+    agent: options.agent ?? filters.agent,
+    project: options.project ?? filters.project,
+    projectKey: options.projectKey ?? filters.projectKey,
+    cwd: options.cwd ?? filters.cwd,
+    tags: mergeSearchLists(options.tags, filters.tags),
+    tools: mergeSearchLists(options.tools, filters.tools),
+    file: options.file ?? filters.file,
+    fileKind: options.fileKind ?? filters.fileKind,
+    costMin: options.costMin ?? filters.costMin,
+    costMax: options.costMax ?? filters.costMax,
+  };
 }
 
 function mergeSearchResults(results: ApiSearchResult[], limit: number): ApiSearchResult[] {
@@ -266,6 +259,56 @@ function mergeSearchResults(results: ApiSearchResult[], limit: number): ApiSearc
   }
 
   return merged;
+}
+
+function matchesRecentSearchFilters(session: SessionHead, options: SearchOptions): boolean {
+  if (options.projectKey && session.project_identity?.key !== options.projectKey) return false;
+  if (options.cwd && !matchesProjectScope(session, options.cwd)) return false;
+  if (options.project) {
+    const projectNeedle = options.project.toLowerCase();
+    const projectText = [
+      session.project_identity?.key,
+      session.project_identity?.displayName,
+      session.directory,
+    ]
+      .filter(Boolean)
+      .join("\n")
+      .toLowerCase();
+    if (!projectText.includes(projectNeedle)) return false;
+  }
+  if (options.tags?.length && !options.tags.every((tag) => session.smart_tags?.includes(tag))) {
+    return false;
+  }
+  if (!sessionMatchesCostFilter(session, options)) return false;
+  return true;
+}
+
+function recentSearchSessions(
+  scanResult: ScanResult,
+  options: SearchOptions & { limit: number },
+): ApiSearchResult[] {
+  const entries = options.agent
+    ? ([[options.agent, scanResult.byAgent[options.agent] ?? []]] as Array<[string, SessionHead[]]>)
+    : Object.entries(scanResult.byAgent);
+
+  return entries
+    .flatMap(([agentName, sessions]) =>
+      filterSessionsByActivityWindow(sessions, options.from, options.to)
+        .filter((session) => matchesRecentSearchFilters(session, options))
+        .map((session) => ({ agentName, session })),
+    )
+    .toSorted(
+      (a, b) =>
+        (b.session.time_updated ?? b.session.time_created) -
+        (a.session.time_updated ?? a.session.time_created),
+    )
+    .slice(0, options.limit)
+    .map(({ agentName, session }) => ({
+      agentName,
+      session,
+      snippet: `Recent session · ${session.directory}`,
+      matchType: "recent",
+    }));
 }
 
 export function handleGetConfig(c: Context, defaults: SessionListDefaults) {
@@ -355,44 +398,38 @@ export function handleSearchSessions(
   defaults: SessionListDefaults = {},
 ) {
   const query = c.req.query("q")?.trim() ?? "";
-  if (!query) {
-    return c.json({ results: [] });
-  }
-
   const scanResult = scanSource.getSnapshot();
-  const agent = c.req.query("agent");
-  const cwd = c.req.query("cwd");
-  const from = parseDateParam(c.req.query("from"), defaults.from);
-  const to = parseDateParam(c.req.query("to"), defaults.to);
-
-  for (const indexedAgent of scanResult.agents) {
-    const sessions = scanResult.byAgent[indexedAgent.name] ?? [];
-    const syncResult = syncSessionSearchIndex(indexedAgent.name, sessions, (sessionId) =>
-      indexedAgent.getSessionData(sessionId),
-    );
-    logSearchIndexSync("api.search", syncResult);
-  }
-
-  const searchOptions = {
-    agent,
-    cwd,
-    from,
-    to,
-    limit: 50,
-  };
-  let results: ApiSearchResult[] = mergeSearchResults(
-    [...searchFileActivitySessions(query, searchOptions), ...searchSessions(query, searchOptions)],
-    50,
+  const searchOptions = parseSearchOptions(c, defaults);
+  const parsedQuery = parseSearchQuery(query);
+  const mergedSearchOptions = mergeSearchOptions(searchOptions, parsedQuery.filters);
+  const textQuery = parsedQuery.text || (parsedQuery.hasQualifiers ? "" : query);
+  const needsIndexedSearch = Boolean(
+    textQuery ||
+    mergedSearchOptions.file ||
+    mergedSearchOptions.fileKind ||
+    mergedSearchOptions.tools?.length,
   );
-  if (results.length === 0) {
-    results = fallbackSearchSessions(scanResult, query, {
-      agent,
-      cwd,
-      from,
-      to,
-      limit: 50,
+
+  if (!needsIndexedSearch) {
+    return c.json({
+      results: recentSearchSessions(
+        scanResult,
+        mergedSearchOptions as SearchOptions & { limit: number },
+      ),
     });
   }
+
+  const fileQuery =
+    mergedSearchOptions.file ??
+    (!parsedQuery.text ? parsedQuery.filters.file : undefined) ??
+    (!parsedQuery.hasQualifiers && query ? parsedQuery.text || query : "");
+  const results: ApiSearchResult[] = mergeSearchResults(
+    [
+      ...(fileQuery ? searchFileActivitySessions(fileQuery, mergedSearchOptions) : []),
+      ...searchSessions(query, mergedSearchOptions),
+    ],
+    mergedSearchOptions.limit ?? 50,
+  );
 
   return c.json({ results });
 }
@@ -418,6 +455,7 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
       agent: optionalQueryValue(c.req.query("agent")),
       sessionId: optionalQueryValue(c.req.query("sessionId")),
       projectKey: optionalQueryValue(c.req.query("projectKey")),
+      project: optionalQueryValue(c.req.query("project")),
       cwd: optionalQueryValue(c.req.query("cwd")),
       path: optionalQueryValue(c.req.query("path")),
       kind: parseFileActivityKind(optionalQueryValue(c.req.query("kind"))),

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -329,14 +329,15 @@ describe("LiveScanStore", () => {
       opencodeRoot: join(tempDir, "opencode"),
     });
 
+    const existingSession = makeSession("existing");
     const newSession = makeSession("new");
     const codex = makeAgent("codex", {
       scan: vi.fn(() => [newSession]),
     });
     core.createRegisteredAgents.mockReturnValue([codex]);
     core.scanSessions.mockResolvedValue({
-      sessions: [],
-      byAgent: { codex: [] },
+      sessions: [existingSession],
+      byAgent: { codex: [existingSession] },
       agents: [codex],
     });
 
@@ -392,13 +393,14 @@ describe("LiveScanStore", () => {
       opencodeRoot: join(tempDir, "opencode"),
     });
 
+    const existingSession = makeSession("existing");
     const codex = makeAgent("codex", {
       scan: vi.fn(() => [makeSession("new")]),
     });
     core.createRegisteredAgents.mockReturnValue([codex]);
     core.scanSessions.mockResolvedValue({
-      sessions: [],
-      byAgent: { codex: [] },
+      sessions: [existingSession],
+      byAgent: { codex: [existingSession] },
       agents: [codex],
     });
 
@@ -440,6 +442,7 @@ describe("LiveScanStore", () => {
       opencodeRoot: join(tempDir, "opencode"),
     });
 
+    const existingSession = makeSession("existing");
     const codex = makeAgent("codex", {
       scan: vi
         .fn()
@@ -450,8 +453,8 @@ describe("LiveScanStore", () => {
     });
     core.createRegisteredAgents.mockReturnValue([codex]);
     core.scanSessions.mockResolvedValue({
-      sessions: [],
-      byAgent: { codex: [] },
+      sessions: [existingSession],
+      byAgent: { codex: [existingSession] },
       agents: [codex],
     });
 

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -1,5 +1,7 @@
 import { existsSync, readdirSync, statSync, watch, type FSWatcher } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
 import {
   createRegisteredAgents,
   filterSessions,
@@ -14,6 +16,7 @@ import {
   type SessionCacheMeta,
   type SessionHead,
 } from "@codesesh/core";
+import type { SearchIndexWorkerMessage } from "./search-index-worker.js";
 import { appLogger, logSearchIndexSync } from "./logging.js";
 
 export interface SessionsUpdatedEvent {
@@ -48,6 +51,7 @@ interface StablePathState {
 }
 
 const REFRESH_DEBOUNCE_MS = 200;
+const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const PENDING_REFRESH_DELAY_MS = 100;
 const WRITE_STABILITY_THRESHOLD_MS = 250;
 const WRITE_STABILITY_POLL_MS = 100;
@@ -277,6 +281,8 @@ export class LiveScanStore {
   private stablePaths = new Map<string, StablePathState>();
   private pendingEvent: SessionsUpdatedEvent | null = null;
   private pendingEventTimer: NodeJS.Timeout | null = null;
+  private initialSearchIndexTimer: NodeJS.Timeout | null = null;
+  private searchIndexWorker: Worker | null = null;
 
   constructor(
     private readonly watchEnabled = true,
@@ -317,6 +323,10 @@ export class LiveScanStore {
     });
     if (this.watchEnabled) {
       this.startWatching();
+      this.initialSearchIndexTimer = setTimeout(() => {
+        this.initialSearchIndexTimer = null;
+        this.startSearchIndexWorker("scan.initial.background");
+      }, 1000);
     }
   }
 
@@ -352,6 +362,14 @@ export class LiveScanStore {
     if (this.pendingEventTimer) {
       clearTimeout(this.pendingEventTimer);
       this.pendingEventTimer = null;
+    }
+    if (this.initialSearchIndexTimer) {
+      clearTimeout(this.initialSearchIndexTimer);
+      this.initialSearchIndexTimer = null;
+    }
+    if (this.searchIndexWorker) {
+      await this.searchIndexWorker.terminate();
+      this.searchIndexWorker = null;
     }
     this.pendingEvent = null;
 
@@ -397,6 +415,57 @@ export class LiveScanStore {
 
   private hasStartupWindow(): boolean {
     return this.startupScanOptions.from != null || this.startupScanOptions.to != null;
+  }
+
+  private getSearchIndexWorkerUrl(): URL | null {
+    const workerUrl = new URL("./search-index-worker.js", import.meta.url);
+    if (workerUrl.protocol === "file:" && !existsSync(fileURLToPath(workerUrl))) {
+      return null;
+    }
+    return workerUrl;
+  }
+
+  private startSearchIndexWorker(context: string): void {
+    if (this.searchIndexWorker) return;
+
+    const workerUrl = this.getSearchIndexWorkerUrl();
+    if (!workerUrl) {
+      appLogger.warn("search_index.worker_missing", { context });
+      return;
+    }
+
+    const worker = new Worker(workerUrl, {
+      workerData: {
+        context,
+        agentNames: this.agents.map((agent) => agent.name),
+        sessionsByAgent: this.byAgent,
+        metaByAgent: Object.fromEntries(
+          this.agents.map((agent) => [agent.name, buildAgentCacheMeta(agent)]),
+        ),
+      },
+    });
+    worker.unref();
+    this.searchIndexWorker = worker;
+
+    worker.on("message", (message: SearchIndexWorkerMessage) => {
+      if (message.type === "sync-result") {
+        logSearchIndexSync(message.context, message.result);
+      } else if (message.type === "done") {
+        appLogger.info(`${message.context}.done`, {
+          duration_ms: Math.round(message.durationMs),
+          sessions: message.sessions,
+        });
+      }
+    });
+    worker.on("error", (error) => {
+      appLogger.error("search_index.worker_error", { context, error });
+    });
+    worker.on("exit", (code) => {
+      this.searchIndexWorker = null;
+      if (code !== 0) {
+        appLogger.warn("search_index.worker_exit", { context, code });
+      }
+    });
   }
 
   private applyScanResult(result: ScanResult): void {
@@ -663,7 +732,11 @@ export class LiveScanStore {
         agentName,
         (this.pendingRefreshPathCounts.get(agentName) ?? 0) + 1,
       );
-      this.scheduleRefresh(agentName);
+      const delayMs =
+        (this.byAgent[agentName]?.length ?? 0) === 0
+          ? EMPTY_AGENT_REFRESH_DEBOUNCE_MS
+          : REFRESH_DEBOUNCE_MS;
+      this.scheduleRefresh(agentName, delayMs);
     }
   }
 

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -1,0 +1,62 @@
+import { parentPort, workerData } from "node:worker_threads";
+import {
+  createRegisteredAgents,
+  syncSessionSearchIndex,
+  type SearchIndexSyncResult,
+  type SessionCacheMeta,
+  type SessionHead,
+} from "@codesesh/core";
+
+export type SearchIndexWorkerMessage =
+  | {
+      type: "sync-result";
+      context: string;
+      result: SearchIndexSyncResult | null;
+    }
+  | {
+      type: "done";
+      context: string;
+      durationMs: number;
+      sessions: number;
+    };
+
+interface SearchIndexWorkerData {
+  context: string;
+  agentNames: string[];
+  sessionsByAgent: Record<string, SessionHead[]>;
+  metaByAgent: Record<string, Record<string, SessionCacheMeta>>;
+}
+
+const data = workerData as SearchIndexWorkerData;
+const startedAt = performance.now();
+const agents = createRegisteredAgents();
+
+for (const agentName of data.agentNames) {
+  const agent = agents.find((item) => item.name === agentName);
+  if (!agent) continue;
+
+  const meta = data.metaByAgent[agentName];
+  if (meta && agent.setSessionMetaMap) {
+    agent.setSessionMetaMap(new Map(Object.entries(meta)));
+  }
+
+  const sessions = data.sessionsByAgent[agentName] ?? [];
+  const result = syncSessionSearchIndex(agentName, sessions, (sessionId) =>
+    agent.getSessionData(sessionId),
+  );
+  parentPort?.postMessage({
+    type: "sync-result",
+    context: data.context,
+    result,
+  } satisfies SearchIndexWorkerMessage);
+}
+
+parentPort?.postMessage({
+  type: "done",
+  context: data.context,
+  durationMs: performance.now() - startedAt,
+  sessions: Object.values(data.sessionsByAgent).reduce(
+    (total, sessions) => total + sessions.length,
+    0,
+  ),
+} satisfies SearchIndexWorkerMessage);

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -4,7 +4,7 @@ const isWatch = process.argv.includes("--watch");
 const bundleCore = process.env.BUNDLE_CORE === "true";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/search-index-worker.ts"],
   format: ["esm"],
   dts: false,
   clean: !isWatch,

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -9,6 +9,7 @@ import {
   listFileActivity,
   listCachedProjectGroups,
   loadCachedSessions,
+  parseSearchQuery,
   searchFileActivitySessions,
   searchSessions,
   saveCachedSessions,
@@ -423,6 +424,25 @@ describe("getCacheInfo", () => {
 });
 
 describe("searchSessions", () => {
+  it("parses lightweight structured search qualifiers", () => {
+    expect(
+      parseSearchQuery(
+        'agent:codex project:codesesh tag:feature-dev tool:apply_patch file:"src/App.tsx" cost:>1 needle',
+      ),
+    ).toEqual({
+      text: "needle",
+      filters: {
+        agent: "codex",
+        project: "codesesh",
+        tags: ["feature-dev"],
+        tools: ["apply_patch"],
+        file: "src/App.tsx",
+        costMin: 1,
+      },
+      hasQualifiers: true,
+    });
+  });
+
   it("creates cache storage when syncing search index first", () => {
     const session = makeSession("first-search");
 
@@ -777,6 +797,97 @@ describe("searchSessions", () => {
     const directWriteResults = searchFileActivitySessions("src/direct.ts");
     expect(directWriteResults).toHaveLength(1);
     expect(directWriteResults[0]?.snippet).toContain("write");
+  });
+
+  it("combines full text with structured filters", () => {
+    const codex = {
+      ...makeSession("structured"),
+      slug: "codex/structured",
+      title: "Structured Retrieval",
+      directory: "/tmp/codesesh",
+      project_identity: {
+        kind: "path" as const,
+        key: "/tmp/codesesh",
+        displayName: "codesesh",
+      },
+      smart_tags: ["feature-dev" as const],
+      smart_tags_source_updated_at: now,
+      stats: {
+        message_count: 2,
+        total_input_tokens: 1,
+        total_output_tokens: 1,
+        total_cost: 2,
+      },
+    };
+    const other = {
+      ...makeSession("other"),
+      slug: "cursor/other",
+      directory: "/tmp/other",
+      smart_tags: ["docs" as const],
+    };
+
+    saveCachedSessions("codex", [codex]);
+    saveCachedSessions("cursor", [other]);
+    syncSessionSearchIndex("codex", [codex], () => ({
+      ...codex,
+      messages: [
+        {
+          id: "structured-user",
+          role: "user",
+          time_created: now,
+          parts: [{ type: "text", text: "needle structured search" }],
+        },
+        {
+          id: "structured-tool",
+          role: "assistant",
+          time_created: now + 1,
+          mode: "tool",
+          parts: [
+            {
+              type: "tool",
+              tool: "apply_patch",
+              state: { input: { path: "src/App.tsx" } },
+            },
+          ],
+        },
+      ],
+    }));
+    syncSessionSearchIndex("cursor", [other], () => makeSessionData("other", "needle other"));
+
+    const results = searchSessions(
+      "needle agent:codex project:codesesh tag:feature-dev tool:apply_patch file:App.tsx cost:>1",
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.session.id).toBe("structured");
+    expect(results[0]?.matchType).toBe("user_message");
+    expect(results[0]?.session.smart_tags).toEqual(["feature-dev"]);
+  });
+
+  it("returns recent sessions for structured-only queries", () => {
+    const recent = {
+      ...makeSession("recent"),
+      slug: "codex/recent",
+      time_updated: now + 10,
+      smart_tags: ["testing" as const],
+    };
+    const old = {
+      ...makeSession("old"),
+      slug: "codex/old",
+      time_updated: now - 10,
+      smart_tags: ["docs" as const],
+    };
+
+    saveCachedSessions("codex", [old, recent]);
+    syncSessionSearchIndex("codex", [old, recent], (sessionId) =>
+      makeSessionData(sessionId, "indexed content"),
+    );
+
+    const results = searchSessions("agent:codex tag:testing");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.session.id).toBe("recent");
+    expect(results[0]?.matchType).toBe("recent");
   });
 
   it("upserts parent session rows before indexed messages", () => {

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -427,20 +427,52 @@ describe("searchSessions", () => {
   it("parses lightweight structured search qualifiers", () => {
     expect(
       parseSearchQuery(
-        'agent:codex project:codesesh tag:feature-dev tool:apply_patch file:"src/App.tsx" cost:>1 needle',
+        'agent:codex project:"code sesh" tag:feature-dev tool:apply_patch file:"src/App File.tsx" cost:>1 needle',
       ),
     ).toEqual({
       text: "needle",
       filters: {
         agent: "codex",
-        project: "codesesh",
+        project: "code sesh",
         tags: ["feature-dev"],
         tools: ["apply_patch"],
-        file: "src/App.tsx",
+        file: "src/App File.tsx",
         costMin: 1,
+        costMinExclusive: true,
       },
       hasQualifiers: true,
     });
+  });
+
+  it("preserves strict cost qualifier comparisons", () => {
+    const below = {
+      ...makeSession("below"),
+      time_updated: now + 1,
+      stats: { ...makeSession("below").stats, total_cost: 0.99 },
+    };
+    const boundary = {
+      ...makeSession("boundary"),
+      time_updated: now + 2,
+      stats: { ...makeSession("boundary").stats, total_cost: 1 },
+    };
+    const above = {
+      ...makeSession("above"),
+      time_updated: now + 3,
+      stats: { ...makeSession("above").stats, total_cost: 1.01 },
+    };
+
+    saveCachedSessions("codex", [below, boundary, above]);
+
+    expect(searchSessions("cost:>1").map((result) => result.session.id)).toEqual(["above"]);
+    expect(searchSessions("cost:<1").map((result) => result.session.id)).toEqual(["below"]);
+    expect(searchSessions("cost:>=1").map((result) => result.session.id)).toEqual([
+      "above",
+      "boundary",
+    ]);
+    expect(searchSessions("cost:<=1").map((result) => result.session.id)).toEqual([
+      "boundary",
+      "below",
+    ]);
   });
 
   it("creates cache storage when syncing search index first", () => {

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -14,6 +14,7 @@ import type {
   SessionFileActivity,
   SessionData,
   SessionHead,
+  SmartTag,
 } from "../types/index.js";
 import { buildProjectGroups, computeIdentity, realFs } from "../projects/index.js";
 import { extractSessionFileActivity } from "../utils/file-activity.js";
@@ -33,6 +34,7 @@ const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
 const SEARCH_INDEX_BULK_SYNC_THRESHOLD = 100;
+let ftsIntegrityCheckedPath: string | null = null;
 
 export interface SessionCacheMeta {
   id: string;
@@ -115,6 +117,13 @@ interface MessageCountRow extends DatabaseRow {
   value?: number;
 }
 
+interface MessageSearchRow extends DatabaseRow {
+  role?: Message["role"];
+  mode?: string | null;
+  content_text?: string;
+  tool_metadata_json?: string | null;
+}
+
 interface MessageBackfillRow extends DatabaseRow {
   message_id?: string;
   role?: Message["role"];
@@ -148,6 +157,9 @@ interface SearchResultRow extends DatabaseRow {
   total_cost?: number;
   cost_source?: string | null;
   total_tokens?: number | null;
+  model_usage_json?: string | null;
+  smart_tags_json?: string | null;
+  smart_tags_source_updated_at?: number | null;
   snippet?: string | null;
 }
 
@@ -215,11 +227,47 @@ export interface SearchResult {
   agentName: string;
   session: SessionHead;
   snippet: string;
+  matchType: SearchMatchType;
+}
+
+export type SearchMatchType =
+  | "recent"
+  | "title"
+  | "user_message"
+  | "assistant_reply"
+  | "tool_output"
+  | "file_path";
+
+export interface SearchQueryFilters {
+  agent?: string;
+  project?: string;
+  projectKey?: string;
+  cwd?: string;
+  tags?: SmartTag[];
+  tools?: string[];
+  file?: string;
+  fileKind?: FileActivityKind;
+  costMin?: number;
+  costMax?: number;
+}
+
+export interface ParsedSearchQuery {
+  text: string;
+  filters: SearchQueryFilters;
+  hasQualifiers: boolean;
 }
 
 export interface SearchOptions {
   agent?: string;
+  project?: string;
+  projectKey?: string;
   cwd?: string;
+  tags?: SmartTag[];
+  tools?: string[];
+  file?: string;
+  fileKind?: FileActivityKind;
+  costMin?: number;
+  costMax?: number;
   from?: number;
   to?: number;
   limit?: number;
@@ -229,6 +277,7 @@ export interface FileActivityOptions {
   agent?: string;
   sessionId?: string;
   projectKey?: string;
+  project?: string;
   cwd?: string;
   path?: string;
   kind?: FileActivityKind;
@@ -1135,18 +1184,28 @@ function shouldBulkSyncSearchIndex(options: SearchIndexSyncOptions, changedCount
   return threshold > 0 && changedCount >= threshold;
 }
 
-function ensureFtsConsistency(db: SQLiteDatabase): void {
+function ensureFtsReady(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents_fts")) {
     createSearchTables(db);
   }
   createSearchTriggers(db);
+}
+
+function ensureFtsConsistency(db: SQLiteDatabase): void {
+  ensureFtsReady(db);
+  const cachePath = getCachePath();
+  if (ftsIntegrityCheckedPath === cachePath) {
+    return;
+  }
 
   try {
     db.exec(
       "INSERT INTO session_documents_fts(session_documents_fts, rank) VALUES ('integrity-check', 1)",
     );
+    ftsIntegrityCheckedPath = cachePath;
   } catch {
     rebuildSearchIndex(db);
+    ftsIntegrityCheckedPath = cachePath;
   }
 }
 
@@ -1231,9 +1290,120 @@ function escapeFtsTerm(value: string): string {
   return value.replaceAll('"', '""');
 }
 
+function splitSearchTokens(input: string): string[] {
+  return input.match(/"[^"]+"|\S+/g) ?? [];
+}
+
+function unwrapSearchValue(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function parseCostQualifier(value: string, filters: SearchQueryFilters): void {
+  const raw = unwrapSearchValue(value);
+  const range = raw.match(/^(\d+(?:\.\d+)?)\.\.(\d+(?:\.\d+)?)$/);
+  if (range) {
+    filters.costMin = Number(range[1]);
+    filters.costMax = Number(range[2]);
+    return;
+  }
+
+  const comparison = raw.match(/^(>=|>|<=|<)(\d+(?:\.\d+)?)$/);
+  if (comparison) {
+    const amount = Number(comparison[2]);
+    if (comparison[1]?.includes(">")) filters.costMin = amount;
+    else filters.costMax = amount;
+    return;
+  }
+
+  const amount = Number(raw);
+  if (!Number.isNaN(amount)) {
+    filters.costMin = amount;
+    filters.costMax = amount;
+  }
+}
+
+function appendUnique<T>(values: T[] | undefined, value: T): T[] {
+  if (values?.includes(value)) return values;
+  return [...(values ?? []), value];
+}
+
+function isSmartTag(value: string): value is SmartTag {
+  return (
+    value === "bugfix" ||
+    value === "refactoring" ||
+    value === "feature-dev" ||
+    value === "testing" ||
+    value === "docs" ||
+    value === "git-ops" ||
+    value === "build-deploy" ||
+    value === "exploration" ||
+    value === "planning"
+  );
+}
+
+export function parseSearchQuery(input: string): ParsedSearchQuery {
+  const filters: SearchQueryFilters = {};
+  const textTokens: string[] = [];
+  let hasQualifiers = false;
+
+  for (const token of splitSearchTokens(input)) {
+    const match = token.match(/^([a-zA-Z][a-zA-Z_-]*):(.+)$/);
+    if (!match) {
+      textTokens.push(token);
+      continue;
+    }
+
+    const key = match[1]!.toLowerCase();
+    const value = unwrapSearchValue(match[2]!);
+    if (!value) continue;
+
+    let consumed = true;
+    if (key === "agent") filters.agent = value.toLowerCase();
+    else if (key === "project") filters.project = value;
+    else if (key === "projectkey" || key === "project-key") filters.projectKey = value;
+    else if (key === "cwd") filters.cwd = value;
+    else if (key === "tool") filters.tools = appendUnique(filters.tools, value.toLowerCase());
+    else if (key === "file" || key === "path") filters.file = value;
+    else if (key === "kind" || key === "filekind" || key === "file-kind") {
+      if (value === "read" || value === "edit" || value === "write" || value === "delete") {
+        filters.fileKind = value;
+      } else {
+        consumed = false;
+      }
+    } else if (key === "tag" || key === "signal") {
+      const tag = value.toLowerCase();
+      if (isSmartTag(tag)) {
+        filters.tags = appendUnique(filters.tags, tag);
+      } else {
+        consumed = false;
+      }
+    } else if (key === "cost") {
+      parseCostQualifier(value, filters);
+    } else {
+      consumed = false;
+    }
+
+    if (consumed) {
+      hasQualifiers = true;
+    } else {
+      textTokens.push(token);
+    }
+  }
+
+  return {
+    text: textTokens.join(" ").trim(),
+    filters,
+    hasQualifiers,
+  };
+}
+
 function toFtsQuery(input: string): string {
-  const tokens = input.match(/"[^"]+"|\S+/g) ?? [];
-  return tokens
+  const tokens = splitSearchTokens(input);
+  const mapped = tokens
     .map((token) => {
       if (/^OR$/i.test(token)) {
         return "OR";
@@ -1243,7 +1413,16 @@ function toFtsQuery(input: string): string {
       }
       return `"${escapeFtsTerm(token)}"`;
     })
-    .join(" ");
+    .filter(
+      (token, index, values) =>
+        token !== "OR" ||
+        (index > 0 &&
+          index < values.length - 1 &&
+          values[index - 1] !== "OR" &&
+          values[index + 1] !== "OR"),
+    );
+
+  return mapped.join(" ");
 }
 
 function appendPlainText(value: unknown, chunks: string[]): void {
@@ -1531,6 +1710,7 @@ export function saveCachedSessions(
 }
 
 export function clearCache(): void {
+  ftsIntegrityCheckedPath = null;
   if (!hasCacheStorage()) {
     deleteLegacyCacheFile();
     return;
@@ -1831,70 +2011,284 @@ export function syncSessionSearchIndex(
 }
 
 function sessionHeadFromSearchRow(row: SearchResultRow): SessionHead {
+  return sessionFromRow(row as SessionRow);
+}
+
+function mergeSearchLists<T>(left: T[] | undefined, right: T[] | undefined): T[] | undefined {
+  const values = [...(left ?? []), ...(right ?? [])];
+  return values.length > 0 ? [...new Set(values)] : undefined;
+}
+
+function mergeSearchQueryOptions(query: string, options: SearchOptions) {
+  const parsed = parseSearchQuery(query);
   return {
-    id: String(row.session_id),
-    slug: String(row.slug),
-    title: String(row.title),
-    directory: String(row.directory),
-    project_identity: row.project_identity_key
-      ? {
-          kind: row.project_identity_kind ?? "path",
-          key: String(row.project_identity_key),
-          displayName: String(row.project_display_name ?? ""),
-        }
-      : undefined,
-    time_created: Number(row.time_created),
-    time_updated: row.time_updated == null ? undefined : Number(row.time_updated),
-    stats: {
-      message_count: Number(row.message_count ?? 0),
-      total_input_tokens: Number(row.total_input_tokens ?? 0),
-      total_output_tokens: Number(row.total_output_tokens ?? 0),
-      total_cache_read_tokens:
-        row.total_cache_read_tokens == null ? undefined : Number(row.total_cache_read_tokens),
-      total_cache_create_tokens:
-        row.total_cache_create_tokens == null ? undefined : Number(row.total_cache_create_tokens),
-      total_cost: Number(row.total_cost ?? 0),
-      cost_source:
-        row.cost_source == null
-          ? undefined
-          : (String(row.cost_source) as SessionHead["stats"]["cost_source"]),
-      total_tokens: row.total_tokens == null ? undefined : Number(row.total_tokens),
+    text: parsed.text || (parsed.hasQualifiers ? "" : query.trim()),
+    options: {
+      ...options,
+      agent: options.agent ?? parsed.filters.agent,
+      project: options.project ?? parsed.filters.project,
+      projectKey: options.projectKey ?? parsed.filters.projectKey,
+      cwd: options.cwd ?? parsed.filters.cwd,
+      tags: mergeSearchLists(options.tags, parsed.filters.tags),
+      tools: mergeSearchLists(options.tools, parsed.filters.tools),
+      file: options.file ?? parsed.filters.file,
+      fileKind: options.fileKind ?? parsed.filters.fileKind,
+      costMin: options.costMin ?? parsed.filters.costMin,
+      costMax: options.costMax ?? parsed.filters.costMax,
     },
+    parsed,
   };
 }
 
+function likePattern(value: string): string {
+  return `%${value
+    .trim()
+    .toLowerCase()
+    .replace(/[\\%_]/g, "\\$&")}%`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildSessionSearchFilters(options: SearchOptions): {
+  where: string;
+  params: unknown[];
+} {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+
+  if (options.agent) {
+    clauses.push("s.agent_name = ?");
+    params.push(options.agent);
+  }
+  if (options.projectKey) {
+    clauses.push("s.project_identity_key = ?");
+    params.push(options.projectKey);
+  }
+  if (options.cwd) {
+    clauses.push("(s.project_identity_key = ? OR LOWER(s.directory) LIKE ? ESCAPE '\\')");
+    params.push(computeIdentity(options.cwd, realFs).key, likePattern(options.cwd));
+  }
+  if (options.project) {
+    clauses.push(
+      "(LOWER(s.project_identity_key) LIKE ? ESCAPE '\\' OR LOWER(s.project_display_name) LIKE ? ESCAPE '\\' OR LOWER(s.directory) LIKE ? ESCAPE '\\')",
+    );
+    const pattern = likePattern(options.project);
+    params.push(pattern, pattern, pattern);
+  }
+  for (const tag of options.tags ?? []) {
+    clauses.push("s.smart_tags_json LIKE ?");
+    params.push(`%"${tag}"%`);
+  }
+  for (const tool of options.tools ?? []) {
+    clauses.push(
+      "EXISTS (SELECT 1 FROM messages m WHERE m.agent_name = s.agent_name AND m.session_id = s.session_id AND LOWER(m.tool_metadata_json) LIKE ? ESCAPE '\\')",
+    );
+    params.push(likePattern(tool));
+  }
+  if (options.file || options.fileKind) {
+    const fileClauses = ["fa.agent_name = s.agent_name", "fa.session_id = s.session_id"];
+    if (options.file) {
+      fileClauses.push("LOWER(fa.path) LIKE ? ESCAPE '\\'");
+      params.push(likePattern(options.file));
+    }
+    if (options.fileKind) {
+      fileClauses.push("fa.kind = ?");
+      params.push(options.fileKind);
+    }
+    clauses.push(
+      `EXISTS (SELECT 1 FROM session_file_activity fa WHERE ${fileClauses.join(" AND ")})`,
+    );
+  }
+  if (options.from != null) {
+    clauses.push("s.activity_time >= ?");
+    params.push(options.from);
+  }
+  if (options.to != null) {
+    clauses.push("s.activity_time <= ?");
+    params.push(options.to);
+  }
+  if (options.costMin != null) {
+    clauses.push("s.total_cost >= ?");
+    params.push(options.costMin);
+  }
+  if (options.costMax != null) {
+    clauses.push("s.total_cost <= ?");
+    params.push(options.costMax);
+  }
+
+  return {
+    where: clauses.length > 0 ? ` AND ${clauses.join(" AND ")}` : "",
+    params,
+  };
+}
+
+function searchSessionColumns(): string {
+  return `
+    s.agent_name,
+    s.session_id,
+    s.slug,
+    s.title,
+    s.directory,
+    s.project_identity_kind,
+    s.project_identity_key,
+    s.project_display_name,
+    s.time_created,
+    s.time_updated,
+    s.message_count,
+    s.total_input_tokens,
+    s.total_output_tokens,
+    s.total_cache_read_tokens,
+    s.total_cache_create_tokens,
+    s.total_cost,
+    s.cost_source,
+    s.total_tokens,
+    s.model_usage_json,
+    s.smart_tags_json,
+    s.smart_tags_source_updated_at
+  `;
+}
+
+function parseTextTerms(input: string): { terms: string[]; mode: "all" | "any" } {
+  const tokens = splitSearchTokens(input);
+  return {
+    terms: tokens
+      .filter((token) => !/^OR$/i.test(token))
+      .map((token) => unwrapSearchValue(token).toLowerCase())
+      .filter(Boolean),
+    mode: tokens.some((token) => /^OR$/i.test(token)) ? "any" : "all",
+  };
+}
+
+function textMatchesTerms(text: string, terms: { terms: string[]; mode: "all" | "any" }) {
+  const lower = text.toLowerCase();
+  if (terms.terms.length === 0) return true;
+  if (terms.mode === "any") return terms.terms.some((term) => lower.includes(term));
+  return terms.terms.every((term) => lower.includes(term));
+}
+
+function highlightTerm(text: string, term: string): string {
+  return text.replace(new RegExp(escapeRegExp(term), "gi"), (match) => `<mark>${match}</mark>`);
+}
+
+function buildTermSnippet(text: string, terms: { terms: string[]; mode: "all" | "any" }): string {
+  const lower = text.toLowerCase();
+  const term = terms.terms.find((item) => lower.includes(item)) ?? terms.terms[0] ?? "";
+  if (!term) return text.slice(0, 180);
+
+  const index = lower.indexOf(term);
+  const start = Math.max(0, index - 80);
+  const end = Math.min(text.length, index + term.length + 80);
+  return `${start > 0 ? "… " : ""}${highlightTerm(text.slice(start, end), term)}${
+    end < text.length ? " …" : ""
+  }`;
+}
+
+function messageMatchType(row: MessageSearchRow): SearchMatchType {
+  if (row.role === "user") return "user_message";
+  if (row.role === "tool" || row.mode === "tool" || row.tool_metadata_json) return "tool_output";
+  return "assistant_reply";
+}
+
+function resolveSearchMatch(
+  db: SQLiteDatabase,
+  row: SearchResultRow,
+  textQuery: string,
+): { snippet: string; matchType: SearchMatchType } {
+  const terms = parseTextTerms(textQuery);
+  const title = String(row.title ?? "");
+
+  if (terms.terms.length === 0) {
+    return {
+      snippet: `Recent session · ${String(row.directory ?? "")}`,
+      matchType: "recent",
+    };
+  }
+
+  if (textMatchesTerms(title, terms)) {
+    return { snippet: buildTermSnippet(title, terms), matchType: "title" };
+  }
+
+  const messages = db
+    .prepare(
+      `
+        SELECT role, mode, content_text, tool_metadata_json
+        FROM messages
+        WHERE agent_name = ? AND session_id = ?
+        ORDER BY message_index
+      `,
+    )
+    .all(row.agent_name, row.session_id) as MessageSearchRow[];
+
+  for (const message of messages) {
+    const text = String(message.content_text ?? "");
+    if (!textMatchesTerms(text, terms)) continue;
+    return {
+      snippet: buildTermSnippet(text, terms),
+      matchType: messageMatchType(message),
+    };
+  }
+
+  return {
+    snippet: String(row.snippet ?? ""),
+    matchType: "assistant_reply",
+  };
+}
+
+function rowsToSearchResults(
+  db: SQLiteDatabase,
+  rows: SearchResultRow[],
+  textQuery: string,
+): SearchResult[] {
+  return rows.map((row) => {
+    const match = resolveSearchMatch(db, row, textQuery);
+    return {
+      agentName: String(row.agent_name),
+      session: sessionHeadFromSearchRow(row),
+      snippet: match.snippet,
+      matchType: match.matchType,
+    };
+  });
+}
+
 export function searchSessions(query: string, options: SearchOptions = {}): SearchResult[] {
-  const normalizedQuery = query.trim();
-  if (!normalizedQuery || !hasCacheStorage()) {
+  const search = mergeSearchQueryOptions(query, options);
+  const normalizedQuery = search.text.trim();
+  if (!hasCacheStorage()) {
     return [];
   }
 
-  const ftsQuery = toFtsQuery(normalizedQuery);
-
   const results = withCacheDb((db) => {
-    ensureFtsConsistency(db);
+    ensureFtsReady(db);
+    const filters = buildSessionSearchFilters(search.options);
+
+    if (!normalizedQuery) {
+      const rows = db
+        .prepare(
+          `
+            SELECT
+              ${searchSessionColumns()},
+              '' AS snippet
+            FROM sessions s
+            WHERE 1 = 1
+              ${filters.where}
+            ORDER BY s.activity_time DESC
+            LIMIT ?
+          `,
+        )
+        .all(...filters.params, search.options.limit ?? 50) as SearchResultRow[];
+
+      return rowsToSearchResults(db, rows, "");
+    }
+
+    const ftsQuery = toFtsQuery(normalizedQuery);
+    if (!ftsQuery) return [];
     const rows = db
       .prepare(
         `
           SELECT
-            s.agent_name,
-            s.session_id,
-            s.slug,
-            s.title,
-            s.directory,
-            s.project_identity_kind,
-            s.project_identity_key,
-            s.project_display_name,
-            s.time_created,
-            s.time_updated,
-            s.message_count,
-            s.total_input_tokens,
-            s.total_output_tokens,
-            s.total_cache_read_tokens,
-            s.total_cache_create_tokens,
-            s.total_cost,
-            s.cost_source,
-            s.total_tokens,
+            ${searchSessionColumns()},
             COALESCE(
               NULLIF(snippet(session_documents_fts, 1, '<mark>', '</mark>', ' … ', 18), ''),
               highlight(session_documents_fts, 0, '<mark>', '</mark>')
@@ -1903,33 +2297,14 @@ export function searchSessions(query: string, options: SearchOptions = {}): Sear
           JOIN session_documents d ON d.id = session_documents_fts.rowid
           JOIN sessions s ON s.agent_name = d.agent_name AND s.session_id = d.session_id
           WHERE session_documents_fts MATCH ?
-            AND (? IS NULL OR s.agent_name = ?)
-            AND (? IS NULL OR s.project_identity_key = ? OR LOWER(s.directory) LIKE ?)
-            AND (? IS NULL OR s.activity_time >= ?)
-            AND (? IS NULL OR s.activity_time <= ?)
+            ${filters.where}
           ORDER BY bm25(session_documents_fts, 8.0, 1.0), s.activity_time DESC
           LIMIT ?
         `,
       )
-      .all(
-        ftsQuery,
-        options.agent ?? null,
-        options.agent ?? null,
-        options.cwd ?? null,
-        options.cwd ? computeIdentity(options.cwd, realFs).key : null,
-        options.cwd ? `%${options.cwd.toLowerCase()}%` : null,
-        options.from ?? null,
-        options.from ?? null,
-        options.to ?? null,
-        options.to ?? null,
-        options.limit ?? 50,
-      ) as SearchResultRow[];
+      .all(ftsQuery, ...filters.params, search.options.limit ?? 50) as SearchResultRow[];
 
-    return rows.map((row) => ({
-      agentName: String(row.agent_name),
-      session: sessionHeadFromSearchRow(row),
-      snippet: String(row.snippet ?? ""),
-    }));
+    return rowsToSearchResults(db, rows, normalizedQuery);
   });
 
   return results ?? [];
@@ -1941,6 +2316,7 @@ function normalizeFilePathSearch(value: string): string {
 
 function fileActivityFilters(options: FileActivityOptions): {
   projectKey: string | null;
+  projectLike: string | null;
   cwdKey: string | null;
   cwdLike: string | null;
   pathLike: string | null;
@@ -1948,9 +2324,10 @@ function fileActivityFilters(options: FileActivityOptions): {
   const path = options.path ? normalizeFilePathSearch(options.path) : "";
   return {
     projectKey: options.projectKey ?? null,
+    projectLike: options.project ? likePattern(options.project) : null,
     cwdKey: options.cwd ? computeIdentity(options.cwd, realFs).key : null,
-    cwdLike: options.cwd ? `%${options.cwd.toLowerCase()}%` : null,
-    pathLike: path ? `%${path.toLowerCase()}%` : null,
+    cwdLike: options.cwd ? likePattern(options.cwd) : null,
+    pathLike: path ? likePattern(path) : null,
   };
 }
 
@@ -2005,8 +2382,9 @@ export function listFileActivity(options: FileActivityOptions = {}): FileActivit
           WHERE (? IS NULL OR fa.agent_name = ?)
             AND (? IS NULL OR fa.session_id = ?)
             AND (? IS NULL OR fa.project_identity_key = ?)
-            AND (? IS NULL OR s.project_identity_key = ? OR LOWER(s.directory) LIKE ?)
-            AND (? IS NULL OR LOWER(fa.path) LIKE ?)
+            AND (? IS NULL OR LOWER(fa.project_identity_key) LIKE ? ESCAPE '\\' OR LOWER(s.project_display_name) LIKE ? ESCAPE '\\' OR LOWER(s.directory) LIKE ? ESCAPE '\\')
+            AND (? IS NULL OR s.project_identity_key = ? OR LOWER(s.directory) LIKE ? ESCAPE '\\')
+            AND (? IS NULL OR LOWER(fa.path) LIKE ? ESCAPE '\\')
             AND (? IS NULL OR fa.kind = ?)
             AND (? IS NULL OR fa.latest_time >= ?)
             AND (? IS NULL OR fa.latest_time <= ?)
@@ -2021,6 +2399,10 @@ export function listFileActivity(options: FileActivityOptions = {}): FileActivit
           options.sessionId ?? null,
           filters.projectKey,
           filters.projectKey,
+          filters.projectLike,
+          filters.projectLike,
+          filters.projectLike,
+          filters.projectLike,
           filters.cwdKey,
           filters.cwdKey,
           filters.cwdLike,
@@ -2066,16 +2448,20 @@ export function searchFileActivitySessions(
   query: string,
   options: SearchOptions = {},
 ): SearchResult[] {
-  const path = normalizeFilePathSearch(query);
+  const search = mergeSearchQueryOptions(query, options);
+  const path = normalizeFilePathSearch(search.options.file ?? search.text);
   if (!path) return [];
 
   const rows = listFileActivity({
-    agent: options.agent,
-    cwd: options.cwd,
+    agent: search.options.agent,
+    projectKey: search.options.projectKey,
+    project: search.options.project,
+    cwd: search.options.cwd,
     path,
-    from: options.from,
-    to: options.to,
-    limit: (options.limit ?? 50) * 3,
+    kind: search.options.fileKind,
+    from: search.options.from,
+    to: search.options.to,
+    limit: (search.options.limit ?? 50) * 3,
   });
   const seen = new Set<string>();
   const results: SearchResult[] = [];
@@ -2088,8 +2474,9 @@ export function searchFileActivitySessions(
       agentName: row.agent_name,
       session: row.session,
       snippet: `${row.kind} ${highlightFilePath(row.path, path)} · ${row.count} events`,
+      matchType: "file_path",
     });
-    if (results.length >= (options.limit ?? 50)) break;
+    if (results.length >= (search.options.limit ?? 50)) break;
   }
 
   return results;

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -249,6 +249,8 @@ export interface SearchQueryFilters {
   fileKind?: FileActivityKind;
   costMin?: number;
   costMax?: number;
+  costMinExclusive?: boolean;
+  costMaxExclusive?: boolean;
 }
 
 export interface ParsedSearchQuery {
@@ -268,6 +270,8 @@ export interface SearchOptions {
   fileKind?: FileActivityKind;
   costMin?: number;
   costMax?: number;
+  costMinExclusive?: boolean;
+  costMaxExclusive?: boolean;
   from?: number;
   to?: number;
   limit?: number;
@@ -1291,7 +1295,31 @@ function escapeFtsTerm(value: string): string {
 }
 
 function splitSearchTokens(input: string): string[] {
-  return input.match(/"[^"]+"|\S+/g) ?? [];
+  const tokens: string[] = [];
+  let token = "";
+  let inQuote = false;
+
+  for (const char of input) {
+    if (char === '"') {
+      inQuote = !inQuote;
+      token += char;
+      continue;
+    }
+    if (/\s/.test(char) && !inQuote) {
+      if (token) {
+        tokens.push(token);
+        token = "";
+      }
+      continue;
+    }
+    token += char;
+  }
+
+  if (token) {
+    tokens.push(token);
+  }
+
+  return tokens;
 }
 
 function unwrapSearchValue(value: string): string {
@@ -1314,8 +1342,13 @@ function parseCostQualifier(value: string, filters: SearchQueryFilters): void {
   const comparison = raw.match(/^(>=|>|<=|<)(\d+(?:\.\d+)?)$/);
   if (comparison) {
     const amount = Number(comparison[2]);
-    if (comparison[1]?.includes(">")) filters.costMin = amount;
-    else filters.costMax = amount;
+    if (comparison[1]?.includes(">")) {
+      filters.costMin = amount;
+      filters.costMinExclusive = comparison[1] === ">";
+    } else {
+      filters.costMax = amount;
+      filters.costMaxExclusive = comparison[1] === "<";
+    }
     return;
   }
 
@@ -2035,9 +2068,26 @@ function mergeSearchQueryOptions(query: string, options: SearchOptions) {
       fileKind: options.fileKind ?? parsed.filters.fileKind,
       costMin: options.costMin ?? parsed.filters.costMin,
       costMax: options.costMax ?? parsed.filters.costMax,
+      costMinExclusive: options.costMinExclusive ?? parsed.filters.costMinExclusive,
+      costMaxExclusive: options.costMaxExclusive ?? parsed.filters.costMaxExclusive,
     },
     parsed,
   };
+}
+
+function sessionMatchesSearchCost(session: SessionHead, options: SearchOptions): boolean {
+  const cost = session.stats.total_cost;
+  if (options.costMin != null) {
+    if (options.costMinExclusive ? cost <= options.costMin : cost < options.costMin) {
+      return false;
+    }
+  }
+  if (options.costMax != null) {
+    if (options.costMaxExclusive ? cost >= options.costMax : cost > options.costMax) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function likePattern(value: string): string {
@@ -2110,11 +2160,11 @@ function buildSessionSearchFilters(options: SearchOptions): {
     params.push(options.to);
   }
   if (options.costMin != null) {
-    clauses.push("s.total_cost >= ?");
+    clauses.push(options.costMinExclusive ? "s.total_cost > ?" : "s.total_cost >= ?");
     params.push(options.costMin);
   }
   if (options.costMax != null) {
-    clauses.push("s.total_cost <= ?");
+    clauses.push(options.costMaxExclusive ? "s.total_cost < ?" : "s.total_cost <= ?");
     params.push(options.costMax);
   }
 
@@ -2469,6 +2519,7 @@ export function searchFileActivitySessions(
   for (const row of rows) {
     const key = `${row.agent_name}/${row.session_id}`;
     if (seen.has(key)) continue;
+    if (!sessionMatchesSearchCost(row.session, search.options)) continue;
     seen.add(key);
     results.push({
       agentName: row.agent_name,

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -10,6 +10,7 @@ export {
   listCachedProjectGroups,
   listFileActivity,
   listSessionFileActivity,
+  parseSearchQuery,
   searchFileActivitySessions,
   searchSessions,
   syncSessionSearchIndex,
@@ -17,8 +18,12 @@ export {
 export type {
   FileActivityOptions,
   FileActivityResult,
+  ParsedSearchQuery,
   SearchIndexSyncOptions,
   SearchIndexSyncResult,
+  SearchMatchType,
+  SearchOptions,
+  SearchQueryFilters,
 } from "./cache.js";
 export { perf } from "../utils/index.js";
 export type { PerfMarker } from "../utils/index.js";


### PR DESCRIPTION
## What changed

- Added structured global search filters for agent, project, tag, signal, file activity, and cost ranges.
- Added lightweight query qualifiers such as `agent:codex`, `tool:apply_patch`, and `file:App.tsx`.
- Moved startup search indexing into a worker and kept empty or structured-only search on the fast in-memory path.
- Added match type snippets and coverage for the new search behavior.

## Why

Opening global search previously triggered expensive per-request indexing, so empty and filtered searches could take around 10 seconds. The search request path now serves recent and structured results from already-scanned session heads, while full-text indexing runs in the background.

## Validation

- `rtk pnpm --filter @codesesh/core test -- src/discovery/__tests__/cache.test.ts`
- `rtk pnpm --filter codesesh test -- src/live-scan-store.test.ts src/api/__tests__/handlers.test.ts`
- `rtk pnpm --filter @codesesh/core lint`
- `rtk pnpm --filter codesesh lint`
- `rtk pnpm --filter @codesesh/web lint`
- `rtk pnpm --filter @codesesh/core build`
- `rtk pnpm --filter @codesesh/web build`
- `rtk pnpm --filter codesesh build`
- `rtk pnpm test:e2e`