### PR TITLE
perf: fix follow-up performance hotspots

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -208,6 +208,34 @@ function formatRelativeTime(timestamp?: number) {
   return `${days}d ago`;
 }
 
+function compareSessionActivityDesc(a: SessionHead, b: SessionHead): number {
+  return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
+}
+
+function applyLiveSessionUpdate(
+  sessions: SessionHead[],
+  event: SessionsUpdatedEvent,
+): SessionHead[] | null {
+  if (!event.changedSessionHeads || !event.removedSessionRefs) return null;
+
+  const byKey = new Map(
+    sessions.map((sessionItem) => [
+      getSessionRouteKey(getSessionAgentKey(sessionItem), sessionItem.id),
+      sessionItem,
+    ]),
+  );
+
+  for (const { agentName, sessionId } of event.removedSessionRefs) {
+    byKey.delete(getSessionRouteKey(agentName, sessionId));
+  }
+
+  for (const { agentName, session: sessionItem } of event.changedSessionHeads) {
+    byKey.set(getSessionRouteKey(agentName, sessionItem.id), sessionItem);
+  }
+
+  return [...byKey.values()].sort(compareSessionActivityDesc);
+}
+
 function toSafeSnippetHtml(snippet: string): string {
   return snippet
     .replaceAll("&", "&amp;")
@@ -802,10 +830,17 @@ export default function App() {
 
   const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
     try {
+      const canApplySessionUpdate = Boolean(event.changedSessionHeads && event.removedSessionRefs);
+      if (canApplySessionUpdate) {
+        setSessions((current) => applyLiveSessionUpdate(current, event) ?? current);
+      }
+
       const [agentList, sessionList, dashboardData, projectData, projectDashboardData, searchData] =
         await Promise.all([
           fetchAgents(),
-          fetchSessions({ from: appConfig?.window.from, to: appConfig?.window.to }),
+          canApplySessionUpdate
+            ? Promise.resolve<{ sessions: SessionHead[] } | null>(null)
+            : fetchSessions({ from: appConfig?.window.from, to: appConfig?.window.to }),
           fetchDashboard(appConfig?.window).catch((err) => {
             console.error("Failed to refresh dashboard:", err);
             return null;
@@ -832,7 +867,7 @@ export default function App() {
             : Promise.resolve<{ results: SearchResult[] } | null>(null),
         ]);
       setAgents(agentList);
-      setSessions(sessionList.sessions);
+      if (sessionList) setSessions(sessionList.sessions);
       setProjects(projectData.projects);
       if (dashboardData) setDashboard(dashboardData);
       if (projectDashboardData) setProjectDashboard(projectDashboardData);

--- a/apps/web/src/components/InteractiveReceipt.tsx
+++ b/apps/web/src/components/InteractiveReceipt.tsx
@@ -551,7 +551,14 @@ export function InteractiveReceipt({ session, toc }: InteractiveReceiptProps) {
     let startedAt = performance.now();
     let lastMetrics: SheetMetrics | null = null;
     let stableFrames = 0;
+    let idleFrames = 0;
     let isVisible = false;
+    let anchorVisible = true;
+    let running = false;
+    const desktopMedia = window.matchMedia("(min-width: 1280px)");
+
+    const shouldRun = () =>
+      desktopMedia.matches && document.visibilityState === "visible" && anchorVisible;
 
     const getSheetMetrics = (): SheetMetrics => {
       const rect = anchor.getBoundingClientRect();
@@ -573,6 +580,15 @@ export function InteractiveReceipt({ session, toc }: InteractiveReceiptProps) {
       hitSurface.style.visibility = visible ? "visible" : "hidden";
     };
 
+    const stopLoop = () => {
+      running = false;
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame);
+        animationFrame = 0;
+      }
+      setVisible(false);
+    };
+
     const resetSheet = (metrics: SheetMetrics, time = performance.now()) => {
       sheet = createSheet(metrics);
       lastMetrics = metrics;
@@ -587,8 +603,24 @@ export function InteractiveReceipt({ session, toc }: InteractiveReceiptProps) {
       canvas.height = Math.floor(height * ratio);
       ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
       stableFrames = 0;
+      idleFrames = 0;
       setVisible(false);
       resetSheet(getSheetMetrics());
+      if (shouldRun()) startLoop();
+    };
+
+    const startLoop = () => {
+      if (running || !shouldRun()) return;
+      running = true;
+      animationFrame = window.requestAnimationFrame(tick);
+    };
+
+    const syncLoopState = () => {
+      if (shouldRun()) {
+        resize();
+      } else {
+        stopLoop();
+      }
     };
 
     const getPoint = (event: PointerEvent) => {
@@ -610,6 +642,8 @@ export function InteractiveReceipt({ session, toc }: InteractiveReceiptProps) {
       pointer.vx = 0;
       pointer.vy = 0;
       pointer.grabbedIndex = target;
+      idleFrames = 0;
+      startLoop();
     };
 
     const onPointerMove = (event: PointerEvent) => {
@@ -743,6 +777,12 @@ export function InteractiveReceipt({ session, toc }: InteractiveReceiptProps) {
     };
 
     const tick = (time: number) => {
+      if (!running) return;
+      if (!shouldRun()) {
+        stopLoop();
+        return;
+      }
+
       const metrics = getSheetMetrics();
       const changed = metricsChanged(lastMetrics, metrics);
       if (changed && pointer.id == null) {
@@ -758,25 +798,41 @@ export function InteractiveReceipt({ session, toc }: InteractiveReceiptProps) {
       integrate(time);
       constrain();
       draw();
+      idleFrames = pointer.id == null ? idleFrames + 1 : 0;
       if (stableFrames >= 2) setVisible(true);
+      if (stableFrames >= 2 && idleFrames >= 90) {
+        running = false;
+        animationFrame = 0;
+        return;
+      }
       animationFrame = window.requestAnimationFrame(tick);
     };
 
     setVisible(false);
-    resize();
+    if (shouldRun()) resize();
     const observer = new ResizeObserver(resize);
     observer.observe(anchor);
-    window.addEventListener("resize", resize);
+    const intersectionObserver = new IntersectionObserver(([entry]) => {
+      anchorVisible = Boolean(entry?.isIntersecting);
+      syncLoopState();
+    });
+    intersectionObserver.observe(anchor);
+    desktopMedia.addEventListener("change", syncLoopState);
+    document.addEventListener("visibilitychange", syncLoopState);
+    window.addEventListener("resize", syncLoopState);
     hitSurface.addEventListener("pointerdown", onPointerDown);
     hitSurface.addEventListener("pointermove", onPointerMove);
     hitSurface.addEventListener("pointerup", releasePointer);
     hitSurface.addEventListener("pointercancel", releasePointer);
-    animationFrame = window.requestAnimationFrame(tick);
+    startLoop();
 
     return () => {
-      window.cancelAnimationFrame(animationFrame);
+      stopLoop();
       observer.disconnect();
-      window.removeEventListener("resize", resize);
+      intersectionObserver.disconnect();
+      desktopMedia.removeEventListener("change", syncLoopState);
+      document.removeEventListener("visibilitychange", syncLoopState);
+      window.removeEventListener("resize", syncLoopState);
       hitSurface.removeEventListener("pointerdown", onPointerDown);
       hitSurface.removeEventListener("pointermove", onPointerMove);
       hitSurface.removeEventListener("pointerup", releasePointer);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -173,6 +173,8 @@ export interface SessionsUpdatedEvent {
   removedSessions: number;
   totalSessions: number;
   timestamp: number;
+  changedSessionHeads?: Array<{ agentName: string; session: SessionHead }>;
+  removedSessionRefs?: Array<{ agentName: string; sessionId: string }>;
 }
 
 export interface DashboardAgentStat {

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -267,6 +267,11 @@ describe("LiveScanStore", () => {
         updatedSessions: 1,
         removedSessions: 0,
         totalSessions: 2,
+        changedSessionHeads: [
+          { agentName: "codex", session: updated },
+          { agentName: "codex", session: added },
+        ],
+        removedSessionRefs: [],
       }),
     ]);
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["session", "added"]);
@@ -332,6 +337,8 @@ describe("LiveScanStore", () => {
         updatedSessions: 0,
         removedSessions: 1,
         totalSessions: 0,
+        changedSessionHeads: [],
+        removedSessionRefs: [{ agentName: "codex", sessionId: "session" }],
       }),
     ]);
     expect(store.getSnapshot().sessions).toEqual([]);
@@ -549,6 +556,11 @@ describe("LiveScanStore", () => {
         updatedSessions: 0,
         removedSessions: 0,
         totalSessions: 4,
+        changedSessionHeads: [
+          { agentName: "codex", session: expect.objectContaining({ id: "codex-new" }) },
+          { agentName: "kimi", session: expect.objectContaining({ id: "kimi-new" }) },
+        ],
+        removedSessionRefs: [],
       }),
     ]);
   });

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -30,6 +30,8 @@ export interface SessionsUpdatedEvent {
   removedSessions: number;
   totalSessions: number;
   timestamp: number;
+  changedSessionHeads: Array<{ agentName: string; session: SessionHead }>;
+  removedSessionRefs: Array<{ agentName: string; sessionId: string }>;
 }
 
 type StoreListener = (event: SessionsUpdatedEvent) => void;
@@ -158,6 +160,8 @@ function buildRefreshDiff(
       removedSessions,
       totalSessions: nextSessions.length,
       timestamp: Date.now(),
+      changedSessionHeads: changedSessions.map(({ session }) => ({ agentName, session })),
+      removedSessionRefs: removedSessionIds.map((sessionId) => ({ agentName, sessionId })),
     },
   };
 }
@@ -226,6 +230,25 @@ function mergeEvents(
   previous: SessionsUpdatedEvent,
   next: SessionsUpdatedEvent,
 ): SessionsUpdatedEvent {
+  const changedSessionHeads = new Map<string, { agentName: string; session: SessionHead }>();
+  const removedSessionRefs = new Map<string, { agentName: string; sessionId: string }>();
+  const sessionKey = (agentName: string, sessionId: string) => `${agentName}\0${sessionId}`;
+  const addChanged = (item: { agentName: string; session: SessionHead }) => {
+    const key = sessionKey(item.agentName, item.session.id);
+    removedSessionRefs.delete(key);
+    changedSessionHeads.set(key, item);
+  };
+  const addRemoved = (item: { agentName: string; sessionId: string }) => {
+    const key = sessionKey(item.agentName, item.sessionId);
+    changedSessionHeads.delete(key);
+    removedSessionRefs.set(key, item);
+  };
+
+  for (const item of previous.changedSessionHeads) addChanged(item);
+  for (const item of previous.removedSessionRefs) addRemoved(item);
+  for (const item of next.changedSessionHeads) addChanged(item);
+  for (const item of next.removedSessionRefs) addRemoved(item);
+
   return {
     type: "sessions-updated",
     changedAgents: Array.from(new Set([...previous.changedAgents, ...next.changedAgents])),
@@ -234,6 +257,8 @@ function mergeEvents(
     removedSessions: previous.removedSessions + next.removedSessions,
     totalSessions: next.totalSessions,
     timestamp: next.timestamp,
+    changedSessionHeads: [...changedSessionHeads.values()],
+    removedSessionRefs: [...removedSessionRefs.values()],
   };
 }
 

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -25,6 +25,24 @@ import {
   firstUserMessageTitle,
 } from "../utils/session-normalization.js";
 
+interface OpenCodeMessageRow {
+  id?: unknown;
+  session_id?: unknown;
+  data?: string;
+  time_created?: unknown;
+}
+
+interface OpenCodePartRow {
+  message_id?: unknown;
+  data?: string;
+  time_created?: unknown;
+}
+
+interface OpenCodeHeadContext {
+  stats: SessionHead["stats"];
+  messageTitle: string | null;
+}
+
 export class OpenCodeAgent extends BaseAgent {
   readonly name = "opencode";
   readonly displayName = "OpenCode";
@@ -66,11 +84,7 @@ export class OpenCodeAgent extends BaseAgent {
           .prepare(`
           SELECT
             s.id, s.title, s.time_created, s.time_updated, s.slug, s.directory,
-            s.version, s.summary_files,
-            (SELECT COUNT(*) FROM message m WHERE m.session_id = s.id) AS message_count,
-            (SELECT m.data FROM message m
-             WHERE m.session_id = s.id AND m.data LIKE '%"modelID"%'
-             ORDER BY m.time_created DESC LIMIT 1) AS model_message_data
+            s.version, s.summary_files
           FROM session s
           WHERE COALESCE(s.time_updated, s.time_created) >= ?
           ORDER BY s.time_created DESC
@@ -88,9 +102,17 @@ export class OpenCodeAgent extends BaseAgent {
           .all(cutoffTime);
       }
 
+      const headContexts = hasMessageTable
+        ? this.buildHeadContexts(
+            this.readHeadMessageRows(db, cutoffTime),
+            this.readHeadPartRows(db, cutoffTime),
+          )
+        : new Map<string, OpenCodeHeadContext>();
       const heads: SessionHead[] = [];
       for (const row of rows) {
-        const head = getParsedSession(this.parseSessionHeadRow(db, row, hasMessageTable));
+        const head = getParsedSession(
+          this.parseSessionHeadRow(row, hasMessageTable, headContexts.get(String(row.id ?? ""))),
+        );
         if (!head) continue;
 
         heads.push(head);
@@ -113,19 +135,19 @@ export class OpenCodeAgent extends BaseAgent {
   }
 
   private parseSessionHeadRow(
-    db: SQLiteDatabase,
     row: Record<string, unknown>,
     hasMessageTable: boolean,
+    context?: OpenCodeHeadContext,
   ): ParseSessionResult<SessionHead> {
     const id = String(row.id ?? "");
     if (!id) return skippedSession("missing session id");
 
     const timeCreated = Number(row.time_created ?? 0);
     const timeUpdated = Number(row.time_updated ?? timeCreated);
-    const stats = hasMessageTable ? this.readSessionStats(db, id) : null;
-    const messageCount = stats?.message_count ?? Number(row.message_count ?? 0);
+    const stats = context?.stats ?? null;
+    const messageCount = stats?.message_count ?? 0;
     if (hasMessageTable && messageCount === 0) return filteredSession("no visible messages");
-    const messageTitle = hasMessageTable ? this.readFirstUserTitle(db, id) : null;
+    const messageTitle = context?.messageTitle ?? null;
 
     return parsedSession({
       id,
@@ -142,6 +164,35 @@ export class OpenCodeAgent extends BaseAgent {
         cost_source: stats?.cost_source,
       },
     });
+  }
+
+  private readHeadMessageRows(db: SQLiteDatabase, cutoffTime: number): OpenCodeMessageRow[] {
+    return db
+      .prepare(
+        `
+          SELECT m.id, m.session_id, m.data, m.time_created
+          FROM message m
+          JOIN session s ON s.id = m.session_id
+          WHERE COALESCE(s.time_updated, s.time_created) >= ?
+          ORDER BY m.session_id, m.time_created ASC
+        `,
+      )
+      .all(cutoffTime) as OpenCodeMessageRow[];
+  }
+
+  private readHeadPartRows(db: SQLiteDatabase, cutoffTime: number): OpenCodePartRow[] {
+    return db
+      .prepare(
+        `
+          SELECT p.message_id, p.data, p.time_created
+          FROM part p
+          JOIN message m ON m.id = p.message_id
+          JOIN session s ON s.id = m.session_id
+          WHERE COALESCE(s.time_updated, s.time_created) >= ?
+          ORDER BY p.message_id, p.time_created ASC
+        `,
+      )
+      .all(cutoffTime) as OpenCodePartRow[];
   }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
@@ -190,111 +241,126 @@ export class OpenCodeAgent extends BaseAgent {
     return this.scan();
   }
 
-  private readMessageParts(db: SQLiteDatabase, messageId: unknown): MessagePart[] {
-    const partRows = db
-      .prepare("SELECT * FROM part WHERE message_id = ? ORDER BY time_created ASC")
-      .all(messageId) as Record<string, unknown>[];
-    const parts: MessagePart[] = [];
+  private parsePartRow(
+    partRow: Pick<OpenCodePartRow, "data" | "time_created">,
+  ): MessagePart | null {
+    const partData = JSON.parse(String(partRow.data ?? "{}")) as Record<string, unknown>;
+    const partType = String(partData.type ?? "");
+    if (isInternalEventType(partType)) return null;
 
-    for (const partRow of partRows) {
-      const partData = JSON.parse(String(partRow.data ?? "{}")) as Record<string, unknown>;
-      const partType = String(partData.type ?? "");
-      if (isInternalEventType(partType)) continue;
-
-      if (partType === "text" || partType === "reasoning") {
-        const text = cleanInternalText(String(partData.text ?? ""));
-        if (text) {
-          parts.push({
-            type: partType as "text" | "reasoning",
-            text,
-            time_created: Number(partRow.time_created ?? 0),
-          });
-        }
-      } else if (partType === "tool") {
-        parts.push({
-          type: "tool",
-          tool: String(partData.tool ?? ""),
-          callID: String(partData.callID ?? ""),
-          title: cleanInternalText(String(partData.title ?? "")),
-          state: (partData.state ?? {}) as MessagePart["state"],
-          time_created: Number(partRow.time_created ?? 0),
-        });
-      }
+    if (partType === "text" || partType === "reasoning") {
+      const text = cleanInternalText(String(partData.text ?? ""));
+      if (!text) return null;
+      return {
+        type: partType as "text" | "reasoning",
+        text,
+        time_created: Number(partRow.time_created ?? 0),
+      };
     }
 
-    return parts;
-  }
-
-  private readFirstUserTitle(db: SQLiteDatabase, sessionId: string): string | null {
-    const rows = db
-      .prepare(
-        "SELECT id, data, time_created FROM message WHERE session_id = ? ORDER BY time_created ASC",
-      )
-      .all(sessionId) as Record<string, unknown>[];
-
-    for (const row of rows) {
-      const msgData = JSON.parse(String(row.data ?? "{}")) as Record<string, unknown>;
-      if (isInternalEventType(msgData.type)) continue;
-      if (String(msgData.role ?? "") !== "user") continue;
-      const parts = this.readMessageParts(db, row.id);
-      const title = firstUserMessageTitle([
-        {
-          id: String(row.id ?? ""),
-          role: "user",
-          agent: null,
-          time_created: Number(row.time_created ?? 0),
-          parts,
-        },
-      ]);
-      if (title) return title;
+    if (partType === "tool") {
+      return {
+        type: "tool",
+        tool: String(partData.tool ?? ""),
+        callID: String(partData.callID ?? ""),
+        title: cleanInternalText(String(partData.title ?? "")),
+        state: (partData.state ?? {}) as MessagePart["state"],
+        time_created: Number(partRow.time_created ?? 0),
+      };
     }
 
     return null;
   }
 
-  private readSessionStats(db: SQLiteDatabase, sessionId: string): SessionHead["stats"] | null {
-    try {
-      const rows = db
-        .prepare("SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created ASC")
-        .all(sessionId) as Array<{ id?: unknown; data?: string }>;
+  private readMessageParts(db: SQLiteDatabase, messageId: unknown): MessagePart[] {
+    const partRows = db
+      .prepare("SELECT data, time_created FROM part WHERE message_id = ? ORDER BY time_created ASC")
+      .all(messageId) as OpenCodePartRow[];
+    return partRows
+      .map((partRow) => this.parsePartRow(partRow))
+      .filter((part): part is MessagePart => part !== null);
+  }
 
-      let totalCost = 0;
-      let totalInputTokens = 0;
-      let totalOutputTokens = 0;
-      let hasEstimatedCost = false;
-      let messageCount = 0;
+  private buildPartsByMessage(partRows: OpenCodePartRow[]): Map<string, MessagePart[]> {
+    const partsByMessage = new Map<string, MessagePart[]>();
+    for (const row of partRows) {
+      const messageId = String(row.message_id ?? "");
+      if (!messageId) continue;
+      const part = this.parsePartRow(row);
+      if (!part) continue;
+      const parts = partsByMessage.get(messageId);
+      if (parts) {
+        parts.push(part);
+      } else {
+        partsByMessage.set(messageId, [part]);
+      }
+    }
+    return partsByMessage;
+  }
 
-      for (const row of rows) {
-        const msgData = JSON.parse(String(row.data ?? "{}")) as Record<string, unknown>;
-        if (isInternalEventType(msgData.type)) continue;
-        const parts = this.readMessageParts(db, row.id);
-        if (parts.length === 0) continue;
+  private buildHeadContexts(
+    messageRows: OpenCodeMessageRow[],
+    partRows: OpenCodePartRow[],
+  ): Map<string, OpenCodeHeadContext> {
+    const partsByMessage = this.buildPartsByMessage(partRows);
+    const contexts = new Map<string, OpenCodeHeadContext>();
 
-        const cost = Number(msgData.cost ?? 0);
-        const tokens = msgData.tokens as Record<string, unknown> | undefined;
-        const inputTokens = Number(tokens?.input ?? 0);
-        const outputTokens = Number(tokens?.output ?? 0);
-        const model = (msgData.modelID as string | null) ?? null;
-        const estimatedCost =
-          cost > 0 ? null : estimateTokenCost(model, { input: inputTokens, output: outputTokens });
+    for (const row of messageRows) {
+      const sessionId = String(row.session_id ?? "");
+      if (!sessionId) continue;
+      const msgData = JSON.parse(String(row.data ?? "{}")) as Record<string, unknown>;
+      if (isInternalEventType(msgData.type)) continue;
+      const parts = partsByMessage.get(String(row.id ?? "")) ?? [];
+      if (parts.length === 0) continue;
 
-        if (estimatedCost !== null) hasEstimatedCost = true;
-        totalCost += cost || estimatedCost || 0;
-        totalInputTokens += inputTokens;
-        totalOutputTokens += outputTokens;
-        messageCount++;
+      let context = contexts.get(sessionId);
+      if (!context) {
+        context = {
+          stats: {
+            message_count: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cost: 0,
+          },
+          messageTitle: null,
+        };
+        contexts.set(sessionId, context);
       }
 
-      return {
-        message_count: messageCount,
-        total_input_tokens: totalInputTokens,
-        total_output_tokens: totalOutputTokens,
-        total_cost: totalCost,
-        cost_source: totalCost > 0 ? (hasEstimatedCost ? "estimated" : "recorded") : undefined,
-      };
-    } catch {
-      return null;
+      const cost = Number(msgData.cost ?? 0);
+      const tokens = msgData.tokens as Record<string, unknown> | undefined;
+      const inputTokens = Number(tokens?.input ?? 0);
+      const outputTokens = Number(tokens?.output ?? 0);
+      const model = (msgData.modelID as string | null) ?? null;
+      const estimatedCost =
+        cost > 0 ? null : estimateTokenCost(model, { input: inputTokens, output: outputTokens });
+
+      if (estimatedCost !== null) context.stats.cost_source = "estimated";
+      context.stats.total_cost += cost || estimatedCost || 0;
+      context.stats.total_input_tokens += inputTokens;
+      context.stats.total_output_tokens += outputTokens;
+      context.stats.message_count += 1;
+
+      if (!context.messageTitle && String(msgData.role ?? "") === "user") {
+        context.messageTitle = firstUserMessageTitle([
+          {
+            id: String(row.id ?? ""),
+            role: "user",
+            agent: null,
+            time_created: Number(row.time_created ?? 0),
+            parts,
+          },
+        ]);
+      }
     }
+
+    for (const context of contexts.values()) {
+      if (context.stats.total_cost > 0 && context.stats.cost_source !== "estimated") {
+        context.stats.cost_source = "recorded";
+      }
+    }
+
+    return contexts;
   }
 
   getSessionData(sessionId: string): SessionData {

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -188,7 +188,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(10);
+    expect(getUserVersion(getCachePath())).toBe(11);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -345,7 +345,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(10);
+    expect(getUserVersion(getCachePath())).toBe(11);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -1056,6 +1056,73 @@ describe("searchSessions", () => {
     expect(searchSessions("updated")).toHaveLength(1);
   });
 
+  it("uses the structured tool index for tool filters", () => {
+    const target = {
+      ...makeSession("tool-target"),
+      stats: { ...makeSession("tool-target").stats, message_count: 1 },
+    };
+    const other = {
+      ...makeSession("tool-other"),
+      stats: { ...makeSession("tool-other").stats, message_count: 1 },
+    };
+
+    saveCachedSessions("claudecode", [target, other]);
+    syncSessionSearchIndex("claudecode", [target, other], (sessionId) => ({
+      ...(sessionId === target.id ? target : other),
+      messages: [
+        {
+          id: `${sessionId}-tool`,
+          role: "assistant",
+          time_created: now,
+          parts: [
+            {
+              type: "tool",
+              tool: sessionId === target.id ? "apply_patch" : "grep",
+              state: { status: "completed" },
+            },
+          ],
+        },
+      ],
+    }));
+
+    expect(searchSessions("tool:apply_patch").map((result) => result.session.id)).toEqual([
+      "tool-target",
+    ]);
+
+    const db = new Database(getCachePath(), { readonly: true });
+    try {
+      const rows = db
+        .prepare("SELECT session_id, tool_name FROM message_tools ORDER BY session_id, tool_name")
+        .all();
+      expect(rows).toEqual([
+        { session_id: "tool-other", tool_name: "grep" },
+        { session_id: "tool-target", tool_name: "apply_patch" },
+      ]);
+
+      const plan = db
+        .prepare(
+          `
+            EXPLAIN QUERY PLAN
+            SELECT s.session_id
+            FROM sessions s
+            WHERE EXISTS (
+              SELECT 1
+              FROM message_tools mt
+              WHERE mt.tool_name = ?
+                AND mt.agent_name = s.agent_name
+                AND mt.session_id = s.session_id
+            )
+          `,
+        )
+        .all("apply_patch")
+        .map((row) => String((row as { detail?: unknown }).detail ?? ""))
+        .join("\n");
+      expect(plan).toContain("idx_message_tools_filter");
+    } finally {
+      db.close();
+    }
+  });
+
   it("indexes file activity from tool calls", () => {
     const session = {
       ...makeSession("files"),
@@ -1230,7 +1297,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(10);
+    expect(getUserVersion(getCachePath())).toBe(11);
   });
 
   it("combines full text with structured filters", () => {

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -278,7 +278,7 @@ describe("sqlite migration smoke", () => {
         bookmarked_at: now - 500,
       },
     ]);
-    expect(getUserVersion(getCachePath())).toBe(10);
+    expect(getUserVersion(getCachePath())).toBe(11);
     expect(getUserVersion(getStatePath())).toBe(1);
   }, 15_000);
 });

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -136,6 +136,7 @@ describe("filterSessions", () => {
 
 vi.mock("../cache.js", () => ({
   loadCachedSessions: vi.fn(() => null),
+  saveCachedSessionChanges: vi.fn(),
   saveCachedSessions: vi.fn(),
 }));
 
@@ -156,10 +157,11 @@ vi.mock("../../agents/index.js", () => ({
 
 import { scanSessions, scanSessionsAsync } from "../scanner.js";
 import { createRegisteredAgents } from "../../agents/index.js";
-import { loadCachedSessions, saveCachedSessions } from "../cache.js";
+import { loadCachedSessions, saveCachedSessionChanges, saveCachedSessions } from "../cache.js";
 
 const mockedCreateRegisteredAgents = vi.mocked(createRegisteredAgents);
 const mockedLoadCachedSessions = vi.mocked(loadCachedSessions);
+const mockedSaveCachedSessionChanges = vi.mocked(saveCachedSessionChanges);
 const mockedSaveCachedSessions = vi.mocked(saveCachedSessions);
 
 beforeEach(() => {
@@ -348,16 +350,79 @@ describe("scanSessions", () => {
 
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0]!.id).toBe("fresh");
-    expect(mockedSaveCachedSessions).toHaveBeenCalledWith(
+    expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
+    expect(mockedSaveCachedSessionChanges).toHaveBeenCalledWith(
       "test",
       [
-        expect.objectContaining({
-          ...refreshedSessions[0]!,
-          project_identity: expect.objectContaining({ kind: "path", key: "/home/user/project" }),
-          smart_tags: [],
-          smart_tags_source_updated_at: 1000,
-        }),
+        {
+          session: expect.objectContaining({
+            ...refreshedSessions[0]!,
+            project_identity: expect.objectContaining({ kind: "path", key: "/home/user/project" }),
+            smart_tags: [],
+            smart_tags_source_updated_at: 1000,
+          }),
+          sortIndex: 0,
+        },
       ],
+      ["cached"],
+      {},
+    );
+  });
+
+  it("writes only changed sessions after smart refresh", async () => {
+    const projectIdentity = {
+      kind: "path" as const,
+      key: "/home/user/project",
+      displayName: "project",
+    };
+    const keep = makeSession("keep", { project_identity: projectIdentity });
+    const changed = makeSession("changed");
+    const removed = makeSession("removed");
+    const updatedChanged = makeSession("changed", { title: "Updated changed" });
+    const added = makeSession("added");
+
+    mockedLoadCachedSessions.mockReturnValue({
+      sessions: [keep, changed, removed],
+      meta: {},
+      timestamp: Date.now(),
+    });
+    mockedCreateRegisteredAgents.mockReturnValue([
+      createTestAgent({
+        name: "test",
+        available: true,
+        sessions: [keep, updatedChanged, added],
+        checkForChangesResult: {
+          hasChanges: true,
+          changedIds: ["changed"],
+          timestamp: Date.now(),
+        },
+        incrementalScanResult: [keep, updatedChanged, added],
+      }),
+    ]);
+
+    await scanSessions({ useCache: true, includeSmartTags: false });
+
+    expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
+    expect(mockedSaveCachedSessionChanges).toHaveBeenCalledWith(
+      "test",
+      [
+        {
+          session: expect.objectContaining({
+            id: "changed",
+            title: "Updated changed",
+            project_identity: expect.objectContaining({ kind: "path", key: "/home/user/project" }),
+          }),
+          sortIndex: 1,
+        },
+        {
+          session: expect.objectContaining({
+            id: "added",
+            project_identity: expect.objectContaining({ kind: "path", key: "/home/user/project" }),
+          }),
+          sortIndex: 2,
+        },
+      ],
+      ["removed"],
       {},
     );
   });

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -30,7 +30,7 @@ import {
   type SQLiteDatabase,
 } from "../utils/sqlite.js";
 
-const CACHE_SCHEMA_VERSION = 10;
+const CACHE_SCHEMA_VERSION = 11;
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
@@ -147,6 +147,13 @@ interface MessageBackfillRow extends DatabaseRow {
   nickname?: string | null;
 }
 
+interface MessageToolBackfillRow extends DatabaseRow {
+  agent_name?: string;
+  session_id?: string;
+  message_index?: number;
+  tool_metadata_json?: string | null;
+}
+
 interface SearchResultRow extends DatabaseRow {
   agent_name?: string;
   session_id?: string;
@@ -230,6 +237,7 @@ interface StructuredMessageRecord {
   nickname?: string | null;
   contentText: string;
   toolMetadataJson?: string | null;
+  toolNames: string[];
 }
 
 interface LoadedSearchIndexEntry {
@@ -431,6 +439,26 @@ function createSessionTables(db: SQLiteDatabase): void {
 
     CREATE INDEX IF NOT EXISTS idx_messages_session
       ON messages(agent_name, session_id, message_index);
+  `);
+
+  createMessageToolTables(db);
+}
+
+function createMessageToolTables(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS message_tools (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      message_index INTEGER NOT NULL,
+      tool_name TEXT NOT NULL,
+      PRIMARY KEY (agent_name, session_id, message_index, tool_name),
+      FOREIGN KEY (agent_name, session_id, message_index)
+        REFERENCES messages(agent_name, session_id, message_index)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_message_tools_filter
+      ON message_tools(tool_name, agent_name, session_id);
   `);
 }
 
@@ -918,6 +946,17 @@ function prepareInsertFileActivity(db: SQLiteDatabase): SQLiteStatement {
   `);
 }
 
+function prepareInsertMessageTool(db: SQLiteDatabase): SQLiteStatement {
+  return db.prepare(`
+    INSERT OR IGNORE INTO message_tools(
+      agent_name,
+      session_id,
+      message_index,
+      tool_name
+    ) VALUES (?, ?, ?, ?)
+  `);
+}
+
 function writeFileActivityRows(
   statement: SQLiteStatement,
   activities: SessionFileActivity[],
@@ -1033,6 +1072,9 @@ function readLegacyCacheVersion(db: SQLiteDatabase): number {
 }
 
 function inferCacheSchemaVersion(db: SQLiteDatabase): number {
+  if (tableExists(db, "message_tools")) {
+    return 11;
+  }
   if (tableExists(db, "session_file_activity_path_fts")) {
     return 10;
   }
@@ -1077,6 +1119,7 @@ function hasAnyCacheSchema(db: SQLiteDatabase): boolean {
     "cached_sessions",
     "sessions",
     "messages",
+    "message_tools",
     "session_file_activity",
     "session_file_activity_path_fts",
     "session_documents",
@@ -1280,6 +1323,35 @@ function messageFromBackfillRow(row: MessageBackfillRow): Message {
   };
 }
 
+function backfillMessageTools(db: SQLiteDatabase): void {
+  createMessageToolTables(db);
+  if (!tableExists(db, "messages")) {
+    return;
+  }
+
+  db.exec("DELETE FROM message_tools");
+  const rows = db
+    .prepare(
+      `
+        SELECT agent_name, session_id, message_index, tool_metadata_json
+        FROM messages
+        WHERE tool_metadata_json IS NOT NULL
+      `,
+    )
+    .all() as MessageToolBackfillRow[];
+  const insertTool = prepareInsertMessageTool(db);
+
+  for (const row of rows) {
+    if (!row.agent_name || !row.session_id || row.message_index == null) {
+      continue;
+    }
+
+    for (const toolName of toolNamesFromMetadataJson(row.tool_metadata_json)) {
+      insertTool.run(row.agent_name, row.session_id, row.message_index, toolName);
+    }
+  }
+}
+
 function backfillFileActivity(db: SQLiteDatabase): void {
   createFileActivityTables(db);
   if (!tableExists(db, "sessions") || !tableExists(db, "messages")) {
@@ -1434,6 +1506,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       "cached_sessions",
       "sessions",
       "messages",
+      "message_tools",
       "session_file_activity",
       "session_documents",
       "project_sessions",
@@ -1465,6 +1538,12 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
         migrate(db) {
           createFileActivityPathSearchTables(db);
           rebuildFileActivityPathIndex(db);
+        },
+      },
+      {
+        version: 11,
+        migrate(db) {
+          backfillMessageTools(db);
         },
       },
     ],
@@ -1697,6 +1776,40 @@ function compactRecord(record: Record<string, unknown>): Record<string, unknown>
   return Object.fromEntries(Object.entries(record).filter(([, value]) => value != null));
 }
 
+function normalizeToolName(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const name = value.trim().toLowerCase();
+  return name || null;
+}
+
+function toolNamesFromMetadataJson(value: unknown): string[] {
+  if (!value) return [];
+
+  try {
+    const metadata = JSON.parse(String(value));
+    if (!Array.isArray(metadata)) return [];
+    const tools = new Set<string>();
+    for (const item of metadata) {
+      if (item == null || typeof item !== "object") continue;
+      const toolName = normalizeToolName((item as Record<string, unknown>).tool);
+      if (toolName) tools.add(toolName);
+    }
+    return [...tools];
+  } catch {
+    return [];
+  }
+}
+
+function toolNamesFromMessage(message: Message): string[] {
+  const tools = new Set<string>();
+  for (const part of message.parts) {
+    if (part.type !== "tool") continue;
+    const toolName = normalizeToolName(part.tool);
+    if (toolName) tools.add(toolName);
+  }
+  return [...tools];
+}
+
 function summarizeToolPart(part: MessagePart): Record<string, unknown> {
   const state =
     part.state == null
@@ -1763,6 +1876,7 @@ function normalizeMessages(session: SessionData): StructuredMessageRecord[] {
       nickname: message.nickname ?? null,
       contentText: buildMessageText(message),
       toolMetadataJson: toolMetadata.length > 0 ? JSON.stringify(toolMetadata) : null,
+      toolNames: toolNamesFromMessage(message),
     };
   });
 }
@@ -1874,6 +1988,9 @@ export function saveCachedSessions(
     const deleteMessages = db.prepare(
       "DELETE FROM messages WHERE agent_name = ? AND session_id = ?",
     );
+    const deleteMessageTools = db.prepare(
+      "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ?",
+    );
     const deleteFileActivity = db.prepare(
       "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
     );
@@ -1905,6 +2022,7 @@ export function saveCachedSessions(
         const sessionId = String(row.session_id);
         if (!sessionIds.has(sessionId)) {
           deleteSearchDocument.run(agentName, sessionId);
+          deleteMessageTools.run(agentName, sessionId);
           deleteMessages.run(agentName, sessionId);
           deleteFileActivity.run(agentName, sessionId);
           deleteProjectSession.run(agentName, sessionId);
@@ -1957,6 +2075,9 @@ export function saveCachedSessionChanges(
     const deleteMessages = db.prepare(
       "DELETE FROM messages WHERE agent_name = ? AND session_id = ?",
     );
+    const deleteMessageTools = db.prepare(
+      "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ?",
+    );
     const deleteFileActivity = db.prepare(
       "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
     );
@@ -1978,6 +2099,7 @@ export function saveCachedSessionChanges(
       for (const sessionId of new Set(removedSessionIds)) {
         deleteLegacySession.run(agentName, sessionId);
         deleteSearchDocument.run(agentName, sessionId);
+        deleteMessageTools.run(agentName, sessionId);
         deleteMessages.run(agentName, sessionId);
         deleteFileActivity.run(agentName, sessionId);
         deleteProjectSession.run(agentName, sessionId);
@@ -2019,6 +2141,7 @@ export function clearCache(): void {
       DELETE FROM cached_sessions;
       DELETE FROM session_documents;
       DELETE FROM session_file_activity;
+      DELETE FROM message_tools;
       DELETE FROM messages;
       DELETE FROM sessions;
       DELETE FROM project_sessions;
@@ -2108,11 +2231,15 @@ function writeSearchIndexRows(
   const deleteMessages = db.prepare(
     "DELETE FROM messages WHERE agent_name = ? AND session_id = ? AND message_index >= ?",
   );
+  const deleteMessageTools = db.prepare(
+    "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ? AND message_index >= ?",
+  );
   const deleteFileActivity = db.prepare(
     "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
   );
   const upsertIndexedSession = prepareUpsertIndexedSession(db);
   const insertFileActivity = prepareInsertFileActivity(db);
+  const insertMessageTool = prepareInsertMessageTool(db);
   const upsertMessage = db.prepare(`
     INSERT INTO messages(
       agent_name,
@@ -2188,6 +2315,7 @@ function writeSearchIndexRows(
   for (const sessionId of new Set(removedSessionIds)) {
     deleteRow.run(agentName, sessionId);
     deleteFileActivity.run(agentName, sessionId);
+    deleteMessageTools.run(agentName, sessionId, 0);
     deleteMessages.run(agentName, sessionId, 0);
   }
 
@@ -2195,6 +2323,7 @@ function writeSearchIndexRows(
     const activityTime = entry.session.time_updated ?? entry.session.time_created;
     upsertSessionRow(upsertIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
     deleteFileActivity.run(agentName, entry.session.id);
+    deleteMessageTools.run(agentName, entry.session.id, 0);
     writeFileActivityRows(insertFileActivity, entry.fileActivity);
     for (const message of entry.messages) {
       upsertMessage.run(
@@ -2218,6 +2347,9 @@ function writeSearchIndexRows(
         message.contentText,
         message.toolMetadataJson ?? null,
       );
+      for (const toolName of message.toolNames) {
+        insertMessageTool.run(agentName, entry.session.id, message.index, toolName);
+      }
     }
     deleteMessages.run(agentName, entry.session.id, entry.messages.length);
     upsertRow.run(
@@ -2498,10 +2630,12 @@ function buildSessionSearchFilters(options: SearchOptions): {
     params.push(`%"${tag}"%`);
   }
   for (const tool of options.tools ?? []) {
+    const toolName = normalizeToolName(tool);
+    if (!toolName) continue;
     clauses.push(
-      "EXISTS (SELECT 1 FROM messages m WHERE m.agent_name = s.agent_name AND m.session_id = s.session_id AND LOWER(m.tool_metadata_json) LIKE ? ESCAPE '\\')",
+      "EXISTS (SELECT 1 FROM message_tools mt WHERE mt.tool_name = ? AND mt.agent_name = s.agent_name AND mt.session_id = s.session_id)",
     );
-    params.push(likePattern(tool));
+    params.push(toolName);
   }
   if (options.file || options.fileKind) {
     const fileClauses = ["fa.agent_name = s.agent_name", "fa.session_id = s.session_id"];

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -5,7 +5,12 @@ import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import { createRegisteredAgents } from "../agents/index.js";
 import { computeIdentity, filterSessionsByProjectScope, realFs } from "../projects/index.js";
 import { classifySessionTags, getSmartTagSourceTimestamp, perf } from "../utils/index.js";
-import { loadCachedSessions, saveCachedSessions } from "./cache.js";
+import {
+  loadCachedSessions,
+  saveCachedSessionChanges,
+  saveCachedSessions,
+  type SessionHeadChange,
+} from "./cache.js";
 
 export interface ScanOptions {
   /** Filter to specific agent name(s) */
@@ -108,6 +113,52 @@ function buildAgentCacheMeta(agent: BaseAgent): Record<string, SessionCacheMeta>
   }
 
   return meta;
+}
+
+function sessionCacheValue(session: SessionHead): string {
+  return JSON.stringify(session);
+}
+
+function buildCacheChanges(
+  cachedSessions: SessionHead[],
+  updatedSessions: SessionHead[],
+  changedIds: string[] = [],
+): { changes: SessionHeadChange[]; removedSessionIds: string[] } {
+  const cachedMap = new Map(cachedSessions.map((session) => [session.id, session]));
+  const updatedIds = new Set(updatedSessions.map((session) => session.id));
+  const changedIdSet = new Set(changedIds);
+  const removedSessionIds = cachedSessions
+    .filter((session) => !updatedIds.has(session.id))
+    .map((session) => session.id);
+  const changes: SessionHeadChange[] = [];
+
+  updatedSessions.forEach((session, sortIndex) => {
+    const cached = cachedMap.get(session.id);
+    if (
+      !cached ||
+      changedIdSet.has(session.id) ||
+      (cached !== session && sessionCacheValue(cached) !== sessionCacheValue(session))
+    ) {
+      changes.push({ session, sortIndex });
+    }
+  });
+
+  return { changes, removedSessionIds };
+}
+
+function saveCachedSessionDiff(
+  agent: BaseAgent,
+  cachedSessions: SessionHead[],
+  updatedSessions: SessionHead[],
+  changedIds: string[] = [],
+): void {
+  const diff = buildCacheChanges(cachedSessions, updatedSessions, changedIds);
+  saveCachedSessionChanges(
+    agent.name,
+    diff.changes,
+    diff.removedSessionIds,
+    buildAgentCacheMeta(agent),
+  );
 }
 
 function getSmartTagWorkerCount(sessionCount: number): number {
@@ -328,7 +379,12 @@ async function scanAgentSmart(
               : await ensureSessionTags(agent, sessionsWithIdentity);
 
           if (options.writeCache !== false && options.from == null && options.to == null) {
-            saveCachedSessions(agent.name, tagged.sessions, buildAgentCacheMeta(agent));
+            saveCachedSessionDiff(
+              agent,
+              cached.sessions,
+              tagged.sessions,
+              checkResult.changedIds ?? [],
+            );
           }
 
           onProgress?.({
@@ -355,7 +411,7 @@ async function scanAgentSmart(
         options.from == null &&
         options.to == null
       ) {
-        saveCachedSessions(agent.name, tagged.sessions, buildAgentCacheMeta(agent));
+        saveCachedSessionDiff(agent, cached.sessions, tagged.sessions);
       }
 
       const filtered = filterSessions(tagged.sessions, options);


### PR DESCRIPTION
## Summary
- stream live scan session diffs to avoid full session reloads after SSE refreshes
- pause the receipt canvas when idle, hidden, offscreen, or below the desktop breakpoint
- batch OpenCode scan metadata reads instead of per-session subqueries
- add a structured message_tools index for tool filters
- persist smart refresh cache diffs instead of rewriting the full agent cache

## Verification
- rtk pnpm test
- rtk pnpm lint
- rtk pnpm format:check
- rtk pnpm build
- rtk git diff --check