### PR TITLE
test: improve unit test coverage

### DIFF
--- a/apps/web/src/components/Dashboard.test.tsx
+++ b/apps/web/src/components/Dashboard.test.tsx
@@ -1,7 +1,13 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import type { DashboardData } from "../lib/api";
+import type {
+  BookmarkedSessionSnapshot,
+  DashboardData,
+  DashboardRecentSession,
+  ProjectGroup,
+  SessionHead,
+} from "../lib/api";
 import { Dashboard } from "./Dashboard";
 
 afterEach(cleanup);
@@ -23,6 +29,60 @@ const dashboardData: DashboardData = {
   recentSessions: [],
   recentFileActivities: [],
   window: { to: Date.now() },
+};
+
+function makeSession(id: string): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: `Session ${id}`,
+    directory: "/workspace",
+    project_identity: { kind: "path", key: "/workspace", displayName: "CodeSesh" },
+    time_created: Date.now() - 1_000,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+const recentSession: DashboardRecentSession = {
+  ...makeSession("recent"),
+  display_title: "Recent work",
+  agentName: "Codex",
+  smart_tags: ["testing"],
+};
+
+const bookmarkedSession: BookmarkedSessionSnapshot = {
+  agentKey: "codex",
+  sessionId: "saved",
+  fullPath: "codex/saved",
+  title: "Saved work",
+  directory: "/workspace",
+  time_created: Date.now() - 2_000,
+  stats: {
+    message_count: 2,
+    total_input_tokens: 10,
+    total_output_tokens: 20,
+    total_cost: 0,
+  },
+  bookmarked_at: Date.now(),
+};
+
+const project: ProjectGroup = {
+  identityKind: "path",
+  identityKey: "/workspace",
+  displayName: "CodeSesh",
+  sources: ["/workspace"],
+  sessionCount: 2,
+  lastActivity: Date.now(),
+  messages: 4,
+  tokens: 1_500_000,
+  cost: 1.25,
+  cost_source: "recorded",
+  agentStats: [{ name: "codex", sessions: 2, messages: 4, tokens: 1_500_000, cost: 1.25 }],
 };
 
 describe("Dashboard charts", () => {
@@ -59,5 +119,142 @@ describe("Dashboard charts", () => {
 
     const models = screen.getByRole("region", { name: "Model Distribution" });
     expect(within(models).getByText("1.0k · 100.0%"));
+  });
+
+  it("renders empty dashboard states without optional sections", () => {
+    render(
+      <MemoryRouter>
+        <Dashboard
+          data={{
+            totals: { sessions: 0, messages: 0, tokens: 0, cost: 0 },
+            perAgent: [],
+            dailyActivity: [],
+            dailyTokenActivity: [],
+            modelDistribution: [],
+            recentSessions: [],
+            recentFileActivities: [],
+            window: { to: Date.now() },
+          }}
+          bookmarkedSessions={[]}
+          isBookmarked={() => false}
+          onToggleBookmark={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("No model data yet")).toBeTruthy();
+    expect(screen.getByText("No agent data yet")).toBeTruthy();
+    expect(screen.getByText("No sessions yet")).toBeTruthy();
+    expect(screen.getByText("No file activity yet")).toBeTruthy();
+    expect(screen.queryByRole("region", { name: "Daily Token Activity" })).toBeNull();
+    expect(screen.queryByText("Projects")).toBeNull();
+    expect(screen.queryByText("Bookmarked Sessions")).toBeNull();
+  });
+
+  it("renders populated dashboard sections and handles chart and bookmark interactions", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const onToggleBookmark = vi.fn();
+    const data: DashboardData = {
+      totals: {
+        sessions: 2,
+        messages: 4,
+        tokens: 1_500_000,
+        cost: 1.25,
+        cost_source: "estimated",
+        latestActivity: Date.now(),
+      },
+      perAgent: [
+        {
+          name: "codex",
+          displayName: "Codex",
+          icon: "/icon/codex.svg",
+          sessions: 2,
+          messages: 4,
+          tokens: 1_500_000,
+        },
+      ],
+      dailyActivity: [
+        { date: "2026-07-11", sessions: 0, messages: 0 },
+        { date: "2026-07-12", sessions: 2, messages: 4 },
+      ],
+      dailyTokenActivity: [
+        { date: "2026-07-11", input: 0, output: 0, cache_read: 0, cache_create: 0 },
+        {
+          date: "2026-07-12",
+          input: 1_000_000,
+          output: 500_000,
+          cache_read: 0,
+          cache_create: 0,
+        },
+      ],
+      modelDistribution: [
+        { model: "unused", tokens: 0, sessions: 0 },
+        { model: "gpt-test", tokens: 1_500_000, sessions: 2 },
+      ],
+      recentSessions: [recentSession],
+      recentFileActivities: [
+        {
+          agent_name: "codex",
+          session_id: "recent",
+          project_identity_key: "path:/workspace",
+          path: "src/index.ts",
+          kind: "edit",
+          count: 3,
+          latest_time: Date.now(),
+          session: recentSession,
+        },
+      ],
+      window: { to: Date.now(), days: 7 },
+    };
+
+    render(
+      <MemoryRouter>
+        <Dashboard
+          data={data}
+          projects={[project]}
+          bookmarkedSessions={[bookmarkedSession]}
+          isBookmarked={() => true}
+          onToggleBookmark={onToggleBookmark}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByText("1.5M").length).toBeGreaterThan(0);
+    expect(
+      screen
+        .getAllByRole("link")
+        .some((link) => link.getAttribute("href") === "/projects/path/%2Fworkspace"),
+    ).toBe(true);
+    expect(screen.getByText("Recent work")).toBeTruthy();
+    expect(screen.getByText("src/index.ts")).toBeTruthy();
+    expect(screen.getByText("Saved work")).toBeTruthy();
+
+    const activity = screen.getByRole("region", { name: "Daily Activity" });
+    const activityButton = within(activity).getByRole("button", {
+      name: "2026-07-12 · 2 sessions · 4 msgs",
+    });
+    fireEvent.pointerEnter(activityButton);
+    expect(within(activity).getByText("2026-07-12 · 2 sessions · 4 msgs")).toBeTruthy();
+    fireEvent.pointerLeave(activityButton.parentElement!);
+    fireEvent.click(activityButton);
+    fireEvent.blur(activityButton);
+
+    const tokens = screen.getByRole("region", { name: "Daily Token Activity" });
+    const tokenButton = within(tokens).getByRole("button", {
+      name: /2026-07-12 · 1500000 total tokens/,
+    });
+    fireEvent.pointerEnter(tokenButton);
+    expect(within(tokens).getByText("2026-07-12 · 1.5M total")).toBeTruthy();
+    expect(within(tokens).getByText("Input: 1.0M")).toBeTruthy();
+    fireEvent.pointerLeave(tokenButton.parentElement!);
+    fireEvent.click(tokenButton);
+    fireEvent.blur(tokenButton);
+
+    const bookmarkButtons = screen.getAllByRole("button", { name: "Remove bookmark" });
+    fireEvent.click(bookmarkButtons[0]!);
+    fireEvent.click(bookmarkButtons[1]!);
+    expect(onToggleBookmark).toHaveBeenNthCalledWith(1, recentSession, "codex");
+    expect(onToggleBookmark).toHaveBeenNthCalledWith(2, bookmarkedSession);
   });
 });

--- a/apps/web/src/components/app/SearchResultsPanel.test.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.test.tsx
@@ -1,27 +1,66 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import type { SearchResult, SessionHead } from "../../lib/api";
 import { SearchResultsPanel } from "./SearchResultsPanel";
 
 afterEach(cleanup);
