### PR TITLE
refactor(web): extract dashboard hooks

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,7 +7,6 @@ import { ModelConfig } from "./config";
 import type {
   AgentInfo,
   AppConfig,
-  DashboardData,
   SessionHead,
   SessionsUpdatedEvent,
   ProjectGroup,
@@ -15,7 +14,6 @@ import type {
 import {
   fetchAgents,
   fetchConfig,
-  fetchDashboard,
   fetchProjects,
   fetchSessions,
   logClientEvent,
@@ -38,6 +36,8 @@ import { useScanStatus } from "./hooks/useScanStatus";
 import { useSessionDetail } from "./hooks/useSessionDetail";
 import { useSessionSearch } from "./hooks/useSessionSearch";
 import { useBookmarks } from "./hooks/useBookmarks";
+import { useDashboard } from "./hooks/useDashboard";
+import { useProjectDashboard } from "./hooks/useProjectDashboard";
 import { BrowseByToggle } from "./components/app/BrowseByToggle";
 import { SidebarFlatSessionList } from "./components/app/SidebarFlatSessionList";
 import { SearchResultsPanel } from "./components/app/SearchResultsPanel";
@@ -116,15 +116,10 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
 
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
-  const [dashboard, setDashboard] = useState<DashboardData | null>(null);
   const [projects, setProjects] = useState<ProjectGroup[]>([]);
   const [browseBy, setBrowseBy] = useState<BrowseBy>("agents");
   const [selectedProjectIdentity, setSelectedProjectIdentity] =
     useState<ProjectRouteIdentity | null>(null);
-  const [projectDashboard, setProjectDashboard] = useState<DashboardData | null>(null);
-  const [projectDashboardLoading, setProjectDashboardLoading] = useState(false);
-  const [projectDashboardError, setProjectDashboardError] = useState<string | null>(null);
-  const [selectedProjectAgent, setSelectedProjectAgent] = useState<string | undefined>(undefined);
   const [appConfig, setAppConfig] = useState<AppConfig | null>(null);
   const { scanStatus, setScanStatus } = useScanStatus();
   const [selectedSidebarSessionId, setSelectedSidebarSessionId] = useState<string | null>(null);
@@ -141,13 +136,9 @@ export default function App() {
       try {
         const config = await fetchConfig();
         setAppConfig(config);
-        const [agentList, sessionList, dashboardData, projectData] = await Promise.all([
+        const [agentList, sessionList, projectData] = await Promise.all([
           fetchAgents(),
           fetchSessions({ from: config.window.from, to: config.window.to }),
-          fetchDashboard(config.window).catch((err) => {
-            console.error("Failed to load dashboard:", err);
-            return null;
-          }),
           fetchProjects().catch((err) => {
             console.error("Failed to load projects:", err);
             return { projects: [] };
@@ -156,13 +147,11 @@ export default function App() {
         setAgents(agentList);
         setSessions(sessionList.sessions);
         setProjects(projectData.projects);
-        if (dashboardData) setDashboard(dashboardData);
         logClientEvent("app.load.done", {
           duration_ms: Math.round(performance.now() - startedAt),
           agents: agentList.length,
           sessions: sessionList.sessions.length,
           projects: projectData.projects.length,
-          dashboard: Boolean(dashboardData),
         });
       } catch (err) {
         console.error("Failed to load data:", err);
@@ -267,6 +256,17 @@ export default function App() {
   const activeProjectIdentityKey = activeProjectIdentity
     ? getProjectIdentityKey(activeProjectIdentity)
     : null;
+
+  const { dashboard, refresh: refreshDashboard } = useDashboard(appConfig);
+  const {
+    projectDashboard,
+    projectDashboardLoading,
+    projectDashboardError,
+    selectedProjectAgent,
+    setSelectedProjectAgent,
+    refresh: refreshProjectDashboard,
+  } = useProjectDashboard(appConfig, activeProjectKind, activeProjectKey, activeProjectIdentityKey);
+
   const openedSessionHead = useMemo(() => {
     if (viewState.mode !== "session") return null;
     return (
@@ -352,36 +352,22 @@ export default function App() {
         setSessions((current) => applyLiveSessionUpdate(current, event) ?? current);
       }
 
-      const [agentList, sessionList, dashboardData, projectData, projectDashboardData] =
-        await Promise.all([
-          fetchAgents(),
-          canApplySessionUpdate
-            ? Promise.resolve<{ sessions: SessionHead[] } | null>(null)
-            : fetchSessions({ from: appConfig?.window.from, to: appConfig?.window.to }),
-          fetchDashboard(appConfig?.window).catch((err) => {
-            console.error("Failed to refresh dashboard:", err);
-            return null;
-          }),
-          fetchProjects().catch((err) => {
-            console.error("Failed to refresh projects:", err);
-            return { projects: [] };
-          }),
-          viewState.mode === "project"
-            ? fetchDashboard(appConfig?.window, {
-                projectKind: viewState.activeProjectKind,
-                projectKey: viewState.activeProjectKey,
-                agent: selectedProjectAgent,
-              }).catch((err) => {
-                console.error("Failed to refresh project dashboard:", err);
-                return null;
-              })
-            : Promise.resolve<DashboardData | null>(null),
-        ]);
+      const [agentList, sessionList, projectData] = await Promise.all([
+        fetchAgents(),
+        canApplySessionUpdate
+          ? Promise.resolve<{ sessions: SessionHead[] } | null>(null)
+          : fetchSessions({ from: appConfig?.window.from, to: appConfig?.window.to }),
+        fetchProjects().catch((err) => {
+          console.error("Failed to refresh projects:", err);
+          return { projects: [] };
+        }),
+      ]);
       setAgents(agentList);
       if (sessionList) setSessions(sessionList.sessions);
       setProjects(projectData.projects);
-      if (dashboardData) setDashboard(dashboardData);
-      if (projectDashboardData) setProjectDashboard(projectDashboardData);
+
+      await refreshDashboard();
+      await refreshProjectDashboard();
 
       if (viewState.mode === "session") {
         await refreshSessionDetail();
@@ -396,47 +382,6 @@ export default function App() {
       console.error("Failed to sync live session update:", err);
     }
   });
-
-  useEffect(() => {
-    if (activeProjectIdentityKey) setSelectedProjectAgent(undefined);
-  }, [activeProjectIdentityKey]);
-
-  useEffect(() => {
-    if (!activeProjectKey || !appConfig) {
-      setProjectDashboard(null);
-      setProjectDashboardError(null);
-      setProjectDashboardLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setProjectDashboardLoading(true);
-    setProjectDashboardError(null);
-
-    void fetchDashboard(appConfig.window, {
-      projectKind: activeProjectKind ?? undefined,
-      projectKey: activeProjectKey,
-      agent: selectedProjectAgent,
-    })
-      .then((data) => {
-        if (cancelled) return;
-        setProjectDashboard(data);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        console.error("Failed to load project dashboard:", err);
-        setProjectDashboard(null);
-        setProjectDashboardError("Failed to load project dashboard");
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setProjectDashboardLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeProjectKind, activeProjectKey, appConfig, selectedProjectAgent]);
 
   useEffect(() => {
     const unsubscribe = subscribeSessionUpdates(

--- a/apps/web/src/hooks/useDashboard.test.ts
+++ b/apps/web/src/hooks/useDashboard.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { AppConfig, DashboardData } from "../lib/api";
+import * as api from "../lib/api";
+import { useDashboard } from "./useDashboard";
+
+vi.mock("../lib/api", () => ({ fetchDashboard: vi.fn() }));
+
+const appConfig = { window: { from: 1, to: 2 } } as unknown as AppConfig;
+const data = { totals: { sessions: 5 }, perAgent: [] } as unknown as DashboardData;
+
+beforeEach(() => {
+  vi.mocked(api.fetchDashboard).mockResolvedValue(data);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useDashboard", () => {
+  it("does not fetch until appConfig is available", () => {
+    const { result } = renderHook(() => useDashboard(null));
+    expect(result.current.dashboard).toBeNull();
+    expect(api.fetchDashboard).not.toHaveBeenCalled();
+  });
+
+  it("fetches once appConfig is set", async () => {
+    const { result } = renderHook(() => useDashboard(appConfig));
+    await waitFor(() => expect(result.current.dashboard).toEqual(data));
+    expect(api.fetchDashboard).toHaveBeenCalledWith(appConfig.window);
+  });
+
+  it("refresh re-fetches the dashboard", async () => {
+    const { result } = renderHook(() => useDashboard(appConfig));
+    await waitFor(() => expect(result.current.dashboard).toEqual(data));
+
+    const next = { totals: { sessions: 9 }, perAgent: [] } as unknown as DashboardData;
+    vi.mocked(api.fetchDashboard).mockResolvedValue(next);
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.dashboard).toEqual(next);
+  });
+});

--- a/apps/web/src/hooks/useDashboard.ts
+++ b/apps/web/src/hooks/useDashboard.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from "react";
+import { type AppConfig, type DashboardData, fetchDashboard } from "../lib/api";
+
+/**
+ * Owns the top-level dashboard: fetches once the app window is known and
+ * exposes refresh() for the live-update subscription.
+ */
+export function useDashboard(appConfig: AppConfig | null) {
+  const [dashboard, setDashboard] = useState<DashboardData | null>(null);
+
+  useEffect(() => {
+    if (!appConfig) return;
+    let cancelled = false;
+    void fetchDashboard(appConfig.window)
+      .then((data) => {
+        if (!cancelled) setDashboard(data);
+      })
+      .catch((err) => {
+        console.error("Failed to load dashboard:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [appConfig]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await fetchDashboard(appConfig?.window);
+      setDashboard(data);
+    } catch (err) {
+      console.error("Failed to refresh dashboard:", err);
+    }
+  }, [appConfig]);
+
+  return { dashboard, refresh };
+}

--- a/apps/web/src/hooks/useProjectDashboard.test.ts
+++ b/apps/web/src/hooks/useProjectDashboard.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { AppConfig, DashboardData, ProjectIdentityKind } from "../lib/api";
+import * as api from "../lib/api";
+import { useProjectDashboard } from "./useProjectDashboard";
+
+vi.mock("../lib/api", () => ({ fetchDashboard: vi.fn() }));
+
+const appConfig = { window: { from: 1, to: 2 } } as unknown as AppConfig;
+const data = { totals: { sessions: 3 }, perAgent: [] } as unknown as DashboardData;
+const kind = "path" as ProjectIdentityKind;
+
+beforeEach(() => {
+  vi.mocked(api.fetchDashboard).mockResolvedValue(data);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useProjectDashboard", () => {
+  it("stays idle without an active project", () => {
+    const { result } = renderHook(() => useProjectDashboard(appConfig, null, null, null));
+    expect(result.current.projectDashboard).toBeNull();
+    expect(api.fetchDashboard).not.toHaveBeenCalled();
+  });
+
+  it("fetches for the active project", async () => {
+    const { result } = renderHook(() => useProjectDashboard(appConfig, kind, "pk", "path:pk"));
+    await waitFor(() => expect(result.current.projectDashboard).toEqual(data));
+    expect(api.fetchDashboard).toHaveBeenCalledWith(appConfig.window, {
+      projectKind: "path",
+      projectKey: "pk",
+      agent: undefined,
+    });
+  });
+
+  it("resets the agent filter when the project changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ idKey }) => useProjectDashboard(appConfig, kind, "pk", idKey),
+      { initialProps: { idKey: "path:pk" } },
+    );
+    act(() => result.current.setSelectedProjectAgent("cc"));
+    expect(result.current.selectedProjectAgent).toBe("cc");
+
+    rerender({ idKey: "path:pk2" });
+    await waitFor(() => expect(result.current.selectedProjectAgent).toBeUndefined());
+  });
+});

--- a/apps/web/src/hooks/useProjectDashboard.ts
+++ b/apps/web/src/hooks/useProjectDashboard.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  type AppConfig,
+  type DashboardData,
+  type ProjectIdentityKind,
+  fetchDashboard,
+} from "../lib/api";
+
+/**
+ * Owns the project-scoped dashboard and its agent filter: fetches when the
+ * active project or filter changes, resets the filter on project switch, and
+ * exposes refresh() for the live-update subscription.
+ */
+export function useProjectDashboard(
+  appConfig: AppConfig | null,
+  activeProjectKind: ProjectIdentityKind | null,
+  activeProjectKey: string | null,
+  activeProjectIdentityKey: string | null,
+) {
+  const [projectDashboard, setProjectDashboard] = useState<DashboardData | null>(null);
+  const [projectDashboardLoading, setProjectDashboardLoading] = useState(false);
+  const [projectDashboardError, setProjectDashboardError] = useState<string | null>(null);
+  const [selectedProjectAgent, setSelectedProjectAgent] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (activeProjectIdentityKey) setSelectedProjectAgent(undefined);
+  }, [activeProjectIdentityKey]);
+
+  useEffect(() => {
+    if (!activeProjectKey || !appConfig) {
+      setProjectDashboard(null);
+      setProjectDashboardError(null);
+      setProjectDashboardLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setProjectDashboardLoading(true);
+    setProjectDashboardError(null);
+
+    void fetchDashboard(appConfig.window, {
+      projectKind: activeProjectKind ?? undefined,
+      projectKey: activeProjectKey,
+      agent: selectedProjectAgent,
+    })
+      .then((data) => {
+        if (cancelled) return;
+        setProjectDashboard(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error("Failed to load project dashboard:", err);
+        setProjectDashboard(null);
+        setProjectDashboardError("Failed to load project dashboard");
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setProjectDashboardLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeProjectKind, activeProjectKey, appConfig, selectedProjectAgent]);
+
+  const refresh = useCallback(async () => {
+    if (!activeProjectKey || !appConfig) return;
+    try {
+      const data = await fetchDashboard(appConfig.window, {
+        projectKind: activeProjectKind ?? undefined,
+        projectKey: activeProjectKey,
+        agent: selectedProjectAgent,
+      });
+      setProjectDashboard(data);
+    } catch (err) {
+      console.error("Failed to refresh project dashboard:", err);
+    }
+  }, [activeProjectKind, activeProjectKey, appConfig, selectedProjectAgent]);
+
+  return {
+    projectDashboard,
+    projectDashboardLoading,
+    projectDashboardError,
+    selectedProjectAgent,
+    setSelectedProjectAgent,
+    refresh,
+  };
+}


### PR DESCRIPTION
## Background

Fifth step of decomposing the ~1700-line `App.tsx` god component into per-domain hooks (after scan-status, session-detail, session-search, bookmarks).

## Changes

- `useDashboard(appConfig)`: owns the top-level dashboard; fetches once the app window is known, exposes `refresh()`.
- `useProjectDashboard(appConfig, kind, key, identityKey)`: owns the project-scoped dashboard, its loading/error state, and the `selectedProjectAgent` filter — including the reset-on-project-switch effect and the route-driven fetch. Exposes `refresh()`.
- Both live-update refreshes now go through the hooks' `refresh()` (same contract as the earlier hooks); the initial dashboard fetch moves out of the shared `Promise.all` into each hook's own effect.
- `selectedProjectAgent` is owned by `useProjectDashboard`; App still composes `projectSidebarSessions` from it.

## Verification

- `pnpm --filter web test`: 20 files, **151 tests pass** (6 new)
- `tsc --noEmit`: exit 0
- `oxlint` / `oxfmt`: pass
