### PR TITLE
feat: improve session cache initialization

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,9 +9,195 @@
     />
     <link rel="icon" type="image/svg+xml" href="/logo.svg?v=3" />
     <title>CodeSesh</title>
+    <style>
+      :root {
+        --console-bg: #f7f7f7;
+        --console-sidebar-bg: #fbfbfb;
+        --console-surface-muted: #f5f5f5;
+        --console-border: #e5e5e5;
+        --console-text: #1a1a1a;
+        --console-muted: #666666;
+      }
+
+      body {
+        margin: 0;
+        background: var(--console-bg);
+        color: var(--console-text);
+        font-family:
+          "Avenir Next",
+          "PingFang SC",
+          -apple-system,
+          sans-serif;
+      }
+
+      .app-shell {
+        display: flex;
+        height: 100vh;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      .app-header {
+        display: grid;
+        min-height: 56px;
+        grid-template-columns: auto 1fr auto;
+        align-items: center;
+        gap: 12px;
+        border-bottom: 1px solid var(--console-border);
+        background: rgba(255, 255, 255, 0.85);
+        padding: 0 16px;
+      }
+
+      .app-brand,
+      .app-search,
+      .app-pill,
+      .app-sidebar-line,
+      .app-card,
+      .app-line {
+        border-radius: 2px;
+      }
+
+      .app-brand {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font: 600 13px "SFMono-Regular", Menlo, monospace;
+        letter-spacing: 0.05em;
+      }
+
+      .app-brand img {
+        width: 24px;
+        height: 24px;
+      }
+
+      .app-search {
+        height: 28px;
+        max-width: 560px;
+        border: 1px solid var(--console-border);
+        background: white;
+      }
+
+      .app-pill {
+        height: 26px;
+        width: 88px;
+        border: 1px solid var(--console-border);
+        background: var(--console-surface-muted);
+      }
+
+      .app-body {
+        display: flex;
+        min-height: 0;
+        flex: 1;
+      }
+
+      .app-sidebar {
+        width: 256px;
+        border-right: 1px solid var(--console-border);
+        background: var(--console-sidebar-bg);
+        padding: 24px 16px;
+      }
+
+      .app-sidebar-line {
+        height: 26px;
+        margin-bottom: 8px;
+        background: var(--console-surface-muted);
+      }
+
+      .app-main {
+        min-width: 0;
+        flex: 1;
+      }
+
+      .app-titlebar {
+        border-bottom: 1px solid var(--console-border);
+        background: rgba(255, 255, 255, 0.7);
+        padding: 18px 32px;
+      }
+
+      .app-title {
+        height: 24px;
+        width: 220px;
+        border-radius: 2px;
+        background: var(--console-surface-muted);
+      }
+
+      .app-content {
+        display: grid;
+        gap: 12px;
+        padding: 24px 32px;
+      }
+
+      .app-card {
+        height: 96px;
+        border: 1px solid var(--console-border);
+        background: rgba(255, 255, 255, 0.8);
+        padding: 16px;
+      }
+
+      .app-line {
+        height: 12px;
+        margin-bottom: 12px;
+        background: var(--console-surface-muted);
+      }
+
+      .app-line.short {
+        width: 46%;
+      }
+
+      @media (max-width: 1023px) {
+        .app-sidebar {
+          display: none;
+        }
+
+        .app-header {
+          grid-template-columns: auto 1fr;
+        }
+
+        .app-pill {
+          display: none;
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="app-shell">
+        <header class="app-header">
+          <div class="app-brand">
+            <img src="/logo.svg?v=3" alt="CodeSesh" />
+            <span>CodeSesh</span>
+          </div>
+          <div class="app-search"></div>
+          <div class="app-pill"></div>
+        </header>
+        <div class="app-body">
+          <aside class="app-sidebar">
+            <div class="app-sidebar-line" style="width: 58%"></div>
+            <div class="app-sidebar-line" style="width: 82%"></div>
+            <div class="app-sidebar-line" style="width: 72%"></div>
+            <div class="app-sidebar-line" style="width: 88%; margin-top: 32px"></div>
+            <div class="app-sidebar-line" style="width: 68%"></div>
+          </aside>
+          <main class="app-main">
+            <section class="app-titlebar">
+              <div class="app-title"></div>
+            </section>
+            <section class="app-content">
+              <div class="app-card">
+                <div class="app-line short"></div>
+                <div class="app-line"></div>
+                <div class="app-line" style="width: 72%"></div>
+              </div>
+              <div class="app-card">
+                <div class="app-line short"></div>
+                <div class="app-line"></div>
+                <div class="app-line" style="width: 64%"></div>
+              </div>
+            </section>
+          </main>
+        </div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import type {
   SearchResult,
   SessionHead,
   SessionData,
+  ScanStatusEvent,
   SessionsUpdatedEvent,
   SmartTag,
   ProjectGroup,
@@ -34,6 +35,7 @@ import {
   fetchConfig,
   fetchDashboard,
   fetchProjects,
+  fetchScanStatus,
   fetchSearchResults,
   fetchSessions,
   fetchSessionData,
@@ -189,6 +191,57 @@ function formatWindowLabel(config: AppConfig | null): string | null {
 function formatSearchSubtitle(query: string, loading: boolean, count: number) {
   if (loading) return query ? `Searching for "${query}"` : "Loading recent sessions";
   return query ? `${count} matches for "${query}"` : `${count} recent sessions`;
+}
+
+function formatScanStatusLabel(status: ScanStatusEvent | null): string | null {
+  if (!status?.active) return null;
+
+  const completed = status.completedAgents.length;
+  const total = status.totalAgents;
+  const current = status.scanningAgents[0];
+  const currentStatus = current ? status.agentStatuses[current] : null;
+  const itemProgress =
+    currentStatus?.total && currentStatus.processed != null
+      ? ` · ${currentStatus.processed}/${currentStatus.total}`
+      : "";
+  const agentProgress =
+    total > 0
+      ? current
+        ? ` · ${current}${itemProgress} · ${completed}/${total} agents ready`
+        : ` · ${completed}/${total} agents ready`
+      : "";
+
+  if (status.phase === "initializing") {
+    return `First-run setup: indexing all local sessions${agentProgress}. Your selected time window appears after this finishes.`;
+  }
+  if (status.phase === "indexing") return "Preparing local session index";
+
+  if (total > 0) {
+    return current
+      ? `Checking for new or changed sessions · ${current}${itemProgress} · ${completed}/${total} agents ready`
+      : `Checking for new or changed sessions · ${completed}/${total} agents ready`;
+  }
+  return "Checking for new or changed sessions";
+}
+
+function formatAgentScanProgress(status: ScanStatusEvent | null, agentName: string): string | null {
+  const agentStatus = status?.agentStatuses[agentName];
+  if (!agentStatus || agentStatus.status === "complete") return null;
+  if (agentStatus.total && agentStatus.processed != null) {
+    return `${agentStatus.processed}/${agentStatus.total}`;
+  }
+  return agentStatus.status === "scanning" ? "Scanning" : "Pending";
+}
+
+function getAgentDisplayCount(
+  status: ScanStatusEvent | null,
+  agentName: string,
+  fallback: number,
+): number {
+  const agentStatus = status?.agentStatuses[agentName];
+  return agentStatus?.status === "complete" && agentStatus.sessions != null
+    ? agentStatus.sessions
+    : fallback;
 }
 
 function getProjectGroupIdentity(project: ProjectGroup): ProjectRouteIdentity {
@@ -352,9 +405,11 @@ function isEditableTarget(target: EventTarget | null) {
 function BrowseByToggle({
   value,
   onChange,
+  projectsDisabled = false,
 }: {
   value: BrowseBy;
   onChange: (value: BrowseBy) => void;
+  projectsDisabled?: boolean;
 }) {
   const options: Array<{ value: BrowseBy; label: string }> = [
     { value: "projects", label: "Projects" },
@@ -365,18 +420,25 @@ function BrowseByToggle({
     <div role="radiogroup" aria-label="Browse by" className="grid gap-1.5">
       {options.map((option) => {
         const active = value === option.value;
+        const disabled = option.value === "projects" && projectsDisabled;
         return (
           <button
             key={option.value}
             type="button"
             role="radio"
             aria-checked={active}
+            disabled={disabled}
             onClick={() => onChange(option.value)}
             className={`console-mono flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left text-xs transition-colors ${
-              active
-                ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
-                : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+              disabled
+                ? "cursor-not-allowed border-transparent text-[var(--console-muted)] opacity-45"
+                : active
+                  ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                  : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
             }`}
+            title={
+              disabled ? "Project grouping is available after the current scan finishes" : undefined
+            }
           >
             <span
               className={`flex size-3 shrink-0 items-center justify-center rounded-full border ${
@@ -489,6 +551,7 @@ export default function App() {
   const [searchFilters, setSearchFilters] = useState<SearchFilterState>({});
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
+  const [scanStatus, setScanStatus] = useState<ScanStatusEvent | null>(null);
   const [selectedSidebarSessionId, setSelectedSidebarSessionId] = useState<string | null>(null);
   const [selectedSearchIndex, setSelectedSearchIndex] = useState(0);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
@@ -506,7 +569,7 @@ export default function App() {
       try {
         const config = await fetchConfig();
         setAppConfig(config);
-        const [agentList, sessionList, dashboardData, projectData, bookmarkData] =
+        const [agentList, sessionList, dashboardData, projectData, bookmarkData, statusData] =
           await Promise.all([
             fetchAgents(),
             fetchSessions({ from: config.window.from, to: config.window.to }),
@@ -519,11 +582,16 @@ export default function App() {
               return { projects: [] };
             }),
             fetchBookmarks(),
+            fetchScanStatus().catch((err) => {
+              console.error("Failed to load scan status:", err);
+              return null;
+            }),
           ]);
         setAgents(agentList);
         setSessions(sessionList.sessions);
         setProjects(projectData.projects);
         setBookmarks(bookmarkData.bookmarks);
+        if (statusData) setScanStatus(statusData);
         if (dashboardData) setDashboard(dashboardData);
         logClientEvent("app.load.done", {
           duration_ms: Math.round(performance.now() - startedAt),
@@ -783,6 +851,8 @@ export default function App() {
   }, [searchFilters]);
   const usesServerSearch =
     activeSearchQuery.trim().length > 0 || Boolean(searchFilters.tool || searchFilters.fileKind);
+  const scanStatusLabel = formatScanStatusLabel(scanStatus);
+  const isScanActive = scanStatus?.active === true;
   const recentSearchResults = useMemo<SearchResult[]>(() => {
     const selectedCost = COST_RANGE_OPTIONS.find((option) => option.id === searchFilters.costRange);
     const agentSessions = searchFilters.agent
@@ -1029,9 +1099,14 @@ export default function App() {
   }, [activeProjectKind, activeProjectKey, appConfig, selectedProjectAgent]);
 
   useEffect(() => {
-    const unsubscribe = subscribeSessionUpdates((event) => {
-      void syncLiveUpdate(event);
-    });
+    const unsubscribe = subscribeSessionUpdates(
+      (event) => {
+        void syncLiveUpdate(event);
+      },
+      (event) => {
+        setScanStatus(event);
+      },
+    );
 
     return unsubscribe;
   }, []);
@@ -1450,6 +1525,7 @@ export default function App() {
   }
 
   function changeBrowseBy(next: BrowseBy) {
+    if (next === "projects" && isScanActive) return;
     setBrowseBy(next);
     setSelectedSidebarSessionId(null);
     if (next === "projects") {
@@ -1693,7 +1769,11 @@ export default function App() {
               <h3 className="console-mono mb-3 text-xs font-bold uppercase text-[var(--console-text)]">
                 BROWSE BY
               </h3>
-              <BrowseByToggle value={browseBy} onChange={changeBrowseBy} />
+              <BrowseByToggle
+                value={browseBy}
+                onChange={changeBrowseBy}
+                projectsDisabled={isScanActive}
+              />
             </section>
 
             <section>
@@ -1726,30 +1806,65 @@ export default function App() {
                       const key = agent.name.toLowerCase();
                       const isSelected = key === activeAgentKey;
                       const config = ModelConfig.agents[key];
+                      const agentProgress = formatAgentScanProgress(scanStatus, agent.name);
+                      const disabled = isScanActive && agentProgress !== null;
+                      const className = `ml-4 flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
+                        disabled
+                          ? "cursor-not-allowed border-transparent text-[var(--console-muted)] opacity-50"
+                          : isSelected
+                            ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                            : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                      }`;
+                      const content = (
+                        <>
+                          {config?.icon && (
+                            <img
+                              src={config.icon}
+                              alt={agent.displayName}
+                              className="size-3.5 object-contain"
+                            />
+                          )}
+                          <span className="console-mono line-clamp-1 flex-1 text-xs">
+                            {agent.displayName}
+                          </span>
+                          <span className="console-mono text-[11px] text-[var(--console-muted)]">
+                            {agentProgress ??
+                              getAgentDisplayCount(scanStatus, agent.name, agent.count)}
+                          </span>
+                        </>
+                      );
                       return (
                         <li key={agent.name}>
-                          <Link
-                            to={`/${key}`}
-                            className={`ml-4 flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
-                              isSelected
-                                ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
-                                : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
-                            }`}
-                          >
-                            {config?.icon && (
-                              <img
-                                src={config.icon}
-                                alt={agent.displayName}
-                                className="size-3.5 object-contain"
+                          {disabled ? (
+                            <span
+                              className={className}
+                              title="Available after this agent scan completes"
+                            >
+                              {content}
+                            </span>
+                          ) : (
+                            <Link to={`/${key}`} className={className}>
+                              {content}
+                            </Link>
+                          )}
+                          {agentProgress ? (
+                            <span className="ml-4 mt-1 block h-1 overflow-hidden rounded-sm bg-[var(--console-surface-muted)]">
+                              <span
+                                className="block h-full bg-[var(--console-accent)]"
+                                style={{
+                                  width: `${
+                                    scanStatus?.agentStatuses[agent.name]?.total
+                                      ? Math.round(
+                                          ((scanStatus.agentStatuses[agent.name]?.processed ?? 0) /
+                                            scanStatus.agentStatuses[agent.name]!.total!) *
+                                            100,
+                                        )
+                                      : 8
+                                  }%`,
+                                }}
                               />
-                            )}
-                            <span className="console-mono line-clamp-1 flex-1 text-xs">
-                              {agent.displayName}
                             </span>
-                            <span className="console-mono text-[11px] text-[var(--console-muted)]">
-                              {agent.count}
-                            </span>
-                          </Link>
+                          ) : null}
                         </li>
                       );
                     })
@@ -1781,14 +1896,14 @@ export default function App() {
                 {browseBy === "agents" && agents.length === 0 && !loading ? (
                   <li>
                     <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
-                      No agents found
+                      {scanStatus?.active ? "Scanning agents..." : "No agents found"}
                     </span>
                   </li>
                 ) : null}
                 {browseBy === "projects" && projects.length === 0 && !loading ? (
                   <li>
                     <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
-                      No projects found
+                      {scanStatus?.active ? "Scanning projects..." : "No projects found"}
                     </span>
                   </li>
                 ) : null}
@@ -1868,7 +1983,7 @@ export default function App() {
                 </span>
               ) : sidebarSessions.length === 0 ? (
                 <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
-                  No sessions yet
+                  {scanStatus?.active ? "Scanning sessions..." : "No sessions yet"}
                 </span>
               ) : browseBy === "projects" ? (
                 <SidebarFlatSessionList
@@ -1983,6 +2098,11 @@ export default function App() {
               {liveNotice ? (
                 <p className="console-mono mt-2 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-text)]">
                   {liveNotice}
+                </p>
+              ) : null}
+              {scanStatusLabel && viewState.mode === "root" ? (
+                <p className="console-mono mt-2 inline-flex max-w-4xl rounded-sm border border-[var(--console-warning-border)] bg-[var(--console-warning-bg)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-warning)]">
+                  {scanStatusLabel}
                 </p>
               ) : null}
             </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -178,6 +178,31 @@ export interface SessionsUpdatedEvent {
   removedSessionRefs?: Array<{ agentName: string; sessionId: string }>;
 }
 
+export interface ScanStatusEvent {
+  type: "scan-status";
+  active: boolean;
+  phase: "idle" | "indexing" | "initializing" | "scanning";
+  pendingAgents: string[];
+  scanningAgents: string[];
+  completedAgents: string[];
+  agentStatuses: Record<string, AgentScanStatus>;
+  totalAgents: number;
+  startedAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface AgentScanStatus {
+  agentName: string;
+  status: "pending" | "scanning" | "complete";
+  total?: number;
+  processed?: number;
+  sessions?: number;
+  startedAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
 export interface DashboardAgentStat {
   name: string;
   displayName: string;
@@ -271,6 +296,12 @@ export interface BookmarkedSessionSnapshot {
 export async function fetchConfig(): Promise<AppConfig> {
   const res = await fetch("/api/config");
   if (!res.ok) throw new Error("Failed to fetch config");
+  return res.json();
+}
+
+export async function fetchScanStatus(): Promise<ScanStatusEvent> {
+  const res = await fetch("/api/status");
+  if (!res.ok) throw new Error("Failed to fetch scan status");
   return res.json();
 }
 
@@ -402,6 +433,7 @@ export function logClientEvent(event: string, data: Record<string, unknown> = {}
 
 export function subscribeSessionUpdates(
   onUpdate: (event: SessionsUpdatedEvent) => void,
+  onScanStatus?: (event: ScanStatusEvent) => void,
 ): () => void {
   const source = new EventSource("/api/events");
 
@@ -410,6 +442,15 @@ export function subscribeSessionUpdates(
       onUpdate(JSON.parse(event.data) as SessionsUpdatedEvent);
     } catch (error) {
       console.error("Failed to parse session update event:", error);
+    }
+  });
+
+  source.addEventListener("scan-status", (event) => {
+    if (!onScanStatus) return;
+    try {
+      onScanStatus(JSON.parse(event.data) as ScanStatusEvent);
+    } catch (error) {
+      console.error("Failed to parse scan status event:", error);
     }
   });
 

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -831,6 +831,68 @@ describe("handleGetSessionData", () => {
     expect(response.file_activity).toEqual([]);
   });
 
+  it("falls back to the current agent index when cached messages are missing", async () => {
+    coreMocks.loadCachedSessionData.mockReturnValue({
+      id: "s1",
+      slug: "claudecode/s1",
+      title: "Cached Session",
+      directory: "/home/user/project",
+      time_created: 1000,
+      time_updated: 1000,
+      messages: [],
+      stats: {
+        message_count: 1,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 0,
+      },
+    });
+
+    class AgentWithDetail extends MockAgent {
+      override getSessionData(_sessionId: string): SessionData {
+        return {
+          id: "s1",
+          slug: "claudecode/s1",
+          title: "Source Session",
+          directory: "/home/user/project",
+          time_created: 1000,
+          time_updated: 1000,
+          messages: [
+            {
+              id: "m1",
+              role: "user",
+              time_created: 1000,
+              parts: [{ type: "text", text: "hello" }],
+            },
+          ],
+          stats: {
+            message_count: 1,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cost: 0,
+          },
+        };
+      }
+    }
+
+    const sessions = [makeSession("s1", { slug: "claudecode/s1" })];
+    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+
+    await handleGetSessionData(
+      c,
+      makeScanSource({
+        sessions,
+        byAgent: { claudecode: sessions },
+        agents: [new AgentWithDetail()],
+      }),
+    );
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.title).toBe("Source Session");
+    expect(response.messages).toHaveLength(1);
+    expect(coreMocks.listSessionFileActivity).not.toHaveBeenCalled();
+  });
+
   it("returns 500 when SQLite cache loading throws", async () => {
     coreMocks.loadCachedSessionData.mockImplementation(() => {
       throw new Error("DB not found");

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -41,6 +41,34 @@ export interface ScanResultSource {
   getSnapshot(): ScanResult;
 }
 
+export interface ScanStatusSource {
+  getScanStatus(): {
+    type: "scan-status";
+    active: boolean;
+    phase: "idle" | "indexing" | "initializing" | "scanning";
+    pendingAgents: string[];
+    scanningAgents: string[];
+    completedAgents: string[];
+    agentStatuses: Record<
+      string,
+      {
+        agentName: string;
+        status: "pending" | "scanning" | "complete";
+        total?: number;
+        processed?: number;
+        sessions?: number;
+        startedAt?: number;
+        updatedAt: number;
+        completedAt?: number;
+      }
+    >;
+    totalAgents: number;
+    startedAt?: number;
+    updatedAt: number;
+    completedAt?: number;
+  };
+}
+
 export interface SessionListDefaults {
   from?: number;
   to?: number;
@@ -449,6 +477,10 @@ export function handleGetConfig(c: Context, defaults: SessionListDefaults) {
   });
 }
 
+export function handleGetScanStatus(c: Context, scanSource: ScanStatusSource) {
+  return c.json(scanSource.getScanStatus());
+}
+
 export function handleGetAgents(
   c: Context,
   scanSource: ScanResultSource,
@@ -614,7 +646,14 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
     const head = scanResult.byAgent[agentName]?.find((item) => item.id === sessionId);
     const loadStartedAt = performance.now();
     const cachedData = loadCachedSessionData(agentName, sessionId);
-    const data: SessionData | null = cachedData ?? (head ? agent.getSessionData(sessionId) : null);
+    const cachedMessageCount = cachedData?.stats.message_count ?? 0;
+    const cacheHasExpectedMessages =
+      cachedData !== null && (cachedData.messages.length > 0 || cachedMessageCount === 0);
+    const data: SessionData | null = cacheHasExpectedMessages
+      ? cachedData
+      : head
+        ? agent.getSessionData(sessionId)
+        : null;
     const loadDuration = performance.now() - loadStartedAt;
     if (!data) {
       appLogger.warn("api.session_data.cache_miss", {
@@ -631,7 +670,7 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       data.project_identity ?? head?.project_identity ?? computeIdentity(data.directory, realFs);
     const fileActivity =
       data.file_activity ??
-      (cachedData
+      (cacheHasExpectedMessages && cachedData
         ? listSessionFileActivity(agentName, sessionId)
         : extractSessionFileActivity(agentName, sessionId, projectIdentity.key, data.messages));
     appLogger.info("api.session_data", {

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -6,6 +6,7 @@ import {
   handleGetDashboard,
   handleGetFileActivity,
   handleGetProjects,
+  handleGetScanStatus,
   handleDeleteBookmark,
   handleImportBookmarks,
   handlePostClientLog,
@@ -36,8 +37,12 @@ function createSseResponse(store: LiveScanStore, signal: AbortSignal): Response 
         };
 
         write("connected", { timestamp: Date.now() });
+        write("scan-status", store.getScanStatus());
 
-        const unsubscribe = store.subscribe((event) => {
+        const unsubscribeSessions = store.subscribe((event) => {
+          write(event.type, event);
+        });
+        const unsubscribeScanStatus = store.subscribeScanStatus((event) => {
           write(event.type, event);
         });
 
@@ -47,7 +52,8 @@ function createSseResponse(store: LiveScanStore, signal: AbortSignal): Response 
 
         const close = () => {
           clearInterval(heartbeat);
-          unsubscribe();
+          unsubscribeSessions();
+          unsubscribeScanStatus();
           controller.close();
         };
 
@@ -80,6 +86,9 @@ export function createApiRoutes(
   };
 
   api.get("/config", (c) => handleGetConfig(c, listDefaults));
+  if (store) {
+    api.get("/status", (c) => handleGetScanStatus(c, store));
+  }
   api.get("/agents", (c) => handleGetAgents(c, scanSource, listDefaults));
   api.get("/projects", (c) => handleGetProjects(c, scanSource, listDefaults));
   api.get("/sessions", (c) => handleGetSessions(c, scanSource, listDefaults));

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -26,6 +26,9 @@ const core = vi.hoisted(() => ({
     kimiRoot: "/tmp/kimi",
     opencodeRoot: "/tmp/opencode",
   })),
+  isAgentCacheInitialized: vi.fn(),
+  loadCachedSessions: vi.fn(),
+  markAgentCacheInitialized: vi.fn(),
   scanSessions: vi.fn(),
   saveCachedSessions: vi.fn(),
   saveCachedSessionChanges: vi.fn(),
@@ -89,6 +92,9 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     createRegisteredAgents: core.createRegisteredAgents,
     filterSessions: core.filterSessions,
     getCursorDataPath: core.getCursorDataPath,
+    isAgentCacheInitialized: core.isAgentCacheInitialized,
+    loadCachedSessions: core.loadCachedSessions,
+    markAgentCacheInitialized: core.markAgentCacheInitialized,
     resolveProviderRoots: core.resolveProviderRoots,
     scanSessions: core.scanSessions,
     saveCachedSessions: core.saveCachedSessions,
@@ -207,6 +213,9 @@ describe("LiveScanStore", () => {
       ) => registerMockWatcher(path, options, listener),
     );
     core.getCursorDataPath.mockReturnValue("/tmp/cursor");
+    core.isAgentCacheInitialized.mockReturnValue(true);
+    core.loadCachedSessions.mockReturnValue(null);
+    core.markAgentCacheInitialized.mockReset();
     core.resolveProviderRoots.mockReturnValue({
       claudeRoot: "/tmp/claude",
       codexRoot: "/tmp/codex",
@@ -270,7 +279,7 @@ describe("LiveScanStore", () => {
     ]);
   });
 
-  it("can initialize from cache and refresh the initial scan in the background", async () => {
+  it("can initialize from cache and refresh sessions in the background", async () => {
     vi.useFakeTimers();
     const cached = makeSession("cached", { title: "cached", time_updated: 1000 });
     const fresh = makeSession("fresh", { title: "fresh", time_updated: 2000 });
@@ -288,7 +297,9 @@ describe("LiveScanStore", () => {
 
     const store = new LiveScanStore(false, {}, {}, { deferInitialRefresh: true });
     const events: unknown[] = [];
+    const statusEvents: unknown[] = [];
     store.subscribe((event) => events.push(event));
+    store.subscribeScanStatus((event) => statusEvents.push(event));
 
     await store.initialize();
 
@@ -306,19 +317,20 @@ describe("LiveScanStore", () => {
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["cached"]);
 
     store.startBackgroundRefresh();
+    expect(statusEvents.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "scan-status",
+        active: true,
+        phase: "scanning",
+        pendingAgents: ["codex"],
+        totalAgents: 1,
+      }),
+    );
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(250);
 
     expect(codex.scan).toHaveBeenCalled();
     expect(workerThreads.workers[0]?.workerData.jobs).toEqual([
-      expect.objectContaining({
-        kind: "full",
-        context: "scan.initial.background",
-        agentName: "codex",
-        sessions: [cached],
-      }),
-    ]);
-    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
       expect.objectContaining({
         kind: "full",
         context: "scan.refresh",
@@ -335,6 +347,284 @@ describe("LiveScanStore", () => {
         newSessions: 1,
         removedSessions: 1,
         totalSessions: 1,
+      }),
+    ]);
+    expect(statusEvents.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "scan-status",
+        active: false,
+        phase: "idle",
+        completedAgents: ["codex"],
+        totalAgents: 1,
+      }),
+    );
+  });
+
+  it("uses full cache change checks for a cached startup time window", async () => {
+    vi.useFakeTimers();
+    const old = makeSession("old", { time_updated: 1000 });
+    const recent = makeSession("recent", { time_updated: 5000 });
+    const codex = makeAgent("codex", {
+      scan: vi.fn(() => [old, recent]),
+      checkForChanges: vi.fn(() => ({
+        hasChanges: false,
+        timestamp: 2000,
+      })),
+      incrementalScan: vi.fn(() => [old, recent]),
+      setSessionMetaMap: vi.fn(),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValueOnce({
+      sessions: [recent],
+      byAgent: { codex: [recent] },
+      agents: [codex],
+      cacheTimestamps: { codex: 1000 },
+    });
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [old, recent],
+      byAgent: { codex: [old, recent] },
+      meta: {
+        old: { id: "old", sourcePath: "/tmp/old" },
+        recent: { id: "recent", sourcePath: "/tmp/recent" },
+      },
+      timestamp: 1000,
+    });
+    core.filterSessions.mockImplementation((sessions: SessionHead[], options: { from?: number }) =>
+      options.from == null
+        ? sessions
+        : sessions.filter(
+            (session) => (session.time_updated ?? session.time_created) >= options.from!,
+          ),
+    );
+
+    const store = new LiveScanStore(false, {}, { from: 3000 }, { deferInitialRefresh: true });
+    await store.initialize();
+
+    store.startBackgroundRefresh();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(codex.checkForChanges).toHaveBeenCalledWith(1000, [old, recent]);
+    expect(codex.setSessionMetaMap).toHaveBeenCalledWith(
+      new Map([
+        ["old", { id: "old", sourcePath: "/tmp/old" }],
+        ["recent", { id: "recent", sourcePath: "/tmp/recent" }],
+      ]),
+    );
+    expect(codex.scan).not.toHaveBeenCalled();
+    expect(codex.incrementalScan).not.toHaveBeenCalled();
+    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
+    expect(workerThreads.workers).toHaveLength(0);
+  });
+
+  it("builds a full cache before applying the startup time window when no cache is available", async () => {
+    vi.useFakeTimers();
+    const old = makeSession("old", { time_updated: 1000 });
+    const recent = makeSession("recent", { time_updated: 5000 });
+    const codex = makeAgent("codex", {
+      scan: vi.fn((options?: { from?: number }) => (options?.from ? [recent] : [old, recent])),
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["recent"],
+        timestamp: 2000,
+      })),
+      incrementalScan: vi.fn(() => [recent]),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValueOnce({
+      sessions: [],
+      byAgent: {},
+      agents: [codex],
+    });
+    core.filterSessions.mockImplementation((sessions: SessionHead[], options: { from?: number }) =>
+      options.from == null
+        ? sessions
+        : sessions.filter(
+            (session) => (session.time_updated ?? session.time_created) >= options.from!,
+          ),
+    );
+
+    const store = new LiveScanStore(false, {}, { from: 3000 }, { deferInitialRefresh: true });
+    await store.initialize();
+
+    store.startBackgroundRefresh();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(core.loadCachedSessions).toHaveBeenCalledWith("codex", { ignoreTtl: true });
+    expect(codex.scan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onProgress: expect.any(Function),
+      }),
+    );
+    expect(codex.scan.mock.calls[0]?.[0]).not.toHaveProperty("from");
+    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
+      expect.objectContaining({
+        kind: "full",
+        context: "scan.refresh",
+        agentName: "codex",
+        sessions: [
+          { ...old, project_identity: projectIdentity },
+          { ...recent, project_identity: projectIdentity },
+        ],
+        saveCache: true,
+      }),
+    ]);
+    expect(workerThreads.workers).toHaveLength(1);
+  });
+
+  it("persists incremental changes outside the startup time window", async () => {
+    vi.useFakeTimers();
+    const old = makeSession("old", { title: "old", time_updated: 1000 });
+    const updatedOld = makeSession("old", { title: "updated", time_updated: 1000 });
+    const recent = makeSession("recent", { time_updated: 5000 });
+    const updatedOldWithProject = { ...updatedOld, project_identity: projectIdentity };
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["old"],
+        timestamp: 2000,
+      })),
+      incrementalScan: vi.fn(() => [updatedOld, recent]),
+      setSessionMetaMap: vi.fn(),
+      getSessionMetaMap: vi.fn(
+        () =>
+          new Map([
+            ["old", { id: "old", sourcePath: "/tmp/old" }],
+            ["recent", { id: "recent", sourcePath: "/tmp/recent" }],
+          ]),
+      ),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValueOnce({
+      sessions: [recent],
+      byAgent: { codex: [recent] },
+      agents: [codex],
+      cacheTimestamps: { codex: 1000 },
+    });
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [old, recent],
+      byAgent: { codex: [old, recent] },
+      meta: {
+        old: { id: "old", sourcePath: "/tmp/old" },
+        recent: { id: "recent", sourcePath: "/tmp/recent" },
+      },
+      timestamp: 1000,
+    });
+    core.filterSessions.mockImplementation((sessions: SessionHead[], options: { from?: number }) =>
+      options.from == null
+        ? sessions
+        : sessions.filter(
+            (session) => (session.time_updated ?? session.time_created) >= options.from!,
+          ),
+    );
+
+    const store = new LiveScanStore(false, {}, { from: 3000 }, { deferInitialRefresh: true });
+    const events: unknown[] = [];
+    store.subscribe((event) => events.push(event));
+    await store.initialize();
+
+    store.startBackgroundRefresh();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(codex.checkForChanges).toHaveBeenCalledWith(1000, [old, recent]);
+    expect(codex.incrementalScan).toHaveBeenCalledWith([old, recent], ["old"]);
+    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
+    expect(events).toEqual([]);
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
+      {
+        kind: "changes",
+        context: "scan.refresh",
+        agentName: "codex",
+        changes: [{ session: updatedOldWithProject, sortIndex: 0 }],
+        removedSessionIds: [],
+        meta: { old: { id: "old", sourcePath: "/tmp/old" } },
+      },
+    ]);
+  });
+
+  it("uses source fingerprints to refresh only changed file-backed sessions", async () => {
+    vi.useFakeTimers();
+    const previous = makeSession("session", { title: "old", time_updated: 1000 });
+    const updated = makeSession("session", { title: "new", time_updated: 2000 });
+    const added = makeSession("added", { time_updated: 2500 });
+    const updatedWithProject = { ...updated, project_identity: projectIdentity };
+    const addedWithProject = { ...added, project_identity: projectIdentity };
+    const scanSessionSource = vi.fn((sourcePath: string) =>
+      sourcePath === "/tmp/s" ? updated : added,
+    );
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => {
+        throw new Error("checkForChanges should not run for source-backed agents");
+      }),
+      incrementalScan: vi.fn(),
+      listSessionSources: vi.fn(() => [
+        { sessionId: "session", sourcePath: "/tmp/s", fingerprint: "next" },
+        { sessionId: "added", sourcePath: "/tmp/added", fingerprint: "new" },
+      ]),
+      scanSessionSource,
+      getSessionMetaMap: vi.fn(
+        () =>
+          new Map([
+            ["session", { id: "session", sourcePath: "/tmp/s", sourceFingerprint: "next" }],
+            ["added", { id: "added", sourcePath: "/tmp/added", sourceFingerprint: "new" }],
+          ]),
+      ),
+      setSessionMetaMap: vi.fn(),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [previous],
+      byAgent: { codex: [previous] },
+      agents: [codex],
+    });
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [previous],
+      meta: {
+        session: { id: "session", sourcePath: "/tmp/s", sourceFingerprint: "old" },
+      },
+      timestamp: 1000,
+    });
+
+    const store = new LiveScanStore(false);
+    const events: unknown[] = [];
+    store.subscribe((event) => events.push(event));
+    await store.initialize();
+    await (store as any).runRefresh("codex");
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(codex.checkForChanges).not.toHaveBeenCalled();
+    expect(codex.incrementalScan).not.toHaveBeenCalled();
+    expect(scanSessionSource).toHaveBeenCalledTimes(2);
+    expect(scanSessionSource).toHaveBeenCalledWith("/tmp/s");
+    expect(scanSessionSource).toHaveBeenCalledWith("/tmp/added");
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
+      {
+        kind: "changes",
+        context: "scan.refresh",
+        agentName: "codex",
+        changes: [
+          { session: updatedWithProject, sortIndex: 0 },
+          { session: addedWithProject, sortIndex: 1 },
+        ],
+        removedSessionIds: [],
+        meta: {
+          session: { id: "session", sourcePath: "/tmp/s", sourceFingerprint: "next" },
+          added: { id: "added", sourcePath: "/tmp/added", sourceFingerprint: "new" },
+        },
+      },
+    ]);
+    expect(events).toEqual([
+      expect.objectContaining({
+        newSessions: 1,
+        updatedSessions: 1,
+        removedSessions: 0,
       }),
     ]);
   });
@@ -503,19 +793,11 @@ describe("LiveScanStore", () => {
     const events: unknown[] = [];
     store.subscribe((event) => events.push(event));
     await store.initialize();
+    const workerCount = workerThreads.workers.length;
     await (store as any).runRefresh("codex");
 
     expect(core.saveCachedSessions).not.toHaveBeenCalled();
-    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
-      {
-        kind: "full",
-        context: "scan.refresh",
-        agentName: "codex",
-        sessions: [],
-        meta: { session: { id: "session", sourcePath: "/tmp/s" } },
-        saveCache: true,
-      },
-    ]);
+    expect(workerThreads.workers).toHaveLength(workerCount);
     expect(events).toEqual([
       expect.objectContaining({
         newSessions: 0,

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -1039,12 +1039,7 @@ export class LiveScanStore {
     }
 
     const sessions = attachMissingProjectIdentities([...sessionMap.values()]);
-    const persistenceDiff = buildRefreshDiff(
-      agent.name,
-      cachedSessions,
-      sessions,
-      [...changedIds],
-    );
+    const persistenceDiff = buildRefreshDiff(agent.name, cachedSessions, sessions, [...changedIds]);
     return {
       sessions,
       changedIds: [...changedIds],

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -7,13 +7,17 @@ import {
   computeIdentity,
   filterSessions,
   getCursorDataPath,
+  isAgentCacheInitialized,
+  loadCachedSessions,
   realFs,
   resolveProviderRoots,
   scanSessions,
+  type AgentScanProgress,
   type BaseAgent,
   type ScanResult,
   type ScanOptions,
   type SessionCacheMeta,
+  type SessionSourceRef,
   type SessionHeadChange,
   type SessionHead,
 } from "@codesesh/core";
@@ -33,7 +37,33 @@ export interface SessionsUpdatedEvent {
   removedSessionRefs: Array<{ agentName: string; sessionId: string }>;
 }
 
+export interface ScanStatusEvent {
+  type: "scan-status";
+  active: boolean;
+  phase: "idle" | "indexing" | "initializing" | "scanning";
+  pendingAgents: string[];
+  scanningAgents: string[];
+  completedAgents: string[];
+  agentStatuses: Record<string, AgentScanStatus>;
+  totalAgents: number;
+  startedAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface AgentScanStatus {
+  agentName: string;
+  status: "pending" | "scanning" | "complete";
+  total?: number;
+  processed?: number;
+  sessions?: number;
+  startedAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
 type StoreListener = (event: SessionsUpdatedEvent) => void;
+type ScanStatusListener = (event: ScanStatusEvent) => void;
 
 interface WatchTarget {
   path: string;
@@ -192,6 +222,18 @@ function buildRefreshDiff(
       removedSessionRefs: removedSessionIds.map((sessionId) => ({ agentName, sessionId })),
     },
   };
+}
+
+function restoreAgentCacheMeta(agent: BaseAgent, meta: Record<string, SessionCacheMeta>): void {
+  agent.setSessionMetaMap?.(new Map(Object.entries(meta)));
+}
+
+function sourceFingerprintFromMeta(meta: SessionCacheMeta | undefined): string | null {
+  return typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : null;
+}
+
+function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string | null {
+  return typeof meta?.sourcePath === "string" ? meta.sourcePath : null;
 }
 
 function toAbsolutePath(path: string): string {
@@ -355,6 +397,17 @@ export class LiveScanStore {
   private byAgent: Record<string, SessionHead[]> = {};
   private sessions: SessionHead[] = [];
   private listeners = new Set<StoreListener>();
+  private scanStatusListeners = new Set<ScanStatusListener>();
+  private scanStatus: Omit<ScanStatusEvent, "type"> = {
+    active: false,
+    phase: "idle",
+    pendingAgents: [],
+    scanningAgents: [],
+    completedAgents: [],
+    agentStatuses: {},
+    totalAgents: 0,
+    updatedAt: Date.now(),
+  };
   private refreshTimers = new Map<string, NodeJS.Timeout>();
   private refreshTimestamps = new Map<string, number>();
   private refreshInFlight = new Set<string>();
@@ -390,18 +443,13 @@ export class LiveScanStore {
     });
     const initialResult = await scanSessions({
       ...this.scanOptions,
-      ...this.startupScanOptions,
+      ...(deferInitialRefresh ? this.startupScanOptions : {}),
       useCache: this.scanOptions.useCache ?? true,
       smartRefresh: false,
       cacheOnly: deferInitialRefresh,
       writeCache: deferInitialRefresh ? false : this.scanOptions.writeCache,
       smartTagWorkerUrl: this.getSmartTagWorkerUrl() ?? undefined,
-      includeSmartTags:
-        deferInitialRefresh ||
-        this.startupScanOptions.from != null ||
-        this.startupScanOptions.to != null
-          ? false
-          : undefined,
+      includeSmartTags: deferInitialRefresh ? false : undefined,
     });
     this.applyScanResult(initialResult);
     const indexStartedAt = performance.now();
@@ -445,11 +493,15 @@ export class LiveScanStore {
     if (this.backgroundRefreshTimer) {
       return;
     }
+    const agentNames = this.agents.map((agent) => agent.name);
+    this.startScanBatch(agentNames, "scanning");
     this.backgroundRefreshTimer = setTimeout(() => {
       this.backgroundRefreshTimer = null;
-      void this.refreshInitialIndex();
-      for (const agent of this.agents) {
-        this.scheduleRefresh(agent.name, 0);
+      for (const agentName of agentNames) {
+        this.scheduleRefresh(agentName, 0);
+      }
+      if (agentNames.length === 0) {
+        this.finishScanBatch();
       }
     }, 0);
   }
@@ -462,10 +514,33 @@ export class LiveScanStore {
     };
   }
 
+  getScanStatus(): ScanStatusEvent {
+    return {
+      type: "scan-status",
+      ...this.scanStatus,
+      pendingAgents: [...this.scanStatus.pendingAgents],
+      scanningAgents: [...this.scanStatus.scanningAgents],
+      completedAgents: [...this.scanStatus.completedAgents],
+      agentStatuses: Object.fromEntries(
+        Object.entries(this.scanStatus.agentStatuses).map(([agentName, status]) => [
+          agentName,
+          { ...status },
+        ]),
+      ),
+    };
+  }
+
   subscribe(listener: StoreListener): () => void {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  subscribeScanStatus(listener: ScanStatusListener): () => void {
+    this.scanStatusListeners.add(listener);
+    return () => {
+      this.scanStatusListeners.delete(listener);
     };
   }
 
@@ -521,6 +596,167 @@ export class LiveScanStore {
     }
   }
 
+  private emitScanStatus(): void {
+    const event = this.getScanStatus();
+    for (const listener of this.scanStatusListeners) {
+      listener(event);
+    }
+  }
+
+  private updateScanStatus(next: Omit<ScanStatusEvent, "type">): void {
+    this.scanStatus = next;
+    this.emitScanStatus();
+  }
+
+  private startScanBatch(agentNames: string[], phase: ScanStatusEvent["phase"]): void {
+    const uniqueAgentNames = [...new Set(agentNames)];
+    const now = Date.now();
+    const agentStatuses = Object.fromEntries(
+      uniqueAgentNames.map((agentName) => [
+        agentName,
+        {
+          agentName,
+          status: "pending" as const,
+          processed: 0,
+          sessions: this.byAgent[agentName]?.length ?? 0,
+          updatedAt: now,
+        },
+      ]),
+    );
+    this.updateScanStatus({
+      active: uniqueAgentNames.length > 0,
+      phase: uniqueAgentNames.length > 0 ? phase : "idle",
+      pendingAgents: uniqueAgentNames,
+      scanningAgents: [],
+      completedAgents: [],
+      agentStatuses,
+      totalAgents: uniqueAgentNames.length,
+      startedAt: uniqueAgentNames.length > 0 ? now : undefined,
+      updatedAt: now,
+      completedAt: uniqueAgentNames.length > 0 ? undefined : now,
+    });
+  }
+
+  private setScanPhase(phase: ScanStatusEvent["phase"]): void {
+    if (!this.scanStatus.active) return;
+    this.updateScanStatus({
+      ...this.scanStatus,
+      phase,
+      updatedAt: Date.now(),
+    });
+  }
+
+  private beginAgentScan(agentName: string): void {
+    if (!this.scanStatus.active) {
+      this.startScanBatch([agentName], "scanning");
+    }
+
+    const pendingAgents = this.scanStatus.pendingAgents.filter((agent) => agent !== agentName);
+    const scanningAgents = [...new Set([...this.scanStatus.scanningAgents, agentName])];
+    const completedAgents = this.scanStatus.completedAgents.filter((agent) => agent !== agentName);
+    const existingStatus = this.scanStatus.agentStatuses[agentName];
+    const agentStatuses = {
+      ...this.scanStatus.agentStatuses,
+      [agentName]: {
+        agentName,
+        status: "scanning" as const,
+        total: existingStatus?.total,
+        processed: existingStatus?.processed ?? 0,
+        sessions: existingStatus?.sessions ?? this.byAgent[agentName]?.length ?? 0,
+        startedAt: existingStatus?.startedAt ?? Date.now(),
+        updatedAt: Date.now(),
+      },
+    };
+    this.updateScanStatus({
+      ...this.scanStatus,
+      active: true,
+      phase: this.scanStatus.phase === "initializing" ? "initializing" : "scanning",
+      pendingAgents,
+      scanningAgents,
+      completedAgents,
+      agentStatuses,
+      totalAgents: Math.max(
+        this.scanStatus.totalAgents,
+        pendingAgents.length + scanningAgents.length,
+      ),
+      updatedAt: Date.now(),
+      completedAt: undefined,
+    });
+  }
+
+  private updateAgentScanProgress(agentName: string, progress: AgentScanProgress): void {
+    const status = this.scanStatus.agentStatuses[agentName];
+    if (!status || status.status !== "scanning") return;
+    this.updateScanStatus({
+      ...this.scanStatus,
+      agentStatuses: {
+        ...this.scanStatus.agentStatuses,
+        [agentName]: {
+          ...status,
+          total: progress.total ?? status.total,
+          processed: progress.processed ?? status.processed,
+          sessions: progress.sessions ?? status.sessions,
+          updatedAt: Date.now(),
+        },
+      },
+      updatedAt: Date.now(),
+    });
+  }
+
+  private finishAgentScan(agentName: string): void {
+    const pendingAgents = this.scanStatus.pendingAgents.filter((agent) => agent !== agentName);
+    const scanningAgents = this.scanStatus.scanningAgents.filter((agent) => agent !== agentName);
+    const completedAgents = [...new Set([...this.scanStatus.completedAgents, agentName])];
+    const active = pendingAgents.length > 0 || scanningAgents.length > 0;
+    const now = Date.now();
+    const previousStatus = this.scanStatus.agentStatuses[agentName];
+    const sessions = this.byAgent[agentName]?.length ?? previousStatus?.sessions ?? 0;
+    const total = previousStatus?.total ?? previousStatus?.processed;
+
+    this.updateScanStatus({
+      ...this.scanStatus,
+      active,
+      phase: active ? "scanning" : "idle",
+      pendingAgents,
+      scanningAgents,
+      completedAgents,
+      agentStatuses: {
+        ...this.scanStatus.agentStatuses,
+        [agentName]: {
+          agentName,
+          status: "complete",
+          total,
+          processed: total,
+          sessions,
+          startedAt: previousStatus?.startedAt,
+          updatedAt: now,
+          completedAt: now,
+        },
+      },
+      updatedAt: now,
+      completedAt: active ? undefined : now,
+    });
+  }
+
+  private finishScanBatch(): void {
+    const now = Date.now();
+    this.updateScanStatus({
+      ...this.scanStatus,
+      active: false,
+      phase: "idle",
+      pendingAgents: [],
+      scanningAgents: [],
+      agentStatuses: Object.fromEntries(
+        Object.entries(this.scanStatus.agentStatuses).map(([agentName, status]) => [
+          agentName,
+          { ...status, status: "complete", completedAt: status.completedAt ?? now, updatedAt: now },
+        ]),
+      ),
+      updatedAt: now,
+      completedAt: now,
+    });
+  }
+
   private queueEvent(event: SessionsUpdatedEvent): void {
     this.pendingEvent = this.pendingEvent ? mergeEvents(this.pendingEvent, event) : event;
     if (this.pendingEventTimer) {
@@ -539,10 +775,6 @@ export class LiveScanStore {
 
   private rebuildSessions(): void {
     this.sessions = sortSessions(Object.values(this.byAgent).flat());
-  }
-
-  private hasStartupWindow(): boolean {
-    return this.startupScanOptions.from != null || this.startupScanOptions.to != null;
   }
 
   private getSearchIndexWorkerUrl(): URL | null {
@@ -573,6 +805,7 @@ export class LiveScanStore {
     agent: BaseAgent,
     previousSessions: SessionHead[],
     changedIds: string[] | null,
+    scanOptions: Pick<ScanOptions, "from" | "to" | "fast">,
   ): Promise<{ sessions: SessionHead[]; meta: Record<string, SessionCacheMeta> }> | null {
     const workerUrl = this.getScanRefreshWorkerUrl();
     if (!workerUrl) return null;
@@ -583,7 +816,7 @@ export class LiveScanStore {
           agentName: agent.name,
           previousSessions,
           changedIds,
-          startupScanOptions: this.startupScanOptions,
+          scanOptions,
           meta: buildAgentCacheMeta(agent),
         },
       });
@@ -597,7 +830,11 @@ export class LiveScanStore {
         callback();
       };
 
-      worker.once("message", (message: ScanRefreshWorkerMessage) => {
+      worker.on("message", (message: ScanRefreshWorkerMessage) => {
+        if (message.type === "progress") {
+          this.updateAgentScanProgress(agent.name, message.progress);
+          return;
+        }
         if (message.type === "done") {
           finish(() => resolve({ sessions: message.sessions, meta: message.meta }));
           return;
@@ -616,13 +853,25 @@ export class LiveScanStore {
   }
 
   private buildFullSearchIndexJobs(context: string): SearchIndexWorkerJob[] {
-    return this.agents.map((agent) => ({
-      kind: "full",
-      context,
-      agentName: agent.name,
-      sessions: this.byAgent[agent.name] ?? [],
-      meta: buildAgentCacheMeta(agent),
-    }));
+    return this.agents.map((agent) => {
+      const cached = loadCachedSessions(agent.name, { ignoreTtl: true });
+      if (cached) {
+        return {
+          kind: "full",
+          context,
+          agentName: agent.name,
+          sessions: cached.sessions,
+          meta: cached.meta,
+        };
+      }
+      return {
+        kind: "full",
+        context,
+        agentName: agent.name,
+        sessions: this.byAgent[agent.name] ?? [],
+        meta: buildAgentCacheMeta(agent),
+      };
+    });
   }
 
   private enqueueSearchIndexJobs(context: string, jobs: SearchIndexWorkerJob[]): Promise<void> {
@@ -740,6 +989,67 @@ export class LiveScanStore {
 
   private applyFilters(sessions: SessionHead[]): SessionHead[] {
     return filterSessions(sessions, { ...this.scanOptions, ...this.startupScanOptions });
+  }
+
+  private canSyncSources(agent: BaseAgent): agent is BaseAgent & {
+    listSessionSources: () => SessionSourceRef[];
+    scanSessionSource: (sourcePath: string) => SessionHead | null;
+  } {
+    return Boolean(agent.listSessionSources && agent.scanSessionSource);
+  }
+
+  private syncAgentSources(
+    agent: BaseAgent & {
+      listSessionSources: () => SessionSourceRef[];
+      scanSessionSource: (sourcePath: string) => SessionHead | null;
+    },
+    cachedSessions: SessionHead[],
+    cachedMeta: Record<string, SessionCacheMeta>,
+  ): {
+    sessions: SessionHead[];
+    changedIds: string[];
+    persistenceDiff: Pick<SessionRefreshDiff, "changedSessions" | "removedSessionIds">;
+  } {
+    const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
+    const sourceRefs = agent.listSessionSources();
+    const currentIds = new Set(sourceRefs.map((source) => source.sessionId));
+    const changedIds = new Set<string>();
+
+    for (const source of sourceRefs) {
+      const cachedSession = sessionMap.get(source.sessionId);
+      const cached = cachedMeta[source.sessionId];
+      const sameSource = sourcePathFromMeta(cached) === source.sourcePath;
+      const sameFingerprint = sourceFingerprintFromMeta(cached) === source.fingerprint;
+      if (cachedSession && sameSource && sameFingerprint) continue;
+
+      const next = agent.scanSessionSource(source.sourcePath);
+      changedIds.add(source.sessionId);
+      if (next) {
+        sessionMap.set(next.id, next);
+      } else {
+        sessionMap.delete(source.sessionId);
+      }
+    }
+
+    for (const session of cachedSessions) {
+      if (!currentIds.has(session.id)) {
+        sessionMap.delete(session.id);
+        changedIds.add(session.id);
+      }
+    }
+
+    const sessions = attachMissingProjectIdentities([...sessionMap.values()]);
+    const persistenceDiff = buildRefreshDiff(
+      agent.name,
+      cachedSessions,
+      sessions,
+      [...changedIds],
+    );
+    return {
+      sessions,
+      changedIds: [...changedIds],
+      persistenceDiff,
+    };
   }
 
   private async refreshInitialIndex(): Promise<void> {
@@ -1020,6 +1330,7 @@ export class LiveScanStore {
     }
 
     this.refreshInFlight.add(agentName);
+    this.beginAgentScan(agentName);
 
     try {
       await this.runRefresh(agentName);
@@ -1028,6 +1339,7 @@ export class LiveScanStore {
       console.error(`[${agentName}] Session refresh failed:`, error);
     } finally {
       this.refreshInFlight.delete(agentName);
+      this.finishAgentScan(agentName);
 
       if (this.pendingRefreshes.delete(agentName)) {
         this.scheduleRefresh(agentName, PENDING_REFRESH_DELAY_MS);
@@ -1046,9 +1358,19 @@ export class LiveScanStore {
     }
 
     const previousSessions = this.byAgent[agentName] ?? [];
+    const cached = loadCachedSessions(agentName, { ignoreTtl: true });
+    const refreshBaseline = cached?.sessions ?? previousSessions;
+    const cacheTimestamp = cached?.timestamp ?? this.refreshTimestamps.get(agentName) ?? 0;
+    if (cached) {
+      restoreAgentCacheMeta(agent, cached.meta);
+    }
+    const isInitialized = isAgentCacheInitialized(agentName);
     let nextSessions = previousSessions;
+    let fullScanSessions: SessionHead[] | null = null;
     let preciseChangedIds: string[] | null = null;
     let usedIncrementalScan = false;
+    let persistenceDiff: Pick<SessionRefreshDiff, "changedSessions" | "removedSessionIds"> | null =
+      null;
     let availabilityDuration = 0;
     let checkDuration = 0;
     let scanDuration = 0;
@@ -1056,6 +1378,7 @@ export class LiveScanStore {
     let diffDuration = 0;
     let persistDuration = 0;
     let searchIndexDuration = 0;
+    let persistentJobKind: SearchIndexWorkerJob["kind"] | undefined;
 
     const availabilityStartedAt = performance.now();
     const isAvailable = agent.isAvailable();
@@ -1064,10 +1387,44 @@ export class LiveScanStore {
     if (!isAvailable) {
       nextSessions = [];
       this.refreshTimestamps.set(agentName, Date.now());
-    } else if (previousSessions.length > 0 && agent.checkForChanges && agent.incrementalScan) {
+    } else if (!isInitialized) {
+      this.setScanPhase("initializing");
+      const scanStartedAt = performance.now();
+      const workerResult = this.scanAgentInWorker(agent, previousSessions, null, {});
+      if (workerResult) {
+        const result = await workerResult;
+        nextSessions = result.sessions;
+        agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
+      } else {
+        nextSessions = await Promise.resolve(
+          agent.scan({
+            onProgress: (progress) => this.updateAgentScanProgress(agentName, progress),
+          }),
+        );
+      }
+      fullScanSessions = attachMissingProjectIdentities(nextSessions);
+      nextSessions = fullScanSessions;
+      scanDuration = performance.now() - scanStartedAt;
+      this.refreshTimestamps.set(agentName, Date.now());
+    } else if (cached && this.canSyncSources(agent)) {
+      const scanStartedAt = performance.now();
+      const result = this.syncAgentSources(agent, cached.sessions, cached.meta);
+      nextSessions = result.sessions;
+      preciseChangedIds = result.changedIds;
+      usedIncrementalScan = true;
+      persistenceDiff = result.persistenceDiff;
+      scanDuration = performance.now() - scanStartedAt;
+      this.refreshTimestamps.set(agentName, Date.now());
+      if (result.changedIds.length === 0) {
+        appLogger.debug("scan.refresh.unchanged", {
+          agent: agentName,
+          duration_ms: Math.round(performance.now() - startedAt),
+        });
+      }
+    } else if (refreshBaseline.length > 0 && agent.checkForChanges && agent.incrementalScan) {
       const checkStartedAt = performance.now();
       const checkResult = await Promise.resolve(
-        agent.checkForChanges(this.refreshTimestamps.get(agentName) ?? 0, previousSessions),
+        agent.checkForChanges(cacheTimestamp, refreshBaseline),
       );
       checkDuration = performance.now() - checkStartedAt;
 
@@ -1083,31 +1440,34 @@ export class LiveScanStore {
       preciseChangedIds = checkResult.changedIds ?? null;
       usedIncrementalScan = Array.isArray(checkResult.changedIds);
       const scanStartedAt = performance.now();
-      const workerResult = this.scanAgentInWorker(
-        agent,
-        previousSessions,
-        checkResult.changedIds ?? [],
+      nextSessions = await Promise.resolve(
+        agent.incrementalScan(refreshBaseline, checkResult.changedIds ?? []),
       );
+      const nextBaseline = attachMissingProjectIdentities(nextSessions);
+      persistenceDiff = buildRefreshDiff(
+        agentName,
+        refreshBaseline,
+        nextBaseline,
+        preciseChangedIds ?? [],
+      );
+      nextSessions = nextBaseline;
+      scanDuration = performance.now() - scanStartedAt;
+    } else {
+      const scanStartedAt = performance.now();
+      const workerResult = this.scanAgentInWorker(agent, previousSessions, null, {});
       if (workerResult) {
         const result = await workerResult;
         nextSessions = result.sessions;
         agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
       } else {
         nextSessions = await Promise.resolve(
-          agent.incrementalScan(previousSessions, checkResult.changedIds ?? []),
+          agent.scan({
+            onProgress: (progress) => this.updateAgentScanProgress(agentName, progress),
+          }),
         );
       }
-      scanDuration = performance.now() - scanStartedAt;
-    } else {
-      const scanStartedAt = performance.now();
-      const workerResult = this.scanAgentInWorker(agent, previousSessions, null);
-      if (workerResult) {
-        const result = await workerResult;
-        nextSessions = result.sessions;
-        agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
-      } else {
-        nextSessions = await Promise.resolve(agent.scan(this.startupScanOptions));
-      }
+      fullScanSessions = attachMissingProjectIdentities(nextSessions);
+      nextSessions = fullScanSessions;
       scanDuration = performance.now() - scanStartedAt;
       this.refreshTimestamps.set(agentName, Date.now());
     }
@@ -1128,8 +1488,11 @@ export class LiveScanStore {
     const searchIndexOptions =
       pendingPathCount >= SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD ? { isBulk: true } : undefined;
     const canPersistIncrementally = usedIncrementalScan;
+    const persistentChanges = persistenceDiff?.changedSessions ?? diff.changedSessions;
+    const persistentRemovedSessionIds =
+      persistenceDiff?.removedSessionIds ?? diff.removedSessionIds;
     const changedSessionIds = canPersistIncrementally
-      ? new Set(diff.changedSessions.map(({ session }) => session.id))
+      ? new Set(persistentChanges.map(({ session }) => session.id))
       : undefined;
     const cacheMeta = buildAgentCacheMeta(agent, changedSessionIds);
     const persistStartedAt = performance.now();
@@ -1138,24 +1501,33 @@ export class LiveScanStore {
           kind: "changes",
           context: "scan.refresh",
           agentName,
-          changes: diff.changedSessions,
-          removedSessionIds: diff.removedSessionIds,
+          changes: persistentChanges,
+          removedSessionIds: persistentRemovedSessionIds,
           meta: cacheMeta,
           ...(searchIndexOptions ? { searchIndexOptions } : {}),
         }
-      : !this.hasStartupWindow()
+      : fullScanSessions
         ? {
             kind: "full",
             context: "scan.refresh",
             agentName,
-            sessions: nextSessions,
+            sessions: fullScanSessions,
             meta: buildAgentCacheMeta(agent),
             saveCache: true,
             ...(searchIndexOptions ? { searchIndexOptions } : {}),
           }
         : null;
     if (persistentJob) {
-      await this.enqueueSearchIndexJobs("scan.refresh", [persistentJob]);
+      persistentJobKind = persistentJob.kind;
+      const persist = this.enqueueSearchIndexJobs("scan.refresh", [persistentJob]);
+      if (!isInitialized && persistentJob.kind === "full") {
+        await persist;
+      } else {
+        void persist.catch((error) => {
+          appLogger.error("scan.refresh.persist.error", { agent: agentName, error });
+          console.error(`[${agentName}] Session persistence failed:`, error);
+        });
+      }
     }
     persistDuration = performance.now() - persistStartedAt;
     const searchIndexStartedAt = performance.now();
@@ -1185,7 +1557,7 @@ export class LiveScanStore {
       diff_ms: Math.round(diffDuration),
       persist_ms: Math.round(persistDuration),
       search_index_ms: Math.round(searchIndexDuration),
-      persistent_index_worker_job: persistentJob?.kind,
+      persistent_index_worker_job: persistentJobKind,
       persistent_index_skipped: !persistentJob || undefined,
     });
   }

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -1,12 +1,17 @@
 import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,
+  type AgentScanProgress,
   type ScanOptions,
   type SessionCacheMeta,
   type SessionHead,
 } from "@codesesh/core";
 
 export type ScanRefreshWorkerMessage =
+  | {
+      type: "progress";
+      progress: AgentScanProgress;
+    }
   | {
       type: "done";
       sessions: SessionHead[];
@@ -23,7 +28,7 @@ interface ScanRefreshWorkerData {
   agentName: string;
   previousSessions: SessionHead[];
   changedIds: string[] | null;
-  startupScanOptions: Pick<ScanOptions, "from" | "to">;
+  scanOptions: Pick<ScanOptions, "from" | "to" | "fast">;
   meta: Record<string, SessionCacheMeta>;
 }
 
@@ -58,7 +63,15 @@ try {
     ? []
     : data.changedIds && agent.incrementalScan
       ? agent.incrementalScan(data.previousSessions, data.changedIds)
-      : agent.scan(data.startupScanOptions);
+      : agent.scan({
+          ...data.scanOptions,
+          onProgress: (progress) => {
+            parentPort?.postMessage({
+              type: "progress",
+              progress,
+            } satisfies ScanRefreshWorkerMessage);
+          },
+        });
 
   parentPort?.postMessage({
     type: "done",

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -1,6 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,
+  markAgentCacheInitialized,
   saveCachedSessionChanges,
   saveCachedSessions,
   syncSessionSearchIndex,
@@ -96,6 +97,9 @@ for (const job of jobs) {
       (sessionId) => agent.getSessionData(sessionId),
       job.searchIndexOptions,
     );
+    if (job.saveCache && result?.skipped === 0) {
+      markAgentCacheInitialized(job.agentName);
+    }
   }
   parentPort?.postMessage({
     type: "sync-result",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -78,7 +78,10 @@ function getListeningPort(server: Server, fallback: number): number {
 
 export async function createServer(
   port: number,
-  store: ScanResultSource & Partial<Pick<LiveScanStore, "subscribe" | "shutdown">>,
+  store: ScanResultSource &
+    Partial<
+      Pick<LiveScanStore, "getScanStatus" | "subscribe" | "subscribeScanStatus" | "shutdown">
+    >,
   options: CreateServerOptions = {},
 ): Promise<{ url: string; shutdown: () => Promise<void> }> {
   const app = new Hono();

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -28,6 +28,13 @@ export interface AgentScanOptions {
   from?: number;
   to?: number;
   fast?: boolean;
+  onProgress?: (progress: AgentScanProgress) => void;
+}
+
+export interface AgentScanProgress {
+  total?: number;
+  processed?: number;
+  sessions?: number;
 }
 
 export function matchesScanWindow(activityTime: number, options?: AgentScanOptions): boolean {
@@ -44,6 +51,12 @@ export interface ChangeCheckResult {
   changedIds?: string[];
   /** 检测时间戳 */
   timestamp: number;
+}
+
+export interface SessionSourceRef {
+  sessionId: string;
+  sourcePath: string;
+  fingerprint: string;
 }
 
 export abstract class BaseAgent {
@@ -96,4 +109,8 @@ export abstract class BaseAgent {
     cachedSessions: SessionHead[],
     changedIds: string[],
   ): Promise<SessionHead[]> | SessionHead[];
+
+  listSessionSources?(): SessionSourceRef[];
+
+  scanSessionSource?(sourcePath: string): SessionHead | null;
 }

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -17,7 +17,12 @@ import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText, cleanParsedMessages } from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
+import type {
+  AgentScanOptions,
+  ChangeCheckResult,
+  SessionCacheMeta,
+  SessionSourceRef,
+} from "./base.js";
 
 const HEAD_INDEX_VERSION = "claudecode-head-v1";
 
@@ -86,15 +91,25 @@ export class ClaudeCodeAgent extends BaseAgent {
     const projectDirs = this.listProjectDirs();
     perf.end(listMarker);
 
-    for (const projectDir of projectDirs) {
+    const filesByProject = projectDirs.map((projectDir) => {
       const fileMarker = perf.start(`listJsonlFiles:${basename(projectDir)}`);
-      const files = this.listJsonlFiles(projectDir);
+      const files = this.listJsonlFiles(projectDir).filter((file) => {
+        try {
+          return matchesScanWindow(statSync(file).mtimeMs, options);
+        } catch {
+          return false;
+        }
+      });
       perf.end(fileMarker);
+      return { projectDir, files };
+    });
+    const totalFiles = filesByProject.reduce((total, item) => total + item.files.length, 0);
+    options?.onProgress?.({ total: totalFiles, processed: 0, sessions: 0 });
 
+    let processed = 0;
+    for (const { projectDir, files } of filesByProject) {
       for (const file of files) {
         try {
-          if (!matchesScanWindow(statSync(file).mtimeMs, options)) continue;
-
           const parseMarker = perf.start(`parseSessionHead:${basename(file)}`);
           const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
           perf.end(parseMarker);
@@ -105,12 +120,40 @@ export class ClaudeCodeAgent extends BaseAgent {
           }
         } catch {
           // skip malformed files
+        } finally {
+          processed += 1;
+          options?.onProgress?.({ total: totalFiles, processed, sessions: heads.length });
         }
       }
     }
 
     perf.end(scanMarker);
     return heads;
+  }
+
+  listSessionSources(): SessionSourceRef[] {
+    if (!this.basePath) return [];
+    const refs: SessionSourceRef[] = [];
+    for (const projectDir of this.listProjectDirs()) {
+      for (const file of this.listJsonlFiles(projectDir)) {
+        const sessionId = basename(file, ".jsonl");
+        refs.push({
+          sessionId,
+          sourcePath: file,
+          fingerprint: this.sourceFingerprint(file, projectDir),
+        });
+      }
+    }
+    return refs;
+  }
+
+  scanSessionSource(sourcePath: string): SessionHead | null {
+    const projectDir = dirname(sourcePath);
+    const head = getParsedSession(this.parseSessionHeadResult(sourcePath, projectDir));
+    if (head) {
+      this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath, projectDir));
+    }
+    return head;
   }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
@@ -303,6 +346,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       id: head.id,
       title: head.title,
       sourcePath: file,
+      sourceFingerprint: this.sourceFingerprint(file, projectDir),
       sourceMtimeMs: statSync(file).mtimeMs,
       indexPath: existsSync(indexPath) ? indexPath : null,
       indexMtimeMs: this.getFileMtimeMs(indexPath),
@@ -322,6 +366,17 @@ export class ClaudeCodeAgent extends BaseAgent {
 
     const indexPath = meta.indexPath ?? this.getSessionsIndexPath(dirname(meta.sourcePath));
     return this.getFileMtimeMs(indexPath) !== (meta.indexMtimeMs ?? null);
+  }
+
+  private sourceFingerprint(file: string, projectDir: string): string {
+    const stat = statSync(file);
+    const indexPath = this.getSessionsIndexPath(projectDir);
+    return JSON.stringify([
+      HEAD_INDEX_VERSION,
+      stat.mtimeMs,
+      stat.size,
+      this.getFileMtimeMs(indexPath),
+    ]);
   }
 
   private getSessionsIndexPath(projectDir: string): string {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -263,7 +263,12 @@ function extractPatchContent(
 // Session meta
 // ---------------------------------------------------------------------------
 
-import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
+import type {
+  AgentScanOptions,
+  ChangeCheckResult,
+  SessionCacheMeta,
+  SessionSourceRef,
+} from "./base.js";
 
 interface SessionMeta extends SessionCacheMeta {
   id: string;
@@ -327,7 +332,9 @@ export class CodexAgent extends BaseAgent {
     const listMarker = perf.start("listRolloutFiles");
     const files = this.listRolloutFiles(options);
     perf.end(listMarker);
+    options?.onProgress?.({ total: files.length, processed: 0, sessions: 0 });
 
+    let processed = 0;
     for (const file of files) {
       try {
         const parseMarker = perf.start(`parseSessionHead:${basename(file)}`);
@@ -340,11 +347,33 @@ export class CodexAgent extends BaseAgent {
         }
       } catch {
         // skip malformed files
+      } finally {
+        processed += 1;
+        options?.onProgress?.({ total: files.length, processed, sessions: heads.length });
       }
     }
 
     perf.end(scanMarker);
     return heads;
+  }
+
+  listSessionSources(): SessionSourceRef[] {
+    if (!this.basePath) return [];
+    this.loadSessionIndex();
+    return this.listRolloutFiles().map((file) => ({
+      sessionId: extractSessionId(file),
+      sourcePath: file,
+      fingerprint: this.sourceFingerprint(file),
+    }));
+  }
+
+  scanSessionSource(sourcePath: string): SessionHead | null {
+    this.loadSessionIndex();
+    const head = getParsedSession(this.parseSessionHeadResult(sourcePath));
+    if (head) {
+      this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath));
+    }
+    return head;
   }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
@@ -648,6 +677,7 @@ export class CodexAgent extends BaseAgent {
       id: head.id,
       title: head.title,
       sourcePath: file,
+      sourceFingerprint: this.sourceFingerprint(file),
       sourceMtimeMs: statSync(file).mtimeMs,
       indexPath: existsSync(indexPath) ? indexPath : null,
       indexMtimeMs: this.getFileMtimeMs(indexPath),
@@ -669,6 +699,18 @@ export class CodexAgent extends BaseAgent {
 
     const indexPath = meta.indexPath ?? this.getSessionIndexPath();
     return this.getFileMtimeMs(indexPath) !== (meta.indexMtimeMs ?? null);
+  }
+
+  private sourceFingerprint(file: string): string {
+    const stat = statSync(file);
+    const indexPath = this.getSessionIndexPath();
+    return JSON.stringify([
+      HEAD_INDEX_VERSION,
+      PARSER_VERSION,
+      stat.mtimeMs,
+      stat.size,
+      this.getFileMtimeMs(indexPath),
+    ]);
   }
 
   private getSessionIndexPath(): string {

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -392,6 +392,8 @@ export class CursorAgent extends BaseAgent {
         .all() as Array<{ key: string; value: string }>;
 
       const heads: SessionHead[] = [];
+      options?.onProgress?.({ total: rows.length, processed: 0, sessions: 0 });
+      let processed = 0;
 
       for (const row of rows) {
         try {
@@ -518,6 +520,9 @@ export class CursorAgent extends BaseAgent {
           });
         } catch {
           // skip malformed entries
+        } finally {
+          processed += 1;
+          options?.onProgress?.({ total: rows.length, processed, sessions: heads.length });
         }
       }
 

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,6 +1,11 @@
 export { BaseAgent } from "./base.js";
 export { filteredSession, getParsedSession, parsedSession, skippedSession } from "./base.js";
-export type { SessionCacheMeta, ChangeCheckResult } from "./base.js";
+export type {
+  AgentScanProgress,
+  ChangeCheckResult,
+  SessionCacheMeta,
+  SessionSourceRef,
+} from "./base.js";
 export type { ParseSessionResult } from "../types/index.js";
 export {
   registerAgent,

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -13,6 +13,7 @@ import type {
   ChangeCheckResult,
   ParseSessionResult,
   SessionCacheMeta,
+  SessionSourceRef,
 } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
@@ -295,16 +296,26 @@ export class KimiAgent extends BaseAgent {
     const sessionDirs = this.listSessionDirs();
     perf.end(listMarker);
 
-    const heads: SessionHead[] = [];
+    const metas: SessionMeta[] = [];
     for (const dir of sessionDirs) {
       try {
         const parseMarker = perf.start(`parseSessionDir:${basename(dir)}`);
         const meta = getParsedSession(this.parseSessionDirResult(dir));
         perf.end(parseMarker);
+        if (meta && matchesScanWindow(meta.createdAt, options)) {
+          metas.push(meta);
+        }
+      } catch {
+        // skip
+      }
+    }
+    options?.onProgress?.({ total: metas.length, processed: 0, sessions: 0 });
 
-        if (!meta) continue;
-        if (!matchesScanWindow(meta.createdAt, options)) continue;
-
+    const heads: SessionHead[] = [];
+    let processed = 0;
+    for (const meta of metas) {
+      try {
+        meta.sourceFingerprint = this.sourceFingerprint(meta);
         this.sessionMetaMap.set(meta.id, meta);
         const stats = this.extractStats(meta.sourcePath);
         heads.push({
@@ -318,11 +329,48 @@ export class KimiAgent extends BaseAgent {
         });
       } catch {
         // skip
+      } finally {
+        processed += 1;
+        options?.onProgress?.({ total: metas.length, processed, sessions: heads.length });
       }
     }
 
     perf.end(scanMarker);
     return heads;
+  }
+
+  listSessionSources(): SessionSourceRef[] {
+    if (!this.basePath) return [];
+    const refs: SessionSourceRef[] = [];
+    for (const dir of this.listSessionDirs()) {
+      const meta = getParsedSession(this.parseSessionDirResult(dir));
+      if (!meta) continue;
+      meta.sourceFingerprint = this.sourceFingerprint(meta);
+      this.sessionMetaMap.set(meta.id, meta);
+      refs.push({
+        sessionId: meta.id,
+        sourcePath: meta.sourcePath,
+        fingerprint: this.sourceFingerprint(meta),
+      });
+    }
+    return refs;
+  }
+
+  scanSessionSource(sourcePath: string): SessionHead | null {
+    const meta = getParsedSession(this.parseSessionDirResult(sourcePath));
+    if (!meta) return null;
+    meta.sourceFingerprint = this.sourceFingerprint(meta);
+    this.sessionMetaMap.set(meta.id, meta);
+    const stats = this.extractStats(meta.sourcePath);
+    return {
+      id: meta.id,
+      slug: `kimi/${meta.id}`,
+      title: meta.title,
+      directory: meta.cwd,
+      time_created: meta.createdAt,
+      time_updated: meta.createdAt,
+      stats,
+    };
   }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
@@ -685,6 +733,22 @@ export class KimiAgent extends BaseAgent {
   }
 
   // --- Helpers ---
+
+  private sourceFingerprint(meta: SessionMeta): string {
+    const fileMtime = (path: string | null) => {
+      if (!path) return null;
+      try {
+        return statSync(path).mtimeMs;
+      } catch {
+        return null;
+      }
+    };
+    return JSON.stringify([
+      fileMtime(meta.metaFile),
+      fileMtime(meta.contextFile),
+      fileMtime(meta.wireFile),
+    ]);
+  }
 
   private buildMessage(opts: {
     messageId: string;

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -109,21 +109,25 @@ export class OpenCodeAgent extends BaseAgent {
           )
         : new Map<string, OpenCodeHeadContext>();
       const heads: SessionHead[] = [];
+      options?.onProgress?.({ total: rows.length, processed: 0, sessions: 0 });
+      let processed = 0;
       for (const row of rows) {
         const head = getParsedSession(
           this.parseSessionHeadRow(row, hasMessageTable, headContexts.get(String(row.id ?? ""))),
         );
-        if (!head) continue;
+        if (head) {
+          heads.push(head);
 
-        heads.push(head);
-
-        // Store session metadata for caching
-        if (this.dbPath) {
-          this.sessionMetaMap.set(head.id, {
-            id: head.id,
-            sourcePath: this.dbPath,
-          });
+          // Store session metadata for caching
+          if (this.dbPath) {
+            this.sessionMetaMap.set(head.id, {
+              id: head.id,
+              sourcePath: this.dbPath,
+            });
+          }
         }
+        processed += 1;
+        options?.onProgress?.({ total: rows.length, processed, sessions: heads.length });
       }
 
       return heads;

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -189,7 +189,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(12);
+    expect(getUserVersion(getCachePath())).toBe(13);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -346,7 +346,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(12);
+    expect(getUserVersion(getCachePath())).toBe(13);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -1349,7 +1349,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(12);
+    expect(getUserVersion(getCachePath())).toBe(13);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -278,7 +278,7 @@ describe("sqlite migration smoke", () => {
         bookmarked_at: now - 500,
       },
     ]);
-    expect(getUserVersion(getCachePath())).toBe(12);
+    expect(getUserVersion(getCachePath())).toBe(13);
     expect(getUserVersion(getStatePath())).toBe(1);
   }, 30_000);
 });

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -136,6 +136,7 @@ describe("filterSessions", () => {
 
 vi.mock("../cache.js", () => ({
   loadCachedSessions: vi.fn(() => null),
+  markAgentCacheInitialized: vi.fn(),
   saveCachedSessionChanges: vi.fn(),
   saveCachedSessions: vi.fn(),
 }));

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -31,7 +31,8 @@ import {
   type SQLiteDatabase,
 } from "../utils/sqlite.js";
 
-const CACHE_SCHEMA_VERSION = 12;
+const CACHE_SCHEMA_VERSION = 13;
+export const CACHE_INITIALIZATION_VERSION = "session-cache-v2";
 const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
@@ -397,6 +398,13 @@ function createCacheTables(db: SQLiteDatabase): void {
       session_json TEXT NOT NULL,
       meta_json TEXT,
       PRIMARY KEY (agent_name, session_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS cache_initialization (
+      agent_name TEXT PRIMARY KEY,
+      initialized_at INTEGER NOT NULL,
+      index_version TEXT NOT NULL,
+      last_sync_at INTEGER NOT NULL
     );
   `);
 }
@@ -1606,6 +1614,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
     backupLabel: "cache-migration",
     backupTables: [
       "agent_cache",
+      "cache_initialization",
       "cached_sessions",
       "sessions",
       "messages",
@@ -1655,6 +1664,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
           refreshProjectIdentities(db);
         },
       },
+      { version: 13, migrate: createCacheTables },
     ],
   });
 
@@ -2015,7 +2025,10 @@ function deleteLegacyCacheFile(): void {
   }
 }
 
-export function loadCachedSessions(agentName: string): CachedResult | null {
+export function loadCachedSessions(
+  agentName: string,
+  options: { ignoreTtl?: boolean } = {},
+): CachedResult | null {
   if (!hasCacheStorage()) {
     return null;
   }
@@ -2026,7 +2039,7 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
       .get(agentName) as ScalarRow | undefined;
     const timestamp = Number(timestampRow?.value ?? 0);
 
-    if (!timestamp || Date.now() - timestamp > CACHE_TTL) {
+    if (!timestamp || (!options.ignoreTtl && Date.now() - timestamp > CACHE_TTL)) {
       return null;
     }
 
@@ -2077,6 +2090,49 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
     }
 
     return { sessions, meta, timestamp };
+  });
+}
+
+export function isAgentCacheInitialized(
+  agentName: string,
+  indexVersion = CACHE_INITIALIZATION_VERSION,
+): boolean {
+  if (!hasCacheStorage()) {
+    return false;
+  }
+
+  return (
+    withCacheDbReadOnly((db) => {
+      if (!tableExists(db, "cache_initialization")) return false;
+      const row = db
+        .prepare(
+          `
+            SELECT index_version
+            FROM cache_initialization
+            WHERE agent_name = ?
+          `,
+        )
+        .get(agentName) as { index_version?: string } | undefined;
+      return row?.index_version === indexVersion;
+    }) ?? false
+  );
+}
+
+export function markAgentCacheInitialized(
+  agentName: string,
+  indexVersion = CACHE_INITIALIZATION_VERSION,
+): void {
+  withCacheDb((db) => {
+    const now = Date.now();
+    db.prepare(
+      `
+        INSERT INTO cache_initialization(agent_name, initialized_at, index_version, last_sync_at)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(agent_name) DO UPDATE SET
+          index_version = excluded.index_version,
+          last_sync_at = excluded.last_sync_at
+      `,
+    ).run(agentName, now, indexVersion, now);
   });
 }
 
@@ -2336,6 +2392,7 @@ export function clearCache(): void {
   withCacheDb((db) => {
     db.exec(`
       DELETE FROM agent_cache;
+      DELETE FROM cache_initialization;
       DELETE FROM cached_sessions;
       DELETE FROM session_documents;
       DELETE FROM session_file_activity;

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -5,6 +5,8 @@ export type { ScanResult, ScanOptions } from "./scanner.js";
 export {
   loadCachedSessions,
   loadCachedSessionData,
+  isAgentCacheInitialized,
+  markAgentCacheInitialized,
   saveCachedSessions,
   saveCachedSessionChanges,
   clearCache,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -7,6 +7,7 @@ import { computeIdentity, filterSessionsByProjectScope, realFs } from "../projec
 import { classifySessionTags, getSmartTagSourceTimestamp, perf } from "../utils/index.js";
 import {
   loadCachedSessions,
+  markAgentCacheInitialized,
   saveCachedSessionChanges,
   saveCachedSessions,
   type SessionHeadChange,
@@ -478,7 +479,20 @@ async function scanAgentFull(
   try {
     const scanMarker = perf.start(`agent:${agent.name}:scan`);
     const t0 = performance.now();
-    const heads = agent.scan({ from: options.from, to: options.to, fast: options.fast });
+    const heads = agent.scan({
+      from: options.from,
+      to: options.to,
+      fast: options.fast,
+      onProgress: (progress) => {
+        onProgress?.({
+          agent: agent.name,
+          phase: "incremental",
+          cachedCount: progress.total,
+          newCount: progress.sessions,
+          changedCount: progress.processed,
+        });
+      },
+    });
     perf.end(scanMarker);
     timing.scan = performance.now() - t0;
 
@@ -499,6 +513,7 @@ async function scanAgentFull(
     // 保存到缓存
     if (options.writeCache !== false && options.from == null && options.to == null) {
       saveCachedSessions(agent.name, tagged.sessions, meta);
+      markAgentCacheInitialized(agent.name);
     }
 
     onProgress?.({ agent: agent.name, phase: "complete", newCount: tagged.sessions.length });


### PR DESCRIPTION
## Summary

- add per-agent cache initialization state and source fingerprints so first-run indexing is distinct from incremental refreshes
- update live scan persistence so full initialization waits for cache/index writes before reporting complete
- recover session details from source files when cached message rows are missing
- clarify Dashboard scan copy and remove the duplicate global header scan badge

## Root Cause

The UI could show an agent scan as complete after parsing session heads while the search/message index worker was still writing details. If the process was stopped during that window, the cache could contain session heads without a completed initialization marker or message rows, which forced a repeated full scan on the next launch and left some details empty.

## Validation

- pnpm --filter @codesesh/core test -- --runInBand
- pnpm --filter @codesesh/core lint
- pnpm --filter @codesesh/core build
- pnpm --filter codesesh test -- --runInBand
- pnpm --filter codesesh lint
- pnpm --filter codesesh build
- pnpm --filter web lint
- pnpm --filter web build

## Notes

Created as a draft PR for review.
