### PR TITLE
perf: skip redundant sessions query for file-only search (CS-32)

### DIFF
--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -15,6 +15,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
 import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
 import type { Message, ProjectIdentity, SessionHead, SmartTag } from "../../types/index.js";
 import type { SearchOptions } from "../../discovery/cache/search.js";
@@ -257,6 +258,24 @@ const limitSessions: FixtureSpec[] = Array.from({ length: 6 }, (_, index) => ({
   messages: [assistantMessage(`limit-${index + 1}-m1`, `docneedle content ${index + 1}`)],
 }));
 
+// Same file path, mismatched tags -- used to pin the current file+tags
+// merge quirk (see "skip redundant sessions query" below).
+const fileTagDocsMatch: FixtureSpec = {
+  id: "file-tag-docs",
+  agent: "claudecode",
+  tags: ["docs"],
+  timeUpdated: now - 14_000,
+  messages: [fileToolMessage("file-tag-docs-m1", "edit", "src/tagcheck.ts")],
+};
+
+const fileTagPlanningMismatch: FixtureSpec = {
+  id: "file-tag-planning",
+  agent: "claudecode",
+  tags: ["planning"],
+  timeUpdated: now - 14_100,
+  messages: [fileToolMessage("file-tag-planning-m1", "edit", "src/tagcheck.ts")],
+};
+
 const recentOld: FixtureSpec = {
   id: "recent-old",
   agent: "claudecode",
@@ -283,6 +302,8 @@ const syncedFixtures: FixtureSpec[] = [
   tagMergeBoth,
   tagMergeRefactoringOnly,
   tagMergeFeatDevOnly,
+  fileTagDocsMatch,
+  fileTagPlanningMismatch,
   ...limitSessions,
 ];
 
@@ -503,5 +524,71 @@ describe("search characterization: recent vs SQLite-indexed equivalence (tag fil
     expect(results.map((r) => r.session.id).sort()).toEqual(
       ["recent-mid", "lagging-session"].sort(),
     );
+  });
+});
+
+// core.searchSessions's empty-query SQL branch is the only place in this
+// module's queries that contains a literal "WHERE 1 = 1" -- its presence (or
+// absence) in the prepared statements below is a reliable proxy for whether
+// searchSessions ran.
+function withPreparedSqlCapture<T>(run: () => T): { result: T; sql: string[] } {
+  const preparedSql: string[] = [];
+  const originalPrepare = Database.prototype.prepare;
+  const prepareSpy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+    this: Database.Database,
+    source: string,
+  ) {
+    preparedSql.push(source);
+    return originalPrepare.call(this, source);
+  });
+
+  try {
+    const result = run();
+    return { result, sql: preparedSql.map((sql) => sql.replace(/\s+/g, " ").trim()) };
+  } finally {
+    prepareSpy.mockRestore();
+  }
+}
+
+function ranSearchSessions(sql: string[]): boolean {
+  return sql.some((statement) => statement.includes("WHERE 1 = 1"));
+}
+
+describe("search characterization: skip redundant sessions query for file-only searches", () => {
+  it("does not query the sessions table when file is the only filter", () => {
+    const { result, sql } = withPreparedSqlCapture(() =>
+      search("", { file: "app.tsx", limit: 50 }),
+    );
+    expect(result.map((r) => r.session.id)).toEqual(["file-only"]);
+    expect(ranSearchSessions(sql)).toBe(false);
+  });
+
+  it("still queries the sessions table for a fileKind-only search (its only data source)", () => {
+    const { result, sql } = withPreparedSqlCapture(() =>
+      search("", { fileKind: "edit", limit: 50 }),
+    );
+    expect(result.map((r) => r.session.id)).toContain("file-only");
+    expect(ranSearchSessions(sql)).toBe(true);
+  });
+
+  it("still queries the sessions table when tags are combined with a file filter", () => {
+    const { result, sql } = withPreparedSqlCapture(() =>
+      search("", { file: "tagcheck.ts", tags: ["docs"], limit: 50 }),
+    );
+    // Quirk: searchFileActivitySessions ignores the tags option, and its
+    // (tag-blind) hits win the first-write-wins dedupe over searchSessions's
+    // (tag-filtered) hits -- so a file match with a mismatched tag still
+    // surfaces even though searchSessions did run with the tag filter.
+    expect(result.map((r) => r.session.id).sort()).toEqual(
+      ["file-tag-docs", "file-tag-planning"].sort(),
+    );
+    expect(ranSearchSessions(sql)).toBe(true);
+  });
+
+  it("still queries the sessions table when a from/to window is combined with a file filter", () => {
+    const { sql } = withPreparedSqlCapture(() =>
+      search("", { file: "app.tsx", from: now - 20_000, limit: 50 }),
+    );
+    expect(ranSearchSessions(sql)).toBe(true);
   });
 });

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -38,7 +38,7 @@ export function executeSessionSearch(
     return searchRecentSessions(snapshot, merged.options);
   }
 
