### PR TITLE
perf: defer startup refresh

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -190,6 +190,12 @@
   margin-top: 0.75rem;
 }
 
+.console-markdown {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .console-markdown p {
   margin: 0;
 }
@@ -283,11 +289,14 @@
   background: #f5f5f5;
   border: 1px solid #e5e7eb;
   border-radius: 0.125rem;
+  overflow-wrap: anywhere;
   padding: 0.08rem 0.32rem;
+  white-space: pre-wrap;
 }
 
 .console-markdown pre {
   margin: 0;
+  max-width: 100%;
   border: 1px solid #e5e7eb;
   background: #fafafa;
   border-radius: 0.125rem;
@@ -298,5 +307,7 @@
 .console-markdown pre code {
   border: none;
   background: transparent;
+  overflow-wrap: normal;
   padding: 0;
+  white-space: pre;
 }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -62,6 +62,7 @@ export const serveCommand = defineCommand({
       !jsonOnly,
       scanOptions,
       jsonOnly ? {} : { from: listDefaultFrom, to: listDefaultTo },
+      { deferInitialRefresh: !jsonOnly },
     );
 
     await store.initialize();
@@ -104,6 +105,9 @@ export const serveCommand = defineCommand({
     }
 
     const { url } = app;
+    if (!jsonOnly) {
+      store.startBackgroundRefresh();
+    }
     let shuttingDown = false;
     const shutdown = async () => {
       if (shuttingDown) return;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -178,7 +178,9 @@ const main = defineCommand({
     const startupScanOptions =
       targetSession || jsonOnly ? {} : { from: listDefaultFrom, to: listDefaultTo };
 
-    const store = new LiveScanStore(!jsonOnly, scanOptions, startupScanOptions);
+    const store = new LiveScanStore(!jsonOnly, scanOptions, startupScanOptions, {
+      deferInitialRefresh: !jsonOnly,
+    });
     await store.initialize();
     const result = store.getSnapshot();
     appLogger.info("cli.scan_ready", {
@@ -242,6 +244,9 @@ const main = defineCommand({
     }
 
     const { url } = app;
+    if (!jsonOnly) {
+      store.startBackgroundRefresh();
+    }
     let shuttingDown = false;
     const shutdown = async (signal: NodeJS.Signals) => {
       if (shuttingDown) return;

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -217,7 +217,9 @@ describe("LiveScanStore", () => {
   });
 
   it("initializes a sorted snapshot for allowed registered agents", async () => {
-    const codex = makeAgent("codex");
+    const codex = makeAgent("codex", {
+      scan: vi.fn(() => [fresh]),
+    });
     const kimi = makeAgent("kimi");
     const older = makeSession("older", { time_updated: 1000 });
     const newer = makeSession("newer", { time_updated: 2000 });
@@ -233,13 +235,15 @@ describe("LiveScanStore", () => {
     await store.initialize();
 
     const snapshot = store.getSnapshot();
-    expect(core.scanSessions).toHaveBeenCalledWith({
-      agents: ["codex", "kimi"],
-      useCache: true,
-      smartRefresh: false,
-      writeCache: undefined,
-      includeSmartTags: undefined,
-    });
+    expect(core.scanSessions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agents: ["codex", "kimi"],
+        useCache: true,
+        smartRefresh: false,
+        writeCache: undefined,
+        includeSmartTags: undefined,
+      }),
+    );
     expect(snapshot.agents.map((agent) => agent.name)).toEqual(["codex", "kimi"]);
     expect(snapshot.byAgent.codex.map((session) => session.id)).toEqual(["newer", "older"]);
     expect(snapshot.byAgent.kimi).toEqual([]);
@@ -256,6 +260,75 @@ describe("LiveScanStore", () => {
         context: "scan.initial",
         agentName: "kimi",
         sessions: [],
+      }),
+    ]);
+  });
+
+  it("can initialize from cache and refresh the initial scan in the background", async () => {
+    vi.useFakeTimers();
+    const cached = makeSession("cached", { title: "cached", time_updated: 1000 });
+    const fresh = makeSession("fresh", { title: "fresh", time_updated: 2000 });
+    const codex = makeAgent("codex", {
+      scan: vi.fn(() => [fresh]),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValueOnce({
+      sessions: [cached],
+      byAgent: { codex: [cached] },
+      agents: [codex],
+      cacheTimestamps: { codex: 500 },
+    });
+
+    const store = new LiveScanStore(false, {}, {}, { deferInitialRefresh: true });
+    const events: unknown[] = [];
+    store.subscribe((event) => events.push(event));
+
+    await store.initialize();
+
+    expect(core.scanSessions).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        useCache: true,
+        smartRefresh: false,
+        cacheOnly: true,
+        writeCache: false,
+        includeSmartTags: false,
+      }),
+    );
+    expect(workerThreads.workers).toHaveLength(0);
+    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["cached"]);
+
+    store.startBackgroundRefresh();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(codex.scan).toHaveBeenCalled();
+    expect(workerThreads.workers[0]?.workerData.jobs).toEqual([
+      expect.objectContaining({
+        kind: "full",
+        context: "scan.initial.background",
+        agentName: "codex",
+        sessions: [cached],
+      }),
+    ]);
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
+      expect.objectContaining({
+        kind: "full",
+        context: "scan.refresh",
+        agentName: "codex",
+        sessions: [fresh],
+      }),
+    ]);
+    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["fresh"]);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "sessions-updated",
+        changedAgents: ["codex"],
+        newSessions: 1,
+        removedSessions: 1,
+        totalSessions: 1,
       }),
     ]);
   });

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -65,6 +65,10 @@ interface SearchIndexJobBatch {
   reject: (error: Error) => void;
 }
 
