### PR TITLE
fix(search): remove message match N+1

### DIFF
--- a/klip/klip-0-performance-hotspots.md
+++ b/klip/klip-0-performance-hotspots.md
@@ -268,7 +268,7 @@ Status: Draft
 - [ ] P1-3：为 `LiveScanStore.runRefresh()` 设计 changed/new/removed ids 传递契约。
 - [ ] P1-4：为 cache 层增加增量 upsert/delete，并验证与全量保存结果一致。
 - [ ] P1-5：为 `syncSessionSearchIndex()` 增加 changed ids 路径，bulk 仍保留全量 rebuild。
-- [ ] P1-6：评估并实现 message-level FTS，消除搜索结果 N+1 message scan。
+- [x] P1-6：评估并实现 message-level FTS，消除搜索结果 N+1 message scan。
 - [ ] P1-7：重写 `listFileActivity()` 动态 WHERE，并用 `EXPLAIN QUERY PLAN` 验证索引。
 - [ ] P1-8：构建 `SessionDetail` display model，复用 `MessageBlock[]`。
 - [ ] P1-9：评估详情页 message virtualization，确认 anchors 和 keyboard/scroll 行为可保留。
@@ -279,6 +279,7 @@ Status: Draft
 ## 实现记录
 
 - 2026-05-20：完成 P1-2。`handleGetDashboard()` 改为在一次 session 扫描中完成 totals、per-agent、daily buckets、token buckets、model distribution 和 recent top 10 聚合；recent top 10 使用固定容量候选集，避免对窗口内全量 session 排序。验证：`pnpm --filter codesesh test`、`pnpm --filter codesesh lint`、`pnpm --filter codesesh format:check`、`pnpm --filter codesesh build`、`git diff --check`、`pnpm bench:perf -- --iterations 1`（236 sessions；dashboard visible 11956ms；detail 139ms）。
+- 2026-05-20：完成 P1-6。新增 `messages_fts` message-level FTS 表和 `messages` 触发器，schema 升级到 v9；`searchSessions()` 保留 session-level FTS 排序，但对返回候选结果只做一次批量 message FTS 查询来解析 `matchType` / `snippet`，移除每条结果单独加载全量 messages 的 N+1 路径。验证：`pnpm --filter @codesesh/core exec vitest run src/discovery/__tests__/cache.test.ts`、`pnpm --filter @codesesh/core exec vitest run src/discovery/__tests__/migration-smoke.test.ts`、`pnpm --filter @codesesh/core test`、`pnpm --filter @codesesh/core lint`、`pnpm --filter @codesesh/core format:check`、`pnpm --filter @codesesh/core build`、`git diff --check`、`pnpm bench:perf -- --iterations 1`（242 sessions；dashboard visible 5081ms；detail 183ms）。
 
 ## 测试矩阵
 

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -188,7 +188,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(8);
+    expect(getUserVersion(getCachePath())).toBe(9);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -345,7 +345,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(8);
+    expect(getUserVersion(getCachePath())).toBe(9);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -561,6 +561,182 @@ describe("searchSessions", () => {
       total_cost: 0.03,
     });
     expect(results[0]?.snippet).toContain("<mark>sqlite</mark>");
