### PR TITLE
perf: improve startup scan performance

### DIFF
--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -357,6 +357,7 @@ export class LiveScanStore {
       ...this.startupScanOptions,
       useCache: this.scanOptions.useCache ?? true,
       smartRefresh: false,
+      smartTagWorkerUrl: this.getSmartTagWorkerUrl() ?? undefined,
       writeCache:
         this.startupScanOptions.from != null || this.startupScanOptions.to != null
           ? false
@@ -373,6 +374,21 @@ export class LiveScanStore {
       agents: Object.fromEntries(
         Object.entries(this.byAgent).map(([key, value]) => [key, value.length]),
       ),
+      agent_timings: initialResult.timings
+        ? Object.fromEntries(
+            Object.entries(initialResult.timings).map(([name, t]) => [
+              name,
+              {
+                total_ms: Math.round(t.total),
+                cache_load_ms: t.cacheLoad != null ? Math.round(t.cacheLoad) : undefined,
+                check_changes_ms: t.checkChanges != null ? Math.round(t.checkChanges) : undefined,
+                scan_ms: t.scan != null ? Math.round(t.scan) : undefined,
+                identity_ms: t.identity != null ? Math.round(t.identity) : undefined,
+                tags_ms: t.tags != null ? Math.round(t.tags) : undefined,
+              },
+            ]),
+          )
+        : undefined,
     });
     if (this.watchEnabled) {
       this.startWatching();
@@ -472,6 +488,14 @@ export class LiveScanStore {
 
   private getSearchIndexWorkerUrl(): URL | null {
     const workerUrl = new URL("./search-index-worker.js", import.meta.url);
+    if (workerUrl.protocol === "file:" && !existsSync(fileURLToPath(workerUrl))) {
+      return null;
+    }
+    return workerUrl;
+  }
+
+  private getSmartTagWorkerUrl(): URL | null {
+    const workerUrl = new URL("./smart-tag-worker.js", import.meta.url);
     if (workerUrl.protocol === "file:" && !existsSync(fileURLToPath(workerUrl))) {
       return null;
     }

--- a/packages/cli/src/smart-tag-worker.ts
+++ b/packages/cli/src/smart-tag-worker.ts
@@ -1,0 +1,47 @@
+import { parentPort, workerData } from "node:worker_threads";
+import {
+  createRegisteredAgents,
+  classifySessionTags,
+  getSmartTagSourceTimestamp,
+  type SessionCacheMeta,
+} from "@codesesh/core";
+
+interface SmartTagWorkerData {
+  agentName: string;
+  sessionIds: string[];
+  meta: Record<string, Record<string, unknown>>;
+}
+
+interface SmartTagWorkerResult {
+  id: string;
+  tags?: ReturnType<typeof classifySessionTags>;
+  sourceUpdatedAt?: number;
+  error?: string;
+}
+
+const data = workerData as SmartTagWorkerData;
+const agents = createRegisteredAgents();
+const agent = agents.find((a) => a.name === data.agentName);
+const results: SmartTagWorkerResult[] = [];
+
+if (agent && agent.setSessionMetaMap) {
+  agent.setSessionMetaMap(new Map(Object.entries(data.meta)) as Map<string, SessionCacheMeta>);
+
+  for (const sessionId of data.sessionIds) {
+    try {
+      const sessionData = agent.getSessionData(sessionId);
+      results.push({
+        id: sessionId,
+        tags: classifySessionTags(sessionData),
+        sourceUpdatedAt: getSmartTagSourceTimestamp(sessionData),
+      });
+    } catch (error) {
+      results.push({
+        id: sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+parentPort?.postMessage(results);

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -4,7 +4,7 @@ const isWatch = process.argv.includes("--watch");
 const bundleCore = process.env.BUNDLE_CORE === "true";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/search-index-worker.ts"],
+  entry: ["src/index.ts", "src/search-index-worker.ts", "src/smart-tag-worker.ts"],
   format: ["esm"],
   dts: false,
   clean: !isWatch,

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -199,65 +199,65 @@ export class ClaudeCodeAgent extends BaseAgent {
 
   /**
    * 检测文件系统变更
-   * 通过比较文件修改时间判断是否有新内容
+   * - 已有 session：statSync 检测文件修改（APFS 写文件不更新 dir mtime，必须 file-level）
+   * - 新 session 检测：readdirSync 文件列表比对，比 dir statSync 快 ~10x
    */
   checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
     if (!this.basePath) {
       return { hasChanges: false, timestamp: Date.now() };
     }
 
-    const now = Date.now();
     const changedIds = new Set<string>();
-    const recentSessions = cachedSessions.filter(
-      (session) => now - session.time_created <= RECENT_SESSION_REVALIDATION_WINDOW_MS,
-    );
+    const now = Date.now();
 
-    for (const session of recentSessions) {
-      changedIds.add(session.id);
-      const meta = this.sessionMetaMap.get(session.id);
-      if (!meta) continue;
-      delete this.sessionsIndexCache[basename(dirname(meta.sourcePath))];
-    }
-
+    // 检查已有 session 文件的 mtime（唯一能检测到文件内容修改的方式）
     for (const session of cachedSessions) {
       const meta = this.sessionMetaMap.get(session.id);
       if (!meta) {
         changedIds.add(session.id);
         continue;
       }
-
       try {
-        const stat = statSync(meta.sourcePath);
-        // 如果文件修改时间晚于缓存时间，说明有变更
-        if (stat.mtimeMs > sinceTimestamp) {
+        if (statSync(meta.sourcePath).mtimeMs > sinceTimestamp) {
           changedIds.add(session.id);
+          delete this.sessionsIndexCache[basename(dirname(meta.sourcePath))];
         }
       } catch {
-        // 文件可能被删除，也视为变更
         changedIds.add(session.id);
       }
     }
 
-    // 检查是否有新文件（简单实现：比较缓存数量和实际文件数量）
-    try {
-      let totalFiles = 0;
-      for (const dir of this.listProjectDirs()) {
-        totalFiles += this.listJsonlFiles(dir).length;
+    for (const session of cachedSessions) {
+      if (now - session.time_created > RECENT_SESSION_REVALIDATION_WINDOW_MS) continue;
+      changedIds.add(session.id);
+      const meta = this.sessionMetaMap.get(session.id);
+      if (meta) {
+        delete this.sessionsIndexCache[basename(dirname(meta.sourcePath))];
       }
-      const hasNewFiles = totalFiles > cachedSessions.length;
-
-      return {
-        hasChanges: changedIds.size > 0 || hasNewFiles,
-        changedIds: Array.from(changedIds),
-        timestamp: Date.now(),
-      };
-    } catch {
-      return {
-        hasChanges: changedIds.size > 0,
-        changedIds: Array.from(changedIds),
-        timestamp: Date.now(),
-      };
     }
+
+    // 用 readdirSync 比对文件列表检测新 session（比 dir statSync 快 ~10x）
+    const cachedIdSet = new Set(cachedSessions.map((s) => s.id));
+    let hasNewFiles = false;
+    try {
+      outer: for (const dir of this.listProjectDirs()) {
+        try {
+          for (const file of this.listJsonlFiles(dir)) {
+            if (!cachedIdSet.has(basename(file, ".jsonl"))) {
+              hasNewFiles = true;
+              delete this.sessionsIndexCache[basename(dir)];
+              break outer;
+            }
+          }
+        } catch {}
+      }
+    } catch {}
+
+    return {
+      hasChanges: changedIds.size > 0 || hasNewFiles,
+      changedIds: Array.from(changedIds),
+      timestamp: Date.now(),
+    };
   }
 
   /**
@@ -266,44 +266,15 @@ export class ClaudeCodeAgent extends BaseAgent {
   incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
     if (!this.basePath) return cachedSessions;
 
-    // 创建缓存会话的 Map 便于更新
     const sessionMap = new Map(cachedSessions.map((s) => [s.id, s]));
+    const changedSet = new Set(changedIds);
 
-    // 重新扫描变更的会话
+    // 单次遍历：变更的 session 重新解析，新出现的 session 直接添加
     for (const projectDir of this.listProjectDirs()) {
       for (const file of this.listJsonlFiles(projectDir)) {
         try {
           const sessionId = basename(file, ".jsonl");
-
-          // 只处理变更的会话
-          if (changedIds.includes(sessionId)) {
-            const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
-            if (head) {
-              sessionMap.set(head.id, head);
-              this.sessionMetaMap.set(head.id, {
-                id: head.id,
-                title: head.title,
-                sourcePath: file,
-                directory: head.directory,
-                model: head.stats.total_tokens ? "unknown" : undefined,
-                messageCount: head.stats.message_count,
-                createdAt: head.time_created,
-                updatedAt: head.time_updated ?? head.time_created,
-              });
-            }
-          }
-        } catch {
-          // skip malformed files
-        }
-      }
-    }
-
-    // 检查是否有新文件需要添加
-    for (const projectDir of this.listProjectDirs()) {
-      for (const file of this.listJsonlFiles(projectDir)) {
-        try {
-          const sessionId = basename(file, ".jsonl");
-          if (!sessionMap.has(sessionId)) {
+          if (changedSet.has(sessionId) || !sessionMap.has(sessionId)) {
             const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
             if (head) {
               sessionMap.set(head.id, head);

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -37,6 +37,7 @@ const PROPOSED_PLAN_PATTERN = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/
 const PLAN_APPROVAL_PREFIX = "PLEASE IMPLEMENT THIS PLAN";
 const SUBAGENT_NOTIFICATION_PATTERN =
   /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
+const RECENT_SESSION_REVALIDATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 const DEVELOPER_LIKE_USER_MARKERS = [
   "agents.md instructions for",
@@ -58,8 +59,6 @@ const CODEX_TOOL_TITLE_MAP: Record<string, string> = {
   spawn_agent: "subagent",
   subagent: "subagent",
 };
-
-const RECENT_SESSION_REVALIDATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Session ID extraction
@@ -346,33 +345,25 @@ export class CodexAgent extends BaseAgent {
       return { hasChanges: false, timestamp: Date.now() };
     }
 
-    const now = Date.now();
-    const changedIds = new Set<string>();
     const currentFiles = this.listRolloutFiles();
     const currentIds = new Set(currentFiles.map((file) => extractSessionId(file)));
     const cachedIds = new Set(cachedSessions.map((session) => session.id));
-    const recentIds = cachedSessions
-      .filter((session) => now - session.time_created <= RECENT_SESSION_REVALIDATION_WINDOW_MS)
-      .map((session) => session.id);
-
-    for (const sessionId of recentIds) {
-      changedIds.add(sessionId);
-    }
+    const changedIds = new Set<string>();
 
     for (const session of cachedSessions) {
-      const meta = this.sessionMetaMap.get(session.id);
       if (!currentIds.has(session.id)) {
         changedIds.add(session.id);
         continue;
       }
+
+      const meta = this.sessionMetaMap.get(session.id);
       if (!meta) {
         changedIds.add(session.id);
         continue;
       }
 
       try {
-        const stat = statSync(meta.sourcePath);
-        if (stat.mtimeMs > sinceTimestamp) {
+        if (statSync(meta.sourcePath).mtimeMs > sinceTimestamp) {
           changedIds.add(session.id);
         }
       } catch {
@@ -380,8 +371,14 @@ export class CodexAgent extends BaseAgent {
       }
     }
 
+    const now = Date.now();
+    for (const session of cachedSessions) {
+      if (now - session.time_created > RECENT_SESSION_REVALIDATION_WINDOW_MS) continue;
+      changedIds.add(session.id);
+    }
+
     const hasAddedSessions = currentFiles.some((file) => !cachedIds.has(extractSessionId(file)));
-    if (recentIds.length > 0) {
+    if (hasAddedSessions || changedIds.size > 0) {
       this.sessionIndexCache.clear();
     }
 
@@ -630,13 +627,18 @@ export class CodexAgent extends BaseAgent {
   private walkDirForRolloutFiles(dir: string, options?: AgentScanOptions): string[] {
     const files: string[] = [];
     try {
-      for (const entry of readdirSync(dir)) {
-        const fullPath = join(dir, entry);
-        const stat = statSync(fullPath);
-        if (stat.isDirectory()) {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
           files.push(...this.walkDirForRolloutFiles(fullPath, options));
-        } else if (entry.endsWith(".jsonl") && entry.startsWith("rollout-")) {
-          if (!matchesScanWindow(stat.mtimeMs, options)) continue;
+        } else if (entry.name.endsWith(".jsonl") && entry.name.startsWith("rollout-")) {
+          if (options?.from != null || options?.to != null) {
+            try {
+              if (!matchesScanWindow(statSync(fullPath).mtimeMs, options)) continue;
+            } catch {
+              continue;
+            }
+          }
           files.push(fullPath);
         }
       }

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -31,12 +31,15 @@ export interface ScanOptions {
   includeSmartTags?: boolean;
   /** Prefer lightweight metadata over complete statistics when the UI needs a fast first paint */
   fast?: boolean;
+  /** URL to the compiled smart-tag worker file; omit to use synchronous fallback */
+  smartTagWorkerUrl?: URL | string;
 }
 
 export interface ScanResult {
   sessions: SessionHead[];
   byAgent: Record<string, SessionHead[]>;
   agents: BaseAgent[];
+  timings?: Record<string, AgentScanTiming>;
 }
 
 /** 扫描状态更新回调 */
@@ -89,11 +92,21 @@ export function filterSessions(sessions: SessionHead[], options: ScanOptions): S
   return result;
 }
 
+export interface AgentScanTiming {
+  cacheLoad?: number;
+  checkChanges?: number;
+  scan?: number;
+  identity?: number;
+  tags?: number;
+  total: number;
+}
+
 interface AgentScanResult {
   agent: BaseAgent;
   heads: SessionHead[];
   fromCache?: boolean;
   refreshed?: boolean;
+  timing?: AgentScanTiming;
 }
 
 interface SmartTagWorkerResult {
@@ -162,7 +175,7 @@ function saveCachedSessionDiff(
 }
 
 function getSmartTagWorkerCount(sessionCount: number): number {
-  if (sessionCount < 8) return 1;
+  if (sessionCount < 50) return 1;
   return Math.min(sessionCount, Math.max(1, Math.min(4, availableParallelism() - 1)));
 }
 
@@ -205,61 +218,16 @@ function ensureSessionTagsSync(
 }
 
 async function classifySessionTagsInWorker(
+  workerUrl: URL | string,
   agentName: string,
   sessionIds: string[],
+  meta: Record<string, SessionCacheMeta>,
 ): Promise<SmartTagWorkerResult[]> {
   return new Promise((resolveWorker, rejectWorker) => {
-    const worker = new Worker(
-      `
-        const { parentPort, workerData } = require("node:worker_threads");
-
-        (async () => {
-          const {
-            createRegisteredAgents,
-            classifySessionTags,
-            getSmartTagSourceTimestamp,
-          } = await import("@codesesh/core");
-
-          const agent = createRegisteredAgents().find((item) => item.name === workerData.agentName);
-          const results = [];
-
-          if (agent) {
-            for (const sessionId of workerData.sessionIds) {
-              try {
-                const data = agent.getSessionData(sessionId);
-                results.push({
-                  id: sessionId,
-                  tags: classifySessionTags(data),
-                  sourceUpdatedAt: getSmartTagSourceTimestamp(data),
-                });
-              } catch (error) {
-                results.push({
-                  id: sessionId,
-                  error: error instanceof Error ? error.message : String(error),
-                });
-              }
-            }
-          }
-
-          parentPort?.postMessage(results);
-        })().catch((error) => {
-          parentPort?.postMessage([
-            {
-              id: "",
-              error: error instanceof Error ? error.message : String(error),
-            },
-          ]);
-        });
-      `,
-      {
-        eval: true,
-        workerData: { agentName, sessionIds },
-      },
-    );
-
-    worker.once("message", (results: SmartTagWorkerResult[]) => {
-      resolveWorker(results);
+    const worker = new Worker(workerUrl, {
+      workerData: { agentName, sessionIds, meta },
     });
+    worker.once("message", (results: SmartTagWorkerResult[]) => resolveWorker(results));
     worker.once("error", rejectWorker);
     worker.once("exit", (code) => {
       if (code !== 0) {
@@ -272,6 +240,7 @@ async function classifySessionTagsInWorker(
 async function ensureSessionTags(
   agent: BaseAgent,
   sessions: SessionHead[],
+  workerUrl?: URL | string,
 ): Promise<{ sessions: SessionHead[]; changed: boolean }> {
   const staleSessions = sessions.filter((session) => {
     const sourceUpdatedAt = session.time_updated ?? session.time_created;
@@ -283,18 +252,21 @@ async function ensureSessionTags(
     return { sessions, changed: false };
   }
 
-  const workerCount = getSmartTagWorkerCount(staleSessions.length);
+  const workerCount = workerUrl ? getSmartTagWorkerCount(staleSessions.length) : 1;
   if (workerCount <= 1) {
     return ensureSessionTagsSync(agent, sessions);
   }
 
+  const meta = buildAgentCacheMeta(agent);
   try {
     const results = (
       await Promise.all(
         chunkSessions(
           staleSessions.map((session) => session.id),
           workerCount,
-        ).map((sessionIds) => classifySessionTagsInWorker(agent.name, sessionIds)),
+        ).map((sessionIds) =>
+          classifySessionTagsInWorker(workerUrl!, agent.name, sessionIds, meta),
+        ),
       )
     ).flat();
     const resultMap = new Map(results.filter((item) => item.tags).map((item) => [item.id, item]));
@@ -327,12 +299,17 @@ async function scanAgentSmart(
   options: ScanOptions,
   onProgress?: (progress: ScanProgress) => void,
 ): Promise<AgentScanResult | null> {
+  const agentStart = performance.now();
+  const timing: AgentScanTiming = { total: 0 };
   const useCache = options.useCache ?? true;
   const canValidateCache = Boolean(agent.checkForChanges && agent.incrementalScan);
 
   // 1. 尝试加载缓存
   if (useCache) {
+    const t0 = performance.now();
     const cached = loadCachedSessions(agent.name);
+    timing.cacheLoad = performance.now() - t0;
+
     if (cached !== null) {
       // 恢复元数据
       if (agent.setSessionMetaMap) {
@@ -358,9 +335,11 @@ async function scanAgentSmart(
       if (canValidateCache) {
         onProgress?.({ agent: agent.name, phase: "checking" });
 
+        const t1 = performance.now();
         const checkResult = await Promise.resolve(
           agent.checkForChanges!(cached.timestamp, cached.sessions),
         );
+        timing.checkChanges = performance.now() - t1;
 
         if (checkResult.hasChanges) {
           onProgress?.({
@@ -369,14 +348,22 @@ async function scanAgentSmart(
             changedCount: checkResult.changedIds?.length,
           });
 
+          const t2 = performance.now();
           const updatedSessions = await Promise.resolve(
             agent.incrementalScan!(cached.sessions, checkResult.changedIds || []),
           );
+          timing.scan = performance.now() - t2;
+
+          const t3 = performance.now();
           const sessionsWithIdentity = attachProjectIdentities(updatedSessions);
+          timing.identity = performance.now() - t3;
+
+          const t4 = performance.now();
           const tagged =
             options.includeSmartTags === false
               ? { sessions: sessionsWithIdentity, changed: false }
-              : await ensureSessionTags(agent, sessionsWithIdentity);
+              : await ensureSessionTags(agent, sessionsWithIdentity, options.smartTagWorkerUrl);
+          timing.tags = performance.now() - t4;
 
           if (options.writeCache !== false && options.from == null && options.to == null) {
             saveCachedSessionDiff(
@@ -394,17 +381,24 @@ async function scanAgentSmart(
           });
 
           const filtered = filterSessions(tagged.sessions, options);
-          return { agent, heads: filtered, fromCache: true, refreshed: true };
+          timing.total = performance.now() - agentStart;
+          return { agent, heads: filtered, fromCache: true, refreshed: true, timing };
         }
 
         onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
       }
 
+      const t3 = performance.now();
       const cachedWithIdentity = attachProjectIdentities(cached.sessions);
+      timing.identity = performance.now() - t3;
+
+      const t4 = performance.now();
       const tagged =
         options.includeSmartTags === false
           ? { sessions: cachedWithIdentity, changed: false }
-          : await ensureSessionTags(agent, cachedWithIdentity);
+          : await ensureSessionTags(agent, cachedWithIdentity, options.smartTagWorkerUrl);
+      timing.tags = performance.now() - t4;
+
       if (
         tagged.changed &&
         options.writeCache !== false &&
@@ -415,12 +409,13 @@ async function scanAgentSmart(
       }
 
       const filtered = filterSessions(tagged.sessions, options);
-      return { agent, heads: filtered, fromCache: true };
+      timing.total = performance.now() - agentStart;
+      return { agent, heads: filtered, fromCache: true, timing };
     }
   }
 
   // 无缓存或缓存失效，执行完整扫描
-  return scanAgentFull(agent, options, onProgress);
+  return scanAgentFull(agent, options, onProgress, timing, agentStart);
 }
 
 /**
@@ -430,6 +425,8 @@ async function scanAgentFull(
   agent: BaseAgent,
   options: ScanOptions,
   onProgress?: (progress: ScanProgress) => void,
+  timing: AgentScanTiming = { total: 0 },
+  agentStart = performance.now(),
 ): Promise<AgentScanResult | null> {
   const availMarker = perf.start(`agent:${agent.name}:isAvailable`);
   const isAvail = agent.isAvailable();
@@ -441,13 +438,21 @@ async function scanAgentFull(
 
   try {
     const scanMarker = perf.start(`agent:${agent.name}:scan`);
+    const t0 = performance.now();
     const heads = agent.scan({ from: options.from, to: options.to, fast: options.fast });
     perf.end(scanMarker);
+    timing.scan = performance.now() - t0;
+
+    const t1 = performance.now();
     const headsWithIdentity = attachProjectIdentities(heads);
+    timing.identity = performance.now() - t1;
+
+    const t2 = performance.now();
     const tagged =
       options.includeSmartTags === false
         ? { sessions: headsWithIdentity, changed: false }
-        : await ensureSessionTags(agent, headsWithIdentity);
+        : await ensureSessionTags(agent, headsWithIdentity, options.smartTagWorkerUrl);
+    timing.tags = performance.now() - t2;
 
     // 收集元数据
     const meta = buildAgentCacheMeta(agent);
@@ -460,7 +465,8 @@ async function scanAgentFull(
     onProgress?.({ agent: agent.name, phase: "complete", newCount: tagged.sessions.length });
 
     const filtered = filterSessions(tagged.sessions, options);
-    return { agent, heads: filtered, fromCache: false };
+    timing.total = performance.now() - agentStart;
+    return { agent, heads: filtered, fromCache: false, timing };
   } catch (err) {
     console.error(`Error scanning ${agent.name}:`, err);
     return { agent, heads: [], fromCache: false };
@@ -498,16 +504,20 @@ export async function scanSessions(
   const results = await Promise.all(scanPromises);
 
   // 处理结果
+  const timings: Record<string, AgentScanTiming> = {};
   for (const result of results) {
     if (result) {
       availableAgents.push(result.agent);
       byAgent[result.agent.name] = result.heads;
       allSessions.push(...result.heads);
+      if (result.timing) {
+        timings[result.agent.name] = result.timing;
+      }
     }
   }
 
   perf.end(scanMarker);
-  return { sessions: allSessions, byAgent, agents: availableAgents };
+  return { sessions: allSessions, byAgent, agents: availableAgents, timings };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Move smart tag classification workers from inline eval code to a compiled worker entry.
- Avoid unnecessary file stats during startup scans and preserve incremental cache correctness for recent sessions.
- Add per-agent startup timing data to initial scan logs.

## Review notes

During review, the first core test run failed because the optimization removed recent-session revalidation for Claude Code and Codex. I restored that correctness guard while keeping the lower-cost file listing and stat behavior.

## Validation

- `pnpm --filter @codesesh/core test`
- `pnpm --filter codesesh test`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter codesesh lint`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter codesesh format:check`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter codesesh build`