### PR TITLE
fix(web): add keyboard access to charts

### DIFF
--- a/apps/web/src/components/Dashboard.test.tsx
+++ b/apps/web/src/components/Dashboard.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import type { DashboardData } from "../lib/api";
+import { Dashboard } from "./Dashboard";
+
+afterEach(cleanup);
+
+const dashboardData: DashboardData = {
+  totals: {
+    sessions: 3,
+    messages: 9,
+    tokens: 1_000,
+    cost: 0,
+    latestActivity: Date.now(),
+  },
+  perAgent: [],
+  dailyActivity: [{ date: "2026-07-11", sessions: 3, messages: 9 }],
+  dailyTokenActivity: [
+    { date: "2026-07-11", input: 400, output: 300, cache_read: 200, cache_create: 100 },
+  ],
+  modelDistribution: [{ model: "gpt-test", tokens: 1_000, sessions: 3 }],
+  recentSessions: [],
+  recentFileActivities: [],
+  window: { to: Date.now() },
+};
+
+describe("Dashboard charts", () => {
+  it("exposes chart data and focus details without hover", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    render(
+      <MemoryRouter>
+        <Dashboard
+          data={dashboardData}
+          bookmarkedSessions={[]}
+          isBookmarked={() => false}
+          onToggleBookmark={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    const activity = screen.getByRole("region", { name: "Daily Activity" });
+    expect(within(activity).getByRole("table", { name: "Daily Activity data" })).toBeTruthy();
+    fireEvent.focus(
+      within(activity).getByRole("button", {
+        name: "2026-07-11 · 3 sessions · 9 msgs",
+      }),
+    );
+    expect(within(activity).getByText("2026-07-11 · 3 sessions · 9 msgs")).toBeTruthy();
+
+    const tokens = screen.getByRole("region", { name: "Daily Token Activity" });
+    expect(within(tokens).getByRole("table", { name: "Daily Token Activity data" })).toBeTruthy();
+    expect(
+      within(tokens).getByRole("button", {
+        name: /2026-07-11 · 1000 total tokens · 400 input/,
+      }),
+    ).toBeTruthy();
+
+    const models = screen.getByRole("region", { name: "Model Distribution" });
+    expect(within(models).getByText("1.0k · 100.0%"));
+  });
+});

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -72,10 +72,16 @@ function DailyActivityChart({ buckets }: { buckets: DashboardDailyBucket[] }) {
   }, [buckets.length]);
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <section
+      aria-labelledby="daily-activity-title"
+      className="rounded-sm border border-[var(--console-border)] bg-white p-4"
+    >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
-          <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+          <h3
+            id="daily-activity-title"
+            className="console-mono text-xs font-bold uppercase text-[var(--console-text)]"
+          >
             Daily Activity
           </h3>
           <p className="console-mono mt-1 text-[11px] text-[var(--console-muted)]">
