### PR TITLE
fix: avoid blocking startup refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
+    "build:app": "pnpm --filter codesesh build",
+    "run:app": "pnpm --filter codesesh start",
     "dev": "turbo run dev",
     "dev:www": "pnpm --filter @codesesh/www dev",
     "serve": "node --watch packages/cli/dist/index.js",

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -41,25 +41,114 @@ const workerThreads = vi.hoisted(() => ({
     url: URL;
     workerData: any;
     on: ReturnType<typeof vi.fn>;
+    once: ReturnType<typeof vi.fn>;
     unref: ReturnType<typeof vi.fn>;
     terminate: ReturnType<typeof vi.fn>;
   }>,
   Worker: vi.fn(function (this: unknown, url: URL, options?: { workerData?: unknown }) {
+    const workerData = options?.workerData as any;
+    const runSourceSync = (agent: any) => {
+      const sessionMap = new Map(
+        (workerData.previousSessions ?? []).map((session: SessionHead) => [session.id, session]),
+      );
+      const changedIds = new Set<string>();
+      const sources = agent.listSessionSources();
+      const currentIds = new Set(sources.map((source: any) => source.sessionId));
+
+      for (const source of sources) {
+        const cachedSession = sessionMap.get(source.sessionId);
+        const cached = workerData.meta?.[source.sessionId];
+        if (
+          cachedSession &&
+          cached?.sourcePath === source.sourcePath &&
+          cached?.sourceFingerprint === source.fingerprint
+        ) {
+          continue;
+        }
+        const next = agent.scanSessionSource(source.sourcePath);
+        changedIds.add(source.sessionId);
+        if (next) sessionMap.set(next.id, next);
+        else sessionMap.delete(source.sessionId);
+      }
+
+      for (const session of workerData.previousSessions ?? []) {
+        if (!currentIds.has(session.id)) {
+          sessionMap.delete(session.id);
+          changedIds.add(session.id);
+        }
+      }
+
+      return { sessions: [...sessionMap.values()], changedIds: [...changedIds] };
+    };
+    const serializeMeta = (agent: any) =>
+      Object.fromEntries(agent.getSessionMetaMap?.()?.entries?.() ?? []);
     const worker = {
       url,
-      workerData: options?.workerData,
+      workerData,
       on: vi.fn((event: string, handler: (message: unknown) => void) => {
         if (event === "message") {
           queueMicrotask(() => {
-            const jobs = (options?.workerData as { jobs?: unknown[] } | undefined)?.jobs ?? [];
+            try {
+              if (workerData?.agentName) {
+                const agent = core
+                  .createRegisteredAgents()
+                  .find((item: any) => item.name === workerData.agentName);
+                agent?.setSessionMetaMap?.(new Map(Object.entries(workerData.meta ?? {})));
+                let sessions: SessionHead[] = [];
+                let changedIds: string[] | undefined;
+                if (agent?.isAvailable?.() !== false) {
+                  if (
+                    workerData.sourceSync &&
+                    agent?.listSessionSources &&
+                    agent?.scanSessionSource
+                  ) {
+                    const result = runSourceSync(agent);
+                    sessions = result.sessions as SessionHead[];
+                    changedIds = result.changedIds;
+                  } else if (workerData.changedIds && agent?.incrementalScan) {
+                    sessions = agent.incrementalScan(
+                      workerData.previousSessions,
+                      workerData.changedIds,
+                    );
+                  } else {
+                    sessions = agent?.scan?.({
+                      ...workerData.scanOptions,
+                      onProgress: () => undefined,
+                    });
+                  }
+                }
+                handler({
+                  type: "done",
+                  sessions,
+                  meta: serializeMeta(agent),
+                  changedIds,
+                  durationMs: 0,
+                });
+                return;
+              }
+            } catch (error) {
+              handler({
+                type: "error",
+                error: error instanceof Error ? error.message : String(error),
+                durationMs: 0,
+              });
+              return;
+            }
+            const jobs = workerData?.jobs ?? [];
             handler({
               type: "done",
-              context: (options?.workerData as { context?: string } | undefined)?.context ?? "",
+              context: workerData?.context ?? "",
               durationMs: 0,
               sessions: jobs.length,
             });
           });
         }
+        if (event === "exit") {
+          queueMicrotask(() => handler(0));
+        }
+        return worker;
+      }),
+      once: vi.fn((event: string, handler: (message: unknown) => void) => {
         if (event === "exit") {
           queueMicrotask(() => handler(0));
         }
@@ -330,14 +419,16 @@ describe("LiveScanStore", () => {
     await vi.advanceTimersByTimeAsync(250);
 
     expect(codex.scan).toHaveBeenCalled();
-    expect(workerThreads.workers[0]?.workerData.jobs).toEqual([
-      expect.objectContaining({
-        kind: "full",
-        context: "scan.refresh",
-        agentName: "codex",
-        sessions: [{ ...fresh, project_identity: projectIdentity }],
-      }),
-    ]);
+    expect(workerThreads.workers.find((worker) => worker.workerData.jobs)?.workerData.jobs).toEqual(
+      [
+        expect.objectContaining({
+          kind: "full",
+          context: "scan.refresh",
+          agentName: "codex",
+          sessions: [{ ...fresh, project_identity: projectIdentity }],
+        }),
+      ],
+    );
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["fresh"]);
     await vi.advanceTimersByTimeAsync(250);
     expect(events).toEqual([
@@ -453,7 +544,7 @@ describe("LiveScanStore", () => {
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(250);
 
-    expect(core.loadCachedSessions).toHaveBeenCalledWith("codex", { ignoreTtl: true });
+    expect(core.loadCachedSessions).toHaveBeenCalledWith("codex");
     expect(codex.scan).toHaveBeenCalledWith(
       expect.objectContaining({
         onProgress: expect.any(Function),
@@ -461,19 +552,21 @@ describe("LiveScanStore", () => {
     );
     expect(codex.scan.mock.calls[0]?.[0]).not.toHaveProperty("from");
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
-    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
-      expect.objectContaining({
-        kind: "full",
-        context: "scan.refresh",
-        agentName: "codex",
-        sessions: [
-          { ...old, project_identity: projectIdentity },
-          { ...recent, project_identity: projectIdentity },
-        ],
-        saveCache: true,
-      }),
-    ]);
-    expect(workerThreads.workers).toHaveLength(1);
+    expect(workerThreads.workers.find((worker) => worker.workerData.jobs)?.workerData.jobs).toEqual(
+      [
+        expect.objectContaining({
+          kind: "full",
+          context: "scan.refresh",
+          agentName: "codex",
+          sessions: [
+            { ...old, project_identity: projectIdentity },
+            { ...recent, project_identity: projectIdentity },
+          ],
+          saveCache: true,
+        }),
+      ],
+    );
+    expect(workerThreads.workers).toHaveLength(2);
   });
 
   it("persists incremental changes outside the startup time window", async () => {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -228,14 +228,6 @@ function restoreAgentCacheMeta(agent: BaseAgent, meta: Record<string, SessionCac
   agent.setSessionMetaMap?.(new Map(Object.entries(meta)));
 }
 
-function sourceFingerprintFromMeta(meta: SessionCacheMeta | undefined): string | null {
-  return typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : null;
-}
-
-function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string | null {
-  return typeof meta?.sourcePath === "string" ? meta.sourcePath : null;
-}
-
 function toAbsolutePath(path: string): string {
   return isAbsolute(path) ? path : resolve(path);
 }
@@ -793,12 +785,8 @@ export class LiveScanStore {
     return workerUrl;
   }
 
-  private getScanRefreshWorkerUrl(): URL | null {
-    const workerUrl = new URL("./scan-refresh-worker.js", import.meta.url);
-    if (workerUrl.protocol === "file:" && !existsSync(fileURLToPath(workerUrl))) {
-      return null;
-    }
-    return workerUrl;
+  private getScanRefreshWorkerUrl(): URL {
+    return new URL("./scan-refresh-worker.js", import.meta.url);
   }
 
   private scanAgentInWorker(
@@ -806,9 +794,13 @@ export class LiveScanStore {
     previousSessions: SessionHead[],
     changedIds: string[] | null,
     scanOptions: Pick<ScanOptions, "from" | "to" | "fast">,
-  ): Promise<{ sessions: SessionHead[]; meta: Record<string, SessionCacheMeta> }> | null {
+    workerOptions: { sourceSync?: boolean; meta?: Record<string, SessionCacheMeta> } = {},
+  ): Promise<{
+    sessions: SessionHead[];
+    meta: Record<string, SessionCacheMeta>;
+    changedIds?: string[];
+  }> {
     const workerUrl = this.getScanRefreshWorkerUrl();
-    if (!workerUrl) return null;
 
     return new Promise((resolve, reject) => {
       const worker = new Worker(workerUrl, {
@@ -816,8 +808,9 @@ export class LiveScanStore {
           agentName: agent.name,
           previousSessions,
           changedIds,
+          sourceSync: workerOptions.sourceSync,
           scanOptions,
-          meta: buildAgentCacheMeta(agent),
+          meta: workerOptions.meta ?? buildAgentCacheMeta(agent),
         },
       });
       worker.unref();
@@ -836,7 +829,13 @@ export class LiveScanStore {
           return;
         }
         if (message.type === "done") {
-          finish(() => resolve({ sessions: message.sessions, meta: message.meta }));
+          finish(() =>
+            resolve({
+              sessions: message.sessions,
+              meta: message.meta,
+              changedIds: message.changedIds,
+            }),
+          );
           return;
         }
         finish(() => reject(new Error(message.error)));
@@ -854,7 +853,7 @@ export class LiveScanStore {
 
   private buildFullSearchIndexJobs(context: string): SearchIndexWorkerJob[] {
     return this.agents.map((agent) => {
-      const cached = loadCachedSessions(agent.name, { ignoreTtl: true });
+      const cached = loadCachedSessions(agent.name);
       if (cached) {
         return {
           kind: "full",
@@ -996,55 +995,6 @@ export class LiveScanStore {
     scanSessionSource: (sourcePath: string) => SessionHead | null;
   } {
     return Boolean(agent.listSessionSources && agent.scanSessionSource);
-  }
-
-  private syncAgentSources(
-    agent: BaseAgent & {
-      listSessionSources: () => SessionSourceRef[];
-      scanSessionSource: (sourcePath: string) => SessionHead | null;
-    },
-    cachedSessions: SessionHead[],
-    cachedMeta: Record<string, SessionCacheMeta>,
-  ): {
-    sessions: SessionHead[];
-    changedIds: string[];
-    persistenceDiff: Pick<SessionRefreshDiff, "changedSessions" | "removedSessionIds">;
-  } {
-    const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
-    const sourceRefs = agent.listSessionSources();
-    const currentIds = new Set(sourceRefs.map((source) => source.sessionId));
-    const changedIds = new Set<string>();
-
-    for (const source of sourceRefs) {
-      const cachedSession = sessionMap.get(source.sessionId);
-      const cached = cachedMeta[source.sessionId];
-      const sameSource = sourcePathFromMeta(cached) === source.sourcePath;
-      const sameFingerprint = sourceFingerprintFromMeta(cached) === source.fingerprint;
-      if (cachedSession && sameSource && sameFingerprint) continue;
-
-      const next = agent.scanSessionSource(source.sourcePath);
-      changedIds.add(source.sessionId);
-      if (next) {
-        sessionMap.set(next.id, next);
-      } else {
-        sessionMap.delete(source.sessionId);
-      }
-    }
-
-    for (const session of cachedSessions) {
-      if (!currentIds.has(session.id)) {
-        sessionMap.delete(session.id);
-        changedIds.add(session.id);
-      }
-    }
-
-    const sessions = attachMissingProjectIdentities([...sessionMap.values()]);
-    const persistenceDiff = buildRefreshDiff(agent.name, cachedSessions, sessions, [...changedIds]);
-    return {
-      sessions,
-      changedIds: [...changedIds],
-      persistenceDiff,
-    };
   }
 
   private async refreshInitialIndex(): Promise<void> {
@@ -1353,7 +1303,7 @@ export class LiveScanStore {
     }
 
     const previousSessions = this.byAgent[agentName] ?? [];
-    const cached = loadCachedSessions(agentName, { ignoreTtl: true });
+    const cached = loadCachedSessions(agentName);
     const refreshBaseline = cached?.sessions ?? previousSessions;
     const cacheTimestamp = cached?.timestamp ?? this.refreshTimestamps.get(agentName) ?? 0;
     if (cached) {
@@ -1385,32 +1335,38 @@ export class LiveScanStore {
     } else if (!isInitialized) {
       this.setScanPhase("initializing");
       const scanStartedAt = performance.now();
-      const workerResult = this.scanAgentInWorker(agent, previousSessions, null, {});
-      if (workerResult) {
-        const result = await workerResult;
-        nextSessions = result.sessions;
-        agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
-      } else {
-        nextSessions = await Promise.resolve(
-          agent.scan({
-            onProgress: (progress) => this.updateAgentScanProgress(agentName, progress),
-          }),
-        );
-      }
+      const result = await this.scanAgentInWorker(agent, previousSessions, null, {});
+      nextSessions = result.sessions;
+      agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
       fullScanSessions = attachMissingProjectIdentities(nextSessions);
       nextSessions = fullScanSessions;
       scanDuration = performance.now() - scanStartedAt;
       this.refreshTimestamps.set(agentName, Date.now());
     } else if (cached && this.canSyncSources(agent)) {
       const scanStartedAt = performance.now();
-      const result = this.syncAgentSources(agent, cached.sessions, cached.meta);
+      const result = await this.scanAgentInWorker(
+        agent,
+        cached.sessions,
+        null,
+        {},
+        {
+          sourceSync: true,
+          meta: cached.meta,
+        },
+      );
       nextSessions = result.sessions;
-      preciseChangedIds = result.changedIds;
+      agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
+      preciseChangedIds = result.changedIds ?? [];
       usedIncrementalScan = true;
-      persistenceDiff = result.persistenceDiff;
+      persistenceDiff = buildRefreshDiff(
+        agentName,
+        cached.sessions,
+        attachMissingProjectIdentities(nextSessions),
+        preciseChangedIds,
+      );
       scanDuration = performance.now() - scanStartedAt;
       this.refreshTimestamps.set(agentName, Date.now());
-      if (result.changedIds.length === 0) {
+      if (preciseChangedIds.length === 0) {
         appLogger.debug("scan.refresh.unchanged", {
           agent: agentName,
           duration_ms: Math.round(performance.now() - startedAt),
@@ -1449,18 +1405,9 @@ export class LiveScanStore {
       scanDuration = performance.now() - scanStartedAt;
     } else {
       const scanStartedAt = performance.now();
-      const workerResult = this.scanAgentInWorker(agent, previousSessions, null, {});
-      if (workerResult) {
-        const result = await workerResult;
-        nextSessions = result.sessions;
-        agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
-      } else {
-        nextSessions = await Promise.resolve(
-          agent.scan({
-            onProgress: (progress) => this.updateAgentScanProgress(agentName, progress),
-          }),
-        );
-      }
+      const result = await this.scanAgentInWorker(agent, previousSessions, null, {});
+      nextSessions = result.sessions;
+      agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
       fullScanSessions = attachMissingProjectIdentities(nextSessions);
       nextSessions = fullScanSessions;
       scanDuration = performance.now() - scanStartedAt;

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -5,6 +5,7 @@ import {
   type ScanOptions,
   type SessionCacheMeta,
   type SessionHead,
+  type SessionSourceRef,
 } from "@codesesh/core";
 
 export type ScanRefreshWorkerMessage =
@@ -16,6 +17,7 @@ export type ScanRefreshWorkerMessage =
       type: "done";
       sessions: SessionHead[];
       meta: Record<string, SessionCacheMeta>;
+      changedIds?: string[];
       durationMs: number;
     }
   | {
@@ -28,6 +30,7 @@ interface ScanRefreshWorkerData {
   agentName: string;
   previousSessions: SessionHead[];
   changedIds: string[] | null;
+  sourceSync?: boolean;
   scanOptions: Pick<ScanOptions, "from" | "to" | "fast">;
   meta: Record<string, SessionCacheMeta>;
 }
@@ -45,10 +48,71 @@ function serializeMeta(agent: {
   return meta;
 }
 
+function sourceFingerprintFromMeta(meta: SessionCacheMeta | undefined): string | null {
+  return typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : null;
+}
+
+function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string | null {
+  return typeof meta?.sourcePath === "string" ? meta.sourcePath : null;
+}
+
+function canSyncSources(agent: unknown): agent is {
+  listSessionSources: () => SessionSourceRef[];
+  scanSessionSource: (sourcePath: string) => SessionHead | null;
+} {
+  return (
+    typeof agent === "object" &&
+    agent !== null &&
+    "listSessionSources" in agent &&
+    "scanSessionSource" in agent &&
+    typeof agent.listSessionSources === "function" &&
+    typeof agent.scanSessionSource === "function"
+  );
+}
+
+function syncAgentSources(
+  agent: {
+    listSessionSources: () => SessionSourceRef[];
+    scanSessionSource: (sourcePath: string) => SessionHead | null;
+  },
+  cachedSessions: SessionHead[],
+  cachedMeta: Record<string, SessionCacheMeta>,
+): { sessions: SessionHead[]; changedIds: string[] } {
+  const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
+  const sourceRefs = agent.listSessionSources();
+  const currentIds = new Set(sourceRefs.map((source) => source.sessionId));
+  const changedIds = new Set<string>();
+
+  for (const source of sourceRefs) {
+    const cachedSession = sessionMap.get(source.sessionId);
+    const cached = cachedMeta[source.sessionId];
+    const sameSource = sourcePathFromMeta(cached) === source.sourcePath;
+    const sameFingerprint = sourceFingerprintFromMeta(cached) === source.fingerprint;
+    if (cachedSession && sameSource && sameFingerprint) continue;
+
+    const next = agent.scanSessionSource(source.sourcePath);
+    changedIds.add(source.sessionId);
+    if (next) {
+      sessionMap.set(next.id, next);
+    } else {
+      sessionMap.delete(source.sessionId);
+    }
+  }
+
+  for (const session of cachedSessions) {
+    if (!currentIds.has(session.id)) {
+      sessionMap.delete(session.id);
+      changedIds.add(session.id);
+    }
+  }
+
+  return { sessions: [...sessionMap.values()], changedIds: [...changedIds] };
+}
+
 const data = workerData as ScanRefreshWorkerData;
 const startedAt = performance.now();
 
-try {
+async function run(): Promise<void> {
   const agent = createRegisteredAgents().find((item) => item.name === data.agentName);
   if (!agent) {
     throw new Error(`Unknown agent: ${data.agentName}`);
@@ -59,26 +123,42 @@ try {
   }
 
   const isAvailable = agent.isAvailable();
-  const sessions = !isAvailable
-    ? []
-    : data.changedIds && agent.incrementalScan
-      ? agent.incrementalScan(data.previousSessions, data.changedIds)
-      : agent.scan({
-          ...data.scanOptions,
-          onProgress: (progress) => {
-            parentPort?.postMessage({
-              type: "progress",
-              progress,
-            } satisfies ScanRefreshWorkerMessage);
-          },
-        });
+  let sessions: SessionHead[];
+  let changedIds: string[] | undefined;
+
+  if (!isAvailable) {
+    sessions = [];
+  } else if (data.sourceSync && canSyncSources(agent)) {
+    const result = syncAgentSources(agent, data.previousSessions, data.meta);
+    sessions = result.sessions;
+    changedIds = result.changedIds;
+  } else if (data.changedIds && agent.incrementalScan) {
+    sessions = await Promise.resolve(agent.incrementalScan(data.previousSessions, data.changedIds));
+  } else {
+    sessions = await Promise.resolve(
+      agent.scan({
+        ...data.scanOptions,
+        onProgress: (progress) => {
+          parentPort?.postMessage({
+            type: "progress",
+            progress,
+          } satisfies ScanRefreshWorkerMessage);
+        },
+      }),
+    );
+  }
 
   parentPort?.postMessage({
     type: "done",
     sessions,
     meta: serializeMeta(agent),
+    changedIds,
     durationMs: performance.now() - startedAt,
   } satisfies ScanRefreshWorkerMessage);
+}
+
+try {
+  await run();
 } catch (error) {
   parentPort?.postMessage({
     type: "error",

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -153,10 +153,10 @@ describe("loadCachedSessions", () => {
     expect(loadCachedSessions("claudecode")).toBeNull();
   });
 
-  it("returns null when cache is too old", () => {
+  it("returns cached sessions even when last refresh is old", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     dateNowSpy.mockReturnValue(now + 8 * 24 * 60 * 60 * 1000);
-    expect(loadCachedSessions("claudecode")).toBeNull();
+    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual(["s1"]);
   });
 
   it("returns cached sessions and meta when valid", () => {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -359,6 +359,28 @@ describe("scanSessions", () => {
     expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
   });
 
+  it("uses cached sessions even when last refresh is old", async () => {
+    mockedLoadCachedSessions.mockReturnValue({
+      sessions: [makeSession("cached")],
+      meta: {},
+      timestamp: 0,
+    });
+    mockedCreateRegisteredAgents.mockReturnValue([
+      createTestAgent({
+        name: "test",
+        available: true,
+        sessions: [makeSession("fresh")],
+      }),
+    ]);
+
+    const result = await scanSessions({ useCache: true, cacheOnly: true });
+
+    expect(mockedLoadCachedSessions).toHaveBeenCalledWith("test");
+    expect(result.sessions.map((session) => session.id)).toEqual(["cached"]);
+    expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
+    expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
+  });
+
   it("refreshes stale cache before returning results", async () => {
     const cachedSessions = [makeSession("cached")];
     const refreshedSessions = [makeSession("fresh")];

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -33,7 +33,6 @@ import {
 
 const CACHE_SCHEMA_VERSION = 13;
 export const CACHE_INITIALIZATION_VERSION = "session-cache-v2";
-const CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
 const SEARCH_INDEX_BULK_SYNC_THRESHOLD = 100;
@@ -2025,10 +2024,7 @@ function deleteLegacyCacheFile(): void {
   }
 }
 
-export function loadCachedSessions(
-  agentName: string,
-  options: { ignoreTtl?: boolean } = {},
-): CachedResult | null {
+export function loadCachedSessions(agentName: string): CachedResult | null {
   if (!hasCacheStorage()) {
     return null;
   }
@@ -2039,7 +2035,7 @@ export function loadCachedSessions(
       .get(agentName) as ScalarRow | undefined;
     const timestamp = Number(timestampRow?.value ?? 0);
 
-    if (!timestamp || (!options.ignoreTtl && Date.now() - timestamp > CACHE_TTL)) {
+    if (!timestamp) {
       return null;
     }
 


### PR DESCRIPTION
## Summary
- keep persisted SQLite session cache usable across old refresh timestamps instead of treating it as empty after 7 days
- move source-backed session refresh into the scan refresh worker so HTTP startup is not blocked by synchronous Codex source checks
- require the packaged scan refresh worker entry instead of silently falling back to main-thread scans
- add root app build/run scripts

## Validation
- pnpm vitest run packages/cli/src/live-scan-store.test.ts packages/core/src/discovery/__tests__/cache.test.ts packages/core/src/discovery/__tests__/scanner.test.ts
- verified with a copied cache whose Codex source fingerprints were forced stale: GET / returned before codex scan.refresh.done

Note: full pnpm build previously hit local SIGKILL/resource limits on this machine, so this PR is validated with focused tests and runtime log verification.