### PR TITLE
refactor(core): unify file agent transcript assembly

### DIFF
--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -20,6 +20,7 @@ interface FakeSource {
 class FakeFileSystemSource extends FileSystemSessionSource {
   readonly name = "fake";
   readonly displayName = "Fake";
+  lastScanOptions: AgentScanOptions | undefined;
 
   constructor(private sources: FakeSource[] = []) {
     super();
@@ -31,10 +32,6 @@ class FakeFileSystemSource extends FileSystemSessionSource {
 
   isAvailable(): boolean {
     return true;
-  }
-
-  scan(): SessionHead[] {
-    return this.sources.map((s) => s.head).filter((h): h is SessionHead => h !== null);
   }
 
   getSessionData(_sessionId: string): SessionData {
@@ -49,7 +46,8 @@ class FakeFileSystemSource extends FileSystemSessionSource {
     }));
   }
 
-  scanSessionSource(sourcePath: string): SessionHead | null {
+  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
+    this.lastScanOptions = options;
     const found = this.sources.find((s) => s.sourcePath === sourcePath);
     if (!found || !found.head) return null;
     this.sessionMetaMap.set(found.sessionId, {
@@ -92,6 +90,32 @@ describe("BaseAgent", () => {
   it("getUri returns correct format", () => {
     const agent = new FakeFileSystemSource();
     expect(agent.getUri("abc123")).toBe("fake://abc123");
+  });
+});
+
+describe("FileSystemSessionSource.scan", () => {
+  it("scans listed sources and reports progress while skipping invalid entries", () => {
+    const agent = new FakeFileSystemSource([
+      source("a"),
+      source("invalid", "fp-1", { head: null }),
+      source("b"),
+    ]);
+    const progress: Array<{ total?: number; processed?: number; sessions?: number }> = [];
+
+    const options = {
+      fast: true,
+      onProgress: (update: (typeof progress)[number]) => progress.push(update),
+    };
+    const sessions = agent.scan(options);
+
+    expect(sessions.map((session) => session.id)).toEqual(["a", "b"]);
+    expect(agent.lastScanOptions).toBe(options);
+    expect(progress).toEqual([
+      { total: 3, processed: 0, sessions: 0 },
+      { total: 3, processed: 1, sessions: 1 },
+      { total: 3, processed: 2, sessions: 1 },
+      { total: 3, processed: 3, sessions: 2 },
+    ]);
   });
 });
 

--- a/packages/core/src/agents/__tests__/transcript-builder.test.ts
+++ b/packages/core/src/agents/__tests__/transcript-builder.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import { TranscriptBuilder } from "../transcript-builder.js";
+
+describe("TranscriptBuilder", () => {
+  it("groups streaming assistant parts until a tool closes the text message", () => {
+    const builder = new TranscriptBuilder();
+    const meta = { id: "assistant", timestampMs: 10, agent: "codex" };
+
+    builder.appendAssistantPart({ type: "reasoning", text: "think" }, meta);
+    builder.appendAssistantPart({ type: "text", text: "answer" }, meta);
+    builder.appendToolCall(
+      { type: "tool", tool: "read", callID: "call-1", state: { input: { path: "a.ts" } } },
+      meta,
+      { markModeAsTool: true },
+    );
+    builder.appendAssistantPart({ type: "text", text: "after tool" }, meta);
+
+    const result = builder.finish();
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toMatchObject({
+      mode: "tool",
+      parts: [
+        { type: "reasoning", text: "think" },
+        { type: "text", text: "answer" },
+        { type: "tool", callID: "call-1" },
+      ],
+    });
+    expect(result.messages[1]?.parts).toEqual([{ type: "text", text: "after tool" }]);
+  });
+
+  it("preserves message defaults and only deduplicates when requested", () => {
+    const builder = new TranscriptBuilder();
+    const meta = { id: "assistant", timestampMs: 10 };
+
+    builder.appendAssistantPart({ type: "text", text: "same" }, meta);
+    builder.appendAssistantPart({ type: "text", text: "same" }, meta);
+    builder.appendAssistantPart({ type: "text", text: "same" }, meta, {
+      deduplicateTail: true,
+    });
+
+    expect(builder.finish().messages[0]).toEqual({
+      id: "assistant",
+      role: "assistant",
+      agent: null,
+      time_created: 10,
+      mode: null,
+      model: null,
+      provider: null,
+      tokens: undefined,
+      cost: 0,
+      cost_source: undefined,
+      parts: [
+        { type: "text", text: "same" },
+        { type: "text", text: "same" },
+      ],
+      subagent_id: undefined,
+      nickname: undefined,
+    });
+  });
+
+  it("supports sparse message fields for adapters that omit defaults", () => {
+    const builder = new TranscriptBuilder({ messageDefaults: "sparse" });
+    builder.appendMessage({
+      id: "user",
+      role: "user",
+      timestampMs: 10,
+      parts: [{ type: "text", text: "visible" }],
+    });
+
+    expect(JSON.stringify(builder.finish().messages[0])).toBe(
+      '{"id":"user","role":"user","time_created":10,"parts":[{"type":"text","text":"visible"}]}',
+    );
+  });
+
+  it("resolves tool calls without exposing message indexes", () => {
+    const builder = new TranscriptBuilder();
+    builder.appendMessage({
+      id: "assistant",
+      role: "assistant",
+      timestampMs: 10,
+      parts: [{ type: "tool", tool: "read", callID: "call-1", state: {} }],
+    });
+
+    expect(
+      builder.resolveToolCall("call-1", {
+        output: [{ type: "text", text: "done" }],
+        status: "completed",
+        consume: true,
+      }),
+    ).toBe(true);
+    expect(builder.resolveToolCall("call-1", { status: "error" })).toBe(false);
+    expect(builder.finish().messages[0]?.parts[0]?.state).toEqual({
+      output: [{ type: "text", text: "done" }],
+      status: "completed",
+    });
+  });
+
+  it("supports turn-based grouping and explicit tool targets", () => {
+    const builder = new TranscriptBuilder();
+    const meta = { id: "assistant", timestampMs: 10, agent: "kimi" };
+
+    builder.appendAssistantPart({ type: "text", text: "before" }, meta, {
+      grouping: "current",
+    });
+    builder.appendToolCall({ type: "tool", tool: "read", callID: "call-1", state: {} }, meta, {
+      target: "current",
+    });
+    builder.appendAssistantPart({ type: "reasoning", text: "after" }, meta, {
+      grouping: "current",
+    });
+
+    expect(builder.finish().messages).toEqual([
+      expect.objectContaining({
+        parts: [
+          { type: "text", text: "before" },
+          { type: "tool", tool: "read", callID: "call-1", state: {} },
+          { type: "reasoning", text: "after" },
+        ],
+      }),
+    ]);
+  });
+
+  it("can clear a stale text target when reasoning opens a new message", () => {
+    const builder = new TranscriptBuilder();
+    const meta = { id: "assistant", timestampMs: 10, agent: "codex" };
+
+    builder.appendAssistantPart({ type: "text", text: "answer" }, meta);
+    builder.appendAssistantPart({ type: "reasoning", text: "next thought" }, meta, {
+      resetLatestText: true,
+    });
+    builder.appendToolCall({ type: "tool", tool: "read", callID: "call-1", state: {} }, meta);
+
+    const messages = builder.finish().messages;
+    expect(messages[0]?.parts).toEqual([{ type: "text", text: "answer" }]);
+    expect(messages[1]?.parts).toEqual([
+      { type: "reasoning", text: "next thought" },
+      { type: "tool", tool: "read", callID: "call-1", state: {} },
+    ]);
+  });
+
+  it("derives stats after cleaning and preserves external stats baselines", () => {
+    const builder = new TranscriptBuilder();
+    builder.appendMessage({
+      id: "empty",
+      role: "user",
+      timestampMs: 1,
+      parts: [{ type: "text", text: "<command-name>clear</command-name>" }],
+    });
+    builder.appendMessage({
+      id: "assistant",
+      role: "assistant",
+      timestampMs: 2,
+      model: "model",
+      tokens: { input: 10, output: 5, cache_read: 3 },
+      cost: 0.2,
+      costSource: "estimated",
+      parts: [{ type: "text", text: "visible" }],
+    });
+
+    expect(
+      builder.finish({
+        message_count: 0,
+        total_input_tokens: 100,
+        total_output_tokens: 50,
+        total_cost: 0.1,
+      }),
+    ).toEqual({
+      messages: [expect.objectContaining({ id: "assistant" })],
+      stats: {
+        message_count: 1,
+        total_input_tokens: 100,
+        total_output_tokens: 50,
+        total_cache_read_tokens: 3,
+        total_cost: 0.1,
+        cost_source: undefined,
+      },
+    });
+  });
+});

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -127,7 +127,30 @@ export abstract class FileSystemSessionSource<
   abstract listSessionSources(options?: AgentScanOptions): SessionSourceRef[];
 
   /** 解析单个源并写入 metaMap，返回会话 head（解析失败/不可见返回 null）。 */
-  abstract scanSessionSource(sourcePath: string): SessionHead | null;
+  abstract scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null;
+
+  scan(options?: AgentScanOptions): SessionHead[] {
+    const sources = this.listSessionSources(options);
+    const sessions: SessionHead[] = [];
+    options?.onProgress?.({ total: sources.length, processed: 0, sessions: 0 });
+
+    for (const [index, source] of sources.entries()) {
+      try {
+        const session = this.scanSessionSource(source.sourcePath, options);
+        if (session) sessions.push(session);
+      } catch {
+        continue;
+      } finally {
+        options?.onProgress?.({
+          total: sources.length,
+          processed: index + 1,
+          sessions: sessions.length,
+        });
+      }
+    }
+
+    return sessions;
+  }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
     return this.sessionMetaMap as Map<string, SessionCacheMeta>;

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -14,10 +14,11 @@ import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
 import { parseJsonlLines } from "../utils/jsonl.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
-import { cleanInternalText, cleanParsedMessages } from "../utils/session-normalization.js";
-import { perf } from "../utils/perf.js";
+import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { perf } from "../utils/perf.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "./base.js";
+import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const HEAD_INDEX_VERSION = "claudecode-head-v2";
 
@@ -200,47 +201,25 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     }
 
     const content = readFileSync(meta.sourcePath, "utf-8");
-    const messages: Message[] = [];
-    const pendingToolCalls = new Map<string, [number, number]>();
+    const builder = new TranscriptBuilder();
     const ignoredToolCallIds = new Set<string>();
     const assistantUuidToToolCalls = new Map<string, string[]>();
     const countedUsageKeys = new Set<string>();
-    const assistantState = {
-      currentIndex: null as number | null,
-      latestTextIndex: null as number | null,
-    };
-
-    let totalCost = 0;
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheRead = 0;
-    let totalCacheCreate = 0;
-
     for (const record of parseJsonlLines(content)) {
       try {
         this.convertRecord(
           record,
-          messages,
-          pendingToolCalls,
+          builder,
           ignoredToolCallIds,
           assistantUuidToToolCalls,
           countedUsageKeys,
-          assistantState,
         );
       } catch {
         // skip malformed records
       }
     }
 
-    const cleanedMessages = cleanParsedMessages(messages);
-
-    for (const msg of cleanedMessages) {
-      totalCost += msg.cost ?? 0;
-      totalInputTokens += msg.tokens?.input ?? 0;
-      totalOutputTokens += msg.tokens?.output ?? 0;
-      totalCacheRead += msg.tokens?.cache_read ?? 0;
-      totalCacheCreate += msg.tokens?.cache_create ?? 0;
-    }
+    const transcript = builder.finish();
 
     return {
       id: meta.id,
@@ -250,16 +229,8 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
       version: undefined,
       time_created: meta.createdAt,
       time_updated: meta.updatedAt,
-      stats: {
-        message_count: cleanedMessages.length,
-        total_input_tokens: totalInputTokens,
-        total_output_tokens: totalOutputTokens,
-        total_cost: totalCost,
-        cost_source: totalCost > 0 ? "estimated" : undefined,
-        total_cache_read_tokens: totalCacheRead,
-        total_cache_create_tokens: totalCacheCreate,
-      },
-      messages: cleanedMessages,
+      stats: transcript.stats,
+      messages: transcript.messages,
     };
   }
 
@@ -525,12 +496,10 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
   private convertRecord(
     data: Record<string, unknown>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    builder: TranscriptBuilder,
     ignoredToolCallIds: Set<string>,
     assistantUuidToToolCalls: Map<string, string[]>,
     countedUsageKeys: Set<string>,
-    assistantState: { currentIndex: number | null; latestTextIndex: number | null },
   ): void {
     if (data["isMeta"] === true) return;
 
@@ -540,35 +509,24 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     if (msgType === "assistant") {
       this.convertAssistantRecord(
         data,
-        messages,
-        pendingToolCalls,
+        builder,
         ignoredToolCallIds,
         assistantUuidToToolCalls,
         countedUsageKeys,
-        assistantState,
       );
     } else if (msgType === "user") {
-      this.convertUserRecord(
-        data,
-        messages,
-        pendingToolCalls,
-        ignoredToolCallIds,
-        assistantUuidToToolCalls,
-        assistantState,
-      );
+      this.convertUserRecord(data, builder, ignoredToolCallIds, assistantUuidToToolCalls);
     } else if (msgType === "tool_result") {
-      this.convertToolResultRecord(data, messages, assistantState);
+      this.convertToolResultRecord(data, builder);
     }
   }
 
   private convertAssistantRecord(
     data: Record<string, unknown>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    builder: TranscriptBuilder,
     ignoredToolCallIds: Set<string>,
     assistantUuidToToolCalls: Map<string, string[]>,
     countedUsageKeys: Set<string>,
-    assistantState: { currentIndex: number | null; latestTextIndex: number | null },
   ): void {
     const msg = (data["message"] ?? {}) as Record<string, unknown>;
     const timestampMs = parseTimestampMs(data);
@@ -576,9 +534,6 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     const uuid = String(data["uuid"] ?? "");
 
     const toolCallIds: string[] = [];
-    let currentAssistantIndex = assistantState.currentIndex;
-    let latestAssistantTextIndex = assistantState.latestTextIndex;
-
     if (Array.isArray(rawContent)) {
       for (const item of rawContent) {
         if (!item || typeof item !== "object") continue;
@@ -588,11 +543,12 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
         if (partType === "thinking") {
           const text = cleanInternalText(String(part["thinking"] ?? ""));
           if (text) {
-            currentAssistantIndex = this.appendAssistantReasoning(
-              messages,
-              { messageId: uuid, data, msg, timestampMs, text, countedUsageKeys },
-              currentAssistantIndex,
+            const message = builder.appendAssistantPart(
+              this.buildReasoningPart(text, timestampMs),
+              { id: uuid, timestampMs, agent: "claude" },
+              { deduplicateTail: true },
             );
+            this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
           }
           continue;
         }
@@ -600,12 +556,16 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
         if (partType === "text") {
           const text = cleanInternalText(String(part["text"] ?? ""));
           if (text) {
-            currentAssistantIndex = this.appendAssistantText(
-              messages,
-              { messageId: uuid, data, msg, timestampMs, text, countedUsageKeys },
-              currentAssistantIndex,
+            const message = builder.appendAssistantPart(
+              this.buildTextPart(text, timestampMs),
+              {
+                id: uuid,
+                timestampMs,
+                agent: "claude",
+              },
+              { deduplicateTail: true },
             );
-            latestAssistantTextIndex = currentAssistantIndex;
+            this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
           }
           continue;
         }
@@ -621,18 +581,13 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
         }
 
         const toolPart = this.buildToolPart(part, timestampMs);
-        const [msgIndex, partIndex] = this.attachToolCallToLatestAssistant(messages, {
-          messageId: uuid,
-          data,
-          msg,
-          timestampMs,
+        const message = builder.appendToolCall(
           toolPart,
-          latestTextIndex: latestAssistantTextIndex,
-          countedUsageKeys,
-        });
-        currentAssistantIndex = msgIndex;
+          { id: uuid, timestampMs, agent: "claude" },
+          { modeOnCreate: "tool" },
+        );
+        this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
         if (toolCallId) {
-          pendingToolCalls.set(toolCallId, [msgIndex, partIndex]);
           toolCallIds.push(toolCallId);
         }
       }
@@ -641,18 +596,13 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     if (toolCallIds.length > 0) {
       assistantUuidToToolCalls.set(uuid, toolCallIds);
     }
-
-    assistantState.currentIndex = currentAssistantIndex;
-    assistantState.latestTextIndex = latestAssistantTextIndex;
   }
 
   private convertUserRecord(
     data: Record<string, unknown>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    builder: TranscriptBuilder,
     ignoredToolCallIds: Set<string>,
     assistantUuidToToolCalls: Map<string, string[]>,
-    assistantState: { currentIndex: number | null; latestTextIndex: number | null },
   ): void {
     const msg = (data["message"] ?? {}) as Record<string, unknown>;
     const timestampMs = parseTimestampMs(data);
@@ -663,19 +613,15 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     if (typeof content === "string") {
       const parts = this.normalizeUserTextParts(content, timestampMs);
       if (parts.length === 0) {
-        assistantState.currentIndex = null;
-        assistantState.latestTextIndex = null;
+        builder.beginTurn();
         return;
       }
-      messages.push(this.buildMessage({ messageId: uuid, role: "user", timestampMs, parts }));
-      assistantState.currentIndex = null;
-      assistantState.latestTextIndex = null;
+      builder.appendMessage({ id: uuid, role: "user", timestampMs, parts });
       return;
     }
 
     if (!Array.isArray(content)) {
-      assistantState.currentIndex = null;
-      assistantState.latestTextIndex = null;
+      builder.beginTurn();
       return;
     }
 
@@ -691,15 +637,7 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
       if (toolCallId && ignoredToolCallIds.has(toolCallId)) continue;
 
       const outputParts = this.normalizeClaudeToolOutput(ci["content"], timestampMs);
-      if (
-        this.backfillToolOutput(
-          messages,
-          pendingToolCalls,
-          toolCallId,
-          outputParts,
-          toolStateUpdates,
-        )
-      ) {
+      if (this.backfillToolOutput(builder, toolCallId, outputParts, toolStateUpdates)) {
         continue;
       }
 
@@ -709,24 +647,17 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
         toolCallId,
         outputParts,
       });
-      if (fallback) messages.push(fallback);
+      if (fallback) builder.appendMessage(fallback);
     }
 
     if (visibleParts.length > 0) {
-      messages.push(
-        this.buildMessage({ messageId: uuid, role: "user", timestampMs, parts: visibleParts }),
-      );
+      builder.appendMessage({ id: uuid, role: "user", timestampMs, parts: visibleParts });
     }
 
-    assistantState.currentIndex = null;
-    assistantState.latestTextIndex = null;
+    builder.beginTurn();
   }
 
-  private convertToolResultRecord(
-    data: Record<string, unknown>,
-    messages: Message[],
-    assistantState: { currentIndex: number | null; latestTextIndex: number | null },
-  ): void {
+  private convertToolResultRecord(data: Record<string, unknown>, builder: TranscriptBuilder): void {
     const timestampMs = parseTimestampMs(data);
     const msg = (data["message"] ?? {}) as Record<string, unknown>;
     const outputParts = this.normalizeClaudeToolOutput(msg["content"], timestampMs);
@@ -738,40 +669,8 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
       toolCallId: null,
       outputParts,
     });
-    if (fallback) messages.push(fallback);
-
-    assistantState.currentIndex = null;
-    assistantState.latestTextIndex = null;
-  }
-
-  // --- Message building ---
-
-  private buildMessage(opts: {
-    messageId: string;
-    role: string;
-    timestampMs: number;
-    parts: MessagePart[];
-    agent?: string;
-    mode?: string;
-    model?: string | null;
-    provider?: string | null;
-    tokens?: Record<string, unknown>;
-    cost?: number;
-    cost_source?: Message["cost_source"];
-  }): Message {
-    return {
-      id: opts.messageId,
-      role: opts.role as Message["role"],
-      agent: opts.agent ?? null,
-      time_created: opts.timestampMs,
-      mode: opts.mode ?? null,
-      model: opts.model ?? null,
-      provider: opts.provider ?? null,
-      tokens: opts.tokens ? (opts.tokens as Message["tokens"]) : undefined,
-      cost: opts.cost ?? 0,
-      cost_source: opts.cost_source,
-      parts: opts.parts,
-    };
+    if (fallback) builder.appendMessage(fallback);
+    builder.beginTurn();
   }
 
   private buildTextPart(text: string, timestampMs: number): MessagePart {
@@ -822,113 +721,6 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
         message.cost_source = "estimated";
       }
     }
-  }
-
-  // --- Assistant message grouping ---
-
-  private appendAssistantReasoning(
-    messages: Message[],
-    opts: {
-      messageId: string;
-      data: Record<string, unknown>;
-      msg: Record<string, unknown>;
-      timestampMs: number;
-      text: string;
-      countedUsageKeys: Set<string>;
-    },
-    currentIndex: number | null,
-  ): number {
-    const part = this.buildReasoningPart(opts.text, opts.timestampMs);
-
-    if (currentIndex !== null) {
-      const message = messages[currentIndex]!;
-      const hasText = message.parts.some((p) => p.type === "text");
-      const hasTool = message.parts.some((p) => p.type === "tool");
-      if (!hasText && !hasTool) {
-        this.appendPartIfNew(message, part);
-        this.applyAssistantMetadata(message, opts.data, opts.msg, opts.countedUsageKeys);
-        return currentIndex;
-      }
-    }
-
-    const message = this.buildMessage({
-      messageId: opts.messageId,
-      role: "assistant",
-      timestampMs: opts.timestampMs,
-      parts: [part],
-      agent: "claude",
-    });
-    this.applyAssistantMetadata(message, opts.data, opts.msg, opts.countedUsageKeys);
-    messages.push(message);
-    return messages.length - 1;
-  }
-
-  private appendAssistantText(
-    messages: Message[],
-    opts: {
-      messageId: string;
-      data: Record<string, unknown>;
-      msg: Record<string, unknown>;
-      timestampMs: number;
-      text: string;
-      countedUsageKeys: Set<string>;
-    },
-    currentIndex: number | null,
-  ): number {
-    const part = this.buildTextPart(opts.text, opts.timestampMs);
-
-    if (currentIndex !== null) {
-      const message = messages[currentIndex]!;
-      const hasTool = message.parts.some((p) => p.type === "tool");
-      if (!hasTool) {
-        this.appendPartIfNew(message, part);
-        this.applyAssistantMetadata(message, opts.data, opts.msg, opts.countedUsageKeys);
-        return currentIndex;
-      }
-    }
-
-    const message = this.buildMessage({
-      messageId: opts.messageId,
-      role: "assistant",
-      timestampMs: opts.timestampMs,
-      parts: [part],
-      agent: "claude",
-    });
-    this.applyAssistantMetadata(message, opts.data, opts.msg, opts.countedUsageKeys);
-    messages.push(message);
-    return messages.length - 1;
-  }
-
-  private attachToolCallToLatestAssistant(
-    messages: Message[],
-    opts: {
-      messageId: string;
-      data: Record<string, unknown>;
-      msg: Record<string, unknown>;
-      timestampMs: number;
-      toolPart: MessagePart;
-      latestTextIndex: number | null;
-      countedUsageKeys: Set<string>;
-    },
-  ): [number, number] {
-    if (opts.latestTextIndex !== null) {
-      const message = messages[opts.latestTextIndex]!;
-      message.parts.push(opts.toolPart);
-      this.applyAssistantMetadata(message, opts.data, opts.msg, opts.countedUsageKeys);
-      return [opts.latestTextIndex, message.parts.length - 1];
-    }
-
-    const message = this.buildMessage({
-      messageId: opts.messageId,
-      role: "assistant",
-      timestampMs: opts.timestampMs,
-      parts: [opts.toolPart],
-      agent: "claude",
-      mode: "tool",
-    });
-    this.applyAssistantMetadata(message, opts.data, opts.msg, opts.countedUsageKeys);
-    messages.push(message);
-    return [messages.length - 1, 0];
   }
 
   // --- User content normalization ---