+  });
+
+  it("resolves search match metadata from message-level FTS", () => {
+    const title = {
+      ...makeSession("title"),
+      title: "titleonly search title",
+    };
+    const user = makeSession("user");
+    const assistant = makeSession("assistant");
+    const tool = makeSession("tool");
+    const quoted = makeSession("quoted");
+    const orFirst = {
+      ...makeSession("or-first"),
+      stats: { ...makeSession("or-first").stats, message_count: 2 },
+    };
+    const sessions = [title, user, assistant, tool, quoted, orFirst];
+    const dataById = new Map<string, SessionData>([
+      [
+        "title",
+        {
+          ...title,
+          messages: [
+            {
+              id: "title-m1",
+              role: "user",
+              time_created: now,
+              parts: [{ type: "text", text: "body without the title token" }],
+            },
+          ],
+        },
+      ],
+      [
+        "user",
+        {
+          ...user,
+          messages: [
+            {
+              id: "user-m1",
+              role: "user",
+              time_created: now,
+              parts: [{ type: "text", text: "userneedle request" }],
+            },
+          ],
+        },
+      ],
+      [
+        "assistant",
+        {
+          ...assistant,
+          messages: [
+            {
+              id: "assistant-m1",
+              role: "assistant",
+              time_created: now,
+              parts: [{ type: "text", text: "assistantneedle reply" }],
+            },
+          ],
+        },
+      ],
+      [
+        "tool",
+        {
+          ...tool,
+          messages: [
+            {
+              id: "tool-m1",
+              role: "assistant",
+              mode: "tool",
+              time_created: now,
+              parts: [
+                {
+                  type: "tool",
+                  tool: "bash",
+                  state: { status: "completed", output: "toolneedle output" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      [
+        "quoted",
+        {
+          ...quoted,
+          messages: [
+            {
+              id: "quoted-m1",
+              role: "user",
+              time_created: now,
+              parts: [{ type: "text", text: "exact quoted phrase marker" }],
+            },
+          ],
+        },
+      ],
+      [
+        "or-first",
+        {
+          ...orFirst,
+          messages: [
+            {
+              id: "or-first-m1",
+              role: "assistant",
+              time_created: now,
+              parts: [{ type: "text", text: "betaneedle first" }],
+            },
+            {
+              id: "or-first-m2",
+              role: "user",
+              time_created: now + 1,
+              parts: [{ type: "text", text: "alphaneedle second" }],
+            },
+          ],
+        },
+      ],
+    ]);
+
+    saveCachedSessions("claudecode", sessions);
+    syncSessionSearchIndex("claudecode", sessions, (sessionId) => dataById.get(sessionId)!);
+
+    expect(searchSessions("titleonly")[0]?.matchType).toBe("title");
+    expect(searchSessions("userneedle")[0]?.matchType).toBe("user_message");
+    expect(searchSessions("assistantneedle")[0]?.matchType).toBe("assistant_reply");
+    expect(searchSessions("toolneedle")[0]?.matchType).toBe("tool_output");
+    expect(searchSessions('"quoted phrase"')[0]?.snippet).toContain("<mark>quoted phrase</mark>");
+
+    const orResults = searchSessions("alphaneedle OR betaneedle");
+    expect(orResults[0]?.session.id).toBe("or-first");
+    expect(orResults[0]?.matchType).toBe("assistant_reply");
+    expect(orResults[0]?.snippet).toContain("<mark>betaneedle</mark>");
+  });
+
+  it("uses a single message FTS lookup for result match metadata", () => {
+    const sessions = Array.from({ length: 3 }, (_, sessionIndex) => ({
+      ...makeSession(`bulk-match-${sessionIndex}`),
+      stats: { ...makeSession(`bulk-match-${sessionIndex}`).stats, message_count: 30 },
+    }));
+
+    saveCachedSessions("claudecode", sessions);
+    syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
+      ...sessions.find((session) => session.id === sessionId)!,
+      messages: Array.from({ length: 30 }, (_, messageIndex) => ({
+        id: `${sessionId}-m${messageIndex}`,
+        role: "user" as const,
+        time_created: now + messageIndex,
+        parts: [
+          {
+            type: "text" as const,
+            text: messageIndex === 29 ? `bulkneedle ${sessionId}` : `filler ${messageIndex}`,
+          },
+        ],
+      })),
+    }));
+
+    const preparedSql: string[] = [];
+    const originalPrepare = Database.prototype.prepare;
+    const prepareSpy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+      this: Database.Database,
+      source: string,
+    ) {
+      preparedSql.push(source);
+      return originalPrepare.call(this, source);
+    });
+
+    try {
+      expect(searchSessions("bulkneedle")).toHaveLength(3);
+    } finally {
+      prepareSpy.mockRestore();
+    }
+
+    const normalizedSql = preparedSql.map((sql) => sql.replace(/\s+/g, " ").trim());
+    expect(normalizedSql.filter((sql) => sql.includes("FROM messages_fts"))).toHaveLength(1);
+    expect(
+      normalizedSql.some((sql) =>
+        /FROM messages WHERE agent_name = \? AND session_id = \? ORDER BY message_index/.test(sql),
+      ),
+    ).toBe(false);
   });
 
   it("bulk sync rebuilds FTS for large initial indexes", () => {

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -278,7 +278,7 @@ describe("sqlite migration smoke", () => {
         bookmarked_at: now - 500,
       },
     ]);
-    expect(getUserVersion(getCachePath())).toBe(8);
+    expect(getUserVersion(getCachePath())).toBe(9);
     expect(getUserVersion(getStatePath())).toBe(1);
   }, 15_000);
 });

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -30,7 +30,7 @@ import {
   type SQLiteDatabase,
 } from "../utils/sqlite.js";
 