+
+function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: `Session ${id}`,
+    directory: "/workspace",
+    time_created: 1,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  state: Parameters<typeof SearchResultsPanel>[0]["state"],
+  overrides: Partial<Parameters<typeof SearchResultsPanel>[0]> = {},
+) {
+  const props = {
+    query: "hello",
+    state,
+    agentNameMap: new Map<string, string>(),
+    agents: [],
+    projects: [],
+    filters: {},
+    onChangeFilters: vi.fn(),
+    onOpenResult: vi.fn(),
+    onRetry: vi.fn(),
+    selectedIndex: 0,
+    registerResultRef: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    ...render(
+      <MemoryRouter>
+        <SearchResultsPanel {...props} />
+      </MemoryRouter>,
+    ),
+    props,
+  };
+}
 
 describe("SearchResultsPanel", () => {
   it("shows a recoverable search error", () => {
     const onRetry = vi.fn();
 
-    render(
-      <SearchResultsPanel
-        query="hello"
-        state={{ status: "failed", error: "Search unavailable" }}
-        agentNameMap={new Map()}
-        agents={[]}
-        projects={[]}
-        filters={{}}
-        onChangeFilters={vi.fn()}
-        onOpenResult={vi.fn()}
-        onRetry={onRetry}
-        selectedIndex={0}
-        registerResultRef={vi.fn()}
-      />,
+    renderPanel(
+      { status: "failed", error: "Search unavailable" },
+      {
+        onRetry,
+      },
     );
 
     expect(
@@ -33,5 +72,80 @@ describe("SearchResultsPanel", () => {
     fireEvent.click(retry);
     expect(onRetry).toHaveBeenCalledOnce();
     expect(screen.queryByText("No matches")).toBeNull();
+  });
+
+  it("shows loading feedback without empty-state content", () => {
+    const { container } = renderPanel({ status: "loading" });
+
+    expect(screen.getByText("Searching…")).toBeTruthy();
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(4);
+    expect(screen.queryByText("No matches")).toBeNull();
+  });
+
+  it("distinguishes empty recent sessions from empty query matches", () => {
+    const first = renderPanel({ status: "loaded", results: [] }, { query: "" });
+    expect(screen.getByText("No recent sessions")).toBeTruthy();
+    expect(screen.queryByText(/^Query:/)).toBeNull();
+    first.unmount();
+
+    renderPanel({ status: "loaded", results: [] }, { query: "needle" });
+    expect(screen.getByText("No matches")).toBeTruthy();
+    expect(screen.getByText("Query: needle")).toBeTruthy();
+  });
+
+  it("renders safe result snippets and opens the selected result", () => {
+    const results: SearchResult[] = [
+      {
+        agentName: "Codex",
+        session: makeSession("s1", {
+          display_title: "Renamed session",
+          smart_tags: ["bugfix"],
+        }),
+        snippet: '<script>alert("x")</script><mark>needle</mark> & more',
+        matchType: "title",
+      },
+      {
+        agentName: "Other",
+        session: makeSession("s2"),
+        snippet: "",
+        matchType: "file_path",
+      },
+    ];
+    const onOpenResult = vi.fn();
+    const registerResultRef = vi.fn();
+
+    const { container } = renderPanel(
+      { status: "loaded", results },
+      {
+        query: "needle",
+        agentNameMap: new Map([["codex", "Codex CLI"]]),
+        selectedIndex: 1,
+        onOpenResult,
+        registerResultRef,
+      },
+    );
+
+    expect(screen.getByText("Codex CLI")).toBeTruthy();
+    expect(screen.getByText("Other")).toBeTruthy();
+    expect(screen.getByText("Title")).toBeTruthy();
+    expect(screen.getByText("File path")).toBeTruthy();
+    expect(screen.getByText("Renamed session")).toBeTruthy();
+    expect(screen.getAllByText("bugfix").some((element) => element.tagName === "SPAN")).toBe(true);
+    expect(screen.getByText("needle").tagName).toBe("MARK");
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.textContent).toContain('<script>alert("x")</script>needle & more');
+
+    const firstLink = screen.getByText("Renamed session").closest("a");
+    const selectedTitle = screen
+      .getAllByText("Session s2")
+      .find((element) => element.tagName === "H2");
+    const selectedLink = selectedTitle?.closest("a");
+    expect(firstLink?.getAttribute("href")).toBe("/codex/s1");
+    expect(firstLink?.className).toContain("border-[var(--console-border)]");
+    expect(selectedLink?.className).toContain("border-[var(--console-border-strong)]");
+    fireEvent.click(selectedLink!);
+    expect(onOpenResult).toHaveBeenCalledOnce();
+    expect(registerResultRef).toHaveBeenCalledWith("Codex/s1", expect.any(HTMLAnchorElement));
+    expect(registerResultRef).toHaveBeenCalledWith("Other/s2", expect.any(HTMLAnchorElement));
   });
 });

--- a/apps/web/src/components/session-detail/message-list.test.tsx
+++ b/apps/web/src/components/session-detail/message-list.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FilteredSessionMessage } from "./toc";
-import { MessageList, VIRTUALIZED_MESSAGE_THRESHOLD } from "./message-list";
+import { MessageList, type MessageListHandle, VIRTUALIZED_MESSAGE_THRESHOLD } from "./message-list";
 
 vi.mock("./message-rendering", () => ({
   MessageItem: ({ messageIndex }: { messageIndex: number }) => (
@@ -51,6 +51,24 @@ function createMessages(): FilteredSessionMessage[] {
 }
 
 describe("MessageList virtualization", () => {
+  it("renders short lists directly and clears a stale virtual API", async () => {
+    const apiRef: { current: MessageListHandle | null } = {
+      current: { scrollToIndex: vi.fn() },
+    };
+    const view = render(
+      <MessageList
+        messages={createMessages().slice(0, 2)}
+        toolAnchorIds={new Map()}
+        sessionAgentKey="claudecode"
+        baseDirectory="/tmp/project"
+        apiRef={apiRef}
+      />,
+    );
+
+    expect(view.container.querySelectorAll("[data-message-index]")).toHaveLength(2);
+    await waitFor(() => expect(apiRef.current).toBeNull());
+  });
+
   it("does not poll layout while idle", () => {
     const setInterval = vi.spyOn(window, "setInterval");
 
@@ -65,6 +83,85 @@ describe("MessageList virtualization", () => {
     );
 
     expect(setInterval).not.toHaveBeenCalled();
+  });
+
+  it("scrolls the window to an offscreen message through the virtual API", async () => {
+    vi.stubGlobal("innerHeight", 0);
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
+    const apiRef: { current: MessageListHandle | null } = { current: null };
+    const view = render(
+      <MessageList
+        messages={createMessages()}
+        toolAnchorIds={new Map()}
+        sessionAgentKey="claudecode"
+        baseDirectory="/tmp/project"
+        apiRef={apiRef}
+      />,
+    );
+    await waitFor(() => expect(apiRef.current).not.toBeNull());
+
+    act(() => apiRef.current?.scrollToIndex(VIRTUALIZED_MESSAGE_THRESHOLD));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: expect.any(Number), behavior: "auto" });
+    expect(view.container.querySelector('[data-message-index="80"]')).not.toBeNull();
+
+    act(() => apiRef.current?.scrollToIndex(10_000));
+    expect(scrollTo).toHaveBeenCalledOnce();
+
+    view.unmount();
+    expect(apiRef.current).toBeNull();
+  });
+
+  it("scrolls a containing element through the virtual API", async () => {
+    const scrollContainer = document.createElement("div");
+    scrollContainer.style.overflowY = "auto";
+    document.body.append(scrollContainer);
+    Object.defineProperty(scrollContainer, "clientHeight", {
+      configurable: true,
+      value: 300,
+    });
+    const scrollTo = vi.fn();
+    scrollContainer.scrollTo = scrollTo;
+    const apiRef: { current: MessageListHandle | null } = { current: null };
+    render(
+      <MessageList
+        messages={createMessages()}
+        toolAnchorIds={new Map()}
+        sessionAgentKey="claudecode"
+        baseDirectory="/tmp/project"
+        apiRef={apiRef}
+      />,
+      { container: scrollContainer },
+    );
+    await waitFor(() => expect(apiRef.current).not.toBeNull());
+
+    act(() => apiRef.current?.scrollToIndex(10));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: expect.any(Number), behavior: "auto" });
+    scrollContainer.remove();
+  });
+
+  it("coalesces viewport events and cancels pending work on unmount", () => {
+    const requestAnimationFrame = vi.spyOn(window, "requestAnimationFrame").mockReturnValue(42);
+    const cancelAnimationFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => undefined);
+    const view = render(
+      <MessageList
+        messages={createMessages()}
+        toolAnchorIds={new Map()}
+        sessionAgentKey="claudecode"
+        baseDirectory="/tmp/project"
+        apiRef={{ current: null }}
+      />,
+    );
+
+    fireEvent.resize(window);
+    fireEvent.resize(window);
+    view.unmount();
+
+    expect(requestAnimationFrame).toHaveBeenCalledOnce();
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42);
   });
 
   it("updates visible rows when the scroll container resizes", async () => {
@@ -126,5 +223,8 @@ describe("MessageList virtualization", () => {
     ResizeObserverMock.instances.forEach((observer) => observer.trigger(row));
 
     await waitFor(() => expect(Number.parseInt(list.style.height, 10)).toBe(initialHeight + 320));
+
+    ResizeObserverMock.instances.forEach((observer) => observer.trigger(row));
+    expect(Number.parseInt(list.style.height, 10)).toBe(initialHeight + 320);
   });
 });

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -113,6 +113,21 @@ describe("useBookmarks", () => {
     expect(result.current.bookmarkedSessions[0]?.sessionId).toBe("new");
   });
 
+  it("falls back to creation time when sorting bookmarks without update times", async () => {
+    const old = { ...snap("old"), time_created: 10, time_updated: undefined };
+    const recent = { ...snap("recent"), time_created: 20, time_updated: undefined };
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [old] });
+    const { result } = renderHook(() => useBookmarks([]));
+    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
+
+    act(() => result.current.toggleBookmark(recent));
+
+    expect(result.current.bookmarkedSessions.map((bookmark) => bookmark.sessionId)).toEqual([
+      "recent",
+      "old",
+    ]);
+  });
+
   it("refreshes bookmarks and reports load failures", async () => {
     const error = new Error("offline");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -183,6 +198,31 @@ describe("useBookmarks", () => {
     );
   });
 
+  it("does not report snapshot sync failures after unmount", async () => {
+    const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
+    vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
+    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) =>
+      previous.length > 0 && sessions.length > 0 ? [snap("s1", 2)] : previous,
+    );
+    const { result, rerender, unmount } = renderHook(({ sessions }) => useBookmarks(sessions), {
+      initialProps: { sessions: [] as SessionHead[] },
+    });
+    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
+    rerender({ sessions: [session("s1")] });
+    await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
+
+    unmount();
+    request.reject(new Error("late failure"));
+    await request.promise.catch(() => undefined);
+
+    expect(consoleError).not.toHaveBeenCalledWith(
+      "Failed to sync bookmark snapshots:",
+      expect.anything(),
+    );
+  });
+
   it("migrates legacy bookmarks once", async () => {
     const legacy = snap("legacy");
     vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([legacy]);
@@ -194,6 +234,21 @@ describe("useBookmarks", () => {
       expect.not.objectContaining({ bookmarked_at: expect.anything() }),
     ]);
     expect(bookmarkUtils.clearLegacyBookmarks).toHaveBeenCalledOnce();
+  });
+
+  it("does not apply a completed legacy migration after unmount", async () => {
+    const legacy = snap("legacy");
+    const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
+    vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([legacy]);
+    vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
+    const { unmount } = renderHook(() => useBookmarks([]));
+    await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
+
+    unmount();
+    request.resolve({ bookmarks: [legacy] });
+    await request.promise;
+
+    expect(bookmarkUtils.clearLegacyBookmarks).not.toHaveBeenCalled();
   });
 
   it("reports legacy migration failures", async () => {
@@ -208,6 +263,24 @@ describe("useBookmarks", () => {
       expect(consoleError).toHaveBeenCalledWith("Failed to migrate legacy bookmarks:", error),
     );
     expect(bookmarkUtils.clearLegacyBookmarks).not.toHaveBeenCalled();
+  });
+
+  it("does not report legacy migration failures after unmount", async () => {
+    const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([snap("legacy")]);
+    vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
+    const { unmount } = renderHook(() => useBookmarks([]));
+    await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
+
+    unmount();
+    request.reject(new Error("late migration failure"));
+    await request.promise.catch(() => undefined);
+
+    expect(consoleError).not.toHaveBeenCalledWith(
+      "Failed to migrate legacy bookmarks:",
+      expect.anything(),
+    );
   });
 
   it("rolls back an optimistic toggle when persistence fails", async () => {

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import type { BookmarkedSessionSnapshot } from "../lib/api";
+import type { BookmarkedSessionSnapshot, SessionHead } from "../lib/api";
 import * as api from "../lib/api";
+import * as bookmarkUtils from "../lib/bookmarks";
 import { useBookmarks } from "./useBookmarks";
 
 vi.mock("../lib/api", () => ({
@@ -18,6 +19,7 @@ vi.mock("../lib/bookmarks", async (importOriginal) => {
     ...actual,
     mergeBookmarksWithSessions: vi.fn((prev) => prev),
     loadLegacyBookmarks: vi.fn(() => []),
+    clearLegacyBookmarks: vi.fn(),
   };
 });
 
@@ -34,11 +36,37 @@ const snap = (id: string, updated = 1): BookmarkedSessionSnapshot =>
     bookmarked_at: 0,
   }) as unknown as BookmarkedSessionSnapshot;
 
+const session = (id: string): SessionHead => ({
+  id,
+  slug: `cc/${id}`,
+  title: id,
+  directory: "/d",
+  time_created: 1,
+  stats: {
+    message_count: 1,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    total_cost: 0,
+  },
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 beforeEach(() => {
   vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [] });
   vi.mocked(api.importBookmarks).mockResolvedValue({ bookmarks: [] });
   vi.mocked(api.upsertBookmark).mockResolvedValue(undefined as never);
   vi.mocked(api.deleteBookmark).mockResolvedValue(undefined as never);
+  vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((prev) => prev);
+  vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([]);
 });
 
 afterEach(() => {
@@ -83,5 +111,131 @@ describe("useBookmarks", () => {
 
     await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(2));
     expect(result.current.bookmarkedSessions[0]?.sessionId).toBe("new");
+  });
+
+  it("refreshes bookmarks and reports load failures", async () => {
+    const error = new Error("offline");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
+    const { result } = renderHook(() => useBookmarks([]));
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith("Failed to load bookmarks:", error),
+    );
+
+    vi.mocked(api.fetchBookmarks).mockResolvedValueOnce({ bookmarks: [snap("refreshed")] });
+    await act(() => result.current.refresh());
+    expect(result.current.isSessionBookmarked("cc", "refreshed")).toBe(true);
+
+    vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
+    await act(() => result.current.refresh());
+    expect(consoleError).toHaveBeenLastCalledWith("Failed to load bookmarks:", error);
+  });
+
+  it("does not apply the initial response after unmount", async () => {
+    const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
+    vi.mocked(api.fetchBookmarks).mockReturnValueOnce(request.promise);
+    const { unmount } = renderHook(() => useBookmarks([]));
+
+    unmount();
+    request.resolve({ bookmarks: [snap("late")] });
+    await request.promise;
+
+    expect(api.fetchBookmarks).toHaveBeenCalledOnce();
+  });
+
+  it("synchronizes changed bookmark snapshots with the server", async () => {
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1", 1)] });
+    const updated = snap("s1", 2);
+    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) =>
+      previous.length > 0 && sessions.length > 0 ? [updated] : previous,
+    );
+    const { result, rerender } = renderHook(({ sessions }) => useBookmarks(sessions), {
+      initialProps: { sessions: [] as SessionHead[] },
+    });
+    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
+
+    rerender({ sessions: [session("s1")] });
+    await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
+
+    expect(api.importBookmarks).toHaveBeenCalledWith([
+      expect.not.objectContaining({ bookmarked_at: expect.anything() }),
+    ]);
+    expect(result.current.bookmarkedSessions[0]?.time_updated).toBe(2);
+  });
+
+  it("reports snapshot sync failures while mounted", async () => {
+    const error = new Error("sync failed");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
+    vi.mocked(api.importBookmarks).mockRejectedValueOnce(error);
+    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) =>
+      previous.length > 0 && sessions.length > 0 ? [snap("s1", 2)] : previous,
+    );
+    const { result, rerender } = renderHook(({ sessions }) => useBookmarks(sessions), {
+      initialProps: { sessions: [] as SessionHead[] },
+    });
+    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
+
+    rerender({ sessions: [session("s1")] });
+
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith("Failed to sync bookmark snapshots:", error),
+    );
+  });
+
+  it("migrates legacy bookmarks once", async () => {
+    const legacy = snap("legacy");
+    vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([legacy]);
+    vi.mocked(api.importBookmarks).mockResolvedValueOnce({ bookmarks: [legacy] });
+    const { result } = renderHook(() => useBookmarks([]));
+
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "legacy")).toBe(true));
+    expect(api.importBookmarks).toHaveBeenCalledWith([
+      expect.not.objectContaining({ bookmarked_at: expect.anything() }),
+    ]);
+    expect(bookmarkUtils.clearLegacyBookmarks).toHaveBeenCalledOnce();
+  });
+
+  it("reports legacy migration failures", async () => {
+    const error = new Error("migration failed");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([snap("legacy")]);
+    vi.mocked(api.importBookmarks).mockRejectedValueOnce(error);
+
+    renderHook(() => useBookmarks([]));
+
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith("Failed to migrate legacy bookmarks:", error),
+    );
+    expect(bookmarkUtils.clearLegacyBookmarks).not.toHaveBeenCalled();
+  });
+
+  it("rolls back an optimistic toggle when persistence fails", async () => {
+    const error = new Error("write failed");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.upsertBookmark).mockRejectedValueOnce(error);
+    const { result } = renderHook(() => useBookmarks([]));
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
+
+    act(() => result.current.toggleBookmark(snap("failed")));
+    expect(result.current.isSessionBookmarked("cc", "failed")).toBe(true);
+
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "failed")).toBe(false));
+    expect(consoleError).toHaveBeenCalledWith("Failed to toggle bookmark:", error);
+    expect(api.logClientEvent).toHaveBeenCalledWith("bookmark.add", {
+      agent: "cc",
+      session: "failed",
+    });
+  });
+
+  it("converts live sessions before toggling bookmarks", async () => {
+    const { result } = renderHook(() => useBookmarks([]));
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
+
+    act(() => result.current.toggleSessionBookmark(session("live"), "cc"));
+
+    expect(api.upsertBookmark).toHaveBeenCalledWith(
+      expect.objectContaining({ agentKey: "cc", sessionId: "live", fullPath: "cc/live" }),
+    );
   });
 });

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,231 @@
+import { cleanup, fireEvent, renderHook } from "@testing-library/react";
+import type { NavigateFunction } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SearchResult, SessionHead } from "../lib/api";
+import { buildSidebarSessionLookup } from "../lib/session-indexes";
+import type { ViewState } from "../lib/view-state";
+import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
+
+afterEach(cleanup);
+
+function makeSession(id: string): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: id,
+    directory: "/workspace",
+    time_created: 1,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+const sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
+const searchResults: SearchResult[] = sessions.slice(0, 2).map((session) => ({
+  agentName: "Codex",
+  session,
+  snippet: session.title,
+  matchType: "title",
+}));
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    viewState: {
+      mode: "root",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+    } satisfies ViewState,
+    browseBy: "agents" as const,
+    navigate: vi.fn() as unknown as NavigateFunction,
+    activeAgentKey: "codex",
+    sidebarSessions: sessions,
+    sidebarSessionLookup: buildSidebarSessionLookup(sessions),
+    selectedSidebarSessionId: null,
+    setSelectedSidebarSessionId: vi.fn(),
+    selectedProjectNavigationIdentity: null,
+    shortcutHelpOpen: false,
+    setShortcutHelpOpen: vi.fn(),
+    dismissShortcutHint: vi.fn(),
+    isSearchMode: false,
+    activeSearchQuery: "needle",
+    searchResults,
+    selectedSearchIndex: 0,
+    setSelectedSearchIndex: vi.fn(),
+    setDraftSearchQuery: vi.fn(),
+    openSearch: vi.fn(),
+    closeSearch: vi.fn(),
+    ...overrides,
+  };
+}
+
+function dispatchKey(key: string, init: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...init });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("useKeyboardShortcuts", () => {
+  it("opens search and shortcut help from global commands", () => {
+    const deps = makeDeps();
+    renderHook(() => useKeyboardShortcuts(deps));
+
+    expect(dispatchKey("k", { metaKey: true }).defaultPrevented).toBe(true);
+    expect(deps.openSearch).toHaveBeenCalledOnce();
+    expect(deps.setSelectedSearchIndex).toHaveBeenCalledWith(0);
+
+    expect(dispatchKey("/").defaultPrevented).toBe(true);
+    expect(deps.openSearch).toHaveBeenCalledTimes(2);
+    expect(deps.dismissShortcutHint).toHaveBeenCalledOnce();
+
+    expect(dispatchKey("?").defaultPrevented).toBe(true);
+    expect(deps.setShortcutHelpOpen).toHaveBeenCalledWith(true);
+    expect(deps.dismissShortcutHint).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores modified, composing, and already-handled events", () => {
+    const deps = makeDeps();
+    renderHook(() => useKeyboardShortcuts(deps));
+
+    dispatchKey("?", { altKey: true });
+    dispatchKey("?", { isComposing: true });
+    const handled = new KeyboardEvent("keydown", { key: "?", bubbles: true, cancelable: true });
+    handled.preventDefault();
+    window.dispatchEvent(handled);
+
+    expect(deps.setShortcutHelpOpen).not.toHaveBeenCalled();
+  });
+
+  it("closes help and protects keyboard input in editable controls", () => {
+    const helpDeps = makeDeps({ shortcutHelpOpen: true });
+    const { unmount } = renderHook(() => useKeyboardShortcuts(helpDeps));
+
+    dispatchKey("j");
+    expect(helpDeps.setSelectedSidebarSessionId).not.toHaveBeenCalled();
+    expect(dispatchKey("Escape").defaultPrevented).toBe(true);
+    expect(helpDeps.setShortcutHelpOpen).toHaveBeenCalledWith(false);
+    unmount();
+
+    const editableDeps = makeDeps();
+    renderHook(() => useKeyboardShortcuts(editableDeps));
+    const input = document.createElement("input");
+    document.body.append(input);
+    input.focus();
+
+    fireEvent.keyDown(input, { key: "j" });
+    expect(editableDeps.setSelectedSidebarSessionId).not.toHaveBeenCalled();
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(document.activeElement).not.toBe(input);
+    input.remove();
+  });
+
+  it("backs out of search and session views", () => {
+    const searchDeps = makeDeps({ isSearchMode: true });
+    const { unmount } = renderHook(() => useKeyboardShortcuts(searchDeps));
+
+    dispatchKey("Escape");
+    expect(searchDeps.closeSearch).toHaveBeenCalledOnce();
+    expect(searchDeps.setDraftSearchQuery).toHaveBeenCalledWith("");
+    unmount();
+
+    const projectDeps = makeDeps({
+      browseBy: "projects" as const,
+      viewState: {
+        mode: "session",
+        activeAgentKey: "codex",
+        activeSessionSlug: "s1",
+      } satisfies ViewState,
+      selectedProjectNavigationIdentity: { kind: "path" as const, key: "/workspace" },
+    });
+    const projectHook = renderHook(() => useKeyboardShortcuts(projectDeps));
+    dispatchKey("Escape");
+    expect(projectDeps.navigate).toHaveBeenCalledWith("/projects/path/%2Fworkspace");
+    projectHook.unmount();
+
+    const agentDeps = makeDeps({
+      viewState: {
+        mode: "session",
+        activeAgentKey: "codex",
+        activeSessionSlug: "s1",
+      } satisfies ViewState,
+    });
+    renderHook(() => useKeyboardShortcuts(agentDeps));
+    dispatchKey("Escape");
+    expect(agentDeps.navigate).toHaveBeenCalledWith("/codex");
+  });
+
+  it("moves through search results and opens the selected result", () => {
+    const deps = makeDeps({ isSearchMode: true, selectedSearchIndex: 1 });
+    renderHook(() => useKeyboardShortcuts(deps));
+
+    dispatchKey("j");
+    const moveDown = deps.setSelectedSearchIndex.mock.calls[0]?.[0] as (value: number) => number;
+    expect(moveDown(1)).toBe(1);
+    dispatchKey("k");
+    const moveUp = deps.setSelectedSearchIndex.mock.calls[1]?.[0] as (value: number) => number;
+    expect(moveUp(0)).toBe(0);
+    dispatchKey("g");
+    dispatchKey("G");
+    expect(deps.setSelectedSearchIndex).toHaveBeenNthCalledWith(3, 0);
+    expect(deps.setSelectedSearchIndex).toHaveBeenNthCalledWith(4, 1);
+
+    expect(dispatchKey("Enter").defaultPrevented).toBe(true);
+    expect(deps.closeSearch).toHaveBeenCalledOnce();
+    expect(deps.navigate).toHaveBeenCalledWith("/codex/s2", {
+      state: { searchQuery: "needle" },
+    });
+  });
+
+  it("moves through sidebar sessions and opens agent or project routes", () => {
+    const deps = makeDeps();
+    const { unmount } = renderHook(() => useKeyboardShortcuts(deps));
+
+    dispatchKey("j");
+    expect(deps.setSelectedSidebarSessionId).toHaveBeenNthCalledWith(1, "s1");
+    dispatchKey("k");
+    expect(deps.setSelectedSidebarSessionId).toHaveBeenNthCalledWith(2, "s3");
+    dispatchKey("g");
+    expect(deps.setSelectedSidebarSessionId).toHaveBeenNthCalledWith(3, "s1");
+    dispatchKey("G");
+    expect(deps.setSelectedSidebarSessionId).toHaveBeenNthCalledWith(4, "s3");
+    unmount();
+
+    const agentDeps = makeDeps({ selectedSidebarSessionId: "s2" });
+    const agentHook = renderHook(() => useKeyboardShortcuts(agentDeps));
+    dispatchKey("Enter");
+    expect(agentDeps.navigate).toHaveBeenCalledWith("/codex/s2");
+    agentHook.unmount();
+
+    const projectDeps = makeDeps({
+      browseBy: "projects" as const,
+      selectedSidebarSessionId: "s2",
+    });
+    renderHook(() => useKeyboardShortcuts(projectDeps));
+    dispatchKey("Enter");
+    expect(projectDeps.navigate).toHaveBeenCalledWith("/codex/s2");
+  });
+
+  it("does nothing without navigable results or sessions", () => {
+    const deps = makeDeps({
+      activeAgentKey: null,
+      sidebarSessions: [],
+      sidebarSessionLookup: buildSidebarSessionLookup([]),
+      isSearchMode: true,
+      searchResults: [],
+    });
+    const { unmount } = renderHook(() => useKeyboardShortcuts(deps));
+
+    dispatchKey("j");
+    dispatchKey("Enter");
+    expect(deps.navigate).not.toHaveBeenCalled();
+    unmount();
+
+    const sidebarDeps = makeDeps({ activeAgentKey: null });
+    renderHook(() => useKeyboardShortcuts(sidebarDeps));
+    dispatchKey("j");
+    expect(sidebarDeps.setSelectedSidebarSessionId).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useProjectDashboard.test.ts
+++ b/apps/web/src/hooks/useProjectDashboard.test.ts
@@ -10,6 +10,14 @@ const appConfig = { window: { from: 1, to: 2 } } as unknown as AppConfig;
 const data = { totals: { sessions: 3 }, perAgent: [] } as unknown as DashboardData;
 const kind = "path" as ProjectIdentityKind;
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
   vi.mocked(api.fetchDashboard).mockResolvedValue(data);
 });
@@ -48,5 +56,88 @@ describe("useProjectDashboard", () => {
 
     rerender({ idKey: "path:pk2" });
     await waitFor(() => expect(result.current.selectedProjectAgent).toBeUndefined());
+  });
+
+  it("exposes load failures and clears the loading state", async () => {
+    const error = new Error("offline");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchDashboard).mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() =>
+      useProjectDashboard(appConfig.window, kind, "pk", "path:pk"),
+    );
+
+    await waitFor(() =>
+      expect(result.current.projectDashboardError).toBe("Failed to load project dashboard"),
+    );
+    expect(result.current.projectDashboard).toBeNull();
+    expect(result.current.projectDashboardLoading).toBe(false);
+    expect(console.error).toHaveBeenCalledWith("Failed to load project dashboard:", error);
+  });
+
+  it("keeps the latest project response when an earlier request finishes late", async () => {
+    const first = deferred<DashboardData>();
+    const secondData = { totals: { sessions: 4 }, perAgent: [] } as unknown as DashboardData;
+    vi.mocked(api.fetchDashboard)
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(secondData);
+    const { result, rerender } = renderHook(
+      ({ projectKey }) =>
+        useProjectDashboard(appConfig.window, kind, projectKey, `path:${projectKey}`),
+      { initialProps: { projectKey: "first" } },
+    );
+
+    rerender({ projectKey: "second" });
+    await waitFor(() => expect(result.current.projectDashboard).toBe(secondData));
+    first.resolve(data);
+    await first.promise;
+
+    expect(result.current.projectDashboard).toBe(secondData);
+    expect(result.current.projectDashboardLoading).toBe(false);
+  });
+
+  it("refetches when the selected agent changes", async () => {
+    const { result } = renderHook(() =>
+      useProjectDashboard(appConfig.window, null, "pk", "path:pk"),
+    );
+    await waitFor(() => expect(result.current.projectDashboard).toEqual(data));
+    vi.mocked(api.fetchDashboard).mockClear();
+
+    act(() => result.current.setSelectedProjectAgent("codex"));
+
+    await waitFor(() =>
+      expect(api.fetchDashboard).toHaveBeenCalledWith(appConfig.window, {
+        projectKind: undefined,
+        projectKey: "pk",
+        agent: "codex",
+      }),
+    );
+  });
+
+  it("refreshes the active dashboard and reports refresh failures", async () => {
+    const error = new Error("refresh failed");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const refreshed = { totals: { sessions: 9 }, perAgent: [] } as unknown as DashboardData;
+    const { result } = renderHook(() =>
+      useProjectDashboard(appConfig.window, kind, "pk", "path:pk"),
+    );
+    await waitFor(() => expect(result.current.projectDashboard).toEqual(data));
+
+    vi.mocked(api.fetchDashboard).mockResolvedValueOnce(refreshed);
+    await act(() => result.current.refresh());
+    expect(result.current.projectDashboard).toBe(refreshed);
+
+    vi.mocked(api.fetchDashboard).mockRejectedValueOnce(error);
+    await act(() => result.current.refresh());
+    expect(console.error).toHaveBeenCalledWith("Failed to refresh project dashboard:", error);
+  });
+
+  it("does not refresh without both a project and a window", async () => {
+    const { result } = renderHook(() => useProjectDashboard(null, kind, "pk", "path:pk"));
+    vi.mocked(api.fetchDashboard).mockClear();
+
+    await act(() => result.current.refresh());
+
+    expect(api.fetchDashboard).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -1,0 +1,580 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const coreMocks = vi.hoisted(() => ({
+  deleteBookmark: vi.fn(),
+  deleteSessionAlias: vi.fn(),
+  importBookmarks: vi.fn(),
+  listBookmarks: vi.fn(),
+  listFileActivity: vi.fn(),
+  listSessionAliases: vi.fn(),
+  upsertBookmark: vi.fn(),
+  upsertSessionAlias: vi.fn(),
+}));
+
+const loggerMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("@codesesh/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codesesh/core")>();
+  return {
+    ...actual,
+    deleteBookmark: coreMocks.deleteBookmark,
+    deleteSessionAlias: coreMocks.deleteSessionAlias,
+    importBookmarks: coreMocks.importBookmarks,
+    listBookmarks: coreMocks.listBookmarks,
+    listFileActivity: coreMocks.listFileActivity,
+    listSessionAliases: coreMocks.listSessionAliases,
+    upsertBookmark: coreMocks.upsertBookmark,
+    upsertSessionAlias: coreMocks.upsertSessionAlias,
+  };
+});
+
+vi.mock("../../logging.js", () => ({ appLogger: loggerMocks }));
+
+import {
+  BookmarkStorageUnavailableError,
+  StateStorageUnavailableError,
+  type BookmarkRecord,
+  type ScanResult,
+} from "@codesesh/core";
+import {
+  handleDeleteBookmark,
+  handleDeleteSessionAlias,
+  handleGetBookmarks,
+  handleGetDashboard,
+  handleGetFileActivity,
+  handleGetSessions,
+  handleImportBookmarks,
+  handlePostClientLog,
+  handlePutBookmark,
+  handlePutSessionAlias,
+  type ScanResultSource,
+} from "../handlers.js";
+
+interface ContextOptions {
+  body?: unknown;
+  rejectBody?: boolean;
+  param?: Record<string, string>;
+  query?: Record<string, string>;
+}
+
+function makeContext(options: ContextOptions = {}) {
+  const params = new URLSearchParams(options.query ?? {});
+  return {
+    req: {
+      json: () =>
+        options.rejectBody
+          ? Promise.reject(new SyntaxError("invalid JSON"))
+          : Promise.resolve(options.body),
+      param: (key: string) => options.param?.[key],
+      query: (key: string) => options.query?.[key],
+      url: `http://localhost/${params.size > 0 ? `?${params.toString()}` : ""}`,
+    },
+    json: vi.fn((payload: unknown, status = 200) => ({ payload, status })),
+  };
+}
+
+function getResponsePayload<T>(context: ReturnType<typeof makeContext>): T {
+  return context.json.mock.calls[0]![0] as T;
+}
+
+const validBookmark: Omit<BookmarkRecord, "bookmarked_at"> = {
+  agentKey: "codex",
+  sessionId: "s1",
+  fullPath: "codex/s1",
+  title: "Session one",
+  directory: "/workspace",
+  time_created: 1,
+  time_updated: 2,
+  stats: {
+    message_count: 1,
+    total_input_tokens: 2,
+    total_output_tokens: 3,
+    total_cost: 0.1,
+    total_tokens: 5,
+  },
+};
+
+const storedBookmark: BookmarkRecord = {
+  ...validBookmark,
+  bookmarked_at: 3,
+};
+
+const scanSource: ScanResultSource = {
+  getSnapshot: () =>
+    ({
+      sessions: [],
+      byAgent: {},
+      agents: [],
+    }) as ScanResult,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  coreMocks.listBookmarks.mockReturnValue([]);
+  coreMocks.listFileActivity.mockReturnValue([]);
+  coreMocks.listSessionAliases.mockReturnValue([]);
+  coreMocks.upsertBookmark.mockReturnValue(storedBookmark);
+  coreMocks.importBookmarks.mockReturnValue([storedBookmark]);
+  coreMocks.upsertSessionAlias.mockReturnValue({
+    agentKey: "codex",
+    sessionId: "s1",
+    alias: "Renamed",
+    updated_at: 1,
+  });
+});
+
+afterEach(() => vi.useRealTimers());
+
+describe("client logging handler", () => {
+  it("rejects malformed and blank log events", async () => {
+    const malformed = makeContext({ rejectBody: true });
+    await handlePostClientLog(malformed as never);
+    expect(malformed.json).toHaveBeenCalledWith({ ok: false }, 400);
+
+    const blank = makeContext({ body: { event: "   " } });
+    await handlePostClientLog(blank as never);
+    expect(blank.json).toHaveBeenCalledWith({ ok: false }, 400);
+    expect(loggerMocks.info).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes event names and bounds structured log data", async () => {
+    const data = {
+      text: "x".repeat(400),
+      count: 2,
+      enabled: true,
+      empty: null,
+      nested: { value: 1 },
+      ...Object.fromEntries(Array.from({ length: 30 }, (_, index) => [`extra${index}`, index])),
+    };
+    const c = makeContext({
+      body: { event: ` feature launch!?${"z".repeat(140)}`, data },
+    });
+
+    await handlePostClientLog(c as never);
+
+    const [event, loggedData] = loggerMocks.info.mock.calls[0]!;
+    expect(event).toMatch(/^client\.feature_launch__/);
+    expect(event).toHaveLength(127);
+    expect(loggedData).toMatchObject({
+      text: "x".repeat(300),
+      count: 2,
+      enabled: true,
+      empty: null,
+      nested: "[object Object]",
+    });
+    expect(Object.keys(loggedData)).toHaveLength(30);
+    expect(c.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it("drops non-record log data", async () => {
+    const c = makeContext({ body: { event: "ready", data: "not-an-object" } });
+
+    await handlePostClientLog(c as never);
+
+    expect(loggerMocks.info).toHaveBeenCalledWith("client.ready", {});
+  });
+});
+
+describe("bookmark handlers", () => {
+  it("projects aliases onto stored bookmark snapshots", () => {
+    coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
+    coreMocks.listSessionAliases.mockReturnValue([
+      { agentKey: "codex", sessionId: "s1", alias: "Renamed", updated_at: 1 },
+    ]);
+    const c = makeContext();
+
+    handleGetBookmarks(c as never);
+
+    expect(c.json).toHaveBeenCalledWith({
+      bookmarks: [{ ...storedBookmark, display_title: "Renamed" }],
+      storageAvailable: true,
+    });
+  });
+
+  it("tolerates unavailable alias storage and logs unexpected alias failures", () => {
+    coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
+    coreMocks.listSessionAliases.mockImplementationOnce(() => {
+      throw new StateStorageUnavailableError();
+    });
+    handleGetBookmarks(makeContext() as never);
+    expect(loggerMocks.warn).not.toHaveBeenCalled();
+
+    coreMocks.listSessionAliases.mockImplementationOnce(() => {
+      throw new Error("corrupt aliases");
+    });
+    handleGetBookmarks(makeContext() as never);
+    expect(loggerMocks.warn).toHaveBeenLastCalledWith("api.session_aliases.load_failed", {
+      error: "corrupt aliases",
+    });
+
+    coreMocks.listSessionAliases.mockImplementationOnce(() => {
+      throw "invalid aliases";
+    });
+    handleGetBookmarks(makeContext() as never);
+    expect(loggerMocks.warn).toHaveBeenLastCalledWith("api.session_aliases.load_failed", {
+      error: "invalid aliases",
+    });
+  });
+
+  it("reports unavailable bookmark storage and rethrows unexpected failures", () => {
+    coreMocks.listBookmarks.mockImplementationOnce(() => {
+      throw new BookmarkStorageUnavailableError();
+    });
+    const unavailable = makeContext();
+    handleGetBookmarks(unavailable as never);
+    expect(unavailable.json).toHaveBeenCalledWith({ bookmarks: [], storageAvailable: false });
+
+    coreMocks.listBookmarks.mockImplementationOnce(() => {
+      throw new Error("unexpected");
+    });
+    expect(() => handleGetBookmarks(makeContext() as never)).toThrow("unexpected");
+  });
+
+  it.each([
+    null,
+    {},
+    { ...validBookmark, agentKey: 1 },
+    { ...validBookmark, sessionId: 1 },
+    { ...validBookmark, fullPath: 1 },
+    { ...validBookmark, title: 1 },
+    { ...validBookmark, directory: 1 },
+    { ...validBookmark, time_created: "1" },
+    { ...validBookmark, time_updated: "2" },
+    { ...validBookmark, stats: null },
+    { ...validBookmark, stats: { ...validBookmark.stats, message_count: "1" } },
+    { ...validBookmark, stats: { ...validBookmark.stats, total_input_tokens: "2" } },
+    { ...validBookmark, stats: { ...validBookmark.stats, total_output_tokens: "3" } },
+    { ...validBookmark, stats: { ...validBookmark.stats, total_cost: "0.1" } },
+    { ...validBookmark, stats: { ...validBookmark.stats, total_tokens: "5" } },
+  ])("rejects invalid bookmark payload %#", async (body) => {
+    const c = makeContext({ body });
+
+    await handlePutBookmark(c as never);
+
+    expect(c.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
+    expect(coreMocks.upsertBookmark).not.toHaveBeenCalled();
+  });
+
+  it("stores valid bookmarks without transport-only fields", async () => {
+    const c = makeContext({ body: { ...validBookmark, bookmarked_at: 99 } });
+
+    await handlePutBookmark(c as never);
+
+    expect(coreMocks.upsertBookmark).toHaveBeenCalledWith(validBookmark);
+    expect(c.json).toHaveBeenCalledWith({ bookmark: storedBookmark, storageAvailable: true });
+  });
+
+  it("maps bookmark write availability errors and rethrows unexpected failures", async () => {
+    coreMocks.upsertBookmark.mockImplementationOnce(() => {
+      throw new BookmarkStorageUnavailableError();
+    });
+    const unavailable = makeContext({ body: validBookmark });
+    await handlePutBookmark(unavailable as never);
+    expect(unavailable.json).toHaveBeenCalledWith(
+      { error: "Bookmark storage is unavailable" },
+      503,
+    );
+
+    coreMocks.upsertBookmark.mockImplementationOnce(() => {
+      throw new Error("unexpected");
+    });
+    await expect(handlePutBookmark(makeContext({ body: validBookmark }) as never)).rejects.toThrow(
+      "unexpected",
+    );
+  });
+
+  it("validates and imports bookmark batches", async () => {
+    const nonArray = makeContext({ body: validBookmark });
+    await handleImportBookmarks(nonArray as never);
+    expect(nonArray.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
+
+    const mixed = makeContext({ body: [validBookmark, { invalid: true }] });
+    await handleImportBookmarks(mixed as never);
+    expect(mixed.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
+
+    const valid = makeContext({ body: [validBookmark] });
+    await handleImportBookmarks(valid as never);
+    expect(coreMocks.importBookmarks).toHaveBeenCalledWith([validBookmark]);
+    expect(valid.json).toHaveBeenCalledWith({
+      bookmarks: [storedBookmark],
+      storageAvailable: true,
+    });
+  });
+
+  it("maps bookmark import availability errors and rethrows unexpected failures", async () => {
+    coreMocks.importBookmarks.mockImplementationOnce(() => {
+      throw new BookmarkStorageUnavailableError();
+    });
+    const unavailable = makeContext({ body: [validBookmark] });
+    await handleImportBookmarks(unavailable as never);
+    expect(unavailable.json).toHaveBeenCalledWith(
+      { error: "Bookmark storage is unavailable" },
+      503,
+    );
+
+    coreMocks.importBookmarks.mockImplementationOnce(() => {
+      throw new Error("unexpected");
+    });
+    await expect(
+      handleImportBookmarks(makeContext({ body: [validBookmark] }) as never),
+    ).rejects.toThrow("unexpected");
+  });
+
+  it("validates bookmark identifiers before deleting", () => {
+    const missingAgent = makeContext({ param: { id: "s1" } });
+    handleDeleteBookmark(missingAgent as never);
+    expect(missingAgent.json).toHaveBeenCalledWith({ error: "Missing bookmark identifier" }, 400);
+
+    const missingSession = makeContext({ param: { agent: "codex" } });
+    handleDeleteBookmark(missingSession as never);
+    expect(missingSession.json).toHaveBeenCalledWith({ error: "Missing bookmark identifier" }, 400);
+    expect(coreMocks.deleteBookmark).not.toHaveBeenCalled();
+  });
+
+  it("deletes bookmarks and handles storage failures", () => {
+    const valid = makeContext({ param: { agent: "codex", id: "s1" } });
+    handleDeleteBookmark(valid as never);
+    expect(coreMocks.deleteBookmark).toHaveBeenCalledWith("codex", "s1");
+    expect(valid.json).toHaveBeenCalledWith({ ok: true, storageAvailable: true });
+
+    coreMocks.deleteBookmark.mockImplementationOnce(() => {
+      throw new BookmarkStorageUnavailableError();
+    });
+    const unavailable = makeContext({ param: { agent: "codex", id: "s1" } });
+    handleDeleteBookmark(unavailable as never);
+    expect(unavailable.json).toHaveBeenCalledWith(
+      { error: "Bookmark storage is unavailable" },
+      503,
+    );
+
+    coreMocks.deleteBookmark.mockImplementationOnce(() => {
+      throw new Error("unexpected");
+    });
+    expect(() =>
+      handleDeleteBookmark(makeContext({ param: { agent: "codex", id: "s1" } }) as never),
+    ).toThrow("unexpected");
+  });
+});
+
+describe("session alias handlers", () => {
+  it("validates alias payloads and identifiers", async () => {
+    const missingAgent = makeContext({ body: { alias: "Renamed" }, param: { id: "s1" } });
+    await handlePutSessionAlias(missingAgent as never);
+    expect(missingAgent.json).toHaveBeenCalledWith({ error: "Invalid session alias payload" }, 400);
+
+    const missingSession = makeContext({
+      body: { alias: "Renamed" },
+      param: { agent: "codex" },
+    });
+    await handlePutSessionAlias(missingSession as never);
+    expect(missingSession.json).toHaveBeenCalledWith(
+      { error: "Invalid session alias payload" },
+      400,
+    );
+
+    const invalidAlias = makeContext({
+      body: { alias: 42 },
+      param: { agent: "codex", id: "s1" },
+    });
+    await handlePutSessionAlias(invalidAlias as never);
+    expect(invalidAlias.json).toHaveBeenCalledWith({ error: "Invalid session alias payload" }, 400);
+  });
+
+  it("stores valid aliases and maps validation failures", async () => {
+    const valid = makeContext({
+      body: { alias: "Renamed" },
+      param: { agent: "codex", id: "s1" },
+    });
+    await handlePutSessionAlias(valid as never);
+    expect(coreMocks.upsertSessionAlias).toHaveBeenCalledWith("codex", "s1", "Renamed");
+
+    coreMocks.upsertSessionAlias.mockImplementationOnce(() => {
+      throw new TypeError("invalid alias");
+    });
+    const invalid = makeContext({
+      body: { alias: " " },
+      param: { agent: "codex", id: "s1" },
+    });
+    await handlePutSessionAlias(invalid as never);
+    expect(invalid.json).toHaveBeenCalledWith(
+      { error: "Session alias must be non-empty and at most 160 characters" },
+      400,
+    );
+  });
+
+  it("maps unavailable alias storage and rethrows unexpected write failures", async () => {
+    coreMocks.upsertSessionAlias.mockImplementationOnce(() => {
+      throw new StateStorageUnavailableError();
+    });
+    const unavailable = makeContext({
+      body: { alias: "Renamed" },
+      param: { agent: "codex", id: "s1" },
+    });
+    await handlePutSessionAlias(unavailable as never);
+    expect(unavailable.json).toHaveBeenCalledWith(
+      { error: "Session alias storage is unavailable" },
+      503,
+    );
+
+    coreMocks.upsertSessionAlias.mockImplementationOnce(() => {
+      throw new Error("unexpected");
+    });
+    await expect(
+      handlePutSessionAlias(
+        makeContext({
+          body: { alias: "Renamed" },
+          param: { agent: "codex", id: "s1" },
+        }) as never,
+      ),
+    ).rejects.toThrow("unexpected");
+  });
+
+  it("validates alias identifiers before deleting", () => {
+    const missingAgent = makeContext({ param: { id: "s1" } });
+    handleDeleteSessionAlias(missingAgent as never);
+    expect(missingAgent.json).toHaveBeenCalledWith(
+      { error: "Missing session alias identifier" },
+      400,
+    );
+
+    const missingSession = makeContext({ param: { agent: "codex" } });
+    handleDeleteSessionAlias(missingSession as never);
+    expect(missingSession.json).toHaveBeenCalledWith(
+      { error: "Missing session alias identifier" },
+      400,
+    );
+  });
+
+  it("deletes aliases and handles storage failures", () => {
+    const valid = makeContext({ param: { agent: "codex", id: "s1" } });
+    handleDeleteSessionAlias(valid as never);
+    expect(coreMocks.deleteSessionAlias).toHaveBeenCalledWith("codex", "s1");
+    expect(valid.json).toHaveBeenCalledWith({ ok: true });
+
+    coreMocks.deleteSessionAlias.mockImplementationOnce(() => {
+      throw new StateStorageUnavailableError();
+    });
+    const unavailable = makeContext({ param: { agent: "codex", id: "s1" } });
+    handleDeleteSessionAlias(unavailable as never);
+    expect(unavailable.json).toHaveBeenCalledWith(
+      { error: "Session alias storage is unavailable" },
+      503,
+    );
+
+    coreMocks.deleteSessionAlias.mockImplementationOnce(() => {
+      throw new Error("unexpected");
+    });
+    expect(() =>
+      handleDeleteSessionAlias(makeContext({ param: { agent: "codex", id: "s1" } }) as never),
+    ).toThrow("unexpected");
+  });
+});
+
+describe("query boundary handlers", () => {
+  it("rejects invalid project identities consistently", () => {
+    const sessions = makeContext({ query: { projectKind: "path" } });
+    handleGetSessions(sessions as never, scanSource);
+    expect(sessions.json).toHaveBeenCalledWith(
+      { error: "projectKind and projectKey must form a valid project identity" },
+      400,
+    );
+
+    const files = makeContext({ query: { projectKind: "invalid", projectKey: "/repo" } });
+    handleGetFileActivity(files as never);
+    expect(files.json).toHaveBeenCalledWith(
+      { error: "projectKind and projectKey must form a valid project identity" },
+      400,
+    );
+
+    const dashboard = makeContext({ query: { projectKey: "/repo" } });
+    handleGetDashboard(dashboard as never, scanSource);
+    expect(dashboard.json).toHaveBeenCalledWith(
+      { error: "projectKind and projectKey must form a valid project identity" },
+      400,
+    );
+  });
+
+  it("normalizes file activity filters and caps the result limit", () => {
+    const c = makeContext({
+      query: {
+        agent: " codex ",
+        sessionId: " s1 ",
+        projectKind: "path",
+        projectKey: "/repo",
+        project: " repo ",
+        cwd: " /repo ",
+        path: " src/index.ts ",
+        kind: "edit",
+        from: "2026-01-01T00:00:00.000Z",
+        to: "2026-01-02T00:00:00.000Z",
+        limit: "999",
+      },
+    });
+
+    handleGetFileActivity(c as never);
+
+    expect(coreMocks.listFileActivity).toHaveBeenCalledWith({
+      agent: "codex",
+      sessionId: "s1",
+      projectKind: "path",
+      projectKey: "/repo",
+      project: "repo",
+      cwd: "/repo",
+      path: "src/index.ts",
+      kind: "edit",
+      from: new Date("2026-01-01T00:00:00.000Z").getTime(),
+      to: new Date("2026-01-02T00:00:00.000Z").getTime(),
+      limit: 200,
+    });
+  });
+
+  it("uses safe defaults for invalid file activity filters", () => {
+    const c = makeContext({ query: { kind: "execute", limit: "invalid" } });
+
+    handleGetFileActivity(c as never);
+
+    expect(coreMocks.listFileActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: undefined, limit: 50 }),
+    );
+  });
+
+  it("derives dashboard days from custom and default windows", () => {
+    const custom = makeContext({
+      query: {
+        from: "2026-01-01T00:00:00.000Z",
+        to: "2026-01-03T00:00:00.000Z",
+      },
+    });
+    handleGetDashboard(custom as never, scanSource);
+    expect(getResponsePayload<{ window: unknown }>(custom).window).toEqual({
+      from: new Date("2026-01-01T00:00:00.000Z").getTime(),
+      to: new Date("2026-01-03T00:00:00.000Z").getTime(),
+      days: 2,
+    });
+
+    const fallback = makeContext({ query: { to: "2026-01-04T00:00:00.000Z" } });
+    handleGetDashboard(fallback as never, scanSource, {
+      from: new Date("2026-01-01T00:00:00.000Z").getTime(),
+    });
+    expect(getResponsePayload<{ window: { days: number } }>(fallback).window.days).toBe(3);
+  });
+
+  it("supports explicit all-time dashboard queries", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-03T00:00:00.000Z"));
+    const c = makeContext({ query: { days: "0" } });
+
+    handleGetDashboard(c as never, scanSource);
+
+    expect(getResponsePayload<{ window: unknown }>(c).window).toEqual({
+      from: undefined,
+      to: Date.now(),
+      days: 0,
+    });
+  });
+});

--- a/packages/cli/src/scan-refresh-worker-entry.test.ts
+++ b/packages/cli/src/scan-refresh-worker-entry.test.ts
@@ -1,0 +1,227 @@
+import type { BaseAgent, SessionHead, SessionSourceRef } from "@codesesh/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class FileSystemSessionSource {}
+
+  return {
+    workerData: {} as Record<string, unknown>,
+    postMessage: vi.fn(),
+    attachMissingProjectIdentities: vi.fn((sessions: SessionHead[]) => sessions),
+    createRegisteredAgents: vi.fn(),
+    ensureSessionTagsSync: vi.fn((_agent: BaseAgent, sessions: SessionHead[]) => ({ sessions })),
+    matchesScanWindow: vi.fn(() => true),
+    FileSystemSessionSource,
+  };
+});
+
+vi.mock("node:worker_threads", () => ({
+  parentPort: { postMessage: mocks.postMessage },
+  get workerData() {
+    return mocks.workerData;
+  },
+}));
+
+vi.mock("@codesesh/core", () => ({
+  attachMissingProjectIdentities: mocks.attachMissingProjectIdentities,
+  createRegisteredAgents: mocks.createRegisteredAgents,
+  ensureSessionTagsSync: mocks.ensureSessionTagsSync,
+  FileSystemSessionSource: mocks.FileSystemSessionSource,
+  matchesScanWindow: mocks.matchesScanWindow,
+}));
+
+function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: id,
+    directory: "/workspace",
+    time_created: Date.now(),
+    time_updated: Date.now(),
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Record<string, unknown> = {}) {
+  return Object.assign(new mocks.FileSystemSessionSource(), {
+    name: "codex",
+    isAvailable: vi.fn(() => true),
+    scan: vi.fn(() => []),
+    incrementalScan: vi.fn(() => []),
+    listSessionSources: vi.fn(() => []),
+    scanSessionSource: vi.fn(() => null),
+    getSessionData: vi.fn(),
+    getSessionMetaMap: vi.fn(() => new Map()),
+    setSessionMetaMap: vi.fn(),
+    ...overrides,
+  });
+}
+
+function setWorkerData(overrides: Record<string, unknown> = {}) {
+  mocks.workerData = {
+    agentName: "codex",
+    previousSessions: [],
+    changedIds: null,
+    scanOptions: { fast: true },
+    meta: {},
+    ...overrides,
+  };
+}
+
+async function runWorker() {
+  await import("./scan-refresh-worker.js");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.attachMissingProjectIdentities.mockImplementation((sessions) => sessions);
+  mocks.ensureSessionTagsSync.mockImplementation((_agent, sessions) => ({ sessions }));
+  mocks.matchesScanWindow.mockReturnValue(true);
+  setWorkerData();
+});
+
+describe("scan refresh worker entry", () => {
+  it("reports an unknown agent as an error", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([]);
+
+    await runWorker();
+
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", error: "Unknown agent: codex" }),
+    );
+  });
+
+  it("returns an empty result when the agent is unavailable", async () => {
+    const agent = makeAgent({ isAvailable: vi.fn(() => false) });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+
+    await runWorker();
+
+    expect(agent.setSessionMetaMap).toHaveBeenCalledWith(new Map());
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", sessions: [], meta: {} }),
+    );
+  });
+
+  it("runs a full scan and forwards progress", async () => {
+    const session = makeSession("fresh");
+    const scan = vi.fn(
+      (options: { onProgress: (progress: { agent: string; current: number }) => void }) => {
+        options.onProgress({ agent: "codex", current: 1 });
+        return [session];
+      },
+    );
+    const agent = makeAgent({
+      scan,
+      getSessionMetaMap: vi.fn(() => new Map([["fresh", { sourcePath: "/fresh" }]])),
+    });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+
+    await runWorker();
+
+    expect(mocks.postMessage).toHaveBeenNthCalledWith(1, {
+      type: "progress",
+      progress: { agent: "codex", current: 1 },
+    });
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "done",
+        sessions: [session],
+        meta: { fresh: { id: "fresh", sourcePath: "/fresh" } },
+      }),
+    );
+  });
+
+  it("runs an incremental scan for explicit changed ids", async () => {
+    const previous = makeSession("previous");
+    const updated = makeSession("updated");
+    const incrementalScan = vi.fn(() => Promise.resolve([updated]));
+    const agent = makeAgent({ incrementalScan });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    setWorkerData({ previousSessions: [previous], changedIds: ["previous"] });
+
+    await runWorker();
+
+    expect(incrementalScan).toHaveBeenCalledWith([previous], ["previous"]);
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", sessions: [updated] }),
+    );
+  });
+
+  it("synchronizes changed, removed, and out-of-window sources", async () => {
+    const unchanged = makeSession("unchanged");
+    const changed = makeSession("changed", { title: "old" });
+    const removed = makeSession("removed");
+    const outsideWindow = makeSession("outside");
+    const compatible = makeSession("compatible", { title: "same title" });
+    const updated = makeSession("changed", { title: "new" });
+    const refs: SessionSourceRef[] = [
+      {
+        sessionId: "unchanged",
+        sourcePath: "/unchanged",
+        fingerprint: "same",
+      },
+      {
+        sessionId: "changed",
+        sourcePath: "/changed",
+        fingerprint: "different",
+      },
+      {
+        sessionId: "compatible",
+        sourcePath: "/compatible",
+        fingerprint: JSON.stringify(["v2", 1, 42, null, "same title"]),
+      },
+      {
+        sessionId: "missing",
+        sourcePath: "/missing",
+        fingerprint: "new",
+      },
+    ];
+    const scanSessionSource = vi.fn((sourcePath: string) =>
+      sourcePath === "/changed" ? updated : null,
+    );
+    const agent = makeAgent({
+      listSessionSources: vi.fn(() => refs),
+      scanSessionSource,
+    });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.matchesScanWindow.mockImplementation((mtimeMs) => mtimeMs !== 5);
+    setWorkerData({
+      sourceSync: true,
+      previousSessions: [unchanged, changed, removed, outsideWindow, compatible],
+      scanOptions: { from: 1, fast: true },
+      meta: {
+        unchanged: { id: "unchanged", sourcePath: "/unchanged", sourceFingerprint: "same" },
+        changed: { id: "changed", sourcePath: "/changed", sourceFingerprint: "old" },
+        removed: { id: "removed", sourcePath: "/removed", sourceMtimeMs: 10 },
+        outside: { id: "outside", sourcePath: "/outside", sourceMtimeMs: 5 },
+        compatible: {
+          id: "compatible",
+          sourcePath: "/compatible",
+          sourceFingerprint: "legacy",
+          sourceMtimeMs: 42,
+        },
+      },
+    });
+
+    await runWorker();
+
+    expect(scanSessionSource).toHaveBeenCalledTimes(2);
+    expect(scanSessionSource).toHaveBeenCalledWith("/changed");
+    expect(scanSessionSource).toHaveBeenCalledWith("/missing");
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "done",
+        sessions: [unchanged, updated, outsideWindow, compatible],
+        changedIds: ["changed", "missing", "removed"],
+      }),
+    );
+  });
+});

