### PR TITLE
test(core): complete dashboard SessionStats fixtures

### DIFF
--- a/packages/core/src/analytics/__tests__/dashboard.test.ts
+++ b/packages/core/src/analytics/__tests__/dashboard.test.ts
@@ -40,12 +40,25 @@ function opts(overrides?: Partial<Parameters<typeof buildDashboard>[1]>) {
 describe("getTotalTokens / getSessionAgentName / getSessionActivityTime", () => {
   it("getTotalTokens prefers total_tokens when present", () => {
     expect(
-      getTotalTokens({ total_tokens: 99, total_input_tokens: 1, total_output_tokens: 2 }),
+      getTotalTokens({
+        message_count: 1,
+        total_cost: 0,
+        total_tokens: 99,
+        total_input_tokens: 1,
+        total_output_tokens: 2,
+      }),
     ).toBe(99);
   });
 
   it("getTotalTokens falls back to input + output", () => {
-    expect(getTotalTokens({ total_input_tokens: 10, total_output_tokens: 5 })).toBe(15);
+    expect(
+      getTotalTokens({
+        message_count: 1,
+        total_cost: 0,
+        total_input_tokens: 10,
+        total_output_tokens: 5,
+      }),
+    ).toBe(15);
   });
 
   it("getSessionAgentName extracts agent from slug", () => {


### PR DESCRIPTION
## Background

While running core `tsc` for CS-12, two pre-existing TypeScript errors surfaced on `main` (unrelated to any current feature work): the two `SessionStats` fixtures passed to `getTotalTokens` in `dashboard.test.ts` are missing the required fields `message_count` and `total_cost`.

```
dashboard.test.ts(43,22): error TS2345: ... missing ... message_count, total_cost
dashboard.test.ts(48,27): error TS2345: ... missing ... message_count, total_cost
```

## Root cause

`getTotalTokens(stats: SessionHead["stats"])` takes the full `SessionStats` type, whose `message_count` and `total_cost` are required. The function body only reads the token fields, but type checking still requires the object literals to include every required field.

## Change

Add `message_count` and `total_cost` to the two fixtures, reusing the same conventional values as the `makeSession` helper in the file. Only test fixtures are touched — no change to the `getTotalTokens` signature or any production code.

## Verification

- `pnpm --filter @codesesh/core exec tsc -p tsconfig.json --noEmit` → clean
- `pnpm --filter @codesesh/core test` → 28 test files, 245 tests all green