### PR TITLE
[codex] Group Codex scratch chats

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -58,6 +58,7 @@ export type ProjectIdentityKind =
   | "git_remote"
   | "git_common_dir"
   | "manifest_path"
+  | "synthetic"
   | "path"
   | "loose";
 

--- a/apps/web/src/lib/projects.ts
+++ b/apps/web/src/lib/projects.ts
@@ -9,6 +9,7 @@ const projectIdentityKinds = new Set<string>([
   "git_remote",
   "git_common_dir",
   "manifest_path",
+  "synthetic",
   "path",
   "loose",
 ]);

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ClaudeCodeAgent } from "../claudecode.js";
-import type { SessionHead } from "../../types/index.js";
+import type { Message, MessagePart, SessionHead } from "../../types/index.js";
 
 let tempDirs: string[] = [];
 
@@ -161,7 +161,9 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
     const assistant = data.messages[1];
-    const readTool = assistant?.parts.find((part) => part.type === "tool" && part.tool === "Read");
+    const readTool = assistant?.parts.find(
+      (part: MessagePart) => part.type === "tool" && part.tool === "Read",
+    );
 
     expect(head).toMatchObject({
       id: sessionId,
@@ -176,7 +178,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       },
       model_usage: { "claude-sonnet-4-5-20250929": 135 },
     });
