### PR TITLE
refactor(cli): centralize scan interfaces and time windows

### DIFF
--- a/packages/cli/src/api/__tests__/contract.test.ts
+++ b/packages/cli/src/api/__tests__/contract.test.ts
@@ -3,7 +3,7 @@ import { SAMPLE_SCAN_STATUS_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/co
 import type { ScanResult } from "@codesesh/core";
 import { createApiRoutes } from "../routes.js";
 import type { ScanResultSource } from "../handlers.js";
-import type { LiveScanStore } from "../../live-scan.js";
+import type { ScanEventSource } from "../../scan-source.js";
 
 function makeScanSource(): ScanResultSource {
   return {
@@ -16,23 +16,23 @@ function makeScanSource(): ScanResultSource {
   };
 }
 
-function makeStoreStub(): LiveScanStore {
+function makeEventSource(): ScanEventSource {
   return {
     getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
     subscribe: () => () => {},
     subscribeScanStatus: () => () => {},
-  } as unknown as LiveScanStore;
+  };
 }
 
 describe("cli routes stay wire-compatible with @codesesh/core/contract", () => {
   it("GET /status returns the ScanStatusEvent fixture as-is", async () => {
-    const app = createApiRoutes(makeScanSource(), makeStoreStub());
+    const app = createApiRoutes(makeScanSource(), makeEventSource());
     const res = await app.request("/status");
     expect(await res.json()).toEqual(SAMPLE_SCAN_STATUS_EVENT);
   });
 
   it("SSE /events opens with the ScanStatusEvent fixture from the store", async () => {
-    const app = createApiRoutes(makeScanSource(), makeStoreStub());
+    const app = createApiRoutes(makeScanSource(), makeEventSource());
     const controller = new AbortController();
     const res = await app.request("/events", { signal: controller.signal });
     const reader = res.body!.getReader();

--- a/packages/cli/src/api/__tests__/routes.test.ts
+++ b/packages/cli/src/api/__tests__/routes.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
+import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
 import { createApiRoutes } from "../routes.js";
 import type { ScanResult } from "@codesesh/core";
 import type { ScanResultSource } from "../handlers.js";
+import type { ScanEventSource } from "../../scan-source.js";
 
 describe("createApiRoutes", () => {
   it("returns a Hono instance with route handlers", () => {
@@ -24,9 +26,8 @@ describe("createApiRoutes", () => {
     const unsubscribeScanStatus = vi.fn();
     let emitSession: ((event: { type: string }) => void) | undefined;
     let emitScanStatus: ((event: { type: string }) => void) | undefined;
-    const store = {
-      getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }),
-      getScanStatus: () => ({ type: "scan-status", active: false, phase: "idle", agents: {} }),
+    const eventSource: ScanEventSource = {
+      getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
       subscribe: vi.fn((listener: (event: { type: string }) => void) => {
         emitSession = listener;
         return unsubscribeSessions;
@@ -36,7 +37,10 @@ describe("createApiRoutes", () => {
         return unsubscribeScanStatus;
       }),
     };
-    const app = createApiRoutes(store as never, store as never);
+    const app = createApiRoutes(
+      { getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }) },
+      eventSource,
+    );
     const requestController = new AbortController();
 
     const response = await app.request(
@@ -54,13 +58,15 @@ describe("createApiRoutes", () => {
   it("cleans up SSE subscriptions once when abort happens first", async () => {
     const unsubscribeSessions = vi.fn();
     const unsubscribeScanStatus = vi.fn();
-    const store = {
-      getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }),
-      getScanStatus: () => ({ type: "scan-status", active: false, phase: "idle", agents: {} }),
+    const eventSource: ScanEventSource = {
+      getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
       subscribe: vi.fn(() => unsubscribeSessions),
       subscribeScanStatus: vi.fn(() => unsubscribeScanStatus),
     };
-    const app = createApiRoutes(store as never, store as never);
+    const app = createApiRoutes(
+      { getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }) },
+      eventSource,
+    );
     const requestController = new AbortController();
     const response = await app.request(
       new Request("http://localhost/events", { signal: requestController.signal }),

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -43,7 +43,6 @@ import {
   getSessionAgentName,
   getSessionActivityTime,
   getTotalTokens,
-  startOfLocalDay,
   type DashboardData,
   type DashboardScope,
   type FileActivityKind,
@@ -52,6 +51,7 @@ import {
   type SearchOptions,
 } from "@codesesh/core";
 import { appLogger } from "../logging.js";
+import { resolveTimeWindow, type TimeWindow } from "../time-window-resolution.js";
 
 export interface ScanResultSource {
   getSnapshot(): ScanResult;
@@ -61,12 +61,7 @@ export interface ScanStatusSource {
   getScanStatus(): ScanStatusEvent;
 }
 
-export interface SessionListDefaults {
-  from?: number;
-  to?: number;
-  /** When --days was used, original value — kept for UI "last N days" label */
-  days?: number;
-}
+export type SessionListDefaults = TimeWindow;
 
 interface ClientLogPayload {
   event?: unknown;
@@ -779,43 +774,6 @@ export function handleDeleteSessionAlias(c: Context) {
   }
 }
 
-function resolveDashboardWindow(
-  defaults: SessionListDefaults,
-  queryDays: string | undefined,
-  queryFrom: string | undefined,
-  queryTo: string | undefined,
-): { from?: number; to: number; days?: number } {
-  const now = Date.now();
-
-  const toTs = parseDateParam(queryTo, defaults.to) ?? now;
-
-  // Resolve days (preferred): query, defaults.days, or derive from defaults.from
-  const hasQueryDays = queryDays != null && queryDays.trim() !== "";
-  const parsedDays = hasQueryDays ? parseInt(queryDays, 10) : NaN;
-  let days: number | undefined =
-    Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : defaults.days;
-
-  const fromFromQuery = parseDateParam(queryFrom, undefined);
-  let fromTs: number;
-  if (fromFromQuery != null) {
-    fromTs = fromFromQuery;
-    days ??= Math.max(1, Math.ceil((toTs - fromTs) / 86400000));
-  } else if (parsedDays === 0 || (!hasQueryDays && defaults.days === 0)) {
-    days = 0;
-    return { to: toTs, days };
-  } else if (defaults.from != null) {
-    fromTs = defaults.from;
-    days ??= Math.max(1, Math.ceil((toTs - fromTs) / 86400000));
-  } else if (days && days > 0) {
-    fromTs = startOfLocalDay(toTs) - (days - 1) * 86400000;
-  } else {
-    days = 30;
-    fromTs = startOfLocalDay(toTs) - (days - 1) * 86400000;
-  }
-
-  return { from: fromTs, to: toTs, days };
-}
-
 export function handleGetDashboard(
   c: Context,
   scanSource: ScanResultSource,
@@ -829,12 +787,15 @@ export function handleGetDashboard(
   if (projectIdentity === null) {
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
-  const { from, to, days } = resolveDashboardWindow(
+  const { from, to, days } = resolveTimeWindow({
+    mode: "dashboard",
+    query: {
+      days: c.req.query("days"),
+      from: c.req.query("from"),
+      to: c.req.query("to"),
+    },
     defaults,
-    c.req.query("days"),
-    c.req.query("from"),
-    c.req.query("to"),
-  );
+  });
   const scope: DashboardScope = {
     agent: optionalQueryValue(c.req.query("agent"))?.toLowerCase(),
     projectKind: projectIdentity?.kind,

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -19,7 +19,7 @@ import {
   type ScanResultSource,
   type SessionListDefaults,
 } from "./handlers.js";
-import type { LiveScanStore } from "../live-scan.js";
+import type { ScanEventSource } from "../scan-source.js";
 
 export interface ApiRouteOptions {
   defaultSessionFrom?: number;
@@ -27,7 +27,7 @@ export interface ApiRouteOptions {
   defaultSessionDays?: number;
 }
 
-function createSseResponse(store: LiveScanStore, signal: AbortSignal): Response {
+function createSseResponse(eventSource: ScanEventSource, signal: AbortSignal): Response {
   const encoder = new TextEncoder();
   let cancelStream = () => {};
 
@@ -42,12 +42,12 @@ function createSseResponse(store: LiveScanStore, signal: AbortSignal): Response 
         };
 
         write("connected", { timestamp: Date.now() });
-        write("scan-status", store.getScanStatus());
+        write("scan-status", eventSource.getScanStatus());
 
-        const unsubscribeSessions = store.subscribe((event) => {
+        const unsubscribeSessions = eventSource.subscribe((event) => {
           write(event.type, event);
         });
-        const unsubscribeScanStatus = store.subscribeScanStatus((event) => {
+        const unsubscribeScanStatus = eventSource.subscribeScanStatus((event) => {
           write(event.type, event);
         });
 
@@ -90,7 +90,7 @@ function createSseResponse(store: LiveScanStore, signal: AbortSignal): Response 
 
 export function createApiRoutes(
   scanSource: ScanResultSource,
-  store?: LiveScanStore,
+  eventSource?: ScanEventSource,
   options: ApiRouteOptions = {},
 ): Hono {
   const api = new Hono();
@@ -101,8 +101,8 @@ export function createApiRoutes(
   };
 
   api.get("/config", (c) => handleGetConfig(c, listDefaults));
-  if (store) {
-    api.get("/status", (c) => handleGetScanStatus(c, store));
+  if (eventSource) {
+    api.get("/status", (c) => handleGetScanStatus(c, eventSource));
   }
   api.get("/agents", (c) => handleGetAgents(c, scanSource, listDefaults));
   api.get("/projects", (c) => handleGetProjects(c, scanSource, listDefaults));
@@ -118,8 +118,8 @@ export function createApiRoutes(
   api.put("/session-aliases/:agent/:id", (c) => handlePutSessionAlias(c));
   api.delete("/session-aliases/:agent/:id", (c) => handleDeleteSessionAlias(c));
   api.post("/logs", (c) => handlePostClientLog(c));
-  if (store) {
-    api.get("/events", (c) => createSseResponse(store, c.req.raw.signal));
+  if (eventSource) {
+    api.get("/events", (c) => createSseResponse(eventSource, c.req.raw.signal));
   }
 
   return api;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { printScanResults } from "./output.js";
 import { VERSION } from "./version.js";
 import { appLogger } from "./logging.js";
 import { isLoopbackHostname } from "./remote-access.js";
+import { resolveTimeWindow } from "./time-window-resolution.js";
 import {
   DEFAULT_PORT,
   DEFAULT_PORT_FALLBACK_ATTEMPTS,
@@ -18,14 +19,6 @@ import {
   type ScanOptions,
   perf,
 } from "@codesesh/core";
-
-function parseDateToTimestamp(dateStr: string): number {
-  const date = new Date(dateStr);
-  if (Number.isNaN(date.getTime())) {
-    throw new Error(`Invalid date: ${dateStr}`);
-  }
-  return date.getTime();
-}
 
 function parseSessionUri(uri: string): { agent: string; sessionId: string } | null {
   const match = uri.match(/^([a-z]+):\/\/(.+)$/i);
@@ -183,22 +176,16 @@ const main = defineCommand({
       cwdFilter = process.cwd();
     }
 
-    // Resolve app-level default window (shared across /api/agents, /sessions, /dashboard).
-    // Priority: --from (absolute) over --days (relative).
-    let listDefaultFrom: number | undefined;
-    let listDefaultDays: number | undefined;
-    if (args.from) {
-      listDefaultFrom = parseDateToTimestamp(args.from as string);
-    } else {
-      const days = parseInt(args.days as string, 10);
-      if (!Number.isNaN(days) && days > 0) {
-        listDefaultFrom = Date.now() - days * 24 * 60 * 60 * 1000;
-        listDefaultDays = days;
-      } else if (days === 0) {
-        listDefaultDays = 0;
-      }
-    }
-    const listDefaultTo = args.to ? parseDateToTimestamp(args.to as string) : undefined;
+    const {
+      from: listDefaultFrom,
+      to: listDefaultTo,
+      days: listDefaultDays,
+    } = resolveTimeWindow({
+      mode: "cli",
+      from: args.from as string | undefined,
+      to: args.to as string | undefined,
+      days: args.days as string | undefined,
+    });
 
     const scanOptions: ScanOptions = {
       agents: targetSession

--- a/packages/cli/src/scan-source.ts
+++ b/packages/cli/src/scan-source.ts
@@ -1,0 +1,7 @@
+import type { ScanStatusEvent, SessionsUpdatedEvent } from "@codesesh/core/contract";
+
+export interface ScanEventSource {
+  getScanStatus(): ScanStatusEvent;
+  subscribe(listener: (event: SessionsUpdatedEvent) => void): () => void;
+  subscribeScanStatus(listener: (event: ScanStatusEvent) => void): () => void;
+}

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -1,5 +1,6 @@
 import { createServer as createNodeServer, type Server as NodeServer } from "node:net";
 import { describe, expect, it, vi } from "vitest";
+import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
 import { createServer } from "./server.js";
 
 const serveOptionsLog = vi.hoisted(() => [] as { hostname?: string; port?: number }[]);
@@ -21,6 +22,9 @@ vi.mock("@hono/node-server", async (importOriginal) => {
 function createStore() {
   return {
     getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }),
+    getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
+    subscribe: () => () => {},
+    subscribeScanStatus: () => () => {},
     shutdown: vi.fn(),
   };
 }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -9,7 +9,6 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ScanResultSource } from "./api/handlers.js";
 import { createApiRoutes, type ApiRouteOptions } from "./api/routes.js";
-import { LiveScanStore } from "./live-scan.js";
 import { appLogger } from "./logging.js";
 import {
   createRemoteAccessToken,
@@ -17,6 +16,7 @@ import {
   REMOTE_ACCESS_QUERY_PARAM,
   remoteAccessAuth,
 } from "./remote-access.js";
+import type { ScanEventSource } from "./scan-source.js";
 
 const MAX_API_REQUEST_BYTES = 1024 * 1024;
 
@@ -90,10 +90,7 @@ function getListeningPort(server: ServerType, fallback: number): number {
 
 export async function createServer(
   port: number,
-  store: ScanResultSource &
-    Partial<
-      Pick<LiveScanStore, "getScanStatus" | "subscribe" | "subscribeScanStatus" | "shutdown">
-    >,
+  store: ScanResultSource & ScanEventSource & { shutdown(): Promise<void> },
   options: CreateServerOptions = {},
 ): Promise<{ url: string; shutdown: () => Promise<void> }> {
   const app = new Hono();
@@ -148,14 +145,7 @@ export async function createServer(
     defaultSessionTo: options.defaultSessionTo,
     defaultSessionDays: options.defaultSessionDays,
   };
-  app.route(
-    "/api",
-    createApiRoutes(
-      store,
-      "subscribe" in store ? (store as LiveScanStore) : undefined,
-      routeOptions,
-    ),
-  );
+  app.route("/api", createApiRoutes(store, store, routeOptions));
 
   // Serve static files from web dist (if available)
   const webDistPath = findWebDistPath();
@@ -185,9 +175,7 @@ export async function createServer(
         continue;
       }
 
-      if (store.shutdown) {
-        await store.shutdown();
-      }
+      await store.shutdown();
 
       if (isAddressInUse(error) && attempts > 1) {
         throw new Error(
@@ -228,9 +216,7 @@ export async function createServer(
         }
         server.close(() => resolve());
       });
-      if (store.shutdown) {
-        await store.shutdown();
-      }
+      await store.shutdown();
     },
   };
 }

--- a/packages/cli/src/time-window-resolution.test.ts
+++ b/packages/cli/src/time-window-resolution.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { startOfLocalDay } from "@codesesh/core";
+import { resolveTimeWindow } from "./time-window-resolution.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-07-17T08:00:00.000Z").getTime();
+
+describe("resolveTimeWindow", () => {
+  it("gives an explicit CLI from value priority over days", () => {
+    const from = "2026-07-01T00:00:00.000Z";
+
+    expect(resolveTimeWindow({ mode: "cli", from, days: "7", now: NOW })).toEqual({
+      from: new Date(from).getTime(),
+      to: undefined,
+    });
+  });
+
+  it("resolves positive CLI days as a rolling window", () => {
+    expect(resolveTimeWindow({ mode: "cli", days: "7", now: NOW })).toEqual({
+      from: NOW - 7 * DAY_MS,
+      to: undefined,
+      days: 7,
+    });
+  });
+
+  it("preserves CLI all-time and date validation semantics", () => {
+    expect(resolveTimeWindow({ mode: "cli", days: "0", now: NOW })).toEqual({
+      to: undefined,
+      days: 0,
+    });
+    expect(() => resolveTimeWindow({ mode: "cli", from: "not-a-date" })).toThrow(
+      "Invalid date: not-a-date",
+    );
+  });
+
+  it("derives dashboard days from an explicit query window", () => {
+    const from = new Date("2026-07-10T00:00:00.000Z").getTime();
+    const to = new Date("2026-07-13T00:00:00.000Z").getTime();
+
+    expect(
+      resolveTimeWindow({
+        mode: "dashboard",
+        query: {
+          from: "2026-07-10T00:00:00.000Z",
+          to: "2026-07-13T00:00:00.000Z",
+        },
+      }),
+    ).toEqual({ from, to, days: 3 });
+  });
+
+  it("keeps the CLI default from value ahead of dashboard query days", () => {
+    const defaultFrom = NOW - 7 * DAY_MS;
+
+    expect(
+      resolveTimeWindow({
+        mode: "dashboard",
+        query: { days: "3" },
+        defaults: { from: defaultFrom, days: 7 },
+        now: NOW,
+      }),
+    ).toEqual({ from: defaultFrom, to: NOW, days: 3 });
+  });
+
+  it("supports explicit all-time dashboard windows", () => {
+    expect(
+      resolveTimeWindow({
+        mode: "dashboard",
+        query: { days: "0" },
+        defaults: { from: NOW - 7 * DAY_MS, days: 7 },
+        now: NOW,
+      }),
+    ).toEqual({ to: NOW, days: 0 });
+  });
+
+  it("uses the 30-day dashboard fallback from the local day boundary", () => {
+    expect(resolveTimeWindow({ mode: "dashboard", query: {}, now: NOW })).toEqual({
+      from: startOfLocalDay(NOW) - 29 * DAY_MS,
+      to: NOW,
+      days: 30,
+    });
+  });
+
+  it("falls back from invalid dashboard query dates", () => {
+    const defaultFrom = NOW - 5 * DAY_MS;
+
+    expect(
+      resolveTimeWindow({
+        mode: "dashboard",
+        query: { from: "invalid", to: "invalid" },
+        defaults: { from: defaultFrom, to: NOW, days: 5 },
+      }),
+    ).toEqual({ from: defaultFrom, to: NOW, days: 5 });
+  });
+});

--- a/packages/cli/src/time-window-resolution.ts
+++ b/packages/cli/src/time-window-resolution.ts
@@ -1,0 +1,109 @@
+import { startOfLocalDay } from "@codesesh/core";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_DASHBOARD_DAYS = 30;
+
+export interface TimeWindow {
+  from?: number;
+  to?: number;
+  /** Original relative window value used by the UI label. */
+  days?: number;
+}
+
+interface RawTimeWindow {
+  from?: string;
+  to?: string;
+  days?: string;
+}
+
+interface CliTimeWindowRequest extends RawTimeWindow {
+  mode: "cli";
+  now?: number;
+}
+
+interface DashboardTimeWindowRequest {
+  mode: "dashboard";
+  query: RawTimeWindow;
+  defaults?: TimeWindow;
+  now?: number;
+}
+
+interface DashboardTimeWindow extends TimeWindow {
+  to: number;
+}
+
+type TimeWindowRequest = CliTimeWindowRequest | DashboardTimeWindowRequest;
+
+export function resolveTimeWindow(request: CliTimeWindowRequest): TimeWindow;
+export function resolveTimeWindow(request: DashboardTimeWindowRequest): DashboardTimeWindow;
+export function resolveTimeWindow(request: TimeWindowRequest): TimeWindow {
+  return request.mode === "cli" ? resolveCliWindow(request) : resolveDashboardWindow(request);
+}
+
+function resolveCliWindow(request: CliTimeWindowRequest): TimeWindow {
+  const now = request.now ?? Date.now();
+  const from = parseRequiredDate(request.from);
+  const to = parseRequiredDate(request.to);
+  if (from != null) return { from, to };
+
+  const days = parseDays(request.days);
+  if (days === 0) return { to, days };
+  if (days == null || days < 0) return { to };
+
+  const rollingFrom = now - days * DAY_MS;
+  return Number.isFinite(rollingFrom) ? { from: rollingFrom, to, days } : { to };
+}
+
+function resolveDashboardWindow(request: DashboardTimeWindowRequest): DashboardTimeWindow {
+  const now = request.now ?? Date.now();
+  const defaults = request.defaults ?? {};
+  const to = parseOptionalDate(request.query.to) ?? defaults.to ?? now;
+  const hasQueryDays = Boolean(request.query.days?.trim());
+  const parsedDays = hasQueryDays ? parseDays(request.query.days) : undefined;
+  let days = parsedDays != null && parsedDays > 0 ? parsedDays : defaults.days;
+
+  const queryFrom = parseOptionalDate(request.query.from);
+  if (queryFrom != null) {
+    days ??= elapsedDays(queryFrom, to);
+    return { from: queryFrom, to, days };
+  }
+
+  if (parsedDays === 0 || (!hasQueryDays && defaults.days === 0)) {
+    return { to, days: 0 };
+  }
+
+  if (defaults.from != null) {
+    days ??= elapsedDays(defaults.from, to);
+    return { from: defaults.from, to, days };
+  }
+
+  const resolvedDays = days != null && days > 0 ? days : DEFAULT_DASHBOARD_DAYS;
+  return {
+    from: startOfLocalDay(to) - (resolvedDays - 1) * DAY_MS,
+    to,
+    days: resolvedDays,
+  };
+}
+
+function parseRequiredDate(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const timestamp = new Date(value).getTime();
+  if (Number.isNaN(timestamp)) throw new Error(`Invalid date: ${value}`);
+  return timestamp;
+}
+
+function parseOptionalDate(value: string | undefined): number | undefined {
+  if (value == null) return undefined;
+  const timestamp = new Date(value).getTime();
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
+function parseDays(value: string | undefined): number | undefined {
+  if (value == null) return undefined;
+  const days = Number.parseInt(value, 10);
+  return Number.isSafeInteger(days) && Number.isSafeInteger(days * DAY_MS) ? days : undefined;
+}
+
+function elapsedDays(from: number, to: number): number {
+  return Math.max(1, Math.ceil((to - from) / DAY_MS));
+}

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -19,6 +19,7 @@ import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
 import type { SessionData, SessionHead } from "../../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
+const SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS = 30_000;
 
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
@@ -724,65 +725,72 @@ describe("searchSessions", () => {
     ).toEqual(["src/changed-new.ts", "src/keep.ts"]);
   });
 
-  it("reads incremental search index state in bounded batches", () => {
-    const sessions = Array.from({ length: 1_000 }, (_, index) => makeSession(`batch-${index}`));
-    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+  it(
+    "reads incremental search index state in bounded batches",
+    () => {
+      const multiBatchSessionCount = 901;
+      const sessions = Array.from({ length: multiBatchSessionCount }, (_, index) =>
+        makeSession(`batch-${index}`),
+      );
+      const sessionMap = new Map(sessions.map((session) => [session.id, session]));
 
-    saveCachedSessions("claudecode", sessions);
-    syncSessionSearchIndex("claudecode", sessions, (sessionId) =>
-      makeSessionData(sessionMap.get(sessionId)!.id, `content ${sessionId}`),
-    );
+      saveCachedSessions("claudecode", sessions);
+      syncSessionSearchIndex("claudecode", sessions, (sessionId) =>
+        makeSessionData(sessionMap.get(sessionId)!.id, `content ${sessionId}`),
+      );
 
-    let stateQueryExecutions = 0;
-    const originalPrepare = Database.prototype.prepare;
-    const prepareSpy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
-      this: Database.Database,
-      source: string,
-    ) {
-      const statement = originalPrepare.call(this, source);
-      const normalized = source.replace(/\s+/g, " ").trim();
-      const isStateQuery =
-        normalized.startsWith("SELECT content_hash FROM session_documents") ||
-        normalized.startsWith("SELECT COUNT(*) AS value FROM messages") ||
-        normalized.startsWith("WITH requested_session_ids");
-      if (!isStateQuery) {
+      let stateQueryExecutions = 0;
+      const originalPrepare = Database.prototype.prepare;
+      const prepareSpy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+        this: Database.Database,
+        source: string,
+      ) {
+        const statement = originalPrepare.call(this, source);
+        const normalized = source.replace(/\s+/g, " ").trim();
+        const isStateQuery =
+          normalized.startsWith("SELECT content_hash FROM session_documents") ||
+          normalized.startsWith("SELECT COUNT(*) AS value FROM messages") ||
+          normalized.startsWith("WITH requested_session_ids");
+        if (!isStateQuery) {
+          return statement;
+        }
+
+        const originalGet = statement.get.bind(statement);
+        statement.get = (...params: unknown[]) => {
+          stateQueryExecutions += 1;
+          return (originalGet as (...boundParams: unknown[]) => unknown)(...params);
+        };
+        const originalAll = statement.all.bind(statement);
+        statement.all = (...params: unknown[]) => {
+          stateQueryExecutions += 1;
+          return (originalAll as (...boundParams: unknown[]) => unknown[])(...params);
+        };
         return statement;
+      });
+
+      const batchExecutions: number[] = [];
+      try {
+        for (const changeCount of [10, 100, multiBatchSessionCount]) {
+          const executionsBeforeSync = stateQueryExecutions;
+          const result = syncSessionSearchIndexChanges(
+            "claudecode",
+            sessions.slice(0, changeCount).map((session, sortIndex) => ({ session, sortIndex })),
+            [],
+            () => {
+              throw new Error("unchanged sessions must not be loaded");
+            },
+          );
+          expect(result?.changed).toBe(0);
+          batchExecutions.push(stateQueryExecutions - executionsBeforeSync);
+        }
+      } finally {
+        prepareSpy.mockRestore();
       }
 
-      const originalGet = statement.get.bind(statement);
-      statement.get = (...params: unknown[]) => {
-        stateQueryExecutions += 1;
-        return (originalGet as (...boundParams: unknown[]) => unknown)(...params);
-      };
-      const originalAll = statement.all.bind(statement);
-      statement.all = (...params: unknown[]) => {
-        stateQueryExecutions += 1;
-        return (originalAll as (...boundParams: unknown[]) => unknown[])(...params);
-      };
-      return statement;
-    });
-
-    const batchExecutions: number[] = [];
-    try {
-      for (const changeCount of [10, 100, 1_000]) {
-        const executionsBeforeSync = stateQueryExecutions;
-        const result = syncSessionSearchIndexChanges(
-          "claudecode",
-          sessions.slice(0, changeCount).map((session, sortIndex) => ({ session, sortIndex })),
-          [],
-          () => {
-            throw new Error("unchanged sessions must not be loaded");
-          },
-        );
-        expect(result?.changed).toBe(0);
-        batchExecutions.push(stateQueryExecutions - executionsBeforeSync);
-      }
-    } finally {
-      prepareSpy.mockRestore();
-    }
-
-    expect(batchExecutions).toEqual([1, 1, 2]);
-  });
+      expect(batchExecutions).toEqual([1, 1, 2]);
+    },
+    SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS,
+  );
 
   it("preserves incremental state defaults and duplicate change semantics", () => {
     const missingDocument = makeSession("missing-document");


### PR DESCRIPTION
## Summary

- define an explicit `ScanEventSource` interface for scan status and SSE subscriptions
- make the server and API routes depend on that interface instead of inspecting `LiveScanStore`
- centralize CLI and dashboard `from`/`days`/`to` precedence in `resolveTimeWindow`
- add direct coverage for rolling, all-time, explicit, fallback, and invalid windows
- keep the cross-batch search integration fixture minimal and give its SQLite workload an explicit timeout

## Why

Real-time route capabilities were inferred from the concrete store shape, while time-window precedence was implemented independently in the CLI entry point and dashboard handler. This made both contracts implicit and allowed their behavior to drift.

The first CI run also exposed that the existing 1,000-session cross-batch integration test consistently exceeded Vitest's default 15-second timeout on Windows with Node 22. The test only needs 901 sessions to cross the production 900-session batch boundary, and it is not a performance assertion.

## Impact

CLI arguments, API query semantics, scan status payloads, SSE payloads, production search behavior, and batch sizes remain unchanged. The change gives scan events and time-window resolution a single explicit owner while making the existing integration check reliable across the CI matrix.

## Validation

- `pnpm build`
- `pnpm test` (856 tests)
- `pnpm lint`
- targeted search integration test (27 tests)
- `codesesh --json --agent __smoke__ --days 0`
- default server startup plus `--from`/`--to`, `/api/status`, and `/api/dashboard` smoke checks
- GitHub Actions: 7/7 checks passed after the Windows test follow-up

Issue: CS-62