### PR TITLE
fix(codex): normalize namespaced tool labels

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -2069,18 +2069,18 @@ function SessionToc({
             {TOC_META.filter(({ id }) => toc.counts[id] > 0).map(({ id, label }) => (
               <label
                 key={id}
-                className="flex cursor-pointer items-center gap-3 rounded-sm px-2 py-2 transition-colors hover:bg-[var(--console-surface-muted)]"
+                className="flex cursor-pointer items-start gap-3 rounded-sm px-2 py-2 transition-colors hover:bg-[var(--console-surface-muted)]"
               >
                 <input
                   type="checkbox"
                   checked={selectedFilters.has(id)}
                   onChange={() => onToggle(id)}
-                  className="size-3.5 rounded border-[var(--console-border-strong)] accent-[var(--console-accent-strong)]"
+                  className="mt-0.5 size-3.5 shrink-0 rounded border-[var(--console-border-strong)] accent-[var(--console-accent-strong)]"
                 />
-                <span className="console-mono min-w-0 flex-1 text-xs text-[var(--console-text)]">
+                <span className="console-mono min-w-0 flex-1 break-all text-xs leading-relaxed text-[var(--console-text)]">
                   {label}
                 </span>
-                <span className="console-mono text-[11px] text-[var(--console-muted)]">
+                <span className="console-mono shrink-0 text-[11px] text-[var(--console-muted)]">
                   {toc.counts[id]}
                 </span>
               </label>
@@ -2091,7 +2091,7 @@ function SessionToc({
                   <label
                     key={tool.id}
                     className={cn(
-                      "flex items-center gap-3 rounded-sm px-2 py-2 transition-colors",
+                      "flex items-start gap-3 rounded-sm px-2 py-2 transition-colors",
                       toolsEnabled
                         ? "cursor-pointer hover:bg-[var(--console-surface-muted)]"
                         : "cursor-not-allowed opacity-50",
@@ -2102,12 +2102,12 @@ function SessionToc({
                       checked={toolsEnabled && selectedFilters.has(tool.id)}
                       disabled={!toolsEnabled}
                       onChange={() => onToggle(tool.id)}
-                      className="size-3.5 rounded border-[var(--console-border-strong)] accent-[var(--console-accent-strong)]"
+                      className="mt-0.5 size-3.5 shrink-0 rounded border-[var(--console-border-strong)] accent-[var(--console-accent-strong)]"
                     />
-                    <span className="console-mono min-w-0 flex-1 text-xs text-[var(--console-muted)]">
+                    <span className="console-mono min-w-0 flex-1 break-all text-xs leading-relaxed text-[var(--console-muted)]">
                       {tool.label}
                     </span>
-                    <span className="console-mono text-[11px] text-[var(--console-muted)]">
+                    <span className="console-mono shrink-0 text-[11px] text-[var(--console-muted)]">
                       {tool.count}
                     </span>
                   </label>

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -123,6 +123,45 @@ describe("CodexAgent cache refresh", () => {
     expect(agent.sessionIndexCache.size).toBe(0);
   });
 
+  it("invalidates cached sessions when the parser version changes", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionFile = join(
+      tempDir,
+      "rollout-2026-04-20T10-00-00-019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa.jsonl",
+    );
+
+    writeFileSync(
+      sessionFile,
+      '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionMetaMap = new Map([
+      [
+        "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
+        {
+          id: "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
+          sourcePath: sessionFile,
+          sourceMtimeMs: statSync(sessionFile).mtimeMs,
+          indexPath: null,
+          indexMtimeMs: null,
+          headIndexVersion: "codex-head-v1",
+          parserVersion: "codex-parser-v2",
+        },
+      ],
+    ]);
+    agent.listRolloutFiles = () => [sessionFile];
+
+    const result = agent.checkForChanges(Date.now(), [
+      makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
+    ]);
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.changedIds).toContain("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa");
+  });
+
   it("removes deleted sessions and adds new sessions during incremental scan", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     const oldA = join(
@@ -421,6 +460,74 @@ describe("CodexAgent cache refresh", () => {
       tool: "bash",
       state: {
         output: [expect.objectContaining({ type: "text", text: "Visible output" })],
+      },
+    });
+  });
+
+  it("normalizes namespaced MCP function calls for display", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionId = "019da000-0000-7000-8000-000000000000";
+    const sessionFile = join(tempDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:00Z",
+          type: "session_meta",
+          payload: { cwd: "/tmp/project" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:01Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "List labels" }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:02Z",
+          type: "response_item",
+          payload: {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Checking Linear" }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:03Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            call_id: "call-linear",
+            name: "_list_issue_labels",
+            namespace: "mcp__codex_apps__linear",
+            arguments: '{"team":"research&develop"}',
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+
+    agent.scan();
+    const data = agent.getSessionData(sessionId);
+    const toolPart = data.messages[1]?.parts.find((part: MessagePart) => part.type === "tool");
+
+    expect(toolPart).toMatchObject({
+      type: "tool",
+      tool: "linear.list_issue_labels",
+      title: "Tool: linear.list_issue_labels",
+      state: {
+        arguments: { team: "research&develop" },
+        metadata: {
+          name: "_list_issue_labels",
+          namespace: "mcp__codex_apps__linear",
+        },
       },
     });
   });

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -38,6 +38,7 @@ const PLAN_APPROVAL_PREFIX = "PLEASE IMPLEMENT THIS PLAN";
 const SUBAGENT_NOTIFICATION_PATTERN =
   /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
 const HEAD_INDEX_VERSION = "codex-head-v1";
+const PARSER_VERSION = "codex-parser-v3";
 
 const DEVELOPER_LIKE_USER_MARKERS = [
   "agents.md instructions for",
@@ -105,8 +106,23 @@ function extractCachedInputTokens(usage: Record<string, unknown> | undefined): n
 // Tool helpers
 // ---------------------------------------------------------------------------
 
-function mapToolTitle(name: string): string {
-  return CODEX_TOOL_TITLE_MAP[name] ?? name;
+function resolveToolIdentity(
+  name: string,
+  namespace: unknown,
+): { tool: string; metadata?: { name: string; namespace: string } } {
+  const mappedName = CODEX_TOOL_TITLE_MAP[name];
+  if (mappedName) return { tool: mappedName };
+
+  const namespaceText = typeof namespace === "string" ? namespace.trim() : "";
+  if (!namespaceText) return { tool: name };
+
+  const namespaceName = namespaceText.split("__").at(-1) ?? namespaceText;
+  const toolName = name.replace(/^_+/, "");
+
+  return {
+    tool: `${namespaceName}.${toolName || name}`,
+    metadata: { name, namespace: namespaceText },
+  };
 }
 
 function normalizeToolArguments(raw: unknown): unknown {
@@ -251,6 +267,7 @@ interface SessionMeta extends SessionCacheMeta {
   indexPath: string | null;
   indexMtimeMs: number | null;
   headIndexVersion: string;
+  parserVersion: string;
   directory: string;
   model: string | null;
   messageCount: number;
@@ -629,6 +646,7 @@ export class CodexAgent extends BaseAgent {
       indexPath: existsSync(indexPath) ? indexPath : null,
       indexMtimeMs: this.getFileMtimeMs(indexPath),
       headIndexVersion: HEAD_INDEX_VERSION,
+      parserVersion: PARSER_VERSION,
       directory: head.directory,
       model: null,
       messageCount: head.stats.message_count,
@@ -639,6 +657,7 @@ export class CodexAgent extends BaseAgent {
 
   private hasMetaChanged(meta: SessionMeta): boolean {
     if (meta.headIndexVersion !== HEAD_INDEX_VERSION) return true;
+    if (meta.parserVersion !== PARSER_VERSION) return true;
     if (typeof meta.sourceMtimeMs !== "number") return true;
     if (statSync(meta.sourcePath).mtimeMs !== meta.sourceMtimeMs) return true;
 
@@ -1321,17 +1340,18 @@ export class CodexAgent extends BaseAgent {
       return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan: null };
     }
 
-    const mappedName = mapToolTitle(name);
+    const toolIdentity = resolveToolIdentity(name, payload["namespace"]);
     const arguments_ = normalizeToolArguments(payload["arguments"]);
 
     const toolPart: MessagePart = {
       type: "tool",
-      tool: mappedName,
+      tool: toolIdentity.tool,
       callID: callId,
-      title: `Tool: ${mappedName}`,
+      title: `Tool: ${toolIdentity.tool}`,
       state: {
         arguments: arguments_,
         output: null,
+        metadata: toolIdentity.metadata,
       },
       time_created: timestampMs,
     };
@@ -1422,18 +1442,19 @@ export class CodexAgent extends BaseAgent {
       return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan: null };
     }
 
-    const mappedName = mapToolTitle(name);
+    const toolIdentity = resolveToolIdentity(name, payload["namespace"]);
     const rawInput = payload["input"];
     const normalizedInput = normalizeCustomToolArguments(name, rawInput);
 
     const toolPart: MessagePart = {
       type: "tool",
-      tool: mappedName,
+      tool: toolIdentity.tool,
       callID: callId,
-      title: `Tool: ${mappedName}`,
+      title: `Tool: ${toolIdentity.tool}`,
       state: {
         arguments: normalizedInput,
         output: null,
+        metadata: toolIdentity.metadata,
       },
       time_created: timestampMs,
     };


### PR DESCRIPTION
## Summary

- Normalize Codex MCP/app tool calls into compact display labels such as `linear.fetch` while preserving raw `name` and `namespace` metadata.
- Add a Codex parser version to invalidate stale cached session details when tool parsing semantics change.
- Allow long Session TOC labels to wrap within the card instead of overflowing horizontally.

## Why

RD-382 exposed that Codex tool calls can carry a separate namespace, and the UI needs to show a stable source-aware tool name without letting long labels break the TOC layout.

## Validation

- `rtk pnpm --filter @codesesh/core test -- src/agents/__tests__/codex.test.ts`
- `rtk pnpm --filter @codesesh/web lint`
- `rtk pnpm --filter @codesesh/web build`
- `rtk pnpm --filter @codesesh/core build`
- `rtk pnpm --filter codesesh build`
- Browser check on `http://localhost:4521/codex/019e4e67-aefe-7d11-a799-549130a3e4ef`: TOC labels report no horizontal overflow, and `linear.fetch` filter toggles normally.