### PR TITLE
refactor(web): unify detail drawer behavior

### DIFF
--- a/apps/web/src/components/DrawerDialog.tsx
+++ b/apps/web/src/components/DrawerDialog.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import { Dialog } from "@base-ui/react/dialog";
+import { X } from "lucide-react";
+
+const VARIANT_STYLES = {
+  desktop: {
+    backdrop: "z-[60] hidden bg-black/20 min-[1025px]:block",
+    popup: "z-[61] hidden w-[min(92vw,430px)] p-4 min-[1025px]:block",
+  },
+  mobile: {
+    backdrop: "z-50 bg-black/30 min-[1025px]:hidden",
+    popup: "console-scrollbar z-[51] w-[min(90vw,380px)] overflow-y-auto p-3 min-[1025px]:hidden",
+  },
+} as const;
+
+export function DrawerDialog({
+  open,
+  onOpenChange,
+  title,
+  variant,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  variant: keyof typeof VARIANT_STYLES;
+  children: ReactNode;
+}) {
+  const styles = VARIANT_STYLES[variant];
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className={`fixed inset-0 ${styles.backdrop}`} />
+        <Dialog.Popup
+          className={`fixed bottom-0 right-0 top-0 overscroll-contain border-l border-[var(--console-border)] bg-[var(--console-bg)] shadow-[-12px_0_32px_rgba(15,23,42,0.18)] outline-none ${styles.popup}`}
+        >
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <Dialog.Title className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">
+              {title}
+            </Dialog.Title>
+            <Dialog.Close
+              aria-label={`Close ${title.toLowerCase()}`}
+              className="rounded-sm border border-[var(--console-border)] bg-white p-2 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              <X className="size-4" aria-hidden="true" />
+            </Dialog.Close>
+          </div>
+          {children}
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/src/components/session-detail/session-detail-aux.tsx
+++ b/apps/web/src/components/session-detail/session-detail-aux.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
-import { FileText, Funnel, X } from "lucide-react";
+import { FileText, Funnel } from "lucide-react";
 import type { SessionData } from "../../lib/api";
 import { InteractiveReceipt } from "../InteractiveReceipt";
 import { RenderProfiler } from "../RenderProfiler";
+import { DrawerDialog } from "../DrawerDialog";
 import type { SessionDetailToc } from "./toc";
 import type { FileChangeSummary } from "./file-change";
 import { FileChangeTracker, getFileTrackerItemCount } from "./file-change-tracker";
@@ -37,20 +38,12 @@ export function DeferredInteractiveReceipt({
     const closeOnSmallViewport = () => {
       if (!desktopQuery.matches) setOpen(false);
     };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", onKeyDown);
     desktopQuery.addEventListener("change", closeOnSmallViewport);
     closeOnSmallViewport();
 
     return () => {
       cancelAnimationFrame(firstFrame);
       if (secondFrame) cancelAnimationFrame(secondFrame);
-      document.body.style.overflow = previousOverflow;
-      window.removeEventListener("keydown", onKeyDown);
       desktopQuery.removeEventListener("change", closeOnSmallViewport);
     };
   }, [open]);
@@ -66,38 +59,15 @@ export function DeferredInteractiveReceipt({
       >
         <span className="[writing-mode:vertical-rl]">Receipt</span>
       </button>
-      {open ? (
-        <div className="fixed inset-0 z-[60] hidden min-[1025px]:block">
-          <button
-            type="button"
-            aria-label="Close session receipt"
-            onClick={() => setOpen(false)}
-            className="absolute inset-0 bg-black/20"
-          />
-          <aside className="absolute right-0 top-0 z-10 h-full w-[min(92vw,430px)] border-l border-[var(--console-border)] bg-[var(--console-bg)] p-4 shadow-[-12px_0_32px_rgba(15,23,42,0.18)]">
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <span className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">
-                Session Receipt
-              </span>
-              <button
-                type="button"
-                aria-label="Close session receipt"
-                onClick={() => setOpen(false)}
-                className="rounded-sm border border-[var(--console-border)] bg-white p-2 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)]"
-              >
-                <X className="size-4" />
-              </button>
-            </div>
-            {ready ? (
-              <RenderProfiler id="InteractiveReceipt">
-                <InteractiveReceipt key={session.id} session={session} toc={toc} />
-              </RenderProfiler>
-            ) : (
-              <div className="h-[calc(100dvh-5.5rem)] min-h-[420px] rounded-sm border border-[var(--console-border)] bg-white" />
-            )}
-          </aside>
-        </div>
-      ) : null}
+      <DrawerDialog open={open} onOpenChange={setOpen} title="Session Receipt" variant="desktop">
+        {ready ? (
+          <RenderProfiler id="InteractiveReceipt">
+            <InteractiveReceipt key={session.id} session={session} toc={toc} />
+          </RenderProfiler>
+        ) : (
+          <div className="h-[calc(100dvh-5.5rem)] min-h-[420px] rounded-sm border border-[var(--console-border)] bg-white" />
+        )}
+      </DrawerDialog>
     </>
   );
 }
@@ -160,50 +130,28 @@ export function SessionDetailAuxOverlay({
 }) {
   useEffect(() => {
     if (!openPanel) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    const previousOverflow = document.body.style.overflow;
     const desktopQuery = window.matchMedia("(min-width: 1025px)");
     const closeOnDesktop = () => {
       if (desktopQuery.matches) onClose();
     };
-    document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", onKeyDown);
     desktopQuery.addEventListener("change", closeOnDesktop);
     closeOnDesktop();
     return () => {
-      document.body.style.overflow = previousOverflow;
-      window.removeEventListener("keydown", onKeyDown);
       desktopQuery.removeEventListener("change", closeOnDesktop);
     };
   }, [onClose, openPanel]);
 
-  if (!openPanel) return null;
-
   return (
-    <div className="fixed inset-0 z-50 min-[1025px]:hidden">
-      <button
-        type="button"
-        aria-label="Close navigation panel"
-        onClick={onClose}
-        className="absolute inset-0 bg-black/30"
-      />
-      <aside className="console-scrollbar absolute right-0 top-0 h-full w-[min(90vw,380px)] overflow-y-auto border-l border-[var(--console-border)] bg-[var(--console-bg)] p-3 shadow-[-10px_0_30px_rgba(15,23,42,0.16)]">
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <span className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">
-            {openPanel === "toc" ? "Session TOC" : "File Tracker"}
-          </span>
-          <button
-            type="button"
-            aria-label="Close navigation panel"
-            onClick={onClose}
-            className="rounded-sm border border-[var(--console-border)] bg-white p-2 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)]"
-          >
-            <X className="size-4" />
-          </button>
-        </div>
-        {openPanel === "toc" ? (
+    <DrawerDialog
+      open={openPanel !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      title={openPanel === "files" ? "File Tracker" : "Session TOC"}
+      variant="mobile"
+    >
+      {openPanel ? (
+        openPanel === "toc" ? (
           <SessionTocFilterPanel toc={toc} selectedFilters={selectedFilters} onToggle={onToggle} />
         ) : (
           <FileChangeTracker
@@ -211,8 +159,8 @@ export function SessionDetailAuxOverlay({
             baseDirectory={baseDirectory}
             onJumpToAnchor={onJumpToAnchor}
           />
-        )}
-      </aside>
-    </div>
+        )
+      ) : null}
+    </DrawerDialog>
   );
 }

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -89,3 +89,40 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
 
   expect(consoleErrors).toEqual([]);
 });
+
+test("keeps detail drawers modal and restores focus", async ({ page }) => {
+  await page.goto("/claudecode/e2e-dashboard");
+  await expect(page.getByTestId("session-detail")).toBeVisible();
+
+  const receiptTrigger = page.getByRole("button", { name: "Open session receipt" });
+  await receiptTrigger.click();
+  const receiptDialog = page.getByRole("dialog", { name: "Session Receipt" });
+  await expect(receiptDialog).toBeVisible();
+  await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
+  await expect(page.getByRole("button", { name: "Close session receipt" })).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect
+    .poll(() => receiptDialog.evaluate((dialog) => dialog.contains(document.activeElement)))
+    .toBe(true);
+  await page.keyboard.press("Escape");
+  await expect(receiptDialog).toBeHidden();
+  await expect(receiptTrigger).toBeFocused();
+  await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  const tocTrigger = page.getByRole("button", { name: /^TOC/ });
+  await tocTrigger.click();
+  const tocDialog = page.getByRole("dialog", { name: "Session TOC" });
+  await expect(tocDialog).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close session toc" })).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect.poll(() => tocDialog.evaluate((dialog) => dialog.contains(document.activeElement))).toBe(true);
+  await page.keyboard.press("Escape");
+  await expect(tocDialog).toBeHidden();
+  await expect(tocTrigger).toBeFocused();
+
+  await tocTrigger.click();
+  await expect(tocDialog).toBeVisible();
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await expect(tocDialog).toBeHidden();
+});


### PR DESCRIPTION
## Summary

- add a shared Base UI-backed drawer module for detail overlays
- give Receipt, TOC, and File Tracker drawers modal dialog semantics and associated titles
- centralize initial focus, focus trapping, Escape dismissal, scroll locking, and focus restoration
- preserve responsive auto-close behavior and delayed Receipt mounting
- cover desktop and mobile drawer lifecycles with Playwright

## Why

The detail overlays independently managed global key handlers and body scroll locking while lacking
dialog semantics, focus trapping, initial focus, and focus restoration. This duplicated lifecycle
knowledge across callers and left keyboard and screen-reader users outside a true modal interaction.

## Impact

All detail drawers now expose the same accessible behavior through a small shared interface. Callers
only own their open state, responsive close condition, title, and content; Base UI owns the modal
lifecycle.

## Validation

- `pnpm test:e2e`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`

Issue: CS-39
