### PR TITLE
fix(web): restore session menu keyboard focus

### DIFF
--- a/apps/web/src/components/SessionActionsMenu.test.tsx
+++ b/apps/web/src/components/SessionActionsMenu.test.tsx
@@ -1,31 +1,77 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionActionsMenu } from "./SessionActionsMenu";
 
 afterEach(cleanup);
 
 describe("SessionActionsMenu", () => {
-  it("closes when focus leaves the menu", () => {
+  it("loops focus through menu items with arrow keys", async () => {
+    render(<SessionActionsMenu bookmarked={false} onRename={vi.fn()} onToggleBookmark={vi.fn()} />);
+
+    const trigger = screen.getByRole("button", { name: "Session options" });
+    trigger.focus();
+    fireEvent.click(trigger);
+    const renameItem = screen.getByRole("menuitem", { name: "Rename" });
+    const bookmarkItem = screen.getByRole("menuitem", { name: "Add bookmark" });
+
+    await waitFor(() => expect(document.activeElement).toBe(renameItem));
+    fireEvent.keyDown(renameItem, { key: "ArrowDown" });
+    await waitFor(() => expect(document.activeElement).toBe(bookmarkItem));
+    fireEvent.keyDown(bookmarkItem, { key: "ArrowDown" });
+    await waitFor(() => expect(document.activeElement).toBe(renameItem));
+    fireEvent.keyDown(renameItem, { key: "ArrowUp" });
+    await waitFor(() => expect(document.activeElement).toBe(bookmarkItem));
+  });
+
+  it("returns focus to the trigger when Escape closes the menu", async () => {
+    render(<SessionActionsMenu bookmarked={false} onRename={vi.fn()} onToggleBookmark={vi.fn()} />);
+    const trigger = screen.getByRole("button", { name: "Session options" });
+
+    trigger.focus();
+    fireEvent.click(trigger);
+    const renameItem = screen.getByRole("menuitem", { name: "Rename" });
+    await waitFor(() => expect(document.activeElement).toBe(renameItem));
+    fireEvent.keyDown(renameItem, { key: "Escape" });
+
+    expect(screen.queryByRole("menu")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it("runs the selected action, closes, and returns focus", async () => {
+    const onRename = vi.fn();
+    render(
+      <SessionActionsMenu bookmarked={false} onRename={onRename} onToggleBookmark={vi.fn()} />,
+    );
+    const trigger = screen.getByRole("button", { name: "Session options" });
+
+    trigger.focus();
+    fireEvent.click(trigger);
+    const renameItem = screen.getByRole("menuitem", { name: "Rename" });
+    await waitFor(() => expect(document.activeElement).toBe(renameItem));
+    fireEvent.click(renameItem);
+
+    expect(onRename).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("menu")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it("returns focus to the trigger when an outside pointer closes the menu", async () => {
     render(
       <>
         <SessionActionsMenu bookmarked={false} onRename={vi.fn()} onToggleBookmark={vi.fn()} />
         <button type="button">Elsewhere</button>
       </>,
     );
+    const trigger = screen.getByRole("button", { name: "Session options" });
 
-    fireEvent.click(screen.getByRole("button", { name: "Session options" }));
-    expect(screen.getByRole("menu")).toBeTruthy();
-
-    fireEvent.focus(screen.getByRole("button", { name: "Elsewhere" }));
-    expect(screen.queryByRole("menu")).toBeNull();
-  });
-
-  it("closes when Escape is pressed", () => {
-    render(<SessionActionsMenu bookmarked={false} onRename={vi.fn()} onToggleBookmark={vi.fn()} />);
-
-    fireEvent.click(screen.getByRole("button", { name: "Session options" }));
-    fireEvent.keyDown(document, { key: "Escape" });
+    trigger.focus();
+    fireEvent.click(trigger);
+    await waitFor(() =>
+      expect(document.activeElement).toBe(screen.getByRole("menuitem", { name: "Rename" })),
+    );
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Elsewhere" }));
 
     expect(screen.queryByRole("menu")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
   });
 });

--- a/apps/web/src/components/SessionActionsMenu.tsx
+++ b/apps/web/src/components/SessionActionsMenu.tsx
@@ -1,5 +1,6 @@
+import { Menu } from "@base-ui/react/menu";
 import { MoreHorizontal, Pencil, Star } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 
 export function SessionActionsMenu({
   bookmarked,
@@ -10,89 +11,45 @@ export function SessionActionsMenu({
   onRename: () => void;
   onToggleBookmark: () => void;
 }) {
-  const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const closeOnOutsidePointer = (event: PointerEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false);
-    };
-    const closeOnFocusOutside = (event: FocusEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    document.addEventListener("pointerdown", closeOnOutsidePointer);
-    document.addEventListener("keydown", closeOnEscape);
-    document.addEventListener("focusin", closeOnFocusOutside);
-    menuRef.current?.querySelector<HTMLButtonElement>("[role='menuitem']")?.focus();
-    return () => {
-      document.removeEventListener("pointerdown", closeOnOutsidePointer);
-      document.removeEventListener("keydown", closeOnEscape);
-      document.removeEventListener("focusin", closeOnFocusOutside);
-    };
-  }, [open]);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   return (
-    <div
-      ref={menuRef}
-      className="relative shrink-0"
-      onBlur={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false);
-      }}
-    >
-      <button
-        type="button"
+    <Menu.Root modal={false}>
+      <Menu.Trigger
+        ref={triggerRef}
         aria-label="Session options"
-        aria-expanded={open}
-        aria-haspopup="menu"
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          setOpen((current) => !current);
-        }}
-        className="inline-flex size-6 items-center justify-center rounded-sm border border-transparent text-[var(--console-muted)] transition-[background-color,border-color,color,transform] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] active:scale-[0.97] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+        onClick={(event) => event.stopPropagation()}
+        className="inline-flex size-6 shrink-0 items-center justify-center rounded-sm border border-transparent text-[var(--console-muted)] transition-[background-color,border-color,color,transform] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] active:scale-[0.97] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         <MoreHorizontal className="size-3.5" aria-hidden="true" />
-      </button>
-      {open ? (
-        <div
-          role="menu"
-          className="absolute right-0 top-7 z-30 w-36 rounded-sm border border-[var(--console-border-strong)] bg-white p-1 shadow-lg"
-        >
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              setOpen(false);
-              onRename();
-            }}
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] focus-visible:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner side="bottom" align="end" sideOffset={4} className="z-30">
+          <Menu.Popup
+            finalFocus={triggerRef}
+            className="w-36 rounded-sm border border-[var(--console-border-strong)] bg-white p-1 shadow-lg focus-visible:outline-none"
           >
-            <Pencil className="size-3" aria-hidden="true" />
-            Rename
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              setOpen(false);
-              onToggleBookmark();
-            }}
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] focus-visible:bg-[var(--console-surface-muted)] focus-visible:outline-none"
-          >
-            <Star
-              className="size-3"
-              fill={bookmarked ? "currentColor" : "none"}
-              aria-hidden="true"
-            />
-            {bookmarked ? "Remove bookmark" : "Add bookmark"}
-          </button>
-        </div>
-      ) : null}
-    </div>
+            <Menu.Item
+              onClick={onRename}
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+            >
+              <Pencil className="size-3" aria-hidden="true" />
+              Rename
+            </Menu.Item>
+            <Menu.Item
+              onClick={onToggleBookmark}
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+            >
+              <Star
+                className="size-3"
+                fill={bookmarked ? "currentColor" : "none"}
+                aria-hidden="true"
+              />
+              {bookmarked ? "Remove bookmark" : "Add bookmark"}
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
   );
 }

