### PR TITLE
fix: secure remote access

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ npx codesesh -j
 |------|-------|---------|-------------|
 | `--port` | `-p` | `4521` | HTTP server starting port; falls back to the next available port if busy |
 | `--host` | — | `127.0.0.1` | HTTP server bind address; default is local-only, set explicitly (e.g. `0.0.0.0`) to expose on the network |
+| `--remote-access` | — | `false` | Enable token-protected access for a non-loopback `--host`; anyone with the startup URL can read session data |
 | `--days` | `-d` | `7` | Only include sessions active in the last N days (`0` = all time) |
 | `--cwd` | — | — | Filter to sessions from a project directory (`.` = current dir) |
 | `--agent` | `-a` | all | Filter to specific agent(s), comma-separated |
@@ -176,6 +177,10 @@ npx codesesh -j
 | `--clear-cache` | — | `false` | Clear scan cache before starting |
 | `-v` | — | — | Print version number |
 | `-h` / `--help` | — | — | Show help |
+
+Non-loopback binding is rejected unless `--remote-access` is also present. CodeSesh generates a
+new access token for every process and includes it in the printed startup URL. Treat that URL as a
+password: do not publish it or place it in shared shell history.
 
 ---
 

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -5,8 +5,52 @@ import {
   fetchSearchResults,
   fetchSessionData,
   fetchSessions,
+  initializeRemoteAccess,
   subscribeSessionUpdates,
 } from "./api";
