### PR TITLE
fix: eliminate scan stalls, redundant rescans, and stale scanning status

### DIFF
--- a/apps/web/src/hooks/useScanStatus.test.ts
+++ b/apps/web/src/hooks/useScanStatus.test.ts
@@ -35,6 +35,47 @@ describe("useScanStatus", () => {
     await waitFor(() => expect(result.current.scanStatus).toEqual(sample));
   });
 
+  it("ignores events older than the current status", async () => {
+    vi.mocked(api.fetchScanStatus).mockResolvedValue(sample);
+    const { result } = renderHook(() => useScanStatus());
+    await waitFor(() => expect(result.current.scanStatus).toEqual(sample));
+
+    const newer: ScanStatusEvent = {
+      ...sample,
+      active: false,
+      phase: "idle",
+      scanningAgents: [],
+      updatedAt: 456,
+    };
+    result.current.setScanStatus(newer);
+    await waitFor(() => expect(result.current.scanStatus).toEqual(newer));
+
+    result.current.setScanStatus({ ...sample, updatedAt: 200 });
+    await waitFor(() => expect(result.current.scanStatus).toEqual(newer));
+  });
+
+  it("applies a stale fetch snapshot only when no fresher event has arrived", async () => {
+    let resolveFetch: (status: ScanStatusEvent) => void = () => {};
+    vi.mocked(api.fetchScanStatus).mockImplementation(
+      () => new Promise((resolve) => (resolveFetch = resolve)),
+    );
+    const { result } = renderHook(() => useScanStatus());
+
+    const fresh: ScanStatusEvent = {
+      ...sample,
+      active: false,
+      phase: "idle",
+      scanningAgents: [],
+      updatedAt: 456,
+    };
+    result.current.setScanStatus(fresh);
+    await waitFor(() => expect(result.current.scanStatus).toEqual(fresh));
+
+    resolveFetch(sample);
+    await waitFor(() => expect(api.fetchScanStatus).toHaveBeenCalledTimes(1));
+    expect(result.current.scanStatus).toEqual(fresh);
+  });
+
   it("stays null when the fetch fails", async () => {
     vi.mocked(api.fetchScanStatus).mockRejectedValue(new Error("boom"));
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/apps/web/src/hooks/useScanStatus.ts
+++ b/apps/web/src/hooks/useScanStatus.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { type ScanStatusEvent, fetchScanStatus } from "../lib/api";
 
 /**
@@ -6,7 +6,14 @@ import { type ScanStatusEvent, fetchScanStatus } from "../lib/api";
  * setScanStatus so the live-update subscription can push SSE events in.
  */
 export function useScanStatus() {
-  const [scanStatus, setScanStatus] = useState<ScanStatusEvent | null>(null);
+  const [scanStatus, setScanStatusState] = useState<ScanStatusEvent | null>(null);
+
+  // The mount-time snapshot fetch races with SSE events; without this guard a
+  // stale snapshot resolving late can overwrite fresher state and freeze the
+  // scanning indicator until the next unrelated event arrives.
+  const setScanStatus = useCallback((next: ScanStatusEvent) => {
+    setScanStatusState((prev) => (prev && next.updatedAt < prev.updatedAt ? prev : next));
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -20,7 +27,7 @@ export function useScanStatus() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [setScanStatus]);
 
   return { scanStatus, setScanStatus };
 }

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1306,20 +1306,90 @@ describe("LiveScanStore", () => {
     const store = new LiveScanStore(false);
     await store.initialize();
 
-    // Three schedule calls arrive within the debounce window; each should
-    // reset the pending timer rather than queue additional runs.
+    // Three schedule calls arrive within the debounce window; scheduleRefresh
+    // throttles (keeps the earliest deadline) rather than debouncing, so the
+    // later calls are no-ops and the run fires 200ms after the first call.
     (store as any).scheduleRefresh("codex");
     await vi.advanceTimersByTimeAsync(50);
     (store as any).scheduleRefresh("codex");
     await vi.advanceTimersByTimeAsync(50);
     (store as any).scheduleRefresh("codex");
-    await vi.advanceTimersByTimeAsync(199);
+    await vi.advanceTimersByTimeAsync(99);
     expect(codex.checkForChanges).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(1);
     expect(codex.checkForChanges).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(500);
+    expect(codex.checkForChanges).toHaveBeenCalledTimes(1);
+  });
+
+  it("backs off the refresh delay after a slow scan to reduce scan duty cycle", async () => {
+    vi.useFakeTimers();
+    const existing = makeSession("existing");
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["fresh"],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [existing, makeSession("fresh")]),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [existing],
+      byAgent: { codex: [existing] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+
+    // Simulate a preceding scan that took 5s: the next refresh should be
+    // delayed to ~4x that cost, well beyond the 200ms debounce floor.
+    (store as any).getRefreshState("codex").lastRefreshDurationMs = 5_000;
+    (store as any).scheduleRefresh("codex");
+
+    await vi.advanceTimersByTimeAsync(19_999);
+    expect(codex.checkForChanges).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(codex.checkForChanges).toHaveBeenCalledTimes(1);
+  });
+
+  it("still fires on a steady stream of events instead of being starved by the adaptive backoff", async () => {
+    vi.useFakeTimers();
+    const existing = makeSession("existing");
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["fresh"],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [existing, makeSession("fresh")]),
+    });
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [existing],
+      byAgent: { codex: [existing] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+
+    (store as any).getRefreshState("codex").lastRefreshDurationMs = 5_000;
+
+    // Writes every 3s never leave a 20s quiet gap. A plain debounce (reset on
+    // every call) would push the deadline out forever; throttling on the
+    // earliest deadline guarantees a refresh still fires around the 20s mark.
+    for (let elapsed = 0; elapsed < 21_000; elapsed += 3_000) {
+      (store as any).scheduleRefresh("codex");
+      await vi.advanceTimersByTimeAsync(3_000);
+    }
+
     expect(codex.checkForChanges).toHaveBeenCalledTimes(1);
   });
 
@@ -1422,6 +1492,29 @@ describe("LiveScanStore", () => {
 
     await vi.advanceTimersByTimeAsync(10_000);
     expect(codex.checkForChanges).not.toHaveBeenCalled();
+  });
+
+  it("skips the FTS integrity check on search-index batches after the first one completes", async () => {
+    core.createRegisteredAgents.mockReturnValue([]);
+    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+
+    const job = {
+      kind: "full" as const,
+      context: "scan.refresh",
+      agentName: "codex",
+      sessions: [],
+      meta: {},
+    };
+    await (store as any).enqueueSearchIndexJobs("scan.refresh", [job]);
+    await (store as any).enqueueSearchIndexJobs("scan.refresh", [job]);
+
+    const searchIndexWorkers = workerThreads.workers.filter((worker) => worker.workerData.jobs);
+    expect(searchIndexWorkers).toHaveLength(2);
+    expect(searchIndexWorkers[0]?.workerData.skipFtsIntegrityCheck).toBe(false);
+    expect(searchIndexWorkers[1]?.workerData.skipFtsIntegrityCheck).toBe(true);
   });
 });
 

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -102,15 +102,22 @@ interface LiveScanStoreOptions {
 
 interface AgentRefreshState {
   timer: NodeJS.Timeout | null;
+  /** Absolute time the pending timer is due to fire; lets scheduleRefresh throttle instead of debounce. */
+  timerDeadline: number;
   inFlight: boolean;
   pendingRerun: boolean;
   lastRefreshAt: number;
+  lastRefreshDurationMs: number;
   pendingPathCount: number;
 }
 
 const REFRESH_DEBOUNCE_MS = 200;
 const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const PENDING_REFRESH_DELAY_MS = 100;
+/** Cap on the adaptive backoff so a single expensive scan can't stall refreshes indefinitely. */
+const MAX_ADAPTIVE_REFRESH_DELAY_MS = 30_000;
+/** Space refreshes out to roughly 4x their own cost, so a slow agent doesn't dominate the event loop. */
+const ADAPTIVE_REFRESH_DELAY_MULTIPLIER = 4;
 const NEW_SESSION_EVENT_WINDOW_MS = 250;
 const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 /** Old files rarely change, but it's not impossible — reconcile full history at most this often. */
@@ -217,6 +224,8 @@ export class LiveScanStore {
   private searchIndexWorker: Worker | null = null;
   private pendingSearchIndexJobs: SearchIndexJobBatch[] = [];
   private shuttingDown = false;
+  /** Set once a search-index worker in this process has completed the FTS integrity check. */
+  private ftsIntegrityChecked = false;
 
   constructor(
     private readonly watchEnabled = true,
@@ -230,9 +239,11 @@ export class LiveScanStore {
     if (!state) {
       state = {
         timer: null,
+        timerDeadline: 0,
         inFlight: false,
         pendingRerun: false,
         lastRefreshAt: 0,
+        lastRefreshDurationMs: 0,
         pendingPathCount: 0,
       };
       this.refreshStates.set(agentName, state);
@@ -381,6 +392,7 @@ export class LiveScanStore {
       if (state.timer) {
         clearTimeout(state.timer);
         state.timer = null;
+        state.timerDeadline = 0;
       }
     }
 
@@ -862,6 +874,7 @@ export class LiveScanStore {
         agentNames: [],
         sessionsByAgent: {},
         metaByAgent: {},
+        skipFtsIntegrityCheck: this.ftsIntegrityChecked,
       },
     });
     worker.unref();
@@ -876,6 +889,7 @@ export class LiveScanStore {
           sessions: message.sessions,
         });
         settled = true;
+        this.ftsIntegrityChecked = true;
         batch.resolve();
       }
     });
