### PR TITLE
refactor(web): extract app shell models

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,7 @@ import { useSessionDetail } from "./hooks/useSessionDetail";
 import { useSessionSearch } from "./hooks/useSessionSearch";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { useDashboard } from "./hooks/useDashboard";
+import { useSidebarModel } from "./hooks/useSidebarModel";
 import { useSessionStore } from "./hooks/useSessionStore";
 import { useWindowedDataLoad } from "./hooks/useWindowedDataLoad";
 import { useLiveSync } from "./hooks/useLiveSync";
@@ -27,19 +28,8 @@ import { ShortcutHelpDialog } from "./components/app/ShortcutHelpDialog";
 import { AppRouteContent } from "./components/app/AppRouteContent";
 import type { BrowseBy } from "./components/app/types";
 import { formatScanStatusLabel, formatSearchSubtitle } from "./lib/scan-format";
-import {
-  getProjectGroupIdentity,
-  getProjectIdentityKey,
-  getProjectPath,
-  type ProjectRouteIdentity,
-} from "./lib/projects";
-import {
-  buildSessionIndexes,
-  buildSidebarSessionLookup,
-  getProjectAgentKey,
-  getSessionAgentKey,
-  getSessionRouteKey,
-} from "./lib/session-indexes";
+import { getProjectIdentityKey, getProjectPath, type ProjectRouteIdentity } from "./lib/projects";
+import { buildSessionIndexes, getSessionAgentKey } from "./lib/session-indexes";
 
 const SHORTCUT_HINT_STORAGE_KEY = "codesesh.shortcuts-hint-dismissed";
 
@@ -67,7 +57,6 @@ export default function App() {
     reload,
   });
 
-  const [browseBy, setBrowseBy] = useState<BrowseBy>("agents");
   const [selectedProjectIdentity, setSelectedProjectIdentity] =
     useState<ProjectRouteIdentity | null>(null);
   const { scanStatus, setScanStatus } = useScanStatus();
@@ -96,19 +85,11 @@ export default function App() {
   }, [location.pathname, viewState.mode, viewState.activeAgentKey, viewState.activeSessionSlug]);
 
   useEffect(() => {
-    if (viewState.mode === "projects" || viewState.mode === "project") {
-      setBrowseBy("projects");
-      if (viewState.mode === "project") {
-        setSelectedProjectIdentity({
-          kind: viewState.activeProjectKind,
-          key: viewState.activeProjectKey,
-        });
-      }
-      return;
-    }
-    if (viewState.mode === "agent" || viewState.mode === "missingAgent") {
-      setBrowseBy("agents");
-    }
+    if (viewState.mode !== "project") return;
+    setSelectedProjectIdentity({
+      kind: viewState.activeProjectKind,
+      key: viewState.activeProjectKey,
+    });
   }, [viewState]);
   const sessionIndexes = useMemo(() => buildSessionIndexes(sessions, agents), [sessions, agents]);
 