@@ -89,18 +95,22 @@ function DailyActivityChart({ buckets }: { buckets: DashboardDailyBucket[] }) {
         </span>
       </div>
 
-      <div className="flex h-32 items-end gap-[2px]" onMouseLeave={() => setHovered(null)}>
+      <div className="flex h-32 items-end gap-[2px]" onPointerLeave={() => setHovered(null)}>
         {buckets.map((bucket) => {
           const pxHeight =
             bucket.sessions > 0 ? Math.max(Math.round((bucket.sessions / maxValue) * 128), 4) : 2;
           const title = `${bucket.date} · ${bucket.sessions} sessions · ${bucket.messages} msgs`;
           const isActive = hovered?.date === bucket.date;
           return (
-            <div
+            <button
+              type="button"
               key={bucket.date}
-              title={title}
-              onMouseEnter={() => setHovered(bucket)}
-              className={`flex-1 cursor-default rounded-t-[1px] transition-opacity ${
+              aria-label={title}
+              onPointerEnter={() => setHovered(bucket)}
+              onClick={() => setHovered(bucket)}
+              onFocus={() => setHovered(bucket)}
+              onBlur={() => setHovered(null)}
+              className={`flex-1 cursor-default rounded-t-[1px] border-0 p-0 transition-opacity focus-visible:ring-2 focus-visible:ring-[var(--console-text)] focus-visible:ring-offset-2 focus-visible:outline-none ${
                 bucket.sessions > 0
                   ? "bg-[var(--console-accent)]"
                   : "bg-[var(--console-surface-muted)]"
@@ -118,7 +128,26 @@ function DailyActivityChart({ buckets }: { buckets: DashboardDailyBucket[] }) {
           </span>
         ))}
       </div>
-    </div>
+      <table className="sr-only">
+        <caption>Daily Activity data</caption>
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Sessions</th>
+            <th scope="col">Messages</th>
+          </tr>
+        </thead>
+        <tbody>
+          {buckets.map((bucket) => (
+            <tr key={bucket.date}>
+              <th scope="row">{bucket.date}</th>
+              <td>{bucket.sessions}</td>
+              <td>{bucket.messages}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
   );
 }
 
@@ -163,10 +192,16 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
   if (totalTokens === 0) return null;
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <section
+      aria-labelledby="daily-token-activity-title"
+      className="rounded-sm border border-[var(--console-border)] bg-white p-4"
+    >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
-          <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+          <h3
+            id="daily-token-activity-title"
+            className="console-mono text-xs font-bold uppercase text-[var(--console-text)]"
+          >
             Daily Token Activity
           </h3>
           <p className="console-mono mt-1 text-[11px] text-[var(--console-muted)]">
@@ -188,6 +223,7 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
               className="console-mono flex items-center gap-1.5 text-[10px] text-[var(--console-muted)]"
             >
               <span
+                aria-hidden="true"
                 className="inline-block size-2 rounded-full"
                 style={{ backgroundColor: TOKEN_COLORS[key] }}
               />
@@ -203,6 +239,7 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
               className="console-mono flex items-center gap-1.5 text-[10px] text-[var(--console-muted)]"
             >
               <span
+                aria-hidden="true"
                 className="inline-block size-2 rounded-full"
                 style={{ backgroundColor: TOKEN_COLORS[key] }}
               />
@@ -212,7 +249,7 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
         </div>
       )}
 
-      <div className="flex h-32 items-end gap-[2px]" onMouseLeave={() => setHovered(null)}>
+      <div className="flex h-32 items-end gap-[2px]" onPointerLeave={() => setHovered(null)}>
         {buckets.map((bucket) => {
           const total = bucket.input + bucket.output + bucket.cache_read + bucket.cache_create;
           const pxHeight = total > 0 ? Math.max(Math.round((total / maxValue) * 128), 4) : 2;
@@ -229,10 +266,15 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
               : [];
 
           return (
-            <div
+            <button
+              type="button"
               key={bucket.date}
-              onMouseEnter={() => setHovered(bucket)}
-              className={`flex flex-1 cursor-default flex-col justify-end overflow-hidden rounded-t-[1px] transition-opacity ${
+              aria-label={`${bucket.date} · ${total} total tokens · ${bucket.input} input · ${bucket.output} output · ${bucket.cache_read} cache read · ${bucket.cache_create} cache create`}
+              onPointerEnter={() => setHovered(bucket)}
+              onClick={() => setHovered(bucket)}
+              onFocus={() => setHovered(bucket)}
+              onBlur={() => setHovered(null)}
+              className={`flex flex-1 cursor-default flex-col justify-end overflow-hidden rounded-t-[1px] border-0 p-0 transition-opacity focus-visible:ring-2 focus-visible:ring-[var(--console-text)] focus-visible:ring-offset-2 focus-visible:outline-none ${
                 isActive ? "opacity-70" : "opacity-100"
               }`}
               style={{ height: `${pxHeight}px` }}
@@ -254,7 +296,7 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
               ) : (
                 <div className="h-full bg-[var(--console-surface-muted)]" />
               )}
-            </div>
+            </button>
           );
         })}
       </div>
@@ -266,7 +308,30 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
           </span>
         ))}
       </div>
-    </div>
+      <table className="sr-only">
+        <caption>Daily Token Activity data</caption>
+        <thead>
+          <tr>
+            <th scope="col">Date</th>
+            <th scope="col">Input</th>
+            <th scope="col">Output</th>
+            <th scope="col">Cache Read</th>
+            <th scope="col">Cache Create</th>
+          </tr>
+        </thead>
+        <tbody>
+          {buckets.map((bucket) => (
+            <tr key={bucket.date}>
+              <th scope="row">{bucket.date}</th>
+              <td>{bucket.input}</td>
+              <td>{bucket.output}</td>
+              <td>{bucket.cache_read}</td>
+              <td>{bucket.cache_create}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
   );
 }
 
@@ -314,9 +379,15 @@ function ModelDistribution({ entries }: { entries: ModelDistributionEntry[] }) {
   }, {});
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <section
+      aria-labelledby="model-distribution-title"
+      className="rounded-sm border border-[var(--console-border)] bg-white p-4"
+    >
       <div className="mb-3 flex items-center justify-between gap-3">
-        <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+        <h3
+          id="model-distribution-title"
+          className="console-mono text-xs font-bold uppercase text-[var(--console-text)]"
+        >
           Model Distribution
         </h3>
         <span className="console-mono text-[11px] text-[var(--console-muted)]">
@@ -326,7 +397,11 @@ function ModelDistribution({ entries }: { entries: ModelDistributionEntry[] }) {
 
       <div className="flex items-center gap-6">
         <div className="flex shrink-0 flex-col items-center">
-          <ChartContainer config={chartConfig} className="aspect-square size-[160px]">
+          <ChartContainer
+            config={chartConfig}
+            className="aspect-square size-[160px]"
+            aria-hidden="true"
+          >
             <PieChart>
               <ChartTooltip
                 content={
@@ -364,6 +439,7 @@ function ModelDistribution({ entries }: { entries: ModelDistributionEntry[] }) {
           {chartData.map((entry) => (
             <li key={entry.model} className="flex items-center gap-2">
               <span
+                aria-hidden="true"
                 className="inline-block size-2.5 shrink-0 rounded-full"
                 style={{ backgroundColor: entry.fill }}
               />
@@ -371,13 +447,13 @@ function ModelDistribution({ entries }: { entries: ModelDistributionEntry[] }) {
                 {entry.model}
               </span>
               <span className="console-mono shrink-0 text-[11px] text-[var(--console-muted)]">
-                {(entry.fraction * 100).toFixed(1)}%
+                {formatCompact(entry.tokens)} · {(entry.fraction * 100).toFixed(1)}%
               </span>
             </li>
           ))}
         </ul>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -123,6 +123,30 @@ describe("SessionMessageTimeline", () => {
     expect(window.style.width).toBe("25%");
   });
 
+  it("scrolls the minimap with standard scrollbar keys", () => {
+    const longEntries = Array.from({ length: 100 }, (_, index) => ({
+      ...entries[index % entries.length]!,
+      id: `entry-${index}`,
+      anchorId: `entry-${index}`,
+    }));
+    const { getByTestId, timeline } = renderTimeline(longEntries);
+    Object.defineProperties(timeline, {
+      clientWidth: { configurable: true, value: 300 },
+      scrollWidth: { configurable: true, value: 1_200 },
+      scrollLeft: { configurable: true, value: 300, writable: true },
+    });
+    fireEvent.scroll(timeline);
+    const minimap = getByTestId("session-timeline-minimap");
+
+    minimap.focus();
+    fireEvent.keyDown(minimap, { key: "ArrowRight" });
+    expect(timeline.scrollLeft).toBeGreaterThan(300);
+    fireEvent.keyDown(minimap, { key: "Home" });
+    expect(timeline.scrollLeft).toBe(0);
+    fireEvent.keyDown(minimap, { key: "End" });
+    expect(timeline.scrollLeft).toBe(900);
+  });
+
   it("hides the minimap when the track fits the viewport", () => {
     const { queryByTestId, timeline } = renderTimeline();
 

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import { createPortal } from "react-dom";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import {
@@ -280,6 +288,26 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
     viewport.scrollLeft = (ratio - grabOffset) * viewport.scrollWidth;
   }, []);
 
+  const handleMinimapKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+    const maxScrollLeft = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
+    const step = Math.max(40, viewport.clientWidth * 0.1);
+    const page = Math.max(120, viewport.clientWidth * 0.75);
+    let next: number | null = null;
+
+    if (event.key === "ArrowLeft") next = viewport.scrollLeft - step;
+    if (event.key === "ArrowRight") next = viewport.scrollLeft + step;
+    if (event.key === "PageUp") next = viewport.scrollLeft - page;
+    if (event.key === "PageDown") next = viewport.scrollLeft + page;
+    if (event.key === "Home") next = 0;
+    if (event.key === "End") next = maxScrollLeft;
+    if (next == null) return;
+
+    event.preventDefault();
+    viewport.scrollLeft = Math.min(maxScrollLeft, Math.max(0, next));
+  }, []);
+
   const showTooltip = useCallback(
     (entry: SessionTimelineEntry, trigger: HTMLElement, source: TimelineTooltip["source"]) => {
       const rect = trigger.getBoundingClientRect();
@@ -473,7 +501,10 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
             aria-valuemin={0}
             aria-valuemax={100}
             aria-valuenow={Math.round((minimapWindow.start / (1 - minimapWindow.size)) * 100)}
-            className="session-timeline-minimap relative mt-2 h-2.5 cursor-pointer touch-none select-none"
+            aria-label="Timeline scroll position"
+            tabIndex={0}
+            className="session-timeline-minimap relative mt-2 h-2.5 cursor-pointer touch-none select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-text)]"
+            onKeyDown={handleMinimapKeyDown}
             onPointerDown={(event) => {
               if (event.button !== 0) return;
               const rect = event.currentTarget.getBoundingClientRect();

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as RechartsPrimitive from "recharts";
 import type { TooltipValueType } from "recharts";
 
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -16,6 +16,11 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
   await expect(dashboard).toBeVisible();
   await expect(dashboard.getByText("Total Sessions")).toBeVisible();
   await expect(dashboard.getByText("Core browsing smoke session")).toBeVisible();
+  const activityChart = page.getByRole("region", { name: "Daily Activity" });
+  const activityBar = activityChart.getByRole("button").first();
+  await activityBar.focus();
+  await expect(activityBar).toBeFocused();
+  await expect(activityChart.getByRole("table", { name: "Daily Activity data" })).toBeAttached();
 
   await page
     .getByRole("link", { name: /Claude Code/ })


### PR DESCRIPTION
## Summary

- make the timeline minimap scrollbar operable with Arrow, Page, Home, and End keys
- expose Daily Activity and Daily Token bars to focus, pointer, and touch interaction
- add accessible names and screen-reader data tables for chart buckets
- expose model token values alongside percentages and hide the redundant pie graphic
- add timeline, Dashboard, and Playwright accessibility coverage

## Root cause

The minimap declared ARIA scrollbar semantics without keyboard behavior or a tab stop. Dashboard
bars only reacted to mouse hover and exposed details through `title`, leaving keyboard, touch, and
screen-reader users without an equivalent path to the data.

## Impact

Every chart now has a labeled region and complete textual data equivalent. Interactive bars share
the same detail state across focus, pointer, and tap, while the timeline scrollbar implements the
standard keyboard navigation model.

## Validation

- `pnpm test:e2e`
- `pnpm --filter @codesesh/web test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`

Issue: CS-40
