### PR TITLE
fix(projects)!: use composite project identities

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -344,12 +344,15 @@ export default function App() {
     for (const result of sourceResults) {
       const identity = result.session.project_identity;
       if (!identity?.key) continue;
-      const current = byKey.get(identity.key);
+      const projectIdentityKey = getProjectIdentityKey(identity);
+      const current = byKey.get(projectIdentityKey);
       if (current) {
         current.count += 1;
       } else {
-        byKey.set(identity.key, {
-          key: identity.key,
+        byKey.set(projectIdentityKey, {
+          key: projectIdentityKey,
+          identityKind: identity.kind,
+          identityKey: identity.key,
           label: identity.displayName || result.session.directory,
           count: 1,
           showCount: false,
@@ -357,15 +360,18 @@ export default function App() {
       }
     }
 
-    if (searchFilters.projectKey && !byKey.has(searchFilters.projectKey)) {
-      const selected = projectOptions.find((project) => project.key === searchFilters.projectKey);
+    const selectedProjectKey = searchFilters.project
+      ? getProjectIdentityKey(searchFilters.project)
+      : undefined;
+    if (selectedProjectKey && !byKey.has(selectedProjectKey)) {
+      const selected = projectOptions.find((project) => project.key === selectedProjectKey);
       if (selected) {
         byKey.set(selected.key, { ...selected, count: 0, showCount: false });
       }
     }
 
     return [...byKey.values()].toSorted((a, b) => b.count - a.count).slice(0, 8);
-  }, [projectOptions, searchFilters.projectKey, searchLoading, searchResults, usesServerSearch]);
+  }, [projectOptions, searchFilters.project, searchLoading, searchResults, usesServerSearch]);
 
   // Header
   let headerTitle = "CodeSesh";

--- a/apps/web/src/components/app/SearchFilterBar.tsx
+++ b/apps/web/src/components/app/SearchFilterBar.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react";
 import type { AgentInfo, FileActivityKind, SmartTag } from "../../lib/api";
+import { getProjectIdentityKey } from "../../lib/projects";
 import { SMART_TAG_LABELS } from "../SmartTagChips";
 import { FilterChip } from "./FilterChip";
 import type { CostRangeId, SearchFilterState, SearchProjectOption } from "./types";
@@ -47,6 +48,7 @@ export function SearchFilterBar({
   onChangeFilters: Dispatch<SetStateAction<SearchFilterState>>;
 }) {
   const hasActiveFilters = Object.values(filters).some(Boolean);
+  const selectedProjectKey = filters.project ? getProjectIdentityKey(filters.project) : undefined;
   const setFilter = <K extends keyof SearchFilterState>(key: K, value: SearchFilterState[K]) => {
     onChangeFilters((current) => ({
       ...current,
@@ -61,18 +63,26 @@ export function SearchFilterBar({
           Scope
         </span>
         <FilterChip
-          active={!filters.projectKey}
+          active={!filters.project}
           label="All"
-          onClick={() => onChangeFilters((current) => ({ ...current, projectKey: undefined }))}
+          onClick={() => onChangeFilters((current) => ({ ...current, project: undefined }))}
         />
         {projects.map((project) => (
           <FilterChip
             key={project.key}
-            active={filters.projectKey === project.key}
+            active={selectedProjectKey === project.key}
             label={
               project.showCount === false ? project.label : `${project.label} · ${project.count}`
             }
-            onClick={() => setFilter("projectKey", project.key)}
+            onClick={() =>
+              onChangeFilters((current) => ({
+                ...current,
+                project:
+                  selectedProjectKey === project.key
+                    ? undefined
+                    : { kind: project.identityKind, key: project.identityKey },
+              }))
+            }
           />
         ))}
       </div>

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared types for the app-shell subcomponents (search panel, sidebar, filters).
  */
-import type { FileActivityKind, SmartTag } from "../../lib/api";
+import type { FileActivityKind, ProjectIdentityKind, SmartTag } from "../../lib/api";
 
 export type BrowseBy = "agents" | "projects";
 
@@ -9,7 +9,10 @@ export type CostRangeId = "paid" | "one_plus" | "ten_plus";
 
 export interface SearchFilterState {
   agent?: string;
-  projectKey?: string;
+  project?: {
+    kind: ProjectIdentityKind;
+    key: string;
+  };
   tag?: SmartTag;
   tool?: string;
   fileKind?: FileActivityKind;
@@ -18,6 +21,8 @@ export interface SearchFilterState {
 
 export interface SearchProjectOption {
   key: string;
+  identityKind: ProjectIdentityKind;
+  identityKey: string;
   label: string;
   count: number;
   showCount?: boolean;

--- a/apps/web/src/hooks/useSessionSearch.test.ts
+++ b/apps/web/src/hooks/useSessionSearch.test.ts
@@ -12,7 +12,8 @@ vi.mock("../lib/api", () => ({
 
 const emptyIndexes = {
   byAgent: new Map(),
-  byProjectKey: new Map(),
+  byProjectIdentityKey: new Map(),
+  projectOptions: [],
   sessionsByActivity: [],
 } as unknown as SessionIndexes;
 
@@ -53,6 +54,39 @@ describe("useSessionSearch", () => {
 
     await waitFor(() => expect(result.current.searchResults).toEqual(serverResults));
     expect(api.fetchSearchResults).toHaveBeenCalledWith("hello", expect.any(Object));
+  });
+
+  it("sends both project identity fields to server search", async () => {
+    const indexes = {
+      ...emptyIndexes,
+      projectOptions: [
+        {
+          key: "git_remote:github.com/acme/app",
+          identityKind: "git_remote",
+          identityKey: "github.com/acme/app",
+          label: "App",
+          count: 1,
+        },
+      ],
+    } as SessionIndexes;
+    const { result } = renderHook(() => useSessionSearch(indexes));
+    act(() =>
+      result.current.setSearchFilters({
+        project: { kind: "git_remote", key: "github.com/acme/app" },
+      }),
+    );
+    act(() => result.current.setDraftSearchQuery("hello"));
+    act(() => result.current.submitSearch());
+
+    await waitFor(() =>
+      expect(api.fetchSearchResults).toHaveBeenCalledWith(
+        "hello",
+        expect.objectContaining({
+          projectKind: "git_remote",
+          projectKey: "github.com/acme/app",
+        }),
+      ),
+    );
   });
 
   it("closeSearch exits and clears the active query", () => {

--- a/apps/web/src/hooks/useSessionSearch.ts
+++ b/apps/web/src/hooks/useSessionSearch.ts
@@ -6,6 +6,7 @@ import {
   logClientEvent,
 } from "../lib/api";
 import { type SessionIndexes, getSessionAgentKey } from "../lib/session-indexes";
+import { getProjectIdentityKey } from "../lib/projects";
 import type { SearchFilterState } from "../components/app/types";
 import { COST_RANGE_OPTIONS } from "../components/app/SearchFilterBar";
 
@@ -31,7 +32,8 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
     const selectedCost = COST_RANGE_OPTIONS.find((option) => option.id === searchFilters.costRange);
     return {
       agent: searchFilters.agent,
-      projectKey: searchFilters.projectKey,
+      projectKind: searchFilters.project?.kind,
+      projectKey: searchFilters.project?.key,
       tag: searchFilters.tag,
       tool: searchFilters.tool,
       fileKind: searchFilters.fileKind,
@@ -47,8 +49,11 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
     const agentSessions = searchFilters.agent
       ? (sessionIndexes.byAgent.get(searchFilters.agent) ?? [])
       : null;
-    const projectSessions = searchFilters.projectKey
-      ? (sessionIndexes.byProjectKey.get(searchFilters.projectKey) ?? [])
+    const projectIdentityKey = searchFilters.project
+      ? getProjectIdentityKey(searchFilters.project)
+      : undefined;
+    const projectSessions = projectIdentityKey
+      ? (sessionIndexes.byProjectIdentityKey.get(projectIdentityKey) ?? [])
       : null;
     const sourceSessions =
       agentSessions && projectSessions
@@ -61,8 +66,9 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
     for (const sessionItem of sourceSessions) {
       if (searchFilters.agent && getSessionAgentKey(sessionItem) !== searchFilters.agent) continue;
       if (
-        searchFilters.projectKey &&
-        sessionItem.project_identity?.key !== searchFilters.projectKey
+        projectIdentityKey &&
+        (!sessionItem.project_identity ||
+          getProjectIdentityKey(sessionItem.project_identity) !== projectIdentityKey)
       ) {
         continue;
       }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { subscribeSessionUpdates } from "./api";
+import { fetchSearchResults, fetchSessions, subscribeSessionUpdates } from "./api";
+
+describe("project identity request filters", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ["sessions", () => fetchSessions({ projectKind: "path", projectKey: "/workspace/app" })],
+    [
+      "search",
+      () => fetchSearchResults("error", { projectKind: "path", projectKey: "/workspace/app" }),
+    ],
+  ])("sends both identity fields for %s requests", async (_name, request) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await request();
+
+    const url = new URL(fetchMock.mock.calls[0]![0], "http://localhost");
+    expect(url.searchParams.get("projectKind")).toBe("path");
+    expect(url.searchParams.get("projectKey")).toBe("/workspace/app");
+  });
+});
 
 class FakeEventSource {
   static instances: FakeEventSource[] = [];

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -281,6 +281,7 @@ export interface SearchResult {
 
 export interface SearchRequestOptions {
   agent?: string;
+  projectKind?: ProjectIdentityKind;
   projectKey?: string;
   tag?: SmartTag;
   tool?: string;
@@ -329,6 +330,7 @@ export async function fetchProjects(): Promise<{ projects: ProjectGroup[] }> {
 export async function fetchSessions(
   options: {
     agent?: string;
+    projectKind?: ProjectIdentityKind;
     projectKey?: string;
     from?: number;
     to?: number;
@@ -336,6 +338,7 @@ export async function fetchSessions(
 ): Promise<{ sessions: SessionHead[] }> {
   const params = new URLSearchParams();
   if (options.agent) params.set("agent", options.agent);
+  if (options.projectKind) params.set("projectKind", options.projectKind);
   if (options.projectKey) params.set("projectKey", options.projectKey);
   if (options.from != null) params.set("from", new Date(options.from).toISOString());
   if (options.to != null) params.set("to", new Date(options.to).toISOString());
@@ -368,6 +371,7 @@ export async function fetchSearchResults(
   const params = new URLSearchParams();
   params.set("q", query);
   if (options.agent) params.set("agent", options.agent);
+  if (options.projectKind) params.set("projectKind", options.projectKind);
   if (options.projectKey) params.set("projectKey", options.projectKey);
   if (options.tag) params.set("tag", options.tag);
   if (options.tool) params.set("tool", options.tool);

--- a/apps/web/src/lib/session-indexes.test.ts
+++ b/apps/web/src/lib/session-indexes.test.ts
@@ -83,11 +83,6 @@ describe("session indexes", () => {
         .get(getProjectAgentKey("path:/workspace/a", "codex"))
         ?.map((session) => session.id),
     ).toEqual(["new", "old"]);
-    expect(indexes.byProjectKey.get("/workspace/a")?.map((session) => session.id)).toEqual([
-      "new",
-      "claude",
-      "old",
-    ]);
     expect(indexes.sessionsByActivity.map((session) => session.id)).toEqual([
       "other",
       "new",
@@ -106,8 +101,52 @@ describe("session indexes", () => {
       "other",
     ]);
     expect(indexes.projectOptions).toEqual([
-      { key: "/workspace/a", label: "Project A", count: 3 },
-      { key: "/workspace/b", label: "Project B", count: 1 },
+      {
+        key: "path:/workspace/a",
+        identityKind: "path",
+        identityKey: "/workspace/a",
+        label: "Project A",
+        count: 3,
+      },
+      {
+        key: "path:/workspace/b",
+        identityKind: "path",
+        identityKey: "/workspace/b",
+        label: "Project B",
+        count: 1,
+      },
+    ]);
+  });
+
+  it("keeps equal project keys from different kinds in separate indexes", () => {
+    const remote = createSession({
+      id: "remote",
+      slug: "codex/remote",
+      title: "Remote",
+      project_identity: {
+        kind: "git_remote",
+        key: "github.com/acme/app",
+        displayName: "App",
+      },
+    });
+    const path = createSession({
+      id: "path",
+      slug: "codex/path",
+      title: "Path",
+      project_identity: {
+        kind: "path",
+        key: "github.com/acme/app",
+        displayName: "App path",
+      },
+    });
+
+    const indexes = buildSessionIndexes([remote, path], agents);
+
+    expect(indexes.byProjectIdentityKey.get("git_remote:github.com/acme/app")).toEqual([remote]);
+    expect(indexes.byProjectIdentityKey.get("path:github.com/acme/app")).toEqual([path]);
+    expect(indexes.projectOptions.map((project) => project.key)).toEqual([
+      "git_remote:github.com/acme/app",
+      "path:github.com/acme/app",
     ]);
   });
 

--- a/apps/web/src/lib/session-indexes.ts
+++ b/apps/web/src/lib/session-indexes.ts
@@ -1,4 +1,4 @@
-import type { AgentInfo, SessionHead } from "./api";
+import type { AgentInfo, ProjectIdentityKind, SessionHead } from "./api";
 import { getProjectIdentityKey } from "./projects";
 
 export interface IndexedSession extends SessionHead {
@@ -9,6 +9,8 @@ export interface IndexedSession extends SessionHead {
 
 export interface SessionProjectOption {
   key: string;
+  identityKind: ProjectIdentityKind;
+  identityKey: string;
   label: string;
   count: number;
 }
@@ -18,7 +20,6 @@ export interface SessionIndexes {
   byAgent: Map<string, SessionHead[]>;
   byProjectIdentityKey: Map<string, SessionHead[]>;
   byProjectAgentKey: Map<string, SessionHead[]>;
-  byProjectKey: Map<string, SessionHead[]>;
   byLandingAgent: Map<string, IndexedSession[]>;
   byLandingProjectIdentityKey: Map<string, IndexedSession[]>;
   landingSessions: IndexedSession[];
@@ -61,7 +62,6 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
   const byAgent = new Map<string, SessionHead[]>();
   const byProjectIdentityKey = new Map<string, SessionHead[]>();
   const byProjectAgentKey = new Map<string, SessionHead[]>();
-  const byProjectKey = new Map<string, SessionHead[]>();
   const byLandingAgent = new Map<string, IndexedSession[]>();
   const byLandingProjectIdentityKey = new Map<string, IndexedSession[]>();
   const projectOptionsByKey = new Map<string, SessionProjectOption>();
@@ -96,12 +96,14 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
     const projectIdentityKey = getProjectIdentityKey(identity);
     pushMapValue(byLandingProjectIdentityKey, projectIdentityKey, indexedSession);
 
-    const option = projectOptionsByKey.get(identity.key);
+    const option = projectOptionsByKey.get(projectIdentityKey);
     if (option) {
       option.count += 1;
     } else {
-      projectOptionsByKey.set(identity.key, {
-        key: identity.key,
+      projectOptionsByKey.set(projectIdentityKey, {
+        key: projectIdentityKey,
+        identityKind: identity.kind,
+        identityKey: identity.key,
         label: identity.displayName || session.directory,
         count: 1,
       });
@@ -119,7 +121,6 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
     const projectIdentityKey = getProjectIdentityKey(identity);
     pushMapValue(byProjectIdentityKey, projectIdentityKey, session);
     pushMapValue(byProjectAgentKey, getProjectAgentKey(projectIdentityKey, agentKey), session);
-    pushMapValue(byProjectKey, identity.key, session);
   }
 
   return {
@@ -127,7 +128,6 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
     byAgent,
     byProjectIdentityKey,
     byProjectAgentKey,
-    byProjectKey,
     byLandingAgent,
     byLandingProjectIdentityKey,
     landingSessions,

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -262,8 +262,17 @@ describe("handleGetSessions", () => {
       makeSession("b", {
         project_identity: { kind: "path", key: "/home/user/other", displayName: "other" },
       }),
+      makeSession("same-key-path", {
+        project_identity: {
+          kind: "path",
+          key: "github.com/acme/app",
+          displayName: "app path",
+        },
+      }),
     ];
-    const c = makeMockContext({ query: { projectKey: "github.com/acme/app" } });
+    const c = makeMockContext({
+      query: { projectKind: "git_remote", projectKey: "github.com/acme/app" },
+    });
     handleGetSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions.map((session: SessionHead) => session.id)).toEqual(["a"]);
@@ -371,6 +380,49 @@ describe("handleSearchSessions", () => {
     expect(response.results).toHaveLength(1);
     expect(response.results[0].agentName).toBe("codex");
     expect(response.results[0].session.id).toBe("codex");
+  });
+
+  it("filters recent sessions by complete project identity", () => {
+    const remote = makeSession("remote", {
+      slug: "codex/remote",
+      project_identity: {
+        kind: "git_remote",
+        key: "github.com/acme/app",
+        displayName: "app",
+      },
+    });
+    const path = makeSession("path", {
+      slug: "codex/path",
+      project_identity: {
+        kind: "path",
+        key: "github.com/acme/app",
+        displayName: "app path",
+      },
+    });
+    const c = makeMockContext({
+      query: { q: "", projectKind: "git_remote", projectKey: "github.com/acme/app" },
+    });
+
+    handleSearchSessions(
+      c,
+      makeScanSource({ sessions: [remote, path], byAgent: { codex: [remote, path] } }),
+    );
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.results.map((result: { session: SessionHead }) => result.session.id)).toEqual([
+      "remote",
+    ]);
+  });
+
+  it("rejects incomplete project identity filters", () => {
+    const c = makeMockContext({ query: { q: "", projectKey: "github.com/acme/app" } });
+
+    handleSearchSessions(c, makeScanSource());
+
+    expect(c.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(String) }),
+      400,
+    );
   });
 });
 

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -17,6 +17,7 @@ import {
   extractSessionFileActivity,
   getSmartTagSourceTimestamp,
   importBookmarks,
+  isProjectIdentityKind,
   loadCachedSessionData,
   listFileActivity,
   listSessionFileActivity,
@@ -28,6 +29,7 @@ import {
   searchSessions,
   upsertBookmark,
   matchesProjectScope as sessionMatchesProjectScope,
+  matchesProjectIdentity,
   buildDashboard,
   getSessionAgentName,
   getSessionActivityTime,
@@ -37,6 +39,7 @@ import {
   type DashboardScope,
   type FileActivityKind,
   type ProjectScopeMatcher,
+  type ProjectIdentityRef,
   type SearchMatchType,
   type SearchOptions,
   type SearchQueryFilters,
@@ -206,13 +209,18 @@ function parseSmartTags(values: string[]): SmartTag[] | undefined {
   return tags.length > 0 ? [...new Set(tags)] : undefined;
 }
 
-function parseSearchOptions(c: Context, defaults: SessionListDefaults): SearchOptions {
+function parseSearchOptions(
+  c: Context,
+  defaults: SessionListDefaults,
+  projectIdentity?: ProjectIdentityRef,
+): SearchOptions {
   const params = searchParams(c);
   const limitValue = parseNumberParam(params.get("limit") ?? undefined);
   return {
     agent: optionalQueryValue(params.get("agent") ?? undefined),
     project: optionalQueryValue(params.get("project") ?? undefined),
-    projectKey: optionalQueryValue(params.get("projectKey") ?? undefined),
+    projectKind: projectIdentity?.kind,
+    projectKey: projectIdentity?.key,
     cwd: optionalQueryValue(params.get("cwd") ?? undefined),
     tags: parseSmartTags(queryValues(params, "tag", "tags", "signal")),
     tools: queryValues(params, "tool", "tools").map((tool) => tool.toLowerCase()),
@@ -287,6 +295,7 @@ function mergeSearchOptions(options: SearchOptions, filters: SearchQueryFilters)
     ...options,
     agent: options.agent ?? filters.agent,
     project: options.project ?? filters.project,
+    projectKind: options.projectKind ?? filters.projectKind,
     projectKey: options.projectKey ?? filters.projectKey,
     cwd: options.cwd ?? filters.cwd,
     tags: mergeSearchLists(options.tags, filters.tags),
@@ -398,7 +407,18 @@ function matchesRecentSearchFilters(
   options: SearchOptions,
   projectScope: ProjectScopeMatcher | null,
 ): boolean {
-  if (options.projectKey && session.project_identity?.key !== options.projectKey) return false;
+  if (options.projectKind || options.projectKey) {
+    if (
+      !options.projectKind ||
+      !options.projectKey ||
+      !matchesProjectIdentity(session.project_identity, {
+        kind: options.projectKind,
+        key: options.projectKey,
+      })
+    ) {
+      return false;
+    }
+  }
   if (projectScope && !sessionMatchesProjectScope(session, projectScope)) return false;
   if (options.project) {
     const projectNeedle = options.project.toLowerCase();
@@ -501,7 +521,13 @@ export function handleGetSessions(
   const agent = c.req.query("agent");
   const q = c.req.query("q")?.toLowerCase();
   const cwd = c.req.query("cwd");
-  const projectKey = c.req.query("projectKey");
+  const projectIdentity = parseProjectIdentityFilter(
+    c.req.query("projectKind"),
+    c.req.query("projectKey"),
+  );
+  if (projectIdentity === null) {
+    return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
+  }
   const tag = c.req.query("tag")?.toLowerCase();
   const from = parseDateParam(c.req.query("from"), defaults.from);
   const to = parseDateParam(c.req.query("to"), defaults.to);
@@ -515,8 +541,10 @@ export function handleGetSessions(
     sessions = [...scanResult.sessions];
   }
 
-  if (projectKey) {
-    sessions = sessions.filter((s) => s.project_identity?.key === projectKey);
+  if (projectIdentity) {
+    sessions = sessions.filter((session) =>
+      matchesProjectIdentity(session.project_identity, projectIdentity),
+    );
   } else if (cwd) {
     const projectScope = createProjectScopeMatcher(cwd);
     sessions = sessions.filter((s) => sessionMatchesProjectScope(s, projectScope));
@@ -540,7 +568,14 @@ export function handleSearchSessions(
 ) {
   const query = c.req.query("q")?.trim() ?? "";
   const scanResult = scanSource.getSnapshot();
-  const searchOptions = parseSearchOptions(c, defaults);
+  const projectIdentity = parseProjectIdentityFilter(
+    c.req.query("projectKind"),
+    c.req.query("projectKey"),
+  );
+  if (projectIdentity === null) {
+    return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
+  }
+  const searchOptions = parseSearchOptions(c, defaults, projectIdentity);
   const parsedQuery = parseSearchQuery(query);
   const mergedSearchOptions = mergeSearchOptions(searchOptions, parsedQuery.filters);
   const textQuery = parsedQuery.text || (parsedQuery.hasQualifiers ? "" : query);
@@ -587,15 +622,34 @@ function optionalQueryValue(value: string | undefined): string | undefined {
   return normalized ? normalized : undefined;
 }
 
+function parseProjectIdentityFilter(
+  kindValue: string | undefined,
+  keyValue: string | undefined,
+): ProjectIdentityRef | null | undefined {
+  const kind = optionalQueryValue(kindValue);
+  const key = optionalQueryValue(keyValue);
+  if (!kind && !key) return undefined;
+  if (!kind || !key || !isProjectIdentityKind(kind)) return null;
+  return { kind, key };
+}
+
 export function handleGetFileActivity(c: Context, defaults: SessionListDefaults = {}) {
   const limitValue = Number(c.req.query("limit"));
   const limit = Number.isFinite(limitValue) && limitValue > 0 ? Math.min(limitValue, 200) : 50;
+  const projectIdentity = parseProjectIdentityFilter(
+    c.req.query("projectKind"),
+    c.req.query("projectKey"),
+  );
+  if (projectIdentity === null) {
+    return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
+  }
 
   return c.json({
     activity: listFileActivity({
       agent: optionalQueryValue(c.req.query("agent")),
       sessionId: optionalQueryValue(c.req.query("sessionId")),
-      projectKey: optionalQueryValue(c.req.query("projectKey")),
+      projectKind: projectIdentity?.kind,
+      projectKey: projectIdentity?.key,
       project: optionalQueryValue(c.req.query("project")),
       cwd: optionalQueryValue(c.req.query("cwd")),
       path: optionalQueryValue(c.req.query("path")),
@@ -809,6 +863,13 @@ export function handleGetDashboard(
   defaults: SessionListDefaults = {},
 ) {
   const scanResult = scanSource.getSnapshot();
+  const projectIdentity = parseProjectIdentityFilter(
+    c.req.query("projectKind"),
+    c.req.query("projectKey"),
+  );
+  if (projectIdentity === null) {
+    return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
+  }
   const { from, to, days } = resolveDashboardWindow(
     defaults,
     c.req.query("days"),
@@ -817,8 +878,8 @@ export function handleGetDashboard(
   );
   const scope: DashboardScope = {
     agent: optionalQueryValue(c.req.query("agent"))?.toLowerCase(),
-    projectKind: optionalQueryValue(c.req.query("projectKind")),
-    projectKey: optionalQueryValue(c.req.query("projectKey")),
+    projectKind: projectIdentity?.kind,
+    projectKey: projectIdentity?.key,
   };
 
   const agentInfo = getAgentInfoMap({});
@@ -836,6 +897,7 @@ export function handleGetDashboard(
     ...aggregate,
     recentFileActivities: listFileActivity({
       agent: scope.agent,
+      projectKind: scope.projectKind,
       projectKey: scope.projectKey,
       from,
       to,

--- a/packages/core/src/analytics/__tests__/dashboard.test.ts
+++ b/packages/core/src/analytics/__tests__/dashboard.test.ts
@@ -183,7 +183,7 @@ describe("buildDashboard", () => {
     expect(result.perAgent.map((p) => p.name)).toEqual(["codex"]);
   });
 
-  it("filters by projectKey", () => {
+  it("filters by complete project identity", () => {
     const result = buildDashboard(
       [
         makeSession("a", {
@@ -192,8 +192,11 @@ describe("buildDashboard", () => {
         makeSession("b", {
           project_identity: { kind: "git_remote", key: "proj-b", displayName: "B" },
         }),
+        makeSession("same-key-path", {
+          project_identity: { kind: "path", key: "proj-a", displayName: "A path" },
+        }),
       ],
-      opts({ scope: { projectKey: "proj-a" } }),
+      opts({ scope: { projectKind: "git_remote", projectKey: "proj-a" } }),
     );
     expect(result.totals.sessions).toBe(1);
   });

--- a/packages/core/src/analytics/dashboard.ts
+++ b/packages/core/src/analytics/dashboard.ts
@@ -5,13 +5,13 @@
  * distribution, and the recent-sessions window.
  */
 import type { AgentInfo } from "../types/index.js";
-import type { SessionHead } from "../types/session.js";
+import type { ProjectIdentityKind, SessionHead } from "../types/session.js";
 
 export const DASHBOARD_RECENT_LIMIT = 10;
 
 export interface DashboardScope {
   agent?: string;
-  projectKind?: string;
+  projectKind?: ProjectIdentityKind;
   projectKey?: string;
 }
 
@@ -162,10 +162,17 @@ export function buildDashboard(
   for (const session of sessions) {
     const agentName = getSessionAgentName(session);
     if (scope.agent && agentName !== scope.agent) continue;
-    if (scope.projectKey) {
+    if (scope.projectKind || scope.projectKey) {
       const identity = session.project_identity;
-      if (!identity || identity.key !== scope.projectKey) continue;
-      if (scope.projectKind && identity.kind !== scope.projectKind) continue;
+      if (
+        !identity ||
+        !scope.projectKind ||
+        !scope.projectKey ||
+        identity.kind !== scope.projectKind ||
+        identity.key !== scope.projectKey
+      ) {
+        continue;
+      }
     }
 
     const activity = getSessionActivityTime(session);

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -567,13 +567,15 @@ describe("searchSessions", () => {
   it("parses lightweight structured search qualifiers", () => {
     expect(
       parseSearchQuery(
-        'agent:codex project:"code sesh" tag:feature-dev tool:apply_patch file:"src/App File.tsx" cost:>1 needle',
+        'agent:codex project:"code sesh" projectkind:git_remote projectkey:github.com/acme/app tag:feature-dev tool:apply_patch file:"src/App File.tsx" cost:>1 needle',
       ),
     ).toEqual({
       text: "needle",
       filters: {
         agent: "codex",
         project: "code sesh",
+        projectKind: "git_remote",
+        projectKey: "github.com/acme/app",
         tags: ["feature-dev"],
         tools: ["apply_patch"],
         file: "src/App File.tsx",
@@ -707,6 +709,39 @@ describe("searchSessions", () => {
       total_cost: 0.03,
     });
     expect(results[0]?.snippet).toContain("<mark>sqlite</mark>");
+  });
+
+  it("filters indexed search by complete project identity", () => {
+    const remote = {
+      ...makeSession("remote"),
+      project_identity: {
+        kind: "git_remote" as const,
+        key: "github.com/acme/app",
+        displayName: "app",
+      },
+    };
+    const path = {
+      ...makeSession("path"),
+      project_identity: {
+        kind: "path" as const,
+        key: "github.com/acme/app",
+        displayName: "app path",
+      },
+    };
+    const sessions = [remote, path];
+    saveCachedSessions("claudecode", sessions);
+    syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
+      ...sessions.find((session) => session.id === sessionId)!,
+      messages: makeSessionData(sessionId, "identity collision needle").messages,
+    }));
+
+    expect(
+      searchSessions("collision", {
+        projectKind: "git_remote",
+        projectKey: "github.com/acme/app",
+      }).map((result) => result.session.id),
+    ).toEqual(["remote"]);
+    expect(searchSessions("collision", { projectKey: "github.com/acme/app" })).toEqual([]);
   });
 
   it("resolves search match metadata from message-level FTS", () => {
@@ -1322,6 +1357,7 @@ describe("searchSessions", () => {
 
     expect(
       listFileActivity({
+        projectKind: "git_remote",
         projectKey: "github.com/acme/app",
         path: "src/App",
         limit: 10,
@@ -1335,6 +1371,7 @@ describe("searchSessions", () => {
       listFileActivity({
         agent: "claudecode",
         sessionId: "files",
+        projectKind: "git_remote",
         projectKey: "github.com/acme/app",
         cwd: FIXTURE_DIR,
         path: "src/App",

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -2,7 +2,12 @@
  * File activity aggregation: per-session / cross-session file activity queries
  * and file-path search.
  */
-import type { FileActivityKind, SessionFileActivity, SessionHead } from "../../types/index.js";
+import type {
+  FileActivityKind,
+  ProjectIdentityKind,
+  SessionFileActivity,
+  SessionHead,
+} from "../../types/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { filePathFtsQuery, hasCacheStorage, likePattern, normalizeFilePathSearch } from "./db.js";
@@ -27,6 +32,7 @@ export interface FileActivityRow extends SearchResultRow {
 export interface FileActivityOptions {
   agent?: string;
   sessionId?: string;
+  projectKind?: ProjectIdentityKind;
   projectKey?: string;
   project?: string;
   cwd?: string;
@@ -42,18 +48,23 @@ export interface FileActivityResult extends SessionFileActivity {
 }
 
 export function fileActivityFilters(options: FileActivityOptions): {
+  projectKind: ProjectIdentityKind | null;
   projectKey: string | null;
   projectLike: string | null;
+  cwdKind: ProjectIdentityKind | null;
   cwdKey: string | null;
   cwdLike: string | null;
   path: string;
   pathLike: string | null;
 } {
   const path = options.path ? normalizeFilePathSearch(options.path) : "";
+  const cwdIdentity = options.cwd ? computeIdentity(options.cwd, realFs) : null;
   return {
+    projectKind: options.projectKind ?? null,
     projectKey: options.projectKey ?? null,
     projectLike: options.project ? likePattern(options.project) : null,
-    cwdKey: options.cwd ? computeIdentity(options.cwd, realFs).key : null,
+    cwdKind: cwdIdentity?.kind ?? null,
+    cwdKey: cwdIdentity?.key ?? null,
     cwdLike: options.cwd ? likePattern(options.cwd) : null,
     path,
     pathLike: path ? likePattern(path) : null,
@@ -88,9 +99,13 @@ export function buildFileActivityWhere(options: FileActivityOptions): {
     clauses.push("fa.session_id = ?");
     params.push(options.sessionId);
   }
-  if (filters.projectKey != null) {
-    clauses.push("fa.project_identity_key = ?");
-    params.push(filters.projectKey);
+  if (filters.projectKind != null || filters.projectKey != null) {
+    if (filters.projectKind != null && filters.projectKey != null) {
+      clauses.push("s.project_identity_kind = ? AND fa.project_identity_key = ?");
+      params.push(filters.projectKind, filters.projectKey);
+    } else {
+      clauses.push("0");
+    }
   }
   if (filters.projectLike != null) {
     clauses.push(
@@ -99,8 +114,10 @@ export function buildFileActivityWhere(options: FileActivityOptions): {
     params.push(filters.projectLike, filters.projectLike, filters.projectLike);
   }
   if (filters.cwdKey != null) {
-    clauses.push("(s.project_identity_key = ? OR LOWER(s.directory) LIKE ? ESCAPE '\\')");
-    params.push(filters.cwdKey, filters.cwdLike);
+    clauses.push(
+      "((s.project_identity_kind = ? AND s.project_identity_key = ?) OR LOWER(s.directory) LIKE ? ESCAPE '\\')",
+    );
+    params.push(filters.cwdKind, filters.cwdKey, filters.cwdLike);
   }
   if (filters.pathLike != null) {
     const pathQuery = filePathFtsQuery(filters.path);
@@ -216,6 +233,7 @@ export function searchFileActivitySessions(
 
   const rows = listFileActivity({
     agent: search.options.agent,
+    projectKind: search.options.projectKind,
     projectKey: search.options.projectKey,
     project: search.options.project,
     cwd: search.options.cwd,

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -12,7 +12,7 @@ import type {
   SessionHead,
   SmartTag,
 } from "../../types/index.js";
-import { computeIdentity, realFs } from "../../projects/index.js";
+import { computeIdentity, isProjectIdentityKind, realFs } from "../../projects/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import {
@@ -130,6 +130,7 @@ export type SearchMatchType =
 export interface SearchQueryFilters {
   agent?: string;
   project?: string;
+  projectKind?: ProjectIdentityKind;
   projectKey?: string;
   cwd?: string;
   tags?: SmartTag[];
@@ -151,6 +152,7 @@ export interface ParsedSearchQuery {
 export interface SearchOptions {
   agent?: string;
   project?: string;
+  projectKind?: ProjectIdentityKind;
   projectKey?: string;
   cwd?: string;
   tags?: SmartTag[];
@@ -301,7 +303,10 @@ export function parseSearchQuery(input: string): ParsedSearchQuery {
     if (key === "agent") filters.agent = value.toLowerCase();
     else if (key === "project") filters.project = value;
     else if (key === "projectkey" || key === "project-key") filters.projectKey = value;
-    else if (key === "cwd") filters.cwd = value;
+    else if (key === "projectkind" || key === "project-kind") {
+      if (isProjectIdentityKind(value)) filters.projectKind = value;
+      else consumed = false;
+    } else if (key === "cwd") filters.cwd = value;
     else if (key === "tool") filters.tools = appendUnique(filters.tools, value.toLowerCase());
     else if (key === "file" || key === "path") filters.file = value;
     else if (key === "kind" || key === "filekind" || key === "file-kind") {
@@ -728,6 +733,7 @@ export function mergeSearchQueryOptions(query: string, options: SearchOptions) {
       ...options,
       agent: options.agent ?? parsed.filters.agent,
       project: options.project ?? parsed.filters.project,
+      projectKind: options.projectKind ?? parsed.filters.projectKind,
       projectKey: options.projectKey ?? parsed.filters.projectKey,
       cwd: options.cwd ?? parsed.filters.cwd,
       tags: mergeSearchLists(options.tags, parsed.filters.tags),
@@ -769,13 +775,20 @@ function buildSessionSearchFilters(options: SearchOptions): {
     clauses.push("s.agent_name = ?");
     params.push(options.agent);
   }
-  if (options.projectKey) {
-    clauses.push("s.project_identity_key = ?");
-    params.push(options.projectKey);
+  if (options.projectKind || options.projectKey) {
+    if (options.projectKind && options.projectKey) {
+      clauses.push("s.project_identity_kind = ? AND s.project_identity_key = ?");
+      params.push(options.projectKind, options.projectKey);
+    } else {
+      clauses.push("0");
+    }
   }
   if (options.cwd) {
-    clauses.push("(s.project_identity_key = ? OR LOWER(s.directory) LIKE ? ESCAPE '\\')");
-    params.push(computeIdentity(options.cwd, realFs).key, likePattern(options.cwd));
+    const identity = computeIdentity(options.cwd, realFs);
+    clauses.push(
+      "((s.project_identity_kind = ? AND s.project_identity_key = ?) OR LOWER(s.directory) LIKE ? ESCAPE '\\')",
+    );
+    params.push(identity.kind, identity.key, likePattern(options.cwd));
   }
   if (options.project) {
     clauses.push(

--- a/packages/core/src/projects/groups.ts
+++ b/packages/core/src/projects/groups.ts
@@ -1,4 +1,5 @@
 import type { ProjectGroup, ProjectIdentity, SessionHead } from "../types/index.js";
+import { getProjectIdentityKey } from "./identity.js";
 
 function getAgentName(session: SessionHead): string {
   return session.slug.split("/")[0]?.toLowerCase() || "unknown";
@@ -14,7 +15,7 @@ export function buildProjectGroups(sessions: SessionHead[]): ProjectGroup[] {
     const identity = session.project_identity;
     if (!identity) continue;
     const activity = session.time_updated ?? session.time_created;
-    const groupKey = `${identity.kind}:${identity.key}`;
+    const groupKey = getProjectIdentityKey(identity);
     const current = groups.get(groupKey);
     if (current) {
       current.sources.add(getAgentName(session));

--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -1,6 +1,12 @@
 import { homedir } from "node:os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { computeIdentity, normalizeGitRemote, type IdentityFs } from "./identity.js";
+import {
+  computeIdentity,
+  getProjectIdentityKey,
+  matchesProjectIdentity,
+  normalizeGitRemote,
+  type IdentityFs,
+} from "./identity.js";
 
 vi.mock("node:os", async () => {
   const actual = await vi.importActual<typeof import("node:os")>("node:os");
@@ -43,6 +49,18 @@ describe("normalizeGitRemote", () => {
     expect(normalizeGitRemote("https://github.com/xingkaixin/codesesh.git")).toBe(
       "github.com/xingkaixin/codesesh",
     );
+  });
+});
+
+describe("project identity comparison", () => {
+  it("keeps equal keys from different kinds distinct", () => {
+    const remote = { kind: "git_remote" as const, key: "github.com/acme/app" };
+    const path = { kind: "path" as const, key: "github.com/acme/app" };
+
+    expect(getProjectIdentityKey(remote)).toBe("git_remote:github.com/acme/app");
+    expect(getProjectIdentityKey(path)).toBe("path:github.com/acme/app");
+    expect(matchesProjectIdentity(remote, path)).toBe(false);
+    expect(matchesProjectIdentity(remote, { ...remote })).toBe(true);
   });
 });
 

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -1,6 +1,6 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ProjectIdentity, ProjectIdentityKind } from "../types/index.js";
+import type { ProjectIdentity, ProjectIdentityKind, ProjectIdentityRef } from "../types/index.js";
 import { fallbackDisplayName } from "./display-name.js";
 
 export interface IdentityFs {
@@ -23,10 +23,33 @@ const PARSEABLE_MANIFESTS = ["package.json", "Cargo.toml", "pyproject.toml"] as 
 
 const LOOSE_DIRS = new Set(["/tmp", "/private/tmp"]);
 const LOOSE_HOME_DIRS = ["Desktop", "Downloads", "Documents"];
+const PROJECT_IDENTITY_KINDS = new Set<ProjectIdentityKind>([
+  "git_remote",
+  "git_common_dir",
+  "manifest_path",
+  "synthetic",
+  "path",
+  "loose",
+]);
 type PathOps = Pick<
   typeof path.posix,
   "dirname" | "isAbsolute" | "join" | "relative" | "resolve" | "sep"
 >;
+
+export function isProjectIdentityKind(value: string): value is ProjectIdentityKind {
+  return PROJECT_IDENTITY_KINDS.has(value as ProjectIdentityKind);
+}
+
+export function getProjectIdentityKey(identity: ProjectIdentityRef): string {
+  return `${identity.kind}:${identity.key}`;
+}
+
+export function matchesProjectIdentity(
+  identity: ProjectIdentityRef | null | undefined,
+  expected: ProjectIdentityRef,
+): boolean {
+  return identity?.kind === expected.kind && identity.key === expected.key;
+}
 
 export function normalizeGitRemote(url: string): string | null {
   if (!url) return null;

--- a/packages/core/src/projects/scope.test.ts
+++ b/packages/core/src/projects/scope.test.ts
@@ -66,6 +66,16 @@ describe("filterSessionsByProjectScope", () => {
         },
       }),
     );
+    sessions.push(
+      makeSession("same-key-path", {
+        directory: "/elsewhere",
+        project_identity: {
+          kind: "path",
+          key: "github.com/acme/app",
+          displayName: "app path",
+        },
+      }),
+    );
 
     const result = filterSessionsByProjectScope(sessions, "/repo/packages/web", fs);
 

--- a/packages/core/src/projects/scope.ts
+++ b/packages/core/src/projects/scope.ts
@@ -1,10 +1,10 @@
 import { resolve, sep } from "node:path";
-import type { SessionHead } from "../types/index.js";
-import { computeIdentity, type IdentityFs } from "./identity.js";
+import type { ProjectIdentityRef, SessionHead } from "../types/index.js";
+import { computeIdentity, matchesProjectIdentity, type IdentityFs } from "./identity.js";
 import { realFs } from "./fs.js";
 
 export interface ProjectScopeMatcher {
-  identityKey: string;
+  identity: ProjectIdentityRef;
   path: string;
 }
 
@@ -12,15 +12,16 @@ export function createProjectScopeMatcher(
   queryPath: string,
   fs: IdentityFs = realFs,
 ): ProjectScopeMatcher {
+  const identity = computeIdentity(queryPath, fs);
   return {
-    identityKey: computeIdentity(queryPath, fs).key,
+    identity: { kind: identity.kind, key: identity.key },
     path: normalizeScopePath(queryPath),
   };
 }
 
 export function matchesProjectScope(session: SessionHead, scope: ProjectScopeMatcher): boolean {
   if (!session.directory) return false;
-  if (session.project_identity?.key === scope.identityKey) return true;
+  if (matchesProjectIdentity(session.project_identity, scope.identity)) return true;
   return isPathScopeMatch(scope.path, session.directory);
 }
 

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -57,6 +57,8 @@ export interface ProjectIdentity {
   displayName: string;
 }
 
+export type ProjectIdentityRef = Pick<ProjectIdentity, "kind" | "key">;
+
 export interface ProjectGroup {
   identityKind: ProjectIdentityKind;
   identityKey: string;


### PR DESCRIPTION
## Summary

- centralize project identity validation, composite keys, and equality checks
- filter sessions, indexed search, file activity, and dashboard data by both identity kind and key
- preserve complete project identities through Web indexes, filter state, and HTTP requests
- add collision regressions for Core, CLI, Web, and request transport

## Root cause

Project identity is defined by `(kind, key)`, but several filtering and grouping paths treated the raw `key` as globally unique. Projects with the same key and different kinds could therefore be merged or returned by the wrong filter.

## Impact

Project filters now keep same-key identities isolated across the full stack.

**Breaking change:** project-filter API requests must provide `projectKind` and `projectKey` together. Incomplete or invalid identities return HTTP 400.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (561 tests)
- `pnpm test:e2e` (1 Chromium test)

Tracks CS-22.