### PR TITLE
fix: handle cold-start session details

### DIFF
--- a/apps/www/src/components/Hero.astro
+++ b/apps/www/src/components/Hero.astro
@@ -10,43 +10,37 @@ interface Props {
 
 const { locale } = Astro.props;
 const t = copy[locale].hero;
-const terminal = copy[locale].terminal;
 const command = "$ npx codesesh";
-const outputLines = [
+type TerminalSegment = {
+  text: string;
+  className?: string;
+};
+
+const outputLines: TerminalSegment[][] = [
   [{ text: "\u00A0" }],
-  [{ text: " ╭─────────────CodeSesh───────────────╮", className: "text-[#64748b]" }],
-  [{ text: " │ local session scan", className: "text-[#64748b]" }],
+  [{ text: " ╭────────────CodeSesh──────────────╮", className: "text-[#64748b]" }],
+  [{ text: " │                                  │", className: "text-[#64748b]" }],
   [
-    { text: " │ ", className: "text-[#64748b]" },
-    { text: `v${packageJson.version} • ${terminal.discovered}`, className: "text-[#e2e8f0]" },
+    { text: " │  ", className: "text-[#64748b]" },
+    { text: `v${packageJson.version} • local session browser`, className: "text-[#e2e8f0]" },
+    { text: "  │", className: "text-[#64748b]" },
   ],
-  [{ text: " │ SQLite local index ready", className: "text-[#64748b]" }],
-  [{ text: " ╰────────────────────────────────────╯", className: "text-[#64748b]" }],
-  [{ text: "\u00A0" }],
-  [
-    { text: " ✔", className: "text-[#4ade80]" },
-    { text: " Claude Code 91 sessions" },
-  ],
-  [
-    { text: " ✔", className: "text-[#4ade80]" },
-    { text: " Cursor 18 sessions" },
-  ],
-  [
-    { text: " ✔", className: "text-[#4ade80]" },
-    { text: " Kimi 2 sessions" },
-  ],
-  [
-    { text: " ✔", className: "text-[#4ade80]" },
-    { text: " Codex 30 sessions" },
-  ],
-  [
-    { text: " ✔", className: "text-[#4ade80]" },
-    { text: " OpenCode indexed" },
-  ],
+  [{ text: " │                                  │", className: "text-[#64748b]" }],
+  [{ text: " ╰──────────────────────────────────╯", className: "text-[#64748b]" }],
   [{ text: "\u00A0" }],
   [
     { text: "ℹ ", className: "text-[#38bdf8]" },
-    { text: terminal.active, className: "text-[#38bdf8]" },
+    {
+      text: "Indexing Claude Code, OpenCode, Kimi-Cli, Codex, Cursor sessions in the background.",
+      className: "text-[#38bdf8]",
+    },
+  ],
+  [
+    { text: "ℹ ", className: "text-[#38bdf8]" },
+    {
+      text: "The Web UI will update automatically as sessions are discovered.",
+      className: "text-[#38bdf8]",
+    },
   ],
   [{ text: "\u00A0" }],
   [{ text: " http://localhost:4521", className: "text-[#38bdf8]" }],

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -58,10 +58,6 @@ interface LandingCopy {
     copyCommand: string;
     runtime: string;
   };
-  terminal: {
-    discovered: string;
-    active: string;
-  };
   tour: {
     label: string;
     title: HeadingCopy;
@@ -127,10 +123,6 @@ export const copy = {
       copied: "已复制",
       copyCommand: "复制命令",
       runtime: "需要 Node.js 18+ · 从终端本地运行",
-    },
-    terminal: {
-      discovered: "123 sessions discovered",
-      active: "Local index ready",
     },
     tour: {
       label: "Product Tour",
@@ -322,10 +314,6 @@ export const copy = {
       copied: "Copied",
       copyCommand: "Copy command",
       runtime: "Requires Node.js 18+ · Runs locally from your terminal",
-    },
-    terminal: {
-      discovered: "123 sessions discovered",
-      active: "Local index ready",
     },
     tour: {
       label: "Product Tour",

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -80,6 +80,7 @@ class MockAgent extends BaseAgent {
       id: "s1",
       slug: "claudecode/s1",
       title: "Test Session",
+      directory: "/home/user/project",
       time_created: 1000,
       time_updated: 1000,
       messages: [],
@@ -805,8 +806,29 @@ describe("handleGetSessionData", () => {
   it("returns 404 when the SQLite session cache is missing", async () => {
     coreMocks.loadCachedSessionData.mockReturnValue(null);
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-    await handleGetSessionData(c, makeScanSource());
+    await handleGetSessionData(
+      c,
+      makeScanSource({
+        sessions: [],
+        byAgent: { claudecode: [] },
+      }),
+    );
     expect(c.json).toHaveBeenCalledWith({ error: "Session cache not ready" }, 404);
+  });
+
+  it("loads session data from the current agent index when SQLite cache is empty", async () => {
+    coreMocks.loadCachedSessionData.mockReturnValue(null);
+    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+
+    await handleGetSessionData(c, makeScanSource());
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.title).toBe("Test Session");
+    expect(response.project_identity).toMatchObject({
+      kind: "path",
+      key: "/home/user/project",
+    });
+    expect(response.file_activity).toEqual([]);
   });
 
   it("returns 500 when SQLite cache loading throws", async () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -14,6 +14,7 @@ import {
   getAgentInfoMap,
   classifySessionTags,
   computeIdentity,
+  extractSessionFileActivity,
   getSmartTagSourceTimestamp,
   importBookmarks,
   loadCachedSessionData,
@@ -610,8 +611,10 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
   }
 
   try {
+    const head = scanResult.byAgent[agentName]?.find((item) => item.id === sessionId);
     const loadStartedAt = performance.now();
-    const data: SessionData | null = loadCachedSessionData(agentName, sessionId);
+    const cachedData = loadCachedSessionData(agentName, sessionId);
+    const data: SessionData | null = cachedData ?? (head ? agent.getSessionData(sessionId) : null);
     const loadDuration = performance.now() - loadStartedAt;
     if (!data) {
       appLogger.warn("api.session_data.cache_miss", {
@@ -624,9 +627,13 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
     const tagStartedAt = performance.now();
     const smartTags = data.smart_tags ?? classifySessionTags(data);
     const tagDuration = performance.now() - tagStartedAt;
-    const head = scanResult.byAgent[agentName]?.find((item) => item.id === sessionId);
     const projectIdentity =
       data.project_identity ?? head?.project_identity ?? computeIdentity(data.directory, realFs);
+    const fileActivity =
+      data.file_activity ??
+      (cachedData
+        ? listSessionFileActivity(agentName, sessionId)
+        : extractSessionFileActivity(agentName, sessionId, projectIdentity.key, data.messages));
     appLogger.info("api.session_data", {
       agent: agentName,
       session_id: sessionId,
@@ -640,7 +647,7 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       project_identity: projectIdentity,
       smart_tags: smartTags,
       smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
-      file_activity: data.file_activity ?? listSessionFileActivity(agentName, sessionId),
+      file_activity: fileActivity,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to load session";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -227,7 +227,7 @@ const main = defineCommand({
 
     // Print console output
     const agents = createRegisteredAgents();
-    printScanResults(agents, result);
+    printScanResults(agents);
 
     // Start server
     let app: Awaited<ReturnType<typeof createServer>>;

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,48 +1,21 @@
 import { consola } from "consola";
 import type { BaseAgent } from "@codesesh/core";
-import type { ScanResult } from "@codesesh/core";
 import { VERSION } from "./version.js";
 
-export function printScanResults(agents: BaseAgent[], result: ScanResult): void {
+export function printScanResults(agents: BaseAgent[]): void {
   consola.log("");
   consola.box({
     title: "CodeSesh",
-    message: `v${VERSION} • ${result.sessions.length} sessions discovered`,
+    message: `v${VERSION} • local session browser`,
     style: {
       padding: 1,
       borderColor: "cyan",
     },
   });
   consola.log("");
-
-  const rows: string[] = [];
-  let availableCount = 0;
-
-  for (const agent of agents) {
-    const sessions = result.byAgent[agent.name];
-    const count = sessions?.length ?? 0;
-    if (count > 0) {
-      availableCount++;
-      rows.push(`  ${green("✔")} ${pad(agent.displayName)} ${dim(`${count} sessions`)}`);
-    } else {
-      rows.push(`  ${dim("✖")} ${pad(agent.displayName)} ${dim("not found")}`);
-    }
-  }
-
-  consola.log(rows.join("\n"));
+  consola.info(
+    `Indexing ${agents.map((agent) => agent.displayName).join(", ")} sessions in the background.`,
+  );
+  consola.info("The Web UI will update automatically as sessions are discovered.");
   consola.log("");
-  consola.info(`Active: ${availableCount}/${agents.length} agents`);
-  consola.log("");
-}
-
-function pad(text: string, length = 16): string {
-  return text.padEnd(length);
-}
-
-function green(text: string): string {
-  return `\x1b[32m${text}\x1b[0m`;
-}
-
-function dim(text: string): string {
-  return `\x1b[2m${text}\x1b[0m`;
 }


### PR DESCRIPTION
## What changed

- Load session details from the current in-memory agent index when SQLite has not populated yet.
- Keep file activity available for uncached session detail reads by extracting it from loaded messages.
- Replace startup terminal output with stable status messaging instead of session and agent counts.
- Update the landing-page terminal example to match the new CLI output.

## Why

On first install or after deleting the SQLite DB, the Web UI could show sessions after background indexing while detail routes still returned `Session cache not ready`. The CLI startup output also reported a scan snapshot that could diverge from the UI due to cache timing and list windows.

## Validation

- `pnpm --filter codesesh test`
- `pnpm --filter codesesh lint`
- `pnpm --filter @codesesh/www build`