### PR TITLE
feat: add semantic tool visualizations

### DIFF
--- a/apps/web/src/components/session-detail/blocks.ts
+++ b/apps/web/src/components/session-detail/blocks.ts
@@ -48,6 +48,7 @@ function isVisiblePart(part: MessagePart) {
 
 export function buildMessageBlocks(parts: MessagePart[]): MessageBlock[] {
   return parts.reduce<MessageBlock[]>((blocks, part) => {
+    if (part.type === "image") return blocks;
     if (!isVisiblePart(part)) return blocks;
 
     const prev = blocks.at(-1);

--- a/apps/web/src/components/session-detail/codex-tool.ts
+++ b/apps/web/src/components/session-detail/codex-tool.ts
@@ -1,4 +1,4 @@
-import type { ToolOutputContent, ToolOutputLanguage } from "../tool-output/types";
+import type { TaskListItem, ToolOutputContent, ToolOutputLanguage } from "../tool-output/types";
 
 export interface ToolDetailItem {
   label: string;
@@ -483,13 +483,17 @@ export function buildCodexUpdatePlanDisplay(inputValue: unknown) {
   const steps = Array.isArray(input.plan) ? input.plan : [];
 
   const counts = new Map<string, number>();
-  const lines = steps.map((entry) => {
+  const items = steps.map((entry) => {
     const item = toRecord(entry);
     const status = toPlainText(item.status) || "pending";
     const step = toPlainText(item.step) || toPlainText(item.content);
     counts.set(status, (counts.get(status) ?? 0) + 1);
-    const marker = status === "completed" ? "x" : status === "in_progress" ? "~" : " ";
-    return `- [${marker}] ${step || "(empty step)"}`;
+    return {
+      label: step || "(empty step)",
+      status: (status === "completed" || status === "in_progress" || status === "error"
+        ? status
+        : "pending") as TaskListItem["status"],
+    };
   });
 
   const details: ToolDetailItem[] = [...counts.entries()].map(([status, count]) => ({
@@ -503,7 +507,7 @@ export function buildCodexUpdatePlanDisplay(inputValue: unknown) {
       [...counts.entries()].map(([status, count]) => `${count} ${status}`).join(" · ") ||
       undefined,
     details,
-    text: lines.join("\n") || explanation || "No plan captured.",
+    items,
   };
 }
 

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -459,17 +459,20 @@ function ToolItem({
     <div id={anchorId} data-session-timeline-anchor={anchorId} className="scroll-mt-20 space-y-2">
       <div className="flex flex-wrap items-start gap-2">
         <div
-          className={`w-full md:w-[560px] rounded-sm border border-[var(--console-border-strong)] bg-white px-3 py-2 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${
+          className={`w-full max-w-[720px] rounded-sm border border-[var(--console-border-strong)] bg-white px-3 py-2.5 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${
             strategy.expandable ? "transition-colors hover:bg-[var(--console-surface-muted)]" : ""
           }`}
         >
           {strategy.expandable ? (
             <button
               type="button"
-              className="flex w-full items-start gap-2 text-left"
+              className="flex w-full items-center gap-2.5 text-left active:scale-[0.995] motion-reduce:transform-none"
               onClick={() => setExpanded(!expanded)}
+              aria-expanded={expanded}
             >
-              <ToolIcon className="mt-0.5 size-3.5 shrink-0 text-[var(--console-accent)]" />
+              <span className="flex size-7 shrink-0 items-center justify-center rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)]">
+                <ToolIcon className="size-3.5 text-[var(--console-accent)]" />
+              </span>
               <span className="min-w-0 flex-1">
                 <span className="console-mono block text-xs font-semibold text-[var(--console-text)]">
                   {strategy.title}
@@ -479,6 +482,14 @@ function ToolItem({
                     {renderHighlightedText(strategy.secondaryText, highlightQuery)}
                   </span>
                 ) : null}
+              </span>
+              <span
+                className={`console-mono inline-flex shrink-0 items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider ${statusMeta.className}`}
+              >
+                <StatusIcon
+                  className={`size-2.5 ${state.status === "running" ? "animate-spin motion-reduce:animate-none" : ""}`}
+                />
+                {statusMeta.label}
               </span>
               <span className="mt-0.5 shrink-0 text-[var(--console-muted)]">
                 {expanded ? (
@@ -489,8 +500,10 @@ function ToolItem({
               </span>
             </button>
           ) : (
-            <div className="flex items-start gap-2">
-              <ToolIcon className="mt-0.5 size-3.5 shrink-0 text-[var(--console-accent)]" />
+            <div className="flex items-center gap-2.5">
+              <span className="flex size-7 shrink-0 items-center justify-center rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)]">
+                <ToolIcon className="size-3.5 text-[var(--console-accent)]" />
+              </span>
               <span className="min-w-0 flex-1">
                 <span className="console-mono block text-xs font-semibold text-[var(--console-text)]">
                   {strategy.title}
@@ -501,23 +514,23 @@ function ToolItem({
                   </span>
                 ) : null}
               </span>
+              <span
+                className={`console-mono inline-flex shrink-0 items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wider ${statusMeta.className}`}
+              >
+                <StatusIcon className="size-2.5" />
+                {statusMeta.label}
+              </span>
             </div>
           )}
         </div>
-        <span
-          className={`console-mono inline-flex items-center gap-1 rounded-sm border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${statusMeta.className}`}
-        >
-          <StatusIcon
-            className={`size-3 ${state.status === "running" ? "animate-spin motion-reduce:animate-none" : ""}`}
-          />
-          {statusMeta.label}
-        </span>
       </div>
 
       {strategy.expandable && expanded ? (
         <div className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
           <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
-            <span className="console-mono text-xs text-[var(--console-muted)]">Output</span>
+            <span className="console-mono text-xs text-[var(--console-muted)]">
+              {strategy.contentLabel ?? "Output"}
+            </span>
           </div>
           <div className="space-y-3 p-3">
             {strategy.details.length > 0 ? (
@@ -531,7 +544,7 @@ function ToolItem({
                       <span className="console-mono shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[var(--console-muted)] md:w-24">
                         {detail.label}
                       </span>
-                      <span className="console-mono whitespace-pre-wrap break-all text-xs leading-relaxed text-[var(--console-text)]">
+                      <span className="console-mono whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-text)]">
                         {renderHighlightedText(detail.value, highlightQuery)}
                       </span>
                     </div>
@@ -546,7 +559,7 @@ function ToolItem({
               <span className="console-mono text-[11px] text-[var(--console-muted)]">
                 Input Preview
               </span>
-              <pre className="console-mono mt-1 max-h-[200px] overflow-x-auto whitespace-pre-wrap break-all text-xs leading-relaxed text-[var(--console-muted)]">
+              <pre className="console-mono mt-1 max-h-[200px] overflow-x-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-muted)]">
                 {renderHighlightedText(inputPreviewText, highlightQuery)}
               </pre>
             </div>

--- a/apps/web/src/components/session-detail/tool-normalize.test.ts
+++ b/apps/web/src/components/session-detail/tool-normalize.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { MessagePart } from "../../lib/api";
 import {
+  buildSemanticOutputContent,
   cleanToolTitle,
   extractCommand,
   extractToolTextSegments,
@@ -130,6 +131,42 @@ describe("formatToolOutput / getOutputOrErrorText", () => {
 
     const emptyState = { ...state, outputValue: null, errorValue: null };
     expect(getOutputOrErrorText(emptyState)).toBe("No output captured.");
+  });
+});
+
+describe("buildSemanticOutputContent", () => {
+  it("preserves image blocks alongside text", () => {
+    expect(
+      buildSemanticOutputContent([
+        { type: "image", mime_type: "image/png", data: "iVBORw0KGgo=" },
+        { type: "text", text: "Browser screenshot" },
+      ]),
+    ).toEqual({
+      kind: "media",
+      items: [
+        {
+          src: "data:image/png;base64,iVBORw0KGgo=",
+          alt: "Tool output image 1",
+        },
+      ],
+      text: "Browser screenshot",
+    });
+  });
+
+  it("turns JSON objects into property rows", () => {
+    expect(buildSemanticOutputContent('{"status":"complete","count":3}')).toEqual({
+      kind: "property-list",
+      items: [
+        { label: "status", value: "complete" },
+        { label: "count", value: 3 },
+      ],
+    });
+  });
+
+  it("does not load remote image URLs from historical output", () => {
+    expect(
+      buildSemanticOutputContent([{ type: "image", url: "https://tracker.example/tool.png" }]),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/session-detail/tool-normalize.ts
+++ b/apps/web/src/components/session-detail/tool-normalize.ts
@@ -37,7 +37,49 @@ export interface ToolDisplayStrategy {
   details: ToolDetailItem[];
   expandable: boolean;
   showInputPreview: boolean;
+  contentLabel?: string;
   outputContent: ToolOutputContent;
+}
+
+function toSafeImageSource(part: Record<string, unknown>) {
+  const mimeType = toPlainText(part.mime_type);
+  const data = toPlainText(part.data);
+  if (mimeType.startsWith("image/") && data) return `data:${mimeType};base64,${data}`;
+
+  const url = toPlainText(part.url);
+  if (/^data:image\//i.test(url)) return url;
+  return "";
+}
+
+export function extractToolMedia(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item, index) => {
+    const record = toRecord(item);
+    if (record.type !== "image") return [];
+    const src = toSafeImageSource(record);
+    if (!src) return [];
+    return [{ src, alt: `Tool output image ${index + 1}` }];
+  });
+}
+
+export function buildSemanticOutputContent(value: unknown): ToolOutputContent | null {
+  const media = extractToolMedia(value);
+  if (media.length > 0) {
+    const text = joinToolText(value, false);
+    return { kind: "media", items: media, text: text || undefined };
+  }
+
+  const parsed =
+    typeof value === "string" && value.trim() ? parseInputCandidate(value.trim()) : value;
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const items = Object.entries(parsed as Record<string, unknown>).map(([label, itemValue]) => ({
+      label,
+      value: itemValue,
+    }));
+    return items.length > 0 ? { kind: "property-list", items } : null;
+  }
+
+  return null;
 }
 
 export function toDisplayText(value: unknown) {

--- a/apps/web/src/components/session-detail/tool-strategy.test.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.test.ts
@@ -322,6 +322,45 @@ describe("getToolDisplayStrategy", () => {
     });
   });
 
+  it("renders Claude messages without raw JSON", () => {
+    const tool = part({
+      tool: "SendMessage",
+      state: {
+        status: "completed",
+        input: {
+          to: "main",
+          recipient: "main",
+          summary: "Renderer findings",
+          message: "The expanded tool card still shows JSON.",
+          content: "The expanded tool card still shows JSON.",
+        },
+        output: [
+          {
+            type: "text",
+            text: '{"success":true,"message":"Message queued for the main conversation."}',
+          },
+        ],
+      },
+    });
+    const strategy = getToolDisplayStrategy("claudecode", tool, normalizeToolState(tool));
+
+    expect(strategy).toMatchObject({
+      title: "send message",
+      secondaryText: "main",
+      showInputPreview: false,
+      contentLabel: "Message details",
+    });
+    expect(strategy.outputContent).toEqual({
+      kind: "property-list",
+      items: [
+        { label: "Recipient", value: "main" },
+        { label: "Summary", value: "Renderer findings" },
+        { label: "Message", value: "The expanded tool card still shows JSON." },
+        { label: "Delivery", value: "Message queued for the main conversation." },
+      ],
+    });
+  });
+
   it("renders Codex collaboration messages semantically", () => {
     const tool = part({
       tool: "collaboration.send_message",

--- a/apps/web/src/components/session-detail/tool-strategy.test.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.test.ts
@@ -206,10 +206,13 @@ describe("getToolDisplayStrategy", () => {
       { label: "in_progress", value: "1" },
       { label: "pending", value: "1" },
     ]);
-    expect(strategy.outputContent).toMatchObject({
-      kind: "plain",
-      language: "markdown",
-      text: "- [x] Define seam\n- [~] Wire backend\n- [ ] Update UI",
+    expect(strategy.outputContent).toEqual({
+      kind: "task-list",
+      items: [
+        { label: "Define seam", status: "completed" },
+        { label: "Wire backend", status: "in_progress" },
+        { label: "Update UI", status: "pending" },
+      ],
     });
   });
 
@@ -247,6 +250,103 @@ describe("getToolDisplayStrategy", () => {
       { label: "Image", value: "shot.jpeg" },
       { label: "Detail", value: "original" },
     ]);
+  });
+
+  it("renders Claude tasks as status rows", () => {
+    const tool = part({
+      tool: "TodoWrite",
+      state: {
+        status: "completed",
+        input: {
+          todos: [
+            { content: "Inspect formats", status: "completed" },
+            { content: "Polish renderer", status: "in_progress", activeForm: "Rendering" },
+          ],
+        },
+      },
+    });
+    const strategy = getToolDisplayStrategy("claudecode", tool, normalizeToolState(tool));
+
+    expect(strategy).toMatchObject({
+      title: "tasks",
+      secondaryText: "1 completed · 1 in_progress",
+      showInputPreview: false,
+      contentLabel: "Task state",
+    });
+    expect(strategy.outputContent).toEqual({
+      kind: "task-list",
+      items: [
+        { label: "Inspect formats", status: "completed", detail: undefined },
+        { label: "Polish renderer", status: "in_progress", detail: "Rendering" },
+      ],
+    });
+  });
+
+  it("renders Claude browser actions without raw input JSON", () => {
+    const tool = part({
+      tool: "mcp__claude-in-chrome__navigate",
+      state: {
+        status: "completed",
+        input: { tabId: 42, url: "http://localhost:4173/session" },
+        output: "Navigated",
+      },
+    });
+    const strategy = getToolDisplayStrategy("claudecode", tool, normalizeToolState(tool));
+
+    expect(strategy).toMatchObject({
+      title: "browser · navigate",
+      secondaryText: "http://localhost:4173/session",
+      details: [{ label: "Tab", value: "42" }],
+      showInputPreview: false,
+      contentLabel: "Browser result",
+    });
+  });
+
+  it("renders Claude structured submissions as fields", () => {
+    const tool = part({
+      tool: "StructuredOutput",
+      state: {
+        status: "completed",
+        input: { verdict: "pass", findings: [{ severity: "low", title: "Spacing" }] },
+        output: "Structured output submitted",
+      },
+    });
+    const strategy = getToolDisplayStrategy("claudecode", tool, normalizeToolState(tool));
+
+    expect(strategy.outputContent).toEqual({
+      kind: "property-list",
+      items: [
+        { label: "verdict", value: "pass" },
+        { label: "findings", value: [{ severity: "low", title: "Spacing" }] },
+      ],
+    });
+  });
+
+  it("renders Codex collaboration messages semantically", () => {
+    const tool = part({
+      tool: "collaboration.send_message",
+      title: "Tool: collaboration.send_message",
+      state: {
+        status: "completed",
+        arguments: { target: "reviewer", message: "Please check the tool renderer." },
+        output: "Delivered",
+      },
+    });
+    const strategy = getToolDisplayStrategy("codex", tool, normalizeToolState(tool));
+
+    expect(strategy).toMatchObject({
+      title: "message agent",
+      secondaryText: "reviewer",
+      showInputPreview: false,
+      contentLabel: "Message",
+    });
+    expect(strategy.outputContent).toEqual({
+      kind: "property-list",
+      items: [
+        { label: "Recipient", value: "reviewer" },
+        { label: "Message", value: "Please check the tool renderer." },
+      ],
+    });
   });
 });
 

--- a/apps/web/src/components/session-detail/tool-strategy/claudecode.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/claudecode.ts
@@ -15,6 +15,7 @@ import {
   type ToolDisplayStrategy,
   getOutputOrErrorText,
   getToolTitle,
+  parseInputCandidate,
   toRecord,
   toStringValue,
 } from "../tool-normalize";
@@ -99,6 +100,19 @@ function displayValue(value: unknown) {
   if (typeof value === "string") return value.trim();
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   return "";
+}
+
+function buildSendMessageOutput(input: Record<string, unknown>, state: NormalizedToolState) {
+  const resultText = getOutputOrErrorText(state);
+  const result = toRecord(parseInputCandidate(resultText));
+  const delivery = toStringValue(result.message) || resultText;
+  const items = [
+    { label: "Recipient", value: toStringValue(input.recipient) || toStringValue(input.to) },
+    { label: "Summary", value: toStringValue(input.summary) },
+    { label: "Message", value: toStringValue(input.message) || toStringValue(input.content) },
+    { label: "Delivery", value: delivery },
+  ];
+  return items.filter((item) => item.value && item.value !== "No output captured.");
 }
 
 export function buildClaudeToolStrategy(
@@ -342,14 +356,19 @@ export function buildClaudeToolStrategy(
   }
 
   if (toolKey === "sendmessage") {
+    const recipient = toStringValue(input.recipient) || toStringValue(input.to);
     return {
       ...defaultStrategy,
       Icon: MessageSquareMore,
       title: "send message",
-      secondaryText: toStringValue(input.summary) || toStringValue(input.recipient) || undefined,
+      secondaryText: recipient || undefined,
       details: [],
       showInputPreview: false,
-      contentLabel: "Delivery",
+      contentLabel: "Message details",
+      outputContent: {
+        kind: "property-list",
+        items: buildSendMessageOutput(input, state),
+      },
     };
   }
 

--- a/apps/web/src/components/session-detail/tool-strategy/claudecode.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/claudecode.ts
@@ -5,9 +5,12 @@
  */
 import type { MessagePart } from "../../../lib/api";
 import { detectLanguageByFilePath } from "../../tool-output/language";
+import type { TaskListItem } from "../../tool-output/types";
 import { buildStructuredDiffFromTexts } from "../diff";
 import { getDisplayPath, getFilePathFromInput } from "../path-extract";
 import {
+  buildSemanticOutputContent,
+  compactText,
   type NormalizedToolState,
   type ToolDisplayStrategy,
   getOutputOrErrorText,
@@ -15,8 +18,88 @@ import {
   toRecord,
   toStringValue,
 } from "../tool-normalize";
+import { getDisplayTextWithRelativePaths } from "../path-extract";
 import { buildDefaultToolStrategy, extractReadContent, extractWriteContent } from "./shared";
-import { BookOpenText, FilePenLine, NotebookPen } from "lucide-react";
+import {
+  Bot,
+  BookOpenText,
+  CircleHelp,
+  FilePenLine,
+  FileSearch,
+  ListTodo,
+  MessageSquareMore,
+  NotebookPen,
+  PanelsTopLeft,
+  Search,
+  SquareTerminal,
+  Wrench,
+} from "lucide-react";
+
+function summarizeTasks(items: unknown[]) {
+  const counts = new Map<string, number>();
+  const tasks = items.map((value) => {
+    const item = toRecord(value);
+    const statusValue = toStringValue(item.status);
+    const status: TaskListItem["status"] =
+      statusValue === "completed" || statusValue === "in_progress" || statusValue === "error"
+        ? statusValue
+        : "pending";
+    counts.set(status, (counts.get(status) ?? 0) + 1);
+    return {
+      label: toStringValue(item.content) || toStringValue(item.subject) || "Untitled task",
+      status,
+      detail: toStringValue(item.activeForm) || toStringValue(item.description) || undefined,
+    };
+  });
+  return {
+    tasks,
+    summary: [...counts.entries()].map(([status, count]) => `${count} ${status}`).join(" · "),
+  };
+}
+
+function buildQuestionOutput(input: Record<string, unknown>, outputText: string) {
+  const answerMatches = [...outputText.matchAll(/"([^"]+)"="([^"]+)"/g)];
+  const answers = new Map(answerMatches.map((match) => [match[1], [match[2]] as string[]]));
+  const questions = (Array.isArray(input.questions) ? input.questions : []).flatMap((value) => {
+    const question = toRecord(value);
+    const questionText = toStringValue(question.question);
+    if (!questionText) return [];
+    const options = (Array.isArray(question.options) ? question.options : []).flatMap(
+      (optionValue) => {
+        const option = toRecord(optionValue);
+        const rawLabel = toStringValue(option.label);
+        if (!rawLabel) return [];
+        const label = rawLabel.replace(/\s*\(Recommended\)\s*$/i, "");
+        return [
+          {
+            label,
+            description: toStringValue(option.description) || undefined,
+            recommended: label !== rawLabel || undefined,
+          },
+        ];
+      },
+    );
+    return [
+      {
+        header: toStringValue(question.header) || undefined,
+        question: questionText,
+        options,
+        answers: answers.get(questionText) ?? [],
+      },
+    ];
+  });
+  return questions;
+}
+
+function claudeToolKey(tool: MessagePart) {
+  return (tool.tool || "").trim().toLowerCase();
+}
+
+function displayValue(value: unknown) {
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
 
 export function buildClaudeToolStrategy(
   tool: MessagePart,
@@ -24,24 +107,27 @@ export function buildClaudeToolStrategy(
   baseDirectory?: string,
 ): ToolDisplayStrategy {
   const defaultStrategy = buildDefaultToolStrategy(tool, state, baseDirectory);
-  const toolKey = (tool.tool || "").toLowerCase();
+  const toolKey = claudeToolKey(tool);
   const input = toRecord(state.inputValue);
   const filePath = getFilePathFromInput(state.inputValue);
   const displayPath = getDisplayPath(filePath, baseDirectory);
 
   if (toolKey === "read") {
+    const semanticOutput = buildSemanticOutputContent(state.outputValue);
     return {
       ...defaultStrategy,
       Icon: BookOpenText,
       title: "read",
       secondaryText: displayPath || undefined,
       showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractReadContent(state.outputValue),
-        language: detectLanguageByFilePath(filePath),
-        isCode: true,
-      },
+      outputContent:
+        semanticOutput ??
+        ({
+          kind: "plain",
+          text: extractReadContent(state.outputValue),
+          language: detectLanguageByFilePath(filePath),
+          isCode: true,
+        } as const),
     };
   }
 
@@ -75,6 +161,195 @@ export function buildClaudeToolStrategy(
         language: detectLanguageByFilePath(filePath),
         isCode: true,
       },
+    };
+  }
+
+  if (toolKey === "bash" || toolKey === "workflow") {
+    const command = toStringValue(input.command) || toStringValue(input.script);
+    const description = toStringValue(input.description);
+    const displayCommand = getDisplayTextWithRelativePaths(command, baseDirectory);
+    return {
+      ...defaultStrategy,
+      Icon: SquareTerminal,
+      title: toolKey === "workflow" ? "workflow" : "bash",
+      secondaryText: description || compactText(displayCommand).slice(0, 120) || undefined,
+      details: command
+        ? [{ label: toolKey === "workflow" ? "Script" : "Command", value: displayCommand }]
+        : [],
+      showInputPreview: false,
+      contentLabel: state.status === "error" ? "Error" : "Terminal output",
+      outputContent: {
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "text",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "todowrite" || toolKey === "taskcreate") {
+    const rawTasks =
+      toolKey === "todowrite" ? (Array.isArray(input.todos) ? input.todos : []) : [input];
+    const taskDisplay = summarizeTasks(rawTasks);
+    return {
+      ...defaultStrategy,
+      Icon: ListTodo,
+      title: toolKey === "todowrite" ? "tasks" : "create task",
+      secondaryText: taskDisplay.summary || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Task state",
+      outputContent: { kind: "task-list", items: taskDisplay.tasks },
+    };
+  }
+
+  if (toolKey === "taskupdate" || toolKey === "tasklist") {
+    const structured = buildSemanticOutputContent(
+      toolKey === "taskupdate" ? input : state.outputValue,
+    );
+    return {
+      ...defaultStrategy,
+      Icon: ListTodo,
+      title: toolKey === "taskupdate" ? "update task" : "list tasks",
+      secondaryText: toStringValue(input.taskId) || toStringValue(input.status) || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Task state",
+      outputContent: structured ?? {
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "text",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "agent") {
+    const agentType = toStringValue(input.subagent_type) || toStringValue(input.name);
+    const description = toStringValue(input.description);
+    return {
+      ...defaultStrategy,
+      Icon: Bot,
+      title: agentType ? `agent · ${agentType}` : "agent",
+      secondaryText: description || undefined,
+      details: [
+        toStringValue(input.model) ? { label: "Model", value: toStringValue(input.model) } : null,
+        input.run_in_background === true ? { label: "Mode", value: "Background" } : null,
+      ].filter((item): item is { label: string; value: string } => item != null),
+      showInputPreview: false,
+      contentLabel: "Agent result",
+      outputContent: {
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "markdown",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "askuserquestion") {
+    const questions = buildQuestionOutput(input, getOutputOrErrorText(state));
+    return {
+      ...defaultStrategy,
+      Icon: CircleHelp,
+      title: "ask",
+      secondaryText: questions.length
+        ? `${questions.length} question${questions.length === 1 ? "" : "s"}`
+        : undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Questions",
+      outputContent: questions.length
+        ? { kind: "question-list", questions }
+        : { kind: "plain", text: getOutputOrErrorText(state), language: "text", isCode: false },
+    };
+  }
+
+  if (toolKey === "websearch" || toolKey === "webfetch") {
+    const query = toStringValue(input.query);
+    const url = toStringValue(input.url);
+    return {
+      ...defaultStrategy,
+      Icon: FileSearch,
+      title: toolKey === "websearch" ? "web search" : "web fetch",
+      secondaryText: query || url || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Results",
+      outputContent: {
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "markdown",
+        isCode: false,
+      },
+    };
+  }
+
+  if (toolKey === "toolsearch") {
+    return {
+      ...defaultStrategy,
+      Icon: Search,
+      title: "find tools",
+      secondaryText: toStringValue(input.query) || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Matches",
+    };
+  }
+
+  if (toolKey === "skill") {
+    return {
+      ...defaultStrategy,
+      Icon: Wrench,
+      title: "skill",
+      secondaryText: toStringValue(input.skill) || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Result",
+    };
+  }
+
+  if (toolKey === "structuredoutput" || toolKey === "reportfindings") {
+    return {
+      ...defaultStrategy,
+      Icon: ListTodo,
+      title: toolKey === "reportfindings" ? "report findings" : "structured output",
+      secondaryText: `${Object.keys(input).length} fields`,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Submitted fields",
+      outputContent: {
+        kind: "property-list",
+        items: Object.entries(input).map(([label, value]) => ({ label, value })),
+      },
+    };
+  }
+
+  if (toolKey.startsWith("mcp__claude-in-chrome__")) {
+    const action = toolKey.replace("mcp__claude-in-chrome__", "").replaceAll("_", " ");
+    const url = toStringValue(input.url);
+    const interaction = toStringValue(input.action) || toStringValue(input.query);
+    const tabId = displayValue(input.tabId);
+    return {
+      ...defaultStrategy,
+      Icon: PanelsTopLeft,
+      title: `browser · ${action}`,
+      secondaryText: url || interaction || undefined,
+      details: tabId ? [{ label: "Tab", value: tabId }] : [],
+      showInputPreview: false,
+      contentLabel: "Browser result",
+    };
+  }
+
+  if (toolKey === "sendmessage") {
+    return {
+      ...defaultStrategy,
+      Icon: MessageSquareMore,
+      title: "send message",
+      secondaryText: toStringValue(input.summary) || toStringValue(input.recipient) || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Delivery",
     };
   }
 

--- a/apps/web/src/components/session-detail/tool-strategy/codex.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/codex.ts
@@ -23,6 +23,7 @@ import { getDisplayPath, getDisplayTextWithRelativePaths } from "../path-extract
 import {
   type NormalizedToolState,
   type ToolDisplayStrategy,
+  buildSemanticOutputContent,
   compactText,
   getOutputOrErrorText,
   getToolTitle,
@@ -34,13 +35,31 @@ import { parseJsonText } from "../utils";
 import { buildDefaultToolStrategy, buildSkillToolStrategy } from "./shared";
 import {
   Bot,
+  Clock3,
   CircleHelp,
   FilePenLine,
   FileSearch,
   Image as ImageIcon,
   ListTodo,
+  MessageSquareMore,
+  Plug,
   SquareTerminal,
+  Target,
+  Users,
 } from "lucide-react";
+
+function humanizeToolName(value: string) {
+  return value.replace(/^_+/, "").replaceAll("_", " ");
+}
+
+function firstSummaryValue(input: Record<string, unknown>) {
+  const keys = ["title", "summary", "query", "q", "url", "objective", "target", "threadId"];
+  for (const key of keys) {
+    const value = compactText(input[key]);
+    if (value) return value.length > 120 ? `${value.slice(0, 120)}…` : value;
+  }
+  return "";
+}
 
 export function extractCodexNodeReplTextOutput(outputText: string) {
   const marker = "Output:\n";
@@ -211,7 +230,8 @@ export function buildCodexToolStrategy(
       secondaryText: display.secondaryText,
       details: display.details,
       showInputPreview: false,
-      outputContent: { kind: "plain", text: display.text, language: "markdown", isCode: false },
+      contentLabel: "Plan",
+      outputContent: { kind: "task-list", items: display.items },
     };
   }
 
@@ -267,6 +287,102 @@ export function buildCodexToolStrategy(
         language: "markdown",
         isCode: false,
       },
+    };
+  }
+
+  if (toolKey === "collaboration.send_message" || toolKey === "collaboration.followup_task") {
+    const input = toRecord(state.inputValue);
+    const target = toPlainText(input.target);
+    const message = toPlainText(input.message);
+    return {
+      ...defaultStrategy,
+      Icon: MessageSquareMore,
+      title: toolKey.endsWith("followup_task") ? "follow up with agent" : "message agent",
+      secondaryText: target || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Message",
+      outputContent: {
+        kind: "property-list",
+        items: [
+          target ? { label: "Recipient", value: target } : null,
+          message ? { label: "Message", value: message } : null,
+        ].filter((item): item is { label: string; value: string } => item != null),
+      },
+    };
+  }
+
+  if (toolKey === "collaboration.wait_agent" || toolKey === "wait") {
+    const input = toRecord(state.inputValue);
+    const timeout = input.timeout_ms;
+    return {
+      ...defaultStrategy,
+      Icon: Clock3,
+      title: "wait for agents",
+      secondaryText:
+        typeof timeout === "number" ? `${Math.round(timeout / 1000)}s timeout` : undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Agent updates",
+    };
+  }
+
+  if (toolKey === "collaboration.list_agents") {
+    return {
+      ...defaultStrategy,
+      Icon: Users,
+      title: "list agents",
+      secondaryText: undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Agent tree",
+    };
+  }
+
+  if (toolKey === "collaboration.interrupt_agent") {
+    const target = toPlainText(toRecord(state.inputValue).target);
+    return {
+      ...defaultStrategy,
+      Icon: Users,
+      title: "interrupt agent",
+      secondaryText: target || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Result",
+    };
+  }
+
+  if (toolKey === "create_goal" || toolKey === "get_goal" || toolKey === "update_goal") {
+    const input = toRecord(state.inputValue);
+    return {
+      ...defaultStrategy,
+      Icon: Target,
+      title: humanizeToolName(toolKey),
+      secondaryText: toPlainText(input.objective) || toPlainText(input.status) || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: "Goal state",
+    };
+  }
+
+  if (namespace.startsWith("mcp__") || toolKey.includes("._")) {
+    const input = toRecord(state.inputValue);
+    const [provider, operation = "tool"] = toolKey.split(".", 2);
+    const semanticInput = Object.entries(input).map(([label, value]) => ({ label, value }));
+    const semanticOutput = buildSemanticOutputContent(state.outputValue);
+    return {
+      ...defaultStrategy,
+      Icon: Plug,
+      title: `${humanizeToolName(provider ?? "integration")} · ${humanizeToolName(operation)}`,
+      secondaryText: firstSummaryValue(input) || undefined,
+      details: [],
+      showInputPreview: false,
+      contentLabel: semanticOutput ? "Result" : "Request",
+      outputContent:
+        semanticOutput ??
+        (semanticInput.length > 0
+          ? { kind: "property-list", items: semanticInput }
+          : defaultStrategy.outputContent),
     };
   }
 

--- a/apps/web/src/components/session-detail/tool-strategy/shared.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/shared.ts
@@ -10,6 +10,7 @@ import {
   type NormalizedToolState,
   type ToolDisplayStrategy,
   type ToolStatus,
+  buildSemanticOutputContent,
   formatToolOutput,
   getOutputOrErrorText,
   getToolTitle,
@@ -69,6 +70,8 @@ export function buildDefaultToolStrategy(
   const previewText =
     compactPreview.length > 72 ? `${compactPreview.slice(0, 72)}...` : compactPreview;
 
+  const semanticOutput = buildSemanticOutputContent(state.outputValue);
+
   return {
     Icon: SquareTerminal,
     title: getToolTitle(tool),
@@ -76,12 +79,14 @@ export function buildDefaultToolStrategy(
     details: [],
     expandable: true,
     showInputPreview: true,
-    outputContent: {
-      kind: "plain",
-      text: getOutputOrErrorText(state),
-      language: "text",
-      isCode: false,
-    },
+    outputContent:
+      semanticOutput ??
+      ({
+        kind: "plain",
+        text: getOutputOrErrorText(state),
+        language: "text",
+        isCode: false,
+      } as const),
   };
 }
 

--- a/apps/web/src/components/tool-output/MediaOutput.tsx
+++ b/apps/web/src/components/tool-output/MediaOutput.tsx
@@ -1,0 +1,33 @@
+import type { MediaItem } from "./types";
+
+export function MediaOutput({ items, text }: { items: MediaItem[]; text?: string }) {
+  return (
+    <div className="space-y-3">
+      <div className={`grid gap-3 ${items.length > 1 ? "sm:grid-cols-2" : ""}`}>
+        {items.map((item, index) => (
+          <figure
+            key={`${item.src.slice(0, 80)}:${index}`}
+            className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)]"
+          >
+            <img
+              src={item.src}
+              alt={item.alt}
+              className="max-h-[520px] w-full object-contain"
+              loading="lazy"
+            />
+            {item.caption ? (
+              <figcaption className="console-mono border-t border-[var(--console-border)] px-3 py-2 text-[11px] text-[var(--console-muted)]">
+                {item.caption}
+              </figcaption>
+            ) : null}
+          </figure>
+        ))}
+      </div>
+      {text ? (
+        <pre className="console-mono whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[#fafafa] p-3 text-xs leading-relaxed text-[var(--console-text)]">
+          {text}
+        </pre>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/tool-output/PropertyListOutput.tsx
+++ b/apps/web/src/components/tool-output/PropertyListOutput.tsx
@@ -1,0 +1,71 @@
+import type { PropertyItem } from "./types";
+
+function displayScalar(value: unknown) {
+  if (value == null || value === "") return "—";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "string" || typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  return null;
+}
+
+function PropertyValue({ value, depth = 0 }: { value: unknown; depth?: number }) {
+  const scalar = displayScalar(value);
+  if (scalar != null) {
+    return <span className="whitespace-pre-wrap break-words">{scalar}</span>;
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= 2) return <span>{value.length} items</span>;
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {value.map((item, index) => (
+          <span
+            key={index}
+            className="rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5"
+          >
+            <PropertyValue value={item} depth={depth + 1} />
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  if (typeof value === "object") {
+    if (depth >= 2) return <span>{Object.keys(value as object).length} fields</span>;
+    return (
+      <dl className="space-y-1.5">
+        {Object.entries(value as Record<string, unknown>).map(([key, nested]) => (
+          <div key={key} className="grid grid-cols-[minmax(80px,auto)_1fr] gap-2">
+            <dt className="text-[var(--console-muted)]">{key}</dt>
+            <dd className="min-w-0">
+              <PropertyValue value={nested} depth={depth + 1} />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    );
+  }
+
+  return <span>{String(value)}</span>;
+}
+
+export function PropertyListOutput({ items }: { items: PropertyItem[] }) {
+  return (
+    <dl className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[#fafafa]">
+      {items.map((item) => (
+        <div
+          key={item.label}
+          className="grid gap-1 border-b border-[var(--console-border)] px-3 py-2.5 last:border-b-0 sm:grid-cols-[130px_1fr] sm:gap-3"
+        >
+          <dt className="console-mono text-[10px] font-semibold uppercase tracking-wide text-[var(--console-muted)]">
+            {item.label}
+          </dt>
+          <dd className="console-mono min-w-0 text-xs leading-relaxed text-[var(--console-text)]">
+            <PropertyValue value={item.value} />
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/apps/web/src/components/tool-output/TaskListOutput.tsx
+++ b/apps/web/src/components/tool-output/TaskListOutput.tsx
@@ -1,0 +1,48 @@
+import { Check, Circle, CircleDashed, X } from "lucide-react";
+import type { TaskListItem } from "./types";
+
+const STATUS_META = {
+  completed: { Icon: Check, label: "Done", className: "text-[var(--console-success)]" },
+  error: { Icon: X, label: "Failed", className: "text-[var(--console-error)]" },
+  in_progress: {
+    Icon: CircleDashed,
+    label: "In progress",
+    className: "text-[var(--console-warning)]",
+  },
+  pending: { Icon: Circle, label: "Pending", className: "text-[var(--console-muted)]" },
+} as const;
+
+export function TaskListOutput({ items }: { items: TaskListItem[] }) {
+  return (
+    <ol className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-white">
+      {items.map((item, index) => {
+        const meta = STATUS_META[item.status];
+        return (
+          <li
+            key={`${item.label}:${index}`}
+            className="flex gap-3 border-b border-[var(--console-border)] px-3 py-2.5 last:border-b-0"
+          >
+            <meta.Icon className={`mt-0.5 size-3.5 shrink-0 ${meta.className}`} />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                <span className="text-xs font-medium leading-relaxed text-[var(--console-text)]">
+                  {item.label}
+                </span>
+                <span
+                  className={`console-mono text-[10px] uppercase tracking-wide ${meta.className}`}
+                >
+                  {meta.label}
+                </span>
+              </div>
+              {item.detail ? (
+                <p className="mt-1 text-xs leading-relaxed text-[var(--console-muted)]">
+                  {item.detail}
+                </p>
+              ) : null}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/web/src/components/tool-output/ToolOutputRenderer.tsx
+++ b/apps/web/src/components/tool-output/ToolOutputRenderer.tsx
@@ -1,7 +1,10 @@
 import { CodeHighlighter } from "./CodeHighlighter";
 import { FileSectionsOutput } from "./FileSectionsOutput";
+import { MediaOutput } from "./MediaOutput";
+import { PropertyListOutput } from "./PropertyListOutput";
 import { QuestionListOutput } from "./QuestionListOutput";
 import { StructuredDiffOutput } from "./StructuredDiffOutput";
+import { TaskListOutput } from "./TaskListOutput";
 import type { ToolOutputContent } from "./types";
 import { UnifiedDiffOutput } from "./UnifiedDiffOutput";
 
@@ -22,11 +25,23 @@ export function ToolOutputRenderer({ outputContent }: ToolOutputRendererProps) {
     return <QuestionListOutput questions={outputContent.questions} />;
   }
 
+  if (outputContent.kind === "task-list") {
+    return <TaskListOutput items={outputContent.items} />;
+  }
+
+  if (outputContent.kind === "media") {
+    return <MediaOutput items={outputContent.items} text={outputContent.text} />;
+  }
+
+  if (outputContent.kind === "property-list") {
+    return <PropertyListOutput items={outputContent.items} />;
+  }
+
   const outputText = outputContent.text || "No output captured.";
 
   if (!outputContent.isCode || outputContent.language === "text") {
     return (
-      <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre-wrap break-all rounded-sm border border-[var(--console-border)] bg-[#fafafa] p-3 text-xs leading-relaxed text-[var(--console-text)]">
+      <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[#fafafa] p-3 text-xs leading-relaxed text-[var(--console-text)]">
         {outputText}
       </pre>
     );

--- a/apps/web/src/components/tool-output/types.ts
+++ b/apps/web/src/components/tool-output/types.ts
@@ -53,8 +53,44 @@ export interface QuestionListToolOutputContent {
   questions: QuestionListItem[];
 }
 
+export interface TaskListItem {
+  label: string;
+  status: "pending" | "in_progress" | "completed" | "error";
+  detail?: string;
+}
+
+export interface TaskListToolOutputContent {
+  kind: "task-list";
+  items: TaskListItem[];
+}
+
+export interface MediaItem {
+  src: string;
+  alt: string;
+  caption?: string;
+}
+
+export interface MediaToolOutputContent {
+  kind: "media";
+  items: MediaItem[];
+  text?: string;
+}
+
+export interface PropertyItem {
+  label: string;
+  value: unknown;
+}
+
+export interface PropertyListToolOutputContent {
+  kind: "property-list";
+  items: PropertyItem[];
+}
+
 export type ToolOutputContent =
   | PlainToolOutputContent
   | StructuredDiffToolOutputContent
   | FileSectionsToolOutputContent
-  | QuestionListToolOutputContent;
+  | QuestionListToolOutputContent
+  | TaskListToolOutputContent
+  | MediaToolOutputContent
+  | PropertyListToolOutputContent;

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -166,7 +166,17 @@ describe("ClaudeCodeAgent cache refresh", () => {
           message: {
             role: "user",
             content: [
-              { type: "tool_result", tool_use_id: "tool-1", content: [{ text: "package output" }] },
+              {
+                type: "tool_result",
+                tool_use_id: "tool-1",
+                content: [
+                  { text: "package output" },
+                  {
+                    type: "image",
+                    source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" },
+                  },
+                ],
+              },
               { type: "text", text: "Continue" },
             ],
           },
@@ -229,7 +239,10 @@ describe("ClaudeCodeAgent cache refresh", () => {
       callID: "tool-1",
       state: {
         input: { file_path: "package.json" },
-        output: [{ type: "text", text: "package output" }],
+        output: [
+          { type: "text", text: "package output" },
+          { type: "image", data: "iVBORw0KGgo=", mime_type: "image/png" },
+        ],
         status: "success",
         meta: { commandName: "read" },
       },

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -251,7 +251,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       assistant?.parts.some(
         (part: MessagePart) => part.type === "tool" && part.tool === "TodoWrite",
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(data.messages[2]?.parts).toMatchObject([{ type: "text", text: "Continue" }]);
     expect(data.messages[3]).toMatchObject({
       role: "tool",

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -151,18 +151,11 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
     const content = readFileSync(meta.sourcePath, "utf-8");
     const builder = new TranscriptBuilder();
-    const ignoredToolCallIds = new Set<string>();
     const assistantUuidToToolCalls = new Map<string, string[]>();
     const countedUsageKeys = new Set<string>();
     for (const record of parseJsonlLines(content)) {
       try {
-        this.convertRecord(
-          record,
-          builder,
-          ignoredToolCallIds,
-          assistantUuidToToolCalls,
-          countedUsageKeys,
-        );
+        this.convertRecord(record, builder, assistantUuidToToolCalls, countedUsageKeys);
       } catch {
         // skip malformed records
       }
@@ -446,7 +439,6 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
   private convertRecord(
     data: Record<string, unknown>,
     builder: TranscriptBuilder,
-    ignoredToolCallIds: Set<string>,
     assistantUuidToToolCalls: Map<string, string[]>,
     countedUsageKeys: Set<string>,
   ): void {
@@ -456,15 +448,9 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     if (isInternalEventType(msgType)) return;
 
     if (msgType === "assistant") {
-      this.convertAssistantRecord(
-        data,
-        builder,
-        ignoredToolCallIds,
-        assistantUuidToToolCalls,
-        countedUsageKeys,
-      );
+      this.convertAssistantRecord(data, builder, assistantUuidToToolCalls, countedUsageKeys);
     } else if (msgType === "user") {
-      this.convertUserRecord(data, builder, ignoredToolCallIds, assistantUuidToToolCalls);
+      this.convertUserRecord(data, builder, assistantUuidToToolCalls);
     } else if (msgType === "tool_result") {
       this.convertToolResultRecord(data, builder);
     }
@@ -473,7 +459,6 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
   private convertAssistantRecord(
     data: Record<string, unknown>,
     builder: TranscriptBuilder,
-    ignoredToolCallIds: Set<string>,
     assistantUuidToToolCalls: Map<string, string[]>,
     countedUsageKeys: Set<string>,
   ): void {
@@ -521,13 +506,7 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
         if (partType !== "tool_use") continue;
 
-        const toolName = String(part["name"] ?? "").trim();
         const toolCallId = String(part["id"] ?? "").trim();
-
-        if (toolName && toolCallId && this.shouldIgnoreTool(toolName)) {
-          ignoredToolCallIds.add(toolCallId);
-          continue;
-        }
 
         const toolPart = this.buildToolPart(part, timestampMs);
         const message = builder.appendToolCall(
@@ -550,7 +529,6 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
   private convertUserRecord(
     data: Record<string, unknown>,
     builder: TranscriptBuilder,
-    ignoredToolCallIds: Set<string>,
     assistantUuidToToolCalls: Map<string, string[]>,
   ): void {
     const msg = (data["message"] ?? {}) as Record<string, unknown>;
@@ -583,7 +561,6 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
       if (ci["type"] !== "tool_result") continue;
 
       const toolCallId = this.resolveToolCallId(data, ci, assistantUuidToToolCalls);
-      if (toolCallId && ignoredToolCallIds.has(toolCallId)) continue;
 
       const outputParts = this.normalizeClaudeToolOutput(ci["content"], timestampMs);
       if (this.backfillToolOutput(builder, toolCallId, outputParts, toolStateUpdates)) {
@@ -805,11 +782,5 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
       timestampMs: opts.timestampMs,
       parts: opts.outputParts,
     };
-  }
-
-  // --- Utilities ---
-
-  private shouldIgnoreTool(toolName: string): boolean {
-    return toolName === "TodoWrite";
   }
 }

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -707,11 +707,17 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
       const parts: MessagePart[] = [];
       for (const item of content) {
         if (typeof item === "object" && item !== null) {
-          const text = String(
-            (item as Record<string, unknown>)["text"] ??
-              (item as Record<string, unknown>)["content"] ??
-              "",
-          );
+          const itemRecord = item as Record<string, unknown>;
+          const source = itemRecord["source"] as Record<string, unknown> | undefined;
+          if (itemRecord["type"] === "image" && source) {
+            const data = typeof source["data"] === "string" ? source["data"] : "";
+            const mimeType = typeof source["media_type"] === "string" ? source["media_type"] : "";
+            if (data && mimeType.startsWith("image/")) {
+              parts.push({ type: "image", data, mime_type: mimeType, time_created: timestampMs });
+            }
+            continue;
+          }
+          const text = String(itemRecord["text"] ?? itemRecord["content"] ?? "");
           const cleaned = cleanInternalText(text);
           if (cleaned) parts.push(this.buildTextPart(cleaned, timestampMs));
         } else if (typeof item === "string") {

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -89,8 +89,11 @@ export interface ToolPartState {
 }
 
 export interface MessagePart {
-  type: "text" | "tool" | "reasoning" | "plan";
+  type: "text" | "tool" | "reasoning" | "plan" | "image";
   text?: unknown;
+  data?: string;
+  mime_type?: string;
+  url?: string;
   tool?: string;
   title?: string;
   nickname?: string;


### PR DESCRIPTION
## Summary

- preserve Claude image and task tool results instead of discarding them
- render task states, structured fields, images, browser actions, agent messages, searches, and connector calls with semantic output components
- refine tool cards with integrated status, contextual labels, and safer wrapping

## Root cause

Tool rendering covered an older, narrow set of tool names. New Claude and Codex tool families therefore fell through to a generic raw input/output view; Claude also dropped TodoWrite and image blocks during parsing.

## Impact

Recent Codex and Claude sessions now surface the intent and result of tool calls without exposing raw JSON as the primary UI. Existing Codex code-mode decoding remains unchanged.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm format:check`
- manual browser verification against recent Codex and Claude sessions