### PR TITLE
refactor(web): extract tool-normalize module from SessionDetail (CS-6 PR1)

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -165,7 +165,6 @@ const VIRTUALIZED_MESSAGE_OVERSCAN = 6;
 // Small helpers
 // ---------------------------------------------------------------------------
 
-
 function buildHighlightPattern(query?: string): RegExp | null {
   const normalized = query?.trim();
   if (!normalized) return null;

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -69,9 +69,29 @@ import {
   buildMessageDisplayModels,
   type MessageDisplayModel,
 } from "./session-detail/display-model";
+import { escapeRegExp, parseJsonText } from "./session-detail/utils";
+import {
+  type NormalizedToolState,
+  type ToolDisplayStrategy,
+  type ToolStatus,
+  compactText,
+  extractCommand,
+  formatToolOutput,
+  getOutputOrErrorText,
+  getToolTitle,
+  joinToolText,
+  normalizeEscapedNewlines,
+  normalizeToolLabel,
+  normalizeToolName,
+  parseInputCandidate,
+  toDisplayText,
+  toPlainText,
+  toRecord,
+  toStringValue,
+} from "./session-detail/tool-normalize";
 import { detectLanguageByFilePath } from "./tool-output/language";
 import { ToolOutputRenderer } from "./tool-output/ToolOutputRenderer";
-import type { DiffBlock, DiffLineItem, ToolOutputContent } from "./tool-output/types";
+import type { DiffBlock, DiffLineItem } from "./tool-output/types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -80,28 +100,6 @@ import type { DiffBlock, DiffLineItem, ToolOutputContent } from "./tool-output/t
 interface SessionDetailProps {
   session: SessionData;
   highlightQuery?: string;
-}
-
-type ToolStatus = "running" | "completed" | "error";
-
-interface NormalizedToolState {
-  status: ToolStatus;
-  inputValue: unknown;
-  outputValue: unknown;
-  errorValue: unknown;
-  metadataValue: unknown;
-  inputText: string;
-  command: string;
-}
-
-interface ToolDisplayStrategy {
-  Icon: typeof LoaderCircle;
-  title: string;
-  secondaryText?: string;
-  details: ToolDetailItem[];
-  expandable: boolean;
-  showInputPreview: boolean;
-  outputContent: ToolOutputContent;
 }
 
 type FileChangeKind = "read" | "edit" | "write" | "delete";
@@ -167,9 +165,6 @@ const VIRTUALIZED_MESSAGE_OVERSCAN = 6;
 // Small helpers
 // ---------------------------------------------------------------------------
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 function buildHighlightPattern(query?: string): RegExp | null {
   const normalized = query?.trim();
@@ -202,121 +197,6 @@ function renderHighlightedText(text: string, query?: string) {
 
 function MessageMarkdown({ text, highlightQuery }: { text: string; highlightQuery?: string }) {
   return <MarkdownContent text={text} highlightQuery={highlightQuery} />;
-}
-
-function toDisplayText(value: unknown) {
-  if (value == null) return "";
-
-  if (typeof value === "string") {
-    const text = value.trim();
-    if (!text) return "";
-    try {
-      const parsed = JSON.parse(text) as unknown;
-      return JSON.stringify(parsed, null, 2);
-    } catch {
-      return value;
-    }
-  }
-
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean") {
-      return `${value}`;
-    }
-    if (typeof value === "symbol") {
-      return value.description ? `Symbol(${value.description})` : "Symbol";
-    }
-    if (typeof value === "function") return "[Function]";
-    return "[Unserializable value]";
-  }
-}
-
-function parseInputCandidate(inputValue: unknown) {
-  if (typeof inputValue !== "string") return inputValue;
-  try {
-    return JSON.parse(inputValue) as unknown;
-  } catch {
-    return inputValue;
-  }
-}
-
-function extractToolTextSegments(value: unknown): string[] {
-  if (typeof value === "string") return [value];
-  if (Array.isArray(value)) return value.flatMap((item) => extractToolTextSegments(item));
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    if (typeof record.text === "string") return [record.text];
-    if (record.content !== undefined) return extractToolTextSegments(record.content);
-  }
-  return [];
-}
-
-function stripSystemTag(text: string) {
-  return text
-    .replace(/^<system>/i, "")
-    .replace(/<\/system>$/i, "")
-    .trim();
-}
-
-function joinToolText(value: unknown, includeSystem = true) {
-  const segments = extractToolTextSegments(value)
-    .map((segment) => segment.trim())
-    .filter((segment) => {
-      if (includeSystem) return Boolean(segment);
-      return Boolean(segment) && !/^<system>[\s\S]*<\/system>$/i.test(segment);
-    });
-
-  if (segments.length === 0) return "";
-
-  return segments
-    .map((segment) =>
-      includeSystem && /^<system>[\s\S]*<\/system>$/i.test(segment)
-        ? stripSystemTag(segment)
-        : segment,
-    )
-    .join("\n");
-}
-
-function extractCommand(inputValue: unknown) {
-  const parsed = parseInputCandidate(inputValue);
-  if (parsed && typeof parsed === "object") {
-    const input = parsed as { cmd?: unknown; command?: unknown };
-    if (typeof input.cmd === "string") return input.cmd;
-    if (typeof input.command === "string") return input.command;
-  }
-  return "";
-}
-
-function compactText(value: unknown) {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function toRecord(value: unknown) {
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  return {};
-}
-
-function toPlainText(value: unknown) {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function toStringValue(value: unknown) {
-  return typeof value === "string" ? value : "";
-}
-
-function normalizeToolLabel(part: MessagePart) {
-  if (typeof part.title === "string" && part.title.trim()) {
-    return cleanToolTitle(part.title);
-  }
-  if (typeof part.tool === "string" && part.tool.trim()) return cleanToolTitle(part.tool);
-  return "tool";
-}
-
-function normalizeToolName(part: MessagePart) {
-  return normalizeToolLabel(part).trim().toLowerCase();
 }
 
 function buildToolAnchorId(messageIndex: number, toolIndex: number) {
@@ -602,14 +482,6 @@ function scrollToToolAnchor(anchorId: string, prepareAnchor?: () => void) {
   element.scrollIntoView({ behavior: "smooth", block: "center" });
 }
 
-function parseJsonText<T>(value: string): T | null {
-  try {
-    return JSON.parse(value) as T;
-  } catch {
-    return null;
-  }
-}
-
 function measureSessionDetailWork<T>(id: string, compute: () => T): T {
   if (!isRenderProfilerEnabled()) return compute();
 
@@ -657,35 +529,6 @@ function DeferredInteractiveReceipt({
       <InteractiveReceipt key={session.id} session={session} toc={toc} />
     </RenderProfiler>
   );
-}
-
-function normalizeEscapedNewlines(text: string) {
-  return text.replace(/\\n/g, "\n");
-}
-
-function cleanToolTitle(value: string) {
-  const trimmed = value.trim();
-  if (!trimmed) return "";
-  return trimmed.replace(/^tool:\s*/i, "").replace(/^\.+(?=\w)/, "");
-}
-
-function getToolTitle(tool: MessagePart, fallback = "Tool") {
-  return cleanToolTitle(toPlainText(tool.title)) || toPlainText(tool.tool) || fallback;
-}
-
-function formatToolOutput(value: unknown) {
-  const structuredText = joinToolText(value);
-  const text = structuredText || toDisplayText(value);
-  const normalized = normalizeEscapedNewlines(text);
-  return normalized || "No output captured.";
-}
-
-function getOutputOrErrorText(state: NormalizedToolState) {
-  const outputText = formatToolOutput(state.outputValue);
-  if (outputText !== "No output captured.") return outputText;
-  const errorText = formatToolOutput(state.errorValue);
-  if (errorText !== "No output captured.") return errorText;
-  return "No output captured.";
 }
 
 function extractCodexNodeReplTextOutput(outputText: string) {

--- a/apps/web/src/components/session-detail/tool-normalize.test.ts
+++ b/apps/web/src/components/session-detail/tool-normalize.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import type { MessagePart } from "../../lib/api";
+import {
+  cleanToolTitle,
+  extractCommand,
+  extractToolTextSegments,
+  formatToolOutput,
+  getOutputOrErrorText,
+  getToolTitle,
+  joinToolText,
+  normalizeEscapedNewlines,
+  normalizeToolLabel,
+  normalizeToolName,
+  stripSystemTag,
+  toDisplayText,
+  type NormalizedToolState,
+} from "./tool-normalize";
+import { escapeRegExp, parseInputCandidate, parseJsonText, toRecord } from "./utils";
+
+function part(overrides?: Partial<MessagePart>): MessagePart {
+  return { role: "tool", tool: "Read", title: "Read", ...overrides } as MessagePart;
+}
+
+describe("utils", () => {
+  it("escapeRegExp escapes regex metacharacters", () => {
+    expect(escapeRegExp("a.b*c")).toBe("a\\.b\\*c");
+  });
+
+  it("parseInputCandidate parses JSON strings", () => {
+    expect(parseInputCandidate('{"a":1}')).toEqual({ a: 1 });
+    expect(parseInputCandidate("plain")).toBe("plain");
+    expect(parseInputCandidate(42)).toBe(42);
+  });
+
+  it("parseJsonText returns null on invalid JSON", () => {
+    expect(parseJsonText("{bad}")).toBeNull();
+    expect(parseJsonText('{"ok":true}')).toEqual({ ok: true });
+  });
+
+  it("toRecord coerces non-objects to empty object", () => {
+    expect(toRecord(null)).toEqual({});
+    expect(toRecord([1, 2])).toEqual({});
+    expect(toRecord({ a: 1 })).toEqual({ a: 1 });
+  });
+});
+
+describe("toDisplayText", () => {
+  it("returns empty string for null/undefined", () => {
+    expect(toDisplayText(null)).toBe("");
+    expect(toDisplayText(undefined)).toBe("");
+  });
+
+  it("pretty-prints JSON-looking strings", () => {
+    expect(toDisplayText('{"b":2,"a":1}')).toBe('{\n  "b": 2,\n  "a": 1\n}');
+  });
+
+  it("serializes objects", () => {
+    expect(toDisplayText({ x: 1 })).toBe('{\n  "x": 1\n}');
+  });
+});
+
+describe("joinToolText / extractToolTextSegments / stripSystemTag", () => {
+  it("extracts text segments recursively", () => {
+    expect(extractToolTextSegments("hello")).toEqual(["hello"]);
+    expect(extractToolTextSegments([{ text: "a" }, { text: "b" }])).toEqual(["a", "b"]);
+    expect(extractToolTextSegments({ content: "nested" })).toEqual(["nested"]);
+  });
+
+  it("joinToolText joins segments", () => {
+    expect(joinToolText([{ text: "a" }, { text: "b" }])).toBe("a\nb");
+  });
+
+  it("joinToolText strips system tags when includeSystem=false", () => {
+    const result = joinToolText(["<system>hidden</system>", "visible"], false);
+    expect(result).toBe("visible");
+  });
+
+  it("stripSystemTag removes system wrappers", () => {
+    expect(stripSystemTag("<system>secret</system>")).toBe("secret");
+  });
+});
+
+describe("cleanToolTitle / normalizeToolLabel / normalizeToolName / getToolTitle", () => {
+  it("cleanToolTitle strips tool: prefix and leading dots", () => {
+    expect(cleanToolTitle("tool: Read")).toBe("Read");
+    expect(cleanToolTitle("...Bash")).toBe("Bash");
+  });
+
+  it("normalizeToolLabel uses title then tool then fallback", () => {
+    expect(normalizeToolLabel(part({ title: "Edit", tool: "Edit" }))).toBe("Edit");
+    expect(normalizeToolLabel(part({ title: "", tool: "Write" }))).toBe("Write");
+    expect(normalizeToolLabel(part({ title: "", tool: "" }))).toBe("tool");
+  });
+
+  it("normalizeToolName lowercases", () => {
+    expect(normalizeToolName(part({ title: "Read" }))).toBe("read");
+  });
+
+  it("getToolTitle prefers clean title, falls back to tool then default", () => {
+    expect(getToolTitle(part({ title: "Read", tool: "read" }))).toBe("Read");
+    expect(getToolTitle(part({ title: "", tool: "Write" }))).toBe("Write");
+    expect(getToolTitle(part({ title: "", tool: "" }))).toBe("Tool");
+  });
+});
+
+describe("formatToolOutput / getOutputOrErrorText", () => {
+  it("formatToolOutput normalizes escaped newlines", () => {
+    expect(formatToolOutput("line1\\nline2")).toBe("line1\nline2");
+  });
+
+  it("formatToolOutput falls back to No output captured", () => {
+    expect(formatToolOutput(null)).toBe("No output captured.");
+    expect(formatToolOutput("")).toBe("No output captured.");
+  });
+
+  it("getOutputOrErrorText prefers output, then error", () => {
+    const state: NormalizedToolState = {
+      status: "completed",
+      inputValue: null,
+      outputValue: "done",
+      errorValue: "oops",
+      metadataValue: null,
+      inputText: "",
+      command: "",
+    };
+    expect(getOutputOrErrorText(state)).toBe("done");
+
+    const errState = { ...state, outputValue: null };
+    expect(getOutputOrErrorText(errState)).toBe("oops");
+
+    const emptyState = { ...state, outputValue: null, errorValue: null };
+    expect(getOutputOrErrorText(emptyState)).toBe("No output captured.");
+  });
+});
+
+describe("extractCommand", () => {
+  it("extracts cmd or command from parsed input", () => {
+    expect(extractCommand('{"cmd":"ls -la"}')).toBe("ls -la");
+    expect(extractCommand('{"command":"pwd"}')).toBe("pwd");
+    expect(extractCommand("not json")).toBe("");
+  });
+});
+
+describe("normalizeEscapedNewlines", () => {
+  it("replaces literal backslash-n with newlines", () => {
+    expect(normalizeEscapedNewlines("a\\nb\\nc")).toBe("a\nb\nc");
+  });
+});

--- a/apps/web/src/components/session-detail/tool-normalize.ts
+++ b/apps/web/src/components/session-detail/tool-normalize.ts
@@ -1,0 +1,162 @@
+/**
+ * Tool / message text normalization and the shared NormalizedToolState type.
+ *
+ * Leaf helpers (escapeRegExp, parseInputCandidate, compactText, toRecord,
+ * toPlainText, toStringValue, parseJsonText, normalizeEscapedNewlines) live
+ * in ./utils and are re-exported here for convenience.
+ */
+import type { LoaderCircle } from "lucide-react";
+import type { MessagePart } from "../../lib/api";
+import type { ToolOutputContent } from "../tool-output/types";
+import type { ToolDetailItem } from "./codex-tool";
+import {
+  compactText,
+  normalizeEscapedNewlines,
+  parseInputCandidate,
+  toPlainText,
+  toRecord,
+  toStringValue,
+} from "./utils";
+
+export type ToolStatus = "running" | "completed" | "error";
+
+export interface NormalizedToolState {
+  status: ToolStatus;
+  inputValue: unknown;
+  outputValue: unknown;
+  errorValue: unknown;
+  metadataValue: unknown;
+  inputText: string;
+  command: string;
+}
+
+export interface ToolDisplayStrategy {
+  Icon: typeof LoaderCircle;
+  title: string;
+  secondaryText?: string;
+  details: ToolDetailItem[];
+  expandable: boolean;
+  showInputPreview: boolean;
+  outputContent: ToolOutputContent;
+}
+
+export function toDisplayText(value: unknown) {
+  if (value == null) return "";
+
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (!text) return "";
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      return JSON.stringify(parsed, null, 2);
+    } catch {
+      return value;
+    }
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    if (typeof value === "number" || typeof value === "bigint" || typeof value === "boolean") {
+      return `${value}`;
+    }
+    if (typeof value === "symbol") {
+      return value.description ? `Symbol(${value.description})` : "Symbol";
+    }
+    if (typeof value === "function") return "[Function]";
+    return "[Unserializable value]";
+  }
+}
+
+export {
+  compactText,
+  normalizeEscapedNewlines,
+  parseInputCandidate,
+  toPlainText,
+  toRecord,
+  toStringValue,
+};
+
+export function extractToolTextSegments(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) return value.flatMap((item) => extractToolTextSegments(item));
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (typeof record.text === "string") return [record.text];
+    if (record.content !== undefined) return extractToolTextSegments(record.content);
+  }
+  return [];
+}
+
+export function stripSystemTag(text: string) {
+  return text
+    .replace(/^<system>/i, "")
+    .replace(/<\/system>$/i, "")
+    .trim();
+}
+
+export function joinToolText(value: unknown, includeSystem = true) {
+  const segments = extractToolTextSegments(value)
+    .map((segment) => segment.trim())
+    .filter((segment) => {
+      if (includeSystem) return Boolean(segment);
+      return Boolean(segment) && !/^<system>[\s\S]*<\/system>$/i.test(segment);
+    });
+
+  if (segments.length === 0) return "";
+
+  return segments
+    .map((segment) =>
+      includeSystem && /^<system>[\s\S]*<\/system>$/i.test(segment)
+        ? stripSystemTag(segment)
+        : segment,
+    )
+    .join("\n");
+}
+
+export function extractCommand(inputValue: unknown) {
+  const parsed = parseInputCandidate(inputValue);
+  if (parsed && typeof parsed === "object") {
+    const input = parsed as { cmd?: unknown; command?: unknown };
+    if (typeof input.cmd === "string") return input.cmd;
+    if (typeof input.command === "string") return input.command;
+  }
+  return "";
+}
+
+export function cleanToolTitle(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.replace(/^tool:\s*/i, "").replace(/^\.+(?=\w)/, "");
+}
+
+export function normalizeToolLabel(part: MessagePart) {
+  if (typeof part.title === "string" && part.title.trim()) {
+    return cleanToolTitle(part.title);
+  }
+  if (typeof part.tool === "string" && part.tool.trim()) return cleanToolTitle(part.tool);
+  return "tool";
+}
+
+export function normalizeToolName(part: MessagePart) {
+  return normalizeToolLabel(part).trim().toLowerCase();
+}
+
+export function getToolTitle(tool: MessagePart, fallback = "Tool") {
+  return cleanToolTitle(toPlainText(tool.title)) || toPlainText(tool.tool) || fallback;
+}
+
+export function formatToolOutput(value: unknown) {
+  const structuredText = joinToolText(value);
+  const text = structuredText || toDisplayText(value);
+  const normalized = normalizeEscapedNewlines(text);
+  return normalized || "No output captured.";
+}
+
+export function getOutputOrErrorText(state: NormalizedToolState) {
+  const outputText = formatToolOutput(state.outputValue);
+  if (outputText !== "No output captured.") return outputText;
+  const errorText = formatToolOutput(state.errorValue);
+  if (errorText !== "No output captured.") return errorText;
+  return "No output captured.";
+}

--- a/apps/web/src/components/session-detail/utils.ts
+++ b/apps/web/src/components/session-detail/utils.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared leaf helpers used across the session-detail logic modules.
+ * None depend on React or on each other beyond what's defined here.
+ */
+
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function parseInputCandidate(inputValue: unknown) {
+  if (typeof inputValue !== "string") return inputValue;
+  try {
+    return JSON.parse(inputValue) as unknown;
+  } catch {
+    return inputValue;
+  }
+}
+
+export function compactText(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function toRecord(value: unknown) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function toPlainText(value: unknown) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function toStringValue(value: unknown) {
+  return typeof value === "string" ? value : "";
+}
+
+export function parseJsonText<T>(value: string): T | null {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeEscapedNewlines(text: string): string {
+  return text.replaceAll(/\\n/g, "\n");
+}


### PR DESCRIPTION
## Why

`SessionDetail.tsx` (3330 lines) mixed ~160 lines of pure value-normalization logic with its JSX — `toDisplayText`, `joinToolText`, `normalizeToolName`, `getToolTitle`, `formatToolOutput`, `getOutputOrErrorText`, plus shared leaf helpers (`escapeRegExp`, `parseJsonText`, `toRecord`, etc.). These are pure functions with no React dependency, yet trapped inside the component, untestable in isolation.

Refs CS-6 (multi-PR; this is **PR1 of 4**). CS-6's design.md now documents the 4-PR plan.

## What Changed

Extracted the normalization logic into two reusable modules under `components/session-detail/`:

- **`utils.ts`** — leaf helpers shared across future modules: `escapeRegExp`, `parseInputCandidate`, `compactText`, `toRecord`, `toPlainText`, `toStringValue`, `parseJsonText`, `normalizeEscapedNewlines`
- **`tool-normalize.ts`** — tool/message text normalization + shared types (`ToolStatus`, `NormalizedToolState`, `ToolDisplayStrategy`): `toDisplayText`, `joinToolText`, `extractToolTextSegments`, `normalizeToolName`/`normalizeToolLabel`, `cleanToolTitle`, `getToolTitle`, `formatToolOutput`, `getOutputOrErrorText`, `extractCommand`
- **`tool-normalize.test.ts`** — 20 unit tests

`SessionDetail.tsx`: **−159 lines**, deleted the duplicated definitions, now imports from the new modules.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [x] API
* [x] Infrastructure

## Notes for Reviewer

- **No behavior change.** The migrated functions are byte-identical to their originals; only their location moved. `SessionDetail.tsx` imports the same symbols it used to define locally.
- All 37 existing web tests pass unchanged; 20 new unit tests cover the migrated logic.
- This follows the existing `session-detail/{display-model,toc,codex-*}.ts` + `.test.ts` pattern.
- **Remaining CS-6 work** (tracked in design.md): PR2 (path-extract/diff/file-change/tool-strategy), PR3 (App lib logic), PR4 (App subcomponents).

## Verification

- `tsc --noEmit`: clean
- `vitest`: 57 passed (37 existing + 20 new)
- `oxlint` + `oxfmt`: clean
