### PR TITLE
refactor(web): remove virtual list polling

### DIFF
--- a/apps/web/src/components/session-detail/message-list.test.tsx
+++ b/apps/web/src/components/session-detail/message-list.test.tsx
@@ -1,0 +1,130 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FilteredSessionMessage } from "./toc";
+import { MessageList, VIRTUALIZED_MESSAGE_THRESHOLD } from "./message-list";
+
+vi.mock("./message-rendering", () => ({
+  MessageItem: ({ messageIndex }: { messageIndex: number }) => (
+    <div data-message-index={messageIndex}>Message {messageIndex}</div>
+  ),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = [];
+
+  readonly targets = new Set<Element>();
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    ResizeObserverMock.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.targets.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.targets.delete(target);
+  }
+
+  disconnect() {
+    this.targets.clear();
+  }
+
+  trigger(target: Element) {
+    if (!this.targets.has(target)) return;
+    this.callback([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver);
+  }
+}
+
+function createMessages(): FilteredSessionMessage[] {
+  return Array.from({ length: VIRTUALIZED_MESSAGE_THRESHOLD + 1 }, (_, index) => ({
+    msg: { id: `message-${index}` } as FilteredSessionMessage["msg"],
+    blocks: [],
+    index,
+  }));
+}
+
+describe("MessageList virtualization", () => {
+  it("does not poll layout while idle", () => {
+    const setInterval = vi.spyOn(window, "setInterval");
+
+    render(
+      <MessageList
+        messages={createMessages()}
+        toolAnchorIds={new Map()}
+        sessionAgentKey="claudecode"
+        baseDirectory="/tmp/project"
+        apiRef={{ current: null }}
+      />,
+    );
+
+    expect(setInterval).not.toHaveBeenCalled();
+  });
+
+  it("updates visible rows when the scroll container resizes", async () => {
+    ResizeObserverMock.instances = [];
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const scrollContainer = document.createElement("div");
+    scrollContainer.style.overflowY = "auto";
+    document.body.append(scrollContainer);
+    let viewportHeight = 100;
+    Object.defineProperty(scrollContainer, "clientHeight", {
+      configurable: true,
+      get: () => viewportHeight,
+    });
+
+    const view = render(
+      <MessageList
+        messages={createMessages()}
+        toolAnchorIds={new Map()}
+        sessionAgentKey="claudecode"
+        baseDirectory="/tmp/project"
+        apiRef={{ current: null }}
+      />,
+      { container: scrollContainer },
+    );
+    await waitFor(() =>
+      expect(view.container.querySelectorAll("[data-message-index]")).toHaveLength(7),
+    );
+
+    viewportHeight = 1_400;
+    ResizeObserverMock.instances.forEach((observer) => observer.trigger(scrollContainer));
+
+    await waitFor(() =>
+      expect(view.container.querySelectorAll("[data-message-index]").length).toBeGreaterThan(7),
+    );
+    scrollContainer.remove();
+  });
+
+  it("remeasures a row after asynchronous content growth", async () => {
+    ResizeObserverMock.instances = [];
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const view = render(
+      <MessageList
+        messages={createMessages()}
+        toolAnchorIds={new Map()}
+        sessionAgentKey="claudecode"
+        baseDirectory="/tmp/project"
+        apiRef={{ current: null }}
+      />,
+    );
+    const list = view.container.firstElementChild as HTMLElement;
+    const initialHeight = Number.parseInt(list.style.height, 10);
+    const row = view.container.querySelector("[data-message-index]")?.parentElement as HTMLElement;
+    vi.spyOn(row, "getBoundingClientRect").mockReturnValue({
+      ...row.getBoundingClientRect(),
+      bottom: 600,
+      height: 600,
+    });
+
+    ResizeObserverMock.instances.forEach((observer) => observer.trigger(row));
+
+    await waitFor(() => expect(Number.parseInt(list.style.height, 10)).toBe(initialHeight + 320));
+  });
+});

--- a/apps/web/src/components/session-detail/message-list.tsx
+++ b/apps/web/src/components/session-detail/message-list.tsx
@@ -203,7 +203,7 @@ function VirtualizedMessageList({
   }, [viewport]);
 
   const updateViewport = useCallback(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined") return null;
 
     const node = containerRef.current;
     const scrollParent = node ? findScrollParent(node) : window;
@@ -221,42 +221,74 @@ function VirtualizedMessageList({
       Math.abs(current.height - next.height) < 1 &&
       Math.abs(current.listTop - next.listTop) < 1
     ) {
-      return;
+      return scrollParent;
     }
 
     viewportRef.current = next;
     setViewport(next);
+    return scrollParent;
   }, []);
 
   useEffect(() => {
-    updateViewport();
-    const scrollParent = scrollParentRef.current ?? window;
     let frame = 0;
+    let scrollParent: ScrollParent | null = null;
+    let resizeObserver: ResizeObserver | null = null;
+
+    const bindScrollParent = (next: ScrollParent) => {
+      if (scrollParent === next) return;
+
+      if (scrollParent) {
+        scrollParent.removeEventListener("scroll", scheduleUpdate);
+        if (resizeObserver && !isWindowScrollParent(scrollParent)) {
+          resizeObserver.unobserve(scrollParent);
+        }
+      }
+
+      scrollParent = next;
+      scrollParent.addEventListener("scroll", scheduleUpdate, { passive: true });
+      if (resizeObserver && !isWindowScrollParent(scrollParent)) {
+        resizeObserver.observe(scrollParent);
+      }
+    };
+
+    const refreshViewport = () => {
+      const nextScrollParent = updateViewport();
+      if (nextScrollParent) bindScrollParent(nextScrollParent);
+    };
+
     const scheduleUpdate = () => {
       if (frame) return;
       frame = requestAnimationFrame(() => {
         frame = 0;
-        updateViewport();
+        refreshViewport();
       });
     };
 
-    scrollParent.addEventListener("scroll", scheduleUpdate, { passive: true });
     window.addEventListener("resize", scheduleUpdate);
-    const interval = window.setInterval(updateViewport, 100);
-
-    let observer: ResizeObserver | null = null;
     if (typeof ResizeObserver !== "undefined") {
-      observer = new ResizeObserver(scheduleUpdate);
-      if (containerRef.current) observer.observe(containerRef.current);
-      if (!isWindowScrollParent(scrollParent)) observer.observe(scrollParent);
-      if (document.body) observer.observe(document.body);
+      resizeObserver = new ResizeObserver(scheduleUpdate);
+      if (containerRef.current) resizeObserver.observe(containerRef.current);
+      if (document.body) resizeObserver.observe(document.body);
     }
+
+    const layoutObserver = new MutationObserver(scheduleUpdate);
+    let ancestor = containerRef.current?.parentElement;
+    while (ancestor) {
+      layoutObserver.observe(ancestor, {
+        attributes: true,
+        attributeFilter: ["class", "style"],
+      });
+      ancestor = ancestor.parentElement;
+    }
+    document.fonts?.addEventListener("loadingdone", scheduleUpdate);
+    refreshViewport();
 
     return () => {
       if (frame) cancelAnimationFrame(frame);
-      observer?.disconnect();
-      window.clearInterval(interval);
-      scrollParent.removeEventListener("scroll", scheduleUpdate);
+      resizeObserver?.disconnect();
+      layoutObserver.disconnect();
+      document.fonts?.removeEventListener("loadingdone", scheduleUpdate);
+      scrollParent?.removeEventListener("scroll", scheduleUpdate);
       window.removeEventListener("resize", scheduleUpdate);
     };
   }, [updateViewport]);


### PR DESCRIPTION
## Summary

- replace the virtual message list's permanent 100 ms layout polling with event-driven updates
- rebind scroll and resize listeners when the effective scroll container changes
- react to container geometry, ancestor layout attributes, and font loading events
- add regression coverage for idle behavior, container resize, and asynchronous row growth

## Why

Every virtualized detail view performed geometry reads ten times per second even when the page was idle. Existing observers covered row growth, but the viewport lifecycle still depended on polling for container and layout changes.

The updated lifecycle coalesces relevant events with `requestAnimationFrame` and performs no recurring work while the page is stable.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (650 passed)
- `pnpm test:e2e` (6 passed)

Closes CS-42
