### PR TITLE
refactor(web): table-dispatch tool strategy

### DIFF
--- a/apps/web/src/components/session-detail/tool-strategy.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.ts
@@ -1389,24 +1389,32 @@ export function buildZCodeToolStrategy(
   return defaultStrategy;
 }
 
+type ToolStrategyBuilder = (
+  tool: MessagePart,
+  state: NormalizedToolState,
+  baseDirectory?: string,
+) => ToolDisplayStrategy;
+
+// agentKey → 展示策略 builder。新增 agent 时在此登记一行；值类型保证 builder
+// 签名一致，未登记的 agent 走 buildDefaultToolStrategy 兜底（默认渲染，非错误）。
+const TOOL_STRATEGY_BUILDERS: Record<string, ToolStrategyBuilder> = {
+  claudecode: buildClaudeToolStrategy,
+  opencode: buildOpencodeToolStrategy,
+  kimi: buildKimiToolStrategy,
+  codex: buildCodexToolStrategy,
+  cursor: buildCursorToolStrategy,
+  pi: buildPiToolStrategy,
+  zcode: buildZCodeToolStrategy,
+};
+
 export function getToolDisplayStrategy(
   sessionAgentKey: string,
   tool: MessagePart,
   state: NormalizedToolState,
   baseDirectory?: string,
 ): ToolDisplayStrategy {
-  const normalizedAgentKey = sessionAgentKey.toLowerCase();
-  if (normalizedAgentKey === "opencode")
-    return buildOpencodeToolStrategy(tool, state, baseDirectory);
-  if (normalizedAgentKey === "codex") return buildCodexToolStrategy(tool, state, baseDirectory);
-  if (normalizedAgentKey === "kimi") return buildKimiToolStrategy(tool, state, baseDirectory);
-  if (normalizedAgentKey === "claudecode") {
-    return buildClaudeToolStrategy(tool, state, baseDirectory);
-  }
-  if (normalizedAgentKey === "cursor") return buildCursorToolStrategy(tool, state, baseDirectory);
-  if (normalizedAgentKey === "pi") return buildPiToolStrategy(tool, state, baseDirectory);
-  if (normalizedAgentKey === "zcode") return buildZCodeToolStrategy(tool, state, baseDirectory);
-  return buildDefaultToolStrategy(tool, state, baseDirectory);
+  const builder = TOOL_STRATEGY_BUILDERS[sessionAgentKey.toLowerCase()] ?? buildDefaultToolStrategy;
+  return builder(tool, state, baseDirectory);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Background

`getToolDisplayStrategy` hardcoded the "agent → tool display strategy" dispatch as a 7-branch `if (agentKey === "...")` chain. Adding an agent required editing this chain, which is asymmetric with core's declarative `register.ts`. A missing branch silently falls through to the default with no error.

## Changes

- Replace the if/else chain with a `Record<string, ToolStrategyBuilder>` lookup; `getToolDisplayStrategy` cyclomatic complexity drops **8 → 1**.
- Adding an agent now takes a single registration line (mirroring core's `register.ts`); the `Record` value type keeps every builder signature consistent.
- Unregistered agents fall back to `buildDefaultToolStrategy` — an expected default-rendering fallback, not an error.
- The 7 per-agent builders are **unchanged** in logic and signature.

## Scope

- Excludes the cursor special-case in `normalizeMessagesForDisplay`: with only a single special case, a registry there would be over-engineering.

## Verification

- `pnpm --filter web test`: 14 files, **130 tests pass**
- `tsc --noEmit`: **exit 0**
- `pnpm --filter web lint`: pass
