### PR TITLE
feat(web): persist app shell UI preferences

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ import { useWindowedDataLoad } from "./hooks/useWindowedDataLoad";
 import { useLiveSync } from "./hooks/useLiveSync";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useTimeWindow } from "./hooks/useTimeWindow";
+import { useUiPreferences } from "./hooks/useUiPreferences";
 import { buildRouteHeaderModel } from "./lib/build-route-header-model";
 import { AppSidebar } from "./components/app/AppSidebar";
 import { ShortcutHelpDialog } from "./components/app/ShortcutHelpDialog";
@@ -31,8 +32,6 @@ import type { BrowseBy } from "./components/app/types";
 import { formatScanStatusLabel, formatSearchSubtitle } from "./lib/scan-format";
 import { getProjectIdentityKey, getProjectPath, type ProjectRouteIdentity } from "./lib/projects";
 import { buildSessionIndexes, getSessionAgentKey } from "./lib/session-indexes";
-
-const SHORTCUT_HINT_STORAGE_KEY = "codesesh.shortcuts-hint-dismissed";
 
 export default function App() {
   const navigate = useNavigate();
@@ -63,8 +62,8 @@ export default function App() {
   const { scanStatus, setScanStatus } = useScanStatus();
   const [selectedSidebarSessionId, setSelectedSidebarSessionId] = useState<string | null>(null);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
-  const [shortcutHintDismissed, setShortcutHintDismissed] = useState(true);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const { shortcutHintDismissed, sidebarCollapsed, dismissShortcutHint, setSidebarCollapsed } =
+    useUiPreferences();
   const [aliasTarget, setAliasTarget] = useState<SessionAliasTarget | null>(null);
 
   const location = useLocation();
@@ -242,14 +241,6 @@ export default function App() {
   }, [aliasTarget, removeAlias]);
 
   useEffect(() => {
-    try {
-      setShortcutHintDismissed(window.localStorage.getItem(SHORTCUT_HINT_STORAGE_KEY) === "1");
-    } catch {
-      setShortcutHintDismissed(true);
-    }
-  }, []);
-
-  useEffect(() => {
     if (isSearchMode) return;
 
     if (viewState.mode === "session") {
@@ -335,15 +326,6 @@ export default function App() {
     />
   );
 
-  function dismissShortcutHint() {
-    setShortcutHintDismissed(true);
-    try {
-      window.localStorage.setItem(SHORTCUT_HINT_STORAGE_KEY, "1");
-    } catch {
-      // Ignore storage failures and keep the UI usable.
-    }
-  }
-
   function changeBrowseBy(next: BrowseBy) {
     if (next === "projects" && isScanActive) return;
     selectBrowseBy(next);
@@ -391,7 +373,7 @@ export default function App() {
               aria-expanded={!sidebarCollapsed}
               aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
               title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-              onClick={() => setSidebarCollapsed((collapsed) => !collapsed)}
+              onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
               className="hidden rounded-sm border border-[var(--console-border)] bg-white p-1.5 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] lg:inline-flex"
             >
               {sidebarCollapsed ? (

--- a/apps/web/src/hooks/useUiPreferences.test.ts
+++ b/apps/web/src/hooks/useUiPreferences.test.ts
@@ -1,0 +1,117 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LEGACY_SHORTCUT_HINT_STORAGE_KEY,
+  UI_PREFERENCES_STORAGE_KEY,
+  parseUiPreferences,
+  useUiPreferences,
+} from "./useUiPreferences";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useUiPreferences", () => {
+  it("uses defaults on first render", () => {
+    const { result } = renderHook(() => useUiPreferences());
+    expect(result.current.shortcutHintDismissed).toBe(false);
+    expect(result.current.sidebarCollapsed).toBe(false);
+  });
+
+  it("hydrates valid preferences synchronously", () => {
+    window.localStorage.setItem(
+      UI_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        state: { shortcutHintDismissed: true, sidebarCollapsed: true },
+      }),
+    );
+
+    const { result } = renderHook(() => useUiPreferences());
+    expect(result.current.shortcutHintDismissed).toBe(true);
+    expect(result.current.sidebarCollapsed).toBe(true);
+  });
+
+  it("persists semantic actions across hook instances", () => {
+    const first = renderHook(() => useUiPreferences());
+    act(() => {
+      first.result.current.dismissShortcutHint();
+      first.result.current.setSidebarCollapsed(true);
+    });
+    first.unmount();
+
+    const second = renderHook(() => useUiPreferences());
+    expect(second.result.current.shortcutHintDismissed).toBe(true);
+    expect(second.result.current.sidebarCollapsed).toBe(true);
+  });
+
+  it("imports the legacy shortcut preference", () => {
+    window.localStorage.setItem(LEGACY_SHORTCUT_HINT_STORAGE_KEY, "1");
+    const { result } = renderHook(() => useUiPreferences());
+    expect(result.current.shortcutHintDismissed).toBe(true);
+  });
+
+  it.each([
+    "not-json",
+    JSON.stringify({ version: 2, state: {} }),
+    JSON.stringify({
+      version: 1,
+      state: { shortcutHintDismissed: "yes", sidebarCollapsed: false },
+    }),
+  ])("falls back for invalid stored data", (raw) => {
+    window.localStorage.setItem(UI_PREFERENCES_STORAGE_KEY, raw);
+    const { result } = renderHook(() => useUiPreferences());
+    expect(result.current.shortcutHintDismissed).toBe(false);
+    expect(result.current.sidebarCollapsed).toBe(false);
+  });
+
+  it("falls back when storage reads fail", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    const { result } = renderHook(() => useUiPreferences());
+    expect(result.current.shortcutHintDismissed).toBe(false);
+    expect(result.current.sidebarCollapsed).toBe(false);
+  });
+
+  it("keeps in-memory updates when storage writes fail", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("full");
+    });
+    const { result } = renderHook(() => useUiPreferences());
+    act(() => result.current.setSidebarCollapsed(true));
+    expect(result.current.sidebarCollapsed).toBe(true);
+  });
+
+  it("writes only the versioned preference whitelist", () => {
+    const { result } = renderHook(() => useUiPreferences());
+    act(() => result.current.dismissShortcutHint());
+
+    expect(JSON.parse(window.localStorage.getItem(UI_PREFERENCES_STORAGE_KEY)!)).toEqual({
+      version: 1,
+      state: { shortcutHintDismissed: true, sidebarCollapsed: false },
+    });
+  });
+});
+
+describe("parseUiPreferences", () => {
+  it("ignores unrelated persisted fields", () => {
+    expect(
+      parseUiPreferences(
+        JSON.stringify({
+          version: 1,
+          state: {
+            shortcutHintDismissed: true,
+            sidebarCollapsed: false,
+            transientSelection: "session-1",
+          },
+        }),
+      ),
+    ).toEqual({ shortcutHintDismissed: true, sidebarCollapsed: false });
+  });
+});

