### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.7.2] - 2026-05-30
+
+### Bug Fixes
+
+- Avoid blocking startup refresh work so the server can become available while background refresh continues. (#42)
+- Avoid Codex refresh storms triggered by index metadata updates. (#43)
+
+### Documentation
+
+- Added the animated CodeSesh logo and refreshed README branding.
+
+### Changelog Detail
+
+- #43 fix(codex): avoid refresh storms from index updates @xingkaixin
+- #42 fix: avoid blocking startup refresh @xingkaixin
+
 ## [0.7.1] - 2026-05-22
 
 ### Bug Fixes

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.7.2] - 2026-05-30
+
+### 问题修复
+
+- 启动刷新改为不阻塞服务可用性，后台刷新继续执行时 HTTP 服务可以先启动。 (#42)
+- 避免 Codex index 元数据更新触发重复刷新风暴。 (#43)
+
+### 文档
+
+- 增加动态 CodeSesh logo，并更新 README 品牌展示。
+
+### Changelog Detail
+
+- #43 fix(codex): avoid refresh storms from index updates @xingkaixin
+- #42 fix: avoid blocking startup refresh @xingkaixin
+
 ## [0.7.1] - 2026-05-22
 
 ### 问题修复

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/web",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/www",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codesesh",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "One place to see every AI coding session you've ever had. Unify Claude Code, Cursor, Kimi, Codex, and OpenCode sessions in a single, beautiful Web UI.",
   "keywords": [
     "ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

- Add the v0.7.2 changelog entries in English and Chinese.
- Bump package versions from 0.7.1 to 0.7.2 for core, CLI, web, and www packages.

## Why

This prepares the next patch release based on the changes since v0.7.1, including the startup refresh and Codex refresh storm fixes plus README branding updates.

## Validation

- Verified all package versions parse as 0.7.2 with Node.js.
- Checked the final git diff scope before committing.