### PR TITLE
Fix receipt motion and search backfill memory use

### DIFF
--- a/apps/web/src/components/InteractiveReceipt.tsx
+++ b/apps/web/src/components/InteractiveReceipt.tsx
@@ -3,7 +3,8 @@ import type { SessionData } from "../lib/api";
 import { getSessionDisplayTitle } from "../lib/session-title";
 import {
   isReceiptSettled,
-  nextReceiptIdleFrame,
+  nextReceiptReleaseFrame,
+  nextReceiptSettledFrame,
   shouldSimulateReceiptFrame,
 } from "../lib/interactive-receipt-frame-policy";
 import { SMART_TAG_LABELS } from "./SmartTagChips";
@@ -520,6 +521,19 @@ function findGrabTarget(particles: Particle[], x: number, y: number) {
   return bestIndex;
 }
 
+function measureSheetMovement(particles: Particle[]) {
+  let maxMovement = 0;
+  for (let i = COLUMNS; i < particles.length; i += 1) {
+    const particle = particles[i];
+    if (!particle) continue;
+    maxMovement = Math.max(
+      maxMovement,
+      Math.hypot(particle.x - particle.oldX, particle.y - particle.oldY),
+    );
+  }
+  return maxMovement;
+}
+
 export function InteractiveReceipt({
   session,
   toc,
@@ -562,27 +576,26 @@ export function InteractiveReceipt({
     let startedAt = performance.now();
     let lastMetrics: SheetMetrics | null = null;
     let stableFrames = 0;
-    let idleFrames = 0;
+    let settledFrames = 0;
+    let releaseFrames = 0;
     let lastSimulationTime = 0;
     let isVisible = false;
-    let anchorVisible = true;
     let running = false;
     const desktopMedia = window.matchMedia(minWidthQuery);
     const reducedMotionMedia = window.matchMedia("(prefers-reduced-motion: reduce)");
 
-    const shouldRun = () =>
-      desktopMedia.matches && document.visibilityState === "visible" && anchorVisible;
+    const shouldRun = () => desktopMedia.matches && document.visibilityState === "visible";
 
     const getSheetMetrics = (): SheetMetrics => {
       const rect = anchor.getBoundingClientRect();
       const anchorWidth = Math.max(280, rect.width || 320);
       const receiptWidth = Math.min(RECEIPT_WIDTH, anchorWidth - 34);
-      const receiptHeight = Math.min(RECEIPT_HEIGHT, Math.max(320, height - rect.top - 42));
+      const receiptHeight = Math.min(RECEIPT_HEIGHT, Math.max(320, height - 42));
       return {
         receiptWidth,
         receiptHeight,
-        startX: rect.left + (rect.width - receiptWidth) / 2,
-        startY: rect.top + 32,
+        startX: (anchorWidth - receiptWidth) / 2,
+        startY: 32,
       };
     };
 
@@ -610,13 +623,15 @@ export function InteractiveReceipt({
 
     const resize = () => {
       const ratio = window.devicePixelRatio || 1;
-      width = Math.max(1, window.innerWidth);
-      height = Math.max(1, window.innerHeight);
+      const rect = anchor.getBoundingClientRect();
+      width = Math.max(1, rect.width);
+      height = Math.max(1, rect.height);
       canvas.width = Math.floor(width * ratio);
       canvas.height = Math.floor(height * ratio);
       ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
       stableFrames = 0;
-      idleFrames = 0;
+      settledFrames = 0;
+      releaseFrames = 0;
       lastSimulationTime = 0;
       setVisible(false);
       resetSheet(getSheetMetrics());
@@ -638,7 +653,8 @@ export function InteractiveReceipt({
     };
 
     const getPoint = (event: PointerEvent) => {
-      return { x: event.clientX, y: event.clientY };
+      const rect = anchor.getBoundingClientRect();
+      return { x: event.clientX - rect.left, y: event.clientY - rect.top };
     };
 
     const onPointerDown = (event: PointerEvent) => {
@@ -656,7 +672,8 @@ export function InteractiveReceipt({
       pointer.vx = 0;
       pointer.vy = 0;
       pointer.grabbedIndex = target;
-      idleFrames = 0;
+      settledFrames = 0;
+      releaseFrames = 0;
       startLoop();
     };
 
@@ -819,10 +836,20 @@ export function InteractiveReceipt({
         constrain();
       }
       draw();
-      idleFrames = nextReceiptIdleFrame(pointer.id != null, idleFrames);
+      const isDragging = pointer.id != null;
+      settledFrames = nextReceiptSettledFrame(
+        isDragging,
+        measureSheetMovement(sheet.particles),
+        settledFrames,
+      );
+      releaseFrames = nextReceiptReleaseFrame(isDragging, releaseFrames);
       const isReducedMotion = reducedMotionMedia.matches;
       if (isReducedMotion || stableFrames >= 2) setVisible(true);
-      if (isReducedMotion || isReceiptSettled(stableFrames, idleFrames)) {
+      if (isReducedMotion || isReceiptSettled(stableFrames, settledFrames, releaseFrames)) {
+        if (!isReducedMotion) {
+          resetSheet(metrics, time);
+          draw();
+        }
         running = false;
         animationFrame = 0;
         return;
@@ -834,11 +861,6 @@ export function InteractiveReceipt({
     if (shouldRun()) resize();
     const observer = new ResizeObserver(resize);
     observer.observe(anchor);
-    const intersectionObserver = new IntersectionObserver(([entry]) => {
-      anchorVisible = Boolean(entry?.isIntersecting);
-      syncLoopState();
-    });
-    intersectionObserver.observe(anchor);
     desktopMedia.addEventListener("change", syncLoopState);
     reducedMotionMedia.addEventListener("change", syncLoopState);
     document.addEventListener("visibilitychange", syncLoopState);
@@ -852,7 +874,6 @@ export function InteractiveReceipt({
     return () => {
       stopLoop();
       observer.disconnect();
-      intersectionObserver.disconnect();
       desktopMedia.removeEventListener("change", syncLoopState);
       reducedMotionMedia.removeEventListener("change", syncLoopState);
       document.removeEventListener("visibilitychange", syncLoopState);
@@ -865,15 +886,15 @@ export function InteractiveReceipt({
   }, [minWidthQuery, payload]);
 
   return (
-    <div ref={anchorRef} className="h-[calc(100dvh-5.5rem)] min-h-[420px]">
+    <div ref={anchorRef} className="relative h-[calc(100dvh-5.5rem)] min-h-[420px]">
       <canvas
         ref={canvasRef}
-        className="invisible pointer-events-none fixed inset-0 z-[61] block h-screen w-screen touch-none"
+        className="invisible pointer-events-none absolute inset-0 z-[61] block h-full w-full touch-none"
         aria-hidden="true"
       />
       <div
         ref={hitSurfaceRef}
-        className="invisible fixed left-0 top-0 z-[62] cursor-grab touch-none active:cursor-grabbing"
+        className="invisible absolute left-0 top-0 z-[62] cursor-grab touch-none active:cursor-grabbing"
         aria-label="Interactive thermal receipt with Verlet paper simulation"
       />
     </div>

--- a/apps/web/src/lib/interactive-receipt-frame-policy.test.ts
+++ b/apps/web/src/lib/interactive-receipt-frame-policy.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   RECEIPT_FRAME_INTERVAL_MS,
+  RECEIPT_MAX_RELEASE_FRAMES,
+  RECEIPT_MOTION_EPSILON_PX,
+  RECEIPT_SETTLED_FRAME_COUNT,
   isReceiptSettled,
-  nextReceiptIdleFrame,
+  nextReceiptReleaseFrame,
+  nextReceiptSettledFrame,
   shouldSimulateReceiptFrame,
 } from "./interactive-receipt-frame-policy";
 
@@ -12,14 +16,22 @@ describe("interactive receipt frame policy", () => {
     expect(shouldSimulateReceiptFrame(RECEIPT_FRAME_INTERVAL_MS + 1, 1)).toBe(true);
   });
 
-  it("resets idle settling while dragging", () => {
-    expect(nextReceiptIdleFrame(true, 20)).toBe(0);
-    expect(nextReceiptIdleFrame(false, 20)).toBe(21);
+  it("requires consecutive low-motion frames after dragging", () => {
+    expect(nextReceiptSettledFrame(true, 0, 5)).toBe(0);
+    expect(nextReceiptSettledFrame(false, RECEIPT_MOTION_EPSILON_PX + 0.01, 5)).toBe(0);
+    expect(nextReceiptSettledFrame(false, RECEIPT_MOTION_EPSILON_PX, 5)).toBe(6);
+    expect(nextReceiptReleaseFrame(true, 20)).toBe(0);
+    expect(nextReceiptReleaseFrame(false, 20)).toBe(21);
   });
 
   it("stops only after layout and motion have settled", () => {
-    expect(isReceiptSettled(1, 36)).toBe(false);
-    expect(isReceiptSettled(2, 35)).toBe(false);
-    expect(isReceiptSettled(2, 36)).toBe(true);
+    expect(isReceiptSettled(1, RECEIPT_SETTLED_FRAME_COUNT, 1)).toBe(false);
+    expect(isReceiptSettled(2, RECEIPT_SETTLED_FRAME_COUNT - 1, 1)).toBe(false);
+    expect(isReceiptSettled(2, RECEIPT_SETTLED_FRAME_COUNT, 1)).toBe(true);
+  });
+
+  it("uses a bounded fallback without treating the current pose as rest", () => {
+    expect(isReceiptSettled(2, 0, RECEIPT_MAX_RELEASE_FRAMES - 1)).toBe(false);
+    expect(isReceiptSettled(2, 0, RECEIPT_MAX_RELEASE_FRAMES)).toBe(true);
   });
 });

--- a/apps/web/src/lib/interactive-receipt-frame-policy.ts
+++ b/apps/web/src/lib/interactive-receipt-frame-policy.ts
@@ -1,14 +1,31 @@
 export const RECEIPT_FRAME_INTERVAL_MS = 1000 / 60;
-export const RECEIPT_IDLE_SETTLE_FRAMES = 36;
+export const RECEIPT_MOTION_EPSILON_PX = 0.12;
+export const RECEIPT_SETTLED_FRAME_COUNT = 8;
+export const RECEIPT_MAX_RELEASE_FRAMES = 300;
 
 export function shouldSimulateReceiptFrame(time: number, lastFrameTime: number): boolean {
   return lastFrameTime === 0 || time - lastFrameTime >= RECEIPT_FRAME_INTERVAL_MS - 1;
 }
 
-export function nextReceiptIdleFrame(isDragging: boolean, idleFrames: number): number {
-  return isDragging ? 0 : idleFrames + 1;
+export function nextReceiptSettledFrame(
+  isDragging: boolean,
+  maxMovement: number,
+  settledFrames: number,
+): number {
+  return !isDragging && maxMovement <= RECEIPT_MOTION_EPSILON_PX ? settledFrames + 1 : 0;
 }
 
-export function isReceiptSettled(stableFrames: number, idleFrames: number): boolean {
-  return stableFrames >= 2 && idleFrames >= RECEIPT_IDLE_SETTLE_FRAMES;
+export function nextReceiptReleaseFrame(isDragging: boolean, releaseFrames: number): number {
+  return isDragging ? 0 : releaseFrames + 1;
+}
+
+export function isReceiptSettled(
+  stableFrames: number,
+  settledFrames: number,
+  releaseFrames: number,
+): boolean {
+  return (
+    stableFrames >= 2 &&
+    (settledFrames >= RECEIPT_SETTLED_FRAME_COUNT || releaseFrames >= RECEIPT_MAX_RELEASE_FRAMES)
+  );
 }

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -232,7 +232,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(13);
+    expect(getUserVersion(getCachePath())).toBe(14);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 5");
@@ -243,7 +243,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(13);
+    expect(getUserVersion(getCachePath())).toBe(14);
   });
 });
 
@@ -251,7 +251,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(13);
+    expect(getUserVersion(getCachePath())).toBe(14);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -408,7 +408,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(13);
+    expect(getUserVersion(getCachePath())).toBe(14);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -964,6 +964,90 @@ describe("searchSessions", () => {
     expect(filteredResults).toHaveLength(1);
     expect(filteredResults[0]?.session.id).toBe("bulk-42");
     expect(filteredResults[0]?.snippet).toContain("<mark>needle</mark>");
+  });
+
+  it("writes each full search entry before loading the next one", () => {
+    const sessions = Array.from({ length: 4 }, (_, index) => makeSession(`stream-${index}`));
+    let loadedCount = 0;
+    let firstWriteLoadedCount: number | undefined;
+    const originalPrepare = Database.prototype.prepare;
+    const prepareSpy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+      this: Database.Database,
+      source: string,
+    ) {
+      const statement = originalPrepare.call(this, source);
+      if (!source.includes("INSERT INTO session_documents(")) return statement;
+
+      const originalRun = statement.run.bind(statement);
+      statement.run = (...params: unknown[]) => {
+        firstWriteLoadedCount ??= loadedCount;
+        return (originalRun as (...boundParams: unknown[]) => Database.RunResult)(...params);
+      };
+      return statement;
+    });
+
+    try {
+      const result = syncSessionSearchIndex("claudecode", sessions, (sessionId) => {
+        loadedCount += 1;
+        return makeSessionData(sessionId, `streamed ${sessionId}`);
+      });
+
+      expect(result).toMatchObject({ changed: 4, indexed: 4, skipped: 0 });
+    } finally {
+      prepareSpy.mockRestore();
+    }
+
+    expect(loadedCount).toBe(4);
+    expect(firstWriteLoadedCount).toBe(1);
+  });
+
+  it("validates normalized message counts instead of raw agent counts", () => {
+    const session = {
+      ...makeSession("normalized-count"),
+      stats: { ...makeSession("normalized-count").stats, message_count: 5 },
+    };
+    const loadSession = vi.fn(() => ({
+      ...session,
+      messages: makeSessionData(session.id, "normalized content").messages,
+    }));
+
+    syncSessionSearchIndex("codex", [session], loadSession);
+    loadSession.mockClear();
+
+    const result = syncSessionSearchIndex("codex", [session], loadSession);
+
+    expect(result).toMatchObject({ changed: 0, indexed: 0, skipped: 0 });
+    expect(loadSession).not.toHaveBeenCalled();
+  });
+
+  it("backfills normalized message counts when migrating existing search documents", () => {
+    const session = makeSession("normalized-count-migration");
+    syncSessionSearchIndex("codex", [session], () =>
+      makeSessionData(session.id, "normalized migration content"),
+    );
+
+    const db = new Database(getCachePath());
+    try {
+      db.prepare("UPDATE session_documents SET indexed_message_count = 0").run();
+      db.pragma("user_version = 13");
+      db.prepare("UPDATE cache_meta SET value = '13' WHERE key = 'version'").run();
+    } finally {
+      db.close();
+    }
+    setSchemaEnsuredPath(null);
+
+    searchSessions("normalized migration");
+
+    const migratedDb = new Database(getCachePath(), { readonly: true });
+    try {
+      const row = migratedDb
+        .prepare("SELECT indexed_message_count FROM session_documents")
+        .get() as { indexed_message_count: number };
+      expect(row.indexed_message_count).toBe(1);
+    } finally {
+      migratedDb.close();
+    }
+    expect(getUserVersion(getCachePath())).toBe(14);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -1576,7 +1660,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(13);
+    expect(getUserVersion(getCachePath())).toBe(14);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -283,7 +283,7 @@ describe("sqlite migration smoke", () => {
         bookmarked_at: now - 500,
       },
     ]);
-    expect(getUserVersion(getCachePath())).toBe(13);
+    expect(getUserVersion(getCachePath())).toBe(14);
     expect(getUserVersion(getStatePath())).toBe(2);
   }, 30_000);
 });

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -37,10 +37,11 @@ import {
   type SessionRow,
 } from "./messages.js";
 
-export const CACHE_SCHEMA_VERSION = 13;
+export const CACHE_SCHEMA_VERSION = 14;
 export interface IndexedSearchRow extends DatabaseRow {
   session_id?: string;
   content_hash?: string;
+  indexed_message_count?: number;
 }
 
 export interface MessageCountRow extends DatabaseRow {
@@ -376,6 +377,7 @@ export function createSearchTables(db: SQLiteDatabase): void {
       activity_time INTEGER NOT NULL,
       content_text TEXT NOT NULL,
       content_hash TEXT NOT NULL,
+      indexed_message_count INTEGER NOT NULL,
       indexed_at INTEGER NOT NULL,
       UNIQUE(agent_name, session_id)
     );
@@ -409,6 +411,27 @@ export function createSearchTriggers(db: SQLiteDatabase): void {
       INSERT INTO session_documents_fts(rowid, title, content_text)
       VALUES (new.id, new.title, new.content_text);
     END;
+  `);
+}
+
+export function addIndexedMessageCount(db: SQLiteDatabase): void {
+  if (!tableExists(db, "session_documents")) return;
+
+  if (!columnExists(db, "session_documents", "indexed_message_count")) {
+    db.exec(
+      "ALTER TABLE session_documents ADD COLUMN indexed_message_count INTEGER NOT NULL DEFAULT 0",
+    );
+  }
+  if (!tableExists(db, "messages")) return;
+
+  db.exec(`
+    UPDATE session_documents
+    SET indexed_message_count = (
+      SELECT COUNT(*)
+      FROM messages
+      WHERE messages.agent_name = session_documents.agent_name
+        AND messages.session_id = session_documents.session_id
+    )
   `);
 }
 
@@ -534,6 +557,9 @@ export function readLegacyCacheVersion(db: SQLiteDatabase): number {
 }
 
 export function inferCacheSchemaVersion(db: SQLiteDatabase): number {
+  if (columnExists(db, "session_documents", "indexed_message_count")) {
+    return 14;
+  }
   if (tableExists(db, "message_tools")) {
     return 11;
   }
@@ -1051,6 +1077,7 @@ export function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
         },
       },
       { version: 13, migrate: createCacheTables },
+      { version: 14, migrate: addIndexedMessageCount },
     ],
   });
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -50,6 +50,7 @@ export interface SearchIndexSyncResult {
 
 interface SearchIndexState {
   contentHashBySessionId: Map<string, string>;
+  indexedMessageCountBySessionId: Map<string, number>;
   messageCountBySessionId: Map<string, number>;
 }
 
@@ -102,6 +103,9 @@ function searchIndexStateFromRows(
     contentHashBySessionId: new Map(
       indexedRows.map((row) => [String(row.session_id), String(row.content_hash ?? "")]),
     ),
+    indexedMessageCountBySessionId: new Map(
+      indexedRows.map((row) => [String(row.session_id), Number(row.indexed_message_count ?? 0)]),
+    ),
     messageCountBySessionId: new Map(
       messageCountRows.map((row) => [String(row.session_id), Number(row.value ?? 0)]),
     ),
@@ -126,13 +130,17 @@ function readSearchIndexState(
           SELECT
             requested.session_id,
             documents.content_hash,
+            documents.indexed_message_count,
             COUNT(messages.message_index) AS value
           FROM requested_session_ids AS requested
           LEFT JOIN session_documents AS documents
             ON documents.agent_name = ? AND documents.session_id = requested.session_id
           LEFT JOIN messages
             ON messages.agent_name = ? AND messages.session_id = requested.session_id
-          GROUP BY requested.session_id, documents.content_hash
+          GROUP BY
+            requested.session_id,
+            documents.content_hash,
+            documents.indexed_message_count
         `,
       )
       .all(...batch, agentName, agentName) as SearchIndexStateRow[];
@@ -140,6 +148,15 @@ function readSearchIndexState(
   }
 
   return searchIndexStateFromRows(rows, rows);
+}
+
+function searchIndexEntryNeedsUpdate(state: SearchIndexState, session: SessionHead): boolean {
+  const sessionId = session.id;
+  return (
+    state.contentHashBySessionId.get(sessionId) !== sessionContentHash(session) ||
+    state.indexedMessageCountBySessionId.get(sessionId) !==
+      (state.messageCountBySessionId.get(sessionId) ?? 0)
+  );
 }
 
 function loadSearchIndexEntry(
@@ -173,12 +190,23 @@ function loadSearchIndexEntry(
   }
 }
 
+function* loadSearchIndexEntries(
+  agentName: string,
+  changes: Iterable<SessionHeadChange>,
+  loadSessionData: (sessionId: string) => SessionData,
+): Generator<LoadedSearchIndexEntry> {
+  for (const change of changes) {
+    const entry = loadSearchIndexEntry(agentName, change, loadSessionData);
+    if (entry) yield entry;
+  }
+}
+
 function writeSearchIndexRows(
   db: SQLiteDatabase,
   agentName: string,
   removedSessionIds: string[],
-  entries: LoadedSearchIndexEntry[],
-): void {
+  entries: Iterable<LoadedSearchIndexEntry>,
+): number {
   const deleteRow = db.prepare(
     "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
   );
@@ -249,8 +277,9 @@ function writeSearchIndexRows(
       activity_time,
       content_text,
       content_hash,
+      indexed_message_count,
       indexed_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id) DO UPDATE SET
       slug = excluded.slug,
       title = excluded.title,
@@ -263,6 +292,7 @@ function writeSearchIndexRows(
       activity_time = excluded.activity_time,
       content_text = excluded.content_text,
       content_hash = excluded.content_hash,
+      indexed_message_count = excluded.indexed_message_count,
       indexed_at = excluded.indexed_at
   `);
 
@@ -273,6 +303,7 @@ function writeSearchIndexRows(
     deleteMessages.run(agentName, sessionId, 0);
   }
 
+  let indexed = 0;
   for (const entry of entries) {
     const activityTime = entry.session.time_updated ?? entry.session.time_created;
     upsertSessionRow(upsertIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
@@ -320,9 +351,12 @@ function writeSearchIndexRows(
       activityTime,
       entry.contentText,
       entry.contentHash,
+      entry.messages.length,
       Date.now(),
     );
+    indexed += 1;
   }
+  return indexed;
 }
 
 export function syncSessionSearchIndex(
@@ -336,7 +370,7 @@ export function syncSessionSearchIndex(
     const startedAt = performance.now();
     const existingRows = db
       .prepare(
-        "SELECT session_id, content_hash FROM session_documents WHERE agent_name = ? ORDER BY id",
+        "SELECT session_id, content_hash, indexed_message_count FROM session_documents WHERE agent_name = ? ORDER BY id",
       )
       .all(agentName) as IndexedSearchRow[];
     const sessionSortIndexMap = new Map(sessions.map((session, index) => [session.id, index]));
@@ -351,28 +385,27 @@ export function syncSessionSearchIndex(
     const toDelete = existingRows
       .map((row) => String(row.session_id))
       .filter((sessionId) => !sessionMap.has(sessionId));
-    const toUpsert = sessions.filter(
-      (session) =>
-        searchIndexState.contentHashBySessionId.get(session.id) !== sessionContentHash(session) ||
-        searchIndexState.messageCountBySessionId.get(session.id) !== session.stats.message_count,
+    const toUpsert = sessions.filter((session) =>
+      searchIndexEntryNeedsUpdate(searchIndexState, session),
     );
     const changedCount = toDelete.length + toUpsert.length;
     const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
-
-    const loaded = toUpsert
-      .map((session) =>
-        loadSearchIndexEntry(
-          agentName,
-          { session, sortIndex: sessionSortIndexMap.get(session.id) ?? 0 },
-          loadSessionData,
-        ),
-      )
-      .filter((entry): entry is LoadedSearchIndexEntry => entry !== null);
-
-    const writeRows = () => writeSearchIndexRows(db, agentName, toDelete, loaded);
+    const changes = toUpsert.map((session) => ({
+      session,
+      sortIndex: sessionSortIndexMap.get(session.id) ?? 0,
+    }));
+    let indexed = 0;
+    const writeRows = () => {
+      indexed = writeSearchIndexRows(
+        db,
+        agentName,
+        toDelete,
+        loadSearchIndexEntries(agentName, changes, loadSessionData),
+      );
+    };
 
     let rebuildDurationMs: number | undefined;
-    const needsRebuild = isBulk && (toDelete.length > 0 || loaded.length > 0);
+    const needsRebuild = isBulk && changedCount > 0;
 
     if (needsRebuild) {
       db.transaction(() => {
@@ -396,8 +429,8 @@ export function syncSessionSearchIndex(
       sessions: sessions.length,
       changed: toUpsert.length,
       deleted: toDelete.length,
-      indexed: loaded.length,
-      skipped: toUpsert.length - loaded.length,
+      indexed,
+      skipped: toUpsert.length - indexed,
       durationMs: performance.now() - startedAt,
       rebuildDurationMs,
     };
@@ -432,23 +465,24 @@ export function syncSessionSearchIndexChanges(
       agentName,
       changes.map(({ session }) => session.id),
     );
-    const toUpsert = changes.filter(
-      ({ session }) =>
-        (searchIndexState.contentHashBySessionId.get(session.id) ?? "") !==
-          sessionContentHash(session) ||
-        (searchIndexState.messageCountBySessionId.get(session.id) ?? 0) !==
-          session.stats.message_count,
+    const toUpsert = changes.filter(({ session }) =>
+      searchIndexEntryNeedsUpdate(searchIndexState, session),
     );
     const uniqueRemovedSessionIds = Array.from(new Set(removedSessionIds));
     const changedCount = uniqueRemovedSessionIds.length + toUpsert.length;
     const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
-    const loaded = toUpsert
-      .map((change) => loadSearchIndexEntry(agentName, change, loadSessionData))
-      .filter((entry): entry is LoadedSearchIndexEntry => entry !== null);
-    const writeRows = () => writeSearchIndexRows(db, agentName, uniqueRemovedSessionIds, loaded);
+    let indexed = 0;
+    const writeRows = () => {
+      indexed = writeSearchIndexRows(
+        db,
+        agentName,
+        uniqueRemovedSessionIds,
+        loadSearchIndexEntries(agentName, toUpsert, loadSessionData),
+      );
+    };
 
     let rebuildDurationMs: number | undefined;
-    const needsRebuild = isBulk && (uniqueRemovedSessionIds.length > 0 || loaded.length > 0);
+    const needsRebuild = isBulk && changedCount > 0;
 
     if (needsRebuild) {
       db.transaction(() => {
@@ -472,8 +506,8 @@ export function syncSessionSearchIndexChanges(
       sessions: changes.length,
       changed: toUpsert.length,
       deleted: uniqueRemovedSessionIds.length,
-      indexed: loaded.length,
-      skipped: toUpsert.length - loaded.length,
+      indexed,
+      skipped: toUpsert.length - indexed,
       durationMs: performance.now() - startedAt,
       rebuildDurationMs,
     };

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -185,7 +185,34 @@ test("keeps detail drawers modal and restores focus", async ({ page }) => {
       }),
     )
     .toBe("opacity, transform|0.2s, 0.26s");
-  await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
+  const receiptCanvas = receiptDialog.locator('canvas[aria-hidden="true"]');
+  await expect(receiptCanvas).toBeVisible();
+  await expect
+    .poll(() =>
+      receiptCanvas.evaluate((element) => {
+        const canvas = element as HTMLCanvasElement;
+        const dialog = canvas.closest('[role="dialog"]');
+        const context = canvas.getContext("2d");
+        const bounds = canvas.getBoundingClientRect();
+        if (!dialog || !context || bounds.width === 0 || bounds.height === 0) return false;
+
+        const dialogBounds = dialog.getBoundingClientRect();
+        const sampleY = Math.min(
+          canvas.height - 1,
+          Math.round((64 / bounds.height) * canvas.height),
+        );
+        const alpha = context.getImageData(Math.floor(canvas.width / 2), sampleY, 1, 1).data[3];
+        return (
+          bounds.left >= dialogBounds.left - 0.5 &&
+          bounds.right <= dialogBounds.right + 0.5 &&
+          Boolean(alpha)
+        );
+      }),
+    )
+    .toBe(true);
+  await expect
+    .poll(() => page.evaluate(() => getComputedStyle(document.body).overflow))
+    .toBe("hidden");
   await expect(page.getByRole("button", { name: "Close session receipt" })).toBeFocused();
   await page.keyboard.press("Tab");
   await expect
@@ -194,7 +221,9 @@ test("keeps detail drawers modal and restores focus", async ({ page }) => {
   await page.keyboard.press("Escape");
   await expect(receiptDialog).toBeHidden();
   await expect(receiptTrigger).toBeFocused();
-  await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+  await expect
+    .poll(() => page.evaluate(() => getComputedStyle(document.body).overflow))
+    .not.toBe("hidden");
 
   await page.setViewportSize({ width: 390, height: 844 });
   const tocTrigger = page.getByRole("button", { name: /^TOC/ });
@@ -203,7 +232,9 @@ test("keeps detail drawers modal and restores focus", async ({ page }) => {
   await expect(tocDialog).toBeVisible();
   await expect(page.getByRole("button", { name: "Close session toc" })).toBeFocused();
   await page.keyboard.press("Tab");
-  await expect.poll(() => tocDialog.evaluate((dialog) => dialog.contains(document.activeElement))).toBe(true);
+  await expect
+    .poll(() => tocDialog.evaluate((dialog) => dialog.contains(document.activeElement)))
+    .toBe(true);
   await page.keyboard.press("Escape");
   await expect(tocDialog).toBeHidden();
   await expect(tocTrigger).toBeFocused();
@@ -212,6 +243,63 @@ test("keeps detail drawers modal and restores focus", async ({ page }) => {
   await expect(tocDialog).toBeVisible();
   await page.setViewportSize({ width: 1280, height: 800 });
   await expect(tocDialog).toBeHidden();
+});
+
+test("returns a dragged receipt to its resting position", async ({ page }) => {
+  await page.goto("/claudecode/e2e-dashboard");
+  await page.getByRole("button", { name: "Open session receipt" }).click();
+
+  const receiptDialog = page.getByRole("dialog", { name: "Session Receipt" });
+  const receiptCanvas = receiptDialog.locator('canvas[aria-hidden="true"]');
+  const receiptHitSurface = page.locator(
+    '[aria-label="Interactive thermal receipt with Verlet paper simulation"]',
+  );
+  await expect(receiptCanvas).toBeVisible();
+  await expect(receiptHitSurface).toBeVisible();
+
+  const readCanvasHash = () =>
+    receiptCanvas.evaluate((element) => {
+      const canvas = element as HTMLCanvasElement;
+      const context = canvas.getContext("2d");
+      if (!context) return 0;
+
+      const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+      let hash = 2166136261;
+      for (let index = 0; index < pixels.length; index += 4) {
+        hash = Math.imul(hash ^ (pixels[index] ?? 0), 16777619);
+        hash = Math.imul(hash ^ (pixels[index + 3] ?? 0), 16777619);
+      }
+      return hash >>> 0;
+    });
+
+  let previousHash: number | undefined;
+  await expect
+    .poll(
+      async () => {
+        const currentHash = await readCanvasHash();
+        const stopped = currentHash === previousHash;
+        previousHash = currentHash;
+        return stopped;
+      },
+      { timeout: 7_000, intervals: [100] },
+    )
+    .toBe(true);
+  const restingHash = await readCanvasHash();
+  const hitBounds = await receiptHitSurface.boundingBox();
+  expect(hitBounds).not.toBeNull();
+  if (!hitBounds) return;
+
+  const startX = hitBounds.x + hitBounds.width / 2;
+  const startY = hitBounds.y + hitBounds.height * 0.75;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 90, startY + 20, { steps: 4 });
+  await page.mouse.up();
+
+  expect(await readCanvasHash()).not.toBe(restingHash);
+  await expect.poll(readCanvasHash, { timeout: 7_000, intervals: [100] }).toBe(restingHash);
+  await page.waitForTimeout(200);
+  expect(await readCanvasHash()).toBe(restingHash);
 });
 
 test("renders a static receipt for reduced motion", async ({ page }) => {
@@ -230,7 +318,7 @@ test("renders a static receipt for reduced motion", async ({ page }) => {
     )
     .toBe("opacity|0.15s|none");
 
-  const receiptCanvas = page.locator('canvas[aria-hidden="true"].fixed');
+  const receiptCanvas = receiptDialog.locator('canvas[aria-hidden="true"]');
   const receiptHitSurface = page.locator(
     '[aria-label="Interactive thermal receipt with Verlet paper simulation"]',
   );


### PR DESCRIPTION
## Summary

- keep the interactive receipt animation running until particle motion settles, then restore the canonical resting pose
- remove the drawer visibility race and keep the canvas and drag surface in drawer-local coordinates
- stream search index backfill writes and persist normalized indexed message counts in cache schema v14

## Root cause

The receipt loop stopped after a fixed number of idle frames instead of observing actual particle movement. The drawer transition could also make `IntersectionObserver` report the receipt as hidden, permanently stopping the loop.

Search index freshness compared raw agent message counts with normalized database rows. Codex sessions therefore remained permanently stale, while the writer loaded every stale session into memory before writing, eventually exhausting the worker heap.

## Impact

Dragged receipts now swing normally and return to their initial position instead of freezing mid-motion. Background persistence avoids unnecessary full reindexing and keeps only one loaded session entry in memory at a time.

## Testing

- related receipt, cache, and migration tests: 60 passed
- repository Vitest suite: all 808 tests obtained passing results; socket tests were rerun outside the restricted sandbox
- dragged receipt Playwright regression passed against the local production build
- Web/Core/CLI type checks passed
- oxfmt and oxlint passed