### PR TITLE
refactor(web): extract useBookmarks hook

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,24 +7,19 @@ import { ModelConfig } from "./config";
 import type {
   AgentInfo,
   AppConfig,
-  BookmarkedSessionSnapshot,
   DashboardData,
   SessionHead,
   SessionsUpdatedEvent,
   ProjectGroup,
 } from "./lib/api";
 import {
-  deleteBookmark,
   fetchAgents,
-  fetchBookmarks,
   fetchConfig,
   fetchDashboard,
   fetchProjects,
   fetchSessions,
-  importBookmarks,
   logClientEvent,
   subscribeSessionUpdates,
-  upsertBookmark,
 } from "./lib/api";
 import { SessionDetail } from "./components/SessionDetail";
 import { SessionDetailSkeleton } from "./components/SessionDetailSkeleton";
@@ -37,17 +32,12 @@ import { CopyResumeButton } from "./components/CopyResumeButton";
 import { SessionTreeSidebar } from "./components/SessionTreeSidebar";
 import { RenderProfiler } from "./components/RenderProfiler";
 import { SmartTagChips } from "./components/SmartTagChips";
-import {
-  clearLegacyBookmarks,
-  getSessionBookmarkKey,
-  loadLegacyBookmarks,
-  mergeBookmarksWithSessions,
-  toBookmarkedSessionSnapshot,
-} from "./lib/bookmarks";
+import { getSessionBookmarkKey } from "./lib/bookmarks";
 import { parseViewState } from "./lib/view-state";
 import { useScanStatus } from "./hooks/useScanStatus";
 import { useSessionDetail } from "./hooks/useSessionDetail";
 import { useSessionSearch } from "./hooks/useSessionSearch";
+import { useBookmarks } from "./hooks/useBookmarks";
 import { BrowseByToggle } from "./components/app/BrowseByToggle";
 import { SidebarFlatSessionList } from "./components/app/SidebarFlatSessionList";
 import { SearchResultsPanel } from "./components/app/SearchResultsPanel";
