### PR TITLE
fix(codex): avoid refresh storms from index updates

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -48,6 +48,24 @@ const workerThreads = vi.hoisted(() => ({
   Worker: vi.fn(function (this: unknown, url: URL, options?: { workerData?: unknown }) {
     const workerData = options?.workerData as any;
     const runSourceSync = (agent: any) => {
+      const parseSourceFingerprint = (fingerprint: string) => {
+        try {
+          const parsed = JSON.parse(fingerprint);
+          return Array.isArray(parsed) ? parsed : null;
+        } catch {
+          return null;
+        }
+      };
+      const sourceFingerprintMatches = (source: any, cachedSession: SessionHead, cached: any) => {
+        if (cached?.sourceFingerprint === source.fingerprint) return true;
+        const current = parseSourceFingerprint(source.fingerprint);
+        return (
+          Boolean(current) &&
+          typeof cached?.sourceMtimeMs === "number" &&
+          cached.sourceMtimeMs === current[2] &&
+          (current![4] == null || cachedSession.title === current![4])
+        );
+      };
       const sessionMap = new Map(
         (workerData.previousSessions ?? []).map((session: SessionHead) => [session.id, session]),
       );
@@ -61,7 +79,7 @@ const workerThreads = vi.hoisted(() => ({
         if (
           cachedSession &&
           cached?.sourcePath === source.sourcePath &&
-          cached?.sourceFingerprint === source.fingerprint
+          sourceFingerprintMatches(source, cachedSession as SessionHead, cached)
         ) {
           continue;
         }
@@ -718,6 +736,82 @@ describe("LiveScanStore", () => {
         newSessions: 1,
         updatedSessions: 1,
         removedSessions: 0,
+      }),
+    ]);
+  });
+
+  it("does not rescan legacy Codex cache entries when only the fingerprint format changed", async () => {
+    const previous = makeSession("session", { title: "same title", time_updated: 1000 });
+    const scanSessionSource = vi.fn(() => makeSession("session", { title: "same title" }));
+    const legacyFingerprint = JSON.stringify([
+      "codex-head-v1",
+      "codex-parser-v3",
+      1234,
+      5678,
+      9999,
+    ]);
+    const currentFingerprint = JSON.stringify([
+      "codex-head-v1",
+      "codex-parser-v3",
+      1234,
+      5678,
+      "same title",
+    ]);
+    const codex = makeAgent("codex", {
+      listSessionSources: vi.fn(() => [
+        {
+          sessionId: "session",
+          sourcePath: "/tmp/s",
+          fingerprint: currentFingerprint,
+        },
+      ]),
+      scanSessionSource,
+      getSessionMetaMap: vi.fn(
+        () =>
+          new Map([
+            [
+              "session",
+              {
+                id: "session",
+                sourcePath: "/tmp/s",
+                sourceFingerprint: legacyFingerprint,
+                sourceMtimeMs: 1234,
+              },
+            ],
+          ]),
+      ),
+      setSessionMetaMap: vi.fn(),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [previous],
+      byAgent: { codex: [previous] },
+      agents: [codex],
+    });
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [previous],
+      meta: {
+        session: {
+          id: "session",
+          sourcePath: "/tmp/s",
+          sourceFingerprint: legacyFingerprint,
+          sourceMtimeMs: 1234,
+        },
+      },
+      timestamp: 1000,
+    });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    await (store as any).runRefresh("codex");
+
+    expect(scanSessionSource).not.toHaveBeenCalled();
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
+      expect.objectContaining({
+        kind: "changes",
+        changes: [],
+        removedSessionIds: [],
       }),
     ]);
   });

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -52,6 +52,33 @@ function sourceFingerprintFromMeta(meta: SessionCacheMeta | undefined): string |
   return typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : null;
 }
 
