### PR TITLE
fix(test): honor project Vitest environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ pnpm bench:perf
 pnpm --filter @codesesh/www deploy:cf
 ```
 
+`test:coverage` runs the Core and CLI suites in Node and the Web suite in
+`happy-dom`. The 75% line threshold applies to the configured Core
+discovery/utils/base modules and CLI API modules, not every monorepo source file.
+
 ### Performance Benchmark
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -223,6 +223,10 @@ pnpm bench:perf
 pnpm --filter @codesesh/www deploy:cf
 ```
 
+`test:coverage` 会在 Node 环境运行 Core、CLI 测试，在 `happy-dom` 环境运行 Web 测试。
+75% 行覆盖率门槛只应用于配置中指定的 Core discovery/utils/base 模块与 CLI API 模块，
+不代表 monorepo 全部源码的覆盖率。
+
 ### 性能 Benchmark
 
 ```bash

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    name: "web",
     passWithNoTests: true,
     include: ["src/**/*.test.{ts,tsx}"],
     environment: "happy-dom",

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    name: "cli",
     passWithNoTests: true,
     include: ["src/**/*.test.ts"],
   },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    name: "core",
     passWithNoTests: true,
     include: ["src/**/*.test.ts"],
     testTimeout: 15_000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,22 +1,19 @@
 import { defineConfig } from "vitest/config";
 
+const COVERAGE_THRESHOLD_SCOPE =
+  "{packages/core/src/utils/**,packages/core/src/discovery/**,packages/core/src/agents/base.ts,packages/cli/src/api/**}";
+
 export default defineConfig({
   test: {
-    passWithNoTests: true,
-    include: ["packages/*/src/**/*.test.ts", "apps/*/src/**/*.test.{ts,tsx}"],
+    projects: ["packages/core", "packages/cli", "apps/web"],
     coverage: {
       provider: "v8",
-      include: [
-        "packages/core/src/utils/**",
-        "!packages/core/src/utils/sqlite.ts",
-        "packages/core/src/discovery/**",
-        "packages/core/src/agents/base.ts",
-        "packages/cli/src/api/**",
-      ],
       exclude: ["**/node_modules/**", "**/dist/**", "packages/core/src/utils/sqlite.ts"],
       reporter: ["text", "html"],
       thresholds: {
-        lines: 75,
+        [COVERAGE_THRESHOLD_SCOPE]: {
+          lines: 75,
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

- run root coverage through the Core, CLI, and Web Vitest projects
- preserve each project environment, including happy-dom for Web tests
- keep the full monorepo report while applying the existing 75% line threshold to its intended scope
- document the root coverage behavior

## Root cause

The root Vitest configuration collected every test directly, bypassing the Web project configuration and running DOM tests in Node.

## Validation

- `pnpm test:coverage`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e`

Issue: CS-26