### PR TITLE
feat: add core diagnostics channel for silent failures (CS-72)

### DIFF
--- a/packages/cli/src/diagnostics-bridge.ts
+++ b/packages/cli/src/diagnostics-bridge.ts
@@ -1,0 +1,15 @@
+import { setCoreDiagnostics } from "@codesesh/core";
+import { appLogger } from "./logging.js";
+
+/**
+ * Bridges core's diagnostics sink to appLogger. Import this once, for its
+ * side effect, from every entry point that gets its own module graph — the
+ * main CLI thread and each worker_threads script (scan-refresh-worker,
+ * search-index-worker, smart-tag-worker) — since core's module-level
+ * diagnostics singleton is per-thread, not shared across workers.
+ */
+setCoreDiagnostics({
+  warn(event, detail) {
+    appLogger.warn(event, detail);
+  },
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,4 @@
+import "./diagnostics-bridge.js";
 import { defineCommand, runMain } from "citty";
 import { createServer, getServerStartupErrorMessage } from "./server.js";
 import { LiveScanStore } from "./live-scan.js";

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -28,6 +28,8 @@ vi.mock("@codesesh/core", () => ({
   ensureSessionTagsSync: mocks.ensureSessionTagsSync,
   FileSystemSessionSource: mocks.FileSystemSessionSource,
   matchesScanWindow: mocks.matchesScanWindow,
+  // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
+  setCoreDiagnostics: vi.fn(),
 }));
 
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -1,3 +1,4 @@
+import "./diagnostics-bridge.js";
 import { parentPort, workerData } from "node:worker_threads";
 import {
   attachMissingProjectIdentities,

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -29,6 +29,8 @@ vi.mock("@codesesh/core", () => ({
   setFtsIntegrityCheckedPath: mocks.setFtsIntegrityCheckedPath,
   syncSessionSearchIndex: mocks.syncSessionSearchIndex,
   syncSessionSearchIndexChanges: mocks.syncSessionSearchIndexChanges,
+  // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
+  setCoreDiagnostics: vi.fn(),
 }));
 
 function makeAgent() {

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -1,3 +1,4 @@
+import "./diagnostics-bridge.js";
 import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,

--- a/packages/cli/src/smart-tag-worker.test.ts
+++ b/packages/cli/src/smart-tag-worker.test.ts
@@ -19,6 +19,8 @@ vi.mock("@codesesh/core", () => ({
   createRegisteredAgents: mocks.createRegisteredAgents,
   classifySessionTags: mocks.classifySessionTags,
   getSmartTagSourceTimestamp: mocks.getSmartTagSourceTimestamp,
+  // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
+  setCoreDiagnostics: vi.fn(),
 }));
 
 async function runWorker() {

--- a/packages/cli/src/smart-tag-worker.ts
+++ b/packages/cli/src/smart-tag-worker.ts
@@ -1,3 +1,4 @@
+import "./diagnostics-bridge.js";
 import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -5,12 +5,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import { DatabaseSessionSource, FileSystemSessionSource } from "../base.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
 import type { SessionData, SessionHead } from "../../types/index.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 interface FakeSource {
   sessionId: string;
   sourcePath: string;
   fingerprint: string;
   head: SessionHead | null;
+  throws?: boolean;
 }
 
 /**
@@ -49,6 +51,7 @@ class FakeFileSystemSource extends FileSystemSessionSource {
   scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
     this.lastScanOptions = options;
     const found = this.sources.find((s) => s.sourcePath === sourcePath);
+    if (found?.throws) throw new Error("parse failed");
     if (!found || !found.head) return null;
     this.sessionMetaMap.set(found.sessionId, {
       id: found.sessionId,
@@ -116,6 +119,31 @@ describe("FileSystemSessionSource.scan", () => {
       { total: 3, processed: 2, sessions: 1 },
       { total: 3, processed: 3, sessions: 2 },
     ]);
+  });
+
+  it("reports agent.session_parse_failed via diagnostics when a source throws", () => {
+    const agent = new FakeFileSystemSource([
+      source("a"),
+      source("broken", "fp-1", { throws: true }),
+    ]);
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const diagnostics: CoreDiagnostics = {
+      warn: (event, detail) => events.push({ event, detail }),
+    };
+    setCoreDiagnostics(diagnostics);
+
+    try {
+      const sessions = agent.scan();
+      expect(sessions.map((session) => session.id)).toEqual(["a"]);
+      expect(events).toEqual([
+        {
+          event: "agent.session_parse_failed",
+          detail: { agentName: "fake", sourcePath: "/tmp/broken.jsonl", message: "parse failed" },
+        },
+      ]);
+    } finally {
+      setCoreDiagnostics(null);
+    }
   });
 });
 

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,5 +1,6 @@
 import { existsSync, statSync } from "node:fs";
 import type { SessionHead, SessionData, ParseSessionResult } from "../types/index.js";
+import { getCoreDiagnostics } from "../utils/diagnostics.js";
 
 export type { ParseSessionResult };
 
@@ -138,7 +139,12 @@ export abstract class FileSystemSessionSource<
       try {
         const session = this.scanSessionSource(source.sourcePath, options);
         if (session) sessions.push(session);
-      } catch {
+      } catch (error) {
+        getCoreDiagnostics()?.warn("agent.session_parse_failed", {
+          agentName: this.name,
+          sourcePath: source.sourcePath,
+          message: error instanceof Error ? error.message : String(error),
+        });
         continue;
       } finally {
         options?.onProgress?.({

--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../../utils/diagnostics.js";
+import { withCacheDb } from "../schema.js";
+
+const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-diag-test-"));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(() => testHomeDir) };
+});
+
+afterEach(() => {
+  setCoreDiagnostics(null);
+});
+
+function collectDiagnostics(): Array<{ event: string; detail?: Record<string, unknown> }> {
+  const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+  const diagnostics: CoreDiagnostics = {
+    warn: (event, detail) => events.push({ event, detail }),
+  };
+  setCoreDiagnostics(diagnostics);
+  return events;
+}
+
+describe("withCacheDb diagnostics", () => {
+  it("reports cache.write_failed when the callback throws", () => {
+    const events = collectDiagnostics();
+
+    const result = withCacheDb(() => {
+      throw new Error("disk full");
+    });
+
+    expect(result).toBeNull();
+    expect(events).toEqual([{ event: "cache.write_failed", detail: { message: "disk full" } }]);
+  });
+
+  it("stays silent when no diagnostics sink is injected", () => {
+    expect(() =>
+      withCacheDb(() => {
+        throw new Error("boom");
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -5,6 +5,7 @@
 import type { ProjectIdentityKind, SessionHead } from "../../types/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
+import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import {
   columnExists,
   getUserVersion,
@@ -97,7 +98,10 @@ export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
       setSchemaEnsuredPath(cachePath);
     }
     return fn(db);
-  } catch {
+  } catch (error) {
+    getCoreDiagnostics()?.warn("cache.write_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
     return null;
   } finally {
     db.close();

--- a/packages/core/src/utils/__tests__/diagnostics.test.ts
+++ b/packages/core/src/utils/__tests__/diagnostics.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getCoreDiagnostics, setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
+
+afterEach(() => {
+  setCoreDiagnostics(null);
+});
+
+describe("core diagnostics", () => {
+  it("defaults to no injected sink", () => {
+    expect(getCoreDiagnostics()).toBeNull();
+  });
+
+  it("returns a sink that forwards to the injected one until reset", () => {
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    getCoreDiagnostics()?.warn("test.event", { a: 1 });
+    expect(calls).toEqual([{ event: "test.event", detail: { a: 1 } }]);
+
+    setCoreDiagnostics(null);
+    expect(getCoreDiagnostics()).toBeNull();
+  });
+
+  it("swallows exceptions thrown by an injected sink", () => {
+    const sink: CoreDiagnostics = {
+      warn: () => {
+        throw new Error("sink boom");
+      },
+    };
+    setCoreDiagnostics(sink);
+
+    expect(() => getCoreDiagnostics()?.warn("test.event")).not.toThrow();
+  });
+});

--- a/packages/core/src/utils/__tests__/jsonl.test.ts
+++ b/packages/core/src/utils/__tests__/jsonl.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../jsonl.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
 
 function collect<T>(gen: Generator<T>): T[] {
   return Array.from(gen);
@@ -22,7 +23,17 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
+  setCoreDiagnostics(null);
 });
+
+function collectDiagnostics(): Array<{ event: string; detail?: Record<string, unknown> }> {
+  const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+  const diagnostics: CoreDiagnostics = {
+    warn: (event, detail) => events.push({ event, detail }),
+  };
+  setCoreDiagnostics(diagnostics);
+  return events;
+}
 
 describe("parseJsonlLines", () => {
   it("returns empty for empty string", () => {
@@ -48,6 +59,22 @@ describe("parseJsonlLines", () => {
     const input = '{"valid":true}\nnot json\n{"also":true}';
     const result = collect(parseJsonlLines(input));
     expect(result).toEqual([{ valid: true }, { also: true }]);
+  });
+
+  it("reports skipped lines via diagnostics", () => {
+    const events = collectDiagnostics();
+    const input = '{"valid":true}\nnot json\n{"also":true}';
+    collect(parseJsonlLines(input));
+
+    expect(events).toEqual([
+      { event: "agent.jsonl_lines_skipped", detail: { skipped: 1, total: 3 } },
+    ]);
+  });
+
+  it("does not report diagnostics when every line parses", () => {
+    const events = collectDiagnostics();
+    collect(parseJsonlLines('{"a":1}\n{"b":2}'));
+    expect(events).toEqual([]);
   });
 
   it("skips empty lines between valid lines", () => {
@@ -103,5 +130,15 @@ describe("readJsonlFile", () => {
 
   it("throws when file does not exist", () => {
     expect(() => collect(readJsonlFile("/missing.jsonl"))).toThrow();
+  });
+
+  it("reports skipped lines via diagnostics", () => {
+    const events = collectDiagnostics();
+    const filePath = writeTempFile('{"valid":true}\nnot json\n{"also":true}');
+    collect(readJsonlFile(filePath));
+
+    expect(events).toEqual([
+      { event: "agent.jsonl_lines_skipped", detail: { skipped: 1, total: 3, filePath } },
+    ]);
   });
 });

--- a/packages/core/src/utils/__tests__/sqlite-unavailable.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite-unavailable.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
+
+// sqlite.ts loads better-sqlite3 via createRequire at module-evaluation time,
+// before any host has a chance to call setCoreDiagnostics — so simulating an
+// unavailable native module requires faking createRequire itself rather than
+// vi.mock("better-sqlite3"), which only intercepts the ESM graph.
+vi.mock("node:module", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:module")>();
+  return {
+    ...actual,
+    createRequire: (url: string | URL) => {
+      const nodeRequire = actual.createRequire(url);
+      return Object.assign((id: string) => {
+        if (id === "better-sqlite3") {
+          throw new Error("Cannot find module 'better-sqlite3'");
+        }
+        return nodeRequire(id);
+      }, nodeRequire);
+    },
+  };
+});
+
+import { isSqliteAvailable, openDb, openDbReadOnly } from "../sqlite.js";
+
+describe("sqlite unavailable", () => {
+  afterEach(() => {
+    setCoreDiagnostics(null);
+  });
+
+  it("reports sqlite.unavailable once, on the first open attempt after a sink is injected", () => {
+    expect(isSqliteAvailable()).toBe(false);
+
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const diagnostics: CoreDiagnostics = {
+      warn: (event, detail) => events.push({ event, detail }),
+    };
+    setCoreDiagnostics(diagnostics);
+
+    expect(openDb("/tmp/codesesh-sqlite-unavailable-test.db")).toBeNull();
+    expect(openDbReadOnly("/tmp/codesesh-sqlite-unavailable-test.db")).toBeNull();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event).toBe("sqlite.unavailable");
+    expect(events[0]?.detail?.message).toContain("better-sqlite3");
+  });
+});

--- a/packages/core/src/utils/__tests__/sqlite.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite.test.ts
@@ -1,6 +1,15 @@
 import Database from "better-sqlite3";
-import { describe, expect, it } from "vitest";
-import { backupDatabaseIfPopulated, type SQLiteDatabase } from "../sqlite.js";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  backupDatabaseIfPopulated,
+  openDb,
+  openDbReadOnly,
+  type SQLiteDatabase,
+} from "../sqlite.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
 
 describe("sqlite migration helpers", () => {
   it("skips backups for in-memory databases", () => {
@@ -17,5 +26,57 @@ describe("sqlite migration helpers", () => {
     } finally {
       db.close();
     }
+  });
+});
+
+describe("sqlite open failures", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    setCoreDiagnostics(null);
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function collectDiagnostics(): Array<{ event: string; detail?: Record<string, unknown> }> {
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const diagnostics: CoreDiagnostics = {
+      warn: (event, detail) => events.push({ event, detail }),
+    };
+    setCoreDiagnostics(diagnostics);
+    return events;
+  }
+
+  it("reports sqlite.open_failed when the write path can't be created", () => {
+    // A file can't be used as a directory segment, so mkdirSync(dirname(dbPath))
+    // fails and openDb hits its catch branch instead of opening a handle.
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-sqlite-open-test-"));
+    tempDirs.push(dir);
+    const blockerFile = join(dir, "blocker");
+    writeFileSync(blockerFile, "not a directory");
+    const dbPath = join(blockerFile, "sub", "cache.db");
+
+    const events = collectDiagnostics();
+    expect(openDb(dbPath)).toBeNull();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event).toBe("sqlite.open_failed");
+    expect(events[0]?.detail?.dbPath).toBe(dbPath);
+    expect(events[0]?.detail?.readonly).toBe(false);
+  });
+
+  it("reports sqlite.open_failed when a read-only handle can't be opened", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-sqlite-open-test-"));
+    tempDirs.push(dir);
+    const dbPath = join(dir, "missing", "cache.db");
+
+    const events = collectDiagnostics();
+    expect(openDbReadOnly(dbPath)).toBeNull();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event).toBe("sqlite.open_failed");
+    expect(events[0]?.detail?.dbPath).toBe(dbPath);
+    expect(events[0]?.detail?.readonly).toBe(true);
   });
 });

--- a/packages/core/src/utils/diagnostics.ts
+++ b/packages/core/src/utils/diagnostics.ts
@@ -1,0 +1,36 @@
+/**
+ * Injectable diagnostics sink for core's failure paths. core stays
+ * framework-agnostic (no logger dependency); hosts opt in by calling
+ * setCoreDiagnostics once at startup. Default is a silent no-op so core's
+ * behavior is unchanged for consumers that never inject one.
+ */
+
+export interface CoreDiagnostics {
+  warn(event: string, detail?: Record<string, unknown>): void;
+}
+
+let diagnostics: CoreDiagnostics | null = null;
+
+/**
+ * A host-injected sink that throws must not escape into core's own control
+ * flow — e.g. abort a `FileSystemSessionSource.scan` loop or turn a cache
+ * write's `catch { return null }` into an uncaught throw. Wrap once here so
+ * every `diagnostics?.warn(...)` call site stays exception-safe for free.
+ */
+function toSafeSink(sink: CoreDiagnostics): CoreDiagnostics {
+  return {
+    warn(event, detail) {
+      try {
+        sink.warn(event, detail);
+      } catch {}
+    },
+  };
+}
+
+export function setCoreDiagnostics(next: CoreDiagnostics | null): void {
+  diagnostics = next ? toSafeSink(next) : null;
+}
+
+export function getCoreDiagnostics(): CoreDiagnostics | null {
+  return diagnostics;
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { parseJsonlLines, readJsonlFile } from "./jsonl.js";
+export { setCoreDiagnostics, type CoreDiagnostics } from "./diagnostics.js";
 export { basenameTitle, resolveSessionTitle, normalizeTitleText } from "./title-fallback.js";
 export { cleanDisplayText, firstVisibleLine } from "./parse-cleanup.js";
 export { openDb, openDbReadOnly, isSqliteAvailable } from "./sqlite.js";

--- a/packages/core/src/utils/jsonl.ts
+++ b/packages/core/src/utils/jsonl.ts
@@ -1,17 +1,27 @@
 import { closeSync, openSync, readSync } from "node:fs";
 import { StringDecoder } from "node:string_decoder";
+import { getCoreDiagnostics } from "./diagnostics.js";
 
 const READ_CHUNK_BYTES = 1 << 20;
 
 export function* parseJsonlLines(content: string): Generator<Record<string, unknown>> {
+  let total = 0;
+  let skipped = 0;
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
+    total += 1;
     try {
       yield JSON.parse(trimmed) as Record<string, unknown>;
     } catch {
-      // Skip malformed lines
+      skipped += 1;
     }
+  }
+  // Reported after the generator is fully drained — a consumer that breaks
+  // out of the loop early (e.g. to grab just the first line) never reaches
+  // this point, so its skipped count goes unreported.
+  if (skipped > 0) {
+    getCoreDiagnostics()?.warn("agent.jsonl_lines_skipped", { skipped, total });
   }
 }
 
@@ -49,11 +59,18 @@ export function* readJsonlFileLines(
 }
 
 export function* readJsonlFile(filePath: string): Generator<Record<string, unknown>> {
+  let total = 0;
+  let skipped = 0;
   for (const line of readJsonlFileLines(filePath)) {
+    total += 1;
     try {
       yield JSON.parse(line) as Record<string, unknown>;
     } catch {
-      // Skip malformed lines
+      skipped += 1;
     }
+  }
+  // Same early-return caveat as parseJsonlLines above.
+  if (skipped > 0) {
+    getCoreDiagnostics()?.warn("agent.jsonl_lines_skipped", { skipped, total, filePath });
   }
 }

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -5,6 +5,7 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { createRequire } from "node:module";
+import { getCoreDiagnostics } from "./diagnostics.js";
 
 interface SQLiteStatement {
   all(...params: unknown[]): DatabaseRow[];
@@ -26,6 +27,7 @@ type SQLiteDatabaseConstructor = (
 ) => SQLiteDatabase & SQLitePragmaCapable;
 
 let DatabaseConstructor: SQLiteDatabaseConstructor | null = null;
+let loadErrorMessage: string | null = null;
 
 try {
   const require = createRequire(import.meta.url);
@@ -34,8 +36,20 @@ try {
   DatabaseConstructor = (
     typeof mod === "function" ? mod : (mod as { default?: unknown }).default
   ) as SQLiteDatabaseConstructor;
-} catch {
-  // better-sqlite3 not installed — adapters that need SQLite will gracefully skip
+} catch (error) {
+  // better-sqlite3 not installed — adapters that need SQLite will gracefully skip.
+  // This module body evaluates before a host has a chance to call
+  // setCoreDiagnostics, so reporting here would always be dropped — defer the
+  // warn to reportUnavailableOnce(), called from the first actual open attempt.
+  loadErrorMessage = error instanceof Error ? error.message : String(error);
+}
+
+let unavailableReported = false;
+
+function reportUnavailableOnce(): void {
+  if (unavailableReported) return;
+  unavailableReported = true;
+  getCoreDiagnostics()?.warn("sqlite.unavailable", { message: loadErrorMessage });
 }
 
 export interface DatabaseRow {
@@ -195,17 +209,28 @@ export function runSchemaMigrations(
  * Returns null if better-sqlite3 is unavailable or the file can't be opened.
  */
 export function openDbReadOnly(dbPath: string): SQLiteDatabase | null {
-  if (!DatabaseConstructor) return null;
+  if (!DatabaseConstructor) {
+    reportUnavailableOnce();
+    return null;
+  }
   try {
     const db = DatabaseConstructor(dbPath, { readonly: true });
     return db;
-  } catch {
+  } catch (error) {
+    getCoreDiagnostics()?.warn("sqlite.open_failed", {
+      dbPath,
+      readonly: true,
+      message: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }
 
 export function openDb(dbPath: string): SQLiteDatabase | null {
-  if (!DatabaseConstructor) return null;
+  if (!DatabaseConstructor) {
+    reportUnavailableOnce();
+    return null;
+  }
   try {
     mkdirSync(dirname(dbPath), { recursive: true });
     const db = DatabaseConstructor(dbPath);
@@ -217,7 +242,12 @@ export function openDb(dbPath: string): SQLiteDatabase | null {
       // The database remains usable when SQLite rejects connection-level tuning.
     }
     return db;
-  } catch {
+  } catch (error) {
+    getCoreDiagnostics()?.warn("sqlite.open_failed", {
+      dbPath,
+      readonly: false,
+      message: error instanceof Error ? error.message : String(error),
+    });
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Every failure path in `packages/core` was silent: `withCacheDb` swallows all exceptions and returns `null`, session parse failures are skipped without a trace, malformed JSONL lines are dropped, and a missing `better-sqlite3` native module degrades everything invisibly. Diagnosing "sessions quietly disappearing" required code instrumentation.

This PR introduces an injectable diagnostics sink so hosts can observe these failures, while keeping core framework-agnostic (zero dependencies) and leaving every failure path's return/throw behavior unchanged.

## Changes

- **`packages/core/src/utils/diagnostics.ts`** (new): `CoreDiagnostics` interface + `setCoreDiagnostics` module-level injection. Injected sinks are wrapped so a throwing sink can never escape into core's control flow.
- **Instrumented failure points** (report-only, no control-flow changes):
  - `withCacheDb` catch → `cache.write_failed`
  - `openDb`/`openDbReadOnly` failures → `sqlite.open_failed`; native module load failure → `sqlite.unavailable` (deferred to first open attempt, since module evaluation happens before any host can inject a sink)
  - `FileSystemSessionSource.scan` catch → `agent.session_parse_failed` (agentName, sourcePath)
  - JSONL malformed lines → aggregated `agent.jsonl_lines_skipped` (skipped/total, reported when the generator drains)
- **`packages/cli/src/diagnostics-bridge.ts`** (new): bridges the sink to `appLogger.warn`. Imported by the main CLI entry **and each worker_threads entry** (scan-refresh, search-index, smart-tag) — the singleton is per-module-graph, so each worker needs its own bridge.

## Testing

- New unit tests: sink injection/safety, JSONL skipped-line reporting, `sqlite.open_failed`/`sqlite.unavailable` reporting, `agent.session_parse_failed` reporting
- `pnpm build` / `pnpm test` (5 tasks, all green: core 374, cli 196, web 349) / `pnpm lint` clean

Issue: CS-72