-  return searchIndexedSessions(query, merged.parsed, merged.options);
+  return searchIndexedSessions(query, merged.text, merged.parsed, merged.options);
 }
 
 // Qualifiers alone (tag:/cost:/agent:/project:) do not force the indexed
@@ -157,17 +157,39 @@ function mergeSearchResultSources(results: SearchResult[], limit: number): Searc
   return merged;
 }
 
+// searchSessions is the only source when: there's text (FTS is the primary
+// source), tools are filtered (its empty-query SQL branch is the sole source
+// for tool-only queries), tags are filtered (listFileActivity has no tag
+// clause), or a from/to window is set (file-activity filters by
+// fa.latest_time, not the session's activity_time, so it can't stand in).
+// Otherwise, once a file path narrowed the results, the file-activity path
+// already covers everything and re-querying sessions is redundant.
+function canSkipSessionsSearch(
+  fileQuery: string,
+  textQuery: string,
+  options: SearchOptions,
+): boolean {
+  return Boolean(
+    fileQuery &&
+    !textQuery &&
+    !options.tools?.length &&
+    !options.tags?.length &&
+    options.from == null &&
+    options.to == null,
+  );
+}
+
 function searchIndexedSessions(
   query: string,
+  textQuery: string,
   parsed: ParsedSearchQuery,
   options: SearchOptions,
 ): SearchResult[] {
   const fileQuery = deriveFileQuery(query, parsed, options);
-  return mergeSearchResultSources(
-    [
-      ...(fileQuery ? searchFileActivitySessions(fileQuery, options) : []),
-      ...searchSessions(query, options),
-    ],
-    options.limit ?? 50,
-  );
+  const fileResults = fileQuery ? searchFileActivitySessions(fileQuery, options) : [];
+  const sessionResults = canSkipSessionsSearch(fileQuery, textQuery, options)
+    ? []
+    : searchSessions(query, options);
+
+  return mergeSearchResultSources([...fileResults, ...sessionResults], options.limit ?? 50);
 }


### PR DESCRIPTION
## Summary

`searchIndexedSessions` always ran `searchSessions` alongside the file-activity path; for file-only queries every one of its hits was dropped by the first-write-wins dedupe — one wasted SQL round-trip per search (found during CS-30 characterization, quirk #7).

The skip is deliberately narrow. `searchSessions` still runs whenever it can contribute:
- **text present** — FTS is the primary source
- **tools filtered** — its empty-query branch is the sole source for tool-only queries
- **tags filtered** — `listFileActivity` has no tag clause, so tag filtering only happens in `searchSessions`
- **from/to window** — the file path filters on `fa.latest_time`, not the session's `activity_time`
- **fileKind-only** — `searchFileActivitySessions` returns nothing without a path, so `searchSessions` is the only source

New outcome tests assert each boundary via a `Database.prototype.prepare` spy (the sessions-table query is provably absent for file-only, provably present for the other four cases). The file+tags test also pins a pre-existing quirk as-is: file-path hits are tag-blind and win the dedupe, so a mismatched-tag session still surfaces today — unchanged by this PR, documented in the issue notes.

## Verification

- `pnpm build` ✓, `pnpm test` ✓ (core 291 / web 228 / cli 105), `pnpm test:e2e` ✓
- All CS-30 characterization/outcome tests pass unchanged

Issue: CS-32