### PR TITLE
perf(web): index app session derivations

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -44,11 +44,7 @@ import {
 } from "./lib/api";
 import { SessionDetail } from "./components/SessionDetail";
 import { SessionDetailSkeleton } from "./components/SessionDetailSkeleton";
-import {
-  DetailLanding,
-  type LandingSession,
-  type LandingAgentItem,
-} from "./components/DetailLanding";
+import { DetailLanding, type LandingAgentItem } from "./components/DetailLanding";
 import { Dashboard } from "./components/Dashboard";
 import { ProjectDashboardView, ProjectsOverview } from "./components/Projects";
 import { ErrorBoundary } from "./components/ErrorBoundary";
@@ -70,6 +66,13 @@ import {
   isProjectIdentityKind,
   type ProjectRouteIdentity,
 } from "./lib/projects";
+import {
+  buildSessionIndexes,
+  buildSidebarSessionLookup,
+  getProjectAgentKey,
+  getSessionAgentKey,
+  getSessionRouteKey,
+} from "./lib/session-indexes";
 
 type BrowseBy = "agents" | "projects";
 
@@ -188,21 +191,8 @@ function formatSearchSubtitle(query: string, loading: boolean, count: number) {
   return query ? `${count} matches for "${query}"` : `${count} recent sessions`;
 }
 