--- a/packages/cli/src/scan-refresh-worker-entry.test.ts
+++ b/packages/cli/src/scan-refresh-worker-entry.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => {
     attachMissingProjectIdentities: vi.fn((sessions: SessionHead[]) => sessions),
     createRegisteredAgents: vi.fn(),
     ensureSessionTagsSync: vi.fn((_agent: BaseAgent, sessions: SessionHead[]) => ({ sessions })),
-    matchesScanWindow: vi.fn(() => true),
+    matchesScanWindow: vi.fn((_mtimeMs: number) => true),
     FileSystemSessionSource,
   };
 });

--- a/packages/cli/src/scan-status-model.test.ts
+++ b/packages/cli/src/scan-status-model.test.ts
@@ -2,6 +2,124 @@ import { describe, expect, it } from "vitest";
 import { ScanStatusModel } from "./scan-status-model.js";
 
 describe("ScanStatusModel", () => {
+  it("keeps empty batches idle and ignores phase changes while inactive", () => {
+    const model = new ScanStatusModel();
+
+    const status = model.startBatch([], "scanning", {});
+
+    expect(status).toEqual(
+      expect.objectContaining({
+        active: false,
+        phase: "idle",
+        totalAgents: 0,
+        startedAt: undefined,
+        completedAt: expect.any(Number),
+      }),
+    );
+    expect(model.setPhase("initializing")).toBeNull();
+  });
+
+  it("starts an implicit batch when an agent begins while idle", () => {
+    const model = new ScanStatusModel();
+
+    const status = model.beginAgent("codex", 3);
+
+    expect(status).toEqual(
+      expect.objectContaining({
+        active: true,
+        phase: "scanning",
+        pendingAgents: [],
+        scanningAgents: ["codex"],
+        totalAgents: 1,
+      }),
+    );
+    expect(status.agentStatuses.codex).toEqual(
+      expect.objectContaining({
+        status: "scanning",
+        processed: 0,
+        sessions: 3,
+        startedAt: expect.any(Number),
+      }),
+    );
+  });
+
+  it("preserves initialization and existing progress when an agent restarts", () => {
+    const model = new ScanStatusModel();
+    model.startBatch(["codex"], "initializing", {});
+    const firstStart = model.beginAgent("codex", 2);
+    model.updateAgent("codex", { total: 5, processed: 2 });
+
+    const restarted = model.beginAgent("codex", 9);
+
+    expect(firstStart.phase).toBe("initializing");
+    expect(restarted.phase).toBe("initializing");
+    expect(restarted.agentStatuses.codex).toEqual(
+      expect.objectContaining({
+        total: 5,
+        processed: 2,
+        sessions: 0,
+        startedAt: firstStart.agentStatuses.codex?.startedAt,
+      }),
+    );
+    expect(restarted.scanningAgents).toEqual(["codex"]);
+  });
+
+  it("ignores invalid progress and retains fields omitted from updates", () => {
+    const model = new ScanStatusModel();
+
+    expect(model.updateAgent("missing", { processed: 1 })).toBeNull();
+    model.beginAgent("codex", 2);
+    const unchanged = model.updateAgent("codex", {});
+    const updated = model.updateAgent("codex", { processed: 1 });
+    const complete = model.finishAgent("codex");
+
+    expect(unchanged?.agentStatuses.codex).toEqual(
+      expect.objectContaining({ total: undefined, processed: 0, sessions: 2 }),
+    );
+    expect(updated?.agentStatuses.codex).toEqual(
+      expect.objectContaining({ total: undefined, processed: 1, sessions: 2 }),
+    );
+    expect(complete.agentStatuses.codex).toEqual(
+      expect.objectContaining({ total: 1, processed: 1, sessions: 2 }),
+    );
+    expect(model.updateAgent("codex", { processed: 2 })).toBeNull();
+  });
+
+  it("completes unseen agents and normalizes unfinished statuses at batch end", () => {
+    const model = new ScanStatusModel();
+    const unseen = model.finishAgent("codex");
+
+    expect(unseen.agentStatuses.codex).toEqual(
+      expect.objectContaining({
+        status: "complete",
+        total: undefined,
+        processed: undefined,
+        sessions: 0,
+        startedAt: undefined,
+      }),
+    );
+
+    model.startBatch(["codex", "claude"], "scanning", {});
+    const codexComplete = model.finishAgent("codex");
+    const complete = model.finishBatch();
+
+    expect(complete).toEqual(
+      expect.objectContaining({
+        active: false,
+        phase: "idle",
+        pendingAgents: [],
+        scanningAgents: [],
+        completedAt: expect.any(Number),
+      }),
+    );
+    expect(complete.agentStatuses.codex?.completedAt).toBe(
+      codexComplete.agentStatuses.codex?.completedAt,
+    );
+    expect(complete.agentStatuses.claude).toEqual(
+      expect.objectContaining({ status: "complete", completedAt: expect.any(Number) }),
+    );
+  });
+
   it("models a complete multi-agent scan lifecycle", () => {
     const model = new ScanStatusModel();
 
@@ -9,6 +127,7 @@ describe("ScanStatusModel", () => {
       codex: 2,
       claude: 3,
     });
+    expect(model.setPhase("initializing")?.phase).toBe("initializing");
     model.beginAgent("codex", 2);
     model.updateAgent("codex", { total: 4, processed: 2, sessions: 3 });
     const firstComplete = model.finishAgent("codex", 4);

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  workerData: {} as Record<string, unknown>,
+  postMessage: vi.fn(),
+  createRegisteredAgents: vi.fn(),
+  getCachePath: vi.fn(() => "/cache"),
+  markAgentCacheInitialized: vi.fn(),
+  saveCachedSessionChanges: vi.fn(),
+  saveCachedSessions: vi.fn(),
+  setFtsIntegrityCheckedPath: vi.fn(),
+  syncSessionSearchIndex: vi.fn(),
+  syncSessionSearchIndexChanges: vi.fn(),
+}));
+
+vi.mock("node:worker_threads", () => ({
+  parentPort: { postMessage: mocks.postMessage },
+  get workerData() {
+    return mocks.workerData;
+  },
+}));
+
+vi.mock("@codesesh/core", () => ({
+  createRegisteredAgents: mocks.createRegisteredAgents,
+  getCachePath: mocks.getCachePath,
+  markAgentCacheInitialized: mocks.markAgentCacheInitialized,
+  saveCachedSessionChanges: mocks.saveCachedSessionChanges,
+  saveCachedSessions: mocks.saveCachedSessions,
+  setFtsIntegrityCheckedPath: mocks.setFtsIntegrityCheckedPath,
+  syncSessionSearchIndex: mocks.syncSessionSearchIndex,
+  syncSessionSearchIndexChanges: mocks.syncSessionSearchIndexChanges,
+}));
+
+function makeAgent() {
+  return {
+    name: "codex",
+    setSessionMetaMap: vi.fn(),
+    getSessionData: vi.fn((id: string) => ({ id })),
+  };
+}
+
+async function runWorker() {
+  await import("./search-index-worker.js");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.workerData = {
+    context: "refresh",
+    agentNames: [],
+    sessionsByAgent: {},
+    metaByAgent: {},
+  };
+});
+
+describe("search index worker", () => {
+  it("builds legacy full jobs and preserves the integrity-check state", async () => {
+    const agent = makeAgent();
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.syncSessionSearchIndex.mockImplementation(
+      (_name: string, _sessions: unknown[], readSession: (id: string) => unknown) => {
+        expect(readSession("s1")).toEqual({ id: "s1" });
+        return { indexed: 1, skipped: 0 };
+      },
+    );
+    mocks.workerData = {
+      context: "startup",
+      agentNames: ["codex", "unknown"],
+      sessionsByAgent: { codex: [{ id: "s1" }] },
+      metaByAgent: { codex: { s1: { id: "s1" } } },
+      skipFtsIntegrityCheck: true,
+    };
+
+    await runWorker();
+
+    expect(mocks.setFtsIntegrityCheckedPath).toHaveBeenCalledWith("/cache");
+    expect(agent.setSessionMetaMap).toHaveBeenCalledWith(new Map([["s1", { id: "s1" }]]));
+    expect(mocks.postMessage).toHaveBeenNthCalledWith(1, {
+      type: "sync-result",
+      context: "startup",
+      result: { indexed: 1, skipped: 0 },
+    });
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", context: "startup", sessions: 1 }),
+    );
+  });
+
+  it("saves a full cache and marks a completely indexed agent initialized", async () => {
+    const agent = makeAgent();
+    const sessions = [{ id: "s1" }, { id: "s2" }];
+    const meta = { s1: { id: "s1" } };
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.syncSessionSearchIndex.mockReturnValue({ indexed: 2, skipped: 0 });
+    mocks.workerData = {
+      context: "refresh",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [
+        {
+          kind: "full",
+          context: "codex-full",
+          agentName: "codex",
+          sessions,
+          meta,
+          saveCache: true,
+          searchIndexOptions: { force: true },
+        },
+      ],
+    };
+
+    await runWorker();
+
+    expect(mocks.saveCachedSessions).toHaveBeenCalledWith("codex", sessions, meta);
+    expect(mocks.syncSessionSearchIndex).toHaveBeenCalledWith(
+      "codex",
+      sessions,
+      expect.any(Function),
+      { force: true },
+    );
+    expect(mocks.markAgentCacheInitialized).toHaveBeenCalledWith("codex");
+  });
+
+  it("applies incremental index changes and reports processed sessions", async () => {
+    const agent = makeAgent();
+    const changes = [{ id: "updated", session: { id: "updated" } }];
+    const removedSessionIds = ["removed"];
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.syncSessionSearchIndexChanges.mockImplementation(
+      (
+        _name: string,
+        _changes: unknown[],
+        _removed: string[],
+        readSession: (id: string) => unknown,
+      ) => {
+        expect(readSession("updated")).toEqual({ id: "updated" });
+        return { indexed: 1, skipped: 0 };
+      },
+    );
+    mocks.workerData = {
+      context: "refresh",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [
+        {
+          kind: "changes",
+          context: "codex-changes",
+          agentName: "codex",
+          changes,
+          removedSessionIds,
+          meta: {},
+          searchIndexOptions: { force: true },
+        },
+      ],
+    };
+
+    await runWorker();
+
+    expect(mocks.saveCachedSessionChanges).toHaveBeenCalledWith(
+      "codex",
+      changes,
+      removedSessionIds,
+      {},
+    );
+    expect(mocks.syncSessionSearchIndexChanges).toHaveBeenCalledWith(
+      "codex",
+      changes,
+      removedSessionIds,
+      expect.any(Function),
+      { force: true },
+    );
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", sessions: 1 }),
+    );
+  });
+});

