### PR TITLE
fix: optimize file activity search

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -249,6 +249,7 @@ interface SearchProjectOption {
   key: string;
   label: string;
   count: number;
+  showCount?: boolean;
 }
 
 const SHORTCUT_HINT_STORAGE_KEY = "codesesh.shortcuts-hint-dismissed";
@@ -1152,6 +1153,37 @@ export default function App() {
     }
     return [...byKey.values()].toSorted((a, b) => b.count - a.count).slice(0, 8);
   }, [sessions]);
+  const searchProjectOptions = useMemo<SearchProjectOption[]>(() => {
+    if (!usesServerSearch) return projectOptions;
+
+    const byKey = new Map<string, SearchProjectOption>();
+    const sourceResults = searchLoading ? [] : searchResults;
+
+    for (const result of sourceResults) {
+      const identity = result.session.project_identity;
+      if (!identity?.key) continue;
+      const current = byKey.get(identity.key);
+      if (current) {
+        current.count += 1;
+      } else {
+        byKey.set(identity.key, {
+          key: identity.key,
+          label: identity.displayName || result.session.directory,
+          count: 1,
+          showCount: false,
+        });
+      }
+    }
+
+    if (searchFilters.projectKey && !byKey.has(searchFilters.projectKey)) {
+      const selected = projectOptions.find((project) => project.key === searchFilters.projectKey);
+      if (selected) {
+        byKey.set(selected.key, { ...selected, count: 0, showCount: false });
+      }
+    }
+
+    return [...byKey.values()].toSorted((a, b) => b.count - a.count).slice(0, 8);
+  }, [projectOptions, searchFilters.projectKey, searchLoading, searchResults, usesServerSearch]);
 
   // Header
   let headerTitle = "CodeSesh";
@@ -1312,7 +1344,7 @@ export default function App() {
         results={searchResults}
         agentNameMap={agentNameMap}
         agents={agents}
-        projects={projectOptions}
+        projects={searchProjectOptions}
         filters={searchFilters}
         onChangeFilters={setSearchFilters}
         onOpenResult={() => {
@@ -2191,7 +2223,9 @@ function SearchFilterBar({
           <FilterChip
             key={project.key}
             active={filters.projectKey === project.key}
-            label={`${project.label} · ${project.count}`}
+            label={
+              project.showCount === false ? project.label : `${project.label} · ${project.count}`
+            }
             onClick={() => setFilter("projectKey", project.key)}
           />
         ))}

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -188,7 +188,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(9);
+    expect(getUserVersion(getCachePath())).toBe(10);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -345,7 +345,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(9);
+    expect(getUserVersion(getCachePath())).toBe(10);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -1118,6 +1118,20 @@ describe("searchSessions", () => {
       { kind: "read", path: "src/App.tsx", count: 1 },
     ]);
 
+    expect(
+      listFileActivity({
+        agent: "claudecode",
+        sessionId: "files",
+        projectKey: "github.com/acme/app",
+        cwd: "/tmp/project",
+        path: "src/App",
+        kind: "edit",
+        from: now + 9,
+        to: now + 11,
+        limit: 10,
+      }).map(({ kind, path, count }) => ({ kind, path, count })),
+    ).toEqual([{ kind: "edit", path: "src/App.tsx", count: 1 }]);
+
     const searchResults = searchFileActivitySessions("src/new.ts");
     expect(searchResults).toHaveLength(1);
     expect(searchResults[0]?.session.id).toBe("files");
@@ -1126,6 +1140,97 @@ describe("searchSessions", () => {
     const directWriteResults = searchFileActivitySessions("src/direct.ts");
     expect(directWriteResults).toHaveLength(1);
     expect(directWriteResults[0]?.snippet).toContain("write");
+  });
+
+  it("uses latest-time indexes for recent file activity query plans", () => {
+    saveCachedSessions("claudecode", [makeSession("indexed")]);
+
+    const db = new Database(getCachePath(), { readonly: true });
+    try {
+      const explain = (where: string, ...params: unknown[]) =>
+        (
+          db
+            .prepare(
+              `
+                EXPLAIN QUERY PLAN
+                SELECT
+                  fa.agent_name,
+                  fa.session_id,
+                  fa.project_identity_key,
+                  fa.path,
+                  fa.kind,
+                  fa.count,
+                  fa.latest_time
+                FROM session_file_activity fa
+                JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
+                ${where}
+                ORDER BY fa.latest_time DESC, fa.count DESC, fa.path
+                LIMIT ?
+              `,
+            )
+            .all(...params, 50) as Array<{ detail?: string }>
+        )
+          .map((row) => String(row.detail ?? ""))
+          .join("\n");
+
+      expect(explain("")).toContain("USING INDEX idx_file_activity_latest");
+      expect(explain("WHERE fa.agent_name = ?", "claudecode")).toContain(
+        "USING INDEX idx_file_activity_agent_latest",
+      );
+      expect(explain("WHERE fa.project_identity_key = ?", "/tmp/project")).toContain(
+        "USING INDEX idx_file_activity_project_latest_ordered",
+      );
+      const pathPlan = explain(
+        "WHERE fa.rowid IN (SELECT rowid FROM session_file_activity_path_fts WHERE path MATCH ?)",
+        '"src/App"',
+      );
+      expect(pathPlan).toContain("session_file_activity_path_fts");
+      expect(pathPlan).not.toContain("SCAN fa\n");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rebuilds path search index when migrating existing file activity rows", () => {
+    const session = makeSession("path-migration");
+
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex("claudecode", [session], () => ({
+      ...session,
+      messages: [
+        {
+          id: "path-migration-tool",
+          role: "assistant",
+          time_created: now,
+          parts: [
+            {
+              type: "tool",
+              tool: "Read",
+              state: { input: { file_path: "src/migrated/App.tsx" } },
+            },
+          ],
+        },
+      ],
+    }));
+
+    const db = new Database(getCachePath());
+    try {
+      db.exec(`
+        DROP TRIGGER IF EXISTS session_file_activity_path_ai;
+        DROP TRIGGER IF EXISTS session_file_activity_path_ad;
+        DROP TRIGGER IF EXISTS session_file_activity_path_au;
+        DROP TABLE IF EXISTS session_file_activity_path_fts;
+        PRAGMA user_version = 9;
+      `);
+      db.prepare("UPDATE cache_meta SET value = '9' WHERE key = 'version'").run();
+    } finally {
+      db.close();
+    }
+
+    expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
+      "src/migrated/App.tsx",
+    ]);
+    expect(getUserVersion(getCachePath())).toBe(10);
   });
 
   it("combines full text with structured filters", () => {

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -278,7 +278,7 @@ describe("sqlite migration smoke", () => {
         bookmarked_at: now - 500,
       },
     ]);
-    expect(getUserVersion(getCachePath())).toBe(9);
+    expect(getUserVersion(getCachePath())).toBe(10);
     expect(getUserVersion(getStatePath())).toBe(1);
   }, 15_000);
 });

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -30,7 +30,7 @@ import {
   type SQLiteDatabase,
 } from "../utils/sqlite.js";
 
