### PR TITLE
chore(release): prepare 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.7.1] - 2026-05-22
+
+### Bug Fixes
+
+- Avoid using the writable cache connection for file activity reads, except when path filtering requires FTS. (#40)
+
+### Changelog Detail
+
+- #40 fix: avoid writable file activity reads @xingkaixin
+
 ## [0.7.0] - 2026-05-22
 
 ### Features

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.7.1] - 2026-05-22
+
+### 问题修复
+
+- 文件活动读取优先使用只读缓存连接，仅在路径筛选需要 FTS 时回退到可写连接。 (#40)
+
+### Changelog Detail
+
+- #40 fix: avoid writable file activity reads @xingkaixin
+
 ## [0.7.0] - 2026-05-22
 
 ### 新功能

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/web",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/www",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codesesh",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "One place to see every AI coding session you've ever had. Unify Claude Code, Cursor, Kimi, Codex, and OpenCode sessions in a single, beautiful Web UI.",
   "keywords": [
     "ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

- Add 0.7.1 release notes to the English and Chinese changelogs.
- Bump the package versions for the publishable and workspace packages to 0.7.1.

## Details

This patch release documents #40, which avoids using the writable cache connection for file activity reads unless path filtering requires FTS.

## Validation

- `git diff --cached --check`