### PR TITLE
feat(codex): decode code-mode exec into native tool displays

### DIFF
--- a/apps/web/src/components/session-detail/codex-tool.ts
+++ b/apps/web/src/components/session-detail/codex-tool.ts
@@ -477,6 +477,79 @@ export function buildCodexRequestUserInputDisplay(
   };
 }
 
+export function buildCodexUpdatePlanDisplay(inputValue: unknown) {
+  const input = toRecord(inputValue);
+  const explanation = toPlainText(input.explanation);
+  const steps = Array.isArray(input.plan) ? input.plan : [];
+
+  const counts = new Map<string, number>();
+  const lines = steps.map((entry) => {
+    const item = toRecord(entry);
+    const status = toPlainText(item.status) || "pending";
+    const step = toPlainText(item.step) || toPlainText(item.content);
+    counts.set(status, (counts.get(status) ?? 0) + 1);
+    const marker = status === "completed" ? "x" : status === "in_progress" ? "~" : " ";
+    return `- [${marker}] ${step || "(empty step)"}`;
+  });
+
+  const details: ToolDetailItem[] = [...counts.entries()].map(([status, count]) => ({
+    label: status,
+    value: String(count),
+  }));
+
+  return {
+    secondaryText:
+      explanation ||
+      [...counts.entries()].map(([status, count]) => `${count} ${status}`).join(" · ") ||
+      undefined,
+    details,
+    text: lines.join("\n") || explanation || "No plan captured.",
+  };
+}
+
+function summarizeWebRunItems(items: unknown[], field: string) {
+  return items
+    .map((item) => toPlainText(toRecord(item)[field]))
+    .filter(Boolean)
+    .join(" · ");
+}
+
+export function buildCodexWebRunDisplay(inputValue: unknown) {
+  const input = toRecord(inputValue);
+
+  if (Array.isArray(input.search_query)) {
+    return {
+      title: "web search",
+      secondaryText: summarizeWebRunItems(input.search_query, "q") || undefined,
+    };
+  }
+  if (Array.isArray(input.open)) {
+    return {
+      title: "web open",
+      secondaryText: summarizeWebRunItems(input.open, "ref_id") || undefined,
+    };
+  }
+
+  const action = Object.keys(input)[0] || "run";
+  return { title: `web ${action}`, secondaryText: undefined };
+}
+
+export function buildCodexViewImageDisplay(
+  inputValue: unknown,
+  formatPathForDisplay: (path: string) => string,
+) {
+  const input = toRecord(inputValue);
+  const path = toPlainText(input.path);
+  const detail = toPlainText(input.detail);
+  const displayPath = path ? formatPathForDisplay(path) : "";
+
+  const details: ToolDetailItem[] = [];
+  appendDetail(details, "Image", displayPath);
+  appendDetail(details, "Detail", detail);
+
+  return { secondaryText: displayPath || undefined, details };
+}
+
 export function extractCodexToolText(value: unknown) {
   return joinToolText(value);
 }

--- a/apps/web/src/components/session-detail/tool-strategy.test.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.test.ts
@@ -179,6 +179,75 @@ describe("getToolDisplayStrategy", () => {
       text: "No output captured.",
     });
   });