@@ -988,42 +780,24 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
   // --- Tool backfill ---
 
   private backfillToolOutput(
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    builder: TranscriptBuilder,
     callId: string,
     outputParts: MessagePart[],
     stateUpdates?: Record<string, unknown>,
   ): boolean {
     if (!callId) return false;
 
-    const location = pendingToolCalls.get(callId);
-    if (location === undefined) return false;
-
-    const [msgIndex, partIndex] = location;
-    const state =
-      messages[msgIndex]!.parts[partIndex]!.state ??
-      (messages[msgIndex]!.parts[partIndex]!.state = {});
-
-    if (outputParts.length > 0) {
-      const existing = state.output;
-      if (Array.isArray(existing)) {
-        existing.push(...outputParts);
-      } else if (existing === null || existing === undefined) {
-        state.output = [...outputParts];
-      } else {
-        state.output = [existing, ...outputParts];
+    return builder.updateToolCall(callId, (part) => {
+      const state = part.state ?? (part.state = {});
+      if (outputParts.length > 0) {
+        const existing = state.output;
+        if (Array.isArray(existing)) existing.push(...outputParts);
+        else if (existing == null) state.output = [...outputParts];
+        else state.output = [existing, ...outputParts];
       }
-    }
-
-    if (stateUpdates) {
-      Object.assign(state, stateUpdates);
-    }
-
-    if (outputParts.length > 0 && !state.status) {
-      state.status = "completed";
-    }
-
-    return outputParts.length > 0 || !!stateUpdates;
+      if (stateUpdates) Object.assign(state, stateUpdates);
+      if (outputParts.length > 0 && !state.status) state.status = "completed";
+    });
   }
 
   private resolveToolCallId(
@@ -1068,29 +842,19 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     timestampMs: number;
     toolCallId: string | null;
     outputParts: MessagePart[];
-  }): Message | null {
+  }): TranscriptMessageInput | null {
     if (opts.outputParts.length === 0) return null;
-    return this.buildMessage({
-      messageId: opts.messageId,
+    return {
+      id: opts.messageId,
       role: "tool",
       timestampMs: opts.timestampMs,
       parts: opts.outputParts,
-    });
+    };
   }
 
   // --- Utilities ---
 
   private shouldIgnoreTool(toolName: string): boolean {
     return toolName === "TodoWrite";
-  }
-
-  private appendPartIfNew(message: Message, part: MessagePart): void {
-    const parts = message.parts;
-    if (parts.length > 0 && parts[parts.length - 1]!.type === part.type) {
-      // Skip if identical to tail part (streaming dedup)
-      const tail = parts[parts.length - 1]!;
-      if (tail.text === part.text) return;
-    }
-    parts.push(part);
   }
 }

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -16,7 +16,6 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import { perf } from "../utils/perf.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "./base.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
@@ -109,56 +108,6 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
       // ignore
     }
     return false;