@@ -963,17 +977,34 @@ export class LiveScanStore {
     }
   }
 
+  /**
+   * Throttles rather than debounces: a pending timer only gets replaced by a
+   * request with an earlier deadline. Plain debounce (reset on every call)
+   * would let a steady stream of events — each arriving before the adaptive
+   * backoff elapses — push the deadline out forever and starve the refresh.
+   */
   private scheduleRefresh(agentName: string, delayMs = REFRESH_DEBOUNCE_MS): void {
-    appLogger.debug("scan.refresh.schedule", { agent: agentName, delay_ms: delayMs });
     const state = this.getRefreshState(agentName);
+    const adaptiveDelayMs = Math.min(
+      state.lastRefreshDurationMs * ADAPTIVE_REFRESH_DELAY_MULTIPLIER,
+      MAX_ADAPTIVE_REFRESH_DELAY_MS,
+    );
+    const effectiveDelayMs = Math.max(delayMs, adaptiveDelayMs);
+    const deadline = Date.now() + effectiveDelayMs;
+
     if (state.timer !== null) {
+      if (deadline >= state.timerDeadline) {
+        return;
+      }
       clearTimeout(state.timer);
     }
 
+    appLogger.debug("scan.refresh.schedule", { agent: agentName, delay_ms: effectiveDelayMs });
+    state.timerDeadline = deadline;
     state.timer = setTimeout(() => {
       state.timer = null;
       void this.refreshAgent(agentName);
-    }, delayMs);
+    }, effectiveDelayMs);
   }
 
   private async refreshAgent(agentName: string): Promise<void> {
@@ -1207,9 +1238,11 @@ export class LiveScanStore {
       event.totalSessions = this.sessions.length;
       this.emit(event);
     }
+    const totalDurationMs = performance.now() - startedAt;
+    state.lastRefreshDurationMs = totalDurationMs;
     appLogger.info("scan.refresh.done", {
       agent: agentName,
-      duration_ms: Math.round(performance.now() - startedAt),
+      duration_ms: Math.round(totalDurationMs),
       sessions: nextSessions.length,
       new_sessions: event?.newSessions ?? 0,
       updated_sessions: event?.updatedSessions ?? 0,

--- a/packages/cli/src/scan-refresh-worker.test.ts
+++ b/packages/cli/src/scan-refresh-worker.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { BaseAgent, SessionHead } from "@codesesh/core";
+import { finalizeSessions } from "./scan-refresh-worker.js";
+
+// Isolated temp directory so computeIdentity resolves a stable "path" identity
+// regardless of manifests that happen to exist above /tmp.
+const FIXTURE_DIR = mkdtempSync(join(tmpdir(), "codesesh-scan-refresh-worker-"));
+
+function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: id,
+    directory: FIXTURE_DIR,
+    time_created: 1000,
+    time_updated: 1000,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+function makeAgent(getSessionData: BaseAgent["getSessionData"]): BaseAgent {
+  return {
+    name: "codex",
+    displayName: "Codex",
+    isAvailable: () => true,
+    scan: () => [],
+    incrementalScan: () => [],
+    getSessionData,
+    getSessionMetaMap: () => new Map(),
+    setSessionMetaMap: () => undefined,
+  } as unknown as BaseAgent;
+}
+
+describe("finalizeSessions", () => {
+  it("attaches project identity to sessions missing one", () => {
+    const agent = makeAgent(() => ({ messages: [] }) as never);
+    const [result] = finalizeSessions(agent, [makeSession("s1")]);
+
+    expect(result?.project_identity).toEqual({
+      kind: "path",
+      key: FIXTURE_DIR,
+      displayName: FIXTURE_DIR.split(/[\\/]/).pop(),
+    });
+  });
+
+  it("computes smart tags for a session whose content changed", () => {
+    const getSessionData = vi.fn(() => ({
+      time_created: 1000,
+      time_updated: 1000,
+      messages: [{ role: "user", parts: [{ type: "text", text: "fix the crash" }] }],
+    })) as unknown as BaseAgent["getSessionData"];
+    const agent = makeAgent(getSessionData);
+
+    const [result] = finalizeSessions(agent, [makeSession("s1")]);
+
+    expect(getSessionData).toHaveBeenCalledWith("s1");
+    expect(result?.smart_tags).toContain("bugfix");
+    expect(result?.smart_tags_source_updated_at).toBe(1000);
+  });
+
+  it("does not recompute tags for a session whose tags are already current", () => {
+    const getSessionData = vi.fn();
+    const agent = makeAgent(getSessionData as unknown as BaseAgent["getSessionData"]);
+
+    const session = makeSession("s1", {
+      smart_tags: ["bugfix"],
+      smart_tags_source_updated_at: 1000,
+    });
+
+    const [result] = finalizeSessions(agent, [session]);
+
+    expect(getSessionData).not.toHaveBeenCalled();
+    expect(result?.smart_tags).toEqual(["bugfix"]);
+  });
+
+  it("skips tag computation for a session still within the settle window", () => {
+    const getSessionData = vi.fn();
+    const agent = makeAgent(getSessionData as unknown as BaseAgent["getSessionData"]);
+
+    const hotSession = makeSession("hot", { time_updated: Date.now() - 10_000 });
+    const settledSession = makeSession("settled");
+
+    const result = finalizeSessions(agent, [hotSession, settledSession]);
+
+    expect(getSessionData).toHaveBeenCalledTimes(1);
+    expect(getSessionData).toHaveBeenCalledWith("settled");
+    expect(result.map((session) => session.id)).toEqual(["hot", "settled"]);
+    expect(result[0]?.smart_tags).toBeUndefined();
+  });
+});

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -1,9 +1,12 @@
 import { parentPort, workerData } from "node:worker_threads";
 import {
+  attachMissingProjectIdentities,
   createRegisteredAgents,
+  ensureSessionTagsSync,
   FileSystemSessionSource,
   matchesScanWindow,
   type AgentScanProgress,
+  type BaseAgent,
   type ScanOptions,
   type SessionCacheMeta,
   type SessionHead,
@@ -146,6 +149,34 @@ function syncAgentSources(
   return { sessions: [...sessionMap.values()], changedIds: [...changedIds] };
 }
 
+/**
+ * A session still receiving writes will be stale again within seconds, so
+ * recomputing its tags every refresh cycle is wasted work — wait for it to
+ * settle before paying the getSessionData() parse cost.
+ */
+const TAG_SETTLE_MS = 60_000;
+
+function isSettled(session: SessionHead, now: number): boolean {
+  return now - (session.time_updated ?? session.time_created) >= TAG_SETTLE_MS;
+}
+
+/**
+ * Runs identity resolution (spawns git) and stale smart-tag reclassification
+ * on the worker thread, off the server's main event loop.
+ */
+export function finalizeSessions(agent: BaseAgent, sessions: SessionHead[]): SessionHead[] {
+  const withIdentity = attachMissingProjectIdentities(sessions);
+
+  const now = Date.now();
+  const settled = withIdentity.filter((session) => isSettled(session, now));
+  if (settled.length === 0) return withIdentity;
+
+  const taggedById = new Map(
+    ensureSessionTagsSync(agent, settled).sessions.map((session) => [session.id, session]),
+  );
+  return withIdentity.map((session) => taggedById.get(session.id) ?? session);
+}
+
 const data = workerData as ScanRefreshWorkerData;
 const startedAt = performance.now();
 
@@ -182,6 +213,8 @@ async function run(): Promise<void> {
       }),
     );
   }
+
+  sessions = finalizeSessions(agent, sessions);
 
   parentPort?.postMessage({
     type: "done",

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -1,9 +1,11 @@
 import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,
+  getCachePath,
   markAgentCacheInitialized,
   saveCachedSessionChanges,
   saveCachedSessions,
+  setFtsIntegrityCheckedPath,
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,
   type SearchIndexSyncResult,
@@ -52,9 +54,14 @@ interface SearchIndexWorkerData {
   agentNames: string[];
   sessionsByAgent: Record<string, SessionHead[]>;
   metaByAgent: Record<string, Record<string, SessionCacheMeta>>;
+  /** Set once this process has already run the FTS integrity check in an earlier batch. */
+  skipFtsIntegrityCheck?: boolean;
 }
 
 const data = workerData as SearchIndexWorkerData;
+if (data.skipFtsIntegrityCheck) {
+  setFtsIntegrityCheckedPath(getCachePath());
+}
 const startedAt = performance.now();
 const agents = createRegisteredAgents();
 const jobs =

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -210,9 +210,9 @@ describe("ensureFtsConsistency", () => {
     withCacheDb((db) => {
       const execSpy = vi.spyOn(db, "exec");
       ensureFtsConsistency(db);
-      expect(
-        execSpy.mock.calls.some((call) => String(call[0]).includes("integrity-check")),
-      ).toBe(true);
+      expect(execSpy.mock.calls.some((call) => String(call[0]).includes("integrity-check"))).toBe(
+        true,
+      );
       expect(getFtsIntegrityCheckedPath()).toBe(getCachePath());
     });
   });
@@ -222,9 +222,9 @@ describe("ensureFtsConsistency", () => {
       setFtsIntegrityCheckedPath(getCachePath());
       const execSpy = vi.spyOn(db, "exec");
       ensureFtsConsistency(db);
-      expect(
-        execSpy.mock.calls.some((call) => String(call[0]).includes("integrity-check")),
-      ).toBe(false);
+      expect(execSpy.mock.calls.some((call) => String(call[0]).includes("integrity-check"))).toBe(
+        false,
+      );
     });
   });
 });

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -23,6 +23,13 @@ import {
   syncSessionSearchIndexChanges,
   type SessionCacheMeta,
 } from "../cache.js";
