### PR TITLE
perf(search): batch incremental index state

### DIFF
--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -1106,6 +1106,124 @@ describe("searchSessions", () => {
     ).toEqual(["src/changed-new.ts", "src/keep.ts"]);
   });
 
+  it("reads incremental search index state in bounded batches", () => {
+    const sessions = Array.from({ length: 1_000 }, (_, index) => makeSession(`batch-${index}`));
+    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+
+    saveCachedSessions("claudecode", sessions);
+    syncSessionSearchIndex("claudecode", sessions, (sessionId) =>
+      makeSessionData(sessionMap.get(sessionId)!.id, `content ${sessionId}`),
+    );
+
+    let stateQueryExecutions = 0;
+    const originalPrepare = Database.prototype.prepare;
+    const prepareSpy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+      this: Database.Database,
+      source: string,
+    ) {
+      const statement = originalPrepare.call(this, source);
+      const normalized = source.replace(/\s+/g, " ").trim();
+      const isStateQuery =
+        normalized.startsWith("SELECT content_hash FROM session_documents") ||
+        normalized.startsWith("SELECT COUNT(*) AS value FROM messages") ||
+        normalized.startsWith("WITH requested_session_ids");
+      if (!isStateQuery) {
+        return statement;
+      }
+
+      const originalGet = statement.get.bind(statement);
+      statement.get = (...params: unknown[]) => {
+        stateQueryExecutions += 1;
+        return (originalGet as (...boundParams: unknown[]) => unknown)(...params);
+      };
+      const originalAll = statement.all.bind(statement);
+      statement.all = (...params: unknown[]) => {
+        stateQueryExecutions += 1;
+        return (originalAll as (...boundParams: unknown[]) => unknown[])(...params);
+      };
+      return statement;
+    });
+
+    const batchExecutions: number[] = [];
+    try {
+      for (const changeCount of [10, 100, 1_000]) {
+        const executionsBeforeSync = stateQueryExecutions;
+        const result = syncSessionSearchIndexChanges(
+          "claudecode",
+          sessions.slice(0, changeCount).map((session, sortIndex) => ({ session, sortIndex })),
+          [],
+          () => {
+            throw new Error("unchanged sessions must not be loaded");
+          },
+        );
+        expect(result?.changed).toBe(0);
+        batchExecutions.push(stateQueryExecutions - executionsBeforeSync);
+      }
+    } finally {
+      prepareSpy.mockRestore();
+    }
+
+    expect(batchExecutions).toEqual([1, 1, 2]);
+  });
+
+  it("preserves incremental state defaults and duplicate change semantics", () => {
+    const missingDocument = makeSession("missing-document");
+    const missingMessages = makeSession("missing-messages");
+    const zeroMessages = {
+      ...makeSession("zero-messages"),
+      stats: { ...makeSession("zero-messages").stats, message_count: 0 },
+    };
+    const sessions = [missingDocument, missingMessages, zeroMessages];
+    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+
+    saveCachedSessions("claudecode", sessions);
+    syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
+      ...sessionMap.get(sessionId)!,
+      messages: sessionId === zeroMessages.id ? [] : makeSessionData(sessionId, sessionId).messages,
+    }));
+
+    const db = new Database(getCachePath());
+    try {
+      db.prepare("DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?").run(
+        "claudecode",
+        missingDocument.id,
+      );
+      db.prepare("DELETE FROM messages WHERE agent_name = ? AND session_id = ?").run(
+        "claudecode",
+        missingMessages.id,
+      );
+    } finally {
+      db.close();
+    }
+
+    const loadSession = vi.fn((sessionId: string) =>
+      makeSessionData(sessionId, `reindexed ${sessionId}`),
+    );
+    const result = syncSessionSearchIndexChanges(
+      "claudecode",
+      [
+        { session: missingDocument, sortIndex: 0 },
+        { session: missingMessages, sortIndex: 1 },
+        { session: missingMessages, sortIndex: 1 },
+        { session: zeroMessages, sortIndex: 2 },
+      ],
+      [],
+      loadSession,
+    );
+
+    expect(result).toMatchObject({
+      sessions: 4,
+      changed: 3,
+      indexed: 3,
+      skipped: 0,
+    });
+    expect(loadSession.mock.calls.map(([sessionId]) => sessionId)).toEqual([
+      missingDocument.id,
+      missingMessages.id,
+      missingMessages.id,
+    ]);
+  });
+
   it("restores missing FTS triggers before incremental sync", () => {
     const session = makeSession("trigger");
     const updated = {

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -67,6 +67,16 @@ export interface SearchIndexSyncResult {
   rebuildDurationMs?: number;
 }
 
+interface SearchIndexState {
+  contentHashBySessionId: Map<string, string>;
+  messageCountBySessionId: Map<string, number>;
+}
+
+type SearchIndexStateRow = IndexedSearchRow & MessageCountRow;
+
+// Leaves room for the two agent parameters under SQLite's legacy 999-variable limit.
+const SEARCH_INDEX_STATE_BATCH_SIZE = 900;
+
 interface MessageSearchRow extends DatabaseRow {
   agent_name?: string;
   session_id?: string;
@@ -193,6 +203,54 @@ function sessionContentHash(session: SessionHead): string {
     session.stats.cost_source ?? "",
     session.stats.total_tokens ?? 0,
   ]);
+}
+
+function searchIndexStateFromRows(
+  indexedRows: IndexedSearchRow[],
+  messageCountRows: MessageCountRow[],
+): SearchIndexState {
+  return {
+    contentHashBySessionId: new Map(
+      indexedRows.map((row) => [String(row.session_id), String(row.content_hash ?? "")]),
+    ),
+    messageCountBySessionId: new Map(
+      messageCountRows.map((row) => [String(row.session_id), Number(row.value ?? 0)]),
+    ),
+  };
+}
+
+function readSearchIndexState(
+  db: SQLiteDatabase,
+  agentName: string,
+  sessionIds: string[],
+): SearchIndexState {
+  const rows: SearchIndexStateRow[] = [];
+  const uniqueSessionIds = [...new Set(sessionIds)];
+
+  for (let offset = 0; offset < uniqueSessionIds.length; offset += SEARCH_INDEX_STATE_BATCH_SIZE) {
+    const batch = uniqueSessionIds.slice(offset, offset + SEARCH_INDEX_STATE_BATCH_SIZE);
+    const requestedRows = batch.map(() => "(?)").join(", ");
+    const batchRows = db
+      .prepare(
+        `
+          WITH requested_session_ids(session_id) AS (VALUES ${requestedRows})
+          SELECT
+            requested.session_id,
+            documents.content_hash,
+            COUNT(messages.message_index) AS value
+          FROM requested_session_ids AS requested
+          LEFT JOIN session_documents AS documents
+            ON documents.agent_name = ? AND documents.session_id = requested.session_id
+          LEFT JOIN messages
+            ON messages.agent_name = ? AND messages.session_id = requested.session_id
+          GROUP BY requested.session_id, documents.content_hash
+        `,
+      )
+      .all(...batch, agentName, agentName) as SearchIndexStateRow[];
+    rows.push(...batchRows);
+  }
+
+  return searchIndexStateFromRows(rows, rows);
 }
 
 function escapeFtsTerm(value: string): string {
@@ -563,18 +621,13 @@ export function syncSessionSearchIndex(
         "SELECT session_id, content_hash FROM session_documents WHERE agent_name = ? ORDER BY id",
       )
       .all(agentName) as IndexedSearchRow[];
-    const existingMap = new Map(
-      existingRows.map((row) => [String(row.session_id), String(row.content_hash ?? "")]),
-    );
     const sessionSortIndexMap = new Map(sessions.map((session, index) => [session.id, index]));
     const messageCountRows = db
       .prepare(
         "SELECT session_id, COUNT(*) AS value FROM messages WHERE agent_name = ? GROUP BY session_id",
       )
       .all(agentName) as MessageCountRow[];
-    const messageCountMap = new Map(
-      messageCountRows.map((row) => [String(row.session_id), Number(row.value ?? 0)]),
-    );
+    const searchIndexState = searchIndexStateFromRows(existingRows, messageCountRows);
     const sessionMap = new Map(sessions.map((session) => [session.id, session]));
 
     const toDelete = existingRows
@@ -582,8 +635,8 @@ export function syncSessionSearchIndex(
       .filter((sessionId) => !sessionMap.has(sessionId));
     const toUpsert = sessions.filter(
       (session) =>
-        existingMap.get(session.id) !== sessionContentHash(session) ||
-        messageCountMap.get(session.id) !== session.stats.message_count,
+        searchIndexState.contentHashBySessionId.get(session.id) !== sessionContentHash(session) ||
+        searchIndexState.messageCountBySessionId.get(session.id) !== session.stats.message_count,
     );
     const changedCount = toDelete.length + toUpsert.length;
     const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
@@ -656,22 +709,18 @@ export function syncSessionSearchIndexChanges(
   return withCacheDb((db) => {
     ensureFtsConsistency(db);
     const startedAt = performance.now();
-    const getIndexedRow = db.prepare(
-      "SELECT content_hash FROM session_documents WHERE agent_name = ? AND session_id = ?",
+    const searchIndexState = readSearchIndexState(
+      db,
+      agentName,
+      changes.map(({ session }) => session.id),
     );
-    const getMessageCount = db.prepare(
-      "SELECT COUNT(*) AS value FROM messages WHERE agent_name = ? AND session_id = ?",
+    const toUpsert = changes.filter(
+      ({ session }) =>
+        (searchIndexState.contentHashBySessionId.get(session.id) ?? "") !==
+          sessionContentHash(session) ||
+        (searchIndexState.messageCountBySessionId.get(session.id) ?? 0) !==
+          session.stats.message_count,
     );
-    const toUpsert = changes.filter(({ session }) => {
-      const indexed = getIndexedRow.get(agentName, session.id) as IndexedSearchRow | undefined;
-      const messageCount = getMessageCount.get(agentName, session.id) as
-        | MessageCountRow
-        | undefined;
-      return (
-        String(indexed?.content_hash ?? "") !== sessionContentHash(session) ||
-        Number(messageCount?.value ?? 0) !== session.stats.message_count
-      );
-    });
     const uniqueRemovedSessionIds = Array.from(new Set(removedSessionIds));
     const changedCount = uniqueRemovedSessionIds.length + toUpsert.length;
     const isBulk = shouldBulkSyncSearchIndex(options, changedCount);


### PR DESCRIPTION
## Summary

- batch incremental search-index state reads with a parameter-safe SQLite CTE
- reuse the full-sync hash and message-count map shape
- preserve missing-row defaults and duplicate change behavior
- add regression coverage for bounded query execution and edge cases

## Root cause

`syncSessionSearchIndexChanges` executed one document lookup and one message-count lookup for every change before deciding whether to use bulk mode. A 1,000-change refresh therefore executed 2,000 synchronous state queries.

## Impact

State reads now require `ceil(unique session IDs / 900)` queries. The 10, 100, and 1,000 change fixtures execute 1, 1, and 2 queries respectively. A local single-run measurement reported approximately 0.57 ms, 0.56 ms, and 3.16 ms for those state-read and filter passes.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- Core: 265 tests
- CLI: 92 tests
- Web: 219 tests

Issue: CS-28