-  }
-
-  scan(options?: AgentScanOptions): SessionHead[] {
-    if (!this.basePath) return [];
-
-    const scanMarker = perf.start("claudecode:scan");
-    const heads: SessionHead[] = [];
-
-    const listMarker = perf.start("listProjectDirs");
-    const projectDirs = this.listProjectDirs();
-    perf.end(listMarker);
-
-    const filesByProject = projectDirs.map((projectDir) => {
-      const fileMarker = perf.start(`listJsonlFiles:${basename(projectDir)}`);
-      const files = this.listJsonlFiles(projectDir).filter((file) => {
-        try {
-          return matchesScanWindow(statSync(file).mtimeMs, options);
-        } catch {
-          return false;
-        }
-      });
-      perf.end(fileMarker);
-      return { projectDir, files };
-    });
-    const totalFiles = filesByProject.reduce((total, item) => total + item.files.length, 0);
-    options?.onProgress?.({ total: totalFiles, processed: 0, sessions: 0 });
-
-    let processed = 0;
-    for (const { projectDir, files } of filesByProject) {
-      for (const file of files) {
-        try {
-          const parseMarker = perf.start(`parseSessionHead:${basename(file)}`);
-          const head = getParsedSession(this.parseSessionHeadResult(file, projectDir));
-          perf.end(parseMarker);
-
-          if (head) {
-            heads.push(head);
-            this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file, projectDir));
-          }
-        } catch {
-          // skip malformed files
-        } finally {
-          processed += 1;
-          options?.onProgress?.({ total: totalFiles, processed, sessions: heads.length });
-        }
-      }
-    }
-
-    perf.end(scanMarker);
-    return heads;
   }
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -23,7 +23,6 @@ import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../utils/jso
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import { perf } from "../utils/perf.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
 
 // ---------------------------------------------------------------------------
@@ -307,45 +306,6 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     } catch {
       return false;
     }
-  }
-
-  scan(options?: AgentScanOptions): SessionHead[] {
-    if (!this.basePath) return [];
-
-    const scanMarker = perf.start("codex:scan");
-
-    const indexMarker = perf.start("loadSessionIndex");
-    this.loadSessionIndex();
-    perf.end(indexMarker);
-
-    const heads: SessionHead[] = [];
-
-    const listMarker = perf.start("listRolloutFiles");
-    const files = this.listRolloutFiles(options);
-    perf.end(listMarker);
-    options?.onProgress?.({ total: files.length, processed: 0, sessions: 0 });
-
-    let processed = 0;
-    for (const file of files) {
-      try {
-        const parseMarker = perf.start(`parseSessionHead:${basename(file)}`);
-        const head = getParsedSession(this.parseSessionHeadResult(file, options));
-        perf.end(parseMarker);
-
-        if (head) {
-          heads.push(head);
-          this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
-        }
-      } catch {
-        // skip malformed files
-      } finally {
-        processed += 1;
-        options?.onProgress?.({ total: files.length, processed, sessions: heads.length });
-      }
-    }
-
-    perf.end(scanMarker);
-    return heads;
   }
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -17,17 +17,14 @@ import {
   skippedSession,
 } from "./base.js";
 import type { ParseSessionResult } from "./base.js";
-import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
+import type { SessionHead, SessionData, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
 import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../utils/jsonl.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
-import {
-  cleanInternalText,
-  cleanParsedMessages,
-  isInternalEventType,
-} from "../utils/session-normalization.js";
-import { perf } from "../utils/perf.js";
+import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { perf } from "../utils/perf.js";
+import { TranscriptBuilder } from "./transcript-builder.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -317,7 +314,6 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
     const scanMarker = perf.start("codex:scan");
 
-    // Pre-load session index for titles
     const indexMarker = perf.start("loadSessionIndex");
     this.loadSessionIndex();
     perf.end(indexMarker);
@@ -362,9 +358,9 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     }));
   }
 
-  scanSessionSource(sourcePath: string): SessionHead | null {
+  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
     this.loadSessionIndex();
-    const head = getParsedSession(this.parseSessionHeadResult(sourcePath));
+    const head = getParsedSession(this.parseSessionHeadResult(sourcePath, options));
     if (head) {
       this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath));
     }
@@ -376,17 +372,13 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     if (!meta) throw new Error(`Session not found: ${sessionId}`);
     if (!existsSync(meta.sourcePath)) throw new Error(`Session file missing: ${meta.sourcePath}`);
 
-    const messages: Message[] = [];
-    const pendingToolCalls = new Map<string, [number, number]>();
+    const transcript = new TranscriptBuilder();
 
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
     let totalCacheReadTokens = 0;
     let totalCost = 0;
 
-    // Assistant message grouping state
-    let currentAssistantIndex: number | null = null;
-    let latestAssistantTextIndex: number | null = null;
     let pendingPlan: MessagePart | null = null;
     let activeModel: string | null = meta.model;
 
@@ -405,25 +397,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
           activeModel = extractModelName(payload["model"]) ?? activeModel;
         }
 
-        const result = this.convertRecord(
-          record,
-          messages,
-          pendingToolCalls,
-          meta.id,
-          currentAssistantIndex,
-          latestAssistantTextIndex,
-          pendingPlan,
-        );
-        currentAssistantIndex = result.currentAssistantIndex;
-        latestAssistantTextIndex = result.latestAssistantTextIndex;
-        pendingPlan = result.pendingPlan;
-
-        if (currentAssistantIndex !== null && activeModel) {
-          const message = messages[currentAssistantIndex];
-          if (message?.role === "assistant" && !message.model) {
-            message.model = activeModel;
-          }
-        }
+        pendingPlan = this.convertRecord(record, transcript, pendingPlan, activeModel);
 
         // Process Codex token_count events
         if (recordType === "event_msg") {
@@ -469,25 +443,19 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
                 totalOutputTokens += outputTokens + reasoningTokens;
                 totalCacheReadTokens += totalCacheRead;
 
-                // Bind to the most recent assistant message without tokens
-                for (let i = messages.length - 1; i >= 0; i--) {
-                  const msg = messages[i]!;
-                  if (msg.role === "assistant" && !msg.tokens) {
-                    msg.tokens = {
-                      input: totalInput,
-                      output: outputTokens,
-                      reasoning: reasoningTokens || undefined,
-                      cache_read: totalCacheRead || undefined,
-                    };
-                    const cost = estimateTokenCost(msg.model ?? activeModel, msg.tokens);
-                    if (cost !== null) {
-                      msg.cost = cost;
-                      msg.cost_source = "estimated";
-                      totalCost += cost;
-                    }
-                    break;
-                  }
-                }
+                const tokens = {
+                  input: totalInput,
+                  output: outputTokens,
+                  reasoning: reasoningTokens || undefined,
+                  cache_read: totalCacheRead || undefined,
+                };
+                const cost = estimateTokenCost(activeModel, tokens);
+                transcript.attachUsageToLatestAssistant(tokens, {
+                  model: activeModel,
+                  cost: cost ?? undefined,
+                  costSource: cost === null ? undefined : "estimated",
+                });
+                totalCost += cost ?? 0;
               }
             }
           }
@@ -497,11 +465,15 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       }
     }
 
