### PR TITLE
refactor(web): extract file-change-tracker from SessionDetail

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -6,15 +6,12 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
-  FilePenLine,
-  FileSearch,
   FileText,
   Funnel,
   Lightbulb,
   LoaderCircle,
   MessageCircleX,
   Minus,
-  NotebookPen,
   X,
   UserRound,
   XCircle,
@@ -50,13 +47,12 @@ import {
 import { buildMessageDisplayModels } from "./session-detail/display-model";
 import { escapeRegExp } from "./session-detail/utils";
 import {
-  type FileChangeKind,
   type FileChangeSummary,
-  type FileChangeSummaryItem,
   buildFileChangeSummary,
   buildFileChangeSummaryFromActivity,
 } from "./session-detail/file-change";
-import { formatTrackedPath, getDisplayTextWithRelativePaths } from "./session-detail/path-extract";
+import { FileChangeTracker, getFileTrackerItemCount } from "./session-detail/file-change-tracker";
+import { getDisplayTextWithRelativePaths } from "./session-detail/path-extract";
 import {
   type ToolStatus,
   formatMessageTime,
@@ -914,10 +910,6 @@ function toggleTocFilter(currentFilters: Set<string>, filterId: string, toc: Ses
   return next;
 }
 
-function getFileTrackerItemCount(summary: FileChangeSummary) {
-  return summary.read.length + summary.edit.length + summary.write.length + summary.delete.length;
-}
-
 function SessionDetailAuxControls({
   toc,
   fileChangeSummary,
@@ -1169,174 +1161,6 @@ function SessionTocFilterPanel({
           </div>
         ) : null}
       </div>
-    </div>
-  );
-}
-
-function FileChangeTracker({
-  summary,
-  baseDirectory,
-  onJumpToAnchor,
-}: {
-  summary: FileChangeSummary;
-  baseDirectory: string;
-  onJumpToAnchor: (anchorId: string) => void;
-}) {
-  const sections = [
-    { key: "read" as const, label: "Read", Icon: FileSearch, items: summary.read },
-    { key: "edit" as const, label: "Edit", Icon: FilePenLine, items: summary.edit },
-    { key: "write" as const, label: "Write", Icon: NotebookPen, items: summary.write },
-    { key: "delete" as const, label: "Delete", Icon: XCircle, items: summary.delete },
-  ].filter((section) => section.items.length > 0) satisfies Array<{
-    key: FileChangeKind;
-    label: string;
-    Icon: typeof LoaderCircle;
-    items: FileChangeSummaryItem[];
-  }>;
-
-  if (sections.length === 0) return null;
-
-  return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-      <div className="flex items-center gap-2 border-b border-[var(--console-border)] px-4 py-3">
-        <FileText className="size-3.5 text-[var(--console-accent)]" />
-        <span className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">
-          File Tracker
-        </span>
-      </div>
-      <div className="space-y-3 p-3">
-        {sections.map(({ key, label, Icon, items }) => (
-          <FileTrackerSection
-            key={key}
-            label={label}
-            Icon={Icon}
-            items={items}
-            baseDirectory={baseDirectory}
-            onJumpToAnchor={onJumpToAnchor}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function FileTrackerSection({
-  label,
-  Icon,
-  items,
-  baseDirectory,
-  onJumpToAnchor,
-}: {
-  label: string;
-  Icon: typeof LoaderCircle;
-  items: FileChangeSummaryItem[];
-  baseDirectory: string;
-  onJumpToAnchor: (anchorId: string) => void;
-}) {
-  const [expanded, setExpanded] = useState(false);
-
-  return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-[#fafafa]">
-      <button
-        type="button"
-        onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--console-surface-muted)]"
-      >
-        <Icon className="size-3.5 shrink-0 text-[var(--console-accent)]" />
-        <span className="console-mono min-w-0 flex-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--console-muted)]">
-          {label}
-        </span>
-        <span className="console-mono shrink-0 text-[10px] text-[var(--console-muted)]">
-          {items.length}
-        </span>
-        {expanded ? (
-          <ChevronUp className="size-3.5 shrink-0 text-[var(--console-muted)]" />
-        ) : (
-          <ChevronDown className="size-3.5 shrink-0 text-[var(--console-muted)]" />
-        )}
-      </button>
-      {expanded ? (
-        <div className="space-y-1 border-t border-[var(--console-border)] p-2">
-          {items.map((item) => (
-            <FileTrackerItem
-              key={`${item.path}:${item.latestAnchorId || item.latestTime}`}
-              item={item}
-              baseDirectory={baseDirectory}
-              onJumpToAnchor={onJumpToAnchor}
-            />
-          ))}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function FileTrackerItem({
-  item,
-  baseDirectory,
-  onJumpToAnchor,
-}: {
-  item: FileChangeSummaryItem;
-  baseDirectory: string;
-  onJumpToAnchor: (anchorId: string) => void;
-}) {
-  const [currentIndex, setCurrentIndex] = useState(0);
-
-  function jumpToIndex(nextIndex: number) {
-    const total = item.anchors.length;
-    if (total === 0) return;
-    const normalizedIndex = ((nextIndex % total) + total) % total;
-    setCurrentIndex(normalizedIndex);
-    const anchor = item.anchors[normalizedIndex];
-    if (anchor) {
-      onJumpToAnchor(anchor.anchorId);
-    }
-  }
-
-  return (
-    <div className="flex items-start gap-2 rounded-sm px-2 py-2 transition-colors hover:bg-[var(--console-surface-muted)]">
-      <button
-        type="button"
-        title={item.path}
-        onClick={() => jumpToIndex(currentIndex)}
-        className="min-w-0 flex-1 text-left"
-      >
-        <span className="console-mono block break-all text-xs text-[var(--console-text)]">
-          {formatTrackedPath(item.path, baseDirectory)}
-        </span>
-      </button>
-      {item.anchors.length > 1 ? (
-        <div className="flex shrink-0 items-center gap-1">
-          <button
-            type="button"
-            aria-label={`Previous ${item.path}`}
-            onClick={() => jumpToIndex(currentIndex - 1)}
-            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-white"
-          >
-            <ChevronUp className="size-3" />
-          </button>
-          <span className="console-mono text-[10px] text-[var(--console-muted)]">
-            {currentIndex + 1}/{item.anchors.length}
-          </span>
-          <button
-            type="button"
-            aria-label={`Next ${item.path}`}
-            onClick={() => jumpToIndex(currentIndex + 1)}
-            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-white"
-          >
-            <ChevronDown className="size-3" />
-          </button>
-        </div>
-      ) : (
-        <button
-          type="button"
-          title="Jump to tool call"
-          onClick={() => jumpToIndex(0)}
-          className="console-mono shrink-0 text-[10px] text-[var(--console-muted)]"
-        >
-          {item.count}
-        </button>
-      )}
     </div>
   );
 }

--- a/apps/web/src/components/session-detail/file-change-tracker.tsx
+++ b/apps/web/src/components/session-detail/file-change-tracker.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import {
+  ChevronDown,
+  ChevronUp,
+  FilePenLine,
+  FileSearch,
+  FileText,
+  LoaderCircle,
+  NotebookPen,
+  XCircle,
+} from "lucide-react";
+import type { FileChangeKind, FileChangeSummary, FileChangeSummaryItem } from "./file-change";
+import { formatTrackedPath } from "./path-extract";
+
+export function getFileTrackerItemCount(summary: FileChangeSummary) {
+  return summary.read.length + summary.edit.length + summary.write.length + summary.delete.length;
+}
+
+export function FileChangeTracker({
+  summary,
+  baseDirectory,
+  onJumpToAnchor,
+}: {
+  summary: FileChangeSummary;
+  baseDirectory: string;
+  onJumpToAnchor: (anchorId: string) => void;
+}) {
+  const sections = [
+    { key: "read" as const, label: "Read", Icon: FileSearch, items: summary.read },
+    { key: "edit" as const, label: "Edit", Icon: FilePenLine, items: summary.edit },
+    { key: "write" as const, label: "Write", Icon: NotebookPen, items: summary.write },
+    { key: "delete" as const, label: "Delete", Icon: XCircle, items: summary.delete },
+  ].filter((section) => section.items.length > 0) satisfies Array<{
+    key: FileChangeKind;
+    label: string;
+    Icon: typeof LoaderCircle;
+    items: FileChangeSummaryItem[];
+  }>;
+
+  if (sections.length === 0) return null;
+
+  return (
+    <div className="rounded-sm border border-[var(--console-border)] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+      <div className="flex items-center gap-2 border-b border-[var(--console-border)] px-4 py-3">
+        <FileText className="size-3.5 text-[var(--console-accent)]" />
+        <span className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">
+          File Tracker
+        </span>
+      </div>
+      <div className="space-y-3 p-3">
+        {sections.map(({ key, label, Icon, items }) => (
+          <FileTrackerSection
+            key={key}
+            label={label}
+            Icon={Icon}
+            items={items}
+            baseDirectory={baseDirectory}
+            onJumpToAnchor={onJumpToAnchor}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FileTrackerSection({
+  label,
+  Icon,
+  items,
+  baseDirectory,
+  onJumpToAnchor,
+}: {
+  label: string;
+  Icon: typeof LoaderCircle;
+  items: FileChangeSummaryItem[];
+  baseDirectory: string;
+  onJumpToAnchor: (anchorId: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-sm border border-[var(--console-border)] bg-[#fafafa]">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--console-surface-muted)]"
+      >
+        <Icon className="size-3.5 shrink-0 text-[var(--console-accent)]" />
+        <span className="console-mono min-w-0 flex-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--console-muted)]">
+          {label}
+        </span>
+        <span className="console-mono shrink-0 text-[10px] text-[var(--console-muted)]">
+          {items.length}
+        </span>
+        {expanded ? (
+          <ChevronUp className="size-3.5 shrink-0 text-[var(--console-muted)]" />
+        ) : (
+          <ChevronDown className="size-3.5 shrink-0 text-[var(--console-muted)]" />
+        )}
+      </button>
+      {expanded ? (
+        <div className="space-y-1 border-t border-[var(--console-border)] p-2">
+          {items.map((item) => (
+            <FileTrackerItem
+              key={`${item.path}:${item.latestAnchorId || item.latestTime}`}
+              item={item}
+              baseDirectory={baseDirectory}
+              onJumpToAnchor={onJumpToAnchor}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FileTrackerItem({
+  item,
+  baseDirectory,
+  onJumpToAnchor,
+}: {
+  item: FileChangeSummaryItem;
+  baseDirectory: string;
+  onJumpToAnchor: (anchorId: string) => void;
+}) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  function jumpToIndex(nextIndex: number) {
+    const total = item.anchors.length;
+    if (total === 0) return;
+    const normalizedIndex = ((nextIndex % total) + total) % total;
+    setCurrentIndex(normalizedIndex);
+    const anchor = item.anchors[normalizedIndex];
+    if (anchor) {
+      onJumpToAnchor(anchor.anchorId);
+    }
+  }
+
+  return (
+    <div className="flex items-start gap-2 rounded-sm px-2 py-2 transition-colors hover:bg-[var(--console-surface-muted)]">
+      <button
+        type="button"
+        title={item.path}
+        onClick={() => jumpToIndex(currentIndex)}
+        className="min-w-0 flex-1 text-left"
+      >
+        <span className="console-mono block break-all text-xs text-[var(--console-text)]">
+          {formatTrackedPath(item.path, baseDirectory)}
+        </span>
+      </button>
+      {item.anchors.length > 1 ? (
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            aria-label={`Previous ${item.path}`}
+            onClick={() => jumpToIndex(currentIndex - 1)}
+            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-white"
+          >
+            <ChevronUp className="size-3" />
+          </button>
+          <span className="console-mono text-[10px] text-[var(--console-muted)]">
+            {currentIndex + 1}/{item.anchors.length}
+          </span>
+          <button
+            type="button"
+            aria-label={`Next ${item.path}`}
+            onClick={() => jumpToIndex(currentIndex + 1)}
+            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-white"
+          >
+            <ChevronDown className="size-3" />
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          title="Jump to tool call"
+          onClick={() => jumpToIndex(0)}
+          className="console-mono shrink-0 text-[10px] text-[var(--console-muted)]"
+        >
+          {item.count}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Background

CS-13 splits the 1840-line `SessionDetail.tsx` into cohesive sub-domains (not strict one-object-per-file — the components form one cohesive render tree; see the issue's design note). This is the first sub-domain: **file tracker**.

## Changes

- Move `FileChangeTracker` + co-located private `FileTrackerSection` / `FileTrackerItem` + `getFileTrackerItemCount` into `session-detail/file-change-tracker.tsx`.
- `SessionDetail.tsx` imports them and drops the now-unused lucide icons / file-change types / path-extract helper. **1840 → 1669 lines**.

## Behavior

Pure move + import rewire — no logic or JSX changed.

## Verification

- `tsc --noEmit`: exit 0
- `pnpm --filter web test`: 26 files, **162 tests pass**
- `oxlint` / `oxfmt`: pass
