### PR TITLE
perf: optimize dashboard aggregation

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -225,7 +225,7 @@ export interface DashboardData {
   modelDistribution: ModelDistributionEntry[];
   recentSessions: DashboardRecentSession[];
   recentFileActivities: FileActivityResult[];
-  window: { from: number; to: number; days: number };
+  window: { from?: number; to: number; days?: number };
 }
 
 export interface AppConfig {

--- a/klip/klip-0-performance-hotspots.md
+++ b/klip/klip-0-performance-hotspots.md
@@ -264,7 +264,7 @@ Status: Draft
 ## 持续跟进 Checklist
 
 - [ ] P1-1：重构 `cwd` scope matcher，预计算 query identity，并补 core/API tests。
-- [ ] P1-2：将 `handleGetDashboard()` 改为单 pass 聚合，并保持 response shape 不变。
+- [x] P1-2：将 `handleGetDashboard()` 改为单 pass 聚合，并保持 response shape 不变。
 - [ ] P1-3：为 `LiveScanStore.runRefresh()` 设计 changed/new/removed ids 传递契约。
 - [ ] P1-4：为 cache 层增加增量 upsert/delete，并验证与全量保存结果一致。
 - [ ] P1-5：为 `syncSessionSearchIndex()` 增加 changed ids 路径，bulk 仍保留全量 rebuild。
@@ -275,6 +275,10 @@ Status: Draft
 - [ ] P1-10：在 `App.tsx` 建立 session indexes，减少重复 `filter()` / `find()`。
 - [ ] 验证：每项优化至少运行相关 package tests。
 - [ ] 验证：完成 P1-2 / P1-3 / P1-6 / P1-8 后运行 `pnpm bench:perf` 记录前后结果。
+
+## 实现记录
+
+- 2026-05-20：完成 P1-2。`handleGetDashboard()` 改为在一次 session 扫描中完成 totals、per-agent、daily buckets、token buckets、model distribution 和 recent top 10 聚合；recent top 10 使用固定容量候选集，避免对窗口内全量 session 排序。验证：`pnpm --filter codesesh test`、`pnpm --filter codesesh lint`、`pnpm --filter codesesh format:check`、`pnpm --filter codesesh build`、`git diff --check`、`pnpm bench:perf -- --iterations 1`（236 sessions；dashboard visible 11956ms；detail 139ms）。
 
 ## 测试矩阵
 
@@ -300,7 +304,7 @@ Status: Draft
 - 已运行 complexity scanner，分别扫描 `packages/core`、`packages/cli`、`apps/web`。
 - 已人工复核 scanner 高噪声区域，排除测试文件和 `.claude/worktrees`。
 - 已确认根脚本存在 `pnpm test`、`pnpm build`、`pnpm lint`、`pnpm bench:perf`。
-- 本文未运行测试或 benchmark，因为本次只新增跟踪文档。
+- 原始审计未运行测试或 benchmark；已实现项的验证命令记录在「实现记录」。
 
 ## 关键参考位置
 

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -80,9 +80,13 @@ class MockAgent extends BaseAgent {
 
 function makeScanResult(overrides?: Partial<ScanResult>): ScanResult {
   const agent = new MockAgent();
+  const sessions = [
+    makeSession("s1", { slug: "claudecode/s1" }),
+    makeSession("s2", { slug: "claudecode/s2" }),
+  ];
   return {
-    sessions: [makeSession("s1"), makeSession("s2")],
-    byAgent: { claudecode: [makeSession("s1"), makeSession("s2")] },
+    sessions,
+    byAgent: { claudecode: sessions },
     agents: [agent],
     ...overrides,
   };
@@ -501,6 +505,56 @@ describe("handleGetDashboard", () => {
     expect(response.recentSessions.map((session: SessionHead) => session.id)).toEqual([
       "app-codex",
     ]);
+  });
+
+  it("scopes dashboard data by agent and keeps the ten most recent sessions", () => {
+    const now = Date.now();
+    const codexSessions = Array.from({ length: 12 }, (_, index) =>
+      makeSession(`codex-${index}`, {
+        slug: `codex/codex-${index}`,
+        time_created: now - index * 1000,
+        time_updated: now - index * 1000,
+        stats: {
+          message_count: 1,
+          total_input_tokens: 2,
+          total_output_tokens: 1,
+          total_cost: 0,
+        },
+      }),
+    );
+    const claudeSession = makeSession("claude", {
+      slug: "claudecode/claude",
+      time_created: now,
+      time_updated: now,
+    });
+    const c = makeMockContext({ query: { agent: "codex" } });
+
+    handleGetDashboard(
+      c,
+      makeScanSource({
+        sessions: [claudeSession, ...codexSessions],
+        byAgent: {
+          claudecode: [claudeSession],
+          codex: codexSessions,
+        },
+      }),
+    );
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.totals.sessions).toBe(12);
+    expect(response.perAgent).toEqual([
+      {
+        name: "codex",
+        displayName: "Codex",
+        icon: "/icon/agent/codex.svg",
+        sessions: 12,
+        messages: 12,
+        tokens: 36,
+      },
+    ]);
+    expect(response.recentSessions.map((session: SessionHead) => session.id)).toEqual(
+      codexSessions.slice(0, 10).map((session) => session.id),
+    );
   });
 
   it("marks dashboard totals as estimated when any session uses estimated cost", () => {

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -586,6 +586,43 @@ describe("handleGetDashboard", () => {
     expect(response.window.days).toBe(7);
   });
 
+  it("honors days 0 as an all-time dashboard window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-20T12:00:00Z"));
+
+    const oldSession = makeSession("old", {
+      slug: "claudecode/old",
+      time_created: new Date("2026-04-20T10:00:00Z").getTime(),
+      time_updated: new Date("2026-04-20T10:00:00Z").getTime(),
+      stats: {
+        message_count: 3,
+        total_input_tokens: 10,
+        total_output_tokens: 5,
+        total_cost: 0,
+      },
+    });
+    const c = makeMockContext();
+
+    handleGetDashboard(
+      c,
+      makeScanSource({ sessions: [oldSession], byAgent: { claudecode: [oldSession] } }),
+      { days: 0 },
+    );
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.totals.sessions).toBe(1);
+    expect(response.recentSessions[0]?.id).toBe("old");
+    expect(response.dailyActivity).toEqual([
+      {
+        date: "2026-04-20",
+        sessions: 1,
+        messages: 3,
+      },
+    ]);
+    expect(response.window.from).toBeUndefined();
+    expect(response.window.days).toBe(0);
+  });
+
   it("produces per-agent breakdown sorted by session count", () => {
     const c = makeMockContext();
     handleGetDashboard(c, makeScanSource());

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -80,6 +80,19 @@ interface DashboardScope {
   projectKey?: string;
 }
 
+interface DashboardAgentAggregate {
+  sessions: number;
+  messages: number;
+  tokens: number;
+}
+
+interface DashboardRecentCandidate {
+  session: SessionHead;
+  activity: number;
+}
+
+const DASHBOARD_RECENT_LIMIT = 10;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -367,24 +380,6 @@ function attachProjectMetrics(
       agentStats: [...(metric?.agentStats.values() ?? [])].sort((a, b) => b.sessions - a.sessions),
     };
   });
