### PR TITLE
fix: clean up cancelled SSE streams

### DIFF
--- a/packages/cli/src/api/__tests__/routes.test.ts
+++ b/packages/cli/src/api/__tests__/routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createApiRoutes } from "../routes.js";
 import type { ScanResult } from "@codesesh/core";
 import type { ScanResultSource } from "../handlers.js";
@@ -17,5 +17,59 @@ describe("createApiRoutes", () => {
     const app = createApiRoutes(scanSource);
     expect(app).toBeDefined();
     expect(app.fetch).toBeDefined();
+  });
+
+  it("cleans up SSE subscriptions once when cancellation and abort overlap", async () => {
+    const unsubscribeSessions = vi.fn();
+    const unsubscribeScanStatus = vi.fn();
+    let emitSession: ((event: { type: string }) => void) | undefined;
+    let emitScanStatus: ((event: { type: string }) => void) | undefined;
+    const store = {
+      getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }),
+      getScanStatus: () => ({ type: "scan-status", active: false, phase: "idle", agents: {} }),
+      subscribe: vi.fn((listener: (event: { type: string }) => void) => {
+        emitSession = listener;
+        return unsubscribeSessions;
+      }),
+      subscribeScanStatus: vi.fn((listener: (event: { type: string }) => void) => {
+        emitScanStatus = listener;
+        return unsubscribeScanStatus;
+      }),
+    };
+    const app = createApiRoutes(store as never, store as never);
+    const requestController = new AbortController();
+
+    const response = await app.request(
+      new Request("http://localhost/events", { signal: requestController.signal }),
+    );
+    await response.body?.cancel();
+    requestController.abort();
+
+    expect(unsubscribeSessions).toHaveBeenCalledOnce();
+    expect(unsubscribeScanStatus).toHaveBeenCalledOnce();
+    expect(() => emitSession?.({ type: "sessions-updated" })).not.toThrow();
+    expect(() => emitScanStatus?.({ type: "scan-status" })).not.toThrow();
+  });
+
+  it("cleans up SSE subscriptions once when abort happens first", async () => {
+    const unsubscribeSessions = vi.fn();
+    const unsubscribeScanStatus = vi.fn();
+    const store = {
+      getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }),
+      getScanStatus: () => ({ type: "scan-status", active: false, phase: "idle", agents: {} }),
+      subscribe: vi.fn(() => unsubscribeSessions),
+      subscribeScanStatus: vi.fn(() => unsubscribeScanStatus),
+    };
+    const app = createApiRoutes(store as never, store as never);
+    const requestController = new AbortController();
+    const response = await app.request(
+      new Request("http://localhost/events", { signal: requestController.signal }),
+    );
+
+    requestController.abort();
+    await response.body?.cancel();
+
+    expect(unsubscribeSessions).toHaveBeenCalledOnce();
+    expect(unsubscribeScanStatus).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -27,11 +27,14 @@ export interface ApiRouteOptions {
 
 function createSseResponse(store: LiveScanStore, signal: AbortSignal): Response {
   const encoder = new TextEncoder();
+  let cancelStream = () => {};
 
   return new Response(
     new ReadableStream({
       start(controller) {
+        let isClosed = false;
         const write = (event: string, data: unknown) => {
+          if (isClosed) return;
           controller.enqueue(encoder.encode(`event: ${event}\n`));
           controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
         };
@@ -47,20 +50,30 @@ function createSseResponse(store: LiveScanStore, signal: AbortSignal): Response 
         });
 
         const heartbeat = setInterval(() => {
-          controller.enqueue(encoder.encode(": keepalive\n\n"));
+          if (!isClosed) controller.enqueue(encoder.encode(": keepalive\n\n"));
         }, 15000);
 
-        const close = () => {
+        const cleanup = () => {
+          if (isClosed) return false;
+          isClosed = true;
           clearInterval(heartbeat);
           unsubscribeSessions();
           unsubscribeScanStatus();
-          controller.close();
+          signal.removeEventListener("abort", abortStream);
+          return true;
+        };
+        const abortStream = () => {
+          if (cleanup()) controller.close();
+        };
+        cancelStream = () => {
+          cleanup();
         };
 
-        signal.addEventListener("abort", close, { once: true });
+        if (signal.aborted) abortStream();
+        else signal.addEventListener("abort", abortStream, { once: true });
       },
       cancel() {
-        return;
+        cancelStream();
       },
     }),
     {


### PR DESCRIPTION
## Summary

- share one idempotent cleanup path between SSE body cancellation and request abort
- clear the heartbeat, unsubscribe both store listeners, and remove the abort listener
- prevent store events and heartbeats from enqueueing after the stream closes
- test both `cancel → abort` and `abort → cancel` ordering

## Root cause

The cleanup closure lived only inside `ReadableStream.start()`, while `cancel()` was empty. A
consumer-side cancellation could therefore leave the heartbeat and both LiveScanStore listeners
active even though the response body was no longer writable.

## Validation

- focused cancellation/abort regression tests
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (642 tests)

Issue: CS-35
