### PR TITLE
fix(ui): polish showcase motion and copy

### DIFF
--- a/apps/web/src/components/BookmarkButton.tsx
+++ b/apps/web/src/components/BookmarkButton.tsx
@@ -15,8 +15,8 @@ export function BookmarkButton({ active, onToggle, className = "" }: BookmarkBut
         event.stopPropagation();
         onToggle();
       }}
-      aria-label={active ? "取消收藏会话" : "收藏会话"}
-      title={active ? "取消收藏" : "收藏"}
+      aria-label={active ? "Remove bookmark" : "Add bookmark"}
+      title={active ? "Remove bookmark" : "Add bookmark"}
       className={`inline-flex size-6 shrink-0 items-center justify-center rounded-sm border transition-colors ${className} ${
         active
           ? "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-text)]"

--- a/apps/www/src/components/ProductShowcase.astro
+++ b/apps/www/src/components/ProductShowcase.astro
@@ -29,7 +29,7 @@ const scenes = copy[locale].scenes;
     <div class="mt-14 grid gap-6 lg:grid-cols-2">
       {
         scenes.map((scene, index) => (
-          <article class="group relative overflow-hidden rounded-md border border-[var(--console-border)] bg-white text-left shadow-[0_24px_70px_rgba(15,23,42,0.08)]">
+          <article class="product-showcase-card group relative overflow-hidden rounded-md border border-[var(--console-border)] bg-white text-left shadow-[0_24px_70px_rgba(15,23,42,0.08)]">
             <div class="border-b border-[var(--console-border)] bg-white px-6 py-5">
               <p class="console-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--console-muted)]">
                 {scene.title}
@@ -44,6 +44,8 @@ const scenes = copy[locale].scenes;
                 <img
                   src={scene.image}
                   alt={scene.description}
+                  width="1586"
+                  height="992"
                   class="aspect-[1586/992] h-auto w-full object-cover object-top"
                   loading="lazy"
                 />
@@ -53,7 +55,7 @@ const scenes = copy[locale].scenes;
             <button
               type="button"
               data-scene-open={String(index)}
-              class="absolute right-6 bottom-6 inline-flex items-center gap-2 rounded-sm border border-white/70 bg-white/92 px-3 py-2 text-xs font-medium text-[var(--console-text)] opacity-0 shadow-lg transition-all duration-200 group-hover:opacity-100 group-focus-within:opacity-100 hover:scale-[1.02]"
+              class="product-showcase-expand product-showcase-pressable absolute right-6 bottom-6 inline-flex items-center gap-2 rounded-sm border border-white/70 bg-white/92 px-3 py-2 text-xs font-medium text-[var(--console-text)] shadow-lg"
               aria-label={`${t.expand} ${scene.title}`}
             >
               <Icon name="expand" class="size-3.5" />
@@ -89,7 +91,7 @@ const scenes = copy[locale].scenes;
             <button
               type="button"
               data-scene-close
-              class="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5 text-xs font-medium text-[var(--console-text)] transition-colors hover:bg-white"
+              class="product-showcase-pressable rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5 text-xs font-medium text-[var(--console-text)] hover:bg-white"
             >
               {t.close}
             </button>
@@ -99,7 +101,7 @@ const scenes = copy[locale].scenes;
             <button
               type="button"
               data-scene-prev
-              class="inline-flex items-center gap-2 rounded-sm border border-[var(--console-border)] bg-white px-3 py-2 text-xs font-medium text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface-muted)]"
+              class="product-showcase-pressable inline-flex items-center gap-2 rounded-sm border border-[var(--console-border)] bg-white px-3 py-2 text-xs font-medium text-[var(--console-text)] hover:bg-[var(--console-surface-muted)]"
             >
               <Icon name="chevron-left" class="size-4" />
               {t.previous}
@@ -110,7 +112,7 @@ const scenes = copy[locale].scenes;
             <button
               type="button"
               data-scene-next
-              class="inline-flex items-center gap-2 rounded-sm border border-[var(--console-border)] bg-white px-3 py-2 text-xs font-medium text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface-muted)]"
+              class="product-showcase-pressable inline-flex items-center gap-2 rounded-sm border border-[var(--console-border)] bg-white px-3 py-2 text-xs font-medium text-[var(--console-text)] hover:bg-[var(--console-surface-muted)]"
             >
               {t.next}
               <Icon name="chevron-right" class="size-4" />
@@ -122,6 +124,8 @@ const scenes = copy[locale].scenes;
               <img
                 src={scene.image}
                 alt={scene.title}
+                width="1586"
+                height="992"
                 class="h-auto w-full object-cover object-top"
               />
             </div>

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -132,6 +132,41 @@
   .animate-status-ping {
     animation: status-ping 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
   }
+
+  .product-showcase-pressable {
+    touch-action: manipulation;
+    transition-property: transform, color, border-color;
+    transition-duration: 150ms;
+    transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .product-showcase-pressable:active {
+    transform: scale(0.97);
+  }
+
+  .product-showcase-expand {
+    opacity: 1;
+    transition-property: opacity, transform, color, border-color;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .product-showcase-expand {
+    opacity: 0;
+  }
+
+  .product-showcase-card:hover .product-showcase-expand,
+  .product-showcase-card:focus-within .product-showcase-expand {
+    opacity: 1;
+  }
+
+  .product-showcase-expand:hover {
+    transform: scale(1.02);
+  }
+
+  .product-showcase-expand:active {
+    transform: scale(0.97);
+  }
 }
 
 @keyframes caret-blink {
@@ -171,5 +206,15 @@
   .animate-terminal-line,
   .animate-status-ping {
     animation: none;
+  }
+
+  .product-showcase-pressable,
+  .product-showcase-pressable:hover,
+  .product-showcase-pressable:active,
+  .product-showcase-expand,
+  .product-showcase-expand:hover,
+  .product-showcase-expand:active {
+    transform: none;
+    transition-property: opacity, color, border-color;
   }
 }

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -74,7 +74,7 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
     })
     .toBe(true);
 
-  await recentSession.getByRole("button", { name: "收藏会话" }).click();
+  await recentSession.getByRole("button", { name: "Add bookmark" }).click();
   await expect
     .poll(async () => {
       const response = await page.request.get("/api/bookmarks");
@@ -87,7 +87,7 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
     })
     .toBe(true);
   await expect(page.getByText("Bookmarked Sessions")).toBeVisible();
-  await expect(recentSession.getByRole("button", { name: "取消收藏会话" })).toBeVisible();
+  await expect(recentSession.getByRole("button", { name: "Remove bookmark" })).toBeVisible();
   await expect(page.locator("section").filter({ hasText: "BOOKMARKS" })).toContainText(
     "Core browsing smoke session",
   );

--- a/tests/e2e/www.spec.ts
+++ b/tests/e2e/www.spec.ts
@@ -61,7 +61,13 @@ test("falls back when the clipboard API rejects", async ({ page }) => {
 
 test("navigates showcase dialogs", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("button", { name: "Expand Engineering Memory Overview" }).click();
+  const expand = page.getByRole("button", { name: "Expand Engineering Memory Overview" });
+  await expand.locator("xpath=ancestor::article").hover();
+  await expect(expand).toHaveCSS("opacity", "1");
+  await expand.focus();
+  await expect(expand).toBeFocused();
+  await expect(expand).toHaveCSS("opacity", "1");
+  await expand.click();
   const first = page.getByRole("dialog", {
     name: "Engineering Memory Overview preview",
   });
@@ -77,4 +83,30 @@ test("navigates showcase dialogs", async ({ page }) => {
   await expect(first).toBeVisible();
   await first.getByRole("button", { name: "Close" }).click();
   await expect(first).toBeHidden();
+});
+
+test("keeps showcase actions visible on touch", async ({ browser }, testInfo) => {
+  const context = await browser.newContext({
+    baseURL: String(testInfo.project.use.baseURL),
+    hasTouch: true,
+    isMobile: true,
+    viewport: { width: 390, height: 844 },
+  });
+  const page = await context.newPage();
+  await page.goto("/");
+
+  const expand = page.getByRole("button", { name: "Expand Engineering Memory Overview" });
+  await expect(expand).toHaveCSS("opacity", "1");
+  await expand.tap();
+  await expect(page.getByRole("dialog", { name: "Engineering Memory Overview preview" })).toBeVisible();
+  await context.close();
+});
+
+test("removes showcase transforms for reduced motion", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/");
+
+  const expand = page.getByRole("button", { name: "Expand Engineering Memory Overview" });
+  await expand.hover();
+  await expect(expand).toHaveCSS("transform", "none");
 });


### PR DESCRIPTION
## Summary

- replace ProductShowcase `transition-all` with explicit opacity, transform, color, and border-color transitions
- gate hover reveal and hover scale behind fine-pointer media queries
- keep showcase actions visible on touch and add 150 ms press feedback
- remove transform motion for reduced-motion users
- add explicit showcase image dimensions
- align bookmark labels with the English application vocabulary

## Impact

Mouse users retain the hover reveal, keyboard focus reveals the action, touch users no longer get a sticky hidden action, and reduced-motion users receive state changes without movement. Bookmark controls now consistently announce Add bookmark and Remove bookmark.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (665 tests)
- `pnpm test:e2e` (9 tests covering mouse, focus, touch, and reduced motion)

Closes CS-49