### PR TITLE
refactor(web): replace pathname parsing with route matches

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,7 +2,7 @@ declare const __APP_VERSION__: string;
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useMatches, useNavigate } from "react-router-dom";
 import type { BookmarkedSessionSnapshot, SessionHead } from "./lib/api";
 import { logClientEvent } from "./lib/api";
 import { ErrorBoundary } from "./components/ErrorBoundary";
@@ -10,7 +10,7 @@ import { CopyResumeButton } from "./components/CopyResumeButton";
 import { SessionAliasDialog, type SessionAliasTarget } from "./components/SessionAliasDialog";
 import { TimeWindowControl } from "./components/TimeWindowControl";
 import { RenderProfiler } from "./components/RenderProfiler";
-import { parseViewState } from "./lib/view-state";
+import { viewStateFromRouteMatches } from "./lib/view-state";
 import { useScanStatus } from "./hooks/useScanStatus";
 import { useSessionDetail } from "./hooks/useSessionDetail";
 import { useSessionSearch } from "./hooks/useSessionSearch";
@@ -68,9 +68,10 @@ export default function App() {
   const [aliasTarget, setAliasTarget] = useState<SessionAliasTarget | null>(null);
 
   const location = useLocation();
+  const routeMatches = useMatches();
   const viewState = useMemo(
-    () => parseViewState(location.pathname, validAgentKeys),
-    [location.pathname, validAgentKeys],
+    () => viewStateFromRouteMatches(routeMatches, validAgentKeys),
+    [routeMatches, validAgentKeys],
   );
 
   const sessionDetail = useSessionDetail(viewState);

--- a/apps/web/src/lib/app-routes.ts
+++ b/apps/web/src/lib/app-routes.ts
@@ -1,0 +1,40 @@
+import type { LoaderFunctionArgs, RouteObject } from "react-router-dom";
+
+export const APP_ROUTE_IDS = {
+  agent: "agent",
+  notFound: "not-found",
+  project: "project",
+  projects: "projects",
+  root: "root",
+  session: "session",
+} as const;
+
+export const appRouteChildren: RouteObject[] = [
+  { index: true, id: APP_ROUTE_IDS.root },
+  {
+    path: "projects",
+    children: [
+      { index: true, id: APP_ROUTE_IDS.projects },
+      { path: ":projectKind/:projectKey", id: APP_ROUTE_IDS.project },
+    ],
+  },
+  {
+    path: ":agentKey",
+    id: APP_ROUTE_IDS.agent,
+    children: [{ path: ":sessionSlug", id: APP_ROUTE_IDS.session }],
+  },
+  { path: "*", id: APP_ROUTE_IDS.notFound },
+];
+
+export function assertValidRouteEncoding(request: Request) {
+  try {
+    decodeURI(new URL(request.url).pathname);
+  } catch {
+    throw new Response("Malformed URL", { status: 400, statusText: "Bad Request" });
+  }
+}
+
+export function validateRouteEncoding({ request }: LoaderFunctionArgs) {
+  assertValidRouteEncoding(request);
+  return null;
+}

--- a/apps/web/src/lib/view-state.test.ts
+++ b/apps/web/src/lib/view-state.test.ts
@@ -1,45 +1,78 @@
 import { describe, expect, it } from "vitest";
-import { parseViewState } from "./view-state";
+import { matchRoutes } from "react-router-dom";
+import type { RouteObject } from "react-router-dom";
+import { APP_ROUTE_IDS, appRouteChildren, assertValidRouteEncoding } from "./app-routes";
+import { getProjectPath } from "./projects";
+import { viewStateFromRouteMatches } from "./view-state";
 
 const agents = new Set(["claudecode", "codex"]);
+const routes: RouteObject[] = [{ path: "/", children: appRouteChildren }];
 
-describe("parseViewState", () => {
-  it("parses root path", () => {
-    expect(parseViewState("/", agents)).toEqual({
+function viewState(path: string) {
+  const matches = (matchRoutes(routes, path) ?? []).map(({ params, route }) => ({
+    id: route.id ?? "",
+    params,
+  }));
+  return viewStateFromRouteMatches(matches, agents);
+}
+
+describe("viewStateFromRouteMatches", () => {
+  it("maps the route graph to app view states", () => {
+    expect(viewState("/")).toEqual({
       mode: "root",
       activeAgentKey: null,
       activeSessionSlug: null,
     });
-  });
-
-  it("parses projects path", () => {
-    expect(parseViewState("/projects", agents).mode).toBe("projects");
-  });
-
-  it("parses agent path", () => {
-    const result = parseViewState("/claudecode", agents);
-    expect(result).toEqual({
+    expect(viewState("/projects").mode).toBe("projects");
+    expect(viewState("/claudecode")).toEqual({
       mode: "agent",
       activeAgentKey: "claudecode",
       activeSessionSlug: null,
     });
-  });
-
-  it("parses session path", () => {
-    const result = parseViewState("/codex/abc-123", agents);
-    expect(result).toEqual({
+    expect(viewState("/codex/abc-123")).toEqual({
       mode: "session",
       activeAgentKey: "codex",
       activeSessionSlug: "abc-123",
     });
   });
 
-  it("returns missingAgent for unknown agent", () => {
-    const result = parseViewState("/unknown", agents);
-    expect(result.mode).toBe("missingAgent");
+  it("keeps the static projects route ahead of the agent parameter", () => {
+    const matches = matchRoutes(routes, "/projects");
+    expect(matches?.at(-1)?.route.id).toBe(APP_ROUTE_IDS.projects);
   });
 
-  it("returns invalidRoute for deeply nested paths", () => {
-    expect(parseViewState("/a/b/c/d", agents).mode).toBe("invalidRoute");
+  it("uses decoded router params for project identities", () => {
+    const path = getProjectPath({ kind: "git_remote", key: "github.com/acme/app" });
+    expect(viewState(path)).toEqual({
+      mode: "project",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+      activeProjectKind: "git_remote",
+      activeProjectKey: "github.com/acme/app",
+    });
+  });
+
+  it("returns missingAgent for an unknown dynamic agent", () => {
+    expect(viewState("/unknown")).toEqual({
+      mode: "missingAgent",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+      attemptedKey: "unknown",
+    });
+  });
+
+  it("maps invalid project kinds and wildcard paths to invalidRoute", () => {
+    expect(viewState("/projects/invalid/key").mode).toBe("invalidRoute");
+    expect(viewState("/a/b/c/d").mode).toBe("invalidRoute");
+  });
+
+  it("keeps query strings outside route identity", () => {
+    expect(viewState("/codex/abc-123?window=7d").mode).toBe("session");
+  });
+
+  it("rejects malformed URL encoding at the route boundary", () => {
+    expect(() =>
+      assertValidRouteEncoding(new Request("http://localhost/projects/git_remote/%ZZ")),
+    ).toThrow(expect.objectContaining({ status: 400 }));
   });
 });

--- a/apps/web/src/lib/view-state.ts
+++ b/apps/web/src/lib/view-state.ts
@@ -1,6 +1,6 @@
 import { APP_ROUTE_IDS } from "./app-routes";
 import type { ProjectIdentityKind } from "./api";
-import { decodeProjectRouteKey, isProjectIdentityKind } from "./projects";
+import { isProjectIdentityKind } from "./projects";
 
 export type ViewState =
   | { mode: "root"; activeAgentKey: null; activeSessionSlug: null }
@@ -75,75 +75,6 @@ export function viewStateFromRouteMatches(
     const sessionSlug = match.params.sessionSlug;
     if (!sessionSlug) return invalidRoute;
     return { mode: "session", activeAgentKey: agentKey, activeSessionSlug: sessionSlug };
-  }
-  return invalidRoute;
-}
-
-export function parseViewState(pathname: string, validAgentKeys: Set<string>): ViewState {
-  const trimmed = pathname.replace(/^\/+|\/+$/g, "");
-  const segments = trimmed
-    ? trimmed
-        .split("/")
-        .map((segment) => segment.trim())
-        .filter(Boolean)
-    : [];
-
-  if (segments.length === 0) {
-    return { mode: "root", activeAgentKey: null, activeSessionSlug: null };
-  }
-  if (segments[0]?.toLowerCase() === "projects") {
-    if (segments.length === 1) {
-      return { mode: "projects", activeAgentKey: null, activeSessionSlug: null };
-    }
-    if (segments.length === 3) {
-      try {
-        const kind = decodeURIComponent(segments[1]!);
-        if (!isProjectIdentityKind(kind)) return invalidRoute;
-        return {
-          mode: "project",
-          activeAgentKey: null,
-          activeSessionSlug: null,
-          activeProjectKind: kind,
-          activeProjectKey: decodeProjectRouteKey(segments[2]!),
-        };
-      } catch {
-        return invalidRoute;
-      }
-    }
-    return invalidRoute;
-  }
-  if (segments.length === 1) {
-    const key = segments[0]!.toLowerCase();
-    if (validAgentKeys.has(key)) {
-      return { mode: "agent", activeAgentKey: key, activeSessionSlug: null };
-    }
-    return {
-      mode: "missingAgent",
-      activeAgentKey: null,
-      activeSessionSlug: null,
-      attemptedKey: key,
-    };
-  }
-  if (segments.length === 2) {
-    const key = segments[0]!.toLowerCase();
-    const slug = segments[1]!;
-    if (validAgentKeys.has(key) && slug) {
-      return { mode: "session", activeAgentKey: key, activeSessionSlug: slug };
-    }
-    if (validAgentKeys.has(key)) {
-      return {
-        mode: "missingSession",
-        activeAgentKey: key,
-        activeSessionSlug: slug,
-        attemptedSessionSlug: slug,
-      };
-    }
-    return {
-      mode: "missingAgent",
-      activeAgentKey: null,
-      activeSessionSlug: null,
-      attemptedKey: key,
-    };
   }
   return invalidRoute;
 }

--- a/apps/web/src/lib/view-state.ts
+++ b/apps/web/src/lib/view-state.ts
@@ -1,7 +1,4 @@
-/**
- * Route → view-state parsing for the app shell.
- * Pure: turns a pathname + valid agent keys into a discriminated ViewState.
- */
+import { APP_ROUTE_IDS } from "./app-routes";
 import type { ProjectIdentityKind } from "./api";
 import { decodeProjectRouteKey, isProjectIdentityKind } from "./projects";
 
@@ -26,12 +23,68 @@ export type ViewState =
     }
   | { mode: "invalidRoute"; activeAgentKey: null; activeSessionSlug: null };
 
+export interface ViewRouteMatch {
+  id: string;
+  params: Readonly<Record<string, string | undefined>>;
+}
+
+const invalidRoute: ViewState = {
+  mode: "invalidRoute",
+  activeAgentKey: null,
+  activeSessionSlug: null,
+};
+
+export function viewStateFromRouteMatches(
+  matches: readonly ViewRouteMatch[],
+  validAgentKeys: ReadonlySet<string>,
+): ViewState {
+  const match = matches.at(-1);
+  if (!match) return invalidRoute;
+
+  if (match.id === APP_ROUTE_IDS.root) {
+    return { mode: "root", activeAgentKey: null, activeSessionSlug: null };
+  }
+  if (match.id === APP_ROUTE_IDS.projects) {
+    return { mode: "projects", activeAgentKey: null, activeSessionSlug: null };
+  }
+  if (match.id === APP_ROUTE_IDS.project) {
+    const kind = match.params.projectKind;
+    const key = match.params.projectKey;
+    if (!kind || !key || !isProjectIdentityKind(kind)) return invalidRoute;
+    return {
+      mode: "project",
+      activeAgentKey: null,
+      activeSessionSlug: null,
+      activeProjectKind: kind,
+      activeProjectKey: key,
+    };
+  }
+  if (match.id === APP_ROUTE_IDS.agent || match.id === APP_ROUTE_IDS.session) {
+    const agentKey = match.params.agentKey?.toLowerCase();
+    if (!agentKey || !validAgentKeys.has(agentKey)) {
+      return {
+        mode: "missingAgent",
+        activeAgentKey: null,
+        activeSessionSlug: null,
+        attemptedKey: agentKey ?? "",
+      };
+    }
+    if (match.id === APP_ROUTE_IDS.agent) {
+      return { mode: "agent", activeAgentKey: agentKey, activeSessionSlug: null };
+    }
+    const sessionSlug = match.params.sessionSlug;
+    if (!sessionSlug) return invalidRoute;
+    return { mode: "session", activeAgentKey: agentKey, activeSessionSlug: sessionSlug };
+  }
+  return invalidRoute;
+}
+
 export function parseViewState(pathname: string, validAgentKeys: Set<string>): ViewState {
   const trimmed = pathname.replace(/^\/+|\/+$/g, "");
   const segments = trimmed
     ? trimmed
         .split("/")
-        .map((s) => s.trim())
+        .map((segment) => segment.trim())
         .filter(Boolean)
     : [];
 
@@ -45,9 +98,7 @@ export function parseViewState(pathname: string, validAgentKeys: Set<string>): V
     if (segments.length === 3) {
       try {
         const kind = decodeURIComponent(segments[1]!);
-        if (!isProjectIdentityKind(kind)) {
-          return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
-        }
+        if (!isProjectIdentityKind(kind)) return invalidRoute;
         return {
           mode: "project",
           activeAgentKey: null,
@@ -56,10 +107,10 @@ export function parseViewState(pathname: string, validAgentKeys: Set<string>): V
           activeProjectKey: decodeProjectRouteKey(segments[2]!),
         };
       } catch {
-        return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+        return invalidRoute;
       }
     }
-    return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+    return invalidRoute;
   }
   if (segments.length === 1) {
     const key = segments[0]!.toLowerCase();
@@ -94,5 +145,5 @@ export function parseViewState(pathname: string, validAgentKeys: Set<string>): V
       attemptedKey: key,
     };
   }
-  return { mode: "invalidRoute", activeAgentKey: null, activeSessionSlug: null };
+  return invalidRoute;
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter } from "react-router-dom";
-import App from "./App.tsx";
 import { RenderProfiler } from "./components/RenderProfiler.tsx";
 import { initializeRemoteAccess } from "./lib/api.ts";
 import { queryClient } from "./lib/query-client.ts";
+import { AppRouter } from "./router.tsx";
 import "./index.css";
 
 initializeRemoteAccess();
@@ -13,11 +12,9 @@ initializeRemoteAccess();
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <RenderProfiler id="App">
-          <App />
-        </RenderProfiler>
-      </BrowserRouter>
+      <RenderProfiler id="App">
+        <AppRouter />
+      </RenderProfiler>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,0 +1,31 @@
+import {
+  createBrowserRouter,
+  isRouteErrorResponse,
+  RouterProvider,
+  useRouteError,
+} from "react-router-dom";
+import App from "./App";
+import { appRouteChildren, validateRouteEncoding } from "./lib/app-routes";
+
+function RouteErrorFallback() {
+  const error = useRouteError();
+  const message = isRouteErrorResponse(error)
+    ? `${error.status} ${error.statusText}`
+    : "The application route failed to render.";
+  return <div role="alert">{message}</div>;
+}
+
+const router = createBrowserRouter([
+  {
+    id: "app-shell",
+    path: "/",
+    Component: App,
+    ErrorBoundary: RouteErrorFallback,
+    loader: validateRouteEncoding,
+    children: appRouteChildren,
+  },
+]);
+
+export function AppRouter() {
+  return <RouterProvider router={router} />;
+}


### PR DESCRIPTION
## Summary

- define the application URL contract as explicit React Router route objects
- derive the existing view-state adapter from route matches and decoded params
- replace `BrowserRouter` with `createBrowserRouter` and a route error boundary
- reject malformed URL encoding without introducing route-owned remote data

## Validation

- `pnpm --filter @codesesh/web test` (338 tests)
- `pnpm --filter @codesesh/web build`
- `pnpm --filter @codesesh/web lint`
- `pnpm test:e2e --project web-chromium` (7 tests)

Issue: CS-68
