### PR TITLE
feat(web): add agent resume copy commands

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1952,11 +1952,12 @@ export default function App() {
                     Esc back
                   </span>
                 ) : null}
-                {!isSearchMode &&
-                viewState.mode === "session" &&
-                session &&
-                activeAgentKey === "claudecode" ? (
-                  <CopyResumeButton sessionId={session.id} directory={session.directory} />
+                {!isSearchMode && viewState.mode === "session" && session ? (
+                  <CopyResumeButton
+                    agentName={viewState.activeAgentKey}
+                    sessionId={session.id}
+                    directory={session.directory}
+                  />
                 ) : null}
               </div>
               {liveNotice ? (

--- a/apps/web/src/components/CopyResumeButton.tsx
+++ b/apps/web/src/components/CopyResumeButton.tsx
@@ -3,17 +3,16 @@ import { useEffect, useState } from "react";
 import { buildResumeCommand } from "../lib/build-resume-command";
 
 interface CopyResumeButtonProps {
-  /** Session ID, will be shell-quoted into `--resume <id>`. */
+  /** Session ID, will be shell-quoted into the resume command. */
   sessionId: string;
+  agentName: string;
   /**
    * Session directory — pass `session.directory` from SessionHead.
    *
-   * Why this field specifically: in claudecode adapter, SessionHead.directory
-   * is derived from the first user record's `cwd`, which is the actual working
+   * Why this field specifically: SessionHead.directory is the actual working
    * directory at session start. For worktree sessions this is the worktree
-   * path, not the main repo root — `claude --resume` must be invoked from
-   * there to find the same context. project_identity.path_root would route a
-   * worktree session back to the wrong dir.
+   * path, not the main repo root, so resume must be invoked from there to find
+   * the same context.
    */
   directory?: string | null;
   className?: string;
@@ -48,15 +47,22 @@ async function writeToClipboard(text: string): Promise<boolean> {
   return ok;
 }
 
-export function CopyResumeButton({ sessionId, directory, className = "" }: CopyResumeButtonProps) {
+export function CopyResumeButton({
+  agentName,
+  sessionId,
+  directory,
+  className = "",
+}: CopyResumeButtonProps) {
   const [copied, setCopied] = useState(false);
-  const command = buildResumeCommand({ sessionId, directory });
+  const command = buildResumeCommand({ agentName, sessionId, directory });
 
   useEffect(() => {
     if (!copied) return;
     const timer = window.setTimeout(() => setCopied(false), 1500);
     return () => window.clearTimeout(timer);
   }, [copied]);
+
+  if (!command) return null;
 
   return (
     <button
@@ -68,9 +74,7 @@ export function CopyResumeButton({ sessionId, directory, className = "" }: CopyR
           if (ok) setCopied(true);
         });
       }}
-      aria-label={
-        copied ? `Resume command copied: ${command}` : `Copy claude --resume command: ${command}`
-      }
+      aria-label={copied ? `Resume command copied: ${command}` : `Copy resume command: ${command}`}
       title={copied ? `Copied: ${command}` : `Copy: ${command}`}
       className={`console-mono inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-[11px] transition-colors ${className} ${
         copied

--- a/apps/web/src/lib/build-resume-command.test.ts
+++ b/apps/web/src/lib/build-resume-command.test.ts
@@ -27,10 +27,36 @@ describe("buildResumeCommand", () => {
   it("emits cd && claude --resume when directory is present", () => {
     expect(
       buildResumeCommand({
+        agentName: "claudecode",
         sessionId: "abc-123",
         directory: "/Users/me/project",
       }),
     ).toBe("cd '/Users/me/project' && claude --resume 'abc-123'");
+  });
+
+  it.each([
+    ["claudecode", "claude --resume"],
+    ["codex", "codex resume"],
+    ["kimi", "kimi -r"],
+    ["opencode", "opencode -s"],
+  ])("emits the %s resume command", (agentName, prefix) => {
+    expect(
+      buildResumeCommand({
+        agentName,
+        sessionId: "abc-123",
+        directory: "/Users/me/project",
+      }),
+    ).toBe(`cd '/Users/me/project' && ${prefix} 'abc-123'`);
+  });
+
+  it("does not emit a resume command for cursor", () => {
+    expect(
+      buildResumeCommand({
+        agentName: "cursor",
+        sessionId: "abc-123",
+        directory: "/Users/me/project",
+      }),
+    ).toBeNull();
   });
 
   it("preserves a worktree path verbatim (no normalization away from worktree)", () => {
@@ -39,6 +65,7 @@ describe("buildResumeCommand", () => {
     // project_identity.path_root is that worktree sessions need to resume in
     // the worktree, not the root repo — so we must pass the path through as-is.
     const cmd = buildResumeCommand({
+      agentName: "claudecode",
       sessionId: "wt-1",
       directory: "/Users/me/repos/myrepo-worktrees/feature-x",
     });
@@ -47,6 +74,7 @@ describe("buildResumeCommand", () => {
 
   it("shell-quotes adversarial directory containing a single quote", () => {
     const cmd = buildResumeCommand({
+      agentName: "claudecode",
       sessionId: "id-1",
       directory: "/tmp/can't escape",
     });
@@ -56,6 +84,7 @@ describe("buildResumeCommand", () => {
 
   it("shell-quotes adversarial sessionId", () => {
     const cmd = buildResumeCommand({
+      agentName: "claudecode",
       sessionId: "x'; rm -rf /tmp/__bad",
       directory: "/tmp/proj",
     });
@@ -63,10 +92,22 @@ describe("buildResumeCommand", () => {
   });
 
   it("falls back to no-cd command when directory is missing", () => {
-    expect(buildResumeCommand({ sessionId: "abc" })).toBe("claude --resume 'abc'");
-    expect(buildResumeCommand({ sessionId: "abc", directory: null })).toBe("claude --resume 'abc'");
-    expect(buildResumeCommand({ sessionId: "abc", directory: undefined })).toBe(
+    expect(buildResumeCommand({ agentName: "claudecode", sessionId: "abc" })).toBe(
       "claude --resume 'abc'",
+    );
+    expect(buildResumeCommand({ agentName: "claudecode", sessionId: "abc", directory: null })).toBe(
+      "claude --resume 'abc'",
+    );
+    expect(
+      buildResumeCommand({ agentName: "claudecode", sessionId: "abc", directory: undefined }),
+    ).toBe("claude --resume 'abc'");
+  });
+
+  it("falls back to no-cd command with the agent-specific resume syntax", () => {
+    expect(buildResumeCommand({ agentName: "codex", sessionId: "abc" })).toBe("codex resume 'abc'");
+    expect(buildResumeCommand({ agentName: "kimi", sessionId: "abc" })).toBe("kimi -r 'abc'");
+    expect(buildResumeCommand({ agentName: "opencode", sessionId: "abc" })).toBe(
+      "opencode -s 'abc'",
     );
   });
 
@@ -75,12 +116,12 @@ describe("buildResumeCommand", () => {
     // confusing and at worst silently masks the missing-directory case. The
     // copy-resume button should produce a runnable command regardless of how
     // the upstream metadata happens to be filled in.
-    expect(buildResumeCommand({ sessionId: "abc", directory: "   " })).toBe(
-      "claude --resume 'abc'",
-    );
-    expect(buildResumeCommand({ sessionId: "abc", directory: "\t\n" })).toBe(
-      "claude --resume 'abc'",
-    );
+    expect(
+      buildResumeCommand({ agentName: "claudecode", sessionId: "abc", directory: "   " }),
+    ).toBe("claude --resume 'abc'");
+    expect(
+      buildResumeCommand({ agentName: "claudecode", sessionId: "abc", directory: "\t\n" }),
+    ).toBe("claude --resume 'abc'");
   });
 
   it("preserves surrounding whitespace inside a non-empty directory", () => {
@@ -89,11 +130,19 @@ describe("buildResumeCommand", () => {
     // would emit a `cd` to a different path than what the session was started
     // from. trim() is for emptiness detection only; the quoted argument stays
     // verbatim.
-    expect(buildResumeCommand({ sessionId: "abc", directory: " /tmp/proj " })).toBe(
-      "cd ' /tmp/proj ' && claude --resume 'abc'",
-    );
-    expect(buildResumeCommand({ sessionId: "abc", directory: "\t/var/log/app" })).toBe(
-      "cd '\t/var/log/app' && claude --resume 'abc'",
-    );
+    expect(
+      buildResumeCommand({
+        agentName: "claudecode",
+        sessionId: "abc",
+        directory: " /tmp/proj ",
+      }),
+    ).toBe("cd ' /tmp/proj ' && claude --resume 'abc'");
+    expect(
+      buildResumeCommand({
+        agentName: "claudecode",
+        sessionId: "abc",
+        directory: "\t/var/log/app",
+      }),
+    ).toBe("cd '\t/var/log/app' && claude --resume 'abc'");
   });
 });

--- a/apps/web/src/lib/build-resume-command.ts
+++ b/apps/web/src/lib/build-resume-command.ts
@@ -6,7 +6,7 @@
  * Always uses `session.directory` (the SessionHead field) for `cd` rather
  * than e.g. `project_identity.path_root`, because `directory` reflects the
  * actual cwd at session start — including git worktree paths — which is the
- * one a `--resume` invocation needs to find the same context. Falsy or empty
+ * one a resume invocation needs to find the same context. Falsy or empty
  * directories degrade gracefully to a no-cd command instead of producing
  * something like `cd '' && ...`.
  */
@@ -16,20 +16,43 @@ export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+const RESUME_COMMAND_PREFIX_BY_AGENT = {
+  claudecode: "claude --resume",
+  codex: "codex resume",
+  kimi: "kimi -r",
+  opencode: "opencode -s",
+} as const;
+
+type ResumeAgentKey = keyof typeof RESUME_COMMAND_PREFIX_BY_AGENT;
+
 export interface BuildResumeCommandInput {
+  agentName: string;
   sessionId: string;
   directory?: string | null;
 }
 
-export function buildResumeCommand({ sessionId, directory }: BuildResumeCommandInput): string {
-  const quotedId = shellQuote(sessionId);
+function getResumeCommandPrefix(agentName: string) {
+  const key = agentName.toLowerCase();
+  if (!(key in RESUME_COMMAND_PREFIX_BY_AGENT)) return null;
+  return RESUME_COMMAND_PREFIX_BY_AGENT[key as ResumeAgentKey];
+}
+
+export function buildResumeCommand({
+  agentName,
+  sessionId,
+  directory,
+}: BuildResumeCommandInput): string | null {
+  const prefix = getResumeCommandPrefix(agentName);
+  if (!prefix) return null;
+
+  const invocation = `${prefix} ${shellQuote(sessionId)}`;
   const raw = directory ?? "";
   // Use trim() only to detect "effectively empty" — don't lose surrounding
   // whitespace from the actual cd argument. The shellQuote'd path must match
   // the directory string verbatim so a path like " /tmp/proj " (a quirky but
   // legitimate cwd) still resolves correctly when pasted into the shell.
   if (!raw.trim()) {
-    return `claude --resume ${quotedId}`;
+    return invocation;
   }
-  return `cd ${shellQuote(raw)} && claude --resume ${quotedId}`;
+  return `cd ${shellQuote(raw)} && ${invocation}`;
 }


### PR DESCRIPTION
## Summary

- Add agent-specific resume command generation for Claude Code, Codex, Kimi, and OpenCode.
- Keep Cursor unsupported by returning no resume command, so the copy button does not render for Cursor sessions.
- Pass the active agent into the existing copy resume button and extend unit coverage for supported and unsupported agents.

## Validation

- `pnpm --filter @codesesh/web test -- src/lib/build-resume-command.test.ts`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web build`