### PR TITLE
refactor(scan): converge shared orchestration helpers

### DIFF
--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -4,15 +4,18 @@ import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import {
   createRegisteredAgents,
-  computeIdentity,
   filterSessions,
   getCursorDataPath,
   isAgentCacheInitialized,
   loadCachedSessions,
-  realFs,
   resolveProviderRoots,
   scanSessions,
   FileSystemSessionSource,
+  attachMissingProjectIdentities,
+  buildAgentCacheMeta,
+  computeSessionDiff,
+  sessionSignature,
+  sortSessions,
   type AgentScanProgress,
   type BaseAgent,
   type ScanResult,
@@ -109,115 +112,35 @@ const WRITE_STABILITY_POLL_MS = 100;
 const NEW_SESSION_EVENT_WINDOW_MS = 250;
 const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 
-function sortSessions(sessions: SessionHead[]): SessionHead[] {
-  return [...sessions].sort(
-    (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
-  );
-}
-
-function sessionSignature(session: SessionHead): string {
-  return JSON.stringify([
-    session.title,
-    session.directory,
-    session.time_created,
-    session.time_updated ?? session.time_created,
-    session.stats.message_count,
-    session.stats.total_input_tokens,
-    session.stats.total_output_tokens,
-    session.stats.total_cost,
-    session.stats.total_tokens ?? 0,
-  ]);
-}
-
-function buildAgentCacheMeta(
-  agent: BaseAgent,
-  sessionIds?: Set<string>,
-): Record<string, SessionCacheMeta> {
-  const metaMap = agent.getSessionMetaMap();
-  const meta: Record<string, SessionCacheMeta> = {};
-
-  for (const [id, data] of metaMap.entries()) {
-    if (sessionIds && !sessionIds.has(id)) continue;
-    meta[id] = { id, ...(data as Record<string, unknown>) } as SessionCacheMeta;
-  }
-
-  return meta;
-}
-
-function attachMissingProjectIdentities(sessions: SessionHead[]): SessionHead[] {
-  const identities = new Map<string, ReturnType<typeof computeIdentity>>();
-
-  return sessions.map((session) => {
-    if (session.project_identity) return session;
-
-    const directory = session.directory || "";
-    let identity = identities.get(directory);
-    if (!identity) {
-      identity = computeIdentity(directory, realFs);
-      identities.set(directory, identity);
-    }
-
-    return { ...session, project_identity: identity };
-  });
-}
-
 function buildRefreshDiff(
   agentName: string,
   previousSessions: SessionHead[],
   nextSessions: SessionHead[],
   candidateChangedIds: string[] = [],
 ): SessionRefreshDiff {
-  const previousMap = new Map(previousSessions.map((session) => [session.id, session]));
-  const nextMap = new Map(nextSessions.map((session) => [session.id, session]));
-  const candidateChangedIdSet = new Set(candidateChangedIds);
-  const changedSessions: SessionHeadChange[] = [];
-  const removedSessionIds: string[] = [];
+  const { changes, removedSessionIds, counts } = computeSessionDiff(
+    previousSessions,
+    nextSessions,
+    candidateChangedIds,
+    sessionSignature,
+  );
 
-  let newSessions = 0;
-  let updatedSessions = 0;
-  let removedSessions = 0;
-
-  nextSessions.forEach((session, index) => {
-    const id = session.id;
-    const previous = previousMap.get(id);
-    if (!previous) {
-      newSessions += 1;
-      changedSessions.push({ session, sortIndex: index });
-      return;
-    }
-    const hasSignatureChange = sessionSignature(previous) !== sessionSignature(session);
-    const hasContentChange = candidateChangedIdSet.has(id);
-    if (hasSignatureChange || hasContentChange) {
-      updatedSessions += 1;
-    }
-    if (hasContentChange || hasSignatureChange) {
-      changedSessions.push({ session, sortIndex: index });
-    }
-  });
-
-  for (const id of previousMap.keys()) {
-    if (!nextMap.has(id)) {
-      removedSessions += 1;
-      removedSessionIds.push(id);
-    }
-  }
-
-  if (newSessions === 0 && updatedSessions === 0 && removedSessions === 0) {
-    return { event: null, changedSessions, removedSessionIds };
+  if (counts.new === 0 && counts.updated === 0 && counts.removed === 0) {
+    return { event: null, changedSessions: changes, removedSessionIds };
   }
 
   return {
-    changedSessions,
+    changedSessions: changes,
     removedSessionIds,
     event: {
       type: "sessions-updated",
       changedAgents: [agentName],
-      newSessions,
-      updatedSessions,
-      removedSessions,
+      newSessions: counts.new,
+      updatedSessions: counts.updated,
+      removedSessions: counts.removed,
       totalSessions: nextSessions.length,
       timestamp: Date.now(),
-      changedSessionHeads: changedSessions.map(({ session }) => ({ agentName, session })),
+      changedSessionHeads: changes.map(({ session }) => ({ agentName, session })),
       removedSessionRefs: removedSessionIds.map((sessionId) => ({ agentName, sessionId })),
     },
   };

--- a/packages/core/src/discovery/__tests__/orchestrate.test.ts
+++ b/packages/core/src/discovery/__tests__/orchestrate.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import type { SessionCacheMeta } from "../../agents/base.js";
+import { BaseAgent } from "../../agents/base.js";
+import type { SessionHead } from "../../types/index.js";
+import {
+  attachMissingProjectIdentities,
+  buildAgentCacheMeta,
+  computeSessionDiff,
+  sessionSignature,
+  sortSessions,
+} from "../orchestrate.js";
+
+function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
+  const timeCreated = overrides?.time_created ?? 1000;
+  return {
+    id,
+    slug: `agent/${id}`,
+    title: `Session ${id}`,
+    directory: "/home/user/project",
+    time_created: timeCreated,
+    time_updated: overrides?.time_updated ?? timeCreated,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("attachMissingProjectIdentities", () => {
+  it("leaves sessions that already have an identity untouched", () => {
+    const existing = { kind: "path" as const, displayName: "proj", key: "/p" };
+    const sessions = [makeSession("a", { project_identity: existing })];
+    const result = attachMissingProjectIdentities(sessions);
+    expect(result[0]!.project_identity).toBe(existing);
+  });
+
+  it("computes an identity for sessions missing one", () => {
+    const sessions = [makeSession("a", { directory: "/tmp/my-project" })];
+    const result = attachMissingProjectIdentities(sessions);
+    expect(result[0]!.project_identity).toBeDefined();
+    expect(result[0]!.project_identity?.displayName).toBeTruthy();
+  });
+
+  it("dedupes identity computation by directory", () => {
+    const sessions = [
+      makeSession("a", { directory: "/tmp/shared" }),
+      makeSession("b", { directory: "/tmp/shared" }),
+    ];
+    const result = attachMissingProjectIdentities(sessions);
+    expect(result[0]!.project_identity).toEqual(result[1]!.project_identity);
+  });
+});
+
+describe("buildAgentCacheMeta", () => {
+  class MetaAgent extends BaseAgent {
+    readonly name = "test";
+    readonly displayName = "test";
+    isAvailable() {
+      return true;
+    }
+    scan() {
+      return [];
+    }
+    getSessionData() {
+      return {} as never;
+    }
+    checkForChanges() {
+      return { hasChanges: false, changedIds: [], timestamp: 0 };
+    }
+    incrementalScan(cached: SessionHead[]) {
+      return cached;
+    }
+    getSessionMetaMap() {
+      return new Map<string, SessionCacheMeta>([
+        ["a", { id: "a", sourcePath: "/a" }],
+        ["b", { id: "b", sourcePath: "/b" }],
+      ]);
+    }
+    setSessionMetaMap() {}
+  }
+
+  it("serializes the full meta map", () => {
+    const meta = buildAgentCacheMeta(new MetaAgent());
+    expect(Object.keys(meta).sort()).toEqual(["a", "b"]);
+    expect(meta.a).toMatchObject({ id: "a", sourcePath: "/a" });
+  });
+
+  it("filters to the requested session ids", () => {
+    const meta = buildAgentCacheMeta(new MetaAgent(), new Set(["a"]));
+    expect(Object.keys(meta)).toEqual(["a"]);
+  });
+});
+
+describe("sessionSignature", () => {
+  it("is stable for identical sessions", () => {
+    const session = makeSession("a");
+    expect(sessionSignature(session)).toBe(sessionSignature(session));
+  });
+
+  it("changes when smart_tags_source_updated_at changes", () => {
+    const base = makeSession("a");
+    const retagged = { ...base, smart_tags_source_updated_at: 9999 };
+    expect(sessionSignature(base)).not.toBe(sessionSignature(retagged));
+  });
+
+  it("changes when a stat field changes", () => {
+    const base = makeSession("a");
+    const grown = {
+      ...base,
+      stats: { ...base.stats, message_count: 42 },
+    };
+    expect(sessionSignature(base)).not.toBe(sessionSignature(grown));
+  });
+});
+
+describe("sortSessions", () => {
+  it("sorts newest first by time_updated", () => {
+    const sessions = [
+      makeSession("old", { time_updated: 1000 }),
+      makeSession("new", { time_updated: 5000 }),
+      makeSession("mid", { time_updated: 3000 }),
+    ];
+    const sorted = sortSessions(sessions);
+    expect(sorted.map((s) => s.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("falls back to time_created when time_updated is missing", () => {
+    const sessions = [
+      makeSession("a", { time_created: 2000, time_updated: undefined }),
+      makeSession("b", { time_created: 1000, time_updated: undefined }),
+    ];
+    const sorted = sortSessions(sessions);
+    expect(sorted.map((s) => s.id)).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const sessions = [makeSession("a", { time_updated: 1 }), makeSession("b", { time_updated: 2 })];
+    const original = [...sessions];
+    sortSessions(sessions);
+    expect(sessions.map((s) => s.id)).toEqual(original.map((s) => s.id));
+  });
+});
+
+describe("computeSessionDiff", () => {
+  it("reports no changes when updated equals cached", () => {
+    const sessions = [makeSession("a"), makeSession("b")];
+    const diff = computeSessionDiff(sessions, sessions);
+    expect(diff.changes).toEqual([]);
+    expect(diff.removedSessionIds).toEqual([]);
+    expect(diff.counts).toEqual({ new: 0, updated: 0, removed: 0 });
+  });
+
+  it("detects new sessions", () => {
+    const cached = [makeSession("a")];
+    const updated = [makeSession("a"), makeSession("b")];
+    const diff = computeSessionDiff(cached, updated);
+    expect(diff.counts).toEqual({ new: 1, updated: 0, removed: 0 });
+    expect(diff.changes.map((c) => c.session.id)).toEqual(["b"]);
+    expect(diff.changes[0]!.sortIndex).toBe(1);
+  });
+
+  it("detects removed sessions", () => {
+    const cached = [makeSession("a"), makeSession("b")];
+    const updated = [makeSession("a")];
+    const diff = computeSessionDiff(cached, updated);
+    expect(diff.counts.removed).toBe(1);
+    expect(diff.removedSessionIds).toEqual(["b"]);
+  });
+
+  it("detects signature changes", () => {
+    const cached = [makeSession("a", { title: "old" })];
+    const updated = [makeSession("a", { title: "new" })];
+    const diff = computeSessionDiff(cached, updated);
+    expect(diff.counts).toEqual({ new: 0, updated: 1, removed: 0 });
+  });
+
+  it("treats ids in changedIds as updated regardless of signature", () => {
+    const cached = [makeSession("a")];
+    const updated = [makeSession("a")];
+    const diff = computeSessionDiff(cached, updated, ["a"]);
+    expect(diff.counts.updated).toBe(1);
+    expect(diff.changes.map((c) => c.session.id)).toEqual(["a"]);
+  });
+
+  it("accepts a custom signature function", () => {
+    const cached = [makeSession("a", { slug: "old" })];
+    const updated = [makeSession("a", { slug: "new" })];
+    // Default signature ignores slug, so no change detected.
+    expect(computeSessionDiff(cached, updated).counts.updated).toBe(0);
+    // Custom signature that includes slug detects the change.
+    expect(computeSessionDiff(cached, updated, [], (s) => s.slug).counts.updated).toBe(1);
+  });
+});

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -3,6 +3,13 @@ export type { ProviderRoots } from "./paths.js";
 export { filterSessions, scanSessions, scanSessionsAsync } from "./scanner.js";
 export type { ScanResult, ScanOptions } from "./scanner.js";
 export {
+  attachMissingProjectIdentities,
+  buildAgentCacheMeta,
+  computeSessionDiff,
+  sessionSignature,
+  sortSessions,
+} from "./orchestrate.js";
+export {
   loadCachedSessions,
   loadCachedSessionData,
   isAgentCacheInitialized,

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -1,0 +1,134 @@
+/**
+ * Shared scan-orchestration helpers — pure functions reused by both the CLI
+ * one-shot scanner (scanner.ts) and the live file-watch refresher (live-scan.ts).
+ *
+ * Nothing here touches SQLite, worker threads, or event emission. The two
+ * orchestrators keep their own branch strategies (one-shot vs live refresh);
+ * these helpers only collapse the duplicated identity / meta / signature / diff
+ * plumbing that previously had to be kept in sync by hand.
+ */
+import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
+import type { ProjectIdentity, SessionHead } from "../types/index.js";
+import type { SessionHeadChange } from "./cache.js";
+import { computeIdentity, realFs } from "../projects/index.js";
+
+function createIdentityResolver() {
+  const cache = new Map<string, ProjectIdentity>();
+  return (directory: string | null | undefined) => {
+    const key = directory || "";
+    const cached = cache.get(key);
+    if (cached) return cached;
+    const identity = computeIdentity(directory, realFs);
+    cache.set(key, identity);
+    return identity;
+  };
+}
+
+/** Attach a project identity to sessions that don't already have one. */
+export function attachMissingProjectIdentities(sessions: SessionHead[]): SessionHead[] {
+  const resolveIdentity = createIdentityResolver();
+  return sessions.map((session) => {
+    if (session.project_identity) return session;
+    return { ...session, project_identity: resolveIdentity(session.directory) };
+  });
+}
+
+/** Serialize an agent's session meta map, optionally restricted to a set of ids. */
+export function buildAgentCacheMeta(
+  agent: BaseAgent,
+  sessionIds?: Set<string>,
+): Record<string, SessionCacheMeta> {
+  const metaMap = agent.getSessionMetaMap?.();
+  const meta: Record<string, SessionCacheMeta> = {};
+  if (!metaMap) return meta;
+
+  for (const [id, data] of metaMap.entries()) {
+    if (sessionIds && !sessionIds.has(id)) continue;
+    meta[id] = { id, ...(data as Record<string, unknown>) } as SessionCacheMeta;
+  }
+
+  return meta;
+}
+
+/**
+ * Stable signature for the user-visible fields that define a session's identity.
+ * Used by both orchestrators to decide whether a session "changed". Includes
+ * smart_tags_source_updated_at so that smart-tag reclassification propagates to
+ * the persistence diff even when the underlying message stats are unchanged.
+ */
+export function sessionSignature(session: SessionHead): string {
+  return JSON.stringify([
+    session.title,
+    session.directory,
+    session.time_created,
+    session.time_updated ?? session.time_created,
+    session.stats.message_count,
+    session.stats.total_input_tokens,
+    session.stats.total_output_tokens,
+    session.stats.total_cost,
+    session.stats.total_tokens ?? 0,
+    session.smart_tags_source_updated_at ?? null,
+  ]);
+}
+
+/** Sort sessions by activity time, newest first. */
+export function sortSessions(sessions: SessionHead[]): SessionHead[] {
+  return [...sessions].sort(
+    (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
+  );
+}
+
+export interface SessionDiffResult {
+  changes: SessionHeadChange[];
+  removedSessionIds: string[];
+  counts: { new: number; updated: number; removed: number };
+}
+
+/**
+ * Compute the diff between a cached session set and an updated one.
+ *
+ * `signature` is injected so callers control the equality口径: a session counts
+ * as "changed" if it is new, if its id is in `changedIds`, or if its signature
+ * differs from the cached copy. The algorithm is pure — event assembly and
+ * no-op short-circuiting stay with the caller.
+ */
+export function computeSessionDiff(
+  cachedSessions: SessionHead[],
+  updatedSessions: SessionHead[],
+  changedIds: string[] = [],
+  signature: (session: SessionHead) => string = sessionSignature,
+): SessionDiffResult {
+  const cachedMap = new Map(cachedSessions.map((session) => [session.id, session]));
+  const updatedIds = new Set(updatedSessions.map((session) => session.id));
+  const changedIdSet = new Set(changedIds);
+  const changes: SessionHeadChange[] = [];
+  const removedSessionIds: string[] = [];
+  let newCount = 0;
+  let updatedCount = 0;
+
+  updatedSessions.forEach((session, sortIndex) => {
+    const cached = cachedMap.get(session.id);
+    if (!cached) {
+      newCount += 1;
+      changes.push({ session, sortIndex });
+      return;
+    }
+    const hasSignatureChange = signature(cached) !== signature(session);
+    if (changedIdSet.has(session.id) || hasSignatureChange) {
+      updatedCount += 1;
+      changes.push({ session, sortIndex });
+    }
+  });
+
+  for (const session of cachedSessions) {
+    if (!updatedIds.has(session.id)) {
+      removedSessionIds.push(session.id);
+    }
+  }
+
+  return {
+    changes,
+    removedSessionIds,
+    counts: { new: newCount, updated: updatedCount, removed: removedSessionIds.length },
+  };
+}

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -1,17 +1,22 @@
 import { availableParallelism } from "node:os";
 import { Worker } from "node:worker_threads";
-import type { ProjectIdentity, SessionHead, SmartTag } from "../types/index.js";
+import type { SessionHead, SmartTag } from "../types/index.js";
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import { createRegisteredAgents } from "../agents/index.js";
-import { computeIdentity, filterSessionsByProjectScope, realFs } from "../projects/index.js";
+import { filterSessionsByProjectScope } from "../projects/index.js";
 import { classifySessionTags, getSmartTagSourceTimestamp, perf } from "../utils/index.js";
 import {
   loadCachedSessions,
   markAgentCacheInitialized,
   saveCachedSessionChanges,
   saveCachedSessions,
-  type SessionHeadChange,
 } from "./cache.js";
+import {
+  attachMissingProjectIdentities,
+  buildAgentCacheMeta,
+  computeSessionDiff,
+  sessionSignature,
+} from "./orchestrate.js";
 
 export interface ScanOptions {
   /** Filter to specific agent name(s) */
@@ -53,29 +58,6 @@ export interface ScanProgress {
   cachedCount?: number;
   newCount?: number;
   changedCount?: number;
-}
-
-function createIdentityResolver() {
-  const cache = new Map<string, ProjectIdentity>();
-  return (directory: string | null | undefined) => {
-    const key = directory || "";
-    const cached = cache.get(key);
-    if (cached) return cached;
-    const identity = computeIdentity(directory, realFs);
-    cache.set(key, identity);
-    return identity;
-  };
-}
-
-function attachProjectIdentities(sessions: SessionHead[]): SessionHead[] {
-  const resolveIdentity = createIdentityResolver();
-  return sessions.map((session) => {
-    if (session.project_identity) return session;
-    return {
-      ...session,
-      project_identity: resolveIdentity(session.directory),
-    };
-  });
 }
 
 export function filterSessions(sessions: SessionHead[], options: ScanOptions): SessionHead[] {
@@ -121,56 +103,13 @@ interface SmartTagWorkerResult {
   error?: string;
 }
 
-function buildAgentCacheMeta(agent: BaseAgent): Record<string, SessionCacheMeta> {
-  const metaMap = agent.getSessionMetaMap?.();
-  const meta: Record<string, SessionCacheMeta> = {};
-  if (!metaMap) return meta;
-
-  for (const [id, data] of metaMap.entries()) {
-    meta[id] = { id, ...(data as Record<string, unknown>) } as SessionCacheMeta;
-  }
-
-  return meta;
-}
-
-function sessionCacheValue(session: SessionHead): string {
-  return JSON.stringify(session);
-}
-
-function buildCacheChanges(
-  cachedSessions: SessionHead[],
-  updatedSessions: SessionHead[],
-  changedIds: string[] = [],
-): { changes: SessionHeadChange[]; removedSessionIds: string[] } {
-  const cachedMap = new Map(cachedSessions.map((session) => [session.id, session]));
-  const updatedIds = new Set(updatedSessions.map((session) => session.id));
-  const changedIdSet = new Set(changedIds);
-  const removedSessionIds = cachedSessions
-    .filter((session) => !updatedIds.has(session.id))
-    .map((session) => session.id);
-  const changes: SessionHeadChange[] = [];
-
-  updatedSessions.forEach((session, sortIndex) => {
-    const cached = cachedMap.get(session.id);
-    if (
-      !cached ||
-      changedIdSet.has(session.id) ||
-      (cached !== session && sessionCacheValue(cached) !== sessionCacheValue(session))
-    ) {
-      changes.push({ session, sortIndex });
-    }
-  });
-
-  return { changes, removedSessionIds };
-}
-
 function saveCachedSessionDiff(
   agent: BaseAgent,
   cachedSessions: SessionHead[],
   updatedSessions: SessionHead[],
   changedIds: string[] = [],
 ): void {
-  const diff = buildCacheChanges(cachedSessions, updatedSessions, changedIds);
+  const diff = computeSessionDiff(cachedSessions, updatedSessions, changedIds, sessionSignature);
   saveCachedSessionChanges(
     agent.name,
     diff.changes,
@@ -330,7 +269,7 @@ async function scanAgentSmart(
         });
         onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
         const t3 = performance.now();
-        const cachedWithIdentity = attachProjectIdentities(cached.sessions);
+        const cachedWithIdentity = attachMissingProjectIdentities(cached.sessions);
         timing.identity = performance.now() - t3;
 
         const filtered = filterSessions(cachedWithIdentity, options);
@@ -378,7 +317,7 @@ async function scanAgentSmart(
         timing.scan = performance.now() - t2;
 
         const t3 = performance.now();
-        const sessionsWithIdentity = attachProjectIdentities(updatedSessions);
+        const sessionsWithIdentity = attachMissingProjectIdentities(updatedSessions);
         timing.identity = performance.now() - t3;
 
         const t4 = performance.now();
@@ -418,7 +357,7 @@ async function scanAgentSmart(
       onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
 
       const t3 = performance.now();
-      const cachedWithIdentity = attachProjectIdentities(cached.sessions);
+      const cachedWithIdentity = attachMissingProjectIdentities(cached.sessions);
       timing.identity = performance.now() - t3;
 
       const t4 = performance.now();
@@ -492,7 +431,7 @@ async function scanAgentFull(
     timing.scan = performance.now() - t0;
 
     const t1 = performance.now();
-    const headsWithIdentity = attachProjectIdentities(heads);
+    const headsWithIdentity = attachMissingProjectIdentities(heads);
     timing.identity = performance.now() - t1;
 
     const t2 = performance.now();


### PR DESCRIPTION
## Why

`scanner.ts` (CLI one-shot scan) and `live-scan.ts` (live file-watch refresh) each carried its own copy of the same identity / meta / signature / diff plumbing — five pairs of functions doing the same job. Any fix to diff semantics, identity attachment, or meta serialization had to land in both files in lockstep, and the two copies had already drifted (scanner diffed the whole `SessionHead` JSON; live-scan diffed a 7-field tuple).

Closes CS-3.

## What Changed

Extracted five pure helpers into a new `core/discovery/orchestrate.ts`, consumed by both orchestrators:

| Helper | Replaces | Notes |
|---|---|---|
| `attachMissingProjectIdentities` | `attachProjectIdentities` (scanner) + `attachMissingProjectIdentities` (live-scan) | Semantically identical; "Missing" name kept |
| `buildAgentCacheMeta` | both `buildAgentCacheMeta` | Merged signature: optional `sessionIds` filter + `?.` guard |
| `sessionSignature` | `sessionCacheValue` (whole-obj) + `sessionSignature` (tuple) | 7-field tuple **+ `smart_tags_source_updated_at`** so tag reclassification propagates |
| `sortSessions` | live-scan local | Lifted to core; **scanner still does not sort** (preserves current order) |
| `computeSessionDiff` | `buildCacheChanges` (scanner) + inline loop in `buildRefreshDiff` | Diff core with **injectable signature** callback; returns `{ changes, removedSessionIds, counts }` |

**The orchestrator bodies stay separate.** `scanAgentSmart` (CLI: cacheOnly / smartTags / onProgress / timing / sync persist) and `runRefresh` (live: isInitialized / sourceSync / worker / events / debouncing) have genuinely different branch strategies — merging them would produce a multi-branch monster. The duplication was at the function level, not the flow level, and that is what this PR collapses.

`buildRefreshDiff` is retained in `live-scan.ts` since it assembles the `SessionsUpdatedEvent` (impure, live-scan-only); it now delegates diff computation to `computeSessionDiff`.

`scanner`'s diff moves from whole-object JSON to the tuple signature. The two scanner tests that previously locked the whole-object behavior still pass unchanged because their fixture changes land inside the tuple fields.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [x] API
* [x] Infrastructure

## Notes for Reviewer

- Net: live-scan −113 lines, scanner −87 lines; new `orchestrate.ts` (~140) + 17 unit tests.
- `orchestrate.test.ts` covers all five helpers + `computeSessionDiff` (new/updated/removed/no-op + custom-signature injection).
- Full suite green via `--force` (turbo cache bypassed): core 224 + cli 60 + web 37 + migration + e2e.
- Based on `main`; no overlap with #58/#59 (already merged).
