### PR TITLE
fix(cli): sync session cache before serving

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -889,8 +889,6 @@ export default function App() {
 
       if (event.newSessions > 0) {
         setLiveNotice(`发现 ${event.newSessions} 个新会话，列表已自动刷新`);
-      } else if (event.updatedSessions > 0) {
-        setLiveNotice("会话内容已同步");
       }
     } catch (err) {
       console.error("Failed to sync live session update:", err);

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -91,17 +91,32 @@ export const serveCommand = defineCommand({
     printScanResults(agents, result);
 
     // Start server
-    let url: string;
+    let app: Awaited<ReturnType<typeof createServer>>;
     try {
-      ({ url } = await createServer(port, store, {
+      app = await createServer(port, store, {
         defaultSessionFrom: listDefaultFrom,
         defaultSessionTo: listDefaultTo,
         portFallbackAttempts: explicitPort ? 1 : DEFAULT_PORT_FALLBACK_ATTEMPTS,
-      }));
+      });
     } catch (error) {
       console.error(getServerStartupErrorMessage(error, port));
       process.exit(1);
     }
+
+    const { url } = app;
+    let shuttingDown = false;
+    const shutdown = async () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      await app.shutdown();
+      process.exit(0);
+    };
+    process.once("SIGINT", () => {
+      void shutdown();
+    });
+    process.once("SIGTERM", () => {
+      void shutdown();
+    });
 
     if (!noOpen) {
       const open = (await import("open")).default;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -228,18 +228,34 @@ const main = defineCommand({
     printScanResults(agents, result);
 
     // Start server
-    let url: string;
+    let app: Awaited<ReturnType<typeof createServer>>;
     try {
-      ({ url } = await createServer(port, store, {
+      app = await createServer(port, store, {
         defaultSessionFrom: listDefaultFrom,
         defaultSessionTo: listDefaultTo,
         defaultSessionDays: listDefaultDays,
         portFallbackAttempts: explicitPort ? 1 : DEFAULT_PORT_FALLBACK_ATTEMPTS,
-      }));
+      });
     } catch (error) {
       console.error(getServerStartupErrorMessage(error, port));
       process.exit(1);
     }
+
+    const { url } = app;
+    let shuttingDown = false;
+    const shutdown = async (signal: NodeJS.Signals) => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      appLogger.info("cli.shutdown", { signal });
+      await app.shutdown();
+      process.exit(0);
+    };
+    process.once("SIGINT", (signal) => {
+      void shutdown(signal);
+    });
+    process.once("SIGTERM", (signal) => {
+      void shutdown(signal);
+    });
 
     console.log(`  ${url}`);
     console.log("");

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -45,7 +45,23 @@ const workerThreads = vi.hoisted(() => ({
     const worker = {
       url,
       workerData: options?.workerData,
-      on: vi.fn(() => worker),
+      on: vi.fn((event: string, handler: (message: unknown) => void) => {
+        if (event === "message") {
+          queueMicrotask(() => {
+            const jobs = (options?.workerData as { jobs?: unknown[] } | undefined)?.jobs ?? [];
+            handler({
+              type: "done",
+              context: (options?.workerData as { context?: string } | undefined)?.context ?? "",
+              durationMs: 0,
+              sessions: jobs.length,
+            });
+          });
+        }
+        if (event === "exit") {
+          queueMicrotask(() => handler(0));
+        }
+        return worker;
+      }),
       unref: vi.fn(),
       terminate: vi.fn(async () => undefined),
     };
@@ -228,6 +244,20 @@ describe("LiveScanStore", () => {
     expect(snapshot.byAgent.codex.map((session) => session.id)).toEqual(["newer", "older"]);
     expect(snapshot.byAgent.kimi).toEqual([]);
     expect(snapshot.sessions.map((session) => session.id)).toEqual(["newer", "older"]);
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
+      expect.objectContaining({
+        kind: "full",
+        context: "scan.initial",
+        agentName: "codex",
+        sessions: [newer, older],
+      }),
+      expect.objectContaining({
+        kind: "full",
+        context: "scan.initial",
+        agentName: "kimi",
+        sessions: [],
+      }),
+    ]);
   });
 
   it("emits refresh events and persists changed agent sessions", async () => {
@@ -274,7 +304,7 @@ describe("LiveScanStore", () => {
     expect(core.saveCachedSessionChanges).not.toHaveBeenCalled();
     expect(core.syncSessionSearchIndex).not.toHaveBeenCalled();
     expect(core.syncSessionSearchIndexChanges).not.toHaveBeenCalled();
-    expect(workerThreads.workers[0]?.workerData.jobs).toEqual([
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
       {
         kind: "changes",
         context: "scan.refresh",
@@ -329,12 +359,49 @@ describe("LiveScanStore", () => {
     (store as any).pendingRefreshPathCounts.set("codex", 101);
     await (store as any).runRefresh("codex");
 
-    expect(workerThreads.workers[0]?.workerData.jobs[0]).toEqual(
+    expect(workerThreads.workers.at(-1)?.workerData.jobs[0]).toEqual(
       expect.objectContaining({
         kind: "changes",
         searchIndexOptions: { isBulk: true },
       }),
     );
+  });
+
+  it("emits an update event when changed session content keeps the same head signature", async () => {
+    const previous = makeSession("session", { title: "same", time_updated: 1000 });
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["session"],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [previous]),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [previous],
+      byAgent: { codex: [previous] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore(false);
+    const events: unknown[] = [];
+    store.subscribe((event) => events.push(event));
+    await store.initialize();
+    await (store as any).runRefresh("codex");
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "sessions-updated",
+        changedAgents: ["codex"],
+        newSessions: 0,
+        updatedSessions: 1,
+        removedSessions: 0,
+        changedSessionHeads: [{ agentName: "codex", session: previous }],
+        removedSessionRefs: [],
+      }),
+    ]);
   });
 
   it("removes sessions when an agent becomes unavailable", async () => {
@@ -357,7 +424,7 @@ describe("LiveScanStore", () => {
     await (store as any).runRefresh("codex");
 
     expect(core.saveCachedSessions).not.toHaveBeenCalled();
-    expect(workerThreads.workers[0]?.workerData.jobs).toEqual([
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
       {
         kind: "full",
         context: "scan.refresh",

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -58,6 +58,13 @@ interface SessionRefreshDiff {
   removedSessionIds: string[];
 }
 
+interface SearchIndexJobBatch {
+  context: string;
+  jobs: SearchIndexWorkerJob[];
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
 const REFRESH_DEBOUNCE_MS = 200;
 const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const PENDING_REFRESH_DELAY_MS = 100;
@@ -127,10 +134,11 @@ function buildRefreshDiff(
       return;
     }
     const hasSignatureChange = sessionSignature(previous) !== sessionSignature(session);
-    if (hasSignatureChange) {
+    const hasContentChange = candidateChangedIdSet.has(id);
+    if (hasSignatureChange || hasContentChange) {
       updatedSessions += 1;
     }
-    if (candidateChangedIdSet.has(id) || hasSignatureChange) {
+    if (hasContentChange || hasSignatureChange) {
       changedSessions.push({ session, sortIndex: index });
     }
   });
@@ -334,9 +342,8 @@ export class LiveScanStore {
   private stablePaths = new Map<string, StablePathState>();
   private pendingEvent: SessionsUpdatedEvent | null = null;
   private pendingEventTimer: NodeJS.Timeout | null = null;
-  private initialSearchIndexTimer: NodeJS.Timeout | null = null;
   private searchIndexWorker: Worker | null = null;
-  private pendingSearchIndexJobs: SearchIndexWorkerJob[] = [];
+  private pendingSearchIndexJobs: SearchIndexJobBatch[] = [];
 
   constructor(
     private readonly watchEnabled = true,
@@ -365,8 +372,15 @@ export class LiveScanStore {
           : undefined,
     });
     this.applyScanResult(initialResult);
+    const indexStartedAt = performance.now();
+    await this.enqueueSearchIndexJobs(
+      "scan.initial",
+      this.buildFullSearchIndexJobs("scan.initial"),
+    );
+    const indexDuration = performance.now() - indexStartedAt;
     appLogger.info("scan.initial.done", {
       duration_ms: Math.round(performance.now() - startedAt),
+      index_ms: Math.round(indexDuration),
       sessions: this.sessions.length,
       agents: Object.fromEntries(
         Object.entries(this.byAgent).map(([key, value]) => [key, value.length]),
@@ -389,10 +403,6 @@ export class LiveScanStore {
     });
     if (this.watchEnabled) {
       this.startWatching();
-      this.initialSearchIndexTimer = setTimeout(() => {
-        this.initialSearchIndexTimer = null;
-        this.startSearchIndexWorker("scan.initial.background");
-      }, 1000);
     }
   }
 
@@ -417,7 +427,6 @@ export class LiveScanStore {
     }
     this.refreshTimers.clear();
     this.pendingRefreshPathCounts.clear();
-
     for (const state of this.stablePaths.values()) {
       if (state.timer) {
         clearTimeout(state.timer);
@@ -429,13 +438,12 @@ export class LiveScanStore {
       clearTimeout(this.pendingEventTimer);
       this.pendingEventTimer = null;
     }
-    if (this.initialSearchIndexTimer) {
-      clearTimeout(this.initialSearchIndexTimer);
-      this.initialSearchIndexTimer = null;
-    }
     if (this.searchIndexWorker) {
       await this.searchIndexWorker.terminate();
       this.searchIndexWorker = null;
+    }
+    for (const batch of this.pendingSearchIndexJobs) {
+      batch.reject(new Error("Live scan store shut down"));
     }
     this.pendingSearchIndexJobs = [];
     this.pendingEvent = null;
@@ -554,42 +562,49 @@ export class LiveScanStore {
     });
   }
 
-  private startSearchIndexWorker(context: string): void {
-    this.enqueueSearchIndexJobs(
+  private buildFullSearchIndexJobs(context: string): SearchIndexWorkerJob[] {
+    return this.agents.map((agent) => ({
+      kind: "full",
       context,
-      this.agents.map((agent) => ({
-        kind: "full",
-        context,
-        agentName: agent.name,
-        sessions: this.byAgent[agent.name] ?? [],
-        meta: buildAgentCacheMeta(agent),
-      })),
-    );
+      agentName: agent.name,
+      sessions: this.byAgent[agent.name] ?? [],
+      meta: buildAgentCacheMeta(agent),
+    }));
   }
 
-  private enqueueSearchIndexJobs(context: string, jobs: SearchIndexWorkerJob[]): void {
-    if (jobs.length === 0) return;
+  private enqueueSearchIndexJobs(context: string, jobs: SearchIndexWorkerJob[]): Promise<void> {
+    if (jobs.length === 0) return Promise.resolve();
 
-    if (this.searchIndexWorker) {
-      this.pendingSearchIndexJobs.push(...jobs);
-      appLogger.debug("search_index.worker_queued", {
-        context,
-        jobs: jobs.length,
-        pending_jobs: this.pendingSearchIndexJobs.length,
-      });
-      return;
-    }
+    return new Promise((resolve, reject) => {
+      const batch: SearchIndexJobBatch = { context, jobs, resolve, reject };
 
+      if (this.searchIndexWorker) {
+        this.pendingSearchIndexJobs.push(batch);
+        appLogger.debug("search_index.worker_queued", {
+          context,
+          jobs: jobs.length,
+          pending_jobs: this.pendingSearchIndexJobs.length,
+        });
+        return;
+      }
+
+      this.startSearchIndexJobBatch(batch);
+    });
+  }
+
+  private startSearchIndexJobBatch(batch: SearchIndexJobBatch): void {
     const workerUrl = this.getSearchIndexWorkerUrl();
     if (!workerUrl) {
-      appLogger.warn("search_index.worker_missing", { context });
+      appLogger.warn("search_index.worker_missing", { context: batch.context });
+      batch.resolve();
       return;
     }
 
+    let settled = false;
     const worker = new Worker(workerUrl, {
       workerData: {
-        context,
-        jobs,
+        context: batch.context,
+        jobs: batch.jobs,
         agentNames: [],
         sessionsByAgent: {},
         metaByAgent: {},
@@ -606,20 +621,29 @@ export class LiveScanStore {
           duration_ms: Math.round(message.durationMs),
           sessions: message.sessions,
         });
+        settled = true;
+        batch.resolve();
       }
     });
     worker.on("error", (error) => {
-      appLogger.error("search_index.worker_error", { context, error });
+      appLogger.error("search_index.worker_error", { context: batch.context, error });
+      if (!settled) {
+        settled = true;
+        batch.reject(error);
+      }
     });
     worker.on("exit", (code) => {
       this.searchIndexWorker = null;
       if (code !== 0) {
-        appLogger.warn("search_index.worker_exit", { context, code });
+        appLogger.warn("search_index.worker_exit", { context: batch.context, code });
+        if (!settled) {
+          settled = true;
+          batch.reject(new Error(`Search index worker exited with code ${code}`));
+        }
       }
       if (this.pendingSearchIndexJobs.length > 0) {
-        const pendingJobs = this.pendingSearchIndexJobs;
-        this.pendingSearchIndexJobs = [];
-        this.enqueueSearchIndexJobs("search_index.worker.drain", pendingJobs);
+        const pendingBatch = this.pendingSearchIndexJobs.shift()!;
+        this.startSearchIndexJobBatch(pendingBatch);
       }
     });
   }
@@ -1057,7 +1081,7 @@ export class LiveScanStore {
           }
         : null;
     if (persistentJob) {
-      this.enqueueSearchIndexJobs("scan.refresh", [persistentJob]);
+      await this.enqueueSearchIndexJobs("scan.refresh", [persistentJob]);
     }
     persistDuration = performance.now() - persistStartedAt;
     const searchIndexStartedAt = performance.now();

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -53,8 +53,10 @@ try {
     agent.setSessionMetaMap(new Map(Object.entries(data.meta)));
   }
 
-  const sessions =
-    data.changedIds && agent.incrementalScan
+  const isAvailable = agent.isAvailable();
+  const sessions = !isAvailable
+    ? []
+    : data.changedIds && agent.incrementalScan
       ? agent.incrementalScan(data.previousSessions, data.changedIds)
       : agent.scan(data.startupScanOptions);
 

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -51,7 +51,7 @@ describe("createServer", () => {
     expect(app.url).toMatch(/^http:\/\/localhost:\d+$/);
     expect(app.url).not.toBe("http://localhost:0");
 
-    app.shutdown();
+    await app.shutdown();
   });
 
   it("falls back to the next port when enabled", async () => {
@@ -63,7 +63,7 @@ describe("createServer", () => {
 
       expect(app.url).toBe(`http://localhost:${port + 1}`);
     } finally {
-      app?.shutdown();
+      await app?.shutdown();
       await close(blocker);
     }
   });

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -80,7 +80,7 @@ export async function createServer(
   port: number,
   store: ScanResultSource & Partial<Pick<LiveScanStore, "subscribe" | "shutdown">>,
   options: CreateServerOptions = {},
-): Promise<{ url: string; shutdown: () => void }> {
+): Promise<{ url: string; shutdown: () => Promise<void> }> {
   const app = new Hono();
 
   app.use("*", async (c, next) => {
@@ -167,11 +167,17 @@ export async function createServer(
 
   return {
     url,
-    shutdown: () => {
+    shutdown: async () => {
       appLogger.info("server.shutdown", { port: actualPort });
-      server?.close();
+      await new Promise<void>((resolve) => {
+        if (!server) {
+          resolve();
+          return;
+        }
+        server.close(() => resolve());
+      });
       if (store.shutdown) {
-        void store.shutdown();
+        await store.shutdown();
       }
     },
   };

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -280,5 +280,5 @@ describe("sqlite migration smoke", () => {
     ]);
     expect(getUserVersion(getCachePath())).toBe(11);
     expect(getUserVersion(getStatePath())).toBe(1);
-  }, 15_000);
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

- wait for the initial SQLite/search-index sync before the server is ready
- make live refresh persistence awaitable before emitting updates
- remove noisy update-only sync notices and cleanly shut down server/store resources

## Root cause

The detail API intentionally reads from SQLite, but startup exposed the server before the background initial index had finished writing session messages. Restarting could therefore still serve stale details until a later watcher event happened to trigger another refresh.

## Validation

- pnpm vitest run packages/cli/src/live-scan-store.test.ts packages/cli/src/live-scan.test.ts packages/cli/src/server.test.ts
- pnpm --filter codesesh lint
- pnpm --filter codesesh build
- manually verified the target Codex session appears in the list and detail page after startup