-const CACHE_SCHEMA_VERSION = 9;
+const CACHE_SCHEMA_VERSION = 10;
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
@@ -498,12 +498,69 @@ function createFileActivityTables(db: SQLiteDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_file_activity_project_latest
       ON session_file_activity(project_identity_key, latest_time);
 
+    CREATE INDEX IF NOT EXISTS idx_file_activity_latest
+      ON session_file_activity(latest_time DESC, count DESC, path);
+
+    CREATE INDEX IF NOT EXISTS idx_file_activity_agent_latest
+      ON session_file_activity(agent_name, latest_time DESC, count DESC, path);
+
+    CREATE INDEX IF NOT EXISTS idx_file_activity_project_latest_ordered
+      ON session_file_activity(project_identity_key, latest_time DESC, count DESC, path);
+
     CREATE INDEX IF NOT EXISTS idx_file_activity_path
       ON session_file_activity(path);
 
     CREATE INDEX IF NOT EXISTS idx_file_activity_kind
       ON session_file_activity(kind);
   `);
+
+  createFileActivityPathSearchTables(db);
+}
+
+function createFileActivityPathSearchTables(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS session_file_activity_path_fts USING fts5(
+      path,
+      content='session_file_activity',
+      content_rowid='rowid',
+      tokenize='trigram'
+    );
+  `);
+
+  createFileActivityPathSearchTriggers(db);
+}
+
+function createFileActivityPathSearchTriggers(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS session_file_activity_path_ai
+    AFTER INSERT ON session_file_activity BEGIN
+      INSERT INTO session_file_activity_path_fts(rowid, path)
+      VALUES (new.rowid, new.path);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS session_file_activity_path_ad
+    AFTER DELETE ON session_file_activity BEGIN
+      INSERT INTO session_file_activity_path_fts(session_file_activity_path_fts, rowid, path)
+      VALUES ('delete', old.rowid, old.path);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS session_file_activity_path_au
+    AFTER UPDATE ON session_file_activity BEGIN
+      INSERT INTO session_file_activity_path_fts(session_file_activity_path_fts, rowid, path)
+      VALUES ('delete', old.rowid, old.path);
+      INSERT INTO session_file_activity_path_fts(rowid, path)
+      VALUES (new.rowid, new.path);
+    END;
+  `);
+}
+
+function rebuildFileActivityPathIndex(db: SQLiteDatabase): void {
+  if (!tableExists(db, "session_file_activity_path_fts")) {
+    return;
+  }
+  db.exec(
+    "INSERT INTO session_file_activity_path_fts(session_file_activity_path_fts) VALUES ('rebuild')",
+  );
 }
 
 function createSearchTables(db: SQLiteDatabase): void {
@@ -976,6 +1033,9 @@ function readLegacyCacheVersion(db: SQLiteDatabase): number {
 }
 
 function inferCacheSchemaVersion(db: SQLiteDatabase): number {
+  if (tableExists(db, "session_file_activity_path_fts")) {
+    return 10;
+  }
   if (tableExists(db, "messages_fts")) {
     return 9;
   }
@@ -1018,6 +1078,7 @@ function hasAnyCacheSchema(db: SQLiteDatabase): boolean {
     "sessions",
     "messages",
     "session_file_activity",
+    "session_file_activity_path_fts",
     "session_documents",
     "session_documents_fts",
     "project_sessions",
@@ -1397,6 +1458,13 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
         migrate(db) {
           createMessageSearchTables(db);
           rebuildMessageSearchIndex(db);
+        },
+      },
+      {
+        version: 10,
+        migrate(db) {
+          createFileActivityPathSearchTables(db);
+          rebuildFileActivityPathIndex(db);
         },
       },
     ],
@@ -2389,6 +2457,12 @@ function likePattern(value: string): string {
     .replace(/[\\%_]/g, "\\$&")}%`;
 }
 
