### PR TITLE
Fix route-derived navigation state

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -175,10 +175,13 @@ export default function App() {
   const openedSessionProjectIdentity =
     openedSessionData?.project_identity ?? openedSessionHead?.project_identity ?? null;
   const selectedProjectNavigationIdentity =
-    browseBy === "projects"
-      ? (activeProjectIdentity ??
-        (viewState.mode === "session" ? openedSessionProjectIdentity : selectedProjectIdentity))
-      : null;
+    browseBy !== "projects"
+      ? null
+      : viewState.mode === "project"
+        ? activeProjectIdentity
+        : viewState.mode === "session"
+          ? openedSessionProjectIdentity
+          : null;
   const selectedProjectNavigationId = selectedProjectNavigationIdentity
     ? getProjectIdentityKey(selectedProjectNavigationIdentity)
     : null;
@@ -573,15 +576,7 @@ export default function App() {
               </nav>
               <div className="flex items-center gap-2">
                 <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-1.5 py-0.5 text-[10px] font-bold uppercase text-[var(--console-muted)]">
-                  {viewState.mode === "session"
-                    ? "Session"
-                    : viewState.mode === "root"
-                      ? "Dashboard"
-                      : viewState.mode === "projects"
-                        ? "Projects"
-                        : viewState.mode === "project"
-                          ? "Project"
-                          : "Landing"}
+                  {routeHeader.contextLabel}
                 </span>
                 <h1 className="console-mono text-xl font-semibold tracking-tight text-[var(--console-text)]">
                   {routeHeader.title}

--- a/apps/web/src/lib/build-route-header-model.test.tsx
+++ b/apps/web/src/lib/build-route-header-model.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { ViewState } from "./view-state";
+import { buildRouteHeaderModel } from "./build-route-header-model";
+
+type RouteHeaderInput = Parameters<typeof buildRouteHeaderModel>[0];
+
+function createInput(
+  viewState: ViewState,
+  overrides: Partial<RouteHeaderInput> = {},
+): RouteHeaderInput {
+  return {
+    viewState,
+    browseBy: "agents",
+    isSearchMode: false,
+    searchSubtitle: "Search results",
+    dashboard: null,
+    projects: [],
+    sessionCount: 0,
+    activeProject: null,
+    activeAgent: null,
+    sidebarSessionCount: 0,
+    session: null,
+    sessionError: null,
+    selectedProjectIdentity: null,
+    selectedProject: null,
+    ...overrides,
+  };
+}
+
+describe("buildRouteHeaderModel", () => {
+  it.each([
+    {
+      mode: "session",
+      activeAgentKey: "claudecode",
+      activeSessionSlug: "session-1",
+    } as const,
+    {
+      mode: "project",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+      activeProjectKind: "path",
+      activeProjectKey: "/tmp/codesesh",
+    } as const,
+  ])("gives search precedence over a $mode route", (viewState) => {
+    const model = buildRouteHeaderModel(
+      createInput(viewState, {
+        isSearchMode: true,
+      }),
+    );
+
+    expect(model).toMatchObject({
+      contextLabel: "Search",
+      title: "Search",
+      breadcrumbs: [{ label: "Search" }],
+    });
+  });
+
+  it.each([
+    [{ mode: "root", activeAgentKey: null, activeSessionSlug: null } as const, "Dashboard"],
+    [{ mode: "projects", activeAgentKey: null, activeSessionSlug: null } as const, "Projects"],
+    [
+      {
+        mode: "project",
+        activeAgentKey: null,
+        activeSessionSlug: null,
+        activeProjectKind: "path",
+        activeProjectKey: "/tmp/codesesh",
+      } as const,
+      "Project",
+    ],
+    [
+      {
+        mode: "session",
+        activeAgentKey: "claudecode",
+        activeSessionSlug: "session-1",
+      } as const,
+      "Session",
+    ],
+    [{ mode: "agent", activeAgentKey: "claudecode", activeSessionSlug: null } as const, "Landing"],
+  ])("keeps the existing $1 context for non-search routes", (viewState, expected) => {
+    expect(buildRouteHeaderModel(createInput(viewState)).contextLabel).toBe(expected);
+  });
+});

--- a/apps/web/src/lib/build-route-header-model.tsx
+++ b/apps/web/src/lib/build-route-header-model.tsx
@@ -30,12 +30,34 @@ interface RouteHeaderInput {
 }
 
 export function buildRouteHeaderModel(input: RouteHeaderInput): {
+  contextLabel: string;
   title: string;
   subtitle: ReactNode;
   breadcrumbs: BreadcrumbItem[];
 } {
   const titleAndSubtitle = routeTitleAndSubtitle(input);
-  return { ...titleAndSubtitle, breadcrumbs: routeBreadcrumbs(input) };
+  return {
+    contextLabel: routeContextLabel(input),
+    ...titleAndSubtitle,
+    breadcrumbs: routeBreadcrumbs(input),
+  };
+}
+
+function routeContextLabel(input: RouteHeaderInput): string {
+  if (input.isSearchMode) return "Search";
+
+  switch (input.viewState.mode) {
+    case "session":
+      return "Session";
+    case "root":
+      return "Dashboard";
+    case "projects":
+      return "Projects";
+    case "project":
+      return "Project";
+    default:
+      return "Landing";
+  }
 }
 
 function routeTitleAndSubtitle(input: RouteHeaderInput): {

--- a/design-plans/cs-53-project-navigation-state.md
+++ b/design-plans/cs-53-project-navigation-state.md
@@ -1,0 +1,73 @@
+# Make Project Navigation Reflect the Current Route
+
+Written against: `67713bea5f33231fddcd468f7fcb560467f04aa9`
+
+## Evidence chain
+
+- Surface: Projects overview, project detail, and the desktop sidebar in `apps/web`.
+- Problem: Returning from a project detail to `/projects` can leave both the Projects overview entry and the previously opened project styled as active. The SESSIONS section can also remain scoped to that stale project even though the main content is the overview.
+- Design evidence: `apps/web/src/App.tsx` derives `selectedProjectNavigationIdentity` from `selectedProjectIdentity` when no project is present in the current route. That value drives both the selected project row and project-scoped sidebar sessions. `selectedProjectIdentity` is navigation memory, not evidence that the current route represents that project.
+- Owner: `apps/web/src/App.tsx` owns route interpretation and the props that describe selected project navigation to `AppSidebar`.
+- Scope and affected surfaces: Project overview, project detail, sessions opened from a project, browse-mode switching, and the desktop sidebar.
+- Uncertainty: None. The conflicting active states follow directly from the current derivation and consumers.
+
+## Design decision
+
+Make project selection presentation a pure derivative of the current route:
+
+```tsx
+const selectedProjectNavigationIdentity =
+  browseBy !== "projects"
+    ? null
+    : viewState.mode === "project"
+      ? activeProjectIdentity
+      : viewState.mode === "session"
+        ? openedSessionProjectIdentity
+        : null;
+```
+
+Keep `selectedProjectIdentity` as navigation memory for `changeBrowseBy`; do not clear it when entering the overview and do not add a second state value. On `/projects`, root, loading, and error routes, no project is active and no project-scoped session list is shown.
+
+## Reuse
+
+- Reuse `viewState`, `activeProjectIdentity`, and `openedSessionProjectIdentity` as the existing route facts.
+- Reuse the existing `selectedProjectNavigationId` and `sidebarSessions` data flow after correcting its input.
+- Reuse the existing `Select a project` empty state in `AppSidebar`.
+- Exemplar: Agent browsing already derives active presentation from the current browse mode and route instead of preserving a stale row selection.
+
+## Changes
+
+1. `apps/web/src/App.tsx`
+   - Change: Derive `selectedProjectNavigationIdentity` only from the current project or session route while `browseBy === "projects"`.
+   - Preserve: Keep `selectedProjectIdentity` and its role in returning to the last project when the user explicitly changes browse mode.
+   - Verify: `/projects` produces a null selected project ID and an empty project-scoped session list; project and project-session routes still select the correct project.
+2. `tests/e2e/browsing.spec.ts`
+   - Change: Add a regression flow that opens a project, returns through the Projects breadcrumb, and verifies the overview has no stale project selection or project session list.
+   - Preserve: Use existing fixtures and navigation helpers; do not introduce a second project-navigation harness.
+   - Verify: The URL is `/projects`, the overview remains active, and `Select a project` is visible in the sidebar.
+
+## Scope
+
+- Inherit: Current project routes, breadcrumb behavior, sidebar active styles, session filtering, and browse-mode memory.
+- Verify: Projects overview, project detail, a session opened from a project, direct URL entry, browser back/forward, and switching between Agents and Projects.
+- Exclude: Mobile navigation redesign, route schema changes, clearing navigation memory, new stored state, and visual restyling of sidebar rows.
+
+## Validation
+
+- Product: Open a project, return to Projects, then switch modes and return; the content, active row, and SESSIONS scope must always describe the same route.
+- Interface: Check the desktop sidebar at overview, project, and project-session routes, including direct entry and browser history traversal.
+- System: Confirm the corrected derivation does not change API calls or project/session identity normalization.
+- Repository: `pnpm --filter @codesesh/web test` → all web unit tests pass.
+- Repository: `pnpm --filter @codesesh/web lint` → no lint errors.
+- Repository: `pnpm --filter @codesesh/web build` → the web application builds.
+- Repository: `pnpm test:e2e --project web-chromium` → the project navigation regression and existing browsing flows pass.
+
+## Stop conditions
+
+- Stop if `selectedProjectIdentity` is found to be required as visible selection on `/projects`; clarify the intended overview interaction before adding special cases.
+- Stop if a project session cannot be associated through `openedSessionProjectIdentity`; fix identity ownership rather than restoring a stale fallback.
+- Stop if the implementation requires modifying project route semantics or adding stored UI state.
+
+## Design documentation
+
+- After acceptance and validation: No design-document update is required; this restores the existing route-driven navigation contract without changing product behavior.

--- a/design-plans/cs-53-search-context-label.md
+++ b/design-plans/cs-53-search-context-label.md
@@ -1,0 +1,85 @@
+# Give Search One Consistent Header Context
+
+Written against: `67713bea5f33231fddcd468f7fcb560467f04aa9`
+
+## Evidence chain
+
+- Surface: The app header while global search is open from dashboard, projects, project detail, or session detail.
+- Problem: Search content, title, and breadcrumb all say Search, while the small context badge can still say Session, Project, Projects, or Dashboard based on the underlying route.
+- Design evidence: `buildRouteHeaderModel` already receives `isSearchMode` and owns the search title and breadcrumb. `App.tsx` independently derives the context badge from `viewState`, bypassing that model and ignoring search mode.
+- Owner: `apps/web/src/lib/build-route-header-model.tsx` is the existing owner of header semantics; `App.tsx` should render its result.
+- Scope and affected surfaces: Global search header and every non-search route label currently shown in the context badge.
+- Uncertainty: None. The badge and the rest of the header currently use different inputs for the same semantic state.
+
+## Design decision
+
+Add `contextLabel` to the route header model and derive it from the same input that determines title and breadcrumbs. Search takes precedence over the underlying route. Preserve the existing non-search copy:
+
+```tsx
+function routeContextLabel(input: RouteHeaderInput) {
+  if (input.isSearchMode) return "Search";
+
+  switch (input.viewState.mode) {
+    case "session":
+      return "Session";
+    case "root":
+      return "Dashboard";
+    case "projects":
+      return "Projects";
+    case "project":
+      return "Project";
+    default:
+      return "Landing";
+  }
+}
+```
+
+`App.tsx` should render `routeHeader.contextLabel` instead of maintaining a parallel conditional. Do not add search state, duplicate labels, or a new visual primitive.
+
+## Reuse
+
+- Reuse `RouteHeaderInput`, `isSearchMode`, and `buildRouteHeaderModel` as the header's semantic owner.
+- Reuse every current label and the existing context badge styling in `App.tsx`.
+- Reuse the existing search-mode precedence already applied to title and breadcrumbs.
+- Exemplar: Search title and breadcrumb are already produced together by `buildRouteHeaderModel`; the badge should follow the same ownership boundary.
+
+## Changes
+
+1. `apps/web/src/lib/build-route-header-model.tsx`
+   - Change: Add `contextLabel` to the returned header model and derive it with search-mode precedence plus the current route-label mapping.
+   - Preserve: Existing title, subtitle, breadcrumb, project identity, and session alias behavior.
+   - Verify: Search mode returns `Search` regardless of the underlying `viewState`; non-search routes retain their current labels.
+2. `apps/web/src/App.tsx`
+   - Change: Replace the inline nested conditional in the context badge with `routeHeader.contextLabel`.
+   - Preserve: Existing badge markup, typography, spacing, and responsive behavior.
+   - Verify: Opening and closing search changes only the semantic label and restores the underlying route label afterward.
+3. `apps/web/src/lib/build-route-header-model.test.tsx`
+   - Change: Add focused model tests for search precedence and representative non-search mappings.
+   - Preserve: Test the public model result instead of component implementation details.
+   - Verify: Session and project inputs return `Search` while search is active; session, project, projects, and root retain their existing labels when it is inactive.
+
+## Scope
+
+- Inherit: Current search open/close behavior, loading/error content, header layout, and all existing route labels.
+- Verify: Search launched from dashboard, projects overview, project detail, and session detail; loading, results, empty, and failure states; closing search.
+- Exclude: Header redesign, new copy outside the context badge, sidebar search active-state changes, search routing changes, and animation changes.
+
+## Validation
+
+- Product: Open search from each underlying route and confirm content, title, breadcrumb, and context badge all describe Search; close it and confirm the route label returns.
+- Interface: Check desktop and narrow viewport header layouts for unchanged spacing and no badge overflow.
+- System: Confirm the model remains a pure function and no new React state or effect is introduced.
+- Repository: `pnpm --filter @codesesh/web test` → the new model tests and all existing web tests pass.
+- Repository: `pnpm --filter @codesesh/web lint` → no lint errors.
+- Repository: `pnpm --filter @codesesh/web build` → the web application builds.
+- Repository: `pnpm test:e2e --project web-chromium` → existing search and browsing flows pass.
+
+## Stop conditions
+
+- Stop if another header owner exists for the context badge; consolidate ownership before adding another mapping.
+- Stop if product requirements intentionally preserve the underlying route label during search; document that exception and align title and breadcrumb semantics before implementation.
+- Stop if the implementation requires new state or changes search routing.
+
+## Design documentation
+
+- After acceptance and validation: No design-document update is required; this consolidates existing header semantics without introducing a new pattern.

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -1,5 +1,23 @@
 import { expect, test } from "playwright/test";
 
+test("keeps project navigation aligned with the overview route", async ({ page }) => {
+  await page.goto("/projects");
+  await expect(page.getByRole("heading", { level: 1, name: "Projects" })).toBeVisible();
+  const projectNavigation = page
+    .locator("aside")
+    .getByRole("link", { name: /codesesh-e2e/ })
+    .first();
+  await projectNavigation.click();
+  await expect(page.getByRole("heading", { level: 1, name: "codesesh-e2e" })).toBeVisible();
+  await page
+    .getByRole("navigation", { name: "Breadcrumb" })
+    .getByRole("link", { name: "Projects" })
+    .click();
+  await expect(page).toHaveURL(/\/projects$/);
+  await expect(page.getByText("Select a project")).toBeVisible();
+  await expect(projectNavigation).not.toHaveClass(/bg-white/);
+});
+
 test("covers dashboard, detail, search, projects, and pin flows", async ({ page }) => {
   const consoleErrors: string[] = [];
   page.on("console", (message) => {
@@ -59,7 +77,9 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
 
   await page.getByRole("searchbox", { name: "Search Sessions" }).fill("needle");
   await page.getByRole("button", { name: "Search" }).click();
-  await expect(page.getByRole("heading", { level: 1, name: "Search" })).toBeVisible();
+  const searchHeading = page.getByRole("heading", { level: 1, name: "Search" });
+  await expect(searchHeading).toBeVisible();
+  await expect(searchHeading.locator("..").locator("span")).toHaveText("Search");
 
   const searchResult = page
     .getByRole("link")


### PR DESCRIPTION
## Summary

- derive the selected project navigation context only from the current project or session route
- move the header context label into the shared route header model so Search has consistent title, breadcrumb, and badge semantics
- add focused unit and browser regression coverage
- document the two UI correction plans for CS-53

## Root cause

The project sidebar reused `selectedProjectIdentity`, which is navigation memory, as visible route state. Returning to the Projects overview therefore kept the previous project active and its sessions scoped in the sidebar.

The Search title and breadcrumbs came from `buildRouteHeaderModel`, while the context badge independently read the underlying `viewState`. This allowed the badge to remain Session or Project while the rest of the header displayed Search.

## Impact

Projects overview navigation now matches the active route, and Search presents one consistent header context. Existing browse-mode memory and non-search labels are preserved.

## Validation

- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web test` — 45 files, 301 tests
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web build`
- `pnpm test:e2e --project web-chromium` — 6 tests

Issue: CS-53