### PR TITLE
fix(web): reconnect SSE stream after it fully closes

### DIFF
--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -6,12 +6,23 @@ import * as api from "../lib/api";
 import { useLiveSync } from "./useLiveSync";
 
 let sessionsCb: ((event: SessionsUpdatedEvent) => void) | undefined;
+let reconnectCb: (() => void) | undefined;
+let disconnectCb: (() => void) | undefined;
 
 vi.mock("../lib/api", () => ({
-  subscribeSessionUpdates: vi.fn((onSessions: (event: SessionsUpdatedEvent) => void) => {
-    sessionsCb = onSessions;
-    return () => {};
-  }),
+  subscribeSessionUpdates: vi.fn(
+    (
+      onSessions: (event: SessionsUpdatedEvent) => void,
+      _onScanStatus?: unknown,
+      onReconnect?: () => void,
+      onDisconnect?: () => void,
+    ) => {
+      sessionsCb = onSessions;
+      reconnectCb = onReconnect;
+      disconnectCb = onDisconnect;
+      return () => {};
+    },
+  ),
 }));
 
 const appConfig = { window: { from: "a", to: "b" } } as unknown as AppConfig;
@@ -37,6 +48,8 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   sessionsCb = undefined;
+  reconnectCb = undefined;
+  disconnectCb = undefined;
 });
 
 describe("useLiveSync", () => {
@@ -69,5 +82,53 @@ describe("useLiveSync", () => {
     });
 
     await waitFor(() => expect(result.current.liveNotice).toContain("3"));
+  });
+
+  it("shows a persistent connection notice on disconnect", () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useLiveSync(deps));
+
+    act(() => {
+      disconnectCb?.();
+    });
+
+    expect(result.current.liveNotice).toBe("实时更新已断开，重连中…");
+  });
+
+  it("clears the connection notice and refreshes everything on reconnect", async () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useLiveSync(deps));
+
+    act(() => {
+      disconnectCb?.();
+    });
+    expect(result.current.liveNotice).toBe("实时更新已断开，重连中…");
+
+    await act(async () => {
+      reconnectCb?.();
+      await Promise.resolve();
+    });
+
+    expect(result.current.liveNotice).toBeNull();
+    expect(deps.refreshAgents).toHaveBeenCalled();
+    expect(deps.refreshDashboard).toHaveBeenCalled();
+    expect(deps.refreshSearch).toHaveBeenCalled();
+  });
+
+  it("connection notice takes priority over a transient liveNotice", async () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useLiveSync(deps));
+
+    await act(async () => {
+      sessionsCb?.({ newSessions: 2 } as SessionsUpdatedEvent);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(result.current.liveNotice).toContain("2"));
+
+    act(() => {
+      disconnectCb?.();
+    });
+
+    expect(result.current.liveNotice).toBe("实时更新已断开，重连中…");
   });
 });

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -23,11 +23,13 @@ interface LiveSyncDeps {
 
 /**
  * Owns the live-update subscription and its fan-out: applies incremental session
- * updates, refreshes every domain, surfaces the transient liveNotice, and routes
- * scan-status events to useScanStatus.
+ * updates, refreshes every domain, surfaces the transient liveNotice, routes
+ * scan-status events to useScanStatus, and surfaces a persistent connection
+ * notice while the SSE stream is reconnecting (takes priority over liveNotice).
  */
 export function useLiveSync(deps: LiveSyncDeps) {
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
+  const [connectionNotice, setConnectionNotice] = useState<string | null>(null);
   const {
     appConfig,
     viewState,
@@ -72,6 +74,19 @@ export function useLiveSync(deps: LiveSyncDeps) {
     }
   });
 
+  const handleReconnect = useEffectEvent(() => {
+    setConnectionNotice(null);
+    void syncLiveUpdate({
+      type: "sessions-updated",
+      changedAgents: [],
+      newSessions: 0,
+      updatedSessions: 0,
+      removedSessions: 0,
+      totalSessions: 0,
+      timestamp: Date.now(),
+    });
+  });
+
   useEffect(() => {
     const unsubscribe = subscribeSessionUpdates(
       (event) => {
@@ -79,6 +94,12 @@ export function useLiveSync(deps: LiveSyncDeps) {
       },
       (event) => {
         setScanStatus(event);
+      },
+      () => {
+        handleReconnect();
+      },
+      () => {
+        setConnectionNotice("实时更新已断开，重连中…");
       },
     );
 
@@ -99,5 +120,5 @@ export function useLiveSync(deps: LiveSyncDeps) {
     };
   }, [liveNotice]);
 
-  return { liveNotice };
+  return { liveNotice: connectionNotice ?? liveNotice };
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { subscribeSessionUpdates } from "./api";
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  static readonly CLOSED = 2;
+
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  listeners: Record<string, ((event: { data: string }) => void)[]> = {};
+  closed = false;
+
+  constructor(public url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: (event: { data: string }) => void) {
+    this.listeners[type] ??= [];
+    this.listeners[type].push(cb);
+  }
+
+  close() {
+    this.closed = true;
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.();
+  }
+
+  emit(type: string, data: unknown) {
+    for (const cb of this.listeners[type] ?? []) {
+      cb({ data: JSON.stringify(data) });
+    }
+  }
+
+  fail() {
+    this.readyState = FakeEventSource.CLOSED;
+    this.onerror?.();
+  }
+}
+
+describe("subscribeSessionUpdates", () => {
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    vi.stubGlobal("EventSource", FakeEventSource);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  function latest(): FakeEventSource {
+    const source = FakeEventSource.instances.at(-1);
+    if (!source) throw new Error("no EventSource created");
+    return source;
+  }
+
+  it("delivers sessions-updated and scan-status events", () => {
+    const onUpdate = vi.fn();
+    const onScanStatus = vi.fn();
+    subscribeSessionUpdates(onUpdate, onScanStatus);
+
+    latest().emit("sessions-updated", { type: "sessions-updated", newSessions: 1 });
+    latest().emit("scan-status", { type: "scan-status", active: true });
+
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ newSessions: 1 }));
+    expect(onScanStatus).toHaveBeenCalledWith(expect.objectContaining({ active: true }));
+  });
+
+  it("does not call onReconnect on the first connection open", () => {
+    const onReconnect = vi.fn();
+    subscribeSessionUpdates(() => {}, undefined, onReconnect);
+
+    latest().open();
+
+    expect(onReconnect).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds the connection with exponential backoff up to the 30s cap", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    subscribeSessionUpdates(() => {});
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    latest().fail();
+    expect(FakeEventSource.instances).toHaveLength(1);
+    vi.advanceTimersByTime(999);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    latest().fail();
+    vi.advanceTimersByTime(2000);
+    expect(FakeEventSource.instances).toHaveLength(3);
+
+    latest().fail();
+    vi.advanceTimersByTime(4000);
+    expect(FakeEventSource.instances).toHaveLength(4);
+
+    latest().fail();
+    vi.advanceTimersByTime(8000);
+    expect(FakeEventSource.instances).toHaveLength(5);
+
+    latest().fail();
+    vi.advanceTimersByTime(16000);
+    expect(FakeEventSource.instances).toHaveLength(6);
+
+    latest().fail();
+    vi.advanceTimersByTime(30000);
+    expect(FakeEventSource.instances).toHaveLength(7);
+
+    vi.spyOn(Math, "random").mockRestore();
+  });
+
+  it("keeps retry delay within +/-20% jitter of the exponential base", () => {
+    subscribeSessionUpdates(() => {});
+    latest().fail();
+
+    const scheduled = vi.getTimerCount();
+    expect(scheduled).toBe(1);
+
+    vi.advanceTimersByTime(799);
+    const before = FakeEventSource.instances.length;
+    vi.advanceTimersByTime(1);
+    const after = FakeEventSource.instances.length;
+
+    expect(before).toBe(1);
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
+
+  it("does not reconnect after unsubscribe", () => {
+    const unsubscribe = subscribeSessionUpdates(() => {});
+    const first = latest();
+
+    unsubscribe();
+    expect(first.closed).toBe(true);
+
+    first.fail();
+    vi.advanceTimersByTime(60_000);
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it("calls onDisconnect once when the stream closes, and onReconnect when it recovers", () => {
+    const onReconnect = vi.fn();
+    const onDisconnect = vi.fn();
+    subscribeSessionUpdates(() => {}, undefined, onReconnect, onDisconnect);
+
+    latest().open();
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    latest().fail();
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1_200);
+    latest().open();
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -425,36 +425,78 @@ export function logClientEvent(event: string, data: Record<string, unknown> = {}
   }).catch(() => {});
 }
 
+const INITIAL_RETRY_MS = 1_000;
+const MAX_RETRY_MS = 30_000;
+
+function jitter(delayMs: number): number {
+  const spread = delayMs * 0.2;
+  return delayMs + (Math.random() * 2 - 1) * spread;
+}
+
 export function subscribeSessionUpdates(
   onUpdate: (event: SessionsUpdatedEvent) => void,
   onScanStatus?: (event: ScanStatusEvent) => void,
+  onReconnect?: () => void,
+  onDisconnect?: () => void,
 ): () => void {
-  const source = new EventSource("/api/events");
+  let disposed = false;
+  let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let retryDelayMs = INITIAL_RETRY_MS;
+  let hasConnectedOnce = false;
+  let disconnectNotified = false;
+  let currentSource: EventSource | undefined;
 
-  source.addEventListener("sessions-updated", (event) => {
-    try {
-      onUpdate(JSON.parse(event.data) as SessionsUpdatedEvent);
-    } catch (error) {
-      console.error("Failed to parse session update event:", error);
-    }
-  });
+  const connect = () => {
+    const source = new EventSource("/api/events");
+    currentSource = source;
 
-  source.addEventListener("scan-status", (event) => {
-    if (!onScanStatus) return;
-    try {
-      onScanStatus(JSON.parse(event.data) as ScanStatusEvent);
-    } catch (error) {
-      console.error("Failed to parse scan status event:", error);
-    }
-  });
+    source.addEventListener("sessions-updated", (event) => {
+      try {
+        onUpdate(JSON.parse(event.data) as SessionsUpdatedEvent);
+      } catch (error) {
+        console.error("Failed to parse session update event:", error);
+      }
+    });
 
-  source.onerror = () => {
-    if (source.readyState !== EventSource.CLOSED) {
-      console.warn("Session update stream disconnected");
-    }
+    source.addEventListener("scan-status", (event) => {
+      if (!onScanStatus) return;
+      try {
+        onScanStatus(JSON.parse(event.data) as ScanStatusEvent);
+      } catch (error) {
+        console.error("Failed to parse scan status event:", error);
+      }
+    });
+
+    source.onopen = () => {
+      retryDelayMs = INITIAL_RETRY_MS;
+      disconnectNotified = false;
+      if (hasConnectedOnce) {
+        onReconnect?.();
+      }
+      hasConnectedOnce = true;
+    };
+
+    source.onerror = () => {
+      if (source.readyState !== EventSource.CLOSED) return;
+      source.close();
+      if (disposed) return;
+      if (!disconnectNotified) {
+        disconnectNotified = true;
+        onDisconnect?.();
+      }
+      const delay = jitter(retryDelayMs);
+      retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_MS);
+      retryTimer = setTimeout(connect, delay);
+    };
   };
 
+  connect();
+
   return () => {
-    source.close();
+    disposed = true;
+    if (retryTimer !== undefined) {
+      clearTimeout(retryTimer);
+    }
+    currentSource?.close();
   };
 }


### PR DESCRIPTION
## Background (CS-17)

`subscribeSessionUpdates` only logged a warning on `EventSource` errors. The browser auto-retries while the connection is in `CONNECTING`, but once it reaches `CLOSED` (typical causes: CLI process restart, non-200 response on `/api/events`, proxy cutting the stream) it never retries. From that point the page silently stops receiving `sessions-updated` / `scan-status` events — live refresh, one of CodeSesh's core features, dies with no user-visible indication until a manual page reload.

## Changes

- Rewrote `subscribeSessionUpdates` to manage a rebuildable connection: on `CLOSED` it recreates the `EventSource` with exponential backoff (1s doubling up to a 30s cap, ±20% jitter); backoff resets on successful open; `unsubscribe` clears the retry timer and closes the active instance so no reconnect can happen afterwards
- Added optional `onReconnect` / `onDisconnect` callbacks (appended parameters, existing callers unaffected); `onReconnect` fires only on re-establishment, not on first connect; `onDisconnect` fires once per outage
- `useLiveSync` shows a persistent "实时更新已断开，重连中…" notice while disconnected (a separate `connectionNotice` state that is exempt from the transient notice's auto-clear, merged as `connectionNotice ?? liveNotice` so App.tsx needs no changes), and triggers a full refresh on reconnect to catch up on events missed during the outage
- Server-side `/api/events` protocol unchanged (no Last-Event-ID resume; a full refresh is sufficient at this data scale)

## Verification

- New `api.test.ts` (6 cases, mocked EventSource + fake timers): event pass-through, 1s/2s/4s/8s/16s/30s-cap rebuild sequence, jitter bounds, no reconnect after unsubscribe, onReconnect on recovery but not on first connect, onDisconnect fired once per outage
- `useLiveSync.test.ts` +3 cases: persistent notice on disconnect, notice cleared + full refresh on reconnect, connection notice takes priority over the transient notice
- `pnpm turbo test lint build` all green (193 web tests); `format:check` clean

Note: the manual smoke test from the issue design (kill CLI → restart → observe recovery within 30s without reloading) was not performed; the backoff/reconnect behavior is locked by unit tests instead.

Issue: CS-17