### PR TITLE
feat(web): refine navigation and transient motion

### DIFF
--- a/apps/web/src/components/DrawerDialog.test.tsx
+++ b/apps/web/src/components/DrawerDialog.test.tsx
@@ -1,0 +1,18 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DrawerDialog } from "./DrawerDialog";
+
+afterEach(cleanup);
+
+describe("DrawerDialog", () => {
+  it("uses the shared backdrop and drawer motion primitives", () => {
+    render(
+      <DrawerDialog open onOpenChange={vi.fn()} title="Test drawer" variant="mobile">
+        Drawer content
+      </DrawerDialog>,
+    );
+
+    expect(document.querySelector(".motion-backdrop")).not.toBeNull();
+    expect(document.querySelector(".motion-drawer")).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/DrawerDialog.tsx
+++ b/apps/web/src/components/DrawerDialog.tsx
@@ -31,9 +31,9 @@ export function DrawerDialog({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Backdrop className={`fixed inset-0 ${styles.backdrop}`} />
+        <Dialog.Backdrop className={`motion-backdrop fixed inset-0 ${styles.backdrop}`} />
         <Dialog.Popup
-          className={`fixed bottom-0 right-0 top-0 overscroll-contain border-l border-[var(--console-border)] bg-[var(--console-bg)] shadow-[-12px_0_32px_rgba(15,23,42,0.18)] outline-none ${styles.popup}`}
+          className={`motion-drawer fixed bottom-0 right-0 top-0 overscroll-contain border-l border-[var(--console-border)] bg-[var(--console-bg)] shadow-[-12px_0_32px_rgba(15,23,42,0.18)] outline-none ${styles.popup}`}
         >
           <div className="mb-3 flex items-center justify-between gap-3">
             <Dialog.Title className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">

--- a/apps/web/src/components/SessionAliasDialog.test.tsx
+++ b/apps/web/src/components/SessionAliasDialog.test.tsx
@@ -23,6 +23,8 @@ describe("SessionAliasDialog", () => {
     expect((screen.getByRole("textbox", { name: "Session title" }) as HTMLInputElement).value).toBe(
       "Current custom title",
     );
+    expect(document.querySelector(".motion-backdrop")).not.toBeNull();
+    expect(screen.getByRole("dialog").className).toContain("motion-modal");
     expect(screen.queryByText(/Original title/)).toBeNull();
   });
 

--- a/apps/web/src/components/SessionAliasDialog.tsx
+++ b/apps/web/src/components/SessionAliasDialog.tsx
@@ -63,8 +63,8 @@ export function SessionAliasDialog({
   return (
     <Dialog.Root open={target !== null} onOpenChange={(open) => (!open ? onClose() : undefined)}>
       <Dialog.Portal>
-        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/35" />
-        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
+        <Dialog.Backdrop className="motion-backdrop fixed inset-0 z-50 bg-black/35" />
+        <Dialog.Popup className="motion-modal fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
           <Dialog.Title className="console-mono text-sm font-semibold text-[var(--console-text)]">
             Rename session
           </Dialog.Title>

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -28,6 +28,10 @@ import {
   SessionDetailAuxOverlay,
 } from "./session-detail/session-detail-aux";
 import { SessionMessageTimeline } from "./session-detail/session-message-timeline";
+import {
+  resolveReducedMotionScrollBehavior,
+  type SessionAnchorScrollBehavior,
+} from "./session-detail/scroll-behavior";
 import { buildSessionTimelineEntries } from "./session-detail/timeline";
 
 // ---------------------------------------------------------------------------
@@ -50,11 +54,15 @@ function scrollToSessionAnchor({
   isCurrent,
 }: {
   anchorId: string;
-  behavior: ScrollBehavior;
+  behavior: SessionAnchorScrollBehavior;
   prepareAnchor?: () => void;
   isCurrent: () => boolean;
 }) {
   if (typeof document === "undefined") return;
+  const scrollBehavior = resolveReducedMotionScrollBehavior(
+    behavior,
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
   let element = document.getElementById(anchorId);
   if (!element && prepareAnchor) {
     prepareAnchor();
@@ -63,7 +71,7 @@ function scrollToSessionAnchor({
       if (!isCurrent()) return;
       element = document.getElementById(anchorId);
       if (element) {
-        element.scrollIntoView({ behavior, block: "center" });
+        element.scrollIntoView({ behavior: scrollBehavior, block: "center" });
         return;
       }
       attempts += 1;
@@ -73,7 +81,7 @@ function scrollToSessionAnchor({
     return;
   }
   if (!element) return;
-  element.scrollIntoView({ behavior, block: "center" });
+  element.scrollIntoView({ behavior: scrollBehavior, block: "center" });
 }
 
 function measureSessionDetailWork<T>(id: string, compute: () => T): T {
@@ -171,7 +179,7 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
     [filteredMessages, toolAnchorIds],
   );
   const handleJumpToMessageAnchor = useCallback(
-    (anchorId: string, messageIndex: number | undefined, behavior: ScrollBehavior = "smooth") => {
+    (anchorId: string, messageIndex: number | undefined, behavior: SessionAnchorScrollBehavior) => {
       const requestId = scrollRequestRef.current + 1;
       scrollRequestRef.current = requestId;
       const listIndex = messageIndex == null ? undefined : anchorListIndexes.get(messageIndex);
@@ -186,8 +194,8 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
     [anchorListIndexes],
   );
   const handleJumpToAnchor = useCallback(
-    (anchorId: string) => {
-      handleJumpToMessageAnchor(anchorId, anchorMessageIndexes.get(anchorId));
+    (anchorId: string, behavior: SessionAnchorScrollBehavior) => {
+      handleJumpToMessageAnchor(anchorId, anchorMessageIndexes.get(anchorId), behavior);
     },
     [anchorMessageIndexes, handleJumpToMessageAnchor],
   );
@@ -210,7 +218,7 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
   return (
     <div
       data-testid="session-detail"
-      className="mx-auto w-full max-w-[1440px] space-y-8 px-2 md:px-4 animate-in fade-in slide-in-from-bottom-2 duration-300"
+      className="mx-auto w-full max-w-[1440px] space-y-8 px-2 md:px-4"
     >
       <SessionSummarySection
         summary={typeof session.summary_files === "string" ? session.summary_files : undefined}
@@ -233,9 +241,9 @@ export function SessionDetail({ session, highlightQuery }: SessionDetailProps) {
               return toggleTocFilter(current, filterId, toc);
             })
           }
-          onJumpToAnchor={(anchorId) => {
+          onJumpToAnchor={(anchorId, behavior) => {
             setOpenAuxPanel(null);
-            handleJumpToAnchor(anchorId);
+            handleJumpToAnchor(anchorId, behavior);
           }}
         />
         <SessionToc

--- a/apps/web/src/components/SessionDetailSkeleton.tsx
+++ b/apps/web/src/components/SessionDetailSkeleton.tsx
@@ -27,18 +27,25 @@ export function SessionDetailSkeleton() {
             <div className="flex gap-4">
               <div className="shrink-0 pt-1">
                 <div className="flex size-8 items-center justify-center rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)]">
-                  <div className="size-3.5 rounded-sm bg-[var(--console-border-strong)] animate-pulse" />
+                  <div className="size-3.5 rounded-sm bg-[var(--console-border-strong)] animate-pulse motion-reduce:animate-none" />
                 </div>
               </div>
               <div className="min-w-0 flex-1 space-y-3">
                 <div className="flex items-center gap-3">
-                  <SkeletonBlock className={`${item.roleWidth} h-3 animate-pulse`} />
-                  <SkeletonBlock className={`${item.timeWidth} h-2.5 animate-pulse`} />
+                  <SkeletonBlock
+                    className={`${item.roleWidth} h-3 animate-pulse motion-reduce:animate-none`}
+                  />
+                  <SkeletonBlock
+                    className={`${item.timeWidth} h-2.5 animate-pulse motion-reduce:animate-none`}
+                  />
                 </div>
                 <div className="rounded-sm border border-[var(--console-border)] bg-white p-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
                   <div className="space-y-2">
                     {item.bodyWidths.map((w) => (
-                      <SkeletonBlock key={`${item.id}-${w}`} className={`${w} h-3 animate-pulse`} />
+                      <SkeletonBlock
+                        key={`${item.id}-${w}`}
+                        className={`${w} h-3 animate-pulse motion-reduce:animate-none`}
+                      />
                     ))}
                   </div>
                 </div>
@@ -47,7 +54,7 @@ export function SessionDetailSkeleton() {
           </article>
         ))}
       </div>
-      <div className="min-h-24 flex-1 rounded-sm border border-[var(--console-border)] bg-white/60 animate-pulse" />
+      <div className="min-h-24 flex-1 rounded-sm border border-[var(--console-border)] bg-white/60 animate-pulse motion-reduce:animate-none" />
     </div>
   );
 }

--- a/apps/web/src/components/TimeWindowControl.tsx
+++ b/apps/web/src/components/TimeWindowControl.tsx
@@ -77,8 +77,8 @@ export function TimeWindowControl({
 
       <Dialog.Root open={customOpen} onOpenChange={setCustomOpen}>
         <Dialog.Portal>
-          <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/35" />
-          <Dialog.Popup className="fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
+          <Dialog.Backdrop className="motion-backdrop fixed inset-0 z-50 bg-black/35" />
+          <Dialog.Popup className="motion-modal fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
             <Dialog.Title className="console-mono text-sm font-semibold text-[var(--console-text)]">
               Custom time range
             </Dialog.Title>

--- a/apps/web/src/components/session-detail/file-change-tracker.test.tsx
+++ b/apps/web/src/components/session-detail/file-change-tracker.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FileChangeSummary } from "./file-change";
+import { FileChangeTracker } from "./file-change-tracker";
+
+const summary: FileChangeSummary = {
+  read: [
+    {
+      path: "/workspace/README.md",
+      count: 1,
+      latestTime: 1,
+      latestAnchorId: "tool-1-0",
+      toolLabel: "Read",
+      anchors: [{ anchorId: "tool-1-0", time: 1, toolLabel: "Read" }],
+    },
+  ],
+  edit: [],
+  write: [],
+  delete: [],
+};
+
+afterEach(cleanup);
+
+describe("FileChangeTracker", () => {
+  it("uses smooth scrolling for pointer activation", () => {
+    const onJumpToAnchor = vi.fn();
+    const view = render(
+      <FileChangeTracker
+        summary={summary}
+        baseDirectory="/workspace"
+        onJumpToAnchor={onJumpToAnchor}
+      />,
+    );
+
+    fireEvent.click(view.getByRole("button", { name: /Read/ }));
+    fireEvent.click(view.getByTitle("/workspace/README.md"), { detail: 1 });
+
+    expect(onJumpToAnchor).toHaveBeenCalledWith("tool-1-0", "smooth");
+  });
+
+  it("uses immediate scrolling for keyboard activation", () => {
+    const onJumpToAnchor = vi.fn();
+    const view = render(
+      <FileChangeTracker
+        summary={summary}
+        baseDirectory="/workspace"
+        onJumpToAnchor={onJumpToAnchor}
+      />,
+    );
+
+    fireEvent.click(view.getByRole("button", { name: /Read/ }));
+    fireEvent.click(view.getByTitle("/workspace/README.md"), { detail: 0 });
+
+    expect(onJumpToAnchor).toHaveBeenCalledWith("tool-1-0", "auto");
+  });
+});

--- a/apps/web/src/components/session-detail/file-change-tracker.tsx
+++ b/apps/web/src/components/session-detail/file-change-tracker.tsx
@@ -11,6 +11,11 @@ import {
 } from "lucide-react";
 import type { FileChangeKind, FileChangeSummary, FileChangeSummaryItem } from "./file-change";
 import { formatTrackedPath } from "./path-extract";
+import {
+  getActivationScrollBehavior,
+  type SessionAnchorScrollBehavior,
+  type SessionAnchorScrollHandler,
+} from "./scroll-behavior";
 
 export function getFileTrackerItemCount(summary: FileChangeSummary) {
   return summary.read.length + summary.edit.length + summary.write.length + summary.delete.length;
@@ -23,7 +28,7 @@ export function FileChangeTracker({
 }: {
   summary: FileChangeSummary;
   baseDirectory: string;
-  onJumpToAnchor: (anchorId: string) => void;
+  onJumpToAnchor: SessionAnchorScrollHandler;
 }) {
   const sections = [
     { key: "read" as const, label: "Read", Icon: FileSearch, items: summary.read },
@@ -74,7 +79,7 @@ function FileTrackerSection({
   Icon: typeof LoaderCircle;
   items: FileChangeSummaryItem[];
   baseDirectory: string;
-  onJumpToAnchor: (anchorId: string) => void;
+  onJumpToAnchor: SessionAnchorScrollHandler;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -121,18 +126,18 @@ function FileTrackerItem({
 }: {
   item: FileChangeSummaryItem;
   baseDirectory: string;
-  onJumpToAnchor: (anchorId: string) => void;
+  onJumpToAnchor: SessionAnchorScrollHandler;
 }) {
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  function jumpToIndex(nextIndex: number) {
+  function jumpToIndex(nextIndex: number, behavior: SessionAnchorScrollBehavior) {
     const total = item.anchors.length;
     if (total === 0) return;
     const normalizedIndex = ((nextIndex % total) + total) % total;
     setCurrentIndex(normalizedIndex);
     const anchor = item.anchors[normalizedIndex];
     if (anchor) {
-      onJumpToAnchor(anchor.anchorId);
+      onJumpToAnchor(anchor.anchorId, behavior);
     }
   }
 
@@ -141,7 +146,7 @@ function FileTrackerItem({
       <button
         type="button"
         title={item.path}
-        onClick={() => jumpToIndex(currentIndex)}
+        onClick={(event) => jumpToIndex(currentIndex, getActivationScrollBehavior(event.detail))}
         className="min-w-0 flex-1 text-left"
       >
         <span className="console-mono block break-all text-xs text-[var(--console-text)]">
@@ -153,7 +158,9 @@ function FileTrackerItem({
           <button
             type="button"
             aria-label={`Previous ${item.path}`}
-            onClick={() => jumpToIndex(currentIndex - 1)}
+            onClick={(event) =>
+              jumpToIndex(currentIndex - 1, getActivationScrollBehavior(event.detail))
+            }
             className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-white"
           >
             <ChevronUp className="size-3" />
@@ -164,7 +171,9 @@ function FileTrackerItem({
           <button
             type="button"
             aria-label={`Next ${item.path}`}
-            onClick={() => jumpToIndex(currentIndex + 1)}
+            onClick={(event) =>
+              jumpToIndex(currentIndex + 1, getActivationScrollBehavior(event.detail))
+            }
             className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-white"
           >
             <ChevronDown className="size-3" />
@@ -174,7 +183,7 @@ function FileTrackerItem({
         <button
           type="button"
           title="Jump to tool call"
-          onClick={() => jumpToIndex(0)}
+          onClick={(event) => jumpToIndex(0, getActivationScrollBehavior(event.detail))}
           className="console-mono shrink-0 text-[10px] text-[var(--console-muted)]"
         >
           {item.count}

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -507,7 +507,9 @@ function ToolItem({
         <span
           className={`console-mono inline-flex items-center gap-1 rounded-sm border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${statusMeta.className}`}
         >
-          <StatusIcon className={`size-3 ${state.status === "running" ? "animate-spin" : ""}`} />
+          <StatusIcon
+            className={`size-3 ${state.status === "running" ? "animate-spin motion-reduce:animate-none" : ""}`}
+          />
           {statusMeta.label}
         </span>
       </div>

--- a/apps/web/src/components/session-detail/scroll-behavior.test.ts
+++ b/apps/web/src/components/session-detail/scroll-behavior.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getActivationScrollBehavior, resolveReducedMotionScrollBehavior } from "./scroll-behavior";
+
+describe("getActivationScrollBehavior", () => {
+  it("uses immediate scrolling for keyboard activation", () => {
+    expect(getActivationScrollBehavior(0)).toBe("auto");
+  });
+
+  it("uses smooth scrolling for pointer activation", () => {
+    expect(getActivationScrollBehavior(1)).toBe("smooth");
+  });
+});
+
+describe("resolveReducedMotionScrollBehavior", () => {
+  it("removes smooth scrolling when reduced motion is enabled", () => {
+    expect(resolveReducedMotionScrollBehavior("smooth", true)).toBe("auto");
+  });
+
+  it("preserves the requested behavior otherwise", () => {
+    expect(resolveReducedMotionScrollBehavior("smooth", false)).toBe("smooth");
+    expect(resolveReducedMotionScrollBehavior("auto", true)).toBe("auto");
+  });
+});

--- a/apps/web/src/components/session-detail/scroll-behavior.ts
+++ b/apps/web/src/components/session-detail/scroll-behavior.ts
@@ -1,0 +1,17 @@
+export type SessionAnchorScrollBehavior = "auto" | "smooth";
+
+export type SessionAnchorScrollHandler = (
+  anchorId: string,
+  behavior: SessionAnchorScrollBehavior,
+) => void;
+
+export function getActivationScrollBehavior(eventDetail: number): SessionAnchorScrollBehavior {
+  return eventDetail === 0 ? "auto" : "smooth";
+}
+
+export function resolveReducedMotionScrollBehavior(
+  behavior: SessionAnchorScrollBehavior,
+  prefersReducedMotion: boolean,
+): SessionAnchorScrollBehavior {
+  return behavior === "smooth" && prefersReducedMotion ? "auto" : behavior;
+}

--- a/apps/web/src/components/session-detail/session-detail-aux.tsx
+++ b/apps/web/src/components/session-detail/session-detail-aux.tsx
@@ -7,6 +7,7 @@ import { DrawerDialog } from "../DrawerDialog";
 import type { SessionDetailToc } from "./toc";
 import type { FileChangeSummary } from "./file-change";
 import { FileChangeTracker, getFileTrackerItemCount } from "./file-change-tracker";
+import type { SessionAnchorScrollHandler } from "./scroll-behavior";
 import { SessionTocFilterPanel } from "./session-toc";
 
 export function DeferredInteractiveReceipt({
@@ -126,7 +127,7 @@ export function SessionDetailAuxOverlay({
   selectedFilters: Set<string>;
   onClose: () => void;
   onToggle: (filterId: string) => void;
-  onJumpToAnchor: (anchorId: string) => void;
+  onJumpToAnchor: SessionAnchorScrollHandler;
 }) {
   useEffect(() => {
     if (!openPanel) return;

--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -52,7 +52,7 @@ describe("SessionMessageTimeline", () => {
 
     fireEvent.pointerDown(target, { button: 0, clientX: 250, pointerId: 1 });
     fireEvent.pointerUp(target, { button: 0, clientX: 250, pointerId: 1 });
-    fireEvent.click(target, { clientX: 250 });
+    fireEvent.click(target, { clientX: 250, detail: 1 });
 
     expect(onNavigate).toHaveBeenCalledOnce();
     expect(onNavigate).toHaveBeenCalledWith(entries[2], "smooth");
@@ -61,9 +61,18 @@ describe("SessionMessageTimeline", () => {
   it("maps clicks between blocks to the timeline position", () => {
     const { onNavigate, track } = renderTimeline();
 
-    fireEvent.click(track, { clientX: 250 });
+    fireEvent.click(track, { clientX: 250, detail: 1 });
 
     expect(onNavigate).toHaveBeenCalledWith(entries[2], "smooth");
+  });
+
+  it("uses immediate scrolling for keyboard activation", () => {
+    const { getAllByRole, onNavigate } = renderTimeline();
+    const target = getAllByRole("button")[1]!;
+
+    fireEvent.click(target, { detail: 0 });
+
+    expect(onNavigate).toHaveBeenCalledWith(entries[1], "auto");
   });
 
   it("captures the pointer only after drag intent is clear", () => {

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -16,13 +16,13 @@ import {
   type SessionTimelineEntry,
   type SessionTimelineEntryKind,
 } from "./timeline";
+import { getActivationScrollBehavior, type SessionAnchorScrollBehavior } from "./scroll-behavior";
 
-type TimelineScrollBehavior = "auto" | "smooth";
 type ScrollParent = HTMLElement | Window;
 
 interface SessionMessageTimelineProps {
   entries: SessionTimelineEntry[];
-  onNavigate: (entry: SessionTimelineEntry, behavior: TimelineScrollBehavior) => void;
+  onNavigate: (entry: SessionTimelineEntry, behavior: SessionAnchorScrollBehavior) => void;
 }
 
 interface TimelineTooltip {
@@ -362,7 +362,7 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
   }, []);
 
   const navigateFromPointer = useCallback(
-    (clientX: number, behavior: TimelineScrollBehavior) => {
+    (clientX: number, behavior: SessionAnchorScrollBehavior) => {
       const track = trackRef.current;
       if (!track) return;
       const rect = track.getBoundingClientRect();
@@ -435,6 +435,7 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
               }}
               onClick={(event) => {
                 if (suppressClickRef.current) return;
+                const behavior = getActivationScrollBehavior(event.detail);
 
                 const indexValue = (event.target as HTMLElement).closest<HTMLButtonElement>(
                   "[data-timeline-index]",
@@ -443,10 +444,10 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
                 const entry =
                   index == null || !Number.isInteger(index) ? undefined : entries[index];
                 if (entry) {
-                  onNavigate(entry, "smooth");
+                  onNavigate(entry, behavior);
                   return;
                 }
-                navigateFromPointer(event.clientX, "smooth");
+                navigateFromPointer(event.clientX, behavior);
               }}
             >
               {entries.map((entry, index) => {

--- a/apps/web/src/components/session-detail/session-toc.tsx
+++ b/apps/web/src/components/session-detail/session-toc.tsx
@@ -3,6 +3,7 @@ import { Check, Funnel, Minus } from "lucide-react";
 import type { SessionDetailToc, TocFilterId } from "./toc";
 import type { FileChangeSummary } from "./file-change";
 import { FileChangeTracker } from "./file-change-tracker";
+import type { SessionAnchorScrollHandler } from "./scroll-behavior";
 
 const TOC_META: Array<{ id: TocFilterId; label: string }> = [
   { id: "user", label: "User" },
@@ -118,7 +119,7 @@ export function SessionToc({
   baseDirectory: string;
   selectedFilters: Set<string>;
   onToggle: (filterId: string) => void;
-  onJumpToAnchor: (anchorId: string) => void;
+  onJumpToAnchor: SessionAnchorScrollHandler;
 }) {
   return (
     <aside className="console-scrollbar hidden min-[1025px]:sticky min-[1025px]:top-4 min-[1025px]:block min-[1025px]:max-h-[calc(100dvh-14rem)] min-[1025px]:overflow-y-auto min-[1025px]:overscroll-contain">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -135,6 +135,8 @@
     --timeline-user: #a85f82;
     --timeline-agent: #5e86aa;
     --timeline-tool: #a3a3a3;
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
     --tt-in-dur: 150ms;
     --tt-out-dur: 50ms;
     --tt-scale: 0.98;
@@ -199,19 +201,70 @@
   }
 
   .shortcut-overlay[data-open] {
-    animation: shortcut-overlay-in 200ms cubic-bezier(0.23, 1, 0.32, 1);
+    animation: shortcut-overlay-in 200ms var(--ease-out);
   }
 
   .shortcut-overlay[data-closed] {
-    animation: shortcut-overlay-out 150ms cubic-bezier(0.23, 1, 0.32, 1);
+    animation: shortcut-overlay-out 150ms var(--ease-out);
   }
 
   .shortcut-content[data-open] {
-    animation: shortcut-content-in 200ms cubic-bezier(0.23, 1, 0.32, 1);
+    animation: shortcut-content-in 200ms var(--ease-out);
   }
 
   .shortcut-content[data-closed] {
-    animation: shortcut-content-out 150ms cubic-bezier(0.23, 1, 0.32, 1);
+    animation: shortcut-content-out 150ms var(--ease-out);
+  }
+
+  .motion-backdrop {
+    opacity: 1;
+    transition: opacity 200ms var(--ease-out);
+  }
+
+  .motion-backdrop[data-starting-style] {
+    opacity: 0;
+  }
+
+  .motion-backdrop[data-ending-style] {
+    opacity: 0;
+    transition-duration: 150ms;
+  }
+
+  .motion-modal {
+    opacity: 1;
+    scale: 1;
+    transform-origin: center;
+    transition:
+      opacity 200ms var(--ease-out),
+      scale 200ms var(--ease-out);
+  }
+
+  .motion-modal[data-starting-style],
+  .motion-modal[data-ending-style] {
+    opacity: 0;
+    scale: 0.96;
+  }
+
+  .motion-modal[data-ending-style] {
+    transition-duration: 150ms;
+  }
+
+  .motion-drawer {
+    opacity: 1;
+    transform: translateX(0);
+    transition:
+      opacity 200ms var(--ease-out),
+      transform 260ms var(--ease-drawer);
+  }
+
+  .motion-drawer[data-starting-style],
+  .motion-drawer[data-ending-style] {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+
+  .motion-drawer[data-ending-style] {
+    transition-duration: 180ms;
   }
 
   .t-tt-wrap {
@@ -317,6 +370,24 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .motion-backdrop,
+  .motion-modal,
+  .motion-drawer {
+    transition: opacity 150ms var(--ease-out);
+  }
+
+  .motion-modal,
+  .motion-modal[data-starting-style],
+  .motion-modal[data-ending-style] {
+    scale: 1;
+  }
+
+  .motion-drawer,
+  .motion-drawer[data-starting-style],
+  .motion-drawer[data-ending-style] {
+    transform: none;
+  }
+
   .shortcut-content[data-open] {
     animation-name: shortcut-overlay-in;
   }

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -122,6 +122,14 @@ test("persists the selected time range across navigation", async ({ page }) => {
   await range.selectOption("custom");
   const dialog = page.getByRole("dialog", { name: "Custom time range" });
   await expect(dialog).toBeVisible();
+  await expect
+    .poll(() =>
+      dialog.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return `${style.transitionProperty}|${style.transitionDuration}|${style.scale}`;
+      }),
+    )
+    .toBe("opacity, scale|0.2s, 0.2s|1");
   await dialog.getByLabel("From").fill("2026-04-01");
   await dialog.getByLabel("To").fill("2026-04-30");
   await dialog.getByRole("button", { name: "Apply range" }).click();
@@ -149,6 +157,14 @@ test("keeps detail drawers modal and restores focus", async ({ page }) => {
   await receiptTrigger.click();
   const receiptDialog = page.getByRole("dialog", { name: "Session Receipt" });
   await expect(receiptDialog).toBeVisible();
+  await expect
+    .poll(() =>
+      receiptDialog.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return `${style.transitionProperty}|${style.transitionDuration}`;
+      }),
+    )
+    .toBe("opacity, transform|0.2s, 0.26s");
   await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
   await expect(page.getByRole("button", { name: "Close session receipt" })).toBeFocused();
   await page.keyboard.press("Tab");
@@ -182,6 +198,17 @@ test("renders a static receipt for reduced motion", async ({ page }) => {
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/claudecode/e2e-dashboard");
   await page.getByRole("button", { name: "Open session receipt" }).click();
+
+  const receiptDialog = page.getByRole("dialog", { name: "Session Receipt" });
+  await expect(receiptDialog).toBeVisible();
+  await expect
+    .poll(() =>
+      receiptDialog.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return `${style.transitionProperty}|${style.transitionDuration}|${style.transform}`;
+      }),
+    )
+    .toBe("opacity|0.15s|none");
 
   const receiptCanvas = page.locator('canvas[aria-hidden="true"].fixed');
   const receiptHitSurface = page.locator(


### PR DESCRIPTION
## Summary

- remove the repeated session-detail entrance animation and make anchor navigation input-aware
- respect reduced-motion preferences for scrolling, loading indicators, modals, and drawers
- add interruptible Base UI lifecycle transitions for transient surfaces
- cover pointer, keyboard, normal-motion, and reduced-motion behavior with unit and Chromium tests

## Why

High-frequency session navigation was replaying a 300 ms page entrance and keyboard-triggered anchor jumps were always smooth. At the same time, lower-frequency dialogs and drawers appeared without spatial transitions. This aligns motion with interaction frequency and preserves accessibility preferences without adding parallel React animation state.

## Validation

- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web build`
- `pnpm test:e2e --project web-chromium`

Tracks CS-52.