### PR TITLE
fix(watcher): restore ibmi recursive watch support (CS-9)

### DIFF
--- a/packages/cli/src/session-watcher.test.ts
+++ b/packages/cli/src/session-watcher.test.ts
@@ -26,7 +26,11 @@ vi.mock("./logging.js", () => ({
   appLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-import { SessionWatcher, resolveAgentWatchTargets } from "./session-watcher.js";
+import {
+  SessionWatcher,
+  resolveAgentWatchTargets,
+  isRecursiveWatchSupported,
+} from "./session-watcher.js";
 
 function registerMockWatcher(
   path: string,
@@ -125,6 +129,31 @@ describe("SessionWatcher", () => {
       vi.unstubAllEnvs();
       rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("isRecursiveWatchSupported", () => {
+  it("supports ibmi on Node 19.1+", () => {
+    expect(isRecursiveWatchSupported("ibmi", "19.1.0")).toBe(true);
+    expect(isRecursiveWatchSupported("ibmi", "20.0.0")).toBe(true);
+  });
+
+  it("does not support ibmi on older Node", () => {
+    expect(isRecursiveWatchSupported("ibmi", "18.0.0")).toBe(false);
+    expect(isRecursiveWatchSupported("ibmi", "19.0.0")).toBe(false);
+  });
+
+  it("supports linux on Node 19.1+", () => {
+    expect(isRecursiveWatchSupported("linux", "19.1.0")).toBe(true);
+  });
+
+  it("always supports darwin and win32", () => {
+    expect(isRecursiveWatchSupported("darwin", "18.0.0")).toBe(true);
+    expect(isRecursiveWatchSupported("win32", "18.0.0")).toBe(true);
+  });
+
+  it("does not support unknown platforms", () => {
+    expect(isRecursiveWatchSupported("freebsd", "20.0.0")).toBe(false);
   });
 });
 

--- a/packages/cli/src/session-watcher.ts
+++ b/packages/cli/src/session-watcher.ts
@@ -64,14 +64,14 @@ function getWatchRoot(path: string): string {
   return stat.isDirectory() ? path : dirname(path);
 }
 
-function isRecursiveWatchSupported(
+export function isRecursiveWatchSupported(
   platform = process.platform,
   nodeVersion = process.versions.node,
 ): boolean {
   if (platform === "darwin" || platform === "win32") {
     return true;
   }
-  if (platform !== "linux" && platform !== "aix") {
+  if (platform !== "linux" && platform !== "aix" && platform !== "ibmi") {
     return false;
   }
 


### PR DESCRIPTION
## Why

PR #61 extracted SessionWatcher but dropped `ibmi` from the recursive-watch platform allowlist (kept only `linux`/`aix`), so IBM i on Node 19.1+ fell through to the `false` fallback. This was a semantic drift during the extraction.

Closes CS-9.

## What Changed

- Restore `ibmi` in `isRecursiveWatchSupported`'s platform check alongside `linux`/`aix`
- Export `isRecursiveWatchSupported` and add 5 unit tests covering ibmi/linux/darwin/win32/unknown platforms to prevent future drift

## Verification
- `session-watcher.test.ts`: 10 passed (5 new)
- `oxlint` + `oxfmt` clean