### PR TITLE
fix(web): make search failures recoverable

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -125,6 +125,7 @@ export default function App() {
     activeSearchQuery,
     searchMode,
     searchFilters,
+    searchState,
     searchResults,
     searchLoading,
     usesServerSearch,
@@ -137,6 +138,7 @@ export default function App() {
     openSearch,
     submitSearch,
     closeSearch,
+    retrySearch,
     refresh: refreshSearch,
   } = useSessionSearch(sessionIndexes);
   const isSearchMode = searchMode;
@@ -372,6 +374,10 @@ export default function App() {
 
     return [...byKey.values()].toSorted((a, b) => b.count - a.count).slice(0, 8);
   }, [projectOptions, searchFilters.project, searchLoading, searchResults, usesServerSearch]);
+  const searchSubtitle =
+    searchState.status === "failed"
+      ? `Search failed for "${activeSearchQuery}"`
+      : formatSearchSubtitle(activeSearchQuery, searchLoading, searchResults.length);
 
   // Header
   let headerTitle = "CodeSesh";
@@ -379,7 +385,7 @@ export default function App() {
   if (viewState.mode === "root") {
     headerTitle = isSearchMode ? "Search" : "Dashboard";
     headerSubtitle = isSearchMode
-      ? formatSearchSubtitle(activeSearchQuery, searchLoading, searchResults.length)
+      ? searchSubtitle
       : dashboard
         ? `${dashboard.totals.sessions.toLocaleString("en-US")} total sessions across ${dashboard.perAgent.length} agents`
         : "Aggregated view across all agents";
@@ -425,7 +431,7 @@ export default function App() {
   }
   if (isSearchMode) {
     headerTitle = "Search";
-    headerSubtitle = formatSearchSubtitle(activeSearchQuery, searchLoading, searchResults.length);
+    headerSubtitle = searchSubtitle;
   }
 
   const breadcrumbItems = useMemo<BreadcrumbItem[]>(() => {
@@ -532,14 +538,14 @@ export default function App() {
       >
         <SearchResultsPanel
           query={activeSearchQuery}
-          loading={searchLoading}
-          results={searchResults}
+          state={searchState}
           agentNameMap={agentNameMap}
           agents={agents}
           projects={searchProjectOptions}
           filters={searchFilters}
           onChangeFilters={setSearchFilters}
           onOpenResult={closeSearch}
+          onRetry={retrySearch}
           selectedIndex={selectedSearchIndex}
           registerResultRef={(key, node) => {
             if (node) searchResultRefs.current.set(key, node);
@@ -731,18 +737,22 @@ export default function App() {
               submitSearch();
             }}
           >
-            <label className="flex min-w-0 flex-1 items-center rounded-sm border border-[var(--console-border)] bg-white px-2 py-1">
+            <label className="flex min-w-0 flex-1 items-center rounded-sm border border-[var(--console-border)] bg-white px-2 py-1 focus-within:border-[var(--console-border-strong)] focus-within:ring-2 focus-within:ring-[var(--console-accent)] focus-within:ring-offset-2">
+              <span className="sr-only">Search Sessions</span>
               <input
                 ref={searchInputRef}
+                type="search"
+                name="session-search"
+                autoComplete="off"
                 value={draftSearchQuery}
                 onChange={(event) => setDraftSearchQuery(event.target.value)}
-                placeholder="Search sessions  /"
+                placeholder="Search sessions…  /"
                 className="console-mono w-full min-w-0 bg-transparent text-xs text-[var(--console-text)] outline-none placeholder:text-[var(--console-muted)]"
               />
             </label>
             <button
               type="submit"
-              className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-white"
+              className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-white focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               Search
             </button>

--- a/apps/web/src/components/app/SearchResultsPanel.test.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.test.tsx
@@ -1,0 +1,37 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SearchResultsPanel } from "./SearchResultsPanel";
+
+afterEach(cleanup);
+
+describe("SearchResultsPanel", () => {
+  it("shows a recoverable search error", () => {
+    const onRetry = vi.fn();
+
+    render(
+      <SearchResultsPanel
+        query="hello"
+        state={{ status: "failed", error: "Search unavailable" }}
+        agentNameMap={new Map()}
+        agents={[]}
+        projects={[]}
+        filters={{}}
+        onChangeFilters={vi.fn()}
+        onOpenResult={vi.fn()}
+        onRetry={onRetry}
+        selectedIndex={0}
+        registerResultRef={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Search unavailable. Check the server connection, then try again."),
+    ).toBeTruthy();
+    const retry = screen.getByRole("button", { name: "Retry Search" });
+    retry.focus();
+    expect(document.activeElement).toBe(retry);
+    fireEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledOnce();
+    expect(screen.queryByText("No matches")).toBeNull();
+  });
+});

--- a/apps/web/src/components/app/SearchResultsPanel.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import type { AgentInfo, SearchResult } from "../../lib/api";
 import { SmartTagChips } from "../SmartTagChips";
 import { SearchFilterBar } from "./SearchFilterBar";
-import type { SearchFilterState, SearchProjectOption } from "./types";
+import type { SearchFilterState, SearchLoadState, SearchProjectOption } from "./types";
 
 const SEARCH_MATCH_LABELS: Record<SearchResult["matchType"], string> = {
   recent: "Recent",
@@ -27,29 +27,30 @@ function toSafeSnippetHtml(snippet: string): string {
 
 export function SearchResultsPanel({
   query,
-  loading,
-  results,
+  state,
   agentNameMap,
   agents,
   projects,
   filters,
   onChangeFilters,
   onOpenResult,
+  onRetry,
   selectedIndex,
   registerResultRef,
 }: {
   query: string;
-  loading: boolean;
-  results: SearchResult[];
+  state: SearchLoadState;
   agentNameMap: Map<string, string>;
   agents: AgentInfo[];
   projects: SearchProjectOption[];
   filters: SearchFilterState;
   onChangeFilters: Dispatch<SetStateAction<SearchFilterState>>;
   onOpenResult: () => void;
+  onRetry: () => void;
   selectedIndex: number;
   registerResultRef: (key: string, node: HTMLAnchorElement | null) => void;
 }) {
+  const results = state.status === "loaded" ? state.results : [];
   const filterBar = (
     <SearchFilterBar
       agents={agents}
@@ -59,15 +60,18 @@ export function SearchResultsPanel({
     />
   );
 
-  if (loading) {
+  if (state.status === "loading") {
     return (
       <div className="flex flex-col gap-3">
         {filterBar}
+        <p className="sr-only" aria-live="polite">
+          Searching…
+        </p>
         <div className="grid gap-3">
           {Array.from({ length: 4 }).map((_, index) => (
             <div
               key={index}
-              className="animate-pulse rounded-sm border border-[var(--console-border)] bg-white/80 p-4"
+              className="animate-pulse rounded-sm border border-[var(--console-border)] bg-white/80 p-4 motion-reduce:animate-none"
             >
               <div className="h-3 w-32 rounded bg-[var(--console-surface-muted)]" />
               <div className="mt-3 h-4 w-2/3 rounded bg-[var(--console-surface-muted)]" />
@@ -75,6 +79,32 @@ export function SearchResultsPanel({
               <div className="mt-1 h-3 w-5/6 rounded bg-[var(--console-surface-muted)]" />
             </div>
           ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === "failed") {
+    return (
+      <div className="flex flex-col gap-3">
+        {filterBar}
+        <div
+          className="rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6"
+          aria-live="polite"
+        >
+          <h2 className="console-mono text-sm font-semibold text-[var(--console-error)]">
+            Search Failed
+          </h2>
+          <p className="console-mono mt-2 break-words text-xs text-[var(--console-error)]">
+            {state.error}. Check the server connection, then try again.
+          </p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="console-mono mt-4 rounded-sm border border-[var(--console-error-border)] bg-white px-3 py-1.5 text-xs font-semibold text-[var(--console-error)] transition-colors hover:bg-[var(--console-error-bg)] focus-visible:ring-2 focus-visible:ring-[var(--console-error)] focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            Retry Search
+          </button>
         </div>
       </div>
     );
@@ -114,7 +144,7 @@ export function SearchResultsPanel({
             to={`/${agentKey}/${result.session.id}`}
             state={{ searchQuery: query }}
             onClick={onOpenResult}
-            className={`rounded-sm border bg-white/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-white ${
+            className={`rounded-sm border bg-white/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-white focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none ${
               index === selectedIndex
                 ? "border-[var(--console-border-strong)]"
                 : "border-[var(--console-border)]"

--- a/apps/web/src/components/app/types.ts
+++ b/apps/web/src/components/app/types.ts
@@ -1,11 +1,17 @@
 /**
  * Shared types for the app-shell subcomponents (search panel, sidebar, filters).
  */
-import type { FileActivityKind, ProjectIdentityKind, SmartTag } from "../../lib/api";
+import type { FileActivityKind, ProjectIdentityKind, SearchResult, SmartTag } from "../../lib/api";
 
 export type BrowseBy = "agents" | "projects";
 
 export type CostRangeId = "paid" | "one_plus" | "ten_plus";
+
+export type SearchLoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "loaded"; results: SearchResult[] }
+  | { status: "failed"; error: string };
 
 export interface SearchFilterState {
   agent?: string;

--- a/apps/web/src/hooks/useSessionSearch.test.ts
+++ b/apps/web/src/hooks/useSessionSearch.test.ts
@@ -34,6 +34,7 @@ describe("useSessionSearch", () => {
   it("starts idle with empty results", () => {
     const { result } = renderHook(() => useSessionSearch(emptyIndexes));
     expect(result.current.searchMode).toBe(false);
+    expect(result.current.searchState).toEqual({ status: "idle" });
     expect(result.current.searchResults).toEqual([]);
   });
 
@@ -54,6 +55,31 @@ describe("useSessionSearch", () => {
 
     await waitFor(() => expect(result.current.searchResults).toEqual(serverResults));
     expect(api.fetchSearchResults).toHaveBeenCalledWith("hello", expect.any(Object));
+  });
+
+  it("exposes a failed search state that can be retried", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchSearchResults).mockRejectedValueOnce(new Error("Search unavailable"));
+    const { result } = renderHook(() => useSessionSearch(emptyIndexes));
+    act(() => result.current.setDraftSearchQuery("hello"));
+    act(() => result.current.submitSearch());
+
+    await waitFor(() =>
+      expect(api.logClientEvent).toHaveBeenCalledWith(
+        "search.error",
+        expect.objectContaining({ error: "Search unavailable" }),
+      ),
+    );
+    expect(result.current.searchState).toEqual({
+      status: "failed",
+      error: "Search unavailable",
+    });
+
+    vi.mocked(api.fetchSearchResults).mockResolvedValueOnce({ results: serverResults });
+    await act(async () => result.current.retrySearch());
+    await waitFor(() =>
+      expect(result.current.searchState).toEqual({ status: "loaded", results: serverResults }),
+    );
   });
 
   it("sends both project identity fields to server search", async () => {

--- a/apps/web/src/hooks/useSessionSearch.ts
+++ b/apps/web/src/hooks/useSessionSearch.ts
@@ -6,7 +6,7 @@ import {
   logClientEvent,
 } from "../lib/api";
 import type { SessionIndexes } from "../lib/session-indexes";
-import type { SearchFilterState } from "../components/app/types";
+import type { SearchFilterState, SearchLoadState } from "../components/app/types";
 import { COST_RANGE_OPTIONS } from "../components/app/SearchFilterBar";
 import {
   buildLocalRecentResults,
@@ -26,8 +26,8 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
   const [activeSearchQuery, setActiveSearchQuery] = useState("");
   const [searchMode, setSearchMode] = useState(false);
   const [searchFilters, setSearchFilters] = useState<SearchFilterState>({});
-  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
+  const [searchState, setSearchState] = useState<SearchLoadState>({ status: "idle" });
+  const [retryVersion, setRetryVersion] = useState(0);
   const [selectedSearchIndex, setSelectedSearchIndex] = useState(0);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const searchResultRefs = useRef(new Map<string, HTMLAnchorElement>());
@@ -48,28 +48,31 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
     () => buildLocalRecentResults(sessionIndexes, searchFilters, costMin),
     [sessionIndexes, searchFilters, costMin],
   );
+  const searchResults = useMemo(
+    () => (searchState.status === "loaded" ? searchState.results : []),
+    [searchState],
+  );
+  const searchLoading = searchState.status === "loading";
 
   useEffect(() => {
     if (!searchMode) {
-      setSearchResults([]);
-      setSearchLoading(false);
+      setSearchState({ status: "idle" });
       return;
     }
     if (!usesServerSearch) {
-      setSearchResults(recentSearchResults);
-      setSearchLoading(false);
+      setSearchState({ status: "loaded", results: recentSearchResults });
       return;
     }
 
     let cancelled = false;
-    setSearchLoading(true);
+    setSearchState({ status: "loading" });
     const startedAt = performance.now();
     logClientEvent("search.start", { query_length: activeSearchQuery.length });
 
     void fetchSearchResults(activeSearchQuery, searchRequestOptions)
       .then((data) => {
         if (cancelled) return;
-        setSearchResults(data.results);
+        setSearchState({ status: "loaded", results: data.results });
         logClientEvent("search.done", {
           duration_ms: Math.round(performance.now() - startedAt),
           results: data.results.length,
@@ -82,17 +85,23 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
           duration_ms: Math.round(performance.now() - startedAt),
           error: err instanceof Error ? err.message : String(err),
         });
-        setSearchResults([]);
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setSearchLoading(false);
+        setSearchState({
+          status: "failed",
+          error: err instanceof Error ? err.message : "Search request failed",
+        });
       });
 
     return () => {
       cancelled = true;
     };
-  }, [activeSearchQuery, searchMode, recentSearchResults, searchRequestOptions, usesServerSearch]);
+  }, [
+    activeSearchQuery,
+    recentSearchResults,
+    retryVersion,
+    searchMode,
+    searchRequestOptions,
+    usesServerSearch,
+  ]);
 
   useEffect(() => {
     if (!searchMode) return;
@@ -129,13 +138,21 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
     setActiveSearchQuery("");
   }, []);
 
+  const retrySearch = useCallback(() => {
+    setRetryVersion((version) => version + 1);
+  }, []);
+
   const refresh = useCallback(async () => {
     if (!(searchMode && usesServerSearch)) return;
     try {
       const data = await fetchSearchResults(activeSearchQuery, searchRequestOptions);
-      setSearchResults(data.results);
+      setSearchState({ status: "loaded", results: data.results });
     } catch (err) {
       console.error("Failed to refresh search results:", err);
+      setSearchState({
+        status: "failed",
+        error: err instanceof Error ? err.message : "Search request failed",
+      });
     }
   }, [searchMode, usesServerSearch, activeSearchQuery, searchRequestOptions]);
 
@@ -144,6 +161,7 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
     activeSearchQuery,
     searchMode,
     searchFilters,
+    searchState,
     searchResults,
     searchLoading,
     usesServerSearch,
@@ -156,6 +174,7 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
     openSearch,
     submitSearch,
     closeSearch,
+    retrySearch,
     refresh,
   };
 }

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -43,7 +43,7 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
     })
     .toBe(true);
 
-  await page.getByPlaceholder("Search sessions  /").fill("needle");
+  await page.getByRole("searchbox", { name: "Search Sessions" }).fill("needle");
   await page.getByRole("button", { name: "Search" }).click();
   await expect(page.getByRole("heading", { level: 1, name: "Search" })).toBeVisible();
 


### PR DESCRIPTION
## Summary

- model session search as `idle | loading | loaded | failed`
- show search failures separately from valid empty results
- add an inline Retry Search action that repeats the active request
- announce async states and add accessible search labeling and keyboard focus styles
- respect reduced-motion preferences in search skeletons

## Root cause

The search hook stored results and loading as independent values. A rejected request cleared the
results array and stopped loading, which was indistinguishable from a successful search with zero
matches. The search input also relied on placeholder text instead of a stable accessible name and
removed its outline without a replacement focus indicator.

## Impact

Failed searches now retain their failure meaning, explain the next step, and can recover without
re-entering the query. Empty searches still render the existing No Matches state. Keyboard and
assistive-technology users receive explicit labels, focus feedback, and async announcements.

## Validation

- reproduced the failure with the existing `search.error` runtime log
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`

Issue: CS-38
