### PR TITLE
refactor(web): extract App pure logic into lib modules (CS-6 PR4)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -72,11 +72,7 @@ import {
   getAgentDisplayCount,
 } from "./lib/scan-format";
 import { applyLiveSessionUpdate } from "./lib/live-update";
-import {
-  getProjectIdentityKey,
-  getProjectPath,
-  type ProjectRouteIdentity,
-} from "./lib/projects";
+import { getProjectIdentityKey, getProjectPath, type ProjectRouteIdentity } from "./lib/projects";
 import {
   buildSessionIndexes,
   buildSidebarSessionLookup,
@@ -87,15 +83,9 @@ import {
 
 type BrowseBy = "agents" | "projects";
 
-
-
-
 function getProjectGroupIdentity(project: ProjectGroup): ProjectRouteIdentity {
   return { kind: project.identityKind, key: project.identityKey };
 }
-
-
-
 
 function toSafeSnippetHtml(snippet: string): string {
   return snippet

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -27,7 +27,6 @@ import type {
   SessionsUpdatedEvent,
   SmartTag,
   ProjectGroup,
-  ProjectIdentityKind,
 } from "./lib/api";
 import {
   deleteBookmark,
@@ -63,11 +62,19 @@ import {
   mergeBookmarksWithSessions,
   toBookmarkedSessionSnapshot,
 } from "./lib/bookmarks";
+import { parseViewState } from "./lib/view-state";
 import {
-  decodeProjectRouteKey,
+  formatAgentScanProgress,
+  formatRelativeTime,
+  formatScanStatusLabel,
+  formatSearchSubtitle,
+  formatWindowLabel,
+  getAgentDisplayCount,
+} from "./lib/scan-format";
+import { applyLiveSessionUpdate } from "./lib/live-update";
+import {
   getProjectIdentityKey,
   getProjectPath,
-  isProjectIdentityKind,
   type ProjectRouteIdentity,
 } from "./lib/projects";
 import {
@@ -80,216 +87,15 @@ import {
 
 type BrowseBy = "agents" | "projects";
 
-type ViewState =
-  | { mode: "root"; activeAgentKey: null; activeSessionSlug: null }
-  | { mode: "projects"; activeAgentKey: null; activeSessionSlug: null }
-  | {
-      mode: "project";
-      activeAgentKey: null;
-      activeSessionSlug: null;
-      activeProjectKind: ProjectIdentityKind;
-      activeProjectKey: string;
-    }
-  | { mode: "agent"; activeAgentKey: string; activeSessionSlug: null }
-  | { mode: "session"; activeAgentKey: string; activeSessionSlug: string }
-  | { mode: "missingAgent"; activeAgentKey: null; activeSessionSlug: null; attemptedKey: string }
-  | {
-      mode: "missingSession";
-      activeAgentKey: string;
-      activeSessionSlug: string;
-      attemptedSessionSlug: string;
-    }
-  | { mode: "invalidRoute"; activeAgentKey: null; activeSessionSlug: null };
 
-function parseViewState(pathname: string, validAgentKeys: Set<string>): ViewState {
-  const trimmed = pathname.replace(/^\/+|\/+$/g, "");
-  const segments = trimmed
-    ? trimmed
-        .split("/")
-        .map((s) => s.trim())
-        .filter(Boolean)
-    : [];
 
-  if (segments.length === 0) {
-    return { mode: "root", activeAgentKey: null, activeSessionSlug: null };
-  }
-  if (segments[0]?.toLowerCase() === "projects") {
-    if (segments.length === 1) {
-      return { mode: "projects", activeAgentKey: null, activeSessionSlug: null };
-    }
-    if (segments.length === 3) {
-      try {
-        const kind = decodeURIComponent(segments[1]!);
-        if (!isProjectIdentityKind(kind)) {
-          return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
-        }
-        return {
-          mode: "project",
-          activeAgentKey: null,
-          activeSessionSlug: null,
-          activeProjectKind: kind,
-          activeProjectKey: decodeProjectRouteKey(segments[2]!),
-        };
-      } catch {
-        return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
-      }
-    }
-    return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
-  }
-  if (segments.length === 1) {
-    const key = segments[0]!.toLowerCase();
-    if (validAgentKeys.has(key)) {
-      return { mode: "agent", activeAgentKey: key, activeSessionSlug: null };
-    }
-    return {
-      mode: "missingAgent",
-      activeAgentKey: null,
-      activeSessionSlug: null,
-      attemptedKey: key,
-    };
-  }
-  if (segments.length === 2) {
-    const key = segments[0]!.toLowerCase();
-    const slug = segments[1]!;
-    if (validAgentKeys.has(key) && slug) {
-      return { mode: "session", activeAgentKey: key, activeSessionSlug: slug };
-    }
-    if (validAgentKeys.has(key)) {
-      return {
-        mode: "missingSession",
-        activeAgentKey: key,
-        activeSessionSlug: slug,
-        attemptedSessionSlug: slug,
-      };
-    }
-    return {
-      mode: "missingAgent",
-      activeAgentKey: null,
-      activeSessionSlug: null,
-      attemptedKey: key,
-    };
-  }
-  return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
-}
-
-function formatIsoDate(ts: number): string {
-  const d = new Date(ts);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
-
-function formatWindowLabel(config: AppConfig | null): string | null {
-  if (!config) return null;
-  const { from, to, days } = config.window;
-  if (from == null) return "All time";
-  const fromStr = formatIsoDate(from);
-  const toStr = formatIsoDate(to ?? Date.now());
-  if (days) return `Last ${days}d · ${fromStr} → ${toStr}`;
-  return `${fromStr} → ${toStr}`;
-}
-
-function formatSearchSubtitle(query: string, loading: boolean, count: number) {
-  if (loading) return query ? `Searching for "${query}"` : "Loading recent sessions";
-  return query ? `${count} matches for "${query}"` : `${count} recent sessions`;
-}
-
-function formatScanStatusLabel(status: ScanStatusEvent | null): string | null {
-  if (!status?.active) return null;
-
-  const completed = status.completedAgents.length;
-  const total = status.totalAgents;
-  const current = status.scanningAgents[0];
-  const currentStatus = current ? status.agentStatuses[current] : null;
-  const itemProgress =
-    currentStatus?.total && currentStatus.processed != null
-      ? ` · ${currentStatus.processed}/${currentStatus.total}`
-      : "";
-  const agentProgress =
-    total > 0
-      ? current
-        ? ` · ${current}${itemProgress} · ${completed}/${total} agents ready`
-        : ` · ${completed}/${total} agents ready`
-      : "";
-
-  if (status.phase === "initializing") {
-    return `First-run setup: indexing all local sessions${agentProgress}. Your selected time window appears after this finishes.`;
-  }
-  if (status.phase === "indexing") return "Preparing local session index";
-
-  if (total > 0) {
-    return current
-      ? `Checking for new or changed sessions · ${current}${itemProgress} · ${completed}/${total} agents ready`
-      : `Checking for new or changed sessions · ${completed}/${total} agents ready`;
-  }
-  return "Checking for new or changed sessions";
-}
-
-function formatAgentScanProgress(status: ScanStatusEvent | null, agentName: string): string | null {
-  const agentStatus = status?.agentStatuses[agentName];
-  if (!agentStatus || agentStatus.status === "complete") return null;
-  if (agentStatus.total && agentStatus.processed != null) {
-    return `${agentStatus.processed}/${agentStatus.total}`;
-  }
-  return agentStatus.status === "scanning" ? "Scanning" : "Pending";
-}
-
-function getAgentDisplayCount(
-  status: ScanStatusEvent | null,
-  agentName: string,
-  fallback: number,
-): number {
-  const agentStatus = status?.agentStatuses[agentName];
-  return agentStatus?.status === "complete" && agentStatus.sessions != null
-    ? agentStatus.sessions
-    : fallback;
-}
 
 function getProjectGroupIdentity(project: ProjectGroup): ProjectRouteIdentity {
   return { kind: project.identityKind, key: project.identityKey };
 }
 
-function formatRelativeTime(timestamp?: number) {
-  if (!timestamp) return "unknown";
-  const diff = Date.now() - timestamp;
-  if (Number.isNaN(diff) || diff < 0) return "just now";
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
-function compareSessionActivityDesc(a: SessionHead, b: SessionHead): number {
-  return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
-}
 
-function applyLiveSessionUpdate(
-  sessions: SessionHead[],
-  event: SessionsUpdatedEvent,
-): SessionHead[] | null {
-  if (!event.changedSessionHeads || !event.removedSessionRefs) return null;
-
-  const byKey = new Map(
-    sessions.map((sessionItem) => [
-      getSessionRouteKey(getSessionAgentKey(sessionItem), sessionItem.id),
-      sessionItem,
-    ]),
-  );
-
-  for (const { agentName, sessionId } of event.removedSessionRefs) {
-    byKey.delete(getSessionRouteKey(agentName, sessionId));
-  }
-
-  for (const { agentName, session: sessionItem } of event.changedSessionHeads) {
-    byKey.set(getSessionRouteKey(agentName, sessionItem.id), sessionItem);
-  }
-
-  return [...byKey.values()].sort(compareSessionActivityDesc);
-}
 
 function toSafeSnippetHtml(snippet: string): string {
   return snippet

--- a/apps/web/src/lib/live-update.test.ts
+++ b/apps/web/src/lib/live-update.test.ts
@@ -25,7 +25,10 @@ describe("compareSessionActivityDesc", () => {
 describe("applyLiveSessionUpdate", () => {
   it("returns null for incomplete event", () => {
     expect(
-      applyLiveSessionUpdate([], { changedSessionHeads: null, removedSessionRefs: null } as never),
+      applyLiveSessionUpdate([], {
+        changedSessionHeads: null,
+        removedSessionRefs: null,
+      } as unknown as never),
     ).toBeNull();
   });
 
@@ -34,7 +37,7 @@ describe("applyLiveSessionUpdate", () => {
     const event = {
       changedSessionHeads: [{ agentName: "codex", session: makeSession("c", 300) }],
       removedSessionRefs: [{ agentName: "codex", sessionId: "a" }],
-    } as SessionsUpdatedEvent;
+    } as unknown as SessionsUpdatedEvent;
 
     const result = applyLiveSessionUpdate(sessions, event);
     expect(result).not.toBeNull();
@@ -45,7 +48,7 @@ describe("applyLiveSessionUpdate", () => {
     const event = {
       changedSessionHeads: [{ agentName: "codex", session: makeSession("new", 999) }],
       removedSessionRefs: [],
-    } as SessionsUpdatedEvent;
+    } as unknown as SessionsUpdatedEvent;
     const result = applyLiveSessionUpdate([makeSession("old", 100)], event);
     expect(result![0]!.id).toBe("new");
   });

--- a/apps/web/src/lib/live-update.test.ts
+++ b/apps/web/src/lib/live-update.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { applyLiveSessionUpdate, compareSessionActivityDesc } from "./live-update";
+import type { SessionHead, SessionsUpdatedEvent } from "./api";
+
+function makeSession(id: string, time: number): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: id,
+    directory: "/tmp",
+    time_created: time,
+    time_updated: time,
+    stats: { message_count: 0, total_input_tokens: 0, total_output_tokens: 0, total_cost: 0 },
+  };
+}
+
+describe("compareSessionActivityDesc", () => {
+  it("sorts newest first", () => {
+    const sessions = [makeSession("a", 100), makeSession("b", 500)];
+    sessions.sort(compareSessionActivityDesc);
+    expect(sessions[0]!.id).toBe("b");
+  });
+});
+
+describe("applyLiveSessionUpdate", () => {
+  it("returns null for incomplete event", () => {
+    expect(
+      applyLiveSessionUpdate([], { changedSessionHeads: null, removedSessionRefs: null } as never),
+    ).toBeNull();
+  });
+
+  it("applies changes and removals", () => {
+    const sessions = [makeSession("a", 100), makeSession("b", 200)];
+    const event = {
+      changedSessionHeads: [{ agentName: "codex", session: makeSession("c", 300) }],
+      removedSessionRefs: [{ agentName: "codex", sessionId: "a" }],
+    } as SessionsUpdatedEvent;
+
+    const result = applyLiveSessionUpdate(sessions, event);
+    expect(result).not.toBeNull();
+    expect(result!.map((s) => s.id).sort()).toEqual(["b", "c"]);
+  });
+
+  it("sorts result by activity desc", () => {
+    const event = {
+      changedSessionHeads: [{ agentName: "codex", session: makeSession("new", 999) }],
+      removedSessionRefs: [],
+    } as SessionsUpdatedEvent;
+    const result = applyLiveSessionUpdate([makeSession("old", 100)], event);
+    expect(result![0]!.id).toBe("new");
+  });
+});

--- a/apps/web/src/lib/live-update.ts
+++ b/apps/web/src/lib/live-update.ts
@@ -1,0 +1,35 @@
+/**
+ * Live session-update application: merge a SessionsUpdatedEvent into the
+ * current session list (apply changes, drop removals, re-sort).
+ */
+import type { SessionHead, SessionsUpdatedEvent } from "./api";
+import { getSessionAgentKey } from "./session-indexes";
+import { getSessionRouteKey } from "./session-indexes";
+
+export function compareSessionActivityDesc(a: SessionHead, b: SessionHead): number {
+  return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
+}
+
+export function applyLiveSessionUpdate(
+  sessions: SessionHead[],
+  event: SessionsUpdatedEvent,
+): SessionHead[] | null {
+  if (!event.changedSessionHeads || !event.removedSessionRefs) return null;
+
+  const byKey = new Map(
+    sessions.map((sessionItem) => [
+      getSessionRouteKey(getSessionAgentKey(sessionItem), sessionItem.id),
+      sessionItem,
+    ]),
+  );
+
+  for (const { agentName, sessionId } of event.removedSessionRefs) {
+    byKey.delete(getSessionRouteKey(agentName, sessionId));
+  }
+
+  for (const { agentName, session: sessionItem } of event.changedSessionHeads) {
+    byKey.set(getSessionRouteKey(agentName, sessionItem.id), sessionItem);
+  }
+
+  return [...byKey.values()].sort(compareSessionActivityDesc);
+}

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAgentScanProgress,
+  formatIsoDate,
+  formatRelativeTime,
+  formatScanStatusLabel,
+  formatSearchSubtitle,
+  formatWindowLabel,
+  getAgentDisplayCount,
+} from "./scan-format";
+import type { ScanStatusEvent } from "./api";
+
+describe("formatIsoDate", () => {
+  it("formats as YYYY-MM-DD", () => {
+    expect(formatIsoDate(new Date("2026-06-21T14:30:00").getTime())).toBe("2026-06-21");
+  });
+});
+
+describe("formatWindowLabel", () => {
+  it("returns All time when from is null", () => {
+    expect(formatWindowLabel({ window: { from: null, to: 1000 } } as never)).toBe("All time");
+  });
+
+  it("returns null for null config", () => {
+    expect(formatWindowLabel(null)).toBeNull();
+  });
+});
+
+describe("formatSearchSubtitle", () => {
+  it("shows searching message while loading", () => {
+    expect(formatSearchSubtitle("query", true, 0)).toContain("Searching");
+  });
+
+  it("shows count when done", () => {
+    expect(formatSearchSubtitle("query", false, 5)).toContain("5 matches");
+  });
+});
+
+describe("formatScanStatusLabel", () => {
+  it("returns null for inactive status", () => {
+    expect(formatScanStatusLabel(null)).toBeNull();
+    expect(formatScanStatusLabel({ active: false } as ScanStatusEvent)).toBeNull();
+  });
+
+  it("returns indexing message for indexing phase", () => {
+    expect(
+      formatScanStatusLabel({
+        active: true,
+        phase: "indexing",
+        completedAgents: [],
+        scanningAgents: [],
+        totalAgents: 0,
+        agentStatuses: {},
+      } as ScanStatusEvent),
+    ).toBe("Preparing local session index");
+  });
+});
+
+describe("formatAgentScanProgress", () => {
+  it("returns null for complete or missing agent", () => {
+    expect(formatAgentScanProgress(null, "codex")).toBeNull();
+  });
+});
+
+describe("getAgentDisplayCount", () => {
+  it("returns fallback when agent status missing", () => {
+    expect(getAgentDisplayCount(null, "codex", 5)).toBe(5);
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("returns unknown for missing timestamp", () => {
+    expect(formatRelativeTime(undefined)).toBe("unknown");
+  });
+
+  it("returns just now for recent", () => {
+    expect(formatRelativeTime(Date.now())).toBe("just now");
+  });
+});

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -51,7 +51,7 @@ describe("formatScanStatusLabel", () => {
         scanningAgents: [],
         totalAgents: 0,
         agentStatuses: {},
-      } as ScanStatusEvent),
+      } as unknown as ScanStatusEvent),
     ).toBe("Preparing local session index");
   });
 });

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -1,0 +1,95 @@
+/**
+ * Scan-status and time-window formatting helpers.
+ * Pure display logic consumed by the app shell and sidebar.
+ */
+import type { AppConfig, ScanStatusEvent } from "./api";
+
+export function formatIsoDate(ts: number): string {
+  const d = new Date(ts);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function formatWindowLabel(config: AppConfig | null): string | null {
+  if (!config) return null;
+  const { from, to, days } = config.window;
+  if (from == null) return "All time";
+  const fromStr = formatIsoDate(from);
+  const toStr = formatIsoDate(to ?? Date.now());
+  if (days) return `Last ${days}d · ${fromStr} → ${toStr}`;
+  return `${fromStr} → ${toStr}`;
+}
+
+export function formatSearchSubtitle(query: string, loading: boolean, count: number) {
+  if (loading) return query ? `Searching for "${query}"` : "Loading recent sessions";
+  return query ? `${count} matches for "${query}"` : `${count} recent sessions`;
+}
+
+export function formatScanStatusLabel(status: ScanStatusEvent | null): string | null {
+  if (!status?.active) return null;
+
+  const completed = status.completedAgents.length;
+  const total = status.totalAgents;
+  const current = status.scanningAgents[0];
+  const currentStatus = current ? status.agentStatuses[current] : null;
+  const itemProgress =
+    currentStatus?.total && currentStatus.processed != null
+      ? ` · ${currentStatus.processed}/${currentStatus.total}`
+      : "";
+  const agentProgress =
+    total > 0
+      ? current
+        ? ` · ${current}${itemProgress} · ${completed}/${total} agents ready`
+        : ` · ${completed}/${total} agents ready`
+      : "";
+
+  if (status.phase === "initializing") {
+    return `First-run setup: indexing all local sessions${agentProgress}. Your selected time window appears after this finishes.`;
+  }
+  if (status.phase === "indexing") return "Preparing local session index";
+
+  if (total > 0) {
+    return current
+      ? `Checking for new or changed sessions · ${current}${itemProgress} · ${completed}/${total} agents ready`
+      : `Checking for new or changed sessions · ${completed}/${total} agents ready`;
+  }
+  return "Checking for new or changed sessions";
+}
+
+export function formatAgentScanProgress(
+  status: ScanStatusEvent | null,
+  agentName: string,
+): string | null {
+  const agentStatus = status?.agentStatuses[agentName];
+  if (!agentStatus || agentStatus.status === "complete") return null;
+  if (agentStatus.total && agentStatus.processed != null) {
+    return `${agentStatus.processed}/${agentStatus.total}`;
+  }
+  return agentStatus.status === "scanning" ? "Scanning" : "Pending";
+}
+
+export function getAgentDisplayCount(
+  status: ScanStatusEvent | null,
+  agentName: string,
+  fallback: number,
+): number {
+  const agentStatus = status?.agentStatuses[agentName];
+  return agentStatus?.status === "complete" && agentStatus.sessions != null
+    ? agentStatus.sessions
+    : fallback;
+}
+
+export function formatRelativeTime(timestamp?: number) {
+  if (!timestamp) return "unknown";
+  const diff = Date.now() - timestamp;
+  if (Number.isNaN(diff) || diff < 0) return "just now";
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/apps/web/src/lib/view-state.test.ts
+++ b/apps/web/src/lib/view-state.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseViewState } from "./view-state";
+
+const agents = new Set(["claudecode", "codex"]);
+
+describe("parseViewState", () => {
+  it("parses root path", () => {
+    expect(parseViewState("/", agents)).toEqual({
+      mode: "root",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+    });
+  });
+
+  it("parses projects path", () => {
+    expect(parseViewState("/projects", agents).mode).toBe("projects");
+  });
+
+  it("parses agent path", () => {
+    const result = parseViewState("/claudecode", agents);
+    expect(result).toEqual({ mode: "agent", activeAgentKey: "claudecode", activeSessionSlug: null });
+  });
+
+  it("parses session path", () => {
+    const result = parseViewState("/codex/abc-123", agents);
+    expect(result).toEqual({ mode: "session", activeAgentKey: "codex", activeSessionSlug: "abc-123" });
+  });
+
+  it("returns missingAgent for unknown agent", () => {
+    const result = parseViewState("/unknown", agents);
+    expect(result.mode).toBe("missingAgent");
+  });
+
+  it("returns invalidRoute for deeply nested paths", () => {
+    expect(parseViewState("/a/b/c/d", agents).mode).toBe("invalidRoute");
+  });
+});

--- a/apps/web/src/lib/view-state.test.ts
+++ b/apps/web/src/lib/view-state.test.ts
@@ -18,12 +18,20 @@ describe("parseViewState", () => {
 
   it("parses agent path", () => {
     const result = parseViewState("/claudecode", agents);
-    expect(result).toEqual({ mode: "agent", activeAgentKey: "claudecode", activeSessionSlug: null });
+    expect(result).toEqual({
+      mode: "agent",
+      activeAgentKey: "claudecode",
+      activeSessionSlug: null,
+    });
   });
 
   it("parses session path", () => {
     const result = parseViewState("/codex/abc-123", agents);
-    expect(result).toEqual({ mode: "session", activeAgentKey: "codex", activeSessionSlug: "abc-123" });
+    expect(result).toEqual({
+      mode: "session",
+      activeAgentKey: "codex",
+      activeSessionSlug: "abc-123",
+    });
   });
 
   it("returns missingAgent for unknown agent", () => {

--- a/apps/web/src/lib/view-state.ts
+++ b/apps/web/src/lib/view-state.ts
@@ -1,0 +1,98 @@
+/**
+ * Route → view-state parsing for the app shell.
+ * Pure: turns a pathname + valid agent keys into a discriminated ViewState.
+ */
+import type { ProjectIdentityKind } from "./api";
+import { decodeProjectRouteKey, isProjectIdentityKind } from "./projects";
+
+export type ViewState =
+  | { mode: "root"; activeAgentKey: null; activeSessionSlug: null }
+  | { mode: "projects"; activeAgentKey: null; activeSessionSlug: null }
+  | {
+      mode: "project";
+      activeAgentKey: null;
+      activeSessionSlug: null;
+      activeProjectKind: ProjectIdentityKind;
+      activeProjectKey: string;
+    }
+  | { mode: "agent"; activeAgentKey: string; activeSessionSlug: null }
+  | { mode: "session"; activeAgentKey: string; activeSessionSlug: string }
+  | { mode: "missingAgent"; activeAgentKey: null; activeSessionSlug: null; attemptedKey: string }
+  | {
+      mode: "missingSession";
+      activeAgentKey: string;
+      activeSessionSlug: string;
+      attemptedSessionSlug: string;
+    }
+  | { mode: "invalidRoute"; activeAgentKey: null; activeSessionSlug: null };
+
+export function parseViewState(pathname: string, validAgentKeys: Set<string>): ViewState {
+  const trimmed = pathname.replace(/^\/+|\/+$/g, "");
+  const segments = trimmed
+    ? trimmed
+        .split("/")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+
+  if (segments.length === 0) {
+    return { mode: "root", activeAgentKey: null, activeSessionSlug: null };
+  }
+  if (segments[0]?.toLowerCase() === "projects") {
+    if (segments.length === 1) {
+      return { mode: "projects", activeAgentKey: null, activeSessionSlug: null };
+    }
+    if (segments.length === 3) {
+      try {
+        const kind = decodeURIComponent(segments[1]!);
+        if (!isProjectIdentityKind(kind)) {
+          return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+        }
+        return {
+          mode: "project",
+          activeAgentKey: null,
+          activeSessionSlug: null,
+          activeProjectKind: kind,
+          activeProjectKey: decodeProjectRouteKey(segments[2]!),
+        };
+      } catch {
+        return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+      }
+    }
+    return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+  }
+  if (segments.length === 1) {
+    const key = segments[0]!.toLowerCase();
+    if (validAgentKeys.has(key)) {
+      return { mode: "agent", activeAgentKey: key, activeSessionSlug: null };
+    }
+    return {
+      mode: "missingAgent",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+      attemptedKey: key,
+    };
+  }
+  if (segments.length === 2) {
+    const key = segments[0]!.toLowerCase();
+    const slug = segments[1]!;
+    if (validAgentKeys.has(key) && slug) {
+      return { mode: "session", activeAgentKey: key, activeSessionSlug: slug };
+    }
+    if (validAgentKeys.has(key)) {
+      return {
+        mode: "missingSession",
+        activeAgentKey: key,
+        activeSessionSlug: slug,
+        attemptedSessionSlug: slug,
+      };
+    }
+    return {
+      mode: "missingAgent",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+      attemptedKey: key,
+    };
+  }
+  return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+}


### PR DESCRIPTION
## Why

`App.tsx` (2512 lines) held ~200 lines of pure logic: route parsing, scan-status formatting, and live-session-update merging. These were untestable in isolation and tangled with component state.

Refs CS-6 (multi-PR; **PR4 of 5**).

## What Changed

Extracted into three lib modules:
- **`lib/view-state.ts`**: `parseViewState` + `ViewState` type (pathname → discriminated view state)
- **`lib/scan-format.ts`**: `formatScanStatusLabel`, `formatAgentScanProgress`, `formatIsoDate`, `formatWindowLabel`, `formatSearchSubtitle`, `getAgentDisplayCount`, `formatRelativeTime`
- **`lib/live-update.ts`**: `applyLiveSessionUpdate`, `compareSessionActivityDesc`

21 new unit tests. `App.tsx`: **−204 lines**.

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [x] API
* [x] Infrastructure

## Notes for Reviewer

- No behavior change. 126 web tests pass (105 existing + 21 new).
- `oxlint` + `oxfmt` clean.
- Remaining: PR5 (App subcomponents: SearchResultsPanel, SearchFilterBar, etc.)

## Verification
- `tsc --noEmit`: clean
- `vitest`: 126 passed
