### PR TITLE
fix: cache project scope identity

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -180,11 +180,30 @@ describe("handleGetSessions", () => {
     expect(response.sessions[0].id).toBe("s1");
   });
 
-  it("filters by cwd (substring match)", () => {
-    const c = makeMockContext({ query: { cwd: "project" } });
-    handleGetSessions(c, makeScanSource());
+  it("filters by cwd using project scope match", () => {
+    const sessions = [
+      makeSession("exact", { directory: "/home/user/project" }),
+      makeSession("child", { directory: "/home/user/project/src" }),
+      makeSession("parent", { directory: "/home/user" }),
+      makeSession("identity", {
+        directory: "/elsewhere",
+        project_identity: {
+          kind: "path",
+          key: "/home/user/project",
+          displayName: "project",
+        },
+      }),
+      makeSession("sibling", { directory: "/home/user/projectile" }),
+    ];
+    const c = makeMockContext({ query: { cwd: "/home/user/project" } });
+    handleGetSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
     const response = c.json.mock.calls[0]![0];
-    expect(response.sessions).toHaveLength(2);
+    expect(response.sessions.map((session: SessionHead) => session.id)).toEqual([
+      "exact",
+      "child",
+      "parent",
+      "identity",
+    ]);
   });
 
   it("filters by project identity key", () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -9,6 +9,7 @@ import type {
 } from "@codesesh/core";
 import {
   BookmarkStorageUnavailableError,
+  createProjectScopeMatcher,
   deleteBookmark,
   extractSessionFileActivity,
   getAgentInfoMap,
@@ -24,8 +25,10 @@ import {
   searchFileActivitySessions,
   searchSessions,
   upsertBookmark,
+  matchesProjectScope as sessionMatchesProjectScope,
   type FileActivityKind,
   type FileActivityResult,
+  type ProjectScopeMatcher,
   type SearchMatchType,
   type SearchOptions,
   type SearchQueryFilters,
@@ -223,13 +226,6 @@ function filterSessionsByActivityWindow(
   });
 }
 
-function matchesProjectScope(session: SessionHead, cwd: string): boolean {
-  if (!session.directory) return false;
-  const identity = computeIdentity(cwd, realFs);
-  if (session.project_identity?.key === identity.key) return true;
-  return session.directory.toLowerCase().includes(cwd.toLowerCase());
-}
-
 function sanitizeClientLogData(value: unknown): Record<string, unknown> {
   if (!isRecord(value)) return {};
 
@@ -391,9 +387,13 @@ function filterSessionsByDashboardScope(
   return sessions.filter((session) => matchesDashboardScope(session, scope));
 }
 
-function matchesRecentSearchFilters(session: SessionHead, options: SearchOptions): boolean {
+function matchesRecentSearchFilters(
+  session: SessionHead,
+  options: SearchOptions,
+  projectScope: ProjectScopeMatcher | null,
+): boolean {
   if (options.projectKey && session.project_identity?.key !== options.projectKey) return false;
-  if (options.cwd && !matchesProjectScope(session, options.cwd)) return false;
+  if (projectScope && !sessionMatchesProjectScope(session, projectScope)) return false;
   if (options.project) {
     const projectNeedle = options.project.toLowerCase();
     const projectText = [
@@ -417,6 +417,7 @@ function recentSearchSessions(
   scanResult: ScanResult,
   options: SearchOptions & { limit: number },
 ): ApiSearchResult[] {
+  const projectScope = options.cwd ? createProjectScopeMatcher(options.cwd) : null;
   const entries = options.agent
     ? ([[options.agent, scanResult.byAgent[options.agent] ?? []]] as Array<[string, SessionHead[]]>)
     : Object.entries(scanResult.byAgent);
@@ -424,7 +425,7 @@ function recentSearchSessions(
   return entries
     .flatMap(([agentName, sessions]) =>
       filterSessionsByActivityWindow(sessions, options.from, options.to)
-        .filter((session) => matchesRecentSearchFilters(session, options))
+        .filter((session) => matchesRecentSearchFilters(session, options, projectScope))
         .map((session) => ({ agentName, session })),
     )
     .toSorted(
@@ -507,7 +508,8 @@ export function handleGetSessions(
   if (projectKey) {
     sessions = sessions.filter((s) => s.project_identity?.key === projectKey);
   } else if (cwd) {
-    sessions = sessions.filter((s) => matchesProjectScope(s, cwd));
+    const projectScope = createProjectScopeMatcher(cwd);
+    sessions = sessions.filter((s) => sessionMatchesProjectScope(s, projectScope));
   }
   sessions = filterSessionsByActivityWindow(sessions, from, to);
   if (tag) {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -47,15 +47,23 @@ describe("filterSessions", () => {
     expect(filterSessions(sessions, {})).toHaveLength(2);
   });
 
-  it("filters by cwd using path scope match", () => {
+  it("filters by cwd using project scope match", () => {
     const sessions = [
-      makeSession("a", { directory: "/home/user/project/src" }),
-      makeSession("b", { directory: "/home/user/other" }),
-      makeSession("c", { directory: "/home/user/project" }),
+      makeSession("exact", { directory: "/home/user/project" }),
+      makeSession("child", { directory: "/home/user/project/src" }),
+      makeSession("parent", { directory: "/home/user" }),
+      makeSession("identity", {
+        directory: "/elsewhere",
+        project_identity: {
+          kind: "path",
+          key: "/home/user/project",
+          displayName: "project",
+        },
+      }),
+      makeSession("sibling", { directory: "/home/user/projectile" }),
     ];
     const result = filterSessions(sessions, { cwd: "/home/user/project" });
-    expect(result).toHaveLength(2);
-    expect(result.map((s) => s.id)).toEqual(["a", "c"]);
+    expect(result.map((s) => s.id)).toEqual(["exact", "child", "parent", "identity"]);
   });
 
   it("filters by cwd excluding non-matching directories", () => {

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -1,10 +1,9 @@
-import { resolve, sep } from "node:path";
 import { availableParallelism } from "node:os";
 import { Worker } from "node:worker_threads";
 import type { ProjectIdentity, SessionHead, SmartTag } from "../types/index.js";
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import { createRegisteredAgents } from "../agents/index.js";
-import { computeIdentity, realFs } from "../projects/index.js";
+import { computeIdentity, filterSessionsByProjectScope, realFs } from "../projects/index.js";
 import { classifySessionTags, getSmartTagSourceTimestamp, perf } from "../utils/index.js";
 import { loadCachedSessions, saveCachedSessions } from "./cache.js";
 
@@ -44,23 +43,6 @@ export interface ScanProgress {
   changedCount?: number;
 }
 
-/**
- * Bidirectional path scope match (mirrors agent-dump's is_path_scope_match).
- * Matches when:
- *   - paths are equal
- *   - queryPath is a parent of sessionPath  (session is inside the queried project)
- *   - sessionPath is a parent of queryPath  (session root contains the queried path)
- */
-function isPathScopeMatch(queryPath: string, sessionPath: string): boolean {
-  if (!sessionPath) return false;
-  const q = resolve(queryPath);
-  const s = resolve(sessionPath);
-  const sepNorm = (p: string) => p.replaceAll(sep, "/");
-  const sn = sepNorm(s);
-  const qn = sepNorm(q);
-  return sn === qn || sn.startsWith(qn + "/") || qn.startsWith(sn + "/");
-}
-
 function createIdentityResolver() {
   const cache = new Map<string, ProjectIdentity>();
   return (directory: string | null | undefined) => {
@@ -84,19 +66,11 @@ function attachProjectIdentities(sessions: SessionHead[]): SessionHead[] {
   });
 }
 
-function isProjectScopeMatch(queryPath: string, session: SessionHead): boolean {
-  if (!session.directory) return false;
-  const queryIdentity = computeIdentity(queryPath, realFs);
-  if (session.project_identity?.key === queryIdentity.key) return true;
-  return isPathScopeMatch(queryPath, session.directory);
-}
-
 export function filterSessions(sessions: SessionHead[], options: ScanOptions): SessionHead[] {
   let result = sessions;
 
   if (options.cwd) {
-    const cwd = options.cwd;
-    result = result.filter((s) => isProjectScopeMatch(cwd, s));
+    result = filterSessionsByProjectScope(result, options.cwd);
   }
 
   if (options.from != null) {

--- a/packages/core/src/projects/index.ts
+++ b/packages/core/src/projects/index.ts
@@ -2,3 +2,4 @@ export * from "./display-name.js";
 export * from "./fs.js";
 export * from "./groups.js";
 export * from "./identity.js";
+export * from "./scope.js";

--- a/packages/core/src/projects/scope.test.ts
+++ b/packages/core/src/projects/scope.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionHead } from "../types/index.js";
+import type { IdentityFs } from "./identity.js";
+import { filterSessionsByProjectScope } from "./scope.js";
+
+function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
+  return {
+    id,
+    slug: `agent/${id}`,
+    title: `Session ${id}`,
+    directory: "/repo",
+    time_created: 1000,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("filterSessionsByProjectScope", () => {
+  it("matches exact, query parent, session parent, and project identity scopes", () => {
+    const sessions = [
+      makeSession("exact", { directory: "/home/user/project" }),
+      makeSession("child", { directory: "/home/user/project/src" }),
+      makeSession("parent", { directory: "/home/user" }),
+      makeSession("identity", {
+        directory: "/elsewhere",
+        project_identity: {
+          kind: "path",
+          key: "/home/user/project",
+          displayName: "project",
+        },
+      }),
+      makeSession("sibling", { directory: "/home/user/projectile" }),
+    ];
+
+    const result = filterSessionsByProjectScope(sessions, "/home/user/project");
+
+    expect(result.map((session) => session.id)).toEqual(["exact", "child", "parent", "identity"]);
+  });
+
+  it("computes the query project identity once for all sessions", () => {
+    const spawn = vi.fn<IdentityFs["spawn"]>(() => ({
+      stdout: "git@github.com:acme/app.git",
+      exitCode: 0,
+    }));
+    const fs: IdentityFs = {
+      exists(path) {
+        return path === "/repo/.git";
+      },
+      readText() {
+        return null;
+      },
+      spawn,
+    };
+    const sessions = Array.from({ length: 5 }, (_, index) =>
+      makeSession(`s${index}`, {
+        directory: `/other/${index}`,
+        project_identity: {
+          kind: "git_remote",
+          key: "github.com/acme/app",
+          displayName: "app",
+        },
+      }),
+    );
+
+    const result = filterSessionsByProjectScope(sessions, "/repo/packages/web", fs);
+
+    expect(result).toHaveLength(5);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/projects/scope.ts
+++ b/packages/core/src/projects/scope.ts
@@ -1,0 +1,47 @@
+import { resolve, sep } from "node:path";
+import type { SessionHead } from "../types/index.js";
+import { computeIdentity, type IdentityFs } from "./identity.js";
+import { realFs } from "./fs.js";
+
+export interface ProjectScopeMatcher {
+  identityKey: string;
+  path: string;
+}
+
+export function createProjectScopeMatcher(
+  queryPath: string,
+  fs: IdentityFs = realFs,
+): ProjectScopeMatcher {
+  return {
+    identityKey: computeIdentity(queryPath, fs).key,
+    path: normalizeScopePath(queryPath),
+  };
+}
+
+export function matchesProjectScope(session: SessionHead, scope: ProjectScopeMatcher): boolean {
+  if (!session.directory) return false;
+  if (session.project_identity?.key === scope.identityKey) return true;
+  return isPathScopeMatch(scope.path, session.directory);
+}
+
+export function filterSessionsByProjectScope(
+  sessions: SessionHead[],
+  queryPath: string,
+  fs?: IdentityFs,
+): SessionHead[] {
+  const scope = createProjectScopeMatcher(queryPath, fs);
+  return sessions.filter((session) => matchesProjectScope(session, scope));
+}
+
+function isPathScopeMatch(queryPath: string, sessionPath: string): boolean {
+  const session = normalizeScopePath(sessionPath);
+  return (
+    session === queryPath ||
+    session.startsWith(queryPath + "/") ||
+    queryPath.startsWith(session + "/")
+  );
+}
+
+function normalizeScopePath(path: string): string {
+  return resolve(path).replaceAll(sep, "/");
+}


### PR DESCRIPTION
## Summary

- Add a shared core project scope matcher that computes the query cwd identity once.
- Reuse the matcher in scanner filtering and API session/recent-search filtering.
- Cover exact path, query-parent, session-parent, project identity, and single identity computation behavior.

## Validation

- `pnpm --filter @codesesh/core test`
- `pnpm --filter codesesh test`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter codesesh lint`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter codesesh format:check`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter codesesh build`