### PR TITLE
fix: persist live refresh incrementally

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -27,7 +27,9 @@ const core = vi.hoisted(() => ({
   })),
   scanSessions: vi.fn(),
   saveCachedSessions: vi.fn(),
+  saveCachedSessionChanges: vi.fn(),
   syncSessionSearchIndex: vi.fn(),
+  syncSessionSearchIndexChanges: vi.fn(),
 }));
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -48,7 +50,9 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     resolveProviderRoots: core.resolveProviderRoots,
     scanSessions: core.scanSessions,
     saveCachedSessions: core.saveCachedSessions,
+    saveCachedSessionChanges: core.saveCachedSessionChanges,
     syncSessionSearchIndex: core.syncSessionSearchIndex,
+    syncSessionSearchIndexChanges: core.syncSessionSearchIndexChanges,
   };
 });
 
@@ -207,6 +211,13 @@ describe("LiveScanStore", () => {
         timestamp: 3000,
       })),
       incrementalScan: vi.fn(() => [updated, added]),
+      getSessionMetaMap: vi.fn(
+        () =>
+          new Map([
+            ["session", { id: "session", sourcePath: "/tmp/s" }],
+            ["unrelated", { id: "unrelated", sourcePath: "/tmp/unrelated" }],
+          ]),
+      ),
     });
 
     core.createRegisteredAgents.mockReturnValue([codex]);
@@ -228,12 +239,24 @@ describe("LiveScanStore", () => {
       "session",
       "added",
     ]);
