### PR TITLE
feat: color timeline tools by activity

### DIFF
--- a/apps/web/src/components/session-detail/file-change.ts
+++ b/apps/web/src/components/session-detail/file-change.ts
@@ -35,27 +35,39 @@ export interface FileChangeSummary {
   delete: FileChangeSummaryItem[];
 }
 
+const FILE_READ_TOOLS = new Set([
+  "read",
+  "read_file",
+  "read_file_v2",
+  "read_text_file",
+  "readfile",
+  "view_image",
+]);
+const FILE_EDIT_TOOLS = new Set([
+  "apply_patch",
+  "edit",
+  "edit_file",
+  "edit_file_v2",
+  "editfile",
+  "multiedit",
+  "notebookedit",
+  "patch",
+  "search_replace",
+  "str_replace",
+]);
+const FILE_WRITE_TOOLS = new Set(["create_file", "write", "write_file", "writefile"]);
+const FILE_DELETE_TOOLS = new Set(["delete", "delete_file"]);
+
 export function buildToolAnchorId(messageIndex: number, toolIndex: number) {
   return `tool-${messageIndex}-${toolIndex}`;
 }
 
 export function classifyToolKind(part: MessagePart): FileChangeKind | null {
   const toolName = normalizeToolName(part);
-  if (toolName === "read") return "read";
-  if (
-    toolName === "edit" ||
-    toolName === "multiedit" ||
-    toolName === "apply_patch" ||
-    toolName === "notebookedit"
-  ) {
-    return "edit";
-  }
-  if (toolName === "write" || toolName === "create_file" || toolName === "write_file") {
-    return "write";
-  }
-  if (toolName === "delete" || toolName === "delete_file") {
-    return "delete";
-  }
+  if (FILE_READ_TOOLS.has(toolName)) return "read";
+  if (FILE_EDIT_TOOLS.has(toolName)) return "edit";
+  if (FILE_WRITE_TOOLS.has(toolName)) return "write";
+  if (FILE_DELETE_TOOLS.has(toolName)) return "delete";
   return null;
 }
 

--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -20,10 +20,10 @@ const entries: SessionTimelineEntry[] = [
   },
   {
     id: "tool-1",
-    kind: "tool",
+    kind: "tool-read",
     anchorId: "tool-1",
     messageIndex: 2,
-    tooltip: "Tool · Read",
+    tooltip: "Read · Read",
   },
 ];
 
