### PR TITLE
perf(search): coalesce pending index jobs

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -52,11 +52,13 @@ const workerThreads = vi.hoisted(() => ({
     once: ReturnType<typeof vi.fn>;
     unref: ReturnType<typeof vi.fn>;
     terminate: ReturnType<typeof vi.fn>;
+    emitDone: () => void;
     emitError: (error: Error) => void;
   }>,
   Worker: vi.fn(function (this: unknown, url: URL, options?: { workerData?: unknown }) {
     const workerData = options?.workerData as any;
     const deferredSearchWorker = workerThreads.deferSearchIndexWorkers && workerData?.jobs;
+    const deferredMessageHandlers: Array<(message: unknown) => void> = [];
     const deferredExitHandlers: Array<(code: number) => void> = [];
     const deferredErrorHandlers: Array<(error: Error) => void> = [];
     const runSourceSync = (agent: any) => {
@@ -117,7 +119,10 @@ const workerThreads = vi.hoisted(() => ({
       workerData,
       on: vi.fn((event: string, handler: (message: unknown) => void) => {
         if (event === "message") {
-          if (deferredSearchWorker) return worker;
+          if (deferredSearchWorker) {
+            deferredMessageHandlers.push(handler);
+            return worker;
+          }
           queueMicrotask(() => {
             try {
               if (workerData?.agentName) {
@@ -194,6 +199,17 @@ const workerThreads = vi.hoisted(() => ({
       terminate: vi.fn(async () => {
         for (const handler of deferredExitHandlers) handler(0);
       }),
+      emitDone: () => {
+        for (const handler of deferredMessageHandlers) {
+          handler({
+            type: "done",
+            context: workerData?.context ?? "",
+            durationMs: 0,
+            sessions: workerData?.jobs?.length ?? 0,
+          });
+        }
+        for (const handler of deferredExitHandlers) handler(0);
+      },
       emitError: (error: Error) => {
         for (const handler of deferredErrorHandlers) handler(error);
       },
@@ -1734,8 +1750,68 @@ describe("LiveScanStore", () => {
       expect.objectContaining({ status: "rejected", reason: expect.any(Error) }),
       expect.objectContaining({ status: "rejected", reason: expect.any(Error) }),
     ]);
-    expect((store as any).pendingSearchIndexJobs).toEqual([]);
+    expect((store as any).pendingSearchIndexJobs.batchCount).toBe(0);
     expect((store as any).searchIndexWorker).toBeNull();
+  });
+
+  it("coalesces pending search-index changes to the latest session state", async () => {
+    core.createRegisteredAgents.mockReturnValue([]);
+    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
+
+    const store = new LiveScanStore(false, {}, {}, { deferInitialRefresh: true });
+    await store.initialize();
+    workerThreads.deferSearchIndexWorkers = true;
+    const active = (store as any).enqueueSearchIndexJobs("scan.refresh", [
+      {
+        kind: "full",
+        context: "scan.refresh",
+        agentName: "codex",
+        sessions: [],
+        meta: {},
+      },
+    ]);
+    const pending = [1, 2, 3].map((version) =>
+      (store as any).enqueueSearchIndexJobs("scan.refresh", [
+        {
+          kind: "changes",
+          context: "scan.refresh",
+          agentName: "codex",
+          changes: [
+            {
+              session: makeSession("active", { title: `version ${version}` }),
+              sortIndex: 0,
+            },
+          ],
+          removedSessionIds: [],
+          meta: {},
+        },
+      ]),
+    );
+    const outcomes = Promise.allSettled([active, ...pending]);
+
+    const activeWorker = workerThreads.workers.find((worker) => worker.workerData.jobs)!;
+    activeWorker.emitDone();
+
+    const searchIndexWorkers = workerThreads.workers.filter((worker) => worker.workerData.jobs);
+    expect(searchIndexWorkers).toHaveLength(2);
+    expect(searchIndexWorkers[1]?.workerData.jobs).toEqual([
+      expect.objectContaining({
+        kind: "changes",
+        changes: [
+          expect.objectContaining({
+            session: expect.objectContaining({ id: "active", title: "version 3" }),
+          }),
+        ],
+      }),
+    ]);
+
+    searchIndexWorkers[1]!.emitDone();
+    expect(await outcomes).toEqual([
+      { status: "fulfilled", value: undefined },
+      { status: "fulfilled", value: undefined },
+      { status: "fulfilled", value: undefined },
+      { status: "fulfilled", value: undefined },
+    ]);
   });
 
   it("makes repeated shutdown calls share one worker termination", async () => {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -25,6 +25,7 @@ import {
 } from "@codesesh/core";
 import type { SearchIndexWorkerJob, SearchIndexWorkerMessage } from "./search-index-worker.js";
 import type { ScanRefreshWorkerMessage } from "./scan-refresh-worker.js";
+import { PendingSearchIndexJobs, type SearchIndexJobBatch } from "./pending-search-index-jobs.js";
 import { SessionWatcher, resolveAgentWatchTargets } from "./session-watcher.js";
 
 export { resolveAgentWatchTargets };
@@ -87,15 +88,6 @@ interface SessionRefreshDiff {
   event: SessionsUpdatedEvent | null;
   changedSessions: SessionHeadChange[];
   removedSessionIds: string[];
-}
-
-interface SearchIndexJobBatch {
-  id: number;
-  context: string;
-  jobs: SearchIndexWorkerJob[];
-  settled: boolean;
-  resolve: () => void;
-  reject: (error: Error) => void;
 }
 
 interface LiveScanStoreOptions {
@@ -238,7 +230,7 @@ export class LiveScanStore {
   private searchIndexWorker: Worker | null = null;
   private activeSearchIndexBatch: SearchIndexJobBatch | null = null;
   private nextSearchIndexBatchId = 1;
-  private pendingSearchIndexJobs: SearchIndexJobBatch[] = [];
+  private pendingSearchIndexJobs = new PendingSearchIndexJobs();
   private shutdownPromise: Promise<void> | null = null;
   private shuttingDown = false;
   /** Set once a search-index worker in this process has completed the FTS integrity check. */
@@ -412,7 +404,7 @@ export class LiveScanStore {
     this.shuttingDown = true;
     appLogger.info("search_index.shutdown.started", {
       active_batch_id: this.activeSearchIndexBatch?.id,
-      pending_batches: this.pendingSearchIndexJobs.length,
+      pending_batches: this.pendingSearchIndexJobs.batchCount,
     });
     for (const state of this.refreshStates.values()) {
       if (state.timer) {
@@ -433,12 +425,10 @@ export class LiveScanStore {
     const shutdownError = new Error("Live scan store shut down");
     const worker = this.searchIndexWorker;
     const activeBatch = this.activeSearchIndexBatch;
-    const pendingBatches = this.pendingSearchIndexJobs;
     this.searchIndexWorker = null;
     this.activeSearchIndexBatch = null;
-    this.pendingSearchIndexJobs = [];
     if (activeBatch) this.settleSearchIndexBatch(activeBatch, shutdownError);
-    for (const batch of pendingBatches) this.settleSearchIndexBatch(batch, shutdownError);
+    this.pendingSearchIndexJobs.rejectAll(shutdownError);
     if (worker) await worker.terminate();
     this.pendingEvent = null;
 
@@ -447,8 +437,8 @@ export class LiveScanStore {
       this.watcher = null;
     }
     appLogger.info("search_index.shutdown.completed", {
-      active_batch_id: this.activeSearchIndexBatch?.id,
-      pending_batches: this.pendingSearchIndexJobs.length,
+      active_batch_id: activeBatch?.id,
+      pending_batches: this.pendingSearchIndexJobs.batchCount,
     });
   }
 
@@ -942,51 +932,40 @@ export class LiveScanStore {
     if (jobs.length === 0) return Promise.resolve();
     if (this.shuttingDown) return Promise.reject(new Error("Live scan store shut down"));
 
-    return new Promise((resolve, reject) => {
-      const batch: SearchIndexJobBatch = {
-        id: this.nextSearchIndexBatchId++,
+    const batchId = this.nextSearchIndexBatchId++;
+    const completion = this.pendingSearchIndexJobs.enqueue(batchId, context, jobs);
+    if (this.searchIndexWorker) {
+      appLogger.debug("search_index.worker_queued", {
+        batch_id: batchId,
         context,
-        jobs,
-        settled: false,
-        resolve,
-        reject,
-      };
-
-      if (this.searchIndexWorker) {
-        this.pendingSearchIndexJobs.push(batch);
-        appLogger.debug("search_index.worker_queued", {
-          batch_id: batch.id,
-          context,
-          jobs: jobs.length,
-          pending_jobs: this.pendingSearchIndexJobs.length,
-        });
-        return;
-      }
-
-      this.startSearchIndexJobBatch(batch);
-    });
+        jobs: jobs.length,
+        pending_batches: this.pendingSearchIndexJobs.batchCount,
+        pending_jobs: this.pendingSearchIndexJobs.jobCount,
+        pending_changes: this.pendingSearchIndexJobs.changeCount,
+      });
+    } else {
+      this.startNextSearchIndexJobBatch();
+    }
+    return completion;
   }
 
   private settleSearchIndexBatch(batch: SearchIndexJobBatch, error?: Error): void {
-    if (batch.settled) return;
-    batch.settled = true;
+    if (!this.pendingSearchIndexJobs.settle(batch, error)) return;
     appLogger.info("search_index.worker_settled", {
       batch_id: batch.id,
       context: batch.context,
       result: error ? "rejected" : "resolved",
     });
-    if (error) batch.reject(error);
-    else batch.resolve();
   }
 
   private startNextSearchIndexJobBatch(): void {
     if (this.shuttingDown || this.searchIndexWorker) return;
-    const pendingBatch = this.pendingSearchIndexJobs.shift();
+    const pendingBatch = this.pendingSearchIndexJobs.take();
     if (!pendingBatch) return;
     appLogger.info("search_index.worker_dequeued", {
       batch_id: pendingBatch.id,
       context: pendingBatch.context,
-      pending_batches: this.pendingSearchIndexJobs.length,
+      pending_batches: this.pendingSearchIndexJobs.batchCount,
     });
     this.startSearchIndexJobBatch(pendingBatch);
   }
@@ -1053,7 +1032,7 @@ export class LiveScanStore {
           batch,
           new Error(`Search index worker exited with code ${code}`),
         );
-      } else if (!batch.settled) {
+      } else {
         this.settleSearchIndexBatch(
           batch,
           new Error("Search index worker exited before completing its batch"),

--- a/packages/cli/src/pending-search-index-jobs.test.ts
+++ b/packages/cli/src/pending-search-index-jobs.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import type { SessionCacheMeta, SessionHead } from "@codesesh/core";
+import { PendingSearchIndexJobs } from "./pending-search-index-jobs.js";
+import type { SearchIndexWorkerJob } from "./search-index-worker.js";
+
+function makeSession(id: string, title: string): SessionHead {
+  return {
+    id,
+    slug: `agent/${id}`,
+    title,
+    directory: "/tmp/project",
+    time_created: 1,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+function makeMeta(id: string, version: number): SessionCacheMeta {
+  return { id, sourcePath: `/tmp/${id}-${version}.jsonl` };
+}
+
+function changesJob(
+  agentName: string,
+  changes: Array<{ id: string; version: number }>,
+  removedSessionIds: string[] = [],
+): SearchIndexWorkerJob {
+  return {
+    kind: "changes",
+    context: "scan.refresh",
+    agentName,
+    changes: changes.map(({ id, version }, sortIndex) => ({
+      session: makeSession(id, `version ${version}`),
+      sortIndex,
+    })),
+    removedSessionIds,
+    meta: Object.fromEntries(changes.map(({ id, version }) => [id, makeMeta(id, version)])),
+  };
+}
+
+function fullJob(agentName: string, version: number): SearchIndexWorkerJob {
+  const session = makeSession("full", `version ${version}`);
+  return {
+    kind: "full",
+    context: "scan.backfill",
+    agentName,
+    sessions: [session],
+    meta: { [session.id]: makeMeta(session.id, version) },
+    saveCache: true,
+  };
+}
+
+describe("PendingSearchIndexJobs", () => {
+  it("keeps the latest change and settles every merged caller", async () => {
+    const pending = new PendingSearchIndexJobs();
+    const first = pending.enqueue(1, "first", [
+      changesJob("codex", [{ id: "active", version: 1 }]),
+    ]);
+    const second = pending.enqueue(2, "second", [
+      changesJob("codex", [{ id: "active", version: 2 }]),
+    ]);
+
+    const batch = pending.take()!;
+    expect(batch.context).toBe("second");
+    expect(batch.jobs).toEqual([
+      expect.objectContaining({
+        kind: "changes",
+        changes: [
+          expect.objectContaining({
+            session: expect.objectContaining({ title: "version 2" }),
+          }),
+        ],
+        meta: { active: makeMeta("active", 2) },
+      }),
+    ]);
+
+    expect(pending.settle(batch)).toBe(true);
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    expect(pending.settle(batch)).toBe(false);
+  });
+
+  it("applies delete and re-add transitions in submission order", async () => {
+    const pending = new PendingSearchIndexJobs();
+    const waiters = [
+      pending.enqueue(1, "change", [changesJob("codex", [{ id: "active", version: 1 }])]),
+      pending.enqueue(2, "delete", [changesJob("codex", [], ["active"])]),
+      pending.enqueue(3, "re-add", [changesJob("codex", [{ id: "active", version: 3 }])]),
+    ];
+
+    const batch = pending.take()!;
+    expect(batch.jobs).toEqual([
+      expect.objectContaining({
+        changes: [
+          expect.objectContaining({
+            session: expect.objectContaining({ title: "version 3" }),
+          }),
+        ],
+        removedSessionIds: [],
+        meta: { active: makeMeta("active", 3) },
+      }),
+    ]);
+    pending.settle(batch);
+    await Promise.all(waiters);
+  });
+
+  it("lets a full job replace earlier changes and keeps later changes as an overlay", async () => {
+    const pending = new PendingSearchIndexJobs();
+    const waiters = [
+      pending.enqueue(1, "old change", [changesJob("codex", [{ id: "old", version: 1 }])]),
+      pending.enqueue(2, "full", [fullJob("codex", 2)]),
+      pending.enqueue(3, "new change", [changesJob("codex", [{ id: "new", version: 3 }])]),
+    ];
+
+    const batch = pending.take()!;
+    expect(batch.jobs).toEqual([
+      expect.objectContaining({
+        kind: "full",
+        sessions: [expect.objectContaining({ title: "version 2" })],
+      }),
+      expect.objectContaining({
+        kind: "changes",
+        changes: [expect.objectContaining({ session: expect.objectContaining({ id: "new" }) })],
+      }),
+    ]);
+    pending.settle(batch);
+    await Promise.all(waiters);
+  });
+
+  it("keeps jobs isolated by agent", async () => {
+    const pending = new PendingSearchIndexJobs();
+    const waiters = [
+      pending.enqueue(1, "codex", [changesJob("codex", [{ id: "shared", version: 1 }])]),
+      pending.enqueue(2, "kimi", [changesJob("kimi", [{ id: "shared", version: 2 }])]),
+    ];
+
+    const batch = pending.take()!;
+    expect(batch.jobs).toEqual([
+      expect.objectContaining({ agentName: "codex" }),
+      expect.objectContaining({ agentName: "kimi" }),
+    ]);
+    pending.settle(batch);
+    await Promise.all(waiters);
+  });
+
+  it("bounds queued work by unique session count", async () => {
+    const pending = new PendingSearchIndexJobs();
+    const waiters = Array.from({ length: 1_000 }, (_, index) =>
+      pending.enqueue(index + 1, "scan.refresh", [
+        changesJob("codex", [{ id: "active", version: index + 1 }]),
+      ]),
+    );
+
+    expect(pending.batchCount).toBe(1);
+    expect(pending.jobCount).toBe(1);
+    expect(pending.changeCount).toBe(1);
+    const batch = pending.take()!;
+    expect(batch.jobs[0]).toEqual(
+      expect.objectContaining({
+        changes: [
+          expect.objectContaining({
+            session: expect.objectContaining({ title: "version 1000" }),
+          }),
+        ],
+      }),
+    );
+    pending.settle(batch);
+    await Promise.all(waiters);
+  });
+
+  it("rejects every merged caller when the worker batch fails", async () => {
+    const pending = new PendingSearchIndexJobs();
+    const waiters = [
+      pending.enqueue(1, "first", [changesJob("codex", [{ id: "one", version: 1 }])]),
+      pending.enqueue(2, "second", [changesJob("codex", [{ id: "two", version: 2 }])]),
+    ];
+    const outcomes = Promise.allSettled(waiters);
+    const batch = pending.take()!;
+
+    pending.settle(batch, new Error("index failed"));
+
+    expect(await outcomes).toEqual([
+      expect.objectContaining({ status: "rejected", reason: new Error("index failed") }),
+      expect.objectContaining({ status: "rejected", reason: new Error("index failed") }),
+    ]);
+  });
+});

--- a/packages/cli/src/pending-search-index-jobs.ts
+++ b/packages/cli/src/pending-search-index-jobs.ts
@@ -1,0 +1,198 @@
+import type { SearchIndexSyncOptions, SessionCacheMeta, SessionHeadChange } from "@codesesh/core";
+import type { SearchIndexWorkerJob } from "./search-index-worker.js";
+
+type FullSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "full" }>;
+type ChangesSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "changes" }>;
+
+interface JobWaiter {
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+interface PendingChanges {
+  context: string;
+  agentName: string;
+  changesBySessionId: Map<string, SessionHeadChange>;
+  removedSessionIds: Set<string>;
+  meta: Record<string, SessionCacheMeta>;
+  searchIndexOptions?: SearchIndexSyncOptions;
+}
+
+interface PendingAgentJobs {
+  full?: FullSearchIndexJob;
+  changes?: PendingChanges;
+}
+
+export interface SearchIndexJobBatch {
+  readonly id: number;
+  readonly context: string;
+  readonly jobs: SearchIndexWorkerJob[];
+}
+
+class PendingSearchIndexJobBatch implements SearchIndexJobBatch {
+  context: string;
+  private readonly jobsByAgent = new Map<string, PendingAgentJobs>();
+  private readonly waiters: JobWaiter[] = [];
+  private settled = false;
+
+  constructor(
+    readonly id: number,
+    context: string,
+    jobs: SearchIndexWorkerJob[],
+    waiter: JobWaiter,
+  ) {
+    this.context = context;
+    this.merge(context, jobs, waiter);
+  }
+
+  get jobs(): SearchIndexWorkerJob[] {
+    const jobs: SearchIndexWorkerJob[] = [];
+    for (const pending of this.jobsByAgent.values()) {
+      if (pending.full) jobs.push(pending.full);
+      if (pending.changes) jobs.push(changesJobFromPending(pending.changes));
+    }
+    return jobs;
+  }
+
+  get changeCount(): number {
+    let count = 0;
+    for (const pending of this.jobsByAgent.values()) {
+      if (!pending.changes) continue;
+      count += pending.changes.changesBySessionId.size + pending.changes.removedSessionIds.size;
+    }
+    return count;
+  }
+
+  merge(context: string, jobs: SearchIndexWorkerJob[], waiter: JobWaiter): void {
+    this.context = context;
+    this.waiters.push(waiter);
+    for (const job of jobs) this.mergeJob(job);
+  }
+
+  settle(error?: Error): boolean {
+    if (this.settled) return false;
+    this.settled = true;
+    for (const waiter of this.waiters) {
+      if (error) waiter.reject(error);
+      else waiter.resolve();
+    }
+    this.waiters.length = 0;
+    return true;
+  }
+
+  private mergeJob(job: SearchIndexWorkerJob): void {
+    const pending = this.jobsByAgent.get(job.agentName) ?? {};
+    this.jobsByAgent.set(job.agentName, pending);
+
+    if (job.kind === "full") {
+      pending.full = job;
+      pending.changes = undefined;
+      return;
+    }
+
+    pending.changes ??= createPendingChanges(job);
+    mergeChanges(pending.changes, job);
+  }
+}
+
+export class PendingSearchIndexJobs {
+  private pendingBatch: PendingSearchIndexJobBatch | null = null;
+
+  get batchCount(): number {
+    return this.pendingBatch ? 1 : 0;
+  }
+
+  get jobCount(): number {
+    return this.pendingBatch?.jobs.length ?? 0;
+  }
+
+  get changeCount(): number {
+    return this.pendingBatch?.changeCount ?? 0;
+  }
+
+  enqueue(id: number, context: string, jobs: SearchIndexWorkerJob[]): Promise<void> {
+    if (jobs.length === 0) return Promise.resolve();
+
+    return new Promise((resolve, reject) => {
+      const waiter = { resolve, reject };
+      if (this.pendingBatch) {
+        this.pendingBatch.merge(context, jobs, waiter);
+      } else {
+        this.pendingBatch = new PendingSearchIndexJobBatch(id, context, jobs, waiter);
+      }
+    });
+  }
+
+  take(): SearchIndexJobBatch | null {
+    const batch = this.pendingBatch;
+    this.pendingBatch = null;
+    return batch;
+  }
+
+  settle(batch: SearchIndexJobBatch, error?: Error): boolean {
+    return batch instanceof PendingSearchIndexJobBatch && batch.settle(error);
+  }
+
+  rejectAll(error: Error): void {
+    const batch = this.take();
+    if (batch) this.settle(batch, error);
+  }
+}
+
+function createPendingChanges(job: ChangesSearchIndexJob): PendingChanges {
+  return {
+    context: job.context,
+    agentName: job.agentName,
+    changesBySessionId: new Map(),
+    removedSessionIds: new Set(),
+    meta: {},
+    searchIndexOptions: job.searchIndexOptions,
+  };
+}
+
+function mergeChanges(pending: PendingChanges, job: ChangesSearchIndexJob): void {
+  pending.context = job.context;
+  pending.searchIndexOptions = mergeSearchIndexOptions(
+    pending.searchIndexOptions,
+    job.searchIndexOptions,
+  );
+
+  for (const sessionId of job.removedSessionIds) {
+    pending.changesBySessionId.delete(sessionId);
+    pending.removedSessionIds.add(sessionId);
+    delete pending.meta[sessionId];
+  }
+
+  for (const change of job.changes) {
+    const sessionId = change.session.id;
+    pending.removedSessionIds.delete(sessionId);
+    pending.changesBySessionId.set(sessionId, change);
+    if (Object.hasOwn(job.meta, sessionId)) pending.meta[sessionId] = job.meta[sessionId]!;
+    else delete pending.meta[sessionId];
+  }
+
+  for (const [sessionId, meta] of Object.entries(job.meta)) {
+    if (!pending.removedSessionIds.has(sessionId)) pending.meta[sessionId] = meta;
+  }
+}
+
+function mergeSearchIndexOptions(
+  current: SearchIndexSyncOptions | undefined,
+  incoming: SearchIndexSyncOptions | undefined,
+): SearchIndexSyncOptions | undefined {
+  if (!current) return incoming;
+  if (!incoming) return current;
+  return { ...current, ...incoming };
+}
+
+function changesJobFromPending(pending: PendingChanges): ChangesSearchIndexJob {
+  return {
+    kind: "changes",
+    context: pending.context,
+    agentName: pending.agentName,
+    changes: [...pending.changesBySessionId.values()],
+    removedSessionIds: [...pending.removedSessionIds],
+    meta: pending.meta,
+    ...(pending.searchIndexOptions ? { searchIndexOptions: pending.searchIndexOptions } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

- replace the unbounded pending search-index FIFO with a coalescing job module
- keep only the latest change per agent/session while preserving delete, re-add, and full-job ordering semantics
- settle every merged caller when the resulting worker batch succeeds or fails
- preserve atomic shutdown behavior and expose bounded pending metrics
- add module-level and LiveScanStore integration coverage

## Root cause

While a search-index worker was busy, every refresh batch was appended to an unbounded FIFO. Repeated updates for the same active session were therefore parsed and indexed once per queued event, even though only the latest state was useful.

## Impact

Pending worker payload now scales with unique agents and sessions instead of refresh event count. A 1,000-update fixture for one session coalesces to one batch, one job, and one change in approximately 3 ms locally. Promise waiters remain per caller so every submission settles correctly.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- Core: 265 tests
- CLI: 99 tests
- Web: 219 tests

Issue: CS-27