### PR TITLE
refactor(web): unify remote state with TanStack Query

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@base-ui/react": "^1.6.0",
     "@pierre/trees": "1.0.0-beta.3",
+    "@tanstack/react-query": "^5.101.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
@@ -40,11 +41,11 @@
     "@types/node": "^25.9.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@typescript/native": "npm:typescript@^7.0.2",
     "@vitejs/plugin-react": "^6.0.3",
     "happy-dom": "^20.10.6",
     "postcss": "^8.5.16",
     "tailwindcss": "^4.3.2",
-    "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vite": "^8.1.4"
   }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,10 @@
 declare const __APP_VERSION__: string;
 
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { BookmarkedSessionSnapshot, SessionHead } from "./lib/api";
-import { deleteSessionAlias, logClientEvent, upsertSessionAlias } from "./lib/api";
+import { logClientEvent } from "./lib/api";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { CopyResumeButton } from "./components/CopyResumeButton";
 import { SessionAliasDialog, type SessionAliasTarget } from "./components/SessionAliasDialog";
@@ -18,6 +18,7 @@ import { useBookmarks } from "./hooks/useBookmarks";
 import { useDashboard } from "./hooks/useDashboard";
 import { useSidebarModel } from "./hooks/useSidebarModel";
 import { useSessionStore } from "./hooks/useSessionStore";
+import { useSessionAliasMutations } from "./hooks/useSessionAliasMutations";
 import { useWindowedDataLoad } from "./hooks/useWindowedDataLoad";
 import { useLiveSync } from "./hooks/useLiveSync";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
@@ -49,7 +50,6 @@ export default function App() {
     agentNameMap,
     loading,
     error,
-    version: storeVersion,
     reload,
     applyLiveEvent,
   } = sessionStore;
@@ -74,7 +74,7 @@ export default function App() {
   );
 
   const sessionDetail = useSessionDetail(viewState);