-    expect(core.saveCachedSessions).toHaveBeenCalledWith("codex", [updated, added], {
-      session: { id: "session", sourcePath: "/tmp/s" },
-    });
-    expect(core.syncSessionSearchIndex).toHaveBeenCalledWith(
+    expect(core.saveCachedSessions).not.toHaveBeenCalled();
+    expect(core.saveCachedSessionChanges).toHaveBeenCalledWith(
       "codex",
-      [updated, added],
+      [
+        { session: updated, sortIndex: 0 },
+        { session: added, sortIndex: 1 },
+      ],
+      [],
+      { session: { id: "session", sourcePath: "/tmp/s" } },
+    );
+    expect(core.syncSessionSearchIndex).not.toHaveBeenCalled();
+    expect(core.syncSessionSearchIndexChanges).toHaveBeenCalledWith(
+      "codex",
+      [
+        { session: updated, sortIndex: 0 },
+        { session: added, sortIndex: 1 },
+      ],
+      [],
       expect.any(Function),
     );
     expect(events).toEqual([

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -9,11 +9,14 @@ import {
   resolveProviderRoots,
   scanSessions,
   syncSessionSearchIndex,
+  syncSessionSearchIndexChanges,
   saveCachedSessions,
+  saveCachedSessionChanges,
   type BaseAgent,
   type ScanResult,
   type ScanOptions,
   type SessionCacheMeta,
+  type SessionHeadChange,
   type SessionHead,
 } from "@codesesh/core";
 import type { SearchIndexWorkerMessage } from "./search-index-worker.js";
@@ -50,6 +53,12 @@ interface StablePathState {
   timer: NodeJS.Timeout | null;
 }
 
+interface SessionRefreshDiff {
+  event: SessionsUpdatedEvent | null;
+  changedSessions: SessionHeadChange[];
+  removedSessionIds: string[];
+}
+
 const REFRESH_DEBOUNCE_MS = 200;
 const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const PENDING_REFRESH_DELAY_MS = 100;
@@ -78,59 +87,78 @@ function sessionSignature(session: SessionHead): string {
   ]);
 }
 
-function buildAgentCacheMeta(agent: BaseAgent): Record<string, SessionCacheMeta> {
+function buildAgentCacheMeta(
+  agent: BaseAgent,
+  sessionIds?: Set<string>,
+): Record<string, SessionCacheMeta> {
   const metaMap = agent.getSessionMetaMap?.();
   const meta: Record<string, SessionCacheMeta> = {};
   if (!metaMap) return meta;
 
   for (const [id, data] of metaMap.entries()) {
+    if (sessionIds && !sessionIds.has(id)) continue;
     meta[id] = { id, ...(data as Record<string, unknown>) } as SessionCacheMeta;
   }
 
   return meta;
 }
 
-function buildUpdateEvent(
+function buildRefreshDiff(
   agentName: string,
   previousSessions: SessionHead[],
   nextSessions: SessionHead[],
-): SessionsUpdatedEvent | null {
+  candidateChangedIds: string[] = [],
+): SessionRefreshDiff {
   const previousMap = new Map(previousSessions.map((session) => [session.id, session]));
   const nextMap = new Map(nextSessions.map((session) => [session.id, session]));
+  const candidateChangedIdSet = new Set(candidateChangedIds);
+  const changedSessions: SessionHeadChange[] = [];
+  const removedSessionIds: string[] = [];
 
   let newSessions = 0;
   let updatedSessions = 0;
   let removedSessions = 0;
 
-  for (const [id, session] of nextMap.entries()) {
+  nextSessions.forEach((session, index) => {
+    const id = session.id;
     const previous = previousMap.get(id);
     if (!previous) {
       newSessions += 1;
-      continue;
+      changedSessions.push({ session, sortIndex: index });
+      return;
     }
-    if (sessionSignature(previous) !== sessionSignature(session)) {
+    const hasSignatureChange = sessionSignature(previous) !== sessionSignature(session);
+    if (hasSignatureChange) {
       updatedSessions += 1;
     }
-  }
+    if (candidateChangedIdSet.has(id) || hasSignatureChange) {
+      changedSessions.push({ session, sortIndex: index });
+    }
+  });
 
   for (const id of previousMap.keys()) {
     if (!nextMap.has(id)) {
       removedSessions += 1;
+      removedSessionIds.push(id);
     }
   }
 
   if (newSessions === 0 && updatedSessions === 0 && removedSessions === 0) {
-    return null;
+    return { event: null, changedSessions, removedSessionIds };
   }
 
   return {
-    type: "sessions-updated",
-    changedAgents: [agentName],
-    newSessions,
-    updatedSessions,
-    removedSessions,
-    totalSessions: nextSessions.length,
-    timestamp: Date.now(),
+    changedSessions,
+    removedSessionIds,
+    event: {
+      type: "sessions-updated",
+      changedAgents: [agentName],
+      newSessions,
+      updatedSessions,
+      removedSessions,
+      totalSessions: nextSessions.length,
+      timestamp: Date.now(),
+    },
   };
 }
 
@@ -795,6 +823,8 @@ export class LiveScanStore {
 
     const previousSessions = this.byAgent[agentName] ?? [];
     let nextSessions = previousSessions;
+    let preciseChangedIds: string[] | null = null;
+    let usedIncrementalScan = false;
 
     if (!agent.isAvailable()) {
       nextSessions = [];
@@ -813,6 +843,8 @@ export class LiveScanStore {
         return;
       }
 
+      preciseChangedIds = checkResult.changedIds ?? null;
+      usedIncrementalScan = Array.isArray(checkResult.changedIds);
       nextSessions = await Promise.resolve(
         agent.incrementalScan(previousSessions, checkResult.changedIds ?? []),
       );
@@ -822,24 +854,52 @@ export class LiveScanStore {
     }
 
     nextSessions = this.applyFilters(nextSessions);
-    if (!this.hasStartupWindow()) {
-      saveCachedSessions(agentName, nextSessions, buildAgentCacheMeta(agent));
-    }
+    const diff = buildRefreshDiff(
+      agentName,
+      previousSessions,
+      nextSessions,
+      preciseChangedIds ?? [],
+    );
     const searchIndexOptions =
       pendingPathCount >= SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD ? { isBulk: true } : undefined;
-    const syncResult = searchIndexOptions
-      ? syncSessionSearchIndex(
+    const canPersistIncrementally =
+      usedIncrementalScan && !searchIndexOptions && !this.hasStartupWindow();
+    const changedSessionIds = canPersistIncrementally
+      ? new Set(diff.changedSessions.map(({ session }) => session.id))
+      : undefined;
+    const cacheMeta = buildAgentCacheMeta(agent, changedSessionIds);
+    if (!this.hasStartupWindow()) {
+      if (canPersistIncrementally) {
+        saveCachedSessionChanges(
           agentName,
-          nextSessions,
-          (sessionId) => agent.getSessionData(sessionId),
-          searchIndexOptions,
-        )
-      : syncSessionSearchIndex(agentName, nextSessions, (sessionId) =>
-          agent.getSessionData(sessionId),
+          diff.changedSessions,
+          diff.removedSessionIds,
+          cacheMeta,
         );
+      } else {
+        saveCachedSessions(agentName, nextSessions, cacheMeta);
+      }
+    }
+    const syncResult = canPersistIncrementally
+      ? syncSessionSearchIndexChanges(
+          agentName,
+          diff.changedSessions,
+          diff.removedSessionIds,
+          (sessionId) => agent.getSessionData(sessionId),
+        )
+      : searchIndexOptions
+        ? syncSessionSearchIndex(
+            agentName,
+            nextSessions,
+            (sessionId) => agent.getSessionData(sessionId),
+            searchIndexOptions,
+          )
+        : syncSessionSearchIndex(agentName, nextSessions, (sessionId) =>
+            agent.getSessionData(sessionId),
+          );
     logSearchIndexSync("scan.refresh", syncResult, { pending_paths: pendingPathCount });
 
-    const event = buildUpdateEvent(agentName, previousSessions, nextSessions);
+    const event = diff.event;
     this.byAgent[agentName] = sortSessions(nextSessions);
     this.rebuildSessions();
 

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -12,8 +12,10 @@ import {
   parseSearchQuery,
   searchFileActivitySessions,
   searchSessions,
+  saveCachedSessionChanges,
   saveCachedSessions,
   syncSessionSearchIndex,
+  syncSessionSearchIndexChanges,
   type SessionCacheMeta,
 } from "../cache.js";
 import type { SessionData, SessionHead } from "../../types/index.js";
@@ -394,6 +396,49 @@ describe("saveCachedSessions", () => {
   });
 });
 
+describe("saveCachedSessionChanges", () => {
+  it("updates changed sessions and removes deleted sessions", () => {
+    const unchanged = makeSession("unchanged");
+    const changed = makeSession("changed");
+    const removed = makeSession("removed");
+
+    saveCachedSessions("claudecode", [unchanged, changed, removed], {
+      unchanged: { id: "unchanged", sourcePath: "/tmp/unchanged" },
+      changed: { id: "changed", sourcePath: "/tmp/changed-old" },
+      removed: { id: "removed", sourcePath: "/tmp/removed" },
+    });
+
+    const updated = {
+      ...changed,
+      title: "Changed updated",
+      time_updated: now + 1_000,
+    };
+
+    saveCachedSessionChanges("claudecode", [{ session: updated, sortIndex: 0 }], ["removed"], {
+      changed: { id: "changed", sourcePath: "/tmp/changed-new" },
+    });
+
+    const cached = loadCachedSessions("claudecode");
+    expect(cached?.sessions.map((session) => session.id)).toEqual(["changed", "unchanged"]);
+    expect(cached?.sessions[0]?.title).toBe("Changed updated");
+    expect(cached?.meta.changed?.sourcePath).toBe("/tmp/changed-new");
+    expect(cached?.meta.unchanged?.sourcePath).toBe("/tmp/unchanged");
+    expect(cached?.meta.removed).toBeUndefined();
+
+    const db = new Database(getCachePath(), { readonly: true });
+    try {
+      for (const table of ["cached_sessions", "sessions", "project_sessions"]) {
+        const row = db
+          .prepare(`SELECT COUNT(*) AS value FROM ${table} WHERE session_id = ?`)
+          .get("removed") as { value?: number };
+        expect(Number(row.value ?? 0)).toBe(0);
+      }
+    } finally {
+      db.close();
+    }
+  });
+});
+
 describe("clearCache", () => {
   it("clears sqlite rows", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
@@ -626,6 +671,82 @@ describe("searchSessions", () => {
     });
     expect(result?.rebuildDurationMs).toBeUndefined();
     expect(searchSessions("instant")).toHaveLength(1);
+  });
+
+  it("syncs changed search rows without diffing untouched sessions", () => {
+    const keep = {
+      ...makeSession("keep"),
+      stats: { ...makeSession("keep").stats, message_count: 2 },
+    };
+    const changed = {
+      ...makeSession("changed"),
+      stats: { ...makeSession("changed").stats, message_count: 2 },
+    };
+    const removed = {
+      ...makeSession("removed"),
+      stats: { ...makeSession("removed").stats, message_count: 2 },
+    };
+    const sessions = [keep, changed, removed];
+    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+    const makeIndexedData = (session: SessionHead, text: string, path: string): SessionData => ({
+      ...session,
+      messages: [
+        {
+          id: `${session.id}-m1`,
+          role: "user",
+          time_created: now,
+          parts: [{ type: "text", text }],
+        },
+        {
+          id: `${session.id}-m2`,
+          role: "assistant",
+          time_created: now + 1,
+          parts: [{ type: "tool", tool: "read", input: { path } }],
+        },
+      ],
+    });
+
+    saveCachedSessions("claudecode", sessions);
+    syncSessionSearchIndex("claudecode", sessions, (sessionId) =>
+      makeIndexedData(sessionMap.get(sessionId)!, `${sessionId}token`, `src/${sessionId}.ts`),
+    );
+
+    const updated = {
+      ...changed,
+      title: "Changed updated",
+      stats: { ...changed.stats, message_count: 2 },
+    };
+    const loadChanged = vi.fn((sessionId: string) => {
+      if (sessionId !== "changed") {
+        throw new Error(`unexpected load ${sessionId}`);
+      }
+      return makeIndexedData(updated, "updatedtoken", "src/changed-new.ts");
+    });
+
+    saveCachedSessionChanges("claudecode", [{ session: updated, sortIndex: 0 }], ["removed"]);
+    const result = syncSessionSearchIndexChanges(
+      "claudecode",
+      [{ session: updated, sortIndex: 0 }],
+      ["removed"],
+      loadChanged,
+    );
+
+    expect(loadChanged).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      mode: "incremental",
+      changed: 1,
+      deleted: 1,
+      indexed: 1,
+    });
+    expect(searchSessions("updatedtoken").map((item) => item.session.id)).toEqual(["changed"]);
+    expect(searchSessions("changedtoken")).toHaveLength(0);
+    expect(searchSessions("removedtoken")).toHaveLength(0);
+    expect(searchSessions("keeptoken").map((item) => item.session.id)).toEqual(["keep"]);
+    expect(
+      listFileActivity({ agent: "claudecode" })
+        .map((item) => item.path)
+        .sort(),
+    ).toEqual(["src/changed-new.ts", "src/keep.ts"]);
   });
 
   it("restores missing FTS triggers before incremental sync", () => {

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -9,6 +9,7 @@ import type {
   FileActivityKind,
   Message,
   MessagePart,
+  ProjectIdentity,
   ProjectGroup,
   ProjectIdentityKind,
   SessionFileActivity,
@@ -46,6 +47,11 @@ export interface CachedResult {
   sessions: SessionHead[];
   meta: Record<string, SessionCacheMeta>;
   timestamp: number;
+}
+
+export interface SessionHeadChange {
+  session: SessionHead;
+  sortIndex: number;
 }
 
 export interface SearchIndexSyncOptions {
@@ -221,6 +227,16 @@ interface StructuredMessageRecord {
   nickname?: string | null;
   contentText: string;
   toolMetadataJson?: string | null;
+}
+
+interface LoadedSearchIndexEntry {
+  session: SessionHead;
+  identity: ProjectIdentity;
+  messages: StructuredMessageRecord[];
+  contentText: string;
+  contentHash: string;
+  fileActivity: SessionFileActivity[];
+  sortIndex: number;
 }
 
 export interface SearchResult {
@@ -604,6 +620,36 @@ function sourcePathFromMetaJson(metaJson: string | null | undefined): string | n
   return sourcePathFromMeta(meta);
 }
 
+function prepareUpsertCachedSession(db: SQLiteDatabase): SQLiteStatement {
+  return db.prepare(`
+    INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(agent_name, session_id) DO UPDATE SET
+      session_json = excluded.session_json,
+      meta_json = excluded.meta_json
+  `);
+}
+
+function prepareUpsertProjectSession(db: SQLiteDatabase): SQLiteStatement {
+  return db.prepare(`
+    INSERT INTO project_sessions(
+      agent_name,
+      session_id,
+      identity_kind,
+      identity_key,
+      display_name,
+      directory,
+      activity_time
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(agent_name, session_id) DO UPDATE SET
+      identity_kind = excluded.identity_kind,
+      identity_key = excluded.identity_key,
+      display_name = excluded.display_name,
+      directory = excluded.directory,
+      activity_time = excluded.activity_time
+  `);
+}
+
 function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
   return db.prepare(`
     INSERT INTO sessions(
@@ -781,6 +827,23 @@ function writeFileActivityRows(
       activity.latest_time,
     );
   }
+}
+
+function writeProjectSessionRow(
+  statement: SQLiteStatement,
+  agentName: string,
+  session: SessionHead,
+  identity: ProjectIdentity,
+): void {
+  statement.run(
+    agentName,
+    session.id,
+    identity.kind,
+    identity.key,
+    identity.displayName,
+    session.directory,
+    session.time_updated ?? session.time_created,
+  );
 }
 
 function sessionFromRow(row: SessionRow): SessionHead {
@@ -1666,8 +1729,14 @@ export function saveCachedSessions(
     const deleteSearchDocument = db.prepare(
       "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
     );
+    const deleteMessages = db.prepare(
+      "DELETE FROM messages WHERE agent_name = ? AND session_id = ?",
+    );
     const deleteFileActivity = db.prepare(
       "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
+    );
+    const deleteProjectSession = db.prepare(
+      "DELETE FROM project_sessions WHERE agent_name = ? AND session_id = ?",
     );
     const deleteProjectSessions = db.prepare("DELETE FROM project_sessions WHERE agent_name = ?");
     const upsertAgent = db.prepare(`
@@ -1675,22 +1744,9 @@ export function saveCachedSessions(
       VALUES (?, ?)
       ON CONFLICT(agent_name) DO UPDATE SET timestamp = excluded.timestamp
     `);
-    const insertCachedSession = db.prepare(`
-      INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json)
-      VALUES (?, ?, ?, ?)
-    `);
+    const upsertCachedSession = prepareUpsertCachedSession(db);
     const upsertSession = prepareUpsertSession(db);
-    const insertProjectSession = db.prepare(`
-      INSERT INTO project_sessions(
-        agent_name,
-        session_id,
-        identity_kind,
-        identity_key,
-        display_name,
-        directory,
-        activity_time
-      ) VALUES (?, ?, ?, ?, ?, ?, ?)
-    `);
+    const upsertProjectSession = prepareUpsertProjectSession(db);
 
     const write = db.transaction(() => {
       const timestamp = Date.now();
@@ -1707,7 +1763,9 @@ export function saveCachedSessions(
         const sessionId = String(row.session_id);
         if (!sessionIds.has(sessionId)) {
           deleteSearchDocument.run(agentName, sessionId);
+          deleteMessages.run(agentName, sessionId);
           deleteFileActivity.run(agentName, sessionId);
+          deleteProjectSession.run(agentName, sessionId);
           deleteSession.run(agentName, sessionId);
         }
       }
@@ -1716,7 +1774,7 @@ export function saveCachedSessions(
         const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
         const sessionMeta = meta[session.id];
         const metaJson = sessionMeta ? JSON.stringify(sessionMeta) : null;
-        insertCachedSession.run(agentName, session.id, JSON.stringify(session), metaJson);
+        upsertCachedSession.run(agentName, session.id, JSON.stringify(session), metaJson);
         upsertSessionRow(
           upsertSession,
           agentName,
@@ -1725,16 +1783,80 @@ export function saveCachedSessions(
           index,
           sourcePathFromMeta(sessionMeta),
         );
-        insertProjectSession.run(
-          agentName,
-          session.id,
-          identity.kind,
-          identity.key,
-          identity.displayName,
-          session.directory,
-          session.time_updated ?? session.time_created,
-        );
+        writeProjectSessionRow(upsertProjectSession, agentName, session, identity);
       });
+    });
+
+    write();
+    deleteLegacyCacheFile();
+  });
+}
+
+export function saveCachedSessionChanges(
+  agentName: string,
+  changes: SessionHeadChange[],
+  removedSessionIds: string[],
+  meta: Record<string, SessionCacheMeta> = {},
+): void {
+  if (changes.length === 0 && removedSessionIds.length === 0) {
+    return;
+  }
+
+  withCacheDb((db) => {
+    const deleteLegacySession = db.prepare(
+      "DELETE FROM cached_sessions WHERE agent_name = ? AND session_id = ?",
+    );
+    const deleteSession = db.prepare(
+      "DELETE FROM sessions WHERE agent_name = ? AND session_id = ?",
+    );
+    const deleteSearchDocument = db.prepare(
+      "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
+    );
+    const deleteMessages = db.prepare(
+      "DELETE FROM messages WHERE agent_name = ? AND session_id = ?",
+    );
+    const deleteFileActivity = db.prepare(
+      "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
+    );
+    const deleteProjectSession = db.prepare(
+      "DELETE FROM project_sessions WHERE agent_name = ? AND session_id = ?",
+    );
+    const upsertAgent = db.prepare(`
+      INSERT INTO agent_cache(agent_name, timestamp)
+      VALUES (?, ?)
+      ON CONFLICT(agent_name) DO UPDATE SET timestamp = excluded.timestamp
+    `);
+    const upsertCachedSession = prepareUpsertCachedSession(db);
+    const upsertSession = prepareUpsertSession(db);
+    const upsertProjectSession = prepareUpsertProjectSession(db);
+
+    const write = db.transaction(() => {
+      upsertAgent.run(agentName, Date.now());
+
+      for (const sessionId of new Set(removedSessionIds)) {
+        deleteLegacySession.run(agentName, sessionId);
+        deleteSearchDocument.run(agentName, sessionId);
+        deleteMessages.run(agentName, sessionId);
+        deleteFileActivity.run(agentName, sessionId);
+        deleteProjectSession.run(agentName, sessionId);
+        deleteSession.run(agentName, sessionId);
+      }
+
+      for (const { session, sortIndex } of changes) {
+        const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
+        const sessionMeta = meta[session.id];
+        const metaJson = sessionMeta ? JSON.stringify(sessionMeta) : null;
+        upsertCachedSession.run(agentName, session.id, JSON.stringify(session), metaJson);
+        upsertSessionRow(
+          upsertSession,
+          agentName,
+          session,
+          metaJson,
+          sortIndex,
+          sourcePathFromMeta(sessionMeta),
+        );
+        writeProjectSessionRow(upsertProjectSession, agentName, session, identity);
+      }
     });
 
     write();
@@ -1801,6 +1923,180 @@ export function getCacheInfo(): { lastScanTime: number | null; size: number } {
   return info ?? { lastScanTime: null, size: 0 };
 }
 
+function loadSearchIndexEntry(
+  agentName: string,
+  change: SessionHeadChange,
+  loadSessionData: (sessionId: string) => SessionData,
+): LoadedSearchIndexEntry | null {
+  try {
+    const data = loadSessionData(change.session.id);
+    const messages = normalizeMessages(data);
+    const identity =
+      change.session.project_identity ??
+      data.project_identity ??
+      computeIdentity(change.session.directory, realFs);
+    return {
+      session: change.session,
+      identity,
+      messages,
+      contentText: buildSessionContentFromMessages(data.title ?? change.session.title, messages),
+      contentHash: sessionContentHash(change.session),
+      fileActivity: extractSessionFileActivity(
+        agentName,
+        change.session.id,
+        identity.key,
+        data.messages,
+      ),
+      sortIndex: change.sortIndex,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeSearchIndexRows(
+  db: SQLiteDatabase,
+  agentName: string,
+  removedSessionIds: string[],
+  entries: LoadedSearchIndexEntry[],
+): void {
+  const deleteRow = db.prepare(
+    "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
+  );
+  const deleteMessages = db.prepare(
+    "DELETE FROM messages WHERE agent_name = ? AND session_id = ? AND message_index >= ?",
+  );
+  const deleteFileActivity = db.prepare(
+    "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
+  );
+  const upsertIndexedSession = prepareUpsertIndexedSession(db);
+  const insertFileActivity = prepareInsertFileActivity(db);
+  const upsertMessage = db.prepare(`
+    INSERT INTO messages(
+      agent_name,
+      session_id,
+      message_index,
+      message_id,
+      role,
+      time_created,
+      time_completed,
+      agent,
+      mode,
+      model,
+      provider,
+      tokens_json,
+      cost,
+      cost_source,
+      parts_json,
+      subagent_id,
+      nickname,
+      content_text,
+      tool_metadata_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(agent_name, session_id, message_index) DO UPDATE SET
+      message_id = excluded.message_id,
+      role = excluded.role,
+      time_created = excluded.time_created,
+      time_completed = excluded.time_completed,
+      agent = excluded.agent,
+      mode = excluded.mode,
+      model = excluded.model,
+      provider = excluded.provider,
+      tokens_json = excluded.tokens_json,
+      cost = excluded.cost,
+      cost_source = excluded.cost_source,
+      parts_json = excluded.parts_json,
+      subagent_id = excluded.subagent_id,
+      nickname = excluded.nickname,
+      content_text = excluded.content_text,
+      tool_metadata_json = excluded.tool_metadata_json
+  `);
+  const upsertRow = db.prepare(`
+    INSERT INTO session_documents(
+      agent_name,
+      session_id,
+      slug,
+      title,
+      directory,
+      project_identity_kind,
+      project_identity_key,
+      project_display_name,
+      time_created,
+      time_updated,
+      activity_time,
+      content_text,
+      content_hash,
+      indexed_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(agent_name, session_id) DO UPDATE SET
+      slug = excluded.slug,
+      title = excluded.title,
+      directory = excluded.directory,
+      project_identity_kind = excluded.project_identity_kind,
+      project_identity_key = excluded.project_identity_key,
+      project_display_name = excluded.project_display_name,
+      time_created = excluded.time_created,
+      time_updated = excluded.time_updated,
+      activity_time = excluded.activity_time,
+      content_text = excluded.content_text,
+      content_hash = excluded.content_hash,
+      indexed_at = excluded.indexed_at
+  `);
+
+  for (const sessionId of new Set(removedSessionIds)) {
+    deleteRow.run(agentName, sessionId);
+    deleteFileActivity.run(agentName, sessionId);
+    deleteMessages.run(agentName, sessionId, 0);
+  }
+
+  for (const entry of entries) {
+    const activityTime = entry.session.time_updated ?? entry.session.time_created;
+    upsertSessionRow(upsertIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
+    deleteFileActivity.run(agentName, entry.session.id);
+    writeFileActivityRows(insertFileActivity, entry.fileActivity);
+    for (const message of entry.messages) {
+      upsertMessage.run(
+        agentName,
+        entry.session.id,
+        message.index,
+        message.id,
+        message.role,
+        message.timeCreated,
+        message.timeCompleted ?? null,
+        message.agent ?? null,
+        message.mode ?? null,
+        message.model ?? null,
+        message.provider ?? null,
+        message.tokensJson ?? null,
+        message.cost ?? null,
+        message.costSource ?? null,
+        message.partsJson,
+        message.subagentId ?? null,
+        message.nickname ?? null,
+        message.contentText,
+        message.toolMetadataJson ?? null,
+      );
+    }
+    deleteMessages.run(agentName, entry.session.id, entry.messages.length);
+    upsertRow.run(
+      agentName,
+      entry.session.id,
+      entry.session.slug,
+      entry.session.title,
+      entry.session.directory,
+      entry.identity.kind,
+      entry.identity.key,
+      entry.identity.displayName,
+      entry.session.time_created,
+      entry.session.time_updated ?? null,
+      activityTime,
+      entry.contentText,
+      entry.contentHash,
+      Date.now(),
+    );
+  }
+}
+
 export function syncSessionSearchIndex(
   agentName: string,
   sessions: SessionHead[],
@@ -1841,177 +2137,16 @@ export function syncSessionSearchIndex(
     const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
 
     const loaded = toUpsert
-      .map((session) => {
-        try {
-          const data = loadSessionData(session.id);
-          const messages = normalizeMessages(data);
-          const identity =
-            session.project_identity ??
-            data.project_identity ??
-            computeIdentity(session.directory, realFs);
-          return {
-            session,
-            identity,
-            messages,
-            contentText: buildSessionContentFromMessages(data.title ?? session.title, messages),
-            contentHash: sessionContentHash(session),
-            fileActivity: extractSessionFileActivity(
-              agentName,
-              session.id,
-              identity.key,
-              data.messages,
-            ),
-          };
-        } catch {
-          return null;
-        }
-      })
-      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
-
-    const deleteRow = db.prepare(
-      "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
-    );
-    const deleteMessages = db.prepare(
-      "DELETE FROM messages WHERE agent_name = ? AND session_id = ? AND message_index >= ?",
-    );
-    const deleteFileActivity = db.prepare(
-      "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
-    );
-    const upsertIndexedSession = prepareUpsertIndexedSession(db);
-    const insertFileActivity = prepareInsertFileActivity(db);
-    const upsertMessage = db.prepare(`
-      INSERT INTO messages(
-        agent_name,
-        session_id,
-        message_index,
-        message_id,
-        role,
-        time_created,
-        time_completed,
-        agent,
-        mode,
-        model,
-        provider,
-        tokens_json,
-        cost,
-        cost_source,
-        parts_json,
-        subagent_id,
-        nickname,
-        content_text,
-        tool_metadata_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(agent_name, session_id, message_index) DO UPDATE SET
-        message_id = excluded.message_id,
-        role = excluded.role,
-        time_created = excluded.time_created,
-        time_completed = excluded.time_completed,
-        agent = excluded.agent,
-        mode = excluded.mode,
-        model = excluded.model,
-        provider = excluded.provider,
-        tokens_json = excluded.tokens_json,
-        cost = excluded.cost,
-        cost_source = excluded.cost_source,
-        parts_json = excluded.parts_json,
-        subagent_id = excluded.subagent_id,
-        nickname = excluded.nickname,
-        content_text = excluded.content_text,
-        tool_metadata_json = excluded.tool_metadata_json
-    `);
-    const upsertRow = db.prepare(`
-      INSERT INTO session_documents(
-        agent_name,
-        session_id,
-        slug,
-        title,
-        directory,
-        project_identity_kind,
-        project_identity_key,
-        project_display_name,
-        time_created,
-        time_updated,
-        activity_time,
-        content_text,
-        content_hash,
-        indexed_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(agent_name, session_id) DO UPDATE SET
-        slug = excluded.slug,
-        title = excluded.title,
-        directory = excluded.directory,
-        project_identity_kind = excluded.project_identity_kind,
-        project_identity_key = excluded.project_identity_key,
-        project_display_name = excluded.project_display_name,
-        time_created = excluded.time_created,
-        time_updated = excluded.time_updated,
-        activity_time = excluded.activity_time,
-        content_text = excluded.content_text,
-        content_hash = excluded.content_hash,
-        indexed_at = excluded.indexed_at
-    `);
-
-    const writeRows = () => {
-      for (const sessionId of toDelete) {
-        deleteRow.run(agentName, sessionId);
-        deleteFileActivity.run(agentName, sessionId);
-        deleteMessages.run(agentName, sessionId, 0);
-      }
-
-      for (const entry of loaded) {
-        const activityTime = entry.session.time_updated ?? entry.session.time_created;
-        upsertSessionRow(
-          upsertIndexedSession,
+      .map((session) =>
+        loadSearchIndexEntry(
           agentName,
-          entry.session,
-          null,
-          sessionSortIndexMap.get(entry.session.id) ?? 0,
-          null,
-        );
-        deleteFileActivity.run(agentName, entry.session.id);
-        writeFileActivityRows(insertFileActivity, entry.fileActivity);
-        for (const message of entry.messages) {
-          upsertMessage.run(
-            agentName,
-            entry.session.id,
-            message.index,
-            message.id,
-            message.role,
-            message.timeCreated,
-            message.timeCompleted ?? null,
-            message.agent ?? null,
-            message.mode ?? null,
-            message.model ?? null,
-            message.provider ?? null,
-            message.tokensJson ?? null,
-            message.cost ?? null,
-            message.costSource ?? null,
-            message.partsJson,
-            message.subagentId ?? null,
-            message.nickname ?? null,
-            message.contentText,
-            message.toolMetadataJson ?? null,
-          );
-        }
-        deleteMessages.run(agentName, entry.session.id, entry.messages.length);
-        upsertRow.run(
-          agentName,
-          entry.session.id,
-          entry.session.slug,
-          entry.session.title,
-          entry.session.directory,
-          entry.identity.kind,
-          entry.identity.key,
-          entry.identity.displayName,
-          entry.session.time_created,
-          entry.session.time_updated ?? null,
-          activityTime,
-          entry.contentText,
-          entry.contentHash,
-          Date.now(),
-        );
-      }
-    };
+          { session, sortIndex: sessionSortIndexMap.get(session.id) ?? 0 },
+          loadSessionData,
+        ),
+      )
+      .filter((entry): entry is LoadedSearchIndexEntry => entry !== null);
+
+    const writeRows = () => writeSearchIndexRows(db, agentName, toDelete, loaded);
 
     let rebuildDurationMs: number | undefined;
     const needsRebuild = isBulk && (toDelete.length > 0 || loaded.length > 0);
@@ -2035,6 +2170,83 @@ export function syncSessionSearchIndex(
       sessions: sessions.length,
       changed: toUpsert.length,
       deleted: toDelete.length,
+      indexed: loaded.length,
+      skipped: toUpsert.length - loaded.length,
+      durationMs: performance.now() - startedAt,
+      rebuildDurationMs,
+    };
+  });
+}
+
+export function syncSessionSearchIndexChanges(
+  agentName: string,
+  changes: SessionHeadChange[],
+  removedSessionIds: string[],
+  loadSessionData: (sessionId: string) => SessionData,
+  options: SearchIndexSyncOptions = {},
+): SearchIndexSyncResult | null {
+  if (changes.length === 0 && removedSessionIds.length === 0) {
+    return {
+      agentName,
+      mode: "incremental",
+      sessions: 0,
+      changed: 0,
+      deleted: 0,
+      indexed: 0,
+      skipped: 0,
+      durationMs: 0,
+    };
+  }
+
+  return withCacheDb((db) => {
+    ensureFtsConsistency(db);
+    const startedAt = performance.now();
+    const getIndexedRow = db.prepare(
+      "SELECT content_hash FROM session_documents WHERE agent_name = ? AND session_id = ?",
+    );
+    const getMessageCount = db.prepare(
+      "SELECT COUNT(*) AS value FROM messages WHERE agent_name = ? AND session_id = ?",
+    );
+    const toUpsert = changes.filter(({ session }) => {
+      const indexed = getIndexedRow.get(agentName, session.id) as IndexedSearchRow | undefined;
+      const messageCount = getMessageCount.get(agentName, session.id) as
+        | MessageCountRow
+        | undefined;
+      return (
+        String(indexed?.content_hash ?? "") !== sessionContentHash(session) ||
+        Number(messageCount?.value ?? 0) !== session.stats.message_count
+      );
+    });
+    const uniqueRemovedSessionIds = Array.from(new Set(removedSessionIds));
+    const changedCount = uniqueRemovedSessionIds.length + toUpsert.length;
+    const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
+    const loaded = toUpsert
+      .map((change) => loadSearchIndexEntry(agentName, change, loadSessionData))
+      .filter((entry): entry is LoadedSearchIndexEntry => entry !== null);
+    const writeRows = () => writeSearchIndexRows(db, agentName, uniqueRemovedSessionIds, loaded);
+
+    let rebuildDurationMs: number | undefined;
+    const needsRebuild = isBulk && (uniqueRemovedSessionIds.length > 0 || loaded.length > 0);
+
+    if (needsRebuild) {
+      db.transaction(() => {
+        dropSearchTriggers(db);
+        writeRows();
+        const rebuildStartedAt = performance.now();
+        rebuildSearchIndex(db);
+        rebuildDurationMs = performance.now() - rebuildStartedAt;
+        createSearchTriggers(db);
+      })();
+    } else {
+      db.transaction(writeRows)();
+    }
+
+    return {
+      agentName,
+      mode: isBulk ? "bulk" : "incremental",
+      sessions: changes.length,
+      changed: toUpsert.length,
+      deleted: uniqueRemovedSessionIds.length,
       indexed: loaded.length,
       skipped: toUpsert.length - loaded.length,
       durationMs: performance.now() - startedAt,

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -5,6 +5,7 @@ export type { ScanResult, ScanOptions } from "./scanner.js";
 export {
   loadCachedSessions,
   saveCachedSessions,
+  saveCachedSessionChanges,
   clearCache,
   getCacheInfo,
   listCachedProjectGroups,
@@ -14,6 +15,7 @@ export {
   searchFileActivitySessions,
   searchSessions,
   syncSessionSearchIndex,
+  syncSessionSearchIndexChanges,
 } from "./cache.js";
 export type {
   FileActivityOptions,
@@ -24,6 +26,7 @@ export type {
   SearchMatchType,
   SearchOptions,
   SearchQueryFilters,
+  SessionHeadChange,
 } from "./cache.js";
 export { perf } from "../utils/index.js";
 export type { PerfMarker } from "../utils/index.js";


### PR DESCRIPTION
## Summary

- Add incremental cache persistence for live refresh changes so changed and removed sessions are written directly instead of rewriting the whole agent cache.
- Add incremental search index syncing for changed sessions and removed session ids.
- Route precise non-bulk `LiveScanStore` refreshes through the incremental paths while keeping bulk, startup-window, and full-scan refreshes on the existing full sync path.

## Root Cause

Single-file live refreshes still passed the full `nextSessions` snapshot into cache persistence and search index sync. That forced agent-wide cache writes and full search-index diff queries even when the agent adapter already knew the changed session ids.

## Validation

- `pnpm --filter @codesesh/core test -- src/discovery/__tests__/cache.test.ts`
- `pnpm --filter codesesh test -- src/live-scan-store.test.ts`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter codesesh build`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter codesesh lint`
- `pnpm bench:perf -- --iterations 3`