--- a/packages/cli/src/smart-tag-worker.test.ts
+++ b/packages/cli/src/smart-tag-worker.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  workerData: {} as Record<string, unknown>,
+  postMessage: vi.fn(),
+  createRegisteredAgents: vi.fn(),
+  classifySessionTags: vi.fn(() => ["bugfix"]),
+  getSmartTagSourceTimestamp: vi.fn(() => 42),
+}));
+
+vi.mock("node:worker_threads", () => ({
+  parentPort: { postMessage: mocks.postMessage },
+  get workerData() {
+    return mocks.workerData;
+  },
+}));
+
+vi.mock("@codesesh/core", () => ({
+  createRegisteredAgents: mocks.createRegisteredAgents,
+  classifySessionTags: mocks.classifySessionTags,
+  getSmartTagSourceTimestamp: mocks.getSmartTagSourceTimestamp,
+}));
+
+async function runWorker() {
+  await import("./smart-tag-worker.js");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.workerData = {
+    agentName: "codex",
+    sessionIds: [],
+    meta: {},
+  };
+});
+
+describe("smart tag worker", () => {
+  it("classifies sessions and isolates per-session failures", async () => {
+    const sessionData = { messages: [] };
+    const agent = {
+      name: "codex",
+      setSessionMetaMap: vi.fn(),
+      getSessionData: vi.fn((id: string) => {
+        if (id === "broken") throw new Error("cannot parse");
+        if (id === "invalid") throw "invalid session";
+        return sessionData;
+      }),
+    };
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.workerData = {
+      agentName: "codex",
+      sessionIds: ["ready", "broken", "invalid"],
+      meta: { ready: { sourcePath: "/ready" } },
+    };
+
+    await runWorker();
+
+    expect(agent.setSessionMetaMap).toHaveBeenCalledWith(
+      new Map([["ready", { sourcePath: "/ready" }]]),
+    );
+    expect(mocks.classifySessionTags).toHaveBeenCalledWith(sessionData);
+    expect(mocks.getSmartTagSourceTimestamp).toHaveBeenCalledWith(sessionData);
+    expect(mocks.postMessage).toHaveBeenCalledWith([
+      { id: "ready", tags: ["bugfix"], sourceUpdatedAt: 42 },
+      { id: "broken", error: "cannot parse" },
+      { id: "invalid", error: "invalid session" },
+    ]);
+  });
+
+  it("returns no results when the requested agent is unavailable", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([]);
+    mocks.workerData = {
+      agentName: "missing",
+      sessionIds: ["s1"],
+      meta: {},
+    };
+
+    await runWorker();
+
+    expect(mocks.postMessage).toHaveBeenCalledWith([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       reporter: ["text", "html"],
       thresholds: {
         statements: 88,
-        branches: 78,
+        branches: 80,
         functions: 88,
         lines: 91,
         [COVERAGE_THRESHOLD_SCOPE]: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,18 +22,18 @@ export default defineConfig({
       exclude: ["**/node_modules/**", "**/dist/**", "packages/core/src/utils/sqlite.ts"],
       reporter: ["text", "html"],
       thresholds: {
-        statements: 85,
-        branches: 75,
-        functions: 85,
-        lines: 88,
+        statements: 88,
+        branches: 78,
+        functions: 88,
+        lines: 91,
         [COVERAGE_THRESHOLD_SCOPE]: {
-          lines: 85,
-        },
-        [CLI_RUNTIME_SCOPE]: {
           lines: 90,
         },
+        [CLI_RUNTIME_SCOPE]: {
+          lines: 91,
+        },
         [WEB_HOOKS_SCOPE]: {
-          lines: 88,
+          lines: 95,
         },
         [WEB_INTERACTIONS_SCOPE]: {
           lines: 87,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,17 +22,21 @@ export default defineConfig({
       exclude: ["**/node_modules/**", "**/dist/**", "packages/core/src/utils/sqlite.ts"],
       reporter: ["text", "html"],
       thresholds: {
+        statements: 85,
+        branches: 75,
+        functions: 85,
+        lines: 88,
         [COVERAGE_THRESHOLD_SCOPE]: {
-          lines: 75,
+          lines: 85,
         },
         [CLI_RUNTIME_SCOPE]: {
-          lines: 78,
+          lines: 90,
         },
         [WEB_HOOKS_SCOPE]: {
-          lines: 63,
+          lines: 88,
         },
         [WEB_INTERACTIONS_SCOPE]: {
-          lines: 76,
+          lines: 87,
         },
       },
     },


### PR DESCRIPTION
## Summary

- add focused unit tests for CLI worker entrypoints, scan status transitions, API state handling, dashboard states, navigation interactions, and web hook failure paths
- cover bookmark cancellation and timestamp fallbacks plus virtual message list scrolling and cleanup branches
- enforce scoped coverage thresholds and raise the global branch coverage gate from 78% to 80%

## Impact

This change improves regression protection across CLI and web behavior without changing production code. Overall branch coverage increases from 78.53% to 80.13%, with 43 additional branches covered.

## Coverage

- Statements: 89.91% (3737/4156)
- Branches: 80.13% (2158/2693)
- Functions: 89.86% (798/888)
- Lines: 92.50% (3467/3748)

## Validation

- `pnpm test:coverage` — 94 files, 774 tests passed
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
