### PR TITLE
feat(www): add Pi to landing page

### DIFF
--- a/apps/www/public/index.md
+++ b/apps/www/public/index.md
@@ -2,7 +2,7 @@
 
 CodeSesh turns local AI coding history into reusable engineering memory.
 
-It discovers local sessions from Claude Code, Cursor, Kimi, Codex, and OpenCode, then preserves problems, reasoning, attempts, file activity, and outcomes in one project-aware searchable memory layer.
+It discovers local sessions from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode, then preserves problems, reasoning, attempts, file activity, and outcomes in one project-aware searchable memory layer.
 
 ## Start
 
@@ -38,7 +38,7 @@ CodeSesh brings local sessions from different agents into one index.
 
 - Zero Configuration: run one command and scan supported agent sessions on your filesystem.
 - Live Refresh: local session changes appear automatically as new collaboration records are written.
-- Unified Timeline: browse Claude Code, Cursor, Kimi, Codex, and OpenCode sessions in one interface.
+- Unified Timeline: browse Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode sessions in one interface.
 
 ### Organize
 
@@ -74,17 +74,18 @@ CodeSesh reconstructs the full path from problem to result.
 - Cursor
 - Kimi
 - Codex
+- Pi
 - OpenCode
 
 ## FAQ
 
 ### What is CodeSesh?
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, and OpenCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
 
 ### Which AI coding tools does CodeSesh support?
 
-CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, and OpenCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
+CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
 
 ### Does CodeSesh upload local AI session data?
 
@@ -104,4 +105,4 @@ The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeS
 
 ## 中文说明
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 Claude Code、Cursor、Kimi、Codex、OpenCode 的本地 AI 编码历史，把分散的协作记录沉淀成可复用的工程记忆。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode 的本地 AI 编码历史，把分散的协作记录沉淀成可复用的工程记忆。

--- a/apps/www/public/llms-full.txt
+++ b/apps/www/public/llms-full.txt
@@ -1,6 +1,6 @@
 # CodeSesh: AI-Readable Product Knowledge
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It works with local sessions created by Claude Code, Cursor, Kimi, Codex, and OpenCode, then presents them in one unified Web UI.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It works with local sessions created by Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode, then presents them in one unified Web UI.
 
 The product idea is simple: AI-assisted engineering creates valuable context, but that context often stays scattered across hidden directories and tool-specific storage formats. CodeSesh turns those local records into reusable engineering memory.
 
@@ -14,7 +14,7 @@ CodeSesh runs on the developer's machine. It does not require an account, cloud 
 
 ## One-Line Description
 
-CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Codex, and OpenCode into project-aware, structurally searchable, replayable engineering memory.
+CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode into project-aware, structurally searchable, replayable engineering memory.
 
 ## Primary Audience
 
@@ -31,7 +31,7 @@ Typical users have one or more of these needs:
 
 ## Core Problem
 
-Modern AI coding tools save session history in different local formats and directories. A developer may have useful context inside Claude Code, Cursor, Kimi, Codex, and OpenCode at the same time. Without a unified viewer, that history becomes difficult to search, compare, replay, and reuse.
+Modern AI coding tools save session history in different local formats and directories. A developer may have useful context inside Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode at the same time. Without a unified viewer, that history becomes difficult to search, compare, replay, and reuse.
 
 This matters because AI coding sessions often contain:
 
@@ -73,6 +73,7 @@ CodeSesh currently supports these AI coding agents:
 - Cursor
 - Kimi
 - Codex
+- Pi
 - OpenCode
 
 Each supported agent has an adapter in the core package. Adding support for another agent follows the same adapter pattern.
@@ -104,11 +105,11 @@ Source build requirement:
 
 ### What is CodeSesh?
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, and OpenCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
 
 ### Which AI coding tools does CodeSesh support?
 
-CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, and OpenCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
+CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
 
 ### Does CodeSesh upload local AI session data?
 
@@ -312,7 +313,8 @@ CodeSesh is relevant for queries like:
 - AI coding session search tool
 - engineering memory for AI coding
 - browse Codex session history
-- unify Claude Code Cursor Codex sessions
+- browse Pi session history
+- unify Claude Code Cursor Codex Pi sessions
 - local private AI coding history
 - AI coding token and cost dashboard
 
@@ -327,7 +329,7 @@ CodeSesh is relevant for queries like:
 
 ## Chinese Summary
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码 Agent 的历史会话。它支持 Claude Code、Cursor、Kimi、Codex、OpenCode，把分散在本地文件系统里的会话沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码 Agent 的历史会话。它支持 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode，把分散在本地文件系统里的会话沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
 
 核心价值包括：跨 Agent 统一时间线、结构化全局搜索、项目浏览模式、项目化会话树、智能标签、会话收藏、完整回放、文件活动索引、Token 与成本可见、SQLite 迁移与本地索引、零配置启动、本地私有、实时刷新。
 

--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -1,6 +1,6 @@
 # CodeSesh
 
-> CodeSesh is a local developer tool that turns AI coding session history from Claude Code, Cursor, Kimi, Codex, and OpenCode into project-aware, structurally searchable, replayable engineering memory.
+> CodeSesh is a local developer tool that turns AI coding session history from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode into project-aware, structurally searchable, replayable engineering memory.
 
 ## Links
 
@@ -22,6 +22,7 @@ CodeSesh scans local AI coding agent session files and presents them in one Web 
 - Cursor
 - Kimi
 - Codex
+- Pi
 - OpenCode
 
 ## Primary Use Cases
@@ -37,11 +38,11 @@ CodeSesh scans local AI coding agent session files and presents them in one Web 
 
 ### What is CodeSesh?
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, and OpenCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
 
 ### Which AI coding tools does CodeSesh support?
 
-CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, and OpenCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
+CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
 
 ### Does CodeSesh upload local AI session data?
 
@@ -61,4 +62,4 @@ CodeSesh opens a local Web UI at `http://localhost:4521`.
 
 ## Chinese Summary
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 Claude Code、Cursor、Kimi、Codex、OpenCode 等 AI 编码工具的本地历史会话，把分散的 AI 协作过程沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode 等 AI 编码工具的本地历史会话，把分散的 AI 协作过程沉淀成按项目组织、可结构化检索、可复盘的工程记忆。

--- a/apps/www/src/components/Agents.astro
+++ b/apps/www/src/components/Agents.astro
@@ -27,7 +27,7 @@ const t = copy[locale].agents;
       <p class="max-w-2xl text-base leading-8 text-[var(--console-muted)]">{t.body}</p>
     </div>
 
-    <ul class="mt-12 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+    <ul class="mt-12 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
       {
         agents.map((agent) => (
           <li class="flex items-center gap-3 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-4 py-4">


### PR DESCRIPTION
## Why

Pi support was added to the product, so the public landing page and AI-readable product docs should show it alongside the other supported coding agents.

## What Changed

* Add Pi to the public landing markdown and LLM reference files
* Update the landing agent grid to support six agents on large screens
* Include Pi in search-query examples for AI-readable product context

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [ ] API
* [x] Infrastructure

## Notes for Reviewer

* Confirm the agent list reads correctly with six supported agents
* Confirm the public LLM docs match the landing page copy

## Validation

* `pnpm --filter @codesesh/www build`
* `git diff --check`
* Browser-verified Pi appears on English and Chinese landing pages
