### PR TITLE
refactor(analytics): sink dashboard aggregation to core

### DIFF
--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -28,8 +28,14 @@ import {
   searchSessions,
   upsertBookmark,
   matchesProjectScope as sessionMatchesProjectScope,
+  buildDashboard,
+  getSessionAgentName,
+  getSessionActivityTime,
+  getTotalTokens,
+  startOfLocalDay,
+  type DashboardData,
+  type DashboardScope,
   type FileActivityKind,
-  type FileActivityResult,
   type ProjectScopeMatcher,
   type SearchMatchType,
   type SearchOptions,
@@ -104,25 +110,6 @@ interface ApiProjectGroup extends ProjectGroup {
   agentStats: ApiProjectAgentStat[];
 }
 
-interface DashboardScope {
-  agent?: string;
-  projectKind?: string;
-  projectKey?: string;
-}
-
-interface DashboardAgentAggregate {
-  sessions: number;
-  messages: number;
-  tokens: number;
-}
-
-interface DashboardRecentCandidate {
-  session: SessionHead;
-  activity: number;
-}
-
-const DASHBOARD_RECENT_LIMIT = 10;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -163,18 +150,6 @@ function parseBookmarkPayload(value: unknown): Omit<BookmarkRecord, "bookmarked_
     time_updated: value.time_updated,
     stats: value.stats,
   };
-}
-
-function getTotalTokens(stats: SessionHead["stats"]): number {
-  return stats.total_tokens ?? stats.total_input_tokens + stats.total_output_tokens;
-}
-
-function getSessionAgentName(session: SessionHead): string {
-  return session.slug.split("/")[0]?.toLowerCase() || "unknown";
-}
-
-function getSessionActivityTime(session: SessionHead): number {
-  return session.time_updated ?? session.time_created;
 }
 
 function parseDateParam(
@@ -785,75 +760,6 @@ export function handleDeleteBookmark(c: Context) {
   }
 }
 
