### PR TITLE
fix(www): restore showcase dialog label

### DIFF
--- a/apps/www/src/components/ProductShowcase.astro
+++ b/apps/www/src/components/ProductShowcase.astro
@@ -107,7 +107,7 @@ const scenes = copy[locale].scenes;
       data-scene-dialog
       data-scene-index={String(index)}
       class="scene-dialog m-0 h-dvh max-h-none w-screen max-w-none bg-transparent p-0 backdrop:bg-black/55 backdrop:backdrop-blur-sm"
-      aria-label={scene.title}
+      aria-label={`${scene.title} preview`}
     >
       <div class="flex min-h-dvh items-center justify-center p-4" data-scene-backdrop>
         <div class="relative flex max-h-[92dvh] w-full max-w-7xl flex-col overflow-hidden rounded-sm border border-white/20 bg-[#f7f7f7] shadow-[0_24px_64px_rgba(0,0,0,0.24)]">


### PR DESCRIPTION
## Summary

- restore the `preview` qualifier in product showcase dialog accessible names
- keep the dialog name distinct from the corresponding showcase card title

## Why

The landing page redesign changed the dialog `aria-label` from `{title} preview` to `{title}` while the established accessibility and E2E contract still targeted the explicit preview name. This broke the `www-chromium` smoke suite on `main` and every subsequent pull request.

## Validation

- `pnpm test:e2e --project www-chromium`
- `pnpm --filter @codesesh/www build`

Issue: CS-70