+function filePathFtsQuery(value: string): string | null {
+  const path = normalizeFilePathSearch(value);
+  if (path.length < 3) return null;
+  return `"${path.replaceAll('"', '""')}"`;
+}
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -2432,8 +2506,16 @@ function buildSessionSearchFilters(options: SearchOptions): {
   if (options.file || options.fileKind) {
     const fileClauses = ["fa.agent_name = s.agent_name", "fa.session_id = s.session_id"];
     if (options.file) {
-      fileClauses.push("LOWER(fa.path) LIKE ? ESCAPE '\\'");
-      params.push(likePattern(options.file));
+      const pathQuery = filePathFtsQuery(options.file);
+      if (pathQuery) {
+        fileClauses.push(
+          "fa.rowid IN (SELECT rowid FROM session_file_activity_path_fts WHERE path MATCH ?)",
+        );
+        params.push(pathQuery);
+      } else {
+        fileClauses.push("LOWER(fa.path) LIKE ? ESCAPE '\\'");
+        params.push(likePattern(options.file));
+      }
     }
     if (options.fileKind) {
       fileClauses.push("fa.kind = ?");
@@ -2711,6 +2793,7 @@ function fileActivityFilters(options: FileActivityOptions): {
   projectLike: string | null;
   cwdKey: string | null;
   cwdLike: string | null;
+  path: string;
   pathLike: string | null;
 } {
   const path = options.path ? normalizeFilePathSearch(options.path) : "";
@@ -2719,6 +2802,7 @@ function fileActivityFilters(options: FileActivityOptions): {
     projectLike: options.project ? likePattern(options.project) : null,
     cwdKey: options.cwd ? computeIdentity(options.cwd, realFs).key : null,
     cwdLike: options.cwd ? likePattern(options.cwd) : null,
+    path,
     pathLike: path ? likePattern(path) : null,
   };
 }
@@ -2735,12 +2819,73 @@ function fileActivityFromRow(row: FileActivityRow): SessionFileActivity {
   };
 }
 
+function buildFileActivityWhere(options: FileActivityOptions): {
+  where: string;
+  params: unknown[];
+} {
+  const filters = fileActivityFilters(options);
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+
+  if (options.agent != null) {
+    clauses.push("fa.agent_name = ?");
+    params.push(options.agent);
+  }
+  if (options.sessionId != null) {
+    clauses.push("fa.session_id = ?");
+    params.push(options.sessionId);
+  }
+  if (filters.projectKey != null) {
+    clauses.push("fa.project_identity_key = ?");
+    params.push(filters.projectKey);
+  }
+  if (filters.projectLike != null) {
+    clauses.push(
+      "(LOWER(fa.project_identity_key) LIKE ? ESCAPE '\\' OR LOWER(s.project_display_name) LIKE ? ESCAPE '\\' OR LOWER(s.directory) LIKE ? ESCAPE '\\')",
+    );
+    params.push(filters.projectLike, filters.projectLike, filters.projectLike);
+  }
+  if (filters.cwdKey != null) {
+    clauses.push("(s.project_identity_key = ? OR LOWER(s.directory) LIKE ? ESCAPE '\\')");
+    params.push(filters.cwdKey, filters.cwdLike);
+  }
+  if (filters.pathLike != null) {
+    const pathQuery = filePathFtsQuery(filters.path);
+    if (pathQuery) {
+      clauses.push(
+        "fa.rowid IN (SELECT rowid FROM session_file_activity_path_fts WHERE path MATCH ?)",
+      );
+      params.push(pathQuery);
+    } else {
+      clauses.push("LOWER(fa.path) LIKE ? ESCAPE '\\'");
+      params.push(filters.pathLike);
+    }
+  }
+  if (options.kind != null) {
+    clauses.push("fa.kind = ?");
+    params.push(options.kind);
+  }
+  if (options.from != null) {
+    clauses.push("fa.latest_time >= ?");
+    params.push(options.from);
+  }
+  if (options.to != null) {
+    clauses.push("fa.latest_time <= ?");
+    params.push(options.to);
+  }
+
+  return {
+    where: clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "",
+    params,
+  };
+}
+
 export function listFileActivity(options: FileActivityOptions = {}): FileActivityResult[] {
   if (!hasCacheStorage()) {
     return [];
   }
 
-  const filters = fileActivityFilters(options);
+  const filters = buildFileActivityWhere(options);
   const rows = withCacheDb(
     (db) =>
       db
@@ -2771,43 +2916,12 @@ export function listFileActivity(options: FileActivityOptions = {}): FileActivit
             s.total_tokens
           FROM session_file_activity fa
           JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
-          WHERE (? IS NULL OR fa.agent_name = ?)
-            AND (? IS NULL OR fa.session_id = ?)
-            AND (? IS NULL OR fa.project_identity_key = ?)
-            AND (? IS NULL OR LOWER(fa.project_identity_key) LIKE ? ESCAPE '\\' OR LOWER(s.project_display_name) LIKE ? ESCAPE '\\' OR LOWER(s.directory) LIKE ? ESCAPE '\\')
-            AND (? IS NULL OR s.project_identity_key = ? OR LOWER(s.directory) LIKE ? ESCAPE '\\')
-            AND (? IS NULL OR LOWER(fa.path) LIKE ? ESCAPE '\\')
-            AND (? IS NULL OR fa.kind = ?)
-            AND (? IS NULL OR fa.latest_time >= ?)
-            AND (? IS NULL OR fa.latest_time <= ?)
+          ${filters.where}
           ORDER BY fa.latest_time DESC, fa.count DESC, fa.path
           LIMIT ?
         `,
         )
-        .all(
-          options.agent ?? null,
-          options.agent ?? null,
-          options.sessionId ?? null,
-          options.sessionId ?? null,
-          filters.projectKey,
-          filters.projectKey,
-          filters.projectLike,
-          filters.projectLike,
-          filters.projectLike,
-          filters.projectLike,
-          filters.cwdKey,
-          filters.cwdKey,
-          filters.cwdLike,
-          filters.pathLike,
-          filters.pathLike,
-          options.kind ?? null,
-          options.kind ?? null,
-          options.from ?? null,
-          options.from ?? null,
-          options.to ?? null,
-          options.to ?? null,
-          options.limit ?? 50,
-        ) as FileActivityRow[],
+        .all(...filters.params, options.limit ?? 50) as FileActivityRow[],
   );
 
   return (rows ?? []).map((row) => ({


### PR DESCRIPTION
## What changed

- Optimized `session_file_activity` queries by replacing nullable-OR filters with dynamic WHERE clauses.
- Added latest-time indexes for recent, agent-scoped, and project-scoped file activity queries.
- Added an FTS5 trigram path index for file activity path contains searches, with triggers and a v10 cache migration/rebuild path.
- Updated the search Scope filter UI so project chips reflect the current search result context instead of showing misleading global project counts.

## Why

`listFileActivity()` and file path search could degrade into scanning `session_file_activity`, and the search UI could show project counts even when the active query had 0 matches. This made both query performance and search filter semantics misleading as local history grew.

## Validation

- `pnpm --filter @codesesh/core exec vitest run src/discovery/__tests__/cache.test.ts`
- `pnpm test:migration`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core test`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web build`
- Playwright smoke check for empty search Scope behavior on `http://localhost:4321`