### PR TITLE
fix(www): correct landing page SEO/AEO inconsistencies

### DIFF
--- a/apps/www/public/index.md
+++ b/apps/www/public/index.md
@@ -93,7 +93,7 @@ CodeSesh runs on the user's machine and uses a local SQLite index with a local W
 
 ### How do you install and start CodeSesh?
 
-The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 18+; source development uses Node.js 22.12+ and pnpm 10+.
+The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 18+; source development uses Node.js 24 and pnpm 11.5.1.
 
 ## Links
 

--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -50,7 +50,7 @@ CodeSesh runs on the user's machine and uses a local SQLite index with a local W
 
 ### How do you install and start CodeSesh?
 
-The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 18+; source development uses Node.js 22.12+ and pnpm 10+.
+The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 18+; source development uses Node.js 24 and pnpm 11.5.1.
 
 ## Install
 

--- a/apps/www/public/sitemap.xml
+++ b/apps/www/public/sitemap.xml
@@ -2,32 +2,14 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://codesesh.xingkaixin.me/</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://codesesh.xingkaixin.me/zh/</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-06-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://codesesh.xingkaixin.me/index.md</loc>
-    <lastmod>2026-05-13</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://codesesh.xingkaixin.me/llms.txt</loc>
-    <lastmod>2026-05-13</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://codesesh.xingkaixin.me/llms-full.txt</loc>
-    <lastmod>2026-05-13</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
   </url>
 </urlset>

--- a/apps/www/src/components/ProductShowcase.astro
+++ b/apps/www/src/components/ProductShowcase.astro
@@ -43,7 +43,7 @@ const scenes = copy[locale].scenes;
               <div class="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[#f8f8f8]">
                 <img
                   src={scene.image}
-                  alt={`${scene.title} demo`}
+                  alt={scene.description}
                   class="aspect-[1586/992] h-auto w-full object-cover object-top"
                   loading="lazy"
                 />
@@ -121,7 +121,7 @@ const scenes = copy[locale].scenes;
             <div class="mx-auto min-w-[56rem] overflow-hidden rounded-sm border border-[var(--console-border)] bg-white shadow-[0_20px_60px_rgba(15,23,42,0.12)]">
               <img
                 src={scene.image}
-                alt={`${scene.title} enlarged preview`}
+                alt={scene.title}
                 class="h-auto w-full object-cover object-top"
               />
             </div>

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -291,7 +291,7 @@ export const copy = {
         {
           question: "如何安装和启动 CodeSesh？",
           answer:
-            "最快的启动方式是在终端运行 npx codesesh。CodeSesh 会扫描受支持的本地 AI 编码会话，并在 http://localhost:4521 打开 Web UI；如果默认端口被占用，会自动尝试下一个可用端口。发布版需要 Node.js 18+，源码开发环境使用 Node.js 20.19+ 和 pnpm 10+。",
+            "最快的启动方式是在终端运行 npx codesesh。CodeSesh 会扫描受支持的本地 AI 编码会话，并在 http://localhost:4521 打开 Web UI；如果默认端口被占用，会自动尝试下一个可用端口。发布版需要 Node.js 18+，源码开发环境使用 Node.js 24 和 pnpm 11.5.1。",
         },
       ],
     },
@@ -493,7 +493,7 @@ export const copy = {
         {
           question: "How do you install and start CodeSesh?",
           answer:
-            "The fastest way to start CodeSesh is running npx codesesh. CodeSesh scans supported local AI coding sessions and opens the Web UI at http://localhost:4521; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 18+; source development uses Node.js 20.19+ and pnpm 10+.",
+            "The fastest way to start CodeSesh is running npx codesesh. CodeSesh scans supported local AI coding sessions and opens the Web UI at http://localhost:4521; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 18+; source development uses Node.js 24 and pnpm 11.5.1.",
         },
       ],
     },

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -12,6 +12,8 @@ const canonicalUrl = new URL(localeRoutes[locale], siteUrl).toString();
 const englishUrl = new URL(localeRoutes.en, siteUrl).toString();
 const chineseUrl = new URL(localeRoutes.zh, siteUrl).toString();
 const language = locale === "zh" ? "zh-CN" : "en";
+const ogLocale = locale === "zh" ? "zh_CN" : "en_US";
+const ogLocaleAlternate = locale === "zh" ? "en_US" : "zh_CN";
 const featureList = t.features.groups.flatMap((group) => group.items.map((item) => item.title));
 const jsonLd = {
   "@context": "https://schema.org",
@@ -107,6 +109,8 @@ const jsonLd = {
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content={t.meta.title} />
     <meta property="og:site_name" content="CodeSesh" />
+    <meta property="og:locale" content={ogLocale} />
+    <meta property="og:locale:alternate" content={ogLocaleAlternate} />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={t.meta.title} />


### PR DESCRIPTION
## Why

A SEO/AEO audit of `apps/www/` surfaced a real content bug plus a few
metadata gaps. The source-build requirement was stated three different
ways across the page copy and the AI-facing files, so search engines
and AI crawlers would read contradictory install instructions.

## What Changed

* Unify source-build requirement to **Node.js 24 / pnpm 11.5.1** (the
  authoritative value in `README.md`) across `landing.ts`, `llms.txt`,
  and `index.md`. Previously: 20.19+, 22.12+, and pnpm 10+ disagreed.
* Remove non-HTML resources (`.md`/`.txt`) from `sitemap.xml`, keeping
  only the canonical `/` and `/zh/` routes; refresh `lastmod`.
* Add `og:locale` / `og:locale:alternate` for proper multi-language
  Open Graph signals.
* Replace generic showcase image `alt` ("X demo" / "X enlarged
  preview") with content-describing, locale-aware values.

## Impact

* [x] Infrastructure (www landing page / SEO / AEO)

## Notes for Reviewer

* `astro check` + build pass.
* Sitemap kept at the stable `/sitemap.xml` URL (already registered in
  Search Console) rather than switching to `@astrojs/sitemap`'s
  `sitemap-index.xml`, to avoid a needless re-submission for a 2-route
  site.
* Out of scope: `index.md` lists two features ("Project Browse Mode",
  "Claude Code Resume Commands") not shown on the page itself — left
  untouched pending a decision on whether to sync them.