-  const { session, sessionError, refresh: refreshSessionDetail } = sessionDetail;
+  const { session, sessionError } = sessionDetail;
 
   useEffect(() => {
     logClientEvent("route.change", {
@@ -124,8 +124,13 @@ export default function App() {
       : "";
 
   const bookmarks = useBookmarks(sessions);
-  const { bookmarkedSessions, isSessionBookmarked, toggleBookmark, toggleSessionBookmark } =
-    bookmarks;
+  const {
+    bookmarkedSessions,
+    isSessionBookmarked,
+    toggleBookmark,
+    toggleSessionBookmark,
+    refresh: refreshBookmarks,
+  } = bookmarks;
 
   const activeProjectKind = viewState.mode === "project" ? viewState.activeProjectKind : null;
   const activeProjectKey = viewState.mode === "project" ? viewState.activeProjectKey : null;
@@ -217,38 +222,23 @@ export default function App() {
     setScanStatus,
   });
 
-  const previousStoreVersion = useRef(0);
-  const refreshOpenSession = useEffectEvent(() => {
-    void refreshSessionDetail();
-  });
-  useEffect(() => {
-    if (storeVersion === 0) return;
-    if (previousStoreVersion.current === 0) {
-      previousStoreVersion.current = storeVersion;
-      return;
-    }
-    previousStoreVersion.current = storeVersion;
-    refreshOpenSession();
-  }, [storeVersion]);
-
   const refreshAliasViews = useCallback(async () => {
-    await Promise.all([timeWindow ? reload(timeWindow) : undefined, bookmarks.refresh()]);
-  }, [bookmarks, reload, timeWindow]);
+    await Promise.all([timeWindow ? reload(timeWindow) : undefined, refreshBookmarks()]);
+  }, [refreshBookmarks, reload, timeWindow]);
+  const { saveAlias, removeAlias } = useSessionAliasMutations(refreshAliasViews);
 
   const saveSessionAlias = useCallback(
     async (alias: string) => {
       if (!aliasTarget) return;
-      await upsertSessionAlias(aliasTarget.agentKey, aliasTarget.sessionId, alias);
-      await refreshAliasViews();
+      await saveAlias(aliasTarget, alias);
     },
-    [aliasTarget, refreshAliasViews],
+    [aliasTarget, saveAlias],
   );
 
   const removeSessionAlias = useCallback(async () => {
     if (!aliasTarget) return;
-    await deleteSessionAlias(aliasTarget.agentKey, aliasTarget.sessionId);
-    await refreshAliasViews();
-  }, [aliasTarget, refreshAliasViews]);
+    await removeAlias(aliasTarget);
+  }, [aliasTarget, removeAlias]);
 
   useEffect(() => {
     try {

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { BookmarkedSessionSnapshot, SessionHead } from "../lib/api";
 import * as api from "../lib/api";
 import * as bookmarkUtils from "../lib/bookmarks";
+import { createQueryWrapper } from "../test/query-wrapper";
 import { useBookmarks } from "./useBookmarks";
 
 vi.mock("../lib/api", () => ({
@@ -74,40 +75,48 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+function renderBookmarks(sessions: SessionHead[] = []) {
+  const { Wrapper } = createQueryWrapper();
+  return renderHook(({ currentSessions }) => useBookmarks(currentSessions), {
+    initialProps: { currentSessions: sessions },
+    wrapper: Wrapper,
+  });
+}
+
 describe("useBookmarks", () => {
   it("loads bookmarks on mount", async () => {
     vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
-    const { result } = renderHook(() => useBookmarks([]));
+    const { result } = renderBookmarks();
 
     await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s1")).toBe(true));
   });
 
   it("toggleBookmark adds optimistically and calls upsert", async () => {
-    const { result } = renderHook(() => useBookmarks([]));
+    const { result } = renderBookmarks();
     await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
 
     act(() => result.current.toggleBookmark(snap("s2")));
 
-    expect(result.current.isSessionBookmarked("cc", "s2")).toBe(true);
-    expect(api.upsertBookmark).toHaveBeenCalledOnce();
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s2")).toBe(true));
+    await waitFor(() => expect(api.upsertBookmark).toHaveBeenCalledOnce());
   });
 
   it("toggleBookmark removes an existing bookmark and calls delete", async () => {
     vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s3")] });
-    const { result } = renderHook(() => useBookmarks([]));
+    const { result } = renderBookmarks();
     await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s3")).toBe(true));
 
     act(() => result.current.toggleBookmark(snap("s3")));
 
-    expect(result.current.isSessionBookmarked("cc", "s3")).toBe(false);
-    expect(api.deleteBookmark).toHaveBeenCalledWith("cc", "s3");
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s3")).toBe(false));
+    await waitFor(() => expect(api.deleteBookmark).toHaveBeenCalledWith("cc", "s3"));
   });
 
   it("bookmarkedSessions is sorted by most-recent activity", async () => {
     vi.mocked(api.fetchBookmarks).mockResolvedValue({
       bookmarks: [snap("old", 10), snap("new", 20)],
     });
-    const { result } = renderHook(() => useBookmarks([]));
+    const { result } = renderBookmarks();
 
     await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(2));
     expect(result.current.bookmarkedSessions[0]?.sessionId).toBe("new");
@@ -117,29 +126,31 @@ describe("useBookmarks", () => {
     const old = { ...snap("old"), time_created: 10, time_updated: undefined };
     const recent = { ...snap("recent"), time_created: 20, time_updated: undefined };
     vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [old] });
-    const { result } = renderHook(() => useBookmarks([]));
+    const { result } = renderBookmarks();
     await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
 
     act(() => result.current.toggleBookmark(recent));
 
-    expect(result.current.bookmarkedSessions.map((bookmark) => bookmark.sessionId)).toEqual([
-      "recent",
-      "old",
-    ]);
+    await waitFor(() =>
+      expect(result.current.bookmarkedSessions.map((bookmark) => bookmark.sessionId)).toEqual([
+        "recent",
+        "old",
+      ]),
+    );
   });
 
   it("refreshes bookmarks and reports load failures", async () => {
     const error = new Error("offline");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
-    const { result } = renderHook(() => useBookmarks([]));
+    const { result } = renderBookmarks();
     await waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith("Failed to load bookmarks:", error),
     );
 
     vi.mocked(api.fetchBookmarks).mockResolvedValueOnce({ bookmarks: [snap("refreshed")] });
     await act(() => result.current.refresh());
-    expect(result.current.isSessionBookmarked("cc", "refreshed")).toBe(true);
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "refreshed")).toBe(true));
 
     vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
     await act(() => result.current.refresh());
@@ -149,7 +160,7 @@ describe("useBookmarks", () => {
   it("does not apply the initial response after unmount", async () => {
     const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
     vi.mocked(api.fetchBookmarks).mockReturnValueOnce(request.promise);
-    const { unmount } = renderHook(() => useBookmarks([]));
+    const { unmount } = renderBookmarks();
 
     unmount();
     request.resolve({ bookmarks: [snap("late")] });
@@ -161,15 +172,16 @@ describe("useBookmarks", () => {
   it("synchronizes changed bookmark snapshots with the server", async () => {
     vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1", 1)] });
     const updated = snap("s1", 2);
-    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) =>
-      previous.length > 0 && sessions.length > 0 ? [updated] : previous,
-    );
-    const { result, rerender } = renderHook(({ sessions }) => useBookmarks(sessions), {
-      initialProps: { sessions: [] as SessionHead[] },
+    let didMerge = false;
+    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) => {
+      if (didMerge || previous.length === 0 || sessions.length === 0) return previous;
+      didMerge = true;
+      return [updated];
     });
+    const { result, rerender } = renderBookmarks();
     await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
 
-    rerender({ sessions: [session("s1")] });
+    rerender({ currentSessions: [session("s1")] });
     await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
 
     expect(api.importBookmarks).toHaveBeenCalledWith([
@@ -186,12 +198,10 @@ describe("useBookmarks", () => {
     vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) =>
       previous.length > 0 && sessions.length > 0 ? [snap("s1", 2)] : previous,
     );
-    const { result, rerender } = renderHook(({ sessions }) => useBookmarks(sessions), {
-      initialProps: { sessions: [] as SessionHead[] },
-    });
+    const { result, rerender } = renderBookmarks();
     await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
 
-    rerender({ sessions: [session("s1")] });
+    rerender({ currentSessions: [session("s1")] });
 
     await waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith("Failed to sync bookmark snapshots:", error),
@@ -203,14 +213,16 @@ describe("useBookmarks", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
     vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
-    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) =>
-      previous.length > 0 && sessions.length > 0 ? [snap("s1", 2)] : previous,
-    );
-    const { result, rerender, unmount } = renderHook(({ sessions }) => useBookmarks(sessions), {
-      initialProps: { sessions: [] as SessionHead[] },
+    const updated = snap("s1", 2);
+    let didMerge = false;
+    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) => {
+      if (didMerge || previous.length === 0 || sessions.length === 0) return previous;
+      didMerge = true;
+      return [updated];
     });
+    const { result, rerender, unmount } = renderBookmarks();
     await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
-    rerender({ sessions: [session("s1")] });
+    rerender({ currentSessions: [session("s1")] });
     await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
 
     unmount();
@@ -227,7 +239,7 @@ describe("useBookmarks", () => {
     const legacy = snap("legacy");
     vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([legacy]);
     vi.mocked(api.importBookmarks).mockResolvedValueOnce({ bookmarks: [legacy] });
-    const { result } = renderHook(() => useBookmarks([]));
+    const { result } = renderBookmarks();
 
     await waitFor(() => expect(result.current.isSessionBookmarked("cc", "legacy")).toBe(true));
     expect(api.importBookmarks).toHaveBeenCalledWith([
@@ -241,7 +253,7 @@ describe("useBookmarks", () => {
     const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
     vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([legacy]);
     vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
-    const { unmount } = renderHook(() => useBookmarks([]));
+    const { unmount } = renderBookmarks();
     await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
 
     unmount();
@@ -257,7 +269,7 @@ describe("useBookmarks", () => {
     vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([snap("legacy")]);
     vi.mocked(api.importBookmarks).mockRejectedValueOnce(error);
 
-    renderHook(() => useBookmarks([]));
+    renderBookmarks();
 
     await waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith("Failed to migrate legacy bookmarks:", error),
@@ -270,7 +282,7 @@ describe("useBookmarks", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([snap("legacy")]);
     vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
-    const { unmount } = renderHook(() => useBookmarks([]));
+    const { unmount } = renderBookmarks();
     await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
 
     unmount();
@@ -285,14 +297,19 @@ describe("useBookmarks", () => {
 
   it("rolls back an optimistic toggle when persistence fails", async () => {
     const error = new Error("write failed");
+    let rejectWrite!: (reason?: unknown) => void;
+    const write = new Promise<never>((_resolve, reject) => {
+      rejectWrite = reject;
+    });
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(api.upsertBookmark).mockRejectedValueOnce(error);
-    const { result } = renderHook(() => useBookmarks([]));
+    vi.mocked(api.upsertBookmark).mockReturnValueOnce(write);
+    const { result } = renderBookmarks();
     await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
 
     act(() => result.current.toggleBookmark(snap("failed")));
-    expect(result.current.isSessionBookmarked("cc", "failed")).toBe(true);
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "failed")).toBe(true));
 
+    rejectWrite(error);
     await waitFor(() => expect(result.current.isSessionBookmarked("cc", "failed")).toBe(false));
     expect(consoleError).toHaveBeenCalledWith("Failed to toggle bookmark:", error);
     expect(api.logClientEvent).toHaveBeenCalledWith("bookmark.add", {
@@ -302,13 +319,15 @@ describe("useBookmarks", () => {
   });
 
   it("converts live sessions before toggling bookmarks", async () => {
-    const { result } = renderHook(() => useBookmarks([]));
+    const { result } = renderBookmarks();
     await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
 
     act(() => result.current.toggleSessionBookmark(session("live"), "cc"));
 
-    expect(api.upsertBookmark).toHaveBeenCalledWith(
-      expect.objectContaining({ agentKey: "cc", sessionId: "live", fullPath: "cc/live" }),
+    await waitFor(() =>
+      expect(api.upsertBookmark).toHaveBeenCalledWith(
+        expect.objectContaining({ agentKey: "cc", sessionId: "live", fullPath: "cc/live" }),
+      ),
     );
   });
 });

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo } from "react";
 import {
   type BookmarkedSessionSnapshot,
   type SessionHead,
@@ -15,84 +16,132 @@ import {
   mergeBookmarksWithSessions,
   toBookmarkedSessionSnapshot,
 } from "../lib/bookmarks";
+import { queryKeys } from "../lib/query-keys";
 
-/**
- * Owns bookmark state: initial fetch, snapshot-merge sync as sessions change,
- * legacy migration, and optimistic add/remove toggles. Takes the current
- * sessions so bookmark snapshots stay in sync with live session data.
- */
+interface ToggleBookmarkVariables {
+  snapshot: BookmarkedSessionSnapshot;
+  isBookmarked: boolean;
+}
+
+const EMPTY_BOOKMARKS: BookmarkedSessionSnapshot[] = [];
+
+function withoutBookmarkTimestamp(bookmarks: BookmarkedSessionSnapshot[]) {
+  return bookmarks.map(({ bookmarked_at: _bookmarkedAt, ...bookmark }) => bookmark);
+}
+
+function toggledBookmarks(
+  bookmarks: BookmarkedSessionSnapshot[],
+  snapshot: BookmarkedSessionSnapshot,
+  isBookmarked: boolean,
+): BookmarkedSessionSnapshot[] {
+  const key = getSessionBookmarkKey(snapshot.agentKey, snapshot.sessionId);
+  if (isBookmarked) {
+    return bookmarks.filter(
+      (bookmark) => getSessionBookmarkKey(bookmark.agentKey, bookmark.sessionId) !== key,
+    );
+  }
+  return [...bookmarks, snapshot].toSorted((a, b) => {
+    const aTime = a.time_updated ?? a.time_created;
+    const bTime = b.time_updated ?? b.time_created;
+    return bTime - aTime;
+  });
+}
+
+function sameBookmarks(
+  left: BookmarkedSessionSnapshot[],
+  right: BookmarkedSessionSnapshot[],
+): boolean {
+  return left.length === right.length && left.every((bookmark, index) => bookmark === right[index]);
+}
+
 export function useBookmarks(sessions: SessionHead[]) {
-  const [bookmarks, setBookmarks] = useState<BookmarkedSessionSnapshot[]>([]);
-
-  const refresh = useCallback(async () => {
-    try {
-      const data = await fetchBookmarks();
-      setBookmarks(data.bookmarks);
-    } catch (err) {
-      console.error("Failed to load bookmarks:", err);
-    }
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    void fetchBookmarks()
-      .then((data) => {
-        if (!cancelled) setBookmarks(data.bookmarks);
-      })
-      .catch((err) => {
-        console.error("Failed to load bookmarks:", err);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    setBookmarks((prev) => {
-      const next = mergeBookmarksWithSessions(prev, sessions);
-      if (next === prev) return prev;
-      void importBookmarks(
-        next.map(({ bookmarked_at: _bookmarkedAt, ...bookmark }) => bookmark),
-      ).catch((error) => {
-        if (!cancelled) {
-          console.error("Failed to sync bookmark snapshots:", error);
-        }
-      });
-      return next;
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [sessions]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    void (async () => {
-      const legacy = loadLegacyBookmarks();
-      if (legacy.length === 0) return;
-
+  const queryClient = useQueryClient();
+  const bookmarksQuery = useQuery({
+    queryKey: queryKeys.bookmarks,
+    queryFn: async ({ signal }) => {
       try {
-        const data = await importBookmarks(
-          legacy.map(({ bookmarked_at: _bookmarkedAt, ...bookmark }) => bookmark),
-        );
-        if (cancelled) return;
+        return await fetchBookmarks({ signal });
+      } catch (error) {
+        if (!signal.aborted) console.error("Failed to load bookmarks:", error);
+        throw error;
+      }
+    },
+  });
+  const bookmarks = bookmarksQuery.data?.bookmarks ?? EMPTY_BOOKMARKS;
+
+  const setBookmarks = useCallback(
+    (next: BookmarkedSessionSnapshot[]) => {
+      queryClient.setQueryData(queryKeys.bookmarks, { bookmarks: next });
+    },
+    [queryClient],
+  );
+
+  const { mutate: mutateBookmark } = useMutation({
+    mutationFn: async ({ snapshot, isBookmarked }: ToggleBookmarkVariables) => {
+      if (isBookmarked) {
+        await deleteBookmark(snapshot.agentKey, snapshot.sessionId);
+        return;
+      }
+      await upsertBookmark({
+        agentKey: snapshot.agentKey,
+        sessionId: snapshot.sessionId,
+        fullPath: snapshot.fullPath,
+        title: snapshot.title,
+        directory: snapshot.directory,
+        time_created: snapshot.time_created,
+        time_updated: snapshot.time_updated,
+        stats: snapshot.stats,
+      });
+    },
+    onMutate: async ({ snapshot, isBookmarked }) => {
+      const cancellation = queryClient.cancelQueries({ queryKey: queryKeys.bookmarks });
+      const previous = queryClient.getQueryData<{ bookmarks: BookmarkedSessionSnapshot[] }>(
+        queryKeys.bookmarks,
+      );
+      setBookmarks(toggledBookmarks(previous?.bookmarks ?? [], snapshot, isBookmarked));
+      logClientEvent(isBookmarked ? "bookmark.delete" : "bookmark.add", {
+        agent: snapshot.agentKey,
+        session: snapshot.sessionId,
+      });
+      await cancellation;
+      return previous;
+    },
+    onError: (error, _variables, previous) => {
+      if (previous) queryClient.setQueryData(queryKeys.bookmarks, previous);
+      console.error("Failed to toggle bookmark:", error);
+    },
+  });
+
+  const { mutate: syncBookmarks } = useMutation({
+    mutationFn: (bookmarks: Omit<BookmarkedSessionSnapshot, "bookmarked_at">[]) =>
+      importBookmarks(bookmarks),
+  });
+  const { mutate: migrateBookmarks } = useMutation({
+    mutationFn: (bookmarks: Omit<BookmarkedSessionSnapshot, "bookmarked_at">[]) =>
+      importBookmarks(bookmarks),
+  });
+
+  useEffect(() => {
+    const next = mergeBookmarksWithSessions(bookmarks, sessions);
+    if (next === bookmarks || sameBookmarks(next, bookmarks)) return;
+    setBookmarks(next);
+    syncBookmarks(withoutBookmarkTimestamp(next), {
+      onError: (error) => console.error("Failed to sync bookmark snapshots:", error),
+    });
+  }, [bookmarks, sessions, setBookmarks, syncBookmarks]);
+
+  useEffect(() => {
+    const legacy = loadLegacyBookmarks();
+    if (legacy.length === 0) return;
+    void queryClient.cancelQueries({ queryKey: queryKeys.bookmarks });
+    migrateBookmarks(withoutBookmarkTimestamp(legacy), {
+      onSuccess: (data) => {
         setBookmarks(data.bookmarks);
         clearLegacyBookmarks();
-      } catch (error) {
-        if (!cancelled) {
-          console.error("Failed to migrate legacy bookmarks:", error);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+      },
+      onError: (error) => console.error("Failed to migrate legacy bookmarks:", error),
+    });
+  }, [migrateBookmarks, queryClient, setBookmarks]);
 
   const bookmarkKeySet = useMemo(
     () =>
@@ -111,43 +160,9 @@ export function useBookmarks(sessions: SessionHead[]) {
   const toggleBookmark = useCallback(
     (snapshot: BookmarkedSessionSnapshot) => {
       const key = getSessionBookmarkKey(snapshot.agentKey, snapshot.sessionId);
-      const exists = bookmarkKeySet.has(key);
-      const previous = bookmarks;
-      const next = exists
-        ? previous.filter(
-            (bookmark) => getSessionBookmarkKey(bookmark.agentKey, bookmark.sessionId) !== key,
-          )
-        : [...previous, snapshot].toSorted((a, b) => {
-            const aTime = a.time_updated ?? a.time_created;
-            const bTime = b.time_updated ?? b.time_created;
-            return bTime - aTime;
-          });
-
-      setBookmarks(next);
-      logClientEvent(exists ? "bookmark.delete" : "bookmark.add", {
-        agent: snapshot.agentKey,
-        session: snapshot.sessionId,
-      });
-
-      void (
-        exists
-          ? deleteBookmark(snapshot.agentKey, snapshot.sessionId)
-          : upsertBookmark({
-              agentKey: snapshot.agentKey,
-              sessionId: snapshot.sessionId,
-              fullPath: snapshot.fullPath,
-              title: snapshot.title,
-              directory: snapshot.directory,
-              time_created: snapshot.time_created,
-              time_updated: snapshot.time_updated,
-              stats: snapshot.stats,
-            })
-      ).catch((error) => {
-        console.error("Failed to toggle bookmark:", error);
-        setBookmarks(previous);
-      });
+      mutateBookmark({ snapshot, isBookmarked: bookmarkKeySet.has(key) });
     },
-    [bookmarkKeySet, bookmarks],
+    [bookmarkKeySet, mutateBookmark],
   );
 
   const toggleSessionBookmark = useCallback(
@@ -164,6 +179,11 @@ export function useBookmarks(sessions: SessionHead[]) {
       ),
     [bookmarks],
   );
+
+  const refreshBookmarks = bookmarksQuery.refetch;
+  const refresh = useCallback(async () => {
+    await refreshBookmarks();
+  }, [refreshBookmarks]);
 
   return {
     bookmarkedSessions,

--- a/apps/web/src/hooks/useDashboard.test.ts
+++ b/apps/web/src/hooks/useDashboard.test.ts
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppConfig, DashboardData, ProjectIdentityKind } from "../lib/api";
 import * as api from "../lib/api";
+import { createQueryWrapper } from "../test/query-wrapper";
 import { useDashboard } from "./useDashboard";
 
 vi.mock("../lib/api", () => ({ fetchDashboard: vi.fn() }));
@@ -21,41 +22,53 @@ afterEach(() => {
 
 describe("useDashboard", () => {
   it("stays idle without a window", () => {
-    const { result } = renderHook(() => useDashboard(null));
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useDashboard(null), { wrapper: Wrapper });
     expect(result.current.dashboard).toBeNull();
     expect(api.fetchDashboard).not.toHaveBeenCalled();
   });
 
   it("loads an unfiltered dashboard", async () => {
-    const { result } = renderHook(() => useDashboard(window));
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useDashboard(window), { wrapper: Wrapper });
     await waitFor(() => expect(result.current.dashboard).toEqual(data));
-    expect(api.fetchDashboard).toHaveBeenCalledWith(window, {
-      projectKind: undefined,
-      projectKey: undefined,
-      agent: undefined,
-    });
+    expect(api.fetchDashboard).toHaveBeenCalledWith(
+      window,
+      {
+        projectKind: undefined,
+        projectKey: undefined,
+        agent: undefined,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it("loads a project dashboard and refetches for its selected agent", async () => {
     const filters = { projectKind, projectKey: "pk", identityKey: "path:pk" };
-    const { result } = renderHook(() => useDashboard(window, filters));
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useDashboard(window, filters), { wrapper: Wrapper });
     await waitFor(() => expect(result.current.dashboard).toEqual(data));
 
     act(() => result.current.setSelectedAgent("codex"));
 
     await waitFor(() =>
-      expect(api.fetchDashboard).toHaveBeenLastCalledWith(window, {
-        projectKind: "path",
-        projectKey: "pk",
-        agent: "codex",
-      }),
+      expect(api.fetchDashboard).toHaveBeenLastCalledWith(
+        window,
+        {
+          projectKind: "path",
+          projectKey: "pk",
+          agent: "codex",
+        },
+        { signal: expect.any(AbortSignal) },
+      ),
     );
   });
 
   it("resets the selected agent when the project changes", async () => {
+    const { Wrapper } = createQueryWrapper();
     const { result, rerender } = renderHook(
       ({ identityKey }) => useDashboard(window, { projectKind, projectKey: "pk", identityKey }),
-      { initialProps: { identityKey: "path:pk" } },
+      { initialProps: { identityKey: "path:pk" }, wrapper: Wrapper },
     );
     act(() => result.current.setSelectedAgent("codex"));
     expect(result.current.selectedAgent).toBe("codex");
@@ -72,10 +85,11 @@ describe("useDashboard", () => {
     });
     const latest = { totals: { sessions: 9 }, perAgent: [] } as unknown as DashboardData;
     vi.mocked(api.fetchDashboard).mockReturnValueOnce(first).mockResolvedValueOnce(latest);
+    const { Wrapper } = createQueryWrapper();
     const { result, rerender } = renderHook(
       ({ projectKey }) =>
         useDashboard(window, { projectKind, projectKey, identityKey: `path:${projectKey}` }),
-      { initialProps: { projectKey: "first" } },
+      { initialProps: { projectKey: "first" }, wrapper: Wrapper },
     );
 
     rerender({ projectKey: "second" });
@@ -91,7 +105,8 @@ describe("useDashboard", () => {
     const error = new Error("dashboard unavailable");
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchDashboard).mockRejectedValueOnce(error);
-    const { result } = renderHook(() => useDashboard(window));
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useDashboard(window), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.error).toBe("Failed to load dashboard"));
 

--- a/apps/web/src/hooks/useDashboard.ts
+++ b/apps/web/src/hooks/useDashboard.ts
@@ -1,10 +1,7 @@
-import { useCallback, useEffect, useState } from "react";
-import {
-  type AppConfig,
-  type DashboardData,
-  type ProjectIdentityKind,
-  fetchDashboard,
-} from "../lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { type AppConfig, type ProjectIdentityKind, fetchDashboard } from "../lib/api";
+import { queryKeys } from "../lib/query-keys";
 
 export interface DashboardFilters {
   projectKind?: ProjectIdentityKind;
@@ -17,58 +14,35 @@ export function useDashboard(window: AppConfig["window"] | null, filters?: Dashb
   const projectKey = filters?.projectKey;
   const identityKey = filters?.identityKey;
   const isFiltered = filters !== undefined;
-  const [dashboard, setDashboard] = useState<DashboardData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [selectedAgent, setSelectedAgent] = useState<string | undefined>(undefined);
+  const isEnabled = window !== null && (!isFiltered || projectKey !== undefined);
 
   useEffect(() => {
     if (identityKey) setSelectedAgent(undefined);
   }, [identityKey]);
 
-  const load = useCallback(async () => {
-    if (!window || (isFiltered && !projectKey)) return null;
-    return fetchDashboard(window, {
-      projectKind,
-      projectKey,
-      agent: selectedAgent,
-    });
-  }, [isFiltered, projectKey, projectKind, selectedAgent, window]);
-
-  useEffect(() => {
-    if (!window || (isFiltered && !projectKey)) {
-      setDashboard(null);
-      setError(null);
-      setLoading(false);
-      return;
-    }
-
-    let current = true;
-    setLoading(true);
-    setError(null);
-    void load()
-      .then((data) => {
-        if (current) setDashboard(data);
-      })
-      .catch((loadError) => {
-        if (!current) return;
-        console.error("Failed to load dashboard:", loadError);
-        setDashboard(null);
-        setError("Failed to load dashboard");
-      })
-      .finally(() => {
-        if (current) setLoading(false);
-      });
-
-    return () => {
-      current = false;
-    };
-  }, [isFiltered, load, projectKey, window]);
+  const query = useQuery({
+    queryKey: queryKeys.dashboard(window ?? {}, { projectKind, projectKey, agent: selectedAgent }),
+    enabled: isEnabled,
+    queryFn: async ({ signal }) => {
+      if (!window) throw new Error("Dashboard window is required");
+      try {
+        return await fetchDashboard(
+          window,
+          { projectKind, projectKey, agent: selectedAgent },
+          { signal },
+        );
+      } catch (error) {
+        if (!signal.aborted) console.error("Failed to load dashboard:", error);
+        throw error;
+      }
+    },
+  });
 
   return {
-    dashboard,
-    loading,
-    error,
+    dashboard: isEnabled ? (query.data ?? null) : null,
+    loading: isEnabled && query.isPending,
+    error: isEnabled && query.isError ? "Failed to load dashboard" : null,
     selectedAgent,
     setSelectedAgent,
   };

--- a/apps/web/src/hooks/useSessionAliasMutations.test.ts
+++ b/apps/web/src/hooks/useSessionAliasMutations.test.ts
@@ -1,0 +1,57 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as api from "../lib/api";
+import { queryKeys } from "../lib/query-keys";
+import { createQueryWrapper } from "../test/query-wrapper";
+import { useSessionAliasMutations } from "./useSessionAliasMutations";
+
+vi.mock("../lib/api", () => ({
+  deleteSessionAlias: vi.fn(),
+  upsertSessionAlias: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useSessionAliasMutations", () => {
+  it("saves an alias and invalidates its consumers", async () => {
+    vi.mocked(api.upsertSessionAlias).mockResolvedValue();
+    const refreshSnapshot = vi.fn().mockResolvedValue(undefined);
+    const { client, Wrapper } = createQueryWrapper();
+    const detailKey = queryKeys.sessionDetail("codex", "session-1");
+    const dashboardKey = queryKeys.dashboard({}, {});
+    const searchKey = queryKeys.search("query", {});
+    client.setQueryData(detailKey, { id: "session-1" });
+    client.setQueryData(dashboardKey, { totals: {} });
+    client.setQueryData(searchKey, []);
+    const { result } = renderHook(() => useSessionAliasMutations(refreshSnapshot), {
+      wrapper: Wrapper,
+    });
+
+    await act(() =>
+      result.current.saveAlias({ agentKey: "codex", sessionId: "session-1" }, "Renamed"),
+    );
+
+    expect(api.upsertSessionAlias).toHaveBeenCalledWith("codex", "session-1", "Renamed");
+    expect(refreshSnapshot).toHaveBeenCalledOnce();
+    expect(client.getQueryState(detailKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(dashboardKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(searchKey)?.isInvalidated).toBe(true);
+  });
+
+  it("removes an alias before refreshing consumers", async () => {
+    vi.mocked(api.deleteSessionAlias).mockResolvedValue();
+    const refreshSnapshot = vi.fn().mockResolvedValue(undefined);
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSessionAliasMutations(refreshSnapshot), {
+      wrapper: Wrapper,
+    });
+
+    await act(() => result.current.removeAlias({ agentKey: "claudecode", sessionId: "session-2" }));
+
+    expect(api.deleteSessionAlias).toHaveBeenCalledWith("claudecode", "session-2");
+    expect(refreshSnapshot).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/hooks/useSessionAliasMutations.ts
+++ b/apps/web/src/hooks/useSessionAliasMutations.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { deleteSessionAlias, upsertSessionAlias } from "../lib/api";
+import { queryKeys } from "../lib/query-keys";
+
+export interface SessionAliasIdentity {
+  agentKey: string;
+  sessionId: string;
+}
+
+interface SaveAliasVariables extends SessionAliasIdentity {
+  alias: string;
+}
+
+export function useSessionAliasMutations(refreshSessionSnapshot: () => Promise<void>) {
+  const queryClient = useQueryClient();
+
+  const refreshAliasConsumers = useCallback(async () => {
+    await Promise.all([
+      refreshSessionSnapshot(),
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboards }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
+    ]);
+  }, [queryClient, refreshSessionSnapshot]);
+
+  const { mutateAsync: mutateAlias } = useMutation({
+    mutationFn: ({ agentKey, sessionId, alias }: SaveAliasVariables) =>
+      upsertSessionAlias(agentKey, sessionId, alias),
+    onSuccess: refreshAliasConsumers,
+  });
+  const { mutateAsync: mutateAliasRemoval } = useMutation({
+    mutationFn: ({ agentKey, sessionId }: SessionAliasIdentity) =>
+      deleteSessionAlias(agentKey, sessionId),
+    onSuccess: refreshAliasConsumers,
+  });
+
+  const saveAlias = useCallback(
+    async (target: SessionAliasIdentity, alias: string) => {
+      await mutateAlias({ ...target, alias });
+    },
+    [mutateAlias],
+  );
+
+  const removeAlias = useCallback(
+    async (target: SessionAliasIdentity) => {
+      await mutateAliasRemoval(target);
+    },
+    [mutateAliasRemoval],
+  );
+
+  return { saveAlias, removeAlias };
+}

--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { SessionData } from "../lib/api";
 import type { ViewState } from "../lib/view-state";
 import * as api from "../lib/api";
+import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionDetail } from "./useSessionDetail";
 
 vi.mock("../lib/api", () => ({
@@ -28,6 +29,14 @@ function deferred<T>() {
   return { promise, reject, resolve };
 }
 
+function renderSessionDetail(view: ViewState = sessionView) {
+  const { Wrapper } = createQueryWrapper();
+  return renderHook(({ currentView }) => useSessionDetail(currentView), {
+    initialProps: { currentView: view },
+    wrapper: Wrapper,
+  });
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -36,7 +45,7 @@ afterEach(() => {
 describe("useSessionDetail", () => {
   it("loads the session for a session route", async () => {
     vi.mocked(api.fetchSessionData).mockResolvedValue(sample);
-    const { result } = renderHook(() => useSessionDetail(sessionView));
+    const { result } = renderSessionDetail();
 
     await waitFor(() => expect(result.current.session).toEqual(sample));
     expect(result.current.sessionError).toBeNull();
@@ -49,7 +58,7 @@ describe("useSessionDetail", () => {
 
   it("sets an error when the fetch fails", async () => {
     vi.mocked(api.fetchSessionData).mockRejectedValue(new Error("nope"));
-    const { result } = renderHook(() => useSessionDetail(sessionView));
+    const { result } = renderSessionDetail();
 
     await waitFor(() => expect(result.current.sessionError).toBe("Session not found"));
     expect(result.current.session).toBeNull();
@@ -57,7 +66,7 @@ describe("useSessionDetail", () => {
 
   it("does not fetch for a non-session route", () => {
     const rootView: ViewState = { mode: "root", activeAgentKey: null, activeSessionSlug: null };
-    const { result } = renderHook(() => useSessionDetail(rootView));
+    const { result } = renderSessionDetail(rootView);
 
     expect(result.current.session).toBeNull();
     expect(api.fetchSessionData).not.toHaveBeenCalled();
@@ -65,7 +74,7 @@ describe("useSessionDetail", () => {
 
   it("refresh re-fetches the open session", async () => {
     vi.mocked(api.fetchSessionData).mockResolvedValue(sample);
-    const { result } = renderHook(() => useSessionDetail(sessionView));
+    const { result } = renderSessionDetail();
     await waitFor(() => expect(result.current.session).toEqual(sample));
 
     const updated = { id: "abc", messages: [1] } as unknown as SessionData;
@@ -73,7 +82,7 @@ describe("useSessionDetail", () => {
     await act(async () => {
       await result.current.refresh();
     });
-    expect(result.current.session).toEqual(updated);
+    await waitFor(() => expect(result.current.session).toEqual(updated));
   });
 
   it("keeps the current route when an older request resolves last", async () => {
@@ -90,12 +99,10 @@ describe("useSessionDetail", () => {
     vi.mocked(api.fetchSessionData).mockImplementation((_agent, sessionId) =>
       sessionId === viewA.activeSessionSlug ? requestA.promise : requestB.promise,
     );
-    const { result, rerender } = renderHook(({ view }) => useSessionDetail(view), {
-      initialProps: { view: viewA as ViewState },
-    });
+    const { result, rerender } = renderSessionDetail(viewA);
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
 
-    rerender({ view: viewB });
+    rerender({ currentView: viewB });
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(2));
     await act(async () => requestB.resolve(sessionB));
     await waitFor(() => expect(result.current.session).toEqual(sessionB));
@@ -113,7 +120,6 @@ describe("useSessionDetail", () => {
         "session.open.cancel:claudecode/claudecode/abc",
         "session.open.start:codex/def",
         "session.open.done:codex/def",
-        "session.open.stale:claudecode/claudecode/abc",
       ],
     });
   });
@@ -135,12 +141,10 @@ describe("useSessionDetail", () => {
         });
       });
     });
-    const { result, rerender } = renderHook(({ view }) => useSessionDetail(view), {
-      initialProps: { view: sessionView as ViewState },
-    });
+    const { result, rerender } = renderSessionDetail();
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
 
-    rerender({ view: viewB });
+    rerender({ currentView: viewB });
     await waitFor(() => expect(result.current.session).toEqual(sessionB));
 
     expect(result.current.sessionError).toBeNull();
@@ -162,12 +166,10 @@ describe("useSessionDetail", () => {
     vi.mocked(api.fetchSessionData).mockImplementation((_agent, sessionId) =>
       sessionId === sessionView.activeSessionSlug ? requestA.promise : requestB.promise,
     );
-    const { result, rerender } = renderHook(({ view }) => useSessionDetail(view), {
-      initialProps: { view: sessionView as ViewState },
-    });
+    const { result, rerender } = renderSessionDetail();
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
 
-    rerender({ view: viewB });
+    rerender({ currentView: viewB });
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(2));
     await act(async () => requestA.reject(new Error("stale failure")));
 
@@ -181,7 +183,7 @@ describe("useSessionDetail", () => {
   it("aborts without committing state after unmount", async () => {
     const request = deferred<SessionData>();
     vi.mocked(api.fetchSessionData).mockReturnValue(request.promise);
-    const { unmount } = renderHook(() => useSessionDetail(sessionView));
+    const { unmount } = renderSessionDetail();
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
     const signal = vi.mocked(api.fetchSessionData).mock.calls[0]?.[2]?.signal;
 
@@ -212,9 +214,7 @@ describe("useSessionDetail", () => {
       .mockResolvedValueOnce(sample)
       .mockReturnValueOnce(refreshRequest.promise)
       .mockResolvedValueOnce(sessionB);
-    const { result, rerender } = renderHook(({ view }) => useSessionDetail(view), {
-      initialProps: { view: sessionView as ViewState },
-    });
+    const { result, rerender } = renderSessionDetail();
     await waitFor(() => expect(result.current.session).toEqual(sample));
 
     let refreshPromise!: Promise<void>;
@@ -222,7 +222,7 @@ describe("useSessionDetail", () => {
       refreshPromise = result.current.refresh();
     });
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(2));
-    rerender({ view: viewB });
+    rerender({ currentView: viewB });
     await waitFor(() => expect(result.current.session).toEqual(sessionB));
     await act(async () => refreshRequest.resolve(refreshedA));
     await refreshPromise;

--- a/apps/web/src/hooks/useSessionDetail.ts
+++ b/apps/web/src/hooks/useSessionDetail.ts
@@ -1,154 +1,91 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { type SessionData, fetchSessionData, logClientEvent } from "../lib/api";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { fetchSessionData, logClientEvent } from "../lib/api";
+import { queryKeys } from "../lib/query-keys";
 import type { ViewState } from "../lib/view-state";
 
-interface SessionDetailRequest {
-  id: number;
-  key: string;
-  controller: AbortController;
+let nextSessionRequestId = 1;
+
+function sessionRoute(viewState: ViewState) {
+  if (viewState.mode !== "session") return null;
+  return {
+    agent: viewState.activeAgentKey,
+    sessionSlug: viewState.activeSessionSlug,
+  };
 }
 
-function getSessionKey(viewState: ViewState): string {
-  return viewState.mode === "session"
-    ? `${viewState.activeAgentKey}/${viewState.activeSessionSlug}`
-    : "";
-}
-
-/**
- * Owns session-detail state: loads the session for the current "session" route
- * (with a loading flag) and exposes refresh() so data snapshot changes can
- * silently re-fetch the open session without flashing the loading state.
- */
 export function useSessionDetail(viewState: ViewState) {
-  const [session, setSession] = useState<SessionData | null>(null);
-  const [sessionLoading, setSessionLoading] = useState(false);
-  const [sessionError, setSessionError] = useState<string | null>(null);
-  const activeRequestRef = useRef<SessionDetailRequest | null>(null);
-  const nextRequestIdRef = useRef(1);
-  const sessionKey = getSessionKey(viewState);
-  const currentSessionKeyRef = useRef(sessionKey);
-  currentSessionKeyRef.current = sessionKey;
-
-  const cancelActiveRequest = useCallback((reason: "route-change" | "superseded") => {
-    const request = activeRequestRef.current;
-    if (!request) return;
-    activeRequestRef.current = null;
-    request.controller.abort();
-    logClientEvent("session.open.cancel", {
-      request_id: request.id,
-      request_key: request.key,
-      reason,
-    });
-  }, []);
-
-  const loadSession = useCallback(
-    async (
-      agent: string,
-      sessionSlug: string,
-      requestKey: string,
-      trigger: "route" | "refresh",
-    ) => {
-      if (currentSessionKeyRef.current !== requestKey) return;
-      cancelActiveRequest("superseded");
-
-      const request: SessionDetailRequest = {
-        id: nextRequestIdRef.current++,
-        key: requestKey,
-        controller: new AbortController(),
-      };
-      activeRequestRef.current = request;
-      if (trigger === "route") {
-        setSessionLoading(true);
-        setSessionError(null);
-      }
+  const route = sessionRoute(viewState);
+  const query = useQuery({
+    queryKey: queryKeys.sessionDetail(route?.agent ?? "", route?.sessionSlug ?? ""),
+    enabled: route !== null,
+    queryFn: async ({ signal }) => {
+      if (!route) throw new Error("Session route is required");
+      const requestId = nextSessionRequestId++;
+      const requestKey = `${route.agent}/${route.sessionSlug}`;
       const startedAt = performance.now();
+      let didLogCancellation = false;
+      const logCancellation = () => {
+        if (didLogCancellation) return;
+        didLogCancellation = true;
+        logClientEvent("session.open.cancel", {
+          request_id: requestId,
+          request_key: requestKey,
+          reason: "route-change",
+        });
+      };
+      signal.addEventListener("abort", logCancellation, { once: true });
       logClientEvent("session.open.start", {
-        request_id: request.id,
-        request_key: request.key,
-        trigger,
-        agent,
-        session: sessionSlug,
+        request_id: requestId,
+        request_key: requestKey,
+        trigger: "route",
+        agent: route.agent,
+        session: route.sessionSlug,
       });
 
       try {
-        const data = await fetchSessionData(agent, sessionSlug, {
-          signal: request.controller.signal,
-        });
-        if (
-          activeRequestRef.current?.id !== request.id ||
-          currentSessionKeyRef.current !== request.key
-        ) {
-          logClientEvent("session.open.stale", {
-            request_id: request.id,
-            request_key: request.key,
-          });
-          return;
-        }
-        setSession(data);
-        setSessionError(null);
+        const data = await fetchSessionData(route.agent, route.sessionSlug, { signal });
+        if (signal.aborted) throw new DOMException("Aborted", "AbortError");
         logClientEvent("session.open.done", {
-          request_id: request.id,
-          request_key: request.key,
-          trigger,
-          agent,
-          session: sessionSlug,
+          request_id: requestId,
+          request_key: requestKey,
+          trigger: "route",
+          agent: route.agent,
+          session: route.sessionSlug,
           duration_ms: Math.round(performance.now() - startedAt),
           messages: data.messages.length,
         });
+        return data;
       } catch (error) {
-        const isCurrent = activeRequestRef.current?.id === request.id;
-        if (
-          request.controller.signal.aborted ||
-          !isCurrent ||
-          currentSessionKeyRef.current !== request.key
-        ) {
-          return;
+        if (signal.aborted) {
+          logCancellation();
+          throw error;
         }
         logClientEvent("session.open.error", {
-          request_id: request.id,
-          request_key: request.key,
-          trigger,
-          agent,
-          session: sessionSlug,
+          request_id: requestId,
+          request_key: requestKey,
+          trigger: "route",
+          agent: route.agent,
+          session: route.sessionSlug,
           duration_ms: Math.round(performance.now() - startedAt),
           error: error instanceof Error ? error.message : String(error),
         });
-        setSessionError("Session not found");
-        setSession(null);
+        throw error;
       } finally {
-        if (activeRequestRef.current?.id === request.id) {
-          activeRequestRef.current = null;
-          setSessionLoading(false);
-        }
+        signal.removeEventListener("abort", logCancellation);
       }
     },
-    [cancelActiveRequest],
-  );
-
-  useEffect(() => {
-    if (viewState.mode !== "session") {
-      cancelActiveRequest("route-change");
-      setSession(null);
-      setSessionError(null);
-      setSessionLoading(false);
-      return;
-    }
-
-    void loadSession(viewState.activeAgentKey, viewState.activeSessionSlug, sessionKey, "route");
-    return () => cancelActiveRequest("route-change");
-  }, [
-    cancelActiveRequest,
-    loadSession,
-    sessionKey,
-    viewState.activeAgentKey,
-    viewState.activeSessionSlug,
-    viewState.mode,
-  ]);
+  });
 
   const refresh = useCallback(async () => {
-    if (viewState.mode !== "session") return;
-    await loadSession(viewState.activeAgentKey, viewState.activeSessionSlug, sessionKey, "refresh");
-  }, [loadSession, sessionKey, viewState]);
+    if (!route) return;
+    await query.refetch({ cancelRefetch: true });
+  }, [query, route]);
 
-  return { session, sessionLoading, sessionError, refresh };
+  return {
+    session: route ? (query.data ?? null) : null,
+    sessionLoading: route !== null && query.isPending,
+    sessionError: route !== null && query.isError ? "Session not found" : null,
+    refresh,
+  };
 }

--- a/apps/web/src/hooks/useSessionSearch.test.ts
+++ b/apps/web/src/hooks/useSessionSearch.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { SearchResult } from "../lib/api";
 import type { SessionIndexes } from "../lib/session-indexes";
 import * as api from "../lib/api";
+import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionSearch } from "./useSessionSearch";
 
 vi.mock("../lib/api", () => ({
@@ -30,16 +31,21 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+function renderSearch(indexes: SessionIndexes = emptyIndexes) {
+  const { Wrapper } = createQueryWrapper();
+  return renderHook(() => useSessionSearch(indexes), { wrapper: Wrapper });
+}
+
 describe("useSessionSearch", () => {
   it("starts idle with empty results", () => {
-    const { result } = renderHook(() => useSessionSearch(emptyIndexes));
+    const { result } = renderSearch();
     expect(result.current.searchMode).toBe(false);
     expect(result.current.searchState).toEqual({ status: "idle" });
     expect(result.current.searchResults).toEqual([]);
   });
 
   it("submitSearch activates the trimmed draft query", () => {
-    const { result } = renderHook(() => useSessionSearch(emptyIndexes));
+    const { result } = renderSearch();
     act(() => result.current.setDraftSearchQuery("  hello  "));
     act(() => result.current.submitSearch());
 
@@ -49,18 +55,20 @@ describe("useSessionSearch", () => {
 
   it("runs a server search for an active query", async () => {
     vi.mocked(api.fetchSearchResults).mockResolvedValue({ results: serverResults });
-    const { result } = renderHook(() => useSessionSearch(emptyIndexes));
+    const { result } = renderSearch();
     act(() => result.current.setDraftSearchQuery("hello"));
     act(() => result.current.submitSearch());
 
     await waitFor(() => expect(result.current.searchResults).toEqual(serverResults));
-    expect(api.fetchSearchResults).toHaveBeenCalledWith("hello", expect.any(Object));
+    expect(api.fetchSearchResults).toHaveBeenCalledWith("hello", expect.any(Object), {
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it("exposes a failed search state that can be retried", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchSearchResults).mockRejectedValueOnce(new Error("Search unavailable"));
-    const { result } = renderHook(() => useSessionSearch(emptyIndexes));
+    const { result } = renderSearch();
     act(() => result.current.setDraftSearchQuery("hello"));
     act(() => result.current.submitSearch());
 
@@ -95,7 +103,7 @@ describe("useSessionSearch", () => {
         },
       ],
     } as SessionIndexes;
-    const { result } = renderHook(() => useSessionSearch(indexes));
+    const { result } = renderSearch(indexes);
     act(() =>
       result.current.setSearchFilters({
         project: { kind: "git_remote", key: "github.com/acme/app" },
@@ -111,12 +119,13 @@ describe("useSessionSearch", () => {
           projectKind: "git_remote",
           projectKey: "github.com/acme/app",
         }),
+        { signal: expect.any(AbortSignal) },
       ),
     );
   });
 
   it("closeSearch exits and clears the active query", () => {
-    const { result } = renderHook(() => useSessionSearch(emptyIndexes));
+    const { result } = renderSearch();
     act(() => result.current.setDraftSearchQuery("hello"));
     act(() => result.current.submitSearch());
     act(() => result.current.closeSearch());
@@ -127,7 +136,7 @@ describe("useSessionSearch", () => {
 
   it("refresh re-fetches server results while searching", async () => {
     vi.mocked(api.fetchSearchResults).mockResolvedValue({ results: serverResults });
-    const { result } = renderHook(() => useSessionSearch(emptyIndexes));
+    const { result } = renderSearch();
     act(() => result.current.setDraftSearchQuery("hello"));
     act(() => result.current.submitSearch());
     await waitFor(() => expect(result.current.searchResults).toEqual(serverResults));
@@ -140,6 +149,6 @@ describe("useSessionSearch", () => {
       await result.current.refresh();
     });
 
-    expect(result.current.searchResults).toEqual(next);
+    await waitFor(() => expect(result.current.searchResults).toEqual(next));
   });
 });

--- a/apps/web/src/hooks/useSessionSearch.ts
+++ b/apps/web/src/hooks/useSessionSearch.ts
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type AppConfig,
@@ -15,6 +16,9 @@ import {
   buildSearchRequestOptions,
   usesServerSearch as computeUsesServerSearch,
 } from "../lib/search";
+import { queryKeys } from "../lib/query-keys";
+
+const EMPTY_SEARCH_RESULTS: SearchResult[] = [];
 
 /**
  * Owns the session-search domain: query/filters state, the local-vs-server
@@ -30,8 +34,6 @@ export function useSessionSearch(
   const [activeSearchQuery, setActiveSearchQuery] = useState("");
   const [searchMode, setSearchMode] = useState(false);
   const [searchFilters, setSearchFilters] = useState<SearchFilterState>({});
-  const [searchState, setSearchState] = useState<SearchLoadState>({ status: "idle" });
-  const [retryVersion, setRetryVersion] = useState(0);
   const [selectedSearchIndex, setSelectedSearchIndex] = useState(0);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const searchResultRefs = useRef(new Map<string, HTMLAnchorElement>());
@@ -56,8 +58,48 @@ export function useSessionSearch(
     () => buildLocalRecentResults(sessionIndexes, searchFilters, costMin),
     [sessionIndexes, searchFilters, costMin],
   );
+  const serverSearchQuery = useQuery({
+    queryKey: queryKeys.search(activeSearchQuery, searchRequestOptions),
+    enabled: searchMode && usesServerSearch,
+    queryFn: async ({ signal }) => {
+      const startedAt = performance.now();
+      logClientEvent("search.start", { query_length: activeSearchQuery.length });
+      try {
+        const data = await fetchSearchResults(activeSearchQuery, searchRequestOptions, { signal });
+        logClientEvent("search.done", {
+          duration_ms: Math.round(performance.now() - startedAt),
+          results: data.results.length,
+        });
+        return data.results;
+      } catch (error) {
+        if (!signal.aborted) {
+          console.error("Failed to load search results:", error);
+          logClientEvent("search.error", {
+            duration_ms: Math.round(performance.now() - startedAt),
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+        throw error;
+      }
+    },
+  });
+  const searchState = useMemo<SearchLoadState>(() => {
+    if (!searchMode) return { status: "idle" };
+    if (!usesServerSearch) return { status: "loaded", results: recentSearchResults };
+    if (serverSearchQuery.isPending) return { status: "loading" };
+    if (serverSearchQuery.isError) {
+      return {
+        status: "failed",
+        error:
+          serverSearchQuery.error instanceof Error
+            ? serverSearchQuery.error.message
+            : "Search request failed",
+      };
+    }
+    return { status: "loaded", results: serverSearchQuery.data };
+  }, [recentSearchResults, searchMode, serverSearchQuery, usesServerSearch]);
   const searchResults = useMemo(
-    () => (searchState.status === "loaded" ? searchState.results : []),
+    () => (searchState.status === "loaded" ? searchState.results : EMPTY_SEARCH_RESULTS),
     [searchState],
   );
   const searchLoading = searchState.status === "loading";
@@ -78,55 +120,6 @@ export function useSessionSearch(
       usesServerSearch,
     ],
   );
-
-  useEffect(() => {
-    if (!searchMode) {
-      setSearchState({ status: "idle" });
-      return;
-    }
-    if (!usesServerSearch) {
-      setSearchState({ status: "loaded", results: recentSearchResults });
-      return;
-    }
-
-    let cancelled = false;
-    setSearchState({ status: "loading" });
-    const startedAt = performance.now();
-    logClientEvent("search.start", { query_length: activeSearchQuery.length });
-
-    void fetchSearchResults(activeSearchQuery, searchRequestOptions)
-      .then((data) => {
-        if (cancelled) return;
-        setSearchState({ status: "loaded", results: data.results });
-        logClientEvent("search.done", {
-          duration_ms: Math.round(performance.now() - startedAt),
-          results: data.results.length,
-        });
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        console.error("Failed to load search results:", err);
-        logClientEvent("search.error", {
-          duration_ms: Math.round(performance.now() - startedAt),
-          error: err instanceof Error ? err.message : String(err),
-        });
-        setSearchState({
-          status: "failed",
-          error: err instanceof Error ? err.message : "Search request failed",
-        });
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    activeSearchQuery,
-    recentSearchResults,
-    retryVersion,
-    searchMode,
-    searchRequestOptions,
-    usesServerSearch,
-  ]);
 
   useEffect(() => {
     if (!searchMode) return;
@@ -164,8 +157,8 @@ export function useSessionSearch(
   }, []);
 
   const retrySearch = useCallback(() => {
-    setRetryVersion((version) => version + 1);
-  }, []);
+    void serverSearchQuery.refetch();
+  }, [serverSearchQuery]);
 
   const registerResultRef = useCallback((key: string, node: HTMLAnchorElement | null) => {
     if (node) searchResultRefs.current.set(key, node);
@@ -174,17 +167,8 @@ export function useSessionSearch(
 
   const refresh = useCallback(async () => {
     if (!(searchMode && usesServerSearch)) return;
-    try {
-      const data = await fetchSearchResults(activeSearchQuery, searchRequestOptions);
-      setSearchState({ status: "loaded", results: data.results });
-    } catch (err) {
-      console.error("Failed to refresh search results:", err);
-      setSearchState({
-        status: "failed",
-        error: err instanceof Error ? err.message : "Search request failed",
-      });
-    }
-  }, [searchMode, usesServerSearch, activeSearchQuery, searchRequestOptions]);
+    await serverSearchQuery.refetch();
+  }, [searchMode, serverSearchQuery, usesServerSearch]);
 
   return {
     draftSearchQuery,

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -7,6 +7,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentInfo, AppConfig, ProjectGroup } from "../lib/api";
 import * as api from "../lib/api";
+import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionStore } from "./useSessionStore";
 
 vi.mock("../lib/api", () => ({
@@ -46,7 +47,8 @@ afterEach(() => {
 });
 
 async function renderStore() {
-  const hook = renderHook(() => useSessionStore());
+  const { Wrapper } = createQueryWrapper();
+  const hook = renderHook(() => useSessionStore(), { wrapper: Wrapper });
   await waitFor(() => expect(hook.result.current.config).toEqual(config));
   return hook;
 }
@@ -65,7 +67,8 @@ describe("useSessionStore", () => {
     const error = new Error("config unavailable");
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchConfig).mockRejectedValueOnce(error);
-    const { result } = renderHook(() => useSessionStore());
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSessionStore(), { wrapper: Wrapper });
 
     await waitFor(() => expect(result.current.error).toContain("Failed to load data"));
 
@@ -100,7 +103,7 @@ describe("useSessionStore", () => {
     expect(result.current.validAgentKeys.has("claudecode")).toBe(true);
     expect(result.current.validAgentKeys.has("codex")).toBe(false);
     expect(result.current.agentNameMap.get("claudecode")).toBe("Claude Code");
-    expect(result.current.version).toBe(1);
+    expect(result.current.version).toBeGreaterThan(0);
   });
 
   it("keeps the latest snapshot when an earlier request finishes late", async () => {
@@ -123,13 +126,14 @@ describe("useSessionStore", () => {
 
     expect(result.current.window).toEqual(latestWindow);
     expect(result.current.agents).toEqual(latestAgents);
-    expect(result.current.version).toBe(1);
+    expect(result.current.version).toBeGreaterThan(0);
   });
 
   it("applies an incremental live session diff without re-fetching sessions", async () => {
     const { result } = await renderStore();
     await act(() => result.current.reload(config.window));
     vi.mocked(api.fetchSessions).mockClear();
+    vi.mocked(api.fetchAgents).mockClear();
     const changedSession = { ...SAMPLE_SESSION_HEAD, display_title: "Renamed" };
 
     await act(() =>
@@ -139,9 +143,9 @@ describe("useSessionStore", () => {
       }),
     );
 
-    expect(result.current.sessions).toEqual([changedSession]);
+    await waitFor(() => expect(result.current.sessions).toEqual([changedSession]));
     expect(api.fetchSessions).not.toHaveBeenCalled();
-    expect(result.current.version).toBe(2);
+    expect(result.current.version).toBeGreaterThan(0);
   });
 
   it("falls back to a full reload for reconnect events without a diff", async () => {
@@ -162,10 +166,10 @@ describe("useSessionStore", () => {
     );
 
     expect(api.fetchSessions).toHaveBeenCalledOnce();
-    expect(result.current.version).toBe(2);
+    expect(result.current.version).toBeGreaterThan(0);
   });
 
-  it("uses a full reload when live events overlap", async () => {
+  it("keeps overlapping live events on the incremental path", async () => {
     const { result } = await renderStore();
     await act(() => result.current.reload(config.window));
     vi.mocked(api.fetchSessions).mockClear();
@@ -173,15 +177,16 @@ describe("useSessionStore", () => {
     vi.mocked(api.fetchAgents).mockReturnValueOnce(firstAgents.promise).mockResolvedValue(agents);
 
     let firstUpdate!: ReturnType<typeof result.current.applyLiveEvent>;
+    let secondUpdate!: ReturnType<typeof result.current.applyLiveEvent>;
     act(() => {
       firstUpdate = result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
+      secondUpdate = result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
     });
-    await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
     firstAgents.resolve(agents);
-    await act(() => firstUpdate);
+    await act(() => Promise.all([firstUpdate, secondUpdate]));
 
-    expect(api.fetchSessions).toHaveBeenCalledOnce();
-    expect(result.current.version).toBe(2);
+    expect(api.fetchSessions).not.toHaveBeenCalled();
+    expect(result.current.version).toBeGreaterThan(0);
   });
 
   it("keeps the snapshot usable when projects fail to load", async () => {
@@ -206,7 +211,7 @@ describe("useSessionStore", () => {
       await expect(result.current.reload(config.window)).rejects.toBe(error);
     });
 
-    expect(result.current.loading).toBe(false);
+    await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toContain("Failed to load data");
     expect(result.current.sessions).toEqual([]);
   });
@@ -224,7 +229,7 @@ describe("useSessionStore", () => {
     });
 
     expect(result.current.loading).toBe(false);
-    expect(result.current.error).toContain("Failed to load data");
-    expect(result.current.version).toBe(1);
+    expect(result.current.error).toBeNull();
+    expect(result.current.version).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -1,5 +1,6 @@
 import { applySessionChanges } from "@codesesh/core/contract";
-import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { isCancelledError, queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
 import {
   type AgentInfo,
   type AppConfig,
@@ -14,6 +15,7 @@ import {
   fetchSessions,
 } from "../lib/api";
 import { createAgentCatalog } from "../lib/agents";
+import { queryKeys } from "../lib/query-keys";
 
 export type LiveSessionsUpdate = Omit<
   SessionsUpdatedEvent,
@@ -29,207 +31,157 @@ export interface SessionStoreSnapshot {
   dashboard: DashboardData;
 }
 
-interface SessionStoreState {
-  config: AppConfig | null;
-  window: AppConfig["window"] | null;
-  agents: AgentInfo[];
-  sessions: SessionHead[];
-  projects: ProjectGroup[];
-  dashboard: DashboardData | null;
-  loading: boolean;
-  error: string | null;
-  version: number;
-}
+type SnapshotAggregates = Pick<SessionStoreSnapshot, "agents" | "projects" | "dashboard">;
 
-const INITIAL_STATE: SessionStoreState = {
-  config: null,
-  window: null,
-  agents: [],
-  sessions: [],
-  projects: [],
+const EMPTY_SNAPSHOT = {
+  agents: [] satisfies AgentInfo[],
+  sessions: [] satisfies SessionHead[],
+  projects: [] satisfies ProjectGroup[],
   dashboard: null,
-  loading: true,
-  error: null,
-  version: 0,
 };
 
-function sameWindow(left: AppConfig["window"] | null, right: AppConfig["window"]): boolean {
-  return left?.from === right.from && left?.to === right.to && left?.days === right.days;
+async function loadProjects(
+  window: AppConfig["window"],
+  signal: AbortSignal,
+): Promise<ProjectGroup[]> {
+  try {
+    return (await fetchProjects(window, { signal })).projects;
+  } catch (error) {
+    if (signal.aborted) throw error;
+    console.error("Failed to load projects:", error);
+    return [];
+  }
 }
 
-function isAbortError(error: unknown): boolean {
-  return error instanceof DOMException && error.name === "AbortError";
+async function fetchSnapshotAggregates(
+  window: AppConfig["window"],
+  signal: AbortSignal,
+): Promise<SnapshotAggregates> {
+  const [agents, projects, dashboard] = await Promise.all([
+    fetchAgents(window, { signal }),
+    loadProjects(window, signal),
+    fetchDashboard(window, {}, { signal }),
+  ]);
+  return { agents, projects, dashboard };
+}
+
+function snapshotAggregatesOptions(window: AppConfig["window"]) {
+  return queryOptions({
+    queryKey: queryKeys.sessionSnapshotAggregates(window),
+    queryFn: ({ signal }) => fetchSnapshotAggregates(window, signal),
+    staleTime: 100,
+  });
+}
+
+function sessionSnapshotOptions(window: AppConfig["window"]) {
+  return queryOptions({
+    queryKey: queryKeys.sessionSnapshot(window),
+    staleTime: Infinity,
+    queryFn: async ({ signal }): Promise<SessionStoreSnapshot> => {
+      const [aggregates, sessionResult] = await Promise.all([
+        fetchSnapshotAggregates(window, signal),
+        fetchSessions({ from: window.from, to: window.to }, { signal }),
+      ]);
+      return {
+        window,
+        ...aggregates,
+        sessions: sessionResult.sessions,
+      };
+    },
+  });
 }
 
 export function useSessionStore() {
-  const [state, dispatch] = useReducer(
-    (_current: SessionStoreState, next: SessionStoreState) => next,
-    INITIAL_STATE,
-  );
-  const stateRef = useRef(state);
-  const activeRequestRef = useRef<AbortController | null>(null);
-  const requestIdRef = useRef(0);
-  const requestedWindowRef = useRef<AppConfig["window"] | null>(null);
-
-  const updateState = useCallback((update: (current: SessionStoreState) => SessionStoreState) => {
-    const next = update(stateRef.current);
-    stateRef.current = next;
-    dispatch(next);
-  }, []);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    void fetchConfig({ signal: controller.signal })
-      .then((config) => {
-        if (controller.signal.aborted) return;
-        updateState((current) => ({ ...current, config }));
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) return;
-        console.error("Failed to load config:", error);
-        updateState((current) => ({
-          ...current,
-          loading: false,
-          error: "Failed to load data. Is the CLI server running?",
-        }));
-      });
-
-    return () => controller.abort();
-  }, [updateState]);
-
-  useEffect(
-    () => () => {
-      activeRequestRef.current?.abort();
-    },
-    [],
-  );
-
-  const beginRequest = useCallback(
-    (window: AppConfig["window"]) => {
-      activeRequestRef.current?.abort();
-      const controller = new AbortController();
-      const id = ++requestIdRef.current;
-      activeRequestRef.current = controller;
-      requestedWindowRef.current = window;
-      updateState((current) => ({ ...current, loading: true, error: null }));
-      return { controller, id };
-    },
-    [updateState],
-  );
-
-  const loadProjects = useCallback(
-    async (window: AppConfig["window"], signal: AbortSignal): Promise<ProjectGroup[]> => {
+  const queryClient = useQueryClient();
+  const [requestedWindow, setRequestedWindow] = useState<AppConfig["window"] | null>(null);
+  const configQuery = useQuery({
+    queryKey: queryKeys.config,
+    queryFn: async ({ signal }) => {
       try {
-        return (await fetchProjects(window, { signal })).projects;
+        return await fetchConfig({ signal });
       } catch (error) {
-        if (signal.aborted) throw error;
-        console.error("Failed to load projects:", error);
-        return [];
-      }
-    },
-    [],
-  );
-
-  const commitSnapshot = useCallback(
-    (requestId: number, snapshot: SessionStoreSnapshot): SessionStoreSnapshot | null => {
-      if (requestIdRef.current !== requestId) return null;
-      activeRequestRef.current = null;
-      const committedWindow = { ...snapshot.window };
-      const committedSnapshot = { ...snapshot, window: committedWindow };
-      updateState((current) => ({
-        ...current,
-        ...committedSnapshot,
-        loading: false,
-        error: null,
-        version: current.version + 1,
-      }));
-      return committedSnapshot;
-    },
-    [updateState],
-  );
-
-  const failRequest = useCallback(
-    (requestId: number, error: unknown) => {
-      if (requestIdRef.current !== requestId || isAbortError(error)) return;
-      activeRequestRef.current = null;
-      updateState((current) => ({
-        ...current,
-        loading: false,
-        error: "Failed to load data. Is the CLI server running?",
-      }));
-    },
-    [updateState],
-  );
-
-  const reload = useCallback(
-    async (window: AppConfig["window"]): Promise<SessionStoreSnapshot | null> => {
-      const { controller, id } = beginRequest(window);
-      try {
-        const [agents, sessionResult, projects, dashboard] = await Promise.all([
-          fetchAgents(window, { signal: controller.signal }),
-          fetchSessions({ from: window.from, to: window.to }, { signal: controller.signal }),
-          loadProjects(window, controller.signal),
-          fetchDashboard(window),
-        ]);
-        return commitSnapshot(id, {
-          window,
-          agents,
-          sessions: sessionResult.sessions,
-          projects,
-          dashboard,
-        });
-      } catch (error) {
-        failRequest(id, error);
-        if (controller.signal.aborted || isAbortError(error)) return null;
+        if (!signal.aborted) console.error("Failed to load config:", error);
         throw error;
       }
     },
-    [beginRequest, commitSnapshot, failRequest, loadProjects],
+  });
+  const snapshotQuery = useQuery({
+    ...sessionSnapshotOptions(requestedWindow ?? {}),
+    enabled: false,
+  });
+  const snapshot = snapshotQuery.data;
+
+  const reload = useCallback(
+    async (window: AppConfig["window"]): Promise<SessionStoreSnapshot | null> => {
+      setRequestedWindow(window);
+      try {
+        await queryClient.cancelQueries({ queryKey: queryKeys.sessionSnapshots });
+        await queryClient.invalidateQueries({
+          queryKey: queryKeys.sessionSnapshot(window),
+          exact: true,
+          refetchType: "none",
+        });
+        return await queryClient.fetchQuery(sessionSnapshotOptions(window));
+      } catch (error) {
+        if (isCancelledError(error)) return null;
+        throw error;
+      }
+    },
+    [queryClient],
   );
 
   const applyLiveEvent = useCallback(
     async (event: LiveSessionsUpdate): Promise<SessionStoreSnapshot | null> => {
-      const window = requestedWindowRef.current;
-      if (!window) return null;
-      if (
-        !event.changedSessionHeads ||
-        !event.removedSessionRefs ||
-        activeRequestRef.current ||
-        !sameWindow(stateRef.current.window, window)
-      ) {
-        return reload(window);
+      if (!requestedWindow) return null;
+      const snapshotKey = queryKeys.sessionSnapshot(requestedWindow);
+      const current = queryClient.getQueryData<SessionStoreSnapshot>(snapshotKey);
+      if (!current || !event.changedSessionHeads || !event.removedSessionRefs) {
+        await queryClient.invalidateQueries({
+          queryKey: snapshotKey,
+          exact: true,
+          refetchType: "none",
+        });
+        return queryClient.fetchQuery(sessionSnapshotOptions(requestedWindow));
       }
 
-      const sessions = applySessionChanges(
-        stateRef.current.sessions,
-        event.changedSessionHeads,
-        event.removedSessionRefs,
+      queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, {
+        ...current,
+        sessions: applySessionChanges(
+          current.sessions,
+          event.changedSessionHeads,
+          event.removedSessionRefs,
+        ),
+      });
+      const aggregates = await queryClient.fetchQuery(snapshotAggregatesOptions(requestedWindow));
+      return (
+        queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, (latest) =>
+          latest ? { ...latest, ...aggregates } : latest,
+        ) ?? null
       );
-      const { controller, id } = beginRequest(window);
-      try {
-        const [agents, projects, dashboard] = await Promise.all([
-          fetchAgents(window, { signal: controller.signal }),
-          loadProjects(window, controller.signal),
-          fetchDashboard(window),
-        ]);
-        return commitSnapshot(id, { window, agents, sessions, projects, dashboard });
-      } catch (error) {
-        failRequest(id, error);
-        if (controller.signal.aborted || isAbortError(error)) return null;
-        throw error;
-      }
     },
-    [beginRequest, commitSnapshot, failRequest, loadProjects, reload],
+    [queryClient, requestedWindow],
   );
 
-  const agentCatalog = useMemo(() => createAgentCatalog(state.agents), [state.agents]);
+  const agents = snapshot?.agents ?? EMPTY_SNAPSHOT.agents;
+  const agentCatalog = useMemo(() => createAgentCatalog(agents), [agents]);
   const validAgentKeys = useMemo(
     () => new Set(agentCatalog.active.map((agent) => agent.name.toLowerCase())),
     [agentCatalog.active],
   );
+  const error = configQuery.error ?? snapshotQuery.error;
 
   return {
-    ...state,
+    config: configQuery.data ?? null,
+    window: snapshot?.window ?? null,
+    agents,
+    sessions: snapshot?.sessions ?? EMPTY_SNAPSHOT.sessions,
+    projects: snapshot?.projects ?? EMPTY_SNAPSHOT.projects,
+    dashboard: snapshot?.dashboard ?? EMPTY_SNAPSHOT.dashboard,
+    loading:
+      configQuery.isPending ||
+      (!configQuery.isError && (requestedWindow === null || snapshotQuery.isPending)),
+    error: error ? "Failed to load data. Is the CLI server running?" : null,
+    version: snapshotQuery.dataUpdatedAt,
     activeAgents: agentCatalog.active,
     agentCatalog,
     validAgentKeys,

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -141,7 +141,9 @@ export function useSessionStore() {
           exact: true,
           refetchType: "none",
         });
-        return queryClient.fetchQuery(sessionSnapshotOptions(requestedWindow));
+        const refreshed = await queryClient.fetchQuery(sessionSnapshotOptions(requestedWindow));
+        await queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails });
+        return refreshed;
       }
 
       queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, {
@@ -153,11 +155,12 @@ export function useSessionStore() {
         ),
       });
       const aggregates = await queryClient.fetchQuery(snapshotAggregatesOptions(requestedWindow));
-      return (
+      const updated =
         queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, (latest) =>
           latest ? { ...latest, ...aggregates } : latest,
-        ) ?? null
-      );
+        ) ?? null;
+      await queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails });
+      return updated;
     },
     [queryClient, requestedWindow],
   );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -177,6 +177,7 @@ export async function fetchSessionData(
 export async function fetchDashboard(
   window?: AppConfig["window"],
   filters: { projectKind?: ProjectIdentityKind; projectKey?: string; agent?: string } = {},
+  options?: FetchOptions,
 ): Promise<DashboardData> {
   const params = new URLSearchParams();
   if (window?.days !== 0) appendTimeWindow(params, window);
@@ -185,12 +186,13 @@ export async function fetchDashboard(
   if (filters.projectKey) params.set("projectKey", filters.projectKey);
   if (filters.agent) params.set("agent", filters.agent);
   const suffix = params.toString();
-  return fetchJson(suffix ? `/api/dashboard?${suffix}` : "/api/dashboard");
+  return fetchJson(suffix ? `/api/dashboard?${suffix}` : "/api/dashboard", options);
 }
 
 export async function fetchSearchResults(
   query: string,
   options: SearchRequestOptions = {},
+  fetchOptions?: FetchOptions,
 ): Promise<{ results: SearchResult[] }> {
   const params = new URLSearchParams();
   params.set("q", query);
@@ -203,11 +205,13 @@ export async function fetchSearchResults(
   if (options.costMin != null) params.set("costMin", String(options.costMin));
   if (options.costMax != null) params.set("costMax", String(options.costMax));
   appendTimeWindow(params, options);
-  return fetchJson(`/api/search?${params}`);
+  return fetchJson(`/api/search?${params}`, fetchOptions);
 }
 
-export async function fetchBookmarks(): Promise<{ bookmarks: BookmarkedSessionSnapshot[] }> {
-  return fetchJson("/api/bookmarks");
+export async function fetchBookmarks(
+  options?: FetchOptions,
+): Promise<{ bookmarks: BookmarkedSessionSnapshot[] }> {
+  return fetchJson("/api/bookmarks", options);
 }
 
 export async function upsertBookmark(

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,18 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnWindowFocus: false,
+        retry: false,
+        staleTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+export const queryClient = createQueryClient();

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -13,6 +13,7 @@ function normalizeWindow(window: TimeWindow) {
 export const queryKeys = {
   bookmarks: ["bookmarks"] as const,
   config: ["config"] as const,
+  dashboards: ["dashboard"] as const,
   dashboard: (
     window: TimeWindow,
     filters: {
@@ -22,6 +23,8 @@ export const queryKeys = {
     },
   ) => ["dashboard", normalizeWindow(window), filters] as const,
   search: (query: string, options: SearchRequestOptions) => ["search", query, options] as const,
+  searches: ["search"] as const,
+  sessionDetails: ["session-detail"] as const,
   sessionDetail: (agent: string, sessionSlug: string) =>
     ["session-detail", agent, sessionSlug] as const,
   sessionSnapshots: ["session-snapshot"] as const,

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -1,0 +1,31 @@
+import type { AppConfig, SearchRequestOptions } from "./api";
+
+type TimeWindow = AppConfig["window"];
+
+function normalizeWindow(window: TimeWindow) {
+  return {
+    days: window.days,
+    from: window.from,
+    to: window.to,
+  };
+}
+
+export const queryKeys = {
+  bookmarks: ["bookmarks"] as const,
+  config: ["config"] as const,
+  dashboard: (
+    window: TimeWindow,
+    filters: {
+      agent?: string;
+      projectKind?: string;
+      projectKey?: string;
+    },
+  ) => ["dashboard", normalizeWindow(window), filters] as const,
+  search: (query: string, options: SearchRequestOptions) => ["search", query, options] as const,
+  sessionDetail: (agent: string, sessionSlug: string) =>
+    ["session-detail", agent, sessionSlug] as const,
+  sessionSnapshots: ["session-snapshot"] as const,
+  sessionSnapshot: (window: TimeWindow) => ["session-snapshot", normalizeWindow(window)] as const,
+  sessionSnapshotAggregates: (window: TimeWindow) =>
+    ["session-snapshot-aggregates", normalizeWindow(window)] as const,
+} as const;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,19 +1,23 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App.tsx";
 import { RenderProfiler } from "./components/RenderProfiler.tsx";
 import { initializeRemoteAccess } from "./lib/api.ts";
+import { queryClient } from "./lib/query-client.ts";
 import "./index.css";
 
 initializeRemoteAccess();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <RenderProfiler id="App">
-        <App />
-      </RenderProfiler>
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <RenderProfiler id="App">
+          <App />
+        </RenderProfiler>
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/apps/web/src/test/query-wrapper.tsx
+++ b/apps/web/src/test/query-wrapper.tsx
@@ -1,0 +1,16 @@
+import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
+import type { PropsWithChildren } from "react";
+import { createQueryClient } from "../lib/query-client";
+
+export function createQueryWrapper(): {
+  client: QueryClient;
+  Wrapper: ({ children }: PropsWithChildren) => React.JSX.Element;
+} {
+  const client = createQueryClient();
+  return {
+    client,
+    Wrapper: ({ children }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@pierre/trees':
         specifier: 1.0.0-beta.3
         version: 1.0.0-beta.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.7)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1476,6 +1479,14 @@ packages:
     resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5036,6 +5047,13 @@ snapshots:
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
       vite: 8.1.4(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/react-query@5.101.2(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 19.2.7
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

- add TanStack Query with explicit local-app defaults and centralized query keys
- migrate the atomic session snapshot, session detail, dashboard, search, and bookmarks to query lifecycle management
- route SSE, bookmark, and session alias updates through query cache updates and targeted invalidation

## Why

The web app maintained separate loading, cancellation, stale-response, refresh, and optimistic rollback state machines for each remote resource. This change gives server state one owner while preserving atomic window snapshots and incremental SSE session updates.

## Validation

- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web build`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm test:e2e --project web-chromium`

Issue: CS-67
