### PR TITLE
feat(web): session message timeline with minimap navigation

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -27,6 +27,8 @@ import {
   SessionDetailAuxControls,
   SessionDetailAuxOverlay,
 } from "./session-detail/session-detail-aux";
+import { SessionMessageTimeline } from "./session-detail/session-message-timeline";
+import { buildSessionTimelineEntries } from "./session-detail/timeline";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,16 +43,27 @@ interface SessionDetailProps {
 // Small helpers
 // ---------------------------------------------------------------------------
 
-function scrollToToolAnchor(anchorId: string, prepareAnchor?: () => void) {
+function scrollToSessionAnchor({
+  anchorId,
+  behavior,
+  prepareAnchor,
+  isCurrent,
+}: {
+  anchorId: string;
+  behavior: ScrollBehavior;
+  prepareAnchor?: () => void;
+  isCurrent: () => boolean;
+}) {
   if (typeof document === "undefined") return;
   let element = document.getElementById(anchorId);
   if (!element && prepareAnchor) {
     prepareAnchor();
     let attempts = 0;
     const retryScroll = () => {
+      if (!isCurrent()) return;
       element = document.getElementById(anchorId);
       if (element) {
-        element.scrollIntoView({ behavior: "smooth", block: "center" });
+        element.scrollIntoView({ behavior, block: "center" });
         return;
       }
       attempts += 1;
@@ -60,7 +73,7 @@ function scrollToToolAnchor(anchorId: string, prepareAnchor?: () => void) {
     return;
   }
   if (!element) return;
-  element.scrollIntoView({ behavior: "smooth", block: "center" });
+  element.scrollIntoView({ behavior, block: "center" });
 }
 
 function measureSessionDetailWork<T>(id: string, compute: () => T): T {
@@ -136,6 +149,7 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
     [messageModels, selectedFilters],
   );
   const virtualListRef = useRef<MessageListHandle | null>(null);
+  const scrollRequestRef = useRef(0);
   const anchorListIndexes = useMemo(() => {
     return measureSessionDetailWork("SessionDetail:buildAnchorListIndexes", () => {
       const indexes = new Map<number, number>();
@@ -152,15 +166,30 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
       ),
     [session.file_activity, localFileChangeSummary],
   );
-  const handleJumpToAnchor = useCallback(
-    (anchorId: string) => {
-      const messageIndex = anchorMessageIndexes.get(anchorId);
+  const timelineEntries = useMemo(
+    () => buildSessionTimelineEntries(filteredMessages, toolAnchorIds),
+    [filteredMessages, toolAnchorIds],
+  );
+  const handleJumpToMessageAnchor = useCallback(
+    (anchorId: string, messageIndex: number | undefined, behavior: ScrollBehavior = "smooth") => {
+      const requestId = scrollRequestRef.current + 1;
+      scrollRequestRef.current = requestId;
       const listIndex = messageIndex == null ? undefined : anchorListIndexes.get(messageIndex);
-      scrollToToolAnchor(anchorId, () => {
-        if (listIndex != null) virtualListRef.current?.scrollToIndex(listIndex);
+      scrollToSessionAnchor({
+        anchorId,
+        behavior,
+        prepareAnchor:
+          listIndex == null ? undefined : () => virtualListRef.current?.scrollToIndex(listIndex),
+        isCurrent: () => scrollRequestRef.current === requestId,
       });
     },
-    [anchorListIndexes, anchorMessageIndexes],
+    [anchorListIndexes],
+  );
+  const handleJumpToAnchor = useCallback(
+    (anchorId: string) => {
+      handleJumpToMessageAnchor(anchorId, anchorMessageIndexes.get(anchorId));
+    },
+    [anchorMessageIndexes, handleJumpToMessageAnchor],
   );
 
   useEffect(() => {
@@ -223,23 +252,31 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
         />
         <div className="flex min-w-0 flex-col gap-8">
           {filteredMessages.length > 0 ? (
-            <RenderProfiler
-              id="MessageList"
-              detail={{
-                messages: filteredMessages.length,
-                virtualized: filteredMessages.length > VIRTUALIZED_MESSAGE_THRESHOLD,
-              }}
-            >
-              <MessageList
-                key={`${session.id}:${selectedFilterSignature}`}
-                messages={filteredMessages}
-                toolAnchorIds={toolAnchorIds}
-                sessionAgentKey={sessionAgentKey}
-                baseDirectory={session.directory}
-                highlightQuery={highlightQuery}
-                apiRef={virtualListRef}
+            <>
+              <SessionMessageTimeline
+                entries={timelineEntries}
+                onNavigate={(entry, behavior) =>
+                  handleJumpToMessageAnchor(entry.anchorId, entry.messageIndex, behavior)
+                }
               />
-            </RenderProfiler>
+              <RenderProfiler
+                id="MessageList"
+                detail={{
+                  messages: filteredMessages.length,
+                  virtualized: filteredMessages.length > VIRTUALIZED_MESSAGE_THRESHOLD,
+                }}
+              >
+                <MessageList
+                  key={`${session.id}:${selectedFilterSignature}`}
+                  messages={filteredMessages}
+                  toolAnchorIds={toolAnchorIds}
+                  sessionAgentKey={sessionAgentKey}
+                  baseDirectory={session.directory}
+                  highlightQuery={highlightQuery}
+                  apiRef={virtualListRef}
+                />
+              </RenderProfiler>
+            </>
           ) : (
             <div className="rounded-sm border border-[var(--console-border)] bg-white p-6 text-sm text-[var(--console-muted)]">
               当前筛选条件下暂无可展示的消息内容。

--- a/apps/web/src/components/session-detail/message-list.tsx
+++ b/apps/web/src/components/session-detail/message-list.tsx
@@ -165,6 +165,7 @@ export function MessageList({
       {messages.map(({ msg, blocks, index }) => (
         <MessageItem
           key={`${msg.id}:${index}`}
+          messageIndex={index}
           msg={msg}
           blocks={blocks}
           toolAnchorIds={toolAnchorIds}
@@ -365,6 +366,7 @@ function VirtualizedMessageList({
             onMeasure={measureItem}
           >
             <MessageItem
+              messageIndex={item.index}
               msg={item.msg}
               blocks={item.blocks}
               toolAnchorIds={toolAnchorIds}

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -20,6 +20,7 @@ import { extractMessageText, type MessageBlock } from "./blocks";
 import { isCodexTurnAbortedMessage } from "./codex-abort";
 import { buildCodexPlanDisplay } from "./codex-plan";
 import { getDisplayTextWithRelativePaths } from "./path-extract";
+import { buildBlockTimelineAnchorId, buildMessageTimelineAnchorId } from "./timeline";
 import { escapeRegExp } from "./utils";
 import {
   type ToolStatus,
@@ -86,6 +87,7 @@ function MessageMarkdown({ text, highlightQuery }: { text: string; highlightQuer
 }
 
 export function MessageItem({
+  messageIndex,
   msg,
   blocks,
   toolAnchorIds,
@@ -94,6 +96,7 @@ export function MessageItem({
   baseDirectory,
   highlightQuery,
 }: {
+  messageIndex: number;
   msg: Message;
   blocks: MessageBlock[];
   toolAnchorIds: Map<MessagePart, string>;
@@ -126,7 +129,11 @@ export function MessageItem({
   const time = formatMessageTime(msg.time_created);
 
   return (
-    <article className="w-full border-l-2 border-[var(--console-thread)] pl-4 pr-3 md:pr-5">
+    <article
+      id={isUser ? buildMessageTimelineAnchorId(messageIndex) : undefined}
+      data-session-timeline-anchor={isUser ? buildMessageTimelineAnchorId(messageIndex) : undefined}
+      className="w-full scroll-mt-20 border-l-2 border-[var(--console-thread)] pl-4 pr-3 md:pr-5"
+    >
       <div className="flex gap-4">
         <div className="shrink-0 pt-1">
           <div className="flex size-8 items-center justify-center rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)]">
@@ -159,10 +166,12 @@ export function MessageItem({
             <AbortToolItem />
           ) : (
             blocks.map((block, index) => {
+              const timelineAnchorId = buildBlockTimelineAnchorId(messageIndex, index);
               if (block.type === "reasoning") {
                 return (
                   <ReasoningSection
                     key={index}
+                    anchorId={timelineAnchorId}
                     parts={block.parts}
                     highlightQuery={highlightQuery}
                   />
@@ -170,7 +179,12 @@ export function MessageItem({
               }
               if (block.type === "plan") {
                 return (
-                  <PlansSection key={index} parts={block.parts} highlightQuery={highlightQuery} />
+                  <PlansSection
+                    key={index}
+                    anchorId={timelineAnchorId}
+                    parts={block.parts}
+                    highlightQuery={highlightQuery}
+                  />
                 );
               }
               if (block.type === "tool") {
@@ -188,7 +202,9 @@ export function MessageItem({
               return (
                 <div
                   key={index}
-                  className="rounded-sm border border-[var(--console-border)] bg-white p-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
+                  id={timelineAnchorId}
+                  data-session-timeline-anchor={timelineAnchorId}
+                  className="scroll-mt-20 rounded-sm border border-[var(--console-border)] bg-white p-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
                 >
                   <div className="console-markdown text-sm leading-relaxed text-[var(--console-text)]">
                     {block.parts.map((part, partIndex) => (
@@ -254,9 +270,11 @@ function AbortToolItem() {
 }
 
 function ReasoningSection({
+  anchorId,
   parts,
   highlightQuery,
 }: {
+  anchorId: string;
   parts: MessagePart[];
   highlightQuery?: string;
 }) {
@@ -267,7 +285,11 @@ function ReasoningSection({
     .join("\n\n");
 
   return (
-    <div className="overflow-hidden rounded-sm border border-[var(--console-thinking-border)] bg-[var(--console-thinking-bg)]">
+    <div
+      id={anchorId}
+      data-session-timeline-anchor={anchorId}
+      className="scroll-mt-20 overflow-hidden rounded-sm border border-[var(--console-thinking-border)] bg-[var(--console-thinking-bg)]"
+    >
       <div
         className="flex cursor-pointer items-center justify-between bg-[var(--console-surface-muted)] px-3 py-2"
         onClick={() => setExpanded(!expanded)}
@@ -323,14 +345,16 @@ function ToolsSection({
 }
 
 function PlansSection({
+  anchorId,
   parts,
   highlightQuery,
 }: {
+  anchorId: string;
   parts: MessagePart[];
   highlightQuery?: string;
 }) {
   return (
-    <div className="space-y-2">
+    <div id={anchorId} data-session-timeline-anchor={anchorId} className="scroll-mt-20 space-y-2">
       {parts.map((plan, i) => (
         <PlanItem key={i} part={plan} highlightQuery={highlightQuery} />
       ))}
@@ -432,7 +456,7 @@ function ToolItem({
   const ToolIcon = strategy.Icon;
 
   return (
-    <div id={anchorId} className="scroll-mt-6 space-y-2">
+    <div id={anchorId} data-session-timeline-anchor={anchorId} className="scroll-mt-20 space-y-2">
       <div className="flex flex-wrap items-start gap-2">
         <div
           className={`w-full md:w-[560px] rounded-sm border border-[var(--console-border-strong)] bg-white px-3 py-2 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${

--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -1,0 +1,130 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionMessageTimeline } from "./session-message-timeline";
+import type { SessionTimelineEntry } from "./timeline";
+
+const entries: SessionTimelineEntry[] = [
+  {
+    id: "user-1",
+    kind: "user",
+    anchorId: "user-1",
+    messageIndex: 0,
+    tooltip: "User · First",
+  },
+  {
+    id: "agent-1",
+    kind: "agent",
+    anchorId: "agent-1",
+    messageIndex: 1,
+    tooltip: "Agent · Second",
+  },
+  {
+    id: "tool-1",
+    kind: "tool",
+    anchorId: "tool-1",
+    messageIndex: 2,
+    tooltip: "Tool · Read",
+  },
+];
+
+afterEach(cleanup);
+
+function renderTimeline(timelineEntries = entries) {
+  const onNavigate = vi.fn();
+  const view = render(<SessionMessageTimeline entries={timelineEntries} onNavigate={onNavigate} />);
+  const timeline = view.getByRole("navigation", { name: "Session message timeline" });
+  const track = view.getByTestId("session-timeline-track");
+  Object.defineProperties(track, {
+    getBoundingClientRect: {
+      value: () => ({ left: 0, width: 300 }),
+    },
+    hasPointerCapture: { value: () => false },
+    releasePointerCapture: { value: vi.fn() },
+    setPointerCapture: { value: vi.fn() },
+  });
+  return { ...view, onNavigate, timeline, track };
+}
+
+describe("SessionMessageTimeline", () => {
+  it("keeps a color block clickable after a pointer press", () => {
+    const { getAllByRole, onNavigate } = renderTimeline();
+    const target = getAllByRole("button")[2]!;
+
+    fireEvent.pointerDown(target, { button: 0, clientX: 250, pointerId: 1 });
+    fireEvent.pointerUp(target, { button: 0, clientX: 250, pointerId: 1 });
+    fireEvent.click(target, { clientX: 250 });
+
+    expect(onNavigate).toHaveBeenCalledOnce();
+    expect(onNavigate).toHaveBeenCalledWith(entries[2], "smooth");
+  });
+
+  it("maps clicks between blocks to the timeline position", () => {
+    const { onNavigate, track } = renderTimeline();
+
+    fireEvent.click(track, { clientX: 250 });
+
+    expect(onNavigate).toHaveBeenCalledWith(entries[2], "smooth");
+  });
+
+  it("captures the pointer only after drag intent is clear", () => {
+    const { getAllByRole, onNavigate, track } = renderTimeline();
+    const target = getAllByRole("button")[0]!;
+
+    fireEvent.pointerDown(target, { button: 0, clientX: 10, pointerId: 1 });
+    expect(track.setPointerCapture).not.toHaveBeenCalled();
+
+    fireEvent.pointerMove(track, { clientX: 250, pointerId: 1 });
+
+    expect(track.setPointerCapture).toHaveBeenCalledWith(1);
+    expect(onNavigate).toHaveBeenCalledWith(entries[2], "auto");
+  });
+
+  it("preserves a readable segment width and exposes horizontal scrolling", () => {
+    const longEntries = Array.from({ length: 100 }, (_, index) => ({
+      ...entries[index % entries.length]!,
+      id: `entry-${index}`,
+      anchorId: `entry-${index}`,
+    }));
+    const { getByRole, onNavigate, timeline, track } = renderTimeline(longEntries);
+    Object.defineProperties(timeline, {
+      clientWidth: { configurable: true, value: 300 },
+      scrollWidth: { configurable: true, value: 1_099 },
+      scrollLeft: { configurable: true, value: 0, writable: true },
+    });
+    fireEvent.scroll(timeline);
+
+    expect(timeline.className).toContain("overflow-x-auto");
+    expect(timeline.className).toContain("overflow-y-hidden");
+    expect(track.style.minWidth).toBe("1099px");
+    expect(track.style.gridTemplateColumns).toBe("repeat(100, minmax(10px, 1fr))");
+
+    fireEvent.click(getByRole("button", { name: "Scroll timeline right" }));
+
+    expect(timeline.scrollLeft).toBe(225);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("renders one unclipped tooltip and hides it while scrolling", () => {
+    const { getAllByRole, getByRole, queryByRole, timeline } = renderTimeline();
+    const target = getAllByRole("button")[1]!;
+
+    fireEvent.pointerEnter(target);
+
+    const tooltip = getByRole("tooltip");
+    expect(tooltip.textContent).toBe("Agent · Second");
+    expect(tooltip.parentElement).toBe(document.body);
+
+    fireEvent.scroll(timeline);
+    expect(queryByRole("tooltip")).toBeNull();
+  });
+
+  it("keeps a focused tooltip aligned while the timeline scrolls", () => {
+    const { getAllByRole, getByRole, timeline } = renderTimeline();
+    const target = getAllByRole("button")[1]!;
+
+    target.focus();
+    fireEvent.scroll(timeline);
+
+    expect(getByRole("tooltip").textContent).toBe("Agent · Second");
+  });
+});

--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -104,6 +104,65 @@ describe("SessionMessageTimeline", () => {
     expect(onNavigate).not.toHaveBeenCalled();
   });
 
+  it("shows a minimap window mirroring the visible range when the track overflows", () => {
+    const longEntries = Array.from({ length: 100 }, (_, index) => ({
+      ...entries[index % entries.length]!,
+      id: `entry-${index}`,
+      anchorId: `entry-${index}`,
+    }));
+    const { getByTestId, timeline } = renderTimeline(longEntries);
+    Object.defineProperties(timeline, {
+      clientWidth: { configurable: true, value: 300 },
+      scrollWidth: { configurable: true, value: 1_200 },
+      scrollLeft: { configurable: true, value: 300, writable: true },
+    });
+    fireEvent.scroll(timeline);
+
+    const window = getByTestId("session-timeline-minimap-window");
+    expect(window.style.left).toBe("25%");
+    expect(window.style.width).toBe("25%");
+  });
+
+  it("hides the minimap when the track fits the viewport", () => {
+    const { queryByTestId, timeline } = renderTimeline();
+
+    fireEvent.scroll(timeline);
+
+    expect(queryByTestId("session-timeline-minimap")).toBeNull();
+  });
+
+  it("drags the minimap window to scroll the timeline", () => {
+    const longEntries = Array.from({ length: 100 }, (_, index) => ({
+      ...entries[index % entries.length]!,
+      id: `entry-${index}`,
+      anchorId: `entry-${index}`,
+    }));
+    const { getByTestId, timeline } = renderTimeline(longEntries);
+    Object.defineProperties(timeline, {
+      clientWidth: { configurable: true, value: 300 },
+      scrollWidth: { configurable: true, value: 1_200 },
+      scrollLeft: { configurable: true, value: 0, writable: true },
+    });
+    fireEvent.scroll(timeline);
+
+    const minimap = getByTestId("session-timeline-minimap");
+    Object.defineProperties(minimap, {
+      getBoundingClientRect: {
+        value: () => ({ left: 0, width: 300 }),
+      },
+      hasPointerCapture: { value: () => false },
+      releasePointerCapture: { value: vi.fn() },
+      setPointerCapture: { value: vi.fn() },
+    });
+
+    // Press outside the window: the window centers on the pointer.
+    fireEvent.pointerDown(minimap, { button: 0, clientX: 150, pointerId: 1 });
+    expect(timeline.scrollLeft).toBe(450);
+
+    fireEvent.pointerMove(minimap, { clientX: 300, pointerId: 1 });
+    expect(timeline.scrollLeft).toBe(1_050);
+  });
+
   it("renders one unclipped tooltip and hides it while scrolling", () => {
     const { getAllByRole, getByRole, queryByRole, timeline } = renderTimeline();
     const target = getAllByRole("button")[1]!;

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -1,0 +1,414 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  findActiveTimelineIndex,
+  findTimelineEdgeIndex,
+  findTimelineIndexAtPointer,
+  type SessionTimelineEntry,
+  type SessionTimelineEntryKind,
+} from "./timeline";
+
+type TimelineScrollBehavior = "auto" | "smooth";
+type ScrollParent = HTMLElement | Window;
+
+interface SessionMessageTimelineProps {
+  entries: SessionTimelineEntry[];
+  onNavigate: (entry: SessionTimelineEntry, behavior: TimelineScrollBehavior) => void;
+}
+
+interface TimelineTooltip {
+  entryId: string;
+  id: string;
+  text: string;
+  anchorX: number;
+  top: number;
+  source: "focus" | "pointer";
+}
+
+const TIMELINE_SEGMENT_MIN_WIDTH = 10;
+const TIMELINE_SCROLL_EDGE_TOLERANCE = 1;
+const TIMELINE_TOOLTIP_VIEWPORT_PADDING = 8;
+
+const KIND_CLASS: Record<SessionTimelineEntryKind, string> = {
+  user: "bg-[var(--timeline-user)]",
+  agent: "bg-[var(--timeline-agent)]",
+  tool: "bg-[var(--timeline-tool)]",
+};
+
+function findScrollParent(node: HTMLElement): ScrollParent {
+  let parent = node.parentElement;
+
+  while (parent) {
+    const { overflowY } = window.getComputedStyle(parent);
+    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") return parent;
+    parent = parent.parentElement;
+  }
+
+  return window;
+}
+
+function isWindowScrollParent(parent: ScrollParent): parent is Window {
+  return parent === window;
+}
+
+function getScrollViewport(parent: ScrollParent) {
+  if (isWindowScrollParent(parent)) {
+    const viewportHeight = window.innerHeight || 900;
+    const scrollingElement = document.scrollingElement ?? document.documentElement;
+    return {
+      center: viewportHeight / 2,
+      scrollTop: window.scrollY || scrollingElement.scrollTop,
+      viewportHeight,
+      scrollHeight: scrollingElement.scrollHeight,
+    };
+  }
+
+  const rect = parent.getBoundingClientRect();
+  return {
+    center: rect.top + parent.clientHeight / 2,
+    scrollTop: parent.scrollTop,
+    viewportHeight: parent.clientHeight,
+    scrollHeight: parent.scrollHeight,
+  };
+}
+
+function getTrackLayout(entryCount: number) {
+  const gap =
+    entryCount > 80
+      ? { className: "gap-px", width: 1 }
+      : entryCount > 40
+        ? { className: "gap-0.5", width: 2 }
+        : { className: "gap-1", width: 4 };
+  return {
+    gapClassName: gap.className,
+    minWidth: entryCount * TIMELINE_SEGMENT_MIN_WIDTH + Math.max(0, entryCount - 1) * gap.width,
+  };
+}
+
+export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTimelineProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const tooltipRef = useRef<HTMLSpanElement | null>(null);
+  const tooltipTriggerRef = useRef<HTMLElement | null>(null);
+  const dragRef = useRef({ active: false, moved: false, startX: 0, lastIndex: -1 });
+  const suppressClickRef = useRef(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [tooltip, setTooltip] = useState<TimelineTooltip | null>(null);
+  const [scrollAvailability, setScrollAvailability] = useState({ left: false, right: false });
+  const entryIndexes = useMemo(
+    () => new Map(entries.map((entry, index) => [entry.anchorId, index])),
+    [entries],
+  );
+  const trackLayout = getTrackLayout(entries.length);
+
+  const updateScrollAvailability = useCallback(() => {
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+    const maxScrollLeft = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
+    const next = {
+      left: viewport.scrollLeft > TIMELINE_SCROLL_EDGE_TOLERANCE,
+      right: viewport.scrollLeft < maxScrollLeft - TIMELINE_SCROLL_EDGE_TOLERANCE,
+    };
+    setScrollAvailability((current) =>
+      current.left === next.left && current.right === next.right ? current : next,
+    );
+  }, []);
+
+  useLayoutEffect(() => {
+    const element = tooltipRef.current;
+    if (!element || !tooltip) return;
+    const halfWidth = element.offsetWidth / 2;
+    const left = Math.min(
+      window.innerWidth - TIMELINE_TOOLTIP_VIEWPORT_PADDING - halfWidth,
+      Math.max(TIMELINE_TOOLTIP_VIEWPORT_PADDING + halfWidth, tooltip.anchorX),
+    );
+    element.style.left = `${left}px`;
+  }, [tooltip]);
+
+  useLayoutEffect(() => {
+    updateScrollAvailability();
+    const viewport = scrollRef.current;
+    const track = trackRef.current;
+    if (!viewport || !track || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(updateScrollAvailability);
+    observer.observe(viewport);
+    observer.observe(track);
+    return () => observer.disconnect();
+  }, [entries.length, updateScrollAvailability]);
+
+  useEffect(() => {
+    setActiveIndex(0);
+    const root = rootRef.current;
+    if (!root || entries.length === 0) return;
+
+    const detail = root.closest<HTMLElement>('[data-testid="session-detail"]');
+    const scrollParent = findScrollParent(root);
+    let frame = 0;
+    const updateActiveEntry = () => {
+      const viewport = getScrollViewport(scrollParent);
+      const edgeIndex = findTimelineEdgeIndex(
+        viewport.scrollTop,
+        viewport.viewportHeight,
+        viewport.scrollHeight,
+        entries.length,
+      );
+      const positions = Array.from(
+        detail?.querySelectorAll<HTMLElement>("[data-session-timeline-anchor]") ?? [],
+      ).flatMap((anchor) => {
+        const anchorId = anchor.dataset.sessionTimelineAnchor;
+        const index = anchorId ? entryIndexes.get(anchorId) : undefined;
+        return index == null ? [] : [{ index, top: anchor.getBoundingClientRect().top }];
+      });
+      const nextIndex = edgeIndex ?? findActiveTimelineIndex(positions, viewport.center);
+      if (nextIndex != null) {
+        setActiveIndex((current) => (current === nextIndex ? current : nextIndex));
+      }
+    };
+    const scheduleUpdate = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        updateActiveEntry();
+      });
+    };
+
+    scheduleUpdate();
+    scrollParent.addEventListener("scroll", scheduleUpdate, { passive: true });
+    window.addEventListener("resize", scheduleUpdate);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleUpdate);
+    if (detail) resizeObserver?.observe(detail);
+
+    const mutationObserver =
+      typeof MutationObserver === "undefined" ? null : new MutationObserver(scheduleUpdate);
+    if (detail) mutationObserver?.observe(detail, { childList: true, subtree: true });
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+      scrollParent.removeEventListener("scroll", scheduleUpdate);
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [entries.length, entryIndexes]);
+
+  useEffect(() => {
+    const scrollViewport = scrollRef.current;
+    const segment = trackRef.current?.querySelector<HTMLElement>(
+      `[data-timeline-index="${activeIndex}"]`,
+    );
+    if (!scrollViewport || !segment) return;
+
+    const viewportRect = scrollViewport.getBoundingClientRect();
+    const segmentRect = segment.getBoundingClientRect();
+    if (segmentRect.left < viewportRect.left) {
+      scrollViewport.scrollLeft -= viewportRect.left - segmentRect.left;
+    } else if (segmentRect.right > viewportRect.right) {
+      scrollViewport.scrollLeft += segmentRect.right - viewportRect.right;
+    }
+  }, [activeIndex]);
+
+  const showTooltip = useCallback(
+    (entry: SessionTimelineEntry, trigger: HTMLElement, source: TimelineTooltip["source"]) => {
+      const rect = trigger.getBoundingClientRect();
+      tooltipTriggerRef.current = trigger;
+      setTooltip({
+        entryId: entry.id,
+        id: `timeline-tooltip-${entry.id}`,
+        text: entry.tooltip,
+        anchorX: rect.left + rect.width / 2,
+        top: rect.bottom + 8,
+        source,
+      });
+    },
+    [],
+  );
+
+  const hideTooltip = useCallback((entryId: string) => {
+    setTooltip((current) => {
+      if (current?.entryId !== entryId) return current;
+      tooltipTriggerRef.current = null;
+      return null;
+    });
+  }, []);
+
+  const handleTimelineScroll = useCallback(() => {
+    updateScrollAvailability();
+    setTooltip((current) => {
+      const trigger = tooltipTriggerRef.current;
+      if (
+        !current ||
+        current.source !== "focus" ||
+        !trigger ||
+        trigger !== document.activeElement
+      ) {
+        tooltipTriggerRef.current = null;
+        return null;
+      }
+
+      const rect = trigger.getBoundingClientRect();
+      return {
+        ...current,
+        anchorX: rect.left + rect.width / 2,
+        top: rect.bottom + 8,
+      };
+    });
+  }, [updateScrollAvailability]);
+
+  const scrollTimeline = useCallback((direction: -1 | 1) => {
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+    viewport.scrollLeft += direction * Math.max(120, viewport.clientWidth * 0.75);
+  }, []);
+
+  const navigateFromPointer = useCallback(
+    (clientX: number, behavior: TimelineScrollBehavior) => {
+      const track = trackRef.current;
+      if (!track) return;
+      const rect = track.getBoundingClientRect();
+      const index = findTimelineIndexAtPointer(clientX, rect.left, rect.width, entries.length);
+      if (index == null || index === dragRef.current.lastIndex) return;
+      const entry = entries[index];
+      if (!entry) return;
+      dragRef.current.lastIndex = index;
+      onNavigate(entry, behavior);
+    },
+    [entries, onNavigate],
+  );
+
+  return (
+    <div className="sticky top-0 z-20 -mx-2 bg-[var(--console-bg)] px-2 py-3">
+      <div
+        ref={rootRef}
+        className="session-message-timeline relative rounded-sm border border-[var(--console-border)] bg-white px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.05)]"
+      >
+        <div className="relative">
+          <div
+            ref={scrollRef}
+            role="navigation"
+            aria-label="Session message timeline"
+            tabIndex={0}
+            className="console-scrollbar overflow-x-auto overflow-y-hidden overscroll-x-contain py-1"
+            onScroll={handleTimelineScroll}
+          >
+            <div
+              ref={trackRef}
+              data-testid="session-timeline-track"
+              className={`grid h-5 w-full select-none items-stretch ${trackLayout.gapClassName}`}
+              style={{
+                gridTemplateColumns: `repeat(${entries.length}, minmax(${TIMELINE_SEGMENT_MIN_WIDTH}px, 1fr))`,
+                minWidth: `${trackLayout.minWidth}px`,
+              }}
+              onPointerDown={(event) => {
+                if (event.button !== 0) return;
+                dragRef.current = {
+                  active: true,
+                  moved: false,
+                  startX: event.clientX,
+                  lastIndex: -1,
+                };
+              }}
+              onPointerMove={(event) => {
+                const drag = dragRef.current;
+                if (!drag.active) return;
+                if (!drag.moved) {
+                  if (Math.abs(event.clientX - drag.startX) < 3) return;
+                  drag.moved = true;
+                  event.currentTarget.setPointerCapture(event.pointerId);
+                }
+                suppressClickRef.current = true;
+                navigateFromPointer(event.clientX, "auto");
+              }}
+              onPointerUp={(event) => {
+                dragRef.current.active = false;
+                if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                  event.currentTarget.releasePointerCapture(event.pointerId);
+                }
+                window.setTimeout(() => {
+                  suppressClickRef.current = false;
+                }, 0);
+              }}
+              onPointerCancel={() => {
+                dragRef.current.active = false;
+                suppressClickRef.current = false;
+              }}
+              onClick={(event) => {
+                if (suppressClickRef.current) return;
+
+                const indexValue = (event.target as HTMLElement).closest<HTMLButtonElement>(
+                  "[data-timeline-index]",
+                )?.dataset.timelineIndex;
+                const index = indexValue == null ? null : Number(indexValue);
+                const entry =
+                  index == null || !Number.isInteger(index) ? undefined : entries[index];
+                if (entry) {
+                  onNavigate(entry, "smooth");
+                  return;
+                }
+                navigateFromPointer(event.clientX, "smooth");
+              }}
+            >
+              {entries.map((entry, index) => {
+                const tooltipId = `timeline-tooltip-${entry.id}`;
+                const isActive = index === activeIndex;
+                return (
+                  <span key={entry.id} className="t-tt-wrap session-timeline-item min-w-0">
+                    <button
+                      type="button"
+                      data-timeline-index={index}
+                      aria-current={isActive ? "location" : undefined}
+                      aria-describedby={tooltip?.entryId === entry.id ? tooltipId : undefined}
+                      aria-label={`Go to ${entry.tooltip}`}
+                      className={`t-tt-trigger session-timeline-segment h-full w-full rounded-[3px] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-text)] ${KIND_CLASS[entry.kind]}`}
+                      onPointerEnter={(event) => showTooltip(entry, event.currentTarget, "pointer")}
+                      onPointerLeave={() => hideTooltip(entry.id)}
+                      onFocus={(event) => showTooltip(entry, event.currentTarget, "focus")}
+                      onBlur={() => hideTooltip(entry.id)}
+                    />
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+          {scrollAvailability.left && (
+            <button
+              type="button"
+              aria-label="Scroll timeline left"
+              className="absolute inset-y-0 left-0 z-10 flex w-8 items-center justify-start bg-[linear-gradient(to_right,#fff_55%,transparent)] pl-0.5 text-[var(--console-muted)] hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--console-text)]"
+              onClick={() => scrollTimeline(-1)}
+            >
+              <ChevronLeft size={14} aria-hidden="true" />
+            </button>
+          )}
+          {scrollAvailability.right && (
+            <button
+              type="button"
+              aria-label="Scroll timeline right"
+              className="absolute inset-y-0 right-0 z-10 flex w-8 items-center justify-end bg-[linear-gradient(to_left,#fff_55%,transparent)] pr-0.5 text-[var(--console-muted)] hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--console-text)]"
+              onClick={() => scrollTimeline(1)}
+            >
+              <ChevronRight size={14} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+        {tooltip &&
+          createPortal(
+            <span
+              ref={tooltipRef}
+              id={tooltip.id}
+              role="tooltip"
+              className="t-tt session-timeline-floating-tooltip console-mono text-[11px]"
+              style={{ left: tooltip.anchorX, top: tooltip.top }}
+            >
+              {tooltip.text}
+            </span>,
+            document.body,
+          )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -36,6 +36,17 @@ const KIND_CLASS: Record<SessionTimelineEntryKind, string> = {
   tool: "bg-[var(--timeline-tool)]",
 };
 
+const KIND_FALLBACK_COLOR: Record<SessionTimelineEntryKind, string> = {
+  user: "#a85f82",
+  agent: "#5e86aa",
+  tool: "#a3a3a3",
+};
+
+interface MinimapWindow {
+  start: number;
+  size: number;
+}
+
 function findScrollParent(node: HTMLElement): ScrollParent {
   let parent = node.parentElement;
 
@@ -94,9 +105,12 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
   const tooltipTriggerRef = useRef<HTMLElement | null>(null);
   const dragRef = useRef({ active: false, moved: false, startX: 0, lastIndex: -1 });
   const suppressClickRef = useRef(false);
+  const minimapCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const minimapDragRef = useRef<{ pointerId: number; grabOffset: number } | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
   const [tooltip, setTooltip] = useState<TimelineTooltip | null>(null);
   const [scrollAvailability, setScrollAvailability] = useState({ left: false, right: false });
+  const [minimapWindow, setMinimapWindow] = useState<MinimapWindow | null>(null);
   const entryIndexes = useMemo(
     () => new Map(entries.map((entry, index) => [entry.anchorId, index])),
     [entries],
@@ -113,6 +127,17 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
     };
     setScrollAvailability((current) =>
       current.left === next.left && current.right === next.right ? current : next,
+    );
+    if (maxScrollLeft <= 0) {
+      setMinimapWindow(null);
+      return;
+    }
+    const window = {
+      start: viewport.scrollLeft / viewport.scrollWidth,
+      size: viewport.clientWidth / viewport.scrollWidth,
+    };
+    setMinimapWindow((current) =>
+      current?.start === window.start && current.size === window.size ? current : window,
     );
   }, []);
 
@@ -212,6 +237,49 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
     }
   }, [activeIndex]);
 
+  const minimapVisible = minimapWindow != null;
+
+  useEffect(() => {
+    const canvas = minimapCanvasRef.current;
+    if (!canvas || !minimapVisible) return;
+
+    const draw = () => {
+      const context = canvas.getContext("2d");
+      const width = canvas.clientWidth;
+      const height = canvas.clientHeight;
+      if (!context || !width || !height || entries.length === 0) return;
+      const ratio = window.devicePixelRatio || 1;
+      canvas.width = Math.round(width * ratio);
+      canvas.height = Math.round(height * ratio);
+      context.scale(ratio, ratio);
+      context.clearRect(0, 0, width, height);
+      const styles = window.getComputedStyle(canvas);
+      const colors: Record<SessionTimelineEntryKind, string> = {
+        user: styles.getPropertyValue("--timeline-user").trim() || KIND_FALLBACK_COLOR.user,
+        agent: styles.getPropertyValue("--timeline-agent").trim() || KIND_FALLBACK_COLOR.agent,
+        tool: styles.getPropertyValue("--timeline-tool").trim() || KIND_FALLBACK_COLOR.tool,
+      };
+      entries.forEach((entry, index) => {
+        const x0 = (index / entries.length) * width;
+        const x1 = ((index + 1) / entries.length) * width;
+        context.fillStyle = colors[entry.kind];
+        context.fillRect(x0, 0, Math.max(x1 - x0, 0.5), height);
+      });
+    };
+
+    draw();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(draw);
+    observer.observe(canvas);
+    return () => observer.disconnect();
+  }, [entries, minimapVisible]);
+
+  const scrollToMinimapRatio = useCallback((ratio: number, grabOffset: number) => {
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+    viewport.scrollLeft = (ratio - grabOffset) * viewport.scrollWidth;
+  }, []);
+
   const showTooltip = useCallback(
     (entry: SessionTimelineEntry, trigger: HTMLElement, source: TimelineTooltip["source"]) => {
       const rect = trigger.getBoundingClientRect();
@@ -289,10 +357,11 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
         <div className="relative">
           <div
             ref={scrollRef}
+            id="session-timeline-viewport"
             role="navigation"
             aria-label="Session message timeline"
             tabIndex={0}
-            className="console-scrollbar overflow-x-auto overflow-y-hidden overscroll-x-contain py-1"
+            className="session-timeline-viewport overflow-x-auto overflow-y-hidden overscroll-x-contain py-1"
             onScroll={handleTimelineScroll}
           >
             <div
@@ -395,6 +464,62 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
             </button>
           )}
         </div>
+        {minimapWindow && (
+          <div
+            data-testid="session-timeline-minimap"
+            role="scrollbar"
+            aria-controls="session-timeline-viewport"
+            aria-orientation="horizontal"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round((minimapWindow.start / (1 - minimapWindow.size)) * 100)}
+            className="session-timeline-minimap relative mt-2 h-2.5 cursor-pointer touch-none select-none"
+            onPointerDown={(event) => {
+              if (event.button !== 0) return;
+              const rect = event.currentTarget.getBoundingClientRect();
+              if (rect.width <= 0) return;
+              const ratio = (event.clientX - rect.left) / rect.width;
+              const withinWindow =
+                ratio >= minimapWindow.start && ratio <= minimapWindow.start + minimapWindow.size;
+              const grabOffset = withinWindow
+                ? ratio - minimapWindow.start
+                : minimapWindow.size / 2;
+              minimapDragRef.current = { pointerId: event.pointerId, grabOffset };
+              event.currentTarget.setPointerCapture(event.pointerId);
+              scrollToMinimapRatio(ratio, grabOffset);
+            }}
+            onPointerMove={(event) => {
+              const drag = minimapDragRef.current;
+              if (!drag || drag.pointerId !== event.pointerId) return;
+              const rect = event.currentTarget.getBoundingClientRect();
+              if (rect.width <= 0) return;
+              scrollToMinimapRatio((event.clientX - rect.left) / rect.width, drag.grabOffset);
+            }}
+            onPointerUp={(event) => {
+              minimapDragRef.current = null;
+              if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+                event.currentTarget.releasePointerCapture(event.pointerId);
+              }
+            }}
+            onPointerCancel={() => {
+              minimapDragRef.current = null;
+            }}
+          >
+            <canvas
+              ref={minimapCanvasRef}
+              aria-hidden="true"
+              className="absolute inset-0 h-full w-full"
+            />
+            <div
+              data-testid="session-timeline-minimap-window"
+              className="session-timeline-minimap-window absolute inset-y-0"
+              style={{
+                left: `${minimapWindow.start * 100}%`,
+                width: `${minimapWindow.size * 100}%`,
+              }}
+            />
+          </div>
+        )}
         {tooltip &&
           createPortal(
             <span

--- a/apps/web/src/components/session-detail/timeline.test.ts
+++ b/apps/web/src/components/session-detail/timeline.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { Message, MessagePart } from "../../lib/api";
+import type { FilteredSessionMessage } from "./toc";
+import {
+  buildBlockTimelineAnchorId,
+  buildMessageTimelineAnchorId,
+  buildSessionTimelineEntries,
+  findActiveTimelineIndex,
+  findTimelineEdgeIndex,
+  findTimelineIndexAtPointer,
+  summarizeTimelineText,
+} from "./timeline";
+
+function message(id: string, role: Message["role"]): Message {
+  return { id, role, time_created: 1, parts: [] };
+}
+
+describe("session timeline", () => {
+  it("builds user, agent, and individual tool entries in display order", () => {
+    const readTool: MessagePart = { type: "tool", tool: "Read" };
+    const writeTool: MessagePart = { type: "tool", title: "Tool: Write" };
+    const messages: FilteredSessionMessage[] = [
+      {
+        msg: message("user", "user"),
+        index: 4,
+        blocks: [{ type: "text", parts: [{ type: "text", text: "  Open\nthis file  " }] }],
+      },
+      {
+        msg: message("assistant", "assistant"),
+        index: 7,
+        blocks: [
+          { type: "reasoning", parts: [{ type: "reasoning", text: "Checking it" }] },
+          { type: "tool", parts: [readTool, writeTool] },
+          { type: "text", parts: [{ type: "text", text: "Done" }] },
+        ],
+      },
+    ];
+    const toolAnchorIds = new Map<MessagePart, string>([
+      [readTool, "tool-7-0"],
+      [writeTool, "tool-7-1"],
+    ]);
+
+    const entries = buildSessionTimelineEntries(messages, toolAnchorIds);
+
+    expect(entries.map((entry) => entry.kind)).toEqual(["user", "agent", "tool", "tool", "agent"]);
+    expect(entries.map((entry) => entry.anchorId)).toEqual([
+      buildMessageTimelineAnchorId(4),
+      buildBlockTimelineAnchorId(7, 0),
+      "tool-7-0",
+      "tool-7-1",
+      buildBlockTimelineAnchorId(7, 2),
+    ]);
+    expect(entries.map((entry) => entry.tooltip)).toEqual([
+      "User · Open this file",
+      "Agent · Checking it",
+      "Tool · Read",
+      "Tool · Write",
+      "Agent · Done",
+    ]);
+  });
+
+  it("compacts and limits message summaries", () => {
+    const summary = summarizeTimelineText(`  ${"a".repeat(80)}\n next  `);
+    expect(summary).toBe(`${"a".repeat(48)}…`);
+    expect(summarizeTimelineText("# Heading <!-- --> with **bold** and `code`")).toBe(
+      "Heading with bold and code",
+    );
+  });
+
+  it("selects the last anchor above the viewport center", () => {
+    expect(
+      findActiveTimelineIndex(
+        [
+          { index: 3, top: 500 },
+          { index: 1, top: 100 },
+          { index: 2, top: 300 },
+        ],
+        420,
+      ),
+    ).toBe(2);
+    expect(findActiveTimelineIndex([{ index: 3, top: 500 }], 100)).toBe(3);
+    expect(findActiveTimelineIndex([], 100)).toBeNull();
+  });
+
+  it("prioritizes the first and last entries at scroll boundaries", () => {
+    expect(findTimelineEdgeIndex(0, 400, 1_000, 8)).toBe(0);
+    expect(findTimelineEdgeIndex(0.5, 400, 1_000, 8)).toBe(0);
+    expect(findTimelineEdgeIndex(599.5, 400, 1_000, 8)).toBe(7);
+    expect(findTimelineEdgeIndex(300, 400, 1_000, 8)).toBeNull();
+    expect(findTimelineEdgeIndex(0, 400, 300, 8)).toBe(0);
+    expect(findTimelineEdgeIndex(0, 400, 1_000, 0)).toBeNull();
+  });
+
+  it("maps pointer position to a clamped timeline entry", () => {
+    expect(findTimelineIndexAtPointer(150, 100, 200, 4)).toBe(1);
+    expect(findTimelineIndexAtPointer(50, 100, 200, 4)).toBe(0);
+    expect(findTimelineIndexAtPointer(400, 100, 200, 4)).toBe(3);
+    expect(findTimelineIndexAtPointer(100, 100, 0, 4)).toBeNull();
+  });
+});

--- a/apps/web/src/components/session-detail/timeline.ts
+++ b/apps/web/src/components/session-detail/timeline.ts
@@ -1,0 +1,144 @@
+import type { MessagePart } from "../../lib/api";
+import { extractMessageText } from "./blocks";
+import { normalizeToolLabel } from "./tool-normalize";
+import type { FilteredSessionMessage } from "./toc";
+
+const TIMELINE_SUMMARY_LENGTH = 48;
+const TIMELINE_SCROLL_EDGE_TOLERANCE = 1;
+
+export type SessionTimelineEntryKind = "user" | "agent" | "tool";
+
+export interface SessionTimelineEntry {
+  id: string;
+  kind: SessionTimelineEntryKind;
+  anchorId: string;
+  messageIndex: number;
+  tooltip: string;
+}
+
+export interface TimelineAnchorPosition {
+  index: number;
+  top: number;
+}
+
+export function buildMessageTimelineAnchorId(messageIndex: number) {
+  return `session-message-${messageIndex}`;
+}
+
+export function buildBlockTimelineAnchorId(messageIndex: number, blockIndex: number) {
+  return `${buildMessageTimelineAnchorId(messageIndex)}-block-${blockIndex}`;
+}
+
+export function summarizeTimelineText(value: string) {
+  const normalized = value
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/(^|\s)#{1,6}\s+/g, "$1")
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/([*_])(.*?)\1/g, "$2")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+  const characters = Array.from(normalized);
+  if (characters.length <= TIMELINE_SUMMARY_LENGTH) return normalized;
+  return `${characters.slice(0, TIMELINE_SUMMARY_LENGTH).join("")}…`;
+}
+
+function summarizeParts(parts: MessagePart[]) {
+  return summarizeTimelineText(
+    parts
+      .map((part) => extractMessageText(part.text))
+      .filter(Boolean)
+      .join(" "),
+  );
+}
+
+export function buildSessionTimelineEntries(
+  messages: FilteredSessionMessage[],
+  toolAnchorIds: Map<MessagePart, string>,
+): SessionTimelineEntry[] {
+  const entries: SessionTimelineEntry[] = [];
+
+  for (const { msg, blocks, index: messageIndex } of messages) {
+    if (msg.role === "user") {
+      const anchorId = buildMessageTimelineAnchorId(messageIndex);
+      const summary = summarizeParts(blocks.flatMap((block) => block.parts));
+      entries.push({
+        id: anchorId,
+        kind: "user",
+        anchorId,
+        messageIndex,
+        tooltip: `User · ${summary || "Message"}`,
+      });
+      continue;
+    }
+
+    blocks.forEach((block, blockIndex) => {
+      if (block.type === "tool") {
+        block.parts.forEach((part) => {
+          const anchorId = toolAnchorIds.get(part);
+          if (!anchorId) return;
+          entries.push({
+            id: anchorId,
+            kind: "tool",
+            anchorId,
+            messageIndex,
+            tooltip: `Tool · ${normalizeToolLabel(part)}`,
+          });
+        });
+        return;
+      }
+
+      const anchorId = buildBlockTimelineAnchorId(messageIndex, blockIndex);
+      const summary = summarizeParts(block.parts);
+      entries.push({
+        id: anchorId,
+        kind: "agent",
+        anchorId,
+        messageIndex,
+        tooltip: `Agent · ${summary || "Response"}`,
+      });
+    });
+  }
+
+  return entries;
+}
+
+export function findActiveTimelineIndex(
+  positions: TimelineAnchorPosition[],
+  viewportCenter: number,
+) {
+  if (positions.length === 0) return null;
+
+  const ordered = positions.toSorted((a, b) => a.top - b.top);
+  let activeIndex = ordered[0]!.index;
+  for (const position of ordered) {
+    if (position.top > viewportCenter) break;
+    activeIndex = position.index;
+  }
+  return activeIndex;
+}
+
+export function findTimelineEdgeIndex(
+  scrollTop: number,
+  viewportHeight: number,
+  scrollHeight: number,
+  entryCount: number,
+) {
+  if (entryCount <= 0) return null;
+  if (scrollTop <= TIMELINE_SCROLL_EDGE_TOLERANCE) return 0;
+
+  const maxScrollTop = Math.max(0, scrollHeight - viewportHeight);
+  if (scrollTop >= maxScrollTop - TIMELINE_SCROLL_EDGE_TOLERANCE) return entryCount - 1;
+  return null;
+}
+
+export function findTimelineIndexAtPointer(
+  clientX: number,
+  trackLeft: number,
+  trackWidth: number,
+  entryCount: number,
+) {
+  if (entryCount <= 0 || trackWidth <= 0) return null;
+  const progress = Math.min(1, Math.max(0, (clientX - trackLeft) / trackWidth));
+  return Math.min(entryCount - 1, Math.floor(progress * entryCount));
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -293,6 +293,31 @@
     box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
   }
 
+  .session-timeline-viewport {
+    scrollbar-width: none;
+  }
+
+  .session-timeline-viewport::-webkit-scrollbar {
+    display: none;
+  }
+
+  .session-timeline-minimap {
+    overflow: hidden;
+    border-radius: 2px;
+  }
+
+  .session-timeline-minimap canvas {
+    opacity: 0.75;
+  }
+
+  /* The oversized shadow dims everything outside the viewport window;
+     the parent's overflow: hidden clips it to the minimap band. */
+  .session-timeline-minimap-window {
+    border: 1px solid rgba(15, 23, 42, 0.45);
+    border-radius: 2px;
+    box-shadow: 0 0 0 9999px rgba(255, 255, 255, 0.62);
+  }
+
   .session-timeline-segment {
     opacity: 0.58;
     transition: opacity 100ms ease;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -155,6 +155,17 @@
     --console-error: #b91c1c;
     --console-error-bg: #fee2e2;
     --console-error-border: #fecaca;
+    --timeline-user: #a85f82;
+    --timeline-agent: #5e86aa;
+    --timeline-tool: #a3a3a3;
+    --tt-in-dur: 150ms;
+    --tt-out-dur: 50ms;
+    --tt-scale: 0.98;
+    --tt-delay: 80ms;
+    --tt-in-ease: ease-out;
+    --tt-out-ease: ease-out;
+    --tt-bg: #ffffff;
+    --tt-fg: #2f2f2f;
   }
 
   .dark {
@@ -225,6 +236,82 @@
   .shortcut-content[data-state="closed"] {
     animation: shortcut-content-out 150ms cubic-bezier(0.23, 1, 0.32, 1);
   }
+
+  .t-tt-wrap {
+    position: relative;
+    display: inline-block;
+  }
+
+  .t-tt {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translate(-50%, 0) scale(var(--tt-scale));
+    transform-origin: 50% 100%;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: var(--tt-bg);
+    color: var(--tt-fg);
+    white-space: nowrap;
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.06),
+      0 2px 6px 0 rgba(0, 0, 0, 0.05),
+      0 4px 42px 0 rgba(0, 0, 0, 0.06);
+    opacity: 0;
+    pointer-events: none;
+    /* Default rule controls the LEAVE state. transition-delay
+       stays unset so leaving plays without delay. */
+    transition:
+      opacity var(--tt-out-dur) var(--tt-out-ease),
+      transform var(--tt-out-dur) var(--tt-out-ease);
+  }
+
+  /* The appear delay belongs ONLY to the hover rule so leaving
+     the trigger snaps the delay back to 0 and the disappear
+     plays immediately. */
+  .t-tt-wrap:hover .t-tt,
+  .t-tt-trigger:focus-visible + .t-tt {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+    transition-duration: var(--tt-in-dur);
+    transition-timing-function: var(--tt-in-ease);
+    transition-delay: var(--tt-delay);
+  }
+
+  .session-timeline-floating-tooltip {
+    position: fixed;
+    bottom: auto;
+    z-index: 50;
+    max-width: calc(100vw - 16px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+    transform-origin: 50% 0;
+    border: 1px solid var(--console-border);
+    border-radius: 2px;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
+  }
+
+  .session-timeline-segment {
+    opacity: 0.58;
+    transition: opacity 100ms ease;
+  }
+
+  .session-timeline-segment[aria-current="location"] {
+    position: relative;
+    z-index: 1;
+    opacity: 1;
+    box-shadow:
+      0 0 0 2px #ffffff,
+      0 0 0 3px var(--console-text);
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .session-timeline-segment:hover {
+    opacity: 0.88;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -234,6 +321,14 @@
 
   .shortcut-content[data-state="closed"] {
     animation-name: shortcut-overlay-out;
+  }
+
+  .t-tt {
+    transition: none !important;
+  }
+
+  .session-timeline-segment {
+    transition: none;
   }
 }
 

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -19,7 +19,7 @@ import {
 import type { ParseSessionResult } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
-import { parseJsonlLines } from "../utils/jsonl.js";
+import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../utils/jsonl.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import {
   cleanInternalText,
@@ -376,7 +376,6 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     if (!meta) throw new Error(`Session not found: ${sessionId}`);
     if (!existsSync(meta.sourcePath)) throw new Error(`Session file missing: ${meta.sourcePath}`);
 
-    const content = readFileSync(meta.sourcePath, "utf-8");
     const messages: Message[] = [];
     const pendingToolCalls = new Map<string, [number, number]>();
 
@@ -398,7 +397,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     let prevReasoning = 0;
     let prevCachedInput = 0;
 
-    for (const record of parseJsonlLines(content)) {
+    for (const record of readJsonlFile(meta.sourcePath)) {
       try {
         const recordType = String(record["type"] ?? "");
         if (recordType === "turn_context") {
@@ -661,33 +660,16 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       return this.parseFastSessionHeadResult(filePath);
     }
 
-    const content = readFileSync(filePath, "utf-8");
-    const lines = content.split("\n").filter((l) => l.trim());
-    if (lines.length === 0) return skippedSession("empty file");
-
     const sessionId = extractSessionId(filePath);
 
-    let firstRecord: Record<string, unknown>;
-    try {
-      firstRecord = JSON.parse(lines[0]!);
-    } catch {
-      return skippedSession("malformed first record");
-    }
+    let firstPayload: Record<string, unknown> = {};
+    let createdAt = 0;
+    let lineCount = 0;
+    const titleLines: string[] = [];
 
-    const payload = (firstRecord["payload"] ?? {}) as Record<string, unknown>;
-    const createdAt =
-      parseTimestampMs(firstRecord) || parseTimestampMs(payload) || statSync(filePath).mtimeMs;
-
-    // Try title from session index
-    const indexTitle = this.getTitleForSession(sessionId);
-    // Fallback: extract from first user message
-    const messageTitle = this.extractTitleFromLines(lines);
-    const directoryTitle = basenameTitle(payload["cwd"] ? String(payload["cwd"]) : null);
-
-    const title = resolveSessionTitle(indexTitle, messageTitle, directoryTitle);
-
-    // Walk all lines to count messages, extract model, and pre-accumulate tokens
-    let updatedAt = createdAt;
+    // Single streaming pass: read the first record, buffer title candidates,
+    // count messages, extract models, and pre-accumulate tokens.
+    let updatedAt = 0;
     let messageCount = 0;
     let model: string | null = null;
     let activeModel: string | null = null;
@@ -707,7 +689,24 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
     let hasNonInternalRecord = false;
 
-    for (const line of lines) {
+    for (const line of readJsonlFileLines(filePath)) {
+      lineCount += 1;
+      if (lineCount === 1) {
+        let firstRecord: Record<string, unknown>;
+        try {
+          firstRecord = JSON.parse(line);
+        } catch {
+          return skippedSession("malformed first record");
+        }
+        firstPayload = (firstRecord["payload"] ?? {}) as Record<string, unknown>;
+        createdAt =
+          parseTimestampMs(firstRecord) ||
+          parseTimestampMs(firstPayload) ||
+          statSync(filePath).mtimeMs;
+        updatedAt = createdAt;
+      }
+      if (titleLines.length < 20) titleLines.push(line);
+
       try {
         const data = JSON.parse(line);
         const recordType = String(data["type"] ?? "");
@@ -802,9 +801,13 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       }
     }
 
+    if (lineCount === 0) return skippedSession("empty file");
     if (!hasNonInternalRecord) return filteredSession("internal events only");
 
-    const directory = payload["cwd"] ? String(payload["cwd"]) : "";
+    const indexTitle = this.getTitleForSession(sessionId);
+    const messageTitle = this.extractTitleFromLines(titleLines);
+    const directory = firstPayload["cwd"] ? String(firstPayload["cwd"]) : "";
+    const title = resolveSessionTitle(indexTitle, messageTitle, basenameTitle(directory || null));
 
     return parsedSession({
       id: sessionId,

--- a/packages/core/src/utils/__tests__/jsonl.test.ts
+++ b/packages/core/src/utils/__tests__/jsonl.test.ts
@@ -1,22 +1,28 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
-// Module-level mock for readFileSync
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  return {
-    ...actual,
-    readFileSync: vi.fn(),
-  };
-});
-
-import { readFileSync } from "node:fs";
-import { parseJsonlLines, readJsonlFile } from "../jsonl.js";
-
-const mockedReadFileSync = vi.mocked(readFileSync);
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../jsonl.js";
 
 function collect<T>(gen: Generator<T>): T[] {
   return Array.from(gen);
 }
+
+const tempDirs: string[] = [];
+
+function writeTempFile(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "codesesh-jsonl-test-"));
+  tempDirs.push(dir);
+  const filePath = join(dir, "data.jsonl");
+  writeFileSync(filePath, content);
+  return filePath;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("parseJsonlLines", () => {
   it("returns empty for empty string", () => {
@@ -57,23 +63,45 @@ describe("parseJsonlLines", () => {
   });
 });
 
-describe("readJsonlFile", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+describe("readJsonlFileLines", () => {
+  it("streams lines split across chunk boundaries", () => {
+    const filePath = writeTempFile('{"a":1}\n{"b":2}\n{"c":3}');
+    const result = collect(readJsonlFileLines(filePath, 4));
+    expect(result).toEqual(['{"a":1}', '{"b":2}', '{"c":3}']);
   });
 
+  it("reassembles multi-byte characters split across chunks", () => {
+    const filePath = writeTempFile('{"标题":"你好世界"}\n{"次":"再见"}\n');
+    const result = collect(readJsonlFileLines(filePath, 5));
+    expect(result).toEqual(['{"标题":"你好世界"}', '{"次":"再见"}']);
+  });
+
+  it("skips blank lines and yields a tail without trailing newline", () => {
+    const filePath = writeTempFile('{"a":1}\n\n  \n{"b":2}');
+    const result = collect(readJsonlFileLines(filePath));
+    expect(result).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it("returns nothing for an empty file", () => {
+    const filePath = writeTempFile("");
+    expect(collect(readJsonlFileLines(filePath))).toEqual([]);
+  });
+});
+
+describe("readJsonlFile", () => {
   it("reads and parses a valid JSONL file", () => {
-    const content = '{"name":"alice"}\n{"name":"bob"}';
-    mockedReadFileSync.mockReturnValue(content);
-    const result = collect(readJsonlFile("/fake/path.jsonl"));
+    const filePath = writeTempFile('{"name":"alice"}\n{"name":"bob"}');
+    const result = collect(readJsonlFile(filePath));
     expect(result).toEqual([{ name: "alice" }, { name: "bob" }]);
-    expect(mockedReadFileSync).toHaveBeenCalledWith("/fake/path.jsonl", "utf-8");
+  });
+
+  it("skips malformed lines", () => {
+    const filePath = writeTempFile('{"valid":true}\nnot json\n{"also":true}');
+    const result = collect(readJsonlFile(filePath));
+    expect(result).toEqual([{ valid: true }, { also: true }]);
   });
 
   it("throws when file does not exist", () => {
-    mockedReadFileSync.mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
-    expect(() => collect(readJsonlFile("/missing.jsonl"))).toThrow("ENOENT");
+    expect(() => collect(readJsonlFile("/missing.jsonl"))).toThrow();
   });
 });

--- a/packages/core/src/utils/jsonl.ts
+++ b/packages/core/src/utils/jsonl.ts
@@ -1,4 +1,7 @@
-import { readFileSync } from "node:fs";
+import { closeSync, openSync, readSync } from "node:fs";
+import { StringDecoder } from "node:string_decoder";
+
+const READ_CHUNK_BYTES = 1 << 20;
 
 export function* parseJsonlLines(content: string): Generator<Record<string, unknown>> {
   for (const line of content.split("\n")) {
@@ -12,7 +15,45 @@ export function* parseJsonlLines(content: string): Generator<Record<string, unkn
   }
 }
 
-export function readJsonlFile(filePath: string): Generator<Record<string, unknown>> {
-  const content = readFileSync(filePath, "utf-8");
-  return parseJsonlLines(content);
+/**
+ * Streams trimmed non-empty lines chunk by chunk so a session log is never
+ * held in memory at once. Codex rollout files can exceed 400 MB; loading them
+ * with readFileSync + split doubles that as UTF-16 strings and OOMs the
+ * scan-refresh worker.
+ */
+export function* readJsonlFileLines(
+  filePath: string,
+  chunkBytes = READ_CHUNK_BYTES,
+): Generator<string> {
+  const fd = openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(chunkBytes);
+    // StringDecoder buffers multi-byte UTF-8 sequences split across chunks.
+    const decoder = new StringDecoder("utf8");
+    let remainder = "";
+    let bytesRead = readSync(fd, buffer, 0, chunkBytes, -1);
+    while (bytesRead > 0) {
+      const lines = (remainder + decoder.write(buffer.subarray(0, bytesRead))).split("\n");
+      remainder = lines.pop()!;
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed) yield trimmed;
+      }
+      bytesRead = readSync(fd, buffer, 0, chunkBytes, -1);
+    }
+    const tail = (remainder + decoder.end()).trim();
+    if (tail) yield tail;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function* readJsonlFile(filePath: string): Generator<Record<string, unknown>> {
+  for (const line of readJsonlFileLines(filePath)) {
+    try {
+      yield JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      // Skip malformed lines
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- **feat(web): session message timeline** — Add a sticky color-block timeline above the session detail message list. Each segment maps to a user message, agent block, or tool call; clicking or dragging jumps to the matching anchor, and the segment under the viewport center is highlighted while scrolling.
- **feat(web): minimap navigation** — Replace the native horizontal scrollbar with a minimap band below the track when it overflows: a canvas-rendered miniature of all entries plus a draggable window indicator, with the area outside the window dimmed so the visible slice of the session is obvious at a glance. Pressing outside the window centers it on the pointer.
- **fix(core): stream codex session parsing** — Codex rollout files can exceed 400 MB. Parsing them with readFileSync + split held the whole file plus a line array in memory (3-4x the file size as UTF-16), killing the scan-refresh worker with `ERR_WORKER_OUT_OF_MEMORY` during backfill. Add a chunked streaming line reader to the jsonl utils (StringDecoder reassembles multi-byte characters split across chunks) and switch the codex head parse and getSessionData to a single streaming pass.

## Test plan

- All suites pass: `@codesesh/core` 261 tests, `codesesh` (cli) 83 tests, `@codesesh/web` 209 tests
- New tests for the streaming jsonl reader (chunk-boundary splits, multi-byte reassembly, blank lines / missing trailing newline) and the minimap (window position mapping, hidden without overflow, drag-to-scroll)
- Real-world check: a 421 MB rollout file parses under `--max-old-space-size=512` — head parse in 2.3s, full message parse in 3.4s, ~148 MB peak heap; it reliably OOMed before the fix