### PR TITLE
feat(agent): add Pi session support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # CodeSesh
 
-**用途**：发现、聚合、可视化本地 AI 编码 Agent（Claude Code、Cursor、Kimi、Codex、OpenCode）的历史会话，通过 Web UI 统一浏览。
+**用途**：发现、聚合、可视化本地 AI 编码 Agent（Claude Code、Cursor、Kimi、Codex、Pi、OpenCode）的历史会话，通过 Web UI 统一浏览。
 
 ## 技术栈
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **One place to see every AI coding session you've ever had.**
 
-You've been coding with AI agents — Claude Code, Cursor, Kimi, Codex, OpenCode — and the conversations are scattered everywhere on your filesystem. Context is lost. Cost is invisible. History is buried.
+You've been coding with AI agents — Claude Code, Cursor, Kimi, Codex, Pi, OpenCode — and the conversations are scattered everywhere on your filesystem. Context is lost. Cost is invisible. History is buried.
 
 **CodeSesh** fixes that. It scans your local machine, finds every AI agent session, and surfaces them in a unified, beautiful Web UI. Think of it as a time machine for your AI-assisted development workflow.
 
@@ -48,6 +48,7 @@ CodeSesh believes your session history belongs to **you** — and you deserve to
 | Cursor | Supported |
 | Kimi | Supported |
 | Codex | Supported |
+| Pi | Supported |
 | OpenCode | Supported |
 
 More agents coming soon. Adding a new one is [a single file](#extending).

--- a/apps/web/public/icon/agent/pi.svg
+++ b/apps/web/public/icon/agent/pi.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <path fill="#09090b" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <path fill="#09090b" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -9,9 +9,12 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
+  FilePlus2,
   FilePenLine,
   FileSearch,
   FileText,
+  ImageIcon,
+  ListTodo,
   LoaderCircle,
   Lightbulb,
   MessageCircleX,
@@ -837,6 +840,81 @@ function buildKimiEditDiffBlocks(state: NormalizedToolState, filePath: string): 
     .filter((block): block is DiffBlock => block != null && block.lines.length > 0);
 }
 
