### PR TITLE
feat(projects): add project browse mode

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,6 +25,7 @@ import type {
   SessionsUpdatedEvent,
   SmartTag,
   ProjectGroup,
+  ProjectIdentityKind,
 } from "./lib/api";
 import {
   deleteBookmark,
@@ -62,14 +63,26 @@ import {
   mergeBookmarksWithSessions,
   toBookmarkedSessionSnapshot,
 } from "./lib/bookmarks";
-import { getProjectPath } from "./lib/projects";
+import {
+  decodeProjectRouteKey,
+  getProjectIdentityKey,
+  getProjectPath,
+  isProjectIdentityKind,
+  type ProjectRouteIdentity,
+} from "./lib/projects";
 
 type BrowseBy = "agents" | "projects";
 
 type ViewState =
   | { mode: "root"; activeAgentKey: null; activeSessionSlug: null }
   | { mode: "projects"; activeAgentKey: null; activeSessionSlug: null }
-  | { mode: "project"; activeAgentKey: null; activeSessionSlug: null; activeProjectKey: string }
+  | {
+      mode: "project";
+      activeAgentKey: null;
+      activeSessionSlug: null;
+      activeProjectKind: ProjectIdentityKind;
+      activeProjectKey: string;
+    }
   | { mode: "agent"; activeAgentKey: string; activeSessionSlug: null }
   | { mode: "session"; activeAgentKey: string; activeSessionSlug: string }
   | { mode: "missingAgent"; activeAgentKey: null; activeSessionSlug: null; attemptedKey: string }
@@ -97,13 +110,18 @@ function parseViewState(pathname: string, validAgentKeys: Set<string>): ViewStat
     if (segments.length === 1) {
       return { mode: "projects", activeAgentKey: null, activeSessionSlug: null };
     }
-    if (segments.length === 2) {
+    if (segments.length === 3) {
       try {
+        const kind = decodeURIComponent(segments[1]!);
+        if (!isProjectIdentityKind(kind)) {
+          return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+        }
         return {
           mode: "project",
           activeAgentKey: null,
           activeSessionSlug: null,
-          activeProjectKey: decodeURIComponent(segments[1]!),
+          activeProjectKind: kind,
+          activeProjectKey: decodeProjectRouteKey(segments[2]!),
         };
       } catch {
         return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
@@ -172,6 +190,19 @@ function formatSearchSubtitle(query: string, loading: boolean, count: number) {
 
 function getSessionAgentKey(session: SessionHead): string {
   return session.slug.split("/")[0]?.toLowerCase() || "unknown";
+}
+
+function getProjectGroupIdentity(project: ProjectGroup): ProjectRouteIdentity {
+  return { kind: project.identityKind, key: project.identityKey };
+}
+
+function matchesProjectIdentity(
+  identity: SessionHead["project_identity"] | SessionData["project_identity"] | undefined,
+  project: ProjectRouteIdentity | null,
+): boolean {
+  return Boolean(
+    identity && project && identity.kind === project.kind && identity.key === project.key,
+  );
 }
 
 function formatRelativeTime(timestamp?: number) {
@@ -426,7 +457,8 @@ export default function App() {
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
   const [projects, setProjects] = useState<ProjectGroup[]>([]);
   const [browseBy, setBrowseBy] = useState<BrowseBy>("agents");
-  const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null);
+  const [selectedProjectIdentity, setSelectedProjectIdentity] =
+    useState<ProjectRouteIdentity | null>(null);
   const [projectDashboard, setProjectDashboard] = useState<DashboardData | null>(null);
   const [projectDashboardLoading, setProjectDashboardLoading] = useState(false);
   const [projectDashboardError, setProjectDashboardError] = useState<string | null>(null);
@@ -520,7 +552,12 @@ export default function App() {
   useEffect(() => {
     if (viewState.mode === "projects" || viewState.mode === "project") {
       setBrowseBy("projects");
-      if (viewState.mode === "project") setSelectedProjectKey(viewState.activeProjectKey);
+      if (viewState.mode === "project") {
+        setSelectedProjectIdentity({
+          kind: viewState.activeProjectKind,
+          key: viewState.activeProjectKey,
+        });
+      }
       return;
     }
     if (viewState.mode === "agent" || viewState.mode === "missingAgent") {
@@ -658,27 +695,66 @@ export default function App() {
   }
 
   const activeAgentKey = viewState.activeAgentKey;
+  const activeProjectKind = viewState.mode === "project" ? viewState.activeProjectKind : null;
   const activeProjectKey = viewState.mode === "project" ? viewState.activeProjectKey : null;
-  const selectedProjectNavigationKey =
-    browseBy === "projects" ? (activeProjectKey ?? selectedProjectKey) : null;
+  const activeProjectIdentity = useMemo<ProjectRouteIdentity | null>(
+    () =>
+      activeProjectKind && activeProjectKey
+        ? { kind: activeProjectKind, key: activeProjectKey }
+        : null,
+    [activeProjectKind, activeProjectKey],
+  );
+  const activeProjectIdentityKey = activeProjectIdentity
+    ? getProjectIdentityKey(activeProjectIdentity)
+    : null;
+  const openedSessionHead = useMemo(() => {
+    if (viewState.mode !== "session") return null;
+    return (
+      sessions.find(
+        (sessionItem) =>
+          getSessionAgentKey(sessionItem) === viewState.activeAgentKey &&
+          sessionItem.id === viewState.activeSessionSlug,
+      ) ?? null
+    );
+  }, [sessions, viewState]);
+  const openedSessionData =
+    viewState.mode === "session" && session?.id === viewState.activeSessionSlug ? session : null;
+  const openedSessionProjectIdentity =
+    openedSessionData?.project_identity ?? openedSessionHead?.project_identity ?? null;
+  const selectedProjectNavigationIdentity =
+    browseBy === "projects"
+      ? (activeProjectIdentity ??
+        (viewState.mode === "session" ? openedSessionProjectIdentity : selectedProjectIdentity))
+      : null;
+  const selectedProjectNavigationId = selectedProjectNavigationIdentity
+    ? getProjectIdentityKey(selectedProjectNavigationIdentity)
+    : null;
   const agentSidebarSessions = useMemo(
     () => (activeAgentKey ? (sessionsByAgent[activeAgentKey] ?? []) : []),
     [activeAgentKey, sessionsByAgent],
   );
   const projectSidebarSessions = useMemo(
     () =>
-      selectedProjectNavigationKey
+      selectedProjectNavigationId
         ? sessions
             .filter(
               (sessionItem) =>
-                sessionItem.project_identity?.key === selectedProjectNavigationKey &&
+                matchesProjectIdentity(
+                  sessionItem.project_identity,
+                  selectedProjectNavigationIdentity,
+                ) &&
                 (!selectedProjectAgent || getSessionAgentKey(sessionItem) === selectedProjectAgent),
             )
             .toSorted(
               (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
             )
         : [],
-    [selectedProjectAgent, selectedProjectNavigationKey, sessions],
+    [
+      selectedProjectAgent,
+      selectedProjectNavigationId,
+      selectedProjectNavigationIdentity,
+      sessions,
+    ],
   );
   const sidebarSessions = browseBy === "projects" ? projectSidebarSessions : agentSidebarSessions;
   const bookmarkedSidebarSessionIds = useMemo(() => {
@@ -759,6 +835,7 @@ export default function App() {
           }),
           viewState.mode === "project"
             ? fetchDashboard(appConfig?.window, {
+                projectKind: viewState.activeProjectKind,
                 projectKey: viewState.activeProjectKey,
                 agent: selectedProjectAgent,
               }).catch((err) => {
@@ -897,8 +974,8 @@ export default function App() {
   }, [sessionFetchKey, viewState.activeAgentKey, viewState.activeSessionSlug, viewState.mode]);
 
   useEffect(() => {
-    if (activeProjectKey) setSelectedProjectAgent(undefined);
-  }, [activeProjectKey]);
+    if (activeProjectIdentityKey) setSelectedProjectAgent(undefined);
+  }, [activeProjectIdentityKey]);
 
   useEffect(() => {
     if (!activeProjectKey || !appConfig) {
@@ -913,6 +990,7 @@ export default function App() {
     setProjectDashboardError(null);
 
     void fetchDashboard(appConfig.window, {
+      projectKind: activeProjectKind ?? undefined,
       projectKey: activeProjectKey,
       agent: selectedProjectAgent,
     })
@@ -934,7 +1012,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [activeProjectKey, appConfig, selectedProjectAgent]);
+  }, [activeProjectKind, activeProjectKey, appConfig, selectedProjectAgent]);
 
   useEffect(() => {
     const unsubscribe = subscribeSessionUpdates((event) => {
@@ -1016,12 +1094,12 @@ export default function App() {
   }, [sessions]);
   const activeProjectSessions = useMemo(
     () =>
-      activeProjectKey
-        ? landingSessions.filter(
-            (sessionItem) => sessionItem.project_identity?.key === activeProjectKey,
+      activeProjectIdentity
+        ? landingSessions.filter((sessionItem) =>
+            matchesProjectIdentity(sessionItem.project_identity, activeProjectIdentity),
           )
         : [],
-    [activeProjectKey, landingSessions],
+    [activeProjectIdentity, landingSessions],
   );
 
   const landingAgentItems = useMemo<LandingAgentItem[]>(() => {
@@ -1040,12 +1118,20 @@ export default function App() {
     [activeAgentKey, agents],
   );
   const activeProject = useMemo(
-    () => projects.find((project) => project.identityKey === activeProjectKey) ?? null,
-    [activeProjectKey, projects],
+    () =>
+      projects.find(
+        (project) =>
+          activeProjectIdentityKey === getProjectIdentityKey(getProjectGroupIdentity(project)),
+      ) ?? null,
+    [activeProjectIdentityKey, projects],
   );
   const selectedProjectNavigation = useMemo(
-    () => projects.find((project) => project.identityKey === selectedProjectNavigationKey) ?? null,
-    [projects, selectedProjectNavigationKey],
+    () =>
+      projects.find(
+        (project) =>
+          selectedProjectNavigationId === getProjectIdentityKey(getProjectGroupIdentity(project)),
+      ) ?? null,
+    [projects, selectedProjectNavigationId],
   );
 
   const projectOptions = useMemo<SearchProjectOption[]>(() => {
@@ -1159,13 +1245,17 @@ export default function App() {
       ];
     }
 
-    if (viewState.mode === "session" && browseBy === "projects" && selectedProjectNavigationKey) {
+    if (
+      viewState.mode === "session" &&
+      browseBy === "projects" &&
+      selectedProjectNavigationIdentity
+    ) {
       return [
         dashboardCrumb,
         { label: "Projects", to: "/projects" },
         {
-          label: selectedProjectNavigation?.displayName ?? selectedProjectNavigationKey,
-          to: getProjectPath(selectedProjectNavigationKey),
+          label: selectedProjectNavigation?.displayName ?? selectedProjectNavigationIdentity.key,
+          to: getProjectPath(selectedProjectNavigationIdentity),
         },
         { label: session?.title || viewState.activeSessionSlug || "Conversation" },
       ];
@@ -1205,7 +1295,7 @@ export default function App() {
     browseBy,
     isSearchMode,
     selectedProjectNavigation,
-    selectedProjectNavigationKey,
+    selectedProjectNavigationIdentity,
     session?.title,
     viewState,
   ]);
@@ -1347,7 +1437,10 @@ export default function App() {
     setBrowseBy(next);
     setSelectedSidebarSessionId(null);
     if (next === "projects") {
-      navigate(selectedProjectKey ? getProjectPath(selectedProjectKey) : "/projects");
+      const project =
+        openedSessionProjectIdentity ??
+        (viewState.mode === "session" ? null : selectedProjectIdentity);
+      navigate(project ? getProjectPath(project) : "/projects");
       return;
     }
     navigate("/");
@@ -1413,8 +1506,8 @@ export default function App() {
         return;
       }
       if (viewState.mode === "session" && viewState.activeAgentKey) {
-        if (browseBy === "projects" && selectedProjectNavigationKey) {
-          navigate(getProjectPath(selectedProjectNavigationKey));
+        if (browseBy === "projects" && selectedProjectNavigationIdentity) {
+          navigate(getProjectPath(selectedProjectNavigationIdentity));
           return;
         }
         navigate(`/${viewState.activeAgentKey}`);
@@ -1641,12 +1734,14 @@ export default function App() {
                       );
                     })
                   : projects.map((project) => {
-                      const isSelected = selectedProjectNavigationKey === project.identityKey;
+                      const projectIdentity = getProjectGroupIdentity(project);
+                      const isSelected =
+                        selectedProjectNavigationId === getProjectIdentityKey(projectIdentity);
                       return (
                         <li key={`${project.identityKind}:${project.identityKey}`}>
                           <Link
-                            to={getProjectPath(project.identityKey)}
-                            onClick={() => setSelectedProjectKey(project.identityKey)}
+                            to={getProjectPath(projectIdentity)}
+                            onClick={() => setSelectedProjectIdentity(projectIdentity)}
                             className={`ml-4 flex min-w-0 items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
                               isSelected
                                 ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
@@ -1747,7 +1842,7 @@ export default function App() {
                 <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
                   Select an agent
                 </span>
-              ) : browseBy === "projects" && !selectedProjectNavigationKey ? (
+              ) : browseBy === "projects" && !selectedProjectNavigationId ? (
                 <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
                   Select a project
                 </span>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,6 +24,7 @@ import type {
   SessionData,
   SessionsUpdatedEvent,
   SmartTag,
+  ProjectGroup,
 } from "./lib/api";
 import {
   deleteBookmark,
@@ -31,6 +32,7 @@ import {
   fetchBookmarks,
   fetchConfig,
   fetchDashboard,
+  fetchProjects,
   fetchSearchResults,
   fetchSessions,
   fetchSessionData,
@@ -47,6 +49,7 @@ import {
   type LandingAgentItem,
 } from "./components/DetailLanding";
 import { Dashboard } from "./components/Dashboard";
+import { ProjectDashboardView, ProjectsOverview } from "./components/Projects";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { BookmarkButton } from "./components/BookmarkButton";
 import { CopyResumeButton } from "./components/CopyResumeButton";
@@ -59,9 +62,14 @@ import {
   mergeBookmarksWithSessions,
   toBookmarkedSessionSnapshot,
 } from "./lib/bookmarks";
+import { getProjectPath } from "./lib/projects";
+
+type BrowseBy = "agents" | "projects";
 
 type ViewState =
   | { mode: "root"; activeAgentKey: null; activeSessionSlug: null }
+  | { mode: "projects"; activeAgentKey: null; activeSessionSlug: null }
+  | { mode: "project"; activeAgentKey: null; activeSessionSlug: null; activeProjectKey: string }
   | { mode: "agent"; activeAgentKey: string; activeSessionSlug: null }
   | { mode: "session"; activeAgentKey: string; activeSessionSlug: string }
   | { mode: "missingAgent"; activeAgentKey: null; activeSessionSlug: null; attemptedKey: string }
@@ -84,6 +92,24 @@ function parseViewState(pathname: string, validAgentKeys: Set<string>): ViewStat
 
   if (segments.length === 0) {
     return { mode: "root", activeAgentKey: null, activeSessionSlug: null };
+  }
+  if (segments[0]?.toLowerCase() === "projects") {
+    if (segments.length === 1) {
+      return { mode: "projects", activeAgentKey: null, activeSessionSlug: null };
+    }
+    if (segments.length === 2) {
+      try {
+        return {
+          mode: "project",
+          activeAgentKey: null,
+          activeSessionSlug: null,
+          activeProjectKey: decodeURIComponent(segments[1]!),
+        };
+      } catch {
+        return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+      }
+    }
+    return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
   }
   if (segments.length === 1) {
     const key = segments[0]!.toLowerCase();
@@ -273,6 +299,118 @@ function isEditableTarget(target: EventTarget | null) {
   );
 }
 
+function BrowseByToggle({
+  value,
+  onChange,
+}: {
+  value: BrowseBy;
+  onChange: (value: BrowseBy) => void;
+}) {
+  const options: Array<{ value: BrowseBy; label: string }> = [
+    { value: "projects", label: "Projects" },
+    { value: "agents", label: "Agents" },
+  ];
+
+  return (
+    <div role="radiogroup" aria-label="Browse by" className="grid gap-1.5">
+      {options.map((option) => {
+        const active = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(option.value)}
+            className={`console-mono flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left text-xs transition-colors ${
+              active
+                ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+            }`}
+          >
+            <span
+              className={`flex size-3 shrink-0 items-center justify-center rounded-full border ${
+                active ? "border-[var(--console-accent)]" : "border-[var(--console-border-strong)]"
+              }`}
+            >
+              {active ? (
+                <span className="size-1.5 rounded-full bg-[var(--console-accent)]" />
+              ) : null}
+            </span>
+            <span>{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SidebarFlatSessionList({
+  sessions,
+  activeSessionId,
+  selectedSessionId,
+  bookmarkedSessionIds,
+  onSelectSession,
+  onToggleBookmark,
+}: {
+  sessions: SessionHead[];
+  activeSessionId: string | null;
+  selectedSessionId: string | null;
+  bookmarkedSessionIds: Set<string>;
+  onSelectSession: (session: SessionHead) => void;
+  onToggleBookmark: (session: SessionHead) => void;
+}) {
+  return (
+    <div className="console-scrollbar h-[min(560px,calc(100vh-410px))] min-h-56 overflow-y-auto">
+      <ul className="space-y-1">
+        {sessions.map((sessionItem) => {
+          const agentKey = getSessionAgentKey(sessionItem);
+          const agentConfig = ModelConfig.agents[agentKey];
+          const active = activeSessionId === sessionItem.id;
+          const selected = selectedSessionId === sessionItem.id;
+          return (
+            <li key={sessionItem.slug}>
+              <div
+                className={`flex items-start gap-1 rounded-sm border px-2 py-1.5 transition-colors ${
+                  active || selected
+                    ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                    : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                }`}
+              >
+                <button
+                  type="button"
+                  onClick={() => onSelectSession(sessionItem)}
+                  className="min-w-0 flex-1 text-left"
+                >
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    {agentConfig?.icon ? (
+                      <img
+                        src={agentConfig.icon}
+                        alt={agentConfig.name}
+                        className="size-3.5 shrink-0 object-contain"
+                      />
+                    ) : null}
+                    <span className="console-mono line-clamp-1 text-xs text-[var(--console-text)]">
+                      {sessionItem.title}
+                    </span>
+                  </span>
+                  <span className="console-mono mt-0.5 block truncate text-[10px] text-[var(--console-muted)]">
+                    {formatRelativeTime(sessionItem.time_updated ?? sessionItem.time_created)}
+                  </span>
+                </button>
+                <BookmarkButton
+                  active={bookmarkedSessionIds.has(sessionItem.id)}
+                  onToggle={() => onToggleBookmark(sessionItem)}
+                />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 export default function App() {
   const navigate = useNavigate();
   const [agents, setAgents] = useState<AgentInfo[]>([]);
@@ -286,6 +424,13 @@ export default function App() {
   const [sessionError, setSessionError] = useState<string | null>(null);
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+  const [projects, setProjects] = useState<ProjectGroup[]>([]);
+  const [browseBy, setBrowseBy] = useState<BrowseBy>("agents");
+  const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(null);
+  const [projectDashboard, setProjectDashboard] = useState<DashboardData | null>(null);
+  const [projectDashboardLoading, setProjectDashboardLoading] = useState(false);
+  const [projectDashboardError, setProjectDashboardError] = useState<string | null>(null);
+  const [selectedProjectAgent, setSelectedProjectAgent] = useState<string | undefined>(undefined);
   const [appConfig, setAppConfig] = useState<AppConfig | null>(null);
   const [draftSearchQuery, setDraftSearchQuery] = useState("");
   const [activeSearchQuery, setActiveSearchQuery] = useState("");
@@ -310,23 +455,30 @@ export default function App() {
       try {
         const config = await fetchConfig();
         setAppConfig(config);
-        const [agentList, sessionList, dashboardData, bookmarkData] = await Promise.all([
-          fetchAgents(),
-          fetchSessions({ from: config.window.from, to: config.window.to }),
-          fetchDashboard(config.window).catch((err) => {
-            console.error("Failed to load dashboard:", err);
-            return null;
-          }),
-          fetchBookmarks(),
-        ]);
+        const [agentList, sessionList, dashboardData, projectData, bookmarkData] =
+          await Promise.all([
+            fetchAgents(),
+            fetchSessions({ from: config.window.from, to: config.window.to }),
+            fetchDashboard(config.window).catch((err) => {
+              console.error("Failed to load dashboard:", err);
+              return null;
+            }),
+            fetchProjects().catch((err) => {
+              console.error("Failed to load projects:", err);
+              return { projects: [] };
+            }),
+            fetchBookmarks(),
+          ]);
         setAgents(agentList);
         setSessions(sessionList.sessions);
+        setProjects(projectData.projects);
         setBookmarks(bookmarkData.bookmarks);
         if (dashboardData) setDashboard(dashboardData);
         logClientEvent("app.load.done", {
           duration_ms: Math.round(performance.now() - startedAt),
           agents: agentList.length,
           sessions: sessionList.sessions.length,
+          projects: projectData.projects.length,
           dashboard: Boolean(dashboardData),
         });
       } catch (err) {
@@ -364,6 +516,17 @@ export default function App() {
       session: viewState.activeSessionSlug,
     });
   }, [location.pathname, viewState.mode, viewState.activeAgentKey, viewState.activeSessionSlug]);
+
+  useEffect(() => {
+    if (viewState.mode === "projects" || viewState.mode === "project") {
+      setBrowseBy("projects");
+      if (viewState.mode === "project") setSelectedProjectKey(viewState.activeProjectKey);
+      return;
+    }
+    if (viewState.mode === "agent" || viewState.mode === "missingAgent") {
+      setBrowseBy("agents");
+    }
+  }, [viewState]);
   const detailHighlightQuery = isSearchMode
     ? activeSearchQuery
     : typeof location.state === "object" &&
@@ -495,20 +658,41 @@ export default function App() {
   }
 
   const activeAgentKey = viewState.activeAgentKey;
-  const sidebarSessions = useMemo(
+  const activeProjectKey = viewState.mode === "project" ? viewState.activeProjectKey : null;
+  const selectedProjectNavigationKey =
+    browseBy === "projects" ? (activeProjectKey ?? selectedProjectKey) : null;
+  const agentSidebarSessions = useMemo(
     () => (activeAgentKey ? (sessionsByAgent[activeAgentKey] ?? []) : []),
     [activeAgentKey, sessionsByAgent],
   );
+  const projectSidebarSessions = useMemo(
+    () =>
+      selectedProjectNavigationKey
+        ? sessions
+            .filter(
+              (sessionItem) =>
+                sessionItem.project_identity?.key === selectedProjectNavigationKey &&
+                (!selectedProjectAgent || getSessionAgentKey(sessionItem) === selectedProjectAgent),
+            )
+            .toSorted(
+              (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
+            )
+        : [],
+    [selectedProjectAgent, selectedProjectNavigationKey, sessions],
+  );
+  const sidebarSessions = browseBy === "projects" ? projectSidebarSessions : agentSidebarSessions;
   const bookmarkedSidebarSessionIds = useMemo(() => {
-    if (!activeAgentKey) return new Set<string>();
+    if (sidebarSessions.length === 0) return new Set<string>();
     return new Set(
       sidebarSessions
         .filter((sessionItem) =>
-          bookmarkKeySet.has(getSessionBookmarkKey(activeAgentKey, sessionItem.id)),
+          bookmarkKeySet.has(
+            getSessionBookmarkKey(getSessionAgentKey(sessionItem), sessionItem.id),
+          ),
         )
         .map((sessionItem) => sessionItem.id),
     );
-  }, [activeAgentKey, bookmarkKeySet, sidebarSessions]);
+  }, [bookmarkKeySet, sidebarSessions]);
 
   const bookmarkedSessions = useMemo(
     () =>
@@ -561,23 +745,39 @@ export default function App() {
 
   const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
     try {
-      const [agentList, sessionList, dashboardData, searchData] = await Promise.all([
-        fetchAgents(),
-        fetchSessions({ from: appConfig?.window.from, to: appConfig?.window.to }),
-        fetchDashboard(appConfig?.window).catch((err) => {
-          console.error("Failed to refresh dashboard:", err);
-          return null;
-        }),
-        isSearchMode && usesServerSearch
-          ? fetchSearchResults(activeSearchQuery, searchRequestOptions).catch((err) => {
-              console.error("Failed to refresh search results:", err);
-              return { results: [] };
-            })
-          : Promise.resolve<{ results: SearchResult[] } | null>(null),
-      ]);
+      const [agentList, sessionList, dashboardData, projectData, projectDashboardData, searchData] =
+        await Promise.all([
+          fetchAgents(),
+          fetchSessions({ from: appConfig?.window.from, to: appConfig?.window.to }),
+          fetchDashboard(appConfig?.window).catch((err) => {
+            console.error("Failed to refresh dashboard:", err);
+            return null;
+          }),
+          fetchProjects().catch((err) => {
+            console.error("Failed to refresh projects:", err);
+            return { projects: [] };
+          }),
+          viewState.mode === "project"
+            ? fetchDashboard(appConfig?.window, {
+                projectKey: viewState.activeProjectKey,
+                agent: selectedProjectAgent,
+              }).catch((err) => {
+                console.error("Failed to refresh project dashboard:", err);
+                return null;
+              })
+            : Promise.resolve<DashboardData | null>(null),
+          isSearchMode && usesServerSearch
+            ? fetchSearchResults(activeSearchQuery, searchRequestOptions).catch((err) => {
+                console.error("Failed to refresh search results:", err);
+                return { results: [] };
+              })
+            : Promise.resolve<{ results: SearchResult[] } | null>(null),
+        ]);
       setAgents(agentList);
       setSessions(sessionList.sessions);
+      setProjects(projectData.projects);
       if (dashboardData) setDashboard(dashboardData);
+      if (projectDashboardData) setProjectDashboard(projectDashboardData);
       if (searchData) setSearchResults(searchData.results);
 
       if (viewState.mode === "session") {
@@ -697,6 +897,46 @@ export default function App() {
   }, [sessionFetchKey, viewState.activeAgentKey, viewState.activeSessionSlug, viewState.mode]);
 
   useEffect(() => {
+    if (activeProjectKey) setSelectedProjectAgent(undefined);
+  }, [activeProjectKey]);
+
+  useEffect(() => {
+    if (!activeProjectKey || !appConfig) {
+      setProjectDashboard(null);
+      setProjectDashboardError(null);
+      setProjectDashboardLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setProjectDashboardLoading(true);
+    setProjectDashboardError(null);
+
+    void fetchDashboard(appConfig.window, {
+      projectKey: activeProjectKey,
+      agent: selectedProjectAgent,
+    })
+      .then((data) => {
+        if (cancelled) return;
+        setProjectDashboard(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("Failed to load project dashboard:", err);
+        setProjectDashboard(null);
+        setProjectDashboardError("Failed to load project dashboard");
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setProjectDashboardLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProjectKey, appConfig, selectedProjectAgent]);
+
+  useEffect(() => {
     const unsubscribe = subscribeSessionUpdates((event) => {
       void syncLiveUpdate(event);
     });
@@ -774,6 +1014,15 @@ export default function App() {
       };
     });
   }, [sessions]);
+  const activeProjectSessions = useMemo(
+    () =>
+      activeProjectKey
+        ? landingSessions.filter(
+            (sessionItem) => sessionItem.project_identity?.key === activeProjectKey,
+          )
+        : [],
+    [activeProjectKey, landingSessions],
+  );
 
   const landingAgentItems = useMemo<LandingAgentItem[]>(() => {
     return agents
@@ -789,6 +1038,14 @@ export default function App() {
   const activeAgent = useMemo(
     () => agents.find((agent) => agent.name.toLowerCase() === activeAgentKey) ?? null,
     [activeAgentKey, agents],
+  );
+  const activeProject = useMemo(
+    () => projects.find((project) => project.identityKey === activeProjectKey) ?? null,
+    [activeProjectKey, projects],
+  );
+  const selectedProjectNavigation = useMemo(
+    () => projects.find((project) => project.identityKey === selectedProjectNavigationKey) ?? null,
+    [projects, selectedProjectNavigationKey],
   );
 
   const projectOptions = useMemo<SearchProjectOption[]>(() => {
@@ -820,6 +1077,16 @@ export default function App() {
       : dashboard
         ? `${dashboard.totals.sessions.toLocaleString("en-US")} total sessions across ${dashboard.perAgent.length} agents`
         : "Aggregated view across all agents";
+  }
+  if (viewState.mode === "projects") {
+    headerTitle = "Projects";
+    headerSubtitle = `${projects.length.toLocaleString("en-US")} projects across ${sessions.length.toLocaleString("en-US")} sessions`;
+  }
+  if (viewState.mode === "project") {
+    headerTitle = activeProject?.displayName ?? "Project";
+    headerSubtitle = activeProject
+      ? `${activeProject.sessionCount.toLocaleString("en-US")} sessions · ${activeProject.agentStats.length} agents`
+      : viewState.activeProjectKey;
   }
   if (viewState.mode === "agent" && activeAgentKey) {
     headerTitle = activeAgent?.displayName ?? activeAgentKey;
@@ -862,11 +1129,46 @@ export default function App() {
 
     const dashboardCrumb: BreadcrumbItem = {
       label: "Dashboard",
-      to: viewState.mode === "root" ? undefined : "/",
+      to:
+        (browseBy === "agents" && viewState.mode === "root") ||
+        (browseBy === "projects" && viewState.mode === "projects")
+          ? undefined
+          : browseBy === "projects"
+            ? "/projects"
+            : "/",
     };
 
     if (viewState.mode === "root") {
       return [{ label: "Dashboard" }];
+    }
+
+    const projectsCrumb: BreadcrumbItem = {
+      label: "Projects",
+      to: viewState.mode === "project" ? "/projects" : undefined,
+    };
+
+    if (viewState.mode === "projects") {
+      return [dashboardCrumb, { label: "Projects" }];
+    }
+
+    if (viewState.mode === "project") {
+      return [
+        dashboardCrumb,
+        projectsCrumb,
+        { label: activeProject?.displayName ?? viewState.activeProjectKey },
+      ];
+    }
+
+    if (viewState.mode === "session" && browseBy === "projects" && selectedProjectNavigationKey) {
+      return [
+        dashboardCrumb,
+        { label: "Projects", to: "/projects" },
+        {
+          label: selectedProjectNavigation?.displayName ?? selectedProjectNavigationKey,
+          to: getProjectPath(selectedProjectNavigationKey),
+        },
+        { label: session?.title || viewState.activeSessionSlug || "Conversation" },
+      ];
     }
 
     if (viewState.mode === "missingAgent") {
@@ -896,7 +1198,17 @@ export default function App() {
     }
 
     return [dashboardCrumb, { label: "Invalid Route" }];
-  }, [activeAgent, activeAgentKey, isSearchMode, session?.title, viewState]);
+  }, [
+    activeAgent,
+    activeAgentKey,
+    activeProject,
+    browseBy,
+    isSearchMode,
+    selectedProjectNavigation,
+    selectedProjectNavigationKey,
+    session?.title,
+    viewState,
+  ]);
 
   // Content
   let content: ReactNode;
@@ -934,6 +1246,7 @@ export default function App() {
     content = dashboard ? (
       <Dashboard
         data={dashboard}
+        projects={projects}
         bookmarkedSessions={bookmarkedSessions}
         isBookmarked={isSessionBookmarked}
         onToggleBookmark={(session, agentKey) => {
@@ -951,6 +1264,23 @@ export default function App() {
         agentItems={landingAgentItems}
         isBookmarked={isSessionBookmarked}
         onToggleBookmark={(session) => toggleSessionBookmark(session, session.agentKey)}
+      />
+    );
+  } else if (viewState.mode === "projects") {
+    content = <ProjectsOverview projects={projects} />;
+  } else if (viewState.mode === "project") {
+    content = (
+      <ProjectDashboardView
+        project={activeProject}
+        projectKey={viewState.activeProjectKey}
+        dashboard={projectDashboard}
+        loading={projectDashboardLoading}
+        error={projectDashboardError}
+        sessions={activeProjectSessions}
+        activeAgent={selectedProjectAgent}
+        onChangeAgent={setSelectedProjectAgent}
+        isBookmarked={isSessionBookmarked}
+        onToggleSessionBookmark={toggleSessionBookmark}
       />
     );
   } else if (viewState.mode === "agent" && activeAgentKey) {
@@ -1013,6 +1343,16 @@ export default function App() {
     }
   }
 
+  function changeBrowseBy(next: BrowseBy) {
+    setBrowseBy(next);
+    setSelectedSidebarSessionId(null);
+    if (next === "projects") {
+      navigate(selectedProjectKey ? getProjectPath(selectedProjectKey) : "/projects");
+      return;
+    }
+    navigate("/");
+  }
+
   const handleGlobalKeydown = useEffectEvent((event: KeyboardEvent) => {
     const key = event.key;
     if ((event.metaKey || event.ctrlKey) && key.toLowerCase() === "k") {
@@ -1073,6 +1413,10 @@ export default function App() {
         return;
       }
       if (viewState.mode === "session" && viewState.activeAgentKey) {
+        if (browseBy === "projects" && selectedProjectNavigationKey) {
+          navigate(getProjectPath(selectedProjectNavigationKey));
+          return;
+        }
         navigate(`/${viewState.activeAgentKey}`);
       }
       return;
@@ -1119,7 +1463,8 @@ export default function App() {
       return;
     }
 
-    if (!activeAgentKey || sidebarSessions.length === 0) return;
+    if (browseBy === "agents" && !activeAgentKey) return;
+    if (sidebarSessions.length === 0) return;
 
     const moveSidebarSelection = (offset: number) => {
       dismissShortcutHint();
@@ -1159,7 +1504,7 @@ export default function App() {
       if (!selected) return;
       event.preventDefault();
       dismissShortcutHint();
-      navigate(`/${activeAgentKey}/${selected.id}`);
+      navigate(browseBy === "projects" ? `/${selected.slug}` : `/${activeAgentKey}/${selected.id}`);
     }
   });
 
@@ -1233,14 +1578,28 @@ export default function App() {
           <div className="console-scrollbar flex-1 space-y-8 overflow-y-auto px-4 py-6">
             <section>
               <h3 className="console-mono mb-3 text-xs font-bold uppercase text-[var(--console-text)]">
+                BROWSE BY
+              </h3>
+              <BrowseByToggle value={browseBy} onChange={changeBrowseBy} />
+            </section>
+
+            <section>
+              <h3 className="console-mono mb-3 text-xs font-bold uppercase text-[var(--console-text)]">
                 NAVIGATION
               </h3>
-              <ul className="space-y-1">
+              <ul
+                className={`space-y-1 ${
+                  browseBy === "projects"
+                    ? "console-scrollbar max-h-[min(280px,calc(100vh-440px))] overflow-y-auto pr-1"
+                    : ""
+                }`}
+              >
                 <li>
                   <Link
-                    to="/"
+                    to={browseBy === "projects" ? "/projects" : "/"}
                     className={`flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
-                      viewState.mode === "root"
+                      (browseBy === "agents" && viewState.mode === "root") ||
+                      (browseBy === "projects" && viewState.mode === "projects")
                         ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
                         : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
                     }`}
@@ -1249,44 +1608,75 @@ export default function App() {
                     <span className="console-mono line-clamp-1 flex-1 text-xs">Dashboard</span>
                   </Link>
                 </li>
-                {agents.map((agent) => {
-                  const key = agent.name.toLowerCase();
-                  const isSelected = key === activeAgentKey;
-                  const config = ModelConfig.agents[key];
-                  return (
-                    <li key={agent.name}>
-                      <Link
-                        to={`/${key}`}
-                        className={`ml-4 flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
-                          isSelected
-                            ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
-                            : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
-                        }`}
-                      >
-                        {config?.icon && (
-                          <img
-                            src={config.icon}
-                            alt={agent.displayName}
-                            className="size-3.5 object-contain"
-                          />
-                        )}
-                        <span className="console-mono line-clamp-1 flex-1 text-xs">
-                          {agent.displayName}
-                        </span>
-                        <span className="console-mono text-[11px] text-[var(--console-muted)]">
-                          {agent.count}
-                        </span>
-                      </Link>
-                    </li>
-                  );
-                })}
-                {agents.length === 0 && !loading && (
+                {browseBy === "agents"
+                  ? agents.map((agent) => {
+                      const key = agent.name.toLowerCase();
+                      const isSelected = key === activeAgentKey;
+                      const config = ModelConfig.agents[key];
+                      return (
+                        <li key={agent.name}>
+                          <Link
+                            to={`/${key}`}
+                            className={`ml-4 flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
+                              isSelected
+                                ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                                : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                            }`}
+                          >
+                            {config?.icon && (
+                              <img
+                                src={config.icon}
+                                alt={agent.displayName}
+                                className="size-3.5 object-contain"
+                              />
+                            )}
+                            <span className="console-mono line-clamp-1 flex-1 text-xs">
+                              {agent.displayName}
+                            </span>
+                            <span className="console-mono text-[11px] text-[var(--console-muted)]">
+                              {agent.count}
+                            </span>
+                          </Link>
+                        </li>
+                      );
+                    })
+                  : projects.map((project) => {
+                      const isSelected = selectedProjectNavigationKey === project.identityKey;
+                      return (
+                        <li key={`${project.identityKind}:${project.identityKey}`}>
+                          <Link
+                            to={getProjectPath(project.identityKey)}
+                            onClick={() => setSelectedProjectKey(project.identityKey)}
+                            className={`ml-4 flex min-w-0 items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
+                              isSelected
+                                ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                                : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                            }`}
+                          >
+                            <span className="console-mono min-w-0 flex-1 truncate text-xs">
+                              {project.displayName}
+                            </span>
+                            <span className="console-mono shrink-0 text-[11px] text-[var(--console-muted)]">
+                              {project.sessionCount}
+                            </span>
+                          </Link>
+                        </li>
+                      );
+                    })}
+                {browseBy === "agents" && agents.length === 0 && !loading ? (
                   <li>
                     <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
                       No agents found
                     </span>
                   </li>
-                )}
+                ) : null}
+                {browseBy === "projects" && projects.length === 0 && !loading ? (
+                  <li>
+                    <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
+                      No projects found
+                    </span>
+                  </li>
+                ) : null}
               </ul>
             </section>
 
@@ -1347,20 +1737,40 @@ export default function App() {
             <section>
               <h3 className="console-mono mb-3 text-xs font-bold uppercase text-[var(--console-text)]">
                 SESSIONS
-                {activeAgentKey ? (
+                {sidebarSessions.length > 0 ? (
                   <span className="ml-2 text-[10px] font-normal text-[var(--console-muted)]">
                     Navigate j k · Open Enter
                   </span>
                 ) : null}
               </h3>
-              {!activeAgentKey ? (
+              {browseBy === "agents" && !activeAgentKey ? (
                 <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
                   Select an agent
+                </span>
+              ) : browseBy === "projects" && !selectedProjectNavigationKey ? (
+                <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
+                  Select a project
                 </span>
               ) : sidebarSessions.length === 0 ? (
                 <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
                   No sessions yet
                 </span>
+              ) : browseBy === "projects" ? (
+                <SidebarFlatSessionList
+                  sessions={sidebarSessions}
+                  activeSessionId={
+                    viewState.mode === "session" ? viewState.activeSessionSlug : null
+                  }
+                  selectedSessionId={selectedSidebarSessionId}
+                  bookmarkedSessionIds={bookmarkedSidebarSessionIds}
+                  onSelectSession={(sessionItem) => {
+                    setSelectedSidebarSessionId(sessionItem.id);
+                    navigate(`/${sessionItem.slug}`);
+                  }}
+                  onToggleBookmark={(sessionItem) =>
+                    toggleSessionBookmark(sessionItem, getSessionAgentKey(sessionItem))
+                  }
+                />
               ) : (
                 <SessionTreeSidebar
                   sessions={sidebarSessions}
@@ -1370,11 +1780,12 @@ export default function App() {
                   selectedSessionId={selectedSidebarSessionId}
                   onSelectSession={(sessionId) => {
                     setSelectedSidebarSessionId(sessionId);
-                    navigate(`/${activeAgentKey}/${sessionId}`);
+                    const selected = sidebarSessions.find((item) => item.id === sessionId);
+                    if (selected) navigate(`/${selected.slug}`);
                   }}
                   bookmarkedSessionIds={bookmarkedSidebarSessionIds}
                   onToggleBookmark={(sessionItem) =>
-                    toggleSessionBookmark(sessionItem, activeAgentKey)
+                    toggleSessionBookmark(sessionItem, getSessionAgentKey(sessionItem))
                   }
                 />
               )}
@@ -1411,7 +1822,11 @@ export default function App() {
                     ? "Session"
                     : viewState.mode === "root"
                       ? "Dashboard"
-                      : "Landing"}
+                      : viewState.mode === "projects"
+                        ? "Projects"
+                        : viewState.mode === "project"
+                          ? "Project"
+                          : "Landing"}
                 </span>
                 <h1 className="console-mono text-xl font-semibold tracking-tight text-[var(--console-text)]">
                   {headerTitle}

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -492,7 +492,7 @@ function TopProjects({ projects }: { projects: ProjectGroup[] }) {
           return (
             <li key={`${project.identityKind}:${project.identityKey}`}>
               <Link
-                to={getProjectPath(project.identityKey)}
+                to={getProjectPath({ kind: project.identityKind, key: project.identityKey })}
                 className="block rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
               >
                 <div className="flex items-center gap-2">

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -11,14 +11,17 @@ import type {
   FileActivityResult,
   ModelDistributionEntry,
   DashboardRecentSession,
+  ProjectGroup,
 } from "../lib/api";
 import { getSessionBookmarkKey } from "../lib/bookmarks";
+import { getProjectPath } from "../lib/projects";
 import { BookmarkButton } from "./BookmarkButton";
 import { SmartTagChips } from "./SmartTagChips";
 import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart";
 
 interface DashboardProps {
   data: DashboardData;
+  projects?: ProjectGroup[];
   bookmarkedSessions: BookmarkedSessionSnapshot[];
   isBookmarked: (agentKey: string, sessionId: string) => boolean;
   onToggleBookmark: (
@@ -467,6 +470,71 @@ function AgentDistribution({ perAgent }: { perAgent: DashboardAgentStat[] }) {
   );
 }
 
+function TopProjects({ projects }: { projects: ProjectGroup[] }) {
+  if (projects.length === 0) return null;
+
+  return (
+    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+          Projects
+        </h3>
+        <Link
+          to="/projects"
+          className="console-mono text-[11px] text-[var(--console-muted)] transition-colors hover:text-[var(--console-text)]"
+        >
+          View all
+        </Link>
+      </div>
+      <ul className="space-y-2">
+        {projects.slice(0, 5).map((project) => {
+          const topAgents = project.agentStats.slice(0, 3);
+          return (
+            <li key={`${project.identityKind}:${project.identityKey}`}>
+              <Link
+                to={getProjectPath(project.identityKey)}
+                className="block rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="console-mono min-w-0 flex-1 truncate text-xs text-[var(--console-text)]">
+                    {project.displayName}
+                  </span>
+                  <span className="console-mono shrink-0 text-[11px] text-[var(--console-muted)]">
+                    {formatNumber(project.sessionCount)} · {formatMoney(project.cost)}
+                  </span>
+                </div>
+                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                  {topAgents.map((agent) => {
+                    const config = ModelConfig.agents[agent.name];
+                    return (
+                      <span
+                        key={agent.name}
+                        className="console-mono inline-flex items-center gap-1 rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5 text-[10px] text-[var(--console-muted)]"
+                      >
+                        {config?.icon ? (
+                          <img
+                            src={config.icon}
+                            alt={config.name}
+                            className="size-3 object-contain"
+                          />
+                        ) : null}
+                        {config?.name ?? agent.name} · {agent.sessions}
+                      </span>
+                    );
+                  })}
+                  <span className="console-mono min-w-0 truncate text-[10px] text-[var(--console-muted)]">
+                    {formatCompact(project.tokens)} tokens
+                  </span>
+                </div>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 function BookmarkedSessions({
   sessions,
   onToggleBookmark,
@@ -644,6 +712,7 @@ function RecentFileActivity({ activity }: { activity: FileActivityResult[] }) {
 
 export function Dashboard({
   data,
+  projects = [],
   bookmarkedSessions,
   isBookmarked,
   onToggleBookmark,
@@ -687,6 +756,8 @@ export function Dashboard({
         <ModelDistribution entries={modelDistribution} />
         <AgentDistribution perAgent={perAgent} />
       </div>
+
+      <TopProjects projects={projects} />
 
       <RecentSessions
         sessions={recentSessions}

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -79,7 +79,7 @@ function ProjectListItem({ project }: { project: ProjectGroup }) {
   return (
     <li>
       <Link
-        to={getProjectPath(project.identityKey)}
+        to={getProjectPath({ kind: project.identityKind, key: project.identityKey })}
         className="block rounded-sm border border-[var(--console-border)] bg-white/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-white"
       >
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -1,0 +1,350 @@
+import { Link } from "react-router-dom";
+import { ModelConfig } from "../config";
+import type { DashboardData, ProjectAgentStat, ProjectGroup, SessionHead } from "../lib/api";
+import { getProjectPath } from "../lib/projects";
+import { Dashboard } from "./Dashboard";
+import type { LandingSession } from "./DetailLanding";
+
+function formatNumber(value: number) {
+  return value.toLocaleString("en-US");
+}
+
+function formatCompact(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+  return formatNumber(value);
+}
+
+function formatMoney(value: number): string {
+  if (value === 0) return "$0.00";
+  if (value < 0.01) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+function formatRelativeTime(timestamp?: number | null) {
+  if (!timestamp) return "unknown";
+  const diff = Date.now() - timestamp;
+  if (Number.isNaN(diff) || diff < 0) return "just now";
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function getSessionTotalTokens(session: SessionHead): number {
+  return (
+    session.stats.total_tokens ??
+    session.stats.total_input_tokens + session.stats.total_output_tokens
+  );
+}
+
+function StatCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+      <p className="console-mono text-[11px] uppercase tracking-wider text-[var(--console-muted)]">
+        {label}
+      </p>
+      <p className="console-mono mt-2 text-xl font-semibold text-[var(--console-text)]">{value}</p>
+      {hint ? <p className="mt-1 text-xs text-[var(--console-muted)]">{hint}</p> : null}
+    </div>
+  );
+}
+
+function AgentPills({ agents }: { agents: ProjectAgentStat[] }) {
+  if (agents.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {agents.slice(0, 4).map((agent) => {
+        const config = ModelConfig.agents[agent.name];
+        return (
+          <span
+            key={agent.name}
+            className="console-mono inline-flex items-center gap-1 rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5 text-[10px] text-[var(--console-muted)]"
+          >
+            {config?.icon ? (
+              <img src={config.icon} alt={config.name} className="size-3 object-contain" />
+            ) : null}
+            {config?.name ?? agent.name} · {agent.sessions}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProjectListItem({ project }: { project: ProjectGroup }) {
+  return (
+    <li>
+      <Link
+        to={getProjectPath(project.identityKey)}
+        className="block rounded-sm border border-[var(--console-border)] bg-white/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-white"
+      >
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div className="min-w-0">
+            <h2 className="console-mono line-clamp-1 text-sm font-semibold text-[var(--console-text)]">
+              {project.displayName}
+            </h2>
+            <p className="console-mono mt-1 break-all text-[11px] text-[var(--console-muted)]">
+              {project.identityKey}
+            </p>
+          </div>
+          <div className="console-mono flex shrink-0 flex-wrap gap-2 text-[11px] text-[var(--console-muted)]">
+            <span>{formatNumber(project.sessionCount)} sessions</span>
+            <span>{formatCompact(project.tokens)} tokens</span>
+            <span>{formatMoney(project.cost)}</span>
+            <span>{formatRelativeTime(project.lastActivity)}</span>
+          </div>
+        </div>
+        <div className="mt-3 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <AgentPills agents={project.agentStats} />
+          <span className="console-mono text-[10px] uppercase text-[var(--console-muted)]">
+            {project.identityKind}
+          </span>
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+export function ProjectsOverview({ projects }: { projects: ProjectGroup[] }) {
+  const totalSessions = projects.reduce((sum, project) => sum + project.sessionCount, 0);
+  const totalTokens = projects.reduce((sum, project) => sum + project.tokens, 0);
+  const totalCost = projects.reduce((sum, project) => sum + project.cost, 0);
+  const latestActivity = Math.max(0, ...projects.map((project) => project.lastActivity ?? 0));
+
+  if (projects.length === 0) {
+    return (
+      <div className="mx-auto max-w-5xl rounded-sm border border-[var(--console-border)] bg-white p-6 text-sm text-[var(--console-muted)]">
+        No projects found
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4">
+      <div className="grid gap-3 md:grid-cols-4">
+        <StatCard label="Projects" value={formatNumber(projects.length)} />
+        <StatCard label="Sessions" value={formatNumber(totalSessions)} />
+        <StatCard label="Tokens" value={formatCompact(totalTokens)} />
+        <StatCard
+          label="Total Cost"
+          value={formatMoney(totalCost)}
+          hint={latestActivity ? `Latest ${formatRelativeTime(latestActivity)}` : undefined}
+        />
+      </div>
+
+      <ul className="grid gap-3">
+        {projects.map((project) => (
+          <ProjectListItem
+            key={`${project.identityKind}:${project.identityKey}`}
+            project={project}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ProjectAgentFilter({
+  agents,
+  activeAgent,
+  onChange,
+}: {
+  agents: ProjectAgentStat[];
+  activeAgent?: string;
+  onChange: (agent?: string) => void;
+}) {
+  return (
+    <div className="rounded-sm border border-[var(--console-border)] bg-white p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
+          Agent
+        </span>
+        <button
+          type="button"
+          onClick={() => onChange(undefined)}
+          className={`console-mono rounded-sm border px-2 py-1 text-[10px] transition-colors ${
+            activeAgent
+              ? "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-white"
+              : "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
+          }`}
+        >
+          All Agents
+        </button>
+        {agents.map((agent) => {
+          const config = ModelConfig.agents[agent.name];
+          const active = activeAgent === agent.name;
+          return (
+            <button
+              key={agent.name}
+              type="button"
+              onClick={() => onChange(active ? undefined : agent.name)}
+              className={`console-mono inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-[10px] transition-colors ${
+                active
+                  ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
+                  : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-white"
+              }`}
+            >
+              {config?.icon ? (
+                <img src={config.icon} alt={config.name} className="size-3 object-contain" />
+              ) : null}
+              {config?.name ?? agent.name} · {agent.sessions}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ProjectHeader({ project }: { project: ProjectGroup }) {
+  return (
+    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="min-w-0">
+          <h2 className="console-mono text-base font-semibold text-[var(--console-text)]">
+            {project.displayName}
+          </h2>
+          <p className="console-mono mt-1 break-all text-[11px] text-[var(--console-muted)]">
+            {project.identityKind}: {project.identityKey}
+          </p>
+        </div>
+        <AgentPills agents={project.agentStats} />
+      </div>
+    </div>
+  );
+}
+
+function TopCostSessions({ sessions }: { sessions: LandingSession[] }) {
+  if (sessions.length === 0) return null;
+
+  const topSessions = sessions
+    .toSorted((a, b) => b.stats.total_cost - a.stats.total_cost)
+    .slice(0, 5);
+
+  return (
+    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+          Top Cost
+        </h3>
+        <span className="console-mono text-[11px] text-[var(--console-muted)]">
+          {topSessions.length} sessions
+        </span>
+      </div>
+      <ul className="space-y-2">
+        {topSessions.map((session) => {
+          const agent = ModelConfig.agents[session.agentKey];
+          return (
+            <li key={session.fullPath}>
+              <Link
+                to={`/${session.fullPath}`}
+                className="block rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+              >
+                <div className="flex items-center gap-2">
+                  {agent?.icon ? (
+                    <img src={agent.icon} alt={agent.name} className="size-3.5 object-contain" />
+                  ) : null}
+                  <span className="line-clamp-1 flex-1 text-sm text-[var(--console-text)]">
+                    {session.title}
+                  </span>
+                  <span className="console-mono text-[11px] text-[var(--console-muted)]">
+                    {formatMoney(session.stats.total_cost)}
+                  </span>
+                </div>
+                <p className="console-mono mt-1 text-[11px] text-[var(--console-muted)]">
+                  /{session.fullPath} · {formatCompact(getSessionTotalTokens(session))} tokens
+                </p>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export function ProjectDashboardView({
+  project,
+  projectKey,
+  dashboard,
+  loading,
+  error,
+  sessions,
+  activeAgent,
+  onChangeAgent,
+  isBookmarked,
+  onToggleSessionBookmark,
+}: {
+  project: ProjectGroup | null;
+  projectKey: string;
+  dashboard: DashboardData | null;
+  loading: boolean;
+  error: string | null;
+  sessions: LandingSession[];
+  activeAgent?: string;
+  onChangeAgent: (agent?: string) => void;
+  isBookmarked: (agentKey: string, sessionId: string) => boolean;
+  onToggleSessionBookmark: (session: SessionHead, agentKey: string) => void;
+}) {
+  if (!project) {
+    return (
+      <div className="mx-auto max-w-4xl rounded-sm border border-[var(--console-border)] bg-white p-6">
+        <h2 className="console-mono text-sm font-semibold text-[var(--console-text)]">
+          Project Not Found
+        </h2>
+        <p className="console-mono mt-2 break-all text-xs text-[var(--console-muted)]">
+          {projectKey}
+        </p>
+        <Link
+          to="/projects"
+          className="console-mono mt-4 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-white"
+        >
+          Back to Projects
+        </Link>
+      </div>
+    );
+  }
+
+  const scopedSessions = activeAgent
+    ? sessions.filter((session) => session.agentKey === activeAgent)
+    : sessions;
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4">
+      <ProjectHeader project={project} />
+      <ProjectAgentFilter
+        agents={project.agentStats}
+        activeAgent={activeAgent}
+        onChange={onChangeAgent}
+      />
+
+      {loading ? (
+        <div className="rounded-sm border border-[var(--console-border)] bg-white p-6 text-sm text-[var(--console-muted)]">
+          Loading project dashboard
+        </div>
+      ) : error ? (
+        <div className="rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6 text-sm text-[var(--console-error)]">
+          {error}
+        </div>
+      ) : dashboard ? (
+        <Dashboard
+          data={dashboard}
+          projects={[]}
+          bookmarkedSessions={[]}
+          isBookmarked={isBookmarked}
+          onToggleBookmark={(session, agentKey) => {
+            if ("agentName" in session) {
+              onToggleSessionBookmark(session, agentKey ?? session.agentName.toLowerCase());
+            }
+          }}
+        />
+      ) : null}
+
+      <TopCostSessions sessions={scopedSessions} />
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -150,6 +150,19 @@ export interface ProjectGroup {
   sources: string[];
   sessionCount: number;
   lastActivity: number | null;
+  messages: number;
+  tokens: number;
+  cost: number;
+  cost_source?: CostSource;
+  agentStats: ProjectAgentStat[];
+}
+
+export interface ProjectAgentStat {
+  name: string;
+  sessions: number;
+  messages: number;
+  tokens: number;
+  cost: number;
 }
 
 export interface SessionsUpdatedEvent {
@@ -294,11 +307,16 @@ export async function fetchSessionData(agent: string, sessionId: string): Promis
   return res.json();
 }
 
-export async function fetchDashboard(window?: AppConfig["window"]): Promise<DashboardData> {
+export async function fetchDashboard(
+  window?: AppConfig["window"],
+  filters: { projectKey?: string; agent?: string } = {},
+): Promise<DashboardData> {
   const params = new URLSearchParams();
   if (window?.from != null) params.set("from", new Date(window.from).toISOString());
   if (window?.to != null) params.set("to", new Date(window.to).toISOString());
   if (window?.days != null && window.days > 0) params.set("days", String(window.days));
+  if (filters.projectKey) params.set("projectKey", filters.projectKey);
+  if (filters.agent) params.set("agent", filters.agent);
   const suffix = params.toString();
   const res = await fetch(suffix ? `/api/dashboard?${suffix}` : "/api/dashboard");
   if (!res.ok) throw new Error("Failed to fetch dashboard");

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -309,12 +309,13 @@ export async function fetchSessionData(agent: string, sessionId: string): Promis
 
 export async function fetchDashboard(
   window?: AppConfig["window"],
-  filters: { projectKey?: string; agent?: string } = {},
+  filters: { projectKind?: ProjectIdentityKind; projectKey?: string; agent?: string } = {},
 ): Promise<DashboardData> {
   const params = new URLSearchParams();
   if (window?.from != null) params.set("from", new Date(window.from).toISOString());
   if (window?.to != null) params.set("to", new Date(window.to).toISOString());
   if (window?.days != null && window.days > 0) params.set("days", String(window.days));
+  if (filters.projectKind) params.set("projectKind", filters.projectKind);
   if (filters.projectKey) params.set("projectKey", filters.projectKey);
   if (filters.agent) params.set("agent", filters.agent);
   const suffix = params.toString();

--- a/apps/web/src/lib/projects.ts
+++ b/apps/web/src/lib/projects.ts
@@ -1,3 +1,31 @@
-export function getProjectPath(projectKey: string): string {
-  return `/projects/${encodeURIComponent(projectKey)}`;
+import type { ProjectIdentityKind } from "./api";
+
+export interface ProjectRouteIdentity {
+  kind: ProjectIdentityKind;
+  key: string;
+}
+
+const projectIdentityKinds = new Set<string>([
+  "git_remote",
+  "git_common_dir",
+  "manifest_path",
+  "path",
+  "loose",
+]);
+
+export function isProjectIdentityKind(value: string): value is ProjectIdentityKind {
+  return projectIdentityKinds.has(value);
+}
+
+export function getProjectIdentityKey(project: ProjectRouteIdentity): string {
+  return `${project.kind}:${project.key}`;
+}
+
+export function decodeProjectRouteKey(value: string): string {
+  return decodeURIComponent(value);
+}
+
+export function getProjectPath(project: ProjectRouteIdentity): string {
+  // React Router decodes path segments before App parses them, so key needs one spare encode pass.
+  return `/projects/${encodeURIComponent(project.kind)}/${encodeURIComponent(encodeURIComponent(project.key))}`;
 }

--- a/apps/web/src/lib/projects.ts
+++ b/apps/web/src/lib/projects.ts
@@ -1,0 +1,3 @@
+export function getProjectPath(projectKey: string): string {
+  return `/projects/${encodeURIComponent(projectKey)}`;
+}

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -314,11 +314,25 @@ describe("handleGetProjects", () => {
         slug: "claudecode/a",
         project_identity: { kind: "git_remote", key: "github.com/acme/app", displayName: "app" },
         time_updated: 100,
+        stats: {
+          message_count: 2,
+          total_input_tokens: 10,
+          total_output_tokens: 5,
+          total_cost: 0.1,
+        },
       }),
       makeSession("b", {
         slug: "codex/b",
         project_identity: { kind: "git_remote", key: "github.com/acme/app", displayName: "app" },
         time_updated: 200,
+        stats: {
+          message_count: 3,
+          total_input_tokens: 1,
+          total_output_tokens: 2,
+          total_cost: 0.2,
+          total_tokens: 20,
+          cost_source: "estimated",
+        },
       }),
     ];
     const c = makeMockContext();
@@ -332,6 +346,26 @@ describe("handleGetProjects", () => {
         sources: ["claudecode", "codex"],
         sessionCount: 2,
         lastActivity: 200,
+        messages: 5,
+        tokens: 35,
+        cost: 0.30000000000000004,
+        cost_source: "estimated",
+        agentStats: [
+          {
+            name: "claudecode",
+            sessions: 1,
+            messages: 2,
+            tokens: 15,
+            cost: 0.1,
+          },
+          {
+            name: "codex",
+            sessions: 1,
+            messages: 3,
+            tokens: 20,
+            cost: 0.2,
+          },
+        ],
       },
     ]);
   });
@@ -375,6 +409,68 @@ describe("handleGetDashboard", () => {
     expect(response.totals.cost).toBeCloseTo(0.15);
     expect(response.totals.cost_source).toBe("recorded");
     expect(response.dailyActivity).toHaveLength(30);
+  });
+
+  it("scopes dashboard data by project and agent", () => {
+    const now = Date.now();
+    const appClaude = makeSession("app-claude", {
+      slug: "claudecode/app-claude",
+      time_updated: now,
+      project_identity: { kind: "git_remote", key: "github.com/acme/app", displayName: "app" },
+      stats: {
+        message_count: 2,
+        total_input_tokens: 10,
+        total_output_tokens: 5,
+        total_cost: 0.1,
+      },
+    });
+    const appCodex = makeSession("app-codex", {
+      slug: "codex/app-codex",
+      time_updated: now,
+      project_identity: { kind: "git_remote", key: "github.com/acme/app", displayName: "app" },
+      stats: {
+        message_count: 4,
+        total_input_tokens: 30,
+        total_output_tokens: 10,
+        total_cost: 0.2,
+      },
+    });
+    const otherCodex = makeSession("other-codex", {
+      slug: "codex/other-codex",
+      time_updated: now,
+      project_identity: { kind: "path", key: "/repo/other", displayName: "other" },
+      stats: {
+        message_count: 9,
+        total_input_tokens: 100,
+        total_output_tokens: 50,
+        total_cost: 0.9,
+      },
+    });
+    const c = makeMockContext({
+      query: { projectKey: "github.com/acme/app", agent: "codex" },
+    });
+
+    handleGetDashboard(
+      c,
+      makeScanSource({
+        sessions: [appClaude, appCodex, otherCodex],
+        byAgent: {
+          claudecode: [appClaude],
+          codex: [appCodex, otherCodex],
+        },
+      }),
+    );
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.totals.sessions).toBe(1);
+    expect(response.totals.messages).toBe(4);
+    expect(response.totals.tokens).toBe(40);
+    expect(response.totals.cost).toBeCloseTo(0.2);
+    expect(response.perAgent).toHaveLength(1);
+    expect(response.perAgent[0]?.name).toBe("codex");
+    expect(response.recentSessions.map((session: SessionHead) => session.id)).toEqual([
+      "app-codex",
+    ]);
   });
 
   it("marks dashboard totals as estimated when any session uses estimated cost", () => {

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -411,7 +411,7 @@ describe("handleGetDashboard", () => {
     expect(response.dailyActivity).toHaveLength(30);
   });
 
-  it("scopes dashboard data by project and agent", () => {
+  it("scopes dashboard data by project identity and agent", () => {
     const now = Date.now();
     const appClaude = makeSession("app-claude", {
       slug: "claudecode/app-claude",
@@ -446,17 +446,28 @@ describe("handleGetDashboard", () => {
         total_cost: 0.9,
       },
     });
+    const sameKeyPathCodex = makeSession("same-key-path-codex", {
+      slug: "codex/same-key-path-codex",
+      time_updated: now,
+      project_identity: { kind: "path", key: "github.com/acme/app", displayName: "app path" },
+      stats: {
+        message_count: 7,
+        total_input_tokens: 20,
+        total_output_tokens: 10,
+        total_cost: 0.7,
+      },
+    });
     const c = makeMockContext({
-      query: { projectKey: "github.com/acme/app", agent: "codex" },
+      query: { projectKind: "git_remote", projectKey: "github.com/acme/app", agent: "codex" },
     });
 
     handleGetDashboard(
       c,
       makeScanSource({
-        sessions: [appClaude, appCodex, otherCodex],
+        sessions: [appClaude, appCodex, otherCodex, sameKeyPathCodex],
         byAgent: {
           claudecode: [appClaude],
-          codex: [appCodex, otherCodex],
+          codex: [appCodex, otherCodex, sameKeyPathCodex],
         },
       }),
     );

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -73,6 +73,7 @@ interface ApiProjectGroup extends ProjectGroup {
 
 interface DashboardScope {
   agent?: string;
+  projectKind?: string;
   projectKey?: string;
 }
 
@@ -374,7 +375,11 @@ function attachProjectMetrics(
 
 function matchesDashboardScope(session: SessionHead, scope: DashboardScope): boolean {
   if (scope.agent && getSessionAgentName(session) !== scope.agent) return false;
-  if (scope.projectKey && session.project_identity?.key !== scope.projectKey) return false;
+  if (scope.projectKey) {
+    const identity = session.project_identity;
+    if (!identity || identity.key !== scope.projectKey) return false;
+    if (scope.projectKind && identity.kind !== scope.projectKind) return false;
+  }
   return true;
 }
 
@@ -849,6 +854,7 @@ export function handleGetDashboard(
   );
   const scope: DashboardScope = {
     agent: optionalQueryValue(c.req.query("agent"))?.toLowerCase(),
+    projectKind: optionalQueryValue(c.req.query("projectKind")),
     projectKey: optionalQueryValue(c.req.query("projectKey")),
   };
 

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 import type {
   BookmarkRecord,
+  ProjectGroup,
   ScanResult,
   SessionData,
   SessionHead,
@@ -54,6 +55,27 @@ interface ApiSearchResult {
   matchType: SearchMatchType;
 }
 
+interface ApiProjectAgentStat {
+  name: string;
+  sessions: number;
+  messages: number;
+  tokens: number;
+  cost: number;
+}
+
+interface ApiProjectGroup extends ProjectGroup {
+  messages: number;
+  tokens: number;
+  cost: number;
+  cost_source?: SessionHead["stats"]["cost_source"];
+  agentStats: ApiProjectAgentStat[];
+}
+
+interface DashboardScope {
+  agent?: string;
+  projectKey?: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -98,6 +120,10 @@ function parseBookmarkPayload(value: unknown): Omit<BookmarkRecord, "bookmarked_
 
 function getTotalTokens(stats: SessionHead["stats"]): number {
   return stats.total_tokens ?? stats.total_input_tokens + stats.total_output_tokens;
+}
+
+function getSessionAgentName(session: SessionHead): string {
+  return session.slug.split("/")[0]?.toLowerCase() || "unknown";
 }
 
 function getSessionActivityTime(session: SessionHead): number {
@@ -268,6 +294,98 @@ function mergeSearchResults(results: ApiSearchResult[], limit: number): ApiSearc
   return merged;
 }
 
+function getProjectGroupKey(identityKind: string, identityKey: string): string {
+  return `${identityKind}:${identityKey}`;
+}
+
+function attachProjectMetrics(
+  projects: ProjectGroup[],
+  sessions: SessionHead[],
+): ApiProjectGroup[] {
+  const metrics = new Map<
+    string,
+    {
+      messages: number;
+      tokens: number;
+      cost: number;
+      hasEstimatedCost: boolean;
+      agentStats: Map<string, ApiProjectAgentStat>;
+    }
+  >();
+
+  for (const session of sessions) {
+    const identity = session.project_identity;
+    if (!identity) continue;
+    const key = getProjectGroupKey(identity.kind, identity.key);
+    let current = metrics.get(key);
+    if (!current) {
+      current = {
+        messages: 0,
+        tokens: 0,
+        cost: 0,
+        hasEstimatedCost: false,
+        agentStats: new Map(),
+      };
+      metrics.set(key, current);
+    }
+
+    const tokens = getTotalTokens(session.stats);
+    const cost = session.stats.total_cost ?? 0;
+    current.messages += session.stats.message_count;
+    current.tokens += tokens;
+    current.cost += cost;
+    if (session.stats.cost_source === "estimated") current.hasEstimatedCost = true;
+
+    const agentName = getSessionAgentName(session);
+    const agent = current.agentStats.get(agentName);
+    if (agent) {
+      agent.sessions += 1;
+      agent.messages += session.stats.message_count;
+      agent.tokens += tokens;
+      agent.cost += cost;
+    } else {
+      current.agentStats.set(agentName, {
+        name: agentName,
+        sessions: 1,
+        messages: session.stats.message_count,
+        tokens,
+        cost,
+      });
+    }
+  }
+
+  return projects.map((project) => {
+    const metric = metrics.get(getProjectGroupKey(project.identityKind, project.identityKey));
+    return {
+      ...project,
+      messages: metric?.messages ?? 0,
+      tokens: metric?.tokens ?? 0,
+      cost: metric?.cost ?? 0,
+      cost_source:
+        metric && metric.cost > 0
+          ? metric.hasEstimatedCost
+            ? "estimated"
+            : "recorded"
+          : undefined,
+      agentStats: [...(metric?.agentStats.values() ?? [])].sort((a, b) => b.sessions - a.sessions),
+    };
+  });
+}
+
+function matchesDashboardScope(session: SessionHead, scope: DashboardScope): boolean {
+  if (scope.agent && getSessionAgentName(session) !== scope.agent) return false;
+  if (scope.projectKey && session.project_identity?.key !== scope.projectKey) return false;
+  return true;
+}
+
+function filterSessionsByDashboardScope(
+  sessions: SessionHead[],
+  scope: DashboardScope,
+): SessionHead[] {
+  if (!scope.agent && !scope.projectKey) return sessions;
+  return sessions.filter((session) => matchesDashboardScope(session, scope));
+}
+
 function matchesRecentSearchFilters(session: SessionHead, options: SearchOptions): boolean {
   if (options.projectKey && session.project_identity?.key !== options.projectKey) return false;
   if (options.cwd && !matchesProjectScope(session, options.cwd)) return false;
@@ -352,10 +470,9 @@ export function handleGetProjects(
 ) {
   const scanResult = scanSource.getSnapshot();
   const { from, to } = defaults;
+  const sessions = filterSessionsByActivityWindow(scanResult.sessions, from, to);
   return c.json({
-    projects: listCachedProjectGroups(
-      filterSessionsByActivityWindow(scanResult.sessions, from, to),
-    ),
+    projects: attachProjectMetrics(listCachedProjectGroups(sessions), sessions),
   });
 }
 
@@ -730,12 +847,22 @@ export function handleGetDashboard(
     c.req.query("from"),
     c.req.query("to"),
   );
+  const scope: DashboardScope = {
+    agent: optionalQueryValue(c.req.query("agent"))?.toLowerCase(),
+    projectKey: optionalQueryValue(c.req.query("projectKey")),
+  };
 
-  const windowed = filterSessionsByActivityWindow(scanResult.sessions, from, to);
+  const scopedSessions = filterSessionsByDashboardScope(scanResult.sessions, scope);
+  const windowed = filterSessionsByActivityWindow(scopedSessions, from, to);
+  const scopedByAgent = Object.fromEntries(
+    Object.entries(scanResult.byAgent)
+      .filter(([name]) => !scope.agent || name.toLowerCase() === scope.agent)
+      .map(([name, sessions]) => [name, filterSessionsByDashboardScope(sessions, scope)]),
+  );
 
   const agentInfo = getAgentInfoMap(
     Object.fromEntries(
-      Object.entries(scanResult.byAgent).map(([name, sessions]) => [
+      Object.entries(scopedByAgent).map(([name, sessions]) => [
         name,
         filterSessionsByActivityWindow(sessions, from, to).length,
       ]),
@@ -757,7 +884,7 @@ export function handleGetDashboard(
     if (activity > latestActivity) latestActivity = activity;
   }
 
-  const perAgent: DashboardAgentStat[] = Object.entries(scanResult.byAgent)
+  const perAgent: DashboardAgentStat[] = Object.entries(scopedByAgent)
     .map(([name, sessions]) => {
       const info = agentInfoMap.get(name);
       const agentWindowed = filterSessionsByActivityWindow(sessions, from, to);
@@ -836,7 +963,7 @@ export function handleGetDashboard(
     .sort((a, b) => getSessionActivityTime(b) - getSessionActivityTime(a))
     .slice(0, 10)
     .map((session) => {
-      const agentKey = session.slug.split("/")[0] ?? "unknown";
+      const agentKey = getSessionAgentName(session);
       return { ...session, agentName: agentKey };
     });
 
@@ -854,7 +981,13 @@ export function handleGetDashboard(
     dailyTokenActivity,
     modelDistribution,
     recentSessions,
-    recentFileActivities: listFileActivity({ from, to, limit: 12 }),
+    recentFileActivities: listFileActivity({
+      agent: scope.agent,
+      projectKey: scope.projectKey,
+      from,
+      to,
+      limit: 12,
+    }),
     window: { from, to, days },
   };
 


### PR DESCRIPTION
## Summary
- Add a Browse By selector above navigation with Agents as the default and Projects as the alternate mode.
- Add project-scoped dashboard metrics, project navigation counts, and sidebar session lists for project mode.
- Add API support and tests for project dashboard/project list aggregation.

## Validation
- pnpm --filter @codesesh/web lint
- pnpm --filter @codesesh/web build
- pnpm --filter codesesh build
- pnpm --filter codesesh test -- src/api/__tests__/handlers.test.ts
- Browser QA for default Agents mode, Projects dashboard, sidebar sessions, and session detail navigation.

Linear: RD-298