### PR TITLE
refactor(web): extract path-extract, diff, file-change modules (CS-6 PR2)

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-array-index-key */
-import { diffLines, type Change } from "diff";
 import {
   Funnel,
   BookOpenText,
@@ -36,7 +35,7 @@ import {
   type ReactNode,
 } from "react";
 import { ModelConfig } from "../config";
-import type { Message, MessagePart, SessionData, SessionFileActivity } from "../lib/api";
+import type { Message, MessagePart, SessionData } from "../lib/api";
 import { InteractiveReceipt } from "./InteractiveReceipt";
 import { MarkdownContent } from "./MarkdownContent";
 import {
@@ -65,10 +64,7 @@ import {
   type SessionDetailToc,
   type TocFilterId,
 } from "./session-detail/toc";
-import {
-  buildMessageDisplayModels,
-  type MessageDisplayModel,
-} from "./session-detail/display-model";
+import { buildMessageDisplayModels } from "./session-detail/display-model";
 import { escapeRegExp, parseJsonText } from "./session-detail/utils";
 import {
   type NormalizedToolState,
@@ -81,7 +77,6 @@ import {
   getToolTitle,
   joinToolText,
   normalizeEscapedNewlines,
-  normalizeToolLabel,
   normalizeToolName,
   parseInputCandidate,
   toDisplayText,
@@ -89,9 +84,27 @@ import {
   toRecord,
   toStringValue,
 } from "./session-detail/tool-normalize";
+import {
+  type FileChangeKind,
+  type FileChangeSummary,
+  type FileChangeSummaryItem,
+  buildFileChangeSummary,
+  buildFileChangeSummaryFromActivity,
+} from "./session-detail/file-change";
+import {
+  formatTrackedPath,
+  getDisplayPath,
+  getDisplayTextWithRelativePaths,
+  getFilePathFromInput,
+} from "./session-detail/path-extract";
+import {
+  buildKimiEditDiffBlocks,
+  buildPiEditDiffBlocks,
+  buildStructuredDiffFromTexts,
+  extractEditDiff,
+} from "./session-detail/diff";
 import { detectLanguageByFilePath } from "./tool-output/language";
 import { ToolOutputRenderer } from "./tool-output/ToolOutputRenderer";
-import type { DiffBlock, DiffLineItem } from "./tool-output/types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -100,32 +113,6 @@ import type { DiffBlock, DiffLineItem } from "./tool-output/types";
 interface SessionDetailProps {
   session: SessionData;
   highlightQuery?: string;
-}
-
-type FileChangeKind = "read" | "edit" | "write" | "delete";
-
-interface FileChangeRecord {
-  kind: FileChangeKind;
-  path: string;
-  anchorId: string;
-  time: number;
-  toolLabel: string;
-}
-
-interface FileChangeSummaryItem {
-  path: string;
-  count: number;
-  latestTime: number;
-  latestAnchorId: string;
-  toolLabel: string;
-  anchors: Array<{ anchorId: string; time: number; toolLabel: string }>;
-}
-
-interface FileChangeSummary {
-  read: FileChangeSummaryItem[];
-  edit: FileChangeSummaryItem[];
-  write: FileChangeSummaryItem[];
-  delete: FileChangeSummaryItem[];
 }
 
 // ---------------------------------------------------------------------------
@@ -196,267 +183,6 @@ function renderHighlightedText(text: string, query?: string) {
 
 function MessageMarkdown({ text, highlightQuery }: { text: string; highlightQuery?: string }) {
   return <MarkdownContent text={text} highlightQuery={highlightQuery} />;
-}
-
-function buildToolAnchorId(messageIndex: number, toolIndex: number) {
-  return `tool-${messageIndex}-${toolIndex}`;
-}
-
-function looksLikeFilePath(value: string) {
-  const text = value.trim();
-  if (!text || text.length > 300) return false;
-  if (text.includes("\n")) return false;
-  if (/^[a-z]+:\/\//i.test(text)) return false;
-  if (/[<>{}]/.test(text)) return false;
-  if (text.startsWith("/")) return true;
-  if (text.startsWith("./") || text.startsWith("../") || text.startsWith("~/")) return true;
-  if (text.includes("/") || text.includes("\\")) return true;
-  return /^[A-Za-z0-9_.@-]+\.[A-Za-z0-9_-]+$/.test(text);
-}
-
-function shouldTreatAsPathKey(key: string) {
-  const normalized = key.trim().toLowerCase();
-  if (!normalized) return false;
-  if (
-    normalized.includes("command") ||
-    normalized.includes("content") ||
-    normalized.includes("text") ||
-    normalized.includes("prompt") ||
-    normalized.includes("url") ||
-    normalized.includes("body") ||
-    normalized.includes("title") ||
-    normalized.includes("description") ||
-    normalized === "cwd" ||
-    normalized === "workdir" ||
-    normalized === "directory"
-  ) {
-    return false;
-  }
-  return (
-    normalized === "path" ||
-    normalized === "paths" ||
-    normalized.includes("file") ||
-    normalized.includes("path")
-  );
-}
-
-function collectPathsFromValue(
-  value: unknown,
-  keyHint: string,
-  paths: Set<string>,
-  depth = 0,
-): void {
-  if (value == null || depth > 4) return;
-
-  if (typeof value === "string") {
-    if (shouldTreatAsPathKey(keyHint) && looksLikeFilePath(value)) {
-      paths.add(value.trim());
-    }
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectPathsFromValue(item, keyHint, paths, depth + 1);
-    }
-    return;
-  }
-
-  if (typeof value === "object") {
-    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
-      collectPathsFromValue(nested, key, paths, depth + 1);
-    }
-  }
-}
-
-function extractPathsFromToolInput(inputValue: unknown) {
-  const paths = new Set<string>();
-  collectPathsFromValue(inputValue, "", paths);
-  return [...paths];
-}
-
-function getToolInputValue(part: MessagePart) {
-  return part.state?.arguments ?? part.state?.input ?? part.input ?? null;
-}
-
-function classifyToolKind(part: MessagePart): FileChangeKind | null {
-  const toolName = normalizeToolName(part);
-  if (toolName === "read") return "read";
-  if (
-    toolName === "edit" ||
-    toolName === "multiedit" ||
-    toolName === "apply_patch" ||
-    toolName === "notebookedit"
-  ) {
-    return "edit";
-  }
-  if (toolName === "write" || toolName === "create_file" || toolName === "write_file") {
-    return "write";
-  }
-  if (toolName === "delete" || toolName === "delete_file") {
-    return "delete";
-  }
-  return null;
-}
-
-function summarizeFileChangeItems(records: FileChangeRecord[]): FileChangeSummaryItem[] {
-  const grouped = new Map<string, FileChangeSummaryItem>();
-
-  for (const record of records) {
-    const current = grouped.get(record.path);
-    if (current) {
-      current.count += 1;
-      current.anchors.push({
-        anchorId: record.anchorId,
-        time: record.time,
-        toolLabel: record.toolLabel,
-      });
-      if (record.time >= current.latestTime) {
-        current.latestTime = record.time;
-        current.latestAnchorId = record.anchorId;
-        current.toolLabel = record.toolLabel;
-      }
-      continue;
-    }
-
-    grouped.set(record.path, {
-      path: record.path,
-      count: 1,
-      latestTime: record.time,
-      latestAnchorId: record.anchorId,
-      toolLabel: record.toolLabel,
-      anchors: [{ anchorId: record.anchorId, time: record.time, toolLabel: record.toolLabel }],
-    });
-  }
-
-  return [...grouped.values()]
-    .map((item) => ({
-      ...item,
-      anchors: item.anchors.toSorted((a, b) => a.time - b.time),
-    }))
-    .toSorted((a, b) => {
-      if (b.latestTime !== a.latestTime) return b.latestTime - a.latestTime;
-      return a.path.localeCompare(b.path);
-    });
-}
-
-function buildFileChangeSummary(messages: MessageDisplayModel[]): {
-  toolAnchorIds: Map<MessagePart, string>;
-  anchorMessageIndexes: Map<string, number>;
-  summary: FileChangeSummary;
-} {
-  const toolAnchorIds = new Map<MessagePart, string>();
-  const anchorMessageIndexes = new Map<string, number>();
-  const fileChanges: Record<FileChangeKind, FileChangeRecord[]> = {
-    read: [],
-    edit: [],
-    write: [],
-    delete: [],
-  };
-
-  messages.forEach(({ msg: message, blocks, index: messageIndex }) => {
-    let toolIndex = 0;
-
-    for (const block of blocks) {
-      if (block.type !== "tool") continue;
-
-      for (const part of block.parts) {
-        const anchorId = buildToolAnchorId(messageIndex, toolIndex);
-        toolIndex += 1;
-        toolAnchorIds.set(part, anchorId);
-        anchorMessageIndexes.set(anchorId, messageIndex);
-
-        const inputValue = getToolInputValue(part);
-        const toolLabel = normalizeToolLabel(part);
-        const time = part.time_created ?? message.time_created;
-
-        const patchEntries = getCodexPatchEntries(inputValue);
-        if (patchEntries.length > 0) {
-          for (const entry of patchEntries) {
-            const path = (entry.path || entry.oldPath).trim();
-            if (!path) continue;
-
-            const kind =
-              entry.type === "write_file"
-                ? "write"
-                : entry.type === "delete_file"
-                  ? "delete"
-                  : "edit";
-            fileChanges[kind].push({ kind, path, anchorId, time, toolLabel });
-          }
-          continue;
-        }
-
-        const kind = classifyToolKind(part);
-        if (!kind) continue;
-
-        const paths = extractPathsFromToolInput(inputValue);
-        for (const path of paths) {
-          fileChanges[kind].push({ kind, path, anchorId, time, toolLabel });
-        }
-      }
-    }
-  });
-
-  return {
-    toolAnchorIds,
-    anchorMessageIndexes,
-    summary: {
-      read: summarizeFileChangeItems(fileChanges.read),
-      edit: summarizeFileChangeItems(fileChanges.edit),
-      write: summarizeFileChangeItems(fileChanges.write),
-      delete: summarizeFileChangeItems(fileChanges.delete),
-    },
-  };
-}
-
-function buildFileChangeSummaryFromActivity(
-  activity: SessionFileActivity[] | undefined,
-  anchorSummary: FileChangeSummary,
-): FileChangeSummary {
-  if (!activity) return anchorSummary;
-
-  const fromActivity: FileChangeSummary = {
-    read: [],
-    edit: [],
-    write: [],
-    delete: [],
-  };
-  const anchorMap = new Map<string, FileChangeSummaryItem>();
-
-  for (const kind of ["read", "edit", "write", "delete"] as const) {
-    for (const item of anchorSummary[kind]) {
-      anchorMap.set(`${kind}\0${item.path}`, item);
-    }
-  }
-
-  for (const item of activity) {
-    const anchors = anchorMap.get(`${item.kind}\0${item.path}`);
-    fromActivity[item.kind].push({
-      path: item.path,
-      count: item.count,
-      latestTime: item.latest_time,
-      latestAnchorId: anchors?.latestAnchorId ?? "",
-      toolLabel: anchors?.toolLabel ?? item.kind,
-      anchors: anchors?.anchors ?? [],
-    });
-  }
-
-  for (const kind of ["read", "edit", "write", "delete"] as const) {
-    fromActivity[kind].sort((a, b) => {
-      if (b.latestTime !== a.latestTime) return b.latestTime - a.latestTime;
-      return a.path.localeCompare(b.path);
-    });
-  }
-
-  return fromActivity;
-}
-
-function formatTrackedPath(path: string, baseDirectory: string) {
-  if (path.startsWith(`${baseDirectory}/`)) {
-    return path.slice(baseDirectory.length + 1);
-  }
-  return path;
 }
 
 function scrollToToolAnchor(anchorId: string, prepareAnchor?: () => void) {
@@ -546,18 +272,6 @@ function extractCodexNodeReplTextOutput(outputText: string) {
   return text || outputText;
 }
 
-function getFilePathFromInput(inputValue: unknown) {
-  const input = toRecord(inputValue);
-  const filePath =
-    toPlainText(input.filePath) ||
-    toPlainText(input.file_path) ||
-    toPlainText(input.path) ||
-    toPlainText(input.targetFile) ||
-    toPlainText(input.effectiveUri) ||
-    toPlainText(input.relativeWorkspacePath);
-  return filePath || "";
-}
-
 function getCursorOutputRecord(rawOutput: unknown) {
   if (rawOutput && typeof rawOutput === "object" && !Array.isArray(rawOutput)) {
     return rawOutput as Record<string, unknown>;
@@ -615,103 +329,6 @@ function formatCursorSearchOutput(rawOutput: unknown) {
   return lines.length > 0 ? lines.join("\n") : "No output captured.";
 }
 
-function buildStructuredDiffFromTexts(
-  filePath: string,
-  oldValue: string,
-  newValue: string,
-): DiffBlock[] {
-  if (!oldValue.trim() && !newValue.trim()) return [];
-  return [
-    {
-      label: getDiffBlockLabel(filePath),
-      lines: diffPartsToLines(
-        diffLines(normalizeEscapedNewlines(oldValue), normalizeEscapedNewlines(newValue)),
-      ),
-    },
-  ];
-}
-
-function createDiffBlock(oldValue: string, newValue: string) {
-  const oldLines = normalizeEscapedNewlines(oldValue).split("\n");
-  const newLines = normalizeEscapedNewlines(newValue).split("\n");
-  const diffLines = [
-    "@@",
-    ...oldLines.map((line) => `- ${line}`),
-    ...newLines.map((line) => `+ ${line}`),
-  ];
-  return diffLines.join("\n");
-}
-
-function splitDiffChunkLines(value: string) {
-  const normalized = normalizeEscapedNewlines(value);
-  const lines = normalized.split("\n");
-  if (normalized.endsWith("\n")) lines.pop();
-  return lines;
-}
-
-function diffPartsToLines(parts: Change[]): DiffLineItem[] {
-  return parts.flatMap((part) => {
-    const type: DiffLineItem["type"] = part.added ? "add" : part.removed ? "remove" : "context";
-    return splitDiffChunkLines(part.value).map((line) => ({ type, text: line }));
-  });
-}
-
-function getKimiEditEntries(inputValue: unknown) {
-  const input = toRecord(inputValue);
-  const rawEdit = input.edit;
-  if (Array.isArray(rawEdit)) return rawEdit;
-  if (rawEdit && typeof rawEdit === "object") return [rawEdit];
-  return [];
-}
-
-function getDiffBlockLabel(filePath: string) {
-  const normalizedPath = filePath.trim();
-  if (!normalizedPath) return "edit";
-  const fileName = normalizedPath.split("/").pop() || normalizedPath;
-  return fileName === normalizedPath ? fileName : `${fileName} · ${normalizedPath}`;
-}
-
-function buildKimiEditDiffBlocks(state: NormalizedToolState, filePath: string): DiffBlock[] {
-  const edits = getKimiEditEntries(state.inputValue);
-  const label = getDiffBlockLabel(filePath);
-
-  return edits
-    .map((entry) => {
-      const edit = toRecord(entry);
-      const oldValue = toStringValue(edit.old);
-      const newValue = toStringValue(edit.new);
-      if (!oldValue.trim() && !newValue.trim()) return null;
-      return {
-        label,
-        lines: diffPartsToLines(
-          diffLines(normalizeEscapedNewlines(oldValue), normalizeEscapedNewlines(newValue)),
-        ),
-      };
-    })
-    .filter((block): block is DiffBlock => block != null && block.lines.length > 0);
-}
-
-function getDisplayPath(filePath: string, baseDirectory?: string) {
-  const normalizedPath = filePath.trim();
-  const normalizedBase = (baseDirectory ?? "").replace(/\/+$/, "");
-  if (!normalizedPath || !normalizedBase) return normalizedPath;
-  if (normalizedPath === normalizedBase) return ".";
-  if (normalizedPath.startsWith(`${normalizedBase}/`)) {
-    return normalizedPath.slice(normalizedBase.length + 1);
-  }
-  return normalizedPath;
-}
-
-function getDisplayTextWithRelativePaths(text: string, baseDirectory?: string) {
-  const normalizedBase = (baseDirectory ?? "").replace(/\/+$/, "");
-  if (!text || !normalizedBase) return text;
-
-  return text.replace(
-    new RegExp(`${escapeRegExp(normalizedBase)}(?=$|/|[\\s"'\\)\\]}:;,])`, "g"),
-    ".",
-  );
-}
-
 function getPiTodoTaskFromDetails(state: NormalizedToolState) {
   const input = toRecord(state.inputValue);
   const details = toRecord(state.metadataValue);
@@ -731,41 +348,6 @@ function getPiTodoStatusChange(state: NormalizedToolState) {
   return `${match[1]} -> ${match[2]}`;
 }
 
-function buildPiEditDiffBlocks(state: NormalizedToolState, filePath: string): DiffBlock[] {
-  const input = toRecord(state.inputValue);
-  const edits = Array.isArray(input.edits) ? input.edits : [];
-  const label = getDiffBlockLabel(filePath);
-  const blocks = edits
-    .map((entry) => {
-      const edit = toRecord(entry);
-      const oldValue = toStringValue(edit.oldText) || toStringValue(edit.old);
-      const newValue = toStringValue(edit.newText) || toStringValue(edit.new);
-      if (!oldValue.trim() && !newValue.trim()) return null;
-      return {
-        label,
-        lines: diffPartsToLines(
-          diffLines(normalizeEscapedNewlines(oldValue), normalizeEscapedNewlines(newValue)),
-        ),
-      };
-    })
-    .filter((block): block is DiffBlock => block != null && block.lines.length > 0);
-
-  if (blocks.length > 0) return blocks;
-
-  const metadata = toRecord(state.metadataValue);
-  const patch = toStringValue(metadata.patch) || toStringValue(metadata.diff);
-  if (!patch.trim()) return [];
-  return [
-    {
-      label,
-      lines: patch.split("\n").map((line) => ({
-        type: line.startsWith("+") ? "add" : line.startsWith("-") ? "remove" : "context",
-        text: line,
-      })),
-    },
-  ];
-}
-
 function buildPiSubagentResultDetails(text: string): ToolDetailItem[] {
   const firstLine = text.split("\n")[0] ?? "";
   const agentMatch = firstLine.match(/^Agent:\s*(.+)$/i);
@@ -774,27 +356,6 @@ function buildPiSubagentResultDetails(text: string): ToolDetailItem[] {
   if (agentMatch?.[1]) details.push({ label: "Agent", value: agentMatch[1].trim() });
   if (summaryLine) details.push({ label: "Summary", value: summaryLine.trim() });
   return details;
-}
-
-function extractEditDiff(state: NormalizedToolState) {
-  const metadata = toRecord(state.metadataValue);
-  const diffText = toStringValue(metadata.diff);
-  if (diffText.trim()) return normalizeEscapedNewlines(diffText);
-
-  const edits = getKimiEditEntries(state.inputValue);
-  const generatedDiff = edits
-    .map((entry) => {
-      const edit = toRecord(entry);
-      const oldValue = toStringValue(edit.old);
-      const newValue = toStringValue(edit.new);
-      if (!oldValue.trim() && !newValue.trim()) return "";
-      return createDiffBlock(oldValue, newValue);
-    })
-    .filter(Boolean)
-    .join("\n\n");
-  if (generatedDiff.trim()) return generatedDiff;
-
-  return getOutputOrErrorText(state);
 }
 
 function extractWriteContent(state: NormalizedToolState) {

--- a/apps/web/src/components/session-detail/diff.test.ts
+++ b/apps/web/src/components/session-detail/diff.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildKimiEditDiffBlocks,
+  buildStructuredDiffFromTexts,
+  createDiffBlock,
+  extractEditDiff,
+  getDiffBlockLabel,
+  getKimiEditEntries,
+  splitDiffChunkLines,
+} from "./diff";
+import type { NormalizedToolState } from "./tool-normalize";
+
+function state(overrides?: Partial<NormalizedToolState>): NormalizedToolState {
+  return {
+    status: "completed",
+    inputValue: null,
+    outputValue: null,
+    errorValue: null,
+    metadataValue: null,
+    inputText: "",
+    command: "",
+    ...overrides,
+  };
+}
+
+describe("getDiffBlockLabel", () => {
+  it("returns filename for simple paths", () => {
+    expect(getDiffBlockLabel("/abs/file.ts")).toBe("file.ts · /abs/file.ts");
+  });
+
+  it("returns edit for empty path", () => {
+    expect(getDiffBlockLabel("")).toBe("edit");
+  });
+});
+
+describe("splitDiffChunkLines", () => {
+  it("splits by newline and drops trailing empty", () => {
+    expect(splitDiffChunkLines("a\nb\n")).toEqual(["a", "b"]);
+    expect(splitDiffChunkLines("a\\nb")).toEqual(["a", "b"]); // escaped newlines
+  });
+});
+
+describe("createDiffBlock", () => {
+  it("produces a unified-diff-like string", () => {
+    const result = createDiffBlock("old", "new");
+    expect(result).toContain("- old");
+    expect(result).toContain("+ new");
+    expect(result).toContain("@@");
+  });
+});
+
+describe("buildStructuredDiffFromTexts", () => {
+  it("returns empty for no content", () => {
+    expect(buildStructuredDiffFromTexts("/f.ts", "", "")).toEqual([]);
+  });
+
+  it("produces diff blocks with add/remove lines", () => {
+    const blocks = buildStructuredDiffFromTexts("/f.ts", "old line", "new line");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.lines.some((l) => l.type === "remove")).toBe(true);
+    expect(blocks[0]!.lines.some((l) => l.type === "add")).toBe(true);
+  });
+});
+
+describe("getKimiEditEntries", () => {
+  it("returns array for single edit object", () => {
+    expect(getKimiEditEntries({ edit: { old: "a", new: "b" } })).toHaveLength(1);
+  });
+
+  it("returns array for edit array", () => {
+    expect(getKimiEditEntries({ edit: [{ old: "a" }, { old: "b" }] })).toHaveLength(2);
+  });
+
+  it("returns empty for no edit", () => {
+    expect(getKimiEditEntries({})).toEqual([]);
+  });
+});
+
+describe("buildKimiEditDiffBlocks", () => {
+  it("builds diff blocks from kimi edit entries", () => {
+    const blocks = buildKimiEditDiffBlocks(
+      state({ inputValue: { edit: { old: "line1", new: "line2" } } }),
+      "/file.ts",
+    );
+    expect(blocks.length).toBeGreaterThan(0);
+  });
+});
+
+describe("extractEditDiff", () => {
+  it("returns metadata diff when present", () => {
+    expect(extractEditDiff(state({ metadataValue: { diff: "+ added\\n- removed" } }))).toBe(
+      "+ added\n- removed",
+    );
+  });
+
+  it("falls back to output when no diff", () => {
+    expect(extractEditDiff(state({ outputValue: "some output" }))).toBe("some output");
+  });
+});

--- a/apps/web/src/components/session-detail/diff.ts
+++ b/apps/web/src/components/session-detail/diff.ts
@@ -1,0 +1,146 @@
+/**
+ * Diff block construction for tool edit/write strategies.
+ * Builds DiffBlock[] from text pairs (claude/pi), Kimi edit arrays,
+ * and extracts edit-diff text for opencode/kimi output.
+ */
+import { diffLines, type Change } from "diff";
+import type { DiffBlock, DiffLineItem } from "../tool-output/types";
+import {
+  type NormalizedToolState,
+  getOutputOrErrorText,
+  normalizeEscapedNewlines,
+  toStringValue,
+  toRecord,
+} from "./tool-normalize";
+
+export function buildStructuredDiffFromTexts(
+  filePath: string,
+  oldValue: string,
+  newValue: string,
+): DiffBlock[] {
+  if (!oldValue.trim() && !newValue.trim()) return [];
+  return [
+    {
+      label: getDiffBlockLabel(filePath),
+      lines: diffPartsToLines(
+        diffLines(normalizeEscapedNewlines(oldValue), normalizeEscapedNewlines(newValue)),
+      ),
+    },
+  ];
+}
+
+export function createDiffBlock(oldValue: string, newValue: string) {
+  const oldLines = normalizeEscapedNewlines(oldValue).split("\n");
+  const newLines = normalizeEscapedNewlines(newValue).split("\n");
+  const diffLines = [
+    "@@",
+    ...oldLines.map((line) => `- ${line}`),
+    ...newLines.map((line) => `+ ${line}`),
+  ];
+  return diffLines.join("\n");
+}
+
+export function splitDiffChunkLines(value: string) {
+  const normalized = normalizeEscapedNewlines(value);
+  const lines = normalized.split("\n");
+  if (normalized.endsWith("\n")) lines.pop();
+  return lines;
+}
+
+export function diffPartsToLines(parts: Change[]): DiffLineItem[] {
+  return parts.flatMap((part) => {
+    const type: DiffLineItem["type"] = part.added ? "add" : part.removed ? "remove" : "context";
+    return splitDiffChunkLines(part.value).map((line) => ({ type, text: line }));
+  });
+}
+
+export function getKimiEditEntries(inputValue: unknown) {
+  const input = toRecord(inputValue);
+  const rawEdit = input.edit;
+  if (Array.isArray(rawEdit)) return rawEdit;
+  if (rawEdit && typeof rawEdit === "object") return [rawEdit];
+  return [];
+}
+
+export function getDiffBlockLabel(filePath: string) {
+  const normalizedPath = filePath.trim();
+  if (!normalizedPath) return "edit";
+  const fileName = normalizedPath.split("/").pop() || normalizedPath;
+  return fileName === normalizedPath ? fileName : `${fileName} · ${normalizedPath}`;
+}
+
+export function buildKimiEditDiffBlocks(state: NormalizedToolState, filePath: string): DiffBlock[] {
+  const edits = getKimiEditEntries(state.inputValue);
+  const label = getDiffBlockLabel(filePath);
+
+  return edits
+    .map((entry) => {
+      const edit = toRecord(entry);
+      const oldValue = toStringValue(edit.old);
+      const newValue = toStringValue(edit.new);
+      if (!oldValue.trim() && !newValue.trim()) return null;
+      return {
+        label,
+        lines: diffPartsToLines(
+          diffLines(normalizeEscapedNewlines(oldValue), normalizeEscapedNewlines(newValue)),
+        ),
+      };
+    })
+    .filter((block): block is DiffBlock => block != null && block.lines.length > 0);
+}
+
+export function buildPiEditDiffBlocks(state: NormalizedToolState, filePath: string): DiffBlock[] {
+  const input = toRecord(state.inputValue);
+  const edits = Array.isArray(input.edits) ? input.edits : [];
+  const label = getDiffBlockLabel(filePath);
+  const blocks = edits
+    .map((entry) => {
+      const edit = toRecord(entry);
+      const oldValue = toStringValue(edit.oldText) || toStringValue(edit.old);
+      const newValue = toStringValue(edit.newText) || toStringValue(edit.new);
+      if (!oldValue.trim() && !newValue.trim()) return null;
+      return {
+        label,
+        lines: diffPartsToLines(
+          diffLines(normalizeEscapedNewlines(oldValue), normalizeEscapedNewlines(newValue)),
+        ),
+      };
+    })
+    .filter((block): block is DiffBlock => block != null && block.lines.length > 0);
+
+  if (blocks.length > 0) return blocks;
+
+  const metadata = toRecord(state.metadataValue);
+  const patch = toStringValue(metadata.patch) || toStringValue(metadata.diff);
+  if (!patch.trim()) return [];
+  return [
+    {
+      label,
+      lines: patch.split("\n").map((line) => ({
+        type: line.startsWith("+") ? "add" : line.startsWith("-") ? "remove" : "context",
+        text: line,
+      })),
+    },
+  ];
+}
+
+export function extractEditDiff(state: NormalizedToolState) {
+  const metadata = toRecord(state.metadataValue);
+  const diffText = toStringValue(metadata.diff);
+  if (diffText.trim()) return normalizeEscapedNewlines(diffText);
+
+  const edits = getKimiEditEntries(state.inputValue);
+  const generatedDiff = edits
+    .map((entry) => {
+      const edit = toRecord(entry);
+      const oldValue = toStringValue(edit.old);
+      const newValue = toStringValue(edit.new);
+      if (!oldValue.trim() && !newValue.trim()) return "";
+      return createDiffBlock(oldValue, newValue);
+    })
+    .filter(Boolean)
+    .join("\n\n");
+  if (generatedDiff.trim()) return generatedDiff;
+
+  return getOutputOrErrorText(state);
+}

--- a/apps/web/src/components/session-detail/file-change.test.ts
+++ b/apps/web/src/components/session-detail/file-change.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { MessagePart } from "../../lib/api";
+import {
+  buildFileChangeSummary,
+  buildFileChangeSummaryFromActivity,
+  buildToolAnchorId,
+  classifyToolKind,
+  summarizeFileChangeItems,
+  type FileChangeRecord,
+  type FileChangeSummary,
+} from "./file-change";
+
+function part(overrides?: Partial<MessagePart>): MessagePart {
+  return { role: "tool", tool: "Read", title: "Read", ...overrides } as MessagePart;
+}
+
+describe("buildToolAnchorId", () => {
+  it("formats as tool-{msg}-{tool}", () => {
+    expect(buildToolAnchorId(3, 7)).toBe("tool-3-7");
+  });
+});
+
+describe("classifyToolKind", () => {
+  it("classifies read tools", () => {
+    expect(classifyToolKind(part({ tool: "read", title: "read" }))).toBe("read");
+  });
+
+  it("classifies edit tools", () => {
+    expect(classifyToolKind(part({ tool: "edit", title: "edit" }))).toBe("edit");
+    expect(classifyToolKind(part({ tool: "apply_patch", title: "apply_patch" }))).toBe("edit");
+  });
+
+  it("classifies write tools", () => {
+    expect(classifyToolKind(part({ tool: "write", title: "write" }))).toBe("write");
+    expect(classifyToolKind(part({ tool: "create_file", title: "create_file" }))).toBe("write");
+  });
+
+  it("classifies delete tools", () => {
+    expect(classifyToolKind(part({ tool: "delete", title: "delete" }))).toBe("delete");
+  });
+
+  it("returns null for unknown tools", () => {
+    expect(classifyToolKind(part({ tool: "bash", title: "bash" }))).toBeNull();
+  });
+});
+
+describe("summarizeFileChangeItems", () => {
+  it("groups by path and counts", () => {
+    const records: FileChangeRecord[] = [
+      { kind: "read", path: "/a.ts", anchorId: "tool-0-0", time: 100, toolLabel: "Read" },
+      { kind: "read", path: "/a.ts", anchorId: "tool-0-1", time: 200, toolLabel: "Read" },
+      { kind: "read", path: "/b.ts", anchorId: "tool-0-2", time: 150, toolLabel: "Read" },
+    ];
+    const result = summarizeFileChangeItems(records);
+    expect(result).toHaveLength(2);
+    const aItem = result.find((r) => r.path === "/a.ts");
+    expect(aItem?.count).toBe(2);
+    expect(aItem?.latestTime).toBe(200);
+    expect(aItem?.anchors).toHaveLength(2);
+  });
+
+  it("sorts by latestTime desc then path", () => {
+    const records: FileChangeRecord[] = [
+      { kind: "read", path: "/z.ts", anchorId: "t1", time: 100, toolLabel: "Read" },
+      { kind: "read", path: "/a.ts", anchorId: "t2", time: 200, toolLabel: "Read" },
+    ];
+    const result = summarizeFileChangeItems(records);
+    expect(result[0]!.path).toBe("/a.ts");
+  });
+});
+
+describe("buildFileChangeSummary", () => {
+  it("returns empty summary for no messages", () => {
+    const result = buildFileChangeSummary([]);
+    expect(result.toolAnchorIds.size).toBe(0);
+    expect(result.summary.read).toEqual([]);
+  });
+});
+
+describe("buildFileChangeSummaryFromActivity", () => {
+  it("returns anchor summary when no activity", () => {
+    const anchor: FileChangeSummary = {
+      read: [
+        {
+          path: "/a.ts",
+          count: 1,
+          latestTime: 100,
+          latestAnchorId: "t1",
+          toolLabel: "Read",
+          anchors: [],
+        },
+      ],
+      edit: [],
+      write: [],
+      delete: [],
+    };
+    expect(buildFileChangeSummaryFromActivity(undefined, anchor)).toBe(anchor);
+  });
+
+  it("merges activity data with anchor info", () => {
+    const anchor: FileChangeSummary = {
+      read: [
+        {
+          path: "/a.ts",
+          count: 1,
+          latestTime: 100,
+          latestAnchorId: "anchor-1",
+          toolLabel: "Read",
+          anchors: [{ anchorId: "anchor-1", time: 100, toolLabel: "Read" }],
+        },
+      ],
+      edit: [],
+      write: [],
+      delete: [],
+    };
+    const result = buildFileChangeSummaryFromActivity(
+      [{ kind: "read", path: "/a.ts", count: 3, latest_time: 200 }],
+      anchor,
+    );
+    expect(result.read[0]!.count).toBe(3);
+    expect(result.read[0]!.latestAnchorId).toBe("anchor-1");
+  });
+});

--- a/apps/web/src/components/session-detail/file-change.test.ts
+++ b/apps/web/src/components/session-detail/file-change.test.ts
@@ -114,7 +114,17 @@ describe("buildFileChangeSummaryFromActivity", () => {
       delete: [],
     };
     const result = buildFileChangeSummaryFromActivity(
-      [{ kind: "read", path: "/a.ts", count: 3, latest_time: 200 }],
+      [
+        {
+          kind: "read",
+          path: "/a.ts",
+          count: 3,
+          latest_time: 200,
+          agent_name: "claudecode",
+          session_id: "s1",
+          project_identity_key: "proj",
+        },
+      ],
       anchor,
     );
     expect(result.read[0]!.count).toBe(3);

--- a/apps/web/src/components/session-detail/file-change.ts
+++ b/apps/web/src/components/session-detail/file-change.ts
@@ -1,0 +1,216 @@
+/**
+ * File-change classification and per-path summary aggregation.
+ * Classifies tool calls into read/edit/write/delete kinds and builds
+ * per-path summaries (with anchor ids for click-to-scroll).
+ */
+import type { Message, MessagePart, SessionFileActivity } from "../../lib/api";
+import type { MessageDisplayModel } from "./display-model";
+import { getCodexPatchEntries } from "./codex-patch";
+import { normalizeToolLabel, normalizeToolName } from "./tool-normalize";
+import { extractPathsFromToolInput, getToolInputValue } from "./path-extract";
+
+export type FileChangeKind = "read" | "edit" | "write" | "delete";
+
+export interface FileChangeRecord {
+  kind: FileChangeKind;
+  path: string;
+  anchorId: string;
+  time: number;
+  toolLabel: string;
+}
+
+export interface FileChangeSummaryItem {
+  path: string;
+  count: number;
+  latestTime: number;
+  latestAnchorId: string;
+  toolLabel: string;
+  anchors: Array<{ anchorId: string; time: number; toolLabel: string }>;
+}
+
+export interface FileChangeSummary {
+  read: FileChangeSummaryItem[];
+  edit: FileChangeSummaryItem[];
+  write: FileChangeSummaryItem[];
+  delete: FileChangeSummaryItem[];
+}
+
+export function buildToolAnchorId(messageIndex: number, toolIndex: number) {
+  return `tool-${messageIndex}-${toolIndex}`;
+}
+
+export function classifyToolKind(part: MessagePart): FileChangeKind | null {
+  const toolName = normalizeToolName(part);
+  if (toolName === "read") return "read";
+  if (
+    toolName === "edit" ||
+    toolName === "multiedit" ||
+    toolName === "apply_patch" ||
+    toolName === "notebookedit"
+  ) {
+    return "edit";
+  }
+  if (toolName === "write" || toolName === "create_file" || toolName === "write_file") {
+    return "write";
+  }
+  if (toolName === "delete" || toolName === "delete_file") {
+    return "delete";
+  }
+  return null;
+}
+
+export function summarizeFileChangeItems(records: FileChangeRecord[]): FileChangeSummaryItem[] {
+  const grouped = new Map<string, FileChangeSummaryItem>();
+
+  for (const record of records) {
+    const current = grouped.get(record.path);
+    if (current) {
+      current.count += 1;
+      current.anchors.push({
+        anchorId: record.anchorId,
+        time: record.time,
+        toolLabel: record.toolLabel,
+      });
+      if (record.time >= current.latestTime) {
+        current.latestTime = record.time;
+        current.latestAnchorId = record.anchorId;
+        current.toolLabel = record.toolLabel;
+      }
+      continue;
+    }
+
+    grouped.set(record.path, {
+      path: record.path,
+      count: 1,
+      latestTime: record.time,
+      latestAnchorId: record.anchorId,
+      toolLabel: record.toolLabel,
+      anchors: [{ anchorId: record.anchorId, time: record.time, toolLabel: record.toolLabel }],
+    });
+  }
+
+  return [...grouped.values()]
+    .map((item) => ({
+      ...item,
+      anchors: item.anchors.toSorted((a, b) => a.time - b.time),
+    }))
+    .toSorted((a, b) => {
+      if (b.latestTime !== a.latestTime) return b.latestTime - a.latestTime;
+      return a.path.localeCompare(b.path);
+    });
+}
+
+export function buildFileChangeSummary(messages: MessageDisplayModel[]): {
+  toolAnchorIds: Map<MessagePart, string>;
+  anchorMessageIndexes: Map<string, number>;
+  summary: FileChangeSummary;
+} {
+  const toolAnchorIds = new Map<MessagePart, string>();
+  const anchorMessageIndexes = new Map<string, number>();
+  const fileChanges: Record<FileChangeKind, FileChangeRecord[]> = {
+    read: [],
+    edit: [],
+    write: [],
+    delete: [],
+  };
+
+  messages.forEach(({ msg: message, blocks, index: messageIndex }) => {
+    let toolIndex = 0;
+
+    for (const block of blocks) {
+      if (block.type !== "tool") continue;
+
+      for (const part of block.parts) {
+        const anchorId = buildToolAnchorId(messageIndex, toolIndex);
+        toolIndex += 1;
+        toolAnchorIds.set(part, anchorId);
+        anchorMessageIndexes.set(anchorId, messageIndex);
+
+        const inputValue = getToolInputValue(part);
+        const toolLabel = normalizeToolLabel(part);
+        const time = part.time_created ?? message.time_created;
+
+        const patchEntries = getCodexPatchEntries(inputValue);
+        if (patchEntries.length > 0) {
+          for (const entry of patchEntries) {
+            const path = (entry.path || entry.oldPath).trim();
+            if (!path) continue;
+
+            const kind =
+              entry.type === "write_file"
+                ? "write"
+                : entry.type === "delete_file"
+                  ? "delete"
+                  : "edit";
+            fileChanges[kind].push({ kind, path, anchorId, time, toolLabel });
+          }
+          continue;
+        }
+
+        const kind = classifyToolKind(part);
+        if (!kind) continue;
+
+        const paths = extractPathsFromToolInput(inputValue);
+        for (const path of paths) {
+          fileChanges[kind].push({ kind, path, anchorId, time, toolLabel });
+        }
+      }
+    }
+  });
+
+  return {
+    toolAnchorIds,
+    anchorMessageIndexes,
+    summary: {
+      read: summarizeFileChangeItems(fileChanges.read),
+      edit: summarizeFileChangeItems(fileChanges.edit),
+      write: summarizeFileChangeItems(fileChanges.write),
+      delete: summarizeFileChangeItems(fileChanges.delete),
+    },
+  };
+}
+
+export function buildFileChangeSummaryFromActivity(
+  activity: SessionFileActivity[] | undefined,
+  anchorSummary: FileChangeSummary,
+): FileChangeSummary {
+  if (!activity) return anchorSummary;
+
+  const fromActivity: FileChangeSummary = {
+    read: [],
+    edit: [],
+    write: [],
+    delete: [],
+  };
+  const anchorMap = new Map<string, FileChangeSummaryItem>();
+
+  for (const kind of ["read", "edit", "write", "delete"] as const) {
+    for (const item of anchorSummary[kind]) {
+      anchorMap.set(`${kind}\0${item.path}`, item);
+    }
+  }
+
+  for (const item of activity) {
+    const anchors = anchorMap.get(`${item.kind}\0${item.path}`);
+    fromActivity[item.kind].push({
+      path: item.path,
+      count: item.count,
+      latestTime: item.latest_time,
+      latestAnchorId: anchors?.latestAnchorId ?? "",
+      toolLabel: anchors?.toolLabel ?? item.kind,
+      anchors: anchors?.anchors ?? [],
+    });
+  }
+
+  for (const kind of ["read", "edit", "write", "delete"] as const) {
+    fromActivity[kind].sort((a, b) => {
+      if (b.latestTime !== a.latestTime) return b.latestTime - a.latestTime;
+      return a.path.localeCompare(b.path);
+    });
+  }
+
+  return fromActivity;
+}
+
+// Keep Message import meaningful for downstream typing consumers.
+export type { Message };

--- a/apps/web/src/components/session-detail/path-extract.test.ts
+++ b/apps/web/src/components/session-detail/path-extract.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  collectPathsFromValue,
+  extractPathsFromToolInput,
+  formatTrackedPath,
+  getDisplayPath,
+  getDisplayTextWithRelativePaths,
+  getFilePathFromInput,
+  looksLikeFilePath,
+  shouldTreatAsPathKey,
+} from "./path-extract";
+
+describe("looksLikeFilePath", () => {
+  it("accepts absolute paths", () => {
+    expect(looksLikeFilePath("/home/user/file.ts")).toBe(true);
+  });
+
+  it("accepts relative paths", () => {
+    expect(looksLikeFilePath("./src/index.ts")).toBe(true);
+    expect(looksLikeFilePath("../parent/dir")).toBe(true);
+  });
+
+  it("rejects URLs", () => {
+    expect(looksLikeFilePath("https://example.com")).toBe(false);
+  });
+
+  it("rejects multiline text", () => {
+    expect(looksLikeFilePath("line1\nline2")).toBe(false);
+  });
+
+  it("rejects excessively long strings", () => {
+    expect(looksLikeFilePath(`${"/path".repeat(100)}`)).toBe(false);
+  });
+});
+
+describe("shouldTreatAsPathKey", () => {
+  it("treats path/file keys as path keys", () => {
+    expect(shouldTreatAsPathKey("path")).toBe(true);
+    expect(shouldTreatAsPathKey("filePath")).toBe(true);
+    expect(shouldTreatAsPathKey("file_path")).toBe(true);
+  });
+
+  it("rejects content/command keys", () => {
+    expect(shouldTreatAsPathKey("command")).toBe(false);
+    expect(shouldTreatAsPathKey("content")).toBe(false);
+    expect(shouldTreatAsPathKey("cwd")).toBe(false);
+  });
+});
+
+describe("collectPathsFromValue / extractPathsFromToolInput", () => {
+  it("collects paths from nested objects under path keys", () => {
+    const paths = new Set<string>();
+    collectPathsFromValue({ filePath: "/abs/file.ts" }, "", paths);
+    expect([...paths]).toEqual(["/abs/file.ts"]);
+  });
+
+  it("extractPathsFromToolInput returns array", () => {
+    expect(extractPathsFromToolInput({ path: "/a.ts", other: { filePath: "/b.ts" } })).toEqual([
+      "/a.ts",
+      "/b.ts",
+    ]);
+  });
+
+  it("ignores non-path values under path keys", () => {
+    expect(extractPathsFromToolInput({ path: "not a path" })).toEqual([]);
+  });
+});
+
+describe("getFilePathFromInput", () => {
+  it("reads from common file fields", () => {
+    expect(getFilePathFromInput({ filePath: "/a.ts" })).toBe("/a.ts");
+    expect(getFilePathFromInput({ file_path: "/b.ts" })).toBe("/b.ts");
+    expect(getFilePathFromInput({ targetFile: "/c.ts" })).toBe("/c.ts");
+    expect(getFilePathFromInput({})).toBe("");
+  });
+});
+
+describe("getDisplayPath", () => {
+  it("strips base directory prefix", () => {
+    expect(getDisplayPath("/base/src/file.ts", "/base")).toBe("src/file.ts");
+  });
+
+  it("returns dot when path equals base", () => {
+    expect(getDisplayPath("/base", "/base")).toBe(".");
+  });
+
+  it("returns path as-is when no base", () => {
+    expect(getDisplayPath("/base/file.ts")).toBe("/base/file.ts");
+  });
+});
+
+describe("getDisplayTextWithRelativePaths", () => {
+  it("replaces base dir with dot", () => {
+    expect(getDisplayTextWithRelativePaths("/base/src/file.ts", "/base")).toBe("./src/file.ts");
+  });
+});
+
+describe("formatTrackedPath", () => {
+  it("strips base directory prefix", () => {
+    expect(formatTrackedPath("/base/src/file.ts", "/base")).toBe("src/file.ts");
+  });
+
+  it("returns path unchanged when no prefix match", () => {
+    expect(formatTrackedPath("/other/file.ts", "/base")).toBe("/other/file.ts");
+  });
+});

--- a/apps/web/src/components/session-detail/path-extract.ts
+++ b/apps/web/src/components/session-detail/path-extract.ts
@@ -1,0 +1,127 @@
+/**
+ * File-path extraction and display-path formatting.
+ * Consumed by file-change summary and tool display strategies.
+ */
+import type { MessagePart } from "../../lib/api";
+import { escapeRegExp, parseJsonText } from "./utils";
+import { toPlainText, toRecord } from "./tool-normalize";
+
+export function looksLikeFilePath(value: string) {
+  const text = value.trim();
+  if (!text || text.length > 300) return false;
+  if (text.includes("\n")) return false;
+  if (/^[a-z]+:\/\//i.test(text)) return false;
+  if (/[<>{}]/.test(text)) return false;
+  if (text.startsWith("/")) return true;
+  if (text.startsWith("./") || text.startsWith("../") || text.startsWith("~/")) return true;
+  if (text.includes("/") || text.includes("\\")) return true;
+  return /^[A-Za-z0-9_.@-]+\.[A-Za-z0-9_-]+$/.test(text);
+}
+
+export function shouldTreatAsPathKey(key: string) {
+  const normalized = key.trim().toLowerCase();
+  if (!normalized) return false;
+  if (
+    normalized.includes("command") ||
+    normalized.includes("content") ||
+    normalized.includes("text") ||
+    normalized.includes("prompt") ||
+    normalized.includes("url") ||
+    normalized.includes("body") ||
+    normalized.includes("title") ||
+    normalized.includes("description") ||
+    normalized === "cwd" ||
+    normalized === "workdir" ||
+    normalized === "directory"
+  ) {
+    return false;
+  }
+  return (
+    normalized === "path" ||
+    normalized === "paths" ||
+    normalized.includes("file") ||
+    normalized.includes("path")
+  );
+}
+
+export function collectPathsFromValue(
+  value: unknown,
+  keyHint: string,
+  paths: Set<string>,
+  depth = 0,
+): void {
+  if (value == null || depth > 4) return;
+
+  if (typeof value === "string") {
+    if (shouldTreatAsPathKey(keyHint) && looksLikeFilePath(value)) {
+      paths.add(value.trim());
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectPathsFromValue(item, keyHint, paths, depth + 1);
+    }
+    return;
+  }
+
+  if (typeof value === "object") {
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      collectPathsFromValue(nested, key, paths, depth + 1);
+    }
+  }
+}
+
+export function extractPathsFromToolInput(inputValue: unknown) {
+  const paths = new Set<string>();
+  collectPathsFromValue(inputValue, "", paths);
+  return [...paths];
+}
+
+export function getToolInputValue(part: MessagePart) {
+  return part.state?.arguments ?? part.state?.input ?? part.input ?? null;
+}
+
+export function getFilePathFromInput(inputValue: unknown) {
+  const input = toRecord(inputValue);
+  const filePath =
+    toPlainText(input.filePath) ||
+    toPlainText(input.file_path) ||
+    toPlainText(input.path) ||
+    toPlainText(input.targetFile) ||
+    toPlainText(input.effectiveUri) ||
+    toPlainText(input.relativeWorkspacePath);
+  return filePath || "";
+}
+
+export function getDisplayPath(filePath: string, baseDirectory?: string) {
+  const normalizedPath = filePath.trim();
+  const normalizedBase = (baseDirectory ?? "").replace(/\/+$/, "");
+  if (!normalizedPath || !normalizedBase) return normalizedPath;
+  if (normalizedPath === normalizedBase) return ".";
+  if (normalizedPath.startsWith(`${normalizedBase}/`)) {
+    return normalizedPath.slice(normalizedBase.length + 1);
+  }
+  return normalizedPath;
+}
+
+export function getDisplayTextWithRelativePaths(text: string, baseDirectory?: string) {
+  const normalizedBase = (baseDirectory ?? "").replace(/\/+$/, "");
+  if (!text || !normalizedBase) return text;
+
+  return text.replace(
+    new RegExp(`${escapeRegExp(normalizedBase)}(?=$|/|[\\s"'\\)\\]}:;,])`, "g"),
+    ".",
+  );
+}
+
+export function formatTrackedPath(path: string, baseDirectory: string) {
+  if (path.startsWith(`${baseDirectory}/`)) {
+    return path.slice(baseDirectory.length + 1);
+  }
+  return path;
+}
+
+// Re-exported for tool-strategy / file-change consumers that need JSON cursor output parsing.
+export { parseJsonText };


### PR DESCRIPTION
## Why

Continues decomposing `SessionDetail.tsx` (PR1 extracted the normalization layer). The next ~460 lines of pure logic — file-path detection, structured diff construction, and tool-classification/file-change aggregation — were trapped inside the component, untestable in isolation.

Refs CS-6 (multi-PR; **PR2 of 5**).

## What Changed

Three new pure modules under `components/session-detail/`:

| Module | Contents |
|---|---|
| **path-extract.ts** | `looksLikeFilePath`, `shouldTreatAsPathKey`, `collectPathsFromValue`, `extractPathsFromToolInput`, `getToolInputValue`, `getFilePathFromInput`, `getDisplayPath`, `getDisplayTextWithRelativePaths`, `formatTrackedPath` |
| **diff.ts** | `buildStructuredDiffFromTexts`, `createDiffBlock`, `splitDiffChunkLines`, `diffPartsToLines`, `getDiffBlockLabel`, `getKimiEditEntries`, `buildKimiEditDiffBlocks`, `buildPiEditDiffBlocks`, `extractEditDiff` |
| **file-change.ts** | `buildToolAnchorId`, `classifyToolKind`, `summarizeFileChangeItems`, `buildFileChangeSummary`, `buildFileChangeSummaryFromActivity` + types (`FileChangeKind`, `FileChangeRecord`, `FileChangeSummary`, `FileChangeSummaryItem`) |

Each module gets a test file — **36 new unit tests** covering path heuristics, diff generation, and change classification/aggregation.

`SessionDetail.tsx`: **−460 lines**, deleted all local copies, imports from the new modules. The remaining tool-strategy functions (6 `build*ToolStrategy` builders + extractors) still live in the component and will move in PR3.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [x] API
* [x] Infrastructure

## Notes for Reviewer

- **No behavior change.** All migrated functions are byte-identical; only location moved.
- 67 web tests pass (31 existing + 36 new).
- `oxlint` + `oxfmt` clean across the whole package.
- **Remaining CS-6 work**: PR3 (tool-strategy builders), PR4 (App lib logic), PR5 (App subcomponents).

## Verification

- `tsc --noEmit`: clean
- `vitest`: 67 passed
- `oxlint` + `oxfmt`: clean