-    expect(data.messages.map((message) => message.role)).toEqual([
+    expect(data.messages.map((message: Message) => message.role)).toEqual([
       "user",
       "assistant",
       "user",
@@ -206,9 +208,11 @@ describe("ClaudeCodeAgent cache refresh", () => {
         meta: { commandName: "read" },
       },
     });
-    expect(assistant?.parts.some((part) => part.type === "tool" && part.tool === "TodoWrite")).toBe(
-      false,
-    );
+    expect(
+      assistant?.parts.some(
+        (part: MessagePart) => part.type === "tool" && part.tool === "TodoWrite",
+      ),
+    ).toBe(false);
     expect(data.messages[2]?.parts).toMatchObject([{ type: "text", text: "Continue" }]);
     expect(data.messages[3]).toMatchObject({
       role: "tool",

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CodexAgent } from "../codex.js";
-import type { SessionHead } from "../../types/index.js";
+import type { Message, MessagePart, SessionHead } from "../../types/index.js";
 
 let tempDirs: string[] = [];
 
@@ -406,7 +406,7 @@ describe("CodexAgent cache refresh", () => {
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
-    const toolPart = data.messages[1]?.parts.find((part) => part.type === "tool");
+    const toolPart = data.messages[1]?.parts.find((part: MessagePart) => part.type === "tool");
 
     expect(head?.title).toBe("Visible request");
     expect(data.messages[0]?.parts).toEqual([
@@ -588,14 +588,14 @@ describe("CodexAgent cache refresh", () => {
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
-    const assistantWithTools = data.messages.find((message) =>
-      message.parts.some((part) => part.type === "tool" && part.tool === "bash"),
+    const assistantWithTools = data.messages.find((message: Message) =>
+      message.parts.some((part: MessagePart) => part.type === "tool" && part.tool === "bash"),
     );
     const bashPart = assistantWithTools?.parts.find(
-      (part) => part.type === "tool" && part.tool === "bash",
+      (part: MessagePart) => part.type === "tool" && part.tool === "bash",
     );
     const patchPart = assistantWithTools?.parts.find(
-      (part) => part.type === "tool" && part.tool === "patch",
+      (part: MessagePart) => part.type === "tool" && part.tool === "patch",
     );
 
     expect(head).toMatchObject({
@@ -610,7 +610,7 @@ describe("CodexAgent cache refresh", () => {
       },
       model_usage: { "gpt-5.5": 125 },
     });
-    expect(data.messages.map((message) => message.role)).toEqual([
+    expect(data.messages.map((message: Message) => message.role)).toEqual([
       "user",
       "assistant",
       "user",

--- a/packages/core/src/agents/__tests__/cursor-opencode.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-opencode.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { CursorAgent } from "../cursor.js";
 import { OpenCodeAgent } from "../opencode.js";
+import type { MessagePart } from "../../types/index.js";
 
 let tempDirs: string[] = [];
 
@@ -61,7 +62,7 @@ describe("SQLite-backed agent parse contracts", () => {
 
     const [head] = agent.scan({ from: 0 });
     const data = agent.getSessionData("composer-1");
-    const tool = data.messages[1]?.parts.find((part) => part.type === "tool");
+    const tool = data.messages[1]?.parts.find((part: MessagePart) => part.type === "tool");
 
     expect(head?.title).toBe("Visible request");
     expect(data.messages).toHaveLength(2);

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { CursorAgent } from "../cursor.js";
+import type { MessagePart } from "../../types/index.js";
 
 let tempDirs: string[] = [];
 
@@ -61,7 +62,7 @@ describe("CursorAgent parsing", () => {
     });
 
     const data = agent.getSessionData("composer-1");
-    const toolPart = data.messages[1]?.parts.find((part) => part.type === "tool");
+    const toolPart = data.messages[1]?.parts.find((part: MessagePart) => part.type === "tool");
 
     expect(data.title).toBe("Visible request");
     expect(data.messages[0]?.parts).toEqual([

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -858,7 +858,7 @@ export class KimiAgent extends BaseAgent {
 
   private extractStats(sessionDir: string): SessionData["stats"] {
     let totalCost = 0;
-    const stats = {
+    const stats: SessionData["stats"] = {
       total_cost: 0,
       total_input_tokens: 0,
       total_output_tokens: 0,

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -189,7 +189,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(11);
+    expect(getUserVersion(getCachePath())).toBe(12);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -346,7 +346,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(11);
+    expect(getUserVersion(getCachePath())).toBe(12);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -537,14 +537,14 @@ describe("searchSessions", () => {
   });
 
   it("loads full session data from the SQLite message cache", () => {
-    const session = {
+    const session: SessionHead = {
       ...makeSession("cached-detail"),
       stats: {
         message_count: 1,
         total_input_tokens: 3,
         total_output_tokens: 5,
         total_cost: 0.02,
-        cost_source: "estimated",
+        cost_source: "estimated" as const,
       },
     };
     syncSessionSearchIndex("codex", [session], (sessionId) => ({
@@ -1349,7 +1349,52 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(11);
+    expect(getUserVersion(getCachePath())).toBe(12);
+  });
+
+  it("refreshes cached project identities when migrating to schema version 12", () => {
+    const directory = join(testHomeDir, "Documents", "Codex", "2026-05-22", "new-chat");
+    saveCachedSessions("codex", [{ ...makeSession("codex-scratch"), directory }]);
+
+    const db = new Database(getCachePath());
+    try {
+      db.prepare(
+        `
+          UPDATE sessions
+          SET project_identity_kind = 'path',
+              project_identity_key = ?,
+              project_display_name = 'new-chat'
+        `,
+      ).run(directory);
+      db.prepare(
+        `
+          UPDATE project_sessions
+          SET identity_kind = 'path',
+              identity_key = ?,
+              display_name = 'new-chat'
+        `,
+      ).run(directory);
+      db.pragma("user_version = 11");
+      db.prepare("UPDATE cache_meta SET value = '11' WHERE key = 'version'").run();
+    } finally {
+      db.close();
+    }
+
+    expect(listCachedProjectGroups()).toEqual([
+      {
+        identityKind: "synthetic",
+        identityKey: "codex:scratch",
+        displayName: "Chats",
+        sources: ["codex"],
+        sessionCount: 1,
+        lastActivity: now,
+      },
+    ]);
+    expect(loadCachedSessions("codex")?.sessions[0]?.project_identity).toEqual({
+      kind: "synthetic",
+      key: "codex:scratch",
+      displayName: "Chats",
+    });
   });
 
   it("combines full text with structured filters", () => {

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -278,7 +278,7 @@ describe("sqlite migration smoke", () => {
         bookmarked_at: now - 500,
       },
     ]);
-    expect(getUserVersion(getCachePath())).toBe(11);
+    expect(getUserVersion(getCachePath())).toBe(12);
     expect(getUserVersion(getStatePath())).toBe(1);
   }, 30_000);
 });

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -31,7 +31,7 @@ import {
   type SQLiteDatabase,
 } from "../utils/sqlite.js";
 
-const CACHE_SCHEMA_VERSION = 11;
+const CACHE_SCHEMA_VERSION = 12;
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
@@ -224,6 +224,13 @@ interface ProjectBackfillDocumentRow extends DatabaseRow {
   time_created?: number;
   time_updated?: number | null;
   activity_time?: number;
+}
+
+interface ProjectIdentityRefreshRow extends DatabaseRow {
+  id?: number;
+  agent_name?: string;
+  session_id?: string;
+  directory?: string;
 }
 
 interface StructuredMessageRecord {
@@ -1229,6 +1236,67 @@ function migrateProjectIdentity(db: SQLiteDatabase): void {
   backfillSessionDocumentProjects(db);
 }
 
+function refreshProjectIdentities(db: SQLiteDatabase): void {
+  if (
+    tableExists(db, "sessions") &&
+    columnExists(db, "sessions", "project_identity_key") &&
+    columnExists(db, "sessions", "directory")
+  ) {
+    const rows = db
+      .prepare("SELECT agent_name, session_id, directory FROM sessions")
+      .all() as ProjectIdentityRefreshRow[];
+    const update = db.prepare(`
+      UPDATE sessions
+      SET
+        project_identity_kind = ?,
+        project_identity_key = ?,
+        project_display_name = ?
+      WHERE agent_name = ? AND session_id = ?
+    `);
+    const updateFileActivity =
+      tableExists(db, "session_file_activity") &&
+      columnExists(db, "session_file_activity", "project_identity_key")
+        ? db.prepare(`
+            UPDATE session_file_activity
+            SET project_identity_key = ?
+            WHERE agent_name = ? AND session_id = ?
+          `)
+        : null;
+
+    for (const row of rows) {
+      const identity = computeIdentity(String(row.directory ?? ""), realFs);
+      update.run(identity.kind, identity.key, identity.displayName, row.agent_name, row.session_id);
+      updateFileActivity?.run(identity.key, row.agent_name, row.session_id);
+    }
+  }
+
+  if (
+    tableExists(db, "project_sessions") &&
+    columnExists(db, "project_sessions", "identity_key") &&
+    columnExists(db, "project_sessions", "directory")
+  ) {
+    const rows = db
+      .prepare("SELECT agent_name, session_id, directory FROM project_sessions")
+      .all() as ProjectIdentityRefreshRow[];
+    const update = db.prepare(`
+      UPDATE project_sessions
+      SET
+        identity_kind = ?,
+        identity_key = ?,
+        display_name = ?
+      WHERE agent_name = ? AND session_id = ?
+    `);
+
+    for (const row of rows) {
+      const identity = computeIdentity(String(row.directory ?? ""), realFs);
+      update.run(identity.kind, identity.key, identity.displayName, row.agent_name, row.session_id);
+    }
+  }
+
+  backfillSessionDocumentProjects(db);
+  recreateProjectGroupsView(db);
+}
+
 function backfillStructuredSessions(db: SQLiteDatabase): void {
   createSessionTables(db);
   recreateProjectGroupsView(db);
@@ -1579,6 +1647,12 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
         version: 11,
         migrate(db) {
           backfillMessageTools(db);
+        },
+      },
+      {
+        version: 12,
+        migrate(db) {
+          refreshProjectIdentities(db);
         },
       },
     ],

--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { homedir } from "node:os";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { computeIdentity, normalizeGitRemote, type IdentityFs } from "./identity.js";
+
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    homedir: vi.fn(actual.homedir),
+  };
+});
 
 function createFs(
   paths: Record<string, string | true>,
@@ -38,6 +47,10 @@ describe("normalizeGitRemote", () => {
 });
 
 describe("computeIdentity", () => {
+  beforeEach(() => {
+    vi.mocked(homedir).mockReturnValue("/Users/test");
+  });
+
   it("uses git remote identity from repository subdirectories", () => {
     const fs = createFs(
       {
@@ -91,6 +104,73 @@ describe("computeIdentity", () => {
       kind: "manifest_path",
       key: "D:\\workspace\\tool",
       displayName: "tool",
+    });
+  });
+
+  it("groups Codex scratch chats under Chats on POSIX paths", () => {
+    vi.mocked(homedir).mockReturnValue("/Users/chen");
+
+    expect(
+      computeIdentity("/Users/chen/Documents/Codex/2026-05-22/new-chat", createFs({})),
+    ).toEqual({
+      kind: "synthetic",
+      key: "codex:scratch",
+      displayName: "Chats",
+    });
+  });
+
+  it("groups Codex scratch chats under Chats on Windows paths", () => {
+    vi.mocked(homedir).mockReturnValue("C:\\Users\\chen");
+
+    expect(
+      computeIdentity("C:\\Users\\chen\\Documents\\Codex\\2026-05-22\\new-chat", createFs({})),
+    ).toEqual({
+      kind: "synthetic",
+      key: "codex:scratch",
+      displayName: "Chats",
+    });
+  });
+
+  it("does not let HOME override os.homedir for Codex scratch paths", () => {
+    const originalHome = process.env["HOME"];
+    process.env["HOME"] = "/tmp/fake-home";
+    vi.mocked(homedir).mockReturnValue("/Users/chen");
+
+    try {
+      expect(
+        computeIdentity("/Users/chen/Documents/Codex/2026-05-22/new-chat", createFs({}))?.key,
+      ).toBe("codex:scratch");
+      expect(
+        computeIdentity("/tmp/fake-home/Documents/Codex/2026-05-22/new-chat", createFs({})),
+      ).toEqual({
+        kind: "path",
+        key: "/tmp/fake-home/Documents/Codex/2026-05-22/new-chat",
+        displayName: "new-chat",
+      });
+    } finally {
+      if (originalHome === undefined) delete process.env["HOME"];
+      else process.env["HOME"] = originalHome;
+    }
+  });
+
+  it("prefers real project signals inside Codex scratch directories", () => {
+    vi.mocked(homedir).mockReturnValue("/Users/chen");
+    const fs = createFs(
+      {
+        "/Users/chen/Documents/Codex/2026-05-22/new-chat/.git": true,
+        "/Users/chen/Documents/Codex/2026-05-22/new-chat/package.json": JSON.stringify({
+          name: "real-project",
+        }),
+      },
+      {
+        "/Users/chen/Documents/Codex/2026-05-22/new-chat": "git@github.com:acme/real-project.git",
+      },
+    );
+
+    expect(computeIdentity("/Users/chen/Documents/Codex/2026-05-22/new-chat/src", fs)).toEqual({
+      kind: "git_remote",
+      key: "github.com/acme/real-project",
+      displayName: "real-project",
     });
   });
 });

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -1,4 +1,4 @@
-import { homedir } from "node:os";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { ProjectIdentity, ProjectIdentityKind } from "../types/index.js";
 import { fallbackDisplayName } from "./display-name.js";
@@ -23,7 +23,10 @@ const PARSEABLE_MANIFESTS = ["package.json", "Cargo.toml", "pyproject.toml"] as 
 
 const LOOSE_DIRS = new Set(["/tmp", "/private/tmp"]);
 const LOOSE_HOME_DIRS = ["Desktop", "Downloads", "Documents"];
-type PathOps = Pick<typeof path.posix, "dirname" | "isAbsolute" | "join" | "resolve">;
+type PathOps = Pick<
+  typeof path.posix,
+  "dirname" | "isAbsolute" | "join" | "relative" | "resolve" | "sep"
+>;
 
 export function normalizeGitRemote(url: string): string | null {
   if (!url) return null;
@@ -40,7 +43,7 @@ export function computeIdentity(cwd: string | null | undefined, fs: IdentityFs):
 
   const pathOps = getPathOps(cwd);
   const absoluteCwd = pathOps.resolve(cwd);
-  const homeDir = homedir();
+  const homeDir = os.homedir();
   const homePathOps = getPathOps(homeDir);
   const home = homePathOps === pathOps ? pathOps.resolve(homeDir) : homeDir;
   if (absoluteCwd === home || LOOSE_DIRS.has(absoluteCwd)) return loose();
@@ -88,6 +91,11 @@ export function computeIdentity(cwd: string | null | undefined, fs: IdentityFs):
     };
   }
 
+  if (homePathOps === pathOps) {
+    const synthetic = synthesizeCodexScratchIdentity(absoluteCwd, home, pathOps);
+    if (synthetic) return synthetic;
+  }
+
   return {
     kind: "path",
     key: absoluteCwd,
@@ -97,6 +105,24 @@ export function computeIdentity(cwd: string | null | undefined, fs: IdentityFs):
 
 function loose(): ProjectIdentity {
   return { kind: "loose", key: "loose", displayName: "Loose" };
+}
+
+function synthesizeCodexScratchIdentity(
+  absoluteCwd: string,
+  home: string,
+  pathOps: PathOps,
+): ProjectIdentity | null {
+  const root = pathOps.resolve(pathOps.join(home, "Documents", "Codex"));
+  const child = pathOps.relative(root, absoluteCwd);
+  if (
+    !child ||
+    child === ".." ||
+    child.startsWith(`..${pathOps.sep}`) ||
+    pathOps.isAbsolute(child)
+  ) {
+    return null;
+  }
+  return { kind: "synthetic", key: "codex:scratch", displayName: "Chats" };
 }
 
 function getPathOps(input: string): PathOps {

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -47,6 +47,7 @@ export type ProjectIdentityKind =
   | "git_remote"
   | "git_common_dir"
   | "manifest_path"
+  | "synthetic"
   | "path"
   | "loose";
 


### PR DESCRIPTION
## Summary

- Group Codex desktop scratch workspaces under a synthetic `Chats` project.
- Add cross-platform path matching based on `os.homedir()` and `path.relative()`.
- Add a cache schema migration that refreshes stored project identities so existing cached Codex scratch sessions stop appearing as separate path projects.
- Fix existing core TypeScript errors by tightening test callback types and Kimi stats typing.

## Root Cause

Codex non-project chats use disposable workspaces under `Documents/Codex`, so plain path identity treats each chat directory as a separate project. The project identity model also did not include a synthetic grouping kind, and old cache rows could preserve stale path identities after the identity logic changes.

## Validation

- `pnpm --filter @codesesh/core exec tsc --noEmit`
- `pnpm --filter @codesesh/core test -- src/projects/identity.test.ts src/discovery/__tests__/cache.test.ts src/discovery/__tests__/migration-smoke.test.ts src/agents/__tests__/claudecode.test.ts src/agents/__tests__/codex.test.ts src/agents/__tests__/cursor.test.ts src/agents/__tests__/cursor-opencode.test.ts`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter @codesesh/web build`
- `git diff --check`