+function parseSourceFingerprint(fingerprint: string): unknown[] | null {
+  try {
+    const parsed = JSON.parse(fingerprint);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function sourceFingerprintMatches(
+  source: SessionSourceRef,
+  cachedSession: SessionHead,
+  cached: SessionCacheMeta | undefined,
+): boolean {
+  const cachedFingerprint = sourceFingerprintFromMeta(cached);
+  if (cachedFingerprint === source.fingerprint) return true;
+
+  const current = parseSourceFingerprint(source.fingerprint);
+  if (!current || current.length < 5) return false;
+
+  return (
+    typeof cached?.sourceMtimeMs === "number" &&
+    cached.sourceMtimeMs === current[2] &&
+    (current[4] == null || cachedSession.title === current[4])
+  );
+}
+
 function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string | null {
   return typeof meta?.sourcePath === "string" ? meta.sourcePath : null;
 }
@@ -87,7 +114,8 @@ function syncAgentSources(
     const cachedSession = sessionMap.get(source.sessionId);
     const cached = cachedMeta[source.sessionId];
     const sameSource = sourcePathFromMeta(cached) === source.sourcePath;
-    const sameFingerprint = sourceFingerprintFromMeta(cached) === source.fingerprint;
+    const sameFingerprint =
+      cachedSession && sourceFingerprintMatches(source, cachedSession, cached);
     if (cachedSession && sameSource && sameFingerprint) continue;
 
     const next = agent.scanSessionSource(source.sourcePath);

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -75,8 +75,9 @@ describe("CodexAgent cache refresh", () => {
     expect(result.changedIds).toContain("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb");
   });
 
-  it("detects session index fingerprint changes without recent-session revalidation", () => {
+  it("ignores unrelated session index changes during cache validation", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
     const codexHome = join(tempDir, ".codex");
     const sessionsDir = join(codexHome, "sessions");
     mkdirSync(sessionsDir, { recursive: true });
@@ -98,29 +99,72 @@ describe("CodexAgent cache refresh", () => {
 
     const agent = new CodexAgent() as any;
     agent.basePath = sessionsDir;
-    agent.sessionIndexCache = new Map([["stale", "stale"]]);
+    agent.sessionIndexCache = new Map();
     agent.sessionMetaMap = new Map([
       [
         "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
         {
           id: "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
+          title: "Old title",
           sourcePath: recentFile,
           sourceMtimeMs: statSync(recentFile).mtimeMs,
           indexPath: indexFile,
           indexMtimeMs: statSync(indexFile).mtimeMs - 1,
           headIndexVersion: "codex-head-v1",
+          parserVersion: "codex-parser-v3",
         },
       ],
     ]);
     agent.listRolloutFiles = () => [recentFile];
 
     const result = agent.checkForChanges(Date.now(), [
-      makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
+      makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa", { title: "Old title" }),
     ]);
 
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toContain("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa");
-    expect(agent.sessionIndexCache.size).toBe(0);
+    expect(result.hasChanges).toBe(false);
+    expect(result.changedIds).toEqual([]);
+  });
+
+  it("uses per-session Codex titles in source fingerprints", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const codexHome = join(tempDir, ".codex");
+    const sessionsDir = join(codexHome, "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("CODEX_HOME", codexHome);
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const sessionFile = join(sessionsDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+    const indexFile = join(codexHome, "session_index.jsonl");
+
+    writeFileSync(
+      sessionFile,
+      '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
+    );
+    writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"Old title"}\n`);
+
+    const firstAgent = new CodexAgent() as any;
+    firstAgent.basePath = sessionsDir;
+    const firstFingerprint = firstAgent.listSessionSources()[0]?.fingerprint;
+
+    writeFileSync(
+      indexFile,
+      [
+        `{"id":"${sessionId}","thread_name":"Old title"}`,
+        '{"id":"019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb","thread_name":"Other title"}',
+        "",
+      ].join("\n"),
+    );
+    const unrelatedAgent = new CodexAgent() as any;
+    unrelatedAgent.basePath = sessionsDir;
+    const unrelatedFingerprint = unrelatedAgent.listSessionSources()[0]?.fingerprint;
+
+    writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"New title"}\n`);
+    const renamedAgent = new CodexAgent() as any;
+    renamedAgent.basePath = sessionsDir;
+    const renamedFingerprint = renamedAgent.listSessionSources()[0]?.fingerprint;
+
+    expect(unrelatedFingerprint).toBe(firstFingerprint);
+    expect(renamedFingerprint).not.toBe(firstFingerprint);
   });
 
   it("invalidates cached sessions when the parser version changes", () => {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -697,19 +697,19 @@ export class CodexAgent extends BaseAgent {
     if (typeof meta.sourceMtimeMs !== "number") return true;
     if (statSync(meta.sourcePath).mtimeMs !== meta.sourceMtimeMs) return true;
 
-    const indexPath = meta.indexPath ?? this.getSessionIndexPath();
-    return this.getFileMtimeMs(indexPath) !== (meta.indexMtimeMs ?? null);
+    const indexTitle = this.getTitleForSession(meta.id);
+    return indexTitle !== null && indexTitle !== meta.title;
   }
 
   private sourceFingerprint(file: string): string {
     const stat = statSync(file);
-    const indexPath = this.getSessionIndexPath();
+    const sessionId = extractSessionId(file);
     return JSON.stringify([
       HEAD_INDEX_VERSION,
       PARSER_VERSION,
       stat.mtimeMs,
       stat.size,
-      this.getFileMtimeMs(indexPath),
+      this.getTitleForSession(sessionId),
     ]);
   }
 


### PR DESCRIPTION
## Summary

- Stop including the global Codex `session_index.jsonl` mtime in every session source fingerprint.
- Compare Codex cached sessions against their own source file state and per-session indexed title instead.
- Keep legacy fingerprint compatibility so the first refresh after this change does not rescan every cached Codex session.

## Root Cause

Codex writes session titles into a global `session_index.jsonl`. The old fingerprint included that file's mtime for every session, so adding or renaming one Codex session changed the fingerprint for all cached Codex sessions. The background refresh then treated the whole startup window as updated and reread every session head.

## Validation

- `pnpm --filter @codesesh/core test -- src/agents/__tests__/codex.test.ts`
- `pnpm --filter codesesh test -- src/live-scan-store.test.ts`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter codesesh lint`