### PR TITLE
fix(live-scan): serialize agent scan operations

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -386,6 +386,7 @@ describe("LiveScanStore", () => {
     restoreRuntime?.();
     restoreRuntime = null;
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("initializes a sorted snapshot for allowed registered agents", async () => {
@@ -636,6 +637,201 @@ describe("LiveScanStore", () => {
       ],
     );
     expect(workerThreads.workers).toHaveLength(2);
+  });
+
+  it("serializes refresh behind an in-flight backfill for the same agent", async () => {
+    const initial = makeSession("session", { title: "initial", time_updated: 1000 });
+    const stale = makeSession("session", { title: "stale backfill", time_updated: 2000 });
+    const fresh = makeSession("session", { title: "fresh refresh", time_updated: 3000 });
+    const codex = makeFileSystemAgent("codex");
+    let releaseBackfill: ((result: unknown) => void) | undefined;
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [initial],
+      byAgent: { codex: [initial] },
+      agents: [codex],
+    });
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [initial],
+      byAgent: { codex: [initial] },
+      meta: {},
+      timestamp: 1000,
+    });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    const logInfo = vi.spyOn(appLogger, "info").mockImplementation(() => undefined);
+    const scanAgentInWorker = vi
+      .spyOn(store as any, "scanAgentInWorker")
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseBackfill = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ sessions: [fresh], meta: {}, changedIds: [fresh.id] });
+
+    const backfill = (store as any).runBackfill("codex");
+    await vi.waitFor(() => expect(scanAgentInWorker).toHaveBeenCalledTimes(1));
+
+    const refresh = (store as any).refreshAgent("codex");
+    await Promise.resolve();
+    expect(scanAgentInWorker).toHaveBeenCalledTimes(1);
+
+    releaseBackfill!({ sessions: [stale], meta: {}, changedIds: [stale.id] });
+    await backfill;
+    await refresh;
+
+    expect(store.getSnapshot().sessions[0]?.title).toBe("fresh refresh");
+    expect(
+      logInfo.mock.calls
+        .filter(([event]) => String(event).startsWith("scan.agent_operation."))
+        .map(([event, fields]) => [event, fields?.operation, fields?.generation, fields?.result]),
+    ).toEqual([
+      ["scan.agent_operation.started", "backfill", 1, undefined],
+      ["scan.agent_operation.completed", "backfill", 1, "committed"],
+      ["scan.agent_operation.started", "refresh", 2, undefined],
+      ["scan.agent_operation.completed", "refresh", 2, "committed"],
+    ]);
+  });
+
+  it("runs a queued refresh after a backfill failure", async () => {
+    const initial = makeSession("session", { title: "initial", time_updated: 1000 });
+    const fresh = makeSession("session", { title: "fresh", time_updated: 2000 });
+    const codex = makeFileSystemAgent("codex");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [initial],
+      byAgent: { codex: [initial] },
+      agents: [codex],
+    });
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [initial],
+      byAgent: { codex: [initial] },
+      meta: {},
+      timestamp: 1000,
+    });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    vi.spyOn(store as any, "scanAgentInWorker")
+      .mockRejectedValueOnce(new Error("backfill failed"))
+      .mockResolvedValueOnce({ sessions: [fresh], meta: {}, changedIds: [fresh.id] });
+
+    const backfill = (store as any).runBackfill("codex");
+    const refresh = (store as any).refreshAgent("codex");
+    await Promise.all([backfill, refresh]);
+
+    expect(consoleError).toHaveBeenCalledWith("[codex] Backfill failed:", expect.any(Error));
+    expect(store.getSnapshot().sessions[0]?.title).toBe("fresh");
+  });
+
+  it("allows another agent to refresh while a backfill is in flight", async () => {
+    const codexInitial = makeSession("codex-session", { slug: "codex/codex-session" });
+    const kimiInitial = makeSession("kimi-session", {
+      slug: "kimi/kimi-session",
+      title: "kimi initial",
+    });
+    const kimiFresh = makeSession("kimi-session", {
+      slug: "kimi/kimi-session",
+      title: "kimi fresh",
+      time_updated: 2000,
+    });
+    const codex = makeFileSystemAgent("codex");
+    const kimi = makeAgent("kimi", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: [kimiFresh.id],
+        timestamp: 2000,
+      })),
+      incrementalScan: vi.fn(() => [kimiFresh]),
+    });
+    let releaseBackfill: ((result: unknown) => void) | undefined;
+
+    core.createRegisteredAgents.mockReturnValue([codex, kimi]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [codexInitial, kimiInitial],
+      byAgent: { codex: [codexInitial], kimi: [kimiInitial] },
+      agents: [codex, kimi],
+    });
+    core.loadCachedSessions.mockReturnValue(null);
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    const scanAgentInWorker = vi.spyOn(store as any, "scanAgentInWorker").mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseBackfill = resolve;
+        }),
+    );
+
+    const backfill = (store as any).runBackfill("codex");
+    await vi.waitFor(() => expect(scanAgentInWorker).toHaveBeenCalledTimes(1));
+
+    await (store as any).refreshAgent("kimi");
+    expect(store.getSnapshot().byAgent.kimi[0]?.title).toBe("kimi fresh");
+
+    releaseBackfill!({ sessions: [codexInitial], meta: {}, changedIds: [] });
+    await backfill;
+  });
+
+  it("coalesces refresh schedules received while backfill is active", async () => {
+    vi.useFakeTimers();
+    const initial = makeSession("session", { title: "initial", time_updated: 1000 });
+    const backfilled = makeSession("session", { title: "backfilled", time_updated: 2000 });
+    const refreshed = makeSession("session", { title: "refreshed", time_updated: 3000 });
+    const rerun = makeSession("session", { title: "rerun", time_updated: 4000 });
+    const codex = makeFileSystemAgent("codex");
+    let releaseBackfill: ((result: unknown) => void) | undefined;
+
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [initial],
+      byAgent: { codex: [initial] },
+      agents: [codex],
+    });
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [initial],
+      byAgent: { codex: [initial] },
+      meta: {},
+      timestamp: 1000,
+    });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    const scanAgentInWorker = vi
+      .spyOn(store as any, "scanAgentInWorker")
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseBackfill = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ sessions: [refreshed], meta: {}, changedIds: [refreshed.id] })
+      .mockResolvedValueOnce({ sessions: [rerun], meta: {}, changedIds: [rerun.id] });
+
+    const backfill = (store as any).runBackfill("codex");
+    await vi.waitFor(() => expect(scanAgentInWorker).toHaveBeenCalledTimes(1));
+
+    (store as any).getRefreshState("codex").pendingPathCount += 1;
+    (store as any).scheduleRefresh("codex", 0);
+    await vi.advanceTimersByTimeAsync(0);
+    (store as any).getRefreshState("codex").pendingPathCount += 2;
+    (store as any).scheduleRefresh("codex", 0);
+    (store as any).scheduleRefresh("codex", 0);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(scanAgentInWorker).toHaveBeenCalledTimes(1);
+    releaseBackfill!({ sessions: [backfilled], meta: {}, changedIds: [backfilled.id] });
+    await backfill;
+    await vi.waitFor(() => expect(scanAgentInWorker).toHaveBeenCalledTimes(2));
+
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.waitFor(() => expect(scanAgentInWorker).toHaveBeenCalledTimes(3));
+    expect(store.getSnapshot().sessions[0]?.title).toBe("rerun");
   });
 
   it("persists incremental changes outside the startup time window", async () => {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -111,6 +111,16 @@ interface AgentRefreshState {
   pendingPathCount: number;
 }
 
+type AgentOperationKind = "backfill" | "refresh";
+type AgentOperationResult = "committed" | "failed" | "skipped" | "unchanged";
+
+interface AgentOperationLifecycle {
+  agentName: string;
+  kind: AgentOperationKind;
+  generation: number;
+  startedAt: number;
+}
+
 const REFRESH_DEBOUNCE_MS = 200;
 const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const PENDING_REFRESH_DELAY_MS = 100;
@@ -217,6 +227,8 @@ export class LiveScanStore {
   private backfillQueue: string[] = [];
   private backfillRunning = false;
   private refreshStates = new Map<string, AgentRefreshState>();
+  private agentOperationGenerations = new Map<string, number>();
+  private agentOperationTails = new Map<string, Promise<void>>();
   private watcher: SessionWatcher | null = null;
   private pendingEvent: SessionsUpdatedEvent | null = null;
   private pendingEventTimer: NodeJS.Timeout | null = null;
@@ -605,6 +617,68 @@ export class LiveScanStore {
     });
   }
 
+  private beginAgentOperation(
+    agentName: string,
+    kind: AgentOperationKind,
+  ): AgentOperationLifecycle {
+    const generation = (this.agentOperationGenerations.get(agentName) ?? 0) + 1;
+    const startedAt = Date.now();
+    this.agentOperationGenerations.set(agentName, generation);
+    appLogger.info("scan.agent_operation.started", {
+      agent: agentName,
+      operation: kind,
+      generation,
+      started_at: startedAt,
+    });
+    return { agentName, kind, generation, startedAt };
+  }
+
+  private completeAgentOperation(
+    lifecycle: AgentOperationLifecycle,
+    result: AgentOperationResult,
+  ): void {
+    const completedAt = Date.now();
+    appLogger.info("scan.agent_operation.completed", {
+      agent: lifecycle.agentName,
+      operation: lifecycle.kind,
+      generation: lifecycle.generation,
+      started_at: lifecycle.startedAt,
+      completed_at: completedAt,
+      duration_ms: completedAt - lifecycle.startedAt,
+      result,
+    });
+  }
+
+  private enqueueAgentOperation(
+    agentName: string,
+    kind: AgentOperationKind,
+    operation: () => Promise<AgentOperationResult>,
+  ): Promise<AgentOperationResult> {
+    const previous = this.agentOperationTails.get(agentName) ?? Promise.resolve();
+    const run = previous.then(async () => {
+      const lifecycle = this.beginAgentOperation(agentName, kind);
+      try {
+        const result = await operation();
+        this.completeAgentOperation(lifecycle, result);
+        return result;
+      } catch (error) {
+        this.completeAgentOperation(lifecycle, "failed");
+        throw error;
+      }
+    });
+    const tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.agentOperationTails.set(agentName, tail);
+    void tail.finally(() => {
+      if (this.agentOperationTails.get(agentName) === tail) {
+        this.agentOperationTails.delete(agentName);
+      }
+    });
+    return run;
+  }
+
   /**
    * Only FileSystemSessionSource agents pay the O(history) enumeration cost this
    * guards against: database agents already do a cheap single-file mtime check.
@@ -652,10 +726,14 @@ export class LiveScanStore {
 
   /** Unbounded per-source sync to reconcile the full session history, not just the display window. */
   private async runBackfill(agentName: string): Promise<void> {
+    await this.enqueueAgentOperation(agentName, "backfill", () => this.performBackfill(agentName));
+  }
+
+  private async performBackfill(agentName: string): Promise<AgentOperationResult> {
     const startedAt = performance.now();
     const agent = this.agents.find((item) => item.name === agentName);
     if (!agent || !(agent instanceof FileSystemSessionSource) || !agent.isAvailable()) {
-      return;
+      return "skipped";
     }
 
     const cached = loadCachedSessions(agentName);
@@ -708,9 +786,11 @@ export class LiveScanStore {
         sessions: fullSessions.length,
         changed: result.changedIds?.length ?? 0,
       });
+      return "committed";
     } catch (error) {
       appLogger.error("scan.backfill.error", { agent: agentName, error });
       console.error(`[${agentName}] Backfill failed:`, error);
+      return "failed";
     }
   }
 
