### PR TITLE
refactor(core): centralize session indexing

### DIFF
--- a/apps/web/src/lib/live-update.ts
+++ b/apps/web/src/lib/live-update.ts
@@ -3,8 +3,7 @@
  * current session list (apply changes, drop removals, re-sort).
  */
 import type { SessionHead, SessionsUpdatedEvent } from "./api";
-import { getSessionAgentKey } from "./session-indexes";
-import { getSessionRouteKey } from "./session-indexes";
+import { applySessionChanges, compareSessionActivityDesc } from "@codesesh/core/contract";
 
 /**
  * A sessions-updated notice that may lack the incremental diff arrays.
@@ -17,9 +16,7 @@ export type LiveSessionsUpdate = Omit<
 > &
   Partial<Pick<SessionsUpdatedEvent, "changedSessionHeads" | "removedSessionRefs">>;
 
-export function compareSessionActivityDesc(a: SessionHead, b: SessionHead): number {
-  return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
-}
+export { compareSessionActivityDesc };
 
 export function applyLiveSessionUpdate(
   sessions: SessionHead[],
@@ -27,20 +24,5 @@ export function applyLiveSessionUpdate(
 ): SessionHead[] | null {
   if (!event.changedSessionHeads || !event.removedSessionRefs) return null;
 
-  const byKey = new Map(
-    sessions.map((sessionItem) => [
-      getSessionRouteKey(getSessionAgentKey(sessionItem), sessionItem.id),
-      sessionItem,
-    ]),
-  );
-
-  for (const { agentName, sessionId } of event.removedSessionRefs) {
-    byKey.delete(getSessionRouteKey(agentName, sessionId));
-  }
-
-  for (const { agentName, session: sessionItem } of event.changedSessionHeads) {
-    byKey.set(getSessionRouteKey(agentName, sessionItem.id), sessionItem);
-  }
-
-  return [...byKey.values()].sort(compareSessionActivityDesc);
+  return applySessionChanges(sessions, event.changedSessionHeads, event.removedSessionRefs);
 }

--- a/apps/web/src/lib/session-indexes.ts
+++ b/apps/web/src/lib/session-indexes.ts
@@ -1,4 +1,10 @@
 import type { AgentInfo, ProjectIdentityKind, SessionHead } from "./api";
+import {
+  createSessionIndex,
+  getProjectAgentKey,
+  getSessionAgentKey,
+  getSessionRouteKey,
+} from "@codesesh/core/contract";
 import { getProjectIdentityKey } from "./projects";
 
 export interface IndexedSession extends SessionHead {
@@ -32,21 +38,7 @@ export interface SidebarSessionLookup {
   indexById: Map<string, number>;
 }
 
-function compareSessionActivityDesc(a: SessionHead, b: SessionHead): number {
-  return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
-}
-
-export function getSessionAgentKey(session: Pick<SessionHead, "slug">): string {
-  return session.slug.split("/")[0]?.toLowerCase() || "unknown";
-}
-
-export function getSessionRouteKey(agentKey: string, sessionId: string): string {
-  return `${agentKey.toLowerCase()}/${sessionId}`;
-}
-
-export function getProjectAgentKey(projectIdentityKey: string, agentKey: string): string {
-  return `${projectIdentityKey}\0${agentKey.toLowerCase()}`;
-}
+export { getProjectAgentKey, getSessionAgentKey, getSessionRouteKey };
 
 function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   const current = map.get(key);
@@ -58,10 +50,8 @@ function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
 }
 
 export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]): SessionIndexes {
-  const byRouteKey = new Map<string, SessionHead>();
+  const canonical = createSessionIndex(sessions);
   const byAgent = new Map<string, SessionHead[]>();
-  const byProjectIdentityKey = new Map<string, SessionHead[]>();
-  const byProjectAgentKey = new Map<string, SessionHead[]>();
   const byLandingAgent = new Map<string, IndexedSession[]>();
   const byLandingProjectIdentityKey = new Map<string, IndexedSession[]>();
   const projectOptionsByKey = new Map<string, SessionProjectOption>();
@@ -83,9 +73,6 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
     };
 
     landingSessions.push(indexedSession);
-    const routeKey = getSessionRouteKey(agentKey, session.id);
-    if (!byRouteKey.has(routeKey)) byRouteKey.set(routeKey, session);
-
     if (knownAgentKeys.has(agentKey)) {
       byLandingAgent.get(agentKey)!.push(indexedSession);
     }
@@ -110,28 +97,19 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
     }
   }
 
-  const sessionsByActivity = sessions.toSorted(compareSessionActivityDesc);
-  for (const session of sessionsByActivity) {
-    const agentKey = getSessionAgentKey(session);
-    if (knownAgentKeys.has(agentKey)) byAgent.get(agentKey)!.push(session);
-
-    const identity = session.project_identity;
-    if (!identity?.key) continue;
-
-    const projectIdentityKey = getProjectIdentityKey(identity);
-    pushMapValue(byProjectIdentityKey, projectIdentityKey, session);
-    pushMapValue(byProjectAgentKey, getProjectAgentKey(projectIdentityKey, agentKey), session);
+  for (const agentKey of knownAgentKeys) {
+    byAgent.set(agentKey, canonical.byAgent.get(agentKey) ?? []);
   }
 
   return {
-    byRouteKey,
+    byRouteKey: canonical.byRouteKey,
     byAgent,
-    byProjectIdentityKey,
-    byProjectAgentKey,
+    byProjectIdentityKey: canonical.byProjectIdentityKey,
+    byProjectAgentKey: canonical.byProjectAgentKey,
     byLandingAgent,
     byLandingProjectIdentityKey,
     landingSessions,
-    sessionsByActivity,
+    sessionsByActivity: canonical.sessionsByActivity,
     projectOptions: [...projectOptionsByKey.values()]
       .toSorted((a, b) => b.count - a.count)
       .slice(0, 8),

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e": "playwright test",
     "test:migration": "vitest run packages/core/src/discovery/__tests__/migration-smoke.test.ts",
     "bench:perf": "node scripts/benchmark-performance.mjs",
+    "bench:session-index": "pnpm --filter @codesesh/core build && node scripts/benchmark-session-index.mjs",
     "test:coverage": "vitest run --coverage",
     "deploy:www": "pnpm --filter @codesesh/www deploy:cf"
   },

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -7,7 +7,7 @@ const distEntry = join(dirname(fileURLToPath(import.meta.url)), "../../../dist/c
 const distExists = existsSync(distEntry);
 
 // Requires `pnpm --filter @codesesh/core build` to have run first — the
-// contract package has no runtime code of its own to test against otherwise.
+// contract package runtime must remain browser-safe.
 describe("contract browser-safety", () => {
   it.skipIf(!distExists)(
     "bundle contains no Node built-ins, better-sqlite3, or agent registration side effects",
@@ -19,7 +19,7 @@ describe("contract browser-safety", () => {
     },
   );
 
-  it.skipIf(!distExists)("imports cleanly and exposes only pure fixture data", async () => {
+  it.skipIf(!distExists)("imports cleanly and exposes only pure runtime values", async () => {
     const contract = await import(distEntry);
     expect(Object.keys(contract).sort()).toEqual(
       [
@@ -27,6 +27,15 @@ describe("contract browser-safety", () => {
         "SAMPLE_SCAN_STATUS_EVENT",
         "SAMPLE_SESSIONS_UPDATED_EVENT",
         "SAMPLE_SESSION_HEAD",
+        "applySessionChanges",
+        "compareSessionActivityDesc",
+        "createSessionIndex",
+        "getProjectAgentKey",
+        "getProjectIdentityKey",
+        "getSessionAgentKey",
+        "getSessionRouteKey",
+        "sortSessionsByActivity",
+        "updateSessionIndex",
       ].sort(),
     );
   });

--- a/packages/core/src/contract/__tests__/session-index.test.ts
+++ b/packages/core/src/contract/__tests__/session-index.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { SessionHead } from "../session.js";
+import {
+  applySessionChanges,
+  createSessionIndex,
+  getProjectAgentKey,
+  getSessionRouteKey,
+  updateSessionIndex,
+} from "../session-index.js";
+
+function createSession(
+  id: string,
+  activity: number,
+  overrides: Partial<SessionHead> = {},
+): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: id,
+    directory: "/workspace/app",
+    time_created: activity,
+    time_updated: activity,
+    stats: {
+      message_count: 0,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+function sessionIds(sessions: SessionHead[] | undefined): string[] {
+  return sessions?.map((session) => session.id) ?? [];
+}
+
+describe("canonical session index", () => {
+  it("preserves stable ordering and the first duplicate route", () => {
+    const first = createSession("same", 100, { title: "First" });
+    const duplicate = createSession("same", 100, { title: "Duplicate" });
+    const next = createSession("next", 100);
+
+    const index = createSessionIndex([first, duplicate, next]);
+
+    expect(index.sessionsByActivity).toEqual([first, duplicate, next]);
+    expect(index.byRouteKey.get(getSessionRouteKey("codex", "same"))).toBe(first);
+  });
+
+  it("keeps project identity kinds and agents in separate indexes", () => {
+    const remote = createSession("remote", 300, {
+      project_identity: {
+        kind: "git_remote",
+        key: "github.com/acme/app",
+        displayName: "App",
+      },
+    });
+    const path = createSession("path", 200, {
+      slug: "claude/path",
+      project_identity: {
+        kind: "path",
+        key: "github.com/acme/app",
+        displayName: "App path",
+      },
+    });
+
+    const index = createSessionIndex([path, remote]);
+
+    expect(sessionIds(index.byProjectIdentityKey.get("git_remote:github.com/acme/app"))).toEqual([
+      "remote",
+    ]);
+    expect(sessionIds(index.byProjectIdentityKey.get("path:github.com/acme/app"))).toEqual([
+      "path",
+    ]);
+    expect(
+      sessionIds(
+        index.byProjectAgentKey.get(getProjectAgentKey("git_remote:github.com/acme/app", "codex")),
+      ),
+    ).toEqual(["remote"]);
+  });
+
+  it("applies route-keyed changes and removals with wire-event semantics", () => {
+    const old = createSession("old", 100);
+    const replaced = createSession("same", 200, { title: "Old title" });
+    const replacement = createSession("same", 400, { title: "New title" });
+    const added = createSession("added", 300, { slug: "claude/added" });
+
+    const sessions = applySessionChanges(
+      [old, replaced],
+      [
+        { agentName: "codex", session: replacement },
+        { agentName: "claude", session: added },
+      ],
+      [{ agentName: "codex", sessionId: "old" }],
+    );
+
+    expect(sessions).toEqual([replacement, added]);
+  });
+
+  it("matches a full rebuild across deterministic incremental batches", () => {
+    let index = createSessionIndex(
+      Array.from({ length: 40 }, (_, value) => createSession(`session-${value}`, value)),
+    );
+
+    for (let batch = 0; batch < 20; batch += 1) {
+      const changedId = `session-${(batch * 7) % 40}`;
+      const added = createSession(`added-${batch}`, 1_000 + batch, {
+        slug: `${batch % 2 === 0 ? "codex" : "claude"}/added-${batch}`,
+      });
+      const changes = [
+        { agentName: "codex", session: createSession(changedId, 500 + batch) },
+        { agentName: added.slug.split("/")[0]!, session: added },
+      ];
+      const removals =
+        batch % 3 === 0 ? [{ agentName: "codex", sessionId: `session-${batch}` }] : [];
+      const expectedSessions = applySessionChanges(index.sourceSessions, changes, removals);
+
+      index = updateSessionIndex(index, changes, removals);
+      const rebuilt = createSessionIndex(expectedSessions);
+
+      expect(index.sessionsByActivity).toEqual(rebuilt.sessionsByActivity);
+      expect([...index.byRouteKey.entries()]).toEqual([...rebuilt.byRouteKey.entries()]);
+      expect([...index.byAgent.entries()]).toEqual([...rebuilt.byAgent.entries()]);
+      expect([...index.byProjectIdentityKey.entries()]).toEqual([
+        ...rebuilt.byProjectIdentityKey.entries(),
+      ]);
+    }
+  });
+});

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -5,5 +5,6 @@ export type * from "./search.js";
 export type * from "./bookmarks.js";
 export type * from "./dashboard.js";
 export type * from "./events.js";
+export * from "./session-index.js";
 export type * from "./api.js";
 export * from "./fixtures.js";

--- a/packages/core/src/contract/session-index.ts
+++ b/packages/core/src/contract/session-index.ts
@@ -1,0 +1,121 @@
+import type { ProjectIdentity, SessionHead } from "./session.js";
+
+export interface SessionHeadChange {
+  agentName: string;
+  session: SessionHead;
+}
+
+export interface SessionHeadRemoval {
+  agentName: string;
+  sessionId: string;
+}
+
+export interface CanonicalSessionIndex {
+  sourceSessions: SessionHead[];
+  sessionsByActivity: SessionHead[];
+  byRouteKey: Map<string, SessionHead>;
+  byAgent: Map<string, SessionHead[]>;
+  byProjectIdentityKey: Map<string, SessionHead[]>;
+  byProjectAgentKey: Map<string, SessionHead[]>;
+}
+
+export function compareSessionActivityDesc(a: SessionHead, b: SessionHead): number {
+  return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
+}
+
+export function sortSessionsByActivity(sessions: SessionHead[]): SessionHead[] {
+  for (let index = 1; index < sessions.length; index += 1) {
+    if (compareSessionActivityDesc(sessions[index - 1]!, sessions[index]!) > 0) {
+      return [...sessions].sort(compareSessionActivityDesc);
+    }
+  }
+  return [...sessions];
+}
+
+export function getSessionAgentKey(session: Pick<SessionHead, "slug">): string {
+  return session.slug.split("/")[0]?.toLowerCase() || "unknown";
+}
+
+export function getSessionRouteKey(agentName: string, sessionId: string): string {
+  return `${agentName.toLowerCase()}/${sessionId}`;
+}
+
+export function getProjectIdentityKey(identity: Pick<ProjectIdentity, "kind" | "key">): string {
+  return `${identity.kind}:${identity.key}`;
+}
+
+export function getProjectAgentKey(projectIdentityKey: string, agentName: string): string {
+  return `${projectIdentityKey}\0${agentName.toLowerCase()}`;
+}
+
+function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const current = map.get(key);
+  if (current) {
+    current.push(value);
+  } else {
+    map.set(key, [value]);
+  }
+}
+
+export function createSessionIndex(sourceSessions: SessionHead[]): CanonicalSessionIndex {
+  const byRouteKey = new Map<string, SessionHead>();
+  const byAgent = new Map<string, SessionHead[]>();
+  const byProjectIdentityKey = new Map<string, SessionHead[]>();
+  const byProjectAgentKey = new Map<string, SessionHead[]>();
+
+  for (const session of sourceSessions) {
+    const agentName = getSessionAgentKey(session);
+    const routeKey = getSessionRouteKey(agentName, session.id);
+    if (!byRouteKey.has(routeKey)) byRouteKey.set(routeKey, session);
+  }
+
+  const sessionsByActivity = sortSessionsByActivity(sourceSessions);
+  for (const session of sessionsByActivity) {
+    const agentName = getSessionAgentKey(session);
+    pushMapValue(byAgent, agentName, session);
+
+    const identity = session.project_identity;
+    if (!identity?.key) continue;
+
+    const projectIdentityKey = getProjectIdentityKey(identity);
+    pushMapValue(byProjectIdentityKey, projectIdentityKey, session);
+    pushMapValue(byProjectAgentKey, getProjectAgentKey(projectIdentityKey, agentName), session);
+  }
+
+  return {
+    sourceSessions,
+    sessionsByActivity,
+    byRouteKey,
+    byAgent,
+    byProjectIdentityKey,
+    byProjectAgentKey,
+  };
+}
+
+export function applySessionChanges(
+  sessions: SessionHead[],
+  changes: SessionHeadChange[],
+  removals: SessionHeadRemoval[],
+): SessionHead[] {
+  const byRouteKey = new Map<string, SessionHead>();
+  for (const session of sessions) {
+    byRouteKey.set(getSessionRouteKey(getSessionAgentKey(session), session.id), session);
+  }
+
+  for (const removal of removals) {
+    byRouteKey.delete(getSessionRouteKey(removal.agentName, removal.sessionId));
+  }
+  for (const change of changes) {
+    byRouteKey.set(getSessionRouteKey(change.agentName, change.session.id), change.session);
+  }
+
+  return sortSessionsByActivity([...byRouteKey.values()]);
+}
+
+export function updateSessionIndex(
+  index: CanonicalSessionIndex,
+  changes: SessionHeadChange[],
+  removals: SessionHeadRemoval[],
+): CanonicalSessionIndex {
+  return createSessionIndex(applySessionChanges(index.sourceSessions, changes, removals));
+}

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -8,6 +8,7 @@
  * plumbing that previously had to be kept in sync by hand.
  */
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
+import { sortSessionsByActivity } from "../contract/session-index.js";
 import type { ProjectIdentity, SessionHead } from "../types/index.js";
 import type { SessionHeadChange } from "./cache.js";
 import { computeIdentity, realFs } from "../projects/index.js";