-    // Finalize pending plan if any
-    if (pendingPlan && currentAssistantIndex !== null) {
-      messages[currentAssistantIndex]!.parts.push(pendingPlan);
-    }
-    const cleanedMessages = cleanParsedMessages(messages);
+    if (pendingPlan) transcript.appendToCurrentAssistant(pendingPlan);
+    const result = transcript.finish({
+      message_count: 0,
+      total_input_tokens: totalInputTokens,
+      total_output_tokens: totalOutputTokens,
+      total_cache_read_tokens: totalCacheReadTokens || undefined,
+      total_cost: totalCost,
+      cost_source: totalCost > 0 ? "estimated" : undefined,
+    });
 
     return {
       id: meta.id,
@@ -510,15 +482,8 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       directory: meta.directory,
       time_created: meta.createdAt,
       time_updated: meta.updatedAt,
-      stats: {
-        message_count: cleanedMessages.length,
-        total_input_tokens: totalInputTokens,
-        total_output_tokens: totalOutputTokens,
-        total_cache_read_tokens: totalCacheReadTokens || undefined,
-        total_cost: totalCost,
-        cost_source: totalCost > 0 ? "estimated" : undefined,
-      },
-      messages: cleanedMessages,
+      stats: result.stats,
+      messages: result.messages,
     };
   }
 
@@ -907,36 +872,22 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
   private convertRecord(
     data: Record<string, unknown>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
-    sessionId: string,
-    currentAssistantIndex: number | null,
-    latestAssistantTextIndex: number | null,
+    transcript: TranscriptBuilder,
     pendingPlan: MessagePart | null,
-  ): {
-    currentAssistantIndex: number | null;
-    latestAssistantTextIndex: number | null;
-    pendingPlan: MessagePart | null;
-  } {
+    activeModel: string | null,
+  ): MessagePart | null {
     const recordType = String(data["type"] ?? "");
-    if (isInternalEventType(recordType)) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-    }
+    if (isInternalEventType(recordType)) return pendingPlan;
 
-    // Skip non-response records
     if (recordType === "session_meta" || recordType === "event_msg") {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+      return pendingPlan;
     }
 
-    if (recordType !== "response_item") {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-    }
+    if (recordType !== "response_item") return pendingPlan;
 
     const payload = (data["payload"] ?? {}) as Record<string, unknown>;
     const payloadType = String(payload["type"] ?? "");
-    if (isInternalEventType(payloadType)) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-    }
+    if (isInternalEventType(payloadType)) return pendingPlan;
     const timestampMs = parseTimestampMs(data) || parseTimestampMs(payload);
 
     switch (payloadType) {
@@ -945,81 +896,54 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
         if (role === "assistant") {
           return this.convertAssistantMessage(
             payload,
-            messages,
+            transcript,
             timestampMs,
-            currentAssistantIndex,
-            latestAssistantTextIndex,
             pendingPlan,
+            activeModel,
           );
         }
         if (role === "user") {
-          return this.convertUserMessage(
-            payload,
-            messages,
-            timestampMs,
-            currentAssistantIndex,
-            latestAssistantTextIndex,
-            pendingPlan,
-          );
+          return this.convertUserMessage(payload, transcript, timestampMs, pendingPlan);
         }
         break;
       }
 
       case "reasoning":
-        return this.convertReasoning(payload, messages, timestampMs, currentAssistantIndex);
+        this.convertReasoning(payload, transcript, timestampMs, activeModel);
+        return null;
 
       case "function_call":
-        return this.convertFunctionCall(
-          payload,
-          messages,
-          pendingToolCalls,
-          timestampMs,
-          currentAssistantIndex,
-          latestAssistantTextIndex,
-        );
+        this.convertFunctionCall(payload, transcript, timestampMs, activeModel);
+        return null;
 
       case "function_call_output":
-        this.convertFunctionCallOutput(payload, messages, pendingToolCalls, timestampMs);
-        return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+        this.convertToolCallOutput(payload, transcript, timestampMs);
+        return pendingPlan;
 
       case "custom_tool_call":
-        return this.convertCustomToolCall(
-          payload,
-          messages,
-          pendingToolCalls,
-          timestampMs,
-          currentAssistantIndex,
-          latestAssistantTextIndex,
-        );
+        this.convertCustomToolCall(payload, transcript, timestampMs, activeModel);
+        return null;
 
       case "custom_tool_call_output":
-        this.convertCustomToolCallOutput(payload, messages, pendingToolCalls, timestampMs);
-        return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+        this.convertToolCallOutput(payload, transcript, timestampMs);
+        return pendingPlan;
     }
 
-    return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+    return pendingPlan;
   }
 
   // ---- Assistant message ----
 
   private convertAssistantMessage(
     payload: Record<string, unknown>,
-    messages: Message[],
+    transcript: TranscriptBuilder,
     timestampMs: number,
-    currentAssistantIndex: number | null,
-    latestAssistantTextIndex: number | null,
     pendingPlan: MessagePart | null,
-  ): {
-    currentAssistantIndex: number | null;
-    latestAssistantTextIndex: number | null;
-    pendingPlan: MessagePart | null;
-  } {
+    activeModel: string | null,
+  ): MessagePart | null {
     const content = payload["content"];
-    if (!Array.isArray(content)) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-    }
+    if (!Array.isArray(content)) return pendingPlan;
 
-    // Extract output_text items
     const textParts: string[] = [];
     for (const item of content) {
       if (typeof item !== "object" || item === null) continue;
@@ -1030,13 +954,10 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       }
     }
 
-    if (textParts.length === 0) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-    }
+    if (textParts.length === 0) return pendingPlan;
 
     const fullText = textParts.join("\n");
 
-    // Check for proposed plan
     const planMatch = fullText.match(PROPOSED_PLAN_PATTERN);
     if (planMatch) {
       const planText = planMatch[1]!.trim();
@@ -1049,54 +970,27 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       pendingPlan = planPart;
     }
 
-    // Build text part (strip the proposed plan tags)
     const displayText = cleanInternalText(fullText.replace(PROPOSED_PLAN_PATTERN, ""));
-    if (!displayText) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-    }
+    if (!displayText) return pendingPlan;
 
     const textPart: MessagePart = { type: "text", text: displayText, time_created: timestampMs };
-
-    // Append to current assistant or create new one
-    if (currentAssistantIndex !== null) {
-      const message = messages[currentAssistantIndex]!;
-      const hasTool = message.parts.some((p) => p.type === "tool");
-      if (!hasTool) {
-        message.parts.push(textPart);
-        latestAssistantTextIndex = currentAssistantIndex;
-        return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-      }
-    }
-
-    messages.push(
-      this.buildMessage({
-        messageId: "",
-        role: "assistant",
-        timestampMs,
-        parts: [textPart],
-        agent: "codex",
-      }),
-    );
-    currentAssistantIndex = messages.length - 1;
-    latestAssistantTextIndex = currentAssistantIndex;
-
-    return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+    transcript.appendAssistantPart(textPart, {
+      id: "",
+      timestampMs,
+      agent: "codex",
+      model: activeModel,
+    });
+    return pendingPlan;
   }
 
   // ---- User message ----
 
   private convertUserMessage(
     payload: Record<string, unknown>,
-    messages: Message[],
+    transcript: TranscriptBuilder,
     timestampMs: number,
-    currentAssistantIndex: number | null,
-    latestAssistantTextIndex: number | null,
     pendingPlan: MessagePart | null,
-  ): {
-    currentAssistantIndex: number | null;
-    latestAssistantTextIndex: number | null;
-    pendingPlan: MessagePart | null;
-  } {
+  ): MessagePart | null {
     const content = payload["content"];
     const text = Array.isArray(content)
       ? content
@@ -1109,39 +1003,21 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       : String(content ?? "");
 
     const visibleText = cleanInternalText(text);
-    if (!visibleText) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-    }
+    if (!visibleText) return pendingPlan;
 
-    // Skip injected developer/system context messages
-    if (isDeveloperLikeUserMessage(visibleText)) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
-    }
+    if (isDeveloperLikeUserMessage(visibleText)) return pendingPlan;
 
-    // Check for plan approval
     if (visibleText.trimStart().startsWith(PLAN_APPROVAL_PREFIX)) {
-      // Finalize pending plan by attaching it to current assistant
-      if (pendingPlan && currentAssistantIndex !== null) {
-        messages[currentAssistantIndex]!.parts.push(pendingPlan);
-      }
-      pendingPlan = null;
-
-      // The approval message itself is a user message
-      messages.push(
-        this.buildMessage({
-          messageId: "",
-          role: "user",
-          timestampMs,
-          parts: [{ type: "text", text: visibleText, time_created: timestampMs }],
-        }),
-      );
-
-      currentAssistantIndex = null;
-      latestAssistantTextIndex = null;
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+      if (pendingPlan) transcript.appendToCurrentAssistant(pendingPlan);
+      transcript.appendMessage({
+        id: "",
+        role: "user",
+        timestampMs,
+        parts: [{ type: "text", text: visibleText, time_created: timestampMs }],
+      });
+      return null;
     }
 
-    // Check for subagent notification
     const subagentMatch = visibleText.match(SUBAGENT_NOTIFICATION_PATTERN);
     if (subagentMatch) {
       try {
@@ -1150,64 +1026,47 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
         const nickname = String(notifPayload["nickname"] ?? "");
         const completedText = String(notifPayload["completed"] ?? "");
 
-        // Convert user message with subagent notification to assistant message
         const textPart: MessagePart = {
           type: "text",
           text: completedText || `Subagent ${nickname} completed`,
           time_created: timestampMs,
         };
 
-        messages.push(
-          this.buildMessage({
-            messageId: "",
-            role: "assistant",
-            timestampMs,
-            parts: [textPart],
-            agent: "codex",
-            subagent_id: agentId || undefined,
-            nickname: nickname || undefined,
-          }),
-        );
-
-        currentAssistantIndex = null;
-        latestAssistantTextIndex = null;
-        return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+        transcript.appendMessage({
+          id: "",
+          role: "assistant",
+          timestampMs,
+          parts: [textPart],
+          agent: "codex",
+          subagentId: agentId || undefined,
+          nickname: nickname || undefined,
+        });
+        transcript.beginTurn();
+        return pendingPlan;
       } catch {
-        // Not valid JSON, treat as normal user message
+        // Treat malformed notification payloads as normal user messages.
       }
     }
 
-    // Normal user message
-    messages.push(
-      this.buildMessage({
-        messageId: "",
-        role: "user",
-        timestampMs,
-        parts: [{ type: "text", text: visibleText, time_created: timestampMs }],
-      }),
-    );
-
-    currentAssistantIndex = null;
-    latestAssistantTextIndex = null;
-    return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan };
+    transcript.appendMessage({
+      id: "",
+      role: "user",
+      timestampMs,
+      parts: [{ type: "text", text: visibleText, time_created: timestampMs }],
+    });
+    return pendingPlan;
   }
 
   // ---- Reasoning ----
 
   private convertReasoning(
     payload: Record<string, unknown>,
-    messages: Message[],
+    transcript: TranscriptBuilder,
     timestampMs: number,
-    currentAssistantIndex: number | null,
-  ): {
-    currentAssistantIndex: number | null;
-    latestAssistantTextIndex: number | null;
-    pendingPlan: MessagePart | null;
-  } {
+    activeModel: string | null,
+  ): void {
     const summary = payload["summary"];
-    if (!Array.isArray(summary)) {
-      return { currentAssistantIndex, latestAssistantTextIndex: null, pendingPlan: null };
-    }
+    if (!Array.isArray(summary)) return;
 
     const texts: string[] = [];
     for (const item of summary) {
@@ -1220,59 +1079,33 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       }
     }
 
-    if (texts.length === 0) {
-      return { currentAssistantIndex, latestAssistantTextIndex: null, pendingPlan: null };
-    }
+    if (texts.length === 0) return;
 
     const reasoningText = texts.join("\n");
     const part: MessagePart = { type: "reasoning", text: reasoningText, time_created: timestampMs };