+import { ensureFtsConsistency, withCacheDb } from "../cache/schema.js";
+import {
+  getFtsIntegrityCheckedPath,
+  getSchemaEnsuredPath,
+  setFtsIntegrityCheckedPath,
+  setSchemaEnsuredPath,
+} from "../cache/db.js";
 import type { SessionData, SessionHead } from "../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
@@ -146,10 +153,14 @@ function getMigrationBackups(): string[] {
 beforeEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   dateNowSpy.mockReturnValue(now);
+  setFtsIntegrityCheckedPath(null);
+  setSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
+  setFtsIntegrityCheckedPath(null);
+  setSchemaEnsuredPath(null);
 });
 
 describe("loadCachedSessions", () => {
@@ -191,6 +202,49 @@ describe("loadCachedSessions", () => {
       meta: {},
       timestamp: now,
     });
+  });
+});
+
+describe("ensureFtsConsistency", () => {
+  it("runs the FTS integrity check once per cache path and marks it checked", () => {
+    withCacheDb((db) => {
+      const execSpy = vi.spyOn(db, "exec");
+      ensureFtsConsistency(db);
+      expect(
+        execSpy.mock.calls.some((call) => String(call[0]).includes("integrity-check")),
+      ).toBe(true);
+      expect(getFtsIntegrityCheckedPath()).toBe(getCachePath());
+    });
+  });
+
+  it("skips the integrity check when the cache path is already marked checked", () => {
+    withCacheDb((db) => {
+      setFtsIntegrityCheckedPath(getCachePath());
+      const execSpy = vi.spyOn(db, "exec");
+      ensureFtsConsistency(db);
+      expect(
+        execSpy.mock.calls.some((call) => String(call[0]).includes("integrity-check")),
+      ).toBe(false);
+    });
+  });
+});
+
+describe("withCacheDb schema memo", () => {
+  it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
+    withCacheDb(() => undefined);
+    expect(getSchemaEnsuredPath()).toBe(getCachePath());
+    expect(getUserVersion(getCachePath())).toBe(13);
+
+    const db = new Database(getCachePath());
+    db.pragma("user_version = 5");
+    db.close();
+
+    withCacheDb(() => undefined);
+    expect(getUserVersion(getCachePath())).toBe(5);
+
+    setSchemaEnsuredPath(null);
+    withCacheDb(() => undefined);
+    expect(getUserVersion(getCachePath())).toBe(13);
   });
 });
 
