### PR TITLE
chore(release): prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.15.0] - 2026-07-20
+
+This release makes session tool calls easier to read: Codex code-mode exec calls are decoded back into native tool displays, tools render with semantic visualizations, and the timeline colors tools by activity.
+
+### Features
+
+- Decoded Codex code-mode `exec` tool calls back into native tool displays (bash, patch, write_stdin, node_repl, subagent, MCP), added dedicated renderers for `update_plan`, `web__run`, and `view_image`, split multi-call exec programs into ordered tool parts, and refreshed stale cached Codex details on upgrade via a lightweight pending-reindex migration. (#152)
+- Added semantic tool visualizations and semantic rendering of Claude messages, while preserving Claude tool images and task tools. (#153)
+- Colored the session timeline tools by activity classification. (#154)
+
+### Changelog Detail
+
+- #154 feat: color timeline tools by activity @xingkaixin
+- #153 feat: add semantic tool visualizations @xingkaixin
+- #152 feat(codex): decode code-mode exec into native tool displays @xingkaixin
+
 ## [0.14.0] - 2026-07-18
 
 This release adds persistent session aliases and interactive time-range filtering, while improving navigation, motion, search backfill memory use, and internal module boundaries.

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.15.0] - 2026-07-20
+
+本版本让会话中的工具调用更易读：将 Codex code-mode 的 exec 调用解码还原为原生工具展示，工具以语义化方式可视化呈现，时间轴还会按活动类型为工具着色。
+
+### 新功能
+
+- 将 Codex code-mode 的 `exec` 工具调用解码还原为原生工具展示（bash、patch、write_stdin、node_repl、subagent、MCP），为 `update_plan`、`web__run` 和 `view_image` 新增专用渲染，把多调用 exec 程序拆分为有序的工具片段，并通过轻量的 pending-reindex 迁移在升级时刷新已缓存的过期 Codex 详情。 (#152)
+- 新增语义化工具可视化与 Claude 消息的语义化渲染，同时保留 Claude 工具图片与 task 工具。 (#153)
+- 时间轴工具按活动分类着色。 (#154)
+
+### Changelog Detail
+
+- #154 feat: color timeline tools by activity @xingkaixin
+- #153 feat: add semantic tool visualizations @xingkaixin
+- #152 feat(codex): decode code-mode exec into native tool displays @xingkaixin
+
 ## [0.14.0] - 2026-07-18
 
 本版本新增持久化会话别名和交互式时间范围筛选，同时提升导航、动效和搜索回填的可靠性与内存效率，并进一步收敛内部模块边界。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/web",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/www",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codesesh",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "One place to see every AI coding session you've ever had. Unify Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode sessions in a single, beautiful Web UI.",
   "keywords": [
     "ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/core",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Prepare the v0.15.0 minor release. This version makes session tool calls easier to read.

- Bump `version` to `0.15.0` across `packages/cli`, `packages/core`, `apps/web`, `apps/www`
- Add `[0.15.0]` sections to `CHANGELOG.md` and `CHANGELOG_CN.md`

## Included changes

- #152 feat(codex): decode code-mode exec into native tool displays
- #153 feat: add semantic tool visualizations
- #154 feat: color timeline tools by activity

## Notes

- Minor bump (new user-facing features).
- README skipped: no new agents or CLI behavior changes; existing docs remain accurate.
- `apps/www` version-only bump; no marketing copy change needed.
- Merging and pushing tag `v0.15.0` triggers the release workflow.