### PR TITLE
refactor(web): extract useInitialLoad and useLiveSync

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useEffectEvent, useMemo, useState, type ReactNo
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { ModelConfig } from "./config";
-import type { SessionHead, SessionsUpdatedEvent, ProjectGroup } from "./lib/api";
-import { logClientEvent, subscribeSessionUpdates } from "./lib/api";
+import type { SessionHead, ProjectGroup } from "./lib/api";
+import { logClientEvent } from "./lib/api";
 import { SessionDetail } from "./components/SessionDetail";
 import { SessionDetailSkeleton } from "./components/SessionDetailSkeleton";
 import { DetailLanding, type LandingAgentItem } from "./components/DetailLanding";
@@ -29,6 +29,8 @@ import { useAppConfig } from "./hooks/useAppConfig";
 import { useAgents } from "./hooks/useAgents";
 import { useSessions } from "./hooks/useSessions";
 import { useProjects } from "./hooks/useProjects";
+import { useInitialLoad } from "./hooks/useInitialLoad";
+import { useLiveSync } from "./hooks/useLiveSync";
 import { BrowseByToggle } from "./components/app/BrowseByToggle";
 import { SidebarFlatSessionList } from "./components/app/SidebarFlatSessionList";
 import { SearchResultsPanel } from "./components/app/SearchResultsPanel";
@@ -108,10 +110,13 @@ export default function App() {
     applyLiveEvent: applySessionsLiveEvent,
   } = useSessions();
   const { projects, refresh: refreshProjects } = useProjects();
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { loading, error } = useInitialLoad({
+    refreshAppConfig,
+    refreshAgents,
+    refreshSessions,
+    refreshProjects,
+  });
 
-  const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [browseBy, setBrowseBy] = useState<BrowseBy>("agents");
   const [selectedProjectIdentity, setSelectedProjectIdentity] =
     useState<ProjectRouteIdentity | null>(null);
