### PR TITLE
refactor(core): centralize scan finalization

### DIFF
--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -173,7 +173,7 @@ vi.mock("../../agents/index.js", () => ({
   BaseAgent: class {},
 }));
 
-import { scanSessions, scanSessionsAsync } from "../scanner.js";
+import { finalizeAgentScan, scanSessions, scanSessionsAsync } from "../scanner.js";
 import { createRegisteredAgents } from "../../agents/index.js";
 import { loadCachedSessions, saveCachedSessionChanges, saveCachedSessions } from "../cache.js";
 
@@ -226,6 +226,123 @@ function createTestAgent(overrides: {
   }
   return agent as BaseAgent;
 }
+
+describe("finalizeAgentScan", () => {
+  it("finalizes cache-only sessions without classifying or writing", async () => {
+    const sessions = [
+      makeSession("old", { time_created: 100 }),
+      makeSession("current", { time_created: 300 }),
+    ];
+    const agent = createTestAgent({ name: "test", available: true, sessions });
+    agent.getSessionData = vi.fn();
+    const onProgress = vi.fn();
+
+    const result = await finalizeAgentScan(agent, sessions, {
+      finalization: {
+        kind: "cache-only",
+        cached: { sessions, meta: {}, timestamp: 123 },
+      },
+      options: { from: 200, includeSmartTags: true },
+      timing: { total: 0 },
+      agentStart: performance.now(),
+      onProgress,
+    });
+
+    expect(result.heads.map((session) => session.id)).toEqual(["current"]);
+    expect(result.heads[0]?.project_identity).toBeDefined();
+    expect(result.cacheTimestamp).toBe(123);
+    expect(agent.getSessionData).not.toHaveBeenCalled();
+    expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
+    expect(onProgress).toHaveBeenCalledWith({
+      agent: "test",
+      phase: "complete",
+      newCount: 2,
+    });
+  });
+
+  it("persists an incremental diff and marks the result refreshed", async () => {
+    const cachedSessions = [makeSession("old")];
+    const updatedSessions = [makeSession("new")];
+    const agent = createTestAgent({ name: "test", available: true, sessions: updatedSessions });
+
+    const result = await finalizeAgentScan(agent, updatedSessions, {
+      finalization: {
+        kind: "incremental",
+        cached: { sessions: cachedSessions, meta: {}, timestamp: 123 },
+        changedIds: ["new"],
+        cacheTimestamp: 456,
+      },
+      options: { includeSmartTags: false },
+      timing: { total: 0 },
+      agentStart: performance.now(),
+    });
+
+    expect(result.refreshed).toBe(true);
+    expect(result.cacheTimestamp).toBe(456);
+    expect(mockedSaveCachedSessionChanges).toHaveBeenCalledWith(
+      "test",
+      [
+        {
+          session: expect.objectContaining({ id: "new", project_identity: expect.any(Object) }),
+          sortIndex: 0,
+        },
+      ],
+      ["old"],
+      {},
+    );
+  });
+
+  it("does not rewrite an unchanged cache when tag maintenance is disabled", async () => {
+    const sessions = [makeSession("cached")];
+    const agent = createTestAgent({ name: "test", available: true, sessions });
+
+    const result = await finalizeAgentScan(agent, sessions, {
+      finalization: {
+        kind: "unchanged",
+        cached: { sessions, meta: {}, timestamp: 123 },
+      },
+      options: { includeSmartTags: false },
+      timing: { total: 0 },
+      agentStart: performance.now(),
+    });
+
+    expect(result.refreshed).toBeUndefined();
+    expect(result.cacheTimestamp).toBe(123);
+    expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
+  });
+
+  it("persists tag maintenance for an otherwise unchanged cache", async () => {
+    const sessions = [makeSession("cached")];
+    const agent = createTestAgent({ name: "test", available: true, sessions });
+
+    const result = await finalizeAgentScan(agent, sessions, {
+      finalization: {
+        kind: "unchanged",
+        cached: { sessions, meta: {}, timestamp: 123 },
+      },
+      options: {},
+      timing: { total: 0 },
+      agentStart: performance.now(),
+    });
+
+    expect(result.heads[0]).toMatchObject({
+      id: "cached",
+      smart_tags: [],
+      smart_tags_source_updated_at: 1000,
+    });
+    expect(mockedSaveCachedSessionChanges).toHaveBeenCalledWith(
+      "test",
+      [
+        {
+          session: expect.objectContaining({ id: "cached", smart_tags: [] }),
+          sortIndex: 0,
+        },
+      ],
+      [],
+      {},
+    );
+  });
+});
 
 describe("scanSessions", () => {
   it("returns empty result when no agents registered", async () => {

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -11,6 +11,7 @@ import {
   markAgentFullSyncCompleted,
   saveCachedSessionChanges,
   saveCachedSessions,
+  type CachedResult,
 } from "./cache.js";
 import {
   attachMissingProjectIdentities,
@@ -95,6 +96,24 @@ interface AgentScanResult {
   refreshed?: boolean;
   timing?: AgentScanTiming;
   cacheTimestamp?: number;
+}
+
+type AgentScanFinalization =
+  | { kind: "cache-only"; cached: CachedResult }
+  | { kind: "unchanged"; cached: CachedResult }
+  | {
+      kind: "incremental";
+      cached: CachedResult;
+      changedIds: string[];
+      cacheTimestamp: number;
+    };
+
+interface FinalizeAgentScanContext {
+  finalization: AgentScanFinalization;
+  options: ScanOptions;
+  timing: AgentScanTiming;
+  agentStart: number;
+  onProgress?: (progress: ScanProgress) => void;
 }
 
 interface SmartTagWorkerResult {
@@ -233,6 +252,61 @@ async function ensureSessionTags(
   }
 }
 
+export async function finalizeAgentScan(
+  agent: BaseAgent,
+  sessions: SessionHead[],
+  context: FinalizeAgentScanContext,
+): Promise<AgentScanResult> {
+  const { finalization, options, timing, agentStart, onProgress } = context;
+  const isIncremental = finalization.kind === "incremental";
+
+  if (!isIncremental) {
+    onProgress?.({ agent: agent.name, phase: "complete", newCount: sessions.length });
+  }
+
+  const identityStart = performance.now();
+  const sessionsWithIdentity = attachMissingProjectIdentities(sessions);
+  timing.identity = performance.now() - identityStart;
+
+  let tagged = { sessions: sessionsWithIdentity, changed: false };
+  if (finalization.kind !== "cache-only") {
+    const tagsStart = performance.now();
+    tagged =
+      options.includeSmartTags === false
+        ? tagged
+        : await ensureSessionTags(agent, sessionsWithIdentity, options.smartTagWorkerUrl);
+    timing.tags = performance.now() - tagsStart;
+  }
+
+  if (options.writeCache !== false) {
+    if (finalization.kind === "incremental") {
+      saveCachedSessionDiff(
+        agent,
+        finalization.cached.sessions,
+        tagged.sessions,
+        finalization.changedIds,
+      );
+    } else if (finalization.kind === "unchanged" && tagged.changed) {
+      saveCachedSessionDiff(agent, finalization.cached.sessions, tagged.sessions);
+    }
+  }
+
+  if (isIncremental) {
+    onProgress?.({ agent: agent.name, phase: "complete", newCount: tagged.sessions.length });
+  }
+
+  const heads = filterSessions(tagged.sessions, options);
+  timing.total = performance.now() - agentStart;
+  return {
+    agent,
+    heads,
+    fromCache: true,
+    ...(isIncremental ? { refreshed: true } : {}),
+    timing,
+    cacheTimestamp: isIncremental ? finalization.cacheTimestamp : finalization.cached.timestamp,
+  };
+}
+
 /**
  * 智能扫描单个 Agent
  * 1. 优先使用缓存立即返回
@@ -268,20 +342,13 @@ async function scanAgentSmart(
           phase: "cache",
           cachedCount: cached.sessions.length,
         });
-        onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
-        const t3 = performance.now();
-        const cachedWithIdentity = attachMissingProjectIdentities(cached.sessions);
-        timing.identity = performance.now() - t3;
-
-        const filtered = filterSessions(cachedWithIdentity, options);
-        timing.total = performance.now() - agentStart;
-        return {
-          agent,
-          heads: filtered,
-          fromCache: true,
+        return finalizeAgentScan(agent, cached.sessions, {
+          finalization: { kind: "cache-only", cached },
+          options,
           timing,
-          cacheTimestamp: cached.timestamp,
-        };
+          agentStart,
+          onProgress,
+        });
       }
 
       const isAvail = agent.isAvailable();
@@ -317,70 +384,27 @@ async function scanAgentSmart(
         );
         timing.scan = performance.now() - t2;
 
-        const t3 = performance.now();
-        const sessionsWithIdentity = attachMissingProjectIdentities(updatedSessions);
-        timing.identity = performance.now() - t3;
-
-        const t4 = performance.now();
-        const tagged =
-          options.includeSmartTags === false
-            ? { sessions: sessionsWithIdentity, changed: false }
-            : await ensureSessionTags(agent, sessionsWithIdentity, options.smartTagWorkerUrl);
-        timing.tags = performance.now() - t4;
-
-        if (options.writeCache !== false) {
-          saveCachedSessionDiff(
-            agent,
-            cached.sessions,
-            tagged.sessions,
-            checkResult.changedIds ?? [],
-          );
-        }
-
-        onProgress?.({
-          agent: agent.name,
-          phase: "complete",
-          newCount: tagged.sessions.length,
-        });
-
-        const filtered = filterSessions(tagged.sessions, options);
-        timing.total = performance.now() - agentStart;
-        return {
-          agent,
-          heads: filtered,
-          fromCache: true,
-          refreshed: true,
+        return finalizeAgentScan(agent, updatedSessions, {
+          finalization: {
+            kind: "incremental",
+            cached,
+            changedIds: checkResult.changedIds ?? [],
+            cacheTimestamp: checkResult.timestamp,
+          },
+          options,
           timing,
-          cacheTimestamp: checkResult.timestamp,
-        };
+          agentStart,
+          onProgress,
+        });
       }
 
-      onProgress?.({ agent: agent.name, phase: "complete", newCount: cached.sessions.length });
-
-      const t3 = performance.now();
-      const cachedWithIdentity = attachMissingProjectIdentities(cached.sessions);
-      timing.identity = performance.now() - t3;
-
-      const t4 = performance.now();
-      const tagged =
-        options.includeSmartTags === false
-          ? { sessions: cachedWithIdentity, changed: false }
-          : await ensureSessionTags(agent, cachedWithIdentity, options.smartTagWorkerUrl);
-      timing.tags = performance.now() - t4;
-
-      if (tagged.changed && options.writeCache !== false) {
-        saveCachedSessionDiff(agent, cached.sessions, tagged.sessions);
-      }
-
-      const filtered = filterSessions(tagged.sessions, options);
-      timing.total = performance.now() - agentStart;
-      return {
-        agent,
-        heads: filtered,
-        fromCache: true,
+      return finalizeAgentScan(agent, cached.sessions, {
+        finalization: { kind: "unchanged", cached },
+        options,
         timing,
-        cacheTimestamp: cached.timestamp,
-      };
+        agentStart,
+        onProgress,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

- add `finalizeAgentScan` as the single owner of cached scan finalization
- model cache-only, incremental, and unchanged paths as explicit closed states
- centralize project identity attachment, smart-tag maintenance, cache diff persistence, filtering, progress completion, and timing
- add direct interface tests for all three finalization paths

## Why

`scanAgentSmart` previously copied the same finalization sequence across three exit paths, with small behavioral differences hidden in each branch. That made cache persistence and tag maintenance changes non-local and easy to drift. The new interface keeps branch decisions in `scanAgentSmart` while placing the shared invariant and path-specific policies in one module.

## Impact

This is an internal discovery refactor. Cache-only, incremental, and unchanged scan outputs, progress ordering, cache timestamps, filtering, and persistence behavior remain unchanged. Worker and full-scan call sites are not modified.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`