-
-    if (currentAssistantIndex !== null) {
-      const message = messages[currentAssistantIndex]!;
-      const hasText = message.parts.some((p) => p.type === "text");
-      const hasTool = message.parts.some((p) => p.type === "tool");
-      if (!hasText && !hasTool) {
-        message.parts.push(part);
-        return { currentAssistantIndex, latestAssistantTextIndex: null, pendingPlan: null };
-      }
-    }
-
-    messages.push(
-      this.buildMessage({
-        messageId: "",
-        role: "assistant",
+    transcript.appendAssistantPart(
+      part,
+      {
+        id: "",
         timestampMs,
-        parts: [part],
         agent: "codex",
-      }),
+        model: activeModel,
+      },
+      { resetLatestText: true },
     );
-
-    return {
-      currentAssistantIndex: messages.length - 1,
-      latestAssistantTextIndex: null,
-      pendingPlan: null,
-    };
   }
 
   // ---- Function call ----
 
   private convertFunctionCall(
     payload: Record<string, unknown>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    transcript: TranscriptBuilder,
     timestampMs: number,
-    currentAssistantIndex: number | null,
-    latestAssistantTextIndex: number | null,
-  ): {
-    currentAssistantIndex: number | null;
-    latestAssistantTextIndex: number | null;
-    pendingPlan: MessagePart | null;
-  } {
+    activeModel: string | null,
+  ): void {
     const callId = String(payload["call_id"] ?? "").trim();
     const name = String(payload["name"] ?? "").trim();
-    if (!name) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan: null };
-    }
+    if (!name) return;
 
     const toolIdentity = resolveToolIdentity(name, payload["namespace"]);
     const arguments_ = normalizeToolArguments(payload["arguments"]);
@@ -1290,69 +1123,30 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       time_created: timestampMs,
     };
 
-    // Attach to latest assistant text message
-    const targetIndex = latestAssistantTextIndex ?? currentAssistantIndex;
-    if (targetIndex !== null) {
-      const message = messages[targetIndex]!;
-      const partIndex = message.parts.length;
-      message.parts.push(toolPart);
-      message.mode = "tool";
-      if (callId) {
-        pendingToolCalls.set(callId, [targetIndex, partIndex]);
-      }
-      return {
-        currentAssistantIndex: targetIndex,
-        latestAssistantTextIndex: targetIndex,
-        pendingPlan: null,
-      };
-    }
-
-    // Fallback: create new assistant message for tool
-    messages.push(
-      this.buildMessage({
-        messageId: "",
-        role: "assistant",
-        timestampMs,
-        parts: [toolPart],
-        agent: "codex",
-        mode: "tool",
-      }),
+    transcript.appendToolCall(
+      toolPart,
+      { id: "", timestampMs, agent: "codex", model: activeModel },
+      { markModeAsTool: true },
     );
-    const newIndex = messages.length - 1;
-    if (callId) {
-      pendingToolCalls.set(callId, [newIndex, 0]);
-    }
-
-    return { currentAssistantIndex: newIndex, latestAssistantTextIndex: null, pendingPlan: null };
   }
 
   // ---- Function call output ----
 
-  private convertFunctionCallOutput(
+  private convertToolCallOutput(
     payload: Record<string, unknown>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    transcript: TranscriptBuilder,
     timestampMs: number,
   ): void {
     const callId = String(payload["call_id"] ?? "").trim();
     if (!callId) return;
-
-    const location = pendingToolCalls.get(callId);
-    if (!location) return;
 
     const outputText = cleanInternalText(String(payload["output"] ?? ""));
     const outputParts: MessagePart[] = outputText
       ? [{ type: "text", text: outputText, time_created: timestampMs }]
       : [];
 
-    const [msgIndex, partIndex] = location;
-    const state =
-      messages[msgIndex]!.parts[partIndex]!.state ??
-      (messages[msgIndex]!.parts[partIndex]!.state = {});
-
     if (outputParts.length > 0) {
-      state.output = [...outputParts];
-      state.status = "completed";
+      transcript.resolveToolCall(callId, { output: outputParts, status: "completed" });
     }
   }
 
@@ -1360,21 +1154,13 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
   private convertCustomToolCall(
     payload: Record<string, unknown>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    transcript: TranscriptBuilder,
     timestampMs: number,
-    currentAssistantIndex: number | null,
-    latestAssistantTextIndex: number | null,
-  ): {
-    currentAssistantIndex: number | null;
-    latestAssistantTextIndex: number | null;
-    pendingPlan: MessagePart | null;
-  } {
+    activeModel: string | null,
+  ): void {
     const callId = String(payload["call_id"] ?? "").trim();
     const name = String(payload["name"] ?? "").trim();
-    if (!name) {
-      return { currentAssistantIndex, latestAssistantTextIndex, pendingPlan: null };
-    }
+    if (!name) return;
 
     const toolIdentity = resolveToolIdentity(name, payload["namespace"]);
     const rawInput = payload["input"];
@@ -1393,101 +1179,10 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       time_created: timestampMs,
     };
 
-    // Attach to latest assistant text message
-    const targetIndex = latestAssistantTextIndex ?? currentAssistantIndex;
-    if (targetIndex !== null) {
-      const message = messages[targetIndex]!;
-      const partIndex = message.parts.length;
-      message.parts.push(toolPart);
-      message.mode = "tool";
-      if (callId) {
-        pendingToolCalls.set(callId, [targetIndex, partIndex]);
-      }
-      return {
-        currentAssistantIndex: targetIndex,
-        latestAssistantTextIndex: targetIndex,
-        pendingPlan: null,
-      };
-    }
-
-    // Fallback: create new assistant message
-    messages.push(
-      this.buildMessage({
-        messageId: "",
-        role: "assistant",
-        timestampMs,
-        parts: [toolPart],
-        agent: "codex",
-        mode: "tool",
-      }),
+    transcript.appendToolCall(
+      toolPart,
+      { id: "", timestampMs, agent: "codex", model: activeModel },
+      { markModeAsTool: true },
     );
-    const newIndex = messages.length - 1;
-    if (callId) {
-      pendingToolCalls.set(callId, [newIndex, 0]);
-    }
-
-    return { currentAssistantIndex: newIndex, latestAssistantTextIndex: null, pendingPlan: null };
-  }
-
-  // ---- Custom tool call output ----
-
-  private convertCustomToolCallOutput(
-    payload: Record<string, unknown>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
-    timestampMs: number,
-  ): void {
-    const callId = String(payload["call_id"] ?? "").trim();
-    if (!callId) return;
-
-    const location = pendingToolCalls.get(callId);
-    if (!location) return;
-
-    const outputText = cleanInternalText(String(payload["output"] ?? ""));
-    const outputParts: MessagePart[] = outputText
-      ? [{ type: "text", text: outputText, time_created: timestampMs }]
-      : [];
-
-    const [msgIndex, partIndex] = location;
-    const state =
-      messages[msgIndex]!.parts[partIndex]!.state ??
-      (messages[msgIndex]!.parts[partIndex]!.state = {});
-
-    if (outputParts.length > 0) {
-      state.output = [...outputParts];
-      state.status = "completed";
-    }
-  }
-
-  // ---- Message builder ----
-
-  private buildMessage(opts: {
-    messageId: string;
-    role: string;
-    timestampMs: number;
-    parts: MessagePart[];
-    agent?: string;
-    mode?: string;
-    model?: string | null;
-    provider?: string | null;
-    tokens?: Record<string, unknown>;
-    cost?: number;
-    subagent_id?: string;
-    nickname?: string;
-  }): Message {
-    return {
-      id: opts.messageId,
-      role: opts.role as Message["role"],
-      agent: opts.agent ?? null,
-      time_created: opts.timestampMs,
-      mode: opts.mode ?? null,
-      model: opts.model ?? null,
-      provider: opts.provider ?? null,
-      tokens: opts.tokens ? (opts.tokens as Message["tokens"]) : undefined,
-      cost: opts.cost ?? 0,
-      parts: opts.parts,
-      subagent_id: opts.subagent_id,
-      nickname: opts.nickname,
-    };
   }
 }

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -21,7 +21,6 @@ import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import { perf } from "../utils/perf.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const KIMI_TOOL_TITLE_MAP: Record<string, string> = {
@@ -284,58 +283,6 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     } catch {
       return skippedSession("malformed metadata");
     }
-  }
-
-  scan(options?: AgentScanOptions): SessionHead[] {
-    if (!this.basePath) return [];
-
-    const scanMarker = perf.start("kimi:scan");
-
-    const listMarker = perf.start("listSessionDirs");
-    const sessionDirs = this.listSessionDirs();
-    perf.end(listMarker);
-
-    const metas: SessionMeta[] = [];
-    for (const dir of sessionDirs) {
-      try {
-        const parseMarker = perf.start(`parseSessionDir:${basename(dir)}`);
-        const meta = getParsedSession(this.parseSessionDirResult(dir));
-        perf.end(parseMarker);
-        if (meta && matchesScanWindow(meta.createdAt, options)) {
-          metas.push(meta);
-        }
-      } catch {
-        // skip
-      }
-    }
-    options?.onProgress?.({ total: metas.length, processed: 0, sessions: 0 });
-
-    const heads: SessionHead[] = [];
-    let processed = 0;
-    for (const meta of metas) {
-      try {
-        meta.sourceFingerprint = this.sourceFingerprint(meta);
-        this.sessionMetaMap.set(meta.id, meta);
-        const stats = this.extractStats(meta.sourcePath);
-        heads.push({
-          id: meta.id,
-          slug: `kimi/${meta.id}`,
-          title: meta.title,
-          directory: meta.cwd,
-          time_created: meta.createdAt,
-          time_updated: meta.createdAt,
-          stats,
-        });
-      } catch {
-        // skip
-      } finally {
-        processed += 1;
-        options?.onProgress?.({ total: metas.length, processed, sessions: heads.length });
-      }
-    }
-
-    perf.end(scanMarker);
-    return heads;
   }
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -14,14 +14,15 @@ import type {
   SessionCacheMeta,
   SessionSourceRef,
 } from "./base.js";
