### PR TITLE
fix: bound incremental scans to the display window

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,6 +37,7 @@ import { SearchResultsPanel } from "./components/app/SearchResultsPanel";
 import { type BrowseBy, type SearchProjectOption } from "./components/app/types";
 import {
   formatAgentScanProgress,
+  formatBackfillLabel,
   formatRelativeTime,
   formatScanStatusLabel,
   formatSearchSubtitle,
@@ -297,6 +298,7 @@ export default function App() {
   );
 
   const scanStatusLabel = formatScanStatusLabel(scanStatus);
+  const backfillLabel = formatBackfillLabel(scanStatus);
   const isScanActive = scanStatus?.active === true;
 
   const { liveNotice } = useLiveSync({
@@ -1285,6 +1287,11 @@ export default function App() {
               {scanStatusLabel && viewState.mode === "root" ? (
                 <p className="console-mono mt-2 inline-flex max-w-4xl rounded-sm border border-[var(--console-warning-border)] bg-[var(--console-warning-bg)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-warning)]">
                   {scanStatusLabel}
+                </p>
+              ) : null}
+              {!scanStatusLabel && backfillLabel && viewState.mode === "root" ? (
+                <p className="console-mono mt-2 inline-flex max-w-4xl rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-text)]">
+                  {backfillLabel}
                 </p>
               ) : null}
             </div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,7 +37,6 @@ import { SearchResultsPanel } from "./components/app/SearchResultsPanel";
 import { type BrowseBy, type SearchProjectOption } from "./components/app/types";
 import {
   formatAgentScanProgress,
-  formatBackfillLabel,
   formatRelativeTime,
   formatScanStatusLabel,
   formatSearchSubtitle,
@@ -298,7 +297,6 @@ export default function App() {
   );
 
   const scanStatusLabel = formatScanStatusLabel(scanStatus);
-  const backfillLabel = formatBackfillLabel(scanStatus);
   const isScanActive = scanStatus?.active === true;
 
   const { liveNotice } = useLiveSync({
@@ -1287,11 +1285,6 @@ export default function App() {
               {scanStatusLabel && viewState.mode === "root" ? (
                 <p className="console-mono mt-2 inline-flex max-w-4xl rounded-sm border border-[var(--console-warning-border)] bg-[var(--console-warning-bg)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-warning)]">
                   {scanStatusLabel}
-                </p>
-              ) : null}
-              {!scanStatusLabel && backfillLabel && viewState.mode === "root" ? (
-                <p className="console-mono mt-2 inline-flex max-w-4xl rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-text)]">
-                  {backfillLabel}
                 </p>
               ) : null}
             </div>

--- a/apps/web/src/hooks/useScanStatus.test.ts
+++ b/apps/web/src/hooks/useScanStatus.test.ts
@@ -18,6 +18,7 @@ const sample: ScanStatusEvent = {
   agentStatuses: {},
   totalAgents: 1,
   updatedAt: 123,
+  backfill: { active: false, pendingAgents: [], completedAgents: [] },
 };
 
 afterEach(() => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -190,6 +190,14 @@ export interface ScanStatusEvent {
   startedAt?: number;
   updatedAt: number;
   completedAt?: number;
+  backfill: BackfillStatus;
+}
+
+export interface BackfillStatus {
+  active: boolean;
+  pendingAgents: string[];
+  currentAgent?: string;
+  completedAgents: string[];
 }
 
 export interface AgentScanStatus {

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -58,6 +58,14 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
   return "Checking for new or changed sessions";
 }
 
+export function formatBackfillLabel(status: ScanStatusEvent | null): string | null {
+  if (!status?.backfill?.active) return null;
+  const current = status.backfill.currentAgent;
+  return current
+    ? `Reconciling full session history in the background · ${current}`
+    : "Reconciling full session history in the background";
+}
+
 export function formatAgentScanProgress(
   status: ScanStatusEvent | null,
   agentName: string,

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -58,14 +58,6 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
   return "Checking for new or changed sessions";
 }
 
-export function formatBackfillLabel(status: ScanStatusEvent | null): string | null {
-  if (!status?.backfill?.active) return null;
-  const current = status.backfill.currentAgent;
-  return current
-    ? `Reconciling full session history in the background · ${current}`
-    : "Reconciling full session history in the background";
-}
-
 export function formatAgentScanProgress(
   status: ScanStatusEvent | null,
   agentName: string,

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -72,6 +72,12 @@ export interface ScanStatusSource {
     startedAt?: number;
     updatedAt: number;
     completedAt?: number;
+    backfill: {
+      active: boolean;
+      pendingAgents: string[];
+      currentAgent?: string;
+      completedAgents: string[];
+    };
   };
 }
 

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -591,7 +591,10 @@ export class LiveScanStore {
   }
 
   private enqueueBackfill(agentName: string): void {
-    if (this.backfillQueue.includes(agentName) || this.scanStatus.backfill.currentAgent === agentName) {
+    if (
+      this.backfillQueue.includes(agentName) ||
+      this.scanStatus.backfill.currentAgent === agentName
+    ) {
       return;
     }
     this.backfillQueue.push(agentName);
@@ -634,7 +637,13 @@ export class LiveScanStore {
     }
 
     try {
-      const result = await this.scanAgentInWorker(agent, baseline, null, {}, { sourceSync: true, meta });
+      const result = await this.scanAgentInWorker(
+        agent,
+        baseline,
+        null,
+        {},
+        { sourceSync: true, meta },
+      );
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const fullSessions = attachMissingProjectIdentities(result.sessions);
       const filtered = this.applyFilters(fullSessions);

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -4,8 +4,10 @@ import { Worker } from "node:worker_threads";
 import {
   createRegisteredAgents,
   filterSessions,
+  getAgentLastFullSyncAt,
   isAgentCacheInitialized,
   loadCachedSessions,
+  markAgentFullSyncCompleted,
   scanSessions,
   FileSystemSessionSource,
   attachMissingProjectIdentities,
@@ -52,6 +54,19 @@ export interface ScanStatusEvent {
   startedAt?: number;
   updatedAt: number;
   completedAt?: number;
+  backfill: BackfillStatus;
+}
+
+/**
+ * Full-history reconciliation runs independently of the main scan phase above:
+ * startup only syncs the display window, so a low-priority background pass
+ * (capped at one agent at a time) periodically re-checks the rest of history.
+ */
+export interface BackfillStatus {
+  active: boolean;
+  pendingAgents: string[];
+  currentAgent?: string;
+  completedAgents: string[];
 }
 
 export interface AgentScanStatus {
@@ -90,6 +105,8 @@ const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const PENDING_REFRESH_DELAY_MS = 100;
 const NEW_SESSION_EVENT_WINDOW_MS = 250;
 const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
+/** Old files rarely change, but it's not impossible — reconcile full history at most this often. */
+const BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 function buildRefreshDiff(
   agentName: string,
@@ -180,7 +197,10 @@ export class LiveScanStore {
     agentStatuses: {},
     totalAgents: 0,
     updatedAt: Date.now(),
+    backfill: { active: false, pendingAgents: [], completedAgents: [] },
   };
+  private backfillQueue: string[] = [];
+  private backfillRunning = false;
   private refreshTimers = new Map<string, NodeJS.Timeout>();
   private refreshTimestamps = new Map<string, number>();
   private refreshInFlight = new Set<string>();
@@ -288,6 +308,11 @@ export class LiveScanStore {
       if (agentNames.length === 0) {
         this.finishScanBatch();
       }
+      for (const agent of this.agents) {
+        if (this.needsBackfill(agent)) {
+          this.enqueueBackfill(agent.name);
+        }
+      }
     }, 0);
   }
 
@@ -312,6 +337,11 @@ export class LiveScanStore {
           { ...status },
         ]),
       ),
+      backfill: {
+        ...this.scanStatus.backfill,
+        pendingAgents: [...this.scanStatus.backfill.pendingAgents],
+        completedAgents: [...this.scanStatus.backfill.completedAgents],
+      },
     };
   }
 
@@ -404,6 +434,7 @@ export class LiveScanStore {
       ]),
     );
     this.updateScanStatus({
+      ...this.scanStatus,
       active: uniqueAgentNames.length > 0,
       phase: uniqueAgentNames.length > 0 ? phase : "idle",
       pendingAgents: uniqueAgentNames,
@@ -535,6 +566,114 @@ export class LiveScanStore {
       updatedAt: now,
       completedAt: now,
     });
+  }
+
+  private updateBackfillStatus(patch: Partial<BackfillStatus>): void {
+    this.updateScanStatus({
+      ...this.scanStatus,
+      backfill: { ...this.scanStatus.backfill, ...patch },
+      updatedAt: Date.now(),
+    });
+  }
+
+  /**
+   * Only FileSystemSessionSource agents pay the O(history) enumeration cost this
+   * guards against: database agents already do a cheap single-file mtime check.
+   * With no startup window configured, the regular refresh path already walks
+   * full history, so backfill would be redundant.
+   */
+  private needsBackfill(agent: BaseAgent): boolean {
+    if (this.startupScanOptions.from == null && this.startupScanOptions.to == null) return false;
+    if (!(agent instanceof FileSystemSessionSource)) return false;
+    if (!agent.isAvailable()) return false;
+    const lastSyncAt = getAgentLastFullSyncAt(agent.name);
+    return lastSyncAt == null || Date.now() - lastSyncAt > BACKFILL_INTERVAL_MS;
+  }
+
+  private enqueueBackfill(agentName: string): void {
+    if (this.backfillQueue.includes(agentName) || this.scanStatus.backfill.currentAgent === agentName) {
+      return;
+    }
+    this.backfillQueue.push(agentName);
+    this.updateBackfillStatus({ active: true, pendingAgents: [...this.backfillQueue] });
+    this.pumpBackfillQueue();
+  }
+
+  private pumpBackfillQueue(): void {
+    if (this.backfillRunning) return;
+    const agentName = this.backfillQueue.shift();
+    if (!agentName) return;
+
+    this.backfillRunning = true;
+    this.updateBackfillStatus({ currentAgent: agentName, pendingAgents: [...this.backfillQueue] });
+
+    void this.runBackfill(agentName).finally(() => {
+      this.backfillRunning = false;
+      this.updateBackfillStatus({
+        currentAgent: undefined,
+        completedAgents: [...new Set([...this.scanStatus.backfill.completedAgents, agentName])],
+        active: this.backfillQueue.length > 0,
+      });
+      this.pumpBackfillQueue();
+    });
+  }
+
+  /** Unbounded per-source sync to reconcile the full session history, not just the display window. */
+  private async runBackfill(agentName: string): Promise<void> {
+    const startedAt = performance.now();
+    const agent = this.agents.find((item) => item.name === agentName);
+    if (!agent || !(agent instanceof FileSystemSessionSource) || !agent.isAvailable()) {
+      return;
+    }
+
+    const cached = loadCachedSessions(agentName);
+    const baseline = cached?.sessions ?? this.byAgent[agentName] ?? [];
+    const meta = cached?.meta ?? buildAgentCacheMeta(agent);
+    if (cached) {
+      restoreAgentCacheMeta(agent, cached.meta);
+    }
+
+    try {
+      const result = await this.scanAgentInWorker(agent, baseline, null, {}, { sourceSync: true, meta });
+      agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
+      const fullSessions = attachMissingProjectIdentities(result.sessions);
+      const filtered = this.applyFilters(fullSessions);
+      const diff = buildRefreshDiff(
+        agentName,
+        this.byAgent[agentName] ?? [],
+        filtered,
+        result.changedIds ?? [],
+      );
+
+      this.byAgent[agentName] = sortSessions(filtered);
+      this.rebuildSessions();
+
+      await this.enqueueSearchIndexJobs("scan.backfill", [
+        {
+          kind: "full",
+          context: "scan.backfill",
+          agentName,
+          sessions: fullSessions,
+          meta: buildAgentCacheMeta(agent),
+          saveCache: true,
+        },
+      ]);
+      markAgentFullSyncCompleted(agentName);
+
+      if (diff.event) {
+        diff.event.totalSessions = this.sessions.length;
+        this.emit(diff.event);
+      }
+      appLogger.info("scan.backfill.done", {
+        agent: agentName,
+        duration_ms: Math.round(performance.now() - startedAt),
+        sessions: fullSessions.length,
+        changed: result.changedIds?.length ?? 0,
+      });
+    } catch (error) {
+      appLogger.error("scan.backfill.error", { agent: agentName, error });
+      console.error(`[${agentName}] Backfill failed:`, error);
+    }
   }
 
   private queueEvent(event: SessionsUpdatedEvent): void {
@@ -878,9 +1017,16 @@ export class LiveScanStore {
       nextSessions = [];
       this.refreshTimestamps.set(agentName, Date.now());
     } else if (!isInitialized) {
+      // First-ever scan is bounded to the display window so startup stays fast;
+      // needsBackfill() picks up the rest of history in the background.
       this.setScanPhase("initializing");
       const scanStartedAt = performance.now();
-      const result = await this.scanAgentInWorker(agent, previousSessions, null, {});
+      const result = await this.scanAgentInWorker(
+        agent,
+        previousSessions,
+        null,
+        this.startupScanOptions,
+      );
       nextSessions = result.sessions;
       agent.setSessionMetaMap?.(new Map(Object.entries(result.meta)));
       fullScanSessions = attachMissingProjectIdentities(nextSessions);
@@ -888,15 +1034,16 @@ export class LiveScanStore {
       scanDuration = performance.now() - scanStartedAt;
       this.refreshTimestamps.set(agentName, Date.now());
     } else if (cached && agent instanceof FileSystemSessionSource) {
-      // File-system agents refresh via precise per-source fingerprint sync.
-      // Database agents lack per-file fingerprints and fall through to the
-      // checkForChanges branch below.
+      // File-system agents refresh via precise per-source fingerprint sync,
+      // bounded to the display window; the background backfill pass
+      // periodically reconciles sessions outside it. Database agents lack
+      // per-file fingerprints and fall through to the checkForChanges branch below.
       const scanStartedAt = performance.now();
       const result = await this.scanAgentInWorker(
         agent,
         cached.sessions,
         null,
-        {},
+        this.startupScanOptions,
         {
           sourceSync: true,
           meta: cached.meta,

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -2,6 +2,7 @@ import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,
   FileSystemSessionSource,
+  matchesScanWindow,
   type AgentScanProgress,
   type ScanOptions,
   type SessionCacheMeta,
@@ -88,6 +89,21 @@ function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string | null {
 }
 
 /**
+ * A cached session outside the current scan window was never enumerated this
+ * pass, so its absence from sourceRefs doesn't mean it was deleted on disk —
+ * treat it as still present. Sessions with no recorded mtime predate this
+ * field; keep them too rather than risk a false-positive removal.
+ */
+function wasEnumeratedThisPass(
+  cached: SessionCacheMeta | undefined,
+  windowOptions: Pick<ScanOptions, "from" | "to"> | undefined,
+): boolean {
+  if (windowOptions?.from == null && windowOptions?.to == null) return true;
+  const mtimeMs = cached?.sourceMtimeMs;
+  return typeof mtimeMs !== "number" || matchesScanWindow(mtimeMs, windowOptions);
+}
+
+/**
  * Source-level incremental sync, mirroring FileSystemSessionSource.incrementalScan.
  * Kept standalone because the worker cannot share the agent's live metaMap with
  * the main thread — it receives cached meta via workerData instead.
@@ -96,9 +112,10 @@ function syncAgentSources(
   agent: FileSystemSessionSource,
   cachedSessions: SessionHead[],
   cachedMeta: Record<string, SessionCacheMeta>,
+  windowOptions?: Pick<ScanOptions, "from" | "to">,
 ): { sessions: SessionHead[]; changedIds: string[] } {
   const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
-  const sourceRefs = agent.listSessionSources();
+  const sourceRefs = agent.listSessionSources(windowOptions);
   const currentIds = new Set(sourceRefs.map((source) => source.sessionId));
   const changedIds = new Set<string>();
 
@@ -120,10 +137,10 @@ function syncAgentSources(
   }
 
   for (const session of cachedSessions) {
-    if (!currentIds.has(session.id)) {
-      sessionMap.delete(session.id);
-      changedIds.add(session.id);
-    }
+    if (currentIds.has(session.id)) continue;
+    if (!wasEnumeratedThisPass(cachedMeta[session.id], windowOptions)) continue;
+    sessionMap.delete(session.id);
+    changedIds.add(session.id);
   }
 
   return { sessions: [...sessionMap.values()], changedIds: [...changedIds] };
@@ -147,7 +164,7 @@ async function run(): Promise<void> {
   if (!isAvailable) {
     sessions = [];
   } else if (data.sourceSync && agent instanceof FileSystemSessionSource) {
-    const result = syncAgentSources(agent, data.previousSessions, data.meta);
+    const result = syncAgentSources(agent, data.previousSessions, data.meta, data.scanOptions);
     sessions = result.sessions;
     changedIds = result.changedIds;
   } else if (data.changedIds) {

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -96,10 +96,12 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const agent = new ClaudeCodeAgent() as any;
     agent.basePath = basePath;
 
-    expect(agent.listSessionSources().map((ref: { sessionId: string }) => ref.sessionId).sort()).toEqual([
-      "new-session",
-      "old-session",
-    ]);
+    expect(
+      agent
+        .listSessionSources()
+        .map((ref: { sessionId: string }) => ref.sessionId)
+        .sort(),
+    ).toEqual(["new-session", "old-session"]);
 
     const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
     expect(windowed.map((ref: { sessionId: string }) => ref.sessionId)).toEqual(["new-session"]);

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -77,6 +77,34 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(agent.listSessionSources()[0]?.fingerprint).not.toBe(baselineFingerprint);
   });
 
+  it("bounds listSessionSources to the mtime window when options are passed", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-window-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    const oldFile = join(projectDir, "old-session.jsonl");
+    const newFile = join(projectDir, "new-session.jsonl");
+    writeFileSync(oldFile, "");
+    writeFileSync(newFile, "");
+
+    const oldTime = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const newTime = new Date();
+    utimesSync(oldFile, oldTime, oldTime);
+    utimesSync(newFile, newTime, newTime);
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    expect(agent.listSessionSources().map((ref: { sessionId: string }) => ref.sessionId).sort()).toEqual([
+      "new-session",
+      "old-session",
+    ]);
+
+    const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
+    expect(windowed.map((ref: { sessionId: string }) => ref.sessionId)).toEqual(["new-session"]);
+  });
+
   it("parses indexed sessions with assistant tools and tool results", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-test-"));
     tempDirs.push(basePath);

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -131,8 +131,14 @@ describe("CodexAgent cache refresh", () => {
       tempDir,
       "rollout-2026-04-20T10-05-00-019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb.jsonl",
     );
-    writeFileSync(oldFile, '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n');
-    writeFileSync(newFile, '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:05:00Z"}}\n');
+    writeFileSync(
+      oldFile,
+      '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
+    );
+    writeFileSync(
+      newFile,
+      '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:05:00Z"}}\n',
+    );
 
     const oldTime = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     const newTime = new Date();
@@ -142,9 +148,12 @@ describe("CodexAgent cache refresh", () => {
     const agent = new CodexAgent() as any;
     agent.basePath = tempDir;
 
-    expect(agent.listSessionSources().map((ref: { sourcePath: string }) => ref.sourcePath).sort()).toEqual(
-      [oldFile, newFile].sort(),
-    );
+    expect(
+      agent
+        .listSessionSources()
+        .map((ref: { sourcePath: string }) => ref.sourcePath)
+        .sort(),
+    ).toEqual([oldFile, newFile].sort());
 
     const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
     expect(windowed.map((ref: { sourcePath: string }) => ref.sourcePath)).toEqual([newFile]);

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -120,6 +120,36 @@ describe("CodexAgent cache refresh", () => {
     expect(agent.listSessionSources()[0]?.fingerprint).toBe(baselineFingerprint);
   });
 
+  it("bounds listSessionSources to the mtime window when options are passed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const oldFile = join(
+      tempDir,
+      "rollout-2026-04-20T10-00-00-019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa.jsonl",
+    );
+    const newFile = join(
+      tempDir,
+      "rollout-2026-04-20T10-05-00-019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb.jsonl",
+    );
+    writeFileSync(oldFile, '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n');
+    writeFileSync(newFile, '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:05:00Z"}}\n');
+
+    const oldTime = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const newTime = new Date();
+    utimesSync(oldFile, oldTime, oldTime);
+    utimesSync(newFile, newTime, newTime);
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+
+    expect(agent.listSessionSources().map((ref: { sourcePath: string }) => ref.sourcePath).sort()).toEqual(
+      [oldFile, newFile].sort(),
+    );
+
+    const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
+    expect(windowed.map((ref: { sourcePath: string }) => ref.sourcePath)).toEqual([newFile]);
+  });
+
   it("uses per-session Codex titles in source fingerprints", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -115,6 +115,27 @@ describe("KimiAgent cache refresh", () => {
     expect(agent.getSessionMetaMap().has("deleted-session")).toBe(false);
   });
 
+  it("bounds listSessionSources to the createdAt window when options are passed", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    const oldTime = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const newTime = Date.now();
+    createSessionDir(basePath, "old-session", "Old", oldTime);
+    createSessionDir(basePath, "new-session", "New", newTime);
+
+    const agent = createAgent(basePath);
+
+    expect(
+      agent
+        .listSessionSources()
+        .map((ref) => ref.sessionId)
+        .sort(),
+    ).toEqual(["new-session", "old-session"]);
+
+    const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
+    expect(windowed.map((ref) => ref.sessionId)).toEqual(["new-session"]);
+  });
+
   it("parses context messages with tool calls and backfilled output", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
     tempDirs.push(basePath);

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -130,6 +130,38 @@ describe("PiAgent", () => {
       text: "Alternate branch should not count",
     });
     expect(tool).toBeUndefined();
+  });
+
+  it("bounds listSessionSources to the mtime window when options are passed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
+    tempDirs.push(tempDir);
+    const piHome = join(tempDir, ".pi");
+    const sessionsDir = join(piHome, "agent", "sessions", "--tmp-project--");
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("PI_HOME", piHome);
+
+    const oldFile = join(sessionsDir, "2026-04-20T10-00-00_old-session.jsonl");
+    const newFile = join(sessionsDir, "2026-04-20T10-05-00_new-session.jsonl");
+    writeFileSync(oldFile, "");
+    writeFileSync(newFile, "");
+
+    const oldTime = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const newTime = new Date();
+    utimesSync(oldFile, oldTime, oldTime);
+    utimesSync(newFile, newTime, newTime);
+
+    const agent = new PiAgent();
+    agent.isAvailable();
+
+    expect(
+      agent
+        .listSessionSources()
+        .map((ref) => ref.sourcePath)
+        .sort(),
+    ).toEqual([oldFile, newFile].sort());
+
+    const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
+    expect(windowed.map((ref) => ref.sourcePath)).toEqual([newFile]);
   });
 
   it("uses session names and parses assistant tools on the selected leaf", () => {

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -123,8 +123,8 @@ export abstract class FileSystemSessionSource<
 > extends BaseAgent {
   protected sessionMetaMap = new Map<string, TMeta>();
 
-  /** 枚举所有会话源及其指纹。 */
-  abstract listSessionSources(): SessionSourceRef[];
+  /** 枚举所有会话源及其指纹。传入 options 时按 mtime 限定扫描窗口。 */
+  abstract listSessionSources(options?: AgentScanOptions): SessionSourceRef[];
 
   /** 解析单个源并写入 metaMap，返回会话 head（解析失败/不可见返回 null）。 */
   abstract scanSessionSource(sourcePath: string): SessionHead | null;

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -160,11 +160,16 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     return heads;
   }
 
-  listSessionSources(): SessionSourceRef[] {
+  listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
     const refs: SessionSourceRef[] = [];
     for (const projectDir of this.listProjectDirs()) {
       for (const file of this.listJsonlFiles(projectDir)) {
+        try {
+          if (!matchesScanWindow(statSync(file).mtimeMs, options)) continue;
+        } catch {
+          continue;
+        }
         const sessionId = basename(file, ".jsonl");
         refs.push({
           sessionId,

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -352,10 +352,10 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     return heads;
   }
 
-  listSessionSources(): SessionSourceRef[] {
+  listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
     this.loadSessionIndex();
-    return this.listRolloutFiles().map((file) => ({
+    return this.listRolloutFiles(options).map((file) => ({
       sessionId: extractSessionId(file),
       sourcePath: file,
       fingerprint: this.sourceFingerprint(file),

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,6 +1,13 @@
 export { BaseAgent, FileSystemSessionSource, DatabaseSessionSource } from "./base.js";
-export { filteredSession, getParsedSession, parsedSession, skippedSession } from "./base.js";
+export {
+  filteredSession,
+  getParsedSession,
+  matchesScanWindow,
+  parsedSession,
+  skippedSession,
+} from "./base.js";
 export type {
+  AgentScanOptions,
   AgentScanProgress,
   ChangeCheckResult,
   SessionCacheMeta,

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -337,12 +337,12 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     return heads;
   }
 
-  listSessionSources(): SessionSourceRef[] {
+  listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
     const refs: SessionSourceRef[] = [];
     for (const dir of this.listSessionDirs()) {
       const meta = getParsedSession(this.parseSessionDirResult(dir));
-      if (!meta) continue;
+      if (!meta || !matchesScanWindow(meta.createdAt, options)) continue;
       refs.push({
         sessionId: meta.id,
         sourcePath: meta.sourcePath,

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -190,9 +190,9 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     return heads;
   }
 
-  listSessionSources(): SessionSourceRef[] {
+  listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
-    return this.listSessionFiles().map((file) => ({
+    return this.listSessionFiles(options).map((file) => ({
       sessionId: extractSessionIdFromFilename(file),
       sourcePath: file,
       fingerprint: this.sourceFingerprint(file),

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -5,11 +5,15 @@ import Database from "better-sqlite3";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearCache,
+  getAgentLastFullSyncAt,
   getCacheInfo,
+  isAgentCacheInitialized,
   listFileActivity,
   listCachedProjectGroups,
   loadCachedSessionData,
   loadCachedSessions,
+  markAgentCacheInitialized,
+  markAgentFullSyncCompleted,
   parseSearchQuery,
   searchFileActivitySessions,
   searchSessions,
@@ -458,6 +462,37 @@ describe("clearCache", () => {
     writeFileSync(getLegacyCachePath(), JSON.stringify({ stale: true }), "utf-8");
     clearCache();
     expect(() => readFileSync(getLegacyCachePath(), "utf-8")).toThrow();
+  });
+});
+
+describe("cache initialization tracking", () => {
+  it("is not initialized and has no full-sync timestamp before any write", () => {
+    expect(isAgentCacheInitialized("claudecode")).toBe(false);
+    expect(getAgentLastFullSyncAt("claudecode")).toBeNull();
+  });
+
+  it("marks the cache initialized without advancing last full sync", () => {
+    markAgentCacheInitialized("claudecode");
+
+    expect(isAgentCacheInitialized("claudecode")).toBe(true);
+    expect(getAgentLastFullSyncAt("claudecode")).toBeNull();
+  });
+
+  it("advances last full sync only once markAgentFullSyncCompleted runs", () => {
+    markAgentCacheInitialized("claudecode");
+    markAgentFullSyncCompleted("claudecode");
+
+    expect(getAgentLastFullSyncAt("claudecode")).toBe(now);
+  });
+
+  it("re-initializing an already-synced agent preserves its last full sync", () => {
+    markAgentCacheInitialized("claudecode");
+    markAgentFullSyncCompleted("claudecode");
+
+    dateNowSpy.mockReturnValue(now + 1000);
+    markAgentCacheInitialized("claudecode");
+
+    expect(getAgentLastFullSyncAt("claudecode")).toBe(now);
   });
 });
 

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -153,6 +153,7 @@ describe("filterSessions", () => {
 vi.mock("../cache.js", () => ({
   loadCachedSessions: vi.fn(() => null),
   markAgentCacheInitialized: vi.fn(),
+  markAgentFullSyncCompleted: vi.fn(),
   saveCachedSessionChanges: vi.fn(),
   saveCachedSessions: vi.fn(),
 }));

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -13,11 +13,13 @@ export {
 export {
   CACHE_INITIALIZATION_VERSION,
   clearCache,
+  getAgentLastFullSyncAt,
   getCacheInfo,
   isAgentCacheInitialized,
   loadCachedSessionData,
   loadCachedSessions,
   markAgentCacheInitialized,
+  markAgentFullSyncCompleted,
   saveCachedSessionChanges,
   saveCachedSessions,
   type CachedResult,

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -139,21 +139,62 @@ export function isAgentCacheInitialized(
   );
 }
 
+/**
+ * Marks the cache as warm/usable so refreshes can rely on incremental checks
+ * instead of a raw full scan. This is deliberately independent of full-history
+ * reconciliation: a first scan may be bounded to a display window, so
+ * last_sync_at defaults to 0 (never synced) here and is only advanced by
+ * markAgentFullSyncCompleted once a genuine unbounded pass completes.
+ */
 export function markAgentCacheInitialized(
   agentName: string,
   indexVersion = CACHE_INITIALIZATION_VERSION,
 ): void {
   withCacheDb((db) => {
-    const now = Date.now();
     db.prepare(
       `
         INSERT INTO cache_initialization(agent_name, initialized_at, index_version, last_sync_at)
-        VALUES (?, ?, ?, ?)
+        VALUES (?, ?, ?, 0)
         ON CONFLICT(agent_name) DO UPDATE SET
-          index_version = excluded.index_version,
-          last_sync_at = excluded.last_sync_at
+          index_version = excluded.index_version
       `,
-    ).run(agentName, now, indexVersion, now);
+    ).run(agentName, Date.now(), indexVersion);
+  });
+}
+
+/** Timestamp of the agent's last full (unbounded) history reconciliation, or null if none yet. */
+export function getAgentLastFullSyncAt(agentName: string): number | null {
+  if (!hasCacheStorage()) {
+    return null;
+  }
+
+  return (
+    withCacheDbReadOnly((db) => {
+      if (!tableExists(db, "cache_initialization")) return null;
+      const row = db
+        .prepare(
+          `
+            SELECT last_sync_at
+            FROM cache_initialization
+            WHERE agent_name = ?
+          `,
+        )
+        .get(agentName) as { last_sync_at?: number } | undefined;
+      return row?.last_sync_at || null;
+    }) ?? null
+  );
+}
+
+/** Record that a full (unbounded) history reconciliation just completed for this agent. */
+export function markAgentFullSyncCompleted(agentName: string): void {
+  withCacheDb((db) => {
+    db.prepare(
+      `
+        UPDATE cache_initialization
+        SET last_sync_at = ?
+        WHERE agent_name = ?
+      `,
+    ).run(Date.now(), agentName);
   });
 }
 

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -14,6 +14,8 @@ export {
   loadCachedSessionData,
   isAgentCacheInitialized,
   markAgentCacheInitialized,
+  getAgentLastFullSyncAt,
+  markAgentFullSyncCompleted,
   saveCachedSessions,
   saveCachedSessionChanges,
   clearCache,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -8,6 +8,7 @@ import { classifySessionTags, getSmartTagSourceTimestamp, perf } from "../utils/
 import {
   loadCachedSessions,
   markAgentCacheInitialized,
+  markAgentFullSyncCompleted,
   saveCachedSessionChanges,
   saveCachedSessions,
 } from "./cache.js";
@@ -448,6 +449,7 @@ async function scanAgentFull(
     if (options.writeCache !== false && options.from == null && options.to == null) {
       saveCachedSessions(agent.name, tagged.sessions, meta);
       markAgentCacheInitialized(agent.name);
+      markAgentFullSyncCompleted(agent.name);
     }
 
     onProgress?.({ agent: agent.name, phase: "complete", newCount: tagged.sessions.length });


### PR DESCRIPTION
## Summary
- File-backed agents (codex, claudecode, kimi, pi) enumerated every session file on disk on each refresh, regardless of the configured time window — "incremental" sync actually cost O(total history) every time. With many concurrent worker threads doing this simultaneously at startup, the resulting disk I/O contention was the real cause of the long white screen on first launch.
- `listSessionSources()` now accepts an optional scan window (`AgentScanOptions`) so startup and background refreshes only enumerate files inside the active window. A cached session outside that window is no longer mistaken for "removed" from disk (`wasEnumeratedThisPass` guard in `scan-refresh-worker.ts`).
- Full-history reconciliation is not removed — only decoupled and de-prioritized. `LiveScanStore` now enqueues a low-priority, concurrency-capped (1) background "backfill" pass per agent at most once every 24h, tracked via a `last_sync_at` column kept independent from cache-initialization state, so a bounded first scan is never mistaken for a completed full sync. The web UI surfaces this with a muted "reconciling full session history in the background" banner.

## Test plan
- [x] `pnpm --filter @codesesh/core test -- run` (253 passed)
- [x] `pnpm --filter codesesh test -- run` (70 passed)
- [x] `pnpm --filter @codesesh/web test -- run` (162 passed)
- [x] `pnpm lint` (0 warnings/errors across core, cli, web)
- [x] Added windowing tests for `listSessionSources` on codex/claudecode/pi/kimi agents
- [x] Added tests for the new cache `last_sync_at` sentinel semantics (`markAgentCacheInitialized` vs `markAgentFullSyncCompleted` vs `getAgentLastFullSyncAt`)