-}
-
-function matchesDashboardScope(session: SessionHead, scope: DashboardScope): boolean {
-  if (scope.agent && getSessionAgentName(session) !== scope.agent) return false;
-  if (scope.projectKey) {
-    const identity = session.project_identity;
-    if (!identity || identity.key !== scope.projectKey) return false;
-    if (scope.projectKind && identity.kind !== scope.projectKind) return false;
-  }
-  return true;
-}
-
-function filterSessionsByDashboardScope(
-  sessions: SessionHead[],
-  scope: DashboardScope,
-): SessionHead[] {
-  if (!scope.agent && !scope.projectKey) return sessions;
-  return sessions.filter((session) => matchesDashboardScope(session, scope));
 }
 
 function matchesRecentSearchFilters(
@@ -860,59 +855,25 @@ export function handleGetDashboard(
     projectKey: optionalQueryValue(c.req.query("projectKey")),
   };
 
-  const scopedSessions = filterSessionsByDashboardScope(scanResult.sessions, scope);
-  const windowed = filterSessionsByActivityWindow(scopedSessions, from, to);
-  const scopedByAgent = Object.fromEntries(
-    Object.entries(scanResult.byAgent)
-      .filter(([name]) => !scope.agent || name.toLowerCase() === scope.agent)
-      .map(([name, sessions]) => [name, filterSessionsByDashboardScope(sessions, scope)]),
-  );
+  const agentMetrics = new Map<string, DashboardAgentAggregate>();
+  const agentMetricKeyByName = new Map<string, string>();
+  for (const name of Object.keys(scanResult.byAgent)) {
+    if (scope.agent && name.toLowerCase() !== scope.agent) continue;
+    agentMetrics.set(name, { sessions: 0, messages: 0, tokens: 0 });
+    agentMetricKeyByName.set(name.toLowerCase(), name);
+  }
 
-  const agentInfo = getAgentInfoMap(
-    Object.fromEntries(
-      Object.entries(scopedByAgent).map(([name, sessions]) => [
-        name,
-        filterSessionsByActivityWindow(sessions, from, to).length,
-      ]),
-    ),
-  );
+  const agentInfo = getAgentInfoMap({});
   const agentInfoMap = new Map(agentInfo.map((a) => [a.name, a]));
 
+  let totalSessions = 0;
   let totalMessages = 0;
   let totalTokens = 0;
   let totalCost = 0;
   let hasEstimatedCost = false;
   let latestActivity = 0;
-  for (const session of windowed) {
-    totalMessages += session.stats.message_count;
-    totalTokens += getTotalTokens(session.stats);
-    totalCost += session.stats.total_cost ?? 0;
-    if (session.stats.cost_source === "estimated") hasEstimatedCost = true;
-    const activity = getSessionActivityTime(session);
-    if (activity > latestActivity) latestActivity = activity;
-  }
-
-  const perAgent: DashboardAgentStat[] = Object.entries(scopedByAgent)
-    .map(([name, sessions]) => {
-      const info = agentInfoMap.get(name);
-      const agentWindowed = filterSessionsByActivityWindow(sessions, from, to);
-      let messages = 0;
-      let tokens = 0;
-      for (const s of agentWindowed) {
-        messages += s.stats.message_count;
-        tokens += getTotalTokens(s.stats);
-      }
-      return {
-        name,
-        displayName: info?.displayName ?? name,
-        icon: info?.icon ?? "",
-        sessions: agentWindowed.length,
-        messages,
-        tokens,
-      };
-    })
-    .filter((item) => item.sessions > 0)
-    .sort((a, b) => b.sessions - a.sessions);
+  const recentCandidates: DashboardRecentCandidate[] = [];
+  const modelAgg = new Map<string, { tokens: number; sessions: number }>();
 
   // Daily activity buckets — one bucket per local day in [from, to]
   const dailyMap = new Map<string, DashboardDailyBucket>();
@@ -926,14 +887,40 @@ export function handleGetDashboard(
     dailyTokenMap.set(key, { date: key, input: 0, output: 0, cache_read: 0, cache_create: 0 });
   }
 
-  const modelAgg = new Map<string, { tokens: number; sessions: number }>();
+  for (const session of scanResult.sessions) {
+    const agentName = getSessionAgentName(session);
+    if (scope.agent && agentName !== scope.agent) continue;
+    if (scope.projectKey) {
+      const identity = session.project_identity;
+      if (!identity || identity.key !== scope.projectKey) continue;
+      if (scope.projectKind && identity.kind !== scope.projectKind) continue;
+    }
 
-  for (const session of windowed) {
-    const key = toLocalDateKey(getSessionActivityTime(session));
+    const activity = getSessionActivityTime(session);
+    if (activity < from || activity > to) continue;
+
+    const messageCount = session.stats.message_count;
+    const sessionTokens = getTotalTokens(session.stats);
+    totalSessions += 1;
+    totalMessages += messageCount;
+    totalTokens += sessionTokens;
+    totalCost += session.stats.total_cost ?? 0;
+    if (session.stats.cost_source === "estimated") hasEstimatedCost = true;
+    if (activity > latestActivity) latestActivity = activity;
+
+    const metricKey = agentMetricKeyByName.get(agentName);
+    if (metricKey) {
+      const metric = agentMetrics.get(metricKey)!;
+      metric.sessions += 1;
+      metric.messages += messageCount;
+      metric.tokens += sessionTokens;
+    }
+
+    const key = toLocalDateKey(activity);
     const bucket = dailyMap.get(key);
     if (bucket) {
       bucket.sessions += 1;
-      bucket.messages += session.stats.message_count;
+      bucket.messages += messageCount;
     }
 
     const tokenBucket = dailyTokenMap.get(key);
@@ -958,7 +945,34 @@ export function handleGetDashboard(
         }
       }
     }
+
+    let recentIndex = recentCandidates.length;
+    for (let i = 0; i < recentCandidates.length; i += 1) {
+      if (activity > recentCandidates[i]!.activity) {
+        recentIndex = i;
+        break;
+      }
+    }
+    if (recentIndex < DASHBOARD_RECENT_LIMIT) {
+      recentCandidates.splice(recentIndex, 0, { session, activity });
+      if (recentCandidates.length > DASHBOARD_RECENT_LIMIT) recentCandidates.pop();
+    }
   }