+
+  it("renders Codex update_plan as a checklist", () => {
+    const tool = part({
+      tool: "update_plan",
+      title: "Tool: update_plan",
+      state: {
+        status: "completed",
+        arguments: {
+          explanation: "halfway",
+          plan: [
+            { step: "Define seam", status: "completed" },
+            { step: "Wire backend", status: "in_progress" },
+            { step: "Update UI", status: "pending" },
+          ],
+        },
+        output: [{ type: "text", text: "ok" }],
+      },
+    });
+    const strategy = getToolDisplayStrategy("codex", tool, normalizeToolState(tool));
+
+    expect(strategy.title).toBe("update plan");
+    expect(strategy.secondaryText).toBe("halfway");
+    expect(strategy.details).toEqual([
+      { label: "completed", value: "1" },
+      { label: "in_progress", value: "1" },
+      { label: "pending", value: "1" },
+    ]);
+    expect(strategy.outputContent).toMatchObject({
+      kind: "plain",
+      language: "markdown",
+      text: "- [x] Define seam\n- [~] Wire backend\n- [ ] Update UI",
+    });
+  });
+
+  it("renders Codex web__run search queries", () => {
+    const tool = part({
+      tool: "web__run",
+      title: "Tool: web__run",
+      state: {
+        status: "completed",
+        arguments: { search_query: [{ q: "MLX audio" }, { q: "diarization" }] },
+        output: "results...",
+      },
+    });
+    const strategy = getToolDisplayStrategy("codex", tool, normalizeToolState(tool));
+
+    expect(strategy.title).toBe("web search");
+    expect(strategy.secondaryText).toBe("MLX audio · diarization");
+  });
+
+  it("renders Codex view_image with a relative path", () => {
+    const tool = part({
+      tool: "view_image",
+      title: "Tool: view_image",
+      state: {
+        status: "completed",
+        arguments: { path: "/repo/shot.jpeg", detail: "original" },
+        output: "",
+      },
+    });
+    const strategy = getToolDisplayStrategy("codex", tool, normalizeToolState(tool), "/repo");
+
+    expect(strategy.title).toBe("view image");
+    expect(strategy.secondaryText).toBe("shot.jpeg");
+    expect(strategy.details).toEqual([
+      { label: "Image", value: "shot.jpeg" },
+      { label: "Detail", value: "original" },
+    ]);
+  });
 });
 
 describe("getAssistantDisplayLabel", () => {

--- a/apps/web/src/components/session-detail/tool-strategy/codex.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/codex.ts
@@ -9,6 +9,9 @@ import { detectLanguageByFilePath } from "../../tool-output/language";
 import {
   buildCodexExecCommandDisplay,
   buildCodexRequestUserInputDisplay,
+  buildCodexUpdatePlanDisplay,
+  buildCodexViewImageDisplay,
+  buildCodexWebRunDisplay,
   buildCodexWriteStdinDisplay,
 } from "../codex-tool";
 import {
@@ -29,7 +32,15 @@ import {
 } from "../tool-normalize";
 import { parseJsonText } from "../utils";
 import { buildDefaultToolStrategy, buildSkillToolStrategy } from "./shared";
-import { Bot, CircleHelp, FilePenLine, SquareTerminal } from "lucide-react";
+import {
+  Bot,
+  CircleHelp,
+  FilePenLine,
+  FileSearch,
+  Image as ImageIcon,
+  ListTodo,
+  SquareTerminal,
+} from "lucide-react";
 
 export function extractCodexNodeReplTextOutput(outputText: string) {
   const marker = "Output:\n";
@@ -188,6 +199,55 @@ export function buildCodexToolStrategy(
         detectLanguageByFilePath,
         formatPathForDisplay,
       ),
+    };
+  }
+
+  if (toolKey === "update_plan") {
+    const display = buildCodexUpdatePlanDisplay(state.inputValue);
+    return {
+      ...defaultStrategy,
+      Icon: ListTodo,
+      title: "update plan",
+      secondaryText: display.secondaryText,
+      details: display.details,
+      showInputPreview: false,
+      outputContent: { kind: "plain", text: display.text, language: "markdown", isCode: false },
+    };
+  }
+
+  if (toolKey === "web__run") {
+    const display = buildCodexWebRunDisplay(state.inputValue);
+    return {
+      ...defaultStrategy,
+      Icon: FileSearch,
+      title: display.title,
+      secondaryText: display.secondaryText,
+      details: [],
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "markdown",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "view_image") {
+    const display = buildCodexViewImageDisplay(state.inputValue, formatPathForDisplay);
+    return {
+      ...defaultStrategy,
+      Icon: ImageIcon,
+      title: "view image",
+      secondaryText: display.secondaryText,
+      details: display.details,
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "text",
+        isCode: false,
+      },
     };
   }
 

--- a/packages/core/src/agents/__tests__/codex-exec-decode.test.ts
+++ b/packages/core/src/agents/__tests__/codex-exec-decode.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   decodeExecCalls,
   getExecPatchText,
+  pickExecOutputTarget,
   splitExecToolName,
   stripExecOutputEnvelope,
 } from "../codex-exec-decode.js";
@@ -81,6 +82,19 @@ describe("splitExecToolName", () => {
   it("leaves plain tool names untouched", () => {
     expect(splitExecToolName("exec_command")).toEqual({ name: "exec_command" });
     expect(splitExecToolName("apply_patch")).toEqual({ name: "apply_patch" });
+  });
+});
+
+describe("pickExecOutputTarget", () => {
+  const call = (name: string) => ({ name, args: {} });
+
+  it("prefers the last output-bearing call over patch/plan", () => {
+    expect(pickExecOutputTarget([call("exec_command"), call("apply_patch")])).toBe(0);
+    expect(pickExecOutputTarget([call("update_plan"), call("exec_command")])).toBe(1);
+  });
+
+  it("falls back to the last call when all are patch/plan", () => {
+    expect(pickExecOutputTarget([call("apply_patch"), call("update_plan")])).toBe(1);
   });
 });
 

--- a/packages/core/src/agents/__tests__/codex-exec-decode.test.ts
+++ b/packages/core/src/agents/__tests__/codex-exec-decode.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeExecCalls,
+  getExecPatchText,
+  splitExecToolName,
+  stripExecOutputEnvelope,
+} from "../codex-exec-decode.js";
+
+describe("decodeExecCalls", () => {
+  it("decodes a single exec_command invocation with inline args", () => {
+    const input =
+      'const r = await tools.exec_command({cmd:"sed -n \'1,20p\' a.md",workdir:"/tmp/p",yield_time_ms:10000,max_output_tokens:20000}); text(r.output)';
+    expect(decodeExecCalls(input)).toEqual([
+      {
+        name: "exec_command",
+        args: {
+          cmd: "sed -n '1,20p' a.md",
+          workdir: "/tmp/p",
+          yield_time_ms: 10000,
+          max_output_tokens: 20000,
+        },
+      },
+    ]);
+  });
+
+  it("resolves an apply_patch shorthand against the declared patch variable", () => {
+    const input =
+      'const patch = "*** Begin Patch\\n*** Add File: a.txt\\n+hello\\n*** End Patch";\nconst r = await tools.apply_patch({patch}); text(r.output)';
+    const calls = decodeExecCalls(input);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.name).toBe("apply_patch");
+    expect(getExecPatchText(calls[0]!.args)).toBe(
+      "*** Begin Patch\n*** Add File: a.txt\n+hello\n*** End Patch",
+    );
+  });
+
+  it("preserves escaped quotes and backslashes inside patch strings", () => {
+    const input = 'const patch = "a: \\"x\\"\\npath\\\\to"; await tools.apply_patch({patch});';
+    const calls = decodeExecCalls(input);
+    expect(getExecPatchText(calls[0]!.args)).toBe('a: "x"\npath\\to');
+  });
+
+  it("decodes nested arrays and objects for update_plan", () => {
+    const input =
+      'await tools.update_plan({plan:[{step:"a",status:"done"},{step:"b",status:"pending"}],explanation:"go"})';
+    expect(decodeExecCalls(input)).toEqual([
+      {
+        name: "update_plan",
+        args: {
+          plan: [
+            { step: "a", status: "done" },
+            { step: "b", status: "pending" },
+          ],
+          explanation: "go",
+        },
+      },
+    ]);
+  });
+
+  it("returns every invocation for multi-tool programs", () => {
+    const input =
+      'let r = await tools.exec_command({cmd:"ls"}); const patch = "*** Begin Patch\\n*** End Patch"; await tools.apply_patch({patch});';
+    const calls = decodeExecCalls(input);
+    expect(calls.map((call) => call.name)).toEqual(["exec_command", "apply_patch"]);
+  });
+
+  it("ignores programs without tool calls", () => {
+    expect(decodeExecCalls("const x = 1; console.log(x)")).toEqual([]);
+    expect(decodeExecCalls(undefined)).toEqual([]);
+  });
+});
+
+describe("splitExecToolName", () => {
+  it("splits MCP namespaced tool names", () => {
+    expect(splitExecToolName("mcp__node_repl__js")).toEqual({
+      name: "js",
+      namespace: "mcp__node_repl__",
+    });
+  });
+
+  it("leaves plain tool names untouched", () => {
+    expect(splitExecToolName("exec_command")).toEqual({ name: "exec_command" });
+    expect(splitExecToolName("apply_patch")).toEqual({ name: "apply_patch" });
+  });
+});
+
+describe("stripExecOutputEnvelope", () => {
+  it("removes the code-mode output wrapper", () => {
+    expect(stripExecOutputEnvelope("Script completed\nWall time 2.3 seconds\nOutput:\nhello")).toBe(
+      "hello",
+    );
+  });
+
+  it("leaves classic output untouched", () => {
+    expect(stripExecOutputEnvelope("package.json")).toBe("package.json");
+  });
+});

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -881,3 +881,182 @@ describe("CodexAgent cache refresh", () => {
     });
   });
 });