@@ -1385,6 +1439,7 @@ describe("searchSessions", () => {
     } finally {
       db.close();
     }
+    setSchemaEnsuredPath(null);
 
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
@@ -1419,6 +1474,7 @@ describe("searchSessions", () => {
     } finally {
       db.close();
     }
+    setSchemaEnsuredPath(null);
 
     expect(listCachedProjectGroups()).toEqual([
       {

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -6,6 +6,7 @@
 export {
   hasCacheStorage,
   getCachePath,
+  setFtsIntegrityCheckedPath,
   type SessionCacheMeta,
   type SessionHeadChange,
 } from "./cache/db.js";

--- a/packages/core/src/discovery/cache/db.ts
+++ b/packages/core/src/discovery/cache/db.ts
@@ -48,6 +48,20 @@ export function setFtsIntegrityCheckedPath(path: string | null): void {
   ftsIntegrityCheckedPath = path;
 }
 
+// One-shot per-process ensureSchema guard; reset by clearCache. Once a path
+// has been schema-checked, withCacheDb skips ensureSchema's DDL exec (which
+// otherwise runs unconditionally on every open) so read-heavy callers stop
+// contending for the write lock.
+let schemaEnsuredPath: string | null = null;
+
+export function getSchemaEnsuredPath(): string | null {
+  return schemaEnsuredPath;
+}
+
+export function setSchemaEnsuredPath(path: string | null): void {
+  schemaEnsuredPath = path;
+}
+
 export function getCacheDir(): string {
   return join(homedir(), ".cache", "codesesh");
 }

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -19,7 +19,9 @@ import {
 import {
   getCachePath,
   getFtsIntegrityCheckedPath,
+  getSchemaEnsuredPath,
   setFtsIntegrityCheckedPath,
+  setSchemaEnsuredPath,
   type CacheRow,
 } from "./db.js";
 import {
@@ -89,7 +91,10 @@ export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
   if (!db) return null;
 
   try {
-    ensureSchema(db, cachePath);
+    if (getSchemaEnsuredPath() !== cachePath) {
+      ensureSchema(db, cachePath);
+      setSchemaEnsuredPath(cachePath);
+    }
     return fn(db);
   } catch {
     return null;

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -10,6 +10,7 @@ import {
   getLegacyCachePath,
   hasCacheStorage,
   setFtsIntegrityCheckedPath,
+  setSchemaEnsuredPath,
   type ScalarRow,
   type SessionCacheMeta,
   type SessionHeadChange,
@@ -446,6 +447,7 @@ export function saveCachedSessionChanges(
 
 export function clearCache(): void {
   setFtsIntegrityCheckedPath(null);
+  setSchemaEnsuredPath(null);
   if (!hasCacheStorage()) {
     deleteLegacyCacheFile();
     return;

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -1,6 +1,11 @@
 export { resolveProviderRoots, getCursorDataPath, firstExisting } from "./paths.js";
 export type { ProviderRoots } from "./paths.js";
-export { ensureSessionTagsSync, filterSessions, scanSessions, scanSessionsAsync } from "./scanner.js";
+export {
+  ensureSessionTagsSync,
+  filterSessions,
+  scanSessions,
+  scanSessionsAsync,
+} from "./scanner.js";
 export type { ScanResult, ScanOptions } from "./scanner.js";
 export {
   attachMissingProjectIdentities,

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -1,6 +1,6 @@
 export { resolveProviderRoots, getCursorDataPath, firstExisting } from "./paths.js";
 export type { ProviderRoots } from "./paths.js";
-export { filterSessions, scanSessions, scanSessionsAsync } from "./scanner.js";
+export { ensureSessionTagsSync, filterSessions, scanSessions, scanSessionsAsync } from "./scanner.js";
 export type { ScanResult, ScanOptions } from "./scanner.js";
 export {
   attachMissingProjectIdentities,
@@ -20,6 +20,8 @@ export {
   saveCachedSessionChanges,
   clearCache,
   getCacheInfo,
+  getCachePath,
+  setFtsIntegrityCheckedPath,
   listCachedProjectGroups,
   listFileActivity,
   listSessionFileActivity,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -132,7 +132,7 @@ function chunkSessions<T>(items: T[], chunkCount: number): T[][] {
   return chunks.filter((chunk) => chunk.length > 0);
 }
 
-function ensureSessionTagsSync(
+export function ensureSessionTagsSync(
   agent: BaseAgent,
   sessions: SessionHead[],
 ): { sessions: SessionHead[]; changed: boolean } {


### PR DESCRIPTION
## Problems

1. Opening a session detail was slow regardless of session size
2. While agents were active (Claude Code / Codex in use), API requests repeatedly hung for 3+ seconds
3. The scanning indicator was on almost permanently (~90% duty cycle)
4. After a restart, the scanning indicator froze on codex for over a minute

## Root causes and fixes

### Backend (`fix(cli)`)

| Root cause | Fix |
|---|---|
| After each worker scan, `attachMissingProjectIdentities` ran `spawnSync` git probes on the main thread, freezing the event loop for seconds | Move identity resolution and smart-tag backfill into scan-refresh-worker (`finalizeSessions`) |
| `withCacheDb` unconditionally ran `ensureSchema` DDL (write lock) on every open, spinning in SQLite's 5s busy loop against long index-worker transactions | Memoize `ensureSchema` per process (keyed by cache path, reset by `clearCache`); the migration entry point is preserved |
| Each search-index worker batch re-ran the full FTS integrity check (10–28s holding the write lock) because the once-per-process guard died with each short-lived worker | Track the checked state in the store and pass a skip flag via workerData |
| With the 200ms debounce, every append to an active session triggered a full reparse + retag (a 31MB file parsed twice, ~4.2s per cycle, back to back) | Skip tag recomputes for sessions updated within the last 60s; throttle refreshes to 4x their own cost (capped at 30s), keeping the earliest deadline so a steady write stream cannot starve refreshes |

### Frontend (`fix(web)`)

The mount-time `GET /api/status` snapshot races with SSE events: when the page load spans a scan finishing, the stale snapshot resolves last and overwrites the fresher state, freezing the scanning indicator until the next unrelated event (97s observed). Fix: drop updates older than the current state (`updatedAt` guard).

## Measurements (real session data)

| Metric | Before | After |
|---|---|---|
| Session detail API (during backfill) | 4.05–4.4s | 2.5–6ms |
| claudecode incremental refresh | constant ~5.2s (busy timeout) | 77–127ms |
| Search-index worker batch | 10–28s each | ~400ms first, 0ms after |
| codex scanning duty cycle (continuous writes) | ~90% | 13–16% |
| Smart-tag recompute on large sessions | ~190ms per request | 0ms (cache hit) |

## Testing

- New/updated tests: scan-refresh-worker (identity attach, tag cooldown), live-scan-store (FTS skip flag, adaptive throttle, starvation guard), cache (ensureSchema memo, FTS skip), useScanStatus (out-of-order guard)
- `pnpm build` / `pnpm test` (core 256 + web 195 + cli 83) / `pnpm lint` all green
- End-to-end on real data: server startup plus continuous touch/append of large session files, 60–90s polling with no timeouts, refreshes firing on the throttled cadence without starvation