@@ -46,6 +46,37 @@ function renderTimeline(timelineEntries = entries) {
 }
 
 describe("SessionMessageTimeline", () => {
+  it("uses distinct colors for read, write, and execute tools", () => {
+    const toolEntries: SessionTimelineEntry[] = [
+      { ...entries[2]!, id: "read", anchorId: "read", kind: "tool-read", tooltip: "Read · Read" },
+      {
+        ...entries[2]!,
+        id: "write",
+        anchorId: "write",
+        kind: "tool-write",
+        tooltip: "Write · Edit",
+      },
+      {
+        ...entries[2]!,
+        id: "execute",
+        anchorId: "execute",
+        kind: "tool-execute",
+        tooltip: "Execute · Bash",
+      },
+    ];
+    const { getByRole } = renderTimeline(toolEntries);
+
+    expect(getByRole("button", { name: "Go to Read · Read" }).className).toContain(
+      "--timeline-tool-read",
+    );
+    expect(getByRole("button", { name: "Go to Write · Edit" }).className).toContain(
+      "--timeline-tool-write",
+    );
+    expect(getByRole("button", { name: "Go to Execute · Bash" }).className).toContain(
+      "--timeline-tool-execute",
+    );
+  });
+
   it("keeps a color block clickable after a pointer press", () => {
     const { getAllByRole, onNavigate } = renderTimeline();
     const target = getAllByRole("button")[2]!;

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -41,13 +41,17 @@ const TIMELINE_TOOLTIP_VIEWPORT_PADDING = 8;
 const KIND_CLASS: Record<SessionTimelineEntryKind, string> = {
   user: "bg-[var(--timeline-user)]",
   agent: "bg-[var(--timeline-agent)]",
-  tool: "bg-[var(--timeline-tool)]",
+  "tool-read": "bg-[var(--timeline-tool-read)]",
+  "tool-write": "bg-[var(--timeline-tool-write)]",
+  "tool-execute": "bg-[var(--timeline-tool-execute)]",
 };
 
 const KIND_FALLBACK_COLOR: Record<SessionTimelineEntryKind, string> = {
   user: "#a85f82",
   agent: "#5e86aa",
-  tool: "#a3a3a3",
+  "tool-read": "#478b7d",
+  "tool-write": "#bd7336",
+  "tool-execute": "#786ca3",
 };
 
 interface MinimapWindow {
@@ -265,7 +269,15 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
       const colors: Record<SessionTimelineEntryKind, string> = {
         user: styles.getPropertyValue("--timeline-user").trim() || KIND_FALLBACK_COLOR.user,
         agent: styles.getPropertyValue("--timeline-agent").trim() || KIND_FALLBACK_COLOR.agent,
-        tool: styles.getPropertyValue("--timeline-tool").trim() || KIND_FALLBACK_COLOR.tool,
+        "tool-read":
+          styles.getPropertyValue("--timeline-tool-read").trim() ||
+          KIND_FALLBACK_COLOR["tool-read"],
+        "tool-write":
+          styles.getPropertyValue("--timeline-tool-write").trim() ||
+          KIND_FALLBACK_COLOR["tool-write"],
+        "tool-execute":
+          styles.getPropertyValue("--timeline-tool-execute").trim() ||
+          KIND_FALLBACK_COLOR["tool-execute"],
       };
       entries.forEach((entry, index) => {
         const x0 = (index / entries.length) * width;

--- a/apps/web/src/components/session-detail/timeline.test.ts
+++ b/apps/web/src/components/session-detail/timeline.test.ts
@@ -5,6 +5,7 @@ import {
   buildBlockTimelineAnchorId,
   buildMessageTimelineAnchorId,
   buildSessionTimelineEntries,
+  classifyTimelineToolKind,
   findActiveTimelineIndex,
   findTimelineEdgeIndex,
   findTimelineIndexAtPointer,
@@ -42,7 +43,13 @@ describe("session timeline", () => {
 
     const entries = buildSessionTimelineEntries(messages, toolAnchorIds);
 
-    expect(entries.map((entry) => entry.kind)).toEqual(["user", "agent", "tool", "tool", "agent"]);
+    expect(entries.map((entry) => entry.kind)).toEqual([
+      "user",
+      "agent",
+      "tool-read",
+      "tool-write",
+      "agent",
+    ]);
     expect(entries.map((entry) => entry.anchorId)).toEqual([
       buildMessageTimelineAnchorId(4),
       buildBlockTimelineAnchorId(7, 0),
@@ -53,10 +60,20 @@ describe("session timeline", () => {
     expect(entries.map((entry) => entry.tooltip)).toEqual([
       "User · Open this file",
       "Agent · Checking it",
-      "Tool · Read",
-      "Tool · Write",
+      "Read · Read",
+      "Write · Write",
       "Agent · Done",
     ]);
+  });
+
+  it("classifies explicit file reads and writes before defaulting to execute", () => {
+    expect(classifyTimelineToolKind({ type: "tool", tool: "read_file_v2" })).toBe("tool-read");
+    expect(classifyTimelineToolKind({ type: "tool", tool: "view_image" })).toBe("tool-read");
+    expect(classifyTimelineToolKind({ type: "tool", tool: "EditFile" })).toBe("tool-write");
+    expect(classifyTimelineToolKind({ type: "tool", tool: "apply_patch" })).toBe("tool-write");
+    expect(classifyTimelineToolKind({ type: "tool", tool: "delete_file" })).toBe("tool-write");
+    expect(classifyTimelineToolKind({ type: "tool", tool: "update_plan" })).toBe("tool-execute");
+    expect(classifyTimelineToolKind({ type: "tool", tool: "image_gen" })).toBe("tool-execute");
   });
 
   it("compacts and limits message summaries", () => {

--- a/apps/web/src/components/session-detail/timeline.ts
+++ b/apps/web/src/components/session-detail/timeline.ts
@@ -1,12 +1,19 @@
 import type { MessagePart } from "../../lib/api";
 import { extractMessageText } from "./blocks";
+import { classifyToolKind } from "./file-change";
 import { normalizeToolLabel } from "./tool-normalize";
 import type { FilteredSessionMessage } from "./toc";
 
 const TIMELINE_SUMMARY_LENGTH = 48;
 const TIMELINE_SCROLL_EDGE_TOLERANCE = 1;
 
-export type SessionTimelineEntryKind = "user" | "agent" | "tool";
+export type SessionTimelineEntryKind =
+  | "user"
+  | "agent"
+  | "tool-read"
+  | "tool-write"
+  | "tool-execute";
+export type ToolTimelineEntryKind = Extract<SessionTimelineEntryKind, `tool-${string}`>;
 
 export interface SessionTimelineEntry {
   id: string;
@@ -52,6 +59,19 @@ function summarizeParts(parts: MessagePart[]) {
   );
 }
 
+export function classifyTimelineToolKind(part: MessagePart): ToolTimelineEntryKind {
+  const fileKind = classifyToolKind(part);
+  if (fileKind === "read") return "tool-read";
+  if (fileKind) return "tool-write";
+  return "tool-execute";
+}
+
+const TOOL_KIND_LABEL = {
+  "tool-read": "Read",
+  "tool-write": "Write",
+  "tool-execute": "Execute",
+} as const;
+
 export function buildSessionTimelineEntries(
   messages: FilteredSessionMessage[],
   toolAnchorIds: Map<MessagePart, string>,
@@ -77,12 +97,13 @@ export function buildSessionTimelineEntries(
         block.parts.forEach((part) => {
           const anchorId = toolAnchorIds.get(part);
           if (!anchorId) return;
+          const kind = classifyTimelineToolKind(part);
           entries.push({
             id: anchorId,
-            kind: "tool",
+            kind,
             anchorId,
             messageIndex,
-            tooltip: `Tool · ${normalizeToolLabel(part)}`,
+            tooltip: `${TOOL_KIND_LABEL[kind]} · ${normalizeToolLabel(part)}`,
           });
         });
         return;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -134,7 +134,9 @@
     --console-error-border: #fecaca;
     --timeline-user: #a85f82;
     --timeline-agent: #5e86aa;
-    --timeline-tool: #a3a3a3;
+    --timeline-tool-read: #478b7d;
+    --timeline-tool-write: #bd7336;
+    --timeline-tool-execute: #786ca3;
     --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
     --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
     --tt-in-dur: 150ms;


### PR DESCRIPTION
## Summary

- classify timeline tool calls as file reads, file writes, or general execution
- color both the primary timeline and draggable minimap with distinct activity colors
- expose the activity category in tooltips and accessible navigation labels

## Classification

Explicit file readers use the read category. Create, edit, patch, and delete tools share the write category because they all mutate files. Shell commands, searches, browser actions, agents, image generation, plans, tasks, and other tools fall back to execute.

## Impact

Session timelines now reveal the shape of an agent's work at a glance while preserving the existing user and agent message colors. The shared classification drives both timeline surfaces so their visual language cannot drift.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm format:check`
- manual browser verification against recent Codex and Claude sessions