### PR TITLE
fix(projects): use single route encoding

### DIFF
--- a/apps/web/src/lib/projects.test.ts
+++ b/apps/web/src/lib/projects.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { decodeProjectRouteKey, getProjectPath, type ProjectRouteIdentity } from "./projects";
+
+function getRouteKey(project: ProjectRouteIdentity): string {
+  const segments = getProjectPath(project)
+    .replace(/^\/+|\/+$/g, "")
+    .split("/");
+
+  return decodeProjectRouteKey(segments[2]!);
+}
+
+describe("project routes", () => {
+  it("round-trips absolute path project keys", () => {
+    const project = {
+      kind: "path",
+      key: "/Users/Kevin/Dropbox/OBSIDIAN/XingKaiXin/90.Clippings",
+    } satisfies ProjectRouteIdentity;
+
+    expect(getProjectPath(project)).toBe(
+      "/projects/path/%2FUsers%2FKevin%2FDropbox%2FOBSIDIAN%2FXingKaiXin%2F90.Clippings",
+    );
+    expect(getRouteKey(project)).toBe(project.key);
+  });
+
+  it("round-trips reserved characters in project keys", () => {
+    const project = {
+      kind: "path",
+      key: "/tmp/100% done",
+    } satisfies ProjectRouteIdentity;
+
+    expect(getProjectPath(project)).toBe("/projects/path/%2Ftmp%2F100%25%20done");
+    expect(getRouteKey(project)).toBe(project.key);
+  });
+});

--- a/apps/web/src/lib/projects.ts
+++ b/apps/web/src/lib/projects.ts
@@ -26,6 +26,5 @@ export function decodeProjectRouteKey(value: string): string {
 }
 
 export function getProjectPath(project: ProjectRouteIdentity): string {
-  // React Router decodes path segments before App parses them, so key needs one spare encode pass.
-  return `/projects/${encodeURIComponent(project.kind)}/${encodeURIComponent(encodeURIComponent(project.key))}`;
+  return `/projects/${encodeURIComponent(project.kind)}/${encodeURIComponent(project.key)}`;
 }


### PR DESCRIPTION
## What changed

- Encode project route keys once when building `/projects/:kind/:key` links.
- Add route round-trip coverage for absolute path project keys and reserved characters.

## Why

The project detail route decoded the key once, while links encoded path keys twice. Absolute path project identities such as `/Users/...` arrived as `%2FUsers...`, so the UI could not match them against API project identities and rendered `Project Not Found`.

## Validation

- `pnpm --filter @codesesh/web test -- projects.test.ts`
- `pnpm --filter @codesesh/web lint`
- Local browser check on `http://localhost:4323/projects` opening `90.Clippings` project detail successfully.