### PR TITLE
chore: add type-check gate to cli package (CS-31)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,8 +42,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup && node scripts/copy-web-dist.js",
-    "release": "tsup && node scripts/copy-web-dist.js",
+    "build": "tsc --noEmit && tsup && node scripts/copy-web-dist.js",
+    "release": "tsc --noEmit && tsup && node scripts/copy-web-dist.js",
     "dev": "tsup --watch",
     "clean": "rm -rf dist",
     "start": "node dist/index.js",

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 const coreMocks = vi.hoisted(() => ({
   loadCachedSessionData: vi.fn(),
   listSessionFileActivity: vi.fn(() => []),
-  executeSessionSearch: vi.fn(() => []),
+  executeSessionSearch: vi.fn((): Array<{ agentName: string; session: SessionHead }> => []),
 }));
 
 vi.mock("@codesesh/core", async (importOriginal) => {
@@ -26,7 +26,13 @@ import {
   handleSearchSessions,
   type ScanResultSource,
 } from "../handlers.js";
-import type { ScanResult, SessionHead, SessionData } from "@codesesh/core";
+import type {
+  ChangeCheckResult,
+  ScanResult,
+  SessionCacheMeta,
+  SessionHead,
+  SessionData,
+} from "@codesesh/core";
 import { BaseAgent } from "@codesesh/core";
 
 // --- Helpers ---
@@ -96,6 +102,20 @@ class MockAgent extends BaseAgent {
       },
     };
   }
+
+  checkForChanges(): ChangeCheckResult {
+    return { hasChanges: false, timestamp: Date.now() };
+  }
+
+  incrementalScan(cachedSessions: SessionHead[]): SessionHead[] {
+    return cachedSessions;
+  }
+
+  getSessionMetaMap(): Map<string, SessionCacheMeta> {
+    return new Map();
+  }
+
+  setSessionMetaMap(): void {}
 }
 
 function makeScanResult(overrides?: Partial<ScanResult>): ScanResult {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -104,7 +104,7 @@ function parseBookmarkPayload(value: unknown): Omit<BookmarkRecord, "bookmarked_
     title: value.title,
     directory: value.directory,
     time_created: value.time_created,
-    time_updated: value.time_updated,
+    time_updated: value.time_updated ?? undefined,
     stats: value.stats,
   };
 }
@@ -469,6 +469,10 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
   const scanResult = scanSource.getSnapshot();
   const agentName = c.req.param("agent");
   const sessionId = c.req.param("id");
