### PR TITLE
refactor(web): consolidate format helpers into lib/format

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -37,12 +37,12 @@ import { SearchResultsPanel } from "./components/app/SearchResultsPanel";
 import { type BrowseBy, type SearchProjectOption } from "./components/app/types";
 import {
   formatAgentScanProgress,
-  formatRelativeTime,
   formatScanStatusLabel,
   formatSearchSubtitle,
   formatWindowLabel,
   getAgentDisplayCount,
 } from "./lib/scan-format";
+import { formatRelativeTime } from "./lib/format";
 import { getProjectIdentityKey, getProjectPath, type ProjectRouteIdentity } from "./lib/projects";
 import {
   buildSessionIndexes,

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -14,6 +14,7 @@ import type {
   ProjectGroup,
 } from "../lib/api";
 import { getSessionBookmarkKey } from "../lib/bookmarks";
+import { formatCostSource, formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
 import { getProjectPath } from "../lib/projects";
 import { BookmarkButton } from "./BookmarkButton";
 import { SmartTagChips } from "./SmartTagChips";
@@ -30,38 +31,10 @@ interface DashboardProps {
   ) => void;
 }
 
-function formatNumber(value: number) {
-  return value.toLocaleString("en-US");
-}
-
 function formatCompact(value: number): string {
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
   return formatNumber(value);
-}
-
-function formatMoney(value: number): string {
-  if (value === 0) return "$0.00";
-  if (value < 0.01) return `$${value.toFixed(4)}`;
-  return `$${value.toFixed(2)}`;
-}
-
-function formatCostSource(source?: "recorded" | "estimated"): string | undefined {
-  if (source === "recorded") return "recorded";
-  if (source === "estimated") return "estimated";
-  return undefined;
-}
-
-function formatRelativeTime(timestamp?: number) {
-  if (!timestamp) return "unknown";
-  const diff = Date.now() - timestamp;
-  if (Number.isNaN(diff) || diff < 0) return "just now";
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
 }
 
 function StatCard({ label, value, hint }: { label: string; value: string; hint?: string }) {

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { ModelConfig } from "../config";
 import type { SessionHead } from "../lib/api";
+import { formatCostSource, formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
 import { BookmarkButton } from "./BookmarkButton";
 import { SmartTagChips } from "./SmartTagChips";
 
@@ -28,36 +29,8 @@ interface DetailLandingProps {
   onToggleBookmark: (session: LandingSession) => void;
 }
 
-function formatNumber(value: number) {
-  return value.toLocaleString("en-US");
-}
-
-function formatMoney(value: number): string {
-  if (value === 0) return "$0.00";
-  if (value < 0.01) return `$${value.toFixed(4)}`;
-  return `$${value.toFixed(2)}`;
-}
-
-function formatCostSource(source?: "recorded" | "estimated"): string | undefined {
-  if (source === "recorded") return "recorded";
-  if (source === "estimated") return "estimated";
-  return undefined;
-}
-
 function getSessionTotalTokens(stats: SessionHead["stats"]) {
   return stats.total_tokens ?? stats.total_input_tokens + stats.total_output_tokens;
-}
-
-function formatRelativeTime(timestamp?: number) {
-  if (!timestamp) return "unknown";
-  const diff = Date.now() - timestamp;
-  if (Number.isNaN(diff) || diff < 0) return "just now";
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
 }
 
 function LandingCard({ label, value, hint }: { label: string; value: string; hint?: string }) {

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -1,36 +1,15 @@
 import { Link } from "react-router-dom";
 import { ModelConfig } from "../config";
 import type { DashboardData, ProjectAgentStat, ProjectGroup, SessionHead } from "../lib/api";
+import { formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
 import { getProjectPath } from "../lib/projects";
 import { Dashboard } from "./Dashboard";
 import type { LandingSession } from "./DetailLanding";
-
-function formatNumber(value: number) {
-  return value.toLocaleString("en-US");
-}
 
 function formatCompact(value: number): string {
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
   return formatNumber(value);
-}
-
-function formatMoney(value: number): string {
-  if (value === 0) return "$0.00";
-  if (value < 0.01) return `$${value.toFixed(4)}`;
-  return `$${value.toFixed(2)}`;
-}
-
-function formatRelativeTime(timestamp?: number | null) {
-  if (!timestamp) return "unknown";
-  const diff = Date.now() - timestamp;
-  if (Number.isNaN(diff) || diff < 0) return "just now";
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
 }
 
 function getSessionTotalTokens(session: SessionHead): number {

--- a/apps/web/src/components/app/SidebarFlatSessionList.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.tsx
@@ -1,7 +1,7 @@
 import type { SessionHead } from "../../lib/api";
 import { ModelConfig } from "../../config";
 import { getSessionAgentKey } from "../../lib/session-indexes";
-import { formatRelativeTime } from "../../lib/scan-format";
+import { formatRelativeTime } from "../../lib/format";
 import { BookmarkButton } from "../BookmarkButton";
 
 export function SidebarFlatSessionList({

--- a/apps/web/src/components/session-detail/message-list.tsx
+++ b/apps/web/src/components/session-detail/message-list.tsx
@@ -8,8 +8,8 @@ import {
   type ReactNode,
 } from "react";
 import type { MessagePart } from "../../lib/api";
+import { formatTokens } from "../../lib/format";
 import type { FilteredSessionMessage } from "./toc";
-import { formatTokens } from "./tool-strategy";
 import { MessageItem } from "./message-rendering";
 
 const MESSAGE_LIST_GAP_PX = 32;

--- a/apps/web/src/components/session-detail/tool-strategy.test.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import type { Message, MessagePart } from "../../lib/api";
 import {
   formatMessageTime,
-  formatTokens,
   getAssistantDisplayLabel,
   getToolDisplayStrategy,
   normalizeMessagesForDisplay,
@@ -180,14 +179,6 @@ describe("getToolDisplayStrategy", () => {
       kind: "plain",
       text: "No output captured.",
     });
-  });
-});
-
-describe("formatTokens", () => {
-  it("formats thousands and millions", () => {
-    expect(formatTokens(0)).toBe("0");
-    expect(formatTokens(1500)).toBe("1.5K");
-    expect(formatTokens(1_500_000)).toBe("1.5M");
   });
 });
 

--- a/apps/web/src/components/session-detail/tool-strategy.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.ts
@@ -3,8 +3,8 @@
  * into a ToolDisplayStrategy (icon, title, details, output content with diff).
  *
  * Also owns the content extractors (read/write/search), subagent helpers,
- * normalizeToolState, normalizeMessagesForDisplay, and the format helpers
- * (formatTokens, formatMessageTime) that the message list consumes.
+ * normalizeToolState, normalizeMessagesForDisplay, and the formatMessageTime
+ * helper that the message list consumes.
  *
  * Pure logic — no React. Consumed by SessionDetail's ToolItem / MessageItem.
  */
@@ -1420,12 +1420,6 @@ export function getToolDisplayStrategy(
 // ---------------------------------------------------------------------------
 // Formatters
 // ---------------------------------------------------------------------------
-
-export function formatTokens(n: number) {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toString();
-}
 
 export function formatMessageTime(rawTime: number | string) {
   if (typeof rawTime === "number" && rawTime <= 0) return "Unknown time";

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCostSource,
+  formatMoney,
+  formatNumber,
+  formatRelativeTime,
+  formatTokens,
+} from "./format";
+
+describe("formatRelativeTime", () => {
+  it("returns unknown for undefined", () => {
+    expect(formatRelativeTime(undefined)).toBe("unknown");
+  });
+
+  it("returns unknown for null", () => {
+    expect(formatRelativeTime(null)).toBe("unknown");
+  });
+
+  it("returns unknown for zero", () => {
+    expect(formatRelativeTime(0)).toBe("unknown");
+  });
+
+  it("returns just now for the current instant", () => {
+    expect(formatRelativeTime(Date.now())).toBe("just now");
+  });
+
+  it("returns just now for a future timestamp", () => {
+    expect(formatRelativeTime(Date.now() + 10_000)).toBe("just now");
+  });
+
+  it("returns just now under one minute", () => {
+    expect(formatRelativeTime(Date.now() - 30 * 1000)).toBe("just now");
+  });
+
+  it("returns minutes ago under one hour", () => {
+    expect(formatRelativeTime(Date.now() - 5 * 60 * 1000)).toBe("5m ago");
+    expect(formatRelativeTime(Date.now() - 59 * 60 * 1000)).toBe("59m ago");
+  });
+
+  it("returns hours ago under one day", () => {
+    expect(formatRelativeTime(Date.now() - 60 * 60 * 1000)).toBe("1h ago");
+    expect(formatRelativeTime(Date.now() - 90 * 60 * 1000)).toBe("1h ago");
+    expect(formatRelativeTime(Date.now() - 23 * 60 * 60 * 1000)).toBe("23h ago");
+  });
+
+  it("returns days ago at and beyond 24 hours", () => {
+    expect(formatRelativeTime(Date.now() - 24 * 60 * 60 * 1000)).toBe("1d ago");
+    expect(formatRelativeTime(Date.now() - 3 * 24 * 60 * 60 * 1000)).toBe("3d ago");
+  });
+});
+
+describe("formatNumber", () => {
+  it("formats zero", () => {
+    expect(formatNumber(0)).toBe("0");
+  });
+
+  it("formats with thousands separators", () => {
+    expect(formatNumber(1000)).toBe("1,000");
+    expect(formatNumber(1234567)).toBe("1,234,567");
+  });
+
+  it("formats negative numbers", () => {
+    expect(formatNumber(-1234)).toBe("-1,234");
+  });
+
+  it("formats decimals", () => {
+    expect(formatNumber(1.5)).toBe("1.5");
+  });
+});
+
+describe("formatMoney", () => {
+  it("formats zero as $0.00", () => {
+    expect(formatMoney(0)).toBe("$0.00");
+  });
+
+  it("formats sub-cent values with 4 decimals", () => {
+    expect(formatMoney(0.001)).toBe("$0.0010");
+    expect(formatMoney(0.009999)).toBe("$0.0100");
+  });
+
+  it("formats values at or above one cent with 2 decimals", () => {
+    expect(formatMoney(0.01)).toBe("$0.01");
+    expect(formatMoney(1.005)).toBe("$1.00");
+    expect(formatMoney(1234.5)).toBe("$1234.50");
+  });
+
+  it("formats negative values", () => {
+    expect(formatMoney(-1)).toBe("$-1.0000");
+  });
+});
+
+describe("formatCostSource", () => {
+  it("returns recorded", () => {
+    expect(formatCostSource("recorded")).toBe("recorded");
+  });
+
+  it("returns estimated", () => {
+    expect(formatCostSource("estimated")).toBe("estimated");
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(formatCostSource(undefined)).toBeUndefined();
+  });
+});
+
+describe("formatTokens", () => {
+  it("formats zero", () => {
+    expect(formatTokens(0)).toBe("0");
+  });
+
+  it("formats values under 1000 as-is", () => {
+    expect(formatTokens(999)).toBe("999");
+  });
+
+  it("formats thousands with K suffix", () => {
+    expect(formatTokens(1000)).toBe("1.0K");
+    expect(formatTokens(1500)).toBe("1.5K");
+    expect(formatTokens(999999)).toBe("1000.0K");
+  });
+
+  it("formats millions with M suffix", () => {
+    expect(formatTokens(1000000)).toBe("1.0M");
+    expect(formatTokens(2500000)).toBe("2.5M");
+  });
+
+  it("formats negative values as-is", () => {
+    expect(formatTokens(-500)).toBe("-500");
+  });
+});

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared display-formatting helpers.
+ * Pure functions consumed across Dashboard, Projects, DetailLanding, and session-detail views.
+ */
+
+export function formatRelativeTime(timestamp?: number | null) {
+  if (!timestamp) return "unknown";
+  const diff = Date.now() - timestamp;
+  if (Number.isNaN(diff) || diff < 0) return "just now";
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+export function formatNumber(value: number) {
+  return value.toLocaleString("en-US");
+}
+
+export function formatMoney(value: number): string {
+  if (value === 0) return "$0.00";
+  if (value < 0.01) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+export function formatCostSource(source?: "recorded" | "estimated"): string | undefined {
+  if (source === "recorded") return "recorded";
+  if (source === "estimated") return "estimated";
+  return undefined;
+}
+
+export function formatTokens(n: number) {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toString();
+}

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   formatAgentScanProgress,
   formatIsoDate,
-  formatRelativeTime,
   formatScanStatusLabel,
   formatSearchSubtitle,
   formatWindowLabel,
@@ -65,15 +64,5 @@ describe("formatAgentScanProgress", () => {
 describe("getAgentDisplayCount", () => {
   it("returns fallback when agent status missing", () => {
     expect(getAgentDisplayCount(null, "codex", 5)).toBe(5);
-  });
-});
-
-describe("formatRelativeTime", () => {
-  it("returns unknown for missing timestamp", () => {
-    expect(formatRelativeTime(undefined)).toBe("unknown");
-  });
-
-  it("returns just now for recent", () => {
-    expect(formatRelativeTime(Date.now())).toBe("just now");
   });
 });

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -80,16 +80,3 @@ export function getAgentDisplayCount(
     ? agentStatus.sessions
     : fallback;
 }
-
-export function formatRelativeTime(timestamp?: number) {
-  if (!timestamp) return "unknown";
-  const diff = Date.now() - timestamp;
-  if (Number.isNaN(diff) || diff < 0) return "just now";
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}


### PR DESCRIPTION
## Background (CS-15)

The same display-formatting behavior was inlined multiple times across `apps/web/src`: `formatRelativeTime` had 4 copies, `formatNumber` 3, `formatMoney` 3, and `formatCostSource` 2, scattered across Projects, Dashboard, and DetailLanding. The copies had already started to drift (incompatible signatures for `formatRelativeTime`), so any formatting fix had to be applied in 3–4 places, and missing one would cause inconsistencies between pages.

## Changes

- Added `apps/web/src/lib/format.ts` as the single implementation of `formatRelativeTime` / `formatNumber` / `formatMoney` / `formatCostSource` / `formatTokens`, unified on the widest signature (`timestamp?: number | null`) with unchanged output
- Removed the local copies from Projects, Dashboard, and DetailLanding; migrated `formatRelativeTime` out of `lib/scan-format.ts` and `formatTokens` out of `session-detail/tool-strategy.ts`, updating all importers
- Added `format.test.ts` (25 cases) locking behavior: typical values plus edge cases (0, negatives, `undefined`, `null`, large numbers, time thresholds); removed the now-duplicated cases from `scan-format.test.ts` and `tool-strategy.test.ts`
- Net −122 lines of duplicated code

Deviation from the issue design: `InteractiveReceipt.tsx` keeps its own `formatMoney` — it is a fixed 4-decimal receipt-alignment variant, a different algorithm rather than a drifted copy, and merging it would change the rendered receipt.

## Verification

- Behavior was locked test-first: expected values were derived from the old copies before migration, guaranteeing zero rendering changes
- `pnpm turbo test lint build format:check` all green (10 tasks)

Issue: CS-15