### PR TITLE
feat: add session time range filtering

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import { deleteSessionAlias, logClientEvent, upsertSessionAlias } from "./lib/ap
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { CopyResumeButton } from "./components/CopyResumeButton";
 import { SessionAliasDialog, type SessionAliasTarget } from "./components/SessionAliasDialog";
+import { TimeWindowControl } from "./components/TimeWindowControl";
 import { RenderProfiler } from "./components/RenderProfiler";
 import { parseViewState } from "./lib/view-state";
 import { useScanStatus } from "./hooks/useScanStatus";
@@ -23,12 +24,13 @@ import { useProjects } from "./hooks/useProjects";
 import { useInitialLoad } from "./hooks/useInitialLoad";
 import { useLiveSync } from "./hooks/useLiveSync";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useTimeWindow } from "./hooks/useTimeWindow";
 import { buildRouteHeaderModel } from "./lib/build-route-header-model";
 import { AppSidebar } from "./components/app/AppSidebar";
 import { ShortcutHelpDialog } from "./components/app/ShortcutHelpDialog";
 import { AppRouteContent } from "./components/app/AppRouteContent";
 import type { BrowseBy } from "./components/app/types";
-import { formatScanStatusLabel, formatSearchSubtitle, formatWindowLabel } from "./lib/scan-format";
+import { formatScanStatusLabel, formatSearchSubtitle } from "./lib/scan-format";
 import {
   getProjectGroupIdentity,
   getProjectIdentityKey,
@@ -48,18 +50,17 @@ const SHORTCUT_HINT_STORAGE_KEY = "codesesh.shortcuts-hint-dismissed";
 export default function App() {
   const navigate = useNavigate();
   const { appConfig, refresh: refreshAppConfig } = useAppConfig();
+  const timeWindowController = useTimeWindow(appConfig?.window);
+  const { timeWindow } = timeWindowController;
   const { agents, validAgentKeys, agentNameMap, refresh: refreshAgents } = useAgents();
-  const {
-    sessions,
-    refresh: refreshSessions,
-    applyLiveEvent: applySessionsLiveEvent,
-  } = useSessions();
+  const { sessions, refresh: refreshSessions } = useSessions();
   const { projects, refresh: refreshProjects } = useProjects();
   const { loading, error } = useInitialLoad({
     refreshAppConfig,
     refreshAgents,
     refreshSessions,
     refreshProjects,
+    resolveWindow: timeWindowController.resolve,
   });
 
   const [browseBy, setBrowseBy] = useState<BrowseBy>("agents");
@@ -107,7 +108,7 @@ export default function App() {
   }, [viewState]);
   const sessionIndexes = useMemo(() => buildSessionIndexes(sessions, agents), [sessions, agents]);
 
-  const search = useSessionSearch(sessionIndexes);
+  const search = useSessionSearch(sessionIndexes, timeWindow);
   const {
     draftSearchQuery,
     activeSearchQuery,
@@ -152,9 +153,9 @@ export default function App() {
     ? getProjectIdentityKey(activeProjectIdentity)
     : null;
 
-  const { dashboard, refresh: refreshDashboard } = useDashboard(appConfig);
+  const { dashboard, refresh: refreshDashboard } = useDashboard(timeWindow);
   const projectController = useProjectDashboard(
-    appConfig,
+    timeWindow,
     activeProjectKind,
     activeProjectKey,
     activeProjectIdentityKey,
@@ -258,9 +259,8 @@ export default function App() {
   const isScanActive = scanStatus?.active === true;
 
   const { liveNotice } = useLiveSync({
-    appConfig,
+    timeWindow,
     viewState,
-    applySessionsLiveEvent,
     refreshAgents,
     refreshSessions,
     refreshProjects,
@@ -273,7 +273,7 @@ export default function App() {
 
   const refreshAliasViews = useCallback(async () => {
     await Promise.all([
-      appConfig ? refreshSessions(appConfig.window) : Promise.resolve(),
+      timeWindow ? refreshSessions(timeWindow) : Promise.resolve(),
       refreshDashboard(),
       refreshProjectDashboard(),
       refreshSessionDetail(),
@@ -281,7 +281,7 @@ export default function App() {
       bookmarks.refresh(),
     ]);
   }, [
-    appConfig,
+    timeWindow,
     bookmarks,
     refreshDashboard,
     refreshProjectDashboard,
@@ -501,13 +501,15 @@ export default function App() {
             >
               ?<span className="hidden sm:inline"> Shortcuts</span>
             </button>
-            {formatWindowLabel(appConfig) ? (
-              <span
-                className="console-mono hidden rounded-sm border border-[var(--console-border)] bg-white px-2 py-1 text-xs text-[var(--console-text)] md:inline-flex"
-                title="Time window applied to agent counts, dashboard, and session list"
-              >
-                {formatWindowLabel(appConfig)}
-              </span>
+            {timeWindow && timeWindowController.preset ? (
+              <TimeWindowControl
+                window={timeWindow}
+                preset={timeWindowController.preset}
+                customFrom={timeWindowController.customFrom}
+                customTo={timeWindowController.customTo}
+                onSelectPreset={timeWindowController.selectPreset}
+                onSelectCustom={timeWindowController.selectCustom}
+              />
             ) : null}
             <span className="console-mono hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-muted)] sm:inline-flex">
               v{__APP_VERSION__}

--- a/apps/web/src/components/TimeWindowControl.tsx
+++ b/apps/web/src/components/TimeWindowControl.tsx
@@ -1,0 +1,129 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useState } from "react";
+import { formatIsoDate, formatWindowLabel } from "../lib/scan-format";
+import type { TimeWindow, TimeWindowPreset } from "../lib/time-window";
+
+const PRESETS: Array<{ value: Exclude<TimeWindowPreset, "custom">; label: string }> = [
+  { value: "7d", label: "Last 7 days" },
+  { value: "14d", label: "Last 14 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "90d", label: "Last 90 days" },
+  { value: "all", label: "All time" },
+];
+
+export function TimeWindowControl({
+  window,
+  preset,
+  customFrom,
+  customTo,
+  onSelectPreset,
+  onSelectCustom,
+}: {
+  window: TimeWindow;
+  preset: TimeWindowPreset;
+  customFrom?: string;
+  customTo?: string;
+  onSelectPreset: (preset: TimeWindowPreset) => void;
+  onSelectCustom: (from: string, to: string) => void;
+}) {
+  const [customOpen, setCustomOpen] = useState(false);
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const label = formatWindowLabel({ window });
+
+  const openCustom = () => {
+    setFrom(customFrom ?? (window.from != null ? formatIsoDate(window.from) : ""));
+    setTo(customTo ?? formatIsoDate(window.to ?? Date.now()));
+    setCustomOpen(true);
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-1">
+        <label className="relative block">
+          <span className="sr-only">Session time range</span>
+          <select
+            value={preset}
+            title={label ?? "Session time range"}
+            onChange={(event) => {
+              const next = event.target.value as TimeWindowPreset;
+              if (next === "custom") openCustom();
+              else onSelectPreset(next);
+            }}
+            className="console-mono w-24 appearance-none rounded-sm border border-[var(--console-border)] bg-white py-1 pr-6 pl-2 text-xs text-[var(--console-text)] outline-none hover:border-[var(--console-border-strong)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 sm:w-auto sm:max-w-44 sm:pr-7"
+          >
+            {PRESETS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+            <option value="custom">Custom range</option>
+          </select>
+          <span className="pointer-events-none absolute top-1/2 right-2 -translate-y-1/2 text-[10px] text-[var(--console-muted)]">
+            ▾
+          </span>
+        </label>
+        {preset === "custom" ? (
+          <button
+            type="button"
+            onClick={openCustom}
+            aria-label="Edit custom time range"
+            className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-1 text-xs text-[var(--console-muted)] hover:border-[var(--console-border-strong)] hover:text-[var(--console-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2"
+          >
+            Edit
+          </button>
+        ) : null}
+      </div>
+
+      <Dialog.Root open={customOpen} onOpenChange={setCustomOpen}>
+        <Dialog.Portal>
+          <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/35" />
+          <Dialog.Popup className="fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
+            <Dialog.Title className="console-mono text-sm font-semibold text-[var(--console-text)]">
+              Custom time range
+            </Dialog.Title>
+            <p className="mt-1 text-xs text-[var(--console-muted)]">Both dates are included.</p>
+            <div className="mt-4 grid grid-cols-2 gap-3">
+              <label className="console-mono text-[11px] uppercase tracking-wide text-[var(--console-muted)]">
+                From
+                <input
+                  type="date"
+                  value={from}
+                  max={to || undefined}
+                  onChange={(event) => setFrom(event.target.value)}
+                  className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-white px-2 py-2 text-xs normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
+                />
+              </label>
+              <label className="console-mono text-[11px] uppercase tracking-wide text-[var(--console-muted)]">
+                To
+                <input
+                  type="date"
+                  value={to}
+                  min={from || undefined}
+                  onChange={(event) => setTo(event.target.value)}
+                  className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-white px-2 py-2 text-xs normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
+                />
+              </label>
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <Dialog.Close className="rounded-sm border border-[var(--console-border)] px-3 py-1.5 text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)]">
+                Cancel
+              </Dialog.Close>
+              <button
+                type="button"
+                disabled={!from || !to || from > to}
+                onClick={() => {
+                  onSelectCustom(from, to);
+                  setCustomOpen(false);
+                }}
+                className="rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-text)] px-3 py-1.5 text-xs text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Apply range
+              </button>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+}

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import type { AgentInfo, ScanStatusEvent } from "../../lib/api";
+import { AppSidebar, type AppSidebarActions } from "./AppSidebar";
+
+afterEach(cleanup);
+
+const actions: AppSidebarActions = {
+  onChangeBrowseBy: vi.fn(),
+  onSelectProject: vi.fn(),
+  onToggleBookmark: vi.fn(),
+  onSelectFlatSidebarSession: vi.fn(),
+  onToggleSidebarSessionBookmark: vi.fn(),
+  onRenameSession: vi.fn(),
+  onRenameBookmarkedSession: vi.fn(),
+  onSelectTreeSidebarSession: vi.fn(),
+};
+
+describe("AppSidebar agent counts", () => {
+  it("uses the filtered API count after scanning completes", () => {
+    const agents = [{ name: "codex", displayName: "Codex", count: 5 }] as AgentInfo[];
+    const scanStatus = {
+      active: false,
+      agentStatuses: {
+        codex: { status: "complete", sessions: 1856 },
+      },
+    } as unknown as ScanStatusEvent;
+
+    render(
+      <MemoryRouter>
+        <AppSidebar
+          model={{
+            sidebarCollapsed: false,
+            browseBy: "agents",
+            isScanActive: false,
+            viewState: { mode: "root", activeAgentKey: null, activeSessionSlug: null },
+            agents,
+            activeAgentKey: null,
+            scanStatus,
+            projects: [],
+            selectedProjectNavigationId: null,
+            loading: false,
+            bookmarkedSessions: [],
+            sidebarSessions: [],
+            selectedSidebarSessionId: null,
+            bookmarkedSidebarSessionIds: new Set(),
+          }}
+          actions={actions}
+        />
+      </MemoryRouter>,
+    );
+
+    const codexLink = screen.getByRole("link", { name: /Codex/ });
+    expect(codexLink.textContent).toContain("5");
+    expect(codexLink.textContent).not.toContain("1856");
+  });
+});

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -8,7 +8,7 @@ import type {
 import { ModelConfig } from "../../config";
 import { getSessionBookmarkKey } from "../../lib/bookmarks";
 import { getSessionDisplayTitle } from "../../lib/session-title";
-import { formatAgentScanProgress, getAgentDisplayCount } from "../../lib/scan-format";
+import { formatAgentScanProgress } from "../../lib/scan-format";
 import { getProjectGroupIdentity, getProjectIdentityKey, getProjectPath } from "../../lib/projects";
 import type { ViewState } from "../../lib/view-state";
 import { RenderProfiler } from "../RenderProfiler";
@@ -52,7 +52,7 @@ function AgentNavList({
             )}
             <span className="console-mono line-clamp-1 flex-1 text-xs">{agent.displayName}</span>
             <span className="console-mono text-[11px] text-[var(--console-muted)]">
-              {agentProgress ?? getAgentDisplayCount(scanStatus, agent.name, agent.count)}
+              {agentProgress ?? agent.count}
             </span>
           </>
         );

--- a/apps/web/src/hooks/useAgents.ts
+++ b/apps/web/src/hooks/useAgents.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { type AgentInfo, fetchAgents } from "../lib/api";
+import { type AgentInfo, type AppConfig, fetchAgents } from "../lib/api";
 
 /**
  * Owns the agent list and its lookup derivations. Refresh is driven by
@@ -14,8 +14,8 @@ export function useAgents() {
     [agents],
   );
 
-  const refresh = useCallback(async () => {
-    const list = await fetchAgents();
+  const refresh = useCallback(async (window?: AppConfig["window"]) => {
+    const list = await fetchAgents(window);
     setAgents(list);
     return list;
   }, []);

--- a/apps/web/src/hooks/useDashboard.test.ts
+++ b/apps/web/src/hooks/useDashboard.test.ts
@@ -26,13 +26,13 @@ describe("useDashboard", () => {
   });
 
   it("fetches once appConfig is set", async () => {
-    const { result } = renderHook(() => useDashboard(appConfig));
+    const { result } = renderHook(() => useDashboard(appConfig.window));
     await waitFor(() => expect(result.current.dashboard).toEqual(data));
     expect(api.fetchDashboard).toHaveBeenCalledWith(appConfig.window);
   });
 
   it("refresh re-fetches the dashboard", async () => {
-    const { result } = renderHook(() => useDashboard(appConfig));
+    const { result } = renderHook(() => useDashboard(appConfig.window));
     await waitFor(() => expect(result.current.dashboard).toEqual(data));
 
     const next = { totals: { sessions: 9 }, perAgent: [] } as unknown as DashboardData;

--- a/apps/web/src/hooks/useDashboard.ts
+++ b/apps/web/src/hooks/useDashboard.ts
@@ -5,13 +5,13 @@ import { type AppConfig, type DashboardData, fetchDashboard } from "../lib/api";
  * Owns the top-level dashboard: fetches once the app window is known and
  * exposes refresh() for the live-update subscription.
  */
-export function useDashboard(appConfig: AppConfig | null) {
+export function useDashboard(window: AppConfig["window"] | null) {
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
 
   useEffect(() => {
-    if (!appConfig) return;
+    if (!window) return;
     let cancelled = false;
-    void fetchDashboard(appConfig.window)
+    void fetchDashboard(window)
       .then((data) => {
         if (!cancelled) setDashboard(data);
       })
@@ -21,16 +21,16 @@ export function useDashboard(appConfig: AppConfig | null) {
     return () => {
       cancelled = true;
     };
-  }, [appConfig]);
+  }, [window]);
 
   const refresh = useCallback(async () => {
     try {
-      const data = await fetchDashboard(appConfig?.window);
+      const data = await fetchDashboard(window ?? undefined);
       setDashboard(data);
     } catch (err) {
       console.error("Failed to refresh dashboard:", err);
     }
-  }, [appConfig]);
+  }, [window]);
 
   return { dashboard, refresh };
 }

--- a/apps/web/src/hooks/useInitialLoad.test.ts
+++ b/apps/web/src/hooks/useInitialLoad.test.ts
@@ -22,6 +22,7 @@ describe("useInitialLoad", () => {
         refreshAgents: vi.fn().mockResolvedValue([]),
         refreshSessions,
         refreshProjects: vi.fn().mockResolvedValue([]),
+        resolveWindow: (window) => window,
       }),
     );
 
@@ -39,6 +40,7 @@ describe("useInitialLoad", () => {
         refreshAgents: vi.fn().mockRejectedValue(new Error("boom")),
         refreshSessions: vi.fn().mockResolvedValue([]),
         refreshProjects: vi.fn().mockResolvedValue([]),
+        resolveWindow: (window) => window,
       }),
     );
 

--- a/apps/web/src/hooks/useInitialLoad.ts
+++ b/apps/web/src/hooks/useInitialLoad.ts
@@ -9,9 +9,10 @@ import {
 
 interface InitialLoadDeps {
   refreshAppConfig: () => Promise<AppConfig>;
-  refreshAgents: () => Promise<AgentInfo[]>;
+  refreshAgents: (window: AppConfig["window"]) => Promise<AgentInfo[]>;
   refreshSessions: (window: AppConfig["window"]) => Promise<SessionHead[]>;
-  refreshProjects: () => Promise<ProjectGroup[]>;
+  refreshProjects: (window: AppConfig["window"]) => Promise<ProjectGroup[]>;
+  resolveWindow: (fallback: AppConfig["window"]) => AppConfig["window"];
 }
 
 /**
@@ -24,6 +25,7 @@ export function useInitialLoad({
   refreshAgents,
   refreshSessions,
   refreshProjects,
+  resolveWindow,
 }: InitialLoadDeps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -35,10 +37,11 @@ export function useInitialLoad({
     (async () => {
       try {
         const config = await refreshAppConfig();
+        const window = resolveWindow(config.window);
         const [agentList, sessionList, projectList] = await Promise.all([
-          refreshAgents(),
-          refreshSessions(config.window),
-          refreshProjects(),
+          refreshAgents(window),
+          refreshSessions(window),
+          refreshProjects(window),
         ]);
         logClientEvent("app.load.done", {
           duration_ms: Math.round(performance.now() - startedAt),
@@ -58,7 +61,7 @@ export function useInitialLoad({
       }
     })();
     return () => ac.abort();
-  }, [refreshAppConfig, refreshAgents, refreshSessions, refreshProjects]);
+  }, [refreshAppConfig, refreshAgents, refreshSessions, refreshProjects, resolveWindow]);
 
   return { loading, error };
 }

--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -30,9 +30,8 @@ const rootView = { mode: "root", activeAgentKey: null, activeSessionSlug: null }
 
 function makeDeps() {
   return {
-    appConfig,
+    timeWindow: appConfig.window,
     viewState: rootView,
-    applySessionsLiveEvent: vi.fn(),
     refreshAgents: vi.fn().mockResolvedValue(undefined),
     refreshSessions: vi.fn().mockResolvedValue(undefined),
     refreshProjects: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -4,12 +4,11 @@ import type { LiveSessionsUpdate } from "../lib/live-update";
 import type { ViewState } from "../lib/view-state";
 
 interface LiveSyncDeps {
-  appConfig: AppConfig | null;
+  timeWindow: AppConfig["window"] | null;
   viewState: ViewState;
-  applySessionsLiveEvent: (event: LiveSessionsUpdate) => void;
-  refreshAgents: () => Promise<unknown>;
+  refreshAgents: (window: AppConfig["window"]) => Promise<unknown>;
   refreshSessions: (window: AppConfig["window"]) => Promise<unknown>;
-  refreshProjects: () => Promise<unknown>;
+  refreshProjects: (window: AppConfig["window"]) => Promise<unknown>;
   refreshDashboard: () => Promise<void>;
   refreshProjectDashboard: () => Promise<void>;
   refreshSessionDetail: () => Promise<void>;
@@ -27,9 +26,8 @@ export function useLiveSync(deps: LiveSyncDeps) {
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [connectionNotice, setConnectionNotice] = useState<string | null>(null);
   const {
-    appConfig,
+    timeWindow,
     viewState,
-    applySessionsLiveEvent,
     refreshAgents,
     refreshSessions,
     refreshProjects,
@@ -42,15 +40,10 @@ export function useLiveSync(deps: LiveSyncDeps) {
 
   const syncLiveUpdate = useEffectEvent(async (event: LiveSessionsUpdate) => {
     try {
-      const canApplySessionUpdate = Boolean(event.changedSessionHeads && event.removedSessionRefs);
-      if (canApplySessionUpdate) {
-        applySessionsLiveEvent(event);
-      }
-
       await Promise.all([
-        refreshAgents(),
-        canApplySessionUpdate || !appConfig ? Promise.resolve() : refreshSessions(appConfig.window),
-        refreshProjects(),
+        timeWindow ? refreshAgents(timeWindow) : Promise.resolve(),
+        timeWindow ? refreshSessions(timeWindow) : Promise.resolve(),
+        timeWindow ? refreshProjects(timeWindow) : Promise.resolve(),
       ]);
 
       await refreshDashboard();

--- a/apps/web/src/hooks/useProjectDashboard.test.ts
+++ b/apps/web/src/hooks/useProjectDashboard.test.ts
@@ -21,13 +21,15 @@ afterEach(() => {
 
 describe("useProjectDashboard", () => {
   it("stays idle without an active project", () => {
-    const { result } = renderHook(() => useProjectDashboard(appConfig, null, null, null));
+    const { result } = renderHook(() => useProjectDashboard(appConfig.window, null, null, null));
     expect(result.current.projectDashboard).toBeNull();
     expect(api.fetchDashboard).not.toHaveBeenCalled();
   });
 
   it("fetches for the active project", async () => {
-    const { result } = renderHook(() => useProjectDashboard(appConfig, kind, "pk", "path:pk"));
+    const { result } = renderHook(() =>
+      useProjectDashboard(appConfig.window, kind, "pk", "path:pk"),
+    );
     await waitFor(() => expect(result.current.projectDashboard).toEqual(data));
     expect(api.fetchDashboard).toHaveBeenCalledWith(appConfig.window, {
       projectKind: "path",
@@ -38,7 +40,7 @@ describe("useProjectDashboard", () => {
 
   it("resets the agent filter when the project changes", async () => {
     const { result, rerender } = renderHook(
-      ({ idKey }) => useProjectDashboard(appConfig, kind, "pk", idKey),
+      ({ idKey }) => useProjectDashboard(appConfig.window, kind, "pk", idKey),
       { initialProps: { idKey: "path:pk" } },
     );
     act(() => result.current.setSelectedProjectAgent("cc"));

--- a/apps/web/src/hooks/useProjectDashboard.ts
+++ b/apps/web/src/hooks/useProjectDashboard.ts
@@ -12,7 +12,7 @@ import {
  * exposes refresh() for the live-update subscription.
  */
 export function useProjectDashboard(
-  appConfig: AppConfig | null,
+  window: AppConfig["window"] | null,
   activeProjectKind: ProjectIdentityKind | null,
   activeProjectKey: string | null,
   activeProjectIdentityKey: string | null,
@@ -27,7 +27,7 @@ export function useProjectDashboard(
   }, [activeProjectIdentityKey]);
 
   useEffect(() => {
-    if (!activeProjectKey || !appConfig) {
+    if (!activeProjectKey || !window) {
       setProjectDashboard(null);
       setProjectDashboardError(null);
       setProjectDashboardLoading(false);
@@ -38,7 +38,7 @@ export function useProjectDashboard(
     setProjectDashboardLoading(true);
     setProjectDashboardError(null);
 
-    void fetchDashboard(appConfig.window, {
+    void fetchDashboard(window, {
       projectKind: activeProjectKind ?? undefined,
       projectKey: activeProjectKey,
       agent: selectedProjectAgent,
@@ -61,12 +61,12 @@ export function useProjectDashboard(
     return () => {
       cancelled = true;
     };
-  }, [activeProjectKind, activeProjectKey, appConfig, selectedProjectAgent]);
+  }, [activeProjectKind, activeProjectKey, selectedProjectAgent, window]);
 
   const refresh = useCallback(async () => {
-    if (!activeProjectKey || !appConfig) return;
+    if (!activeProjectKey || !window) return;
     try {
-      const data = await fetchDashboard(appConfig.window, {
+      const data = await fetchDashboard(window, {
         projectKind: activeProjectKind ?? undefined,
         projectKey: activeProjectKey,
         agent: selectedProjectAgent,
@@ -75,7 +75,7 @@ export function useProjectDashboard(
     } catch (err) {
       console.error("Failed to refresh project dashboard:", err);
     }
-  }, [activeProjectKind, activeProjectKey, appConfig, selectedProjectAgent]);
+  }, [activeProjectKind, activeProjectKey, selectedProjectAgent, window]);
 
   return {
     projectDashboard,

--- a/apps/web/src/hooks/useProjects.ts
+++ b/apps/web/src/hooks/useProjects.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { type ProjectGroup, fetchProjects } from "../lib/api";
+import { type AppConfig, type ProjectGroup, fetchProjects } from "../lib/api";
 
 /**
  * Owns the project list. Refresh tolerates failures (keeps the UI usable) and
@@ -8,9 +8,9 @@ import { type ProjectGroup, fetchProjects } from "../lib/api";
 export function useProjects() {
   const [projects, setProjects] = useState<ProjectGroup[]>([]);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async (window?: AppConfig["window"]) => {
     try {
-      const result = await fetchProjects();
+      const result = await fetchProjects(window);
       setProjects(result.projects);
       return result.projects;
     } catch (err) {

--- a/apps/web/src/hooks/useScanStatus.test.ts
+++ b/apps/web/src/hooks/useScanStatus.test.ts
@@ -18,7 +18,7 @@ const sample: ScanStatusEvent = {
   agentStatuses: {},
   totalAgents: 1,
   updatedAt: 123,
-  backfill: { active: false, pendingAgents: [], completedAgents: [] },
+  backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
 };
 
 afterEach(() => {

--- a/apps/web/src/hooks/useSessionSearch.ts
+++ b/apps/web/src/hooks/useSessionSearch.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  type AppConfig,
   type SearchRequestOptions,
   type SearchResult,
   fetchSearchResults,
@@ -21,7 +22,10 @@ import {
  * live-update subscription; the global keydown handler stays in App and
  * drives selection via the returned state + setters.
  */
-export function useSessionSearch(sessionIndexes: SessionIndexes) {
+export function useSessionSearch(
+  sessionIndexes: SessionIndexes,
+  timeWindow: AppConfig["window"] | null = null,
+) {
   const [draftSearchQuery, setDraftSearchQuery] = useState("");
   const [activeSearchQuery, setActiveSearchQuery] = useState("");
   const [searchMode, setSearchMode] = useState(false);
@@ -38,8 +42,12 @@ export function useSessionSearch(sessionIndexes: SessionIndexes) {
   );
 
   const searchRequestOptions = useMemo<SearchRequestOptions>(
-    () => buildSearchRequestOptions(searchFilters, costMin),
-    [searchFilters, costMin],
+    () => ({
+      ...buildSearchRequestOptions(searchFilters, costMin),
+      from: timeWindow?.from,
+      to: timeWindow?.to,
+    }),
+    [searchFilters, costMin, timeWindow],
   );
 
   const usesServerSearch = computeUsesServerSearch(activeSearchQuery, searchFilters);

--- a/apps/web/src/hooks/useSessions.test.ts
+++ b/apps/web/src/hooks/useSessions.test.ts
@@ -1,12 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook } from "@testing-library/react";
-import type { AppConfig, SessionHead, SessionsUpdatedEvent } from "../lib/api";
+import type { AppConfig, SessionHead } from "../lib/api";
 import * as api from "../lib/api";
-import * as liveUpdate from "../lib/live-update";
 import { useSessions } from "./useSessions";
 
 vi.mock("../lib/api", () => ({ fetchSessions: vi.fn() }));
-vi.mock("../lib/live-update", () => ({ applyLiveSessionUpdate: vi.fn() }));
 
 const window = { from: "a", to: "b" } as unknown as AppConfig["window"];
 const sessions = [{ id: "s1" }] as unknown as SessionHead[];
@@ -26,14 +24,5 @@ describe("useSessions", () => {
     });
     expect(result.current.sessions).toEqual(sessions);
     expect(api.fetchSessions).toHaveBeenCalledWith({ from: "a", to: "b" });
-  });
-
-  it("applyLiveEvent applies an incremental update", () => {
-    const updated = [{ id: "s2" }] as unknown as SessionHead[];
-    vi.mocked(liveUpdate.applyLiveSessionUpdate).mockReturnValue(updated);
-    const { result } = renderHook(() => useSessions());
-
-    act(() => result.current.applyLiveEvent({} as SessionsUpdatedEvent));
-    expect(result.current.sessions).toEqual(updated);
   });
 });

--- a/apps/web/src/hooks/useSessions.ts
+++ b/apps/web/src/hooks/useSessions.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { type AppConfig, type SessionHead, fetchSessions } from "../lib/api";
-import { applyLiveSessionUpdate, type LiveSessionsUpdate } from "../lib/live-update";
 
 /**
  * Owns the session list. Exposes refresh(window) for a full reload and
@@ -16,9 +15,5 @@ export function useSessions() {
     return result.sessions;
   }, []);
 
-  const applyLiveEvent = useCallback((event: LiveSessionsUpdate) => {
-    setSessions((current) => applyLiveSessionUpdate(current, event) ?? current);
-  }, []);
-
-  return { sessions, refresh, applyLiveEvent };
+  return { sessions, refresh };
 }

--- a/apps/web/src/hooks/useTimeWindow.test.tsx
+++ b/apps/web/src/hooks/useTimeWindow.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Link, MemoryRouter, useLocation } from "react-router-dom";
+import { useTimeWindow } from "./useTimeWindow";
+
+afterEach(cleanup);
+
+function TimeWindowHarness({ observedPresets }: { observedPresets: Array<string | null> }) {
+  const location = useLocation();
+  const controller = useTimeWindow({ days: 7 });
+  observedPresets.push(controller.preset);
+
+  return (
+    <>
+      <span data-testid="preset">{controller.preset}</span>
+      <span data-testid="search">{location.search}</span>
+      <Link to="/session">Open session</Link>
+      <button type="button" onClick={() => controller.selectPreset("30d")}>
+        Select 30 days
+      </button>
+      <button type="button" onClick={() => controller.selectCustom("2026-04-01", "2026-04-30")}>
+        Select custom
+      </button>
+    </>
+  );
+}
+
+describe("useTimeWindow", () => {
+  it("does not fall back to the default while restoring range after navigation", () => {
+    const observedPresets: Array<string | null> = [];
+    render(
+      <MemoryRouter initialEntries={["/?range=14d"]}>
+        <TimeWindowHarness observedPresets={observedPresets} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Open session" }));
+
+    expect(screen.getByTestId("preset").textContent).toBe("14d");
+    expect(screen.getByTestId("search").textContent).toBe("?range=14d");
+    expect(observedPresets).not.toContain("7d");
+  });
+
+  it("writes preset and custom selections to the current URL", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <TimeWindowHarness observedPresets={[]} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select 30 days" }));
+    expect(screen.getByTestId("search").textContent).toBe("?range=30d");
+
+    fireEvent.click(screen.getByRole("button", { name: "Select custom" }));
+    expect(screen.getByTestId("search").textContent).toBe(
+      "?range=custom&from=2026-04-01&to=2026-04-30",
+    );
+  });
+});

--- a/apps/web/src/hooks/useTimeWindow.ts
+++ b/apps/web/src/hooks/useTimeWindow.ts
@@ -38,8 +38,11 @@ export function useTimeWindow(defaultWindow: TimeWindow | undefined) {
   const effectiveParams = useMemo(() => new URLSearchParams(effectiveSearch), [effectiveSearch]);
 
   useEffect(() => {
+    if (effectiveSearch !== search) {
+      setSearchParams(effectiveParams, { replace: true });
+      return;
+    }
     previousPath.current = location.pathname;
-    if (effectiveSearch !== search) setSearchParams(effectiveParams, { replace: true });
   }, [effectiveParams, effectiveSearch, location.pathname, search, setSearchParams]);
 
   const resolved = useMemo(

--- a/apps/web/src/hooks/useTimeWindow.ts
+++ b/apps/web/src/hooks/useTimeWindow.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useLocation, useSearchParams } from "react-router-dom";
+import {
+  resolveTimeWindow,
+  writeCustomTimeWindow,
+  writeTimeWindowPreset,
+  type TimeWindow,
+  type TimeWindowPreset,
+} from "../lib/time-window";
+
+export function useTimeWindow(defaultWindow: TimeWindow | undefined) {
+  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const search = searchParams.toString();
+  const hasRange = searchParams.has("range");
+  const previousPath = useRef(location.pathname);
+  const rememberedRange = useRef<string | null>(null);
+  if (hasRange) {
+    const rangeParams = new URLSearchParams();
+    for (const key of ["range", "from", "to"]) {
+      const value = searchParams.get(key);
+      if (value != null) rangeParams.set(key, value);
+    }
+    rememberedRange.current = rangeParams.toString();
+  }
+  const pathChanged = previousPath.current !== location.pathname;
+  const effectiveSearch = useMemo(() => {
+    if (hasRange || !pathChanged || !rememberedRange.current) {
+      return search;
+    }
+    const next = new URLSearchParams(search);
+    const remembered = new URLSearchParams(rememberedRange.current);
+    for (const [key, value] of remembered) {
+      next.set(key, value);
+    }
+    return next.toString();
+  }, [hasRange, pathChanged, search]);
+  const effectiveParams = useMemo(() => new URLSearchParams(effectiveSearch), [effectiveSearch]);
+
+  useEffect(() => {
+    previousPath.current = location.pathname;
+    if (effectiveSearch !== search) setSearchParams(effectiveParams, { replace: true });
+  }, [effectiveParams, effectiveSearch, location.pathname, search, setSearchParams]);
+
+  const resolved = useMemo(
+    () => (defaultWindow ? resolveTimeWindow(effectiveParams, defaultWindow) : null),
+    [defaultWindow, effectiveParams],
+  );
+  const resolve = useCallback(
+    (fallback: TimeWindow) => resolveTimeWindow(effectiveParams, fallback).window,
+    [effectiveParams],
+  );
+  const selectPreset = useCallback(
+    (preset: TimeWindowPreset) =>
+      setSearchParams(writeTimeWindowPreset(new URLSearchParams(search), preset)),
+    [search, setSearchParams],
+  );
+  const selectCustom = useCallback(
+    (from: string, to: string) =>
+      setSearchParams(writeCustomTimeWindow(new URLSearchParams(search), from, to)),
+    [search, setSearchParams],
+  );
+
+  return {
+    timeWindow: resolved?.window ?? null,
+    preset: resolved?.preset ?? null,
+    customFrom: resolved?.customFrom,
+    customTo: resolved?.customTo,
+    resolve,
+    selectPreset,
+    selectCustom,
+  };
+}

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -68,6 +68,18 @@ describe("fetchDashboard", () => {
 
     expect(result).toEqual(SAMPLE_DASHBOARD_DATA);
   });
+
+  it("uses days=0 without expanding all-time into thousands of daily buckets", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(SAMPLE_DASHBOARD_DATA),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchDashboard({ from: 0, days: 0 });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/dashboard?days=0");
+  });
 });
 
 describe("fetchSessionData", () => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -100,6 +100,8 @@ export interface SearchRequestOptions {
   fileKind?: FileActivityKind;
   costMin?: number;
   costMax?: number;
+  from?: number;
+  to?: number;
 }
 
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
@@ -119,12 +121,23 @@ export async function fetchScanStatus(): Promise<ScanStatusEvent> {
   return fetchJson("/api/status");
 }
 
-export async function fetchAgents(): Promise<AgentInfo[]> {
-  return fetchJson("/api/agents");
+function appendTimeWindow(params: URLSearchParams, window?: AppConfig["window"]): void {
+  if (window?.from != null) params.set("from", new Date(window.from).toISOString());
+  if (window?.to != null) params.set("to", new Date(window.to).toISOString());
 }
 
-export async function fetchProjects(): Promise<{ projects: ApiProjectGroup[] }> {
-  return fetchJson("/api/projects");
+export async function fetchAgents(window?: AppConfig["window"]): Promise<AgentInfo[]> {
+  const params = new URLSearchParams();
+  appendTimeWindow(params, window);
+  return fetchJson(`/api/agents?${params}`);
+}
+
+export async function fetchProjects(
+  window?: AppConfig["window"],
+): Promise<{ projects: ApiProjectGroup[] }> {
+  const params = new URLSearchParams();
+  appendTimeWindow(params, window);
+  return fetchJson(`/api/projects?${params}`);
 }
 
 export async function fetchSessions(
@@ -140,8 +153,7 @@ export async function fetchSessions(
   if (options.agent) params.set("agent", options.agent);
   if (options.projectKind) params.set("projectKind", options.projectKind);
   if (options.projectKey) params.set("projectKey", options.projectKey);
-  if (options.from != null) params.set("from", new Date(options.from).toISOString());
-  if (options.to != null) params.set("to", new Date(options.to).toISOString());
+  appendTimeWindow(params, options);
   return fetchJson(`/api/sessions?${params}`);
 }
 
@@ -158,9 +170,8 @@ export async function fetchDashboard(
   filters: { projectKind?: ProjectIdentityKind; projectKey?: string; agent?: string } = {},
 ): Promise<DashboardData> {
   const params = new URLSearchParams();
-  if (window?.from != null) params.set("from", new Date(window.from).toISOString());
-  if (window?.to != null) params.set("to", new Date(window.to).toISOString());
-  if (window?.days != null && window.days > 0) params.set("days", String(window.days));
+  if (window?.days !== 0) appendTimeWindow(params, window);
+  if (window?.days != null) params.set("days", String(window.days));
   if (filters.projectKind) params.set("projectKind", filters.projectKind);
   if (filters.projectKey) params.set("projectKey", filters.projectKey);
   if (filters.agent) params.set("agent", filters.agent);
@@ -182,6 +193,7 @@ export async function fetchSearchResults(
   if (options.fileKind) params.set("fileActivity", options.fileKind);
   if (options.costMin != null) params.set("costMin", String(options.costMin));
   if (options.costMax != null) params.set("costMax", String(options.costMax));
+  appendTimeWindow(params, options);
   return fetchJson(`/api/search?${params}`);
 }
 

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -5,7 +5,6 @@ import {
   formatScanStatusLabel,
   formatSearchSubtitle,
   formatWindowLabel,
-  getAgentDisplayCount,
 } from "./scan-format";
 import type { ScanStatusEvent } from "./api";
 
@@ -73,11 +72,5 @@ describe("formatScanStatusLabel", () => {
 describe("formatAgentScanProgress", () => {
   it("returns null for complete or missing agent", () => {
     expect(formatAgentScanProgress(null, "codex")).toBeNull();
-  });
-});
-
-describe("getAgentDisplayCount", () => {
-  it("returns fallback when agent status missing", () => {
-    expect(getAgentDisplayCount(null, "codex", 5)).toBe(5);
   });
 });

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -53,6 +53,21 @@ describe("formatScanStatusLabel", () => {
       } as unknown as ScanStatusEvent),
     ).toBe("Preparing local session index");
   });
+
+  it("shows full-history backfill progress after the main scan finishes", () => {
+    expect(
+      formatScanStatusLabel({
+        active: false,
+        backfill: {
+          active: true,
+          currentAgent: "codex",
+          pendingAgents: ["claudecode"],
+          completedAgents: [],
+          failedAgents: [],
+        },
+      } as unknown as ScanStatusEvent),
+    ).toBe("Indexing full history · codex · 1 queued");
+  });
 });
 
 describe("formatAgentScanProgress", () => {

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -80,14 +80,3 @@ export function formatAgentScanProgress(
   }
   return agentStatus.status === "scanning" ? "Scanning" : "Pending";
 }
-
-export function getAgentDisplayCount(
-  status: ScanStatusEvent | null,
-  agentName: string,
-  fallback: number,
-): number {
-  const agentStatus = status?.agentStatuses[agentName];
-  return agentStatus?.status === "complete" && agentStatus.sessions != null
-    ? agentStatus.sessions
-    : fallback;
-}

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -15,7 +15,7 @@ export function formatIsoDate(ts: number): string {
 export function formatWindowLabel(config: AppConfig | null): string | null {
   if (!config) return null;
   const { from, to, days } = config.window;
-  if (from == null) return "All time";
+  if (days === 0 || from == null) return "All time";
   const fromStr = formatIsoDate(from);
   const toStr = formatIsoDate(to ?? Date.now());
   if (days) return `Last ${days}d · ${fromStr} → ${toStr}`;
@@ -28,7 +28,18 @@ export function formatSearchSubtitle(query: string, loading: boolean, count: num
 }
 
 export function formatScanStatusLabel(status: ScanStatusEvent | null): string | null {
-  if (!status?.active) return null;
+  if (!status) return null;
+  if (status.backfill?.active) {
+    const current = status.backfill.currentAgent;
+    const pending = status.backfill.pendingAgents.length;
+    return current
+      ? `Indexing full history · ${current}${pending > 0 ? ` · ${pending} queued` : ""}`
+      : "Indexing full history";
+  }
+  if (status.backfill?.failedAgents.length) {
+    return `History indexing failed · ${status.backfill.failedAgents.join(", ")}`;
+  }
+  if (!status.active) return null;
 
   const completed = status.completedAgents.length;
   const total = status.totalAgents;
@@ -46,7 +57,7 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
       : "";
 
   if (status.phase === "initializing") {
-    return `First-run setup: indexing all local sessions${agentProgress}. Your selected time window appears after this finishes.`;
+    return `First-run setup: indexing recent sessions${agentProgress}. Full history continues in the background.`;
   }
   if (status.phase === "indexing") return "Preparing local session index";
 

--- a/apps/web/src/lib/time-window.test.ts
+++ b/apps/web/src/lib/time-window.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveTimeWindow, writeCustomTimeWindow, writeTimeWindowPreset } from "./time-window";
+
+const now = new Date(2026, 6, 14, 12).getTime();
+
+describe("time window URL state", () => {
+  it("resolves presets to inclusive local calendar days", () => {
+    const result = resolveTimeWindow(new URLSearchParams("range=14d"), { days: 7 }, now);
+
+    expect(result.preset).toBe("14d");
+    expect(result.window).toEqual({
+      from: new Date(2026, 6, 1).getTime(),
+      to: new Date(2026, 6, 15).getTime() - 1,
+      days: 14,
+    });
+  });
+
+  it("represents all time explicitly instead of falling back to server defaults", () => {
+    expect(resolveTimeWindow(new URLSearchParams("range=all"), { days: 7 }, now).window).toEqual({
+      from: 0,
+      days: 0,
+    });
+  });
+
+  it("includes the complete custom end date", () => {
+    const result = resolveTimeWindow(
+      new URLSearchParams("range=custom&from=2026-07-02&to=2026-07-05"),
+      { days: 7 },
+      now,
+    );
+
+    expect(result.window).toEqual({
+      from: new Date(2026, 6, 2).getTime(),
+      to: new Date(2026, 6, 6).getTime() - 1,
+    });
+  });
+
+  it("falls back when a custom range is invalid", () => {
+    const fallback = { from: 10, to: 20, days: 7 };
+    expect(
+      resolveTimeWindow(
+        new URLSearchParams("range=custom&from=2026-07-20&to=2026-07-05"),
+        fallback,
+        now,
+      ).window,
+    ).toBe(fallback);
+  });
+
+  it("preserves unrelated URL parameters", () => {
+    const params = new URLSearchParams("view=projects&from=old&to=old");
+    expect(writeTimeWindowPreset(params, "30d").toString()).toBe("view=projects&range=30d");
+    expect(writeCustomTimeWindow(params, "2026-07-01", "2026-07-14").toString()).toBe(
+      "view=projects&from=2026-07-01&to=2026-07-14&range=custom",
+    );
+  });
+});

--- a/apps/web/src/lib/time-window.ts
+++ b/apps/web/src/lib/time-window.ts
@@ -1,0 +1,121 @@
+import type { AppConfig } from "./api";
+
+export type TimeWindow = AppConfig["window"];
+export type TimeWindowPreset = "7d" | "14d" | "30d" | "90d" | "all" | "custom";
+
+export interface ResolvedTimeWindow {
+  preset: TimeWindowPreset;
+  window: TimeWindow;
+  customFrom?: string;
+  customTo?: string;
+}
+
+const PRESET_DAYS: Record<Exclude<TimeWindowPreset, "all" | "custom">, number> = {
+  "7d": 7,
+  "14d": 14,
+  "30d": 30,
+  "90d": 90,
+};
+
+function startOfLocalDay(timestamp: number): number {
+  const date = new Date(timestamp);
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function endOfLocalDay(timestamp: number): number {
+  const date = new Date(startOfLocalDay(timestamp));
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1).getTime() - 1;
+}
+
+function parseLocalDate(value: string, endOfDay: boolean): number | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const date = endOfDay ? new Date(year, month, day + 1, 0, 0, 0, -1) : new Date(year, month, day);
+  const validation = new Date(year, month, day);
+  if (
+    validation.getFullYear() !== year ||
+    validation.getMonth() !== month ||
+    validation.getDate() !== day
+  ) {
+    return null;
+  }
+  return date.getTime();
+}
+
+function presetFromDefault(window: TimeWindow): TimeWindowPreset {
+  if (window.days === 0 || window.from == null) return "all";
+  if (window.days === 7 || window.days === 14 || window.days === 30 || window.days === 90) {
+    return `${window.days}d`;
+  }
+  return "custom";
+}
+
+function presetWindow(preset: Exclude<TimeWindowPreset, "custom">, now: number): TimeWindow {
+  const todayStart = startOfLocalDay(now);
+  const todayEnd = endOfLocalDay(now);
+  if (preset === "all") return { from: 0, days: 0 };
+  const days = PRESET_DAYS[preset];
+  const today = new Date(todayStart);
+  const from = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate() - days + 1,
+  ).getTime();
+  return { from, to: todayEnd, days };
+}
+
+export function resolveTimeWindow(
+  params: URLSearchParams,
+  fallback: TimeWindow,
+  now = Date.now(),
+): ResolvedTimeWindow {
+  const range = params.get("range") as TimeWindowPreset | null;
+  if (range && range !== "custom" && range in PRESET_DAYS) {
+    return { preset: range, window: presetWindow(range, now) };
+  }
+  if (range === "all") return { preset: range, window: presetWindow(range, now) };
+  if (range === "custom") {
+    const customFrom = params.get("from") ?? "";
+    const customTo = params.get("to") ?? "";
+    const from = parseLocalDate(customFrom, false);
+    const to = parseLocalDate(customTo, true);
+    if (from != null && to != null && from <= to) {
+      return { preset: range, window: { from, to }, customFrom, customTo };
+    }
+  }
+  const fallbackPreset = presetFromDefault(fallback);
+  if (fallbackPreset !== "custom") return { preset: fallbackPreset, window: fallback };
+  return {
+    preset: fallbackPreset,
+    window: fallback,
+    customFrom: fallback.from == null ? undefined : formatLocalDate(fallback.from),
+    customTo: formatLocalDate(fallback.to ?? now),
+  };
+}
+
+function formatLocalDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const year = String(date.getFullYear()).padStart(4, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function writeTimeWindowPreset(params: URLSearchParams, preset: TimeWindowPreset) {
+  const next = new URLSearchParams(params);
+  next.set("range", preset);
+  next.delete("from");
+  next.delete("to");
+  return next;
+}
+
+export function writeCustomTimeWindow(params: URLSearchParams, from: string, to: string) {
+  const next = new URLSearchParams(params);
+  next.set("range", "custom");
+  next.set("from", from);
+  next.set("to", to);
+  return next;
+}

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -230,6 +230,20 @@ describe("handleGetAgents", () => {
     const claudecode = response.find((a: { name: string }) => a.name === "claudecode");
     expect(claudecode.count).toBe(1);
   });
+
+  it("lets request dates override the default time window", () => {
+    const recent = makeSession("recent", { time_updated: 5000 });
+    const old = makeSession("old", { time_updated: 1000 });
+    const c = makeMockContext({ query: { from: new Date(0).toISOString() } });
+
+    handleGetAgents(
+      c,
+      makeScanSource({ sessions: [recent, old], byAgent: { claudecode: [recent, old] } }),
+      { from: 3000 },
+    );
+
+    expect(c.json.mock.calls[0]![0][0].count).toBe(2);
+  });
 });
 
 describe("handleGetConfig", () => {
@@ -512,6 +526,20 @@ describe("handleGetFileActivity", () => {
 });
 
 describe("handleGetProjects", () => {
+  it("lets request dates override the default time window", () => {
+    const old = makeSession("old", {
+      time_updated: 1000,
+      project_identity: { kind: "path", key: "/old", displayName: "old" },
+    });
+    const c = makeMockContext({ query: { from: new Date(0).toISOString() } });
+
+    handleGetProjects(c, makeScanSource({ sessions: [old], byAgent: { claudecode: [old] } }), {
+      from: 3000,
+    });
+
+    expect(c.json.mock.calls[0]![0].projects[0].displayName).toBe("old");
+  });
+
   it("returns project groups sorted by recent activity", () => {
     const sessions = [
       makeSession("a", {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -418,7 +418,8 @@ export function handleGetAgents(
   defaults: SessionListDefaults = {},
 ) {
   const scanResult = scanSource.getSnapshot();
-  const { from, to } = defaults;
+  const from = parseDateParam(c.req.query("from"), defaults.from);
+  const to = parseDateParam(c.req.query("to"), defaults.to);
   const counts = Object.fromEntries(
     Object.entries(scanResult.byAgent).map(([agentName, sessions]) => [
       agentName,
@@ -435,7 +436,8 @@ export function handleGetProjects(
   defaults: SessionListDefaults = {},
 ) {
   const scanResult = scanSource.getSnapshot();
-  const { from, to } = defaults;
+  const from = parseDateParam(c.req.query("from"), defaults.from);
+  const to = parseDateParam(c.req.query("to"), defaults.to);
   const sessions = filterSessionsByActivityWindow(scanResult.sessions, from, to);
   return c.json({
     projects: attachProjectMetrics(listCachedProjectGroups(sessions), sessions),

--- a/packages/cli/src/backfill-coordinator.test.ts
+++ b/packages/cli/src/backfill-coordinator.test.ts
@@ -38,6 +38,17 @@ describe("BackfillCoordinator", () => {
       pendingAgents: [],
       currentAgent: undefined,
       completedAgents: [],
+      failedAgents: [],
     });
+  });
+
+  it("reports failed work separately from completed coverage", () => {
+    const coordinator = new BackfillCoordinator();
+    coordinator.enqueue("cursor");
+    coordinator.take();
+
+    expect(coordinator.complete("cursor", false)).toEqual(
+      expect.objectContaining({ completedAgents: [], failedAgents: ["cursor"] }),
+    );
   });
 });

--- a/packages/cli/src/backfill-coordinator.ts
+++ b/packages/cli/src/backfill-coordinator.ts
@@ -9,6 +9,7 @@ export class BackfillCoordinator {
   private queue: string[] = [];
   private currentAgent: string | undefined;
   private completedAgents: string[] = [];
+  private failedAgents: string[] = [];
 
   get isRunning(): boolean {
     return this.currentAgent != null;
@@ -29,9 +30,14 @@ export class BackfillCoordinator {
     return { agentName, status: this.snapshot() };
   }
 
-  complete(agentName: string): BackfillStatus {
+  complete(agentName: string, succeeded = true): BackfillStatus {
     if (this.currentAgent === agentName) this.currentAgent = undefined;
-    if (!this.completedAgents.includes(agentName)) this.completedAgents.push(agentName);
+    if (succeeded) {
+      if (!this.completedAgents.includes(agentName)) this.completedAgents.push(agentName);
+      this.failedAgents = this.failedAgents.filter((agent) => agent !== agentName);
+    } else if (!this.failedAgents.includes(agentName)) {
+      this.failedAgents.push(agentName);
+    }
     return this.snapshot();
   }
 
@@ -46,6 +52,7 @@ export class BackfillCoordinator {
       pendingAgents: [...this.queue],
       currentAgent: this.currentAgent,
       completedAgents: [...this.completedAgents],
+      failedAgents: [...this.failedAgents],
     };
   }
 }

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -35,6 +35,7 @@ const core = vi.hoisted(() => ({
   createRegisteredAgents: vi.fn(),
   filterSessions: vi.fn((sessions: SessionHead[], _options: ScanOptions) => sessions),
   getCursorDataPath: vi.fn(() => "/tmp/cursor"),
+  getAgentLastFullSyncAt: vi.fn(),
   resolveProviderRoots: vi.fn(
     (): ProviderRoots => ({
       claudeRoot: "/tmp/claude",
@@ -48,6 +49,7 @@ const core = vi.hoisted(() => ({
   isAgentCacheInitialized: vi.fn(),
   loadCachedSessions: vi.fn(),
   markAgentCacheInitialized: vi.fn(),
+  markAgentFullSyncCompleted: vi.fn(),
   scanSessions: vi.fn(),
   saveCachedSessions: vi.fn(),
   saveCachedSessionChanges: vi.fn(),
@@ -256,9 +258,11 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     createRegisteredAgents: core.createRegisteredAgents,
     filterSessions: core.filterSessions,
     getCursorDataPath: core.getCursorDataPath,
+    getAgentLastFullSyncAt: core.getAgentLastFullSyncAt,
     isAgentCacheInitialized: core.isAgentCacheInitialized,
     loadCachedSessions: core.loadCachedSessions,
     markAgentCacheInitialized: core.markAgentCacheInitialized,
+    markAgentFullSyncCompleted: core.markAgentFullSyncCompleted,
     resolveProviderRoots: core.resolveProviderRoots,
     scanSessions: core.scanSessions,
     saveCachedSessions: core.saveCachedSessions,
@@ -420,6 +424,7 @@ describe("LiveScanStore", () => {
       ) => registerMockWatcher(path, options, listener),
     );
     core.getCursorDataPath.mockReturnValue("/tmp/cursor");
+    core.getAgentLastFullSyncAt.mockReturnValue(Date.now());
     core.isAgentCacheInitialized.mockReturnValue(true);
     core.loadCachedSessions.mockReturnValue(null);
     core.markAgentCacheInitialized.mockReset();
@@ -629,7 +634,7 @@ describe("LiveScanStore", () => {
     expect(workerThreads.workers).toHaveLength(0);
   });
 
-  it("builds a full cache before applying the startup time window when no cache is available", async () => {
+  it("publishes the startup window before backfilling a database agent", async () => {
     vi.useFakeTimers();
     const old = makeSession("old", { time_updated: 1000 });
     const recent = makeSession("recent", { time_updated: 5000 });
@@ -644,6 +649,8 @@ describe("LiveScanStore", () => {
     });
 
     core.createRegisteredAgents.mockReturnValue([codex]);
+    core.isAgentCacheInitialized.mockReturnValue(false);
+    core.getAgentLastFullSyncAt.mockReturnValue(null);
     core.scanSessions.mockResolvedValueOnce({
       sessions: [],
       byAgent: {},
@@ -665,28 +672,32 @@ describe("LiveScanStore", () => {
     await vi.advanceTimersByTimeAsync(250);
 
     expect(core.loadCachedSessions).toHaveBeenCalledWith("codex");
-    expect(codex.scan).toHaveBeenCalledWith(
+    expect(codex.scan).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
+        from: 3000,
         onProgress: expect.any(Function),
       }),
     );
-    expect((codex.scan as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]).not.toHaveProperty("from");
-    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
-    expect(workerThreads.workers.find((worker) => worker.workerData.jobs)?.workerData.jobs).toEqual(
-      [
-        expect.objectContaining({
-          kind: "full",
-          context: "scan.refresh",
-          agentName: "codex",
-          sessions: [
-            { ...old, project_identity: projectIdentity },
-            { ...recent, project_identity: projectIdentity },
-          ],
-          saveCache: true,
-        }),
-      ],
+    expect((codex.scan as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]?.from).toBeUndefined();
+    await vi.waitFor(() =>
+      expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent", "old"]),
     );
-    expect(workerThreads.workers).toHaveLength(2);
+    const backfillJob = workerThreads.workers.filter((worker) => worker.workerData.jobs).at(-1)
+      ?.workerData.jobs;
+    expect(backfillJob).toEqual([
+      expect.objectContaining({
+        kind: "full",
+        context: "scan.backfill",
+        agentName: "codex",
+        sessions: [
+          { ...old, project_identity: projectIdentity },
+          { ...recent, project_identity: projectIdentity },
+        ],
+        saveCache: true,
+      }),
+    ]);
+    expect(workerThreads.workers).toHaveLength(4);
   });
 
   it("serializes refresh behind an in-flight backfill for the same agent", async () => {
@@ -967,7 +978,7 @@ describe("LiveScanStore", () => {
 
     expect(codex.checkForChanges).toHaveBeenCalledWith(1000, [old, recent]);
     expect(codex.incrementalScan).toHaveBeenCalledWith([old, recent], ["old"]);
-    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
+    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent", "old"]);
     expect(events).toEqual([]);
     expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
       {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import {
   createRegisteredAgents,
-  filterSessions,
   getAgentLastFullSyncAt,
   isAgentCacheInitialized,
   loadCachedSessions,
@@ -174,7 +173,6 @@ export class LiveScanStore {
     });
     const initialResult = await scanSessions({
       ...this.scanOptions,
-      ...(deferInitialRefresh ? this.startupScanOptions : {}),
       useCache: this.scanOptions.useCache ?? true,
       smartRefresh: false,
       cacheOnly: deferInitialRefresh,
@@ -244,11 +242,6 @@ export class LiveScanStore {
       }
       if (agentNames.length === 0) {
         this.finishScanBatch();
-      }
-      for (const agent of this.agents) {
-        if (this.needsBackfill(agent)) {
-          this.enqueueBackfill(agent.name);
-        }
       }
     }, 0);
   }
@@ -382,14 +375,11 @@ export class LiveScanStore {
   }
 
   /**
-   * Only FileSystemSessionSource agents pay the O(history) enumeration cost this
-   * guards against: database agents already do a cheap single-file mtime check.
    * With no startup window configured, the regular refresh path already walks
    * full history, so backfill would be redundant.
    */
   private needsBackfill(agent: BaseAgent): boolean {
     if (this.startupScanOptions.from == null && this.startupScanOptions.to == null) return false;
-    if (!(agent instanceof FileSystemSessionSource)) return false;
     if (!agent.isAvailable()) return false;
     const lastSyncAt = getAgentLastFullSyncAt(agent.name);
     return lastSyncAt == null || Date.now() - lastSyncAt > BACKFILL_INTERVAL_MS;
@@ -409,22 +399,22 @@ export class LiveScanStore {
     if (!work) return;
     this.updateBackfillStatus(work.status);
 
-    void this.runBackfill(work.agentName).finally(() => {
+    void this.runBackfill(work.agentName).then((result) => {
       if (this.shuttingDown) return;
-      this.updateBackfillStatus(this.backfills.complete(work.agentName));
+      this.updateBackfillStatus(this.backfills.complete(work.agentName, result === "committed"));
       this.pumpBackfillQueue();
     });
   }
 
   /** Unbounded per-source sync to reconcile the full session history, not just the display window. */
-  private async runBackfill(agentName: string): Promise<void> {
-    await this.refreshes.serialize(agentName, "backfill", () => this.performBackfill(agentName));
+  private runBackfill(agentName: string): Promise<AgentOperationResult> {
+    return this.refreshes.serialize(agentName, "backfill", () => this.performBackfill(agentName));
   }
 
   private async performBackfill(agentName: string): Promise<AgentOperationResult> {
     const startedAt = performance.now();
     const agent = this.agents.find((item) => item.name === agentName);
-    if (!agent || !(agent instanceof FileSystemSessionSource) || !agent.isAvailable()) {
+    if (!agent || !agent.isAvailable()) {
       return "skipped";
     }
 
@@ -441,19 +431,21 @@ export class LiveScanStore {
         baseline,
         null,
         {},
-        { sourceSync: true, meta },
+        {
+          sourceSync: agent instanceof FileSystemSessionSource,
+          meta,
+        },
       );
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const fullSessions = attachMissingProjectIdentities(result.sessions);
-      const filtered = this.applyFilters(fullSessions);
       const diff = buildRefreshDiff(
         agentName,
         this.byAgent[agentName] ?? [],
-        filtered,
+        fullSessions,
         result.changedIds ?? [],
       );
 
-      this.byAgent[agentName] = sortSessions(filtered);
+      this.byAgent[agentName] = sortSessions(fullSessions);
       this.rebuildSessions();
 
       await this.searchIndexJobs.enqueue("scan.backfill", [
@@ -651,10 +643,6 @@ export class LiveScanStore {
     return new Set(this.scanOptions.agents.map((agent) => agent.toLowerCase()));
   }
 
-  private applyFilters(sessions: SessionHead[]): SessionHead[] {
-    return filterSessions(sessions, { ...this.scanOptions, ...this.startupScanOptions });
-  }
-
   private async refreshInitialIndex(): Promise<void> {
     const startedAt = performance.now();
     const context = "scan.initial.background";
@@ -695,6 +683,8 @@ export class LiveScanStore {
         return "failed";
       } finally {
         this.finishAgentScan(agentName);
+        const agent = this.agents.find((item) => item.name === agentName);
+        if (agent && this.needsBackfill(agent)) this.enqueueBackfill(agentName);
       }
     });
   }
@@ -725,7 +715,6 @@ export class LiveScanStore {
     let availabilityDuration = 0;
     let checkDuration = 0;
     let scanDuration = 0;
-    let filterDuration = 0;
     let diffDuration = 0;
     let persistDuration = 0;
     let searchIndexDuration = 0;
@@ -833,9 +822,6 @@ export class LiveScanStore {
 
     nextSessions = attachMissingProjectIdentities(nextSessions);
 
-    const filterStartedAt = performance.now();
-    nextSessions = this.applyFilters(nextSessions);
-    filterDuration = performance.now() - filterStartedAt;
     const diffStartedAt = performance.now();
     const diff = buildRefreshDiff(
       agentName,
@@ -914,7 +900,6 @@ export class LiveScanStore {
       availability_ms: Math.round(availabilityDuration),
       check_ms: Math.round(checkDuration),
       scan_ms: Math.round(scanDuration),
-      filter_ms: Math.round(filterDuration),
       diff_ms: Math.round(diffDuration),
       persist_ms: Math.round(persistDuration),
       search_index_ms: Math.round(searchIndexDuration),

--- a/packages/cli/src/scan-status-model.test.ts
+++ b/packages/cli/src/scan-status-model.test.ts
@@ -56,6 +56,7 @@ describe("ScanStatusModel", () => {
       currentAgent: "codex",
       pendingAgents: ["claude"],
       completedAgents: [],
+      failedAgents: [],
     });
   });
 });

--- a/packages/cli/src/scan-status-model.ts
+++ b/packages/cli/src/scan-status-model.ts
@@ -13,7 +13,7 @@ export class ScanStatusModel {
     agentStatuses: {},
     totalAgents: 0,
     updatedAt: Date.now(),
-    backfill: { active: false, pendingAgents: [], completedAgents: [] },
+    backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
   };
 
   snapshot(): ScanStatusEvent {
@@ -33,6 +33,7 @@ export class ScanStatusModel {
         ...this.status.backfill,
         pendingAgents: [...this.status.backfill.pendingAgents],
         completedAgents: [...this.status.backfill.completedAgents],
+        failedAgents: [...this.status.backfill.failedAgents],
       },
     };
   }

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -33,6 +33,7 @@ export interface BackfillStatus {
   pendingAgents: string[];
   currentAgent?: string;
   completedAgents: string[];
+  failedAgents: string[];
 }
 
 export interface ScanStatusEvent {

--- a/packages/core/src/contract/fixtures.ts
+++ b/packages/core/src/contract/fixtures.ts
@@ -52,7 +52,12 @@ export const SAMPLE_SCAN_STATUS_EVENT = {
   startedAt: 1_700_000_000_000,
   updatedAt: 1_700_000_010_000,
   completedAt: 1_700_000_010_000,
-  backfill: { active: false, pendingAgents: [], completedAgents: ["claudecode"] },
+  backfill: {
+    active: false,
+    pendingAgents: [],
+    completedAgents: ["claudecode"],
+    failedAgents: [],
+  },
 } satisfies ScanStatusEvent;
 
 export const SAMPLE_SESSIONS_UPDATED_EVENT = {

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -105,6 +105,32 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
   expect(consoleErrors).toEqual([]);
 });
 
+test("persists the selected time range across navigation", async ({ page }) => {
+  await page.goto("/claudecode/e2e-dashboard?range=14d");
+
+  const range = page.getByRole("combobox", { name: "Session time range" });
+  await expect(range).toHaveValue("14d");
+
+  await page
+    .getByRole("navigation", { name: "Breadcrumb" })
+    .getByRole("link", { name: "Dashboard" })
+    .click();
+  await expect.poll(() => new URL(page.url()).searchParams.get("range")).toBe("14d");
+  await page.reload();
+  await expect(range).toHaveValue("14d");
+
+  await range.selectOption("custom");
+  const dialog = page.getByRole("dialog", { name: "Custom time range" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByLabel("From").fill("2026-04-01");
+  await dialog.getByLabel("To").fill("2026-04-30");
+  await dialog.getByRole("button", { name: "Apply range" }).click();
+
+  await expect.poll(() => new URL(page.url()).searchParams.get("range")).toBe("custom");
+  await expect.poll(() => new URL(page.url()).searchParams.get("from")).toBe("2026-04-01");
+  await expect.poll(() => new URL(page.url()).searchParams.get("to")).toBe("2026-04-30");
+});
+
 test("keeps detail drawers modal and restores focus", async ({ page }) => {
   await page.goto("/claudecode/e2e-dashboard");
   await expect(page.getByTestId("session-detail")).toBeVisible();

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -131,6 +131,16 @@ test("persists the selected time range across navigation", async ({ page }) => {
   await expect.poll(() => new URL(page.url()).searchParams.get("to")).toBe("2026-04-30");
 });
 
+test("keeps the time range when opening a session", async ({ page }) => {
+  await page.goto("/claudecode?range=custom&from=2026-04-01&to=2026-04-30");
+  await expect(page.getByRole("combobox", { name: "Session time range" })).toHaveValue("custom");
+
+  await page.getByText("Core browsing smoke session").first().click();
+
+  await expect(page.getByRole("combobox", { name: "Session time range" })).toHaveValue("custom");
+  await expect.poll(() => new URL(page.url()).searchParams.get("range")).toBe("custom");
+});
+
 test("keeps detail drawers modal and restores focus", async ({ page }) => {
   await page.goto("/claudecode/e2e-dashboard");
   await expect(page.getByTestId("session-detail")).toBeVisible();


### PR DESCRIPTION
## Summary

- add URL-backed 7, 14, 30, and 90 day, all-time, and custom session ranges
- apply the selected range consistently to sessions, agents, projects, dashboards, file activity, and search
- preserve fast first-run startup while backfilling and persisting full history for every agent type
- expose background history indexing progress and failures, then refresh the active range through SSE

## Behavior

A cold start publishes the configured startup window first and indexes full history in the background. A warm start restores the complete cached session snapshot, so expanding the UI range is a local query and does not rescan upstream agent history. If coverage is still partial, the UI shows known results immediately and updates after backfill completes.

Custom dates use inclusive local-day boundaries. The selected range is stored in the URL and survives navigation and reloads.

## Testing

- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e --project web-chromium`

Closes #5
