### PR TITLE
feat(resume): add Pi session command

### DIFF
--- a/apps/web/src/lib/build-resume-command.test.ts
+++ b/apps/web/src/lib/build-resume-command.test.ts
@@ -39,6 +39,7 @@ describe("buildResumeCommand", () => {
     ["codex", "codex resume"],
     ["kimi", "kimi -r"],
     ["opencode", "opencode -s"],
+    ["pi", "pi --session"],
   ])("emits the %s resume command", (agentName, prefix) => {
     expect(
       buildResumeCommand({
@@ -109,6 +110,7 @@ describe("buildResumeCommand", () => {
     expect(buildResumeCommand({ agentName: "opencode", sessionId: "abc" })).toBe(
       "opencode -s 'abc'",
     );
+    expect(buildResumeCommand({ agentName: "pi", sessionId: "abc" })).toBe("pi --session 'abc'");
   });
 
   it("falls back to no-cd command when directory is whitespace-only", () => {

--- a/apps/web/src/lib/build-resume-command.ts
+++ b/apps/web/src/lib/build-resume-command.ts
@@ -21,6 +21,7 @@ const RESUME_COMMAND_PREFIX_BY_AGENT = {
   codex: "codex resume",
   kimi: "kimi -r",
   opencode: "opencode -s",
+  pi: "pi --session",
 } as const;
 
 type ResumeAgentKey = keyof typeof RESUME_COMMAND_PREFIX_BY_AGENT;


### PR DESCRIPTION
## Why

Pi sessions can be resumed from the command line with `pi --session {session_id}`, but the session detail copy-resume button did not know that Pi supports a resume command. Users could not copy a ready-to-run Pi resume command from CodeSesh like they can for Claude Code and Codex.

## What Changed

* Add Pi to the shared resume command prefix map as `pi --session`.
* Extend resume command tests to cover Pi with and without a session directory.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [x] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [ ] API
* [ ] Infrastructure

## Notes for Reviewer

Please focus on:

* Whether `pi --session {session_id}` is the correct Pi CLI syntax.
* Whether Pi should use the same worktree-aware `cd {directory} && ...` behavior as the other supported agents.

Validation:

* `pnpm --filter @codesesh/web test -- build-resume-command`
* `pnpm --filter @codesesh/web lint`
* `pnpm --filter @codesesh/web format:check`