### PR TITLE
perf: track session cache fingerprints

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1,4 +1,19 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
+
+const coreMocks = vi.hoisted(() => ({
+  loadCachedSessionData: vi.fn(),
+  listSessionFileActivity: vi.fn(() => []),
+}));
+
+vi.mock("@codesesh/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codesesh/core")>();
+  return {
+    ...actual,
+    loadCachedSessionData: coreMocks.loadCachedSessionData,
+    listSessionFileActivity: coreMocks.listSessionFileActivity,
+  };
+});
+
 import {
   handleGetAgents,
   handleGetConfig,
@@ -112,6 +127,9 @@ function toLocalDateKey(ts: number): string {
 // --- Tests ---
 
 afterEach(() => {
+  coreMocks.loadCachedSessionData.mockReset();
+  coreMocks.listSessionFileActivity.mockReset();
+  coreMocks.listSessionFileActivity.mockReturnValue([]);
   vi.useRealTimers();
 });
 
@@ -749,11 +767,27 @@ describe("handleGetDashboard", () => {
 
 describe("handleGetSessionData", () => {
   it("returns session data for valid agent and id", async () => {
+    coreMocks.loadCachedSessionData.mockReturnValue({
+      id: "s1",
+      slug: "claudecode/s1",
+      title: "Test Session",
+      directory: "/home/user/project",
+      time_created: 1000,
+      time_updated: 1000,
+      messages: [],
+      stats: {
+        message_count: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 0,
+      },
+    });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
     await handleGetSessionData(c, makeScanSource());
     expect(c.json).toHaveBeenCalled();
     const response = c.json.mock.calls[0]![0];
     expect(response.title).toBe("Test Session");
+    expect(coreMocks.loadCachedSessionData).toHaveBeenCalledWith("claudecode", "s1");
   });
 
   it("returns 400 when session ID is missing", async () => {
@@ -768,13 +802,19 @@ describe("handleGetSessionData", () => {
     expect(c.json).toHaveBeenCalledWith({ error: "Unknown agent: unknown" }, 404);
   });
 
-  it("returns 500 when agent throws", async () => {
-    const agent = new MockAgent();
-    agent.getSessionData = () => {
-      throw new Error("DB not found");
-    };
+  it("returns 404 when the SQLite session cache is missing", async () => {
+    coreMocks.loadCachedSessionData.mockReturnValue(null);
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-    await handleGetSessionData(c, makeScanSource({ agents: [agent] }));
+    await handleGetSessionData(c, makeScanSource());
+    expect(c.json).toHaveBeenCalledWith({ error: "Session cache not ready" }, 404);
+  });
+
+  it("returns 500 when SQLite cache loading throws", async () => {
+    coreMocks.loadCachedSessionData.mockImplementation(() => {
+      throw new Error("DB not found");
+    });
+    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+    await handleGetSessionData(c, makeScanSource());
     expect(c.json).toHaveBeenCalledWith({ error: "DB not found" }, 500);
   });
 });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -11,13 +11,14 @@ import {
   BookmarkStorageUnavailableError,
   createProjectScopeMatcher,
   deleteBookmark,
-  extractSessionFileActivity,
   getAgentInfoMap,
   classifySessionTags,
   computeIdentity,
   getSmartTagSourceTimestamp,
   importBookmarks,
+  loadCachedSessionData,
   listFileActivity,
+  listSessionFileActivity,
   listCachedProjectGroups,
   listBookmarks,
   parseSearchQuery,
@@ -610,10 +611,18 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
 
   try {
     const loadStartedAt = performance.now();
-    const data: SessionData = agent.getSessionData(sessionId);
+    const data: SessionData | null = loadCachedSessionData(agentName, sessionId);
     const loadDuration = performance.now() - loadStartedAt;
+    if (!data) {
+      appLogger.warn("api.session_data.cache_miss", {
+        agent: agentName,
+        session_id: sessionId,
+        duration_ms: Math.round(performance.now() - startedAt),
+      });
+      return c.json({ error: "Session cache not ready" }, 404);
+    }
     const tagStartedAt = performance.now();
-    const smartTags = classifySessionTags(data);
+    const smartTags = data.smart_tags ?? classifySessionTags(data);
     const tagDuration = performance.now() - tagStartedAt;
     const head = scanResult.byAgent[agentName]?.find((item) => item.id === sessionId);
     const projectIdentity =
@@ -631,12 +640,7 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       project_identity: projectIdentity,
       smart_tags: smartTags,
       smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
-      file_activity: extractSessionFileActivity(
-        agentName,
-        sessionId,
-        projectIdentity.key,
-        data.messages,
-      ),
+      file_activity: data.file_activity ?? listSessionFileActivity(agentName, sessionId),
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to load session";

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -6,6 +6,7 @@ import type { SessionHead } from "@codesesh/core";
 
 const fsWatch = vi.hoisted(() => ({
   watch: vi.fn(),
+  existsSync: vi.fn(),
   watchers: [] as Array<{
     path: string;
     options: { recursive?: boolean };
@@ -32,10 +33,35 @@ const core = vi.hoisted(() => ({
   syncSessionSearchIndexChanges: vi.fn(),
 }));
 
+const workerThreads = vi.hoisted(() => ({
+  workers: [] as Array<{
+    url: URL;
+    workerData: any;
+    on: ReturnType<typeof vi.fn>;
+    unref: ReturnType<typeof vi.fn>;
+    terminate: ReturnType<typeof vi.fn>;
+  }>,
+  Worker: vi.fn(function (this: unknown, url: URL, options?: { workerData?: unknown }) {
+    const worker = {
+      url,
+      workerData: options?.workerData,
+      on: vi.fn(() => worker),
+      unref: vi.fn(),
+      terminate: vi.fn(async () => undefined),
+    };
+    workerThreads.workers.push(worker);
+    return worker;
+  }),
+}));
+
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
+  fsWatch.existsSync.mockImplementation((path: Parameters<typeof actual.existsSync>[0]) =>
+    String(path).endsWith("search-index-worker.js") ? true : actual.existsSync(path),
+  );
   return {
     ...actual,
+    existsSync: fsWatch.existsSync,
     watch: fsWatch.watch,
   };
 });
@@ -55,6 +81,10 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     syncSessionSearchIndexChanges: core.syncSessionSearchIndexChanges,
   };
 });
+
+vi.mock("node:worker_threads", () => ({
+  Worker: workerThreads.Worker,
+}));
 
 import { LiveScanStore, resolveAgentWatchTargets, type SessionsUpdatedEvent } from "./live-scan.js";
 import { appLogger } from "./logging.js";
@@ -146,6 +176,7 @@ describe("LiveScanStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fsWatch.watchers.length = 0;
+    workerThreads.workers.length = 0;
     fsWatch.watch.mockImplementation(
       (
         path: string,
@@ -240,25 +271,22 @@ describe("LiveScanStore", () => {
       "added",
     ]);
     expect(core.saveCachedSessions).not.toHaveBeenCalled();
-    expect(core.saveCachedSessionChanges).toHaveBeenCalledWith(
-      "codex",
-      [
-        { session: updated, sortIndex: 0 },
-        { session: added, sortIndex: 1 },
-      ],
-      [],
-      { session: { id: "session", sourcePath: "/tmp/s" } },
-    );
+    expect(core.saveCachedSessionChanges).not.toHaveBeenCalled();
     expect(core.syncSessionSearchIndex).not.toHaveBeenCalled();
-    expect(core.syncSessionSearchIndexChanges).toHaveBeenCalledWith(
-      "codex",
-      [
-        { session: updated, sortIndex: 0 },
-        { session: added, sortIndex: 1 },
-      ],
-      [],
-      expect.any(Function),
-    );
+    expect(core.syncSessionSearchIndexChanges).not.toHaveBeenCalled();
+    expect(workerThreads.workers[0]?.workerData.jobs).toEqual([
+      {
+        kind: "changes",
+        context: "scan.refresh",
+        agentName: "codex",
+        changes: [
+          { session: updated, sortIndex: 0 },
+          { session: added, sortIndex: 1 },
+        ],
+        removedSessionIds: [],
+        meta: { session: { id: "session", sourcePath: "/tmp/s" } },
+      },
+    ]);
     expect(events).toEqual([
       expect.objectContaining({
         type: "sessions-updated",
@@ -301,11 +329,11 @@ describe("LiveScanStore", () => {
     (store as any).pendingRefreshPathCounts.set("codex", 101);
     await (store as any).runRefresh("codex");
 
-    expect(core.syncSessionSearchIndex).toHaveBeenLastCalledWith(
-      "codex",
-      [updated],
-      expect.any(Function),
-      { isBulk: true },
+    expect(workerThreads.workers[0]?.workerData.jobs[0]).toEqual(
+      expect.objectContaining({
+        kind: "changes",
+        searchIndexOptions: { isBulk: true },
+      }),
     );
   });
 
@@ -328,9 +356,17 @@ describe("LiveScanStore", () => {
     await store.initialize();
     await (store as any).runRefresh("codex");
 
-    expect(core.saveCachedSessions).toHaveBeenCalledWith("codex", [], {
-      session: { id: "session", sourcePath: "/tmp/s" },
-    });
+    expect(core.saveCachedSessions).not.toHaveBeenCalled();
+    expect(workerThreads.workers[0]?.workerData.jobs).toEqual([
+      {
+        kind: "full",
+        context: "scan.refresh",
+        agentName: "codex",
+        sessions: [],
+        meta: { session: { id: "session", sourcePath: "/tmp/s" } },
+        saveCache: true,
+      },
+    ]);
     expect(events).toEqual([
       expect.objectContaining({
         newSessions: 0,
@@ -376,20 +412,28 @@ describe("LiveScanStore", () => {
     store.subscribe((event) => events.push(event));
 
     await store.initialize();
-    expect(fsWatch.watchers).toEqual([
-      expect.objectContaining({
-        path: codexRoot,
-        options: { recursive: true },
-      }),
-    ]);
+    expect(fsWatch.watchers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: sessionsDir,
+          options: { recursive: true },
+        }),
+        expect.objectContaining({
+          path: codexRoot,
+          options: { recursive: true },
+        }),
+      ]),
+    );
+    const sessionsWatcher = fsWatch.watchers.find((watcher) => watcher.path === sessionsDir);
+    expect(sessionsWatcher).toBeDefined();
 
     writeFileSync(sessionFile, "partial");
-    fsWatch.watchers[0]!.listener("change", join("sessions", "new.jsonl"));
+    sessionsWatcher!.listener("change", "new.jsonl");
     await Promise.resolve();
     await vi.advanceTimersByTimeAsync(150);
 
     appendFileSync(sessionFile, "\ncomplete");
-    fsWatch.watchers[0]!.listener("change", join("sessions", "new.jsonl"));
+    sessionsWatcher!.listener("change", "new.jsonl");
     await Promise.resolve();
     expect(codex.scan).not.toHaveBeenCalled();
 

--- a/packages/cli/src/live-scan.test.ts
+++ b/packages/cli/src/live-scan.test.ts
@@ -11,7 +11,8 @@ describe("resolveAgentWatchTargets", () => {
     vi.stubEnv("CODEX_HOME", "/tmp/codex-home");
 
     expect(resolveAgentWatchTargets("codex")).toEqual([
-      { root: "/tmp/codex-home", path: join("/tmp/codex-home", "sessions") },
+      { path: join("/tmp/codex-home", "sessions") },
+      { path: join("/tmp/codex-home", "session_index.jsonl") },
     ]);
   });
 

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -8,10 +8,6 @@ import {
   getCursorDataPath,
   resolveProviderRoots,
   scanSessions,
-  syncSessionSearchIndex,
-  syncSessionSearchIndexChanges,
-  saveCachedSessions,
-  saveCachedSessionChanges,
   type BaseAgent,
   type ScanResult,
   type ScanOptions,
@@ -19,7 +15,8 @@ import {
   type SessionHeadChange,
   type SessionHead,
 } from "@codesesh/core";
-import type { SearchIndexWorkerMessage } from "./search-index-worker.js";
+import type { SearchIndexWorkerJob, SearchIndexWorkerMessage } from "./search-index-worker.js";
+import type { ScanRefreshWorkerMessage } from "./scan-refresh-worker.js";
 import { appLogger, logSearchIndexSync } from "./logging.js";
 
 export interface SessionsUpdatedEvent {
@@ -293,7 +290,10 @@ export function resolveAgentWatchTargets(agentName: string): WatchTarget[] {
         { path: "data/claudecode" },
       ];
     case "codex":
-      return [{ root: roots.codexRoot, path: join(roots.codexRoot, "sessions") }];
+      return [
+        { path: join(roots.codexRoot, "sessions") },
+        { path: join(roots.codexRoot, "session_index.jsonl") },
+      ];
     case "cursor":
       return cursorDataPath
         ? [
@@ -336,6 +336,7 @@ export class LiveScanStore {
   private pendingEventTimer: NodeJS.Timeout | null = null;
   private initialSearchIndexTimer: NodeJS.Timeout | null = null;
   private searchIndexWorker: Worker | null = null;
+  private pendingSearchIndexJobs: SearchIndexWorkerJob[] = [];
 
   constructor(
     private readonly watchEnabled = true,
@@ -358,10 +359,6 @@ export class LiveScanStore {
       useCache: this.scanOptions.useCache ?? true,
       smartRefresh: false,
       smartTagWorkerUrl: this.getSmartTagWorkerUrl() ?? undefined,
-      writeCache:
-        this.startupScanOptions.from != null || this.startupScanOptions.to != null
-          ? false
-          : undefined,
       includeSmartTags:
         this.startupScanOptions.from != null || this.startupScanOptions.to != null
           ? false
@@ -440,6 +437,7 @@ export class LiveScanStore {
       await this.searchIndexWorker.terminate();
       this.searchIndexWorker = null;
     }
+    this.pendingSearchIndexJobs = [];
     this.pendingEvent = null;
 
     await Promise.all(this.watchers.map((watcher) => watcher.close()));
@@ -502,8 +500,85 @@ export class LiveScanStore {
     return workerUrl;
   }
 
+  private getScanRefreshWorkerUrl(): URL | null {
+    const workerUrl = new URL("./scan-refresh-worker.js", import.meta.url);
+    if (workerUrl.protocol === "file:" && !existsSync(fileURLToPath(workerUrl))) {
+      return null;
+    }
+    return workerUrl;
+  }
+
+  private scanAgentInWorker(
+    agent: BaseAgent,
+    previousSessions: SessionHead[],
+    changedIds: string[] | null,
+  ): Promise<{ sessions: SessionHead[]; meta: Record<string, SessionCacheMeta> }> | null {
+    const workerUrl = this.getScanRefreshWorkerUrl();
+    if (!workerUrl) return null;
+
+    return new Promise((resolve, reject) => {
+      const worker = new Worker(workerUrl, {
+        workerData: {
+          agentName: agent.name,
+          previousSessions,
+          changedIds,
+          startupScanOptions: this.startupScanOptions,
+          meta: buildAgentCacheMeta(agent),
+        },
+      });
+      worker.unref();
+
+      let settled = false;
+      const finish = (callback: () => void) => {
+        if (settled) return;
+        settled = true;
+        void worker.terminate();
+        callback();
+      };
+
+      worker.once("message", (message: ScanRefreshWorkerMessage) => {
+        if (message.type === "done") {
+          finish(() => resolve({ sessions: message.sessions, meta: message.meta }));
+          return;
+        }
+        finish(() => reject(new Error(message.error)));
+      });
+      worker.once("error", (error) => {
+        finish(() => reject(error));
+      });
+      worker.once("exit", (code) => {
+        if (!settled && code !== 0) {
+          finish(() => reject(new Error(`Scan refresh worker exited with code ${code}`)));
+        }
+      });
+    });
+  }
+
   private startSearchIndexWorker(context: string): void {
-    if (this.searchIndexWorker) return;
+    this.enqueueSearchIndexJobs(
+      context,
+      this.agents.map((agent) => ({
+        kind: "full",
+        context,
+        agentName: agent.name,
+        sessions: this.byAgent[agent.name] ?? [],
+        meta: buildAgentCacheMeta(agent),
+      })),
+    );
+  }
+
+  private enqueueSearchIndexJobs(context: string, jobs: SearchIndexWorkerJob[]): void {
+    if (jobs.length === 0) return;
+
+    if (this.searchIndexWorker) {
+      this.pendingSearchIndexJobs.push(...jobs);
+      appLogger.debug("search_index.worker_queued", {
+        context,
+        jobs: jobs.length,
+        pending_jobs: this.pendingSearchIndexJobs.length,
+      });
+      return;
+    }
 
     const workerUrl = this.getSearchIndexWorkerUrl();
     if (!workerUrl) {
@@ -514,11 +589,10 @@ export class LiveScanStore {
     const worker = new Worker(workerUrl, {
       workerData: {
         context,
-        agentNames: this.agents.map((agent) => agent.name),
-        sessionsByAgent: this.byAgent,
-        metaByAgent: Object.fromEntries(
-          this.agents.map((agent) => [agent.name, buildAgentCacheMeta(agent)]),
-        ),
+        jobs,
+        agentNames: [],
+        sessionsByAgent: {},
+        metaByAgent: {},
       },
     });
     worker.unref();
@@ -541,6 +615,11 @@ export class LiveScanStore {
       this.searchIndexWorker = null;
       if (code !== 0) {
         appLogger.warn("search_index.worker_exit", { context, code });
+      }
+      if (this.pendingSearchIndexJobs.length > 0) {
+        const pendingJobs = this.pendingSearchIndexJobs;
+        this.pendingSearchIndexJobs = [];
+        this.enqueueSearchIndexJobs("search_index.worker.drain", pendingJobs);
       }
     });
   }
@@ -874,14 +953,27 @@ export class LiveScanStore {
     let nextSessions = previousSessions;
     let preciseChangedIds: string[] | null = null;
     let usedIncrementalScan = false;
+    let availabilityDuration = 0;
+    let checkDuration = 0;
+    let scanDuration = 0;
+    let filterDuration = 0;
+    let diffDuration = 0;
+    let persistDuration = 0;
+    let searchIndexDuration = 0;
 
-    if (!agent.isAvailable()) {
+    const availabilityStartedAt = performance.now();
+    const isAvailable = agent.isAvailable();
+    availabilityDuration = performance.now() - availabilityStartedAt;
+
+    if (!isAvailable) {
       nextSessions = [];
       this.refreshTimestamps.set(agentName, Date.now());
     } else if (previousSessions.length > 0 && agent.checkForChanges && agent.incrementalScan) {
+      const checkStartedAt = performance.now();
       const checkResult = await Promise.resolve(
         agent.checkForChanges(this.refreshTimestamps.get(agentName) ?? 0, previousSessions),
       );
+      checkDuration = performance.now() - checkStartedAt;
 
       this.refreshTimestamps.set(agentName, checkResult.timestamp);
       if (!checkResult.hasChanges) {
@@ -894,59 +986,83 @@ export class LiveScanStore {
 
       preciseChangedIds = checkResult.changedIds ?? null;
       usedIncrementalScan = Array.isArray(checkResult.changedIds);
-      nextSessions = await Promise.resolve(
-        agent.incrementalScan(previousSessions, checkResult.changedIds ?? []),
+      const scanStartedAt = performance.now();
+      const workerResult = this.scanAgentInWorker(
+        agent,
+        previousSessions,
+        checkResult.changedIds ?? [],
       );
+      if (workerResult) {
+        const result = await workerResult;
+        nextSessions = result.sessions;
+        agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
+      } else {
+        nextSessions = await Promise.resolve(
+          agent.incrementalScan(previousSessions, checkResult.changedIds ?? []),
+        );
+      }
+      scanDuration = performance.now() - scanStartedAt;
     } else {
-      nextSessions = await Promise.resolve(agent.scan(this.startupScanOptions));
+      const scanStartedAt = performance.now();
+      const workerResult = this.scanAgentInWorker(agent, previousSessions, null);
+      if (workerResult) {
+        const result = await workerResult;
+        nextSessions = result.sessions;
+        agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
+      } else {
+        nextSessions = await Promise.resolve(agent.scan(this.startupScanOptions));
+      }
+      scanDuration = performance.now() - scanStartedAt;
       this.refreshTimestamps.set(agentName, Date.now());
     }
 
+    const filterStartedAt = performance.now();
     nextSessions = this.applyFilters(nextSessions);
+    filterDuration = performance.now() - filterStartedAt;
+    const diffStartedAt = performance.now();
     const diff = buildRefreshDiff(
       agentName,
       previousSessions,
       nextSessions,
       preciseChangedIds ?? [],
     );
+    diffDuration = performance.now() - diffStartedAt;
     const searchIndexOptions =
       pendingPathCount >= SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD ? { isBulk: true } : undefined;
-    const canPersistIncrementally =
-      usedIncrementalScan && !searchIndexOptions && !this.hasStartupWindow();
+    const canPersistIncrementally = usedIncrementalScan;
     const changedSessionIds = canPersistIncrementally
       ? new Set(diff.changedSessions.map(({ session }) => session.id))
       : undefined;
     const cacheMeta = buildAgentCacheMeta(agent, changedSessionIds);
-    if (!this.hasStartupWindow()) {
-      if (canPersistIncrementally) {
-        saveCachedSessionChanges(
+    const persistStartedAt = performance.now();
+    const persistentJob: SearchIndexWorkerJob | null = canPersistIncrementally
+      ? {
+          kind: "changes",
+          context: "scan.refresh",
           agentName,
-          diff.changedSessions,
-          diff.removedSessionIds,
-          cacheMeta,
-        );
-      } else {
-        saveCachedSessions(agentName, nextSessions, cacheMeta);
-      }
-    }
-    const syncResult = canPersistIncrementally
-      ? syncSessionSearchIndexChanges(
-          agentName,
-          diff.changedSessions,
-          diff.removedSessionIds,
-          (sessionId) => agent.getSessionData(sessionId),
-        )
-      : searchIndexOptions
-        ? syncSessionSearchIndex(
+          changes: diff.changedSessions,
+          removedSessionIds: diff.removedSessionIds,
+          meta: cacheMeta,
+          ...(searchIndexOptions ? { searchIndexOptions } : {}),
+        }
+      : !this.hasStartupWindow()
+        ? {
+            kind: "full",
+            context: "scan.refresh",
             agentName,
-            nextSessions,
-            (sessionId) => agent.getSessionData(sessionId),
-            searchIndexOptions,
-          )
-        : syncSessionSearchIndex(agentName, nextSessions, (sessionId) =>
-            agent.getSessionData(sessionId),
-          );
-    logSearchIndexSync("scan.refresh", syncResult, { pending_paths: pendingPathCount });
+            sessions: nextSessions,
+            meta: buildAgentCacheMeta(agent),
+            saveCache: true,
+            ...(searchIndexOptions ? { searchIndexOptions } : {}),
+          }
+        : null;
+    if (persistentJob) {
+      this.enqueueSearchIndexJobs("scan.refresh", [persistentJob]);
+    }
+    persistDuration = performance.now() - persistStartedAt;
+    const searchIndexStartedAt = performance.now();
+    searchIndexDuration = performance.now() - searchIndexStartedAt;
+    logSearchIndexSync("scan.refresh", null, { pending_paths: pendingPathCount });
 
     const event = diff.event;
     this.byAgent[agentName] = sortSessions(nextSessions);
@@ -964,11 +1080,15 @@ export class LiveScanStore {
       updated_sessions: event?.updatedSessions ?? 0,
       removed_sessions: event?.removedSessions ?? 0,
       pending_paths: pendingPathCount,
-      search_index_mode: syncResult?.mode,
-      search_index_rebuild_duration_ms:
-        syncResult?.rebuildDurationMs == null
-          ? undefined
-          : Math.round(syncResult.rebuildDurationMs),
+      availability_ms: Math.round(availabilityDuration),
+      check_ms: Math.round(checkDuration),
+      scan_ms: Math.round(scanDuration),
+      filter_ms: Math.round(filterDuration),
+      diff_ms: Math.round(diffDuration),
+      persist_ms: Math.round(persistDuration),
+      search_index_ms: Math.round(searchIndexDuration),
+      persistent_index_worker_job: persistentJob?.kind,
+      persistent_index_skipped: !persistentJob || undefined,
     });
   }
 }

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -1,0 +1,73 @@
+import { parentPort, workerData } from "node:worker_threads";
+import {
+  createRegisteredAgents,
+  type ScanOptions,
+  type SessionCacheMeta,
+  type SessionHead,
+} from "@codesesh/core";
+
+export type ScanRefreshWorkerMessage =
+  | {
+      type: "done";
+      sessions: SessionHead[];
+      meta: Record<string, SessionCacheMeta>;
+      durationMs: number;
+    }
+  | {
+      type: "error";
+      error: string;
+      durationMs: number;
+    };
+
+interface ScanRefreshWorkerData {
+  agentName: string;
+  previousSessions: SessionHead[];
+  changedIds: string[] | null;
+  startupScanOptions: Pick<ScanOptions, "from" | "to">;
+  meta: Record<string, SessionCacheMeta>;
+}
+
+function serializeMeta(agent: {
+  getSessionMetaMap?: () => Map<string, SessionCacheMeta>;
+}): Record<string, SessionCacheMeta> {
+  const metaMap = agent.getSessionMetaMap?.();
+  if (!metaMap) return {};
+
+  const meta: Record<string, SessionCacheMeta> = {};
+  for (const [id, data] of metaMap.entries()) {
+    meta[id] = { id, ...(data as Record<string, unknown>) } as SessionCacheMeta;
+  }
+  return meta;
+}
+
+const data = workerData as ScanRefreshWorkerData;
+const startedAt = performance.now();
+
+try {
+  const agent = createRegisteredAgents().find((item) => item.name === data.agentName);
+  if (!agent) {
+    throw new Error(`Unknown agent: ${data.agentName}`);
+  }
+
+  if (agent.setSessionMetaMap) {
+    agent.setSessionMetaMap(new Map(Object.entries(data.meta)));
+  }
+
+  const sessions =
+    data.changedIds && agent.incrementalScan
+      ? agent.incrementalScan(data.previousSessions, data.changedIds)
+      : agent.scan(data.startupScanOptions);
+
+  parentPort?.postMessage({
+    type: "done",
+    sessions,
+    meta: serializeMeta(agent),
+    durationMs: performance.now() - startedAt,
+  } satisfies ScanRefreshWorkerMessage);
+} catch (error) {
+  parentPort?.postMessage({
+    type: "error",
+    error: error instanceof Error ? error.message : String(error),
+    durationMs: performance.now() - startedAt,
+  } satisfies ScanRefreshWorkerMessage);
+}

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -1,9 +1,14 @@
 import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,
+  saveCachedSessionChanges,
+  saveCachedSessions,
   syncSessionSearchIndex,
+  syncSessionSearchIndexChanges,
   type SearchIndexSyncResult,
+  type SearchIndexSyncOptions,
   type SessionCacheMeta,
+  type SessionHeadChange,
   type SessionHead,
 } from "@codesesh/core";
 
@@ -20,7 +25,28 @@ export type SearchIndexWorkerMessage =
       sessions: number;
     };
 
+export type SearchIndexWorkerJob =
+  | {
+      kind: "full";
+      context: string;
+      agentName: string;
+      sessions: SessionHead[];
+      meta: Record<string, SessionCacheMeta>;
+      saveCache?: boolean;
+      searchIndexOptions?: SearchIndexSyncOptions;
+    }
+  | {
+      kind: "changes";
+      context: string;
+      agentName: string;
+      changes: SessionHeadChange[];
+      removedSessionIds: string[];
+      meta: Record<string, SessionCacheMeta>;
+      searchIndexOptions?: SearchIndexSyncOptions;
+    };
+
 interface SearchIndexWorkerData {
+  jobs?: SearchIndexWorkerJob[];
   context: string;
   agentNames: string[];
   sessionsByAgent: Record<string, SessionHead[]>;
@@ -30,23 +56,50 @@ interface SearchIndexWorkerData {
 const data = workerData as SearchIndexWorkerData;
 const startedAt = performance.now();
 const agents = createRegisteredAgents();
+const jobs =
+  data.jobs ??
+  data.agentNames.map(
+    (agentName): SearchIndexWorkerJob => ({
+      kind: "full",
+      context: data.context,
+      agentName,
+      sessions: data.sessionsByAgent[agentName] ?? [],
+      meta: data.metaByAgent[agentName] ?? {},
+    }),
+  );
 
-for (const agentName of data.agentNames) {
-  const agent = agents.find((item) => item.name === agentName);
+for (const job of jobs) {
+  const agent = agents.find((item) => item.name === job.agentName);
   if (!agent) continue;
 
-  const meta = data.metaByAgent[agentName];
-  if (meta && agent.setSessionMetaMap) {
-    agent.setSessionMetaMap(new Map(Object.entries(meta)));
+  if (agent.setSessionMetaMap) {
+    agent.setSessionMetaMap(new Map(Object.entries(job.meta)));
   }
 
-  const sessions = data.sessionsByAgent[agentName] ?? [];
-  const result = syncSessionSearchIndex(agentName, sessions, (sessionId) =>
-    agent.getSessionData(sessionId),
-  );
+  let result: SearchIndexSyncResult | null;
+  if (job.kind === "changes") {
+    saveCachedSessionChanges(job.agentName, job.changes, job.removedSessionIds, job.meta);
+    result = syncSessionSearchIndexChanges(
+      job.agentName,
+      job.changes,
+      job.removedSessionIds,
+      (sessionId) => agent.getSessionData(sessionId),
+      job.searchIndexOptions,
+    );
+  } else {
+    if (job.saveCache) {
+      saveCachedSessions(job.agentName, job.sessions, job.meta);
+    }
+    result = syncSessionSearchIndex(
+      job.agentName,
+      job.sessions,
+      (sessionId) => agent.getSessionData(sessionId),
+      job.searchIndexOptions,
+    );
+  }
   parentPort?.postMessage({
     type: "sync-result",
-    context: data.context,
+    context: job.context,
     result,
   } satisfies SearchIndexWorkerMessage);
 }
@@ -55,8 +108,8 @@ parentPort?.postMessage({
   type: "done",
   context: data.context,
   durationMs: performance.now() - startedAt,
-  sessions: Object.values(data.sessionsByAgent).reduce(
-    (total, sessions) => total + sessions.length,
+  sessions: jobs.reduce(
+    (total, job) => total + (job.kind === "full" ? job.sessions.length : job.changes.length),
     0,
   ),
 } satisfies SearchIndexWorkerMessage);

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -4,7 +4,12 @@ const isWatch = process.argv.includes("--watch");
 const bundleCore = process.env.BUNDLE_CORE === "true";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/search-index-worker.ts", "src/smart-tag-worker.ts"],
+  entry: [
+    "src/index.ts",
+    "src/search-index-worker.ts",
+    "src/scan-refresh-worker.ts",
+    "src/smart-tag-worker.ts",
+  ],
   format: ["esm"],
   dts: false,
   clean: !isWatch,

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -33,9 +33,26 @@ afterEach(() => {
 });
 
 describe("ClaudeCodeAgent cache refresh", () => {
-  it("revalidates recent sessions and invalidates sessions index cache", () => {
+  it("detects sessions-index fingerprint changes without recent-session revalidation", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-cache-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const sessionFile = join(projectDir, "session-1.jsonl");
+    const indexFile = join(projectDir, "sessions-index.json");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      sessionFile,
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-04-20T10:00:00Z",
+        cwd: "/tmp/project",
+        message: { role: "user", content: "hello" },
+      }),
+    );
+    writeFileSync(indexFile, JSON.stringify({ entries: [{ sessionId: "session-1" }] }));
+
     const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = "/tmp/claudecode";
+    agent.basePath = basePath;
     agent.sessionsIndexCache = { project: new Map([["stale", {}]]) };
     agent.sessionMetaMap = new Map([
       [
@@ -43,7 +60,11 @@ describe("ClaudeCodeAgent cache refresh", () => {
         {
           id: "session-1",
           title: "Old",
-          sourcePath: "/tmp/claudecode/project/session-1.jsonl",
+          sourcePath: sessionFile,
+          sourceMtimeMs: statSync(sessionFile).mtimeMs,
+          indexPath: indexFile,
+          indexMtimeMs: statSync(indexFile).mtimeMs - 1,
+          headIndexVersion: "claudecode-head-v1",
           directory: "/tmp/project",
           model: null,
           messageCount: 1,
@@ -53,10 +74,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ],
     ]);
 
-    const now = Date.now();
-    const result = agent.checkForChanges(now, [
-      makeSession("session-1", { time_created: now - 60_000 }),
-    ]);
+    const result = agent.checkForChanges(Date.now(), [makeSession("session-1")]);
 
     expect(result.hasChanges).toBe(true);
     expect(result.changedIds).toContain("session-1");

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -28,6 +28,7 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
 describe("CodexAgent cache refresh", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -74,32 +75,47 @@ describe("CodexAgent cache refresh", () => {
     expect(result.changedIds).toContain("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb");
   });
 
-  it("revalidates recent sessions even without file changes", () => {
+  it("detects session index fingerprint changes without recent-session revalidation", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    const codexHome = join(tempDir, ".codex");
+    const sessionsDir = join(codexHome, "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("CODEX_HOME", codexHome);
     const recentFile = join(
-      tempDir,
+      sessionsDir,
       "rollout-2026-04-20T10-00-00-019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa.jsonl",
     );
+    const indexFile = join(codexHome, "session_index.jsonl");
 
     writeFileSync(
       recentFile,
       '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
     );
+    writeFileSync(
+      indexFile,
+      '{"id":"019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa","thread_name":"Old title"}\n',
+    );
 
     const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    agent.basePath = sessionsDir;
     agent.sessionIndexCache = new Map([["stale", "stale"]]);
     agent.sessionMetaMap = new Map([
       [
         "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
-        { id: "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa", sourcePath: recentFile },
+        {
+          id: "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
+          sourcePath: recentFile,
+          sourceMtimeMs: statSync(recentFile).mtimeMs,
+          indexPath: indexFile,
+          indexMtimeMs: statSync(indexFile).mtimeMs - 1,
+          headIndexVersion: "codex-head-v1",
+        },
       ],
     ]);
     agent.listRolloutFiles = () => [recentFile];
 
-    const now = Date.now();
-    const result = agent.checkForChanges(now, [
-      makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa", { time_created: now - 60_000 }),
+    const result = agent.checkForChanges(Date.now(), [
+      makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
     ]);
 
     expect(result.hasChanges).toBe(true);

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -19,12 +19,16 @@ import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
 
-const RECENT_SESSION_REVALIDATION_WINDOW_MS = 24 * 60 * 60 * 1000;
+const HEAD_INDEX_VERSION = "claudecode-head-v1";
 
 interface SessionMeta extends SessionCacheMeta {
   id: string;
   title: string;
   sourcePath: string;
+  sourceMtimeMs: number;
+  indexPath: string | null;
+  indexMtimeMs: number | null;
+  headIndexVersion: string;
   directory: string;
   model: string | null | undefined;
   messageCount: number;
@@ -97,16 +101,7 @@ export class ClaudeCodeAgent extends BaseAgent {
 
           if (head) {
             heads.push(head);
-            this.sessionMetaMap.set(head.id, {
-              id: head.id,
-              title: head.title,
-              sourcePath: file,
-              directory: head.directory,
-              model: head.stats.total_tokens ? "unknown" : undefined,
-              messageCount: head.stats.message_count,
-              createdAt: head.time_created,
-              updatedAt: head.time_updated ?? head.time_created,
-            });
+            this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file, projectDir));
           }
         } catch {
           // skip malformed files
@@ -202,15 +197,13 @@ export class ClaudeCodeAgent extends BaseAgent {
    * - 已有 session：statSync 检测文件修改（APFS 写文件不更新 dir mtime，必须 file-level）
    * - 新 session 检测：readdirSync 文件列表比对，比 dir statSync 快 ~10x
    */
-  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
+  checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
     if (!this.basePath) {
       return { hasChanges: false, timestamp: Date.now() };
     }
 
     const changedIds = new Set<string>();
-    const now = Date.now();
 
-    // 检查已有 session 文件的 mtime（唯一能检测到文件内容修改的方式）
     for (const session of cachedSessions) {
       const meta = this.sessionMetaMap.get(session.id);
       if (!meta) {
@@ -218,21 +211,12 @@ export class ClaudeCodeAgent extends BaseAgent {
         continue;
       }
       try {
-        if (statSync(meta.sourcePath).mtimeMs > sinceTimestamp) {
+        if (this.hasMetaChanged(meta)) {
           changedIds.add(session.id);
           delete this.sessionsIndexCache[basename(dirname(meta.sourcePath))];
         }
       } catch {
         changedIds.add(session.id);
-      }
-    }
-
-    for (const session of cachedSessions) {
-      if (now - session.time_created > RECENT_SESSION_REVALIDATION_WINDOW_MS) continue;
-      changedIds.add(session.id);
-      const meta = this.sessionMetaMap.get(session.id);
-      if (meta) {
-        delete this.sessionsIndexCache[basename(dirname(meta.sourcePath))];
       }
     }
 
@@ -278,16 +262,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
             if (head) {
               sessionMap.set(head.id, head);
-              this.sessionMetaMap.set(head.id, {
-                id: head.id,
-                title: head.title,
-                sourcePath: file,
-                directory: head.directory,
-                model: head.stats.total_tokens ? "unknown" : undefined,
-                messageCount: head.stats.message_count,
-                createdAt: head.time_created,
-                updatedAt: head.time_updated ?? head.time_created,
-              });
+              this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file, projectDir));
             }
           }
         } catch {
@@ -322,13 +297,52 @@ export class ClaudeCodeAgent extends BaseAgent {
     }
   }
 
+  private buildSessionMeta(head: SessionHead, file: string, projectDir: string): SessionMeta {
+    const indexPath = this.getSessionsIndexPath(projectDir);
+    return {
+      id: head.id,
+      title: head.title,
+      sourcePath: file,
+      sourceMtimeMs: statSync(file).mtimeMs,
+      indexPath: existsSync(indexPath) ? indexPath : null,
+      indexMtimeMs: this.getFileMtimeMs(indexPath),
+      headIndexVersion: HEAD_INDEX_VERSION,
+      directory: head.directory,
+      model: head.stats.total_tokens ? "unknown" : undefined,
+      messageCount: head.stats.message_count,
+      createdAt: head.time_created,
+      updatedAt: head.time_updated ?? head.time_created,
+    };
+  }
+
+  private hasMetaChanged(meta: SessionMeta): boolean {
+    if (meta.headIndexVersion !== HEAD_INDEX_VERSION) return true;
+    if (typeof meta.sourceMtimeMs !== "number") return true;
+    if (statSync(meta.sourcePath).mtimeMs !== meta.sourceMtimeMs) return true;
+
+    const indexPath = meta.indexPath ?? this.getSessionsIndexPath(dirname(meta.sourcePath));
+    return this.getFileMtimeMs(indexPath) !== (meta.indexMtimeMs ?? null);
+  }
+
+  private getSessionsIndexPath(projectDir: string): string {
+    return join(projectDir, "sessions-index.json");
+  }
+
+  private getFileMtimeMs(filePath: string): number | null {
+    try {
+      return statSync(filePath).mtimeMs;
+    } catch {
+      return null;
+    }
+  }
+
   private loadSessionsIndex(projectDir: string): Map<string, Record<string, unknown>> {
     const cacheKey = basename(projectDir);
     if (cacheKey in this.sessionsIndexCache) {
       return this.sessionsIndexCache[cacheKey];
     }
 
-    const indexPath = join(projectDir, "sessions-index.json");
+    const indexPath = this.getSessionsIndexPath(projectDir);
     const map = new Map<string, Record<string, unknown>>();
 
     if (existsSync(indexPath)) {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -37,7 +37,7 @@ const PROPOSED_PLAN_PATTERN = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/
 const PLAN_APPROVAL_PREFIX = "PLEASE IMPLEMENT THIS PLAN";
 const SUBAGENT_NOTIFICATION_PATTERN =
   /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
-const RECENT_SESSION_REVALIDATION_WINDOW_MS = 24 * 60 * 60 * 1000;
+const HEAD_INDEX_VERSION = "codex-head-v1";
 
 const DEVELOPER_LIKE_USER_MARKERS = [
   "agents.md instructions for",
@@ -247,6 +247,10 @@ interface SessionMeta extends SessionCacheMeta {
   id: string;
   title: string;
   sourcePath: string;
+  sourceMtimeMs: number;
+  indexPath: string | null;
+  indexMtimeMs: number | null;
+  headIndexVersion: string;
   directory: string;
   model: string | null;
   messageCount: number;
@@ -309,16 +313,7 @@ export class CodexAgent extends BaseAgent {
 
         if (head) {
           heads.push(head);
-          this.sessionMetaMap.set(head.id, {
-            id: head.id,
-            title: head.title,
-            sourcePath: file,
-            directory: head.directory,
-            model: null,
-            messageCount: head.stats.message_count,
-            createdAt: head.time_created,
-            updatedAt: head.time_updated ?? head.time_created,
-          });
+          this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
         }
       } catch {
         // skip malformed files
@@ -340,7 +335,7 @@ export class CodexAgent extends BaseAgent {
   /**
    * 检测文件系统变更
    */
-  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
+  checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
     if (!this.basePath) {
       return { hasChanges: false, timestamp: Date.now() };
     }
@@ -363,18 +358,12 @@ export class CodexAgent extends BaseAgent {
       }
 
       try {
-        if (statSync(meta.sourcePath).mtimeMs > sinceTimestamp) {
+        if (this.hasMetaChanged(meta)) {
           changedIds.add(session.id);
         }
       } catch {
         changedIds.add(session.id);
       }
-    }
-
-    const now = Date.now();
-    for (const session of cachedSessions) {
-      if (now - session.time_created > RECENT_SESSION_REVALIDATION_WINDOW_MS) continue;
-      changedIds.add(session.id);
     }
 
     const hasAddedSessions = currentFiles.some((file) => !cachedIds.has(extractSessionId(file)));
@@ -416,16 +405,7 @@ export class CodexAgent extends BaseAgent {
           const head = this.parseSessionHead(file);
           if (head) {
             sessionMap.set(head.id, head);
-            this.sessionMetaMap.set(head.id, {
-              id: head.id,
-              title: head.title,
-              sourcePath: file,
-              directory: head.directory,
-              model: null,
-              messageCount: head.stats.message_count,
-              createdAt: head.time_created,
-              updatedAt: head.time_updated ?? head.time_created,
-            });
+            this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
           }
         }
       } catch {
@@ -441,16 +421,7 @@ export class CodexAgent extends BaseAgent {
           const head = this.parseSessionHead(file);
           if (head) {
             sessionMap.set(head.id, head);
-            this.sessionMetaMap.set(head.id, {
-              id: head.id,
-              title: head.title,
-              sourcePath: file,
-              directory: head.directory,
-              model: null,
-              messageCount: head.stats.message_count,
-              createdAt: head.time_created,
-              updatedAt: head.time_updated ?? head.time_created,
-            });
+            this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
           }
         }
       } catch {
@@ -648,13 +619,52 @@ export class CodexAgent extends BaseAgent {
     return files;
   }
 
+  private buildSessionMeta(head: SessionHead, file: string): SessionMeta {
+    const indexPath = this.getSessionIndexPath();
+    return {
+      id: head.id,
+      title: head.title,
+      sourcePath: file,
+      sourceMtimeMs: statSync(file).mtimeMs,
+      indexPath: existsSync(indexPath) ? indexPath : null,
+      indexMtimeMs: this.getFileMtimeMs(indexPath),
+      headIndexVersion: HEAD_INDEX_VERSION,
+      directory: head.directory,
+      model: null,
+      messageCount: head.stats.message_count,
+      createdAt: head.time_created,
+      updatedAt: head.time_updated ?? head.time_created,
+    };
+  }
+
+  private hasMetaChanged(meta: SessionMeta): boolean {
+    if (meta.headIndexVersion !== HEAD_INDEX_VERSION) return true;
+    if (typeof meta.sourceMtimeMs !== "number") return true;
+    if (statSync(meta.sourcePath).mtimeMs !== meta.sourceMtimeMs) return true;
+
+    const indexPath = meta.indexPath ?? this.getSessionIndexPath();
+    return this.getFileMtimeMs(indexPath) !== (meta.indexMtimeMs ?? null);
+  }
+
+  private getSessionIndexPath(): string {
+    const roots = resolveProviderRoots();
+    return join(roots.codexRoot, "session_index.jsonl");
+  }
+
+  private getFileMtimeMs(filePath: string): number | null {
+    try {
+      return statSync(filePath).mtimeMs;
+    } catch {
+      return null;
+    }
+  }
+
   // ---- Session index ----
 
   private loadSessionIndex(): void {
     if (this.sessionIndexCache.size > 0) return;
 
-    const roots = resolveProviderRoots();
-    const indexPath = join(roots.codexRoot, "session_index.jsonl");
+    const indexPath = this.getSessionIndexPath();
     if (!existsSync(indexPath)) return;
 
     try {

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -8,6 +8,7 @@ import {
   getCacheInfo,
   listFileActivity,
   listCachedProjectGroups,
+  loadCachedSessionData,
   loadCachedSessions,
   parseSearchQuery,
   searchFileActivitySessions,
@@ -533,6 +534,57 @@ describe("searchSessions", () => {
       skipped: 0,
     });
     expect(searchSessions("sqlite")).toHaveLength(1);
+  });
+
+  it("loads full session data from the SQLite message cache", () => {
+    const session = {
+      ...makeSession("cached-detail"),
+      stats: {
+        message_count: 1,
+        total_input_tokens: 3,
+        total_output_tokens: 5,
+        total_cost: 0.02,
+        cost_source: "estimated",
+      },
+    };
+    syncSessionSearchIndex("codex", [session], (sessionId) => ({
+      ...makeSessionData(sessionId, "detail view reads sqlite"),
+      messages: [
+        {
+          id: "m1",
+          role: "assistant",
+          time_created: now,
+          tokens: { input: 3, output: 5 },
+          cost: 0.02,
+          cost_source: "estimated",
+          parts: [{ type: "text", text: "detail view reads sqlite" }],
+        },
+      ],
+    }));
+
+    const data = loadCachedSessionData("codex", "cached-detail");
+
+    expect(data).toMatchObject({
+      id: "cached-detail",
+      title: "Session cached-detail",
+      stats: {
+        message_count: 1,
+        total_input_tokens: 3,
+        total_output_tokens: 5,
+        total_cost: 0.02,
+        cost_source: "estimated",
+      },
+      messages: [
+        {
+          id: "m1",
+          role: "assistant",
+          tokens: { input: 3, output: 5 },
+          cost: 0.02,
+          cost_source: "estimated",
+          parts: [{ type: "text", text: "detail view reads sqlite" }],
+        },
+      ],
+    });
   });
 
   it("indexes session content and returns highlighted matches", () => {

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -23,6 +23,7 @@ import {
   columnExists,
   getUserVersion,
   openDb,
+  openDbReadOnly,
   runSchemaMigrations,
   setUserVersion,
   tableExists,
@@ -145,6 +146,12 @@ interface MessageBackfillRow extends DatabaseRow {
   parts_json?: string;
   subagent_id?: string | null;
   nickname?: string | null;
+}
+
+interface CachedMessageRow extends MessageBackfillRow {
+  tokens_json?: string | null;
+  cost?: number | null;
+  cost_source?: SessionHead["stats"]["cost_source"] | null;
 }
 
 interface MessageToolBackfillRow extends DatabaseRow {
@@ -344,6 +351,19 @@ function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
 
   try {
     ensureSchema(db, cachePath);
+    return fn(db);
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): T | null {
+  const db = openDbReadOnly(getCachePath());
+  if (!db) return null;
+
+  try {
     return fn(db);
   } catch {
     return null;
@@ -1323,6 +1343,21 @@ function messageFromBackfillRow(row: MessageBackfillRow): Message {
   };
 }
 
+function messageFromCachedRow(row: CachedMessageRow): Message {
+  const message = messageFromBackfillRow(row);
+  const tokens = parseOptionalJson<Message["tokens"]>(row.tokens_json);
+  if (tokens) {
+    message.tokens = tokens;
+  }
+  if (row.cost != null) {
+    message.cost = Number(row.cost);
+  }
+  if (row.cost_source) {
+    message.cost_source = row.cost_source;
+  }
+  return message;
+}
+
 function backfillMessageTools(db: SQLiteDatabase): void {
   createMessageToolTables(db);
   if (!tableExists(db, "messages")) {
@@ -1968,6 +2003,95 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
     }
 
     return { sessions, meta, timestamp };
+  });
+}
+
+export function loadCachedSessionData(agentName: string, sessionId: string): SessionData | null {
+  if (!hasCacheStorage()) {
+    return null;
+  }
+
+  return withCacheDbReadOnly((db) => {
+    const row = db
+      .prepare(
+        `
+          SELECT
+            session_id,
+            sort_index,
+            slug,
+            title,
+            source_path,
+            directory,
+            project_identity_kind,
+            project_identity_key,
+            project_display_name,
+            time_created,
+            time_updated,
+            message_count,
+            total_input_tokens,
+            total_output_tokens,
+            total_cache_read_tokens,
+            total_cache_create_tokens,
+            total_cost,
+            cost_source,
+            total_tokens,
+            model_usage_json,
+            smart_tags_json,
+            smart_tags_source_updated_at,
+            meta_json
+          FROM sessions
+          WHERE agent_name = ? AND session_id = ?
+        `,
+      )
+      .get(agentName, sessionId) as SessionRow | undefined;
+
+    if (!row) {
+      return null;
+    }
+
+    const messageRows = db
+      .prepare(
+        `
+          SELECT
+            message_id,
+            role,
+            time_created,
+            time_completed,
+            agent,
+            mode,
+            model,
+            provider,
+            tokens_json,
+            cost,
+            cost_source,
+            parts_json,
+            subagent_id,
+            nickname
+          FROM messages
+          WHERE agent_name = ? AND session_id = ?
+          ORDER BY message_index
+        `,
+      )
+      .all(agentName, sessionId) as CachedMessageRow[];
+
+    const head = sessionFromRow(row);
+    const fileActivityRows = db
+      .prepare(
+        `
+          SELECT agent_name, session_id, project_identity_key, path, kind, count, latest_time
+          FROM session_file_activity
+          WHERE agent_name = ? AND session_id = ?
+          ORDER BY latest_time DESC, count DESC, path
+          LIMIT 500
+        `,
+      )
+      .all(agentName, sessionId) as FileActivityRow[];
+
+    return {
+      ...head,
+      messages: messageRows.map((messageRow) => messageFromCachedRow(messageRow)),
+      file_activity: fileActivityRows.map((activityRow) => fileActivityFromRow(activityRow)),
+    };
   });
 }
 

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -4,6 +4,7 @@ export { filterSessions, scanSessions, scanSessionsAsync } from "./scanner.js";
 export type { ScanResult, ScanOptions } from "./scanner.js";
 export {
   loadCachedSessions,
+  loadCachedSessionData,
   saveCachedSessions,
   saveCachedSessionChanges,
   clearCache,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -365,7 +365,7 @@ async function scanAgentSmart(
               : await ensureSessionTags(agent, sessionsWithIdentity, options.smartTagWorkerUrl);
           timing.tags = performance.now() - t4;
 
-          if (options.writeCache !== false && options.from == null && options.to == null) {
+          if (options.writeCache !== false) {
             saveCachedSessionDiff(
               agent,
               cached.sessions,
@@ -399,12 +399,7 @@ async function scanAgentSmart(
           : await ensureSessionTags(agent, cachedWithIdentity, options.smartTagWorkerUrl);
       timing.tags = performance.now() - t4;
 
-      if (
-        tagged.changed &&
-        options.writeCache !== false &&
-        options.from == null &&
-        options.to == null
-      ) {
+      if (tagged.changed && options.writeCache !== false) {
         saveCachedSessionDiff(agent, cached.sessions, tagged.sessions);
       }
 


### PR DESCRIPTION
## Summary

- Replace Claude Code and Codex recent-session revalidation with per-session cache fingerprints.
- Store source file mtime, sidecar/global index mtime, and head parser version in session cache metadata.
- Let cache-backed incremental refreshes persist cache/search-index diffs even when startup uses a `from/to` display window.
- Move refresh-time cache/search-index writes out of the main process and into `search-index-worker` jobs.
- Move refresh scanning/parsing itself into `scan-refresh-worker`, so long `incrementalScan` work no longer blocks foreground HTTP requests.
- Watch Codex `sessions` directly and track `session_index.jsonl` separately so deep session appends and title updates trigger refresh reliably.
- Load session detail data from SQLite `sessions/messages` cache through a read-only connection instead of parsing source session files on the foreground API path.
- Add refresh phase timing logs to separate scan, diff, persist scheduling, and search-index costs.

## Rationale

The previous 24-hour recent-session window was a correctness guard for sidecar title/index changes, but it forced active sessions to revalidate even when neither their source file nor index state changed. This makes the invalidation condition explicit: a cached head is stale when one of the files it depends on, or its parser version, differs from the metadata saved with that head.

The slow hot-start regression came from the startup window path: `LiveScanStore` passed `writeCache: false` whenever `startup_from` was present, so old cache rows never persisted their new fingerprint metadata. Every launch therefore repeated the same incremental parse. The fix keeps full-scan window results from overwriting cache, but permits cache-backed incremental refreshes to persist complete cache diffs.

The slow session-open symptom exposed an event-loop boundary problem. Logs showed the detail endpoint was often fast once it ran, but foreground requests were queued behind refresh work. Moving only search-index writes was not enough because `agent.incrementalScan()` could still spend tens of seconds synchronously scanning/parsing on the main thread. Refresh scan now runs in a worker, and the foreground detail endpoint reads the indexed SQLite message cache via a read-only connection. Codex watch also now anchors on `~/.codex/sessions` instead of the parent `~/.codex`, because parent recursive events were not reliably firing for deep JSONL appends.

## Local verification

- Before persisted fingerprints: initial startup around 22.5s while old cache rows were upgraded.
- After persisted fingerprints: second startup `scan.initial.done` in 133ms and `cli.ready` in 150ms.
- Observed slow session-open logs showed foreground detail requests queueing behind refresh scan work; the remaining blocking phase was `scan_ms` inside refresh, now workerized.
- Observed Codex JSONL mtime advancing while current process emitted no Codex refresh; watch target now points at the concrete sessions tree plus `session_index.jsonl`.

## Validation

- `pnpm --filter @codesesh/core test -- src/discovery/__tests__/cache.test.ts`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter codesesh test -- src/live-scan-store.test.ts src/api/__tests__/handlers.test.ts`
- `pnpm --filter codesesh test -- src/live-scan.test.ts src/live-scan-store.test.ts`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`
- `pnpm --filter codesesh build`

