### PR TITLE
feat(perf): add benchmark profiling

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 declare const __APP_VERSION__: string;
 
 import {
+  useCallback,
   useEffect,
   useEffectEvent,
   useMemo,
@@ -53,6 +54,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { BookmarkButton } from "./components/BookmarkButton";
 import { CopyResumeButton } from "./components/CopyResumeButton";
 import { SessionTreeSidebar } from "./components/SessionTreeSidebar";
+import { RenderProfiler } from "./components/RenderProfiler";
 import { SMART_TAG_LABELS, SmartTagChips } from "./components/SmartTagChips";
 import {
   clearLegacyBookmarks,
@@ -717,52 +719,60 @@ export default function App() {
     [bookmarks],
   );
 
-  function isSessionBookmarked(agentKey: string, sessionId: string): boolean {
-    return bookmarkKeySet.has(getSessionBookmarkKey(agentKey, sessionId));
-  }
+  const isSessionBookmarked = useCallback(
+    (agentKey: string, sessionId: string): boolean =>
+      bookmarkKeySet.has(getSessionBookmarkKey(agentKey, sessionId)),
+    [bookmarkKeySet],
+  );
 
-  function toggleBookmark(snapshot: BookmarkedSessionSnapshot) {
-    const key = getSessionBookmarkKey(snapshot.agentKey, snapshot.sessionId);
-    const exists = bookmarkKeySet.has(key);
-    const previous = bookmarks;
-    const next = exists
-      ? previous.filter(
-          (bookmark) => getSessionBookmarkKey(bookmark.agentKey, bookmark.sessionId) !== key,
-        )
-      : [...previous, snapshot].toSorted((a, b) => {
-          const aTime = a.time_updated ?? a.time_created;
-          const bTime = b.time_updated ?? b.time_created;
-          return bTime - aTime;
-        });
+  const toggleBookmark = useCallback(
+    (snapshot: BookmarkedSessionSnapshot) => {
+      const key = getSessionBookmarkKey(snapshot.agentKey, snapshot.sessionId);
+      const exists = bookmarkKeySet.has(key);
+      const previous = bookmarks;
+      const next = exists
+        ? previous.filter(
+            (bookmark) => getSessionBookmarkKey(bookmark.agentKey, bookmark.sessionId) !== key,
+          )
+        : [...previous, snapshot].toSorted((a, b) => {
+            const aTime = a.time_updated ?? a.time_created;
+            const bTime = b.time_updated ?? b.time_created;
+            return bTime - aTime;
+          });
 
-    setBookmarks(next);
-    logClientEvent(exists ? "bookmark.delete" : "bookmark.add", {
-      agent: snapshot.agentKey,
-      session: snapshot.sessionId,
-    });
+      setBookmarks(next);
+      logClientEvent(exists ? "bookmark.delete" : "bookmark.add", {
+        agent: snapshot.agentKey,
+        session: snapshot.sessionId,
+      });
 
-    void (
-      exists
-        ? deleteBookmark(snapshot.agentKey, snapshot.sessionId)
-        : upsertBookmark({
-            agentKey: snapshot.agentKey,
-            sessionId: snapshot.sessionId,
-            fullPath: snapshot.fullPath,
-            title: snapshot.title,
-            directory: snapshot.directory,
-            time_created: snapshot.time_created,
-            time_updated: snapshot.time_updated,
-            stats: snapshot.stats,
-          })
-    ).catch((error) => {
-      console.error("Failed to toggle bookmark:", error);
-      setBookmarks(previous);
-    });
-  }
+      void (
+        exists
+          ? deleteBookmark(snapshot.agentKey, snapshot.sessionId)
+          : upsertBookmark({
+              agentKey: snapshot.agentKey,
+              sessionId: snapshot.sessionId,
+              fullPath: snapshot.fullPath,
+              title: snapshot.title,
+              directory: snapshot.directory,
+              time_created: snapshot.time_created,
+              time_updated: snapshot.time_updated,
+              stats: snapshot.stats,
+            })
+      ).catch((error) => {
+        console.error("Failed to toggle bookmark:", error);
+        setBookmarks(previous);
+      });
+    },
+    [bookmarkKeySet, bookmarks],
+  );
 
-  function toggleSessionBookmark(session: SessionHead, agentKey: string) {
-    toggleBookmark(toBookmarkedSessionSnapshot(session, agentKey));
-  }
+  const toggleSessionBookmark = useCallback(
+    (session: SessionHead, agentKey: string) => {
+      toggleBookmark(toBookmarkedSessionSnapshot(session, agentKey));
+    },
+    [toggleBookmark],
+  );
 
   const activeAgentKey = viewState.activeAgentKey;
   const activeProjectKind = viewState.mode === "project" ? viewState.activeProjectKind : null;
@@ -836,6 +846,30 @@ export default function App() {
         (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
       ),
     [bookmarks],
+  );
+
+  const handleSelectFlatSidebarSession = useCallback(
+    (sessionItem: SessionHead) => {
+      setSelectedSidebarSessionId(sessionItem.id);
+      navigate(`/${sessionItem.slug}`);
+    },
+    [navigate],
+  );
+
+  const handleToggleSidebarSessionBookmark = useCallback(
+    (sessionItem: SessionHead) => {
+      toggleSessionBookmark(sessionItem, getSessionAgentKey(sessionItem));
+    },
+    [toggleSessionBookmark],
+  );
+
+  const handleSelectTreeSidebarSession = useCallback(
+    (sessionId: string) => {
+      setSelectedSidebarSessionId(sessionId);
+      const selected = sidebarSessionLookup.byId.get(sessionId);
+      if (selected) navigate(`/${selected.slug}`);
+    },
+    [navigate, sidebarSessionLookup],
   );
 
   const searchRequestOptions = useMemo<SearchRequestOptions>(() => {
@@ -1397,25 +1431,30 @@ export default function App() {
     content = <SessionDetailSkeleton />;
   } else if (isSearchMode) {
     content = (
-      <SearchResultsPanel
-        query={activeSearchQuery}
-        loading={searchLoading}
-        results={searchResults}
-        agentNameMap={agentNameMap}
-        agents={agents}
-        projects={searchProjectOptions}
-        filters={searchFilters}
-        onChangeFilters={setSearchFilters}
-        onOpenResult={() => {
-          setSearchMode(false);
-          setActiveSearchQuery("");
-        }}
-        selectedIndex={selectedSearchIndex}
-        registerResultRef={(key, node) => {
-          if (node) searchResultRefs.current.set(key, node);
-          else searchResultRefs.current.delete(key);
-        }}
-      />
+      <RenderProfiler
+        id="SearchResultsPanel"
+        detail={{ results: searchResults.length, loading: searchLoading }}
+      >
+        <SearchResultsPanel
+          query={activeSearchQuery}
+          loading={searchLoading}
+          results={searchResults}
+          agentNameMap={agentNameMap}
+          agents={agents}
+          projects={searchProjectOptions}
+          filters={searchFilters}
+          onChangeFilters={setSearchFilters}
+          onOpenResult={() => {
+            setSearchMode(false);
+            setActiveSearchQuery("");
+          }}
+          selectedIndex={selectedSearchIndex}
+          registerResultRef={(key, node) => {
+            if (node) searchResultRefs.current.set(key, node);
+            else searchResultRefs.current.delete(key);
+          }}
+        />
+      </RenderProfiler>
     );
   } else if (error) {
     content = (
@@ -1425,19 +1464,24 @@ export default function App() {
     );
   } else if (viewState.mode === "root") {
     content = dashboard ? (
-      <Dashboard
-        data={dashboard}
-        projects={projects}
-        bookmarkedSessions={bookmarkedSessions}
-        isBookmarked={isSessionBookmarked}
-        onToggleBookmark={(session, agentKey) => {
-          if ("agentName" in session) {
-            toggleSessionBookmark(session, agentKey ?? session.agentName.toLowerCase());
-            return;
-          }
-          toggleBookmark(session);
-        }}
-      />
+      <RenderProfiler
+        id="Dashboard"
+        detail={{ sessions: dashboard.totals.sessions, projects: projects.length }}
+      >
+        <Dashboard
+          data={dashboard}
+          projects={projects}
+          bookmarkedSessions={bookmarkedSessions}
+          isBookmarked={isSessionBookmarked}
+          onToggleBookmark={(session, agentKey) => {
+            if ("agentName" in session) {
+              toggleSessionBookmark(session, agentKey ?? session.agentName.toLowerCase());
+              return;
+            }
+            toggleBookmark(session);
+          }}
+        />
+      </RenderProfiler>
     ) : (
       <DetailLanding
         type="global"
@@ -1492,7 +1536,14 @@ export default function App() {
         />
       );
     } else {
-      content = <SessionDetail session={session} highlightQuery={detailHighlightQuery} />;
+      content = (
+        <RenderProfiler
+          id="SessionDetail"
+          detail={{ messages: session.messages.length, session: session.id }}
+        >
+          <SessionDetail session={session} highlightQuery={detailHighlightQuery} />
+        </RenderProfiler>
+      );
     }
   } else if (viewState.mode === "missingAgent") {
     content = (
@@ -1993,31 +2044,25 @@ export default function App() {
                   }
                   selectedSessionId={selectedSidebarSessionId}
                   bookmarkedSessionIds={bookmarkedSidebarSessionIds}
-                  onSelectSession={(sessionItem) => {
-                    setSelectedSidebarSessionId(sessionItem.id);
-                    navigate(`/${sessionItem.slug}`);
-                  }}
-                  onToggleBookmark={(sessionItem) =>
-                    toggleSessionBookmark(sessionItem, getSessionAgentKey(sessionItem))
-                  }
+                  onSelectSession={handleSelectFlatSidebarSession}
+                  onToggleBookmark={handleToggleSidebarSessionBookmark}
                 />
               ) : (
-                <SessionTreeSidebar
-                  sessions={sidebarSessions}
-                  activeSessionId={
-                    viewState.mode === "session" ? viewState.activeSessionSlug : null
-                  }
-                  selectedSessionId={selectedSidebarSessionId}
-                  onSelectSession={(sessionId) => {
-                    setSelectedSidebarSessionId(sessionId);
-                    const selected = sidebarSessionLookup.byId.get(sessionId);
-                    if (selected) navigate(`/${selected.slug}`);
-                  }}
-                  bookmarkedSessionIds={bookmarkedSidebarSessionIds}
-                  onToggleBookmark={(sessionItem) =>
-                    toggleSessionBookmark(sessionItem, getSessionAgentKey(sessionItem))
-                  }
-                />
+                <RenderProfiler
+                  id="SessionTreeSidebar"
+                  detail={{ sessions: sidebarSessions.length }}
+                >
+                  <SessionTreeSidebar
+                    sessions={sidebarSessions}
+                    activeSessionId={
+                      viewState.mode === "session" ? viewState.activeSessionSlug : null
+                    }
+                    selectedSessionId={selectedSidebarSessionId}
+                    onSelectSession={handleSelectTreeSidebarSession}
+                    bookmarkedSessionIds={bookmarkedSidebarSessionIds}
+                    onToggleBookmark={handleToggleSidebarSessionBookmark}
+                  />
+                </RenderProfiler>
               )}
             </section>
           </div>
@@ -2109,7 +2154,18 @@ export default function App() {
           </section>
 
           <section className="console-scrollbar bg-grid min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8">
-            <ErrorBoundary>{content}</ErrorBoundary>
+            <ErrorBoundary>
+              <RenderProfiler
+                id="MainContent"
+                detail={{
+                  mode: viewState.mode,
+                  search: isSearchMode,
+                  sessions: sessions.length,
+                }}
+              >
+                {content}
+              </RenderProfiler>
+            </ErrorBoundary>
           </section>
         </main>
       </div>

--- a/apps/web/src/components/RenderProfiler.tsx
+++ b/apps/web/src/components/RenderProfiler.tsx
@@ -1,0 +1,162 @@
+import {
+  Profiler,
+  useLayoutEffect,
+  useRef,
+  type ProfilerOnRenderCallback,
+  type ReactNode,
+} from "react";
+import { logClientEvent } from "../lib/api";
+
+const PROFILER_STORAGE_KEY = "codeseshProfiler";
+const PROFILER_LOG_STORAGE_KEY = "codeseshProfilerLog";
+const PROFILER_SLOW_COMMIT_MS = 16;
+const PROFILER_MAX_ENTRIES = 500;
+
+interface RenderProfileEntry {
+  id: string;
+  source: "react-profiler" | "commit-latency" | "custom-timing";
+  phase: "mount" | "update" | "nested-update" | "measure";
+  actualDuration: number;
+  baseDuration: number;
+  startTime: number;
+  commitTime: number;
+  route: string;
+  detail?: Record<string, unknown>;
+}
+
+declare global {
+  interface Window {
+    __CODESHESH_RENDER_PROFILE__?: RenderProfileEntry[];
+  }
+}
+
+export function isRenderProfilerEnabled() {
+  if (typeof window === "undefined") return false;
+
+  try {
+    return window.localStorage.getItem(PROFILER_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function shouldLogRenderProfilerEntries() {
+  if (typeof window === "undefined") return false;
+
+  try {
+    return window.localStorage.getItem(PROFILER_LOG_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function pushProfileEntry(entry: RenderProfileEntry) {
+  const entries = window.__CODESHESH_RENDER_PROFILE__ ?? [];
+  entries.push(entry);
+  if (entries.length > PROFILER_MAX_ENTRIES) {
+    entries.splice(0, entries.length - PROFILER_MAX_ENTRIES);
+  }
+  window.__CODESHESH_RENDER_PROFILE__ = entries;
+}
+
+export function recordRenderProfileEntry(
+  entry: Omit<RenderProfileEntry, "commitTime" | "route" | "startTime"> & {
+    startTime?: number;
+    commitTime?: number;
+    route?: string;
+  },
+) {
+  if (!isRenderProfilerEnabled() || typeof window === "undefined") return;
+
+  const now = performance.now();
+  pushProfileEntry({
+    ...entry,
+    startTime: roundDuration(entry.startTime ?? now),
+    commitTime: roundDuration(entry.commitTime ?? now),
+    route: entry.route ?? window.location.pathname,
+  });
+}
+
+function roundDuration(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
+export function RenderProfiler({
+  id,
+  detail,
+  children,
+}: {
+  id: string;
+  detail?: Record<string, unknown>;
+  children: ReactNode;
+}) {
+  if (!isRenderProfilerEnabled()) return children;
+
+  const onRender: ProfilerOnRenderCallback = (
+    profilerId,
+    phase,
+    actualDuration,
+    baseDuration,
+    startTime,
+    commitTime,
+  ) => {
+    const entry: RenderProfileEntry = {
+      id: profilerId,
+      source: "react-profiler",
+      phase,
+      actualDuration: roundDuration(actualDuration),
+      baseDuration: roundDuration(baseDuration),
+      startTime: roundDuration(startTime),
+      commitTime: roundDuration(commitTime),
+      route: window.location.pathname,
+      ...(detail ? { detail } : {}),
+    };
+
+    pushProfileEntry(entry);
+
+    if (entry.actualDuration >= PROFILER_SLOW_COMMIT_MS && shouldLogRenderProfilerEntries()) {
+      logClientEvent("react.profiler.commit", { ...entry });
+    }
+  };
+
+  return (
+    <Profiler id={id} onRender={onRender}>
+      <CommitLatencyProfiler id={id} detail={detail}>
+        {children}
+      </CommitLatencyProfiler>
+    </Profiler>
+  );
+}
+
+function CommitLatencyProfiler({
+  id,
+  detail,
+  children,
+}: {
+  id: string;
+  detail?: Record<string, unknown>;
+  children: ReactNode;
+}) {
+  const renderStartedAt = performance.now();
+  const commitCountRef = useRef(0);
+
+  useLayoutEffect(() => {
+    commitCountRef.current += 1;
+    const commitTime = performance.now();
+    const entry: RenderProfileEntry = {
+      id,
+      source: "commit-latency",
+      phase: commitCountRef.current === 1 ? "mount" : "update",
+      actualDuration: roundDuration(commitTime - renderStartedAt),
+      baseDuration: 0,
+      startTime: roundDuration(renderStartedAt),
+      commitTime: roundDuration(commitTime),
+      route: window.location.pathname,
+      ...(detail ? { detail } : {}),
+    };
+
+    pushProfileEntry(entry);
+  });
+
+  return children;
+}

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -27,6 +27,11 @@ import { cn } from "../lib/utils";
 import type { Message, MessagePart, SessionData, SessionFileActivity } from "../lib/api";
 import { InteractiveReceipt } from "./InteractiveReceipt";
 import { MarkdownContent } from "./MarkdownContent";
+import {
+  isRenderProfilerEnabled,
+  recordRenderProfileEntry,
+  RenderProfiler,
+} from "./RenderProfiler";
 import { extractMessageText, type MessageBlock } from "./session-detail/blocks";
 import { isCodexTurnAbortedMessage } from "./session-detail/codex-abort";
 import {
@@ -591,6 +596,55 @@ function parseJsonText<T>(value: string): T | null {
   } catch {
     return null;
   }
+}
+
+function measureSessionDetailWork<T>(id: string, compute: () => T): T {
+  if (!isRenderProfilerEnabled()) return compute();
+
+  const startedAt = performance.now();
+  const value = compute();
+  const endedAt = performance.now();
+  recordRenderProfileEntry({
+    id,
+    source: "custom-timing",
+    phase: "measure",
+    actualDuration: Math.round((endedAt - startedAt) * 100) / 100,
+    baseDuration: 0,
+    startTime: startedAt,
+    commitTime: endedAt,
+  });
+  return value;
+}
+
+function DeferredInteractiveReceipt({
+  session,
+  toc,
+}: {
+  session: SessionData;
+  toc: SessionDetailToc;
+}) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setReady(false);
+    let secondFrame = 0;
+    const firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => setReady(true));
+    });
+
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      if (secondFrame) cancelAnimationFrame(secondFrame);
+    };
+  }, [session.id]);
+
+  if (!ready) return <aside className="hidden xl:block" aria-hidden="true" />;
+
+  return (
+    <RenderProfiler id="InteractiveReceipt">
+      <InteractiveReceipt key={session.id} session={session} toc={toc} />
+    </RenderProfiler>
+  );
 }
 
 function normalizeEscapedNewlines(text: string) {
@@ -1956,19 +2010,37 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
   const sessionAgentKey =
     sessionSlug.split("/")[0] || ModelConfig.getDefaultAgentKey() || "claudecode";
   const normalizedMessages = useMemo(
-    () => normalizeMessagesForDisplay(session.messages, sessionAgentKey),
+    () =>
+      measureSessionDetailWork("SessionDetail:normalizeMessages", () =>
+        normalizeMessagesForDisplay(session.messages, sessionAgentKey),
+      ),
     [session.messages, sessionAgentKey],
   );
   const messageModels = useMemo(
-    () => buildMessageDisplayModels(normalizedMessages),
+    () =>
+      measureSessionDetailWork("SessionDetail:buildMessageDisplayModels", () =>
+        buildMessageDisplayModels(normalizedMessages),
+      ),
     [normalizedMessages],
   );
   const {
     toolAnchorIds,
     anchorMessageIndexes,
     summary: localFileChangeSummary,
-  } = useMemo(() => buildFileChangeSummary(messageModels), [messageModels]);
-  const toc = useMemo(() => buildSessionDetailToc(messageModels), [messageModels]);
+  } = useMemo(
+    () =>
+      measureSessionDetailWork("SessionDetail:buildFileChangeSummary", () =>
+        buildFileChangeSummary(messageModels),
+      ),
+    [messageModels],
+  );
+  const toc = useMemo(
+    () =>
+      measureSessionDetailWork("SessionDetail:buildSessionDetailToc", () =>
+        buildSessionDetailToc(messageModels),
+      ),
+    [messageModels],
+  );
   const [selectedFilters, setSelectedFilters] = useState<Set<string>>(() => new Set(toc.filterIds));
   const tocSignature = useMemo(() => [...toc.filterIds].toSorted().join("|"), [toc.filterIds]);
   const selectedFilterSignature = useMemo(
@@ -1976,19 +2048,27 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
     [selectedFilters],
   );
   const filteredMessages = useMemo(
-    () => filterSessionMessages(messageModels, selectedFilters),
+    () =>
+      measureSessionDetailWork("SessionDetail:filterSessionMessages", () =>
+        filterSessionMessages(messageModels, selectedFilters),
+      ),
     [messageModels, selectedFilters],
   );
   const virtualListRef = useRef<MessageListHandle | null>(null);
   const anchorListIndexes = useMemo(() => {
-    const indexes = new Map<number, number>();
-    filteredMessages.forEach((item, listIndex) => {
-      indexes.set(item.index, listIndex);
+    return measureSessionDetailWork("SessionDetail:buildAnchorListIndexes", () => {
+      const indexes = new Map<number, number>();
+      filteredMessages.forEach((item, listIndex) => {
+        indexes.set(item.index, listIndex);
+      });
+      return indexes;
     });
-    return indexes;
   }, [filteredMessages]);
   const fileChangeSummary = useMemo(
-    () => buildFileChangeSummaryFromActivity(session.file_activity, localFileChangeSummary),
+    () =>
+      measureSessionDetailWork("SessionDetail:mergeFileActivitySummary", () =>
+        buildFileChangeSummaryFromActivity(session.file_activity, localFileChangeSummary),
+      ),
     [session.file_activity, localFileChangeSummary],
   );
   const handleJumpToAnchor = useCallback(
@@ -2046,21 +2126,29 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
         />
         <div className="flex min-w-0 flex-col gap-8">
           {filteredMessages.length > 0 ? (
-            <MessageList
-              key={`${session.id}:${selectedFilterSignature}`}
-              messages={filteredMessages}
-              toolAnchorIds={toolAnchorIds}
-              sessionAgentKey={sessionAgentKey}
-              highlightQuery={highlightQuery}
-              apiRef={virtualListRef}
-            />
+            <RenderProfiler
+              id="MessageList"
+              detail={{
+                messages: filteredMessages.length,
+                virtualized: filteredMessages.length > VIRTUALIZED_MESSAGE_THRESHOLD,
+              }}
+            >
+              <MessageList
+                key={`${session.id}:${selectedFilterSignature}`}
+                messages={filteredMessages}
+                toolAnchorIds={toolAnchorIds}
+                sessionAgentKey={sessionAgentKey}
+                highlightQuery={highlightQuery}
+                apiRef={virtualListRef}
+              />
+            </RenderProfiler>
           ) : (
             <div className="rounded-sm border border-[var(--console-border)] bg-white p-6 text-sm text-[var(--console-muted)]">
               当前筛选条件下暂无可展示的消息内容。
             </div>
           )}
         </div>
-        <InteractiveReceipt key={session.id} session={session} toc={toc} />
+        <DeferredInteractiveReceipt session={session} toc={toc} />
       </div>
     </div>
   );

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -1,7 +1,8 @@
 import type { FileTreeSortEntry } from "@pierre/trees";
 import { FileTree, useFileTree } from "@pierre/trees/react";
-import { useEffect, useMemo, useRef, type CSSProperties, type MouseEvent } from "react";
+import { memo, useEffect, useMemo, useRef, type CSSProperties, type MouseEvent } from "react";
 import type { SessionHead } from "../lib/api";
+import { isRenderProfilerEnabled, recordRenderProfileEntry } from "./RenderProfiler";
 
 interface SessionTreeSidebarProps {
   sessions: SessionHead[];
@@ -218,7 +219,25 @@ function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel {
   };
 }
 
-export function SessionTreeSidebar({
+function measureSessionTreeWork<T>(id: string, compute: () => T): T {
+  if (!isRenderProfilerEnabled()) return compute();
+
+  const startedAt = performance.now();
+  const value = compute();
+  const endedAt = performance.now();
+  recordRenderProfileEntry({
+    id,
+    source: "custom-timing",
+    phase: "measure",
+    actualDuration: Math.round((endedAt - startedAt) * 100) / 100,
+    baseDuration: 0,
+    startTime: startedAt,
+    commitTime: endedAt,
+  });
+  return value;
+}
+
+export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   sessions,
   activeSessionId,
   selectedSessionId,
@@ -226,7 +245,13 @@ export function SessionTreeSidebar({
   bookmarkedSessionIds,
   onToggleBookmark,
 }: SessionTreeSidebarProps) {
-  const modelData = useMemo(() => buildSessionTreeModel(sessions), [sessions]);
+  const modelData = useMemo(
+    () =>
+      measureSessionTreeWork("SessionTreeSidebar:buildTreeModel", () =>
+        buildSessionTreeModel(sessions),
+      ),
+    [sessions],
+  );
   const sortOrderRef = useRef(modelData.sortOrderByPath);
   const sessionIdByPathRef = useRef(modelData.sessionIdByPath);
   const groupCountByPathRef = useRef(modelData.groupCountByPath);
@@ -337,4 +362,4 @@ export function SessionTreeSidebar({
       <FileTree model={model} style={{ height: "100%" }} aria-label="Sessions" />
     </div>
   );
-}
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,12 +2,15 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.tsx";
+import { RenderProfiler } from "./components/RenderProfiler.tsx";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <RenderProfiler id="App">
+        <App />
+      </RenderProfiler>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/scripts/benchmark-performance.mjs
+++ b/scripts/benchmark-performance.mjs
@@ -23,6 +23,10 @@ function parseArgs(argv) {
     port: 0,
     timeoutMs: 120_000,
     headless: true,
+    reactProfile: false,
+    coldStart: false,
+    target: "auto",
+    navigation: "direct",
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -47,17 +51,33 @@ function parseArgs(argv) {
       index += 1;
     } else if (arg === "--headed") {
       options.headless = false;
+    } else if (arg === "--react-profile") {
+      options.reactProfile = true;
+    } else if (arg === "--cold") {
+      options.coldStart = true;
+    } else if (arg === "--target" && next) {
+      options.target = next;
+      index += 1;
+    } else if (arg === "--navigation" && next) {
+      options.navigation = next;
+      index += 1;
     }
   }
 
-  if (!Number.isFinite(options.days) || options.days < 1) {
-    throw new Error("--days must be a positive number");
+  if (!Number.isFinite(options.days) || options.days < 0) {
+    throw new Error("--days must be 0 or a positive number");
   }
   if (!Number.isFinite(options.iterations) || options.iterations < 1) {
     throw new Error("--iterations must be a positive number");
   }
   if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 1000) {
     throw new Error("--timeout must be at least 1000ms");
+  }
+  if (!["auto", "latest", "smallest", "largest", "lightest", "heaviest"].includes(options.target)) {
+    throw new Error("--target must be one of: auto, latest, smallest, largest, lightest, heaviest");
+  }
+  if (!["direct", "click"].includes(options.navigation)) {
+    throw new Error("--navigation must be one of: direct, click");
   }
 
   return options;
@@ -80,10 +100,76 @@ function summarize(values) {
 }
 
 function printSummary(label, values) {
+  if (values.length === 0) {
+    console.log(`${label}: no samples`);
+    return;
+  }
+
   const summary = summarize(values);
   console.log(
     `${label}: avg ${formatMs(summary.avg)} | p50 ${formatMs(summary.p50)} | p95 ${formatMs(summary.p95)} | min ${formatMs(summary.min)} | max ${formatMs(summary.max)}`,
   );
+}
+
+function summarizeReactProfile(entries) {
+  const groups = new Map();
+
+  for (const entry of entries) {
+    const id = String(entry.id ?? "unknown");
+    const source = String(entry.source ?? "unknown");
+    const key = `${source}:${id}`;
+    const actualDuration = Number(entry.actualDuration);
+    if (!Number.isFinite(actualDuration)) continue;
+
+    const group = groups.get(key) ?? {
+      id,
+      source,
+      commits: 0,
+      totalActualDuration: 0,
+      maxActualDuration: 0,
+    };
+    group.commits += 1;
+    group.totalActualDuration += actualDuration;
+    group.maxActualDuration = Math.max(group.maxActualDuration, actualDuration);
+    groups.set(key, group);
+  }
+
+  return [...groups.values()]
+    .map((group) => ({
+      ...group,
+      avgActualDuration: group.totalActualDuration / group.commits,
+    }))
+    .sort((a, b) => b.totalActualDuration - a.totalActualDuration);
+}
+
+function printReactProfileSummary(label, entries) {
+  if (entries.length === 0) {
+    console.log(
+      `${label}: no React profile entries. Confirm the served web bundle includes RenderProfiler and localStorage.codeseshProfiler is set.`,
+    );
+    return;
+  }
+
+  console.log(label);
+  for (const group of summarizeReactProfile(entries).slice(0, 8)) {
+    console.log(
+      `  [${group.source}] ${group.id}: commits ${group.commits}, total ${formatMs(group.totalActualDuration)}, max ${formatMs(group.maxActualDuration)}, avg ${formatMs(group.avgActualDuration)}`,
+    );
+  }
+}
+
+function withTimeout(promise, timeoutMs, label) {
+  let timer = null;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }
 
 async function findFreePort() {
@@ -144,16 +230,15 @@ function stopCli(child) {
   }
 }
 
-function spawnCli(port, days) {
-  const child = spawn(
-    process.execPath,
-    [cliPath, "--port", String(port), "--days", String(days), "--noOpen", "--no-cache"],
-    {
-      cwd: repoRoot,
-      env: { ...process.env, FORCE_COLOR: "0" },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
+function spawnCli(port, days, coldStart) {
+  const args = [cliPath, "--port", String(port), "--days", String(days), "--noOpen"];
+  if (coldStart) args.push("--no-cache");
+
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    env: { ...process.env, FORCE_COLOR: "0" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 
   let output = "";
   child.stdout.on("data", (chunk) => {
@@ -205,7 +290,7 @@ function restoreCache(backup) {
 }
 
 function restoreActiveCaches() {
-  for (const backup of [...activeCacheBackups]) {
+  for (const backup of activeCacheBackups) {
     restoreCache(backup);
   }
 }
@@ -234,6 +319,78 @@ async function getWindowedSessions(url) {
   return response.json();
 }
 
+async function waitForWindowedSessions(url, timeoutMs) {
+  const startedAt = performance.now();
+  let lastResult = { sessions: [] };
+
+  while (performance.now() - startedAt < timeoutMs) {
+    lastResult = await getWindowedSessions(url);
+    if (Array.isArray(lastResult.sessions) && lastResult.sessions.length > 0) {
+      return lastResult;
+    }
+
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 250));
+  }
+
+  return lastResult;
+}
+
+function getSessionMessageCount(session) {
+  const value = Number(session?.stats?.message_count);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function getSessionTokenCount(session) {
+  const stats = session?.stats ?? {};
+  const total = Number(stats.total_tokens);
+  if (Number.isFinite(total) && total > 0) return total;
+
+  const input = Number(stats.total_input_tokens);
+  const output = Number(stats.total_output_tokens);
+  const fallback = (Number.isFinite(input) ? input : 0) + (Number.isFinite(output) ? output : 0);
+  return fallback > 0 ? fallback : null;
+}
+
+function formatSessionTokenCount(session) {
+  return getSessionTokenCount(session)?.toLocaleString("en-US") ?? "unknown";
+}
+
+function sortByKnownTokens(sessions) {
+  const withTokens = sessions.filter((session) => getSessionTokenCount(session) != null);
+  return withTokens.toSorted((a, b) => getSessionTokenCount(a) - getSessionTokenCount(b));
+}
+
+function selectBenchmarkTarget(sessions, targetMode) {
+  if (targetMode === "latest") return sessions[0];
+
+  const sortedByMessages = [...sessions].sort(
+    (a, b) => getSessionMessageCount(a) - getSessionMessageCount(b),
+  );
+  if (targetMode === "smallest") return sortedByMessages[0];
+  if (targetMode === "largest") return sortedByMessages[sortedByMessages.length - 1];
+
+  const sortedByTokens = sortByKnownTokens(sessions);
+  if (targetMode === "lightest") return sortedByTokens[0] ?? sortedByMessages[0];
+  if (targetMode === "heaviest") {
+    return (
+      sortedByTokens[sortedByTokens.length - 1] ?? sortedByMessages[sortedByMessages.length - 1]
+    );
+  }
+
+  const representative = sessions
+    .filter((session) => {
+      const count = getSessionMessageCount(session);
+      const tokens = getSessionTokenCount(session);
+      return count >= 20 && count <= 250 && (tokens == null || tokens <= 150_000);
+    })
+    .toSorted(
+      (a, b) =>
+        Math.abs(getSessionMessageCount(a) - 120) - Math.abs(getSessionMessageCount(b) - 120),
+    );
+
+  return representative[0] ?? sessions[0];
+}
+
 async function clickSessionLink(page, targetPath) {
   return page.evaluate((path) => {
     const link = [...document.querySelectorAll("a")].find((anchor) => {
@@ -246,16 +403,55 @@ async function clickSessionLink(page, targetPath) {
   }, targetPath);
 }
 
+async function waitForSessionDetailVisible(page, target, timeoutMs) {
+  try {
+    await withTimeout(
+      page.waitForFunction(
+        ({ title }) => {
+          if (document.querySelector('[data-testid="session-detail"]')) return true;
+
+          const normalizedTitle = String(title ?? "").trim();
+          if (!normalizedTitle) return false;
+
+          return [...document.querySelectorAll("h1,h2,h3")].some((element) =>
+            element.textContent?.includes(normalizedTitle),
+          );
+        },
+        { title: target.title },
+        { timeout: timeoutMs },
+      ),
+      timeoutMs,
+      "session detail UI",
+    );
+  } catch (error) {
+    const diagnostics = await withTimeout(
+      page.evaluate(() => ({
+        url: window.location.href,
+        bodyText: document.body.textContent?.replace(/\s+/g, " ").trim().slice(0, 500) ?? "",
+      })),
+      1000,
+      "session detail diagnostics",
+    ).catch(() => ({
+      url: "(unavailable)",
+      bodyText: "(renderer did not respond to diagnostics)",
+    }));
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Timed out waiting for session detail UI. ${message}\nURL: ${diagnostics.url}\nBody: ${diagnostics.bodyText}`,
+    );
+  }
+}
+
 async function runIteration(iteration, options) {
   const port = options.port || (await findFreePort());
   const url = `http://localhost:${port}`;
-  const cacheBackup = moveCacheAside();
+  const cacheBackup = options.coldStart ? moveCacheAside() : null;
   let cli = null;
   let browser = null;
 
   try {
     const startedAt = performance.now();
-    cli = spawnCli(port, options.days);
+    cli = spawnCli(port, options.days, options.coldStart);
 
     await waitForServer(url, cli.child, options.timeoutMs);
     const serverReadyMs = performance.now() - startedAt;
@@ -263,6 +459,11 @@ async function runIteration(iteration, options) {
 
     browser = await launchBrowser(options.headless);
     const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    if (options.reactProfile) {
+      await context.addInitScript(() => {
+        window.localStorage.setItem("codeseshProfiler", "1");
+      });
+    }
     const page = await context.newPage();
 
     await page.goto(url, { waitUntil: "domcontentloaded", timeout: options.timeoutMs });
@@ -273,37 +474,73 @@ async function runIteration(iteration, options) {
     const dashboardReadyMs = performance.now() - startedAt;
     console.log(`#${iteration} dashboard visible in ${formatMs(dashboardReadyMs)}`);
 
-    const { sessions } = await getWindowedSessions(url);
+    const { sessions } = await waitForWindowedSessions(url, options.timeoutMs);
     if (!Array.isArray(sessions) || sessions.length === 0) {
-      throw new Error(`No sessions found in the last ${options.days} days`);
+      const windowLabel = options.days === 0 ? "all time" : `the last ${options.days} days`;
+      const retryHint =
+        options.days === 0
+          ? "Check that local agent session paths are configured and contain sessions."
+          : "Retry with a wider window, for example --days 365, or use --days 0 for all time.";
+      throw new Error(`No sessions found in ${windowLabel}. ${retryHint}`);
     }
     console.log(`#${iteration} loaded ${sessions.length} windowed sessions`);
 
-    const target = sessions[0];
+    const target = selectBenchmarkTarget(sessions, options.target);
     const [agentKey, sessionId] = String(target.slug).split("/");
     const targetPath = `/${target.slug}`;
     const sessionApiPath = `/api/sessions/${agentKey}/${sessionId}`;
-    console.log(`#${iteration} clicking ${targetPath}`);
+    console.log(
+      `#${iteration} opening ${targetPath} (${getSessionMessageCount(target)} messages, ${formatSessionTokenCount(target)} tokens, target=${options.target}, navigation=${options.navigation})`,
+    );
     const clickStartedAt = performance.now();
-    const responsePromise = page.waitForResponse((response) => {
-      const path = new URL(response.url()).pathname;
-      return path === sessionApiPath && response.ok();
-    }, { timeout: options.timeoutMs });
 
-    const clicked = await clickSessionLink(page, targetPath);
-    console.log(`#${iteration} click dispatched`);
-    if (!clicked) {
-      throw new Error(`Session link not found: ${targetPath}`);
+    if (options.navigation === "click") {
+      const responsePromise = page.waitForResponse(
+        (response) => {
+          const path = new URL(response.url()).pathname;
+          return path === sessionApiPath && response.ok();
+        },
+        { timeout: options.timeoutMs },
+      );
+
+      const clicked = await clickSessionLink(page, targetPath);
+      console.log(`#${iteration} click dispatched`);
+      if (!clicked) {
+        throw new Error(`Session link not found: ${targetPath}`);
+      }
+
+      await responsePromise;
+    } else {
+      const responsePromise = page.waitForResponse(
+        (response) => {
+          const path = new URL(response.url()).pathname;
+          return path === sessionApiPath && response.ok();
+        },
+        { timeout: options.timeoutMs },
+      );
+
+      await page.goto(`${url}${targetPath}`, {
+        waitUntil: "domcontentloaded",
+        timeout: options.timeoutMs,
+      });
+      await responsePromise;
     }
 
-    await responsePromise;
     console.log(`#${iteration} detail API returned`);
-    await page.locator('[data-testid="session-detail"]').waitFor({
-      state: "visible",
-      timeout: options.timeoutMs,
-    });
+    await waitForSessionDetailVisible(page, target, options.timeoutMs);
     const sessionClickMs = performance.now() - clickStartedAt;
     console.log(`#${iteration} session detail visible in ${formatMs(sessionClickMs)}`);
+
+    const reactProfileEntries = options.reactProfile
+      ? await withTimeout(
+          page.evaluate(() => window.__CODESHESH_RENDER_PROFILE__ ?? []),
+          2000,
+          "React profile collection",
+        ).catch(() => [])
+      : [];
+    if (options.reactProfile) {
+      printReactProfileSummary(`#${iteration} React profile`, reactProfileEntries);
+    }
 
     await browser.close();
     browser = null;
@@ -318,6 +555,8 @@ async function runIteration(iteration, options) {
       serverReadyMs,
       dashboardReadyMs,
       sessionClickMs,
+      reactProfileEntries,
+      reactProfileSummary: summarizeReactProfile(reactProfileEntries),
     };
   } catch (error) {
     const output = cli?.getOutput() ?? "";
@@ -332,7 +571,7 @@ async function runIteration(iteration, options) {
     if (cli) {
       stopCli(cli.child);
     }
-    restoreCache(cacheBackup);
+    if (cacheBackup) restoreCache(cacheBackup);
   }
 }
 
@@ -345,7 +584,7 @@ async function main() {
   const results = [];
 
   console.log(
-    `Running CodeSesh performance benchmark: days=${options.days}, iterations=${options.iterations}`,
+    `Running CodeSesh performance benchmark: days=${options.days}, iterations=${options.iterations}, cold=${options.coldStart}, target=${options.target}, navigation=${options.navigation}`,
   );
 
   for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
@@ -365,6 +604,12 @@ async function main() {
     "Click session to visible detail",
     results.map((result) => result.sessionClickMs),
   );
+  if (options.reactProfile) {
+    printReactProfileSummary(
+      "Combined React profile",
+      results.flatMap((result) => result.reactProfileEntries),
+    );
+  }
   console.log("");
   console.log(JSON.stringify({ options, results }, null, 2));
 }


### PR DESCRIPTION
## Summary
- Add opt-in render profiling for the web app and collect profile output in the performance benchmark.
- Improve benchmark targeting, cached runs, direct navigation, session polling, timeout diagnostics, and React profile summaries.
- Defer the interactive receipt on session detail so the first visible detail commit does less non-critical work.

## Why
The benchmark previously hid local cached data behind cold no-cache runs and could not identify where session detail rendering time was spent. This adds measurable profiler output and fixes target selection so lightest/heaviest benchmark runs use real token data when available.

## Validation
- ./node_modules/.bin/tsc -b apps/web
- ./node_modules/.bin/oxlint apps/web/src/ scripts/benchmark-performance.mjs
- ../../node_modules/.bin/vitest run (from apps/web)
- node --check scripts/benchmark-performance.mjs
- git diff --check