--- a/apps/web/src/hooks/useUiPreferences.ts
+++ b/apps/web/src/hooks/useUiPreferences.ts
@@ -1,0 +1,113 @@
+import { useCallback, useRef, useState } from "react";
+
+export interface UiPreferences {
+  shortcutHintDismissed: boolean;
+  sidebarCollapsed: boolean;
+}
+
+interface StoredUiPreferences {
+  version: 1;
+  state: UiPreferences;
+}
+
+type UiPreferencesStorage = Pick<Storage, "getItem" | "removeItem" | "setItem">;
+
+export const UI_PREFERENCES_STORAGE_KEY = "codesesh.ui-preferences";
+export const LEGACY_SHORTCUT_HINT_STORAGE_KEY = "codesesh.shortcuts-hint-dismissed";
+
+const DEFAULT_UI_PREFERENCES: UiPreferences = {
+  shortcutHintDismissed: false,
+  sidebarCollapsed: false,
+};
+
+function getBrowserStorage(): UiPreferencesStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function parseUiPreferences(raw: string | null): UiPreferences | null {
+  if (!raw) return null;
+  try {
+    const envelope: unknown = JSON.parse(raw);
+    if (!isRecord(envelope) || envelope.version !== 1 || !isRecord(envelope.state)) return null;
+    const { shortcutHintDismissed, sidebarCollapsed } = envelope.state;
+    if (typeof shortcutHintDismissed !== "boolean" || typeof sidebarCollapsed !== "boolean") {
+      return null;
+    }
+    return { shortcutHintDismissed, sidebarCollapsed };
+  } catch {
+    return null;
+  }
+}
+
+function loadUiPreferences(
+  storage: UiPreferencesStorage | null = getBrowserStorage(),
+): UiPreferences {
+  if (!storage) return DEFAULT_UI_PREFERENCES;
+  try {
+    const raw = storage.getItem(UI_PREFERENCES_STORAGE_KEY);
+    if (raw !== null) return parseUiPreferences(raw) ?? DEFAULT_UI_PREFERENCES;
+    return {
+      ...DEFAULT_UI_PREFERENCES,
+      shortcutHintDismissed: storage.getItem(LEGACY_SHORTCUT_HINT_STORAGE_KEY) === "1",
+    };
+  } catch {
+    return DEFAULT_UI_PREFERENCES;
+  }
+}
+
+function persistUiPreferences(
+  preferences: UiPreferences,
+  storage: UiPreferencesStorage | null = getBrowserStorage(),
+) {
+  if (!storage) return;
+  const envelope: StoredUiPreferences = {
+    version: 1,
+    state: {
+      shortcutHintDismissed: preferences.shortcutHintDismissed,
+      sidebarCollapsed: preferences.sidebarCollapsed,
+    },
+  };
+  try {
+    storage.setItem(UI_PREFERENCES_STORAGE_KEY, JSON.stringify(envelope));
+    storage.removeItem(LEGACY_SHORTCUT_HINT_STORAGE_KEY);
+  } catch {
+    return;
+  }
+}
+
+export function useUiPreferences() {
+  const [preferences, setPreferences] = useState(loadUiPreferences);
+  const preferencesRef = useRef(preferences);
+
+  const updatePreferences = useCallback((next: UiPreferences) => {
+    preferencesRef.current = next;
+    setPreferences(next);
+    persistUiPreferences(next);
+  }, []);
+
+  const dismissShortcutHint = useCallback(() => {
+    updatePreferences({ ...preferencesRef.current, shortcutHintDismissed: true });
+  }, [updatePreferences]);
+
+  const setSidebarCollapsed = useCallback(
+    (sidebarCollapsed: boolean) => {
+      updatePreferences({ ...preferencesRef.current, sidebarCollapsed });
+    },
+    [updatePreferences],
+  );
+
+  return {
+    ...preferences,
+    dismissShortcutHint,
+    setSidebarCollapsed,
+  };
+}

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -18,6 +18,21 @@ test("keeps project navigation aligned with the overview route", async ({ page }
   await expect(projectNavigation).not.toHaveClass(/bg-white/);
 });
 
+test("persists app shell preferences across reloads", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(page.getByRole("button", { name: "Expand sidebar" })).toBeVisible();
+  await page.getByRole("button", { name: "Dismiss keyboard shortcuts hint" }).click();
+
+  await page.reload();
+
+  await expect(page.getByRole("button", { name: "Expand sidebar" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Dismiss keyboard shortcuts hint" })).toHaveCount(
+    0,
+  );
+});
+
 test("covers dashboard, detail, search, projects, and pin flows", async ({ page }) => {
   const consoleErrors: string[] = [];
   page.on("console", (message) => {


### PR DESCRIPTION
## Summary

- add a focused, versioned persistence owner for app shell UI preferences
- hydrate shortcut hint and sidebar preferences synchronously with safe fallbacks
- preserve the legacy shortcut hint preference without adding Zustand
- keep in-memory actions effective when browser storage is unavailable
- cover schema validation, storage failures, whitelisted persistence, and reload behavior

## Validation

- `pnpm --filter @codesesh/web test` (349 tests)
- `pnpm --filter @codesesh/web build`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm test:e2e --project web-chromium` (8 tests)

Issue: CS-69