@@ -120,39 +125,6 @@ export default function App() {
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const [shortcutHintDismissed, setShortcutHintDismissed] = useState(true);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-
-  // Load config + agents + sessions + dashboard (all share the same app-level window)
-  useEffect(() => {
-    const ac = new AbortController();
-    const startedAt = performance.now();
-    logClientEvent("app.load.start", { path: window.location.pathname });
-    (async () => {
-      try {
-        const config = await refreshAppConfig();
-        const [agentList, sessionList, projectList] = await Promise.all([
-          refreshAgents(),
-          refreshSessions(config.window),
-          refreshProjects(),
-        ]);
-        logClientEvent("app.load.done", {
-          duration_ms: Math.round(performance.now() - startedAt),
-          agents: agentList.length,
-          sessions: sessionList.length,
-          projects: projectList.length,
-        });
-      } catch (err) {
-        console.error("Failed to load data:", err);
-        logClientEvent("app.load.error", {
-          duration_ms: Math.round(performance.now() - startedAt),
-          error: err instanceof Error ? err.message : String(err),
-        });
-        setError("Failed to load data. Is the CLI server running?");
-      } finally {
-        setLoading(false);
-      }
-    })();
-    return () => ac.abort();
-  }, [refreshAppConfig, refreshAgents, refreshSessions, refreshProjects]);
 
   const location = useLocation();
   const viewState = useMemo(
@@ -327,62 +299,19 @@ export default function App() {
   const scanStatusLabel = formatScanStatusLabel(scanStatus);
   const isScanActive = scanStatus?.active === true;
 
-  const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
-    try {
-      const canApplySessionUpdate = Boolean(event.changedSessionHeads && event.removedSessionRefs);
-      if (canApplySessionUpdate) {
-        applySessionsLiveEvent(event);
-      }
-
-      await Promise.all([
-        refreshAgents(),
-        canApplySessionUpdate || !appConfig ? Promise.resolve() : refreshSessions(appConfig.window),
-        refreshProjects(),
-      ]);
-
-      await refreshDashboard();
-      await refreshProjectDashboard();
-
-      if (viewState.mode === "session") {
-        await refreshSessionDetail();
-      }
-
-      await refreshSearch();
-
-      if (event.newSessions > 0) {
-        setLiveNotice(`发现 ${event.newSessions} 个新会话，列表已自动刷新`);
-      }
-    } catch (err) {
-      console.error("Failed to sync live session update:", err);
-    }
+  const { liveNotice } = useLiveSync({
+    appConfig,
+    viewState,
+    applySessionsLiveEvent,
+    refreshAgents,
+    refreshSessions,
+    refreshProjects,
+    refreshDashboard,
+    refreshProjectDashboard,
+    refreshSessionDetail,
+    refreshSearch,
+    setScanStatus,
   });
-
-  useEffect(() => {
-    const unsubscribe = subscribeSessionUpdates(
-      (event) => {
-        void syncLiveUpdate(event);
-      },
-      (event) => {
-        setScanStatus(event);
-      },
-    );
-
-    return unsubscribe;
-  }, [setScanStatus]);
-
-  useEffect(() => {
-    if (!liveNotice) {
-      return;
-    }
-
-    const timer = window.setTimeout(() => {
-      setLiveNotice(null);
-    }, 3500);
-
-    return () => {
-      window.clearTimeout(timer);
-    };
-  }, [liveNotice]);
 
   useEffect(() => {
     try {

--- a/apps/web/src/hooks/useInitialLoad.test.ts
+++ b/apps/web/src/hooks/useInitialLoad.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { AppConfig } from "../lib/api";
+import { useInitialLoad } from "./useInitialLoad";
+
+vi.mock("../lib/api", () => ({ logClientEvent: vi.fn() }));
+
+const appConfig = { window: { from: "a", to: "b" } } as unknown as AppConfig;
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useInitialLoad", () => {
+  it("loads config then base data and clears loading", async () => {
+    const refreshAppConfig = vi.fn().mockResolvedValue(appConfig);
+    const refreshSessions = vi.fn().mockResolvedValue([]);
+    const { result } = renderHook(() =>
+      useInitialLoad({
+        refreshAppConfig,
+        refreshAgents: vi.fn().mockResolvedValue([]),
+        refreshSessions,
+        refreshProjects: vi.fn().mockResolvedValue([]),
+      }),
+    );
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(refreshSessions).toHaveBeenCalledWith(appConfig.window);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when a base fetch fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useInitialLoad({
+        refreshAppConfig: vi.fn().mockResolvedValue(appConfig),
+        refreshAgents: vi.fn().mockRejectedValue(new Error("boom")),
+        refreshSessions: vi.fn().mockResolvedValue([]),
+        refreshProjects: vi.fn().mockResolvedValue([]),
+      }),
+    );
+
+    await waitFor(() => expect(result.current.error).toContain("Failed to load"));
+    expect(result.current.loading).toBe(false);
+    errorSpy.mockRestore();
+  });
+});

--- a/apps/web/src/hooks/useInitialLoad.ts
+++ b/apps/web/src/hooks/useInitialLoad.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import {
+  type AgentInfo,
+  type AppConfig,
+  type ProjectGroup,
+  type SessionHead,
+  logClientEvent,
+} from "../lib/api";
+
+interface InitialLoadDeps {
+  refreshAppConfig: () => Promise<AppConfig>;
+  refreshAgents: () => Promise<AgentInfo[]>;
+  refreshSessions: (window: AppConfig["window"]) => Promise<SessionHead[]>;
+  refreshProjects: () => Promise<ProjectGroup[]>;
+}
+
+/**
+ * Orchestrates the one-time startup load: config first (for the shared window),
+ * then the base data in parallel, holding the single loading/error gate for the
+ * whole app.
+ */
+export function useInitialLoad({
+  refreshAppConfig,
+  refreshAgents,
+  refreshSessions,
+  refreshProjects,
+}: InitialLoadDeps) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    const startedAt = performance.now();
+    logClientEvent("app.load.start", { path: window.location.pathname });
+    (async () => {
+      try {
+        const config = await refreshAppConfig();
+        const [agentList, sessionList, projectList] = await Promise.all([
+          refreshAgents(),
+          refreshSessions(config.window),
+          refreshProjects(),
+        ]);
+        logClientEvent("app.load.done", {
+          duration_ms: Math.round(performance.now() - startedAt),
+          agents: agentList.length,
+          sessions: sessionList.length,
+          projects: projectList.length,
+        });
+      } catch (err) {
+        console.error("Failed to load data:", err);
+        logClientEvent("app.load.error", {
+          duration_ms: Math.round(performance.now() - startedAt),
+          error: err instanceof Error ? err.message : String(err),
+        });
+        setError("Failed to load data. Is the CLI server running?");
+      } finally {
+        setLoading(false);
+      }
+    })();
+    return () => ac.abort();
+  }, [refreshAppConfig, refreshAgents, refreshSessions, refreshProjects]);
+
+  return { loading, error };
+}