@@ -142,84 +123,45 @@ export default function App() {
   const { bookmarkedSessions, isSessionBookmarked, toggleBookmark, toggleSessionBookmark } =
     bookmarks;
 
-  const activeAgentKey = viewState.activeAgentKey;
   const activeProjectKind = viewState.mode === "project" ? viewState.activeProjectKind : null;
   const activeProjectKey = viewState.mode === "project" ? viewState.activeProjectKey : null;
-  const activeProjectIdentity = useMemo<ProjectRouteIdentity | null>(
-    () =>
-      activeProjectKind && activeProjectKey
-        ? { kind: activeProjectKind, key: activeProjectKey }
-        : null,
-    [activeProjectKind, activeProjectKey],
-  );
-  const activeProjectIdentityKey = activeProjectIdentity
-    ? getProjectIdentityKey(activeProjectIdentity)
-    : null;
 
   const projectDashboardFilters = useMemo(
     () => ({
       projectKind: activeProjectKind ?? undefined,
       projectKey: activeProjectKey ?? undefined,
-      identityKey: activeProjectIdentityKey ?? undefined,
+      identityKey:
+        activeProjectKind && activeProjectKey
+          ? getProjectIdentityKey({ kind: activeProjectKind, key: activeProjectKey })
+          : undefined,
     }),
-    [activeProjectIdentityKey, activeProjectKey, activeProjectKind],
+    [activeProjectKey, activeProjectKind],
   );
   const projectController = useDashboard(loadedWindow, projectDashboardFilters);
-  const selectedProjectAgent = projectController.selectedAgent;
-
-  const openedSessionHead = useMemo(() => {
-    if (viewState.mode !== "session") return null;
-    return (
-      sessionIndexes.byRouteKey.get(
-        getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionSlug),
-      ) ?? null
-    );
-  }, [sessionIndexes, viewState]);
-  const openedSessionData =
-    viewState.mode === "session" && session?.id === viewState.activeSessionSlug ? session : null;
-  const openedSessionProjectIdentity =
-    openedSessionData?.project_identity ?? openedSessionHead?.project_identity ?? null;
-  const selectedProjectNavigationIdentity =
-    browseBy !== "projects"
-      ? null
-      : viewState.mode === "project"
-        ? activeProjectIdentity
-        : viewState.mode === "session"
-          ? openedSessionProjectIdentity
-          : null;
-  const selectedProjectNavigationId = selectedProjectNavigationIdentity
-    ? getProjectIdentityKey(selectedProjectNavigationIdentity)
-    : null;
-  const agentSidebarSessions = useMemo(
-    () => (activeAgentKey ? (sessionIndexes.byAgent.get(activeAgentKey) ?? []) : []),
-    [activeAgentKey, sessionIndexes],
-  );
-  const projectSidebarSessions = useMemo(() => {
-    if (!selectedProjectNavigationId) return [];
-    if (selectedProjectAgent) {
-      return (
-        sessionIndexes.byProjectAgentKey.get(
-          getProjectAgentKey(selectedProjectNavigationId, selectedProjectAgent),
-        ) ?? []
-      );
-    }
-    return sessionIndexes.byProjectIdentityKey.get(selectedProjectNavigationId) ?? [];
-  }, [selectedProjectAgent, selectedProjectNavigationId, sessionIndexes]);
-  const sidebarSessions = browseBy === "projects" ? projectSidebarSessions : agentSidebarSessions;
-  const sidebarSessionLookup = useMemo(
-    () => buildSidebarSessionLookup(sidebarSessions),
-    [sidebarSessions],
-  );
-  const bookmarkedSidebarSessionIds = useMemo(() => {
-    if (sidebarSessions.length === 0) return new Set<string>();
-    return new Set(
-      sidebarSessions
-        .filter((sessionItem) =>
-          isSessionBookmarked(getSessionAgentKey(sessionItem), sessionItem.id),
-        )
-        .map((sessionItem) => sessionItem.id),
-    );
-  }, [isSessionBookmarked, sidebarSessions]);
+  const sidebar = useSidebarModel({
+    viewState,
+    sessionIndexes,
+    session,
+    agents,
+    projects,
+    selectedProjectAgent: projectController.selectedAgent,
+    isSessionBookmarked,
+  });
+  const {
+    browseBy,
+    selectBrowseBy,
+    activeAgentKey,
+    activeAgent,
+    activeProject,
+    activeProjectSessions,
+    openedSessionProjectIdentity,
+    selectedProjectNavigation,
+    sidebarSessions,
+    sidebarSessionLookup,
+    bookmarkedSidebarSessionIds,
+  } = sidebar;
+  const selectedProjectNavigationIdentity = selectedProjectNavigation?.identity ?? null;
+  const selectedProjectNavigationId = selectedProjectNavigation?.identityKey ?? null;
 
   const handleSelectFlatSidebarSession = useCallback(
     (sessionItem: SessionHead) => {
@@ -328,27 +270,6 @@ export default function App() {
     setSelectedSidebarSessionId(null);
   }, [isSearchMode, viewState.mode, viewState.activeSessionSlug, sidebarSessions]);
 
-  const activeAgent = useMemo(
-    () => agents.find((agent) => agent.name.toLowerCase() === activeAgentKey) ?? null,
-    [activeAgentKey, agents],
-  );
-  const activeProject = useMemo(
-    () =>
-      projects.find(
-        (project) =>
-          activeProjectIdentityKey === getProjectIdentityKey(getProjectGroupIdentity(project)),
-      ) ?? null,
-    [activeProjectIdentityKey, projects],
-  );
-  const selectedProjectNavigation = useMemo(
-    () =>
-      projects.find(
-        (project) =>
-          selectedProjectNavigationId === getProjectIdentityKey(getProjectGroupIdentity(project)),
-      ) ?? null,
-    [projects, selectedProjectNavigationId],
-  );
-
   const searchSubtitle =
     searchState.status === "failed"
       ? `Search failed for "${activeSearchQuery}"`
@@ -362,13 +283,13 @@ export default function App() {
     dashboard,
     projects,
     sessionCount: sessions.length,
-    activeProject,
+    activeProject: activeProject?.project ?? null,
     activeAgent,
     sidebarSessionCount: sidebarSessions.length,
     session,
     sessionError,
     selectedProjectIdentity: selectedProjectNavigationIdentity,
-    selectedProject: selectedProjectNavigation,
+    selectedProject: selectedProjectNavigation?.project ?? null,
   });
 
   const content = (
@@ -380,12 +301,41 @@ export default function App() {
       agents={agents}
       agentNameMap={agentNameMap}
       projects={projects}
-      sessionIndexes={sessionIndexes}
+      landingSessions={sessionIndexes.landingSessions}
+      sessionsByAgent={sessionIndexes.byLandingAgent}
+      activeProject={activeProject?.project ?? null}
+      activeProjectSessions={activeProjectSessions}
       dashboard={dashboard}
-      sessionDetail={sessionDetail}
-      projectController={projectController}
-      search={search}
-      bookmarks={bookmarks}
+      sessionDetail={{
+        session: sessionDetail.session,
+        loading: sessionDetail.sessionLoading,
+        error: sessionDetail.sessionError,
+      }}
+      projectDashboard={{
+        dashboard: projectController.dashboard,
+        loading: projectController.loading,
+        error: projectController.error,
+        selectedAgent: projectController.selectedAgent,
+        onChangeAgent: projectController.setSelectedAgent,
+      }}
+      search={{
+        active: search.searchMode,
+        query: search.activeSearchQuery,
+        state: search.searchState,
+        projectOptions: search.projectOptions,
+        filters: search.searchFilters,
+        onChangeFilters: search.setSearchFilters,
+        onClose: search.closeSearch,
+        onRetry: search.retrySearch,
+        selectedIndex: search.selectedSearchIndex,
+        registerResultRef: search.registerResultRef,
+      }}
+      bookmarks={{
+        sessions: bookmarks.bookmarkedSessions,
+        isBookmarked: bookmarks.isSessionBookmarked,
+        toggleBookmark: bookmarks.toggleBookmark,
+        toggleSessionBookmark: bookmarks.toggleSessionBookmark,
+      }}
     />
   );
 
@@ -400,7 +350,7 @@ export default function App() {
 
   function changeBrowseBy(next: BrowseBy) {
     if (next === "projects" && isScanActive) return;
-    setBrowseBy(next);
+    selectBrowseBy(next);
     setSelectedSidebarSessionId(null);
     if (next === "projects") {
       const project =

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProjectGroup } from "../../lib/api";
+import { AppRouteContent } from "./AppRouteContent";
+
+const project = {
+  identityKind: "git_remote",
+  identityKey: "github.com/acme/app",
+  displayName: "acme/app",
+  sources: ["/repo"],
+  sessionCount: 0,
+  lastActivity: 0,
+  messages: 0,
+  tokens: 0,
+  cost: 0,
+  agentStats: [],
+} satisfies ProjectGroup;
+
+function makeProps(): Parameters<typeof AppRouteContent>[0] {
+  return {
+    loading: false,
+    error: null,
+    viewState: {
+      mode: "root",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+    },
+    detailHighlightQuery: "",
+    agents: [],
+    agentNameMap: new Map(),
+    projects: [project],
+    landingSessions: [],
+    sessionsByAgent: new Map(),
+    activeProject: null,
+    activeProjectSessions: [],
+    dashboard: null,
+    sessionDetail: { session: null, loading: false, error: null },
+    projectDashboard: {
+      dashboard: null,
+      loading: false,
+      error: null,
+      onChangeAgent: vi.fn(),
+    },
+    search: {
+      active: false,
+      query: "",
+      state: { status: "idle" },
+      projectOptions: [],
+      filters: {},
+      onChangeFilters: vi.fn(),
+      onClose: vi.fn(),
+      onRetry: vi.fn(),
+      selectedIndex: 0,
+      registerResultRef: vi.fn(),
+    },
+    bookmarks: {
+      sessions: [],
+      isBookmarked: vi.fn(() => false),
+      toggleBookmark: vi.fn(),
+      toggleSessionBookmark: vi.fn(),
+    },
+  };
+}
+
+afterEach(cleanup);
+
+describe("AppRouteContent", () => {
+  it("renders a project from the resolved project model", () => {
+    const props = makeProps();
+    props.viewState = {
+      mode: "project",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+      activeProjectKind: "git_remote",
+      activeProjectKey: project.identityKey,
+    };
+    props.activeProject = project;
+
+    render(
+      <MemoryRouter>
+        <AppRouteContent {...props} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "acme/app" })).toBeTruthy();
+  });
+
+  it("renders search content from the explicit search contract", () => {
+    const props = makeProps();
+    props.search.active = true;
+
+    render(
+      <MemoryRouter>
+        <AppRouteContent {...props} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "No recent sessions" })).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -1,20 +1,55 @@
-import { useMemo } from "react";
+import { useMemo, type Dispatch, type SetStateAction } from "react";
 import { Dashboard } from "../Dashboard";
-import { DetailLanding, type LandingAgentItem } from "../DetailLanding";
+import { DetailLanding, type LandingAgentItem, type LandingSession } from "../DetailLanding";
 import { ProjectDashboardView, ProjectsOverview } from "../Projects";
 import { RenderProfiler } from "../RenderProfiler";
 import { SessionDetail } from "../SessionDetail";
 import { SessionDetailSkeleton } from "../SessionDetailSkeleton";
-import type { useBookmarks } from "../../hooks/useBookmarks";
-import type { useDashboard } from "../../hooks/useDashboard";
-import type { useSessionDetail } from "../../hooks/useSessionDetail";
-import type { useSessionSearch } from "../../hooks/useSessionSearch";
-import type { AgentInfo, ProjectGroup } from "../../lib/api";
-import { getProjectGroupIdentity, getProjectIdentityKey } from "../../lib/projects";
-import type { SessionIndexes } from "../../lib/session-indexes";
+import type {
+  AgentInfo,
+  BookmarkedSessionSnapshot,
+  DashboardData,
+  ProjectGroup,
+  SessionData,
+  SessionHead,
+} from "../../lib/api";
 import type { ViewState } from "../../lib/view-state";
-import type { SearchProjectOption } from "./types";
 import { SearchResultsPanel } from "./SearchResultsPanel";
+import type { SearchFilterState, SearchLoadState, SearchProjectOption } from "./types";
+
+interface SessionDetailModel {
+  session: SessionData | null;
+  loading: boolean;
+  error: string | null;
+}
+
+interface ProjectDashboardModel {
+  dashboard: DashboardData | null;
+  loading: boolean;
+  error: string | null;
+  selectedAgent?: string;
+  onChangeAgent: (agent?: string) => void;
+}
+
+interface SearchContentModel {
+  active: boolean;
+  query: string;
+  state: SearchLoadState;
+  projectOptions: SearchProjectOption[];
+  filters: SearchFilterState;
+  onChangeFilters: Dispatch<SetStateAction<SearchFilterState>>;
+  onClose: () => void;
+  onRetry: () => void;
+  selectedIndex: number;
+  registerResultRef: (key: string, node: HTMLAnchorElement | null) => void;
+}
+
+interface BookmarkContentModel {
+  sessions: BookmarkedSessionSnapshot[];
+  isBookmarked: (agentKey: string, sessionId: string) => boolean;
+  toggleBookmark: (session: BookmarkedSessionSnapshot) => void;
+  toggleSessionBookmark: (session: SessionHead, agentKey: string) => void;
+}
 
 interface AppRouteContentProps {
   loading: boolean;
@@ -24,12 +59,15 @@ interface AppRouteContentProps {
   agents: AgentInfo[];
   agentNameMap: Map<string, string>;
   projects: ProjectGroup[];
-  sessionIndexes: SessionIndexes;
-  dashboard: ReturnType<typeof useDashboard>["dashboard"];
-  sessionDetail: ReturnType<typeof useSessionDetail>;
-  projectController: ReturnType<typeof useDashboard>;
-  search: ReturnType<typeof useSessionSearch>;
-  bookmarks: ReturnType<typeof useBookmarks>;
+  landingSessions: LandingSession[];
+  sessionsByAgent: Map<string, LandingSession[]>;
+  activeProject: ProjectGroup | null;
+  activeProjectSessions: LandingSession[];
+  dashboard: DashboardData | null;
+  sessionDetail: SessionDetailModel;
+  projectDashboard: ProjectDashboardModel;
+  search: SearchContentModel;
+  bookmarks: BookmarkContentModel;
 }
 
 export function AppRouteContent({
@@ -40,10 +78,13 @@ export function AppRouteContent({
   agents,
   agentNameMap,
   projects,
-  sessionIndexes,
+  landingSessions,
+  sessionsByAgent,
+  activeProject,
+  activeProjectSessions,
   dashboard,
   sessionDetail,
-  projectController,
+  projectDashboard,
   search,
   bookmarks,
 }: AppRouteContentProps) {
@@ -59,48 +100,26 @@ export function AppRouteContent({
         })),
     [agents],
   );
-  const activeProjectIdentityKey =
-    viewState.mode === "project"
-      ? getProjectIdentityKey({
-          kind: viewState.activeProjectKind,
-          key: viewState.activeProjectKey,
-        })
-      : null;
-  const activeProject = useMemo(
-    () =>
-      projects.find(
-        (project) =>
-          activeProjectIdentityKey === getProjectIdentityKey(getProjectGroupIdentity(project)),
-      ) ?? null,
-    [activeProjectIdentityKey, projects],
-  );
-  const activeProjectSessions = activeProjectIdentityKey
-    ? (sessionIndexes.byLandingProjectIdentityKey.get(activeProjectIdentityKey) ?? [])
-    : [];
-  const searchProjectOptions = buildSearchProjectOptions(search, sessionIndexes.projectOptions);
-
   if (loading) return <SessionDetailSkeleton />;
-  if (search.searchMode) {
+  if (search.active) {
+    const resultCount = search.state.status === "loaded" ? search.state.results.length : 0;
     return (
       <RenderProfiler
         id="SearchResultsPanel"
-        detail={{ results: search.searchResults.length, loading: search.searchLoading }}
+        detail={{ results: resultCount, loading: search.state.status === "loading" }}
       >
         <SearchResultsPanel
-          query={search.activeSearchQuery}
-          state={search.searchState}
+          query={search.query}
+          state={search.state}
           agentNameMap={agentNameMap}
           agents={agents}
-          projects={searchProjectOptions}
-          filters={search.searchFilters}
-          onChangeFilters={search.setSearchFilters}
-          onOpenResult={search.closeSearch}
-          onRetry={search.retrySearch}
-          selectedIndex={search.selectedSearchIndex}
-          registerResultRef={(key, node) => {
-            if (node) search.searchResultRefs.current.set(key, node);
-            else search.searchResultRefs.current.delete(key);
-          }}
+          projects={search.projectOptions}
+          filters={search.filters}
+          onChangeFilters={search.onChangeFilters}
+          onOpenResult={search.onClose}
+          onRetry={search.onRetry}
+          selectedIndex={search.selectedIndex}
+          registerResultRef={search.registerResultRef}
         />
       </RenderProfiler>
     );
@@ -121,8 +140,8 @@ export function AppRouteContent({
         <Dashboard
           data={dashboard}
           projects={projects}
-          bookmarkedSessions={bookmarks.bookmarkedSessions}
-          isBookmarked={bookmarks.isSessionBookmarked}
+          bookmarkedSessions={bookmarks.sessions}
+          isBookmarked={bookmarks.isBookmarked}
           onToggleBookmark={(session, agentKey) => {
             if ("agentName" in session) {
               bookmarks.toggleSessionBookmark(session, agentKey ?? session.agentName.toLowerCase());
@@ -135,9 +154,9 @@ export function AppRouteContent({
     ) : (
       <DetailLanding
         type="global"
-        sessions={sessionIndexes.landingSessions}
+        sessions={landingSessions}
         agentItems={landingAgentItems}
-        isBookmarked={bookmarks.isSessionBookmarked}
+        isBookmarked={bookmarks.isBookmarked}
         onToggleBookmark={(session) => bookmarks.toggleSessionBookmark(session, session.agentKey)}
       />
     );
@@ -148,13 +167,13 @@ export function AppRouteContent({
       <ProjectDashboardView
         project={activeProject}
         projectKey={viewState.activeProjectKey}
-        dashboard={projectController.dashboard}
-        loading={projectController.loading}
-        error={projectController.error}
+        dashboard={projectDashboard.dashboard}
+        loading={projectDashboard.loading}
+        error={projectDashboard.error}
         sessions={activeProjectSessions}
-        activeAgent={projectController.selectedAgent}
-        onChangeAgent={projectController.setSelectedAgent}
-        isBookmarked={bookmarks.isSessionBookmarked}
+        activeAgent={projectDashboard.selectedAgent}
+        onChangeAgent={projectDashboard.onChangeAgent}
+        isBookmarked={bookmarks.isBookmarked}
         onToggleSessionBookmark={bookmarks.toggleSessionBookmark}
       />
     );
@@ -163,25 +182,25 @@ export function AppRouteContent({
     return (
       <DetailLanding
         type="agent"
-        sessions={sessionIndexes.byLandingAgent.get(viewState.activeAgentKey) ?? []}
+        sessions={sessionsByAgent.get(viewState.activeAgentKey) ?? []}
         agentItems={landingAgentItems}
         activeAgentKey={viewState.activeAgentKey}
-        isBookmarked={bookmarks.isSessionBookmarked}
+        isBookmarked={bookmarks.isBookmarked}
         onToggleBookmark={(session) => bookmarks.toggleSessionBookmark(session, session.agentKey)}
       />
     );
   }
   if (viewState.mode === "session") {
-    if (sessionDetail.sessionLoading) return <SessionDetailSkeleton />;
-    if (sessionDetail.sessionError || !sessionDetail.session) {
+    if (sessionDetail.loading) return <SessionDetailSkeleton />;
+    if (sessionDetail.error || !sessionDetail.session) {
       return (
         <DetailLanding
           type="missing-session"
-          sessions={sessionIndexes.byLandingAgent.get(viewState.activeAgentKey) ?? []}
+          sessions={sessionsByAgent.get(viewState.activeAgentKey) ?? []}
           agentItems={landingAgentItems}
           activeAgentKey={viewState.activeAgentKey}
           attemptedSessionSlug={viewState.activeSessionSlug}
-          isBookmarked={bookmarks.isSessionBookmarked}
+          isBookmarked={bookmarks.isBookmarked}
           onToggleBookmark={(session) => bookmarks.toggleSessionBookmark(session, session.agentKey)}
         />
       );
@@ -202,52 +221,13 @@ export function AppRouteContent({
     return (
       <DetailLanding
         type="missing-agent"
-        sessions={sessionIndexes.landingSessions}
+        sessions={landingSessions}
         agentItems={landingAgentItems}
         attemptedAgentKey={viewState.attemptedKey}
-        isBookmarked={bookmarks.isSessionBookmarked}
+        isBookmarked={bookmarks.isBookmarked}
         onToggleBookmark={(session) => bookmarks.toggleSessionBookmark(session, session.agentKey)}
       />
     );
   }
   return <div className="text-sm text-[var(--console-muted)]">Invalid route.</div>;
-}
-
-function buildSearchProjectOptions(
-  search: ReturnType<typeof useSessionSearch>,
-  projectOptions: SearchProjectOption[],
-): SearchProjectOption[] {
-  if (!search.usesServerSearch) return projectOptions;
-
-  const byKey = new Map<string, SearchProjectOption>();
-  const sourceResults = search.searchLoading ? [] : search.searchResults;
-  for (const result of sourceResults) {
-    const identity = result.session.project_identity;
-    if (!identity?.key) continue;
-    const key = getProjectIdentityKey(identity);
-    const current = byKey.get(key);
-    if (current) {
-      current.count += 1;
-    } else {
-      byKey.set(key, {
-        key,
-        identityKind: identity.kind,
-        identityKey: identity.key,
-        label: identity.displayName || result.session.directory,
-        count: 1,
-        showCount: false,
-      });
-    }
-  }
-
-  const selectedKey = search.searchFilters.project
-    ? getProjectIdentityKey(search.searchFilters.project)
-    : undefined;
-  const selected = selectedKey
-    ? projectOptions.find((project) => project.key === selectedKey)
-    : undefined;
-  if (selectedKey && selected && !byKey.has(selectedKey)) {
-    byKey.set(selected.key, { ...selected, count: 0, showCount: false });
-  }
-  return [...byKey.values()].toSorted((a, b) => b.count - a.count).slice(0, 8);
 }

--- a/apps/web/src/hooks/useSessionSearch.ts
+++ b/apps/web/src/hooks/useSessionSearch.ts
@@ -11,6 +11,7 @@ import type { SearchFilterState, SearchLoadState } from "../components/app/types
 import { COST_RANGE_OPTIONS } from "../components/app/SearchFilterBar";
 import {
   buildLocalRecentResults,
+  buildSearchProjectOptions,
   buildSearchRequestOptions,
   usesServerSearch as computeUsesServerSearch,
 } from "../lib/search";
@@ -60,6 +61,23 @@ export function useSessionSearch(
     [searchState],
   );
   const searchLoading = searchState.status === "loading";
+  const projectOptions = useMemo(
+    () =>
+      buildSearchProjectOptions({
+        usesServerSearch,
+        isLoading: searchLoading,
+        results: searchResults,
+        selectedProject: searchFilters.project,
+        recentProjectOptions: sessionIndexes.projectOptions,
+      }),
+    [
+      searchFilters.project,
+      searchLoading,
+      searchResults,
+      sessionIndexes.projectOptions,
+      usesServerSearch,
+    ],
+  );
 
   useEffect(() => {
     if (!searchMode) {
@@ -149,6 +167,11 @@ export function useSessionSearch(
     setRetryVersion((version) => version + 1);
   }, []);
 
+  const registerResultRef = useCallback((key: string, node: HTMLAnchorElement | null) => {
+    if (node) searchResultRefs.current.set(key, node);
+    else searchResultRefs.current.delete(key);
+  }, []);
+
   const refresh = useCallback(async () => {
     if (!(searchMode && usesServerSearch)) return;
     try {
@@ -171,10 +194,11 @@ export function useSessionSearch(
     searchState,
     searchResults,
     searchLoading,
+    projectOptions,
     usesServerSearch,
     selectedSearchIndex,
     searchInputRef,
-    searchResultRefs,
+    registerResultRef,
     setDraftSearchQuery,
     setSearchFilters,
     setSelectedSearchIndex,

--- a/apps/web/src/hooks/useSidebarModel.test.ts
+++ b/apps/web/src/hooks/useSidebarModel.test.ts
@@ -1,0 +1,146 @@
+import { SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentInfo, ProjectGroup, SessionHead } from "../lib/api";
+import { buildSessionIndexes } from "../lib/session-indexes";
+import type { ViewState } from "../lib/view-state";
+import { useSidebarModel } from "./useSidebarModel";
+
+const projectIdentity = {
+  kind: "git_remote" as const,
+  key: "github.com/acme/app",
+  displayName: "acme/app",
+};
+const agents = [
+  { name: "codex", displayName: "Codex", count: 2 },
+  { name: "claudecode", displayName: "Claude Code", count: 1 },
+] as AgentInfo[];
+const projects = [
+  {
+    identityKind: projectIdentity.kind,
+    identityKey: projectIdentity.key,
+    displayName: projectIdentity.displayName,
+    sources: ["/repo"],
+    sessionCount: 2,
+    lastActivity: 2,
+    messages: 2,
+    tokens: 2,
+    cost: 0,
+    agentStats: [],
+  },
+] as ProjectGroup[];
+const codexSession = {
+  ...SAMPLE_SESSION_HEAD,
+  id: "codex-session",
+  slug: "codex/codex-session",
+  project_identity: projectIdentity,
+} satisfies SessionHead;
+const claudeSession = {
+  ...SAMPLE_SESSION_HEAD,
+  id: "claude-session",
+  slug: "claudecode/claude-session",
+  project_identity: projectIdentity,
+} satisfies SessionHead;
+const sessionIndexes = buildSessionIndexes([codexSession, claudeSession], agents);
+
+const rootView = {
+  mode: "root",
+  activeAgentKey: null,
+  activeSessionSlug: null,
+} satisfies ViewState;
+const projectView = {
+  mode: "project",
+  activeAgentKey: null,
+  activeSessionSlug: null,
+  activeProjectKind: projectIdentity.kind,
+  activeProjectKey: projectIdentity.key,
+} satisfies ViewState;
+const sessionView = {
+  mode: "session",
+  activeAgentKey: "codex",
+  activeSessionSlug: codexSession.id,
+} satisfies ViewState;
+
+afterEach(cleanup);
+
+function renderModel(initialViewState: ViewState = rootView) {
+  const isSessionBookmarked = vi.fn((agentKey, sessionId) => {
+    return agentKey === "codex" && sessionId === codexSession.id;
+  });
+  return renderHook(
+    ({ viewState, selectedProjectAgent }) =>
+      useSidebarModel({
+        viewState,
+        sessionIndexes,
+        session: null,
+        agents,
+        projects,
+        selectedProjectAgent,
+        isSessionBookmarked,
+      }),
+    {
+      initialProps: {
+        viewState: initialViewState,
+        selectedProjectAgent: undefined as string | undefined,
+      },
+    },
+  );
+}
+
+describe("useSidebarModel", () => {
+  it("derives agent navigation from an agent route", () => {
+    const agentView = {
+      mode: "agent",
+      activeAgentKey: "codex",
+      activeSessionSlug: null,
+    } satisfies ViewState;
+    const { result } = renderModel(agentView);
+
+    expect(result.current.browseBy).toBe("agents");
+    expect(result.current.activeAgent?.displayName).toBe("Codex");
+    expect(result.current.sidebarSessions).toEqual([codexSession]);
+  });
+
+  it("preserves project browsing when a project opens a session", async () => {
+    const { result, rerender } = renderModel(projectView);
+    expect(result.current.browseBy).toBe("projects");
+    await waitFor(() => expect(result.current.browseBy).toBe("projects"));
+
+    rerender({ viewState: sessionView, selectedProjectAgent: undefined });
+
+    expect(result.current.browseBy).toBe("projects");
+    expect(result.current.selectedProjectNavigation?.identity).toEqual(projectIdentity);
+    expect(result.current.sidebarSessions).toEqual([codexSession, claudeSession]);
+  });
+
+  it("remembers an explicit browsing choice on ambiguous routes", () => {
+    const { result } = renderModel();
+    expect(result.current.browseBy).toBe("agents");
+
+    act(() => result.current.selectBrowseBy("projects"));
+
+    expect(result.current.browseBy).toBe("projects");
+  });
+
+  it("filters project sessions by the selected agent", async () => {
+    const { result, rerender } = renderModel(projectView);
+    await waitFor(() => expect(result.current.browseBy).toBe("projects"));
+
+    rerender({ viewState: projectView, selectedProjectAgent: "codex" });
+
+    expect(result.current.sidebarSessions).toEqual([codexSession]);
+    expect(result.current.bookmarkedSidebarSessionIds).toEqual(new Set([codexSession.id]));
+    expect(result.current.sidebarSessionLookup.byId.get(codexSession.id)).toBe(codexSession);
+  });
+
+  it("resolves the active project once for route consumers", () => {
+    const { result } = renderModel(projectView);
+
+    expect(result.current.activeProject).toEqual({
+      identity: { kind: projectIdentity.kind, key: projectIdentity.key },
+      identityKey: "git_remote:github.com/acme/app",
+      project: projects[0],
+    });
+    expect(result.current.activeProjectSessions).toHaveLength(2);
+  });
+});

--- a/apps/web/src/hooks/useSidebarModel.ts
+++ b/apps/web/src/hooks/useSidebarModel.ts
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AgentInfo, ProjectGroup, SessionData, SessionHead } from "../lib/api";
+import {
+  getProjectGroupIdentity,
+  getProjectIdentityKey,
+  type ProjectRouteIdentity,
+} from "../lib/projects";
+import {
+  buildSidebarSessionLookup,
+  getProjectAgentKey,
+  getSessionAgentKey,
+  getSessionRouteKey,
+  type SessionIndexes,
+} from "../lib/session-indexes";
+import type { ViewState } from "../lib/view-state";
+import type { BrowseBy } from "../components/app/types";
+
+interface UseSidebarModelOptions {
+  viewState: ViewState;
+  sessionIndexes: SessionIndexes;
+  session: SessionData | null;
+  agents: AgentInfo[];
+  projects: ProjectGroup[];
+  selectedProjectAgent?: string;
+  isSessionBookmarked: (agentKey: string, sessionId: string) => boolean;
+}
+
+export interface ProjectNavigationModel {
+  identity: ProjectRouteIdentity;
+  identityKey: string;
+  project: ProjectGroup | null;
+}
+
+function browseByForRoute(viewState: ViewState): BrowseBy | null {
+  if (viewState.mode === "projects" || viewState.mode === "project") return "projects";
+  if (viewState.mode === "agent" || viewState.mode === "missingAgent") return "agents";
+  return null;
+}
+
+function findProject(
+  projects: ProjectGroup[],
+  identityKey: string,
+): ProjectNavigationModel["project"] {
+  return (
+    projects.find(
+      (project) => identityKey === getProjectIdentityKey(getProjectGroupIdentity(project)),
+    ) ?? null
+  );
+}
+
+function getProjectSessions(
+  sessionIndexes: SessionIndexes,
+  projectIdentityKey: string | null,
+  agentKey?: string,
+): SessionHead[] {
+  if (!projectIdentityKey) return [];
+  if (!agentKey) {
+    return sessionIndexes.byProjectIdentityKey.get(projectIdentityKey) ?? [];
+  }
+  return (
+    sessionIndexes.byProjectAgentKey.get(getProjectAgentKey(projectIdentityKey, agentKey)) ?? []
+  );
+}
+
+export function useSidebarModel({
+  viewState,
+  sessionIndexes,
+  session,
+  agents,
+  projects,
+  selectedProjectAgent,
+  isSessionBookmarked,
+}: UseSidebarModelOptions) {
+  const routeBrowseBy = browseByForRoute(viewState);
+  const [rememberedBrowseBy, setRememberedBrowseBy] = useState<BrowseBy>(routeBrowseBy ?? "agents");
+  const browseBy = routeBrowseBy ?? rememberedBrowseBy;
+
+  useEffect(() => {
+    if (routeBrowseBy) setRememberedBrowseBy(routeBrowseBy);
+  }, [routeBrowseBy]);
+
+  const selectBrowseBy = useCallback((next: BrowseBy) => {
+    setRememberedBrowseBy(next);
+  }, []);
+
+  const model = useMemo(() => {
+    const activeAgentKey = viewState.activeAgentKey;
+    const activeAgent = agents.find((agent) => agent.name.toLowerCase() === activeAgentKey) ?? null;
+    const activeProjectIdentity: ProjectRouteIdentity | null =
+      viewState.mode === "project"
+        ? { kind: viewState.activeProjectKind, key: viewState.activeProjectKey }
+        : null;
+    const activeProjectIdentityKey = activeProjectIdentity
+      ? getProjectIdentityKey(activeProjectIdentity)
+      : null;
+    const activeProject =
+      activeProjectIdentity && activeProjectIdentityKey
+        ? {
+            identity: activeProjectIdentity,
+            identityKey: activeProjectIdentityKey,
+            project: findProject(projects, activeProjectIdentityKey),
+          }
+        : null;
+    const activeProjectSessions = activeProjectIdentityKey
+      ? (sessionIndexes.byLandingProjectIdentityKey.get(activeProjectIdentityKey) ?? [])
+      : [];
+
+    const openedSessionHead =
+      viewState.mode === "session"
+        ? (sessionIndexes.byRouteKey.get(
+            getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionSlug),
+          ) ?? null)
+        : null;
+    const openedSessionData =
+      viewState.mode === "session" && session?.id === viewState.activeSessionSlug ? session : null;
+    const openedSessionProjectIdentity =
+      openedSessionData?.project_identity ?? openedSessionHead?.project_identity ?? null;
+    const selectedProjectIdentity =
+      browseBy !== "projects"
+        ? null
+        : viewState.mode === "project"
+          ? activeProjectIdentity
+          : viewState.mode === "session"
+            ? openedSessionProjectIdentity
+            : null;
+    const selectedProjectIdentityKey = selectedProjectIdentity
+      ? getProjectIdentityKey(selectedProjectIdentity)
+      : null;
+    let selectedProjectNavigation: ProjectNavigationModel | null = null;
+    if (selectedProjectIdentity && selectedProjectIdentityKey) {
+      selectedProjectNavigation =
+        activeProject?.identityKey === selectedProjectIdentityKey
+          ? activeProject
+          : {
+              identity: selectedProjectIdentity,
+              identityKey: selectedProjectIdentityKey,
+              project: findProject(projects, selectedProjectIdentityKey),
+            };
+    }
+
+    const agentSessions = activeAgentKey ? (sessionIndexes.byAgent.get(activeAgentKey) ?? []) : [];
+    const projectSessions = getProjectSessions(
+      sessionIndexes,
+      selectedProjectIdentityKey,
+      selectedProjectAgent,
+    );
+    const sidebarSessions = browseBy === "projects" ? projectSessions : agentSessions;
+    const sidebarSessionLookup = buildSidebarSessionLookup(sidebarSessions);
+    const bookmarkedSidebarSessionIds = new Set(
+      sidebarSessions
+        .filter((sessionItem) =>
+          isSessionBookmarked(getSessionAgentKey(sessionItem), sessionItem.id),
+        )
+        .map((sessionItem) => sessionItem.id),
+    );
+
+    return {
+      activeAgentKey,
+      activeAgent,
+      activeProject,
+      activeProjectSessions,
+      openedSessionProjectIdentity,
+      selectedProjectNavigation,
+      sidebarSessions,
+      sidebarSessionLookup,
+      bookmarkedSidebarSessionIds,
+    };
+  }, [
+    agents,
+    browseBy,
+    isSessionBookmarked,
+    projects,
+    selectedProjectAgent,
+    session,
+    sessionIndexes,
+    viewState,
+  ]);
+
+  return { browseBy, selectBrowseBy, ...model };
+}

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { SessionHead } from "./api";
+import type { SearchResult, SessionHead } from "./api";
+import type { SearchProjectOption } from "../components/app/types";
 import type { SessionIndexes } from "./session-indexes";
 import { getProjectIdentityKey } from "./projects";
-import { buildLocalRecentResults, usesServerSearch } from "./search";
+import { buildLocalRecentResults, buildSearchProjectOptions, usesServerSearch } from "./search";
 
 describe("usesServerSearch", () => {
   it("stays false with no text and only agent/tag/cost filters", () => {
@@ -140,5 +141,88 @@ describe("buildLocalRecentResults", () => {
     const results = buildLocalRecentResults(indexes, { tag: "bugfix" }, undefined);
 
     expect(results).toHaveLength(50);
+  });
+});
+
+describe("buildSearchProjectOptions", () => {
+  const recentProjectOptions: SearchProjectOption[] = [
+    {
+      key: "git_remote:github.com/acme/app",
+      identityKind: "git_remote",
+      identityKey: "github.com/acme/app",
+      label: "acme/app",
+      count: 12,
+      showCount: true,
+    },
+  ];
+
+  function makeResult(id: string, projectKey: string, displayName: string): SearchResult {
+    return {
+      agentName: "codex",
+      snippet: "match",
+      matchType: "title",
+      session: {
+        id,
+        slug: `codex/${id}`,
+        title: id,
+        directory: `/repo/${id}`,
+        time_created: 0,
+        time_updated: 0,
+        stats: {
+          message_count: 1,
+          total_input_tokens: 0,
+          total_output_tokens: 0,
+          total_cost: 0,
+        },
+        project_identity: {
+          kind: "git_remote",
+          key: projectKey,
+          displayName,
+        },
+      } as SessionHead,
+    };
+  }
+
+  it("reuses recent project options for local search", () => {
+    expect(
+      buildSearchProjectOptions({
+        usesServerSearch: false,
+        isLoading: false,
+        results: [],
+        selectedProject: undefined,
+        recentProjectOptions,
+      }),
+    ).toBe(recentProjectOptions);
+  });
+
+  it("builds and sorts project facets from server results", () => {
+    const options = buildSearchProjectOptions({
+      usesServerSearch: true,
+      isLoading: false,
+      results: [
+        makeResult("other", "github.com/acme/other", "acme/other"),
+        makeResult("app-1", "github.com/acme/app", "acme/app"),
+        makeResult("app-2", "github.com/acme/app", "acme/app"),
+      ],
+      selectedProject: undefined,
+      recentProjectOptions,
+    });
+
+    expect(options.map(({ key, count }) => ({ key, count }))).toEqual([
+      { key: "git_remote:github.com/acme/app", count: 2 },
+      { key: "git_remote:github.com/acme/other", count: 1 },
+    ]);
+  });
+
+  it("retains the selected project while server facets are loading", () => {
+    expect(
+      buildSearchProjectOptions({
+        usesServerSearch: true,
+        isLoading: true,
+        results: [makeResult("app", "github.com/acme/app", "acme/app")],
+        selectedProject: { kind: "git_remote", key: "github.com/acme/app" },
+        recentProjectOptions,
+      }),
+    ).toEqual([{ ...recentProjectOptions[0], count: 0, showCount: false }]);
   });
 });

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -1,7 +1,15 @@
 import { type SearchRequestOptions, type SearchResult } from "./api";
 import { type SessionIndexes, getSessionAgentKey } from "./session-indexes";
 import { getProjectIdentityKey } from "./projects";
-import type { SearchFilterState } from "../components/app/types";
+import type { SearchFilterState, SearchProjectOption } from "../components/app/types";
+
+interface SearchProjectOptionsInput {
+  usesServerSearch: boolean;
+  isLoading: boolean;
+  results: SearchResult[];
+  selectedProject: SearchFilterState["project"];
+  recentProjectOptions: SearchProjectOption[];
+}
 
 export function buildSearchRequestOptions(
   filters: SearchFilterState,
@@ -62,4 +70,44 @@ export function buildLocalRecentResults(
   }
 
   return results;
+}
+
+export function buildSearchProjectOptions({
+  usesServerSearch,
+  isLoading,
+  results,
+  selectedProject,
+  recentProjectOptions,
+}: SearchProjectOptionsInput): SearchProjectOption[] {
+  if (!usesServerSearch) return recentProjectOptions;
+
+  const optionsByKey = new Map<string, SearchProjectOption>();
+  const sourceResults = isLoading ? [] : results;
+  for (const result of sourceResults) {
+    const identity = result.session.project_identity;
+    if (!identity?.key) continue;
+    const key = getProjectIdentityKey(identity);
+    const current = optionsByKey.get(key);
+    if (current) {
+      current.count += 1;
+      continue;
+    }
+    optionsByKey.set(key, {
+      key,
+      identityKind: identity.kind,
+      identityKey: identity.key,
+      label: identity.displayName || result.session.directory,
+      count: 1,
+      showCount: false,
+    });
+  }
+
+  const selectedKey = selectedProject ? getProjectIdentityKey(selectedProject) : undefined;
+  const selectedOption = selectedKey
+    ? recentProjectOptions.find((project) => project.key === selectedKey)
+    : undefined;
+  if (selectedKey && selectedOption && !optionsByKey.has(selectedKey)) {
+    optionsByKey.set(selectedKey, { ...selectedOption, count: 0, showCount: false });
+  }
+  return [...optionsByKey.values()].toSorted((left, right) => right.count - left.count).slice(0, 8);
 }


### PR DESCRIPTION
## Summary

- centralize sidebar navigation derivations in `useSidebarModel` with only the browse preference retained as explicit memory
- narrow `AppRouteContent` to explicit view contracts and reuse the resolved active project
- move search project facet derivation into the search domain and cover the new seams with focused tests

## Validation

- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web build`
- `pnpm test:e2e --project web-chromium`