-const CACHE_SCHEMA_VERSION = 8;
+const CACHE_SCHEMA_VERSION = 9;
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
@@ -124,6 +124,9 @@ interface MessageCountRow extends DatabaseRow {
 }
 
 interface MessageSearchRow extends DatabaseRow {
+  agent_name?: string;
+  session_id?: string;
+  message_index?: number;
   role?: Message["role"];
   mode?: string | null;
   content_text?: string;
@@ -431,6 +434,51 @@ function createSessionTables(db: SQLiteDatabase): void {
   `);
 }
 
+function createMessageSearchTables(db: SQLiteDatabase): void {
+  if (!tableExists(db, "messages")) {
+    createSessionTables(db);
+  }
+
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+      content_text,
+      content='messages',
+      content_rowid='rowid'
+    );
+  `);
+
+  createMessageSearchTriggers(db);
+}
+
+function createMessageSearchTriggers(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+      INSERT INTO messages_fts(rowid, content_text)
+      VALUES (new.rowid, new.content_text);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content_text)
+      VALUES ('delete', old.rowid, old.content_text);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content_text)
+      VALUES ('delete', old.rowid, old.content_text);
+      INSERT INTO messages_fts(rowid, content_text)
+      VALUES (new.rowid, new.content_text);
+    END;
+  `);
+}
+
+function dropMessageSearchTriggers(db: SQLiteDatabase): void {
+  db.exec(`
+    DROP TRIGGER IF EXISTS messages_ai;
+    DROP TRIGGER IF EXISTS messages_ad;
+    DROP TRIGGER IF EXISTS messages_au;
+  `);
+}
+
 function createFileActivityTables(db: SQLiteDatabase): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS session_file_activity (
@@ -597,6 +645,7 @@ function recreateProjectGroupsView(db: SQLiteDatabase): void {
 function createLatestCacheSchema(db: SQLiteDatabase): void {
   createCacheTables(db);
   createSessionTables(db);
+  createMessageSearchTables(db);
   createFileActivityTables(db);
   createSearchTables(db);
   createProjectTables(db);
@@ -927,6 +976,9 @@ function readLegacyCacheVersion(db: SQLiteDatabase): number {
 }
 
 function inferCacheSchemaVersion(db: SQLiteDatabase): number {
+  if (tableExists(db, "messages_fts")) {
+    return 9;
+  }
   if (tableExists(db, "session_file_activity")) {
     return 8;
   }
@@ -1242,6 +1294,13 @@ function rebuildSearchIndex(db: SQLiteDatabase): void {
   db.exec("INSERT INTO session_documents_fts(session_documents_fts) VALUES ('rebuild')");
 }
 
+function rebuildMessageSearchIndex(db: SQLiteDatabase): void {
+  if (!tableExists(db, "messages_fts")) {
+    return;
+  }
+  db.exec("INSERT INTO messages_fts(messages_fts) VALUES ('rebuild')");
+}
+
 function shouldBulkSyncSearchIndex(options: SearchIndexSyncOptions, changedCount: number): boolean {
   if (options.isBulk != null) {
     return options.isBulk;
@@ -1256,6 +1315,12 @@ function ensureFtsReady(db: SQLiteDatabase): void {
     createSearchTables(db);
   }
   createSearchTriggers(db);
+
+  const needsMessageSearchRebuild = !tableExists(db, "messages_fts");
+  createMessageSearchTables(db);
+  if (needsMessageSearchRebuild) {
+    rebuildMessageSearchIndex(db);
+  }
 }
 
 function ensureFtsConsistency(db: SQLiteDatabase): void {
@@ -1269,9 +1334,11 @@ function ensureFtsConsistency(db: SQLiteDatabase): void {
     db.exec(
       "INSERT INTO session_documents_fts(session_documents_fts, rank) VALUES ('integrity-check', 1)",
     );
+    db.exec("INSERT INTO messages_fts(messages_fts, rank) VALUES ('integrity-check', 1)");
     ftsIntegrityCheckedPath = cachePath;
   } catch {
     rebuildSearchIndex(db);
+    rebuildMessageSearchIndex(db);
     ftsIntegrityCheckedPath = cachePath;
   }
 }
@@ -1325,6 +1392,13 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       },
       { version: 7, migrate: backfillStructuredSessions },
       { version: 8, migrate: backfillFileActivity },
+      {
+        version: 9,
+        migrate(db) {
+          createMessageSearchTables(db);
+          rebuildMessageSearchIndex(db);
+        },
+      },
     ],
   });
 
@@ -2154,11 +2228,14 @@ export function syncSessionSearchIndex(
     if (needsRebuild) {
       db.transaction(() => {
         dropSearchTriggers(db);
+        dropMessageSearchTriggers(db);
         writeRows();
         const rebuildStartedAt = performance.now();
         rebuildSearchIndex(db);
+        rebuildMessageSearchIndex(db);
         rebuildDurationMs = performance.now() - rebuildStartedAt;
         createSearchTriggers(db);
+        createMessageSearchTriggers(db);
       })();
     } else {
       db.transaction(writeRows)();
@@ -2231,11 +2308,14 @@ export function syncSessionSearchIndexChanges(
     if (needsRebuild) {
       db.transaction(() => {
         dropSearchTriggers(db);
+        dropMessageSearchTriggers(db);
         writeRows();
         const rebuildStartedAt = performance.now();
         rebuildSearchIndex(db);
+        rebuildMessageSearchIndex(db);
         rebuildDurationMs = performance.now() - rebuildStartedAt;
         createSearchTriggers(db);
+        createMessageSearchTriggers(db);
       })();
     } else {
       db.transaction(writeRows)();
@@ -2453,12 +2533,70 @@ function messageMatchType(row: MessageSearchRow): SearchMatchType {
   return "assistant_reply";
 }
 
-function resolveSearchMatch(
+function searchResultRowKey(row: Pick<SearchResultRow, "agent_name" | "session_id">): string {
+  return `${String(row.agent_name)}\u0000${String(row.session_id)}`;
+}
+
+function fetchMessageSearchMatches(
   db: SQLiteDatabase,
+  rows: SearchResultRow[],
+  ftsQuery: string,
+  terms: { terms: string[]; mode: "all" | "any" },
+): Map<string, { snippet: string; matchType: SearchMatchType }> {
+  const candidates = rows.filter((row) => !textMatchesTerms(String(row.title ?? ""), terms));
+  if (candidates.length === 0) {
+    return new Map();
+  }
+
+  const clauses: string[] = [];
+  const params: unknown[] = [ftsQuery];
+  for (const row of candidates) {
+    clauses.push("(m.agent_name = ? AND m.session_id = ?)");
+    params.push(String(row.agent_name), String(row.session_id));
+  }
+
+  const messageRows = db
+    .prepare(
+      `
+        SELECT
+          m.agent_name,
+          m.session_id,
+          m.message_index,
+          m.role,
+          m.mode,
+          m.content_text,
+          m.tool_metadata_json
+        FROM messages_fts
+        JOIN messages m ON m.rowid = messages_fts.rowid
+        WHERE messages_fts MATCH ?
+          AND (${clauses.join(" OR ")})
+        ORDER BY m.message_index
+      `,
+    )
+    .all(...params) as MessageSearchRow[];
+  const matches = new Map<string, { snippet: string; matchType: SearchMatchType }>();
+
+  for (const message of messageRows) {
+    const key = searchResultRowKey(message);
+    if (matches.has(key)) continue;
+
+    const text = String(message.content_text ?? "");
+    if (!textMatchesTerms(text, terms)) continue;
+
+    matches.set(key, {
+      snippet: buildTermSnippet(text, terms),
+      matchType: messageMatchType(message),
+    });
+  }
+
+  return matches;
+}
+
+function resolveSearchMatch(
   row: SearchResultRow,
-  textQuery: string,
+  terms: { terms: string[]; mode: "all" | "any" },
+  messageMatches: Map<string, { snippet: string; matchType: SearchMatchType }>,
 ): { snippet: string; matchType: SearchMatchType } {
-  const terms = parseTextTerms(textQuery);
   const title = String(row.title ?? "");
 
   if (terms.terms.length === 0) {
@@ -2472,24 +2610,9 @@ function resolveSearchMatch(
     return { snippet: buildTermSnippet(title, terms), matchType: "title" };
   }
 
-  const messages = db
-    .prepare(
-      `
-        SELECT role, mode, content_text, tool_metadata_json
-        FROM messages
-        WHERE agent_name = ? AND session_id = ?
-        ORDER BY message_index
-      `,
-    )
-    .all(row.agent_name, row.session_id) as MessageSearchRow[];
-
-  for (const message of messages) {
-    const text = String(message.content_text ?? "");
-    if (!textMatchesTerms(text, terms)) continue;
-    return {
-      snippet: buildTermSnippet(text, terms),
-      matchType: messageMatchType(message),
-    };
+  const messageMatch = messageMatches.get(searchResultRowKey(row));
+  if (messageMatch) {
+    return messageMatch;
   }
 
   return {
@@ -2502,9 +2625,16 @@ function rowsToSearchResults(
   db: SQLiteDatabase,
   rows: SearchResultRow[],
   textQuery: string,
+  ftsQuery = toFtsQuery(textQuery),
 ): SearchResult[] {
+  const terms = parseTextTerms(textQuery);
+  const messageMatches =
+    terms.terms.length > 0 && ftsQuery
+      ? fetchMessageSearchMatches(db, rows, ftsQuery, terms)
+      : new Map<string, { snippet: string; matchType: SearchMatchType }>();
+
   return rows.map((row) => {
-    const match = resolveSearchMatch(db, row, textQuery);
+    const match = resolveSearchMatch(row, terms, messageMatches);
     return {
       agentName: String(row.agent_name),
       session: sessionHeadFromSearchRow(row),
@@ -2566,7 +2696,7 @@ export function searchSessions(query: string, options: SearchOptions = {}): Sear
       )
       .all(ftsQuery, ...filters.params, search.options.limit ?? 50) as SearchResultRow[];
 
-    return rowsToSearchResults(db, rows, normalizedQuery);
+    return rowsToSearchResults(db, rows, normalizedQuery, ftsQuery);
   });
 
   return results ?? [];


### PR DESCRIPTION
## What changed

- Added a `messages_fts` message-level FTS index maintained by `messages` table triggers.
- Updated search result match resolution to batch message FTS lookups for returned candidates instead of loading all messages per result.
- Added coverage for title, user, assistant, tool, quoted, and OR search match metadata, plus a migration smoke update for schema v9.
- Marked KLIP-0 P1-6 complete with validation notes.

## Why

Search results previously used session-level FTS first, then performed one full `messages` query per result to derive `matchType` and `snippet`. That produced an N+1 path that scaled with result count and average messages per session.

## Validation

- `pnpm --filter @codesesh/core exec vitest run src/discovery/__tests__/cache.test.ts`
- `pnpm --filter @codesesh/core exec vitest run src/discovery/__tests__/migration-smoke.test.ts`
- `pnpm --filter @codesesh/core test`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core build`
- `git diff --check`
- `pnpm bench:perf -- --iterations 1`