### PR TITLE
fix(web): keep rolling time windows current

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -262,7 +262,7 @@ export default function App() {
   const isScanActive = scanStatus?.active === true;
 
   const { liveNotice } = useLiveSync({
-    timeWindow,
+    resolveTimeWindow: timeWindowController.resolveCurrent,
     viewState,
     refreshAgents,
     refreshSessions,

--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { AppConfig, SessionsUpdatedEvent } from "../lib/api";
 import type { ViewState } from "../lib/view-state";
 import * as api from "../lib/api";
+import { resolveTimeWindow as resolveWindowFromParams } from "../lib/time-window";
 import { useLiveSync } from "./useLiveSync";
 
 let sessionsCb: ((event: SessionsUpdatedEvent) => void) | undefined;
@@ -30,7 +31,7 @@ const rootView = { mode: "root", activeAgentKey: null, activeSessionSlug: null }
 
 function makeDeps() {
   return {
-    timeWindow: appConfig.window,
+    resolveTimeWindow: vi.fn(() => appConfig.window),
     viewState: rootView,
     refreshAgents: vi.fn().mockResolvedValue(undefined),
     refreshSessions: vi.fn().mockResolvedValue(undefined),
@@ -45,6 +46,7 @@ function makeDeps() {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.clearAllMocks();
   sessionsCb = undefined;
   reconnectCb = undefined;
@@ -52,6 +54,28 @@ afterEach(() => {
 });
 
 describe("useLiveSync", () => {
+  it("resolves the rolling preset when an update arrives after midnight", async () => {
+    vi.useFakeTimers();
+    const openedAt = new Date(2026, 6, 15, 12).getTime();
+    vi.setSystemTime(openedAt);
+    const params = new URLSearchParams("range=7d");
+    const fallback = { days: 7 };
+    const deps = makeDeps();
+    deps.resolveTimeWindow = vi.fn(() => resolveWindowFromParams(params, fallback).window);
+    renderHook(() => useLiveSync(deps));
+
+    const refreshedAt = new Date(2026, 6, 16, 12).getTime();
+    vi.setSystemTime(refreshedAt);
+    await act(async () => {
+      sessionsCb?.({ newSessions: 1 } as SessionsUpdatedEvent);
+      await Promise.resolve();
+    });
+
+    expect(deps.refreshSessions).toHaveBeenCalledWith(
+      resolveWindowFromParams(params, fallback, refreshedAt).window,
+    );
+  });
+
   it("subscribes on mount", () => {
     renderHook(() => useLiveSync(makeDeps()));
     expect(api.subscribeSessionUpdates).toHaveBeenCalledOnce();
@@ -67,6 +91,7 @@ describe("useLiveSync", () => {
     });
 
     expect(deps.refreshAgents).toHaveBeenCalled();
+    expect(deps.resolveTimeWindow).toHaveBeenCalled();
     expect(deps.refreshDashboard).toHaveBeenCalled();
     expect(deps.refreshSearch).toHaveBeenCalled();
   });

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -4,7 +4,7 @@ import type { LiveSessionsUpdate } from "../lib/live-update";
 import type { ViewState } from "../lib/view-state";
 
 interface LiveSyncDeps {
-  timeWindow: AppConfig["window"] | null;
+  resolveTimeWindow: () => AppConfig["window"] | null;
   viewState: ViewState;
   refreshAgents: (window: AppConfig["window"]) => Promise<unknown>;
   refreshSessions: (window: AppConfig["window"]) => Promise<unknown>;
@@ -26,7 +26,7 @@ export function useLiveSync(deps: LiveSyncDeps) {
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [connectionNotice, setConnectionNotice] = useState<string | null>(null);
   const {
-    timeWindow,
+    resolveTimeWindow,
     viewState,
     refreshAgents,
     refreshSessions,
@@ -40,6 +40,7 @@ export function useLiveSync(deps: LiveSyncDeps) {
 
   const syncLiveUpdate = useEffectEvent(async (event: LiveSessionsUpdate) => {
     try {
+      const timeWindow = resolveTimeWindow();
       await Promise.all([
         timeWindow ? refreshAgents(timeWindow) : Promise.resolve(),
         timeWindow ? refreshSessions(timeWindow) : Promise.resolve(),

--- a/apps/web/src/hooks/useTimeWindow.test.tsx
+++ b/apps/web/src/hooks/useTimeWindow.test.tsx
@@ -1,9 +1,12 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Link, MemoryRouter, useLocation } from "react-router-dom";
 import { useTimeWindow } from "./useTimeWindow";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 type ResolveWindow = ReturnType<typeof useTimeWindow>["resolve"];
 
@@ -23,6 +26,8 @@ function TimeWindowHarness({
     <>
       <span data-testid="preset">{controller.preset}</span>
       <span data-testid="search">{location.search}</span>
+      <span data-testid="from">{controller.timeWindow?.from}</span>
+      <span data-testid="to">{controller.timeWindow?.to}</span>
       <Link to="/session">Open session</Link>
       <Link to="/?range=14d&view=timeline">Change view</Link>
       <button type="button" onClick={() => controller.selectPreset("30d")}>
@@ -79,5 +84,38 @@ describe("useTimeWindow", () => {
     fireEvent.click(screen.getByRole("link", { name: "Change view" }));
 
     expect(observedResolvers.at(-1)).toBe(initialResolver);
+  });
+
+  it("refreshes a rolling preset at local midnight", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 15, 23, 59, 59, 900));
+    render(
+      <MemoryRouter initialEntries={["/?range=7d"]}>
+        <TimeWindowHarness observedPresets={[]} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("to").textContent).toBe(String(new Date(2026, 6, 16).getTime() - 1));
+
+    act(() => vi.advanceTimersByTime(100));
+
+    expect(screen.getByTestId("to").textContent).toBe(String(new Date(2026, 6, 17).getTime() - 1));
+  });
+
+  it("keeps a custom range fixed across local midnight", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 15, 23, 59, 59, 900));
+    render(
+      <MemoryRouter initialEntries={["/?range=custom&from=2026-07-01&to=2026-07-15"]}>
+        <TimeWindowHarness observedPresets={[]} />
+      </MemoryRouter>,
+    );
+    const initialFrom = screen.getByTestId("from").textContent;
+    const initialTo = screen.getByTestId("to").textContent;
+
+    act(() => vi.advanceTimersByTime(48 * 60 * 60 * 1000));
+
+    expect(screen.getByTestId("from").textContent).toBe(initialFrom);
+    expect(screen.getByTestId("to").textContent).toBe(initialTo);
   });
 });

--- a/apps/web/src/hooks/useTimeWindow.ts
+++ b/apps/web/src/hooks/useTimeWindow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useSearchParams } from "react-router-dom";
 import {
   resolveTimeWindow,
@@ -19,6 +19,19 @@ function selectedTimeWindowSearch(params: URLSearchParams): string {
   return selectedParams.toString();
 }
 
+function nextLocalMidnight(now = Date.now()): number {
+  const date = new Date(now);
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1).getTime();
+}
+
+function currentLocalDayEnd(nextRefreshAt: number, now = Date.now()): number {
+  return (nextRefreshAt > now ? nextRefreshAt : nextLocalMidnight(now)) - 1;
+}
+
+function isRollingPreset(preset: TimeWindowPreset | null): boolean {
+  return preset !== null && preset !== "all" && preset !== "custom";
+}
+
 export function useTimeWindow(defaultWindow: TimeWindow | undefined) {
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -26,6 +39,7 @@ export function useTimeWindow(defaultWindow: TimeWindow | undefined) {
   const hasRange = searchParams.has("range");
   const previousPath = useRef(location.pathname);
   const rememberedRange = useRef<string | null>(null);
+  const [nextPresetRefreshAt, setNextPresetRefreshAt] = useState(nextLocalMidnight);
   if (hasRange) {
     rememberedRange.current = selectedTimeWindowSearch(searchParams);
   }
@@ -57,13 +71,35 @@ export function useTimeWindow(defaultWindow: TimeWindow | undefined) {
   }, [effectiveParams, effectiveSearch, location.pathname, search, setSearchParams]);
 
   const resolved = useMemo(
-    () => (defaultWindow ? resolveTimeWindow(selectedWindowParams, defaultWindow) : null),
-    [defaultWindow, selectedWindowParams],
+    () =>
+      defaultWindow
+        ? resolveTimeWindow(
+            selectedWindowParams,
+            defaultWindow,
+            currentLocalDayEnd(nextPresetRefreshAt),
+          )
+        : null,
+    [defaultWindow, nextPresetRefreshAt, selectedWindowParams],
   );
   const resolve = useCallback(
     (fallback: TimeWindow) => resolveTimeWindow(selectedWindowParams, fallback).window,
     [selectedWindowParams],
   );
+  const resolveCurrent = useCallback(
+    () => (defaultWindow ? resolve(defaultWindow) : null),
+    [defaultWindow, resolve],
+  );
+
+  useEffect(() => {
+    if (!isRollingPreset(resolved?.preset ?? null)) return;
+
+    const delay = Math.max(0, nextPresetRefreshAt - Date.now());
+    const timer = window.setTimeout(() => {
+      setNextPresetRefreshAt(nextLocalMidnight());
+    }, delay);
+
+    return () => window.clearTimeout(timer);
+  }, [nextPresetRefreshAt, resolved?.preset]);
   const selectPreset = useCallback(
     (preset: TimeWindowPreset) =>
       setSearchParams(writeTimeWindowPreset(new URLSearchParams(search), preset)),
@@ -81,6 +117,7 @@ export function useTimeWindow(defaultWindow: TimeWindow | undefined) {
     customFrom: resolved?.customFrom,
     customTo: resolved?.customTo,
     resolve,
+    resolveCurrent,
     selectPreset,
     selectCustom,
   };

--- a/apps/web/src/lib/time-window.test.ts
+++ b/apps/web/src/lib/time-window.test.ts
@@ -36,7 +36,7 @@ describe("time window URL state", () => {
   });
 
   it("falls back when a custom range is invalid", () => {
-    const fallback = { from: 10, to: 20, days: 7 };
+    const fallback = { from: 10, to: 20, days: 3 };
     expect(
       resolveTimeWindow(
         new URLSearchParams("range=custom&from=2026-07-20&to=2026-07-05"),
@@ -44,6 +44,26 @@ describe("time window URL state", () => {
         now,
       ).window,
     ).toBe(fallback);
+  });
+
+  it("re-resolves a preset fallback at the current local day", () => {
+    const result = resolveTimeWindow(new URLSearchParams(), { from: 10, to: 20, days: 7 }, now);
+
+    expect(result).toEqual({
+      preset: "7d",
+      window: {
+        from: new Date(2026, 6, 8).getTime(),
+        to: new Date(2026, 6, 15).getTime() - 1,
+        days: 7,
+      },
+    });
+  });
+
+  it("removes the fixed upper bound from an all-time fallback", () => {
+    expect(resolveTimeWindow(new URLSearchParams(), { to: 20, days: 0 }, now).window).toEqual({
+      from: 0,
+      days: 0,
+    });
   });
 
   it("preserves unrelated URL parameters", () => {

--- a/apps/web/src/lib/time-window.ts
+++ b/apps/web/src/lib/time-window.ts
@@ -87,7 +87,9 @@ export function resolveTimeWindow(
     }
   }
   const fallbackPreset = presetFromDefault(fallback);
-  if (fallbackPreset !== "custom") return { preset: fallbackPreset, window: fallback };
+  if (fallbackPreset !== "custom") {
+    return { preset: fallbackPreset, window: presetWindow(fallbackPreset, now) };
+  }
   return {
     preset: fallbackPreset,
     window: fallback,


### PR DESCRIPTION
## Summary

- re-resolve recognized fallback presets against the current local calendar day
- refresh rolling preset state at the next local midnight while leaving custom ranges fixed
- remove stale upper bounds from all-time fallbacks
- resolve the active time window when an SSE update arrives instead of reusing a memoized timestamp range

## Root cause

Preset windows were converted to concrete `from` and `to` timestamps once and then memoized. Long-lived pages therefore kept the previous day's upper bound, and live refreshes silently excluded sessions created after midnight. The default server-provided `7d` and `all` windows were also returned unchanged, so they remained anchored to server startup even when no explicit `range` parameter was present.

## Impact

Rolling windows now stay aligned with the current local day. SSE refreshes include newly created sessions after midnight, labels and dependent dashboard data refresh at the day boundary, custom ranges remain fixed, and all-time mode no longer carries a stale `to` limit.

## Validation

- `pnpm test`
- `pnpm test:e2e`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web build`

Issue: CS-54