### PR TITLE
refactor(web): extract useSessionDetail hook

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -20,7 +20,6 @@ import type {
   SearchRequestOptions,
   SearchResult,
   SessionHead,
-  SessionData,
   SessionsUpdatedEvent,
   ProjectGroup,
 } from "./lib/api";
@@ -33,7 +32,6 @@ import {
   fetchProjects,
   fetchSearchResults,
   fetchSessions,
-  fetchSessionData,
   importBookmarks,
   logClientEvent,
   subscribeSessionUpdates,
@@ -59,6 +57,7 @@ import {
 } from "./lib/bookmarks";
 import { parseViewState } from "./lib/view-state";
 import { useScanStatus } from "./hooks/useScanStatus";
+import { useSessionDetail } from "./hooks/useSessionDetail";
 import { BrowseByToggle } from "./components/app/BrowseByToggle";
 import { SidebarFlatSessionList } from "./components/app/SidebarFlatSessionList";
 import { SearchResultsPanel } from "./components/app/SearchResultsPanel";
@@ -142,9 +141,6 @@ export default function App() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [session, setSession] = useState<SessionData | null>(null);
-  const [sessionLoading, setSessionLoading] = useState(false);
-  const [sessionError, setSessionError] = useState<string | null>(null);
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
   const [projects, setProjects] = useState<ProjectGroup[]>([]);
@@ -233,6 +229,13 @@ export default function App() {
     () => parseViewState(location.pathname, validAgentKeys),
     [location.pathname, validAgentKeys],
   );
+
+  const {
+    session,
+    sessionLoading,
+    sessionError,
+    refresh: refreshSessionDetail,
+  } = useSessionDetail(viewState);
 
   useEffect(() => {
     logClientEvent("route.change", {
@@ -531,12 +534,6 @@ export default function App() {
     return results;
   }, [searchFilters, sessionIndexes]);
 
-  // Stable key for session fetch
-  const sessionFetchKey =
-    viewState.mode === "session"
-      ? `${viewState.activeAgentKey}/${viewState.activeSessionSlug}`
-      : "";
-
   const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
     try {
       const canApplySessionUpdate = Boolean(event.changedSessionHeads && event.removedSessionRefs);
@@ -583,17 +580,7 @@ export default function App() {
       if (searchData) setSearchResults(searchData.results);
 
       if (viewState.mode === "session") {
-        try {
-          const data = await fetchSessionData(
-            viewState.activeAgentKey,
-            viewState.activeSessionSlug,
-          );
-          setSession(data);
-          setSessionError(null);
-        } catch {
-          setSession(null);
-          setSessionError("Session not found");
-        }
+        await refreshSessionDetail();
       }
 
       if (event.newSessions > 0) {
@@ -654,47 +641,6 @@ export default function App() {
     searchRequestOptions,
     usesServerSearch,
   ]);
-
-  // Load session detail
-  useEffect(() => {
-    if (viewState.mode !== "session") {
-      setSession(null);
-      setSessionError(null);
-      return;
-    }
-    const ac = new AbortController();
-    setSessionLoading(true);
-    setSessionError(null);
-    const startedAt = performance.now();
-    logClientEvent("session.open.start", {
-      agent: viewState.activeAgentKey,
-      session: viewState.activeSessionSlug,
-    });
-    (async () => {
-      try {
-        const data = await fetchSessionData(viewState.activeAgentKey, viewState.activeSessionSlug);
-        setSession(data);
-        logClientEvent("session.open.done", {
-          agent: viewState.activeAgentKey,
-          session: viewState.activeSessionSlug,
-          duration_ms: Math.round(performance.now() - startedAt),
-          messages: data.messages.length,
-        });
-      } catch (err) {
-        logClientEvent("session.open.error", {
-          agent: viewState.activeAgentKey,
-          session: viewState.activeSessionSlug,
-          duration_ms: Math.round(performance.now() - startedAt),
-          error: err instanceof Error ? err.message : String(err),
-        });
-        setSessionError("Session not found");
-        setSession(null);
-      } finally {
-        setSessionLoading(false);
-      }
-    })();
-    return () => ac.abort();
-  }, [sessionFetchKey, viewState.activeAgentKey, viewState.activeSessionSlug, viewState.mode]);
 
   useEffect(() => {
     if (activeProjectIdentityKey) setSelectedProjectAgent(undefined);

--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { SessionData } from "../lib/api";
+import type { ViewState } from "../lib/view-state";
+import * as api from "../lib/api";
+import { useSessionDetail } from "./useSessionDetail";
+
+vi.mock("../lib/api", () => ({
+  fetchSessionData: vi.fn(),
+  logClientEvent: vi.fn(),
+}));
+
+const sessionView: ViewState = {
+  mode: "session",
+  activeAgentKey: "claudecode",
+  activeSessionSlug: "claudecode/abc",
+};
+
+const sample = { id: "abc", messages: [] } as unknown as SessionData;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useSessionDetail", () => {
+  it("loads the session for a session route", async () => {
+    vi.mocked(api.fetchSessionData).mockResolvedValue(sample);
+    const { result } = renderHook(() => useSessionDetail(sessionView));
+
+    await waitFor(() => expect(result.current.session).toEqual(sample));
+    expect(result.current.sessionError).toBeNull();
+    expect(api.fetchSessionData).toHaveBeenCalledWith("claudecode", "claudecode/abc");
+  });
+
+  it("sets an error when the fetch fails", async () => {
+    vi.mocked(api.fetchSessionData).mockRejectedValue(new Error("nope"));
+    const { result } = renderHook(() => useSessionDetail(sessionView));
+
+    await waitFor(() => expect(result.current.sessionError).toBe("Session not found"));
+    expect(result.current.session).toBeNull();
+  });
+
+  it("does not fetch for a non-session route", () => {
+    const rootView: ViewState = { mode: "root", activeAgentKey: null, activeSessionSlug: null };
+    const { result } = renderHook(() => useSessionDetail(rootView));
+
+    expect(result.current.session).toBeNull();
+    expect(api.fetchSessionData).not.toHaveBeenCalled();
+  });
+
+  it("refresh re-fetches the open session", async () => {
+    vi.mocked(api.fetchSessionData).mockResolvedValue(sample);
+    const { result } = renderHook(() => useSessionDetail(sessionView));
+    await waitFor(() => expect(result.current.session).toEqual(sample));
+
+    const updated = { id: "abc", messages: [1] } as unknown as SessionData;
+    vi.mocked(api.fetchSessionData).mockResolvedValue(updated);
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.session).toEqual(updated);
+  });
+});

--- a/apps/web/src/hooks/useSessionDetail.ts
+++ b/apps/web/src/hooks/useSessionDetail.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+import { type SessionData, fetchSessionData, logClientEvent } from "../lib/api";
+import type { ViewState } from "../lib/view-state";
+
+/**
+ * Owns session-detail state: loads the session for the current "session" route
+ * (with a loading flag) and exposes refresh() for the live-update subscription
+ * to silently re-fetch the open session without flashing the loading state.
+ */
+export function useSessionDetail(viewState: ViewState) {
+  const [session, setSession] = useState<SessionData | null>(null);
+  const [sessionLoading, setSessionLoading] = useState(false);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+
+  const sessionKey =
+    viewState.mode === "session"
+      ? `${viewState.activeAgentKey}/${viewState.activeSessionSlug}`
+      : "";
+
+  useEffect(() => {
+    if (viewState.mode !== "session") {
+      setSession(null);
+      setSessionError(null);
+      return;
+    }
+    const ac = new AbortController();
+    setSessionLoading(true);
+    setSessionError(null);
+    const startedAt = performance.now();
+    logClientEvent("session.open.start", {
+      agent: viewState.activeAgentKey,
+      session: viewState.activeSessionSlug,
+    });
+    (async () => {
+      try {
+        const data = await fetchSessionData(viewState.activeAgentKey, viewState.activeSessionSlug);
+        setSession(data);
+        logClientEvent("session.open.done", {
+          agent: viewState.activeAgentKey,
+          session: viewState.activeSessionSlug,
+          duration_ms: Math.round(performance.now() - startedAt),
+          messages: data.messages.length,
+        });
+      } catch (err) {
+        logClientEvent("session.open.error", {
+          agent: viewState.activeAgentKey,
+          session: viewState.activeSessionSlug,
+          duration_ms: Math.round(performance.now() - startedAt),
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setSessionError("Session not found");
+        setSession(null);
+      } finally {
+        setSessionLoading(false);
+      }
+    })();
+    return () => ac.abort();
+  }, [sessionKey, viewState.activeAgentKey, viewState.activeSessionSlug, viewState.mode]);
+
+  const refresh = useCallback(async () => {
+    if (viewState.mode !== "session") return;
+    try {
+      const data = await fetchSessionData(viewState.activeAgentKey, viewState.activeSessionSlug);
+      setSession(data);
+      setSessionError(null);
+    } catch {
+      setSession(null);
+      setSessionError("Session not found");
+    }
+  }, [viewState]);
+
+  return { session, sessionLoading, sessionError, refresh };
+}


### PR DESCRIPTION
## Background

Second step of decomposing the ~1700-line `App.tsx` god component into per-domain hooks (after `useScanStatus`).

## Changes

- Extract `useSessionDetail(viewState)`: owns `session` / `sessionLoading` / `sessionError` and the load effect for the current `session` route.
- The hook exposes `refresh()` — a silent re-fetch (no loading flag) that the live-update subscription calls to update the open session, replacing the inline `fetchSessionData` + `setSession` block in `syncLiveUpdate`.
- `App.tsx` drops 3 `useState`, the `sessionFetchKey` helper, and the load effect (net −72 lines).
- `liveNotice` stays in `App` — it belongs to the live-update domain (future `useLiveSync`), not session detail.

## Behavior

Equivalent to before: the route-driven load keeps its loading flag; live updates re-fetch silently. `session` consumers are unchanged (same variable). The load effect keeps the same dependency set (via `sessionKey`).

## Verification

- `pnpm --filter web test`: 16 files, **136 tests pass** (4 new for the hook: load / error / non-session / refresh)
- `tsc --noEmit`: exit 0
- `oxlint` / `oxfmt`: pass