+
+describe("remote access", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.history.replaceState(null, "", "/");
+    initializeRemoteAccess();
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+    window.history.replaceState(null, "", "/");
+    initializeRemoteAccess();
+    vi.unstubAllGlobals();
+  });
+
+  it("stores the startup token, removes it from the URL, and authorizes fetch", async () => {
+    window.history.replaceState(null, "", "/?access_token=remote-secret");
+    initializeRemoteAccess();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(SAMPLE_DASHBOARD_DATA),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchDashboard();
+
+    expect(window.location.search).toBe("");
+    expect(window.sessionStorage.getItem("codesesh:remote-access-token")).toBe("remote-secret");
+    const init = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer remote-secret");
+  });
+
+  it("adds the startup token to the EventSource URL", () => {
+    vi.stubGlobal("EventSource", FakeEventSource);
+    window.history.replaceState(null, "", "/?access_token=remote-secret");
+    initializeRemoteAccess();
+
+    const unsubscribe = subscribeSessionUpdates(() => {});
+
+    expect(FakeEventSource.instances.at(-1)?.url).toBe("/api/events?access_token=remote-secret");
+    unsubscribe();
+  });
+});
 
 describe("fetchDashboard", () => {
   afterEach(() => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -47,6 +47,50 @@ import type {
   SmartTag,
 } from "@codesesh/core/contract";
 
+const REMOTE_ACCESS_QUERY_PARAM = "access_token";
+const REMOTE_ACCESS_STORAGE_KEY = "codesesh:remote-access-token";
+let remoteAccessToken: string | null = null;
+
+export function initializeRemoteAccess(): void {
+  if (typeof window === "undefined") return;
+
+  const url = new URL(window.location.href);
+  const urlToken = url.searchParams.get(REMOTE_ACCESS_QUERY_PARAM);
+  if (urlToken) {
+    remoteAccessToken = urlToken;
+    try {
+      window.sessionStorage.setItem(REMOTE_ACCESS_STORAGE_KEY, urlToken);
+    } catch {}
+    url.searchParams.delete(REMOTE_ACCESS_QUERY_PARAM);
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+    return;
+  }
+
+  try {
+    remoteAccessToken = window.sessionStorage.getItem(REMOTE_ACCESS_STORAGE_KEY);
+  } catch {
+    remoteAccessToken = null;
+  }
+}
+
+function withRemoteAccess(init: RequestInit = {}): RequestInit {
+  if (!remoteAccessToken) return init;
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${remoteAccessToken}`);
+  return { ...init, headers };
+}
+
+function remoteAccessUrl(path: string): string {
+  if (!remoteAccessToken) return path;
+  const url = new URL(path, window.location.origin);
+  url.searchParams.set(REMOTE_ACCESS_QUERY_PARAM, remoteAccessToken);
+  return `${url.pathname}${url.search}`;
+}
+
 export interface SearchRequestOptions {
   agent?: string;
   projectKind?: ProjectIdentityKind;
@@ -59,7 +103,7 @@ export interface SearchRequestOptions {
 }
 
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(path, init);
+  const res = await fetch(path, withRemoteAccess(init));
   if (!res.ok) {
     const method = init?.method ?? "GET";
     throw new Error(`${method} ${path} failed: ${res.status} ${res.statusText}`);
@@ -175,18 +219,21 @@ export function logClientEvent(event: string, data: Record<string, unknown> = {}
   const body = JSON.stringify({ event, data });
 
   try {
-    if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+    if (!remoteAccessToken && typeof navigator !== "undefined" && navigator.sendBeacon) {
       const blob = new Blob([body], { type: "application/json" });
       if (navigator.sendBeacon("/api/logs", blob)) return;
     }
   } catch {}
 
-  void fetch("/api/logs", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body,
-    keepalive: true,
-  }).catch(() => {});
+  void fetch(
+    "/api/logs",
+    withRemoteAccess({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      keepalive: true,
+    }),
+  ).catch(() => {});
 }
 
 const INITIAL_RETRY_MS = 1_000;
@@ -211,7 +258,7 @@ export function subscribeSessionUpdates(
   let currentSource: EventSource | undefined;
 
   const connect = () => {
-    const source = new EventSource("/api/events");
+    const source = new EventSource(remoteAccessUrl("/api/events"));
     currentSource = source;
 
     source.addEventListener("sessions-updated", (event) => {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,7 +3,10 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.tsx";
 import { RenderProfiler } from "./components/RenderProfiler.tsx";
+import { initializeRemoteAccess } from "./lib/api.ts";
 import "./index.css";
+
+initializeRemoteAccess();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -80,6 +80,8 @@ npx codesesh --trace
 | Flag        | Alias | Default | Description                                                 |
 | ----------- | ----- | ------- | ----------------------------------------------------------- |
 | `--port`    | `-p`  | `4521`  | HTTP server starting port; falls back to the next available port if busy |
+| `--host`    | —     | `127.0.0.1` | HTTP server bind address; non-loopback values require `--remote-access` |
+| `--remote-access` | — | `false` | Enable token-protected access on a non-loopback host                  |
 | `--days`    | `-d`  | `7`     | Only include sessions active in the last N days (`0` = all time) |
 | `--cwd`     | —     | —       | Filter to sessions from a project directory                 |
 | `--agent`   | `-a`  | all     | Filter to specific agent(s), comma-separated                |
@@ -92,6 +94,10 @@ npx codesesh --trace
 | `--cache`   | —     | `true`  | Use cached scan results when available                      |
 | `--clear-cache` | — | `false` | Clear scan cache before starting                            |
 | `-v`        | —     | —       | Print version number                                        |
+
+When remote access is enabled, CodeSesh prints a startup URL containing a fresh access token.
+Anyone with that URL can read the indexed AI session history, so treat it as a password and do not
+share or persist it.
 
 ## Requirements
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ import { LiveScanStore } from "./live-scan.js";
 import { printScanResults } from "./output.js";
 import { VERSION } from "./version.js";
 import { appLogger } from "./logging.js";
+import { isLoopbackHostname } from "./remote-access.js";
 import {
   DEFAULT_PORT,
   DEFAULT_PORT_FALLBACK_ATTEMPTS,
@@ -32,6 +33,20 @@ function parseSessionUri(uri: string): { agent: string; sessionId: string } | nu
   return { agent: match[1]!, sessionId: match[2]! };
 }
 
+function appendStartupPath(startupUrl: string, path: string): string {
+  const url = new URL(startupUrl);
+  url.pathname = path;
+  return url.toString();
+}
+
+function redactStartupUrl(startupUrl: string): string {
+  const url = new URL(startupUrl);
+  for (const key of url.searchParams.keys()) {
+    url.searchParams.set(key, "[redacted]");
+  }
+  return url.toString();
+}
+
 const main = defineCommand({
   meta: {
     name: "codesesh",
@@ -49,6 +64,11 @@ const main = defineCommand({
       type: "string",
       description: "HTTP server bind address (default 127.0.0.1, local access only)",
       default: "127.0.0.1",
+    },
+    "remote-access": {
+      type: "boolean",
+      description: "Allow authenticated access when binding to a non-loopback address",
+      default: false,
     },
     agent: {
       type: "string",
@@ -114,6 +134,15 @@ const main = defineCommand({
     const trace = args.trace as boolean;
     const useCache = args.cache as boolean;
     const clearCache = args["clear-cache"] as boolean;
+    const hostname = args.host as string;
+    const remoteAccess = args["remote-access"] as boolean;
+
+    if (!isLoopbackHostname(hostname) && !remoteAccess) {
+      console.error(
+        `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
+      );
+      process.exit(1);
+    }
 
     if (trace) {
       perf.enable();
@@ -242,7 +271,8 @@ const main = defineCommand({
         defaultSessionTo: listDefaultTo,
         defaultSessionDays: listDefaultDays,
         portFallbackAttempts: explicitPort ? 1 : DEFAULT_PORT_FALLBACK_ATTEMPTS,
-        hostname: args.host as string,
+        hostname,
+        remoteAccess,
       });
     } catch (error) {
       console.error(getServerStartupErrorMessage(error, port));
@@ -271,7 +301,7 @@ const main = defineCommand({
     console.log(`  ${url}`);
     console.log("");
     appLogger.info("cli.ready", {
-      url,
+      url: redactStartupUrl(url),
       duration_ms: Math.round(performance.now() - startedAt),
       log_path: appLogger.getLogPath(),
     });
@@ -279,9 +309,9 @@ const main = defineCommand({
     if (!noOpen) {
       const open = (await import("open")).default;
       const targetUrl = targetSession
-        ? `${url}/${targetSession.agent.toLowerCase()}/${targetSession.sessionId}`
+        ? appendStartupPath(url, `/${targetSession.agent.toLowerCase()}/${targetSession.sessionId}`)
         : url;
-      appLogger.info("browser.open", { url: targetUrl });
+      appLogger.info("browser.open", { url: redactStartupUrl(targetUrl) });
       await open(targetUrl);
     }
   },

--- a/packages/cli/src/remote-access.test.ts
+++ b/packages/cli/src/remote-access.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createRemoteAccessToken, isLoopbackHostname } from "./remote-access.js";
+
+describe("remote access", () => {
+  it.each(["localhost", "LOCALHOST", "127.0.0.1", "127.20.30.40", "::1", "[::1]"])(
+    "recognizes %s as loopback",
+    (hostname) => {
+      expect(isLoopbackHostname(hostname)).toBe(true);
+    },
+  );
+
+  it.each(["0.0.0.0", "192.168.1.10", "::", "codesesh.local"])(
+    "recognizes %s as non-loopback",
+    (hostname) => {
+      expect(isLoopbackHostname(hostname)).toBe(false);
+    },
+  );
+
+  it("creates a fresh 256-bit URL-safe token", () => {
+    const first = createRemoteAccessToken();
+    const second = createRemoteAccessToken();
+
+    expect(first).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(second).not.toBe(first);
+  });
+});

--- a/packages/cli/src/remote-access.ts
+++ b/packages/cli/src/remote-access.ts
@@ -1,0 +1,46 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { isIP } from "node:net";
+import type { Context, MiddlewareHandler } from "hono";
+
+export const REMOTE_ACCESS_QUERY_PARAM = "access_token";
+
+export function createRemoteAccessToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  return isIP(normalized) === 4 && normalized.startsWith("127.");
+}
+
+function tokenMatches(actual: string | undefined, expected: string): boolean {
+  if (!actual) return false;
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  return (
+    actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer)
+  );
+}
+
+function bearerToken(c: Context): string | undefined {
+  const authorization = c.req.header("Authorization");
+  if (!authorization?.startsWith("Bearer ")) return undefined;
+  return authorization.slice("Bearer ".length);
+}
+
+function requestToken(c: Context): string | undefined {
+  const bearer = bearerToken(c);
+  if (bearer) return bearer;
+  if (c.req.method !== "GET") return undefined;
+  return c.req.query(REMOTE_ACCESS_QUERY_PARAM);
+}
+
+export function remoteAccessAuth(expectedToken: string): MiddlewareHandler {
+  return async (c, next) => {
+    if (!tokenMatches(requestToken(c), expectedToken)) {
+      return c.json({ error: "Remote access authentication required" }, 401);
+    }
+    await next();
+  };
+}

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -93,18 +93,77 @@ describe("createServer", () => {
     await app.shutdown();
   });
 
-  it("binds to the provided hostname and reflects it in the url", async () => {
+  it("refuses a non-loopback hostname without remote access", async () => {
+    await expect(createServer(0, createStore(), { hostname: "0.0.0.0" })).rejects.toThrow(
+      "Add --remote-access",
+    );
+  });
+
+  it("protects remote API requests with the generated access token", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     try {
-      const app = await createServer(0, createStore(), { hostname: "0.0.0.0" });
+      const app = await createServer(0, createStore(), {
+        hostname: "0.0.0.0",
+        remoteAccess: true,
+        remoteAccessToken: "test-access-token",
+      });
+      const startupUrl = new URL(app.url);
+      const requestOrigin = `http://127.0.0.1:${startupUrl.port}`;
 
       expect(serveOptionsLog.at(-1)?.hostname).toBe("0.0.0.0");
-      expect(app.url).toMatch(/^http:\/\/0\.0\.0\.0:\d+$/);
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("0.0.0.0"));
+      expect(startupUrl.searchParams.get("access_token")).toBe("test-access-token");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("远程访问已启用"));
+
+      expect((await fetch(`${requestOrigin}/api/agents`)).status).toBe(401);
+      expect(
+        (
+          await fetch(`${requestOrigin}/api/agents`, {
+            headers: { Authorization: "Bearer test-access-token" },
+          })
+        ).status,
+      ).toBe(200);
+      expect(
+        (await fetch(`${requestOrigin}/api/agents?access_token=test-access-token`)).status,
+      ).toBe(200);
+      expect(
+        (
+          await fetch(`${requestOrigin}/api/logs?access_token=test-access-token`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ event: "test" }),
+          })
+        ).status,
+      ).toBe(401);
 
       await app.shutdown();
     } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("rejects oversized authenticated request bodies", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = await createServer(0, createStore(), {
+      hostname: "0.0.0.0",
+      remoteAccessToken: "test-access-token",
+    });
+    const startupUrl = new URL(app.url);
+    const requestOrigin = `http://127.0.0.1:${startupUrl.port}`;
+
+    try {
+      const response = await fetch(`${requestOrigin}/api/logs`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-access-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ event: "test", data: "x".repeat(1024 * 1024) }),
+      });
+
+      expect(response.status).toBe(413);
+    } finally {
+      await app.shutdown();
       warnSpy.mockRestore();
     }
   });

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { serve } from "@hono/node-server";
 import type { ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
@@ -10,6 +11,14 @@ import type { ScanResultSource } from "./api/handlers.js";
 import { createApiRoutes, type ApiRouteOptions } from "./api/routes.js";
 import { LiveScanStore } from "./live-scan.js";
 import { appLogger } from "./logging.js";
+import {
+  createRemoteAccessToken,
+  isLoopbackHostname,
+  REMOTE_ACCESS_QUERY_PARAM,
+  remoteAccessAuth,
+} from "./remote-access.js";
+
+const MAX_API_REQUEST_BYTES = 1024 * 1024;
 
 export interface CreateServerOptions {
   defaultSessionFrom?: number;
@@ -17,6 +26,8 @@ export interface CreateServerOptions {
   defaultSessionDays?: number;
   portFallbackAttempts?: number;
   hostname?: string;
+  remoteAccess?: boolean;
+  remoteAccessToken?: string;
 }
 
 function findWebDistPath(): string | null {
@@ -86,6 +97,17 @@ export async function createServer(
   options: CreateServerOptions = {},
 ): Promise<{ url: string; shutdown: () => Promise<void> }> {
   const app = new Hono();
+  const hostname = options.hostname ?? "127.0.0.1";
+  const isLoopback = isLoopbackHostname(hostname);
+  const remoteAccessToken = !isLoopback
+    ? (options.remoteAccessToken ?? (options.remoteAccess ? createRemoteAccessToken() : null))
+    : null;
+
+  if (!isLoopback && !remoteAccessToken) {
+    throw new Error(
+      `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
+    );
+  }
 
   app.use("*", async (c, next) => {
     const startedAt = performance.now();
@@ -108,6 +130,17 @@ export async function createServer(
       });
     }
   });
+
+  if (remoteAccessToken) {
+    app.use("/api/*", remoteAccessAuth(remoteAccessToken));
+  }
+  app.use(
+    "/api/*",
+    bodyLimit({
+      maxSize: MAX_API_REQUEST_BYTES,
+      onError: (c) => c.json({ error: "Request body too large" }, 413),
+    }),
+  );
 
   // API routes
   const routeOptions: ApiRouteOptions = {
@@ -133,7 +166,6 @@ export async function createServer(
   }
 
   const attempts = Math.max(1, options.portFallbackAttempts ?? 1);
-  const hostname = options.hostname ?? "127.0.0.1";
   let server: ServerType | null = null;
   let actualPort = port;
 
@@ -167,15 +199,22 @@ export async function createServer(
     }
   }
 
-  const isLoopback = hostname === "127.0.0.1" || hostname === "localhost";
-  const url = isLoopback ? `http://localhost:${actualPort}` : `http://${hostname}:${actualPort}`;
-  appLogger.info("server.listen", { port: actualPort, requested_port: port, hostname, url });
+  const baseUrl = isLoopback
+    ? `http://localhost:${actualPort}`
+    : `http://${hostname}:${actualPort}`;
+  const url = remoteAccessToken
+    ? `${baseUrl}/?${REMOTE_ACCESS_QUERY_PARAM}=${encodeURIComponent(remoteAccessToken)}`
+    : baseUrl;
+  appLogger.info("server.listen", {
+    port: actualPort,
+    requested_port: port,
+    hostname,
+    remote_access: Boolean(remoteAccessToken),
+  });
 
   if (!isLoopback) {
-    appLogger.warn("server.listen.exposed", { hostname, port: actualPort });
-    console.warn(
-      `\n⚠ 服务监听 ${hostname}，局域网内其他设备可读取你的全部 AI 会话记录（无鉴权）。\n`,
-    );
+    appLogger.warn("server.listen.remote_access", { hostname, port: actualPort });
+    console.warn(`\n⚠ 远程访问已启用。任何持有启动 URL 的人都可以读取你的 AI 会话记录。\n`);
   }
 
   return {


### PR DESCRIPTION
## Summary

- reject non-loopback binding unless authenticated remote access is explicitly enabled
- generate a fresh 256-bit token per process and protect every API and SSE route
- bootstrap the Web client from the startup URL, then remove the token from browser history
- cap API request bodies and keep query-token authentication read-only for EventSource

## Root cause

`--host` previously changed the listen address without changing the trust model. Binding to a LAN
address therefore exposed complete local AI session history and mutable bookmark/log endpoints to
every reachable client.

## Impact

Default loopback usage is unchanged. Remote users must now add `--remote-access` and open the
generated startup URL. The token is redacted from application logs and regenerated on every run.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (639 tests)
- real CLI smoke: unprotected startup rejected; unauthenticated API 401; Bearer API 200;
  query-token POST 401; generated token absent from application logs

Issue: CS-33