-function getSessionAgentKey(session: SessionHead): string {
-  return session.slug.split("/")[0]?.toLowerCase() || "unknown";
-}
-
 function getProjectGroupIdentity(project: ProjectGroup): ProjectRouteIdentity {
   return { kind: project.identityKind, key: project.identityKey };
-}
-
-function matchesProjectIdentity(
-  identity: SessionHead["project_identity"] | SessionData["project_identity"] | undefined,
-  project: ProjectRouteIdentity | null,
-): boolean {
-  return Boolean(
-    identity && project && identity.kind === project.kind && identity.key === project.key,
-  );
 }
 
 function formatRelativeTime(timestamp?: number) {
@@ -574,24 +564,7 @@ export default function App() {
       ? location.state.searchQuery
       : "";
 
-  const sessionsByAgent = useMemo(() => {
-    const grouped: Record<string, SessionHead[]> = {};
-    for (const a of agents) {
-      grouped[a.name] = [];
-    }
-    for (const s of sessions) {
-      const agentKey = s.slug.split("/")[0]?.toLowerCase();
-      if (agentKey && grouped[agentKey]) {
-        grouped[agentKey].push(s);
-      }
-    }
-    for (const key of Object.keys(grouped)) {
-      grouped[key]!.sort(
-        (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
-      );
-    }
-    return grouped;
-  }, [sessions, agents]);
+  const sessionIndexes = useMemo(() => buildSessionIndexes(sessions, agents), [sessions, agents]);
 
   useEffect(() => {
     let cancelled = false;
@@ -711,13 +684,11 @@ export default function App() {
   const openedSessionHead = useMemo(() => {
     if (viewState.mode !== "session") return null;
     return (
-      sessions.find(
-        (sessionItem) =>
-          getSessionAgentKey(sessionItem) === viewState.activeAgentKey &&
-          sessionItem.id === viewState.activeSessionSlug,
+      sessionIndexes.byRouteKey.get(
+        getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionSlug),
       ) ?? null
     );
-  }, [sessions, viewState]);
+  }, [sessionIndexes, viewState]);
   const openedSessionData =
     viewState.mode === "session" && session?.id === viewState.activeSessionSlug ? session : null;
   const openedSessionProjectIdentity =
@@ -731,33 +702,25 @@ export default function App() {
     ? getProjectIdentityKey(selectedProjectNavigationIdentity)
     : null;
   const agentSidebarSessions = useMemo(
-    () => (activeAgentKey ? (sessionsByAgent[activeAgentKey] ?? []) : []),
-    [activeAgentKey, sessionsByAgent],
+    () => (activeAgentKey ? (sessionIndexes.byAgent.get(activeAgentKey) ?? []) : []),
+    [activeAgentKey, sessionIndexes],
   );
-  const projectSidebarSessions = useMemo(
-    () =>
-      selectedProjectNavigationId
-        ? sessions
-            .filter(
-              (sessionItem) =>
-                matchesProjectIdentity(
-                  sessionItem.project_identity,
-                  selectedProjectNavigationIdentity,
-                ) &&
-                (!selectedProjectAgent || getSessionAgentKey(sessionItem) === selectedProjectAgent),
-            )
-            .toSorted(
-              (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
-            )
-        : [],
-    [
-      selectedProjectAgent,
-      selectedProjectNavigationId,
-      selectedProjectNavigationIdentity,
-      sessions,
-    ],
-  );
+  const projectSidebarSessions = useMemo(() => {
+    if (!selectedProjectNavigationId) return [];
+    if (selectedProjectAgent) {
+      return (
+        sessionIndexes.byProjectAgentKey.get(
+          getProjectAgentKey(selectedProjectNavigationId, selectedProjectAgent),
+        ) ?? []
+      );
+    }
+    return sessionIndexes.byProjectIdentityKey.get(selectedProjectNavigationId) ?? [];
+  }, [selectedProjectAgent, selectedProjectNavigationId, sessionIndexes]);
   const sidebarSessions = browseBy === "projects" ? projectSidebarSessions : agentSidebarSessions;
+  const sidebarSessionLookup = useMemo(
+    () => buildSidebarSessionLookup(sidebarSessions),
+    [sidebarSessions],
+  );
   const bookmarkedSidebarSessionIds = useMemo(() => {
     if (sidebarSessions.length === 0) return new Set<string>();
     return new Set(
@@ -794,25 +757,42 @@ export default function App() {
     activeSearchQuery.trim().length > 0 || Boolean(searchFilters.tool || searchFilters.fileKind);
   const recentSearchResults = useMemo<SearchResult[]>(() => {
     const selectedCost = COST_RANGE_OPTIONS.find((option) => option.id === searchFilters.costRange);
-    return sessions
-      .filter((item) => {
-        if (searchFilters.agent && getSessionAgentKey(item) !== searchFilters.agent) return false;
-        if (searchFilters.projectKey && item.project_identity?.key !== searchFilters.projectKey) {
-          return false;
-        }
-        if (searchFilters.tag && !item.smart_tags?.includes(searchFilters.tag)) return false;
-        if (selectedCost && item.stats.total_cost < selectedCost.costMin) return false;
-        return true;
-      })
-      .toSorted((a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created))
-      .slice(0, 50)
-      .map((sessionItem) => ({
+    const agentSessions = searchFilters.agent
+      ? (sessionIndexes.byAgent.get(searchFilters.agent) ?? [])
+      : null;
+    const projectSessions = searchFilters.projectKey
+      ? (sessionIndexes.byProjectKey.get(searchFilters.projectKey) ?? [])
+      : null;
+    const sourceSessions =
+      agentSessions && projectSessions
+        ? agentSessions.length <= projectSessions.length
+          ? agentSessions
+          : projectSessions
+        : (agentSessions ?? projectSessions ?? sessionIndexes.sessionsByActivity);
+    const results: SearchResult[] = [];
+
+    for (const sessionItem of sourceSessions) {
+      if (searchFilters.agent && getSessionAgentKey(sessionItem) !== searchFilters.agent) continue;
+      if (
+        searchFilters.projectKey &&
+        sessionItem.project_identity?.key !== searchFilters.projectKey
+      ) {
+        continue;
+      }
+      if (searchFilters.tag && !sessionItem.smart_tags?.includes(searchFilters.tag)) continue;
+      if (selectedCost && sessionItem.stats.total_cost < selectedCost.costMin) continue;
+
+      results.push({
         agentName: getSessionAgentKey(sessionItem),
         session: sessionItem,
         snippet: `Recent session · ${sessionItem.directory}`,
         matchType: "recent" as const,
-      }));
-  }, [searchFilters, sessions]);
+      });
+      if (results.length >= 50) break;
+    }
+
+    return results;
+  }, [searchFilters, sessionIndexes]);
 
   // Stable key for session fetch
   const sessionFetchKey =
@@ -1082,25 +1062,13 @@ export default function App() {
   }, [isSearchMode, searchResults, selectedSearchIndex]);
 
   // Build landing data
-  const landingSessions = useMemo<LandingSession[]>(() => {
-    return sessions.map((s) => {
-      const agentKey = s.slug.split("/")[0]?.toLowerCase() || "unknown";
-      return {
-        ...s,
-        agentKey,
-        sessionSlug: s.id,
-        fullPath: s.slug,
-      };
-    });
-  }, [sessions]);
+  const landingSessions = sessionIndexes.landingSessions;
   const activeProjectSessions = useMemo(
     () =>
-      activeProjectIdentity
-        ? landingSessions.filter((sessionItem) =>
-            matchesProjectIdentity(sessionItem.project_identity, activeProjectIdentity),
-          )
+      activeProjectIdentityKey
+        ? (sessionIndexes.byLandingProjectIdentityKey.get(activeProjectIdentityKey) ?? [])
         : [],
-    [activeProjectIdentity, landingSessions],
+    [activeProjectIdentityKey, sessionIndexes],
   );
 
   const landingAgentItems = useMemo<LandingAgentItem[]>(() => {
@@ -1135,24 +1103,7 @@ export default function App() {
     [projects, selectedProjectNavigationId],
   );
 
-  const projectOptions = useMemo<SearchProjectOption[]>(() => {
-    const byKey = new Map<string, SearchProjectOption>();
-    for (const item of sessions) {
-      const identity = item.project_identity;
-      if (!identity?.key) continue;
-      const current = byKey.get(identity.key);
-      if (current) {
-        current.count += 1;
-      } else {
-        byKey.set(identity.key, {
-          key: identity.key,
-          label: identity.displayName || item.directory,
-          count: 1,
-        });
-      }
-    }
-    return [...byKey.values()].toSorted((a, b) => b.count - a.count).slice(0, 8);
-  }, [sessions]);
+  const projectOptions = sessionIndexes.projectOptions;
   const searchProjectOptions = useMemo<SearchProjectOption[]>(() => {
     if (!usesServerSearch) return projectOptions;
 
@@ -1406,7 +1357,7 @@ export default function App() {
       />
     );
   } else if (viewState.mode === "agent" && activeAgentKey) {
-    const agentSessions = landingSessions.filter((s) => s.agentKey === activeAgentKey);
+    const agentSessions = sessionIndexes.byLandingAgent.get(activeAgentKey) ?? [];
     content = (
       <DetailLanding
         type="agent"
@@ -1424,7 +1375,7 @@ export default function App() {
       content = (
         <DetailLanding
           type="missing-session"
-          sessions={landingSessions.filter((s) => s.agentKey === viewState.activeAgentKey)}
+          sessions={sessionIndexes.byLandingAgent.get(viewState.activeAgentKey) ?? []}
           agentItems={landingAgentItems}
           activeAgentKey={viewState.activeAgentKey}
           attemptedSessionSlug={viewState.activeSessionSlug}
@@ -1593,9 +1544,10 @@ export default function App() {
 
     const moveSidebarSelection = (offset: number) => {
       dismissShortcutHint();
-      const currentIndex = sidebarSessions.findIndex(
-        (sessionItem) => sessionItem.id === selectedSidebarSessionId,
-      );
+      const currentIndex =
+        selectedSidebarSessionId != null
+          ? (sidebarSessionLookup.indexById.get(selectedSidebarSessionId) ?? -1)
+          : -1;
       const baseIndex =
         currentIndex >= 0 ? currentIndex : offset >= 0 ? -1 : sidebarSessions.length;
       const nextIndex = Math.max(0, Math.min(baseIndex + offset, sidebarSessions.length - 1));
@@ -1625,7 +1577,10 @@ export default function App() {
       return;
     }
     if (key === "Enter") {
-      const selected = sidebarSessions.find((item) => item.id === selectedSidebarSessionId);
+      const selected =
+        selectedSidebarSessionId != null
+          ? sidebarSessionLookup.byId.get(selectedSidebarSessionId)
+          : null;
       if (!selected) return;
       event.preventDefault();
       dismissShortcutHint();
@@ -1907,7 +1862,7 @@ export default function App() {
                   selectedSessionId={selectedSidebarSessionId}
                   onSelectSession={(sessionId) => {
                     setSelectedSidebarSessionId(sessionId);
-                    const selected = sidebarSessions.find((item) => item.id === sessionId);
+                    const selected = sidebarSessionLookup.byId.get(sessionId);
                     if (selected) navigate(`/${selected.slug}`);
                   }}
                   bookmarkedSessionIds={bookmarkedSidebarSessionIds}

--- a/apps/web/src/lib/session-indexes.test.ts
+++ b/apps/web/src/lib/session-indexes.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { AgentInfo, SessionHead } from "./api";
+import {
+  buildSessionIndexes,
+  buildSidebarSessionLookup,
+  getProjectAgentKey,
+  getSessionRouteKey,
+} from "./session-indexes";
+
+const agents: AgentInfo[] = [
+  { name: "codex", displayName: "Codex", count: 3, icon: "/codex.svg" },
+  { name: "claude", displayName: "Claude", count: 1, icon: "/claude.svg" },
+];
+
+function createSession(
+  overrides: Partial<SessionHead> & Pick<SessionHead, "id" | "slug" | "title">,
+): SessionHead {
+  return {
+    id: overrides.id,
+    slug: overrides.slug,
+    title: overrides.title,
+    directory: overrides.directory ?? "/workspace/a",
+    project_identity: overrides.project_identity,
+    time_created: overrides.time_created ?? 1,
+    time_updated: overrides.time_updated,
+    stats: overrides.stats ?? {
+      message_count: 1,
+      total_input_tokens: 2,
+      total_output_tokens: 3,
+      total_cost: 0,
+    },
+    smart_tags: overrides.smart_tags,
+  };
+}
+
+describe("session indexes", () => {
+  it("indexes sessions once by route, agent, project, and activity order", () => {
+    const projectA = { kind: "path" as const, key: "/workspace/a", displayName: "Project A" };
+    const projectB = { kind: "path" as const, key: "/workspace/b", displayName: "Project B" };
+    const oldCodex = createSession({
+      id: "old",
+      slug: "codex/old",
+      title: "Old",
+      project_identity: projectA,
+      time_updated: 100,
+    });
+    const claude = createSession({
+      id: "claude",
+      slug: "claude/claude",
+      title: "Claude",
+      project_identity: projectA,
+      time_updated: 200,
+    });
+    const newCodex = createSession({
+      id: "new",
+      slug: "codex/new",
+      title: "New",
+      project_identity: projectA,
+      time_updated: 300,
+    });
+    const otherCodex = createSession({
+      id: "other",
+      slug: "codex/other",
+      title: "Other",
+      directory: "/workspace/b",
+      project_identity: projectB,
+      time_updated: 400,
+    });
+
+    const indexes = buildSessionIndexes([oldCodex, claude, newCodex, otherCodex], agents);
+
+    expect(indexes.byRouteKey.get(getSessionRouteKey("CoDeX", "old"))).toBe(oldCodex);
+    expect(indexes.byAgent.get("codex")?.map((session) => session.id)).toEqual([
+      "other",
+      "new",
+      "old",
+    ]);
+    expect(
+      indexes.byProjectIdentityKey.get("path:/workspace/a")?.map((session) => session.id),
+    ).toEqual(["new", "claude", "old"]);
+    expect(
+      indexes.byProjectAgentKey
+        .get(getProjectAgentKey("path:/workspace/a", "codex"))
+        ?.map((session) => session.id),
+    ).toEqual(["new", "old"]);
+    expect(indexes.byProjectKey.get("/workspace/a")?.map((session) => session.id)).toEqual([
+      "new",
+      "claude",
+      "old",
+    ]);
+    expect(indexes.sessionsByActivity.map((session) => session.id)).toEqual([
+      "other",
+      "new",
+      "claude",
+      "old",
+    ]);
+    expect(indexes.landingSessions.map((session) => session.id)).toEqual([
+      "old",
+      "claude",
+      "new",
+      "other",
+    ]);
+    expect(indexes.byLandingAgent.get("codex")?.map((session) => session.id)).toEqual([
+      "old",
+      "new",
+      "other",
+    ]);
+    expect(indexes.projectOptions).toEqual([
+      { key: "/workspace/a", label: "Project A", count: 3 },
+      { key: "/workspace/b", label: "Project B", count: 1 },
+    ]);
+  });
+
+  it("keeps sidebar lookup compatible with first-match selection", () => {
+    const first = createSession({ id: "same", slug: "codex/same", title: "First" });
+    const duplicate = createSession({ id: "same", slug: "claude/same", title: "Duplicate" });
+    const next = createSession({ id: "next", slug: "codex/next", title: "Next" });
+
+    const lookup = buildSidebarSessionLookup([first, duplicate, next]);
+
+    expect(lookup.byId.get("same")).toBe(first);
+    expect(lookup.indexById.get("same")).toBe(0);
+    expect(lookup.byId.get("next")).toBe(next);
+    expect(lookup.indexById.get("next")).toBe(2);
+  });
+
+  it("keeps route lookup compatible with first-match session search", () => {
+    const first = createSession({ id: "same", slug: "codex/same", title: "First" });
+    const duplicate = createSession({ id: "same", slug: "codex/same", title: "Duplicate" });
+
+    const indexes = buildSessionIndexes([first, duplicate], agents);
+
+    expect(indexes.byRouteKey.get(getSessionRouteKey("codex", "same"))).toBe(first);
+  });
+});

--- a/apps/web/src/lib/session-indexes.ts
+++ b/apps/web/src/lib/session-indexes.ts
@@ -1,0 +1,153 @@
+import type { AgentInfo, SessionHead } from "./api";
+import { getProjectIdentityKey } from "./projects";
+
+export interface IndexedSession extends SessionHead {
+  agentKey: string;
+  sessionSlug: string;
+  fullPath: string;
+}
+
+export interface SessionProjectOption {
+  key: string;
+  label: string;
+  count: number;
+}
+
+export interface SessionIndexes {
+  byRouteKey: Map<string, SessionHead>;
+  byAgent: Map<string, SessionHead[]>;
+  byProjectIdentityKey: Map<string, SessionHead[]>;
+  byProjectAgentKey: Map<string, SessionHead[]>;
+  byProjectKey: Map<string, SessionHead[]>;
+  byLandingAgent: Map<string, IndexedSession[]>;
+  byLandingProjectIdentityKey: Map<string, IndexedSession[]>;
+  landingSessions: IndexedSession[];
+  sessionsByActivity: SessionHead[];
+  projectOptions: SessionProjectOption[];
+}
+
+export interface SidebarSessionLookup {
+  byId: Map<string, SessionHead>;
+  indexById: Map<string, number>;
+}
+
+function compareSessionActivityDesc(a: SessionHead, b: SessionHead): number {
+  return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
+}
+
+export function getSessionAgentKey(session: Pick<SessionHead, "slug">): string {
+  return session.slug.split("/")[0]?.toLowerCase() || "unknown";
+}
+
+export function getSessionRouteKey(agentKey: string, sessionId: string): string {
+  return `${agentKey.toLowerCase()}/${sessionId}`;
+}
+
+export function getProjectAgentKey(projectIdentityKey: string, agentKey: string): string {
+  return `${projectIdentityKey}\0${agentKey.toLowerCase()}`;
+}
+
+function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const current = map.get(key);
+  if (current) {
+    current.push(value);
+    return;
+  }
+  map.set(key, [value]);
+}
+
+export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]): SessionIndexes {
+  const byRouteKey = new Map<string, SessionHead>();
+  const byAgent = new Map<string, SessionHead[]>();
+  const byProjectIdentityKey = new Map<string, SessionHead[]>();
+  const byProjectAgentKey = new Map<string, SessionHead[]>();
+  const byProjectKey = new Map<string, SessionHead[]>();
+  const byLandingAgent = new Map<string, IndexedSession[]>();
+  const byLandingProjectIdentityKey = new Map<string, IndexedSession[]>();
+  const projectOptionsByKey = new Map<string, SessionProjectOption>();
+  const landingSessions: IndexedSession[] = [];
+  const knownAgentKeys = new Set(agents.map((agent) => agent.name.toLowerCase()));
+
+  for (const agentKey of knownAgentKeys) {
+    byAgent.set(agentKey, []);
+    byLandingAgent.set(agentKey, []);
+  }
+
+  for (const session of sessions) {
+    const agentKey = getSessionAgentKey(session);
+    const indexedSession: IndexedSession = {
+      ...session,
+      agentKey,
+      sessionSlug: session.id,
+      fullPath: session.slug,
+    };
+
+    landingSessions.push(indexedSession);
+    const routeKey = getSessionRouteKey(agentKey, session.id);
+    if (!byRouteKey.has(routeKey)) byRouteKey.set(routeKey, session);
+
+    if (knownAgentKeys.has(agentKey)) {
+      byLandingAgent.get(agentKey)!.push(indexedSession);
+    }
+
+    const identity = session.project_identity;
+    if (!identity?.key) continue;
+
+    const projectIdentityKey = getProjectIdentityKey(identity);
+    pushMapValue(byLandingProjectIdentityKey, projectIdentityKey, indexedSession);
+
+    const option = projectOptionsByKey.get(identity.key);
+    if (option) {
+      option.count += 1;
+    } else {
+      projectOptionsByKey.set(identity.key, {
+        key: identity.key,
+        label: identity.displayName || session.directory,
+        count: 1,
+      });
+    }
+  }
+
+  const sessionsByActivity = sessions.toSorted(compareSessionActivityDesc);
+  for (const session of sessionsByActivity) {
+    const agentKey = getSessionAgentKey(session);
+    if (knownAgentKeys.has(agentKey)) byAgent.get(agentKey)!.push(session);
+
+    const identity = session.project_identity;
+    if (!identity?.key) continue;
+
+    const projectIdentityKey = getProjectIdentityKey(identity);
+    pushMapValue(byProjectIdentityKey, projectIdentityKey, session);
+    pushMapValue(byProjectAgentKey, getProjectAgentKey(projectIdentityKey, agentKey), session);
+    pushMapValue(byProjectKey, identity.key, session);
+  }
+
+  return {
+    byRouteKey,
+    byAgent,
+    byProjectIdentityKey,
+    byProjectAgentKey,
+    byProjectKey,
+    byLandingAgent,
+    byLandingProjectIdentityKey,
+    landingSessions,
+    sessionsByActivity,
+    projectOptions: [...projectOptionsByKey.values()]
+      .toSorted((a, b) => b.count - a.count)
+      .slice(0, 8),
+  };
+}
+
+export function buildSidebarSessionLookup(sessions: SessionHead[]): SidebarSessionLookup {
+  const byId = new Map<string, SessionHead>();
+  const indexById = new Map<string, number>();
+
+  for (let index = 0; index < sessions.length; index += 1) {
+    const session = sessions[index]!;
+    if (byId.has(session.id)) continue;
+    byId.set(session.id, session);
+    indexById.set(session.id, index);
+  }
+
+  return { byId, indexById };
+}

--- a/klip/klip-0-performance-hotspots.md
+++ b/klip/klip-0-performance-hotspots.md
@@ -272,7 +272,7 @@ Status: Draft
 - [ ] P1-7：重写 `listFileActivity()` 动态 WHERE，并用 `EXPLAIN QUERY PLAN` 验证索引。
 - [x] P1-8：构建 `SessionDetail` display model，复用 `MessageBlock[]`。
 - [x] P1-9：评估详情页 message virtualization，确认 anchors 和 keyboard/scroll 行为可保留。
-- [ ] P1-10：在 `App.tsx` 建立 session indexes，减少重复 `filter()` / `find()`。
+- [x] P1-10：在 `App.tsx` 建立 session indexes，减少重复 `filter()` / `find()`。
 - [ ] 验证：每项优化至少运行相关 package tests。
 - [ ] 验证：完成 P1-2 / P1-3 / P1-6 / P1-8 后运行 `pnpm bench:perf` 记录前后结果。
 
@@ -281,6 +281,7 @@ Status: Draft
 - 2026-05-20：完成 P1-2。`handleGetDashboard()` 改为在一次 session 扫描中完成 totals、per-agent、daily buckets、token buckets、model distribution 和 recent top 10 聚合；recent top 10 使用固定容量候选集，避免对窗口内全量 session 排序。验证：`pnpm --filter codesesh test`、`pnpm --filter codesesh lint`、`pnpm --filter codesesh format:check`、`pnpm --filter codesesh build`、`git diff --check`、`pnpm bench:perf -- --iterations 1`（236 sessions；dashboard visible 11956ms；detail 139ms）。
 - 2026-05-20：完成 P1-6。新增 `messages_fts` message-level FTS 表和 `messages` 触发器，schema 升级到 v9；`searchSessions()` 保留 session-level FTS 排序，但对返回候选结果只做一次批量 message FTS 查询来解析 `matchType` / `snippet`，移除每条结果单独加载全量 messages 的 N+1 路径。验证：`pnpm --filter @codesesh/core exec vitest run src/discovery/__tests__/cache.test.ts`、`pnpm --filter @codesesh/core exec vitest run src/discovery/__tests__/migration-smoke.test.ts`、`pnpm --filter @codesesh/core test`、`pnpm --filter @codesesh/core lint`、`pnpm --filter @codesesh/core format:check`、`pnpm --filter @codesesh/core build`、`git diff --check`、`pnpm bench:perf -- --iterations 1`（242 sessions；dashboard visible 5081ms；detail 183ms）。
 - 2026-05-20：完成 P1-8 / P1-9。`SessionDetail` 先构建一次 `MessageDisplayModel[]`，TOC、filter、render 和 file tracker 复用同一批 `MessageBlock[]`；长会话消息列表改为绑定实际滚动父级的窗口化渲染，并在 file tracker 跳转远端 tool anchor 时强制挂载目标 message，保持锚点可达。验证：`pnpm --filter @codesesh/web test`、`pnpm --filter @codesesh/web lint`、`pnpm --filter @codesesh/web format:check`、`pnpm --filter @codesesh/web exec tsc -b`、`pnpm --filter codesesh build`；Browser 验证 2500-message 会话初屏只挂载 8 个 article，滚动后约 11 个 article，File Tracker `Next` 锚点可跳到远端 tool 区域且无新增 console error；`pnpm bench:perf -- --iterations 1`（247 sessions；dashboard visible 14478ms；detail 230ms）。
+- 2026-05-20：完成 P1-10。`App.tsx` 新增 session indexes 复用路径：route session head、agent sidebar、project sidebar、landing sessions、project options 和 recent search 都从一次 `buildSessionIndexes()` 派生；sidebar keyboard navigation 和 tree select 改为使用 `buildSidebarSessionLookup()`，移除交互路径上的 `findIndex()` / `find()`。补充 `session-indexes.test.ts` 覆盖 route/agent/project/activity 顺序和 sidebar first-match lookup。验证：`pnpm --filter @codesesh/web test`、`pnpm --filter @codesesh/web lint`、`pnpm --filter @codesesh/web format:check`、`pnpm --filter @codesesh/web exec tsc -b`、`pnpm --filter @codesesh/web build`、`git diff --check`、`pnpm bench:perf -- --iterations 1`（249 sessions；dashboard visible 4879ms；detail 200ms）。
 
 ## 测试矩阵
 


### PR DESCRIPTION
## Summary

- Add app-level session indexes for route, agent, project, landing, recent search, and sidebar lookup data.
- Reuse the indexes in `App.tsx` to avoid repeated session filtering and linear lookup during render and keyboard navigation.
- Mark KLIP-0 P1-10 complete with validation notes.

## Validation

- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web build`
- `git diff --check`
- `pnpm bench:perf -- --iterations 1`