### PR TITLE
feat: add local session aliases

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,10 +3,11 @@ declare const __APP_VERSION__: string;
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import type { SessionHead } from "./lib/api";
-import { logClientEvent } from "./lib/api";
+import type { BookmarkedSessionSnapshot, SessionHead } from "./lib/api";
+import { deleteSessionAlias, logClientEvent, upsertSessionAlias } from "./lib/api";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { CopyResumeButton } from "./components/CopyResumeButton";
+import { SessionAliasDialog, type SessionAliasTarget } from "./components/SessionAliasDialog";
 import { RenderProfiler } from "./components/RenderProfiler";
 import { parseViewState } from "./lib/view-state";
 import { useScanStatus } from "./hooks/useScanStatus";
@@ -69,6 +70,7 @@ export default function App() {
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const [shortcutHintDismissed, setShortcutHintDismissed] = useState(true);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [aliasTarget, setAliasTarget] = useState<SessionAliasTarget | null>(null);
 
   const location = useLocation();
   const viewState = useMemo(
@@ -225,6 +227,24 @@ export default function App() {
     [toggleSessionBookmark],
   );
 
+  const handleRenameSession = useCallback((sessionItem: SessionHead) => {
+    setAliasTarget({
+      agentKey: getSessionAgentKey(sessionItem),
+      sessionId: sessionItem.id,
+      title: sessionItem.title,
+      displayTitle: sessionItem.display_title,
+    });
+  }, []);
+
+  const handleRenameBookmarkedSession = useCallback((session: BookmarkedSessionSnapshot) => {
+    setAliasTarget({
+      agentKey: session.agentKey,
+      sessionId: session.sessionId,
+      title: session.title,
+      displayTitle: session.display_title,
+    });
+  }, []);
+
   const handleSelectTreeSidebarSession = useCallback(
     (sessionId: string) => {
       setSelectedSidebarSessionId(sessionId);
@@ -250,6 +270,40 @@ export default function App() {
     refreshSearch,
     setScanStatus,
   });
+
+  const refreshAliasViews = useCallback(async () => {
+    await Promise.all([
+      appConfig ? refreshSessions(appConfig.window) : Promise.resolve(),
+      refreshDashboard(),
+      refreshProjectDashboard(),
+      refreshSessionDetail(),
+      refreshSearch(),
+      bookmarks.refresh(),
+    ]);
+  }, [
+    appConfig,
+    bookmarks,
+    refreshDashboard,
+    refreshProjectDashboard,
+    refreshSearch,
+    refreshSessionDetail,
+    refreshSessions,
+  ]);
+
+  const saveSessionAlias = useCallback(
+    async (alias: string) => {
+      if (!aliasTarget) return;
+      await upsertSessionAlias(aliasTarget.agentKey, aliasTarget.sessionId, alias);
+      await refreshAliasViews();
+    },
+    [aliasTarget, refreshAliasViews],
+  );
+
+  const removeSessionAlias = useCallback(async () => {
+    if (!aliasTarget) return;
+    await deleteSessionAlias(aliasTarget.agentKey, aliasTarget.sessionId);
+    await refreshAliasViews();
+  }, [aliasTarget, refreshAliasViews]);
 
   useEffect(() => {
     try {
@@ -486,6 +540,8 @@ export default function App() {
             onToggleBookmark: toggleBookmark,
             onSelectFlatSidebarSession: handleSelectFlatSidebarSession,
             onToggleSidebarSessionBookmark: handleToggleSidebarSessionBookmark,
+            onRenameSession: handleRenameSession,
+            onRenameBookmarkedSession: handleRenameBookmarkedSession,
             onSelectTreeSidebarSession: handleSelectTreeSidebarSession,
           }}
         />
@@ -592,6 +648,12 @@ export default function App() {
         </main>
       </div>
       <ShortcutHelpDialog open={shortcutHelpOpen} onClose={() => setShortcutHelpOpen(false)} />
+      <SessionAliasDialog
+        target={aliasTarget}
+        onClose={() => setAliasTarget(null)}
+        onSave={saveSessionAlias}
+        onRemove={removeSessionAlias}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -16,6 +16,7 @@ import type {
 import { getSessionBookmarkKey } from "../lib/bookmarks";
 import { formatCostSource, formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
 import { getProjectPath } from "../lib/projects";
+import { getSessionDisplayTitle } from "../lib/session-title";
 import { BookmarkButton } from "./BookmarkButton";
 import { SmartTagChips } from "./SmartTagChips";
 import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "./ui/chart";
@@ -620,7 +621,7 @@ function BookmarkedSessions({
                   ) : null}
                   <div className="min-w-0 flex-1">
                     <p className="line-clamp-1 text-sm text-[var(--console-text)]">
-                      {session.title}
+                      {getSessionDisplayTitle(session)}
                     </p>
                     <p className="console-mono mt-0.5 line-clamp-1 text-[11px] text-[var(--console-muted)]">
                       /{session.fullPath} · {formatRelativeTime(updated)}
@@ -683,7 +684,7 @@ function RecentSessions({
                       />
                     ) : null}
                     <p className="line-clamp-1 flex-1 text-sm text-[var(--console-text)]">
-                      {session.title}
+                      {getSessionDisplayTitle(session)}
                     </p>
                     <span className="console-mono shrink-0 text-[11px] text-[var(--console-muted)]">
                       {formatRelativeTime(updated)}
@@ -748,7 +749,7 @@ function RecentFileActivity({ activity }: { activity: FileActivityResult[] }) {
                 </div>
                 <p className="console-mono mt-1 line-clamp-1 text-[11px] text-[var(--console-muted)]">
                   {item.session.project_identity?.displayName ?? item.session.directory} ·{" "}
-                  {item.session.title} · {item.count} events
+                  {getSessionDisplayTitle(item.session)} · {item.count} events
                 </p>
               </Link>
             </li>

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { ModelConfig } from "../config";
 import type { SessionHead } from "../lib/api";
 import { formatCostSource, formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
+import { getSessionDisplayTitle } from "../lib/session-title";
 import { BookmarkButton } from "./BookmarkButton";
 import { SmartTagChips } from "./SmartTagChips";
 
@@ -176,7 +177,9 @@ function RecentSessions({
             <li key={session.id}>
               <div className="flex items-start gap-2 rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]">
                 <Link to={`/${session.fullPath}`} className="min-w-0 flex-1">
-                  <p className="line-clamp-1 text-sm text-[var(--console-text)]">{session.title}</p>
+                  <p className="line-clamp-1 text-sm text-[var(--console-text)]">
+                    {getSessionDisplayTitle(session)}
+                  </p>
                   <p className="console-mono mt-0.5 text-[11px] text-[var(--console-muted)]">
                     /{session.fullPath} ·{" "}
                     {formatRelativeTime(session.time_updated || session.time_created)}

--- a/apps/web/src/components/InteractiveReceipt.tsx
+++ b/apps/web/src/components/InteractiveReceipt.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useMemo, useRef } from "react";
 import type { SessionData } from "../lib/api";
+import { getSessionDisplayTitle } from "../lib/session-title";
 import {
   isReceiptSettled,
   nextReceiptIdleFrame,
@@ -148,7 +149,7 @@ function createReceiptPayload(session: SessionData, toc: SessionDetailToc): Rece
   const agent = session.slug?.split("/")[0] || "codesesh";
   return {
     id: session.id,
-    title: session.title || "Untitled session",
+    title: getSessionDisplayTitle(session) || "Untitled session",
     agent,
     updatedAt: session.time_updated ?? session.time_created,
     tags: session.smart_tags,

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -3,6 +3,7 @@ import { ModelConfig } from "../config";
 import type { DashboardData, ProjectAgentStat, ProjectGroup, SessionHead } from "../lib/api";
 import { formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
 import { getProjectPath } from "../lib/projects";
+import { getSessionDisplayTitle } from "../lib/session-title";
 import { Dashboard } from "./Dashboard";
 import type { LandingSession } from "./DetailLanding";
 
@@ -228,7 +229,7 @@ function TopCostSessions({ sessions }: { sessions: LandingSession[] }) {
                     <img src={agent.icon} alt={agent.name} className="size-3.5 object-contain" />
                   ) : null}
                   <span className="line-clamp-1 flex-1 text-sm text-[var(--console-text)]">
-                    {session.title}
+                    {getSessionDisplayTitle(session)}
                   </span>
                   <span className="console-mono text-[11px] text-[var(--console-muted)]">
                     {formatMoney(session.stats.total_cost)}

--- a/apps/web/src/components/SessionActionsMenu.test.tsx
+++ b/apps/web/src/components/SessionActionsMenu.test.tsx
@@ -1,0 +1,31 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionActionsMenu } from "./SessionActionsMenu";
+
+afterEach(cleanup);
+
+describe("SessionActionsMenu", () => {
+  it("closes when focus leaves the menu", () => {
+    render(
+      <>
+        <SessionActionsMenu bookmarked={false} onRename={vi.fn()} onToggleBookmark={vi.fn()} />
+        <button type="button">Elsewhere</button>
+      </>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Session options" }));
+    expect(screen.getByRole("menu")).toBeTruthy();
+
+    fireEvent.focus(screen.getByRole("button", { name: "Elsewhere" }));
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("closes when Escape is pressed", () => {
+    render(<SessionActionsMenu bookmarked={false} onRename={vi.fn()} onToggleBookmark={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Session options" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+});

--- a/apps/web/src/components/SessionActionsMenu.tsx
+++ b/apps/web/src/components/SessionActionsMenu.tsx
@@ -1,0 +1,98 @@
+import { MoreHorizontal, Pencil, Star } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+export function SessionActionsMenu({
+  bookmarked,
+  onRename,
+  onToggleBookmark,
+}: {
+  bookmarked: boolean;
+  onRename: () => void;
+  onToggleBookmark: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    const closeOnFocusOutside = (event: FocusEvent) => {
+      if (!menuRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", closeOnOutsidePointer);
+    document.addEventListener("keydown", closeOnEscape);
+    document.addEventListener("focusin", closeOnFocusOutside);
+    menuRef.current?.querySelector<HTMLButtonElement>("[role='menuitem']")?.focus();
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutsidePointer);
+      document.removeEventListener("keydown", closeOnEscape);
+      document.removeEventListener("focusin", closeOnFocusOutside);
+    };
+  }, [open]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="relative shrink-0"
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false);
+      }}
+    >
+      <button
+        type="button"
+        aria-label="Session options"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setOpen((current) => !current);
+        }}
+        className="inline-flex size-6 items-center justify-center rounded-sm border border-transparent text-[var(--console-muted)] transition-[background-color,border-color,color,transform] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] active:scale-[0.97] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
+        <MoreHorizontal className="size-3.5" aria-hidden="true" />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-7 z-30 w-36 rounded-sm border border-[var(--console-border-strong)] bg-white p-1 shadow-lg"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onRename();
+            }}
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] focus-visible:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+          >
+            <Pencil className="size-3" aria-hidden="true" />
+            Rename
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onToggleBookmark();
+            }}
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] focus-visible:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+          >
+            <Star
+              className="size-3"
+              fill={bookmarked ? "currentColor" : "none"}
+              aria-hidden="true"
+            />
+            {bookmarked ? "Remove bookmark" : "Add bookmark"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/SessionAliasDialog.test.tsx
+++ b/apps/web/src/components/SessionAliasDialog.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionAliasDialog } from "./SessionAliasDialog";
 
@@ -39,5 +39,31 @@ describe("SessionAliasDialog", () => {
     expect((screen.getByRole("textbox", { name: "Session title" }) as HTMLInputElement).value).toBe(
       "Source title",
     );
+  });
+
+  it("removes the alias when saving the source title", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onRemove = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SessionAliasDialog
+        target={{
+          agentKey: "codex",
+          sessionId: "session-1",
+          title: "Source title",
+          displayTitle: "Current custom title",
+        }}
+        onClose={vi.fn()}
+        onSave={onSave}
+        onRemove={onRemove}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Session title" }), {
+      target: { value: "Source title" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save title" }));
+
+    await waitFor(() => expect(onRemove).toHaveBeenCalledOnce());
+    expect(onSave).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/SessionAliasDialog.test.tsx
+++ b/apps/web/src/components/SessionAliasDialog.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionAliasDialog } from "./SessionAliasDialog";
+
+afterEach(cleanup);
+
+describe("SessionAliasDialog", () => {
+  it("starts editing from the current visible title", () => {
+    render(
+      <SessionAliasDialog
+        target={{
+          agentKey: "codex",
+          sessionId: "session-1",
+          title: "Source title",
+          displayTitle: "Current custom title",
+        }}
+        onClose={vi.fn()}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect((screen.getByRole("textbox", { name: "Session title" }) as HTMLInputElement).value).toBe(
+      "Current custom title",
+    );
+    expect(screen.queryByText(/Original title/)).toBeNull();
+  });
+
+  it("uses the source title when no custom title exists", () => {
+    render(
+      <SessionAliasDialog
+        target={{ agentKey: "codex", sessionId: "session-1", title: "Source title" }}
+        onClose={vi.fn()}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect((screen.getByRole("textbox", { name: "Session title" }) as HTMLInputElement).value).toBe(
+      "Source title",
+    );
+  });
+});

--- a/apps/web/src/components/SessionAliasDialog.tsx
+++ b/apps/web/src/components/SessionAliasDialog.tsx
@@ -1,0 +1,118 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useEffect, useState } from "react";
+
+export interface SessionAliasTarget {
+  agentKey: string;
+  sessionId: string;
+  title: string;
+  displayTitle?: string;
+}
+
+export function SessionAliasDialog({
+  target,
+  onClose,
+  onSave,
+  onRemove,
+}: {
+  target: SessionAliasTarget | null;
+  onClose: () => void;
+  onSave: (alias: string) => Promise<void>;
+  onRemove: () => Promise<void>;
+}) {
+  const [alias, setAlias] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setAlias(target?.displayTitle ?? target?.title ?? "");
+    setError(null);
+  }, [target]);
+
+  const saveAlias = async () => {
+    const nextAlias = alias.trim();
+    if (!nextAlias) {
+      await removeAlias();
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(nextAlias);
+      onClose();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Could not rename this session.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const removeAlias = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onRemove();
+      onClose();
+    } catch (removeError) {
+      setError(removeError instanceof Error ? removeError.message : "Could not restore the title.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog.Root open={target !== null} onOpenChange={(open) => (!open ? onClose() : undefined)}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/35" />
+        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
+          <Dialog.Title className="console-mono text-sm font-semibold text-[var(--console-text)]">
+            Rename session
+          </Dialog.Title>
+          <label className="console-mono mt-4 block text-[11px] uppercase tracking-wide text-[var(--console-muted)]">
+            Session title
+            <input
+              autoFocus
+              autoComplete="off"
+              name="session-title"
+              maxLength={160}
+              value={alias}
+              onChange={(event) => setAlias(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void saveAlias();
+              }}
+              className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-white px-3 py-2 text-sm normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
+            />
+          </label>
+          {error ? (
+            <p aria-live="polite" className="mt-2 text-xs text-[var(--console-error)]">
+              {error}
+            </p>
+          ) : null}
+          <div className="mt-5 flex items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={() => void removeAlias()}
+              disabled={saving || !target?.displayTitle}
+              className="text-xs text-[var(--console-muted)] underline decoration-[var(--console-border-strong)] underline-offset-4 hover:text-[var(--console-text)] disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Remove custom title
+            </button>
+            <div className="flex items-center gap-2">
+              <Dialog.Close className="rounded-sm border border-[var(--console-border)] px-3 py-1.5 text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)]">
+                Cancel
+              </Dialog.Close>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => void saveAlias()}
+                className="rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-text)] px-3 py-1.5 text-xs text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {saving ? "Saving…" : "Save title"}
+              </button>
+            </div>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/src/components/SessionAliasDialog.tsx
+++ b/apps/web/src/components/SessionAliasDialog.tsx
@@ -30,7 +30,7 @@ export function SessionAliasDialog({
 
   const saveAlias = async () => {
     const nextAlias = alias.trim();
-    if (!nextAlias) {
+    if (!nextAlias || nextAlias === target?.title.trim()) {
       await removeAlias();
       return;
     }

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -1,7 +1,16 @@
 import type { FileTreeSortEntry } from "@pierre/trees";
 import { FileTree, useFileTree } from "@pierre/trees/react";
-import { memo, useEffect, useMemo, useRef, type CSSProperties, type MouseEvent } from "react";
+import {
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent,
+} from "react";
 import type { SessionHead } from "../lib/api";
+import { getSessionDisplayTitle } from "../lib/session-title";
 import { isRenderProfilerEnabled, recordRenderProfileEntry } from "./RenderProfiler";
 
 interface SessionTreeSidebarProps {
@@ -11,6 +20,7 @@ interface SessionTreeSidebarProps {
   onSelectSession: (sessionId: string) => void;
   bookmarkedSessionIds: Set<string>;
   onToggleBookmark: (session: SessionHead) => void;
+  onRenameSession: (session: SessionHead) => void;
 }
 
 interface SessionTreeModel {
@@ -44,7 +54,7 @@ const SESSION_TREE_CSS = `
 
   [data-type='item'][data-item-type='file'] > [data-item-section='decoration'] {
     flex: 0 0 auto;
-    padding-inline: 8px 6px;
+    padding-inline: 6px 2px;
   }
 
   [data-type='item'][data-item-type='file'] > [data-item-section='decoration'] > span {
@@ -182,14 +192,16 @@ function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel {
     groupCountByPath.set(groupPath, `${group.sessions.length}`);
     groupCountByPath.set(bareGroupPath, `${group.sessions.length}`);
     for (const session of group.sessions) {
-      titleCounts.set(session.title, (titleCounts.get(session.title) ?? 0) + 1);
+      const title = getSessionDisplayTitle(session);
+      titleCounts.set(title, (titleCounts.get(title) ?? 0) + 1);
     }
 
     for (const session of group.sessions) {
-      const needsDisambiguation = (titleCounts.get(session.title) ?? 0) > 1;
+      const title = getSessionDisplayTitle(session);
+      const needsDisambiguation = (titleCounts.get(title) ?? 0) > 1;
       const leaf = needsDisambiguation
-        ? `${sanitizeSegment(session.title)} #${session.id.slice(0, 8)}`
-        : sanitizeSegment(session.title);
+        ? `${sanitizeSegment(title)} #${session.id.slice(0, 8)}`
+        : sanitizeSegment(title);
       let path = `${groupPath}${leaf}`;
       let suffix = 2;
       while (usedPaths.has(path)) {
@@ -244,7 +256,13 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   onSelectSession,
   bookmarkedSessionIds,
   onToggleBookmark,
+  onRenameSession,
 }: SessionTreeSidebarProps) {
+  const [options, setOptions] = useState<{
+    session: SessionHead;
+    top: number;
+    right: number;
+  } | null>(null);
   const modelData = useMemo(
     () =>
       measureSessionTreeWork("SessionTreeSidebar:buildTreeModel", () =>
@@ -257,8 +275,10 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   const groupCountByPathRef = useRef(modelData.groupCountByPath);
   const sessionByPathRef = useRef(modelData.sessionByPath);
   const bookmarkedSessionIdsRef = useRef(bookmarkedSessionIds);
+  const optionsMenuRef = useRef<HTMLDivElement>(null);
   const onSelectSessionRef = useRef(onSelectSession);
   const onToggleBookmarkRef = useRef(onToggleBookmark);
+  const onRenameSessionRef = useRef(onRenameSession);
   const treeHostStyle: TreeHostStyle = {
     "--trees-bg-override": "transparent",
     "--trees-border-color-override": "var(--console-border)",
@@ -268,7 +288,8 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
       '"JetBrains Mono", "IBM Plex Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace',
     "--trees-font-size-override": "12px",
     "--trees-item-margin-x-override": "0px",
-    "--trees-item-padding-x-override": "8px",
+    "--trees-item-padding-x-override": "4px",
+    "--trees-padding-inline-override": "4px",
     "--trees-selected-bg-override": "var(--console-surface-muted)",
   };
   const { model } = useFileTree({
@@ -285,8 +306,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     renderRowDecoration({ item }) {
       const session = sessionByPathRef.current.get(item.path);
       if (session) {
-        const active = bookmarkedSessionIdsRef.current.has(session.id);
-        return { text: active ? "★" : "☆", title: active ? "Remove bookmark" : "Add bookmark" };
+        return { text: "⋯", title: "Session options" };
       }
       return groupCountByPathRef.current.get(item.path)
         ? { text: groupCountByPathRef.current.get(item.path)!, title: "Sessions" }
@@ -308,12 +328,38 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
 
   useEffect(() => {
     bookmarkedSessionIdsRef.current = bookmarkedSessionIds;
-    model.resetPaths(modelData.paths);
-  }, [bookmarkedSessionIds, model, modelData.paths]);
+  }, [bookmarkedSessionIds]);
+
+  useEffect(() => {
+    if (!options) return;
+
+    const closeOnOutsidePointer = (event: PointerEvent) => {
+      if (!optionsMenuRef.current?.contains(event.target as Node)) setOptions(null);
+    };
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOptions(null);
+    };
+    const closeOnFocusOutside = (event: FocusEvent) => {
+      if (!optionsMenuRef.current?.contains(event.target as Node)) setOptions(null);
+    };
+    document.addEventListener("pointerdown", closeOnOutsidePointer);
+    document.addEventListener("keydown", closeOnEscape);
+    document.addEventListener("focusin", closeOnFocusOutside);
+    optionsMenuRef.current?.querySelector<HTMLButtonElement>("[role='menuitem']")?.focus();
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutsidePointer);
+      document.removeEventListener("keydown", closeOnEscape);
+      document.removeEventListener("focusin", closeOnFocusOutside);
+    };
+  }, [options]);
 
   useEffect(() => {
     onToggleBookmarkRef.current = onToggleBookmark;
   }, [onToggleBookmark]);
+
+  useEffect(() => {
+    onRenameSessionRef.current = onRenameSession;
+  }, [onRenameSession]);
 
   function handleTreeClickCapture(event: MouseEvent<HTMLDivElement>) {
     const path = event.nativeEvent.composedPath();
@@ -333,7 +379,8 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     if (!decoration || !session) return;
     event.preventDefault();
     event.stopPropagation();
-    onToggleBookmarkRef.current(session);
+    const rect = decoration.getBoundingClientRect();
+    setOptions({ session, top: rect.bottom + 4, right: window.innerWidth - rect.right });
   }
 
   useEffect(() => {
@@ -360,6 +407,42 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
       onClickCapture={handleTreeClickCapture}
     >
       <FileTree model={model} style={{ height: "100%" }} aria-label="Sessions" />
+      {options ? (
+        <div
+          ref={optionsMenuRef}
+          role="menu"
+          style={{ position: "fixed", top: options.top, right: options.right }}
+          className="z-40 w-36 rounded-sm border border-[var(--console-border-strong)] bg-white p-1 shadow-lg"
+          onBlur={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget)) setOptions(null);
+          }}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              onRenameSessionRef.current(options.session);
+              setOptions(null);
+            }}
+            className="block w-full rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] focus-visible:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+          >
+            Rename
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              onToggleBookmarkRef.current(options.session);
+              setOptions(null);
+            }}
+            className="block w-full rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] focus-visible:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+          >
+            {bookmarkedSessionIdsRef.current.has(options.session.id)
+              ? "Remove bookmark"
+              : "Add bookmark"}
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 });

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent,
 } from "react";
 import type { SessionHead } from "../lib/api";
@@ -262,6 +263,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     session: SessionHead;
     top: number;
     right: number;
+    trigger: HTMLElement;
   } | null>(null);
   const modelData = useMemo(
     () =>
@@ -337,7 +339,10 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
       if (!optionsMenuRef.current?.contains(event.target as Node)) setOptions(null);
     };
     const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOptions(null);
+      if (event.key === "Escape") {
+        options.trigger.focus();
+        setOptions(null);
+      }
     };
     const closeOnFocusOutside = (event: FocusEvent) => {
       if (!optionsMenuRef.current?.contains(event.target as Node)) setOptions(null);
@@ -376,11 +381,42 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
       ? sessionByPathRef.current.get(item.getAttribute("data-item-path") ?? "")
       : null;
 
-    if (!decoration || !session) return;
+    if (!decoration || !item || !session) return;
     event.preventDefault();
     event.stopPropagation();
     const rect = decoration.getBoundingClientRect();
-    setOptions({ session, top: rect.bottom + 4, right: window.innerWidth - rect.right });
+    setOptions({
+      session,
+      top: rect.bottom + 4,
+      right: window.innerWidth - rect.right,
+      trigger: item,
+    });
+  }
+
+  function handleTreeKeyDownCapture(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "ContextMenu" && !(event.shiftKey && event.key === "F10")) return;
+
+    const path = event.nativeEvent.composedPath();
+    const item = path.find(
+      (target): target is HTMLElement =>
+        target instanceof HTMLElement && target.getAttribute("data-type") === "item",
+    );
+    const session = item
+      ? sessionByPathRef.current.get(item.getAttribute("data-item-path") ?? "")
+      : null;
+    if (!item || !session) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    const anchor =
+      item.querySelector<HTMLElement>("[data-item-section='decoration'] > span") ?? item;
+    const rect = anchor.getBoundingClientRect();
+    setOptions({
+      session,
+      top: rect.bottom + 4,
+      right: window.innerWidth - rect.right,
+      trigger: item,
+    });
   }
 
   useEffect(() => {
@@ -405,6 +441,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
       className="session-tree h-[min(560px,calc(100vh-410px))] min-h-56 overflow-hidden"
       style={treeHostStyle}
       onClickCapture={handleTreeClickCapture}
+      onKeyDownCapture={handleTreeKeyDownCapture}
     >
       <FileTree model={model} style={{ height: "100%" }} aria-label="Sessions" />
       {options ? (

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -7,11 +7,12 @@ import type {
 } from "../../lib/api";
 import { ModelConfig } from "../../config";
 import { getSessionBookmarkKey } from "../../lib/bookmarks";
+import { getSessionDisplayTitle } from "../../lib/session-title";
 import { formatAgentScanProgress, getAgentDisplayCount } from "../../lib/scan-format";
 import { getProjectGroupIdentity, getProjectIdentityKey, getProjectPath } from "../../lib/projects";
 import type { ViewState } from "../../lib/view-state";
-import { BookmarkButton } from "../BookmarkButton";
 import { RenderProfiler } from "../RenderProfiler";
+import { SessionActionsMenu } from "../SessionActionsMenu";
 import { SessionTreeSidebar } from "../SessionTreeSidebar";
 import { Link } from "react-router-dom";
 import { BrowseByToggle } from "./BrowseByToggle";
@@ -153,6 +154,8 @@ export interface AppSidebarActions {
   onToggleBookmark: (session: BookmarkedSessionSnapshot) => void;
   onSelectFlatSidebarSession: (session: SessionHead) => void;
   onToggleSidebarSessionBookmark: (session: SessionHead) => void;
+  onRenameSession: (session: SessionHead) => void;
+  onRenameBookmarkedSession: (session: BookmarkedSessionSnapshot) => void;
   onSelectTreeSidebarSession: (sessionId: string) => void;
 }
 
@@ -179,6 +182,8 @@ export function AppSidebar({
     onToggleBookmark,
     onSelectFlatSidebarSession,
     onToggleSidebarSessionBookmark,
+    onRenameSession,
+    onRenameBookmarkedSession,
     onSelectTreeSidebarSession,
   },
 }: {
@@ -297,14 +302,18 @@ export function AppSidebar({
                         ) : null}
                         <div className="min-w-0 flex-1">
                           <span className="console-mono line-clamp-1 block text-xs">
-                            {session.title}
+                            {getSessionDisplayTitle(session)}
                           </span>
                           <span className="console-mono mt-0.5 line-clamp-1 block text-[10px] text-[var(--console-muted)]">
                             {agent?.name ?? session.agentKey}
                           </span>
                         </div>
                       </Link>
-                      <BookmarkButton active onToggle={() => onToggleBookmark(session)} />
+                      <SessionActionsMenu
+                        bookmarked
+                        onRename={() => onRenameBookmarkedSession(session)}
+                        onToggleBookmark={() => onToggleBookmark(session)}
+                      />
                     </div>
                   </li>
                 );
@@ -342,6 +351,7 @@ export function AppSidebar({
               bookmarkedSessionIds={bookmarkedSidebarSessionIds}
               onSelectSession={onSelectFlatSidebarSession}
               onToggleBookmark={onToggleSidebarSessionBookmark}
+              onRenameSession={onRenameSession}
             />
           ) : (
             <RenderProfiler id="SessionTreeSidebar" detail={{ sessions: sidebarSessions.length }}>
@@ -352,6 +362,7 @@ export function AppSidebar({
                 onSelectSession={onSelectTreeSidebarSession}
                 bookmarkedSessionIds={bookmarkedSidebarSessionIds}
                 onToggleBookmark={onToggleSidebarSessionBookmark}
+                onRenameSession={onRenameSession}
               />
             </RenderProfiler>
           )}

--- a/apps/web/src/components/app/SearchResultsPanel.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.tsx
@@ -1,6 +1,7 @@
 import type { Dispatch, SetStateAction } from "react";
 import { Link } from "react-router-dom";
 import type { AgentInfo, SearchResult } from "../../lib/api";
+import { getSessionDisplayTitle } from "../../lib/session-title";
 import { SmartTagChips } from "../SmartTagChips";
 import { SearchFilterBar } from "./SearchFilterBar";
 import type { SearchFilterState, SearchLoadState, SearchProjectOption } from "./types";
@@ -162,13 +163,13 @@ export function SearchResultsPanel({
               </span>
             </div>
             <h2 className="console-mono mt-3 text-sm font-semibold text-[var(--console-text)]">
-              {result.session.title}
+              {getSessionDisplayTitle(result.session)}
             </h2>
             <SmartTagChips tags={result.session.smart_tags} className="mt-2" />
             <p
               className="console-mono mt-2 text-xs leading-6 text-[var(--console-muted)] [&_mark]:bg-[var(--console-accent)] [&_mark]:px-0.5 [&_mark]:text-white"
               dangerouslySetInnerHTML={{
-                __html: toSafeSnippetHtml(result.snippet || result.session.title),
+                __html: toSafeSnippetHtml(result.snippet || getSessionDisplayTitle(result.session)),
               }}
             />
           </Link>

--- a/apps/web/src/components/app/SidebarFlatSessionList.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.tsx
@@ -2,7 +2,8 @@ import type { SessionHead } from "../../lib/api";
 import { ModelConfig } from "../../config";
 import { getSessionAgentKey } from "../../lib/session-indexes";
 import { formatRelativeTime } from "../../lib/format";
-import { BookmarkButton } from "../BookmarkButton";
+import { getSessionDisplayTitle } from "../../lib/session-title";
+import { SessionActionsMenu } from "../SessionActionsMenu";
 
 export function SidebarFlatSessionList({
   sessions,
@@ -11,6 +12,7 @@ export function SidebarFlatSessionList({
   bookmarkedSessionIds,
   onSelectSession,
   onToggleBookmark,
+  onRenameSession,
 }: {
   sessions: SessionHead[];
   activeSessionId: string | null;
@@ -18,6 +20,7 @@ export function SidebarFlatSessionList({
   bookmarkedSessionIds: Set<string>;
   onSelectSession: (session: SessionHead) => void;
   onToggleBookmark: (session: SessionHead) => void;
+  onRenameSession: (session: SessionHead) => void;
 }) {
   return (
     <div className="console-scrollbar h-[min(560px,calc(100vh-410px))] min-h-56 overflow-y-auto">
@@ -50,16 +53,17 @@ export function SidebarFlatSessionList({
                       />
                     ) : null}
                     <span className="console-mono line-clamp-1 text-xs text-[var(--console-text)]">
-                      {sessionItem.title}
+                      {getSessionDisplayTitle(sessionItem)}
                     </span>
                   </span>
                   <span className="console-mono mt-0.5 block truncate text-[10px] text-[var(--console-muted)]">
                     {formatRelativeTime(sessionItem.time_updated ?? sessionItem.time_created)}
                   </span>
                 </button>
-                <BookmarkButton
-                  active={bookmarkedSessionIds.has(sessionItem.id)}
-                  onToggle={() => onToggleBookmark(sessionItem)}
+                <SessionActionsMenu
+                  bookmarked={bookmarkedSessionIds.has(sessionItem.id)}
+                  onRename={() => onRenameSession(sessionItem)}
+                  onToggleBookmark={() => onToggleBookmark(sessionItem)}
                 />
               </div>
             </li>

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -24,6 +24,15 @@ import {
 export function useBookmarks(sessions: SessionHead[]) {
   const [bookmarks, setBookmarks] = useState<BookmarkedSessionSnapshot[]>([]);
 
+  const refresh = useCallback(async () => {
+    try {
+      const data = await fetchBookmarks();
+      setBookmarks(data.bookmarks);
+    } catch (err) {
+      console.error("Failed to load bookmarks:", err);
+    }
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     void fetchBookmarks()
@@ -161,5 +170,6 @@ export function useBookmarks(sessions: SessionHead[]) {
     isSessionBookmarked,
     toggleBookmark,
     toggleSessionBookmark,
+    refresh,
   };
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -215,6 +215,30 @@ export async function deleteBookmark(agentKey: string, sessionId: string): Promi
   });
 }
 
+export async function upsertSessionAlias(
+  agentKey: string,
+  sessionId: string,
+  alias: string,
+): Promise<void> {
+  await fetchJson(
+    `/api/session-aliases/${encodeURIComponent(agentKey)}/${encodeURIComponent(sessionId)}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ alias }),
+    },
+  );
+}
+
+export async function deleteSessionAlias(agentKey: string, sessionId: string): Promise<void> {
+  await fetchJson(
+    `/api/session-aliases/${encodeURIComponent(agentKey)}/${encodeURIComponent(sessionId)}`,
+    {
+      method: "DELETE",
+    },
+  );
+}
+
 export function logClientEvent(event: string, data: Record<string, unknown> = {}): void {
   const body = JSON.stringify({ event, data });
 

--- a/apps/web/src/lib/build-route-header-model.tsx
+++ b/apps/web/src/lib/build-route-header-model.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { AgentInfo, DashboardData, ProjectGroup, SessionData } from "../lib/api";
 import { formatRelativeTime } from "../lib/format";
 import { getProjectPath, type ProjectRouteIdentity } from "../lib/projects";
+import { getSessionDisplayTitle } from "./session-title";
 import type { ViewState } from "../lib/view-state";
 import { SmartTagChips } from "../components/SmartTagChips";
 import type { BrowseBy } from "../components/app/types";
@@ -81,7 +82,7 @@ function routeTitleAndSubtitle(input: RouteHeaderInput): {
     if (input.session) {
       const updated = input.session.time_updated ?? input.session.time_created;
       return {
-        title: input.session.title || "Conversation",
+        title: getSessionDisplayTitle(input.session) || "Conversation",
         subtitle: (
           <>
             <span>ID: #{input.session.id.slice(0, 8)}</span>
@@ -140,7 +141,11 @@ function routeBreadcrumbs(input: RouteHeaderInput): BreadcrumbItem[] {
         label: input.selectedProject?.displayName ?? input.selectedProjectIdentity.key,
         to: getProjectPath(input.selectedProjectIdentity),
       },
-      { label: input.session?.title || viewState.activeSessionSlug || "Conversation" },
+      {
+        label: input.session
+          ? getSessionDisplayTitle(input.session)
+          : viewState.activeSessionSlug || "Conversation",
+      },
     ];
   }
   if (viewState.mode === "missingAgent") {
@@ -160,7 +165,11 @@ function routeBreadcrumbs(input: RouteHeaderInput): BreadcrumbItem[] {
     return [
       dashboard,
       agent,
-      { label: input.session?.title || viewState.activeSessionSlug || "Conversation" },
+      {
+        label: input.session
+          ? getSessionDisplayTitle(input.session)
+          : viewState.activeSessionSlug || "Conversation",
+      },
     ];
   }
   return [dashboard, { label: "Invalid Route" }];

--- a/apps/web/src/lib/session-title.ts
+++ b/apps/web/src/lib/session-title.ts
@@ -1,0 +1,8 @@
+export interface SessionTitle {
+  title: string;
+  display_title?: string;
+}
+
+export function getSessionDisplayTitle(session: SessionTitle): string {
+  return session.display_title ?? session.title;
+}

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -3,6 +3,9 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 const coreMocks = vi.hoisted(() => ({
   loadCachedSessionData: vi.fn(),
   listSessionFileActivity: vi.fn(() => []),
+  listSessionAliases: vi.fn<
+    () => Array<{ agentKey: string; sessionId: string; alias: string; updated_at: number }>
+  >(() => []),
   executeSessionSearch: vi.fn((): Array<{ agentName: string; session: SessionHead }> => []),
 }));
 
@@ -12,6 +15,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     ...actual,
     loadCachedSessionData: coreMocks.loadCachedSessionData,
     listSessionFileActivity: coreMocks.listSessionFileActivity,
+    listSessionAliases: coreMocks.listSessionAliases,
     executeSessionSearch: coreMocks.executeSessionSearch,
   };
 });
@@ -155,6 +159,8 @@ afterEach(() => {
   coreMocks.loadCachedSessionData.mockReset();
   coreMocks.listSessionFileActivity.mockReset();
   coreMocks.listSessionFileActivity.mockReturnValue([]);
+  coreMocks.listSessionAliases.mockReset();
+  coreMocks.listSessionAliases.mockReturnValue([]);
   coreMocks.executeSessionSearch.mockReset();
   coreMocks.executeSessionSearch.mockReturnValue([]);
   vi.useRealTimers();
@@ -252,6 +258,26 @@ describe("handleGetSessions", () => {
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(1);
     expect(response.sessions[0].id).toBe("s1");
+  });
+
+  it("projects a persisted alias without changing the source title", () => {
+    coreMocks.listSessionAliases.mockReturnValue([
+      {
+        agentKey: "claudecode",
+        sessionId: "s1",
+        alias: "Fix session cache refresh",
+        updated_at: Date.now(),
+      },
+    ]);
+    const c = makeMockContext();
+
+    handleGetSessions(c, makeScanSource());
+
+    const session = c.json.mock.calls[0]![0].sessions[0];
+    expect(session).toMatchObject({
+      title: "Session s1",
+      display_title: "Fix session cache refresh",
+    });
   });
 
   it("filters by cwd using project scope match", () => {

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -2,11 +2,18 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 
 const coreMocks = vi.hoisted(() => ({
   loadCachedSessionData: vi.fn(),
+  listFileActivity: vi.fn((): FileActivityResult[] => []),
   listSessionFileActivity: vi.fn(() => []),
   listSessionAliases: vi.fn<
     () => Array<{ agentKey: string; sessionId: string; alias: string; updated_at: number }>
   >(() => []),
-  executeSessionSearch: vi.fn((): Array<{ agentName: string; session: SessionHead }> => []),
+  executeSessionSearch: vi.fn(
+    (
+      _query: string,
+      _options?: unknown,
+      _scanResult?: unknown,
+    ): Array<{ agentName: string; session: SessionHead }> => [],
+  ),
 }));
 
 vi.mock("@codesesh/core", async (importOriginal) => {
@@ -14,6 +21,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
   return {
     ...actual,
     loadCachedSessionData: coreMocks.loadCachedSessionData,
+    listFileActivity: coreMocks.listFileActivity,
     listSessionFileActivity: coreMocks.listSessionFileActivity,
     listSessionAliases: coreMocks.listSessionAliases,
     executeSessionSearch: coreMocks.executeSessionSearch,
@@ -24,6 +32,7 @@ import {
   handleGetAgents,
   handleGetConfig,
   handleGetDashboard,
+  handleGetFileActivity,
   handleGetProjects,
   handleGetSessions,
   handleGetSessionData,
@@ -32,6 +41,7 @@ import {
 } from "../handlers.js";
 import type {
   ChangeCheckResult,
+  FileActivityResult,
   ScanResult,
   SessionCacheMeta,
   SessionHead,
@@ -157,6 +167,8 @@ function toLocalDateKey(ts: number): string {
 
 afterEach(() => {
   coreMocks.loadCachedSessionData.mockReset();
+  coreMocks.listFileActivity.mockReset();
+  coreMocks.listFileActivity.mockReturnValue([]);
   coreMocks.listSessionFileActivity.mockReset();
   coreMocks.listSessionFileActivity.mockReturnValue([]);
   coreMocks.listSessionAliases.mockReset();
@@ -429,6 +441,74 @@ describe("handleSearchSessions", () => {
     );
     expect(coreMocks.executeSessionSearch).not.toHaveBeenCalled();
   });
+
+  it("matches aliases while preserving query qualifiers", () => {
+    const aliased = makeSession("s1", { slug: "claudecode/s1" });
+    coreMocks.listSessionAliases.mockReturnValue([
+      { agentKey: "claudecode", sessionId: "s1", alias: "Custom cache title", updated_at: 1 },
+    ]);
+    coreMocks.executeSessionSearch.mockImplementation((query) =>
+      query ? [] : [{ agentName: "claudecode", session: aliased }],
+    );
+    const c = makeMockContext({ query: { q: "agent:claudecode custom cache" } });
+
+    handleSearchSessions(c, makeScanSource());
+
+    expect(coreMocks.executeSessionSearch).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({ agent: "claudecode", limit: 2 }),
+      expect.anything(),
+    );
+    expect(c.json.mock.calls[0]![0].results[0].session.display_title).toBe("Custom cache title");
+  });
+
+  it("does not cap alias search candidates at one thousand sessions", () => {
+    const sessions = Array.from({ length: 1001 }, (_, index) =>
+      makeSession(`s${index}`, { slug: `claudecode/s${index}` }),
+    );
+    coreMocks.listSessionAliases.mockReturnValue([
+      { agentKey: "claudecode", sessionId: "s1000", alias: "Old alias", updated_at: 1 },
+    ]);
+    coreMocks.executeSessionSearch.mockImplementation((query) =>
+      query ? [] : [{ agentName: "claudecode", session: sessions[1000]! }],
+    );
+    const c = makeMockContext({ query: { q: "old alias" } });
+
+    handleSearchSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
+
+    expect(coreMocks.executeSessionSearch).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({ limit: 1001 }),
+      expect.anything(),
+    );
+    expect(c.json.mock.calls[0]![0].results[0].session.id).toBe("s1000");
+  });
+});
+
+describe("handleGetFileActivity", () => {
+  it("projects aliases onto nested sessions", () => {
+    const session = makeSession("s1", { slug: "claudecode/s1" });
+    coreMocks.listSessionAliases.mockReturnValue([
+      { agentKey: "claudecode", sessionId: "s1", alias: "Activity alias", updated_at: 1 },
+    ]);
+    coreMocks.listFileActivity.mockReturnValue([
+      {
+        agent_name: "claudecode",
+        session_id: "s1",
+        project_identity_key: "path:/tmp",
+        path: "src/index.ts",
+        kind: "edit",
+        count: 1,
+        latest_time: 1,
+        session,
+      },
+    ]);
+    const c = makeMockContext();
+
+    handleGetFileActivity(c);
+
+    expect(c.json.mock.calls[0]![0].activity[0].session.display_title).toBe("Activity alias");
+  });
 });
 
 describe("handleGetProjects", () => {
@@ -496,6 +576,32 @@ describe("handleGetProjects", () => {
 });
 
 describe("handleGetDashboard", () => {
+  it("projects aliases onto recent file activity sessions", () => {
+    const session = makeSession("s1", { slug: "claudecode/s1" });
+    coreMocks.listSessionAliases.mockReturnValue([
+      { agentKey: "claudecode", sessionId: "s1", alias: "Activity alias", updated_at: 1 },
+    ]);
+    coreMocks.listFileActivity.mockReturnValue([
+      {
+        agent_name: "claudecode",
+        session_id: "s1",
+        project_identity_key: "path:/tmp",
+        path: "src/index.ts",
+        kind: "edit",
+        count: 1,
+        latest_time: 1,
+        session,
+      },
+    ]);
+    const c = makeMockContext();
+
+    handleGetDashboard(c, makeScanSource());
+
+    expect(c.json.mock.calls[0]![0].recentFileActivities[0].session.display_title).toBe(
+      "Activity alias",
+    );
+  });
+
   it("aggregates totals across all sessions", () => {
     const c = makeMockContext();
     const sessions = [

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -15,6 +15,7 @@ import type {
 } from "@codesesh/core/contract";
 import {
   BookmarkStorageUnavailableError,
+  StateStorageUnavailableError,
   createProjectScopeMatcher,
   deleteBookmark,
   getAgentInfoMap,
@@ -31,6 +32,7 @@ import {
   listCachedProjectGroups,
   listBookmarks,
   listSessionAliases,
+  mergeSearchQueryOptions,
   deleteSessionAlias,
   upsertSessionAlias,
   realFs,
@@ -45,6 +47,7 @@ import {
   type DashboardData,
   type DashboardScope,
   type FileActivityKind,
+  type FileActivityResult,
   type ProjectIdentityRef,
   type SearchOptions,
 } from "@codesesh/core";
@@ -92,13 +95,18 @@ function loadSessionAliasMap(): SessionAliasMap {
         alias.alias,
       ]),
     );
-  } catch {
+  } catch (error) {
+    if (!(error instanceof StateStorageUnavailableError)) {
+      appLogger.warn("api.session_aliases.load_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
     return new Map();
   }
 }
 
 function isStateStorageUnavailable(error: unknown): boolean {
-  return error instanceof Error && error.message === "SQLite state database is unavailable";
+  return error instanceof StateStorageUnavailableError;
 }
 
 function withDisplayTitle<T extends { id: string; title: string; display_title?: string }>(
@@ -118,16 +126,31 @@ function withBookmarkDisplayTitle(
   return alias ? { ...bookmark, display_title: alias } : bookmark;
 }
 
+function withFileActivityDisplayTitle(
+  activity: FileActivityResult,
+  aliases: SessionAliasMap,
+): FileActivityResult {
+  return {
+    ...activity,
+    session: withDisplayTitle(activity.session, activity.agent_name, aliases),
+  };
+}
+
 function findAliasSearchResults(
   query: string,
   options: SearchOptions,
   scanResult: ScanResult,
   aliases: SessionAliasMap,
 ) {
-  const needle = query.trim().toLowerCase();
-  if (!needle || needle.includes(":")) return [];
+  const search = mergeSearchQueryOptions(query, options);
+  const needle = search.text.trim().toLowerCase();
+  if (!needle || aliases.size === 0) return [];
 
-  return executeSessionSearch("", { ...options, limit: 1_000 }, scanResult).flatMap((result) => {
+  return executeSessionSearch(
+    "",
+    { ...search.options, limit: Math.max(scanResult.sessions.length, 1) },
+    scanResult,
+  ).flatMap((result) => {
     const alias = aliases.get(getSessionAliasKey(result.agentName, result.session.id));
     if (!alias || !alias.toLowerCase().includes(needle)) return [];
     return [
@@ -537,6 +560,7 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
 
+  const aliases = loadSessionAliasMap();
   return c.json({
     activity: listFileActivity({
       agent: optionalQueryValue(c.req.query("agent")),
@@ -550,7 +574,7 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
       from: parseDateParam(c.req.query("from"), defaults.from),
       to: parseDateParam(c.req.query("to"), defaults.to),
       limit,
-    }),
+    }).map((activity) => withFileActivityDisplayTitle(activity, aliases)),
   });
 }
 
@@ -852,6 +876,9 @@ export function handleGetDashboard(
     ...data,
     recentSessions: data.recentSessions.map((session) =>
       withDisplayTitle(session, session.agentName, aliases),
+    ),
+    recentFileActivities: data.recentFileActivities.map((activity) =>
+      withFileActivityDisplayTitle(activity, aliases),
     ),
   });
 }

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -30,6 +30,9 @@ import {
   listSessionFileActivity,
   listCachedProjectGroups,
   listBookmarks,
+  listSessionAliases,
+  deleteSessionAlias,
+  upsertSessionAlias,
   realFs,
   upsertBookmark,
   matchesProjectScope as sessionMatchesProjectScope,
@@ -65,6 +68,77 @@ export interface SessionListDefaults {
 interface ClientLogPayload {
   event?: unknown;
   data?: unknown;
+}
+
+interface SessionAliasPayload {
+  alias?: unknown;
+}
+
+type SessionAliasMap = Map<string, string>;
+
+function getSessionAliasKey(agentKey: string, sessionId: string): string {
+  return `${agentKey.toLowerCase()}\0${sessionId}`;
+}
+
+function getSessionAgentKey(session: Pick<SessionHead, "slug">): string {
+  return session.slug.split("/")[0]?.toLowerCase() ?? "";
+}
+
+function loadSessionAliasMap(): SessionAliasMap {
+  try {
+    return new Map(
+      listSessionAliases().map((alias) => [
+        getSessionAliasKey(alias.agentKey, alias.sessionId),
+        alias.alias,
+      ]),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
+function isStateStorageUnavailable(error: unknown): boolean {
+  return error instanceof Error && error.message === "SQLite state database is unavailable";
+}
+
+function withDisplayTitle<T extends { id: string; title: string; display_title?: string }>(
+  session: T,
+  agentKey: string,
+  aliases: SessionAliasMap,
+): T {
+  const alias = aliases.get(getSessionAliasKey(agentKey, session.id));
+  return alias ? { ...session, display_title: alias } : session;
+}
+
+function withBookmarkDisplayTitle(
+  bookmark: BookmarkRecord,
+  aliases: SessionAliasMap,
+): BookmarkRecord {
+  const alias = aliases.get(getSessionAliasKey(bookmark.agentKey, bookmark.sessionId));
+  return alias ? { ...bookmark, display_title: alias } : bookmark;
+}
+
+function findAliasSearchResults(
+  query: string,
+  options: SearchOptions,
+  scanResult: ScanResult,
+  aliases: SessionAliasMap,
+) {
+  const needle = query.trim().toLowerCase();
+  if (!needle || needle.includes(":")) return [];
+
+  return executeSessionSearch("", { ...options, limit: 1_000 }, scanResult).flatMap((result) => {
+    const alias = aliases.get(getSessionAliasKey(result.agentName, result.session.id));
+    if (!alias || !alias.toLowerCase().includes(needle)) return [];
+    return [
+      {
+        agentName: result.agentName,
+        session: withDisplayTitle(result.session, result.agentName, aliases),
+        snippet: `Alias · ${result.session.directory}`,
+        matchType: "title" as const,
+      },
+    ];
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -387,11 +461,18 @@ export function handleGetSessions(
     sessions = sessions.filter((s) => s.smart_tags?.includes(tag as SmartTag));
   }
 
+  const aliases = loadSessionAliasMap();
   if (q) {
-    sessions = sessions.filter((s) => s.title.toLowerCase().includes(q));
+    sessions = sessions.filter((session) => {
+      const alias = aliases.get(getSessionAliasKey(getSessionAgentKey(session), session.id));
+      return session.title.toLowerCase().includes(q) || alias?.toLowerCase().includes(q);
+    });
   }
-
-  return c.json({ sessions });
+  return c.json({
+    sessions: sessions.map((session) =>
+      withDisplayTitle(session, getSessionAgentKey(session), aliases),
+    ),
+  });
 }
 
 export function handleSearchSessions(
@@ -409,8 +490,17 @@ export function handleSearchSessions(
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
   const searchOptions = parseSearchOptions(c, defaults, projectIdentity);
-  const results = executeSessionSearch(query, searchOptions, scanResult);
-  return c.json({ results });
+  const aliases = loadSessionAliasMap();
+  const results = executeSessionSearch(query, searchOptions, scanResult).map((result) => ({
+    ...result,
+    session: withDisplayTitle(result.session, result.agentName, aliases),
+  }));
+  const aliasResults = findAliasSearchResults(query, searchOptions, scanResult, aliases);
+  const deduped = new Map<string, (typeof results)[number]>();
+  for (const result of [...aliasResults, ...results]) {
+    deduped.set(`${result.agentName}\0${result.session.id}`, result);
+  }
+  return c.json({ results: [...deduped.values()].slice(0, searchOptions.limit ?? 50) });
 }
 
 function parseFileActivityKind(value: string | undefined): FileActivityKind | undefined {
@@ -523,8 +613,9 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       tag_duration_ms: Math.round(tagDuration),
       duration_ms: Math.round(performance.now() - startedAt),
     });
+    const aliases = loadSessionAliasMap();
     return c.json({
-      ...data,
+      ...withDisplayTitle(data, agentName, aliases),
       project_identity: projectIdentity,
       smart_tags: smartTags,
       smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
@@ -560,7 +651,11 @@ export async function handlePostClientLog(c: Context) {
 
 export function handleGetBookmarks(c: Context) {
   try {
-    return c.json({ bookmarks: listBookmarks(), storageAvailable: true });
+    const aliases = loadSessionAliasMap();
+    return c.json({
+      bookmarks: listBookmarks().map((bookmark) => withBookmarkDisplayTitle(bookmark, aliases)),
+      storageAvailable: true,
+    });
   } catch (error) {
     if (error instanceof BookmarkStorageUnavailableError) {
       return c.json({ bookmarks: [], storageAvailable: false });
@@ -622,6 +717,45 @@ export function handleDeleteBookmark(c: Context) {
   } catch (error) {
     if (error instanceof BookmarkStorageUnavailableError) {
       return c.json({ error: "Bookmark storage is unavailable" }, 503);
+    }
+    throw error;
+  }
+}
+
+export async function handlePutSessionAlias(c: Context) {
+  const agentKey = c.req.param("agent");
+  const sessionId = c.req.param("id");
+  const payload = (await c.req.json().catch(() => null)) as SessionAliasPayload | null;
+  if (!agentKey || !sessionId || typeof payload?.alias !== "string") {
+    return c.json({ error: "Invalid session alias payload" }, 400);
+  }
+
+  try {
+    return c.json({ alias: upsertSessionAlias(agentKey, sessionId, payload.alias) });
+  } catch (error) {
+    if (error instanceof TypeError) {
+      return c.json({ error: "Session alias must be non-empty and at most 160 characters" }, 400);
+    }
+    if (isStateStorageUnavailable(error)) {
+      return c.json({ error: "Session alias storage is unavailable" }, 503);
+    }
+    throw error;
+  }
+}
+
+export function handleDeleteSessionAlias(c: Context) {
+  const agentKey = c.req.param("agent");
+  const sessionId = c.req.param("id");
+  if (!agentKey || !sessionId) {
+    return c.json({ error: "Missing session alias identifier" }, 400);
+  }
+
+  try {
+    deleteSessionAlias(agentKey, sessionId);
+    return c.json({ ok: true });
+  } catch (error) {
+    if (isStateStorageUnavailable(error)) {
+      return c.json({ error: "Session alias storage is unavailable" }, 503);
     }
     throw error;
   }
@@ -713,5 +847,11 @@ export function handleGetDashboard(
     window: { from, to, days },
   };
 
-  return c.json(data);
+  const aliases = loadSessionAliasMap();
+  return c.json({
+    ...data,
+    recentSessions: data.recentSessions.map((session) =>
+      withDisplayTitle(session, session.agentName, aliases),
+    ),
+  });
 }

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -8,12 +8,14 @@ import {
   handleGetProjects,
   handleGetScanStatus,
   handleDeleteBookmark,
+  handleDeleteSessionAlias,
   handleImportBookmarks,
   handlePostClientLog,
   handleSearchSessions,
   handleGetSessions,
   handleGetSessionData,
   handlePutBookmark,
+  handlePutSessionAlias,
   type ScanResultSource,
   type SessionListDefaults,
 } from "./handlers.js";
@@ -113,6 +115,8 @@ export function createApiRoutes(
   api.put("/bookmarks", (c) => handlePutBookmark(c));
   api.post("/bookmarks/import", (c) => handleImportBookmarks(c));
   api.delete("/bookmarks/:agent/:id", (c) => handleDeleteBookmark(c));
+  api.put("/session-aliases/:agent/:id", (c) => handlePutSessionAlias(c));
+  api.delete("/session-aliases/:agent/:id", (c) => handleDeleteSessionAlias(c));
   api.post("/logs", (c) => handlePostClientLog(c));
   if (store) {
     api.get("/events", (c) => createSseResponse(store, c.req.raw.signal));

--- a/packages/core/src/contract/bookmarks.ts
+++ b/packages/core/src/contract/bookmarks.ts
@@ -5,6 +5,7 @@ export interface BookmarkRecord {
   sessionId: string;
   fullPath: string;
   title: string;
+  display_title?: string;
   directory: string;
   time_created: number;
   time_updated?: number;

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -125,6 +125,7 @@ export interface SessionHead {
   id: string;
   slug: string;
   title: string;
+  display_title?: string;
   directory: string;
   project_identity?: ProjectIdentity;
   time_created: number;
@@ -139,6 +140,7 @@ export interface SessionHead {
 export interface SessionData {
   id: string;
   title: string;
+  display_title?: string;
   slug?: string | null;
   directory: string;
   project_identity?: ProjectIdentity;

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -284,6 +284,6 @@ describe("sqlite migration smoke", () => {
       },
     ]);
     expect(getUserVersion(getCachePath())).toBe(13);
-    expect(getUserVersion(getStatePath())).toBe(1);
+    expect(getUserVersion(getStatePath())).toBe(2);
   }, 30_000);
 });

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -27,6 +27,7 @@ export {
 } from "./cache/sessions.js";
 
 export {
+  mergeSearchQueryOptions,
   parseSearchQuery,
   searchSessions,
   syncSessionSearchIndex,

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -30,6 +30,7 @@ export {
   listCachedProjectGroups,
   listFileActivity,
   listSessionFileActivity,
+  mergeSearchQueryOptions,
   parseSearchQuery,
   searchFileActivitySessions,
   searchSessions,

--- a/packages/core/src/state/__tests__/bookmarks.test.ts
+++ b/packages/core/src/state/__tests__/bookmarks.test.ts
@@ -83,7 +83,7 @@ describe("bookmarks state storage", () => {
         bookmarked_at: now,
       },
     ]);
-    expect(getUserVersion(getStatePath())).toBe(1);
+    expect(getUserVersion(getStatePath())).toBe(2);
   });
 
   it("preserves bookmarked_at when refreshing a snapshot", () => {
@@ -126,7 +126,7 @@ describe("bookmarks state storage", () => {
 
     upsertBookmark(makeBookmark());
 
-    expect(getUserVersion(join(stateDir, "state.db"))).toBe(1);
+    expect(getUserVersion(join(stateDir, "state.db"))).toBe(2);
   });
 
   it("uses memory state storage when configured", () => {
@@ -157,6 +157,6 @@ describe("bookmarks state storage", () => {
     }
 
     expect(listBookmarks()[0]?.sessionId).toBe("s1");
-    expect(getUserVersion(getStatePath())).toBe(1);
+    expect(getUserVersion(getStatePath())).toBe(2);
   });
 });

--- a/packages/core/src/state/__tests__/bookmarks.test.ts
+++ b/packages/core/src/state/__tests__/bookmarks.test.ts
@@ -159,4 +159,17 @@ describe("bookmarks state storage", () => {
     expect(listBookmarks()[0]?.sessionId).toBe("s1");
     expect(getUserVersion(getStatePath())).toBe(2);
   });
+
+  it("does not downgrade a state database created by a newer version", () => {
+    upsertBookmark(makeBookmark());
+    const db = new Database(getStatePath());
+    try {
+      db.exec("PRAGMA user_version = 3");
+    } finally {
+      db.close();
+    }
+
+    expect(listBookmarks()[0]?.sessionId).toBe("s1");
+    expect(getUserVersion(getStatePath())).toBe(3);
+  });
 });

--- a/packages/core/src/state/__tests__/session-aliases.test.ts
+++ b/packages/core/src/state/__tests__/session-aliases.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { deleteSessionAlias, listSessionAliases, upsertSessionAlias } from "../session-aliases.js";
+
+const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-aliases-test-"));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => testHomeDir),
+    platform: vi.fn(() => "linux"),
+  };
+});
+
+beforeEach(() => {
+  rmSync(join(testHomeDir, ".local"), { recursive: true, force: true });
+  vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  rmSync(join(testHomeDir, ".local"), { recursive: true, force: true });
+});
+
+describe("session aliases", () => {
+  it("persists aliases by agent and session ID", () => {
+    upsertSessionAlias("codex", "shared", "Investigate cache invalidation");
+    upsertSessionAlias("claudecode", "shared", "Fix checkout regression");
+
+    expect(listSessionAliases()).toEqual([
+      {
+        agentKey: "codex",
+        sessionId: "shared",
+        alias: "Investigate cache invalidation",
+        updated_at: 1_700_000_000_000,
+      },
+      {
+        agentKey: "claudecode",
+        sessionId: "shared",
+        alias: "Fix checkout regression",
+        updated_at: 1_700_000_000_000,
+      },
+    ]);
+  });
+
+  it("updates and removes aliases", () => {
+    upsertSessionAlias("codex", "s1", "First title");
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_100);
+    upsertSessionAlias("codex", "s1", "Second title");
+
+    expect(listSessionAliases()[0]).toMatchObject({
+      alias: "Second title",
+      updated_at: 1_700_000_000_100,
+    });
+
+    deleteSessionAlias("codex", "s1");
+    expect(listSessionAliases()).toEqual([]);
+  });
+});

--- a/packages/core/src/state/bookmarks.ts
+++ b/packages/core/src/state/bookmarks.ts
@@ -1,29 +1,11 @@
-import { homedir, platform } from "node:os";
-import { join } from "node:path";
 import type { SessionStats } from "../types/index.js";
 import type { BookmarkRecord } from "../contract/index.js";
-import {
-  columnExists,
-  getUserVersion,
-  openDb,
-  runSchemaMigrations,
-  setUserVersion,
-  tableExists,
-  type DatabaseRow,
-  type SQLiteDatabase,
-} from "../utils/sqlite.js";
+import { StateStorageUnavailableError, useMemoryStateStore, withStateDb } from "./database.js";
+import type { DatabaseRow } from "../utils/sqlite.js";
 
-const BOOKMARK_DB_FILENAME = "state.db";
-const BOOKMARK_SCHEMA_VERSION = 1;
-const MEMORY_STATE_STORE = "memory";
 const memoryBookmarks = new Map<string, BookmarkRecord>();
 
-export class BookmarkStorageUnavailableError extends Error {
-  constructor() {
-    super("SQLite state database is unavailable");
-    this.name = "BookmarkStorageUnavailableError";
-  }
-}
+export { StateStorageUnavailableError as BookmarkStorageUnavailableError };
 
 export type { BookmarkRecord };
 
@@ -37,30 +19,6 @@ interface BookmarkRow extends DatabaseRow {
   time_updated?: number | null;
   stats_json?: string;
   bookmarked_at?: number;
-}
-
-function getStateDir(): string {
-  if (process.env.CODESESH_STATE_DIR) {
-    return process.env.CODESESH_STATE_DIR;
-  }
-
-  const p = platform();
-  if (p === "darwin") {
-    return join(homedir(), "Library", "Application Support", "codesesh");
-  }
-  if (p === "win32") {
-    const appData = process.env.APPDATA ?? process.env.LOCALAPPDATA;
-    return join(appData ?? join(homedir(), "AppData", "Roaming"), "codesesh");
-  }
-  return join(process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share"), "codesesh");
-}
-
-function getStateDbPath(): string {
-  return join(getStateDir(), BOOKMARK_DB_FILENAME);
-}
-
-function useMemoryStateStore(): boolean {
-  return process.env.CODESESH_STATE_STORE === MEMORY_STATE_STORE;
 }
 
 function getBookmarkKey(agentKey: string, sessionId: string): string {
@@ -90,111 +48,6 @@ function upsertMemoryBookmark(bookmark: Omit<BookmarkRecord, "bookmarked_at">): 
   };
   memoryBookmarks.set(key, saved);
   return saved;
-}
-
-function createStateSchema(db: SQLiteDatabase): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS state_meta (
-      key TEXT PRIMARY KEY,
-      value TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS bookmarks (
-      agent_name TEXT NOT NULL,
-      session_id TEXT NOT NULL,
-      slug TEXT NOT NULL,
-      title TEXT NOT NULL,
-      directory TEXT NOT NULL,
-      time_created INTEGER NOT NULL,
-      time_updated INTEGER,
-      stats_json TEXT NOT NULL,
-      bookmarked_at INTEGER NOT NULL,
-      PRIMARY KEY (agent_name, session_id)
-    );
-  `);
-}
-
-function readLegacyStateVersion(db: SQLiteDatabase): number {
-  if (
-    !tableExists(db, "state_meta") ||
-    !columnExists(db, "state_meta", "key") ||
-    !columnExists(db, "state_meta", "value")
-  ) {
-    return 0;
-  }
-
-  const row = db.prepare("SELECT value FROM state_meta WHERE key = 'version'").get() as
-    | DatabaseRow
-    | undefined;
-  return Number(row?.value ?? 0);
-}
-
-function getCurrentStateSchemaVersion(db: SQLiteDatabase): number {
-  const userVersion = getUserVersion(db);
-  if (userVersion > 0) {
-    return userVersion;
-  }
-
-  const legacyVersion = readLegacyStateVersion(db);
-  if (legacyVersion > 0) {
-    return legacyVersion;
-  }
-
-  return tableExists(db, "bookmarks") ? 1 : 0;
-}
-
-function hasAnyStateSchema(db: SQLiteDatabase): boolean {
-  return tableExists(db, "state_meta") || tableExists(db, "bookmarks");
-}
-
-function setStateSchemaVersion(db: SQLiteDatabase): void {
-  createStateSchema(db);
-  setUserVersion(db, BOOKMARK_SCHEMA_VERSION);
-  db.prepare(
-    `
-      INSERT INTO state_meta(key, value)
-      VALUES ('version', ?)
-      ON CONFLICT(key) DO UPDATE SET value = excluded.value
-    `,
-  ).run(String(BOOKMARK_SCHEMA_VERSION));
-}
-
-function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
-  const currentVersion = getCurrentStateSchemaVersion(db);
-  if (currentVersion === 0 && !hasAnyStateSchema(db)) {
-    setStateSchemaVersion(db);
-    return;
-  }
-
-  runSchemaMigrations(db, {
-    dbPath,
-    currentVersion,
-    targetVersion: BOOKMARK_SCHEMA_VERSION,
-    backupLabel: "state-migration",
-    backupTables: ["bookmarks"],
-    migrations: [{ version: 1, migrate: createStateSchema }],
-  });
-
-  createStateSchema(db);
-
-  if (getUserVersion(db) <= BOOKMARK_SCHEMA_VERSION) {
-    setStateSchemaVersion(db);
-  }
-}
-
-function withStateDb<T>(fn: (db: SQLiteDatabase) => T): T {
-  const statePath = getStateDbPath();
-  const db = openDb(statePath);
-  if (!db) {
-    throw new BookmarkStorageUnavailableError();
-  }
-
-  try {
-    ensureSchema(db, statePath);
-    return fn(db);
-  } finally {
-    db.close();
-  }
 }
 
 function toBookmarkRecord(row: BookmarkRow): BookmarkRecord {

--- a/packages/core/src/state/database.ts
+++ b/packages/core/src/state/database.ts
@@ -144,7 +144,9 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
     ],
   });
 
-  setStateSchemaVersion(db);
+  if (currentVersion <= STATE_SCHEMA_VERSION) {
+    setStateSchemaVersion(db);
+  }
 }
 
 export function withStateDb<T>(fn: (db: SQLiteDatabase) => T): T {

--- a/packages/core/src/state/database.ts
+++ b/packages/core/src/state/database.ts
@@ -1,0 +1,161 @@
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import {
+  columnExists,
+  getUserVersion,
+  openDb,
+  runSchemaMigrations,
+  setUserVersion,
+  tableExists,
+  type DatabaseRow,
+  type SQLiteDatabase,
+} from "../utils/sqlite.js";
+
+const STATE_DB_FILENAME = "state.db";
+const STATE_SCHEMA_VERSION = 2;
+const MEMORY_STATE_STORE = "memory";
+
+export class StateStorageUnavailableError extends Error {
+  constructor() {
+    super("SQLite state database is unavailable");
+    this.name = "StateStorageUnavailableError";
+  }
+}
+
+function getStateDir(): string {
+  if (process.env.CODESESH_STATE_DIR) return process.env.CODESESH_STATE_DIR;
+
+  const currentPlatform = platform();
+  if (currentPlatform === "darwin") {
+    return join(homedir(), "Library", "Application Support", "codesesh");
+  }
+  if (currentPlatform === "win32") {
+    const appData = process.env.APPDATA ?? process.env.LOCALAPPDATA;
+    return join(appData ?? join(homedir(), "AppData", "Roaming"), "codesesh");
+  }
+  return join(process.env.XDG_DATA_HOME ?? join(homedir(), ".local", "share"), "codesesh");
+}
+
+function getStateDbPath(): string {
+  return join(getStateDir(), STATE_DB_FILENAME);
+}
+
+export function useMemoryStateStore(): boolean {
+  return process.env.CODESESH_STATE_STORE === MEMORY_STATE_STORE;
+}
+
+function createBookmarksTable(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS bookmarks (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      slug TEXT NOT NULL,
+      title TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER,
+      stats_json TEXT NOT NULL,
+      bookmarked_at INTEGER NOT NULL,
+      PRIMARY KEY (agent_name, session_id)
+    );
+  `);
+}
+
+function createSessionAliasesTable(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_aliases (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      alias TEXT NOT NULL,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (agent_name, session_id)
+    );
+  `);
+}
+
+function createStateSchema(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS state_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+  `);
+  createBookmarksTable(db);
+  createSessionAliasesTable(db);
+}
+
+function readLegacyStateVersion(db: SQLiteDatabase): number {
+  if (
+    !tableExists(db, "state_meta") ||
+    !columnExists(db, "state_meta", "key") ||
+    !columnExists(db, "state_meta", "value")
+  ) {
+    return 0;
+  }
+
+  const row = db.prepare("SELECT value FROM state_meta WHERE key = 'version'").get() as
+    | DatabaseRow
+    | undefined;
+  return Number(row?.value ?? 0);
+}
+
+function getCurrentStateSchemaVersion(db: SQLiteDatabase): number {
+  const userVersion = getUserVersion(db);
+  if (userVersion > 0) return userVersion;
+
+  const legacyVersion = readLegacyStateVersion(db);
+  if (legacyVersion > 0) return legacyVersion;
+
+  return tableExists(db, "bookmarks") ? 1 : 0;
+}
+
+function hasAnyStateSchema(db: SQLiteDatabase): boolean {
+  return tableExists(db, "state_meta") || tableExists(db, "bookmarks");
+}
+
+function setStateSchemaVersion(db: SQLiteDatabase): void {
+  createStateSchema(db);
+  setUserVersion(db, STATE_SCHEMA_VERSION);
+  db.prepare(
+    `
+      INSERT INTO state_meta(key, value)
+      VALUES ('version', ?)
+      ON CONFLICT(key) DO UPDATE SET value = excluded.value
+    `,
+  ).run(String(STATE_SCHEMA_VERSION));
+}
+
+function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
+  const currentVersion = getCurrentStateSchemaVersion(db);
+  if (currentVersion === 0 && !hasAnyStateSchema(db)) {
+    setStateSchemaVersion(db);
+    return;
+  }
+
+  runSchemaMigrations(db, {
+    dbPath,
+    currentVersion,
+    targetVersion: STATE_SCHEMA_VERSION,
+    backupLabel: "state-migration",
+    backupTables: ["bookmarks", "session_aliases"],
+    migrations: [
+      { version: 1, migrate: createBookmarksTable },
+      { version: 2, migrate: createSessionAliasesTable },
+    ],
+  });
+
+  setStateSchemaVersion(db);
+}
+
+export function withStateDb<T>(fn: (db: SQLiteDatabase) => T): T {
+  const statePath = getStateDbPath();
+  const db = openDb(statePath);
+  if (!db) throw new StateStorageUnavailableError();
+
+  try {
+    ensureSchema(db, statePath);
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -6,3 +6,12 @@ export {
   BookmarkStorageUnavailableError,
   type BookmarkRecord,
 } from "./bookmarks.js";
+export {
+  deleteSessionAlias,
+  listSessionAliases,
+  normalizeSessionAlias,
+  SESSION_ALIAS_MAX_LENGTH,
+  StateStorageUnavailableError,
+  upsertSessionAlias,
+  type SessionAlias,
+} from "./session-aliases.js";

--- a/packages/core/src/state/session-aliases.ts
+++ b/packages/core/src/state/session-aliases.ts
@@ -1,0 +1,110 @@
+import { StateStorageUnavailableError, useMemoryStateStore, withStateDb } from "./database.js";
+import type { DatabaseRow } from "../utils/sqlite.js";
+
+export const SESSION_ALIAS_MAX_LENGTH = 160;
+
+export interface SessionAlias {
+  agentKey: string;
+  sessionId: string;
+  alias: string;
+  updated_at: number;
+}
+
+interface SessionAliasRow extends DatabaseRow {
+  agent_name?: string;
+  session_id?: string;
+  alias?: string;
+  updated_at?: number;
+}
+
+const memoryAliases = new Map<string, SessionAlias>();
+
+function getAliasKey(agentKey: string, sessionId: string): string {
+  return JSON.stringify([agentKey, sessionId]);
+}
+
+function toSessionAlias(row: SessionAliasRow): SessionAlias {
+  return {
+    agentKey: String(row.agent_name ?? ""),
+    sessionId: String(row.session_id ?? ""),
+    alias: String(row.alias ?? ""),
+    updated_at: Number(row.updated_at ?? 0),
+  };
+}
+
+export function normalizeSessionAlias(value: string): string | null {
+  const alias = value.trim();
+  if (!alias || alias.length > SESSION_ALIAS_MAX_LENGTH) return null;
+  return alias;
+}
+
+export function listSessionAliases(): SessionAlias[] {
+  if (useMemoryStateStore()) return [...memoryAliases.values()];
+
+  return withStateDb((db) =>
+    (
+      db
+        .prepare(
+          `
+          SELECT agent_name, session_id, alias, updated_at
+          FROM session_aliases
+          ORDER BY updated_at DESC
+        `,
+        )
+        .all() as SessionAliasRow[]
+    ).map(toSessionAlias),
+  );
+}
+
+export function upsertSessionAlias(
+  agentKey: string,
+  sessionId: string,
+  alias: string,
+): SessionAlias {
+  const normalizedAlias = normalizeSessionAlias(alias);
+  if (!normalizedAlias) {
+    throw new TypeError("Invalid session alias");
+  }
+
+  const saved: SessionAlias = {
+    agentKey,
+    sessionId,
+    alias: normalizedAlias,
+    updated_at: Date.now(),
+  };
+  if (useMemoryStateStore()) {
+    memoryAliases.set(getAliasKey(agentKey, sessionId), saved);
+    return saved;
+  }
+
+  return withStateDb((db) => {
+    db.prepare(
+      `
+        INSERT INTO session_aliases(agent_name, session_id, alias, updated_at)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(agent_name, session_id) DO UPDATE SET
+          alias = excluded.alias,
+          updated_at = excluded.updated_at
+      `,
+    ).run(saved.agentKey, saved.sessionId, saved.alias, saved.updated_at);
+    return saved;
+  });
+}
+
+export function deleteSessionAlias(agentKey: string, sessionId: string): void {
+  if (useMemoryStateStore()) {
+    memoryAliases.delete(getAliasKey(agentKey, sessionId));
+    return;
+  }
+
+  withStateDb((db) => {
+    db.prepare(
+      `
+        DELETE FROM session_aliases
+        WHERE agent_name = ? AND session_id = ?
+      `,
+    ).run(agentKey, sessionId);
+  });
+}
+
+export { StateStorageUnavailableError };

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -27,7 +27,16 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
     .first()
     .click();
   await expect(page.getByRole("heading", { level: 1, name: "Claude Code" })).toBeVisible();
-  await expect(page.getByRole("treeitem", { name: /codesesh-e2e/ })).toBeVisible();
+  const projectTreeItem = page.getByRole("treeitem", { name: /codesesh-e2e/ });
+  await expect(projectTreeItem).toBeVisible();
+  await projectTreeItem.click();
+
+  const treeSession = page.getByRole("treeitem", { name: /Core browsing smoke session/ });
+  await treeSession.focus();
+  await treeSession.press("Shift+F10");
+  await expect(page.getByRole("menuitem", { name: "Rename" })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(treeSession).toBeFocused();
 
   await page.getByText("Core browsing smoke session").first().click();
   await expect(page).toHaveURL(/\/claudecode\/e2e-dashboard$/);
@@ -63,6 +72,7 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
 
   await page.goto("/");
   const recentSession = page
+    .getByTestId("dashboard")
     .locator("li")
     .filter({ hasText: "Core browsing smoke session" })
     .first();


### PR DESCRIPTION
## Summary

- persist CodeSesh-only session aliases without changing upstream Agent sessions
- expose aliases across session APIs, search, bookmarks, dashboard, and detail views
- add consistent rename/bookmark actions to sidebar session lists and preserve tree expansion state
- reclaim sidebar tree width so longer session titles remain visible

## Validation

- `pnpm --filter @codesesh/core test`
- `pnpm --filter codesesh test`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web build`

## Related issue

Related to #5 (item 3: custom session aliases).

Local tracking: CS-51