-import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
+import type { SessionHead, SessionData, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
 import { parseJsonlLines } from "../utils/jsonl.js";
 import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
-import { cleanInternalText, cleanParsedMessages } from "../utils/session-normalization.js";
-import { perf } from "../utils/perf.js";
+import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { perf } from "../utils/perf.js";
+import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const KIMI_TOOL_TITLE_MAP: Record<string, string> = {
   ReadFile: "read",
@@ -383,8 +384,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     if (!meta.contextFile) throw new Error("context.jsonl is missing");
 
     const content = readFileSync(meta.contextFile, "utf-8");
-    const messages: Message[] = [];
-    const pendingToolCalls = new Map<string, [number, number]>();
+    const builder = new TranscriptBuilder();
     const ignoredToolCallIds = new Set<string>();
 
     let seq = 0;
@@ -398,31 +398,25 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
         if (role === "user") {
           const text = cleanInternalText(kimiContentText(record.content));
           if (text) {
-            messages.push(
-              this.buildMessage({
-                messageId: `context-${seq}`,
-                role: "user",
-                timestampMs: fallbackTs,
-                parts: [{ type: "text", text, time_created: fallbackTs }],
-              }),
-            );
+            builder.appendMessage({
+              id: `context-${seq}`,
+              role: "user",
+              timestampMs: fallbackTs,
+              parts: [{ type: "text", text, time_created: fallbackTs }],
+            });
           }
           continue;
         }
 
         if (role === "assistant") {
-          const { message, toolIndexes } = this.buildContextAssistantMessage(
+          const message = this.buildContextAssistantMessage(
             record,
             seq,
             ignoredToolCallIds,
             fallbackTs,
           );
           if (!message) continue;
-          const msgIndex = messages.length;
-          messages.push(message);
-          for (const [callId, partIndex] of toolIndexes) {
-            pendingToolCalls.set(callId, [msgIndex, partIndex]);
-          }
+          builder.appendMessage(message);
           continue;
         }
 
@@ -430,18 +424,16 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
           const callId = String(record.tool_call_id ?? "").trim();
           if (callId && ignoredToolCallIds.has(callId)) continue;
           const outputParts = normalizeToolOutputParts(record.content, fallbackTs);
-          if (callId && this.backfillToolOutput(messages, pendingToolCalls, callId, outputParts)) {
+          if (callId && this.backfillToolOutput(builder, callId, outputParts)) {
             continue;
           }
           if (outputParts.length > 0) {
-            messages.push(
-              this.buildMessage({
-                messageId: `context-${seq}`,
-                role: "tool",
-                timestampMs: fallbackTs,
-                parts: outputParts,
-              }),
-            );
+            builder.appendMessage({
+              id: `context-${seq}`,
+              role: "tool",
+              timestampMs: fallbackTs,
+              parts: outputParts,
+            });
           }
         }
       } catch {
@@ -450,7 +442,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     }
 
     const stats = this.extractStats(meta.sourcePath);
-    return this.buildSessionData(meta, messages, stats);
+    return this.buildSessionData(meta, builder, stats);
   }
 
   private getSessionDataFromWire(meta: SessionMeta): SessionData {
@@ -458,12 +450,10 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     if (!existsSync(wirePath)) throw new Error("wire.jsonl is missing");
 
     const content = readFileSync(wirePath, "utf-8");
-    const messages: Message[] = [];
-    const pendingToolCalls = new Map<string, [number, number]>();
+    const builder = new TranscriptBuilder();
     const ignoredToolCallIds = new Set<string>();
     const openToolArgumentBuffer = new Map<string, string>();
 
-    let currentAssistantIndex: number | null = null;
     let openToolCallId: string | null = null;
     let seq = 0;
 
@@ -483,19 +473,13 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
           const inputTokens = Number(usage["input_tokens"] ?? 0);
           const outputTokens = Number(usage["output_tokens"] ?? 0);
           if (inputTokens || outputTokens) {
-            for (let i = messages.length - 1; i >= 0; i--) {
-              const msg = messages[i]!;
-              if (msg.role === "assistant" && !msg.tokens) {
-                msg.tokens = { input: inputTokens, output: outputTokens };
-                msg.model ??= this.defaultModel;
-                const cost = estimateTokenCost(msg.model, msg.tokens);
-                if (cost !== null) {
-                  msg.cost = cost;
-                  msg.cost_source = "estimated";
-                }
-                break;
-              }
-            }
+            const tokens = { input: inputTokens, output: outputTokens };
+            const cost = estimateTokenCost(this.defaultModel, tokens);
+            builder.attachUsageToLatestAssistant(tokens, {
+              model: this.defaultModel,
+              cost: cost ?? undefined,
+              costSource: cost === null ? undefined : "estimated",
+            });
           }
         }
 
@@ -504,38 +488,38 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
           if (Array.isArray(userInput) && userInput.length > 0) {
             const text = cleanInternalText(kimiContentText(userInput));
             if (text) {
-              messages.push(
-                this.buildMessage({
-                  messageId: `wire-${seq}`,
-                  role: "user",
-                  timestampMs,
-                  parts: [{ type: "text", text, time_created: timestampMs }],
-                }),
-              );
+              builder.appendMessage({
+                id: `wire-${seq}`,
+                role: "user",
+                timestampMs,
+                parts: [{ type: "text", text, time_created: timestampMs }],
+              });
             }
           }
-          currentAssistantIndex = null;
+          builder.beginTurn();
           openToolCallId = null;
           continue;
         }
 
         if (msgType === "ContentPart") {
-          currentAssistantIndex = this.getOrCreateWireAssistant(
-            messages,
-            currentAssistantIndex,
-            `wire-${seq}`,
-          );
-          const assistant = messages[currentAssistantIndex]!;
           const partType = String(payload.type ?? "");
           if (partType === "think") {
             const text = cleanInternalText(String(payload.think ?? ""));
             if (text) {
-              assistant.parts.push({ type: "reasoning", text, time_created: timestampMs });
+              builder.appendAssistantPart(
+                { type: "reasoning", text, time_created: timestampMs },
+                { id: `wire-${seq}`, timestampMs: 0, agent: "kimi" },
+                { grouping: "current" },
+              );
             }
           } else if (partType === "text") {
             const text = cleanInternalText(String(payload.text ?? ""));
             if (text) {
-              assistant.parts.push({ type: "text", text, time_created: timestampMs });
+              builder.appendAssistantPart(
+                { type: "text", text, time_created: timestampMs },
+                { id: `wire-${seq}`, timestampMs: 0, agent: "kimi" },
+                { grouping: "current" },
+              );
             }
           }
           continue;
@@ -554,13 +538,6 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
 
           if (!function_ || !callId || !toolName) continue;
 
-          currentAssistantIndex = this.getOrCreateWireAssistant(
-            messages,
-            currentAssistantIndex,
-            `wire-${seq}`,
-          );
-          const assistant = messages[currentAssistantIndex]!;
-
           const rawArgs = function_.arguments;
           const normalizedArgs = normalizeToolArguments(rawArgs);
           const buffer =
@@ -575,10 +552,11 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
             time_created: timestampMs,
           };
 
-          const partIndex = assistant.parts.length;
-          assistant.parts.push(toolPart);
-          assistant.mode = "tool";
-          pendingToolCalls.set(callId, [currentAssistantIndex, partIndex]);
+          builder.appendToolCall(
+            toolPart,
+            { id: `wire-${seq}`, timestampMs: 0, agent: "kimi" },
+            { markModeAsTool: true, target: "current" },
+          );
           openToolCallId = callId;
 
           if (buffer !== null) {
@@ -594,8 +572,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
             argumentsPart,
             openToolCallId,
             openToolArgumentBuffer,
-            messages,
-            pendingToolCalls,
+            builder,
           );
           continue;
         }
@@ -604,18 +581,16 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
           const callId = String(payload.tool_call_id ?? "").trim();
           if (callId && ignoredToolCallIds.has(callId)) continue;
           const outputParts = normalizeWireToolOutputParts(payload.return_value, timestampMs);
-          if (callId && this.backfillToolOutput(messages, pendingToolCalls, callId, outputParts)) {
+          if (callId && this.backfillToolOutput(builder, callId, outputParts)) {
             continue;
           }
           if (outputParts.length > 0) {
-            messages.push(
-              this.buildMessage({
-                messageId: `wire-${seq}`,
-                role: "tool",
-                timestampMs,
-                parts: outputParts,
-              }),
-            );
+            builder.appendMessage({
+              id: `wire-${seq}`,
+              role: "tool",
+              timestampMs,
+              parts: outputParts,
+            });
           }
           continue;
         }
@@ -626,10 +601,8 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       }
     }
 
-    // Filter out messages with empty parts
-    const filteredMessages = messages.filter((m) => m.parts.length > 0);
     const stats = this.extractStats(meta.sourcePath);
-    return this.buildSessionData(meta, filteredMessages, stats);
+    return this.buildSessionData(meta, builder, stats);
   }
 
   // --- Helpers ---
@@ -650,40 +623,13 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     ]);
   }
 
-  private buildMessage(opts: {
-    messageId: string;
-    role: string;
-    timestampMs: number;
-    parts: MessagePart[];
-    agent?: string;
-    mode?: string;
-    model?: string | null;
-    provider?: string | null;
-    tokens?: Record<string, unknown>;
-    cost?: number;
-  }): Message {
-    return {
-      id: opts.messageId,
-      role: opts.role as Message["role"],
-      agent: opts.agent ?? null,
-      time_created: opts.timestampMs,
-      mode: opts.mode ?? null,
-      model: opts.model ?? null,
-      provider: opts.provider ?? null,
-      tokens: opts.tokens ? (opts.tokens as Message["tokens"]) : undefined,
-      cost: opts.cost ?? 0,
-      parts: opts.parts,
-    };
-  }
-
   private buildContextAssistantMessage(
     record: Record<string, unknown>,
     seq: number,
     ignoredToolCallIds: Set<string>,
     fallbackTs: number,
-  ): { message: Message; toolIndexes: Map<string, number> } {
+  ): TranscriptMessageInput | null {
     const parts: MessagePart[] = [];
-    const toolIndexes = new Map<string, number>();
 
     const content = record.content;
     if (Array.isArray(content)) {
@@ -728,96 +674,59 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
           state: { arguments: normalizeToolArguments(function_.arguments), output: null },
           time_created: fallbackTs,
         };
-        toolIndexes.set(callId, parts.length);
         parts.push(part);
       }
     }
 
     if (parts.length === 0) {
-      return {
-        message: this.buildMessage({
-          messageId: `context-${seq}`,
-          role: "assistant",
-          timestampMs: fallbackTs,
-          parts: [],
-        }),
-        toolIndexes,
-      };
+      return null;
     }
 
     const allTools = parts.every((p) => p.type === "tool");
