### PR TITLE
fix(live-scan): stop search workers atomically

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -44,6 +44,7 @@ const core = vi.hoisted(() => ({
 }));
 
 const workerThreads = vi.hoisted(() => ({
+  deferSearchIndexWorkers: false,
   workers: [] as Array<{
     url: URL;
     workerData: any;
@@ -51,9 +52,13 @@ const workerThreads = vi.hoisted(() => ({
     once: ReturnType<typeof vi.fn>;
     unref: ReturnType<typeof vi.fn>;
     terminate: ReturnType<typeof vi.fn>;
+    emitError: (error: Error) => void;
   }>,
   Worker: vi.fn(function (this: unknown, url: URL, options?: { workerData?: unknown }) {
     const workerData = options?.workerData as any;
+    const deferredSearchWorker = workerThreads.deferSearchIndexWorkers && workerData?.jobs;
+    const deferredExitHandlers: Array<(code: number) => void> = [];
+    const deferredErrorHandlers: Array<(error: Error) => void> = [];
     const runSourceSync = (agent: any) => {
       const parseSourceFingerprint = (fingerprint: string) => {
         try {
@@ -112,6 +117,7 @@ const workerThreads = vi.hoisted(() => ({
       workerData,
       on: vi.fn((event: string, handler: (message: unknown) => void) => {
         if (event === "message") {
+          if (deferredSearchWorker) return worker;
           queueMicrotask(() => {
             try {
               if (workerData?.agentName) {
@@ -169,18 +175,28 @@ const workerThreads = vi.hoisted(() => ({
           });
         }
         if (event === "exit") {
-          queueMicrotask(() => handler(0));
+          if (deferredSearchWorker) deferredExitHandlers.push(handler);
+          else queueMicrotask(() => handler(0));
+        }
+        if (event === "error" && deferredSearchWorker) {
+          deferredErrorHandlers.push(handler);
         }
         return worker;
       }),
       once: vi.fn((event: string, handler: (message: unknown) => void) => {
         if (event === "exit") {
-          queueMicrotask(() => handler(0));
+          if (deferredSearchWorker) deferredExitHandlers.push(handler);
+          else queueMicrotask(() => handler(0));
         }
         return worker;
       }),
       unref: vi.fn(),
-      terminate: vi.fn(async () => undefined),
+      terminate: vi.fn(async () => {
+        for (const handler of deferredExitHandlers) handler(0);
+      }),
+      emitError: (error: Error) => {
+        for (const handler of deferredErrorHandlers) handler(error);
+      },
     };
     workerThreads.workers.push(worker);
     return worker;
@@ -360,6 +376,7 @@ describe("LiveScanStore", () => {
     vi.clearAllMocks();
     fsWatch.watchers.length = 0;
     workerThreads.workers.length = 0;
+    workerThreads.deferSearchIndexWorkers = false;
     fsWatch.watch.mockImplementation(
       (
         path: string,
@@ -1688,6 +1705,92 @@ describe("LiveScanStore", () => {
 
     await vi.advanceTimersByTimeAsync(10_000);
     expect(codex.checkForChanges).not.toHaveBeenCalled();
+  });
+
+  it("does not start a pending search-index batch while shutting down", async () => {
+    core.createRegisteredAgents.mockReturnValue([]);
+    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    workerThreads.deferSearchIndexWorkers = true;
+    const job = {
+      kind: "full" as const,
+      context: "scan.refresh",
+      agentName: "codex",
+      sessions: [],
+      meta: {},
+    };
+
+    const current = (store as any).enqueueSearchIndexJobs("scan.refresh", [job]);
+    const pending = (store as any).enqueueSearchIndexJobs("scan.refresh", [job]);
+    const outcomes = Promise.allSettled([current, pending]);
+    expect(workerThreads.workers.filter((worker) => worker.workerData.jobs)).toHaveLength(1);
+
+    await store.shutdown();
+
+    expect(workerThreads.workers.filter((worker) => worker.workerData.jobs)).toHaveLength(1);
+    expect(await outcomes).toEqual([
+      expect.objectContaining({ status: "rejected", reason: expect.any(Error) }),
+      expect.objectContaining({ status: "rejected", reason: expect.any(Error) }),
+    ]);
+    expect((store as any).pendingSearchIndexJobs).toEqual([]);
+    expect((store as any).searchIndexWorker).toBeNull();
+  });
+
+  it("makes repeated shutdown calls share one worker termination", async () => {
+    core.createRegisteredAgents.mockReturnValue([]);
+    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    workerThreads.deferSearchIndexWorkers = true;
+    const job = {
+      kind: "full" as const,
+      context: "scan.refresh",
+      agentName: "codex",
+      sessions: [],
+      meta: {},
+    };
+    const batch = (store as any).enqueueSearchIndexJobs("scan.refresh", [job]);
+    const outcome = batch.catch((error: Error) => error);
+    const worker = workerThreads.workers.at(-1)!;
+
+    await Promise.all([store.shutdown(), store.shutdown()]);
+
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(await outcome).toBeInstanceOf(Error);
+    await expect((store as any).enqueueSearchIndexJobs("scan.refresh", [job])).rejects.toThrow(
+      "Live scan store shut down",
+    );
+  });
+
+  it("settles a worker error once when shutdown follows", async () => {
+    core.createRegisteredAgents.mockReturnValue([]);
+    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
+
+    const store = new LiveScanStore(false);
+    await store.initialize();
+    workerThreads.deferSearchIndexWorkers = true;
+    const job = {
+      kind: "full" as const,
+      context: "scan.refresh",
+      agentName: "codex",
+      sessions: [],
+      meta: {},
+    };
+    const batch = (store as any).enqueueSearchIndexJobs("scan.refresh", [job]);
+    const outcome = Promise.allSettled([batch]);
+    const worker = workerThreads.workers.at(-1)!;
+
+    worker.emitError(new Error("index failed"));
+    await store.shutdown();
+
+    expect(await outcome).toEqual([
+      expect.objectContaining({ status: "rejected", reason: new Error("index failed") }),
+    ]);
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(workerThreads.workers.filter((item) => item.workerData.jobs)).toHaveLength(1);
   });
 
   it("skips the FTS integrity check on search-index batches after the first one completes", async () => {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -90,8 +90,10 @@ interface SessionRefreshDiff {
 }
 
 interface SearchIndexJobBatch {
+  id: number;
   context: string;
   jobs: SearchIndexWorkerJob[];
+  settled: boolean;
   resolve: () => void;
   reject: (error: Error) => void;
 }
@@ -234,7 +236,10 @@ export class LiveScanStore {
   private pendingEventTimer: NodeJS.Timeout | null = null;
   private backgroundRefreshTimer: NodeJS.Timeout | null = null;
   private searchIndexWorker: Worker | null = null;
+  private activeSearchIndexBatch: SearchIndexJobBatch | null = null;
+  private nextSearchIndexBatchId = 1;
   private pendingSearchIndexJobs: SearchIndexJobBatch[] = [];
+  private shutdownPromise: Promise<void> | null = null;
   private shuttingDown = false;
   /** Set once a search-index worker in this process has completed the FTS integrity check. */
   private ftsIntegrityChecked = false;
@@ -398,8 +403,17 @@ export class LiveScanStore {
     };
   }
 
-  async shutdown(): Promise<void> {
+  shutdown(): Promise<void> {
+    this.shutdownPromise ??= this.performShutdown();
+    return this.shutdownPromise;
+  }
+
+  private async performShutdown(): Promise<void> {
     this.shuttingDown = true;
+    appLogger.info("search_index.shutdown.started", {
+      active_batch_id: this.activeSearchIndexBatch?.id,
+      pending_batches: this.pendingSearchIndexJobs.length,
+    });
     for (const state of this.refreshStates.values()) {
       if (state.timer) {
         clearTimeout(state.timer);
@@ -416,20 +430,26 @@ export class LiveScanStore {
       clearTimeout(this.backgroundRefreshTimer);
       this.backgroundRefreshTimer = null;
     }
-    if (this.searchIndexWorker) {
-      await this.searchIndexWorker.terminate();
-      this.searchIndexWorker = null;
-    }
-    for (const batch of this.pendingSearchIndexJobs) {
-      batch.reject(new Error("Live scan store shut down"));
-    }
+    const shutdownError = new Error("Live scan store shut down");
+    const worker = this.searchIndexWorker;
+    const activeBatch = this.activeSearchIndexBatch;
+    const pendingBatches = this.pendingSearchIndexJobs;
+    this.searchIndexWorker = null;
+    this.activeSearchIndexBatch = null;
     this.pendingSearchIndexJobs = [];
+    if (activeBatch) this.settleSearchIndexBatch(activeBatch, shutdownError);
+    for (const batch of pendingBatches) this.settleSearchIndexBatch(batch, shutdownError);
+    if (worker) await worker.terminate();
     this.pendingEvent = null;
 
     if (this.watcher) {
       await this.watcher.dispose();
       this.watcher = null;
     }
+    appLogger.info("search_index.shutdown.completed", {
+      active_batch_id: this.activeSearchIndexBatch?.id,
+      pending_batches: this.pendingSearchIndexJobs.length,
+    });
   }
 
   private emit(event: SessionsUpdatedEvent): void {
@@ -920,13 +940,22 @@ export class LiveScanStore {
 
   private enqueueSearchIndexJobs(context: string, jobs: SearchIndexWorkerJob[]): Promise<void> {
     if (jobs.length === 0) return Promise.resolve();
+    if (this.shuttingDown) return Promise.reject(new Error("Live scan store shut down"));
 
     return new Promise((resolve, reject) => {
-      const batch: SearchIndexJobBatch = { context, jobs, resolve, reject };
+      const batch: SearchIndexJobBatch = {
+        id: this.nextSearchIndexBatchId++,
+        context,
+        jobs,
+        settled: false,
+        resolve,
+        reject,
+      };
 
       if (this.searchIndexWorker) {
         this.pendingSearchIndexJobs.push(batch);
         appLogger.debug("search_index.worker_queued", {
+          batch_id: batch.id,
           context,
           jobs: jobs.length,
           pending_jobs: this.pendingSearchIndexJobs.length,
@@ -938,15 +967,47 @@ export class LiveScanStore {
     });
   }
 
+  private settleSearchIndexBatch(batch: SearchIndexJobBatch, error?: Error): void {
+    if (batch.settled) return;
+    batch.settled = true;
+    appLogger.info("search_index.worker_settled", {
+      batch_id: batch.id,
+      context: batch.context,
+      result: error ? "rejected" : "resolved",
+    });
+    if (error) batch.reject(error);
+    else batch.resolve();
+  }
+
+  private startNextSearchIndexJobBatch(): void {
+    if (this.shuttingDown || this.searchIndexWorker) return;
+    const pendingBatch = this.pendingSearchIndexJobs.shift();
+    if (!pendingBatch) return;
+    appLogger.info("search_index.worker_dequeued", {
+      batch_id: pendingBatch.id,
+      context: pendingBatch.context,
+      pending_batches: this.pendingSearchIndexJobs.length,
+    });
+    this.startSearchIndexJobBatch(pendingBatch);
+  }
+
   private startSearchIndexJobBatch(batch: SearchIndexJobBatch): void {
+    if (this.shuttingDown) {
+      this.settleSearchIndexBatch(batch, new Error("Live scan store shut down"));
+      return;
+    }
     const workerUrl = this.getSearchIndexWorkerUrl();
     if (!workerUrl) {
       appLogger.warn("search_index.worker_missing", { context: batch.context });
-      batch.resolve();
+      this.settleSearchIndexBatch(batch);
       return;
     }
+    appLogger.info("search_index.worker_started", {
+      batch_id: batch.id,
+      context: batch.context,
+      jobs: batch.jobs.length,
+    });
 
-    let settled = false;
     const worker = new Worker(workerUrl, {
       workerData: {
         context: batch.context,
@@ -959,6 +1020,7 @@ export class LiveScanStore {
     });
     worker.unref();
     this.searchIndexWorker = worker;
+    this.activeSearchIndexBatch = batch;
 
     worker.on("message", (message: SearchIndexWorkerMessage) => {
       if (message.type === "sync-result") {
@@ -968,31 +1030,36 @@ export class LiveScanStore {
           duration_ms: Math.round(message.durationMs),
           sessions: message.sessions,
         });
-        settled = true;
         this.ftsIntegrityChecked = true;
-        batch.resolve();
+        this.settleSearchIndexBatch(batch);
       }
     });
     worker.on("error", (error) => {
       appLogger.error("search_index.worker_error", { context: batch.context, error });
-      if (!settled) {
-        settled = true;
-        batch.reject(error);
-      }
+      this.settleSearchIndexBatch(batch, error);
     });
     worker.on("exit", (code) => {
-      this.searchIndexWorker = null;
+      appLogger.info("search_index.worker_exited", {
+        batch_id: batch.id,
+        context: batch.context,
+        code,
+        shutting_down: this.shuttingDown || undefined,
+      });
+      if (this.searchIndexWorker === worker) this.searchIndexWorker = null;
+      if (this.activeSearchIndexBatch === batch) this.activeSearchIndexBatch = null;
       if (code !== 0) {
         appLogger.warn("search_index.worker_exit", { context: batch.context, code });
-        if (!settled) {
-          settled = true;
-          batch.reject(new Error(`Search index worker exited with code ${code}`));
-        }
+        this.settleSearchIndexBatch(
+          batch,
+          new Error(`Search index worker exited with code ${code}`),
+        );
+      } else if (!batch.settled) {
+        this.settleSearchIndexBatch(
+          batch,
+          new Error("Search index worker exited before completing its batch"),
+        );
       }
-      if (this.pendingSearchIndexJobs.length > 0) {
-        const pendingBatch = this.pendingSearchIndexJobs.shift()!;
-        this.startSearchIndexJobBatch(pendingBatch);
-      }
+      this.startNextSearchIndexJobBatch();
     });
   }
 


### PR DESCRIPTION
## Summary

- close the search-index queue before terminating the active worker
- atomically detach the active batch, pending batches, and worker during shutdown
- reject active and pending batch promises deterministically
- prevent enqueue, dequeue, or worker creation after shutdown begins
- make repeated shutdown calls share one lifecycle promise
- add batch lifecycle logging and deterministic worker race tests

## Root cause

`Worker.terminate()` triggers the worker exit handler before shutdown finishes awaiting termination. The exit handler could dequeue a pending batch and create a second worker, after which shutdown cleared the shared worker reference. That orphaned worker could continue writing cache and FTS data, while current or pending promises remained unsettled.

## Impact

Shutdown now returns only after the captured worker has terminated, with no queued batch or untracked search-index worker left behind. Normal FIFO processing and FTS integrity-check behavior remain unchanged.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (568 tests)
- `pnpm test:e2e` (1 Chromium test)

Tracks CS-24.