@@ -73,9 +74,7 @@ export function sessionSignature(session: SessionHead): string {
 
 /** Sort sessions by activity time, newest first. */
 export function sortSessions(sessions: SessionHead[]): SessionHead[] {
-  return [...sessions].sort(
-    (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
-  );
+  return sortSessionsByActivity(sessions);
 }
 
 export interface SessionDiffResult {

--- a/scripts/benchmark-session-index.mjs
+++ b/scripts/benchmark-session-index.mjs
@@ -1,0 +1,66 @@
+import { performance } from "node:perf_hooks";
+import { applySessionChanges, createSessionIndex } from "../packages/core/dist/contract/index.mjs";
+
+const sessionCount = Number(process.env.SESSION_INDEX_BENCH_SIZE ?? 25_000);
+const changeCount = Number(process.env.SESSION_INDEX_BENCH_CHANGES ?? 100);
+const sessions = Array.from({ length: sessionCount }, (_, index) => ({
+  id: `session-${index}`,
+  slug: `${index % 2 === 0 ? "codex" : "claude"}/session-${index}`,
+  title: `Session ${index}`,
+  directory: `/workspace/${index % 200}`,
+  project_identity: {
+    kind: "path",
+    key: `/workspace/${index % 200}`,
+    displayName: `Project ${index % 200}`,
+  },
+  time_created: sessionCount - index,
+  time_updated: sessionCount - index,
+  stats: {
+    message_count: 1,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    total_cost: 0,
+  },
+}));
+const changes = Array.from({ length: changeCount }, (_, index) => ({
+  agentName: index % 2 === 0 ? "codex" : "claude",
+  session: {
+    ...sessions[index * 2],
+    time_updated: sessionCount + index + 1,
+  },
+}));
+
+function measure(run) {
+  const durations = [];
+  for (let iteration = 0; iteration < 8; iteration += 1) {
+    const startedAt = performance.now();
+    run();
+    durations.push(performance.now() - startedAt);
+  }
+  return durations.toSorted((a, b) => a - b)[Math.floor(durations.length / 2)];
+}
+
+const canonicalMs = measure(() => {
+  const updated = applySessionChanges(sessions, changes, []);
+  createSessionIndex(updated);
+});
+const repeatedSortMs = measure(() => {
+  const updated = applySessionChanges(sessions, changes, []);
+  const redundantlySorted = [...updated].sort(
+    (a, b) => (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created),
+  );
+  createSessionIndex(redundantlySorted);
+});
+
+console.log(
+  JSON.stringify(
+    {
+      sessions: sessionCount,
+      changes: changeCount,
+      canonical_ms: Number(canonicalMs.toFixed(2)),
+      repeated_sort_ms: Number(repeatedSortMs.toFixed(2)),
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## Summary

- add a browser-safe canonical session index module for activity, route, agent, project, and project-agent lookups
- centralize route-keyed change/removal merging and stable activity ordering
- make the Web live-update and derived-index adapters reuse the canonical implementation
- keep CLI sorting on the same comparator and sorted-input fast path
- add characterization, deterministic incremental/full equivalence tests, and a reproducible benchmark

## Why

Session ordering and lookup semantics were independently implemented in core orchestration, Web live updates, and Web indexes. That duplication made first-match route behavior, project identity keys, and SSE replacement semantics vulnerable to drift.

The new contract seam is pure and browser-safe, so both Node and Web adapters share behavior without sharing runtime-dependent instances.

## Complexity note

The original `O(K log N)` target is not achievable end to end while CLI and React callers require complete array snapshots: materializing a snapshot has an `O(N)` lower bound. This change avoids sorting already ordered snapshots and centralizes the work, but does not claim a benchmark speedup. At 25,000 sessions and 100 changes, the median comparison was 27.46 ms for the canonical path versus 26.80 ms for the repeated-sort model.

A balanced incremental structure should only be introduced if callers can consume lazy ordered views; otherwise it adds implementation complexity without removing snapshot cost.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (654 passed)
- `pnpm test:e2e` (6 passed)
- `pnpm bench:session-index`

Closes CS-43