@@ -122,7 +112,6 @@ export default function App() {
   const navigate = useNavigate();
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [sessions, setSessions] = useState<SessionHead[]>([]);
-  const [bookmarks, setBookmarks] = useState<BookmarkedSessionSnapshot[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -152,24 +141,21 @@ export default function App() {
       try {
         const config = await fetchConfig();
         setAppConfig(config);
-        const [agentList, sessionList, dashboardData, projectData, bookmarkData] =
-          await Promise.all([
-            fetchAgents(),
-            fetchSessions({ from: config.window.from, to: config.window.to }),
-            fetchDashboard(config.window).catch((err) => {
-              console.error("Failed to load dashboard:", err);
-              return null;
-            }),
-            fetchProjects().catch((err) => {
-              console.error("Failed to load projects:", err);
-              return { projects: [] };
-            }),
-            fetchBookmarks(),
-          ]);
+        const [agentList, sessionList, dashboardData, projectData] = await Promise.all([
+          fetchAgents(),
+          fetchSessions({ from: config.window.from, to: config.window.to }),
+          fetchDashboard(config.window).catch((err) => {
+            console.error("Failed to load dashboard:", err);
+            return null;
+          }),
+          fetchProjects().catch((err) => {
+            console.error("Failed to load projects:", err);
+            return { projects: [] };
+          }),
+        ]);
         setAgents(agentList);
         setSessions(sessionList.sessions);
         setProjects(projectData.projects);
-        setBookmarks(bookmarkData.bookmarks);
         if (dashboardData) setDashboard(dashboardData);
         logClientEvent("app.load.done", {
           duration_ms: Math.round(performance.now() - startedAt),
@@ -265,115 +251,8 @@ export default function App() {
       ? location.state.searchQuery
       : "";
 
-  useEffect(() => {
-    let cancelled = false;
-
-    setBookmarks((prev) => {
-      const next = mergeBookmarksWithSessions(prev, sessions);
-      if (next === prev) return prev;
-      void importBookmarks(
-        next.map(({ bookmarked_at: _bookmarkedAt, ...bookmark }) => bookmark),
-      ).catch((error) => {
-        if (!cancelled) {
-          console.error("Failed to sync bookmark snapshots:", error);
-        }
-      });
-      return next;
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sessions]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    void (async () => {
-      const legacy = loadLegacyBookmarks();
-      if (legacy.length === 0) return;
-
-      try {
-        const data = await importBookmarks(
-          legacy.map(({ bookmarked_at: _bookmarkedAt, ...bookmark }) => bookmark),
-        );
-        if (cancelled) return;
-        setBookmarks(data.bookmarks);
-        clearLegacyBookmarks();
-      } catch (error) {
-        if (!cancelled) {
-          console.error("Failed to migrate legacy bookmarks:", error);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const bookmarkKeySet = useMemo(
-    () =>
-      new Set(
-        bookmarks.map((bookmark) => getSessionBookmarkKey(bookmark.agentKey, bookmark.sessionId)),
-      ),
-    [bookmarks],
-  );
-
-  const isSessionBookmarked = useCallback(
-    (agentKey: string, sessionId: string): boolean =>
-      bookmarkKeySet.has(getSessionBookmarkKey(agentKey, sessionId)),
-    [bookmarkKeySet],
-  );
-
-  const toggleBookmark = useCallback(
-    (snapshot: BookmarkedSessionSnapshot) => {
-      const key = getSessionBookmarkKey(snapshot.agentKey, snapshot.sessionId);
-      const exists = bookmarkKeySet.has(key);
-      const previous = bookmarks;
-      const next = exists
-        ? previous.filter(
-            (bookmark) => getSessionBookmarkKey(bookmark.agentKey, bookmark.sessionId) !== key,
-          )
-        : [...previous, snapshot].toSorted((a, b) => {
-            const aTime = a.time_updated ?? a.time_created;
-            const bTime = b.time_updated ?? b.time_created;
-            return bTime - aTime;
-          });
-
-      setBookmarks(next);
-      logClientEvent(exists ? "bookmark.delete" : "bookmark.add", {
-        agent: snapshot.agentKey,
-        session: snapshot.sessionId,
-      });
-
-      void (
-        exists
-          ? deleteBookmark(snapshot.agentKey, snapshot.sessionId)
-          : upsertBookmark({
-              agentKey: snapshot.agentKey,
-              sessionId: snapshot.sessionId,
-              fullPath: snapshot.fullPath,
-              title: snapshot.title,
-              directory: snapshot.directory,
-              time_created: snapshot.time_created,
-              time_updated: snapshot.time_updated,
-              stats: snapshot.stats,
-            })
-      ).catch((error) => {
-        console.error("Failed to toggle bookmark:", error);
-        setBookmarks(previous);
-      });
-    },
-    [bookmarkKeySet, bookmarks],
-  );
-
-  const toggleSessionBookmark = useCallback(
-    (session: SessionHead, agentKey: string) => {
-      toggleBookmark(toBookmarkedSessionSnapshot(session, agentKey));
-    },
-    [toggleBookmark],
-  );
+  const { bookmarkedSessions, isSessionBookmarked, toggleBookmark, toggleSessionBookmark } =
+    useBookmarks(sessions);
 
   const activeAgentKey = viewState.activeAgentKey;
   const activeProjectKind = viewState.mode === "project" ? viewState.activeProjectKind : null;
@@ -433,21 +312,11 @@ export default function App() {
     return new Set(
       sidebarSessions
         .filter((sessionItem) =>
-          bookmarkKeySet.has(
-            getSessionBookmarkKey(getSessionAgentKey(sessionItem), sessionItem.id),
-          ),
+          isSessionBookmarked(getSessionAgentKey(sessionItem), sessionItem.id),
         )
         .map((sessionItem) => sessionItem.id),
     );
-  }, [bookmarkKeySet, sidebarSessions]);
-
-  const bookmarkedSessions = useMemo(
-    () =>
-      bookmarks.toSorted(
-        (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
-      ),
-    [bookmarks],
-  );
+  }, [isSessionBookmarked, sidebarSessions]);
 
   const handleSelectFlatSidebarSession = useCallback(
     (sessionItem: SessionHead) => {

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { BookmarkedSessionSnapshot } from "../lib/api";
+import * as api from "../lib/api";
+import { useBookmarks } from "./useBookmarks";
+
+vi.mock("../lib/api", () => ({
+  fetchBookmarks: vi.fn(),
+  importBookmarks: vi.fn(),
+  deleteBookmark: vi.fn(),
+  upsertBookmark: vi.fn(),
+  logClientEvent: vi.fn(),
+}));
+
+vi.mock("../lib/bookmarks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/bookmarks")>();
+  return {
+    ...actual,
+    mergeBookmarksWithSessions: vi.fn((prev) => prev),
+    loadLegacyBookmarks: vi.fn(() => []),
+  };
+});
+
+const snap = (id: string, updated = 1): BookmarkedSessionSnapshot =>
+  ({
+    agentKey: "cc",
+    sessionId: id,
+    fullPath: `cc/${id}`,
+    title: id,
+    directory: "/d",
+    time_created: 1,
+    time_updated: updated,
+    stats: {},
+    bookmarked_at: 0,
+  }) as unknown as BookmarkedSessionSnapshot;
+
+beforeEach(() => {
+  vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [] });
+  vi.mocked(api.importBookmarks).mockResolvedValue({ bookmarks: [] });
+  vi.mocked(api.upsertBookmark).mockResolvedValue(undefined as never);
+  vi.mocked(api.deleteBookmark).mockResolvedValue(undefined as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useBookmarks", () => {
+  it("loads bookmarks on mount", async () => {
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
+    const { result } = renderHook(() => useBookmarks([]));
+
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s1")).toBe(true));
+  });
+
+  it("toggleBookmark adds optimistically and calls upsert", async () => {
+    const { result } = renderHook(() => useBookmarks([]));
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
+
+    act(() => result.current.toggleBookmark(snap("s2")));
+
+    expect(result.current.isSessionBookmarked("cc", "s2")).toBe(true);
+    expect(api.upsertBookmark).toHaveBeenCalledOnce();
+  });
+
+  it("toggleBookmark removes an existing bookmark and calls delete", async () => {
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s3")] });
+    const { result } = renderHook(() => useBookmarks([]));
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s3")).toBe(true));
+
+    act(() => result.current.toggleBookmark(snap("s3")));
+
+    expect(result.current.isSessionBookmarked("cc", "s3")).toBe(false);
+    expect(api.deleteBookmark).toHaveBeenCalledWith("cc", "s3");
+  });
+
+  it("bookmarkedSessions is sorted by most-recent activity", async () => {
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({
+      bookmarks: [snap("old", 10), snap("new", 20)],
+    });
+    const { result } = renderHook(() => useBookmarks([]));
+
+    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(2));
+    expect(result.current.bookmarkedSessions[0]?.sessionId).toBe("new");
+  });
+});

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type BookmarkedSessionSnapshot,
+  type SessionHead,
+  deleteBookmark,
+  fetchBookmarks,
+  importBookmarks,
+  logClientEvent,
+  upsertBookmark,
+} from "../lib/api";
+import {
+  clearLegacyBookmarks,
+  getSessionBookmarkKey,
+  loadLegacyBookmarks,
+  mergeBookmarksWithSessions,
+  toBookmarkedSessionSnapshot,
+} from "../lib/bookmarks";
+
+/**
+ * Owns bookmark state: initial fetch, snapshot-merge sync as sessions change,
+ * legacy migration, and optimistic add/remove toggles. Takes the current
+ * sessions so bookmark snapshots stay in sync with live session data.
+ */
+export function useBookmarks(sessions: SessionHead[]) {
+  const [bookmarks, setBookmarks] = useState<BookmarkedSessionSnapshot[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchBookmarks()
+      .then((data) => {
+        if (!cancelled) setBookmarks(data.bookmarks);
+      })
+      .catch((err) => {
+        console.error("Failed to load bookmarks:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setBookmarks((prev) => {
+      const next = mergeBookmarksWithSessions(prev, sessions);
+      if (next === prev) return prev;
+      void importBookmarks(
+        next.map(({ bookmarked_at: _bookmarkedAt, ...bookmark }) => bookmark),
+      ).catch((error) => {
+        if (!cancelled) {
+          console.error("Failed to sync bookmark snapshots:", error);
+        }
+      });
+      return next;
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessions]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const legacy = loadLegacyBookmarks();
+      if (legacy.length === 0) return;
+
+      try {
+        const data = await importBookmarks(
+          legacy.map(({ bookmarked_at: _bookmarkedAt, ...bookmark }) => bookmark),
+        );
+        if (cancelled) return;
+        setBookmarks(data.bookmarks);
+        clearLegacyBookmarks();
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Failed to migrate legacy bookmarks:", error);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const bookmarkKeySet = useMemo(
+    () =>
+      new Set(
+        bookmarks.map((bookmark) => getSessionBookmarkKey(bookmark.agentKey, bookmark.sessionId)),
+      ),
+    [bookmarks],
+  );
+
+  const isSessionBookmarked = useCallback(
+    (agentKey: string, sessionId: string): boolean =>
+      bookmarkKeySet.has(getSessionBookmarkKey(agentKey, sessionId)),
+    [bookmarkKeySet],
+  );
+
+  const toggleBookmark = useCallback(
+    (snapshot: BookmarkedSessionSnapshot) => {
+      const key = getSessionBookmarkKey(snapshot.agentKey, snapshot.sessionId);
+      const exists = bookmarkKeySet.has(key);
+      const previous = bookmarks;
+      const next = exists
+        ? previous.filter(
+            (bookmark) => getSessionBookmarkKey(bookmark.agentKey, bookmark.sessionId) !== key,
+          )
+        : [...previous, snapshot].toSorted((a, b) => {
+            const aTime = a.time_updated ?? a.time_created;
+            const bTime = b.time_updated ?? b.time_created;
+            return bTime - aTime;
+          });
+
+      setBookmarks(next);
+      logClientEvent(exists ? "bookmark.delete" : "bookmark.add", {
+        agent: snapshot.agentKey,
+        session: snapshot.sessionId,
+      });
+
+      void (
+        exists
+          ? deleteBookmark(snapshot.agentKey, snapshot.sessionId)
+          : upsertBookmark({
+              agentKey: snapshot.agentKey,
+              sessionId: snapshot.sessionId,
+              fullPath: snapshot.fullPath,
+              title: snapshot.title,
+              directory: snapshot.directory,
+              time_created: snapshot.time_created,
+              time_updated: snapshot.time_updated,
+              stats: snapshot.stats,
+            })
+      ).catch((error) => {
+        console.error("Failed to toggle bookmark:", error);
+        setBookmarks(previous);
+      });
+    },
+    [bookmarkKeySet, bookmarks],
+  );
+
+  const toggleSessionBookmark = useCallback(
+    (session: SessionHead, agentKey: string) => {
+      toggleBookmark(toBookmarkedSessionSnapshot(session, agentKey));
+    },
+    [toggleBookmark],
+  );
+
+  const bookmarkedSessions = useMemo(
+    () =>
+      bookmarks.toSorted(
+        (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
+      ),
+    [bookmarks],
+  );
+
+  return {
+    bookmarkedSessions,
+    isSessionBookmarked,
+    toggleBookmark,
+    toggleSessionBookmark,
+  };
+}


### PR DESCRIPTION
## Background

Fourth step of decomposing the ~1700-line `App.tsx` god component into per-domain hooks (after `useScanStatus`, `useSessionDetail`, `useSessionSearch`).

## Changes

- Extract `useBookmarks(sessions)`: owns bookmark state, initial fetch, snapshot-merge sync as sessions change, legacy migration, and optimistic add/remove toggles (with rollback on failure).
- Exposes `bookmarkedSessions` (sorted), `isSessionBookmarked`, `toggleBookmark`, `toggleSessionBookmark`.
- `bookmarkedSidebarSessionIds` **stays in App** — it depends on the App-level `sidebarSessions` composition, not the bookmark domain — and now derives from the hook's `isSessionBookmarked` instead of the internal key set.
- `App.tsx` sheds ~150 lines: the state, two effects, the key-set memo, and three handlers.

## Behavior

Equivalent to before. Like the earlier hooks, the initial bookmark fetch moves out of the shared `Promise.all` into the hook's own mount effect (`fetchBookmarks()` takes no args, so it's independent); the sessions-driven merge sync and legacy migration are unchanged.

## Verification

- `pnpm --filter web test`: 18 files, **145 tests pass** (4 new: load / add / remove / sort)
- `tsc --noEmit`: exit 0
- `oxlint` / `oxfmt`: pass
