### PR TITLE
refactor(agent): reshape adapter seam for change detection

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -340,8 +340,7 @@ function makeFileSystemAgent(
   agent.getSessionData = vi.fn(() => ({}));
   agent.listSessionSources = overrides.listSessionSources ?? vi.fn(() => []);
   agent.scanSessionSource = overrides.scanSessionSource ?? vi.fn(() => null);
-  agent.getSessionMetaMap =
-    overrides.getSessionMetaMap ?? vi.fn(() => new Map());
+  agent.getSessionMetaMap = overrides.getSessionMetaMap ?? vi.fn(() => new Map());
   agent.setSessionMetaMap = overrides.setSessionMetaMap ?? vi.fn();
   agent.checkForChanges =
     overrides.checkForChanges ??

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -2,7 +2,7 @@ import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SessionHead } from "@codesesh/core";
+import { FileSystemSessionSource, type SessionHead } from "@codesesh/core";
 
 const fsWatch = vi.hoisted(() => ({
   watch: vi.fn(),
@@ -283,11 +283,10 @@ const projectIdentity = {
 };
 
 function makeAgent(name: string, overrides: Record<string, unknown> = {}) {
-  return {
+  const agent: Record<string, unknown> = {
     name,
     displayName: name,
     isAvailable: vi.fn(() => true),
-    scan: vi.fn(() => []),
     getSessionData: vi.fn(() => ({
       id: "session",
       title: "session",
@@ -304,8 +303,51 @@ function makeAgent(name: string, overrides: Record<string, unknown> = {}) {
       messages: [],
     })),
     getSessionMetaMap: vi.fn(() => new Map([["session", { id: "session", sourcePath: "/tmp/s" }]])),
-    ...overrides,
+    setSessionMetaMap: vi.fn(),
+    // Database-style agents detect changes via checkForChanges and rescan via
+    // incrementalScan (which delegates to scan), mirroring DatabaseSessionSource.
+    checkForChanges: vi.fn(() => ({ hasChanges: true, changedIds: [], timestamp: 0 })),
+    incrementalScan: vi.fn(() => agent.scan()),
   };
+  agent.scan = vi.fn(() => []);
+  Object.assign(agent, overrides);
+  return agent;
+}
+
+/**
+ * Builds a mock agent that is a real FileSystemSessionSource instance, so the
+ * live-scan refresh routes it through the source-sync path. Each primitive is
+ * overridable via vi.fn.
+ */
+function makeFileSystemAgent(
+  name: string,
+  overrides: {
+    listSessionSources?: ReturnType<typeof vi.fn>;
+    scanSessionSource?: ReturnType<typeof vi.fn>;
+    getSessionMetaMap?: ReturnType<typeof vi.fn>;
+    setSessionMetaMap?: ReturnType<typeof vi.fn>;
+    checkForChanges?: ReturnType<typeof vi.fn>;
+    incrementalScan?: ReturnType<typeof vi.fn>;
+  } = {},
+) {
+  const agent = Object.create(FileSystemSessionSource.prototype) as InstanceType<
+    typeof FileSystemSessionSource
+  >;
+  Object.defineProperty(agent, "name", { value: name, configurable: true });
+  Object.defineProperty(agent, "displayName", { value: name, configurable: true });
+  agent.isAvailable = vi.fn(() => true);
+  agent.scan = vi.fn(() => []);
+  agent.getSessionData = vi.fn(() => ({}));
+  agent.listSessionSources = overrides.listSessionSources ?? vi.fn(() => []);
+  agent.scanSessionSource = overrides.scanSessionSource ?? vi.fn(() => null);
+  agent.getSessionMetaMap =
+    overrides.getSessionMetaMap ?? vi.fn(() => new Map());
+  agent.setSessionMetaMap = overrides.setSessionMetaMap ?? vi.fn();
+  agent.checkForChanges =
+    overrides.checkForChanges ??
+    vi.fn(() => ({ hasChanges: false, changedIds: [], timestamp: Date.now() }));
+  agent.incrementalScan = overrides.incrementalScan ?? vi.fn((cached: SessionHead[]) => cached);
+  return agent;
 }
 
 describe("LiveScanStore", () => {
@@ -442,10 +484,11 @@ describe("LiveScanStore", () => {
     expect(workerThreads.workers.find((worker) => worker.workerData.jobs)?.workerData.jobs).toEqual(
       [
         expect.objectContaining({
-          kind: "full",
+          kind: "changes",
           context: "scan.refresh",
           agentName: "codex",
-          sessions: [{ ...fresh, project_identity: projectIdentity }],
+          changes: [{ session: { ...fresh, project_identity: projectIdentity }, sortIndex: 0 }],
+          removedSessionIds: ["cached"],
         }),
       ],
     );
@@ -671,7 +714,7 @@ describe("LiveScanStore", () => {
     const scanSessionSource = vi.fn((sourcePath: string) =>
       sourcePath === "/tmp/s" ? updated : added,
     );
-    const codex = makeAgent("codex", {
+    const codex = makeFileSystemAgent("codex", {
       checkForChanges: vi.fn(() => {
         throw new Error("checkForChanges should not run for source-backed agents");
       }),
@@ -759,7 +802,7 @@ describe("LiveScanStore", () => {
       5678,
       "same title",
     ]);
-    const codex = makeAgent("codex", {
+    const codex = makeFileSystemAgent("codex", {
       listSessionSources: vi.fn(() => [
         {
           sessionId: "session",

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -12,6 +12,7 @@ import {
   realFs,
   resolveProviderRoots,
   scanSessions,
+  FileSystemSessionSource,
   type AgentScanProgress,
   type BaseAgent,
   type ScanResult,
@@ -133,9 +134,8 @@ function buildAgentCacheMeta(
   agent: BaseAgent,
   sessionIds?: Set<string>,
 ): Record<string, SessionCacheMeta> {
-  const metaMap = agent.getSessionMetaMap?.();
+  const metaMap = agent.getSessionMetaMap();
   const meta: Record<string, SessionCacheMeta> = {};
-  if (!metaMap) return meta;
 
   for (const [id, data] of metaMap.entries()) {
     if (sessionIds && !sessionIds.has(id)) continue;
@@ -225,7 +225,7 @@ function buildRefreshDiff(
 }
 
 function restoreAgentCacheMeta(agent: BaseAgent, meta: Record<string, SessionCacheMeta>): void {
-  agent.setSessionMetaMap?.(new Map(Object.entries(meta)));
+  agent.setSessionMetaMap(new Map(Object.entries(meta)));
 }
 
 function toAbsolutePath(path: string): string {
@@ -995,13 +995,6 @@ export class LiveScanStore {
     return filterSessions(sessions, { ...this.scanOptions, ...this.startupScanOptions });
   }
 
-  private canSyncSources(agent: BaseAgent): agent is BaseAgent & {
-    listSessionSources: () => SessionSourceRef[];
-    scanSessionSource: (sourcePath: string) => SessionHead | null;
-  } {
-    return Boolean(agent.listSessionSources && agent.scanSessionSource);
-  }
-
   private async refreshInitialIndex(): Promise<void> {
     const startedAt = performance.now();
     const context = "scan.initial.background";
@@ -1347,7 +1340,10 @@ export class LiveScanStore {
       nextSessions = fullScanSessions;
       scanDuration = performance.now() - scanStartedAt;
       this.refreshTimestamps.set(agentName, Date.now());
-    } else if (cached && this.canSyncSources(agent)) {
+    } else if (cached && agent instanceof FileSystemSessionSource) {
+      // File-system agents refresh via precise per-source fingerprint sync.
+      // Database agents lack per-file fingerprints and fall through to the
+      // checkForChanges branch below.
       const scanStartedAt = performance.now();
       const result = await this.scanAgentInWorker(
         agent,
@@ -1360,7 +1356,7 @@ export class LiveScanStore {
         },
       );
       nextSessions = result.sessions;
-      agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
+      agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       preciseChangedIds = result.changedIds ?? [];
       usedIncrementalScan = true;
       persistenceDiff = buildRefreshDiff(
@@ -1377,7 +1373,7 @@ export class LiveScanStore {
           duration_ms: Math.round(performance.now() - startedAt),
         });
       }
-    } else if (refreshBaseline.length > 0 && agent.checkForChanges && agent.incrementalScan) {
+    } else if (refreshBaseline.length > 0) {
       const checkStartedAt = performance.now();
       const checkResult = await Promise.resolve(
         agent.checkForChanges(cacheTimestamp, refreshBaseline),
@@ -1412,7 +1408,7 @@ export class LiveScanStore {
       const scanStartedAt = performance.now();
       const result = await this.scanAgentInWorker(agent, previousSessions, null, {});
       nextSessions = result.sessions;
-      agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
+      agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       fullScanSessions = attachMissingProjectIdentities(nextSessions);
       nextSessions = fullScanSessions;
       scanDuration = performance.now() - scanStartedAt;

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -18,7 +18,6 @@ import {
   type ScanResult,
   type ScanOptions,
   type SessionCacheMeta,
-  type SessionSourceRef,
   type SessionHeadChange,
   type SessionHead,
 } from "@codesesh/core";

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -1,6 +1,7 @@
 import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,
+  FileSystemSessionSource,
   type AgentScanProgress,
   type ScanOptions,
   type SessionCacheMeta,
@@ -36,11 +37,9 @@ interface ScanRefreshWorkerData {
 }
 
 function serializeMeta(agent: {
-  getSessionMetaMap?: () => Map<string, SessionCacheMeta>;
+  getSessionMetaMap: () => Map<string, SessionCacheMeta>;
 }): Record<string, SessionCacheMeta> {
-  const metaMap = agent.getSessionMetaMap?.();
-  if (!metaMap) return {};
-
+  const metaMap = agent.getSessionMetaMap();
   const meta: Record<string, SessionCacheMeta> = {};
   for (const [id, data] of metaMap.entries()) {
     meta[id] = { id, ...(data as Record<string, unknown>) } as SessionCacheMeta;
@@ -61,13 +60,18 @@ function parseSourceFingerprint(fingerprint: string): unknown[] | null {
   }
 }
 
+/**
+ * Compare a live source fingerprint against the cached meta. A direct string
+ * match is the fast path; the fallback tolerates older cache entries written by
+ * a different fingerprint format as long as the underlying mtime (array slot 2)
+ * is unchanged, so a fingerprint-format bump does not force a full rescan.
+ */
 function sourceFingerprintMatches(
   source: SessionSourceRef,
   cachedSession: SessionHead,
   cached: SessionCacheMeta | undefined,
 ): boolean {
-  const cachedFingerprint = sourceFingerprintFromMeta(cached);
-  if (cachedFingerprint === source.fingerprint) return true;
+  if (sourceFingerprintFromMeta(cached) === source.fingerprint) return true;
 
   const current = parseSourceFingerprint(source.fingerprint);
   if (!current || current.length < 5) return false;
@@ -83,25 +87,13 @@ function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string | null {
   return typeof meta?.sourcePath === "string" ? meta.sourcePath : null;
 }
 
-function canSyncSources(agent: unknown): agent is {
-  listSessionSources: () => SessionSourceRef[];
-  scanSessionSource: (sourcePath: string) => SessionHead | null;
-} {
-  return (
-    typeof agent === "object" &&
-    agent !== null &&
-    "listSessionSources" in agent &&
-    "scanSessionSource" in agent &&
-    typeof agent.listSessionSources === "function" &&
-    typeof agent.scanSessionSource === "function"
-  );
-}
-
+/**
+ * Source-level incremental sync, mirroring FileSystemSessionSource.incrementalScan.
+ * Kept standalone because the worker cannot share the agent's live metaMap with
+ * the main thread — it receives cached meta via workerData instead.
+ */
 function syncAgentSources(
-  agent: {
-    listSessionSources: () => SessionSourceRef[];
-    scanSessionSource: (sourcePath: string) => SessionHead | null;
-  },
+  agent: FileSystemSessionSource,
   cachedSessions: SessionHead[],
   cachedMeta: Record<string, SessionCacheMeta>,
 ): { sessions: SessionHead[]; changedIds: string[] } {
@@ -146,9 +138,7 @@ async function run(): Promise<void> {
     throw new Error(`Unknown agent: ${data.agentName}`);
   }
 
-  if (agent.setSessionMetaMap) {
-    agent.setSessionMetaMap(new Map(Object.entries(data.meta)));
-  }
+  agent.setSessionMetaMap(new Map(Object.entries(data.meta)));
 
   const isAvailable = agent.isAvailable();
   let sessions: SessionHead[];
@@ -156,11 +146,11 @@ async function run(): Promise<void> {
 
   if (!isAvailable) {
     sessions = [];
-  } else if (data.sourceSync && canSyncSources(agent)) {
+  } else if (data.sourceSync && agent instanceof FileSystemSessionSource) {
     const result = syncAgentSources(agent, data.previousSessions, data.meta);
     sessions = result.sessions;
     changedIds = result.changedIds;
-  } else if (data.changedIds && agent.incrementalScan) {
+  } else if (data.changedIds) {
     sessions = await Promise.resolve(agent.incrementalScan(data.previousSessions, data.changedIds));
   } else {
     sessions = await Promise.resolve(

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -1,36 +1,278 @@
-import { describe, it, expect } from "vitest";
-import { BaseAgent } from "../base.js";
-import type { SessionHead, SessionData } from "../../types/index.js";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { DatabaseSessionSource, FileSystemSessionSource } from "../base.js";
+import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
+import type { SessionData, SessionHead } from "../../types/index.js";
 
-/** Concrete implementation for testing abstract base */
-class TestAgent extends BaseAgent {
-  readonly name = "test";
-  readonly displayName = "Test Agent";
+interface FakeSource {
+  sessionId: string;
+  sourcePath: string;
+  fingerprint: string;
+  head: SessionHead | null;
+}
 
-  isAvailable() {
+/**
+ * In-memory file-system source for exercising the shared change detection
+ * algorithm without touching the disk. Only the two primitives are faked.
+ */
+class FakeFileSystemSource extends FileSystemSessionSource {
+  readonly name = "fake";
+  readonly displayName = "Fake";
+
+  constructor(private sources: FakeSource[] = []) {
+    super();
+  }
+
+  setSources(sources: FakeSource[]): void {
+    this.sources = sources;
+  }
+
+  isAvailable(): boolean {
     return true;
   }
 
   scan(): SessionHead[] {
-    return [];
+    return this.sources.map((s) => s.head).filter((h): h is SessionHead => h !== null);
   }
 
   getSessionData(_sessionId: string): SessionData {
     return {} as SessionData;
   }
+
+  listSessionSources(): SessionSourceRef[] {
+    return this.sources.map((s) => ({
+      sessionId: s.sessionId,
+      sourcePath: s.sourcePath,
+      fingerprint: s.fingerprint,
+    }));
+  }
+
+  scanSessionSource(sourcePath: string): SessionHead | null {
+    const found = this.sources.find((s) => s.sourcePath === sourcePath);
+    if (!found || !found.head) return null;
+    this.sessionMetaMap.set(found.sessionId, {
+      id: found.sessionId,
+      sourcePath: found.sourcePath,
+      sourceFingerprint: found.fingerprint,
+    });
+    return found.head;
+  }
+}
+
+function makeSession(id: string): SessionHead {
+  return {
+    id,
+    slug: `fake/${id}`,
+    title: id,
+    directory: "/tmp",
+    time_created: 1000,
+    time_updated: 1000,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+function source(id: string, fingerprint = "fp-1", overrides: Partial<FakeSource> = {}): FakeSource {
+  return {
+    sessionId: id,
+    sourcePath: `/tmp/${id}.jsonl`,
+    fingerprint,
+    head: makeSession(id),
+    ...overrides,
+  };
 }
 
 describe("BaseAgent", () => {
   it("getUri returns correct format", () => {
-    const agent = new TestAgent();
-    expect(agent.getUri("abc123")).toBe("test://abc123");
+    const agent = new FakeFileSystemSource();
+    expect(agent.getUri("abc123")).toBe("fake://abc123");
+  });
+});
+
+describe("FileSystemSessionSource.checkForChanges", () => {
+  it("reports no changes when fingerprints and paths match", () => {
+    const agent = new FakeFileSystemSource([source("a"), source("b")]);
+    // Seed metaMap as if a prior scan populated it.
+    agent.scanSessionSource("/tmp/a.jsonl");
+    agent.scanSessionSource("/tmp/b.jsonl");
+
+    const result = agent.checkForChanges(Date.now(), [makeSession("a"), makeSession("b")]);
+    expect(result.hasChanges).toBe(false);
+    expect(result.changedIds).toEqual([]);
   });
 
-  it("optional methods are undefined by default", () => {
-    const agent = new TestAgent();
-    expect(agent.getSessionMetaMap).toBeUndefined();
-    expect(agent.setSessionMetaMap).toBeUndefined();
-    expect(agent.checkForChanges).toBeUndefined();
-    expect(agent.incrementalScan).toBeUndefined();
+  it("detects added sources", () => {
+    const agent = new FakeFileSystemSource([source("a"), source("b")]);
+    agent.scanSessionSource("/tmp/a.jsonl");
+
+    const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
+    expect(result.hasChanges).toBe(true);
+    expect(result.changedIds).toEqual(["b"]);
+  });
+
+  it("detects removed sources", () => {
+    const agent = new FakeFileSystemSource([source("a")]);
+    agent.scanSessionSource("/tmp/a.jsonl");
+
+    const result = agent.checkForChanges(Date.now(), [makeSession("a"), makeSession("ghost")]);
+    expect(result.hasChanges).toBe(true);
+    expect(result.changedIds).toEqual(["ghost"]);
+  });
+
+  it("detects changed fingerprints", () => {
+    const agent = new FakeFileSystemSource([source("a", "fp-2")]);
+    // Cached meta still carries the old fingerprint.
+    agent.getSessionMetaMap().set("a", {
+      id: "a",
+      sourcePath: "/tmp/a.jsonl",
+      sourceFingerprint: "fp-1",
+    });
+
+    const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
+    expect(result.hasChanges).toBe(true);
+    expect(result.changedIds).toEqual(["a"]);
+  });
+
+  it("detects changed source paths even with identical fingerprints", () => {
+    const agent = new FakeFileSystemSource([source("a", "fp-1")]);
+    agent.getSessionMetaMap().set("a", {
+      id: "a",
+      sourcePath: "/tmp/old-a.jsonl",
+      sourceFingerprint: "fp-1",
+    });
+
+    const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
+    expect(result.hasChanges).toBe(true);
+    expect(result.changedIds).toEqual(["a"]);
+  });
+
+  it("treats missing fingerprint as changed", () => {
+    const agent = new FakeFileSystemSource([source("a")]);
+    agent.getSessionMetaMap().set("a", { id: "a", sourcePath: "/tmp/a.jsonl" });
+
+    const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
+    expect(result.hasChanges).toBe(true);
+    expect(result.changedIds).toEqual(["a"]);
+  });
+});
+
+describe("FileSystemSessionSource.incrementalScan", () => {
+  it("re-parses changed sources and merges into cached sessions", () => {
+    const agent = new FakeFileSystemSource([
+      source("a", "fp-1", { head: makeSession("a") }),
+      source("b", "fp-1", { head: makeSession("b") }),
+    ]);
+
+    const updated = agent.incrementalScan([makeSession("a"), makeSession("b")], ["a"]);
+    expect(updated.map((s) => s.id).sort()).toEqual(["a", "b"]);
+    expect(agent.getSessionMetaMap().get("a")?.sourceFingerprint).toBe("fp-1");
+  });
+
+  it("adds new sources when listed but missing from cache", () => {
+    const agent = new FakeFileSystemSource([source("a"), source("b")]);
+    const updated = agent.incrementalScan([makeSession("a")], ["b"]);
+    expect(updated.map((s) => s.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("drops sources that no longer parse", () => {
+    const agent = new FakeFileSystemSource([source("a"), source("b", "fp-1", { head: null })]);
+    const updated = agent.incrementalScan([makeSession("a"), makeSession("b")], ["b"]);
+    expect(updated.map((s) => s.id)).toEqual(["a"]);
+    expect(agent.getSessionMetaMap().has("b")).toBe(false);
+  });
+});
+
+describe("DatabaseSessionSource", () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  function makeDb(): string {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-db-test-"));
+    tempDirs.push(dir);
+    const dbPath = join(dir, "state.vscdb");
+    writeFileSync(dbPath, "init");
+    return dbPath;
+  }
+
+  class FakeDatabaseSource extends DatabaseSessionSource {
+    readonly name = "fakedb";
+    readonly displayName = "Fake DB";
+    scanCount = 0;
+
+    constructor(private dbPath: string | null) {
+      super();
+    }
+
+    isAvailable(): boolean {
+      return true;
+    }
+
+    scan(_options?: AgentScanOptions): SessionHead[] {
+      this.scanCount += 1;
+      return [makeSession("db-1")];
+    }
+
+    getSessionData(_sessionId: string): SessionData {
+      return {} as SessionData;
+    }
+
+    protected getDatabasePath(): string | null {
+      return this.dbPath;
+    }
+  }
+
+  it("flags all sessions as changed when db mtime advances past since", () => {
+    const dbPath = makeDb();
+    const agent = new FakeDatabaseSource(dbPath);
+    const cached = [makeSession("db-1")];
+
+    // since far in the future → no changes
+    const fresh = agent.checkForChanges(Date.now() + 1_000_000, cached);
+    expect(fresh.hasChanges).toBe(false);
+    expect(fresh.changedIds).toEqual([]);
+  });
+
+  it("reports changes when db mtime is newer than since", () => {
+    const dbPath = makeDb();
+    const agent = new FakeDatabaseSource(dbPath);
+    const cached = [makeSession("db-1"), makeSession("db-2")];
+
+    const stale = agent.checkForChanges(0, cached);
+    expect(stale.hasChanges).toBe(true);
+    expect(stale.changedIds).toEqual(["db-1", "db-2"]);
+  });
+
+  it("reports no changes when database path is missing", () => {
+    const agent = new FakeDatabaseSource(null);
+    const result = agent.checkForChanges(0, [makeSession("db-1")]);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("incrementalScan delegates to a full scan", () => {
+    const agent = new FakeDatabaseSource(makeDb());
+    const sessions = agent.incrementalScan([makeSession("stale")], ["stale"]);
+    expect(agent.scanCount).toBe(1);
+    expect(sessions.map((s) => s.id)).toEqual(["db-1"]);
+  });
+
+  it("rememberSession records meta keyed by db path", () => {
+    const agent = new FakeDatabaseSource("/tmp/fake.db") as FakeDatabaseSource & {
+      rememberSession(id: string): void;
+    };
+    agent.rememberSession("db-1");
+    const meta: SessionCacheMeta | undefined = agent.getSessionMetaMap().get("db-1");
+    expect(meta?.sourcePath).toBe("/tmp/fake.db");
   });
 });

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 describe("ClaudeCodeAgent cache refresh", () => {
-  it("detects sessions-index fingerprint changes without recent-session revalidation", () => {
+  it("detects sessions-index changes via fingerprint comparison", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-cache-"));
     tempDirs.push(basePath);
     const projectDir = join(basePath, "project");
@@ -53,32 +53,28 @@ describe("ClaudeCodeAgent cache refresh", () => {
 
     const agent = new ClaudeCodeAgent() as any;
     agent.basePath = basePath;
-    agent.sessionsIndexCache = { project: new Map([["stale", {}]]) };
-    agent.sessionMetaMap = new Map([
-      [
-        "session-1",
-        {
-          id: "session-1",
-          title: "Old",
-          sourcePath: sessionFile,
-          sourceMtimeMs: statSync(sessionFile).mtimeMs,
-          indexPath: indexFile,
-          indexMtimeMs: statSync(indexFile).mtimeMs - 1,
-          headIndexVersion: "claudecode-head-v1",
-          directory: "/tmp/project",
-          model: null,
-          messageCount: 1,
-          createdAt: 1000,
-          updatedAt: 1000,
-        },
-      ],
-    ]);
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("session-1")]);
+    // Seed baseline: a full scan populates metaMap with the source fingerprint.
+    agent.scan();
+    const baselineFingerprint = agent.listSessionSources()[0]?.fingerprint;
+    expect(baselineFingerprint).toBeDefined();
 
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toContain("session-1");
-    expect(agent.sessionsIndexCache.project).toBeUndefined();
+    // No changes yet.
+    const unchanged = agent.checkForChanges(Date.now(), [makeSession("session-1")]);
+    expect(unchanged.hasChanges).toBe(false);
+
+    // Rewrite the index file (bumps its mtime → fingerprint changes).
+    const later = new Date(Date.now() + 2000);
+    writeFileSync(indexFile, JSON.stringify({ entries: [{ sessionId: "session-1" }] }), {
+      flag: "w",
+    });
+    utimesSync(indexFile, later, later);
+
+    const changed = agent.checkForChanges(Date.now(), [makeSession("session-1")]);
+    expect(changed.hasChanges).toBe(true);
+    expect(changed.changedIds).toContain("session-1");
+    // The fingerprint now reflects the new index mtime.
+    expect(agent.listSessionSources()[0]?.fingerprint).not.toBe(baselineFingerprint);
   });
 
   it("parses indexed sessions with assistant tools and tool results", () => {
@@ -302,7 +298,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       total_cache_create_tokens: 5,
       total_cost: 0.00062175,
     });
-    expect(data.messages.filter((message: Message) => message.cost > 0)).toHaveLength(1);
+    expect(data.messages.filter((message: Message) => (message.cost ?? 0) > 0)).toHaveLength(1);
   });
 
   it("filters internal-only sessions", () => {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -82,47 +82,42 @@ describe("CodexAgent cache refresh", () => {
     const sessionsDir = join(codexHome, "sessions");
     mkdirSync(sessionsDir, { recursive: true });
     vi.stubEnv("CODEX_HOME", codexHome);
-    const recentFile = join(
-      sessionsDir,
-      "rollout-2026-04-20T10-00-00-019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa.jsonl",
-    );
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const recentFile = join(sessionsDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
     const indexFile = join(codexHome, "session_index.jsonl");
 
     writeFileSync(
       recentFile,
       '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
     );
-    writeFileSync(
-      indexFile,
-      '{"id":"019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa","thread_name":"Old title"}\n',
-    );
+    writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"Old title"}\n`);
 
     const agent = new CodexAgent() as any;
     agent.basePath = sessionsDir;
-    agent.sessionIndexCache = new Map();
-    agent.sessionMetaMap = new Map([
+    // Seed baseline meta with the live fingerprint.
+    agent.scan();
+    const baselineFingerprint = agent.listSessionSources()[0]?.fingerprint;
+
+    // Append an unrelated index entry (mtime changes, but this session's
+    // title is unchanged → its fingerprint must stay stable).
+    const later = new Date(Date.now() + 2000);
+    writeFileSync(
+      indexFile,
       [
-        "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
-        {
-          id: "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
-          title: "Old title",
-          sourcePath: recentFile,
-          sourceMtimeMs: statSync(recentFile).mtimeMs,
-          indexPath: indexFile,
-          indexMtimeMs: statSync(indexFile).mtimeMs - 1,
-          headIndexVersion: "codex-head-v1",
-          parserVersion: "codex-parser-v3",
-        },
-      ],
-    ]);
-    agent.listRolloutFiles = () => [recentFile];
+        `{"id":"${sessionId}","thread_name":"Old title"}`,
+        '{"id":"019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb","thread_name":"Other title"}',
+        "",
+      ].join("\n"),
+    );
+    utimesSync(indexFile, later, later);
 
     const result = agent.checkForChanges(Date.now(), [
-      makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa", { title: "Old title" }),
+      makeSession(sessionId, { title: "Old title" }),
     ]);
 
     expect(result.hasChanges).toBe(false);
     expect(result.changedIds).toEqual([]);
+    expect(agent.listSessionSources()[0]?.fingerprint).toBe(baselineFingerprint);
   });
 
   it("uses per-session Codex titles in source fingerprints", () => {
@@ -223,21 +218,9 @@ describe("CodexAgent cache refresh", () => {
 
     const agent = new CodexAgent() as any;
     agent.basePath = tempDir;
-    agent.sessionMetaMap = new Map([
-      [
-        "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
-        { id: "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa", sourcePath: oldA },
-      ],
-      [
-        "019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb",
-        {
-          id: "019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb",
-          sourcePath: join(tempDir, "missing.jsonl"),
-        },
-      ],
-    ]);
-    agent.listRolloutFiles = () => [oldA, newC];
-    agent.parseSessionHead = (file: string) => {
+    // Drive the new primitives directly: listSessionSources enumerates the
+    // on-disk files, scanSessionSource parses each head.
+    agent.scanSessionSource = (file: string) => {
       if (file === oldA) return makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa");
       if (file === newC) return makeSession("019dcccc-cccc-7ccc-cccc-cccccccccccc");
       return null;
@@ -248,7 +231,7 @@ describe("CodexAgent cache refresh", () => {
         makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
         makeSession("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb"),
       ],
-      ["019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb"],
+      ["019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb", "019dcccc-cccc-7ccc-cccc-cccccccccccc"],
     );
 
     expect(sessions.map((session: SessionHead) => session.id).sort()).toEqual([

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -68,13 +68,16 @@ describe("KimiAgent cache refresh", () => {
   it("detects added session directories during cache validation", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
     tempDirs.push(basePath);
-    const cachedAt = 2_000;
     createSessionDir(basePath, "old-session", "Old", 1_000);
-    createSessionDir(basePath, "new-session", "New", 1_000);
 
     const agent = createAgent(basePath);
+    // Seed baseline meta so old-session is recognized as known.
+    agent.scan();
 
-    const result = agent.checkForChanges(cachedAt, [makeSession("old-session")]);
+    // A new session appears on disk after the baseline scan.
+    createSessionDir(basePath, "new-session", "New", 1_000);
+
+    const result = agent.checkForChanges(Date.now(), [makeSession("old-session")]);
 
     expect(result.hasChanges).toBe(true);
     expect(result.changedIds).toEqual(["new-session"]);

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,3 +1,4 @@
+import { existsSync, statSync } from "node:fs";
 import type { SessionHead, SessionData, ParseSessionResult } from "../types/index.js";
 
 export type { ParseSessionResult };
@@ -72,29 +73,13 @@ export abstract class BaseAgent {
   /** Load full session data including all messages. */
   abstract getSessionData(sessionId: string): SessionData;
 
-  getUri(sessionId: string): string {
-    return `${this.name}://${sessionId}`;
-  }
-
-  /**
-   * Get session metadata for caching.
-   * Override this to enable caching of session metadata.
-   */
-  getSessionMetaMap?(): Map<string, SessionCacheMeta>;
-
-  /**
-   * Restore session metadata from cache.
-   * Override this to enable restoring cached metadata.
-   */
-  setSessionMetaMap?(meta: Map<string, SessionCacheMeta>): void;
-
   /**
    * 检查是否有变更（用于智能刷新）
    * @param sinceTimestamp 上次缓存时间戳
    * @param cachedSessions 缓存的会话列表
    * @returns 变更检测结果
    */
-  checkForChanges?(
+  abstract checkForChanges(
     sinceTimestamp: number,
     cachedSessions: SessionHead[],
   ): Promise<ChangeCheckResult> | ChangeCheckResult;
@@ -105,12 +90,165 @@ export abstract class BaseAgent {
    * @param changedIds 变更的会话 ID 列表
    * @returns 更新后的会话列表
    */
-  incrementalScan?(
+  abstract incrementalScan(
     cachedSessions: SessionHead[],
     changedIds: string[],
   ): Promise<SessionHead[]> | SessionHead[];
 
-  listSessionSources?(): SessionSourceRef[];
+  /** Get session metadata for caching. */
+  abstract getSessionMetaMap(): Map<string, SessionCacheMeta>;
 
-  scanSessionSource?(sourcePath: string): SessionHead | null;
+  /** Restore session metadata from cache. */
+  abstract setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void;
+
+  getUri(sessionId: string): string {
+    return `${this.name}://${sessionId}`;
+  }
+}
+
+/**
+ * 文件型 Agent 基类：每个会话对应磁盘上一个独立文件/目录。
+ *
+ * 子类只需实现两个文件级原语：
+ *   - listSessionSources(): 枚举所有源 + 计算指纹
+ *   - scanSessionSource(): 解析单个源（同时写入 metaMap）
+ *
+ * 变更检测 / 增量扫描 / metaMap 管理由本基类统一提供：
+ *   checkForChanges 用 listSessionSources 的指纹与缓存 metaMap 比对，
+ *   incrementalScan 对变更集合调用 scanSessionSource 重解析。
+ * 两原语在各子类中复用同一个 sourceFingerprint 计算，故指纹精确比对即等价于变更检测。
+ */
+export abstract class FileSystemSessionSource<
+  TMeta extends SessionCacheMeta = SessionCacheMeta,
+> extends BaseAgent {
+  protected sessionMetaMap = new Map<string, TMeta>();
+
+  /** 枚举所有会话源及其指纹。 */
+  abstract listSessionSources(): SessionSourceRef[];
+
+  /** 解析单个源并写入 metaMap，返回会话 head（解析失败/不可见返回 null）。 */
+  abstract scanSessionSource(sourcePath: string): SessionHead | null;
+
+  getSessionMetaMap(): Map<string, SessionCacheMeta> {
+    return this.sessionMetaMap as Map<string, SessionCacheMeta>;
+  }
+
+  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
+    this.sessionMetaMap = meta as Map<string, TMeta>;
+  }
+
+  /**
+   * 变更检测：枚举当前源 → 与缓存 metaMap 的指纹/路径比对。
+   * 新增、变更、删除三类统一产出 changedIds。
+   */
+  checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
+    const currentRefs = this.listSessionSources();
+    const currentIds = new Set(currentRefs.map((ref) => ref.sessionId));
+    const changedIds = new Set<string>();
+
+    for (const ref of currentRefs) {
+      const meta = this.sessionMetaMap.get(ref.sessionId);
+      const samePath = meta?.sourcePath === ref.sourcePath;
+      const sameFingerprint =
+        typeof meta?.sourceFingerprint === "string" && meta.sourceFingerprint === ref.fingerprint;
+      if (!samePath || !sameFingerprint) changedIds.add(ref.sessionId);
+    }
+
+    for (const session of cachedSessions) {
+      if (!currentIds.has(session.id)) changedIds.add(session.id);
+    }
+
+    const changedIdList = [...changedIds];
+    return {
+      hasChanges: changedIdList.length > 0,
+      changedIds: changedIdList,
+      timestamp: Date.now(),
+    };
+  }
+
+  /**
+   * 增量扫描：对变更/新增源调用 scanSessionSource 重解析，
+   * 删除已消失的源，合并回 cachedSessions。
+   */
+  incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
+    const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
+    const changedSet = new Set(changedIds);
+    const currentIds = new Set<string>();
+
+    for (const ref of this.listSessionSources()) {
+      currentIds.add(ref.sessionId);
+      if (!changedSet.has(ref.sessionId)) continue;
+      const head = this.scanSessionSource(ref.sourcePath);
+      if (head) {
+        sessionMap.set(head.id, head);
+      } else {
+        sessionMap.delete(ref.sessionId);
+        this.sessionMetaMap.delete(ref.sessionId);
+      }
+    }
+
+    // Drop sessions flagged as changed but no longer present on disk.
+    for (const id of changedSet) {
+      if (!currentIds.has(id)) {
+        sessionMap.delete(id);
+        this.sessionMetaMap.delete(id);
+      }
+    }
+
+    return [...sessionMap.values()];
+  }
+}
+
+/**
+ * 数据库型 Agent 基类：所有会话聚合在单个 SQLite 数据库中，
+ * 无法做 per-file 指纹，故变更检测退化为"库文件 mtime 是否推进"，
+ * 增量扫描退化为全量重扫。
+ */
+export abstract class DatabaseSessionSource extends BaseAgent {
+  protected sessionMetaMap = new Map<string, SessionCacheMeta>();
+
+  /** 返回数据库文件路径（供 mtime 检测）。 */
+  protected abstract getDatabasePath(): string | null;
+
+  /** 记录单个会话的缓存 meta（sourcePath = dbPath）。 */
+  protected rememberSession(sessionId: string): void {
+    const dbPath = this.getDatabasePath();
+    if (!dbPath) return;
+    this.sessionMetaMap.set(sessionId, { id: sessionId, sourcePath: dbPath });
+  }
+
+  getSessionMetaMap(): Map<string, SessionCacheMeta> {
+    return this.sessionMetaMap;
+  }
+
+  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
+    this.sessionMetaMap = meta;
+  }
+
+  /**
+   * 变更检测：数据库内部变更难以按行定位，简单起见按库文件 mtime 判定。
+   * 库有变更则标记全部缓存会话刷新。
+   */
+  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
+    const dbPath = this.getDatabasePath();
+    if (!dbPath || !existsSync(dbPath)) {
+      return { hasChanges: false, timestamp: Date.now() };
+    }
+
+    try {
+      const hasChanges = statSync(dbPath).mtimeMs > sinceTimestamp;
+      return {
+        hasChanges,
+        changedIds: hasChanges ? cachedSessions.map((session) => session.id) : [],
+        timestamp: Date.now(),
+      };
+    } catch {
+      return { hasChanges: false, timestamp: Date.now() };
+    }
+  }
+
+  /** 增量扫描：数据库型无法增量，直接全量重扫。 */
+  incrementalScan(_cachedSessions: SessionHead[], _changedIds: string[]): SessionHead[] {
+    return this.scan();
+  }
 }

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import {
-  BaseAgent,
+  FileSystemSessionSource,
   filteredSession,
   getParsedSession,
   matchesScanWindow,
@@ -17,12 +17,7 @@ import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText, cleanParsedMessages } from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import type {
-  AgentScanOptions,
-  ChangeCheckResult,
-  SessionCacheMeta,
-  SessionSourceRef,
-} from "./base.js";
+import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "./base.js";
 
 const HEAD_INDEX_VERSION = "claudecode-head-v2";
 
@@ -85,14 +80,14 @@ function extractClaudeUsage(
   };
 }
 
-export class ClaudeCodeAgent extends BaseAgent {
+export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
   readonly name = "claudecode";
   readonly displayName = "Claude Code";
 
   private basePath: string | null = null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private sessionsIndexCache: Record<string, any> = {};
-  private sessionMetaMap = new Map<string, SessionMeta>();
+  private sessionsIndexMtime: Record<string, number | null> = {};
 
   private findBasePath(): string | null {
     const roots = resolveProviderRoots();
@@ -190,14 +185,6 @@ export class ClaudeCodeAgent extends BaseAgent {
     return head;
   }
 
-  getSessionMetaMap(): Map<string, SessionCacheMeta> {
-    return this.sessionMetaMap;
-  }
-
-  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
-    this.sessionMetaMap = meta as Map<string, SessionMeta>;
-  }
-
   getSessionData(sessionId: string): SessionData {
     const meta = this.sessionMetaMap.get(sessionId);
     if (!meta) {
@@ -271,88 +258,6 @@ export class ClaudeCodeAgent extends BaseAgent {
     };
   }
 
-  /**
-   * 检测文件系统变更
-   * - 已有 session：statSync 检测文件修改（APFS 写文件不更新 dir mtime，必须 file-level）
-   * - 新 session 检测：readdirSync 文件列表比对，比 dir statSync 快 ~10x
-   */
-  checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    if (!this.basePath) {
-      return { hasChanges: false, timestamp: Date.now() };
-    }
-
-    const changedIds = new Set<string>();
-
-    for (const session of cachedSessions) {
-      const meta = this.sessionMetaMap.get(session.id);
-      if (!meta) {
-        changedIds.add(session.id);
-        continue;
-      }
-      try {
-        if (this.hasMetaChanged(meta)) {
-          changedIds.add(session.id);
-          delete this.sessionsIndexCache[basename(dirname(meta.sourcePath))];
-        }
-      } catch {
-        changedIds.add(session.id);
-      }
-    }
-
-    // 用 readdirSync 比对文件列表检测新 session（比 dir statSync 快 ~10x）
-    const cachedIdSet = new Set(cachedSessions.map((s) => s.id));
-    let hasNewFiles = false;
-    try {
-      outer: for (const dir of this.listProjectDirs()) {
-        try {
-          for (const file of this.listJsonlFiles(dir)) {
-            if (!cachedIdSet.has(basename(file, ".jsonl"))) {
-              hasNewFiles = true;
-              delete this.sessionsIndexCache[basename(dir)];
-              break outer;
-            }
-          }
-        } catch {}
-      }
-    } catch {}
-
-    return {
-      hasChanges: changedIds.size > 0 || hasNewFiles,
-      changedIds: Array.from(changedIds),
-      timestamp: Date.now(),
-    };
-  }
-
-  /**
-   * 增量扫描 - 只扫描变更的会话
-   */
-  incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
-    if (!this.basePath) return cachedSessions;
-
-    const sessionMap = new Map(cachedSessions.map((s) => [s.id, s]));
-    const changedSet = new Set(changedIds);
-
-    // 单次遍历：变更的 session 重新解析，新出现的 session 直接添加
-    for (const projectDir of this.listProjectDirs()) {
-      for (const file of this.listJsonlFiles(projectDir)) {
-        try {
-          const sessionId = basename(file, ".jsonl");
-          if (changedSet.has(sessionId) || !sessionMap.has(sessionId)) {
-            const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
-            if (head) {
-              sessionMap.set(head.id, head);
-              this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file, projectDir));
-            }
-          }
-        } catch {
-          // skip malformed files
-        }
-      }
-    }
-
-    return Array.from(sessionMap.values());
-  }
-
   // --- Private helpers ---
 
   private listProjectDirs(): string[] {
@@ -395,15 +300,6 @@ export class ClaudeCodeAgent extends BaseAgent {
     };
   }
 
-  private hasMetaChanged(meta: SessionMeta): boolean {
-    if (meta.headIndexVersion !== HEAD_INDEX_VERSION) return true;
-    if (typeof meta.sourceMtimeMs !== "number") return true;
-    if (statSync(meta.sourcePath).mtimeMs !== meta.sourceMtimeMs) return true;
-
-    const indexPath = meta.indexPath ?? this.getSessionsIndexPath(dirname(meta.sourcePath));
-    return this.getFileMtimeMs(indexPath) !== (meta.indexMtimeMs ?? null);
-  }
-
   private sourceFingerprint(file: string, projectDir: string): string {
     const stat = statSync(file);
     const indexPath = this.getSessionsIndexPath(projectDir);
@@ -429,11 +325,15 @@ export class ClaudeCodeAgent extends BaseAgent {
 
   private loadSessionsIndex(projectDir: string): Map<string, Record<string, unknown>> {
     const cacheKey = basename(projectDir);
-    if (cacheKey in this.sessionsIndexCache) {
+    const indexPath = this.getSessionsIndexPath(projectDir);
+    const mtime = this.getFileMtimeMs(indexPath);
+
+    // Invalidate when the index file mtime advances so long-running processes
+    // pick up title changes without relying on callers to evict manually.
+    if (cacheKey in this.sessionsIndexCache && this.sessionsIndexMtime[cacheKey] === mtime) {
       return this.sessionsIndexCache[cacheKey];
     }
 
-    const indexPath = this.getSessionsIndexPath(projectDir);
     const map = new Map<string, Record<string, unknown>>();
 
     if (existsSync(indexPath)) {
@@ -452,6 +352,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     }
 
     this.sessionsIndexCache[cacheKey] = map;
+    this.sessionsIndexMtime[cacheKey] = mtime;
     return map;
   }
 

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { join, basename } from "node:path";
 import {
-  BaseAgent,
+  FileSystemSessionSource,
   filteredSession,
   getParsedSession,
   matchesScanWindow,
@@ -263,12 +263,7 @@ function extractPatchContent(
 // Session meta
 // ---------------------------------------------------------------------------
 
-import type {
-  AgentScanOptions,
-  ChangeCheckResult,
-  SessionCacheMeta,
-  SessionSourceRef,
-} from "./base.js";
+import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "./base.js";
 
 interface SessionMeta extends SessionCacheMeta {
   id: string;
@@ -290,13 +285,13 @@ interface SessionMeta extends SessionCacheMeta {
 // CodexAgent
 // ---------------------------------------------------------------------------
 
-export class CodexAgent extends BaseAgent {
+export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
   readonly name = "codex";
   readonly displayName = "Codex";
 
   private basePath: string | null = null;
   private sessionIndexCache = new Map<string, string>();
-  private sessionMetaMap = new Map<string, SessionMeta>();
+  private sessionIndexMtime: number | null = null;
 
   // ---- BaseAgent implementation ----
 
@@ -374,114 +369,6 @@ export class CodexAgent extends BaseAgent {
       this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath));
     }
     return head;
-  }
-
-  getSessionMetaMap(): Map<string, SessionCacheMeta> {
-    return this.sessionMetaMap;
-  }
-
-  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
-    this.sessionMetaMap = meta as Map<string, SessionMeta>;
-  }
-
-  /**
-   * 检测文件系统变更
-   */
-  checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    if (!this.basePath) {
-      return { hasChanges: false, timestamp: Date.now() };
-    }
-
-    const currentFiles = this.listRolloutFiles();
-    const currentIds = new Set(currentFiles.map((file) => extractSessionId(file)));
-    const cachedIds = new Set(cachedSessions.map((session) => session.id));
-    const changedIds = new Set<string>();
-
-    for (const session of cachedSessions) {
-      if (!currentIds.has(session.id)) {
-        changedIds.add(session.id);
-        continue;
-      }
-
-      const meta = this.sessionMetaMap.get(session.id);
-      if (!meta) {
-        changedIds.add(session.id);
-        continue;
-      }
-
-      try {
-        if (this.hasMetaChanged(meta)) {
-          changedIds.add(session.id);
-        }
-      } catch {
-        changedIds.add(session.id);
-      }
-    }
-
-    const hasAddedSessions = currentFiles.some((file) => !cachedIds.has(extractSessionId(file)));
-    if (hasAddedSessions || changedIds.size > 0) {
-      this.sessionIndexCache.clear();
-    }
-
-    return {
-      hasChanges: changedIds.size > 0 || hasAddedSessions,
-      changedIds: Array.from(changedIds),
-      timestamp: Date.now(),
-    };
-  }
-
-  /**
-   * 增量扫描
-   */
-  incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
-    if (!this.basePath) return cachedSessions;
-
-    const sessionMap = new Map(cachedSessions.map((s) => [s.id, s]));
-    const changedSet = new Set(changedIds);
-    const currentFiles = this.listRolloutFiles();
-    const currentIds = new Set(currentFiles.map((file) => extractSessionId(file)));
-
-    for (const session of cachedSessions) {
-      if (!currentIds.has(session.id)) {
-        sessionMap.delete(session.id);
-        this.sessionMetaMap.delete(session.id);
-      }
-    }
-
-    // 重新扫描变更的会话
-    for (const file of currentFiles) {
-      try {
-        const sessionId = extractSessionId(file);
-
-        if (changedSet.has(sessionId)) {
-          const head = this.parseSessionHead(file);
-          if (head) {
-            sessionMap.set(head.id, head);
-            this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
-          }
-        }
-      } catch {
-        // skip
-      }
-    }
-
-    // 检查新文件
-    for (const file of currentFiles) {
-      try {
-        const sessionId = extractSessionId(file);
-        if (!sessionMap.has(sessionId)) {
-          const head = this.parseSessionHead(file);
-          if (head) {
-            sessionMap.set(head.id, head);
-            this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
-          }
-        }
-      } catch {
-        // skip
-      }
-    }
-
-    return Array.from(sessionMap.values());
   }
 
   getSessionData(sessionId: string): SessionData {
@@ -691,16 +578,6 @@ export class CodexAgent extends BaseAgent {
     };
   }
 
-  private hasMetaChanged(meta: SessionMeta): boolean {
-    if (meta.headIndexVersion !== HEAD_INDEX_VERSION) return true;
-    if (meta.parserVersion !== PARSER_VERSION) return true;
-    if (typeof meta.sourceMtimeMs !== "number") return true;
-    if (statSync(meta.sourcePath).mtimeMs !== meta.sourceMtimeMs) return true;
-
-    const indexTitle = this.getTitleForSession(meta.id);
-    return indexTitle !== null && indexTitle !== meta.title;
-  }
-
   private sourceFingerprint(file: string): string {
     const stat = statSync(file);
     const sessionId = extractSessionId(file);
@@ -729,10 +606,16 @@ export class CodexAgent extends BaseAgent {
   // ---- Session index ----
 
   private loadSessionIndex(): void {
-    if (this.sessionIndexCache.size > 0) return;
-
     const indexPath = this.getSessionIndexPath();
-    if (!existsSync(indexPath)) return;
+    const mtime = this.getFileMtimeMs(indexPath);
+
+    // Invalidate when the index file mtime advances so long-running processes
+    // pick up title changes without relying on callers to evict manually.
+    if (this.sessionIndexCache.size > 0 && this.sessionIndexMtime === mtime) return;
+
+    this.sessionIndexCache.clear();
+    this.sessionIndexMtime = mtime;
+    if (mtime === null) return;
 
     try {
       const content = readFileSync(indexPath, "utf-8");

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -1,13 +1,13 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, normalize } from "node:path";
 import {
-  BaseAgent,
+  DatabaseSessionSource,
   filteredSession,
   getParsedSession,
   matchesScanWindow,
   parsedSession,
 } from "./base.js";
-import type { AgentScanOptions, SessionCacheMeta, ChangeCheckResult } from "./base.js";
+import type { AgentScanOptions } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { getCursorDataPath } from "../discovery/paths.js";
 import { openDbReadOnly, isSqliteAvailable, type SQLiteDatabase } from "../utils/sqlite.js";
@@ -259,7 +259,7 @@ function convertActionToPart(action: ActionEntry, timestampMs: number): MessageP
 // CursorAgent
 // ---------------------------------------------------------------------------
 
-export class CursorAgent extends BaseAgent {
+export class CursorAgent extends DatabaseSessionSource {
   readonly name = "cursor";
   readonly displayName = "Cursor";
 
@@ -268,8 +268,12 @@ export class CursorAgent extends BaseAgent {
   // Cache composer data from scan so getSessionData can reuse it
   private composerCache = new Map<string, ComposerData>();
 
-  // Session metadata for caching
-  private sessionMetaMap = new Map<string, { id: string; sourcePath: string }>();
+  protected getDatabasePath(): string | null {
+    if (!this.dbPath) {
+      this.dbPath = this.findDbPath();
+    }
+    return this.dbPath;
+  }
 
   private findDbPath(): string | null {
     if (!isSqliteAvailable()) return null;
@@ -533,54 +537,6 @@ export class CursorAgent extends BaseAgent {
     } finally {
       db.close();
     }
-  }
-
-  getSessionMetaMap(): Map<string, SessionCacheMeta> {
-    return this.sessionMetaMap as Map<string, SessionCacheMeta>;
-  }
-
-  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
-    this.sessionMetaMap = meta as Map<string, { id: string; sourcePath: string }>;
-  }
-
-  /**
-   * 检测数据库变更
-   * 对于 SQLite，检测数据库文件修改时间
-   */
-  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    if (!this.dbPath) {
-      this.dbPath = this.findDbPath();
-    }
-    if (!this.dbPath || !existsSync(this.dbPath)) {
-      return { hasChanges: false, timestamp: Date.now() };
-    }
-
-    try {
-      // 检测数据库文件修改时间
-      const stat = statSync(this.dbPath);
-      const hasChanges = stat.mtimeMs > sinceTimestamp;
-
-      // 如果数据库有变更，标记所有缓存会话需要刷新
-      // 因为 SQLite 内部变更检测较复杂，简单起见全部刷新
-      const changedIds = hasChanges ? cachedSessions.map((s) => s.id) : [];
-
-      return {
-        hasChanges,
-        changedIds,
-        timestamp: Date.now(),
-      };
-    } catch {
-      return { hasChanges: false, timestamp: Date.now() };
-    }
-  }
-
-  /**
-   * 增量扫描 - 重新查询数据库
-   */
-  incrementalScan(_cachedSessions: SessionHead[], _changedIds: string[]): SessionHead[] {
-    // 对于 Cursor，直接重新执行完整扫描
-    // 因为 scan() 方法已经做了很好的优化
-    return this.scan();
   }
 
   getSessionData(sessionId: string): SessionData {

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,4 +1,4 @@
-export { BaseAgent } from "./base.js";
+export { BaseAgent, FileSystemSessionSource, DatabaseSessionSource } from "./base.js";
 export { filteredSession, getParsedSession, parsedSession, skippedSession } from "./base.js";
 export type {
   AgentScanProgress,

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import {
-  BaseAgent,
+  FileSystemSessionSource,
   getParsedSession,
   matchesScanWindow,
   parsedSession,
@@ -10,7 +10,6 @@ import {
 } from "./base.js";
 import type {
   AgentScanOptions,
-  ChangeCheckResult,
   ParseSessionResult,
   SessionCacheMeta,
   SessionSourceRef,
@@ -146,12 +145,11 @@ function extractFirstUserTitle(contextFile: string | null, wireFile: string | nu
   return null;
 }
 
-export class KimiAgent extends BaseAgent {
+export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
   readonly name = "kimi";
   readonly displayName = "Kimi-Cli";
 
   private basePath: string | null = null;
-  private sessionMetaMap = new Map<string, SessionMeta>();
   private projectMap = new Map<string, string>();
   private defaultModel: string | null = null;
 
@@ -345,8 +343,6 @@ export class KimiAgent extends BaseAgent {
     for (const dir of this.listSessionDirs()) {
       const meta = getParsedSession(this.parseSessionDirResult(dir));
       if (!meta) continue;
-      meta.sourceFingerprint = this.sourceFingerprint(meta);
-      this.sessionMetaMap.set(meta.id, meta);
       refs.push({
         sessionId: meta.id,
         sourcePath: meta.sourcePath,
@@ -371,102 +367,6 @@ export class KimiAgent extends BaseAgent {
       time_updated: meta.createdAt,
       stats,
     };
-  }
-
-  getSessionMetaMap(): Map<string, SessionCacheMeta> {
-    return this.sessionMetaMap;
-  }
-
-  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
-    this.sessionMetaMap = meta as Map<string, SessionMeta>;
-  }
-
-  /**
-   * 检测文件系统变更
-   */
-  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    const changedIds = new Set<string>();
-    const cachedIds = new Set(cachedSessions.map((session) => session.id));
-    const currentIds = new Set<string>();
-
-    for (const dir of this.listSessionDirs()) {
-      const meta = getParsedSession(this.parseSessionDirResult(dir));
-      if (!meta) continue;
-
-      currentIds.add(meta.id);
-      this.sessionMetaMap.set(meta.id, meta);
-
-      if (!cachedIds.has(meta.id)) {
-        changedIds.add(meta.id);
-        continue;
-      }
-
-      const dataFile = meta.wireFile || meta.contextFile;
-      try {
-        const metaStat = statSync(meta.metaFile);
-        if (metaStat.mtimeMs > sinceTimestamp) {
-          changedIds.add(meta.id);
-          continue;
-        }
-        if (dataFile) {
-          const dataStat = statSync(dataFile);
-          if (dataStat.mtimeMs > sinceTimestamp) {
-            changedIds.add(meta.id);
-          }
-        }
-      } catch {
-        changedIds.add(meta.id);
-      }
-    }
-
-    for (const session of cachedSessions) {
-      if (!currentIds.has(session.id)) changedIds.add(session.id);
-    }
-
-    const changedIdList = Array.from(changedIds);
-    return {
-      hasChanges: changedIdList.length > 0,
-      changedIds: changedIdList,
-      timestamp: Date.now(),
-    };
-  }
-
-  /**
-   * 增量扫描
-   */
-  incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
-    const sessionMap = new Map(cachedSessions.map((s) => [s.id, s]));
-    const changedIdSet = new Set(changedIds);
-
-    for (const id of changedIdSet) {
-      sessionMap.delete(id);
-      this.sessionMetaMap.delete(id);
-    }
-
-    for (const dir of this.listSessionDirs()) {
-      try {
-        const meta = getParsedSession(this.parseSessionDirResult(dir));
-        if (!meta) continue;
-
-        if (changedIdSet.has(meta.id)) {
-          this.sessionMetaMap.set(meta.id, meta);
-          const stats = this.extractStats(meta.sourcePath);
-          sessionMap.set(meta.id, {
-            id: meta.id,
-            slug: `kimi/${meta.id}`,
-            title: meta.title,
-            directory: meta.cwd,
-            time_created: meta.createdAt,
-            time_updated: meta.createdAt,
-            stats,
-          });
-        }
-      } catch {
-        // skip
-      }
-    }
-
-    return Array.from(sessionMap.values());
   }
 
   getSessionData(sessionId: string): SessionData {

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -1,18 +1,12 @@
-import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import {
-  BaseAgent,
+  DatabaseSessionSource,
   filteredSession,
   getParsedSession,
   parsedSession,
   skippedSession,
 } from "./base.js";
-import type {
-  AgentScanOptions,
-  ChangeCheckResult,
-  ParseSessionResult,
-  SessionCacheMeta,
-} from "./base.js";
+import type { AgentScanOptions, ParseSessionResult } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
 import { openDbReadOnly, isSqliteAvailable, type SQLiteDatabase } from "../utils/sqlite.js";
@@ -43,14 +37,18 @@ interface OpenCodeHeadContext {
   messageTitle: string | null;
 }
 
-export class OpenCodeAgent extends BaseAgent {
+export class OpenCodeAgent extends DatabaseSessionSource {
   readonly name = "opencode";
   readonly displayName = "OpenCode";
 
   private dbPath: string | null = null;
 
-  // Session metadata for caching
-  private sessionMetaMap = new Map<string, { id: string; sourcePath: string }>();
+  protected getDatabasePath(): string | null {
+    if (!this.dbPath) {
+      this.dbPath = this.findDbPath();
+    }
+    return this.dbPath;
+  }
 
   private findDbPath(): string | null {
     if (!isSqliteAvailable()) return null;
@@ -197,52 +195,6 @@ export class OpenCodeAgent extends BaseAgent {
         `,
       )
       .all(cutoffTime) as OpenCodePartRow[];
-  }
-
-  getSessionMetaMap(): Map<string, SessionCacheMeta> {
-    return this.sessionMetaMap as Map<string, SessionCacheMeta>;
-  }
-
-  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
-    this.sessionMetaMap = meta as Map<string, { id: string; sourcePath: string }>;
-  }
-
-  /**
-   * 检测数据库变更
-   * 对于 SQLite，检测数据库文件修改时间
-   */
-  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    if (!this.dbPath) {
-      this.dbPath = this.findDbPath();
-    }
-    if (!this.dbPath || !existsSync(this.dbPath)) {
-      return { hasChanges: false, timestamp: Date.now() };
-    }
-
-    try {
-      // 检测数据库文件修改时间
-      const stat = statSync(this.dbPath);
-      const hasChanges = stat.mtimeMs > sinceTimestamp;
-
-      // 如果数据库有变更，标记所有缓存会话需要刷新
-      const changedIds = hasChanges ? cachedSessions.map((s) => s.id) : [];
-
-      return {
-        hasChanges,
-        changedIds,
-        timestamp: Date.now(),
-      };
-    } catch {
-      return { hasChanges: false, timestamp: Date.now() };
-    }
-  }
-
-  /**
-   * 增量扫描 - 重新查询数据库
-   */
-  incrementalScan(_cachedSessions: SessionHead[], _changedIds: string[]): SessionHead[] {
-    // 对于 OpenCode，直接重新执行完整扫描
-    return this.scan();
   }
 
   private parsePartRow(

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
 import {
-  BaseAgent,
+  FileSystemSessionSource,
   filteredSession,
   getParsedSession,
   matchesScanWindow,
@@ -9,7 +9,6 @@ import {
 } from "./base.js";
 import type {
   AgentScanOptions,
-  ChangeCheckResult,
   ParseSessionResult,
   SessionCacheMeta,
   SessionSourceRef,
@@ -146,12 +145,11 @@ function buildCurrentPathEntries(entries: Record<string, unknown>[]): Record<str
   return path.reverse();
 }
 
-export class PiAgent extends BaseAgent {
+export class PiAgent extends FileSystemSessionSource<SessionMeta> {
   readonly name = "pi";
   readonly displayName = "Pi";
 
   private basePath: string | null = null;
-  private sessionMetaMap = new Map<string, SessionMeta>();
 
   private findBasePath(): string | null {
     const roots = resolveProviderRoots();
@@ -207,83 +205,6 @@ export class PiAgent extends BaseAgent {
       this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath));
     }
     return head;
-  }
-
-  getSessionMetaMap(): Map<string, SessionCacheMeta> {
-    return this.sessionMetaMap;
-  }
-
-  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
-    this.sessionMetaMap = meta as Map<string, SessionMeta>;
-  }
-
-  checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    if (!this.basePath) return { hasChanges: false, timestamp: Date.now() };
-
-    const currentFiles = this.listSessionFiles();
-    const currentIds = new Set(currentFiles.map((file) => extractSessionIdFromFilename(file)));
-    const cachedIds = new Set(cachedSessions.map((session) => session.id));
-    const changedIds = new Set<string>();
-
-    for (const session of cachedSessions) {
-      if (!currentIds.has(session.id)) {
-        changedIds.add(session.id);
-        continue;
-      }
-
-      const meta = this.sessionMetaMap.get(session.id);
-      if (!meta) {
-        changedIds.add(session.id);
-        continue;
-      }
-
-      try {
-        if (this.hasMetaChanged(meta)) changedIds.add(session.id);
-      } catch {
-        changedIds.add(session.id);
-      }
-    }
-
-    const hasAddedSessions = currentFiles.some(
-      (file) => !cachedIds.has(extractSessionIdFromFilename(file)),
-    );
-    return {
-      hasChanges: changedIds.size > 0 || hasAddedSessions,
-      changedIds: [...changedIds],
-      timestamp: Date.now(),
-    };
-  }
-
-  incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
-    if (!this.basePath) return cachedSessions;
-
-    const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
-    const changedSet = new Set(changedIds);
-    const currentFiles = this.listSessionFiles();
-    const currentIds = new Set(currentFiles.map((file) => extractSessionIdFromFilename(file)));
-
-    for (const session of cachedSessions) {
-      if (!currentIds.has(session.id)) {
-        sessionMap.delete(session.id);
-        this.sessionMetaMap.delete(session.id);
-      }
-    }
-
-    for (const file of currentFiles) {
-      try {
-        const sessionId = extractSessionIdFromFilename(file);
-        if (!changedSet.has(sessionId) && sessionMap.has(sessionId)) continue;
-        const head = getParsedSession(this.parseSessionHeadResult(file));
-        if (head) {
-          sessionMap.set(head.id, head);
-          this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
-        }
-      } catch {
-        // skip malformed files
-      }
-    }
-
-    return [...sessionMap.values()];
   }
 
   getSessionData(sessionId: string): SessionData {
@@ -353,12 +274,6 @@ export class PiAgent extends BaseAgent {
       createdAt: head.time_created,
       updatedAt: head.time_updated ?? head.time_created,
     };
-  }
-
-  private hasMetaChanged(meta: SessionMeta): boolean {
-    if (meta.headIndexVersion !== HEAD_INDEX_VERSION) return true;
-    if (meta.parserVersion !== PARSER_VERSION) return true;
-    return statSync(meta.sourcePath).mtimeMs !== meta.sourceMtimeMs;
   }
 
   private sourceFingerprint(file: string): string {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -39,6 +39,22 @@ class TestAgent extends BaseAgent {
   getSessionData(): SessionData {
     return {} as SessionData;
   }
+
+  checkForChanges(): ChangeCheckResult {
+    return { hasChanges: false, changedIds: [], timestamp: Date.now() };
+  }
+
+  incrementalScan(cached: SessionHead[]): SessionHead[] {
+    return cached;
+  }
+
+  getSessionMetaMap(): Map<string, SessionCacheMeta> {
+    return new Map();
+  }
+
+  setSessionMetaMap(): void {
+    // no-op
+  }
 }
 
 describe("filterSessions", () => {
@@ -200,14 +216,13 @@ function createTestAgent(overrides: {
       total_cost: 0,
     },
   });
-  agent.getSessionMetaMap = overrides.metaMap ? () => overrides.metaMap! : undefined;
-  agent.setSessionMetaMap = undefined;
-  agent.checkForChanges = overrides.checkForChangesResult
-    ? () => overrides.checkForChangesResult!
-    : undefined;
-  agent.incrementalScan = overrides.incrementalScanResult
-    ? () => overrides.incrementalScanResult!
-    : undefined;
+  agent.getSessionMetaMap = overrides.metaMap ? () => overrides.metaMap! : agent.getSessionMetaMap;
+  if (overrides.checkForChangesResult) {
+    agent.checkForChanges = () => overrides.checkForChangesResult!;
+  }
+  if (overrides.incrementalScanResult) {
+    agent.incrementalScan = () => overrides.incrementalScanResult!;
+  }
   return agent as BaseAgent;
 }
 

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -307,7 +307,6 @@ async function scanAgentSmart(
   const agentStart = performance.now();
   const timing: AgentScanTiming = { total: 0 };
   const useCache = options.useCache ?? true;
-  const canValidateCache = Boolean(agent.checkForChanges && agent.incrementalScan);
 
   // 1. 尝试加载缓存
   if (useCache) {
@@ -317,13 +316,11 @@ async function scanAgentSmart(
 
     if (cached !== null) {
       // 恢复元数据
-      if (agent.setSessionMetaMap) {
-        const metaMap = new Map<string, SessionCacheMeta>();
-        for (const [id, meta] of Object.entries(cached.meta)) {
-          metaMap.set(id, meta);
-        }
-        agent.setSessionMetaMap(metaMap);
+      const metaMap = new Map<string, SessionCacheMeta>();
+      for (const [id, meta] of Object.entries(cached.meta)) {
+        metaMap.set(id, meta);
       }
+      agent.setSessionMetaMap(metaMap);
 
       if (options.cacheOnly) {
         onProgress?.({
@@ -359,68 +356,66 @@ async function scanAgentSmart(
         cachedCount: cached.sessions.length,
       });
 
-      if (canValidateCache) {
-        onProgress?.({ agent: agent.name, phase: "checking" });
+      onProgress?.({ agent: agent.name, phase: "checking" });
 
-        const t1 = performance.now();
-        const checkResult = await Promise.resolve(
-          agent.checkForChanges!(cached.timestamp, cached.sessions),
+      const t1 = performance.now();
+      const checkResult = await Promise.resolve(
+        agent.checkForChanges(cached.timestamp, cached.sessions),
+      );
+      timing.checkChanges = performance.now() - t1;
+
+      if (checkResult.hasChanges) {
+        onProgress?.({
+          agent: agent.name,
+          phase: "incremental",
+          changedCount: checkResult.changedIds?.length,
+        });
+
+        const t2 = performance.now();
+        const updatedSessions = await Promise.resolve(
+          agent.incrementalScan(cached.sessions, checkResult.changedIds || []),
         );
-        timing.checkChanges = performance.now() - t1;
+        timing.scan = performance.now() - t2;
 
-        if (checkResult.hasChanges) {
-          onProgress?.({
-            agent: agent.name,
-            phase: "incremental",
-            changedCount: checkResult.changedIds?.length,
-          });
+        const t3 = performance.now();
+        const sessionsWithIdentity = attachProjectIdentities(updatedSessions);
+        timing.identity = performance.now() - t3;
 
-          const t2 = performance.now();
-          const updatedSessions = await Promise.resolve(
-            agent.incrementalScan!(cached.sessions, checkResult.changedIds || []),
-          );
-          timing.scan = performance.now() - t2;
+        const t4 = performance.now();
+        const tagged =
+          options.includeSmartTags === false
+            ? { sessions: sessionsWithIdentity, changed: false }
+            : await ensureSessionTags(agent, sessionsWithIdentity, options.smartTagWorkerUrl);
+        timing.tags = performance.now() - t4;
 
-          const t3 = performance.now();
-          const sessionsWithIdentity = attachProjectIdentities(updatedSessions);
-          timing.identity = performance.now() - t3;
-
-          const t4 = performance.now();
-          const tagged =
-            options.includeSmartTags === false
-              ? { sessions: sessionsWithIdentity, changed: false }
-              : await ensureSessionTags(agent, sessionsWithIdentity, options.smartTagWorkerUrl);
-          timing.tags = performance.now() - t4;
-
-          if (options.writeCache !== false) {
-            saveCachedSessionDiff(
-              agent,
-              cached.sessions,
-              tagged.sessions,
-              checkResult.changedIds ?? [],
-            );
-          }
-
-          onProgress?.({
-            agent: agent.name,
-            phase: "complete",
-            newCount: tagged.sessions.length,
-          });
-
-          const filtered = filterSessions(tagged.sessions, options);
-          timing.total = performance.now() - agentStart;
-          return {
+        if (options.writeCache !== false) {
+          saveCachedSessionDiff(
             agent,
-            heads: filtered,
-            fromCache: true,
-            refreshed: true,
-            timing,
-            cacheTimestamp: checkResult.timestamp,
-          };
+            cached.sessions,
+            tagged.sessions,
+            checkResult.changedIds ?? [],
+          );
         }
 
-        onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
+        onProgress?.({
+          agent: agent.name,
+          phase: "complete",
+          newCount: tagged.sessions.length,
+        });
+
+        const filtered = filterSessions(tagged.sessions, options);
+        timing.total = performance.now() - agentStart;
+        return {
+          agent,
+          heads: filtered,
+          fromCache: true,
+          refreshed: true,
+          timing,
+          cacheTimestamp: checkResult.timestamp,
+        };
       }
+
+      onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
 
       const t3 = performance.now();
       const cachedWithIdentity = attachProjectIdentities(cached.sessions);


### PR DESCRIPTION
## Why

`BaseAgent` declared six "optional" methods (`getSessionMetaMap`, `setSessionMetaMap`, `checkForChanges`, `incrementalScan`, `listSessionSources`, `scanSessionSource`) that were in fact implemented by every adapter, so the optionality was fictitious — callers were forced into feature detection (`Boolean(agent.checkForChanges && agent.incrementalScan)`, `canSyncSources` type guards, `getSessionMetaMap?.()`). Worse, `checkForChanges` / `incrementalScan` were near line-by-line duplicated across claudecode/codex/kimi/pi, with the only real per-agent variation being *how to enumerate sources* and *how to parse one source* — exactly the two primitives `listSessionSources` and `scanSessionSource` already provide.

Closes CS-1.

## What Changed

- **`FileSystemSessionSource` (new abstract base)** — file-backed agents implement only `listSessionSources()` + `scanSessionSource()`. Change detection (`checkForChanges`) and incremental scan (`incrementalScan`) are shared, driven by the per-source fingerprint each adapter already computes. `getSessionMetaMap` / `setSessionMetaMap` are concrete.
- **`DatabaseSessionSource` (new abstract base)** — consolidates cursor/opencode's identical "db.mtime check + full rescan" into one place.
- **claudecode / codex / kimi / pi** now extend `FileSystemSessionSource` and drop their private `checkForChanges` / `incrementalScan` / `hasMetaChanged` / metaMap plumbing — only the two primitives remain. claudecode's and codex's session-index caches now self-invalidate on index mtime change, replacing the manual `delete sessionsIndexCache[…]` side effects that lived in the deleted methods.
- **kimi's `listSessionSources`** is now a pure enumeration (no longer writes the live metaMap), so the shared `checkForChanges` sees an untampered baseline.
- **`BaseAgent`** declares the four methods as required (no more `?`), removing the fictitious optionality.
- **scanner.ts / live-scan.ts / scan-refresh-worker.ts** drop the feature-detection branches (`canValidateCache`, `canSyncSources`, `?.()` chains, `!` assertions). The worker routes source-sync via `instanceof FileSystemSessionSource`; database agents fall back to their full-rescan `incrementalScan`.

Net: −92 lines, four duplicated change-detection implementations collapsed into one.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [x] API
* [x] Infrastructure

## Notes for Reviewer

- This is a pure internal seam refactor: no public signatures, cache disk format, SQLite schema, or observed behavior change.
- `base.test.ts` now drives the shared `checkForChanges` / `incrementalScan` via an in-memory fake source covering added / changed / removed.
- A few existing agent/live-scan tests were rewritten from white-box (hand-built `SessionMeta` with `sourceMtimeMs`/`headIndexVersion`) to black-box (seed via `scan`/`listSessionSources`, then mutate files), since the internal `hasMetaChanged` comparison is gone — fingerprint comparison is now the contract.
- Full suite: core 207 + cli 60 passing, `oxlint` and `oxfmt` clean.
- Non-goals held: cache format/schema untouched (CS-2), scanner/live-scan orchestration unmerged (CS-3), cursor/opencode full-rescan behavior unchanged.