+
+describe("CodexAgent code-mode exec decoding", () => {
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  function writeCodeModeSession(records: Record<string, unknown>[]): {
+    agent: any;
+    sessionId: string;
+  } {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-codemode-"));
+    tempDirs.push(tempDir);
+    const sessionId = "019dcode-0000-7000-8000-000000000000";
+    const sessionFile = join(tempDir, `rollout-2026-07-19T10-00-00-${sessionId}.jsonl`);
+
+    const lines = [
+      JSON.stringify({
+        timestamp: "2026-07-19T10:00:00Z",
+        type: "session_meta",
+        payload: { cwd: "/tmp/project", cli_version: "0.144.0-alpha.4" },
+      }),
+      ...records.map((record) => JSON.stringify({ timestamp: "2026-07-19T10:00:01Z", ...record })),
+      "",
+    ];
+    writeFileSync(sessionFile, lines.join("\n"));
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.scan();
+    return { agent, sessionId };
+  }
+
+  function firstToolPart(agent: any, sessionId: string): MessagePart | undefined {
+    const data = agent.getSessionData(sessionId);
+    for (const message of data.messages) {
+      const part = message.parts.find((candidate: MessagePart) => candidate.type === "tool");
+      if (part) return part;
+    }
+    return undefined;
+  }
+
+  it("decodes exec_command into a bash tool with stripped output", () => {
+    const { agent, sessionId } = writeCodeModeSession([
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          call_id: "call-1",
+          name: "exec",
+          input:
+            'const r = await tools.exec_command({cmd:"ls",workdir:"/tmp/project"}); text(r.output)',
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call_output",
+          call_id: "call-1",
+          output: [
+            { type: "input_text", text: "Script completed\nWall time 0.1 seconds\nOutput:\n" },
+            { type: "input_text", text: "package.json" },
+          ],
+        },
+      },
+    ]);
+
+    expect(firstToolPart(agent, sessionId)).toMatchObject({
+      type: "tool",
+      tool: "bash",
+      state: {
+        arguments: { cmd: "ls", workdir: "/tmp/project" },
+        output: [{ type: "text", text: "package.json" }],
+        status: "completed",
+      },
+    });
+  });
+
+  it("decodes apply_patch into a patch tool with parsed blocks", () => {
+    const { agent, sessionId } = writeCodeModeSession([
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          call_id: "call-2",
+          name: "exec",
+          input:
+            'const patch = "*** Begin Patch\\n*** Add File: a.txt\\n+hello\\n*** End Patch";\nconst r = await tools.apply_patch({patch}); text(r.output)',
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call_output",
+          call_id: "call-2",
+          output: [
+            { type: "input_text", text: "Script completed\nWall time 0.0 seconds\nOutput:\n" },
+            { type: "input_text", text: "Success" },
+          ],
+        },
+      },
+    ]);
+
+    expect(firstToolPart(agent, sessionId)).toMatchObject({
+      type: "tool",
+      tool: "patch",
+      state: {
+        arguments: [{ type: "write_file", path: "a.txt", content: "+hello" }],
+        output: [{ type: "text", text: "Success" }],
+        status: "completed",
+      },
+    });
+  });
+
+  it("decodes a namespaced node_repl js call", () => {
+    const { agent, sessionId } = writeCodeModeSession([
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          call_id: "call-3",
+          name: "exec",
+          input:
+            'const r = await tools.mcp__node_repl__js({title:"Check state",code:"1+1"}); text(r)',
+        },
+      },
+    ]);
+
+    expect(firstToolPart(agent, sessionId)).toMatchObject({
+      type: "tool",
+      tool: "js",
+      title: "Tool: js",
+      state: {
+        arguments: { title: "Check state", code: "1+1" },
+        metadata: { name: "js", namespace: "mcp__node_repl__" },
+      },
+    });
+  });
+
+  it("decodes write_stdin", () => {
+    const { agent, sessionId } = writeCodeModeSession([
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          call_id: "call-4",
+          name: "exec",
+          input:
+            'const r = await tools.write_stdin({session_id:68920,chars:"yes"}); text(r.output)',
+        },
+      },
+    ]);
+
+    expect(firstToolPart(agent, sessionId)).toMatchObject({
+      type: "tool",
+      tool: "write_stdin",
+      state: { arguments: { session_id: 68920, chars: "yes" } },
+    });
+  });
+
+  it("falls back to a raw exec tool for multi-call programs", () => {
+    const { agent, sessionId } = writeCodeModeSession([
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call",
+          call_id: "call-5",
+          name: "exec",
+          input:
+            'await tools.exec_command({cmd:"ls"}); const patch = "*** Begin Patch\\n*** End Patch"; await tools.apply_patch({patch})',
+        },
+      },
+    ]);
+
+    expect(firstToolPart(agent, sessionId)).toMatchObject({ type: "tool", tool: "exec" });
+  });
+});

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1043,7 +1043,7 @@ describe("CodexAgent code-mode exec decoding", () => {
     });
   });
 