+function getDisplayPath(filePath: string, baseDirectory?: string) {
+  const normalizedPath = filePath.trim();
+  const normalizedBase = (baseDirectory ?? "").replace(/\/+$/, "");
+  if (!normalizedPath || !normalizedBase) return normalizedPath;
+  if (normalizedPath === normalizedBase) return ".";
+  if (normalizedPath.startsWith(`${normalizedBase}/`)) {
+    return normalizedPath.slice(normalizedBase.length + 1);
+  }
+  return normalizedPath;
+}
+
+function getPiTodoTaskFromDetails(state: NormalizedToolState) {
+  const input = toRecord(state.inputValue);
+  const details = toRecord(state.metadataValue);
+  const rawTasks = Array.isArray(details.tasks) ? details.tasks : [];
+  const inputId = Number(input.id);
+  const target =
+    Number.isFinite(inputId) && inputId > 0
+      ? rawTasks.find((task) => Number(toRecord(task).id) === inputId)
+      : rawTasks.at(-1);
+  return toRecord(target);
+}
+
+function getPiTodoStatusChange(state: NormalizedToolState) {
+  const text = getOutputOrErrorText(state);
+  const match = text.match(/\(([^()]+?)\s*→\s*([^()]+?)\)/);
+  if (!match) return "";
+  return `${match[1]} -> ${match[2]}`;
+}
+
+function buildPiEditDiffBlocks(state: NormalizedToolState, filePath: string): DiffBlock[] {
+  const input = toRecord(state.inputValue);
+  const edits = Array.isArray(input.edits) ? input.edits : [];
+  const label = getDiffBlockLabel(filePath);
+  const blocks = edits
+    .map((entry) => {
+      const edit = toRecord(entry);
+      const oldValue = toStringValue(edit.oldText) || toStringValue(edit.old);
+      const newValue = toStringValue(edit.newText) || toStringValue(edit.new);
+      if (!oldValue.trim() && !newValue.trim()) return null;
+      return {
+        label,
+        lines: diffPartsToLines(
+          diffLines(normalizeEscapedNewlines(oldValue), normalizeEscapedNewlines(newValue)),
+        ),
+      };
+    })
+    .filter((block): block is DiffBlock => block != null && block.lines.length > 0);
+
+  if (blocks.length > 0) return blocks;
+
+  const metadata = toRecord(state.metadataValue);
+  const patch = toStringValue(metadata.patch) || toStringValue(metadata.diff);
+  if (!patch.trim()) return [];
+  return [
+    {
+      label,
+      lines: patch.split("\n").map((line) => ({
+        type: line.startsWith("+") ? "add" : line.startsWith("-") ? "remove" : "context",
+        text: line,
+      })),
+    },
+  ];
+}
+
+function buildPiSubagentResultDetails(text: string): ToolDetailItem[] {
+  const firstLine = text.split("\n")[0] ?? "";
+  const agentMatch = firstLine.match(/^Agent:\s*(.+)$/i);
+  const summaryLine = text.split("\n").find((line) => line.includes("Status:"));
+  const details: ToolDetailItem[] = [];
+  if (agentMatch?.[1]) details.push({ label: "Agent", value: agentMatch[1].trim() });
+  if (summaryLine) details.push({ label: "Summary", value: summaryLine.trim() });
+  return details;
+}
+
 function extractEditDiff(state: NormalizedToolState) {
   const metadata = toRecord(state.metadataValue);
   const diffText = toStringValue(metadata.diff);
@@ -1550,10 +1628,201 @@ function buildCursorToolStrategy(
   return { ...defaultStrategy, title: getToolTitle(tool) };
 }
 
+function buildPiToolStrategy(
+  tool: MessagePart,
+  state: NormalizedToolState,
+  baseDirectory?: string,
+): ToolDisplayStrategy {
+  const defaultStrategy = buildDefaultToolStrategy(tool, state);
+  const toolKey = (tool.tool || "").toLowerCase();
+  const input = toRecord(state.inputValue);
+  const metadata = toRecord(state.metadataValue);
+  const filePath = getFilePathFromInput(state.inputValue);
+  const displayPath = getDisplayPath(filePath, baseDirectory);
+
+  if (toolKey === "todo") {
+    const action = toPlainText(input.action) || toPlainText(metadata.action) || "todo";
+    const task = getPiTodoTaskFromDetails(state);
+    const taskId = Number(task.id) || Number(input.id);
+    const subject = toPlainText(task.subject) || toPlainText(input.subject);
+    const description = toPlainText(task.description) || toPlainText(input.description);
+    const status = toPlainText(task.status) || toPlainText(input.status);
+    const statusChange = getPiTodoStatusChange(state);
+    const secondaryParts = [
+      taskId ? `#${taskId}` : "",
+      subject,
+      action === "update" && statusChange ? statusChange : status,
+    ].filter(Boolean);
+
+    return {
+      ...defaultStrategy,
+      Icon: ListTodo,
+      title: action === "create" ? "todo create" : action === "update" ? "todo update" : "todo",
+      secondaryText: secondaryParts.join(" · ") || undefined,
+      details: [
+        taskId ? { label: "ID", value: `#${taskId}` } : null,
+        subject ? { label: "Subject", value: subject } : null,
+        status ? { label: "Status", value: status } : null,
+        statusChange ? { label: "Change", value: statusChange } : null,
+      ].filter((item): item is ToolDetailItem => item != null),
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: description || getOutputOrErrorText(state),
+        language: "markdown",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "read") {
+    return {
+      ...defaultStrategy,
+      Icon: BookOpenText,
+      title: "read",
+      secondaryText: displayPath || undefined,
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: extractReadContent(state.outputValue),
+        language: detectLanguageByFilePath(filePath),
+        isCode: true,
+      },
+    };
+  }
+
+  if (toolKey === "write") {
+    return {
+      ...defaultStrategy,
+      Icon: FilePlus2,
+      title: "write",
+      secondaryText: displayPath || undefined,
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: extractWriteContent(state),
+        language: detectLanguageByFilePath(filePath),
+        isCode: state.status === "completed",
+      },
+    };
+  }
+
+  if (toolKey === "edit") {
+    const diffBlocks = buildPiEditDiffBlocks(state, displayPath || filePath);
+    const firstChangedLine =
+      typeof metadata.firstChangedLine === "number"
+        ? String(metadata.firstChangedLine)
+        : toStringValue(metadata.firstChangedLine);
+    return {
+      ...defaultStrategy,
+      Icon: FilePenLine,
+      title: "edit",
+      secondaryText: displayPath || undefined,
+      details: firstChangedLine ? [{ label: "Line", value: firstChangedLine }] : [],
+      showInputPreview: false,
+      outputContent:
+        diffBlocks.length > 0
+          ? { kind: "structured-diff", blocks: diffBlocks }
+          : { kind: "plain", text: getOutputOrErrorText(state), language: "text", isCode: false },
+    };
+  }
+
+  if (toolKey === "agent") {
+    const description = toPlainText(input.description) || toPlainText(metadata.description);
+    const subagentType = toPlainText(input.subagent_type) || toPlainText(metadata.subagentType);
+    const agentId = toPlainText(metadata.agentId);
+    const status = toPlainText(metadata.status);
+    return {
+      ...defaultStrategy,
+      Icon: Bot,
+      title: subagentType ? `agent · ${subagentType}` : "agent",
+      secondaryText: [agentId ? `#${agentId}` : "", description].filter(Boolean).join(" · "),
+      details: [
+        agentId ? { label: "Agent", value: agentId } : null,
+        subagentType ? { label: "Type", value: subagentType } : null,
+        status ? { label: "Status", value: status } : null,
+      ].filter((item): item is ToolDetailItem => item != null),
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: toStringValue(input.prompt) || getOutputOrErrorText(state),
+        language: "markdown",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "get_subagent_result") {
+    const agentId = toPlainText(input.agent_id);
+    const outputText = getOutputOrErrorText(state);
+    return {
+      ...defaultStrategy,
+      Icon: Bot,
+      title: "subagent result",
+      secondaryText: agentId ? `#${agentId}` : undefined,
+      details: buildPiSubagentResultDetails(outputText),
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: outputText,
+        language: "markdown",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "analyze_image") {
+    const images = Array.isArray(input.images)
+      ? input.images.map((image) => toStringValue(image)).filter(Boolean)
+      : [];
+    const question = toStringValue(input.question);
+    return {
+      ...defaultStrategy,
+      Icon: ImageIcon,
+      title: "analyze image",
+      secondaryText: images.map((image) => getDisplayPath(image, baseDirectory)).join(", "),
+      details: [
+        ...images.map((image, index) => ({
+          label: index === 0 ? "Image" : `Image ${index + 1}`,
+          value: getDisplayPath(image, baseDirectory),
+        })),
+        question ? { label: "Question", value: question } : null,
+      ].filter((item): item is ToolDetailItem => item != null),
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "markdown",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "bash" || toolKey === "batch") {
+    const command = toPlainText(input.command);
+    return {
+      ...defaultStrategy,
+      Icon: SquareTerminal,
+      title: toolKey === "batch" ? "batch" : "bash",
+      secondaryText: command ? `(${command})` : undefined,
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "text",
+        isCode: false,
+      },
+    };
+  }
+
+  return defaultStrategy;
+}
+
 function getToolDisplayStrategy(
   sessionAgentKey: string,
   tool: MessagePart,
   state: NormalizedToolState,
+  baseDirectory?: string,
 ): ToolDisplayStrategy {
   const normalizedAgentKey = sessionAgentKey.toLowerCase();
   if (normalizedAgentKey === "opencode") return buildOpencodeToolStrategy(tool, state);
@@ -1561,6 +1830,7 @@ function getToolDisplayStrategy(
   if (normalizedAgentKey === "kimi") return buildKimiToolStrategy(tool, state);
   if (normalizedAgentKey === "claudecode") return buildClaudeToolStrategy(tool, state);
   if (normalizedAgentKey === "cursor") return buildCursorToolStrategy(tool, state);
+  if (normalizedAgentKey === "pi") return buildPiToolStrategy(tool, state, baseDirectory);
   return buildDefaultToolStrategy(tool, state);
 }
 
@@ -1614,6 +1884,7 @@ interface MessageListProps {
   messages: FilteredSessionMessage[];
   toolAnchorIds: Map<MessagePart, string>;
   sessionAgentKey: string;
+  baseDirectory: string;
   highlightQuery?: string;
   apiRef: { current: MessageListHandle | null };
 }
@@ -1725,6 +1996,7 @@ function MessageList({
   messages,
   toolAnchorIds,
   sessionAgentKey,
+  baseDirectory,
   highlightQuery,
   apiRef,
 }: MessageListProps) {
@@ -1740,6 +2012,7 @@ function MessageList({
         messages={messages}
         toolAnchorIds={toolAnchorIds}
         sessionAgentKey={sessionAgentKey}
+        baseDirectory={baseDirectory}
         highlightQuery={highlightQuery}
         apiRef={apiRef}
       />
@@ -1756,6 +2029,7 @@ function MessageList({
           toolAnchorIds={toolAnchorIds}
           formatTokens={formatTokens}
           sessionAgentKey={sessionAgentKey}
+          baseDirectory={baseDirectory}
           highlightQuery={highlightQuery}
         />
       ))}
@@ -1767,6 +2041,7 @@ function VirtualizedMessageList({
   messages,
   toolAnchorIds,
   sessionAgentKey,
+  baseDirectory,
   highlightQuery,
   apiRef,
 }: MessageListProps) {
@@ -1954,6 +2229,7 @@ function VirtualizedMessageList({
               toolAnchorIds={toolAnchorIds}
               formatTokens={formatTokens}
               sessionAgentKey={sessionAgentKey}
+              baseDirectory={baseDirectory}
               highlightQuery={highlightQuery}
             />
           </VirtualizedMessageRow>
@@ -2138,6 +2414,7 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
                 messages={filteredMessages}
                 toolAnchorIds={toolAnchorIds}
                 sessionAgentKey={sessionAgentKey}
+                baseDirectory={session.directory}
                 highlightQuery={highlightQuery}
                 apiRef={virtualListRef}
               />
@@ -2476,6 +2753,7 @@ function MessageItem({
   toolAnchorIds,
   formatTokens: fmtTokens,
   sessionAgentKey,
+  baseDirectory,
   highlightQuery,
 }: {
   msg: Message;
@@ -2483,6 +2761,7 @@ function MessageItem({
   toolAnchorIds: Map<MessagePart, string>;
   formatTokens: (n: number) => string;
   sessionAgentKey: string;
+  baseDirectory: string;
   highlightQuery?: string;
 }) {
   const isUser = msg.role === "user";
@@ -2563,6 +2842,7 @@ function MessageItem({
                     parts={block.parts}
                     toolAnchorIds={toolAnchorIds}
                     sessionAgentKey={sessionAgentKey}
+                    baseDirectory={baseDirectory}
                     highlightQuery={highlightQuery}
                   />
                 );
@@ -2681,11 +2961,13 @@ function ToolsSection({
   parts,
   toolAnchorIds,
   sessionAgentKey,
+  baseDirectory,
   highlightQuery,
 }: {
   parts: MessagePart[];
   toolAnchorIds: Map<MessagePart, string>;
   sessionAgentKey: string;
+  baseDirectory: string;
   highlightQuery?: string;
 }) {
   return (
@@ -2697,6 +2979,7 @@ function ToolsSection({
             tool={tool}
             anchorId={toolAnchorIds.get(tool)}
             sessionAgentKey={sessionAgentKey}
+            baseDirectory={baseDirectory}
             highlightQuery={highlightQuery}
           />
         ))}
@@ -2797,16 +3080,18 @@ function ToolItem({
   tool,
   anchorId,
   sessionAgentKey,
+  baseDirectory,
   highlightQuery,
 }: {
   tool: MessagePart;
   anchorId?: string;
   sessionAgentKey: string;
+  baseDirectory?: string;
   highlightQuery?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
   const state = normalizeToolState(tool);
-  const strategy = getToolDisplayStrategy(sessionAgentKey, tool, state);
+  const strategy = getToolDisplayStrategy(sessionAgentKey, tool, state, baseDirectory);
   const statusMeta = TOOL_STATUS_META[state.status];
   const StatusIcon = statusMeta.icon;
   const ToolIcon = strategy.Icon;

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -8,6 +8,10 @@ export const ModelConfig = {
       name: "Codex",
       icon: "/icon/agent/codex.svg",
     },
+    pi: {
+      name: "Pi",
+      icon: "/icon/agent/pi.svg",
+    },
     cursor: {
       name: "Cursor",
       icon: "/icon/agent/cursor.svg",

--- a/apps/www/public/icon/agent/pi.svg
+++ b/apps/www/public/icon/agent/pi.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <path fill="#09090b" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <path fill="#09090b" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/apps/www/src/components/Hero.astro
+++ b/apps/www/src/components/Hero.astro
@@ -31,7 +31,7 @@ const outputLines: TerminalSegment[][] = [
   [
     { text: "ℹ ", className: "text-[#38bdf8]" },
     {
-      text: "Indexing Claude Code, OpenCode, Kimi-Cli, Codex, Cursor sessions in the background.",
+      text: "Indexing Claude Code, OpenCode, Kimi-Cli, Codex, Pi, Cursor sessions in the background.",
       className: "text-[#38bdf8]",
     },
   ],

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -100,6 +100,7 @@ export const agents = [
   { name: "Cursor", icon: "/icon/agent/cursor.svg" },
   { name: "Kimi", icon: "/icon/agent/kimi.svg" },
   { name: "Codex", icon: "/icon/agent/codex.svg" },
+  { name: "Pi", icon: "/icon/agent/pi.svg" },
   { name: "OpenCode", icon: "/icon/agent/opencode.svg" },
 ] as const;
 
@@ -108,7 +109,7 @@ export const copy = {
     meta: {
       title: "CodeSesh — 可复用的 AI 编码工程记忆",
       description:
-        "CodeSesh 把 Claude Code、Cursor、Kimi、Codex 和 OpenCode 的本地 AI 编码历史，沉淀成按项目组织、可结构化检索、可复盘的工程记忆。",
+        "CodeSesh 把 Claude Code、Cursor、Kimi、Codex、Pi 和 OpenCode 的本地 AI 编码历史，沉淀成按项目组织、可结构化检索、可复盘的工程记忆。",
     },
     header: {
       github: "GitHub",
@@ -117,7 +118,7 @@ export const copy = {
     hero: {
       title: ["把 AI 编码历史，", "变成可复用的", "工程记忆。"],
       latest: "最新版",
-      body: "CodeSesh 自动发现 Claude Code、Cursor、Kimi、Codex 和 OpenCode 的本地会话，把问题、推理、尝试、文件活动和结果沉淀成按项目组织、可结构化检索、可复盘的工程记忆。",
+      body: "CodeSesh 自动发现 Claude Code、Cursor、Kimi、Codex、Pi 和 OpenCode 的本地会话，把问题、推理、尝试、文件活动和结果沉淀成按项目组织、可结构化检索、可复盘的工程记忆。",
       commandTitle: "从本地开始积累",
       command: "npx codesesh",
       copied: "已复制",
@@ -180,7 +181,7 @@ export const copy = {
               icon: "eye",
               title: "统一时间线",
               description:
-                "在一个界面里浏览 Claude Code、Cursor、Kimi、Codex 和 OpenCode 的历史会话。",
+                "在一个界面里浏览 Claude Code、Cursor、Kimi、Codex、Pi 和 OpenCode 的历史会话。",
             },
           ],
         },
@@ -275,12 +276,12 @@ export const copy = {
         {
           question: "CodeSesh 是什么？",
           answer:
-            "CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码会话历史。它把 Claude Code、Cursor、Kimi、Codex 和 OpenCode 的本地记录整理成一个按项目组织的工程记忆层，帮助开发者找回历史决策、文件活动和完整协作过程。",
+            "CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码会话历史。它把 Claude Code、Cursor、Kimi、Codex、Pi 和 OpenCode 的本地记录整理成一个按项目组织的工程记忆层，帮助开发者找回历史决策、文件活动和完整协作过程。",
         },
         {
           question: "CodeSesh 支持哪些 AI 编码工具？",
           answer:
-            "CodeSesh 当前支持 Claude Code、Cursor、Kimi、Codex 和 OpenCode。每个工具通过 core 包里的 Agent 适配器接入，扫描本地会话存储后统一生成会话列表、项目浏览、结构化搜索索引、文件活动、标签、Token 统计和会话详情。",
+            "CodeSesh 当前支持 Claude Code、Cursor、Kimi、Codex、Pi 和 OpenCode。每个工具通过 core 包里的 Agent 适配器接入，扫描本地会话存储后统一生成会话列表、项目浏览、结构化搜索索引、文件活动、标签、Token 统计和会话详情。",
         },
         {
           question: "CodeSesh 会上传本地 AI 会话数据吗？",
@@ -299,7 +300,7 @@ export const copy = {
     meta: {
       title: "CodeSesh — Reusable Engineering Memory for AI Coding",
       description:
-        "CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Codex, and OpenCode into project-aware, structurally searchable, replayable engineering memory.",
+        "CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode into project-aware, structurally searchable, replayable engineering memory.",
     },
     header: {
       github: "GitHub",
@@ -308,7 +309,7 @@ export const copy = {
     hero: {
       title: ["Turn AI coding history", "into reusable engineering memory."],
       latest: "Latest",
-      body: "CodeSesh discovers local sessions from Claude Code, Cursor, Kimi, Codex, and OpenCode, then preserves problems, reasoning, attempts, file activity, and outcomes in one project-aware searchable memory layer.",
+      body: "CodeSesh discovers local sessions from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode, then preserves problems, reasoning, attempts, file activity, and outcomes in one project-aware searchable memory layer.",
       commandTitle: "Start from your machine",
       command: "npx codesesh",
       copied: "Copied",
@@ -375,7 +376,7 @@ export const copy = {
               icon: "eye",
               title: "Unified Timeline",
               description:
-                "Browse Claude Code, Cursor, Kimi, Codex, and OpenCode sessions in one interface.",
+                "Browse Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode sessions in one interface.",
             },
           ],
         },
@@ -477,12 +478,12 @@ export const copy = {
         {
           question: "What is CodeSesh?",
           answer:
-            "CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, and OpenCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.",
+            "CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.",
         },
         {
           question: "Which AI coding tools does CodeSesh support?",
           answer:
-            "CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, and OpenCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.",
+            "CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.",
         },
         {
           question: "Does CodeSesh upload local AI session data?",

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -86,7 +86,7 @@ const jsonLd = {
     <meta name="description" content={t.meta.description} />
     <meta
       name="keywords"
-      content="AI coding, Claude Code, Cursor, Kimi, Codex, OpenCode, engineering memory, session history, developer tools, AI pair programming"
+      content="AI coding, Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, engineering memory, session history, developer tools, AI pair programming"
     />
     <meta name="author" content="XingKaiXin" />
     <meta name="robots" content="index, follow" />

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><strong>One place to see every AI coding session you've ever had.</strong></p>
 
-CodeSesh scans your local machine, finds every AI agent session (Claude Code, Cursor, Kimi, Codex, OpenCode), and surfaces them in a unified, beautiful Web UI.
+CodeSesh scans your local machine, finds every AI agent session (Claude Code, Cursor, Kimi, Codex, Pi, OpenCode), and surfaces them in a unified, beautiful Web UI.
 
 ## Quick Start
 
@@ -43,6 +43,7 @@ Your browser will open at `http://localhost:4521` with all your sessions ready t
 | Cursor      | ✅ Supported |
 | Kimi        | ✅ Supported |
 | Codex       | ✅ Supported |
+| Pi          | ✅ Supported |
 | OpenCode    | ✅ Supported |
 
 ## Usage

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codesesh",
   "version": "0.8.0",
-  "description": "One place to see every AI coding session you've ever had. Unify Claude Code, Cursor, Kimi, Codex, and OpenCode sessions in a single, beautiful Web UI.",
+  "description": "One place to see every AI coding session you've ever had. Unify Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode sessions in a single, beautiful Web UI.",
   "keywords": [
     "ai",
     "claude",
@@ -12,6 +12,7 @@
     "history",
     "kimi",
     "opencode",
+    "pi",
     "session",
     "visualization",
     "web-ui"

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -25,6 +25,7 @@ const core = vi.hoisted(() => ({
     codexRoot: "/tmp/codex",
     kimiRoot: "/tmp/kimi",
     opencodeRoot: "/tmp/opencode",
+    piRoot: "/tmp/pi",
   })),
   isAgentCacheInitialized: vi.fn(),
   loadCachedSessions: vi.fn(),
@@ -328,6 +329,7 @@ describe("LiveScanStore", () => {
       codexRoot: "/tmp/codex",
       kimiRoot: "/tmp/kimi",
       opencodeRoot: "/tmp/opencode",
+      piRoot: "/tmp/pi",
     });
     core.filterSessions.mockImplementation((sessions: SessionHead[]) => sessions);
   });
@@ -1011,6 +1013,7 @@ describe("LiveScanStore", () => {
       codexRoot,
       kimiRoot: join(tempDir, "kimi"),
       opencodeRoot: join(tempDir, "opencode"),
+      piRoot: join(tempDir, "pi"),
     });
 
     const existingSession = makeSession("existing");
@@ -1083,6 +1086,7 @@ describe("LiveScanStore", () => {
       codexRoot,
       kimiRoot: join(tempDir, "kimi"),
       opencodeRoot: join(tempDir, "opencode"),
+      piRoot: join(tempDir, "pi"),
     });
 
     const existingSession = makeSession("existing");
@@ -1132,6 +1136,7 @@ describe("LiveScanStore", () => {
       codexRoot,
       kimiRoot: join(tempDir, "kimi"),
       opencodeRoot: join(tempDir, "opencode"),
+      piRoot: join(tempDir, "pi"),
     });
 
     const existingSession = makeSession("existing");

--- a/packages/cli/src/live-scan.test.ts
+++ b/packages/cli/src/live-scan.test.ts
@@ -16,6 +16,15 @@ describe("resolveAgentWatchTargets", () => {
     ]);
   });
 
+  it("watches Pi session files", () => {
+    vi.stubEnv("PI_HOME", "/tmp/pi-home");
+
+    expect(resolveAgentWatchTargets("pi")).toEqual([
+      { root: "/tmp/pi-home", path: join("/tmp/pi-home", "agent", "sessions") },
+      { root: "data/pi", path: "data/pi" },
+    ]);
+  });
+
   it("keeps Claude Code watch depth aligned with project/session layout", () => {
     vi.stubEnv("CLAUDE_CONFIG_DIR", "/tmp/claude-home");
 

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -359,6 +359,11 @@ export function resolveAgentWatchTargets(agentName: string): WatchTarget[] {
         { path: join(roots.codexRoot, "sessions") },
         { path: join(roots.codexRoot, "session_index.jsonl") },
       ];
+    case "pi":
+      return [
+        { root: roots.piRoot, path: join(roots.piRoot, "agent", "sessions") },
+        { root: "data/pi", path: "data/pi" },
+      ];
     case "cursor":
       return cursorDataPath
         ? [

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -1,0 +1,255 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PiAgent } from "../pi.js";
+import type { MessagePart } from "../../types/index.js";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("PiAgent", () => {
+  it("parses only the current branch path", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
+    tempDirs.push(tempDir);
+    const piHome = join(tempDir, ".pi");
+    const sessionsDir = join(piHome, "agent", "sessions", "--tmp-project--");
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const sessionFile = join(sessionsDir, `2026-04-20T10-00-00_${sessionId}.jsonl`);
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("PI_HOME", piHome);
+
+    writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: sessionId,
+          timestamp: "2026-04-20T10:00:00.000Z",
+          cwd: "/tmp/project",
+        },
+        {
+          type: "message",
+          id: "a1",
+          parentId: null,
+          timestamp: "2026-04-20T10:00:01.000Z",
+          message: { role: "user", content: "Inspect package metadata" },
+        },
+        {
+          type: "message",
+          id: "b1",
+          parentId: "a1",
+          timestamp: "2026-04-20T10:00:02.000Z",
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-5",
+            usage: {
+              input: 100,
+              output: 20,
+              cacheRead: 10,
+              cacheWrite: 5,
+              totalTokens: 135,
+              cost: { total: 0.25 },
+            },
+            content: [
+              { type: "thinking", thinking: "Need to read package.json" },
+              { type: "text", text: "I will inspect it." },
+              { type: "toolCall", id: "tool-1", name: "read", arguments: { path: "package.json" } },
+            ],
+          },
+        },
+        {
+          type: "message",
+          id: "c1",
+          parentId: "b1",
+          timestamp: "2026-04-20T10:00:03.000Z",
+          message: {
+            role: "toolResult",
+            toolCallId: "tool-1",
+            toolName: "read",
+            content: [{ type: "text", text: "package output" }],
+            isError: false,
+          },
+        },
+        {
+          type: "session_info",
+          id: "d1",
+          parentId: "c1",
+          timestamp: "2026-04-20T10:00:04.000Z",
+          name: "Package inspection",
+        },
+        {
+          type: "message",
+          id: "branch1",
+          parentId: "a1",
+          timestamp: "2026-04-20T10:00:05.000Z",
+          message: { role: "user", content: "Alternate branch should not count" },
+        },
+        "",
+      ]
+        .map((item) => (typeof item === "string" ? item : JSON.stringify(item)))
+        .join("\n"),
+    );
+
+    const agent = new PiAgent();
+    expect(agent.isAvailable()).toBe(true);
+
+    const [head] = agent.scan();
+    const data = agent.getSessionData(sessionId);
+    const tool = data.messages[1]?.parts.find((part: MessagePart) => part.type === "tool");
+
+    expect(head).toMatchObject({
+      id: sessionId,
+      slug: `pi/${sessionId}`,
+      title: "Inspect package metadata",
+      directory: "/tmp/project",
+      stats: {
+        message_count: 2,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 0,
+      },
+    });
+    expect(data.messages.map((message) => message.role)).toEqual(["user", "user"]);
+    expect(data.messages[0]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "Inspect package metadata",
+    });
+    expect(data.messages[1]?.parts[0]).toMatchObject({
+      type: "text",
+      text: "Alternate branch should not count",
+    });
+    expect(tool).toBeUndefined();
+  });
+
+  it("uses session names and parses assistant tools on the selected leaf", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
+    tempDirs.push(tempDir);
+    const piHome = join(tempDir, ".pi");
+    const sessionsDir = join(piHome, "agent", "sessions", "--tmp-project--");
+    const sessionId = "019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb";
+    const sessionFile = join(sessionsDir, `2026-04-20T10-00-00_${sessionId}.jsonl`);
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("PI_HOME", piHome);
+
+    writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: sessionId,
+          timestamp: "2026-04-20T10:00:00.000Z",
+          cwd: "/tmp/project",
+        },
+        {
+          type: "message",
+          id: "a1",
+          parentId: null,
+          timestamp: "2026-04-20T10:00:01.000Z",
+          message: { role: "user", content: "Inspect package metadata" },
+        },
+        {
+          type: "message",
+          id: "b1",
+          parentId: "a1",
+          timestamp: "2026-04-20T10:00:02.000Z",
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-5",
+            usage: {
+              input: 100,
+              output: 20,
+              cacheRead: 10,
+              cacheWrite: 5,
+              totalTokens: 135,
+              cost: { total: 0.25 },
+            },
+            content: [
+              { type: "thinking", thinking: "Need to read package.json" },
+              { type: "text", text: "I will inspect it." },
+              { type: "toolCall", id: "tool-1", name: "read", arguments: { path: "package.json" } },
+            ],
+          },
+        },
+        {
+          type: "message",
+          id: "c1",
+          parentId: "b1",
+          timestamp: "2026-04-20T10:00:03.000Z",
+          message: {
+            role: "toolResult",
+            toolCallId: "tool-1",
+            toolName: "read",
+            content: [{ type: "text", text: "package output" }],
+            isError: false,
+          },
+        },
+        {
+          type: "session_info",
+          id: "d1",
+          parentId: "c1",
+          timestamp: "2026-04-20T10:00:04.000Z",
+          name: "Package inspection",
+        },
+        "",
+      ]
+        .map((item) => (typeof item === "string" ? item : JSON.stringify(item)))
+        .join("\n"),
+    );
+
+    const agent = new PiAgent();
+    expect(agent.isAvailable()).toBe(true);
+
+    const [head] = agent.scan();
+    const data = agent.getSessionData(sessionId);
+    const assistant = data.messages[1];
+    const tool = assistant?.parts.find((part: MessagePart) => part.type === "tool");
+
+    expect(head).toMatchObject({
+      id: sessionId,
+      slug: `pi/${sessionId}`,
+      title: "Package inspection",
+      directory: "/tmp/project",
+      stats: {
+        message_count: 2,
+        total_input_tokens: 115,
+        total_output_tokens: 20,
+        total_cache_read_tokens: 10,
+        total_cache_create_tokens: 5,
+        total_cost: 0.25,
+        cost_source: "recorded",
+      },
+      model_usage: { "claude-sonnet-4-5": 135 },
+    });
+    expect(data.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(assistant?.parts[0]).toMatchObject({
+      type: "reasoning",
+      text: "Need to read package.json",
+    });
+    expect(assistant?.parts[1]).toMatchObject({
+      type: "text",
+      text: "I will inspect it.",
+    });
+    expect(tool).toMatchObject({
+      type: "tool",
+      tool: "read",
+      state: {
+        status: "completed",
+        input: { path: "package.json" },
+        output: [{ type: "text", text: "package output" }],
+      },
+    });
+  });
+});

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,0 +1,787 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+import {
+  BaseAgent,
+  filteredSession,
+  getParsedSession,
+  matchesScanWindow,
+  parsedSession,
+} from "./base.js";
+import type {
+  AgentScanOptions,
+  ChangeCheckResult,
+  ParseSessionResult,
+  SessionCacheMeta,
+  SessionSourceRef,
+} from "./base.js";
+import type { Message, MessagePart, SessionData, SessionHead } from "../types/index.js";
+import { firstExisting, resolveProviderRoots } from "../discovery/paths.js";
+import { parseJsonlLines } from "../utils/jsonl.js";
+import { perf } from "../utils/perf.js";
+import { estimateTokenCost } from "../utils/cost.js";
+import { cleanInternalText, cleanParsedMessages } from "../utils/session-normalization.js";
+import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
+
+const HEAD_INDEX_VERSION = "pi-head-v1";
+const PARSER_VERSION = "pi-parser-v1";
+
+interface SessionMeta extends SessionCacheMeta {
+  id: string;
+  title: string;
+  sourcePath: string;
+  sourceMtimeMs: number;
+  headIndexVersion: string;
+  parserVersion: string;
+  directory: string;
+  messageCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface ParsedPiFile {
+  sessionId: string;
+  directory: string;
+  createdAt: number;
+  updatedAt: number;
+  title: string;
+  pathEntries: Record<string, unknown>[];
+}
+
+function parseTimestampMs(value: unknown): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  const text = String(value ?? "").trim();
+  if (!text) return 0;
+  const ts = Date.parse(text);
+  return Number.isNaN(ts) ? 0 : ts;
+}
+
+function extractSessionIdFromFilename(filePath: string): string {
+  const stem = basename(filePath, ".jsonl");
+  const underscore = stem.indexOf("_");
+  return underscore >= 0 ? stem.slice(underscore + 1) || stem : stem;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function contentToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((item) => {
+      if (!isObject(item)) return "";
+      if (item["type"] === "text") return String(item["text"] ?? "");
+      if (item["type"] === "image") return "[image]";
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function normalizeTextParts(content: unknown, timestampMs: number): MessagePart[] {
+  const text = cleanInternalText(contentToText(content));
+  return text ? [{ type: "text", text, time_created: timestampMs }] : [];
+}
+
+function buildMessage(params: {
+  id: string;
+  role: Message["role"];
+  timestampMs: number;
+  parts: MessagePart[];
+  agent?: string;
+  provider?: string | null;
+  model?: string | null;
+  tokens?: Message["tokens"];
+  cost?: number;
+  costSource?: Message["cost_source"];
+}): Message {
+  return {
+    id: params.id,
+    role: params.role,
+    agent: params.agent,
+    time_created: params.timestampMs,
+    provider: params.provider,
+    model: params.model,
+    tokens: params.tokens,
+    cost: params.cost,
+    cost_source: params.costSource,
+    parts: params.parts,
+  };
+}
+
+function getEntryTimestamp(entry: Record<string, unknown>): number {
+  return parseTimestampMs(entry["timestamp"]);
+}
+
+function chooseLeafEntry(entries: Record<string, unknown>[]): Record<string, unknown> | null {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (typeof entries[index]?.["id"] === "string") return entries[index]!;
+  }
+  return null;
+}
+
+function buildCurrentPathEntries(entries: Record<string, unknown>[]): Record<string, unknown>[] {
+  const byId = new Map<string, Record<string, unknown>>();
+  for (const entry of entries) {
+    const id = entry["id"];
+    if (typeof id === "string" && id) byId.set(id, entry);
+  }
+
+  const leaf = chooseLeafEntry(entries);
+  if (!leaf) return [];
+
+  const path: Record<string, unknown>[] = [];
+  const seen = new Set<string>();
+  let current: Record<string, unknown> | undefined = leaf;
+  while (current) {
+    const id = String(current["id"] ?? "");
+    if (!id || seen.has(id)) break;
+    seen.add(id);
+    path.push(current);
+    const parentId: unknown = current["parentId"];
+    current = typeof parentId === "string" ? byId.get(parentId) : undefined;
+  }
+
+  return path.reverse();
+}
+
+export class PiAgent extends BaseAgent {
+  readonly name = "pi";
+  readonly displayName = "Pi";
+
+  private basePath: string | null = null;
+  private sessionMetaMap = new Map<string, SessionMeta>();
+
+  private findBasePath(): string | null {
+    const roots = resolveProviderRoots();
+    return firstExisting(join(roots.piRoot, "agent", "sessions"), "data/pi");
+  }
+
+  isAvailable(): boolean {
+    this.basePath = this.findBasePath();
+    if (!this.basePath) return false;
+    return this.listSessionFiles().length > 0;
+  }
+
+  scan(options?: AgentScanOptions): SessionHead[] {
+    if (!this.basePath) return [];
+
+    const scanMarker = perf.start("pi:scan");
+    const files = this.listSessionFiles(options);
+    options?.onProgress?.({ total: files.length, processed: 0, sessions: 0 });
+
+    const heads: SessionHead[] = [];
+    let processed = 0;
+    for (const file of files) {
+      try {
+        const head = getParsedSession(this.parseSessionHeadResult(file));
+        if (head) {
+          heads.push(head);
+          this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
+        }
+      } catch {
+        // skip malformed files
+      } finally {
+        processed += 1;
+        options?.onProgress?.({ total: files.length, processed, sessions: heads.length });
+      }
+    }
+
+    perf.end(scanMarker);
+    return heads;
+  }
+
+  listSessionSources(): SessionSourceRef[] {
+    if (!this.basePath) return [];
+    return this.listSessionFiles().map((file) => ({
+      sessionId: extractSessionIdFromFilename(file),
+      sourcePath: file,
+      fingerprint: this.sourceFingerprint(file),
+    }));
+  }
+
+  scanSessionSource(sourcePath: string): SessionHead | null {
+    const head = getParsedSession(this.parseSessionHeadResult(sourcePath));
+    if (head) {
+      this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath));
+    }
+    return head;
+  }
+
+  getSessionMetaMap(): Map<string, SessionCacheMeta> {
+    return this.sessionMetaMap;
+  }
+
+  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
+    this.sessionMetaMap = meta as Map<string, SessionMeta>;
+  }
+
+  checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
+    if (!this.basePath) return { hasChanges: false, timestamp: Date.now() };
+
+    const currentFiles = this.listSessionFiles();
+    const currentIds = new Set(currentFiles.map((file) => extractSessionIdFromFilename(file)));
+    const cachedIds = new Set(cachedSessions.map((session) => session.id));
+    const changedIds = new Set<string>();
+
+    for (const session of cachedSessions) {
+      if (!currentIds.has(session.id)) {
+        changedIds.add(session.id);
+        continue;
+      }
+
+      const meta = this.sessionMetaMap.get(session.id);
+      if (!meta) {
+        changedIds.add(session.id);
+        continue;
+      }
+
+      try {
+        if (this.hasMetaChanged(meta)) changedIds.add(session.id);
+      } catch {
+        changedIds.add(session.id);
+      }
+    }
+
+    const hasAddedSessions = currentFiles.some(
+      (file) => !cachedIds.has(extractSessionIdFromFilename(file)),
+    );
+    return {
+      hasChanges: changedIds.size > 0 || hasAddedSessions,
+      changedIds: [...changedIds],
+      timestamp: Date.now(),
+    };
+  }
+
+  incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
+    if (!this.basePath) return cachedSessions;
+
+    const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
+    const changedSet = new Set(changedIds);
+    const currentFiles = this.listSessionFiles();
+    const currentIds = new Set(currentFiles.map((file) => extractSessionIdFromFilename(file)));
+
+    for (const session of cachedSessions) {
+      if (!currentIds.has(session.id)) {
+        sessionMap.delete(session.id);
+        this.sessionMetaMap.delete(session.id);
+      }
+    }
+
+    for (const file of currentFiles) {
+      try {
+        const sessionId = extractSessionIdFromFilename(file);
+        if (!changedSet.has(sessionId) && sessionMap.has(sessionId)) continue;
+        const head = getParsedSession(this.parseSessionHeadResult(file));
+        if (head) {
+          sessionMap.set(head.id, head);
+          this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
+        }
+      } catch {
+        // skip malformed files
+      }
+    }
+
+    return [...sessionMap.values()];
+  }
+
+  getSessionData(sessionId: string): SessionData {
+    const meta = this.sessionMetaMap.get(sessionId);
+    if (!meta) throw new Error(`Session not found: ${sessionId}`);
+    if (!existsSync(meta.sourcePath)) throw new Error(`Session file missing: ${meta.sourcePath}`);
+
+    const parsed = this.parsePiFile(meta.sourcePath);
+    const state = this.convertEntries(parsed.pathEntries);
+    const cleanedMessages = cleanParsedMessages(state.messages);
+
+    return {
+      id: meta.id,
+      title: meta.title,
+      slug: `pi/${meta.id}`,
+      directory: meta.directory,
+      time_created: meta.createdAt,
+      time_updated: meta.updatedAt,
+      stats: {
+        message_count: cleanedMessages.length,
+        total_input_tokens: state.totalInputTokens,
+        total_output_tokens: state.totalOutputTokens,
+        total_cache_read_tokens: state.totalCacheReadTokens || undefined,
+        total_cache_create_tokens: state.totalCacheCreateTokens || undefined,
+        total_cost: state.totalCost,
+        cost_source: state.totalCost > 0 ? "recorded" : undefined,
+      },
+      messages: cleanedMessages,
+    };
+  }
+
+  private listSessionFiles(options?: AgentScanOptions): string[] {
+    if (!this.basePath) return [];
+    return this.walkJsonlFiles(this.basePath, options);
+  }
+
+  private walkJsonlFiles(dir: string, options?: AgentScanOptions): string[] {
+    const files: string[] = [];
+    try {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          files.push(...this.walkJsonlFiles(fullPath, options));
+          continue;
+        }
+        if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+        if (!matchesScanWindow(statSync(fullPath).mtimeMs, options)) continue;
+        files.push(fullPath);
+      }
+    } catch {
+      // skip inaccessible dirs
+    }
+    return files;
+  }
+
+  private buildSessionMeta(head: SessionHead, file: string): SessionMeta {
+    return {
+      id: head.id,
+      title: head.title,
+      sourcePath: file,
+      sourceFingerprint: this.sourceFingerprint(file),
+      sourceMtimeMs: statSync(file).mtimeMs,
+      headIndexVersion: HEAD_INDEX_VERSION,
+      parserVersion: PARSER_VERSION,
+      directory: head.directory,
+      messageCount: head.stats.message_count,
+      createdAt: head.time_created,
+      updatedAt: head.time_updated ?? head.time_created,
+    };
+  }
+
+  private hasMetaChanged(meta: SessionMeta): boolean {
+    if (meta.headIndexVersion !== HEAD_INDEX_VERSION) return true;
+    if (meta.parserVersion !== PARSER_VERSION) return true;
+    return statSync(meta.sourcePath).mtimeMs !== meta.sourceMtimeMs;
+  }
+
+  private sourceFingerprint(file: string): string {
+    const stat = statSync(file);
+    return JSON.stringify([HEAD_INDEX_VERSION, PARSER_VERSION, stat.mtimeMs, stat.size]);
+  }
+
+  private parseSessionHeadResult(filePath: string): ParseSessionResult<SessionHead> {
+    const parsed = this.parsePiFile(filePath);
+    const state = this.convertEntries(parsed.pathEntries);
+    const messageCount = state.messages.length;
+    if (messageCount === 0) return filteredSession("no visible messages");
+
+    const modelUsage = Object.keys(state.modelUsage).length > 0 ? state.modelUsage : undefined;
+    return parsedSession({
+      id: parsed.sessionId,
+      slug: `pi/${parsed.sessionId}`,
+      title: parsed.title,
+      directory: parsed.directory,
+      time_created: parsed.createdAt,
+      time_updated: parsed.updatedAt,
+      stats: {
+        message_count: messageCount,
+        total_input_tokens: state.totalInputTokens,
+        total_output_tokens: state.totalOutputTokens,
+        total_cache_read_tokens: state.totalCacheReadTokens || undefined,
+        total_cache_create_tokens: state.totalCacheCreateTokens || undefined,
+        total_cost: state.totalCost,
+        cost_source: state.totalCost > 0 ? "recorded" : undefined,
+      },
+      model_usage: modelUsage,
+    });
+  }
+
+  private parsePiFile(filePath: string): ParsedPiFile {
+    const records = Array.from(parseJsonlLines(readFileSync(filePath, "utf-8")));
+    if (records.length === 0) throw new Error("empty file");
+
+    const header = records.find((record) => record["type"] === "session");
+    if (!header) throw new Error("missing session header");
+
+    const entries = records.filter((record) => record["type"] !== "session");
+    const pathEntries = buildCurrentPathEntries(entries);
+    if (pathEntries.length === 0) throw new Error("empty session tree");
+
+    const sessionId = String(header["id"] ?? extractSessionIdFromFilename(filePath)).trim();
+    if (!sessionId) throw new Error("missing session id");
+
+    const stat = statSync(filePath);
+    const directory = String(header["cwd"] ?? "").trim() || basename(filePath, ".jsonl");
+    const createdAt = parseTimestampMs(header["timestamp"]) || stat.mtimeMs;
+    const updatedAt = pathEntries.reduce(
+      (max, entry) => Math.max(max, getEntryTimestamp(entry)),
+      createdAt,
+    );
+    const explicitTitle = this.extractSessionName(pathEntries);
+    const messageTitle = this.extractTitle(pathEntries);
+    const directoryTitle = basenameTitle(directory);
+
+    return {
+      sessionId,
+      directory,
+      createdAt,
+      updatedAt,
+      title: resolveSessionTitle(explicitTitle, messageTitle, directoryTitle),
+      pathEntries,
+    };
+  }
+
+  private extractSessionName(entries: Record<string, unknown>[]): string | null {
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const entry = entries[index]!;
+      if (entry["type"] !== "session_info") continue;
+      const name = normalizeTitleText(String(entry["name"] ?? ""));
+      if (name) return name;
+    }
+    return null;
+  }
+
+  private extractTitle(entries: Record<string, unknown>[]): string | null {
+    for (const entry of entries) {
+      if (entry["type"] !== "message") continue;
+      const message = entry["message"];
+      if (!isObject(message) || message["role"] !== "user") continue;
+      const title = normalizeTitleText(contentToText(message["content"]));
+      if (title) return title;
+    }
+    return null;
+  }
+
+  private convertEntries(entries: Record<string, unknown>[]): {
+    messages: Message[];
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalCacheReadTokens: number;
+    totalCacheCreateTokens: number;
+    totalCost: number;
+    modelUsage: Record<string, number>;
+  } {
+    const messages: Message[] = [];
+    const pendingToolCalls = new Map<string, [number, number]>();
+    const modelUsage: Record<string, number> = {};
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalCacheReadTokens = 0;
+    let totalCacheCreateTokens = 0;
+    let totalCost = 0;
+
+    for (const entry of entries) {
+      const timestampMs = getEntryTimestamp(entry);
+      const type = String(entry["type"] ?? "");
+
+      if (type === "message") {
+        const message = entry["message"];
+        if (!isObject(message)) continue;
+        const result = this.convertAgentMessage(
+          entry,
+          message,
+          timestampMs,
+          pendingToolCalls,
+          messages.length,
+          messages,
+        );
+        if (!result) continue;
+        if (result.message) messages.push(result.message);
+        totalInputTokens += result.inputTokens;
+        totalOutputTokens += result.outputTokens;
+        totalCacheReadTokens += result.cacheReadTokens;
+        totalCacheCreateTokens += result.cacheCreateTokens;
+        totalCost += result.cost;
+        if (result.model && result.totalTokens > 0) {
+          modelUsage[result.model] = (modelUsage[result.model] ?? 0) + result.totalTokens;
+        }
+        continue;
+      }
+
+      const summary = this.convertSummaryEntry(entry, timestampMs);
+      if (summary) messages.push(summary);
+    }
+
+    return {
+      messages,
+      totalInputTokens,
+      totalOutputTokens,
+      totalCacheReadTokens,
+      totalCacheCreateTokens,
+      totalCost,
+      modelUsage,
+    };
+  }
+
+  private convertAgentMessage(
+    entry: Record<string, unknown>,
+    message: Record<string, unknown>,
+    timestampMs: number,
+    pendingToolCalls: Map<string, [number, number]>,
+    nextMessageIndex: number,
+    messages: Message[],
+  ): {
+    message?: Message;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+    totalTokens: number;
+    cost: number;
+    model: string | null;
+  } | null {
+    const id = String(entry["id"] ?? "");
+    const role = String(message["role"] ?? "");
+
+    if (role === "user") {
+      const parts = normalizeTextParts(message["content"], timestampMs);
+      if (parts.length === 0) return null;
+      return this.emptyUsageResult(buildMessage({ id, role: "user", timestampMs, parts }));
+    }
+
+    if (role === "assistant") {
+      const parts = this.normalizeAssistantParts(
+        message["content"],
+        timestampMs,
+        pendingToolCalls,
+        nextMessageIndex,
+      );
+      if (parts.length === 0) return null;
+      const usage = this.normalizeUsage(message["usage"]);
+      const model = typeof message["model"] === "string" ? message["model"].trim() : null;
+      const cost = usage.cost ?? estimateTokenCost(model, usage.tokens) ?? 0;
+      return {
+        message: buildMessage({
+          id,
+          role: "assistant",
+          agent: "pi",
+          timestampMs,
+          parts,
+          provider: typeof message["provider"] === "string" ? message["provider"] : null,
+          model,
+          tokens: usage.tokens,
+          cost: cost || undefined,
+          costSource: cost > 0 ? "recorded" : undefined,
+        }),
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        cacheReadTokens: usage.cacheReadTokens,
+        cacheCreateTokens: usage.cacheCreateTokens,
+        totalTokens: usage.totalTokens,
+        cost,
+        model,
+      };
+    }
+
+    if (role === "toolResult") {
+      this.attachToolResult(message, timestampMs, pendingToolCalls, messages);
+      return this.emptyUsageResult();
+    }
+
+    if (role === "bashExecution") {
+      return this.emptyUsageResult(this.convertBashExecution(id, message, timestampMs));
+    }
+
+    if (role === "custom" && message["display"] === true) {
+      const parts = normalizeTextParts(message["content"], timestampMs);
+      if (parts.length === 0) return null;
+      return this.emptyUsageResult(buildMessage({ id, role: "user", timestampMs, parts }));
+    }
+
+    if (role === "branchSummary" || role === "compactionSummary") {
+      const summary = String(message["summary"] ?? "").trim();
+      if (!summary) return null;
+      return this.emptyUsageResult(
+        buildMessage({
+          id,
+          role: "assistant",
+          agent: "pi",
+          timestampMs,
+          parts: [{ type: "text", text: summary, time_created: timestampMs }],
+        }),
+      );
+    }
+
+    return null;
+  }
+
+  private normalizeAssistantParts(
+    content: unknown,
+    timestampMs: number,
+    pendingToolCalls: Map<string, [number, number]>,
+    messageIndex: number,
+  ): MessagePart[] {
+    if (!Array.isArray(content)) return [];
+
+    const parts: MessagePart[] = [];
+    for (const item of content) {
+      if (!isObject(item)) continue;
+      const type = item["type"];
+
+      if (type === "text") {
+        const text = cleanInternalText(String(item["text"] ?? ""));
+        if (text) parts.push({ type: "text", text, time_created: timestampMs });
+        continue;
+      }
+
+      if (type === "thinking") {
+        const text = cleanInternalText(String(item["thinking"] ?? ""));
+        if (text) parts.push({ type: "reasoning", text, time_created: timestampMs });
+        continue;
+      }
+
+      if (type === "toolCall") {
+        const callId = String(item["id"] ?? "").trim();
+        const toolName = String(item["name"] ?? "").trim() || "tool";
+        const toolPart: MessagePart = {
+          type: "tool",
+          tool: toolName,
+          title: `Tool: ${toolName}`,
+          callID: callId || undefined,
+          time_created: timestampMs,
+          state: {
+            status: "running",
+            input: item["arguments"] ?? {},
+          },
+        };
+        parts.push(toolPart);
+        if (callId) pendingToolCalls.set(callId, [messageIndex, parts.length - 1]);
+      }
+    }
+
+    return parts;
+  }
+
+  private attachToolResult(
+    message: Record<string, unknown>,
+    timestampMs: number,
+    pendingToolCalls: Map<string, [number, number]>,
+    messages: Message[],
+  ): void {
+    const callId = String(message["toolCallId"] ?? "").trim();
+    const output = normalizeTextParts(message["content"], timestampMs);
+    const location = callId ? pendingToolCalls.get(callId) : undefined;
+    if (!location) return;
+
+    const [messageIndex, partIndex] = location;
+    const target = messages[messageIndex]?.parts[partIndex];
+    if (!target?.state) return;
+    target.state.output = output;
+    target.state.status = message["isError"] === true ? "error" : "completed";
+    target.state.metadata = message["details"];
+    pendingToolCalls.delete(callId);
+  }
+
+  private convertBashExecution(
+    id: string,
+    message: Record<string, unknown>,
+    timestampMs: number,
+  ): Message {
+    const command = String(message["command"] ?? "");
+    const output = String(message["output"] ?? "");
+    const isError = Number(message["exitCode"] ?? 0) !== 0 || message["cancelled"] === true;
+    return buildMessage({
+      id,
+      role: "tool",
+      timestampMs,
+      parts: [
+        {
+          type: "tool",
+          tool: "bash",
+          title: "Tool: bash",
+          time_created: timestampMs,
+          state: {
+            status: isError ? "error" : "completed",
+            input: { command },
+            output: output ? [{ type: "text", text: output, time_created: timestampMs }] : [],
+            metadata: {
+              exitCode: message["exitCode"],
+              cancelled: message["cancelled"],
+              truncated: message["truncated"],
+              fullOutputPath: message["fullOutputPath"],
+            },
+          },
+        },
+      ],
+    });
+  }
+
+  private convertSummaryEntry(
+    entry: Record<string, unknown>,
+    timestampMs: number,
+  ): Message | null {
+    const type = entry["type"];
+    if (type !== "compaction" && type !== "branch_summary" && type !== "custom_message") {
+      return null;
+    }
+
+    if (type === "custom_message" && entry["display"] !== true) return null;
+
+    const rawText =
+      type === "custom_message" ? contentToText(entry["content"]) : String(entry["summary"] ?? "");
+    const text = cleanInternalText(rawText);
+    if (!text) return null;
+
+    return buildMessage({
+      id: String(entry["id"] ?? ""),
+      role: type === "custom_message" ? "user" : "assistant",
+      agent: type === "custom_message" ? undefined : "pi",
+      timestampMs,
+      parts: [{ type: "text", text, time_created: timestampMs }],
+    });
+  }
+
+  private normalizeUsage(raw: unknown): {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+    totalTokens: number;
+    cost: number | null;
+    tokens: Message["tokens"];
+  } {
+    const usage = isObject(raw) ? raw : {};
+    const inputTokens = Number(usage["input"] ?? 0);
+    const outputTokens = Number(usage["output"] ?? 0);
+    const cacheReadTokens = Number(usage["cacheRead"] ?? 0);
+    const cacheCreateTokens = Number(usage["cacheWrite"] ?? 0);
+    const totalTokens = Number(
+      usage["totalTokens"] ?? inputTokens + outputTokens + cacheReadTokens + cacheCreateTokens,
+    );
+    const cost = isObject(usage["cost"]) ? Number(usage["cost"]["total"] ?? 0) : null;
+
+    return {
+      inputTokens: inputTokens + cacheReadTokens + cacheCreateTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheCreateTokens,
+      totalTokens,
+      cost: cost && Number.isFinite(cost) ? cost : null,
+      tokens: {
+        input: inputTokens + cacheReadTokens + cacheCreateTokens,
+        output: outputTokens,
+        cache_read: cacheReadTokens || undefined,
+        cache_create: cacheCreateTokens || undefined,
+      },
+    };
+  }
+
+  private emptyUsageResult(message?: Message): {
+    message?: Message;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheCreateTokens: number;
+    totalTokens: number;
+    cost: number;
+    model: string | null;
+  } {
+    return {
+      message,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreateTokens: 0,
+      totalTokens: 0,
+      cost: 0,
+      model: null,
+    };
+  }
+}

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -703,10 +703,7 @@ export class PiAgent extends BaseAgent {
     });
   }
 
-  private convertSummaryEntry(
-    entry: Record<string, unknown>,
-    timestampMs: number,
-  ): Message | null {
+  private convertSummaryEntry(entry: Record<string, unknown>, timestampMs: number): Message | null {
     const type = entry["type"];
     if (type !== "compaction" && type !== "branch_summary" && type !== "custom_message") {
       return null;

--- a/packages/core/src/agents/register.ts
+++ b/packages/core/src/agents/register.ts
@@ -4,6 +4,7 @@ import { OpenCodeAgent } from "./opencode.js";
 import { KimiAgent } from "./kimi.js";
 import { CodexAgent } from "./codex.js";
 import { CursorAgent } from "./cursor.js";
+import { PiAgent } from "./pi.js";
 
 registerAgent({
   name: "claudecode",
@@ -31,6 +32,13 @@ registerAgent({
   displayName: "Codex",
   icon: "/icon/agent/codex.svg",
   create: () => new CodexAgent(),
+});
+
+registerAgent({
+  name: "pi",
+  displayName: "Pi",
+  icon: "/icon/agent/pi.svg",
+  create: () => new PiAgent(),
 });
 
 registerAgent({

--- a/packages/core/src/discovery/__tests__/paths.test.ts
+++ b/packages/core/src/discovery/__tests__/paths.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
   vi.stubEnv("CODEX_HOME", undefined);
   vi.stubEnv("CLAUDE_CONFIG_DIR", undefined);
   vi.stubEnv("KIMI_SHARE_DIR", undefined);
+  vi.stubEnv("PI_HOME", undefined);
   vi.stubEnv("CURSOR_DATA_PATH", undefined);
   vi.stubEnv("XDG_DATA_HOME", undefined);
   vi.stubEnv("LOCALAPPDATA", undefined);
@@ -50,6 +51,7 @@ describe("resolveProviderRoots", () => {
     expectPath(roots.codexRoot).toBe("/home/user/.codex");
     expectPath(roots.claudeRoot).toBe("/home/user/.claude");
     expectPath(roots.kimiRoot).toBe("/home/user/.kimi");
+    expectPath(roots.piRoot).toBe("/home/user/.pi");
   });
 
   it("respects CODEX_HOME override", () => {
@@ -71,6 +73,13 @@ describe("resolveProviderRoots", () => {
     mockedHomedir.mockReturnValue("/home/user");
     const roots = resolveProviderRoots();
     expectPath(roots.kimiRoot).toBe("/custom/kimi");
+  });
+
+  it("respects PI_HOME override", () => {
+    vi.stubEnv("PI_HOME", "/custom/pi");
+    mockedHomedir.mockReturnValue("/home/user");
+    const roots = resolveProviderRoots();
+    expectPath(roots.piRoot).toBe("/custom/pi");
   });
 
   it("computes opencodeRoot from getDataHome", () => {

--- a/packages/core/src/discovery/paths.ts
+++ b/packages/core/src/discovery/paths.ts
@@ -33,6 +33,7 @@ export interface ProviderRoots {
   claudeRoot: string;
   kimiRoot: string;
   opencodeRoot: string;
+  piRoot: string;
 }
 
 export function resolveProviderRoots(): ProviderRoots {
@@ -42,6 +43,7 @@ export function resolveProviderRoots(): ProviderRoots {
     claudeRoot: envPath("CLAUDE_CONFIG_DIR") ?? join(home, ".claude"),
     kimiRoot: envPath("KIMI_SHARE_DIR") ?? join(home, ".kimi"),
     opencodeRoot: join(getDataHome(), "opencode"),
+    piRoot: envPath("PI_HOME") ?? join(home, ".pi"),
   };
 }
 


### PR DESCRIPTION
## Why

Pi sessions should be discoverable and readable in CodeSesh alongside the existing coding agents. Pi tool calls also need user-friendly rendering instead of raw JSON payloads.

## What Changed

* Add a Pi agent adapter, session discovery paths, live scan coverage, tests, and docs/config entries.
* Add Pi logos for the web app and marketing site.
* Add Pi-specific tool display for todo, read, write, edit, agent, subagent result, analyze image, bash, and batch tools.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [ ] API
* [x] Infrastructure

## Notes for Reviewer

* Review Pi JSONL parsing against real Pi session shapes.
* Check the Pi tool rendering in session detail, especially todo updates and edit diffs.
* Validation run locally: core tests, cli tests, web tests, web typecheck, web lint, web build, cli build, and git diff --check.