-    const message = this.buildMessage({
-      messageId: `context-${seq}`,
+    return {
+      id: `context-${seq}`,
       role: "assistant",
       timestampMs: fallbackTs,
       parts,
       agent: "kimi",
       mode: allTools ? "tool" : undefined,
-    });
-
-    return { message, toolIndexes };
-  }
-
-  private getOrCreateWireAssistant(
-    messages: Message[],
-    currentIndex: number | null,
-    messageId: string,
-  ): number {
-    if (currentIndex !== null) return currentIndex;
-    messages.push(
-      this.buildMessage({
-        messageId,
-        role: "assistant",
-        timestampMs: 0,
-        parts: [],
-        agent: "kimi",
-      }),
-    );
-    return messages.length - 1;
+    };
   }
 
   private appendWireToolCallPart(
     argumentsPart: string,
     openCallId: string | null,
     buffer: Map<string, string>,
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    builder: TranscriptBuilder,
   ): void {
-    if (!openCallId || !pendingToolCalls.has(openCallId)) return;
+    if (!openCallId) return;
 
     const existing = buffer.get(openCallId) ?? "";
     const combined = existing + argumentsPart;
 
     try {
       const parsed = JSON.parse(combined) as unknown;
-      const location = pendingToolCalls.get(openCallId);
-      if (!location) return;
-      const msgPart = messages[location[0]]?.parts[location[1]];
-      if (msgPart?.state) {
-        msgPart.state.arguments = parsed;
+      if (
+        builder.updateToolCall(openCallId, (part) => {
+          const state = part.state ?? (part.state = {});
+          state.arguments = parsed;
+        })
+      ) {
+        buffer.delete(openCallId);
       }
-      buffer.delete(openCallId);
     } catch {
       buffer.set(openCallId, combined);
     }
   }
 
   private backfillToolOutput(
-    messages: Message[],
-    pendingToolCalls: Map<string, [number, number]>,
+    builder: TranscriptBuilder,
     callId: string,
     outputParts: MessagePart[],
   ): boolean {
     if (!outputParts.length || !callId) return false;
 
-    const location = pendingToolCalls.get(callId);
-    if (!location) return false;
-
-    const part = messages[location[0]]?.parts[location[1]];
-    if (!part) return false;
-    if (!part.state) part.state = {};
-    part.state.output = [...outputParts];
-    return true;
+    return builder.resolveToolCall(callId, { output: [...outputParts] });
   }
 
   private extractStats(sessionDir: string): SessionData["stats"] {
@@ -890,16 +799,10 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
 
   private buildSessionData(
     meta: SessionMeta,
-    messages: Message[],
+    builder: TranscriptBuilder,
     stats: SessionData["stats"],
   ): SessionData {
-    const cleanedMessages = cleanParsedMessages(messages);
-    stats.message_count = cleanedMessages.length;
-    const totalCost = cleanedMessages.reduce((sum, message) => sum + (message.cost ?? 0), 0);
-    if (totalCost > 0) {
-      stats.total_cost = Number(totalCost.toFixed(8));
-      stats.cost_source = "estimated";
-    }
+    const transcript = builder.finish(stats);
     return {
       id: meta.id,
       title: meta.title,
@@ -907,8 +810,8 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       directory: meta.cwd,
       time_created: meta.createdAt,
       time_updated: meta.createdAt,
-      stats,
-      messages: cleanedMessages,
+      stats: transcript.stats,
+      messages: transcript.messages,
     };
   }
 }

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -16,10 +16,11 @@ import type {
 import type { Message, MessagePart, SessionData, SessionHead } from "../types/index.js";
 import { firstExisting, resolveProviderRoots } from "../discovery/paths.js";
 import { parseJsonlLines } from "../utils/jsonl.js";
-import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import { cleanInternalText, cleanParsedMessages } from "../utils/session-normalization.js";
+import { cleanInternalText } from "../utils/session-normalization.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
+import { perf } from "../utils/perf.js";
+import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const HEAD_INDEX_VERSION = "pi-head-v1";
 const PARSER_VERSION = "pi-parser-v1";
@@ -81,32 +82,6 @@ function contentToText(content: unknown): string {
 function normalizeTextParts(content: unknown, timestampMs: number): MessagePart[] {
   const text = cleanInternalText(contentToText(content));
   return text ? [{ type: "text", text, time_created: timestampMs }] : [];
-}
-
-function buildMessage(params: {
-  id: string;
-  role: Message["role"];
-  timestampMs: number;
-  parts: MessagePart[];
-  agent?: string;
-  provider?: string | null;
-  model?: string | null;
-  tokens?: Message["tokens"];
-  cost?: number;
-  costSource?: Message["cost_source"];
-}): Message {
-  return {
-    id: params.id,
-    role: params.role,
-    agent: params.agent,
-    time_created: params.timestampMs,
-    provider: params.provider,
-    model: params.model,
-    tokens: params.tokens,
-    cost: params.cost,
-    cost_source: params.costSource,
-    parts: params.parts,
-  };
 }
 
 function getEntryTimestamp(entry: Record<string, unknown>): number {
@@ -214,7 +189,6 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
 
     const parsed = this.parsePiFile(meta.sourcePath);
     const state = this.convertEntries(parsed.pathEntries);
-    const cleanedMessages = cleanParsedMessages(state.messages);
 
     return {
       id: meta.id,
@@ -224,7 +198,7 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
       time_created: meta.createdAt,
       time_updated: meta.updatedAt,
       stats: {
-        message_count: cleanedMessages.length,
+        message_count: state.messages.length,
         total_input_tokens: state.totalInputTokens,
         total_output_tokens: state.totalOutputTokens,
         total_cache_read_tokens: state.totalCacheReadTokens || undefined,
@@ -232,7 +206,7 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
         total_cost: state.totalCost,
         cost_source: state.totalCost > 0 ? "recorded" : undefined,
       },
-      messages: cleanedMessages,
+      messages: state.messages,
     };
   }
 
@@ -373,14 +347,8 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     totalCost: number;
     modelUsage: Record<string, number>;
   } {
-    const messages: Message[] = [];
-    const pendingToolCalls = new Map<string, [number, number]>();
+    const builder = new TranscriptBuilder({ messageDefaults: "sparse" });
     const modelUsage: Record<string, number> = {};
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheReadTokens = 0;
-    let totalCacheCreateTokens = 0;
-    let totalCost = 0;
 
     for (const entry of entries) {
       const timestampMs = getEntryTimestamp(entry);
@@ -389,21 +357,9 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
       if (type === "message") {
         const message = entry["message"];
         if (!isObject(message)) continue;
-        const result = this.convertAgentMessage(
-          entry,
-          message,
-          timestampMs,
-          pendingToolCalls,
-          messages.length,
-          messages,
-        );
+        const result = this.convertAgentMessage(entry, message, timestampMs, builder);
         if (!result) continue;
-        if (result.message) messages.push(result.message);
-        totalInputTokens += result.inputTokens;
-        totalOutputTokens += result.outputTokens;
-        totalCacheReadTokens += result.cacheReadTokens;
-        totalCacheCreateTokens += result.cacheCreateTokens;
-        totalCost += result.cost;
+        if (result.message) builder.appendMessage(result.message);
         if (result.model && result.totalTokens > 0) {
           modelUsage[result.model] = (modelUsage[result.model] ?? 0) + result.totalTokens;
         }
@@ -411,16 +367,18 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
       }
 
       const summary = this.convertSummaryEntry(entry, timestampMs);
-      if (summary) messages.push(summary);
+      if (summary) builder.appendMessage(summary);
     }
 
+    const result = builder.finish();
+
     return {
-      messages,
-      totalInputTokens,
-      totalOutputTokens,
-      totalCacheReadTokens,
-      totalCacheCreateTokens,
-      totalCost,
+      messages: result.messages,
+      totalInputTokens: result.stats.total_input_tokens,
+      totalOutputTokens: result.stats.total_output_tokens,
+      totalCacheReadTokens: result.stats.total_cache_read_tokens ?? 0,
+      totalCacheCreateTokens: result.stats.total_cache_create_tokens ?? 0,
+      totalCost: result.stats.total_cost,
       modelUsage,
     };
   }
@@ -429,17 +387,10 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     entry: Record<string, unknown>,
     message: Record<string, unknown>,
     timestampMs: number,
-    pendingToolCalls: Map<string, [number, number]>,
-    nextMessageIndex: number,
-    messages: Message[],
+    builder: TranscriptBuilder,
   ): {
-    message?: Message;
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreateTokens: number;
+    message?: TranscriptMessageInput;
     totalTokens: number;
-    cost: number;
     model: string | null;
   } | null {
     const id = String(entry["id"] ?? "");
@@ -448,22 +399,17 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     if (role === "user") {
       const parts = normalizeTextParts(message["content"], timestampMs);
       if (parts.length === 0) return null;
-      return this.emptyUsageResult(buildMessage({ id, role: "user", timestampMs, parts }));
+      return this.emptyUsageResult({ id, role: "user", timestampMs, parts });
     }
 
     if (role === "assistant") {
-      const parts = this.normalizeAssistantParts(
-        message["content"],
-        timestampMs,
-        pendingToolCalls,
-        nextMessageIndex,
-      );
+      const parts = this.normalizeAssistantParts(message["content"], timestampMs);
       if (parts.length === 0) return null;
       const usage = this.normalizeUsage(message["usage"]);
       const model = typeof message["model"] === "string" ? message["model"].trim() : null;
       const cost = usage.cost ?? estimateTokenCost(model, usage.tokens) ?? 0;
       return {
-        message: buildMessage({
+        message: {
           id,
           role: "assistant",
           agent: "pi",
@@ -474,19 +420,14 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
           tokens: usage.tokens,
           cost: cost || undefined,
           costSource: cost > 0 ? "recorded" : undefined,
-        }),
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
-        cacheReadTokens: usage.cacheReadTokens,
-        cacheCreateTokens: usage.cacheCreateTokens,
+        },
         totalTokens: usage.totalTokens,
-        cost,
         model,
       };
     }
 
     if (role === "toolResult") {
-      this.attachToolResult(message, timestampMs, pendingToolCalls, messages);
+      this.attachToolResult(message, timestampMs, builder);
       return this.emptyUsageResult();
     }
 
@@ -497,32 +438,25 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     if (role === "custom" && message["display"] === true) {
       const parts = normalizeTextParts(message["content"], timestampMs);
       if (parts.length === 0) return null;
-      return this.emptyUsageResult(buildMessage({ id, role: "user", timestampMs, parts }));
+      return this.emptyUsageResult({ id, role: "user", timestampMs, parts });
     }
 
     if (role === "branchSummary" || role === "compactionSummary") {
       const summary = String(message["summary"] ?? "").trim();
       if (!summary) return null;
-      return this.emptyUsageResult(
-        buildMessage({
-          id,
-          role: "assistant",
-          agent: "pi",
-          timestampMs,
-          parts: [{ type: "text", text: summary, time_created: timestampMs }],
-        }),
-      );
+      return this.emptyUsageResult({
+        id,
+        role: "assistant",
+        agent: "pi",
+        timestampMs,
+        parts: [{ type: "text", text: summary, time_created: timestampMs }],
+      });
     }
 
     return null;
   }
 
-  private normalizeAssistantParts(
-    content: unknown,
-    timestampMs: number,
-    pendingToolCalls: Map<string, [number, number]>,
-    messageIndex: number,
-  ): MessagePart[] {
+  private normalizeAssistantParts(content: unknown, timestampMs: number): MessagePart[] {
     if (!Array.isArray(content)) return [];
 
     const parts: MessagePart[] = [];
@@ -557,7 +491,6 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
           },
         };
         parts.push(toolPart);
-        if (callId) pendingToolCalls.set(callId, [messageIndex, parts.length - 1]);
       }
     }
 
@@ -567,32 +500,28 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
   private attachToolResult(
     message: Record<string, unknown>,
     timestampMs: number,
-    pendingToolCalls: Map<string, [number, number]>,
-    messages: Message[],
+    builder: TranscriptBuilder,
   ): void {
     const callId = String(message["toolCallId"] ?? "").trim();
     const output = normalizeTextParts(message["content"], timestampMs);
-    const location = callId ? pendingToolCalls.get(callId) : undefined;
-    if (!location) return;
-
-    const [messageIndex, partIndex] = location;
-    const target = messages[messageIndex]?.parts[partIndex];
-    if (!target?.state) return;
-    target.state.output = output;
-    target.state.status = message["isError"] === true ? "error" : "completed";
-    target.state.metadata = message["details"];
-    pendingToolCalls.delete(callId);
+    if (!callId) return;
+    builder.resolveToolCall(callId, {
+      output,
+      status: message["isError"] === true ? "error" : "completed",
+      metadata: message["details"],
+      consume: true,
+    });
   }
 
   private convertBashExecution(
     id: string,
     message: Record<string, unknown>,
     timestampMs: number,
-  ): Message {
+  ): TranscriptMessageInput {
     const command = String(message["command"] ?? "");
     const output = String(message["output"] ?? "");
     const isError = Number(message["exitCode"] ?? 0) !== 0 || message["cancelled"] === true;
-    return buildMessage({
+    return {
       id,
       role: "tool",
       timestampMs,
@@ -615,10 +544,13 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
           },
         },
       ],
-    });
+    };
   }
 