-  it("falls back to a raw exec tool for multi-call programs", () => {
+  it("splits a multi-call program into ordered tool parts", () => {
     const { agent, sessionId } = writeCodeModeSession([
       {
         type: "response_item",
@@ -1052,11 +1052,36 @@ describe("CodexAgent code-mode exec decoding", () => {
           call_id: "call-5",
           name: "exec",
           input:
-            'await tools.exec_command({cmd:"ls"}); const patch = "*** Begin Patch\\n*** End Patch"; await tools.apply_patch({patch})',
+            'let r = await tools.exec_command({cmd:"ls"}); text(r.output); const patch = "*** Begin Patch\\n*** Add File: a.txt\\n+hi\\n*** End Patch"; await tools.apply_patch({patch})',
+        },
+      },
+      {
+        type: "response_item",
+        payload: {
+          type: "custom_tool_call_output",
+          call_id: "call-5",
+          output: [
+            { type: "input_text", text: "Script completed\nWall time 0.1 seconds\nOutput:\n" },
+            { type: "input_text", text: "a.txt" },
+          ],
         },
       },
     ]);
 
-    expect(firstToolPart(agent, sessionId)).toMatchObject({ type: "tool", tool: "exec" });
+    const data = agent.getSessionData(sessionId);
+    const toolParts = data.messages
+      .flatMap((message: Message) => message.parts)
+      .filter((partValue: MessagePart) => partValue.type === "tool");
+
+    expect(toolParts.map((partValue: MessagePart) => partValue.tool)).toEqual(["bash", "patch"]);
+    // The combined output routes to the output-bearing bash part, not the patch.
+    expect(toolParts[0]).toMatchObject({
+      tool: "bash",
+      state: { output: [{ type: "text", text: "a.txt" }], status: "completed" },
+    });
+    expect(toolParts[1]).toMatchObject({
+      tool: "patch",
+      state: { arguments: [{ type: "write_file", path: "a.txt", content: "+hi" }], output: null },
+    });
   });
 });

--- a/packages/core/src/agents/codex-exec-decode.ts
+++ b/packages/core/src/agents/codex-exec-decode.ts
@@ -42,6 +42,19 @@ export function splitExecToolName(name: string): { name: string; namespace?: str
   return { name };
 }
 
+/**
+ * Pick which decoded call receives the exec program's combined output. Patch
+ * and plan calls do not emit stdout, so prefer the last output-bearing call;
+ * otherwise fall back to the last call.
+ */
+export function pickExecOutputTarget(calls: ExecInnerCall[]): number {
+  for (let index = calls.length - 1; index >= 0; index -= 1) {
+    const { name } = splitExecToolName(calls[index]!.name);
+    if (name !== "apply_patch" && name !== "update_plan") return index;
+  }
+  return calls.length - 1;
+}
+
 /** Extract the patch text from an `apply_patch` argument (`{patch}` or a string). */
 export function getExecPatchText(args: unknown): string {
   if (typeof args === "string") return args;

--- a/packages/core/src/agents/codex-exec-decode.ts
+++ b/packages/core/src/agents/codex-exec-decode.ts
@@ -1,0 +1,301 @@
+/**
+ * Codex "code mode" exec decoding.
+ *
+ * Since Codex 0.144.x the agent no longer calls tools directly. Every tool
+ * invocation is now a `custom_tool_call` named "exec" whose `input` is a small
+ * JS program that calls `tools.<name>({...})` (e.g. `tools.exec_command`,
+ * `tools.apply_patch`). This module extracts those inner invocations so the
+ * adapter can present each one as the native tool call it used to be.
+ *
+ * The inner argument objects are JS object literals, not JSON — unquoted keys,
+ * single/double/template strings, and shorthand `{patch}` that references a
+ * `const patch = "..."` declared earlier. A small tolerant reader handles that
+ * subset and resolves string variables; anything it cannot parse degrades to an
+ * empty result so the caller can fall back to the raw exec display.
+ */
+
+export interface ExecInnerCall {
+  name: string;
+  args: unknown;
+}
+
+const PARSE_FAIL = Symbol("parse-fail");
+
+const EXEC_OUTPUT_ENVELOPE_RE = /^Script completed\nWall time [^\n]*\nOutput:\n?/;
+
+/** Strip the `Script completed / Wall time / Output:` wrapper code-mode adds. */
+export function stripExecOutputEnvelope(text: string): string {
+  return text.replace(EXEC_OUTPUT_ENVELOPE_RE, "");
+}
+
+/**
+ * Split an inner tool name into `resolveToolIdentity(name, namespace)` inputs.
+ * `mcp__node_repl__js` → { name: "js", namespace: "mcp__node_repl__" }.
+ */
+export function splitExecToolName(name: string): { name: string; namespace?: string } {
+  if (name.startsWith("mcp__")) {
+    const separator = name.lastIndexOf("__");
+    if (separator > 0 && separator + 2 < name.length) {
+      return { name: name.slice(separator + 2), namespace: name.slice(0, separator + 2) };
+    }
+  }
+  return { name };
+}
+
+/** Extract the patch text from an `apply_patch` argument (`{patch}` or a string). */
+export function getExecPatchText(args: unknown): string {
+  if (typeof args === "string") return args;
+  if (args && typeof args === "object") {
+    const patch = (args as Record<string, unknown>)["patch"];
+    if (typeof patch === "string") return patch;
+  }
+  return "";
+}
+
+/** Decode the `tools.<name>({...})` invocations inside a code-mode exec program. */
+export function decodeExecCalls(input: unknown): ExecInnerCall[] {
+  if (typeof input !== "string" || !input.includes("tools.")) return [];
+
+  const scope = collectStringVars(input);
+  const calls: ExecInnerCall[] = [];
+  const callRe = /tools\.([A-Za-z_$][\w$]*)\s*\(/g;
+  let match: RegExpExecArray | null;
+  while ((match = callRe.exec(input)) !== null) {
+    const reader = new JsValueReader(input, callRe.lastIndex, scope);
+    const args = reader.parseValue();
+    if (args !== PARSE_FAIL) {
+      calls.push({ name: match[1]!, args });
+      callRe.lastIndex = reader.pos;
+    }
+  }
+  return calls;
+}
+
+/** Pre-scan `const/let/var NAME = "..."` so shorthand args can resolve them. */
+function collectStringVars(input: string): Map<string, unknown> {
+  const scope = new Map<string, unknown>();
+  const assignRe = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*/g;
+  let match: RegExpExecArray | null;
+  while ((match = assignRe.exec(input)) !== null) {
+    const reader = new JsValueReader(input, assignRe.lastIndex, scope);
+    const value = reader.parseValue();
+    if (value !== PARSE_FAIL) {
+      if (typeof value === "string") scope.set(match[1]!, value);
+      assignRe.lastIndex = reader.pos;
+    }
+  }
+  return scope;
+}
+
+const IDENT_START_RE = /[A-Za-z_$]/;
+const IDENT_PART_RE = /[\w$]/;
+
+/** Recursive-descent reader for the JS-literal subset used in exec args. */
+class JsValueReader {
+  pos: number;
+  private readonly src: string;
+  private readonly scope: Map<string, unknown>;
+
+  constructor(src: string, start: number, scope: Map<string, unknown>) {
+    this.src = src;
+    this.pos = start;
+    this.scope = scope;
+  }
+
+  parseValue(): unknown | typeof PARSE_FAIL {
+    this.skipTrivia();
+    const char = this.src[this.pos];
+    if (char === undefined) return PARSE_FAIL;
+    if (char === "{") return this.parseObject();
+    if (char === "[") return this.parseArray();
+    if (char === '"' || char === "'" || char === "`") return this.parseString(char);
+    if (char === "-" || char === "+" || (char >= "0" && char <= "9")) return this.parseNumber();
+    if (IDENT_START_RE.test(char)) return this.parseIdentifierValue();
+    return PARSE_FAIL;
+  }
+
+  private parseObject(): unknown | typeof PARSE_FAIL {
+    this.pos++; // {
+    const result: Record<string, unknown> = {};
+    this.skipTrivia();
+    if (this.src[this.pos] === "}") {
+      this.pos++;
+      return result;
+    }
+    while (this.pos < this.src.length) {
+      this.skipTrivia();
+      const key = this.parseKey();
+      if (key === PARSE_FAIL) return PARSE_FAIL;
+      this.skipTrivia();
+      if (this.src[this.pos] === ":") {
+        this.pos++;
+        const value = this.parseValue();
+        if (value === PARSE_FAIL) return PARSE_FAIL;
+        result[key] = value;
+      } else {
+        result[key] = this.resolveIdentifier(key);
+      }
+      this.skipTrivia();
+      const next = this.src[this.pos];
+      if (next === ",") {
+        this.pos++;
+        this.skipTrivia();
+        if (this.src[this.pos] === "}") {
+          this.pos++;
+          return result;
+        }
+        continue;
+      }
+      if (next === "}") {
+        this.pos++;
+        return result;
+      }
+      return PARSE_FAIL;
+    }
+    return PARSE_FAIL;
+  }
+
+  private parseArray(): unknown | typeof PARSE_FAIL {
+    this.pos++; // [
+    const result: unknown[] = [];
+    this.skipTrivia();
+    if (this.src[this.pos] === "]") {
+      this.pos++;
+      return result;
+    }
+    while (this.pos < this.src.length) {
+      const value = this.parseValue();
+      if (value === PARSE_FAIL) return PARSE_FAIL;
+      result.push(value);
+      this.skipTrivia();
+      const next = this.src[this.pos];
+      if (next === ",") {
+        this.pos++;
+        this.skipTrivia();
+        if (this.src[this.pos] === "]") {
+          this.pos++;
+          return result;
+        }
+        continue;
+      }
+      if (next === "]") {
+        this.pos++;
+        return result;
+      }
+      return PARSE_FAIL;
+    }
+    return PARSE_FAIL;
+  }
+
+  private parseKey(): string | typeof PARSE_FAIL {
+    const char = this.src[this.pos];
+    if (char === '"' || char === "'" || char === "`") {
+      const value = this.parseString(char);
+      return typeof value === "string" ? value : PARSE_FAIL;
+    }
+    if (char !== undefined && IDENT_START_RE.test(char)) return this.readIdentifier();
+    return PARSE_FAIL;
+  }
+
+  private parseString(quote: string): string {
+    this.pos++; // opening quote
+    let out = "";
+    while (this.pos < this.src.length) {
+      const char = this.src[this.pos++]!;
+      if (char === "\\") {
+        out += this.readEscape();
+        continue;
+      }
+      if (char === quote) break;
+      out += char;
+    }
+    return out;
+  }
+
+  private readEscape(): string {
+    const char = this.src[this.pos++];
+    switch (char) {
+      case "n":
+        return "\n";
+      case "t":
+        return "\t";
+      case "r":
+        return "\r";
+      case "b":
+        return "\b";
+      case "f":
+        return "\f";
+      case "v":
+        return "\v";
+      case "0":
+        return "\0";
+      case "u": {
+        const hex = this.src.slice(this.pos, this.pos + 4);
+        if (/^[0-9a-fA-F]{4}$/.test(hex)) {
+          this.pos += 4;
+          return String.fromCharCode(parseInt(hex, 16));
+        }
+        return "u";
+      }
+      case "x": {
+        const hex = this.src.slice(this.pos, this.pos + 2);
+        if (/^[0-9a-fA-F]{2}$/.test(hex)) {
+          this.pos += 2;
+          return String.fromCharCode(parseInt(hex, 16));
+        }
+        return "x";
+      }
+      default:
+        return char ?? "";
+    }
+  }
+
+  private parseNumber(): number | typeof PARSE_FAIL {
+    const numberRe = /[-+]?(?:0[xX][0-9a-fA-F]+|(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)/y;
+    numberRe.lastIndex = this.pos;
+    const match = numberRe.exec(this.src);
+    if (!match) return PARSE_FAIL;
+    this.pos += match[0].length;
+    return Number(match[0]);
+  }
+
+  private parseIdentifierValue(): unknown {
+    const name = this.readIdentifier();
+    if (name === "true") return true;
+    if (name === "false") return false;
+    if (name === "null") return null;
+    if (name === "undefined") return undefined;
+    return this.resolveIdentifier(name);
+  }
+
+  private resolveIdentifier(name: string): unknown {
+    return this.scope.has(name) ? this.scope.get(name) : undefined;
+  }
+
+  private readIdentifier(): string {
+    const start = this.pos;
+    while (this.pos < this.src.length && IDENT_PART_RE.test(this.src[this.pos]!)) this.pos++;
+    return this.src.slice(start, this.pos);
+  }
+
+  private skipTrivia(): void {
+    while (this.pos < this.src.length) {
+      const char = this.src[this.pos]!;
+      if (char === " " || char === "\t" || char === "\n" || char === "\r") {
+        this.pos++;
+        continue;
+      }
+      if (char === "/" && this.src[this.pos + 1] === "/") {
+        const newline = this.src.indexOf("\n", this.pos + 2);
+        this.pos = newline === -1 ? this.src.length : newline + 1;
+        continue;
+      }
+      if (char === "/" && this.src[this.pos + 1] === "*") {
+        const close = this.src.indexOf("*/", this.pos + 2);
+        this.pos = close === -1 ? this.src.length : close + 2;
+        continue;
+      }
+      break;
+    }
+  }
+}

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -28,6 +28,7 @@ import {
   type ExecInnerCall,
   decodeExecCalls,
   getExecPatchText,
+  pickExecOutputTarget,
   splitExecToolName,
   stripExecOutputEnvelope,
 } from "./codex-exec-decode.js";
@@ -1152,13 +1153,13 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     const name = String(payload["name"] ?? "").trim();
     if (!name) return;
 
-    // Code-mode exec: the JS program wraps a native tool call. Decode a
-    // single inner call back to its classic tool part so existing displays
-    // apply. Multi-call programs fall through to the raw exec representation.
+    // Code-mode exec: the JS program wraps native tool calls. Decode each
+    // inner call back to its classic tool part so existing displays apply.
+    // Programs with no recognizable call fall through to the raw exec part.
     if (name === "exec") {
       const decoded = decodeExecCalls(payload["input"]);
-      if (decoded.length === 1) {
-        this.appendDecodedExecCall(decoded[0]!, callId, transcript, timestampMs, activeModel);
+      if (decoded.length > 0) {
+        this.appendDecodedExecCalls(decoded, callId, transcript, timestampMs, activeModel);
         return;
       }
     }
@@ -1187,7 +1188,24 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     );
   }
 
-  // ---- Decoded code-mode exec call ----
+  // ---- Decoded code-mode exec calls ----
+
+  private appendDecodedExecCalls(
+    calls: ExecInnerCall[],
+    callId: string,
+    transcript: TranscriptBuilder,
+    timestampMs: number,
+    activeModel: string | null,
+  ): void {
+    // Only one output record follows, keyed by the exec call id; route it to
+    // the output-bearing part and give the rest unique ids so they still
+    // register and render, just without a resolved output.
+    const outputIndex = pickExecOutputTarget(calls);
+    calls.forEach((call, index) => {
+      const partCallId = index === outputIndex ? callId : `${callId}#${index}`;
+      this.appendDecodedExecCall(call, partCallId, transcript, timestampMs, activeModel);
+    });
+  }
 
   private appendDecodedExecCall(
     call: ExecInnerCall,

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -24,6 +24,13 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
+import {
+  type ExecInnerCall,
+  decodeExecCalls,
+  getExecPatchText,
+  splitExecToolName,
+  stripExecOutputEnvelope,
+} from "./codex-exec-decode.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -34,7 +41,7 @@ const PLAN_APPROVAL_PREFIX = "PLEASE IMPLEMENT THIS PLAN";
 const SUBAGENT_NOTIFICATION_PATTERN =
   /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
 const HEAD_INDEX_VERSION = "codex-head-v1";
-const PARSER_VERSION = "codex-parser-v3";
+const PARSER_VERSION = "codex-parser-v4";
 
 const DEVELOPER_LIKE_USER_MARKERS = [
   "agents.md instructions for",
@@ -143,6 +150,27 @@ function normalizeCustomToolArguments(toolName: string, input: unknown): unknown
     return parseApplyPatchInput(input);
   }
   return input;
+}
+
+/**
+ * Flatten tool-call output to text. Classic outputs are strings; code-mode
+ * outputs are arrays of `{ type: "input_text", text }` segments.
+ */
+function flattenOutputText(output: unknown): string {
+  if (typeof output === "string") return output;
+  if (Array.isArray(output)) {
+    return output
+      .map((item) => {
+        if (typeof item === "string") return item;
+        if (item && typeof item === "object") {
+          const text = (item as Record<string, unknown>)["text"];
+          if (typeof text === "string") return text;
+        }
+        return "";
+      })
+      .join("");
+  }
+  return "";
 }
 
 // ---------------------------------------------------------------------------
@@ -1100,7 +1128,9 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     const callId = String(payload["call_id"] ?? "").trim();
     if (!callId) return;
 
-    const outputText = cleanInternalText(String(payload["output"] ?? ""));
+    const outputText = cleanInternalText(
+      stripExecOutputEnvelope(flattenOutputText(payload["output"])),
+    );
     const outputParts: MessagePart[] = outputText
       ? [{ type: "text", text: outputText, time_created: timestampMs }]
       : [];
@@ -1122,6 +1152,17 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     const name = String(payload["name"] ?? "").trim();
     if (!name) return;
 
+    // Code-mode exec: the JS program wraps a native tool call. Decode a
+    // single inner call back to its classic tool part so existing displays
+    // apply. Multi-call programs fall through to the raw exec representation.
+    if (name === "exec") {
+      const decoded = decodeExecCalls(payload["input"]);
+      if (decoded.length === 1) {
+        this.appendDecodedExecCall(decoded[0]!, callId, transcript, timestampMs, activeModel);
+        return;
+      }
+    }
+
     const toolIdentity = resolveToolIdentity(name, payload["namespace"]);
     const rawInput = payload["input"];
     const normalizedInput = normalizeCustomToolArguments(name, rawInput);
@@ -1133,6 +1174,40 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       title: `Tool: ${toolIdentity.tool}`,
       state: {
         arguments: normalizedInput,
+        output: null,
+        metadata: toolIdentity.metadata,
+      },
+      time_created: timestampMs,
+    };
+
+    transcript.appendToolCall(
+      toolPart,
+      { id: "", timestampMs, agent: "codex", model: activeModel },
+      { markModeAsTool: true },
+    );
+  }
+
+  // ---- Decoded code-mode exec call ----
+
+  private appendDecodedExecCall(
+    call: ExecInnerCall,
+    callId: string,
+    transcript: TranscriptBuilder,
+    timestampMs: number,
+    activeModel: string | null,
+  ): void {
+    const { name, namespace } = splitExecToolName(call.name);
+    const toolIdentity = resolveToolIdentity(name, namespace);
+    const arguments_ =
+      name === "apply_patch" ? parseApplyPatchInput(getExecPatchText(call.args)) : call.args;
+
+    const toolPart: MessagePart = {
+      type: "tool",
+      tool: toolIdentity.tool,
+      callID: callId,
+      title: `Tool: ${toolIdentity.tool}`,
+      state: {
+        arguments: arguments_,
         output: null,
         metadata: toolIdentity.metadata,
       },

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -16,6 +16,8 @@ import {
   syncSessionSearchIndexChanges,
 } from "../../cache.js";
 import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
+import { migrateCodexExecDecode } from "../schema.js";
+import type { SQLiteDatabase } from "../../../utils/sqlite.js";
 import type { SessionData, SessionHead } from "../../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
@@ -118,6 +120,76 @@ afterEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
+});
+
+describe("session detail re-indexing", () => {
+  function toolSessionData(id: string, tool: string): SessionData {
+    const session = makeSession(id);
+    return {
+      ...session,
+      messages: [
+        {
+          id: `${id}-m1`,
+          role: "assistant",
+          time_created: now,
+          parts: [{ type: "tool", tool, callID: "c1", state: {} }],
+        },
+      ],
+    };
+  }
+
+  it("refreshes cached detail when the content hash goes stale", () => {
+    const session = makeSession("codex-1");
+    saveCachedSessions("codex", [session], {});
+    syncSessionSearchIndex("codex", [session], (id) => toolSessionData(id, "exec"));
+
+    expect(loadCachedSessionData("codex", "codex-1")?.messages[0]?.parts[0]).toMatchObject({
+      tool: "exec",
+    });
+
+    // The upgrade migration clears cached content hashes; simulate a stale one.
+    const db = new Database(getCachePath());
+    db.prepare(
+      "UPDATE session_documents SET content_hash = 'stale' WHERE agent_name = 'codex'",
+    ).run();
+    db.close();
+
+    syncSessionSearchIndex("codex", [session], (id) => toolSessionData(id, "bash"));
+
+    expect(loadCachedSessionData("codex", "codex-1")?.messages[0]?.parts[0]).toMatchObject({
+      tool: "bash",
+    });
+  });
+
+  it("marks Codex details pending once on the exec-decode migration", () => {
+    saveCachedSessions("codex", [makeSession("codex-1")], {});
+    saveCachedSessions("claudecode", [makeSession("cc-1")], {});
+    syncSessionSearchIndex("codex", [makeSession("codex-1")], (id) => toolSessionData(id, "exec"));
+    syncSessionSearchIndex("claudecode", [makeSession("cc-1")], (id) =>
+      makeSessionData(id, "keep me"),
+    );
+    expect(loadCachedSessionData("codex", "codex-1")?.messages).toHaveLength(1);
+
+    // Simulate a pre-migration cache (flag not yet set) and run the migration.
+    const raw = new Database(getCachePath());
+    raw.prepare("DELETE FROM cache_meta WHERE key = 'codex_exec_decode_migrated_v3'").run();
+    migrateCodexExecDecode(raw as unknown as SQLiteDatabase);
+    raw.close();
+
+    // Codex details read as pending (no messages) so the API re-parses them;
+    // other agents are untouched. No bulk deletion happens.
+    expect(loadCachedSessionData("codex", "codex-1")?.messages).toHaveLength(0);
+    expect(loadCachedSessionData("claudecode", "cc-1")?.messages).toHaveLength(1);
+
+    // Idempotent: re-parsed rows survive a second run because the flag is set.
+    syncSessionSearchIndex("codex", [makeSession("codex-1")], (id) => toolSessionData(id, "bash"));
+    const raw2 = new Database(getCachePath());
+    migrateCodexExecDecode(raw2 as unknown as SQLiteDatabase);
+    raw2.close();
+    expect(loadCachedSessionData("codex", "codex-1")?.messages[0]?.parts[0]).toMatchObject({
+      tool: "bash",
+    });
+  });
 });
 
 describe("searchSessions", () => {

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -143,6 +143,12 @@ export function createCacheTables(db: SQLiteDatabase): void {
       index_version TEXT NOT NULL,
       last_sync_at INTEGER NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS pending_reindex (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      PRIMARY KEY (agent_name, session_id)
+    );
   `);
 }
 
@@ -952,6 +958,37 @@ export function invalidateSearchContentHashes(db: SQLiteDatabase): void {
   }
 }
 
+const CODEX_EXEC_DECODE_MIGRATION_KEY = "codex_exec_decode_migrated_v3";
+
+/**
+ * One-time: mark every cached Codex detail as pending re-index so code-mode
+ * exec decoding takes effect on upgrade. The search content hash derives only
+ * from head-level fields, none of which the decoder touches, so nothing would
+ * otherwise trigger a refresh. Session rows carry huge content_text, so
+ * rewriting them (or clearing a hash) is slow; instead we record just the
+ * session ids in the lightweight pending_reindex table. loadCachedSessionData
+ * treats a marked session as pending and re-parses its detail fresh on view;
+ * the search index clears the marker as it repopulates each one. Gated by a
+ * cache_meta flag; a fresh cache just records it.
+ */
+export function migrateCodexExecDecode(db: SQLiteDatabase): void {
+  if (!tableExists(db, "cache_meta")) return;
+  const done = db
+    .prepare("SELECT value FROM cache_meta WHERE key = ?")
+    .get(CODEX_EXEC_DECODE_MIGRATION_KEY);
+  if (done) return;
+
+  if (tableExists(db, "sessions") && tableExists(db, "pending_reindex")) {
+    db.exec(
+      "INSERT OR IGNORE INTO pending_reindex(agent_name, session_id) " +
+        "SELECT agent_name, session_id FROM sessions WHERE agent_name = 'codex'",
+    );
+  }
+  db.prepare(
+    "INSERT INTO cache_meta(key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = '1'",
+  ).run(CODEX_EXEC_DECODE_MIGRATION_KEY);
+}
+
 export function rebuildSearchIndex(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents_fts")) {
     return;
@@ -1016,6 +1053,7 @@ export function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   if (currentVersion === 0 && !hasAnyCacheSchema(db)) {
     createLatestCacheSchema(db);
     setCacheSchemaVersion(db);
+    migrateCodexExecDecode(db);
     return;
   }
 
@@ -1086,4 +1124,6 @@ export function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   if (getUserVersion(db) <= CACHE_SCHEMA_VERSION) {
     setCacheSchemaVersion(db);
   }
+
+  migrateCodexExecDecode(db);
 }

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -52,6 +52,14 @@ interface SearchIndexState {
   contentHashBySessionId: Map<string, string>;
   indexedMessageCountBySessionId: Map<string, number>;
   messageCountBySessionId: Map<string, number>;
+  pendingReindexSessionIds: Set<string>;
+}
+
+function readPendingReindexIds(db: SQLiteDatabase, agentName: string): Set<string> {
+  const rows = db
+    .prepare("SELECT session_id FROM pending_reindex WHERE agent_name = ?")
+    .all(agentName) as Array<{ session_id?: string }>;
+  return new Set(rows.map((row) => String(row.session_id)));
 }
 
 type SearchIndexStateRow = IndexedSearchRow & MessageCountRow;
@@ -98,6 +106,7 @@ function sessionContentHash(session: SessionHead): string {
 function searchIndexStateFromRows(
   indexedRows: IndexedSearchRow[],
   messageCountRows: MessageCountRow[],
+  pendingReindexSessionIds: Set<string> = new Set(),
 ): SearchIndexState {
   return {
     contentHashBySessionId: new Map(
@@ -109,6 +118,7 @@ function searchIndexStateFromRows(
     messageCountBySessionId: new Map(
       messageCountRows.map((row) => [String(row.session_id), Number(row.value ?? 0)]),
     ),
+    pendingReindexSessionIds,
   };
 }
 
@@ -147,12 +157,13 @@ function readSearchIndexState(
     rows.push(...batchRows);
   }
 
-  return searchIndexStateFromRows(rows, rows);
+  return searchIndexStateFromRows(rows, rows, readPendingReindexIds(db, agentName));
 }
 
 function searchIndexEntryNeedsUpdate(state: SearchIndexState, session: SessionHead): boolean {
   const sessionId = session.id;
   return (
+    state.pendingReindexSessionIds.has(sessionId) ||
     state.contentHashBySessionId.get(sessionId) !== sessionContentHash(session) ||
     state.indexedMessageCountBySessionId.get(sessionId) !==
       (state.messageCountBySessionId.get(sessionId) ?? 0)
@@ -296,11 +307,16 @@ function writeSearchIndexRows(
       indexed_at = excluded.indexed_at
   `);
 
+  const clearPendingReindex = db.prepare(
+    "DELETE FROM pending_reindex WHERE agent_name = ? AND session_id = ?",
+  );
+
   for (const sessionId of new Set(removedSessionIds)) {
     deleteRow.run(agentName, sessionId);
     deleteFileActivity.run(agentName, sessionId);
     deleteMessageTools.run(agentName, sessionId, 0);
     deleteMessages.run(agentName, sessionId, 0);
+    clearPendingReindex.run(agentName, sessionId);
   }
 
   let indexed = 0;
@@ -309,6 +325,7 @@ function writeSearchIndexRows(
     upsertSessionRow(upsertIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
     deleteFileActivity.run(agentName, entry.session.id);
     deleteMessageTools.run(agentName, entry.session.id, 0);
+    clearPendingReindex.run(agentName, entry.session.id);
     writeFileActivityRows(insertFileActivity, entry.fileActivity);
     for (const message of entry.messages) {
       upsertMessage.run(
@@ -379,7 +396,11 @@ export function syncSessionSearchIndex(
         "SELECT session_id, COUNT(*) AS value FROM messages WHERE agent_name = ? GROUP BY session_id",
       )
       .all(agentName) as MessageCountRow[];
-    const searchIndexState = searchIndexStateFromRows(existingRows, messageCountRows);
+    const searchIndexState = searchIndexStateFromRows(
+      existingRows,
+      messageCountRows,
+      readPendingReindexIds(db, agentName),
+    );
     const sessionMap = new Map(sessions.map((session) => [session.id, session]));
 
     const toDelete = existingRows

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -242,9 +242,20 @@ export function loadCachedSessionData(agentName: string, sessionId: string): Ses
       return null;
     }
 
-    const messageRows = db
-      .prepare(
-        `
+    // A pending_reindex marker means the cached detail predates a parser change
+    // (e.g. the code-mode exec decode migration). Report no cached messages so
+    // the API re-parses it fresh rather than serving the stale cache; the search
+    // index drops the marker as it repopulates the session.
+    const pendingReindex =
+      db
+        .prepare("SELECT 1 FROM pending_reindex WHERE agent_name = ? AND session_id = ?")
+        .get(agentName, sessionId) != null;
+
+    const messageRows = pendingReindex
+      ? []
+      : (db
+          .prepare(
+            `
           SELECT
             message_id,
             role,
@@ -264,8 +275,8 @@ export function loadCachedSessionData(agentName: string, sessionId: string): Ses
           WHERE agent_name = ? AND session_id = ?
           ORDER BY message_index
         `,
-      )
-      .all(agentName, sessionId) as CachedMessageRow[];
+          )
+          .all(agentName, sessionId) as CachedMessageRow[]);
 
     const head = sessionFromRow(row);
     const fileActivityRows = db


### PR DESCRIPTION
## Background

Starting with Codex `0.144.0-alpha.4` (first seen 2026-07-10; `0.142.5` and
earlier still use the classic format), Codex switched to a **code mode**: the
agent no longer calls tools directly. Every tool call now arrives as a single
`custom_tool_call` named `exec` whose `input` is a small JS program that invokes
`tools.<name>({...})` (e.g. `tools.apply_patch`, `tools.exec_command`), and its
output is an array of `{ type: "input_text", text }` segments wrapped in a
`Script completed / Wall time / Output:` envelope.

As a result CodeSesh rendered every Codex tool call as a raw JS blob, patch
diffs disappeared, and outputs collapsed to `[object Object]`.

This PR decodes code-mode exec back into the native tool parts the classic
format produced, so existing displays apply unchanged.

## Changes

**Phase 1 — core decoder (`cd0c096`)**
- New `codex-exec-decode.ts`: a tolerant JS-literal reader that extracts the
  inner `tools.<name>({...})` invocations, resolving `const patch = "..."`
  shorthand references.
- Decode a single inner call into its classic tool part (`bash`, `patch`,
  `write_stdin`, node_repl `js`, `subagent`, and MCP tools) reusing
  `resolveToolIdentity` / `parseApplyPatchInput`.
- Flatten code-mode output arrays and strip the `Script completed … Output:`
  envelope (fixes the `[object Object]` outputs for all execs).

**Phase 2 — web displays (`f760777`)**
- Add Codex strategy branches for `update_plan` (status checklist), `web__run`
  (search-query / opened-ref summary), and `view_image` (path + detail). Pure
  presentation — no cache impact.

**Phase 3 — multi-call splitting (`bf49bcb`)**
- Programs that call several tools (e.g. `exec_command` then `apply_patch`) are
  split into ordered tool parts, with the combined program output routed to the
  output-bearing call so a command and its patch both render fully.

**Cache refresh on upgrade (`8f89a86`)**
- Parsed details are cached in SQLite and served without re-parsing; the decoder
  runs in that parse, and the search content hash (head-derived) never changes,
  so upgraded installs kept serving stale raw `exec` parts. Codex session rows
  carry huge `content_text`, so clearing a hash or deleting them on upgrade
  blocks startup for tens of seconds. Instead a one-time `cache_meta`-gated
  migration records just the session ids in a lightweight `pending_reindex`
  table (instant). `loadCachedSessionData` treats a marked session as pending so
  the API re-parses its detail fresh on view, and the search index drops the
  marker (and repopulates the cache) as it re-indexes each one through the
  normal refresh. Startup stays instant; the cache warms in the background.
  Decoding stays in core (not presentation) because it also feeds file-activity,
  which keys off tool names like `apply_patch`.

## Validation

- New unit + integration tests for the decoder, output handling, all decoded
  tool types, the new web displays, multi-call splitting, and the pending
  re-index migration.
- Decoder run over ~7,000 real exec calls across five days: **93% decode to a
  single native tool**, ~4.6% multi-call, ~2.3% tool-less JS that stays raw.
- `pnpm test` (362 core + 325 web) and `pnpm lint` pass across the monorepo.