+interface LiveScanStoreOptions {
+  deferInitialRefresh?: boolean;
+}
+
 const REFRESH_DEBOUNCE_MS = 200;
 const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const PENDING_REFRESH_DELAY_MS = 100;
@@ -342,45 +346,57 @@ export class LiveScanStore {
   private stablePaths = new Map<string, StablePathState>();
   private pendingEvent: SessionsUpdatedEvent | null = null;
   private pendingEventTimer: NodeJS.Timeout | null = null;
+  private backgroundRefreshTimer: NodeJS.Timeout | null = null;
   private searchIndexWorker: Worker | null = null;
   private pendingSearchIndexJobs: SearchIndexJobBatch[] = [];
+  private shuttingDown = false;
 
   constructor(
     private readonly watchEnabled = true,
     private readonly scanOptions: ScanOptions = {},
     private readonly startupScanOptions: Pick<ScanOptions, "from" | "to"> = {},
+    private readonly storeOptions: LiveScanStoreOptions = {},
   ) {}
 
   async initialize(): Promise<void> {
     const startedAt = performance.now();
+    const deferInitialRefresh = this.storeOptions.deferInitialRefresh === true;
     appLogger.info("scan.initial.start", {
       watch_enabled: this.watchEnabled,
       agents: this.scanOptions.agents,
       use_cache: this.scanOptions.useCache ?? true,
       startup_from: this.startupScanOptions.from,
       startup_to: this.startupScanOptions.to,
+      deferred: deferInitialRefresh || undefined,
     });
     const initialResult = await scanSessions({
       ...this.scanOptions,
       ...this.startupScanOptions,
       useCache: this.scanOptions.useCache ?? true,
       smartRefresh: false,
+      cacheOnly: deferInitialRefresh,
+      writeCache: deferInitialRefresh ? false : this.scanOptions.writeCache,
       smartTagWorkerUrl: this.getSmartTagWorkerUrl() ?? undefined,
       includeSmartTags:
-        this.startupScanOptions.from != null || this.startupScanOptions.to != null
+        deferInitialRefresh ||
+        this.startupScanOptions.from != null ||
+        this.startupScanOptions.to != null
           ? false
           : undefined,
     });
     this.applyScanResult(initialResult);
     const indexStartedAt = performance.now();
-    await this.enqueueSearchIndexJobs(
-      "scan.initial",
-      this.buildFullSearchIndexJobs("scan.initial"),
-    );
+    if (!deferInitialRefresh) {
+      await this.enqueueSearchIndexJobs(
+        "scan.initial",
+        this.buildFullSearchIndexJobs("scan.initial"),
+      );
+    }
     const indexDuration = performance.now() - indexStartedAt;
     appLogger.info("scan.initial.done", {
       duration_ms: Math.round(performance.now() - startedAt),
-      index_ms: Math.round(indexDuration),
+      index_ms: deferInitialRefresh ? undefined : Math.round(indexDuration),
+      deferred: deferInitialRefresh || undefined,
       sessions: this.sessions.length,
       agents: Object.fromEntries(
         Object.entries(this.byAgent).map(([key, value]) => [key, value.length]),
@@ -406,6 +422,19 @@ export class LiveScanStore {
     }
   }
 
+  startBackgroundRefresh(): void {
+    if (this.backgroundRefreshTimer) {
+      return;
+    }
+    this.backgroundRefreshTimer = setTimeout(() => {
+      this.backgroundRefreshTimer = null;
+      void this.refreshInitialIndex();
+      for (const agent of this.agents) {
+        this.scheduleRefresh(agent.name, 0);
+      }
+    }, 0);
+  }
+
   getSnapshot(): ScanResult {
     return {
       sessions: this.sessions,
@@ -422,6 +451,7 @@ export class LiveScanStore {
   }
 
   async shutdown(): Promise<void> {
+    this.shuttingDown = true;
     for (const timer of this.refreshTimers.values()) {
       clearTimeout(timer);
     }
@@ -437,6 +467,10 @@ export class LiveScanStore {
     if (this.pendingEventTimer) {
       clearTimeout(this.pendingEventTimer);
       this.pendingEventTimer = null;
+    }
+    if (this.backgroundRefreshTimer) {
+      clearTimeout(this.backgroundRefreshTimer);
+      this.backgroundRefreshTimer = null;
     }
     if (this.searchIndexWorker) {
       await this.searchIndexWorker.terminate();
@@ -672,7 +706,7 @@ export class LiveScanStore {
     this.byAgent = {};
     for (const agent of this.agents) {
       this.byAgent[agent.name] = sortSessions(result.byAgent[agent.name] ?? []);
-      this.refreshTimestamps.set(agent.name, Date.now());
+      this.refreshTimestamps.set(agent.name, result.cacheTimestamps?.[agent.name] ?? Date.now());
     }
 
     this.rebuildSessions();
@@ -687,6 +721,25 @@ export class LiveScanStore {
 
   private applyFilters(sessions: SessionHead[]): SessionHead[] {
     return filterSessions(sessions, { ...this.scanOptions, ...this.startupScanOptions });
+  }
+
+  private async refreshInitialIndex(): Promise<void> {
+    const startedAt = performance.now();
+    const context = "scan.initial.background";
+
+    try {
+      await this.enqueueSearchIndexJobs(context, this.buildFullSearchIndexJobs(context));
+      appLogger.info(`${context}.complete`, {
+        duration_ms: Math.round(performance.now() - startedAt),
+        sessions: this.sessions.length,
+      });
+    } catch (error) {
+      if (this.shuttingDown) {
+        return;
+      }
+      appLogger.error(`${context}.error`, { error });
+      console.error("[search] Background index sync failed:", error);
+    }
   }
 
   private startWatching(): void {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -324,6 +324,40 @@ describe("scanSessions", () => {
     expect(result.sessions[0]!.id).toBe("cached");
   });
 
+  it("can return cached sessions without validating agent availability", async () => {
+    const cachedSessions = [makeSession("cached")];
+    mockedLoadCachedSessions.mockReturnValue({
+      sessions: cachedSessions,
+      meta: {},
+      timestamp: Date.now(),
+    });
+    mockedCreateRegisteredAgents.mockReturnValue([
+      createTestAgent({
+        name: "test",
+        available: false,
+        sessions: [makeSession("fresh")],
+        checkForChangesResult: {
+          hasChanges: true,
+          changedIds: ["fresh"],
+          timestamp: Date.now(),
+        },
+        incrementalScanResult: [makeSession("fresh")],
+      }),
+    ]);
+
+    const result = await scanSessions({ useCache: true, cacheOnly: true });
+
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]!.id).toBe("cached");
+    expect(result.sessions[0]!.project_identity).toEqual({
+      kind: "path",
+      key: "/home/user/project",
+      displayName: "project",
+    });
+    expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
+    expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
+  });
+
   it("refreshes stale cache before returning results", async () => {
     const cachedSessions = [makeSession("cached")];
     const refreshedSessions = [makeSession("fresh")];

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -25,6 +25,8 @@ export interface ScanOptions {
   useCache?: boolean;
   /** Enable smart refresh (fast cache + background incremental scan) */
   smartRefresh?: boolean;
+  /** Return cached session heads without validating the filesystem */
+  cacheOnly?: boolean;
   /** Persist scan results to the SQLite cache */
   writeCache?: boolean;
   /** Classify sessions by reading full conversation content */
@@ -40,6 +42,7 @@ export interface ScanResult {
   byAgent: Record<string, SessionHead[]>;
   agents: BaseAgent[];
   timings?: Record<string, AgentScanTiming>;
+  cacheTimestamps?: Record<string, number>;
 }
 
 /** 扫描状态更新回调 */
@@ -107,6 +110,7 @@ interface AgentScanResult {
   fromCache?: boolean;
   refreshed?: boolean;
   timing?: AgentScanTiming;
+  cacheTimestamp?: number;
 }
 
 interface SmartTagWorkerResult {
@@ -320,6 +324,28 @@ async function scanAgentSmart(
         agent.setSessionMetaMap(metaMap);
       }
 
+      if (options.cacheOnly) {
+        onProgress?.({
+          agent: agent.name,
+          phase: "cache",
+          cachedCount: cached.sessions.length,
+        });
+        onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
+        const t3 = performance.now();
+        const cachedWithIdentity = attachProjectIdentities(cached.sessions);
+        timing.identity = performance.now() - t3;
+
+        const filtered = filterSessions(cachedWithIdentity, options);
+        timing.total = performance.now() - agentStart;
+        return {
+          agent,
+          heads: filtered,
+          fromCache: true,
+          timing,
+          cacheTimestamp: cached.timestamp,
+        };
+      }
+
       const isAvail = agent.isAvailable();
       if (!isAvail) {
         return null;
@@ -382,7 +408,14 @@ async function scanAgentSmart(
 
           const filtered = filterSessions(tagged.sessions, options);
           timing.total = performance.now() - agentStart;
-          return { agent, heads: filtered, fromCache: true, refreshed: true, timing };
+          return {
+            agent,
+            heads: filtered,
+            fromCache: true,
+            refreshed: true,
+            timing,
+            cacheTimestamp: checkResult.timestamp,
+          };
         }
 
         onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
@@ -405,8 +438,19 @@ async function scanAgentSmart(
 
       const filtered = filterSessions(tagged.sessions, options);
       timing.total = performance.now() - agentStart;
-      return { agent, heads: filtered, fromCache: true, timing };
+      return {
+        agent,
+        heads: filtered,
+        fromCache: true,
+        timing,
+        cacheTimestamp: cached.timestamp,
+      };
     }
+  }
+
+  if (options.cacheOnly) {
+    timing.total = performance.now() - agentStart;
+    return null;
   }
 
   // 无缓存或缓存失效，执行完整扫描
@@ -480,6 +524,7 @@ export async function scanSessions(
   const byAgent: Record<string, SessionHead[]> = {};
   const allSessions: SessionHead[] = [];
   const availableAgents: BaseAgent[] = [];
+  const cacheTimestamps: Record<string, number> = {};
 
   const agentFilter = options.agents?.length
     ? new Set(options.agents.map((a) => a.toLowerCase()))
@@ -508,11 +553,20 @@ export async function scanSessions(
       if (result.timing) {
         timings[result.agent.name] = result.timing;
       }
+      if (result.cacheTimestamp != null) {
+        cacheTimestamps[result.agent.name] = result.cacheTimestamp;
+      }
     }
   }
 
   perf.end(scanMarker);
-  return { sessions: allSessions, byAgent, agents: availableAgents, timings };
+  return {
+    sessions: allSessions,
+    byAgent,
+    agents: availableAgents,
+    timings,
+    cacheTimestamps: Object.keys(cacheTimestamps).length > 0 ? cacheTimestamps : undefined,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Hydrate cached session heads during web startup and defer filesystem refresh plus search indexing to background work.
- Preserve synchronous scan behavior for JSON output.
- Ensure cache-only session heads still receive project identities so Codex scratch chats group under Chats.
- Prevent long user message content from overflowing session detail cards.

## Root Cause

Startup was waiting for the full initial scan and search index sync before the server became ready. After deferring that path, cache-only startup also needed the same project identity normalization as the normal cached scan path; otherwise sidebar grouping could fall back to raw scratch directories such as new-chat-4.

Long JSON/log messages were rendered inside markdown content without a wrap constraint, so unbroken text could expand beyond the message card.

## Validation

- pnpm --dir packages/core test -- discovery/__tests__/scanner.test.ts
- pnpm --dir packages/cli test -- live-scan-store.test.ts
- pnpm --dir packages/core build
- pnpm --dir packages/cli build
- pnpm --dir apps/web build
- pnpm --dir packages/core lint
- pnpm --dir packages/cli lint
- pnpm --dir apps/web lint
- git diff --check
- Browser check on a temporary local server for Chats grouping and long-message overflow