-  private convertSummaryEntry(entry: Record<string, unknown>, timestampMs: number): Message | null {
+  private convertSummaryEntry(
+    entry: Record<string, unknown>,
+    timestampMs: number,
+  ): TranscriptMessageInput | null {
     const type = entry["type"];
     if (type !== "compaction" && type !== "branch_summary" && type !== "custom_message") {
       return null;
@@ -631,13 +563,13 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     const text = cleanInternalText(rawText);
     if (!text) return null;
 
-    return buildMessage({
+    return {
       id: String(entry["id"] ?? ""),
       role: type === "custom_message" ? "user" : "assistant",
       agent: type === "custom_message" ? undefined : "pi",
       timestampMs,
       parts: [{ type: "text", text, time_created: timestampMs }],
-    });
+    };
   }
 
   private normalizeUsage(raw: unknown): {
@@ -675,24 +607,14 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     };
   }
 
-  private emptyUsageResult(message?: Message): {
-    message?: Message;
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreateTokens: number;
+  private emptyUsageResult(message?: TranscriptMessageInput): {
+    message?: TranscriptMessageInput;
     totalTokens: number;
-    cost: number;
     model: string | null;
   } {
     return {
       message,
-      inputTokens: 0,
-      outputTokens: 0,
-      cacheReadTokens: 0,
-      cacheCreateTokens: 0,
       totalTokens: 0,
-      cost: 0,
       model: null,
     };
   }

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -19,7 +19,6 @@ import { parseJsonlLines } from "../utils/jsonl.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
-import { perf } from "../utils/perf.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const HEAD_INDEX_VERSION = "pi-head-v1";
@@ -135,34 +134,6 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     this.basePath = this.findBasePath();
     if (!this.basePath) return false;
     return this.listSessionFiles().length > 0;
-  }
-
-  scan(options?: AgentScanOptions): SessionHead[] {
-    if (!this.basePath) return [];
-
-    const scanMarker = perf.start("pi:scan");
-    const files = this.listSessionFiles(options);
-    options?.onProgress?.({ total: files.length, processed: 0, sessions: 0 });
-
-    const heads: SessionHead[] = [];
-    let processed = 0;
-    for (const file of files) {
-      try {
-        const head = getParsedSession(this.parseSessionHeadResult(file));
-        if (head) {
-          heads.push(head);
-          this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, file));
-        }
-      } catch {
-        // skip malformed files
-      } finally {
-        processed += 1;
-        options?.onProgress?.({ total: files.length, processed, sessions: heads.length });
-      }
-    }
-
-    perf.end(scanMarker);
-    return heads;
   }
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {

--- a/packages/core/src/agents/transcript-builder.ts
+++ b/packages/core/src/agents/transcript-builder.ts
@@ -1,0 +1,261 @@
+import type { Message, MessagePart, SessionStats } from "../types/index.js";
+import { cleanParsedMessages } from "../utils/session-normalization.js";
+
+export interface TranscriptMessageInput {
+  id: string;
+  role: Message["role"];
+  timestampMs: number;
+  parts?: MessagePart[];
+  agent?: string | null;
+  mode?: string | null;
+  model?: string | null;
+  provider?: string | null;
+  tokens?: Message["tokens"];
+  cost?: number;
+  costSource?: Message["cost_source"];
+  subagentId?: string;
+  nickname?: string;
+}
+
+export type AssistantMessageInput = Omit<TranscriptMessageInput, "role" | "parts">;
+
+export interface ToolResolution {
+  output?: unknown;
+  status?: NonNullable<MessagePart["state"]>["status"];
+  metadata?: unknown;
+  consume?: boolean;
+}
+
+export interface TranscriptResult {
+  messages: Message[];
+  stats: SessionStats;
+}
+
+export class TranscriptBuilder {
+  private readonly messages: Message[] = [];
+  private readonly pendingToolCalls = new Map<string, MessagePart>();
+  private currentAssistant: Message | null = null;
+  private latestTextAssistant: Message | null = null;
+
+  constructor(private readonly options: { messageDefaults?: "nullable" | "sparse" } = {}) {}
+
+  beginTurn(): void {
+    this.currentAssistant = null;
+    this.latestTextAssistant = null;
+  }
+
+  appendMessage(input: TranscriptMessageInput): Message {
+    const message = this.createMessage(input);
+    this.messages.push(message);
+    this.registerToolCalls(message.parts);
+
+    if (message.role === "assistant") {
+      this.currentAssistant = message;
+      if (message.parts.some((part) => part.type === "text")) {
+        this.latestTextAssistant = message;
+      }
+    } else if (message.role === "user") {
+      this.beginTurn();
+    }
+
+    return message;
+  }
+
+  appendAssistantPart(
+    part: MessagePart,
+    input: AssistantMessageInput,
+    options: {
+      grouping?: "compatible" | "current";
+      resetLatestText?: boolean;
+      deduplicateTail?: boolean;
+    } = {},
+  ): Message {
+    const current = this.currentAssistant;
+    const canReuse =
+      current !== null &&
+      (options.grouping === "current" ||
+        (part.type === "text"
+          ? !current.parts.some((item) => item.type === "tool")
+          : part.type === "reasoning"
+            ? !current.parts.some((item) => item.type === "text" || item.type === "tool")
+            : false));
+
+    const message = canReuse
+      ? current
+      : this.appendMessage({ ...input, role: "assistant", parts: [part] });
+
+    if (canReuse) {
+      if (options.deduplicateTail) this.appendPartIfNew(message, part);
+      else message.parts.push(part);
+      this.applyMissingMetadata(message, input);
+    }
+    if (part.type === "text") {
+      this.latestTextAssistant = message;
+    } else if (options.resetLatestText) {
+      this.latestTextAssistant = null;
+    }
+    return message;
+  }
+
+  appendToolCall(
+    part: MessagePart,
+    input: AssistantMessageInput,
+    options: {
+      markModeAsTool?: boolean;
+      modeOnCreate?: string;
+      target?: "latest-text" | "current";
+    } = {},
+  ): Message {
+    const target =
+      options.target === "current"
+        ? this.currentAssistant
+        : (this.latestTextAssistant ?? this.currentAssistant);
+    const message = target
+      ? target
+      : this.appendMessage({
+          ...input,
+          role: "assistant",
+          mode: options.modeOnCreate ?? (options.markModeAsTool ? "tool" : input.mode),
+          parts: [part],
+        });
+
+    if (target) {
+      message.parts.push(part);
+      this.applyMissingMetadata(message, input);
+      if (options.markModeAsTool) message.mode = "tool";
+      this.registerToolCall(part);
+    }
+
+    this.currentAssistant = message;
+    return message;
+  }
+
+  appendToCurrentAssistant(part: MessagePart): boolean {
+    if (!this.currentAssistant) return false;
+    this.currentAssistant.parts.push(part);
+    return true;
+  }
+
+  updateToolCall(callId: string, update: (part: MessagePart) => void): boolean {
+    const part = this.pendingToolCalls.get(callId);
+    if (!part) return false;
+    update(part);
+    return true;
+  }
+
+  resolveToolCall(callId: string, resolution: ToolResolution): boolean {
+    return this.updateToolCall(callId, (part) => {
+      const state = part.state ?? (part.state = {});
+      if (resolution.output !== undefined) state.output = resolution.output;
+      if (resolution.status !== undefined) state.status = resolution.status;
+      if (resolution.metadata !== undefined) state.metadata = resolution.metadata;
+      if (resolution.consume) this.pendingToolCalls.delete(callId);
+    });
+  }
+
+  attachUsageToLatestAssistant(
+    tokens: Message["tokens"],
+    options: { model?: string | null; cost?: number; costSource?: Message["cost_source"] } = {},
+  ): boolean {
+    for (let index = this.messages.length - 1; index >= 0; index -= 1) {
+      const message = this.messages[index]!;
+      if (message.role !== "assistant" || message.tokens) continue;
+      message.tokens = tokens;
+      if (options.model !== undefined) message.model ??= options.model;
+      if (options.cost !== undefined) message.cost = options.cost;
+      if (options.costSource !== undefined) message.cost_source = options.costSource;
+      return true;
+    }
+    return false;
+  }
+
+  finish(baseStats?: SessionStats): TranscriptResult {
+    const messages = cleanParsedMessages(this.messages);
+    const derived = this.deriveStats(messages);
+    if (!baseStats) return { messages, stats: derived };
+
+    return {
+      messages,
+      stats: {
+        ...derived,
+        ...baseStats,
+        message_count: messages.length,
+        cost_source: baseStats.cost_source,
+      },
+    };
+  }
+
+  private createMessage(input: TranscriptMessageInput): Message {
+    const sparse = this.options.messageDefaults === "sparse";
+    return {
+      id: input.id,
+      role: input.role,
+      agent: sparse ? input.agent : (input.agent ?? null),
+      time_created: input.timestampMs,
+      mode: sparse ? input.mode : (input.mode ?? null),
+      model: sparse ? input.model : (input.model ?? null),
+      provider: sparse ? input.provider : (input.provider ?? null),
+      tokens: input.tokens,
+      cost: sparse ? input.cost : (input.cost ?? 0),
+      cost_source: input.costSource,
+      parts: input.parts ?? [],
+      subagent_id: input.subagentId,
+      nickname: input.nickname,
+    };
+  }
+
+  private registerToolCalls(parts: MessagePart[]): void {
+    for (const part of parts) this.registerToolCall(part);
+  }
+
+  private registerToolCall(part: MessagePart): void {
+    if (part.type === "tool" && part.callID) {
+      this.pendingToolCalls.set(part.callID, part);
+    }
+  }
+
+  private appendPartIfNew(message: Message, part: MessagePart): void {
+    const tail = message.parts.at(-1);
+    if (tail?.type === part.type && tail.text === part.text) return;
+    message.parts.push(part);
+  }
+
+  private applyMissingMetadata(message: Message, input: AssistantMessageInput): void {
+    if (!message.id && input.id) message.id = input.id;
+    if (message.agent == null && input.agent !== undefined) message.agent = input.agent;
+    if (message.mode == null && input.mode !== undefined) message.mode = input.mode;
+    if (message.model == null && input.model !== undefined) message.model = input.model;
+    if (message.provider == null && input.provider !== undefined) message.provider = input.provider;
+    if (!message.tokens && input.tokens) message.tokens = input.tokens;
+    if ((message.cost ?? 0) === 0 && input.cost !== undefined) message.cost = input.cost;
+    if (!message.cost_source && input.costSource) message.cost_source = input.costSource;
+  }
+
+  private deriveStats(messages: Message[]): SessionStats {
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalCacheReadTokens = 0;
+    let totalCacheCreateTokens = 0;
+    let totalCost = 0;
+    let hasEstimatedCost = false;
+
+    for (const message of messages) {
+      totalInputTokens += message.tokens?.input ?? 0;
+      totalOutputTokens += message.tokens?.output ?? 0;
+      totalCacheReadTokens += message.tokens?.cache_read ?? 0;
+      totalCacheCreateTokens += message.tokens?.cache_create ?? 0;
+      totalCost += message.cost ?? 0;
+      if (message.cost_source === "estimated") hasEstimatedCost = true;
+    }
+
+    return {
+      message_count: messages.length,
+      total_input_tokens: totalInputTokens,
+      total_output_tokens: totalOutputTokens,
+      total_cache_read_tokens: totalCacheReadTokens || undefined,
+      total_cache_create_tokens: totalCacheCreateTokens || undefined,
+      total_cost: totalCost,
+      cost_source: totalCost > 0 ? (hasEstimatedCost ? "estimated" : "recorded") : undefined,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- add a shared `TranscriptBuilder` for message creation, streaming assistant grouping, tool-call resolution, cleanup, and derived statistics
- migrate the Claude Code, Codex, Kimi, and Pi adapters to the shared transcript assembly path while preserving their protocol-specific grouping and message shapes
- provide the default full-scan implementation in `FileSystemSessionSource` and remove duplicated adapter scans

## Why

The four file-backed adapters independently maintained the same message assembly state machines and full-scan loops. That duplication made tool-call fixes non-local and allowed behavior to drift between adapters. The shared builder keeps protocol mapping in each adapter while centralizing the invariant transcript mechanics.

## Impact

This is an internal refactor. Session contracts, discovery/cache behavior, and database-backed adapters are unchanged. Existing adapter fixtures remain the regression boundary, including Codex fast scans and Kimi turn-based grouping.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`