### PR TITLE
refactor: browser-safe HTTP contract module (CS-29)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@codesesh/core": "workspace:*",
     "@tailwindcss/postcss": "^4.3.0",
     "@tailwindcss/vite": "^4.3.0",
     "@testing-library/dom": "^10.4.1",

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -14,7 +14,7 @@ export interface LandingSession extends SessionHead {
 export interface LandingAgentItem {
   key: string;
   name: string;
-  icon: string;
+  icon?: string;
   count: number;
 }
 
@@ -125,7 +125,9 @@ function RecommendedAgents({ agentItems }: { agentItems: LandingAgentItem[] }) {
               to={`/${agent.key}`}
               className="flex min-h-11 items-center gap-2 rounded-sm border border-transparent px-3 py-2 transition-colors duration-200 hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
             >
-              <img src={agent.icon} alt={agent.name} className="size-4 object-contain" />
+              {agent.icon ? (
+                <img src={agent.icon} alt={agent.name} className="size-4 object-contain" />
+              ) : null}
               <span className="console-mono flex-1 text-xs text-[var(--console-text)]">
                 {agent.name}
               </span>
@@ -310,7 +312,9 @@ export function DetailLanding({
                   to={`/${agent.key}`}
                   className="flex items-center gap-2 rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
                 >
-                  <img src={agent.icon} alt={agent.name} className="size-4 object-contain" />
+                  {agent.icon ? (
+                    <img src={agent.icon} alt={agent.name} className="size-4 object-contain" />
+                  ) : null}
                   <span className="console-mono flex-1 text-xs text-[var(--console-text)]">
                     {agent.name}
                   </span>

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -1,16 +1,12 @@
 import { useEffect, useEffectEvent, useState } from "react";
-import {
-  type AppConfig,
-  type ScanStatusEvent,
-  type SessionsUpdatedEvent,
-  subscribeSessionUpdates,
-} from "../lib/api";
+import { type AppConfig, type ScanStatusEvent, subscribeSessionUpdates } from "../lib/api";
+import type { LiveSessionsUpdate } from "../lib/live-update";
 import type { ViewState } from "../lib/view-state";
 
 interface LiveSyncDeps {
   appConfig: AppConfig | null;
   viewState: ViewState;
-  applySessionsLiveEvent: (event: SessionsUpdatedEvent) => void;
+  applySessionsLiveEvent: (event: LiveSessionsUpdate) => void;
   refreshAgents: () => Promise<unknown>;
   refreshSessions: (window: AppConfig["window"]) => Promise<unknown>;
   refreshProjects: () => Promise<unknown>;
@@ -44,7 +40,7 @@ export function useLiveSync(deps: LiveSyncDeps) {
     setScanStatus,
   } = deps;
 
-  const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
+  const syncLiveUpdate = useEffectEvent(async (event: LiveSessionsUpdate) => {
     try {
       const canApplySessionUpdate = Boolean(event.changedSessionHeads && event.removedSessionRefs);
       if (canApplySessionUpdate) {

--- a/apps/web/src/hooks/useSessions.ts
+++ b/apps/web/src/hooks/useSessions.ts
@@ -1,11 +1,6 @@
 import { useCallback, useState } from "react";
-import {
-  type AppConfig,
-  type SessionHead,
-  type SessionsUpdatedEvent,
-  fetchSessions,
-} from "../lib/api";
-import { applyLiveSessionUpdate } from "../lib/live-update";
+import { type AppConfig, type SessionHead, fetchSessions } from "../lib/api";
+import { applyLiveSessionUpdate, type LiveSessionsUpdate } from "../lib/live-update";
 
 /**
  * Owns the session list. Exposes refresh(window) for a full reload and
@@ -21,7 +16,7 @@ export function useSessions() {
     return result.sessions;
   }, []);
 
-  const applyLiveEvent = useCallback((event: SessionsUpdatedEvent) => {
+  const applyLiveEvent = useCallback((event: LiveSessionsUpdate) => {
     setSessions((current) => applyLiveSessionUpdate(current, event) ?? current);
   }, []);
 

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,10 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SAMPLE_DASHBOARD_DATA } from "@codesesh/core/contract";
 import {
+  fetchDashboard,
   fetchSearchResults,
   fetchSessionData,
   fetchSessions,
   subscribeSessionUpdates,
 } from "./api";
+
+describe("fetchDashboard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("decodes the dashboard response as-is", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(SAMPLE_DASHBOARD_DATA),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchDashboard();
+
+    expect(result).toEqual(SAMPLE_DASHBOARD_DATA);
+  });
+});
 
 describe("fetchSessionData", () => {
   afterEach(() => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,283 +1,51 @@
-export interface AgentInfo {
-  name: string;
-  displayName: string;
-  count: number;
-  icon: string;
-}
+export type {
+  AgentInfo,
+  SmartTag,
+  FileActivityKind,
+  CostSource,
+  SessionHead,
+  SessionFileActivity,
+  FileActivityResult,
+  ProjectIdentityKind,
+  ProjectIdentity,
+  MessageTokens,
+  ToolPartState,
+  MessagePart,
+  Message,
+  SessionData,
+  ScanStatusEvent,
+  BackfillStatus,
+  AgentScanStatus,
+  DashboardAgentStat,
+  DashboardDailyBucket,
+  DailyTokenBucket,
+  ModelDistributionEntry,
+  DashboardTotals,
+  DashboardRecentSession,
+  DashboardData,
+  AppConfig,
+  SearchResult,
+  SessionsUpdatedEvent,
+  ApiProjectGroup as ProjectGroup,
+  ApiProjectAgentStat as ProjectAgentStat,
+  BookmarkRecord as BookmarkedSessionSnapshot,
+} from "@codesesh/core/contract";
 
-export type SmartTag =
-  | "bugfix"
-  | "refactoring"
-  | "feature-dev"
-  | "testing"
-  | "docs"
-  | "git-ops"
-  | "build-deploy"
-  | "exploration"
-  | "planning";
-
-export type FileActivityKind = "read" | "edit" | "write" | "delete";
-
-export type CostSource = "recorded" | "estimated";
-
-export interface SessionHead {
-  id: string;
-  slug: string;
-  title: string;
-  directory: string;
-  project_identity?: ProjectIdentity;
-  time_created: number;
-  time_updated?: number;
-  stats: {
-    message_count: number;
-    total_input_tokens: number;
-    total_output_tokens: number;
-    total_cost: number;
-    cost_source?: CostSource;
-    total_tokens?: number;
-  };
-  smart_tags?: SmartTag[];
-  smart_tags_source_updated_at?: number;
-}
-
-export interface SessionFileActivity {
-  agent_name: string;
-  session_id: string;
-  project_identity_key: string;
-  path: string;
-  kind: FileActivityKind;
-  count: number;
-  latest_time: number;
-}
-
-export interface FileActivityResult extends SessionFileActivity {
-  session: SessionHead;
-}
-
-export type ProjectIdentityKind =
-  | "git_remote"
-  | "git_common_dir"
-  | "manifest_path"
-  | "synthetic"
-  | "path"
-  | "loose";
-
-export interface ProjectIdentity {
-  kind: ProjectIdentityKind;
-  key: string;
-  displayName: string;
-}
-
-export interface MessageTokens {
-  input?: number;
-  output?: number;
-  reasoning?: number;
-  cache_read?: number;
-  cache_create?: number;
-}
-
-export interface ToolPartState {
-  status?: "running" | "completed" | "error";
-  input?: unknown;
-  arguments?: unknown;
-  output?: unknown;
-  result?: unknown;
-  error?: unknown;
-  metadata?: unknown;
-  prompt?: unknown;
-  [key: string]: unknown;
-}
-
-export interface MessagePart {
-  type: "text" | "tool" | "reasoning" | "plan";
-  text?: unknown;
-  tool?: string;
-  title?: string;
-  nickname?: string;
-  subagent_id?: string;
-  input?: unknown;
-  output?: unknown;
-  approval_status?: "success" | "fail";
-  callID?: string;
-  state?: ToolPartState;
-  time_created?: number;
-}
-
-export interface Message {
-  id: string;
-  role: "user" | "assistant" | "tool";
-  agent?: string | null;
-  time_created: number;
-  time_completed?: number | null;
-  mode?: string | null;
-  model?: string | null;
-  provider?: string | null;
-  tokens?: MessageTokens;
-  cost?: number;
-  cost_source?: CostSource;
-  parts: MessagePart[];
-  subagent_id?: string;
-  nickname?: string;
-}
-
-export interface SessionData {
-  id: string;
-  title: string;
-  slug?: string | null;
-  directory: string;
-  project_identity?: ProjectIdentity;
-  version?: string | null;
-  time_created: number;
-  time_updated?: number;
-  summary_files?: unknown;
-  stats: {
-    message_count: number;
-    total_input_tokens: number;
-    total_output_tokens: number;
-    total_cost: number;
-    cost_source?: CostSource;
-    total_tokens?: number;
-  };
-  messages: Message[];
-  smart_tags?: SmartTag[];
-  smart_tags_source_updated_at?: number;
-  file_activity?: SessionFileActivity[];
-}
-
-export interface ProjectGroup {
-  identityKind: ProjectIdentityKind;
-  identityKey: string;
-  displayName: string;
-  sources: string[];
-  sessionCount: number;
-  lastActivity: number | null;
-  messages: number;
-  tokens: number;
-  cost: number;
-  cost_source?: CostSource;
-  agentStats: ProjectAgentStat[];
-}
-
-export interface ProjectAgentStat {
-  name: string;
-  sessions: number;
-  messages: number;
-  tokens: number;
-  cost: number;
-}
-
-export interface SessionsUpdatedEvent {
-  type: "sessions-updated";
-  changedAgents: string[];
-  newSessions: number;
-  updatedSessions: number;
-  removedSessions: number;
-  totalSessions: number;
-  timestamp: number;
-  changedSessionHeads?: Array<{ agentName: string; session: SessionHead }>;
-  removedSessionRefs?: Array<{ agentName: string; sessionId: string }>;
-}
-
-export interface ScanStatusEvent {
-  type: "scan-status";
-  active: boolean;
-  phase: "idle" | "indexing" | "initializing" | "scanning";
-  pendingAgents: string[];
-  scanningAgents: string[];
-  completedAgents: string[];
-  agentStatuses: Record<string, AgentScanStatus>;
-  totalAgents: number;
-  startedAt?: number;
-  updatedAt: number;
-  completedAt?: number;
-  backfill: BackfillStatus;
-}
-
-export interface BackfillStatus {
-  active: boolean;
-  pendingAgents: string[];
-  currentAgent?: string;
-  completedAgents: string[];
-}
-
-export interface AgentScanStatus {
-  agentName: string;
-  status: "pending" | "scanning" | "complete";
-  total?: number;
-  processed?: number;
-  sessions?: number;
-  startedAt?: number;
-  updatedAt: number;
-  completedAt?: number;
-}
-
-export interface DashboardAgentStat {
-  name: string;
-  displayName: string;
-  icon: string;
-  sessions: number;
-  messages: number;
-  tokens: number;
-}
-
-export interface DashboardDailyBucket {
-  date: string;
-  sessions: number;
-  messages: number;
-}
-
-export interface DailyTokenBucket {
-  date: string;
-  input: number;
-  output: number;
-  cache_read: number;
-  cache_create: number;
-}
-
-export interface ModelDistributionEntry {
-  model: string;
-  tokens: number;
-  sessions: number;
-}
-
-export interface DashboardTotals {
-  sessions: number;
-  messages: number;
-  tokens: number;
-  cost: number;
-  cost_source?: CostSource;
-  latestActivity?: number;
-}
-
-export interface DashboardRecentSession extends SessionHead {
-  agentName: string;
-}
-
-export interface DashboardData {
-  totals: DashboardTotals;
-  perAgent: DashboardAgentStat[];
-  dailyActivity: DashboardDailyBucket[];
-  dailyTokenActivity: DailyTokenBucket[];
-  modelDistribution: ModelDistributionEntry[];
-  recentSessions: DashboardRecentSession[];
-  recentFileActivities: FileActivityResult[];
-  window: { from?: number; to: number; days?: number };
-}
-
-export interface AppConfig {
-  window: {
-    from?: number;
-    to?: number;
-    days?: number;
-  };
-}
-
-export interface SearchResult {
-  agentName: string;
-  session: SessionHead;
-  snippet: string;
-  matchType: "recent" | "title" | "user_message" | "assistant_reply" | "tool_output" | "file_path";
-}
+import type {
+  AgentInfo,
+  ApiProjectGroup,
+  AppConfig,
+  BookmarkRecord as BookmarkedSessionSnapshot,
+  DashboardData,
+  FileActivityKind,
+  ProjectIdentityKind,
+  ScanStatusEvent,
+  SearchResult,
+  SessionData,
+  SessionHead,
+  SessionsUpdatedEvent,
+  SmartTag,
+} from "@codesesh/core/contract";
 
 export interface SearchRequestOptions {
   agent?: string;
@@ -288,18 +56,6 @@ export interface SearchRequestOptions {
   fileKind?: FileActivityKind;
   costMin?: number;
   costMax?: number;
-}
-
-export interface BookmarkedSessionSnapshot {
-  agentKey: string;
-  sessionId: string;
-  fullPath: string;
-  title: string;
-  directory: string;
-  time_created: number;
-  time_updated?: number;
-  stats: SessionHead["stats"];
-  bookmarked_at: number;
 }
 
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
@@ -323,7 +79,7 @@ export async function fetchAgents(): Promise<AgentInfo[]> {
   return fetchJson("/api/agents");
 }
 
-export async function fetchProjects(): Promise<{ projects: ProjectGroup[] }> {
+export async function fetchProjects(): Promise<{ projects: ApiProjectGroup[] }> {
   return fetchJson("/api/projects");
 }
 

--- a/apps/web/src/lib/live-update.test.ts
+++ b/apps/web/src/lib/live-update.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { SAMPLE_SESSIONS_UPDATED_EVENT } from "@codesesh/core/contract";
 import { applyLiveSessionUpdate, compareSessionActivityDesc } from "./live-update";
 import type { SessionHead, SessionsUpdatedEvent } from "./api";
 
@@ -51,5 +52,11 @@ describe("applyLiveSessionUpdate", () => {
     } as unknown as SessionsUpdatedEvent;
     const result = applyLiveSessionUpdate([makeSession("old", 100)], event);
     expect(result![0]!.id).toBe("new");
+  });
+
+  it("applies a real wire SessionsUpdatedEvent fixture", () => {
+    const result = applyLiveSessionUpdate([], SAMPLE_SESSIONS_UPDATED_EVENT);
+    expect(result).not.toBeNull();
+    expect(result![0]!.id).toBe(SAMPLE_SESSIONS_UPDATED_EVENT.changedSessionHeads[0]!.session.id);
   });
 });

--- a/apps/web/src/lib/live-update.ts
+++ b/apps/web/src/lib/live-update.ts
@@ -6,13 +6,24 @@ import type { SessionHead, SessionsUpdatedEvent } from "./api";
 import { getSessionAgentKey } from "./session-indexes";
 import { getSessionRouteKey } from "./session-indexes";
 
+/**
+ * A sessions-updated notice that may lack the incremental diff arrays.
+ * The SSE stream always sends the full wire SessionsUpdatedEvent, but a
+ * reconnect synthesizes a refresh-everything intent without that diff.
+ */
+export type LiveSessionsUpdate = Omit<
+  SessionsUpdatedEvent,
+  "changedSessionHeads" | "removedSessionRefs"
+> &
+  Partial<Pick<SessionsUpdatedEvent, "changedSessionHeads" | "removedSessionRefs">>;
+
 export function compareSessionActivityDesc(a: SessionHead, b: SessionHead): number {
   return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
 }
 
 export function applyLiveSessionUpdate(
   sessions: SessionHead[],
-  event: SessionsUpdatedEvent,
+  event: LiveSessionsUpdate,
 ): SessionHead[] | null {
   if (!event.changedSessionHeads || !event.removedSessionRefs) return null;
 

--- a/packages/cli/src/api/__tests__/contract.test.ts
+++ b/packages/cli/src/api/__tests__/contract.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { SAMPLE_SCAN_STATUS_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
+import type { ScanResult } from "@codesesh/core";
+import { createApiRoutes } from "../routes.js";
+import type { ScanResultSource } from "../handlers.js";
+import type { LiveScanStore } from "../../live-scan.js";
+
+function makeScanSource(): ScanResultSource {
+  return {
+    getSnapshot: () =>
+      ({
+        sessions: [SAMPLE_SESSION_HEAD],
+        byAgent: { claudecode: [SAMPLE_SESSION_HEAD] },
+        agents: [],
+      }) as ScanResult,
+  };
+}
+
+function makeStoreStub(): LiveScanStore {
+  return {
+    getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
+    subscribe: () => () => {},
+    subscribeScanStatus: () => () => {},
+  } as unknown as LiveScanStore;
+}
+
+describe("cli routes stay wire-compatible with @codesesh/core/contract", () => {
+  it("GET /status returns the ScanStatusEvent fixture as-is", async () => {
+    const app = createApiRoutes(makeScanSource(), makeStoreStub());
+    const res = await app.request("/status");
+    expect(await res.json()).toEqual(SAMPLE_SCAN_STATUS_EVENT);
+  });
+
+  it("SSE /events opens with the ScanStatusEvent fixture from the store", async () => {
+    const app = createApiRoutes(makeScanSource(), makeStoreStub());
+    const controller = new AbortController();
+    const res = await app.request("/events", { signal: controller.signal });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let text = "";
+    // "connected" then "scan-status" are each written as an "event:" line + a "data:" line.
+    for (let i = 0; i < 4; i++) {
+      const { value } = await reader.read();
+      text += decoder.decode(value);
+    }
+    controller.abort();
+
+    expect(text).toContain(
+      `event: scan-status\ndata: ${JSON.stringify(SAMPLE_SCAN_STATUS_EVENT)}\n\n`,
+    );
+  });
+
+  it("GET /search falls back to recent sessions shaped like the contract SearchResult", async () => {
+    const app = createApiRoutes(makeScanSource());
+    const res = await app.request("/search");
+    const body = (await res.json()) as { results: unknown[] };
+
+    expect(body.results).toEqual([
+      {
+        agentName: "claudecode",
+        session: SAMPLE_SESSION_HEAD,
+        snippet: `Recent session · ${SAMPLE_SESSION_HEAD.directory}`,
+        matchType: "recent",
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -7,6 +7,13 @@ import type {
   SessionHead,
   SmartTag,
 } from "@codesesh/core";
+import type {
+  ApiProjectAgentStat,
+  ApiProjectGroup,
+  AppConfig,
+  ScanStatusEvent,
+  SearchResult,
+} from "@codesesh/core/contract";
 import {
   BookmarkStorageUnavailableError,
   createProjectScopeMatcher,
@@ -40,7 +47,6 @@ import {
   type FileActivityKind,
   type ProjectScopeMatcher,
   type ProjectIdentityRef,
-  type SearchMatchType,
   type SearchOptions,
   type SearchQueryFilters,
 } from "@codesesh/core";
@@ -51,37 +57,7 @@ export interface ScanResultSource {
 }
 
 export interface ScanStatusSource {
-  getScanStatus(): {
-    type: "scan-status";
-    active: boolean;
-    phase: "idle" | "indexing" | "initializing" | "scanning";
-    pendingAgents: string[];
-    scanningAgents: string[];
-    completedAgents: string[];
-    agentStatuses: Record<
-      string,
-      {
-        agentName: string;
-        status: "pending" | "scanning" | "complete";
-        total?: number;
-        processed?: number;
-        sessions?: number;
-        startedAt?: number;
-        updatedAt: number;
-        completedAt?: number;
-      }
-    >;
-    totalAgents: number;
-    startedAt?: number;
-    updatedAt: number;
-    completedAt?: number;
-    backfill: {
-      active: boolean;
-      pendingAgents: string[];
-      currentAgent?: string;
-      completedAgents: string[];
-    };
-  };
+  getScanStatus(): ScanStatusEvent;
 }
 
 export interface SessionListDefaults {
@@ -94,29 +70,6 @@ export interface SessionListDefaults {
 interface ClientLogPayload {
   event?: unknown;
   data?: unknown;
-}
-
-interface ApiSearchResult {
-  agentName: string;
-  session: SessionHead;
-  snippet: string;
-  matchType: SearchMatchType;
-}
-
-interface ApiProjectAgentStat {
-  name: string;
-  sessions: number;
-  messages: number;
-  tokens: number;
-  cost: number;
-}
-
-interface ApiProjectGroup extends ProjectGroup {
-  messages: number;
-  tokens: number;
-  cost: number;
-  cost_source?: SessionHead["stats"]["cost_source"];
-  agentStats: ApiProjectAgentStat[];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -309,9 +262,9 @@ function mergeSearchOptions(options: SearchOptions, filters: SearchQueryFilters)
   };
 }
 
-function mergeSearchResults(results: ApiSearchResult[], limit: number): ApiSearchResult[] {
+function mergeSearchResults(results: SearchResult[], limit: number): SearchResult[] {
   const seen = new Set<string>();
-  const merged: ApiSearchResult[] = [];
+  const merged: SearchResult[] = [];
 
   for (const result of results) {
     const key = `${result.agentName}/${result.session.id}`;
@@ -442,7 +395,7 @@ function matchesRecentSearchFilters(
 function recentSearchSessions(
   scanResult: ScanResult,
   options: SearchOptions & { limit: number },
-): ApiSearchResult[] {
+): SearchResult[] {
   const projectScope = options.cwd ? createProjectScopeMatcher(options.cwd) : null;
   const entries = options.agent
     ? ([[options.agent, scanResult.byAgent[options.agent] ?? []]] as Array<[string, SessionHead[]]>)
@@ -469,13 +422,14 @@ function recentSearchSessions(
 }
 
 export function handleGetConfig(c: Context, defaults: SessionListDefaults) {
-  return c.json({
+  const payload: AppConfig = {
     window: {
       from: defaults.from,
       to: defaults.to,
       days: defaults.days,
     },
-  });
+  };
+  return c.json(payload);
 }
 
 export function handleGetScanStatus(c: Context, scanSource: ScanStatusSource) {
@@ -599,7 +553,7 @@ export function handleSearchSessions(
     mergedSearchOptions.file ??
     (!parsedQuery.text ? parsedQuery.filters.file : undefined) ??
     (!parsedQuery.hasQualifiers && query ? parsedQuery.text || query : "");
-  const results: ApiSearchResult[] = mergeSearchResults(
+  const results: SearchResult[] = mergeSearchResults(
     [
       ...(fileQuery ? searchFileActivitySessions(fileQuery, mergedSearchOptions) : []),
       ...searchSessions(query, mergedSearchOptions),

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -30,56 +30,14 @@ import { SessionWatcher, resolveAgentWatchTargets } from "./session-watcher.js";
 
 export { resolveAgentWatchTargets };
 import { appLogger, logSearchIndexSync } from "./logging.js";
+import type {
+  AgentScanStatus,
+  BackfillStatus,
+  ScanStatusEvent,
+  SessionsUpdatedEvent,
+} from "@codesesh/core/contract";
 
-export interface SessionsUpdatedEvent {
-  type: "sessions-updated";
-  changedAgents: string[];
-  newSessions: number;
-  updatedSessions: number;
-  removedSessions: number;
-  totalSessions: number;
-  timestamp: number;
-  changedSessionHeads: Array<{ agentName: string; session: SessionHead }>;
-  removedSessionRefs: Array<{ agentName: string; sessionId: string }>;
-}
-
-export interface ScanStatusEvent {
-  type: "scan-status";
-  active: boolean;
-  phase: "idle" | "indexing" | "initializing" | "scanning";
-  pendingAgents: string[];
-  scanningAgents: string[];
-  completedAgents: string[];
-  agentStatuses: Record<string, AgentScanStatus>;
-  totalAgents: number;
-  startedAt?: number;
-  updatedAt: number;
-  completedAt?: number;
-  backfill: BackfillStatus;
-}
-
-/**
- * Full-history reconciliation runs independently of the main scan phase above:
- * startup only syncs the display window, so a low-priority background pass
- * (capped at one agent at a time) periodically re-checks the rest of history.
- */
-export interface BackfillStatus {
-  active: boolean;
-  pendingAgents: string[];
-  currentAgent?: string;
-  completedAgents: string[];
-}
-
-export interface AgentScanStatus {
-  agentName: string;
-  status: "pending" | "scanning" | "complete";
-  total?: number;
-  processed?: number;
-  sessions?: number;
-  startedAt?: number;
-  updatedAt: number;
-  completedAt?: number;
-}
+export type { AgentScanStatus, BackfillStatus, ScanStatusEvent, SessionsUpdatedEvent };
 
 type StoreListener = (event: SessionsUpdatedEvent) => void;
 type ScanStatusListener = (event: ScanStatusEvent) => void;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./contract": {
+      "types": "./dist/contract/index.d.ts",
+      "import": "./dist/contract/index.mjs",
+      "require": "./dist/contract/index.js"
     }
   },
   "scripts": {

--- a/packages/core/src/analytics/dashboard.ts
+++ b/packages/core/src/analytics/dashboard.ts
@@ -6,6 +6,27 @@
  */
 import type { AgentInfo } from "../types/index.js";
 import type { ProjectIdentityKind, SessionHead } from "../types/session.js";
+import type {
+  DailyTokenBucket,
+  DashboardAgentStat,
+  DashboardAggregate,
+  DashboardDailyBucket,
+  DashboardData,
+  DashboardRecentSession,
+  DashboardTotals,
+  ModelDistributionEntry,
+} from "../contract/index.js";
+
+export type {
+  DailyTokenBucket,
+  DashboardAgentStat,
+  DashboardAggregate,
+  DashboardDailyBucket,
+  DashboardData,
+  DashboardRecentSession,
+  DashboardTotals,
+  ModelDistributionEntry,
+};
 
 export const DASHBOARD_RECENT_LIMIT = 10;
 
@@ -13,39 +34,6 @@ export interface DashboardScope {
   agent?: string;
   projectKind?: ProjectIdentityKind;
   projectKey?: string;
-}
-
-export interface DashboardAgentStat {
-  name: string;
-  displayName: string;
-  icon: string;
-  sessions: number;
-  messages: number;
-  tokens: number;
-}
-
-export interface DashboardDailyBucket {
-  date: string;
-  sessions: number;
-  messages: number;
-}
-
-export interface DailyTokenBucket {
-  date: string;
-  input: number;
-  output: number;
-  cache_read: number;
-  cache_create: number;
-}
-
-export interface ModelDistributionEntry {
-  model: string;
-  tokens: number;
-  sessions: number;
-}
-
-export interface DashboardRecentSession extends SessionHead {
-  agentName: string;
 }
 
 interface DashboardAgentAggregate {
@@ -57,29 +45,6 @@ interface DashboardAgentAggregate {
 interface DashboardRecentCandidate {
   session: SessionHead;
   activity: number;
-}
-
-export interface DashboardTotals {
-  sessions: number;
-  messages: number;
-  tokens: number;
-  cost: number;
-  cost_source?: "estimated" | "recorded";
-  latestActivity?: number;
-}
-
-export interface DashboardAggregate {
-  totals: DashboardTotals;
-  perAgent: DashboardAgentStat[];
-  dailyActivity: DashboardDailyBucket[];
-  dailyTokenActivity: DailyTokenBucket[];
-  modelDistribution: ModelDistributionEntry[];
-  recentSessions: DashboardRecentSession[];
-}
-
-export interface DashboardData extends DashboardAggregate {
-  recentFileActivities: unknown[];
-  window: { from?: number; to: number; days?: number };
 }
 
 export interface DashboardOptions {

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const distEntry = join(dirname(fileURLToPath(import.meta.url)), "../../../dist/contract/index.mjs");
+const distExists = existsSync(distEntry);
+
+// Requires `pnpm --filter @codesesh/core build` to have run first — the
+// contract package has no runtime code of its own to test against otherwise.
+describe("contract browser-safety", () => {
+  it.skipIf(!distExists)(
+    "bundle contains no Node built-ins, better-sqlite3, or agent registration side effects",
+    () => {
+      const source = readFileSync(distEntry, "utf8");
+      expect(source).not.toContain("node:");
+      expect(source).not.toContain("better-sqlite3");
+      expect(source).not.toContain("register");
+    },
+  );
+
+  it.skipIf(!distExists)("imports cleanly and exposes only pure fixture data", async () => {
+    const contract = await import(distEntry);
+    expect(Object.keys(contract).sort()).toEqual(
+      [
+        "SAMPLE_DASHBOARD_DATA",
+        "SAMPLE_SCAN_STATUS_EVENT",
+        "SAMPLE_SESSIONS_UPDATED_EVENT",
+        "SAMPLE_SESSION_HEAD",
+      ].sort(),
+    );
+  });
+});

--- a/packages/core/src/contract/agent.ts
+++ b/packages/core/src/contract/agent.ts
@@ -1,0 +1,6 @@
+export interface AgentInfo {
+  name: string;
+  displayName: string;
+  count: number;
+  icon?: string;
+}

--- a/packages/core/src/contract/api.ts
+++ b/packages/core/src/contract/api.ts
@@ -1,0 +1,25 @@
+import type { CostSource, ProjectGroup } from "./session.js";
+
+export interface AppConfig {
+  window: {
+    from?: number;
+    to?: number;
+    days?: number;
+  };
+}
+
+export interface ApiProjectAgentStat {
+  name: string;
+  sessions: number;
+  messages: number;
+  tokens: number;
+  cost: number;
+}
+
+export interface ApiProjectGroup extends ProjectGroup {
+  messages: number;
+  tokens: number;
+  cost: number;
+  cost_source?: CostSource;
+  agentStats: ApiProjectAgentStat[];
+}

--- a/packages/core/src/contract/bookmarks.ts
+++ b/packages/core/src/contract/bookmarks.ts
@@ -1,0 +1,13 @@
+import type { SessionStats } from "./session.js";
+
+export interface BookmarkRecord {
+  agentKey: string;
+  sessionId: string;
+  fullPath: string;
+  title: string;
+  directory: string;
+  time_created: number;
+  time_updated?: number;
+  stats: SessionStats;
+  bookmarked_at: number;
+}

--- a/packages/core/src/contract/dashboard.ts
+++ b/packages/core/src/contract/dashboard.ts
@@ -1,0 +1,58 @@
+import type { FileActivityResult } from "./file-activity.js";
+import type { SessionHead } from "./session.js";
+
+export interface DashboardAgentStat {
+  name: string;
+  displayName: string;
+  icon: string;
+  sessions: number;
+  messages: number;
+  tokens: number;
+}
+
+export interface DashboardDailyBucket {
+  date: string;
+  sessions: number;
+  messages: number;
+}
+
+export interface DailyTokenBucket {
+  date: string;
+  input: number;
+  output: number;
+  cache_read: number;
+  cache_create: number;
+}
+
+export interface ModelDistributionEntry {
+  model: string;
+  tokens: number;
+  sessions: number;
+}
+
+export interface DashboardRecentSession extends SessionHead {
+  agentName: string;
+}
+
+export interface DashboardTotals {
+  sessions: number;
+  messages: number;
+  tokens: number;
+  cost: number;
+  cost_source?: "estimated" | "recorded";
+  latestActivity?: number;
+}
+
+export interface DashboardAggregate {
+  totals: DashboardTotals;
+  perAgent: DashboardAgentStat[];
+  dailyActivity: DashboardDailyBucket[];
+  dailyTokenActivity: DailyTokenBucket[];
+  modelDistribution: ModelDistributionEntry[];
+  recentSessions: DashboardRecentSession[];
+}
+
+export interface DashboardData extends DashboardAggregate {
+  recentFileActivities: FileActivityResult[];
+  window: { from?: number; to: number; days?: number };
+}

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -1,0 +1,51 @@
+import type { SessionHead } from "./session.js";
+
+export interface SessionsUpdatedEvent {
+  type: "sessions-updated";
+  changedAgents: string[];
+  newSessions: number;
+  updatedSessions: number;
+  removedSessions: number;
+  totalSessions: number;
+  timestamp: number;
+  changedSessionHeads: Array<{ agentName: string; session: SessionHead }>;
+  removedSessionRefs: Array<{ agentName: string; sessionId: string }>;
+}
+
+export interface AgentScanStatus {
+  agentName: string;
+  status: "pending" | "scanning" | "complete";
+  total?: number;
+  processed?: number;
+  sessions?: number;
+  startedAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+/**
+ * Full-history reconciliation runs independently of the main scan phase:
+ * startup only syncs the display window, so a low-priority background pass
+ * (capped at one agent at a time) periodically re-checks the rest of history.
+ */
+export interface BackfillStatus {
+  active: boolean;
+  pendingAgents: string[];
+  currentAgent?: string;
+  completedAgents: string[];
+}
+
+export interface ScanStatusEvent {
+  type: "scan-status";
+  active: boolean;
+  phase: "idle" | "indexing" | "initializing" | "scanning";
+  pendingAgents: string[];
+  scanningAgents: string[];
+  completedAgents: string[];
+  agentStatuses: Record<string, AgentScanStatus>;
+  totalAgents: number;
+  startedAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+  backfill: BackfillStatus;
+}

--- a/packages/core/src/contract/file-activity.ts
+++ b/packages/core/src/contract/file-activity.ts
@@ -1,0 +1,5 @@
+import type { SessionFileActivity, SessionHead } from "./session.js";
+
+export interface FileActivityResult extends SessionFileActivity {
+  session: SessionHead;
+}

--- a/packages/core/src/contract/fixtures.ts
+++ b/packages/core/src/contract/fixtures.ts
@@ -1,0 +1,97 @@
+import type { DashboardData } from "./dashboard.js";
+import type { AgentScanStatus, ScanStatusEvent, SessionsUpdatedEvent } from "./events.js";
+import type { SessionHead } from "./session.js";
+
+export const SAMPLE_SESSION_HEAD = {
+  id: "session-1",
+  slug: "claudecode/session-1",
+  title: "Fix flaky search index test",
+  directory: "/Users/dev/project",
+  project_identity: {
+    kind: "git_remote",
+    key: "github.com/example/project",
+    displayName: "example/project",
+  },
+  time_created: 1_700_000_000_000,
+  time_updated: 1_700_003_600_000,
+  stats: {
+    message_count: 12,
+    total_input_tokens: 4200,
+    total_output_tokens: 1800,
+    total_cost: 0.042,
+    cost_source: "recorded",
+    total_tokens: 6000,
+    total_cache_read_tokens: 3000,
+    total_cache_create_tokens: 500,
+  },
+  model_usage: { "claude-5-sonnet": 6000 },
+  smart_tags: ["bugfix"],
+  smart_tags_source_updated_at: 1_700_003_600_000,
+} satisfies SessionHead;
+
+const SAMPLE_AGENT_SCAN_STATUS = {
+  agentName: "claudecode",
+  status: "complete",
+  total: 42,
+  processed: 42,
+  sessions: 42,
+  startedAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_010_000,
+  completedAt: 1_700_000_010_000,
+} satisfies AgentScanStatus;
+
+export const SAMPLE_SCAN_STATUS_EVENT = {
+  type: "scan-status",
+  active: false,
+  phase: "idle",
+  pendingAgents: [],
+  scanningAgents: [],
+  completedAgents: ["claudecode"],
+  agentStatuses: { claudecode: SAMPLE_AGENT_SCAN_STATUS },
+  totalAgents: 1,
+  startedAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_010_000,
+  completedAt: 1_700_000_010_000,
+  backfill: { active: false, pendingAgents: [], completedAgents: ["claudecode"] },
+} satisfies ScanStatusEvent;
+
+export const SAMPLE_SESSIONS_UPDATED_EVENT = {
+  type: "sessions-updated",
+  changedAgents: ["claudecode"],
+  newSessions: 1,
+  updatedSessions: 0,
+  removedSessions: 0,
+  totalSessions: 43,
+  timestamp: 1_700_000_020_000,
+  changedSessionHeads: [{ agentName: "claudecode", session: SAMPLE_SESSION_HEAD }],
+  removedSessionRefs: [],
+} satisfies SessionsUpdatedEvent;
+
+export const SAMPLE_DASHBOARD_DATA = {
+  totals: {
+    sessions: 1,
+    messages: 12,
+    tokens: 6000,
+    cost: 0.042,
+    cost_source: "recorded",
+    latestActivity: 1_700_003_600_000,
+  },
+  perAgent: [
+    {
+      name: "claudecode",
+      displayName: "Claude Code",
+      icon: "claude",
+      sessions: 1,
+      messages: 12,
+      tokens: 6000,
+    },
+  ],
+  dailyActivity: [{ date: "2023-11-14", sessions: 1, messages: 12 }],
+  dailyTokenActivity: [
+    { date: "2023-11-14", input: 700, output: 1800, cache_read: 3000, cache_create: 500 },
+  ],
+  modelDistribution: [{ model: "claude-5-sonnet", tokens: 6000, sessions: 1 }],
+  recentSessions: [{ ...SAMPLE_SESSION_HEAD, agentName: "claudecode" }],
+  recentFileActivities: [],
+  window: { from: 1_699_900_000_000, to: 1_700_003_600_000, days: 1 },
+} satisfies DashboardData;

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -1,0 +1,9 @@
+export type * from "./session.js";
+export type * from "./agent.js";
+export type * from "./file-activity.js";
+export type * from "./search.js";
+export type * from "./bookmarks.js";
+export type * from "./dashboard.js";
+export type * from "./events.js";
+export type * from "./api.js";
+export * from "./fixtures.js";

--- a/packages/core/src/contract/search.ts
+++ b/packages/core/src/contract/search.ts
@@ -1,0 +1,16 @@
+import type { SessionHead } from "./session.js";
+
+export type SearchMatchType =
+  | "recent"
+  | "title"
+  | "user_message"
+  | "assistant_reply"
+  | "tool_output"
+  | "file_path";
+
+export interface SearchResult {
+  agentName: string;
+  session: SessionHead;
+  snippet: string;
+  matchType: SearchMatchType;
+}

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -1,0 +1,154 @@
+export interface SessionStats {
+  message_count: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  total_cost: number;
+  cost_source?: CostSource;
+  total_tokens?: number;
+  total_cache_read_tokens?: number;
+  total_cache_create_tokens?: number;
+}
+
+export type CostSource = "recorded" | "estimated";
+
+export type SmartTag =
+  | "bugfix"
+  | "refactoring"
+  | "feature-dev"
+  | "testing"
+  | "docs"
+  | "git-ops"
+  | "build-deploy"
+  | "exploration"
+  | "planning";
+
+export type FileActivityKind = "read" | "edit" | "write" | "delete";
+
+export interface SessionFileActivity {
+  agent_name: string;
+  session_id: string;
+  project_identity_key: string;
+  path: string;
+  kind: FileActivityKind;
+  count: number;
+  latest_time: number;
+}
+
+export interface SessionFileActivityOccurrence {
+  path: string;
+  kind: FileActivityKind;
+  time: number;
+  tool_label: string;
+  message_index: number;
+  tool_index: number;
+}
+
+export type ProjectIdentityKind =
+  | "git_remote"
+  | "git_common_dir"
+  | "manifest_path"
+  | "synthetic"
+  | "path"
+  | "loose";
+
+export interface ProjectIdentity {
+  kind: ProjectIdentityKind;
+  key: string;
+  displayName: string;
+}
+
+export type ProjectIdentityRef = Pick<ProjectIdentity, "kind" | "key">;
+
+export interface ProjectGroup {
+  identityKind: ProjectIdentityKind;
+  identityKey: string;
+  displayName: string;
+  sources: string[];
+  sessionCount: number;
+  lastActivity: number | null;
+}
+
+export interface MessageTokens {
+  input?: number;
+  output?: number;
+  reasoning?: number;
+  cache_read?: number;
+  cache_create?: number;
+}
+
+export interface ToolPartState {
+  status?: "running" | "completed" | "error";
+  input?: unknown;
+  arguments?: unknown;
+  output?: unknown;
+  result?: unknown;
+  error?: unknown;
+  metadata?: unknown;
+  prompt?: unknown;
+  [key: string]: unknown;
+}
+
+export interface MessagePart {
+  type: "text" | "tool" | "reasoning" | "plan";
+  text?: unknown;
+  tool?: string;
+  title?: string;
+  nickname?: string;
+  subagent_id?: string;
+  input?: unknown;
+  output?: unknown;
+  approval_status?: "success" | "fail";
+  callID?: string;
+  state?: ToolPartState;
+  time_created?: number;
+}
+
+export interface Message {
+  id: string;
+  role: "user" | "assistant" | "tool";
+  agent?: string | null;
+  time_created: number;
+  time_completed?: number | null;
+  mode?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  tokens?: MessageTokens;
+  cost?: number;
+  cost_source?: CostSource;
+  parts: MessagePart[];
+  subagent_id?: string;
+  nickname?: string;
+}
+
+/** Lightweight metadata for session listing */
+export interface SessionHead {
+  id: string;
+  slug: string;
+  title: string;
+  directory: string;
+  project_identity?: ProjectIdentity;
+  time_created: number;
+  time_updated?: number;
+  stats: SessionStats;
+  model_usage?: Record<string, number>;
+  smart_tags?: SmartTag[];
+  smart_tags_source_updated_at?: number;
+}
+
+/** Full session data for detail view */
+export interface SessionData {
+  id: string;
+  title: string;
+  slug?: string | null;
+  directory: string;
+  project_identity?: ProjectIdentity;
+  version?: string | null;
+  time_created: number;
+  time_updated?: number;
+  summary_files?: unknown;
+  stats: SessionStats;
+  messages: Message[];
+  smart_tags?: SmartTag[];
+  smart_tags_source_updated_at?: number;
+  file_activity?: SessionFileActivity[];
+}

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -6,8 +6,8 @@ import type {
   FileActivityKind,
   ProjectIdentityKind,
   SessionFileActivity,
-  SessionHead,
 } from "../../types/index.js";
+import type { FileActivityResult } from "../../contract/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { filePathFtsQuery, hasCacheStorage, likePattern, normalizeFilePathSearch } from "./db.js";
@@ -20,6 +20,8 @@ import {
   type SearchResult,
   type SearchResultRow,
 } from "./search.js";
+
+export type { FileActivityResult };
 
 export interface FileActivityRow extends SearchResultRow {
   project_identity_key?: string;
@@ -41,10 +43,6 @@ export interface FileActivityOptions {
   from?: number;
   to?: number;
   limit?: number;
-}
-
-export interface FileActivityResult extends SessionFileActivity {
-  session: SessionHead;
 }
 
 export function fileActivityFilters(options: FileActivityOptions): {

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -12,6 +12,7 @@ import type {
   SessionHead,
   SmartTag,
 } from "../../types/index.js";
+import type { SearchMatchType, SearchResult } from "../../contract/index.js";
 import { computeIdentity, isProjectIdentityKind, realFs } from "../../projects/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
@@ -122,20 +123,7 @@ interface LoadedSearchIndexEntry {
   sortIndex: number;
 }
 
-export interface SearchResult {
-  agentName: string;
-  session: SessionHead;
-  snippet: string;
-  matchType: SearchMatchType;
-}
-
-export type SearchMatchType =
-  | "recent"
-  | "title"
-  | "user_message"
-  | "assistant_reply"
-  | "tool_output"
-  | "file_path";
+export type { SearchMatchType, SearchResult };
 
 export interface SearchQueryFilters {
   agent?: string;

--- a/packages/core/src/state/bookmarks.ts
+++ b/packages/core/src/state/bookmarks.ts
@@ -1,6 +1,7 @@
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { SessionStats } from "../types/index.js";
+import type { BookmarkRecord } from "../contract/index.js";
 import {
   columnExists,
   getUserVersion,
@@ -24,17 +25,7 @@ export class BookmarkStorageUnavailableError extends Error {
   }
 }
 
-export interface BookmarkRecord {
-  agentKey: string;
-  sessionId: string;
-  fullPath: string;
-  title: string;
-  directory: string;
-  time_created: number;
-  time_updated?: number;
-  stats: SessionStats;
-  bookmarked_at: number;
-}
+export type { BookmarkRecord };
 
 interface BookmarkRow extends DatabaseRow {
   agent_name?: string;

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -1,9 +1,4 @@
-export interface AgentInfo {
-  name: string;
-  displayName: string;
-  count: number;
-  icon?: string;
-}
+export type { AgentInfo } from "../contract/agent.js";
 
 export interface FilterOptions {
   agent?: string;

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -1,157 +1,21 @@
-export interface SessionStats {
-  message_count: number;
-  total_input_tokens: number;
-  total_output_tokens: number;
-  total_cost: number;
-  cost_source?: CostSource;
-  total_tokens?: number;
-  total_cache_read_tokens?: number;
-  total_cache_create_tokens?: number;
-}
-
-export type CostSource = "recorded" | "estimated";
-
-export type SmartTag =
-  | "bugfix"
-  | "refactoring"
-  | "feature-dev"
-  | "testing"
-  | "docs"
-  | "git-ops"
-  | "build-deploy"
-  | "exploration"
-  | "planning";
-
-export type FileActivityKind = "read" | "edit" | "write" | "delete";
-
-export interface SessionFileActivity {
-  agent_name: string;
-  session_id: string;
-  project_identity_key: string;
-  path: string;
-  kind: FileActivityKind;
-  count: number;
-  latest_time: number;
-}
-
-export interface SessionFileActivityOccurrence {
-  path: string;
-  kind: FileActivityKind;
-  time: number;
-  tool_label: string;
-  message_index: number;
-  tool_index: number;
-}
-
-export type ProjectIdentityKind =
-  | "git_remote"
-  | "git_common_dir"
-  | "manifest_path"
-  | "synthetic"
-  | "path"
-  | "loose";
-
-export interface ProjectIdentity {
-  kind: ProjectIdentityKind;
-  key: string;
-  displayName: string;
-}
-
-export type ProjectIdentityRef = Pick<ProjectIdentity, "kind" | "key">;
-
-export interface ProjectGroup {
-  identityKind: ProjectIdentityKind;
-  identityKey: string;
-  displayName: string;
-  sources: string[];
-  sessionCount: number;
-  lastActivity: number | null;
-}
-
-export interface MessageTokens {
-  input?: number;
-  output?: number;
-  reasoning?: number;
-  cache_read?: number;
-  cache_create?: number;
-}
-
-export interface ToolPartState {
-  status?: "running" | "completed" | "error";
-  input?: unknown;
-  arguments?: unknown;
-  output?: unknown;
-  result?: unknown;
-  error?: unknown;
-  metadata?: unknown;
-  prompt?: unknown;
-  [key: string]: unknown;
-}
-
-export interface MessagePart {
-  type: "text" | "tool" | "reasoning" | "plan";
-  text?: unknown;
-  tool?: string;
-  title?: string;
-  nickname?: string;
-  subagent_id?: string;
-  input?: unknown;
-  output?: unknown;
-  approval_status?: "success" | "fail";
-  callID?: string;
-  state?: ToolPartState;
-  time_created?: number;
-}
-
-export interface Message {
-  id: string;
-  role: "user" | "assistant" | "tool";
-  agent?: string | null;
-  time_created: number;
-  time_completed?: number | null;
-  mode?: string | null;
-  model?: string | null;
-  provider?: string | null;
-  tokens?: MessageTokens;
-  cost?: number;
-  cost_source?: CostSource;
-  parts: MessagePart[];
-  subagent_id?: string;
-  nickname?: string;
-}
-
-/** Lightweight metadata for session listing */
-export interface SessionHead {
-  id: string;
-  slug: string;
-  title: string;
-  directory: string;
-  project_identity?: ProjectIdentity;
-  time_created: number;
-  time_updated?: number;
-  stats: SessionStats;
-  model_usage?: Record<string, number>;
-  smart_tags?: SmartTag[];
-  smart_tags_source_updated_at?: number;
-}
-
-/** Full session data for detail view */
-export interface SessionData {
-  id: string;
-  title: string;
-  slug?: string | null;
-  directory: string;
-  project_identity?: ProjectIdentity;
-  version?: string | null;
-  time_created: number;
-  time_updated?: number;
-  summary_files?: unknown;
-  stats: SessionStats;
-  messages: Message[];
-  smart_tags?: SmartTag[];
-  smart_tags_source_updated_at?: number;
-  file_activity?: SessionFileActivity[];
-}
+export type {
+  SessionStats,
+  CostSource,
+  SmartTag,
+  FileActivityKind,
+  SessionFileActivity,
+  SessionFileActivityOccurrence,
+  ProjectIdentityKind,
+  ProjectIdentity,
+  ProjectIdentityRef,
+  ProjectGroup,
+  MessageTokens,
+  ToolPartState,
+  MessagePart,
+  Message,
+  SessionHead,
+  SessionData,
+} from "../contract/session.js";
 
 export type ParseSessionResult<T> =
   | { status: "parsed"; data: T }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "tsup";
 const isWatch = process.argv.includes("--watch");
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/contract/index.ts"],
   format: ["esm", "cjs"],
   dts: false,
   clean: !isWatch,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.3.0)
     devDependencies:
+      '@codesesh/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0


### PR DESCRIPTION
## Summary

Session, Dashboard, and SSE wire types were hand-copied across core, CLI, and Web, and had already drifted (Web was missing cache token fields and model_usage, SSE array optionality diverged, and AgentInfo.icon optionality was inconsistent). This PR establishes a single browser-safe contract module so all three layers share one vocabulary and type changes are verified end-to-end by the compiler.

- **core**: Add `src/contract/`, exposed via the `@codesesh/core/contract` subpath export (no agent-registration side effects, no better-sqlite3). Existing type modules re-export from it, keeping core's public API unchanged. Ships shared fixtures and a browser-safety smoke test that asserts the built bundle contains no `node:` imports, sqlite, or registration side effects.
- **cli**: live-scan's SSE event types and the inline structural copy in handlers' ScanStatusSource now import from the contract. New fixture-backed route tests pin the wire shapes served by Hono. Verified that the `BUNDLE_CORE=true` release build inlines the contract subpath as well.
- **web**: Remove all hand-copied types from lib/api.ts (-313 lines) in favor of contract re-exports; ~70 consumer files compile with zero changes. The wire SessionsUpdatedEvent keeps its diff arrays required; reconnect-synthesized refreshes use a UI-local `LiveSessionsUpdate` type instead. Fixes the AgentInfo.icon optionality drift (DetailLanding now renders the icon conditionally).

## Verification

- `pnpm build` ✓
- `pnpm test` ✓ (core 267 / web 221 / cli 102)
- `pnpm test:e2e` ✓
- contract browser-safety smoke test ✓
- `BUNDLE_CORE=true` release bundle has no external `@codesesh/core` references ✓

Issue: CS-29