### PR TITLE
fix(api): hide empty agents

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -143,6 +143,31 @@ describe("handleGetAgents", () => {
     expect(Array.isArray(response)).toBe(true);
   });
 
+  it("omits agents with no sessions in the current window", () => {
+    const c = makeMockContext();
+    const now = Date.now();
+    const old = makeSession("old", {
+      slug: "codex/old",
+      time_created: now - 30 * 86400000,
+      time_updated: now - 30 * 86400000,
+    });
+    const recent = makeSession("recent", {
+      slug: "claudecode/recent",
+      time_created: now - 86400000,
+      time_updated: now - 86400000,
+    });
+    handleGetAgents(
+      c,
+      makeScanSource({
+        sessions: [old, recent],
+        byAgent: { codex: [old], claudecode: [recent] },
+      }),
+      { from: now - 7 * 86400000 },
+    );
+    const response = c.json.mock.calls[0]![0];
+    expect(response.map((agent: { name: string }) => agent.name)).toEqual(["claudecode"]);
+  });
+
   it("applies default time window to agent counts", () => {
     const c = makeMockContext();
     const from = Date.now() - 7 * 86400000;

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -494,7 +494,7 @@ export function handleGetAgents(
       filterSessionsByWindow(sessions, from, to).length,
     ]),
   );
-  const info = getAgentInfoMap(counts);
+  const info = getAgentInfoMap(counts).filter((agent) => agent.count > 0);
   return c.json(info);
 }
 


### PR DESCRIPTION
## Why

Agents with zero sessions in the active statistics window were still returned by `/api/agents` because the handler expanded counts through the full registered agent list. That made unused or inactive coding agents appear in navigation and filters with a `0` count.

## What Changed

* Filter `/api/agents` results to agents whose current-window session count is greater than zero.
* Add a regression test covering an agent with historical sessions but no sessions in the active window.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [x] API
* [ ] Infrastructure

## Notes for Reviewer

* Dashboard per-agent data already filtered empty agents; this change applies the same current-window semantics to `/api/agents`.
* Validated with CLI tests and lint for the CLI and web packages.