--- a/apps/web/src/components/app/SidebarFlatSessionList.test.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionHead } from "../../lib/api";
+import { SidebarFlatSessionList } from "./SidebarFlatSessionList";
+
+afterEach(cleanup);
+
+const session: SessionHead = {
+  id: "session-1",
+  slug: "codex/session-1",
+  title: "Test session",
+  directory: "/repo",
+  time_created: 1,
+  stats: {
+    message_count: 1,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    total_cost: 0,
+  },
+};
+
+describe("SidebarFlatSessionList", () => {
+  it("forwards session menu actions without selecting the row", () => {
+    const onSelectSession = vi.fn();
+    const onRenameSession = vi.fn();
+    const onToggleBookmark = vi.fn();
+
+    render(
+      <SidebarFlatSessionList
+        sessions={[session]}
+        activeSessionId={null}
+        selectedSessionId={null}
+        bookmarkedSessionIds={new Set()}
+        onSelectSession={onSelectSession}
+        onRenameSession={onRenameSession}
+        onToggleBookmark={onToggleBookmark}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Session options" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+    expect(onRenameSession).toHaveBeenCalledWith(session);
+
+    fireEvent.click(screen.getByRole("button", { name: "Session options" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add bookmark" }));
+    expect(onToggleBookmark).toHaveBeenCalledWith(session);
+    expect(onSelectSession).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- replace the hand-written session actions menu with the existing Base UI Menu primitive
- add looping ArrowUp/ArrowDown navigation and restore focus to the trigger after Escape, item selection, or outside dismissal
- cover menu focus behavior and flat sidebar rename/bookmark callbacks with interaction tests

## Root cause

The component declared ARIA menu roles but only managed opening and dismissal. It had no roving keyboard focus, and unmounting the focused menu item left focus on the document body.

## User impact

Keyboard and assistive-technology users can now navigate session actions predictably and retain their position after the menu closes. The existing menu appearance and consumer API remain unchanged.

## Validation

- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web build`
- `pnpm test`
- `pnpm test:e2e`