-export interface DashboardAgentStat {
-  name: string;
-  displayName: string;
-  icon: string;
-  sessions: number;
-  messages: number;
-  tokens: number;
-}
-
-export interface DashboardDailyBucket {
-  /** Local YYYY-MM-DD */
-  date: string;
-  sessions: number;
-  messages: number;
-}
-
-export interface DailyTokenBucket {
-  date: string;
-  input: number;
-  output: number;
-  cache_read: number;
-  cache_create: number;
-}
-
-export interface ModelDistributionEntry {
-  model: string;
-  tokens: number;
-  sessions: number;
-}
-
-export interface DashboardTotals {
-  sessions: number;
-  messages: number;
-  tokens: number;
-  cost: number;
-  cost_source?: "recorded" | "estimated";
-  latestActivity?: number;
-}
-
-export interface DashboardRecentSession extends SessionHead {
-  agentName: string;
-}
-
-export interface DashboardData {
-  totals: DashboardTotals;
-  perAgent: DashboardAgentStat[];
-  dailyActivity: DashboardDailyBucket[];
-  dailyTokenActivity: DailyTokenBucket[];
-  modelDistribution: ModelDistributionEntry[];
-  recentSessions: DashboardRecentSession[];
-  recentFileActivities: FileActivityResult[];
-  /** Time window covered by dailyActivity (inclusive, ms) */
-  window: { from?: number; to: number; days?: number };
-}
-
-function toLocalDateKey(ts: number): string {
-  const d = new Date(ts);
-  const year = d.getFullYear();
-  const month = `${d.getMonth() + 1}`.padStart(2, "0");
-  const day = `${d.getDate()}`.padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
-function startOfLocalDay(ts: number): number {
-  const d = new Date(ts);
-  d.setHours(0, 0, 0, 0);
-  return d.getTime();
-}
-
 function resolveDashboardWindow(
   defaults: SessionListDefaults,
   queryDays: string | undefined,
@@ -909,160 +815,19 @@ export function handleGetDashboard(
     projectKey: optionalQueryValue(c.req.query("projectKey")),
   };
 
-  const agentMetrics = new Map<string, DashboardAgentAggregate>();
-  const agentMetricKeyByName = new Map<string, string>();
-  for (const name of Object.keys(scanResult.byAgent)) {
-    if (scope.agent && name.toLowerCase() !== scope.agent) continue;
-    agentMetrics.set(name, { sessions: 0, messages: 0, tokens: 0 });
-    agentMetricKeyByName.set(name.toLowerCase(), name);
-  }
-
   const agentInfo = getAgentInfoMap({});
   const agentInfoMap = new Map(agentInfo.map((a) => [a.name, a]));
 
-  let totalSessions = 0;
-  let totalMessages = 0;
-  let totalTokens = 0;
-  let totalCost = 0;
-  let hasEstimatedCost = false;
-  let latestActivity = 0;
-  const recentCandidates: DashboardRecentCandidate[] = [];
-  const modelAgg = new Map<string, { tokens: number; sessions: number }>();
-
-  // Daily activity buckets — one bucket per local day in [from, to]
-  const dailyMap = new Map<string, DashboardDailyBucket>();
-  const dailyTokenMap = new Map<string, DailyTokenBucket>();
-  if (from != null) {
-    const bucketStart = startOfLocalDay(from);
-    const bucketDays = Math.floor((startOfLocalDay(to) - bucketStart) / 86400000) + 1;
-    for (let i = 0; i < bucketDays; i += 1) {
-      const ts = bucketStart + i * 86400000;
-      const key = toLocalDateKey(ts);
-      dailyMap.set(key, { date: key, sessions: 0, messages: 0 });
-      dailyTokenMap.set(key, { date: key, input: 0, output: 0, cache_read: 0, cache_create: 0 });
-    }
-  }
-
-  for (const session of scanResult.sessions) {
-    const agentName = getSessionAgentName(session);
-    if (scope.agent && agentName !== scope.agent) continue;
-    if (scope.projectKey) {
-      const identity = session.project_identity;
-      if (!identity || identity.key !== scope.projectKey) continue;
-      if (scope.projectKind && identity.kind !== scope.projectKind) continue;
-    }
-
-    const activity = getSessionActivityTime(session);
-    if (from != null && activity < from) continue;
-    if (activity > to) continue;
-
-    const messageCount = session.stats.message_count;
-    const sessionTokens = getTotalTokens(session.stats);
-    totalSessions += 1;
-    totalMessages += messageCount;
-    totalTokens += sessionTokens;
-    totalCost += session.stats.total_cost ?? 0;
-    if (session.stats.cost_source === "estimated") hasEstimatedCost = true;
-    if (activity > latestActivity) latestActivity = activity;
-
-    const metricKey = agentMetricKeyByName.get(agentName);
-    if (metricKey) {
-      const metric = agentMetrics.get(metricKey)!;
-      metric.sessions += 1;
-      metric.messages += messageCount;
-      metric.tokens += sessionTokens;
-    }
-
-    const key = toLocalDateKey(activity);
-    let bucket = dailyMap.get(key);
-    if (!bucket) {
-      bucket = { date: key, sessions: 0, messages: 0 };
-      dailyMap.set(key, bucket);
-    }
-    bucket.sessions += 1;
-    bucket.messages += messageCount;
-
-    let tokenBucket = dailyTokenMap.get(key);
-    if (!tokenBucket) {
-      tokenBucket = { date: key, input: 0, output: 0, cache_read: 0, cache_create: 0 };
-      dailyTokenMap.set(key, tokenBucket);
-    }
-    const cacheRead = session.stats.total_cache_read_tokens ?? 0;
-    const cacheCreate = session.stats.total_cache_create_tokens ?? 0;
-    const pureInput = session.stats.total_input_tokens - cacheRead - cacheCreate;
-    tokenBucket.input += Math.max(0, pureInput);
-    tokenBucket.output += session.stats.total_output_tokens;
-    tokenBucket.cache_read += cacheRead;
-    tokenBucket.cache_create += cacheCreate;
-
-    if (session.model_usage) {
-      for (const [model, tokens] of Object.entries(session.model_usage)) {
-        const entry = modelAgg.get(model);
-        if (entry) {
-          entry.tokens += tokens;
-          entry.sessions += 1;
-        } else {
-          modelAgg.set(model, { tokens, sessions: 1 });
-        }
-      }
-    }
-
-    let recentIndex = recentCandidates.length;
-    for (let i = 0; i < recentCandidates.length; i += 1) {
-      if (activity > recentCandidates[i]!.activity) {
-        recentIndex = i;
-        break;
-      }
-    }
-    if (recentIndex < DASHBOARD_RECENT_LIMIT) {
-      recentCandidates.splice(recentIndex, 0, { session, activity });
-      if (recentCandidates.length > DASHBOARD_RECENT_LIMIT) recentCandidates.pop();
-    }
-  }
-
-  const perAgent: DashboardAgentStat[] = [...agentMetrics.entries()]
-    .map(([name, metrics]) => {
-      const info = agentInfoMap.get(name);
-      return {
-        name,
-        displayName: info?.displayName ?? name,
-        icon: info?.icon ?? "",
-        sessions: metrics.sessions,
-        messages: metrics.messages,
-        tokens: metrics.tokens,
-      };
-    })
-    .filter((item) => item.sessions > 0)
-    .sort((a, b) => b.sessions - a.sessions);
-
-  const dailyActivity = [...dailyMap.values()].sort((a, b) => a.date.localeCompare(b.date));
-  const dailyTokenActivity = [...dailyTokenMap.values()].sort((a, b) =>
-    a.date.localeCompare(b.date),
-  );
-
-  const modelDistribution: ModelDistributionEntry[] = [...modelAgg.entries()]
-    .map(([model, { tokens, sessions: count }]) => ({ model, tokens, sessions: count }))
-    .sort((a, b) => b.tokens - a.tokens);
-
-  const recentSessions: DashboardRecentSession[] = recentCandidates.map(({ session }) => {
-    const agentKey = getSessionAgentName(session);
-    return { ...session, agentName: agentKey };
+  const aggregate = buildDashboard(scanResult.sessions, {
+    byAgentNames: Object.keys(scanResult.byAgent),
+    scope,
+    from,
+    to,
+    agentInfoMap,
   });
 
   const data: DashboardData = {
-    totals: {
-      sessions: totalSessions,
-      messages: totalMessages,
-      tokens: totalTokens,
-      cost: totalCost,
-      cost_source: totalCost > 0 ? (hasEstimatedCost ? "estimated" : "recorded") : undefined,
-      latestActivity: latestActivity || undefined,
-    },
-    perAgent,
-    dailyActivity,
-    dailyTokenActivity,
-    modelDistribution,
-    recentSessions,
+    ...aggregate,
     recentFileActivities: listFileActivity({
       agent: scope.agent,
       projectKey: scope.projectKey,

--- a/packages/core/src/analytics/__tests__/dashboard.test.ts
+++ b/packages/core/src/analytics/__tests__/dashboard.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDashboard,
+  getSessionActivityTime,
+  getSessionAgentName,
+  getTotalTokens,
+  startOfLocalDay,
+  toLocalDateKey,
+} from "../dashboard.js";
+import type { SessionHead } from "../../types/session.js";
+
+function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
+  const timeCreated = overrides?.time_created ?? 1_000_000_000_000;
+  return {
+    id,
+    slug: `claudecode/${id}`,
+    title: id,
+    directory: "/home/user/project",
+    time_created: timeCreated,
+    time_updated: overrides?.time_updated ?? timeCreated,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+function opts(overrides?: Partial<Parameters<typeof buildDashboard>[1]>) {
+  return {
+    byAgentNames: ["claudecode"],
+    scope: {},
+    to: Date.now() + 86400000,
+    ...overrides,
+  };
+}
+
+describe("getTotalTokens / getSessionAgentName / getSessionActivityTime", () => {
+  it("getTotalTokens prefers total_tokens when present", () => {
+    expect(
+      getTotalTokens({ total_tokens: 99, total_input_tokens: 1, total_output_tokens: 2 }),
+    ).toBe(99);
+  });
+
+  it("getTotalTokens falls back to input + output", () => {
+    expect(getTotalTokens({ total_input_tokens: 10, total_output_tokens: 5 })).toBe(15);
+  });
+
+  it("getSessionAgentName extracts agent from slug", () => {
+    expect(getSessionAgentName(makeSession("a", { slug: "codex/abc" }))).toBe("codex");
+    expect(getSessionAgentName({ ...makeSession("x"), slug: "" })).toBe("unknown");
+  });
+
+  it("getSessionActivityTime prefers time_updated", () => {
+    expect(getSessionActivityTime(makeSession("a", { time_created: 100, time_updated: 200 }))).toBe(
+      200,
+    );
+    expect(getSessionActivityTime(makeSession("a", { time_created: 100 }))).toBe(100);
+  });
+});
+
+describe("toLocalDateKey / startOfLocalDay", () => {
+  it("toLocalDateKey formats as YYYY-MM-DD", () => {
+    const key = toLocalDateKey(new Date("2026-03-05T14:30:00").getTime());
+    expect(key).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("startOfLocalDay zeroes the time", () => {
+    const ts = new Date("2026-03-05T14:30:00").getTime();
+    const start = startOfLocalDay(ts);
+    expect(new Date(start).getHours()).toBe(0);
+    expect(new Date(start).getMinutes()).toBe(0);
+  });
+});
+
+describe("buildDashboard", () => {
+  it("aggregates totals across sessions", () => {
+    const result = buildDashboard(
+      [
+        makeSession("a", {
+          stats: {
+            message_count: 3,
+            total_input_tokens: 10,
+            total_output_tokens: 5,
+            total_cost: 0.1,
+          },
+        }),
+        makeSession("b", {
+          stats: {
+            message_count: 2,
+            total_input_tokens: 4,
+            total_output_tokens: 1,
+            total_cost: 0.05,
+            total_tokens: 12,
+          },
+        }),
+      ],
+      opts(),
+    );
+    expect(result.totals.sessions).toBe(2);
+    expect(result.totals.messages).toBe(5);
+    expect(result.totals.tokens).toBe(27);
+    expect(result.totals.cost).toBeCloseTo(0.15);
+    expect(result.totals.cost_source).toBe("recorded");
+  });
+
+  it("marks cost as estimated when any session uses estimated cost", () => {
+    const result = buildDashboard(
+      [
+        makeSession("a", {
+          stats: {
+            message_count: 1,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cost: 0.1,
+          },
+        }),
+        makeSession("b", {
+          stats: {
+            message_count: 1,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cost: 0.2,
+            cost_source: "estimated",
+          },
+        }),
+      ],
+      opts(),
+    );
+    expect(result.totals.cost_source).toBe("estimated");
+  });
+
+  it("tracks latest activity time", () => {
+    const result = buildDashboard(
+      [
+        makeSession("a", { time_created: 1000, time_updated: 1000 }),
+        makeSession("b", { time_created: 500, time_updated: 5000 }),
+      ],
+      opts(),
+    );
+    expect(result.totals.latestActivity).toBe(5000);
+  });
+
+  it("aggregates per-agent metrics", () => {
+    const result = buildDashboard(
+      [
+        makeSession("a", {
+          slug: "claudecode/a",
+          stats: { message_count: 2, total_input_tokens: 5, total_output_tokens: 5, total_cost: 0 },
+        }),
+        makeSession("b", {
+          slug: "claudecode/b",
+          stats: { message_count: 1, total_input_tokens: 3, total_output_tokens: 2, total_cost: 0 },
+        }),
+      ],
+      opts({ byAgentNames: ["claudecode"] }),
+    );
+    expect(result.perAgent).toHaveLength(1);
+    expect(result.perAgent[0]).toMatchObject({ name: "claudecode", sessions: 2, messages: 3 });
+  });
+
+  it("filters by scope.agent", () => {
+    const result = buildDashboard(
+      [makeSession("a", { slug: "claudecode/a" }), makeSession("b", { slug: "codex/b" })],
+      opts({ byAgentNames: ["claudecode", "codex"], scope: { agent: "codex" } }),
+    );
+    expect(result.totals.sessions).toBe(1);
+    expect(result.perAgent.map((p) => p.name)).toEqual(["codex"]);
+  });
+
+  it("filters by projectKey", () => {
+    const result = buildDashboard(
+      [
+        makeSession("a", {
+          project_identity: { kind: "git_remote", key: "proj-a", displayName: "A" },
+        }),
+        makeSession("b", {
+          project_identity: { kind: "git_remote", key: "proj-b", displayName: "B" },
+        }),
+      ],
+      opts({ scope: { projectKey: "proj-a" } }),
+    );
+    expect(result.totals.sessions).toBe(1);
+  });
+
+  it("applies time window (from/to)", () => {
+    const result = buildDashboard(
+      [
+        makeSession("old", { time_created: 1000, time_updated: 1000 }),
+        makeSession("new", { time_created: 9000, time_updated: 9000 }),
+      ],
+      opts({ from: 5000, to: 10000 }),
+    );
+    expect(result.totals.sessions).toBe(1);
+  });
+
+  it("buckets token activity including cache split", () => {
+    const ts = startOfLocalDay(Date.now());
+    const result = buildDashboard(
+      [
+        makeSession("a", {
+          time_created: ts,
+          time_updated: ts,
+          stats: {
+            message_count: 1,
+            total_input_tokens: 100,
+            total_output_tokens: 50,
+            total_cache_read_tokens: 20,
+            total_cache_create_tokens: 10,
+            total_cost: 0,
+          },
+        }),
+      ],
+      opts({ from: ts, to: ts + 86400000 }),
+    );
+    expect(result.dailyTokenActivity.length).toBeGreaterThan(0);
+    const bucket = result.dailyTokenActivity[0]!;
+    expect(bucket.cache_read).toBe(20);
+    expect(bucket.cache_create).toBe(10);
+    // pure input = 100 - 20 - 10 = 70
+    expect(bucket.input).toBe(70);
+    expect(bucket.output).toBe(50);
+  });
+
+  it("aggregates model distribution sorted by tokens desc", () => {
+    const result = buildDashboard(
+      [
+        makeSession("a", { model_usage: { "gpt-4": 100, "gpt-3.5": 50 } }),
+        makeSession("b", { model_usage: { "gpt-4": 200 } }),
+      ],
+      opts(),
+    );
+    expect(result.modelDistribution[0]).toMatchObject({ model: "gpt-4", tokens: 300, sessions: 2 });
+    expect(result.modelDistribution[1]).toMatchObject({
+      model: "gpt-3.5",
+      tokens: 50,
+      sessions: 1,
+    });
+  });
+
+  it("keeps the ten most recent sessions", () => {
+    const sessions = Array.from({ length: 15 }, (_, i) =>
+      makeSession(`s${i}`, { time_created: 1000 + i, time_updated: 1000 + i }),
+    );
+    const result = buildDashboard(sessions, opts());
+    expect(result.recentSessions).toHaveLength(10);
+    // Most recent first (activity desc).
+    expect(result.recentSessions[0]!.id).toBe("s14");
+  });
+
+  it("returns empty aggregates for no sessions", () => {
+    const result = buildDashboard([], opts());
+    expect(result.totals.sessions).toBe(0);
+    expect(result.perAgent).toEqual([]);
+    expect(result.recentSessions).toEqual([]);
+  });
+});

--- a/packages/core/src/analytics/dashboard.ts
+++ b/packages/core/src/analytics/dashboard.ts
@@ -1,0 +1,283 @@
+/**
+ * Dashboard analytics — pure aggregation over SessionHead[] with no HTTP or DB
+ * coupling. The handler parses request params and supplies file-activity; this
+ * module owns the domain math: per-agent metrics, daily buckets, model
+ * distribution, and the recent-sessions window.
+ */
+import type { AgentInfo } from "../types/index.js";
+import type { SessionHead } from "../types/session.js";
+
+export const DASHBOARD_RECENT_LIMIT = 10;
+
+export interface DashboardScope {
+  agent?: string;
+  projectKind?: string;
+  projectKey?: string;
+}
+
+export interface DashboardAgentStat {
+  name: string;
+  displayName: string;
+  icon: string;
+  sessions: number;
+  messages: number;
+  tokens: number;
+}
+
+export interface DashboardDailyBucket {
+  date: string;
+  sessions: number;
+  messages: number;
+}
+
+export interface DailyTokenBucket {
+  date: string;
+  input: number;
+  output: number;
+  cache_read: number;
+  cache_create: number;
+}
+
+export interface ModelDistributionEntry {
+  model: string;
+  tokens: number;
+  sessions: number;
+}
+
+export interface DashboardRecentSession extends SessionHead {
+  agentName: string;
+}
+
+interface DashboardAgentAggregate {
+  sessions: number;
+  messages: number;
+  tokens: number;
+}
+
+interface DashboardRecentCandidate {
+  session: SessionHead;
+  activity: number;
+}
+
+export interface DashboardTotals {
+  sessions: number;
+  messages: number;
+  tokens: number;
+  cost: number;
+  cost_source?: "estimated" | "recorded";
+  latestActivity?: number;
+}
+
+export interface DashboardAggregate {
+  totals: DashboardTotals;
+  perAgent: DashboardAgentStat[];
+  dailyActivity: DashboardDailyBucket[];
+  dailyTokenActivity: DailyTokenBucket[];
+  modelDistribution: ModelDistributionEntry[];
+  recentSessions: DashboardRecentSession[];
+}
+
+export interface DashboardData extends DashboardAggregate {
+  recentFileActivities: unknown[];
+  window: { from?: number; to: number; days?: number };
+}
+
+export interface DashboardOptions {
+  byAgentNames: string[];
+  scope: DashboardScope;
+  from?: number;
+  to: number;
+  agentInfoMap?: Map<string, AgentInfo>;
+}
+
+// --- SessionHead domain helpers (shared with other handlers via re-export) ---
+
+export function getTotalTokens(stats: SessionHead["stats"]): number {
+  return stats.total_tokens ?? stats.total_input_tokens + stats.total_output_tokens;
+}
+
+export function getSessionAgentName(session: SessionHead): string {
+  return session.slug.split("/")[0]?.toLowerCase() || "unknown";
+}
+
+export function getSessionActivityTime(session: SessionHead): number {
+  return session.time_updated ?? session.time_created;
+}
+
+// --- Local-day bucketing helpers ---
+
+export function toLocalDateKey(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
+    d.getDate(),
+  ).padStart(2, "0")}`;
+}
+
+export function startOfLocalDay(ts: number): number {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/**
+ * Aggregate sessions into dashboard metrics, daily buckets, model distribution,
+ * and the recent-sessions window. Pure — no HTTP, no DB.
+ */
+export function buildDashboard(
+  sessions: SessionHead[],
+  options: DashboardOptions,
+): DashboardAggregate {
+  const { byAgentNames, scope, from, to, agentInfoMap } = options;
+
+  const agentMetrics = new Map<string, DashboardAgentAggregate>();
+  const agentMetricKeyByName = new Map<string, string>();
+  for (const name of byAgentNames) {
+    if (scope.agent && name.toLowerCase() !== scope.agent) continue;
+    agentMetrics.set(name, { sessions: 0, messages: 0, tokens: 0 });
+    agentMetricKeyByName.set(name.toLowerCase(), name);
+  }
+
+  let totalSessions = 0;
+  let totalMessages = 0;
+  let totalTokens = 0;
+  let totalCost = 0;
+  let hasEstimatedCost = false;
+  let latestActivity = 0;
+  const recentCandidates: DashboardRecentCandidate[] = [];
+  const modelAgg = new Map<string, { tokens: number; sessions: number }>();
+
+  const dailyMap = new Map<string, DashboardDailyBucket>();
+  const dailyTokenMap = new Map<string, DailyTokenBucket>();
+  if (from != null) {
+    const bucketStart = startOfLocalDay(from);
+    const bucketDays = Math.floor((startOfLocalDay(to) - bucketStart) / 86400000) + 1;
+    for (let i = 0; i < bucketDays; i += 1) {
+      const ts = bucketStart + i * 86400000;
+      const key = toLocalDateKey(ts);
+      dailyMap.set(key, { date: key, sessions: 0, messages: 0 });
+      dailyTokenMap.set(key, { date: key, input: 0, output: 0, cache_read: 0, cache_create: 0 });
+    }
+  }
+
+  for (const session of sessions) {
+    const agentName = getSessionAgentName(session);
+    if (scope.agent && agentName !== scope.agent) continue;
+    if (scope.projectKey) {
+      const identity = session.project_identity;
+      if (!identity || identity.key !== scope.projectKey) continue;
+      if (scope.projectKind && identity.kind !== scope.projectKind) continue;
+    }
+
+    const activity = getSessionActivityTime(session);
+    if (from != null && activity < from) continue;
+    if (activity > to) continue;
+
+    const messageCount = session.stats.message_count;
+    const sessionTokens = getTotalTokens(session.stats);
+    totalSessions += 1;
+    totalMessages += messageCount;
+    totalTokens += sessionTokens;
+    totalCost += session.stats.total_cost ?? 0;
+    if (session.stats.cost_source === "estimated") hasEstimatedCost = true;
+    if (activity > latestActivity) latestActivity = activity;
+
+    const metricKey = agentMetricKeyByName.get(agentName);
+    if (metricKey) {
+      const metric = agentMetrics.get(metricKey)!;
+      metric.sessions += 1;
+      metric.messages += messageCount;
+      metric.tokens += sessionTokens;
+    }
+
+    const key = toLocalDateKey(activity);
+    let bucket = dailyMap.get(key);
+    if (!bucket) {
+      bucket = { date: key, sessions: 0, messages: 0 };
+      dailyMap.set(key, bucket);
+    }
+    bucket.sessions += 1;
+    bucket.messages += messageCount;
+
+    let tokenBucket = dailyTokenMap.get(key);
+    if (!tokenBucket) {
+      tokenBucket = { date: key, input: 0, output: 0, cache_read: 0, cache_create: 0 };
+      dailyTokenMap.set(key, tokenBucket);
+    }
+    const cacheRead = session.stats.total_cache_read_tokens ?? 0;
+    const cacheCreate = session.stats.total_cache_create_tokens ?? 0;
+    const pureInput = session.stats.total_input_tokens - cacheRead - cacheCreate;
+    tokenBucket.input += Math.max(0, pureInput);
+    tokenBucket.output += session.stats.total_output_tokens;
+    tokenBucket.cache_read += cacheRead;
+    tokenBucket.cache_create += cacheCreate;
+
+    if (session.model_usage) {
+      for (const [model, tokens] of Object.entries(session.model_usage)) {
+        const entry = modelAgg.get(model);
+        if (entry) {
+          entry.tokens += tokens;
+          entry.sessions += 1;
+        } else {
+          modelAgg.set(model, { tokens, sessions: 1 });
+        }
+      }
+    }
+
+    let recentIndex = recentCandidates.length;
+    for (let i = 0; i < recentCandidates.length; i += 1) {
+      if (activity > recentCandidates[i]!.activity) {
+        recentIndex = i;
+        break;
+      }
+    }
+    if (recentIndex < DASHBOARD_RECENT_LIMIT) {
+      recentCandidates.splice(recentIndex, 0, { session, activity });
+      if (recentCandidates.length > DASHBOARD_RECENT_LIMIT) recentCandidates.pop();
+    }
+  }
+
+  const perAgent: DashboardAgentStat[] = [...agentMetrics.entries()]
+    .map(([name, metrics]) => {
+      const info = agentInfoMap?.get(name);
+      return {
+        name,
+        displayName: info?.displayName ?? name,
+        icon: info?.icon ?? "",
+        sessions: metrics.sessions,
+        messages: metrics.messages,
+        tokens: metrics.tokens,
+      };
+    })
+    .filter((item) => item.sessions > 0)
+    .sort((a, b) => b.sessions - a.sessions);
+
+  const dailyActivity = [...dailyMap.values()].sort((a, b) => a.date.localeCompare(b.date));
+  const dailyTokenActivity = [...dailyTokenMap.values()].sort((a, b) =>
+    a.date.localeCompare(b.date),
+  );
+
+  const modelDistribution: ModelDistributionEntry[] = [...modelAgg.entries()]
+    .map(([model, { tokens, sessions: count }]) => ({ model, tokens, sessions: count }))
+    .sort((a, b) => b.tokens - a.tokens);
+
+  const recentSessions: DashboardRecentSession[] = recentCandidates.map(({ session }) => {
+    const agentKey = getSessionAgentName(session);
+    return { ...session, agentName: agentKey };
+  });
+
+  return {
+    totals: {
+      sessions: totalSessions,
+      messages: totalMessages,
+      tokens: totalTokens,
+      cost: totalCost,
+      cost_source: totalCost > 0 ? (hasEstimatedCost ? "estimated" : "recorded") : undefined,
+      latestActivity: latestActivity || undefined,
+    },
+    perAgent,
+    dailyActivity,
+    dailyTokenActivity,
+    modelDistribution,
+    recentSessions,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,4 @@ export * from "./projects/index.js";
 export * from "./state/index.js";
 export * from "./utils/index.js";
 export * from "./pricing/index.js";
+export * from "./analytics/dashboard.js";


### PR DESCRIPTION
## Why

`handleGetDashboard` mixed HTTP param parsing with ~130 lines of pure aggregation math: per-agent metrics, daily activity/token buckets, model distribution, and the recent-sessions window. This domain logic was untestable in isolation (locked behind HTTP request setup) and duplicated helper functions that other handlers also used.

Closes CS-5.

## What Changed

Sank the aggregation into a new pure module `core/analytics/dashboard.ts`:

```ts
function buildDashboard(sessions: SessionHead[], options: DashboardOptions): DashboardAggregate
//   → totals + perAgent + dailyActivity + dailyTokenActivity + modelDistribution + recentSessions
```

**Also lifted to core** (previously private to the handler, but used across multiple handlers):
- `getTotalTokens`, `getSessionAgentName`, `getSessionActivityTime` — SessionHead domain helpers
- `toLocalDateKey`, `startOfLocalDay` — local-day bucketing helpers
- All dashboard types (`DashboardData`, `DashboardScope`, `DashboardAgentStat`, etc.)

**The handler now** (~40 lines): parse params → `resolveDashboardWindow` → `buildDashboard` → attach `recentFileActivities` (DB query, stays in handler) + `window` → `c.json`.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [x] API
* [x] Infrastructure

## Notes for Reviewer

- **Response shape unchanged.** The `/api/dashboard` JSON is identical; the frontend (`apps/web`) has its own type declarations and is unaffected.
- **Handler dashboard tests (8+) pass without modification** — they assert the full response structure, confirming behavioral equivalence.
- New `dashboard.test.ts` (17 tests) covers the aggregation in isolation: totals, per-agent, daily/token buckets (incl. cache-split), model distribution sort, recent-sessions window, scope filtering, time-window filtering.
- `handlers.ts`: −249 lines. `analytics/dashboard.ts`: +283 (+259 test).
- Full suite green: core 241 + cli 65 + migration + e2e; `oxlint` and `oxfmt` clean.
- Based on `main`; no overlap with prior PRs.