+
+  if (!agentName) {
+    return c.json({ error: "Missing agent name" }, 400);
+  }
 
   if (!sessionId) {
     return c.json({ error: "Missing session ID" }, 400);

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -2,7 +2,17 @@ import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { FileSystemSessionSource, type SessionHead } from "@codesesh/core";
+import {
+  FileSystemSessionSource,
+  type AgentScanOptions,
+  type ChangeCheckResult,
+  type ProviderRoots,
+  type ScanOptions,
+  type SessionCacheMeta,
+  type SessionData,
+  type SessionHead,
+  type SessionSourceRef,
+} from "@codesesh/core";
 
 // Isolated temp directory for session fixtures so computeIdentity always
 // resolves to a "path" identity regardless of manifests in /tmp.
@@ -23,16 +33,18 @@ const fsWatch = vi.hoisted(() => ({
 
 const core = vi.hoisted(() => ({
   createRegisteredAgents: vi.fn(),
-  filterSessions: vi.fn((sessions: SessionHead[]) => sessions),
+  filterSessions: vi.fn((sessions: SessionHead[], _options: ScanOptions) => sessions),
   getCursorDataPath: vi.fn(() => "/tmp/cursor"),
-  resolveProviderRoots: vi.fn(() => ({
-    claudeRoot: "/tmp/claude",
-    codexRoot: "/tmp/codex",
-    kimiRoot: "/tmp/kimi",
-    opencodeRoot: "/tmp/opencode",
-    piRoot: "/tmp/pi",
-    zcodeRoot: "/tmp/zcode",
-  })),
+  resolveProviderRoots: vi.fn(
+    (): ProviderRoots => ({
+      claudeRoot: "/tmp/claude",
+      codexRoot: "/tmp/codex",
+      kimiRoot: "/tmp/kimi",
+      opencodeRoot: "/tmp/opencode",
+      piRoot: "/tmp/pi",
+      zcodeRoot: "/tmp/zcode",
+    }),
+  ),
   isAgentCacheInitialized: vi.fn(),
   loadCachedSessions: vi.fn(),
   markAgentCacheInitialized: vi.fn(),
@@ -76,7 +88,7 @@ const workerThreads = vi.hoisted(() => ({
         return (
           Boolean(current) &&
           typeof cached?.sourceMtimeMs === "number" &&
-          cached.sourceMtimeMs === current[2] &&
+          cached.sourceMtimeMs === current![2] &&
           (current![4] == null || cachedSession.title === current![4])
         );
       };
@@ -345,7 +357,7 @@ function makeAgent(name: string, overrides: Record<string, unknown> = {}) {
     // Database-style agents detect changes via checkForChanges and rescan via
     // incrementalScan (which delegates to scan), mirroring DatabaseSessionSource.
     checkForChanges: vi.fn(() => ({ hasChanges: true, changedIds: [], timestamp: 0 })),
-    incrementalScan: vi.fn(() => agent.scan()),
+    incrementalScan: vi.fn(() => (agent.scan as () => SessionHead[])()),
   };
   agent.scan = vi.fn(() => []);
   Object.assign(agent, overrides);
@@ -360,12 +372,12 @@ function makeAgent(name: string, overrides: Record<string, unknown> = {}) {
 function makeFileSystemAgent(
   name: string,
   overrides: {
-    listSessionSources?: ReturnType<typeof vi.fn>;
-    scanSessionSource?: ReturnType<typeof vi.fn>;
-    getSessionMetaMap?: ReturnType<typeof vi.fn>;
-    setSessionMetaMap?: ReturnType<typeof vi.fn>;
-    checkForChanges?: ReturnType<typeof vi.fn>;
-    incrementalScan?: ReturnType<typeof vi.fn>;
+    listSessionSources?: (options?: AgentScanOptions) => SessionSourceRef[];
+    scanSessionSource?: (sourcePath: string) => SessionHead | null;
+    getSessionMetaMap?: () => Map<string, SessionCacheMeta>;
+    setSessionMetaMap?: (meta: Map<string, SessionCacheMeta>) => void;
+    checkForChanges?: (sinceTimestamp: number, cachedSessions: SessionHead[]) => ChangeCheckResult;
+    incrementalScan?: (cachedSessions: SessionHead[], changedIds: string[]) => SessionHead[];
   } = {},
 ) {
   const agent = Object.create(FileSystemSessionSource.prototype) as InstanceType<
@@ -375,7 +387,7 @@ function makeFileSystemAgent(
   Object.defineProperty(agent, "displayName", { value: name, configurable: true });
   agent.isAvailable = vi.fn(() => true);
   agent.scan = vi.fn(() => []);
-  agent.getSessionData = vi.fn(() => ({}));
+  agent.getSessionData = vi.fn(() => ({}) as SessionData);
   agent.listSessionSources = overrides.listSessionSources ?? vi.fn(() => []);
   agent.scanSessionSource = overrides.scanSessionSource ?? vi.fn(() => null);
   agent.getSessionMetaMap = overrides.getSessionMetaMap ?? vi.fn(() => new Map());
@@ -423,9 +435,7 @@ describe("LiveScanStore", () => {
   });
 
   it("initializes a sorted snapshot for allowed registered agents", async () => {
-    const codex = makeAgent("codex", {
-      scan: vi.fn(() => [fresh]),
-    });
+    const codex = makeAgent("codex");
     const kimi = makeAgent("kimi");
     const older = makeSession("older", { time_updated: 1000 });
     const newer = makeSession("newer", { time_updated: 2000 });
@@ -451,7 +461,7 @@ describe("LiveScanStore", () => {
       }),
     );
     expect(snapshot.agents.map((agent) => agent.name)).toEqual(["codex", "kimi"]);
-    expect(snapshot.byAgent.codex.map((session) => session.id)).toEqual(["newer", "older"]);
+    expect(snapshot.byAgent.codex!.map((session) => session.id)).toEqual(["newer", "older"]);
     expect(snapshot.byAgent.kimi).toEqual([]);
     expect(snapshot.sessions.map((session) => session.id)).toEqual(["newer", "older"]);
     expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
@@ -653,7 +663,7 @@ describe("LiveScanStore", () => {
         onProgress: expect.any(Function),
       }),
     );
-    expect(codex.scan.mock.calls[0]?.[0]).not.toHaveProperty("from");
+    expect((codex.scan as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).not.toHaveProperty("from");
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
     expect(workerThreads.workers.find((worker) => worker.workerData.jobs)?.workerData.jobs).toEqual(
       [
@@ -805,7 +815,7 @@ describe("LiveScanStore", () => {
     await vi.waitFor(() => expect(scanAgentInWorker).toHaveBeenCalledTimes(1));
 
     await (store as any).refreshAgent("kimi");
-    expect(store.getSnapshot().byAgent.kimi[0]?.title).toBe("kimi fresh");
+    expect(store.getSnapshot().byAgent.kimi![0]?.title).toBe("kimi fresh");
 
     releaseBackfill!({ sessions: [codexInitial], meta: {}, changedIds: [] });
     await backfill;

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -119,7 +119,7 @@ export class AppLogger {
         level,
         event,
         pid: process.pid,
-        ...toLogValue(data),
+        ...(toLogValue(data) as Record<string, unknown>),
       })}\n`;
       this.rotateIfNeeded(Buffer.byteLength(line));
       appendFileSync(this.currentPath, line, "utf8");

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
+import type { ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { existsSync } from "node:fs";
-import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -37,7 +37,7 @@ function findWebDistPath(): string | null {
   return null;
 }
 
-function waitForListening(server: Server): Promise<void> {
+function waitForListening(server: ServerType): Promise<void> {
   return new Promise((resolve, reject) => {
     const handleListening = () => {
       server.off("error", handleError);
@@ -72,7 +72,7 @@ function isAddressInUse(error: unknown): boolean {
   );
 }
 
-function getListeningPort(server: Server, fallback: number): number {
+function getListeningPort(server: ServerType, fallback: number): number {
   const address = server.address();
   return typeof address === "object" && address !== null ? (address as AddressInfo).port : fallback;
 }
@@ -134,7 +134,7 @@ export async function createServer(
 
   const attempts = Math.max(1, options.portFallbackAttempts ?? 1);
   const hostname = options.hostname ?? "127.0.0.1";
-  let server: Server | null = null;
+  let server: ServerType | null = null;
   let actualPort = port;
 
   for (let offset = 0; offset < attempts; offset += 1) {

--- a/packages/cli/src/session-watcher.ts
+++ b/packages/cli/src/session-watcher.ts
@@ -65,7 +65,9 @@ function getWatchRoot(path: string): string {
 }
 
 export function isRecursiveWatchSupported(
-  platform = process.platform,
+  // "ibmi" is a real process.platform value on IBM i (PASE) but is not yet
+  // declared in @types/node's Platform union.
+  platform: NodeJS.Platform | "ibmi" = process.platform,
   nodeVersion = process.versions.node,
 ): boolean {
   if (platform === "darwin" || platform === "win32") {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "lib": ["ES2023"],
     "outDir": "dist",
     "rootDir": "src",
     "types": ["node"]


### PR DESCRIPTION
## Summary

The cli package was the only one in the monorepo without a type-check step — its build runs tsup, which strips types without checking them (core gates via `tsc6 --emitDeclarationOnly`, web via `tsc && vite build`). This hid 40 accumulated tsc errors, discovered during CS-30 when code moved from cli into core and immediately failed core's gate.

- **fix(cli)**: resolve all 40 latent errors with zero runtime behavior change:
  - `lib: ES2023` in cli's tsconfig (aligned with apps/web; `toSorted` in logging.ts/server.ts already required it)
  - server.ts types the handle as hono's `ServerType` instead of node:http `Server` (the actual return type of `serve()`)
  - session-watcher widens the platform param to `NodeJS.Platform | "ibmi"` — a real process.platform value missing from @types/node
  - typed test mocks in live-scan-store.test.ts; removed a dead `scan` override that referenced an undefined variable (`fresh`) and was never invoked
  - null-to-undefined normalization in bookmark payload parsing; missing-agent-param guard mirroring the existing session-id guard
- **chore(cli)**: `build` and `release` now run `tsc --noEmit` first, so new type errors fail the build instead of shipping.

## Verification

- `tsc --noEmit` in packages/cli: 0 errors
- Negative check: an injected type error fails `pnpm --filter codesesh build` ✓
- `pnpm build` ✓, `pnpm test` ✓ (core 287 / web 228 / cli 105), `pnpm test:e2e` ✓

Issue: CS-31