--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { AppConfig, SessionsUpdatedEvent } from "../lib/api";
+import type { ViewState } from "../lib/view-state";
+import * as api from "../lib/api";
+import { useLiveSync } from "./useLiveSync";
+
+let sessionsCb: ((event: SessionsUpdatedEvent) => void) | undefined;
+
+vi.mock("../lib/api", () => ({
+  subscribeSessionUpdates: vi.fn((onSessions: (event: SessionsUpdatedEvent) => void) => {
+    sessionsCb = onSessions;
+    return () => {};
+  }),
+}));
+
+const appConfig = { window: { from: "a", to: "b" } } as unknown as AppConfig;
+const rootView = { mode: "root", activeAgentKey: null, activeSessionSlug: null } as ViewState;
+
+function makeDeps() {
+  return {
+    appConfig,
+    viewState: rootView,
+    applySessionsLiveEvent: vi.fn(),
+    refreshAgents: vi.fn().mockResolvedValue(undefined),
+    refreshSessions: vi.fn().mockResolvedValue(undefined),
+    refreshProjects: vi.fn().mockResolvedValue(undefined),
+    refreshDashboard: vi.fn().mockResolvedValue(undefined),
+    refreshProjectDashboard: vi.fn().mockResolvedValue(undefined),
+    refreshSessionDetail: vi.fn().mockResolvedValue(undefined),
+    refreshSearch: vi.fn().mockResolvedValue(undefined),
+    setScanStatus: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  sessionsCb = undefined;
+});
+
+describe("useLiveSync", () => {
+  it("subscribes on mount", () => {
+    renderHook(() => useLiveSync(makeDeps()));
+    expect(api.subscribeSessionUpdates).toHaveBeenCalledOnce();
+  });
+
+  it("fans out refreshes on a session event", async () => {
+    const deps = makeDeps();
+    renderHook(() => useLiveSync(deps));
+
+    await act(async () => {
+      sessionsCb?.({ newSessions: 0 } as SessionsUpdatedEvent);
+      await Promise.resolve();
+    });
+
+    expect(deps.refreshAgents).toHaveBeenCalled();
+    expect(deps.refreshDashboard).toHaveBeenCalled();
+    expect(deps.refreshSearch).toHaveBeenCalled();
+  });
+
+  it("surfaces liveNotice when new sessions arrive", async () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useLiveSync(deps));
+
+    await act(async () => {
+      sessionsCb?.({ newSessions: 3 } as SessionsUpdatedEvent);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.liveNotice).toContain("3"));
+  });
+});

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -1,0 +1,103 @@
+import { useEffect, useEffectEvent, useState } from "react";
+import {
+  type AppConfig,
+  type ScanStatusEvent,
+  type SessionsUpdatedEvent,
+  subscribeSessionUpdates,
+} from "../lib/api";
+import type { ViewState } from "../lib/view-state";
+
+interface LiveSyncDeps {
+  appConfig: AppConfig | null;
+  viewState: ViewState;
+  applySessionsLiveEvent: (event: SessionsUpdatedEvent) => void;
+  refreshAgents: () => Promise<unknown>;
+  refreshSessions: (window: AppConfig["window"]) => Promise<unknown>;
+  refreshProjects: () => Promise<unknown>;
+  refreshDashboard: () => Promise<void>;
+  refreshProjectDashboard: () => Promise<void>;
+  refreshSessionDetail: () => Promise<void>;
+  refreshSearch: () => Promise<void>;
+  setScanStatus: (event: ScanStatusEvent) => void;
+}
+
+/**
+ * Owns the live-update subscription and its fan-out: applies incremental session
+ * updates, refreshes every domain, surfaces the transient liveNotice, and routes
+ * scan-status events to useScanStatus.
+ */
+export function useLiveSync(deps: LiveSyncDeps) {
+  const [liveNotice, setLiveNotice] = useState<string | null>(null);
+  const {
+    appConfig,
+    viewState,
+    applySessionsLiveEvent,
+    refreshAgents,
+    refreshSessions,
+    refreshProjects,
+    refreshDashboard,
+    refreshProjectDashboard,
+    refreshSessionDetail,
+    refreshSearch,
+    setScanStatus,
+  } = deps;
+
+  const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
+    try {
+      const canApplySessionUpdate = Boolean(event.changedSessionHeads && event.removedSessionRefs);
+      if (canApplySessionUpdate) {
+        applySessionsLiveEvent(event);
+      }
+
+      await Promise.all([
+        refreshAgents(),
+        canApplySessionUpdate || !appConfig ? Promise.resolve() : refreshSessions(appConfig.window),
+        refreshProjects(),
+      ]);
+
+      await refreshDashboard();
+      await refreshProjectDashboard();
+
+      if (viewState.mode === "session") {
+        await refreshSessionDetail();
+      }
+
+      await refreshSearch();
+
+      if (event.newSessions > 0) {
+        setLiveNotice(`发现 ${event.newSessions} 个新会话，列表已自动刷新`);
+      }
+    } catch (err) {
+      console.error("Failed to sync live session update:", err);
+    }
+  });
+
+  useEffect(() => {
+    const unsubscribe = subscribeSessionUpdates(
+      (event) => {
+        void syncLiveUpdate(event);
+      },
+      (event) => {
+        setScanStatus(event);
+      },
+    );
+
+    return unsubscribe;
+  }, [setScanStatus]);
+
+  useEffect(() => {
+    if (!liveNotice) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setLiveNotice(null);
+    }, 3500);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [liveNotice]);
+
+  return { liveNotice };
+}


### PR DESCRIPTION
## Background

Final step of decomposing `App.tsx` (1862 → ~1370 lines). After the domain and data-layer hooks, only the two cross-cutting orchestrations remained.

## Changes

- `useInitialLoad`: owns the single startup loading/error gate — config first (for the shared window), then base data in parallel, plus the `app.load.*` logging.
- `useLiveSync`: owns the subscription + live fan-out (incremental `applyLiveEvent` with conditional full refetch, then every domain's `refresh`) + the transient `liveNotice` (3.5s auto-dismiss) + routing scan-status events to `useScanStatus`.
- `App.tsx` now holds only UI-chrome state (browseBy / sidebar selection / shortcuts / collapsed), viewState derivation, and composes the hooks — no domain data or effects.

## Behavior

Equivalent: startup still loads config → 3-way parallel; live updates still apply incremental session diffs, conditionally skip the full sessions refetch, fan out to all domains, and show the new-session notice.

## Verification

- `pnpm --filter web test`: 26 files, **162 tests pass** (5 new)
- `tsc --noEmit`: exit 0
- `oxlint` / `oxfmt`: pass
