### PR TITLE
fix(web): cancel stale session detail requests

### DIFF
--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -18,6 +18,16 @@ const sessionView: ViewState = {
 
 const sample = { id: "abc", messages: [] } as unknown as SessionData;
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -30,7 +40,11 @@ describe("useSessionDetail", () => {
 
     await waitFor(() => expect(result.current.session).toEqual(sample));
     expect(result.current.sessionError).toBeNull();
-    expect(api.fetchSessionData).toHaveBeenCalledWith("claudecode", "claudecode/abc");
+    expect(api.fetchSessionData).toHaveBeenCalledWith(
+      "claudecode",
+      "claudecode/abc",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("sets an error when the fetch fails", async () => {
@@ -60,5 +74,160 @@ describe("useSessionDetail", () => {
       await result.current.refresh();
     });
     expect(result.current.session).toEqual(updated);
+  });
+
+  it("keeps the current route when an older request resolves last", async () => {
+    const requestA = deferred<SessionData>();
+    const requestB = deferred<SessionData>();
+    const viewA = sessionView;
+    const viewB: ViewState = {
+      mode: "session",
+      activeAgentKey: "codex",
+      activeSessionSlug: "def",
+    };
+    const sessionA = { id: "a", messages: [] } as unknown as SessionData;
+    const sessionB = { id: "b", messages: [] } as unknown as SessionData;
+    vi.mocked(api.fetchSessionData).mockImplementation((_agent, sessionId) =>
+      sessionId === viewA.activeSessionSlug ? requestA.promise : requestB.promise,
+    );
+    const { result, rerender } = renderHook(({ view }) => useSessionDetail(view), {
+      initialProps: { view: viewA as ViewState },
+    });
+    await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
+
+    rerender({ view: viewB });
+    await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(2));
+    await act(async () => requestB.resolve(sessionB));
+    await waitFor(() => expect(result.current.session).toEqual(sessionB));
+    await act(async () => requestA.resolve(sessionA));
+
+    expect({
+      sessionId: result.current.session?.id,
+      lifecycle: vi
+        .mocked(api.logClientEvent)
+        .mock.calls.map(([event, fields]) => `${event}:${fields?.request_key}`),
+    }).toEqual({
+      sessionId: "b",
+      lifecycle: [
+        "session.open.start:claudecode/claudecode/abc",
+        "session.open.cancel:claudecode/claudecode/abc",
+        "session.open.start:codex/def",
+        "session.open.done:codex/def",
+        "session.open.stale:claudecode/claudecode/abc",
+      ],
+    });
+  });
+
+  it("does not surface an aborted route request as an error", async () => {
+    const viewB: ViewState = {
+      mode: "session",
+      activeAgentKey: "codex",
+      activeSessionSlug: "def",
+    };
+    const sessionB = { id: "b", messages: [] } as unknown as SessionData;
+    vi.mocked(api.fetchSessionData).mockImplementation((agent, _sessionId, options) => {
+      if (agent === "codex") return Promise.resolve(sessionB);
+      return new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        });
+      });
+    });
+    const { result, rerender } = renderHook(({ view }) => useSessionDetail(view), {
+      initialProps: { view: sessionView as ViewState },
+    });
+    await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
+
+    rerender({ view: viewB });
+    await waitFor(() => expect(result.current.session).toEqual(sessionB));
+
+    expect(result.current.sessionError).toBeNull();
+    expect(api.logClientEvent).not.toHaveBeenCalledWith(
+      "session.open.error",
+      expect.objectContaining({ request_key: "claudecode/claudecode/abc" }),
+    );
+  });
+
+  it("does not let a stale failure clear loading for the current request", async () => {
+    const requestA = deferred<SessionData>();
+    const requestB = deferred<SessionData>();
+    const viewB: ViewState = {
+      mode: "session",
+      activeAgentKey: "codex",
+      activeSessionSlug: "def",
+    };
+    const sessionB = { id: "b", messages: [] } as unknown as SessionData;
+    vi.mocked(api.fetchSessionData).mockImplementation((_agent, sessionId) =>
+      sessionId === sessionView.activeSessionSlug ? requestA.promise : requestB.promise,
+    );
+    const { result, rerender } = renderHook(({ view }) => useSessionDetail(view), {
+      initialProps: { view: sessionView as ViewState },
+    });
+    await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
+
+    rerender({ view: viewB });
+    await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(2));
+    await act(async () => requestA.reject(new Error("stale failure")));
+
+    expect(result.current.sessionLoading).toBe(true);
+    expect(result.current.sessionError).toBeNull();
+    await act(async () => requestB.resolve(sessionB));
+    await waitFor(() => expect(result.current.sessionLoading).toBe(false));
+    expect(result.current.session).toEqual(sessionB);
+  });
+
+  it("aborts without committing state after unmount", async () => {
+    const request = deferred<SessionData>();
+    vi.mocked(api.fetchSessionData).mockReturnValue(request.promise);
+    const { unmount } = renderHook(() => useSessionDetail(sessionView));
+    await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
+    const signal = vi.mocked(api.fetchSessionData).mock.calls[0]?.[2]?.signal;
+
+    unmount();
+    await act(async () => request.resolve(sample));
+
+    expect(signal?.aborted).toBe(true);
+    expect(api.logClientEvent).not.toHaveBeenCalledWith(
+      "session.open.done",
+      expect.objectContaining({ request_key: "claudecode/claudecode/abc" }),
+    );
+    expect(api.logClientEvent).not.toHaveBeenCalledWith(
+      "session.open.error",
+      expect.objectContaining({ request_key: "claudecode/claudecode/abc" }),
+    );
+  });
+
+  it("does not let an old refresh overwrite a navigated session", async () => {
+    const refreshRequest = deferred<SessionData>();
+    const refreshedA = { id: "a-refreshed", messages: [] } as unknown as SessionData;
+    const sessionB = { id: "b", messages: [] } as unknown as SessionData;
+    const viewB: ViewState = {
+      mode: "session",
+      activeAgentKey: "codex",
+      activeSessionSlug: "def",
+    };
+    vi.mocked(api.fetchSessionData)
+      .mockResolvedValueOnce(sample)
+      .mockReturnValueOnce(refreshRequest.promise)
+      .mockResolvedValueOnce(sessionB);
+    const { result, rerender } = renderHook(({ view }) => useSessionDetail(view), {
+      initialProps: { view: sessionView as ViewState },
+    });
+    await waitFor(() => expect(result.current.session).toEqual(sample));
+
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+    await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(2));
+    rerender({ view: viewB });
+    await waitFor(() => expect(result.current.session).toEqual(sessionB));
+    await act(async () => refreshRequest.resolve(refreshedA));
+    await refreshPromise;
+
+    expect(result.current.session).toEqual(sessionB);
+    expect(result.current.sessionError).toBeNull();
   });
 });

