### PR TITLE
fix(www): sync llms-full.txt build requirements to Node 24 / pnpm 11.5.1

### DIFF
--- a/apps/www/public/llms-full.txt
+++ b/apps/www/public/llms-full.txt
@@ -98,8 +98,8 @@ Published CLI requirement:
 
 Source build requirement:
 
-- Node.js 22.12+
-- pnpm 10+
+- Node.js 24
+- pnpm 11.5.1
 
 ## Key Questions
 
@@ -117,7 +117,7 @@ CodeSesh runs on the user's machine and uses a local SQLite index with a local W
 
 ### How do you install and start CodeSesh?
 
-The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 18+; source development uses Node.js 22.12+ and pnpm 10+.
+The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 18+; source development uses Node.js 24 and pnpm 11.5.1.
 
 ## Common CLI Usage
 


### PR DESCRIPTION
## Why

PR #57 unified README, llms.txt, index.md, and landing copy to Node.js 24 / pnpm 11.5.1, but `llms-full.txt` still exposed Node.js 22.12+ / pnpm 10+. Since `LandingLayout` exposes this file as an AI knowledge `<link rel="alternate">`, the stale requirements contradicted the rest of the docs.

Closes CS-7.

## What Changed

Updated 3 occurrences in `apps/www/public/llms-full.txt`:
- Source build requirement list: `Node.js 22.12+` → `Node.js 24`, `pnpm 10+` → `pnpm 11.5.1`
- Inline reference in quickstart paragraph: same update

Published CLI requirement stays `Node.js 18+` (unchanged).

## Verification
- `rg -n 'Node\.js 22\.12|pnpm 10+' apps/www` → no matches
- `pnpm --filter @codesesh/www build` → success