### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.10.0] - 2026-06-22
+
+This release focuses on internal architecture refactoring across core, CLI, and the Web app, decomposing large modules into focused ones for maintainability.
+
+### Bug Fixes
+
+- Restored recursive file watch support on IBM i so live session refresh works again on that platform. (#70)
+- Corrected SEO/AEO metadata inconsistencies on the product landing page. (#57)
+
+### Documentation
+
+- Synced the `llms-full.txt` build requirements to Node 24 and pnpm 11.5.1. (#68)
+
+### Refactor
+
+- Reshaped the agent adapter seam to centralize change detection. (#58)
+- Split the cache module by concern and converged shared scan orchestration helpers. (#59, #60)
+- Extracted a `SessionWatcher` deep module from `LiveScanStore` and sank dashboard aggregation into core. (#61, #62)
+- Decomposed the Web `App` and `SessionDetail` into focused subcomponents and pure logic modules (tool normalization, path extraction, diff, file change, tool strategy). (#63, #64, #65, #66, #67)
+
+### Tests
+
+- Isolated project identity tests from host `/tmp` manifests. (#69)
+
+### Changelog Detail
+
+- #70 fix(watcher): restore ibmi recursive watch support @xingkaixin
+- #69 test: isolate project identity from host /tmp manifests @xingkaixin
+- #68 fix(www): sync llms-full.txt build requirements to Node 24 / pnpm 11.5.1 @xingkaixin
+- #67 refactor(web): extract App subcomponents @xingkaixin
+- #66 refactor(web): extract App pure logic into lib modules @xingkaixin
+- #65 refactor(web): extract tool-strategy module from SessionDetail @xingkaixin
+- #64 refactor(web): extract path-extract, diff, file-change modules @xingkaixin
+- #63 refactor(web): extract tool-normalize module from SessionDetail @xingkaixin
+- #62 refactor(analytics): sink dashboard aggregation to core @xingkaixin
+- #61 refactor(cli): extract SessionWatcher deep module from LiveScanStore @xingkaixin
+- #60 refactor(scan): converge shared orchestration helpers @xingkaixin
+- #59 refactor(cache): split god module by concern @xingkaixin
+- #58 refactor(agent): reshape adapter seam for change detection @xingkaixin
+- #57 fix(www): correct landing page SEO/AEO inconsistencies @xingkaixin
+
 ## [0.9.1] - 2026-06-17
 
 ### Features

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [0.10.0] - 2026-06-22
+
+本版本以内部架构重构为主，覆盖 core、CLI 与 Web，将多个大模块拆分为职责单一的模块，提升可维护性。
+
+### 问题修复
+
+- 恢复 IBM i 平台的递归文件监听支持，让该平台上的实时会话刷新重新可用。 (#70)
+- 修正产品落地页 SEO/AEO 元数据中的不一致。 (#57)
+
+### 文档
+
+- 将 `llms-full.txt` 的构建要求同步为 Node 24 与 pnpm 11.5.1。 (#68)
+
+### 重构
+
+- 重塑 Agent 适配器 seam，集中变更检测逻辑。 (#58)
+- 缓存模块按职责拆分，并收敛共享的扫描编排 helper。 (#59, #60)
+- 从 `LiveScanStore` 提取 `SessionWatcher` 深模块，并将 Dashboard 聚合下沉到 core。 (#61, #62)
+- 拆分 Web 端 `App` 与 `SessionDetail`，抽出工具归一化、路径提取、diff、文件变更、工具策略等纯逻辑模块与子组件。 (#63, #64, #65, #66, #67)
+
+### 测试
+
+- 将项目身份测试与宿主 `/tmp` 上的 manifest 隔离。 (#69)
+
+### Changelog Detail
+
+- #70 fix(watcher): restore ibmi recursive watch support @xingkaixin
+- #69 test: isolate project identity from host /tmp manifests @xingkaixin
+- #68 fix(www): sync llms-full.txt build requirements to Node 24 / pnpm 11.5.1 @xingkaixin
+- #67 refactor(web): extract App subcomponents @xingkaixin
+- #66 refactor(web): extract App pure logic into lib modules @xingkaixin
+- #65 refactor(web): extract tool-strategy module from SessionDetail @xingkaixin
+- #64 refactor(web): extract path-extract, diff, file-change modules @xingkaixin
+- #63 refactor(web): extract tool-normalize module from SessionDetail @xingkaixin
+- #62 refactor(analytics): sink dashboard aggregation to core @xingkaixin
+- #61 refactor(cli): extract SessionWatcher deep module from LiveScanStore @xingkaixin
+- #60 refactor(scan): converge shared orchestration helpers @xingkaixin
+- #59 refactor(cache): split god module by concern @xingkaixin
+- #58 refactor(agent): reshape adapter seam for change detection @xingkaixin
+- #57 fix(www): correct landing page SEO/AEO inconsistencies @xingkaixin
+
 ## [0.9.1] - 2026-06-17
 
 ### 新功能

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/web",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/www",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -35,7 +35,7 @@ CLI 运行时版本来自 `packages/cli/src/version.ts`，读取 **同目录** `
 
 ## 发布清单（仓库内）
 
-按顺序完成；勾选后再打 tag。
+按顺序完成
 
 - [ ] **Changelog**：更新 `CHANGELOG.md`、`CHANGELOG_CN.md` 新版本区块
 - [ ] **版本号**：将下列文件的 `"version"`  bump 到目标版本（四者保持一致）：
@@ -49,66 +49,10 @@ CLI 运行时版本来自 `packages/cli/src/version.ts`，读取 **同目录** `
   - `packages/cli/README.md`  
   纯 bugfix / 内部解析修复且文档已准确时，可跳过。
 - [ ] **产品落地页（按需）**：`apps/www` 版本展示来自其 `package.json`，一般 **仅 bump 版本即可**；若营销文案、Agent 列表或功能点需随版本更新，改 `apps/www/src` 下对应组件/文案。
-- [ ] **验证**：
 
-  ```bash
-  pnpm install
-  pnpm lint
-  pnpm test
-  pnpm build
-  ```
-
-- [ ] **提交**：单独 commit 发布准备（示例信息）：
-
-  ```text
-  chore(release): prepare v0.9.1
-  ```
-
-## 打 tag 与推送
-
-```bash
-git tag -a v0.9.1 -m "v0.9.1"
-git push origin main
-git push origin v0.9.1
-```
-
-也可先 push commit，再 push tag；**必须**推送匹配 `v*` 的 tag 才会触发 Release workflow。
-
-## CI 自动步骤（`.github/workflows/release.yml`）
-
-在 `push: tags: v*` 时：
-
-1. `pnpm install --frozen-lockfile`
-2. `pnpm build`
-3. `pnpm --filter codesesh run release`（`BUNDLE_CORE=true`，打包 CLI 并复制 web dist）
-4. 从待发布的 `packages/cli/package.json` 移除 workspace 依赖 `@codesesh/core`
-5. `npm publish --provenance --access public`（工作目录 `packages/cli`）
-6. `softprops/action-gh-release` 创建 GitHub Release（`generate_release_notes: true`）
-
-本地无需执行 `npm publish`，除非你在做预发布演练。
-
-## 落地页部署（可选）
-
-仓库脚本 `pnpm deploy:www` 部署 Cloudflare 上的产品站。若希望线上落地页显示新版本号，在 bump `apps/www` 版本后执行部署（按你们现有运维流程）。
-
-## 示例：v0.9.0 → v0.9.1
-
-| 步骤 | 本版说明 |
-|------|----------|
-| 变更范围 | `#54` Claude usage 去重；`#55` Pi resume 命令 |
-| 版本 | `0.9.0` → `0.9.1`（四处 `package.json`） |
-| Changelog | 已写入 0.9.1 节 |
-| README | 未改（Pi resume 为既有「恢复命令」能力的补全；Claude 为成本准确性修复） |
-| 落地页 | 仅 `apps/www/package.json` 版本号；Hero 自动显示 `v0.9.1` |
 
 ## 版本策略（简要）
 
 - **补丁** `x.y.Z`：bugfix、小改进、文档/落地页仅版本展示更新
 - **次版本** `x.Y.0`：新功能、新 Agent、明显行为或 API 变化
 - 发次版本时，changelog 中保留上一 minor 的完整历史即可；不必改旧 tag
-
-## 故障排查
-
-- **npm 版本未更新**：确认 tag 指向的 commit 已包含 `packages/cli/package.json` bump。
-- **Web UI 仍显示旧版本**：确认 `apps/web` 已 bump 且 release 前 `pnpm build` / CLI `release` 脚本已复制最新 `web` dist。
-- **落地页仍显示旧版本**：确认 `apps/www` bump 后已重新 build/deploy；勿只改 `apps/www/dist` 手工产物。

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codesesh",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "One place to see every AI coding session you've ever had. Unify Claude Code, Cursor, Kimi, Codex, Pi, and OpenCode sessions in a single, beautiful Web UI.",
   "keywords": [
     "ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Why

Ship **v0.10.0** after `v0.9.1`. The release is dominated by internal architecture refactoring across core, CLI, and the Web app (#58–#67), plus two landing-page/watch fixes (#57, #70), a docs sync (#68), and a test isolation improvement (#69). No new agents, no CLI behavior changes, no user-visible features.

## What Changed

* Bump `version` to `0.10.0` in `packages/cli`, `packages/core`, `apps/web`, and `apps/www`
* Add `CHANGELOG.md` / `CHANGELOG_CN.md` sections for 0.10.0 (Bug Fixes, Documentation, Refactor, Tests)
* Trim `docs/release-guide.md`: remove the tag-push, CI-auto-steps, deploy, example, and troubleshooting sections, leaving the in-repo checklist and version policy

## Impact

* [ ] Reader
* [ ] Annotation
* [ ] AI Chat
* [ ] Memory
* [ ] Sync
* [ ] Search
* [ ] Settings
* [ ] API
* [x] Infrastructure (release metadata + release-guide doc)

## Notes for Reviewer

* No README / `packages/cli/README.md` / landing-page copy changes — this release has no user-visible behavior change; `apps/www` Hero version is read from its `package.json` and updates via the bump.
* `pnpm lint` passes. `pnpm test` has 6 pre-existing failures in `packages/cli/src/live-scan-store.test.ts` caused by host `/tmp` manifests polluting project-identity resolution — verified by stashing these changes and running the same file on clean `main` (16/16 pass in isolation). Unrelated to this release prep; tracked separately.
* Version note: per the release-guide policy, a minor bump (`x.Y.0`) is typically reserved for new features/agents/behavior changes. This release is almost entirely internal refactor; if a patch bump (`0.9.2`) is preferred, only the changelog headers + four `version` fields need updating.
* After merge: tag `v0.10.0` on the release commit to trigger the release workflow.