--- a/apps/web/src/hooks/useSessionDetail.ts
+++ b/apps/web/src/hooks/useSessionDetail.ts
@@ -1,6 +1,18 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type SessionData, fetchSessionData, logClientEvent } from "../lib/api";
 import type { ViewState } from "../lib/view-state";
+
+interface SessionDetailRequest {
+  id: number;
+  key: string;
+  controller: AbortController;
+}
+
+function getSessionKey(viewState: ViewState): string {
+  return viewState.mode === "session"
+    ? `${viewState.activeAgentKey}/${viewState.activeSessionSlug}`
+    : "";
+}
 
 /**
  * Owns session-detail state: loads the session for the current "session" route
@@ -11,63 +23,132 @@ export function useSessionDetail(viewState: ViewState) {
   const [session, setSession] = useState<SessionData | null>(null);
   const [sessionLoading, setSessionLoading] = useState(false);
   const [sessionError, setSessionError] = useState<string | null>(null);
+  const activeRequestRef = useRef<SessionDetailRequest | null>(null);
+  const nextRequestIdRef = useRef(1);
+  const sessionKey = getSessionKey(viewState);
+  const currentSessionKeyRef = useRef(sessionKey);
+  currentSessionKeyRef.current = sessionKey;
 
-  const sessionKey =
-    viewState.mode === "session"
-      ? `${viewState.activeAgentKey}/${viewState.activeSessionSlug}`
-      : "";
-
-  useEffect(() => {
-    if (viewState.mode !== "session") {
-      setSession(null);
-      setSessionError(null);
-      return;
-    }
-    const ac = new AbortController();
-    setSessionLoading(true);
-    setSessionError(null);
-    const startedAt = performance.now();
-    logClientEvent("session.open.start", {
-      agent: viewState.activeAgentKey,
-      session: viewState.activeSessionSlug,
+  const cancelActiveRequest = useCallback((reason: "route-change" | "superseded") => {
+    const request = activeRequestRef.current;
+    if (!request) return;
+    activeRequestRef.current = null;
+    request.controller.abort();
+    logClientEvent("session.open.cancel", {
+      request_id: request.id,
+      request_key: request.key,
+      reason,
     });
-    (async () => {
+  }, []);
+
+  const loadSession = useCallback(
+    async (
+      agent: string,
+      sessionSlug: string,
+      requestKey: string,
+      trigger: "route" | "refresh",
+    ) => {
+      if (currentSessionKeyRef.current !== requestKey) return;
+      cancelActiveRequest("superseded");
+
+      const request: SessionDetailRequest = {
+        id: nextRequestIdRef.current++,
+        key: requestKey,
+        controller: new AbortController(),
+      };
+      activeRequestRef.current = request;
+      if (trigger === "route") {
+        setSessionLoading(true);
+        setSessionError(null);
+      }
+      const startedAt = performance.now();
+      logClientEvent("session.open.start", {
+        request_id: request.id,
+        request_key: request.key,
+        trigger,
+        agent,
+        session: sessionSlug,
+      });
+
       try {
-        const data = await fetchSessionData(viewState.activeAgentKey, viewState.activeSessionSlug);
+        const data = await fetchSessionData(agent, sessionSlug, {
+          signal: request.controller.signal,
+        });
+        if (
+          activeRequestRef.current?.id !== request.id ||
+          currentSessionKeyRef.current !== request.key
+        ) {
+          logClientEvent("session.open.stale", {
+            request_id: request.id,
+            request_key: request.key,
+          });
+          return;
+        }
         setSession(data);
+        setSessionError(null);
         logClientEvent("session.open.done", {
-          agent: viewState.activeAgentKey,
-          session: viewState.activeSessionSlug,
+          request_id: request.id,
+          request_key: request.key,
+          trigger,
+          agent,
+          session: sessionSlug,
           duration_ms: Math.round(performance.now() - startedAt),
           messages: data.messages.length,
         });
-      } catch (err) {
+      } catch (error) {
+        const isCurrent = activeRequestRef.current?.id === request.id;
+        if (
+          request.controller.signal.aborted ||
+          !isCurrent ||
+          currentSessionKeyRef.current !== request.key
+        ) {
+          return;
+        }
         logClientEvent("session.open.error", {
-          agent: viewState.activeAgentKey,
-          session: viewState.activeSessionSlug,
+          request_id: request.id,
+          request_key: request.key,
+          trigger,
+          agent,
+          session: sessionSlug,
           duration_ms: Math.round(performance.now() - startedAt),
-          error: err instanceof Error ? err.message : String(err),
+          error: error instanceof Error ? error.message : String(error),
         });
         setSessionError("Session not found");
         setSession(null);
       } finally {
-        setSessionLoading(false);
+        if (activeRequestRef.current?.id === request.id) {
+          activeRequestRef.current = null;
+          setSessionLoading(false);
+        }
       }
-    })();
-    return () => ac.abort();
-  }, [sessionKey, viewState.activeAgentKey, viewState.activeSessionSlug, viewState.mode]);
+    },
+    [cancelActiveRequest],
+  );
+
+  useEffect(() => {
+    if (viewState.mode !== "session") {
+      cancelActiveRequest("route-change");
+      setSession(null);
+      setSessionError(null);
+      setSessionLoading(false);
+      return;
+    }
+
+    void loadSession(viewState.activeAgentKey, viewState.activeSessionSlug, sessionKey, "route");
+    return () => cancelActiveRequest("route-change");
+  }, [
+    cancelActiveRequest,
+    loadSession,
+    sessionKey,
+    viewState.activeAgentKey,
+    viewState.activeSessionSlug,
+    viewState.mode,
+  ]);
 
   const refresh = useCallback(async () => {
     if (viewState.mode !== "session") return;
-    try {
-      const data = await fetchSessionData(viewState.activeAgentKey, viewState.activeSessionSlug);
-      setSession(data);
-      setSessionError(null);
-    } catch {
-      setSession(null);
-      setSessionError("Session not found");
-    }
-  }, [viewState]);
+    await loadSession(viewState.activeAgentKey, viewState.activeSessionSlug, sessionKey, "refresh");
+  }, [loadSession, sessionKey, viewState]);
 
   return { session, sessionLoading, sessionError, refresh };
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchSearchResults, fetchSessions, subscribeSessionUpdates } from "./api";
+import {
+  fetchSearchResults,
+  fetchSessionData,
+  fetchSessions,
+  subscribeSessionUpdates,
+} from "./api";
+
+describe("fetchSessionData", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards the abort signal to fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const controller = new AbortController();
+
+    await fetchSessionData("codex", "session", { signal: controller.signal });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/sessions/codex/session", {
+      signal: controller.signal,
+    });
+  });
+});
 
 describe("project identity request filters", () => {
   afterEach(() => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -345,8 +345,12 @@ export async function fetchSessions(
   return fetchJson(`/api/sessions?${params}`);
 }
 
-export async function fetchSessionData(agent: string, sessionId: string): Promise<SessionData> {
-  return fetchJson(`/api/sessions/${agent}/${sessionId}`);
+export async function fetchSessionData(
+  agent: string,
+  sessionId: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<SessionData> {
+  return fetchJson(`/api/sessions/${agent}/${sessionId}`, { signal: options.signal });
 }
 
 export async function fetchDashboard(


### PR DESCRIPTION
## Summary

- pass `AbortSignal` from the session-detail hook through the fetch adapter
- make route loads and live refreshes share one request owner
- abort superseded requests and guard state commits by request ID and route key
- prevent stale responses from changing session, loading, or error state
- add request start, completion, cancellation, and stale-response lifecycle logs
- cover out-of-order responses, abort errors, unmounts, stale failures, and refresh/navigation races

## Root cause

`useSessionDetail` created and aborted an `AbortController`, but the signal was never passed to `fetchSessionData` or `fetchJson`. Older requests therefore continued running and could commit after a newer route request, displaying session data that did not match the URL. Refresh used a separate unguarded request path with the same problem.

## Impact

Rapid navigation and live refreshes now keep session detail state aligned with the current route. Aborted or stale requests do not show `Session not found` and cannot clear the current loading state.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (574 tests)
- `pnpm test:e2e` (1 Chromium test)

Tracks CS-25.