+
+  const perAgent: DashboardAgentStat[] = [...agentMetrics.entries()]
+    .map(([name, metrics]) => {
+      const info = agentInfoMap.get(name);
+      return {
+        name,
+        displayName: info?.displayName ?? name,
+        icon: info?.icon ?? "",
+        sessions: metrics.sessions,
+        messages: metrics.messages,
+        tokens: metrics.tokens,
+      };
+    })
+    .filter((item) => item.sessions > 0)
+    .sort((a, b) => b.sessions - a.sessions);
 
   const dailyActivity = [...dailyMap.values()];
   const dailyTokenActivity = [...dailyTokenMap.values()];
@@ -967,17 +981,14 @@ export function handleGetDashboard(
     .map(([model, { tokens, sessions: count }]) => ({ model, tokens, sessions: count }))
     .sort((a, b) => b.tokens - a.tokens);
 
-  const recentSessions: DashboardRecentSession[] = [...windowed]
-    .sort((a, b) => getSessionActivityTime(b) - getSessionActivityTime(a))
-    .slice(0, 10)
-    .map((session) => {
-      const agentKey = getSessionAgentName(session);
-      return { ...session, agentName: agentKey };
-    });
+  const recentSessions: DashboardRecentSession[] = recentCandidates.map(({ session }) => {
+    const agentKey = getSessionAgentName(session);
+    return { ...session, agentName: agentKey };
+  });
 
   const data: DashboardData = {
     totals: {
-      sessions: windowed.length,
+      sessions: totalSessions,
       messages: totalMessages,
       tokens: totalTokens,
       cost: totalCost,

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -787,7 +787,7 @@ export interface DashboardData {
   recentSessions: DashboardRecentSession[];
   recentFileActivities: FileActivityResult[];
   /** Time window covered by dailyActivity (inclusive, ms) */
-  window: { from: number; to: number; days: number };
+  window: { from?: number; to: number; days?: number };
 }
 
 function toLocalDateKey(ts: number): string {
@@ -809,13 +809,14 @@ function resolveDashboardWindow(
   queryDays: string | undefined,
   queryFrom: string | undefined,
   queryTo: string | undefined,
-): { from: number; to: number; days: number } {
+): { from?: number; to: number; days?: number } {
   const now = Date.now();
 
   const toTs = parseDateParam(queryTo, defaults.to) ?? now;
 
   // Resolve days (preferred): query, defaults.days, or derive from defaults.from
-  const parsedDays = queryDays ? parseInt(queryDays, 10) : NaN;
+  const hasQueryDays = queryDays != null && queryDays.trim() !== "";
+  const parsedDays = hasQueryDays ? parseInt(queryDays, 10) : NaN;
   let days: number | undefined =
     Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : defaults.days;
 
@@ -824,6 +825,9 @@ function resolveDashboardWindow(
   if (fromFromQuery != null) {
     fromTs = fromFromQuery;
     days ??= Math.max(1, Math.ceil((toTs - fromTs) / 86400000));
+  } else if (parsedDays === 0 || (!hasQueryDays && defaults.days === 0)) {
+    days = 0;
+    return { to: toTs, days };
   } else if (defaults.from != null) {
     fromTs = defaults.from;
     days ??= Math.max(1, Math.ceil((toTs - fromTs) / 86400000));
@@ -878,13 +882,15 @@ export function handleGetDashboard(
   // Daily activity buckets — one bucket per local day in [from, to]
   const dailyMap = new Map<string, DashboardDailyBucket>();
   const dailyTokenMap = new Map<string, DailyTokenBucket>();
-  const bucketStart = startOfLocalDay(from);
-  const bucketDays = Math.floor((startOfLocalDay(to) - bucketStart) / 86400000) + 1;
-  for (let i = 0; i < bucketDays; i += 1) {
-    const ts = bucketStart + i * 86400000;
-    const key = toLocalDateKey(ts);
-    dailyMap.set(key, { date: key, sessions: 0, messages: 0 });
-    dailyTokenMap.set(key, { date: key, input: 0, output: 0, cache_read: 0, cache_create: 0 });
+  if (from != null) {
+    const bucketStart = startOfLocalDay(from);
+    const bucketDays = Math.floor((startOfLocalDay(to) - bucketStart) / 86400000) + 1;
+    for (let i = 0; i < bucketDays; i += 1) {
+      const ts = bucketStart + i * 86400000;
+      const key = toLocalDateKey(ts);
+      dailyMap.set(key, { date: key, sessions: 0, messages: 0 });
+      dailyTokenMap.set(key, { date: key, input: 0, output: 0, cache_read: 0, cache_create: 0 });
+    }
   }
 
   for (const session of scanResult.sessions) {
@@ -897,7 +903,8 @@ export function handleGetDashboard(
     }
 
     const activity = getSessionActivityTime(session);
-    if (activity < from || activity > to) continue;
+    if (from != null && activity < from) continue;
+    if (activity > to) continue;
 
     const messageCount = session.stats.message_count;
     const sessionTokens = getTotalTokens(session.stats);
@@ -917,22 +924,26 @@ export function handleGetDashboard(
     }
 
     const key = toLocalDateKey(activity);
-    const bucket = dailyMap.get(key);
-    if (bucket) {
-      bucket.sessions += 1;
-      bucket.messages += messageCount;
+    let bucket = dailyMap.get(key);
+    if (!bucket) {
+      bucket = { date: key, sessions: 0, messages: 0 };
+      dailyMap.set(key, bucket);
     }
+    bucket.sessions += 1;
+    bucket.messages += messageCount;
 
-    const tokenBucket = dailyTokenMap.get(key);
-    if (tokenBucket) {
-      const cacheRead = session.stats.total_cache_read_tokens ?? 0;
-      const cacheCreate = session.stats.total_cache_create_tokens ?? 0;
-      const pureInput = session.stats.total_input_tokens - cacheRead - cacheCreate;
-      tokenBucket.input += Math.max(0, pureInput);
-      tokenBucket.output += session.stats.total_output_tokens;
-      tokenBucket.cache_read += cacheRead;
-      tokenBucket.cache_create += cacheCreate;
+    let tokenBucket = dailyTokenMap.get(key);
+    if (!tokenBucket) {
+      tokenBucket = { date: key, input: 0, output: 0, cache_read: 0, cache_create: 0 };
+      dailyTokenMap.set(key, tokenBucket);
     }
+    const cacheRead = session.stats.total_cache_read_tokens ?? 0;
+    const cacheCreate = session.stats.total_cache_create_tokens ?? 0;
+    const pureInput = session.stats.total_input_tokens - cacheRead - cacheCreate;
+    tokenBucket.input += Math.max(0, pureInput);
+    tokenBucket.output += session.stats.total_output_tokens;
+    tokenBucket.cache_read += cacheRead;
+    tokenBucket.cache_create += cacheCreate;
 
     if (session.model_usage) {
       for (const [model, tokens] of Object.entries(session.model_usage)) {
@@ -974,8 +985,10 @@ export function handleGetDashboard(
     .filter((item) => item.sessions > 0)
     .sort((a, b) => b.sessions - a.sessions);
 
-  const dailyActivity = [...dailyMap.values()];
-  const dailyTokenActivity = [...dailyTokenMap.values()];
+  const dailyActivity = [...dailyMap.values()].sort((a, b) => a.date.localeCompare(b.date));
+  const dailyTokenActivity = [...dailyTokenMap.values()].sort((a, b) =>
+    a.date.localeCompare(b.date),
+  );
 
   const modelDistribution: ModelDistributionEntry[] = [...modelAgg.entries()]
     .map(([model, { tokens, sessions: count }]) => ({ model, tokens, sessions: count }))

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -153,6 +153,8 @@ const main = defineCommand({
       if (!Number.isNaN(days) && days > 0) {
         listDefaultFrom = Date.now() - days * 24 * 60 * 60 * 1000;
         listDefaultDays = days;
+      } else if (days === 0) {
+        listDefaultDays = 0;
       }
     }
     const listDefaultTo = args.to ? parseDateToTimestamp(args.to as string) : undefined;


### PR DESCRIPTION
## Summary

- Rework the dashboard API aggregation to compute totals, per-agent metrics, daily buckets, token buckets, model distribution, and recent sessions in one pass over the session snapshot.
- Keep the dashboard response shape unchanged while replacing full-window recent-session sorting with a fixed-size top-10 candidate list.
- Preserve `--days 0` / all-time dashboard semantics so smoke fixtures and all-time views are not clipped by the fallback 30-day window.
- Add focused route coverage for agent-scoped dashboard aggregation and all-time dashboard windows, and record KLIP P1-2 completion.

## Why

The dashboard handler repeatedly filtered and traversed the same session set, then sorted the whole dashboard window just to return the ten most recent sessions. That made dashboard requests spend extra CPU as session counts grow.

A follow-up CI smoke failure showed a separate root issue in the same path: `--days 0` means all time at the CLI boundary, but the dashboard API fell back to 30 days when no positive default window existed. The fix carries that all-time intent through the API and lets the dashboard aggregate without a lower time bound.

## Validation

- `pnpm --filter codesesh test -- src/api/__tests__/handlers.test.ts`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`
- `pnpm --filter codesesh build`
- `pnpm --filter @codesesh/web build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm bench:perf -- --iterations 1`
- `git diff --check`