### PR TITLE
test(ci): gate high-risk coverage scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm test:coverage
+
       - run: pnpm test:migration
 
       - run: pnpm exec playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm build
+
       - run: pnpm test:coverage
 
       - run: pnpm test:migration

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,17 +2,37 @@ import { defineConfig } from "vitest/config";
 
 const COVERAGE_THRESHOLD_SCOPE =
   "{packages/core/src/utils/**,packages/core/src/discovery/**,packages/core/src/agents/base.ts,packages/cli/src/api/**}";
+const CLI_RUNTIME_SCOPE =
+  "{packages/cli/src/live-scan.ts,packages/cli/src/session-watcher.ts,packages/cli/src/*-coordinator.ts,packages/cli/src/*-worker.ts,packages/cli/src/pending-search-index-jobs.ts,packages/cli/src/scan-status-model.ts}";
+const WEB_HOOKS_SCOPE = "apps/web/src/hooks/**";
+const WEB_INTERACTIONS_SCOPE =
+  "{apps/web/src/components/Dashboard.tsx,apps/web/src/components/app/SearchResultsPanel.tsx,apps/web/src/components/session-detail/message-list.tsx,apps/web/src/components/session-detail/session-message-timeline.tsx}";
 
 export default defineConfig({
   test: {
     projects: ["packages/core", "packages/cli", "apps/web"],
     coverage: {
       provider: "v8",
+      include: [
+        COVERAGE_THRESHOLD_SCOPE,
+        CLI_RUNTIME_SCOPE,
+        WEB_HOOKS_SCOPE,
+        WEB_INTERACTIONS_SCOPE,
+      ],
       exclude: ["**/node_modules/**", "**/dist/**", "packages/core/src/utils/sqlite.ts"],
       reporter: ["text", "html"],
       thresholds: {
         [COVERAGE_THRESHOLD_SCOPE]: {
           lines: 75,
+        },
+        [CLI_RUNTIME_SCOPE]: {
+          lines: 78,
+        },
+        [WEB_HOOKS_SCOPE]: {
+          lines: 63,
+        },
+        [WEB_INTERACTIONS_SCOPE]: {
+          lines: 76,
         },
       },
     },


### PR DESCRIPTION
## Summary

- explicitly include high-risk Core, CLI runtime, Web hooks, and Web interaction sources in coverage collection
- add independent line thresholds for each scope based on the measured baseline
- run the coverage gate in the Ubuntu smoke job

## Impact

Coverage regressions now fail CI in the affected scope instead of being hidden by an aggregate repository percentage. Previously unloaded workers and hooks are counted as zero coverage rather than omitted from the report.

## Baselines and thresholds

| Scope | Baseline | Threshold |
| --- | ---: | ---: |
| Core cache/runtime | 87.51% | 75% |
| CLI runtime | 79.20% | 78% |
| Web hooks | 64.86% | 63% |
| Web interactions | 77.73% | 76% |

## Validation

- `pnpm test:coverage` (662 tests)
- temporarily removed `live-scan-store.test.ts`; CLI runtime coverage fell to 35.39% and the gate failed as expected
- `pnpm format`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (662 tests)
- `pnpm test:e2e` (6 tests)

Closes CS-48