### PR TITLE
fix: avoid writable file activity reads

### DIFF
--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -3275,11 +3275,10 @@ export function listFileActivity(options: FileActivityOptions = {}): FileActivit
   }
 
   const filters = buildFileActivityWhere(options);
-  const rows = withCacheDb(
-    (db) =>
-      db
-        .prepare(
-          `
+  const queryRows = (db: SQLiteDatabase) =>
+    db
+      .prepare(
+        `
           SELECT
             fa.agent_name,
             fa.session_id,
@@ -3309,9 +3308,13 @@ export function listFileActivity(options: FileActivityOptions = {}): FileActivit
           ORDER BY fa.latest_time DESC, fa.count DESC, fa.path
           LIMIT ?
         `,
-        )
-        .all(...filters.params, options.limit ?? 50) as FileActivityRow[],
-  );
+      )
+      .all(...filters.params, options.limit ?? 50) as FileActivityRow[];
+
+  let rows = withCacheDbReadOnly(queryRows);
+  if (rows == null && options.path) {
+    rows = withCacheDb(queryRows);
+  }
 
   return (rows ?? []).map((row) => ({
     ...fileActivityFromRow(row),


### PR DESCRIPTION
## What changed

- Use a read-only SQLite connection for `listFileActivity` reads.
- Keep a narrow writable fallback for path-filtered queries when an older cache still needs the file activity FTS migration.

## Why

Dashboard startup calls recent file activity while the background search-index worker may be writing the same cache database. The previous read path opened a writable connection and ran schema checks, so it could wait on SQLite's busy timeout during startup and make `/api/dashboard` take about 5 seconds.

Read-only access avoids contending with background writes for the normal dashboard path while preserving legacy cache behavior for path search.

## Validation

- `pnpm --filter @codesesh/core test -- src/discovery/__tests__/cache.test.ts`
- `pnpm --filter codesesh test -- src/api/__tests__/handlers.test.ts`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter codesesh build`

Manual startup check: first dashboard request dropped from about 5.2s to about 5ms in the reproduced cache state.