### PR TITLE
fix: improve Codex tool display

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -292,9 +292,9 @@ function toStringValue(value: unknown) {
 
 function normalizeToolLabel(part: MessagePart) {
   if (typeof part.title === "string" && part.title.trim()) {
-    return part.title.trim().replace(/^tool:\s*/i, "");
+    return cleanToolTitle(part.title);
   }
-  if (typeof part.tool === "string" && part.tool.trim()) return part.tool.trim();
+  if (typeof part.tool === "string" && part.tool.trim()) return cleanToolTitle(part.tool);
   return "tool";
 }
 
@@ -600,7 +600,7 @@ function normalizeEscapedNewlines(text: string) {
 function cleanToolTitle(value: string) {
   const trimmed = value.trim();
   if (!trimmed) return "";
-  return trimmed.replace(/^tool:\s*/i, "");
+  return trimmed.replace(/^tool:\s*/i, "").replace(/^\.+(?=\w)/, "");
 }
 
 function getToolTitle(tool: MessagePart, fallback = "Tool") {
@@ -620,6 +620,22 @@ function getOutputOrErrorText(state: NormalizedToolState) {
   const errorText = formatToolOutput(state.errorValue);
   if (errorText !== "No output captured.") return errorText;
   return "No output captured.";
+}
+
+function extractCodexNodeReplTextOutput(outputText: string) {
+  const marker = "Output:\n";
+  const markerIndex = outputText.indexOf(marker);
+  if (markerIndex === -1) return outputText;
+
+  const rawOutput = outputText.slice(markerIndex + marker.length).trim();
+  const parsed = parseJsonText<unknown>(rawOutput);
+  if (!Array.isArray(parsed)) return outputText;
+
+  const text = parsed
+    .map((item) => toPlainText(toRecord(item).text))
+    .filter(Boolean)
+    .join("\n");
+  return text || outputText;
 }
 
 function getFilePathFromInput(inputValue: unknown) {
@@ -1231,13 +1247,37 @@ function buildCodexToolStrategy(
   state: NormalizedToolState,
 ): ToolDisplayStrategy {
   const defaultStrategy = buildDefaultToolStrategy(tool, state);
-  const toolKey = (tool.tool || "").toLowerCase();
+  const toolKey = normalizeToolName(tool);
+  const metadata = toRecord(state.metadataValue);
+  const namespace = toPlainText(metadata.namespace);
 
   if (toolKey === "skill") {
     return buildSkillToolStrategy(tool, state, defaultStrategy);
   }
 
-  if (toolKey === "exec_command") {
+  if (
+    toolKey === "js" &&
+    (namespace === "mcp__node_repl__" || namespace === "mcp__node_repl__.js")
+  ) {
+    const input = toRecord(state.inputValue);
+    const title = toPlainText(input.title);
+    return {
+      ...defaultStrategy,
+      Icon: SquareTerminal,
+      title: "Browser",
+      secondaryText: title || undefined,
+      details: [],
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: extractCodexNodeReplTextOutput(getOutputOrErrorText(state)),
+        language: "text",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "exec_command" || toolKey === "bash") {
     const display = buildCodexExecCommandDisplay(
       state.inputValue,
       getOutputOrErrorText(state),

--- a/apps/web/src/components/session-detail/toc.test.ts
+++ b/apps/web/src/components/session-detail/toc.test.ts
@@ -80,9 +80,7 @@ describe("session detail display model", () => {
       tool: ".js",
       title: "Tool: .js",
     } satisfies MessagePart;
-    const models = buildMessageDisplayModels([
-      createMessage("assistant", "assistant", [jsTool]),
-    ]);
+    const models = buildMessageDisplayModels([createMessage("assistant", "assistant", [jsTool])]);
 
     const toc = buildSessionDetailToc(models);
     expect(toc.tools).toEqual([{ id: "tool:js", toolKey: "js", label: "js", count: 1 }]);

--- a/apps/web/src/components/session-detail/toc.test.ts
+++ b/apps/web/src/components/session-detail/toc.test.ts
@@ -73,4 +73,41 @@ describe("session detail display model", () => {
     expect(filtered[0]?.msg.id).toBe("assistant");
     expect(filtered[0]?.blocks).toEqual([{ type: "tool", parts: [readTool] }]);
   });
+
+  it("normalizes legacy leading-dot tool labels", () => {
+    const jsTool = {
+      type: "tool",
+      tool: ".js",
+      title: "Tool: .js",
+    } satisfies MessagePart;
+    const models = buildMessageDisplayModels([
+      createMessage("assistant", "assistant", [jsTool]),
+    ]);
+
+    const toc = buildSessionDetailToc(models);
+    expect(toc.tools).toEqual([{ id: "tool:js", toolKey: "js", label: "js", count: 1 }]);
+
+    const filtered = filterSessionMessages(models, new Set(["tools_all", "tool:js"]));
+    expect(filtered[0]?.blocks).toEqual([{ type: "tool", parts: [jsTool] }]);
+  });
+
+  it("labels Codex node repl js tools as Browser", () => {
+    const browserTool = {
+      type: "tool",
+      tool: "js",
+      title: "Tool: js",
+      state: { metadata: { name: "js", namespace: "mcp__node_repl__" } },
+    } satisfies MessagePart;
+    const models = buildMessageDisplayModels([
+      createMessage("assistant", "assistant", [browserTool]),
+    ]);
+
+    const toc = buildSessionDetailToc(models);
+    expect(toc.tools).toEqual([
+      { id: "tool:browser", toolKey: "browser", label: "Browser", count: 1 },
+    ]);
+
+    const filtered = filterSessionMessages(models, new Set(["tools_all", "tool:browser"]));
+    expect(filtered[0]?.blocks).toEqual([{ type: "tool", parts: [browserTool] }]);
+  });
 });

--- a/apps/web/src/components/session-detail/toc.ts
+++ b/apps/web/src/components/session-detail/toc.ts
@@ -24,16 +24,42 @@ export interface FilteredSessionMessage {
 }
 
 function buildToolLabel(part: MessagePart) {
+  if (isNodeReplBrowserTool(part)) return "Browser";
   if (typeof part.title === "string" && part.title.trim()) {
-    return part.title.trim().replace(/^tool:\s*/i, "");
+    return cleanToolLabel(part.title);
   }
-  if (typeof part.tool === "string" && part.tool.trim()) return part.tool.trim();
+  if (typeof part.tool === "string" && part.tool.trim()) return cleanToolLabel(part.tool);
   return "tool";
 }
 
 function normalizeToolKey(part: MessagePart) {
+  if (isNodeReplBrowserTool(part)) return "browser";
   const raw = typeof part.tool === "string" && part.tool.trim() ? part.tool : buildToolLabel(part);
-  return raw.trim().toLowerCase();
+  return cleanToolLabel(raw).toLowerCase();
+}
+
+function cleanToolLabel(value: string) {
+  return value.trim().replace(/^tool:\s*/i, "").replace(/^\.+(?=\w)/, "");
+}
+
+function toRecord(value: unknown) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function toPlainText(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isNodeReplBrowserTool(part: MessagePart) {
+  const metadata = toRecord(part.state?.metadata);
+  const namespace = toPlainText(metadata.namespace);
+  return (
+    cleanToolLabel(toPlainText(part.tool)).toLowerCase() === "js" &&
+    (namespace === "mcp__node_repl__" || namespace === "mcp__node_repl__.js")
+  );
 }
 
 function countToolPart(toolMap: Map<string, ToolFilterItem>, part: MessagePart) {

--- a/apps/web/src/components/session-detail/toc.ts
+++ b/apps/web/src/components/session-detail/toc.ts
@@ -39,7 +39,10 @@ function normalizeToolKey(part: MessagePart) {
 }
 
 function cleanToolLabel(value: string) {
-  return value.trim().replace(/^tool:\s*/i, "").replace(/^\.+(?=\w)/, "");
+  return value
+    .trim()
+    .replace(/^tool:\s*/i, "")
+    .replace(/^\.+(?=\w)/, "");
 }
 
 function toRecord(value: unknown) {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -532,6 +532,56 @@ describe("CodexAgent cache refresh", () => {
     });
   });
 
+  it("uses the tool name when the MCP namespace has no display segment", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionId = "019da001-0000-7000-8000-000000000000";
+    const sessionFile = join(tempDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:00Z",
+          type: "session_meta",
+          payload: { cwd: "/tmp/project" },
+        }),
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:01Z",
+          type: "response_item",
+          payload: {
+            type: "function_call",
+            call_id: "call-node",
+            name: "js",
+            namespace: "mcp__node_repl__",
+            arguments: '{"code":"1 + 1"}',
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+
+    agent.scan();
+    const data = agent.getSessionData(sessionId);
+    const toolPart = data.messages[0]?.parts.find((part: MessagePart) => part.type === "tool");
+
+    expect(toolPart).toMatchObject({
+      type: "tool",
+      tool: "js",
+      title: "Tool: js",
+      state: {
+        arguments: { code: "1 + 1" },
+        metadata: {
+          name: "js",
+          namespace: "mcp__node_repl__",
+        },
+      },
+    });
+  });
+
   it("parses messages, plans, tools, outputs, and token usage", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -117,7 +117,13 @@ function resolveToolIdentity(
   if (!namespaceText) return { tool: name };
 
   const namespaceName = namespaceText.split("__").at(-1) ?? namespaceText;
-  const toolName = name.replace(/^_+/, "");
+  const toolName = name.replace(/^[_.]+/, "");
+  if (!namespaceName) {
+    return {
+      tool: toolName || name,
+      metadata: { name, namespace: namespaceText },
+    };
+  }
 
   return {
     tool: `${namespaceName}.${toolName || name}`,


### PR DESCRIPTION
## Summary

- Normalize Codex MCP tool display so `mcp__node_repl__` JavaScript calls render as `Browser` instead of `.js`/`js`.
- Show Browser tool cards with the call `title` as the summary and only the returned output text when expanded.
- Keep Codex bash output focused on command output and hide the raw input preview.

## Root Cause

Codex tool identity parsing used the namespace suffix even when `mcp__node_repl__` ended with an empty display segment, and the web tool strategy treated cached `bash`/`js` labels as generic tools. That left stale `.js` labels in the TOC and exposed raw input previews for Codex tool cards.

## Validation

- `rtk pnpm --filter @codesesh/core test -- codex.test.ts`
- `rtk pnpm --filter @codesesh/web test -- toc.test.ts display-model.test.ts`
- `rtk pnpm --filter @codesesh/core lint`
- `rtk pnpm --filter @codesesh/web lint`
- `rtk pnpm --filter @codesesh/web build`