### PR TITLE
test(e2e): establish website interaction baseline

### DIFF
--- a/apps/www/src/components/Hero.astro
+++ b/apps/www/src/components/Hero.astro
@@ -113,6 +113,7 @@ const terminalHtml = [
             data-copy-command={t.command}
             data-copy-label={t.copyCommand}
             data-copied-label={t.copied}
+            data-copy-failed-label={t.copyFailed}
             class="console-mono inline-flex items-center justify-center gap-2 rounded-sm bg-[var(--console-accent-strong)] px-4 py-3 text-xs font-semibold text-white transition-colors hover:bg-black"
           >
             <span data-copy-icon="idle"><Icon name="copy" class="size-4" /></span>
@@ -120,6 +121,7 @@ const terminalHtml = [
             <span data-copy-text>{t.copyCommand}</span>
           </button>
         </div>
+        <span class="sr-only" aria-live="polite" data-copy-status></span>
         <p class="mt-3 text-sm leading-6 text-[var(--console-muted)]">{t.runtime}</p>
       </div>
     </div>
@@ -144,19 +146,24 @@ const terminalHtml = [
   async function copyText(value: string) {
     try {
       await navigator.clipboard.writeText(value);
-      return;
+      return true;
     } catch {
-      const textarea = document.createElement("textarea");
-      textarea.value = value;
-      textarea.setAttribute("readonly", "");
-      textarea.style.position = "fixed";
-      textarea.style.top = "-9999px";
-      document.body.append(textarea);
-      textarea.select();
-      const execCommand = Reflect.get(document, "execCommand") as (command: string) => boolean;
-      const copied = execCommand.call(document, "copy");
-      textarea.remove();
-      if (!copied) throw new Error("Copy command failed");
+      try {
+        const textarea = document.createElement("textarea");
+        textarea.value = value;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.top = "-9999px";
+        document.body.append(textarea);
+        textarea.select();
+        const execCommand = Reflect.get(document, "execCommand");
+        const copied =
+          typeof execCommand === "function" && execCommand.call(document, "copy") === true;
+        textarea.remove();
+        return copied;
+      } catch {
+        return false;
+      }
     }
   }
 
@@ -164,24 +171,27 @@ const terminalHtml = [
     const command = button.dataset.copyCommand;
     const copyLabel = button.dataset.copyLabel ?? "";
     const copiedLabel = button.dataset.copiedLabel ?? "";
+    const copyFailedLabel = button.dataset.copyFailedLabel ?? "";
     const text = button.querySelector("[data-copy-text]");
+    const status = button.parentElement?.parentElement?.querySelector("[data-copy-status]");
     const idleIcon = button.querySelector<HTMLElement>('[data-copy-icon="idle"]');
     const doneIcon = button.querySelector<HTMLElement>('[data-copy-icon="done"]');
 
     if (!command || !text || !idleIcon || !doneIcon) return;
 
-    button.addEventListener("click", () => {
-      copyText(command).then(() => {
-        text.textContent = copiedLabel;
-        idleIcon.hidden = true;
-        doneIcon.hidden = false;
+    button.addEventListener("click", async () => {
+      const copied = await copyText(command);
+      const feedback = copied ? copiedLabel : copyFailedLabel;
+      text.textContent = feedback;
+      if (status) status.textContent = feedback;
+      idleIcon.hidden = copied;
+      doneIcon.hidden = !copied;
 
-        window.setTimeout(() => {
-          text.textContent = copyLabel;
-          idleIcon.hidden = false;
-          doneIcon.hidden = true;
-        }, 2000);
-      });
+      window.setTimeout(() => {
+        text.textContent = copyLabel;
+        idleIcon.hidden = false;
+        doneIcon.hidden = true;
+      }, 2000);
     });
   });
 </script>

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -55,6 +55,7 @@ interface LandingCopy {
     commandTitle: string;
     command: string;
     copied: string;
+    copyFailed: string;
     copyCommand: string;
     runtime: string;
   };
@@ -123,6 +124,7 @@ export const copy = {
       commandTitle: "从本地开始积累",
       command: "npx codesesh",
       copied: "已复制",
+      copyFailed: "复制失败，请手动复制命令",
       copyCommand: "复制命令",
       runtime: "需要 Node.js 22+ · 从终端本地运行",
     },
@@ -314,6 +316,7 @@ export const copy = {
       commandTitle: "Start from your machine",
       command: "npx codesesh",
       copied: "Copied",
+      copyFailed: "Copy failed. Copy the command manually.",
       copyCommand: "Copy command",
       runtime: "Requires Node.js 22+ · Runs locally from your terminal",
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { defineConfig, devices } from "playwright/test";
 
 const port = Number(process.env.CODESESH_E2E_PORT ?? 4387);
+const wwwPort = Number(process.env.CODESESH_WWW_E2E_PORT ?? 4388);
 const e2eHome = mkdtempSync(join(tmpdir(), "codesesh-e2e-home-"));
 const fixtureRoot = resolve("tests/e2e/fixtures");
 
@@ -29,34 +30,47 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
   use: {
-    baseURL: `http://127.0.0.1:${port}`,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
   },
-  webServer: {
-    command: `pnpm build && node packages/cli/dist/index.js --port ${port} --agent claudecode --days 0 --noOpen --cache false`,
-    url: `http://127.0.0.1:${port}/api/config`,
-    reuseExistingServer: false,
-    timeout: 60_000,
-    env: {
-      HOME: e2eHome,
-      USERPROFILE: e2eHome,
-      XDG_DATA_HOME: join(e2eHome, ".local", "share"),
-      XDG_CONFIG_HOME: join(e2eHome, ".config"),
-      APPDATA: join(e2eHome, "AppData", "Roaming"),
-      LOCALAPPDATA: join(e2eHome, "AppData", "Local"),
-      CODESESH_STATE_STORE: "memory",
-      CODESESH_STATE_DIR: join(e2eHome, "state"),
-      CLAUDE_CONFIG_DIR: join(fixtureRoot, "claude"),
-      CODEX_HOME: join(e2eHome, ".codex"),
-      KIMI_SHARE_DIR: join(e2eHome, ".kimi"),
-      CURSOR_DATA_PATH: join(e2eHome, "cursor"),
+  webServer: [
+    {
+      command: `pnpm build && node packages/cli/dist/index.js --port ${port} --agent claudecode --days 0 --noOpen --cache false`,
+      url: `http://127.0.0.1:${port}/api/config`,
+      reuseExistingServer: false,
+      timeout: 60_000,
+      env: {
+        HOME: e2eHome,
+        USERPROFILE: e2eHome,
+        XDG_DATA_HOME: join(e2eHome, ".local", "share"),
+        XDG_CONFIG_HOME: join(e2eHome, ".config"),
+        APPDATA: join(e2eHome, "AppData", "Roaming"),
+        LOCALAPPDATA: join(e2eHome, "AppData", "Local"),
+        CODESESH_STATE_STORE: "memory",
+        CODESESH_STATE_DIR: join(e2eHome, "state"),
+        CLAUDE_CONFIG_DIR: join(fixtureRoot, "claude"),
+        CODEX_HOME: join(e2eHome, ".codex"),
+        KIMI_SHARE_DIR: join(e2eHome, ".kimi"),
+        CURSOR_DATA_PATH: join(e2eHome, "cursor"),
+      },
     },
-  },
+    {
+      command: `pnpm --filter @codesesh/www dev --host 127.0.0.1 --port ${wwwPort}`,
+      url: `http://127.0.0.1:${wwwPort}`,
+      reuseExistingServer: false,
+      timeout: 60_000,
+    },
+  ],
   projects: [
     {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      name: "web-chromium",
+      testMatch: "browsing.spec.ts",
+      use: { ...devices["Desktop Chrome"], baseURL: `http://127.0.0.1:${port}` },
+    },
+    {
+      name: "www-chromium",
+      testMatch: "www.spec.ts",
+      use: { ...devices["Desktop Chrome"], baseURL: `http://127.0.0.1:${wwwPort}` },
     },
   ],
 });

--- a/tests/e2e/www.spec.ts
+++ b/tests/e2e/www.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "playwright/test";
+
+test("copies the install command with the clipboard API", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: () => Promise.resolve() },
+    });
+  });
+  await page.goto("/");
+
+  const copy = page.locator("[data-copy-command]");
+  await copy.click();
+
+  await expect(copy).toContainText("Copied");
+});
+
+test("reports copy failure without an unhandled rejection", async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: () => Promise.reject(new Error("denied")) },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: () => false,
+    });
+  });
+  await page.goto("/");
+
+  const copy = page.locator("[data-copy-command]");
+  await copy.click();
+
+  await expect(copy).toContainText("Copy failed");
+  await expect(page.locator("[data-copy-status]")).toHaveText(
+    "Copy failed. Copy the command manually.",
+  );
+  expect(pageErrors).toEqual([]);
+});
+
+test("falls back when the clipboard API rejects", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: () => Promise.reject(new Error("denied")) },
+    });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: () => true,
+    });
+  });
+  await page.goto("/");
+
+  const copy = page.locator("[data-copy-command]");
+  await copy.click();
+
+  await expect(copy).toContainText("Copied");
+});
+
+test("navigates showcase dialogs", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Expand Engineering Memory Overview" }).click();
+  const first = page.getByRole("dialog", {
+    name: "Engineering Memory Overview preview",
+  });
+  await expect(first).toBeVisible();
+
+  await first.getByRole("button", { name: "Next" }).click();
+  const next = page.getByRole("dialog", {
+    name: "Structured Global Search preview",
+  });
+  await expect(next).toBeVisible();
+
+  await next.getByRole("button", { name: "Previous" }).click();
+  await expect(first).toBeVisible();
+  await first.getByRole("button", { name: "Close" }).click();
+  await expect(first).toBeHidden();
+});


### PR DESCRIPTION
## Summary

- run the Web app and marketing site as separate Playwright projects
- cover website copy success, fallback, failure feedback, and showcase navigation
- handle clipboard rejection without unhandled promises and announce failures through `aria-live`
- retain the existing Web search, keyboard, and detail-drawer coverage

## Why

Critical website interactions had no browser-level regression coverage. The copy handler also treated a failed fallback as success and could leave an unhandled rejection.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e` (6 passed)

Closes CS-41