@@ -1016,16 +1096,22 @@ export class LiveScanStore {
     }
 
     state.inFlight = true;
-    this.beginAgentScan(agentName);
 
     try {
-      await this.runRefresh(agentName);
-    } catch (error) {
-      appLogger.error("scan.refresh.error", { agent: agentName, error });
-      console.error(`[${agentName}] Session refresh failed:`, error);
+      await this.enqueueAgentOperation(agentName, "refresh", async () => {
+        this.beginAgentScan(agentName);
+        try {
+          return await this.runRefresh(agentName);
+        } catch (error) {
+          appLogger.error("scan.refresh.error", { agent: agentName, error });
+          console.error(`[${agentName}] Session refresh failed:`, error);
+          return "failed";
+        } finally {
+          this.finishAgentScan(agentName);
+        }
+      });
     } finally {
       state.inFlight = false;
-      this.finishAgentScan(agentName);
 
       if (state.pendingRerun) {
         state.pendingRerun = false;
@@ -1034,7 +1120,7 @@ export class LiveScanStore {
     }
   }
 
-  private async runRefresh(agentName: string): Promise<void> {
+  private async runRefresh(agentName: string): Promise<Exclude<AgentOperationResult, "failed">> {
     const startedAt = performance.now();
     const state = this.getRefreshState(agentName);
     const pendingPathCount = state.pendingPathCount;
@@ -1042,7 +1128,7 @@ export class LiveScanStore {
     const agent = this.agents.find((item) => item.name === agentName);
     if (!agent) {
       appLogger.warn("scan.refresh.missing_agent", { agent: agentName });
-      return;
+      return "skipped";
     }
 
     const previousSessions = this.byAgent[agentName] ?? [];
@@ -1139,7 +1225,7 @@ export class LiveScanStore {
           agent: agentName,
           duration_ms: Math.round(performance.now() - startedAt),
         });
-        return;
+        return "unchanged";
       }
 
       preciseChangedIds = checkResult.changedIds ?? null;
@@ -1258,5 +1344,6 @@ export class LiveScanStore {
       persistent_index_worker_job: persistentJobKind,
       persistent_index_skipped: !persistentJob || undefined,
     });
+    return "committed";
   }
 }


### PR DESCRIPTION
## Summary

- serialize backfill and refresh operations through a per-agent promise tail
- preserve concurrent scanning across independent agents
- emit structured lifecycle logs with operation kind, generation, timestamps, duration, and result
- coalesce refresh requests that arrive while a backfill is active
- cover serialization, failure recovery, cross-agent concurrency, and queued reruns with deterministic tests

## Root cause

Backfill and refresh used independent coordination paths while both mutated the same agent snapshot, cache metadata, and search index. A backfill that started earlier but completed after a newer refresh could overwrite the newer state.

## Impact

Operations for the same agent now execute and commit in order. Other agents remain independent, and refresh work queued during backfill still runs afterward. No SSE event shape changes.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (565 tests)
- `pnpm test:e2e` (1 Chromium test)

Tracks CS-23.