### PR TITLE
fix: eliminate state.db write amplification and add busy_timeout (CS-71)

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
@@ -1,6 +1,49 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-project-groups-test-"));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return {
+    ...actual,
+    homedir: vi.fn(() => testHomeDir),
+  };
+});
+
+// Wrap (not replace) withCacheDb so the writable-fallback path is still
+// exercised for real, while letting the test assert whether it ran.
+vi.mock("../schema.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../schema.js")>();
+  return { ...actual, withCacheDb: vi.fn(actual.withCacheDb) };
+});
+
 import { listCachedProjectGroups } from "../project-groups.js";
-import { makeSessionHead } from "./fixtures.js";
+import { saveCachedSessions } from "../../cache.js";
+import { withCacheDb } from "../schema.js";
+import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
+import { makeSessionHead, TEST_NOW } from "./fixtures.js";
+
+const mockedWithCacheDb = vi.mocked(withCacheDb);
+
+function getCacheDir(): string {
+  return join(testHomeDir, ".cache", "codesesh");
+}
+
+beforeEach(() => {
+  rmSync(getCacheDir(), { recursive: true, force: true });
+  setSchemaEnsuredPath(null);
+  setFtsIntegrityCheckedPath(null);
+  mockedWithCacheDb.mockClear();
+});
+
+afterEach(() => {
+  rmSync(getCacheDir(), { recursive: true, force: true });
+  setSchemaEnsuredPath(null);
+  setFtsIntegrityCheckedPath(null);
+});
 
 describe("cached project groups", () => {
   it("groups an explicit session set without opening cache storage", () => {
@@ -30,5 +73,25 @@ describe("cached project groups", () => {
         lastActivity: 1_700_000_000_001,
       },
     ]);
+    expect(mockedWithCacheDb).not.toHaveBeenCalled();
+  });
+
+  it("reads existing cache data through the read-only connection", () => {
+    saveCachedSessions("codex", [makeSessionHead("one")]);
+    mockedWithCacheDb.mockClear();
+
+    const groups = listCachedProjectGroups();
+
+    expect(groups).toEqual([
+      {
+        identityKind: "path",
+        identityKey: "/workspace/project",
+        displayName: "project",
+        sources: ["codex"],
+        sessionCount: 1,
+        lastActivity: TEST_NOW + 1,
+      },
+    ]);
+    expect(mockedWithCacheDb).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -1329,6 +1329,14 @@ describe("searchSessions", () => {
     }
     setSchemaEnsuredPath(null);
 
+    // loadCachedSessions opens the writable connection, so it's what actually
+    // runs the pending migration; listCachedProjectGroups now reads through
+    // the read-only connection and must not trigger migrations itself.
+    expect(loadCachedSessions("codex")?.sessions[0]?.project_identity).toEqual({
+      kind: "synthetic",
+      key: "codex:scratch",
+      displayName: "Chats",
+    });
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "synthetic",
@@ -1339,11 +1347,6 @@ describe("searchSessions", () => {
         lastActivity: now,
       },
     ]);
-    expect(loadCachedSessions("codex")?.sessions[0]?.project_identity).toEqual({
-      kind: "synthetic",
-      key: "codex:scratch",
-      displayName: "Chats",
-    });
   });
 
   it("combines full text with structured filters", () => {

--- a/packages/core/src/discovery/cache/project-groups.ts
+++ b/packages/core/src/discovery/cache/project-groups.ts
@@ -4,9 +4,9 @@
  */
 import type { ProjectGroup, ProjectIdentityKind, SessionHead } from "../../types/index.js";
 import { buildProjectGroups } from "../../projects/index.js";
-import type { DatabaseRow } from "../../utils/sqlite.js";
+import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { hasCacheStorage } from "./db.js";
-import { withCacheDb } from "./schema.js";
+import { withCacheDb, withCacheDbReadOnly } from "./schema.js";
 
 export interface ProjectGroupRow extends DatabaseRow {
   identity_kind?: ProjectIdentityKind;
@@ -26,8 +26,8 @@ export function listCachedProjectGroups(sessions?: SessionHead[]): ProjectGroup[
     return [];
   }
 
-  const groups = withCacheDb((db) => {
-    const rows = db
+  const queryRows = (db: SQLiteDatabase) =>
+    db
       .prepare(
         `
           SELECT identity_kind, identity_key, display_name, sources_csv, session_count, last_activity
@@ -40,18 +40,20 @@ export function listCachedProjectGroups(sessions?: SessionHead[]): ProjectGroup[
       )
       .all() as ProjectGroupRow[];
 
-    return rows.map((row) => ({
-      identityKind: row.identity_kind ?? "path",
-      identityKey: String(row.identity_key ?? ""),
-      displayName: String(row.display_name ?? ""),
-      sources: String(row.sources_csv ?? "")
-        .split(",")
-        .filter(Boolean)
-        .sort(),
-      sessionCount: Number(row.session_count ?? 0),
-      lastActivity: row.last_activity == null ? null : Number(row.last_activity),
-    }));
-  });
+  let rows = withCacheDbReadOnly(queryRows);
+  if (rows == null) {
+    rows = withCacheDb(queryRows);
+  }
 
-  return groups ?? [];
+  return (rows ?? []).map((row) => ({
+    identityKind: row.identity_kind ?? "path",
+    identityKey: String(row.identity_key ?? ""),
+    displayName: String(row.display_name ?? ""),
+    sources: String(row.sources_csv ?? "")
+      .split(",")
+      .filter(Boolean)
+      .sort(),
+    sessionCount: Number(row.session_count ?? 0),
+    lastActivity: row.last_activity == null ? null : Number(row.last_activity),
+  }));
 }

--- a/packages/core/src/state/__tests__/bookmarks.test.ts
+++ b/packages/core/src/state/__tests__/bookmarks.test.ts
@@ -10,6 +10,7 @@ import {
   upsertBookmark,
   type BookmarkRecord,
 } from "../bookmarks.js";
+import { setStateSchemaEnsuredPath } from "../database.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-bookmarks-test-"));
 
@@ -64,12 +65,14 @@ function makeBookmark(
 
 beforeEach(() => {
   rmSync(getStateDir(), { recursive: true, force: true });
+  setStateSchemaEnsuredPath(null);
   dateNowSpy.mockReturnValue(now);
 });
 
 afterEach(() => {
   rmSync(join(testHomeDir, "custom-state"), { recursive: true, force: true });
   vi.unstubAllEnvs();
+  setStateSchemaEnsuredPath(null);
   rmSync(getStateDir(), { recursive: true, force: true });
 });
 
@@ -156,6 +159,9 @@ describe("bookmarks state storage", () => {
       db.close();
     }
 
+    // Force ensureSchema to re-run against the externally rewritten file,
+    // as a fresh process would on its first open.
+    setStateSchemaEnsuredPath(null);
     expect(listBookmarks()[0]?.sessionId).toBe("s1");
     expect(getUserVersion(getStatePath())).toBe(2);
   });
@@ -169,6 +175,7 @@ describe("bookmarks state storage", () => {
       db.close();
     }
 
+    setStateSchemaEnsuredPath(null);
     expect(listBookmarks()[0]?.sessionId).toBe("s1");
     expect(getUserVersion(getStatePath())).toBe(3);
   });

--- a/packages/core/src/state/__tests__/database.test.ts
+++ b/packages/core/src/state/__tests__/database.test.ts
@@ -1,8 +1,14 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useMemoryStateStore, withStateDb } from "../database.js";
+import {
+  getStateSchemaEnsuredPath,
+  setStateSchemaEnsuredPath,
+  useMemoryStateStore,
+  withStateDb,
+} from "../database.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-state-database-test-"));
 
@@ -15,8 +21,22 @@ vi.mock("node:os", async (importOriginal) => {
   };
 });
 
+function getStatePath(): string {
+  return join(testHomeDir, ".local", "share", "codesesh", "state.db");
+}
+
+function getUserVersion(dbPath: string): number {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return Number(db.pragma("user_version", { simple: true }));
+  } finally {
+    db.close();
+  }
+}
+
 afterEach(() => {
   vi.unstubAllEnvs();
+  setStateSchemaEnsuredPath(null);
   rmSync(join(testHomeDir, ".local"), { recursive: true, force: true });
 });
 
@@ -36,5 +56,24 @@ describe("state database", () => {
     expect(useMemoryStateStore()).toBe(false);
     vi.stubEnv("CODESESH_STATE_STORE", "memory");
     expect(useMemoryStateStore()).toBe(true);
+  });
+
+  it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
+    withStateDb(() => undefined);
+    expect(getStateSchemaEnsuredPath()).toBe(getStatePath());
+    expect(getUserVersion(getStatePath())).toBe(2);
+
+    // Downgrade the on-disk version to prove the next open leaves it alone:
+    // if ensureSchema ran, it would migrate this back up to 2.
+    const db = new Database(getStatePath());
+    db.pragma("user_version = 1");
+    db.close();
+
+    withStateDb(() => undefined);
+    expect(getUserVersion(getStatePath())).toBe(1);
+
+    setStateSchemaEnsuredPath(null);
+    withStateDb(() => undefined);
+    expect(getUserVersion(getStatePath())).toBe(2);
   });
 });

--- a/packages/core/src/state/__tests__/session-aliases.test.ts
+++ b/packages/core/src/state/__tests__/session-aliases.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { deleteSessionAlias, listSessionAliases, upsertSessionAlias } from "../session-aliases.js";
+import { setStateSchemaEnsuredPath } from "../database.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-aliases-test-"));
 
@@ -17,12 +18,14 @@ vi.mock("node:os", async (importOriginal) => {
 
 beforeEach(() => {
   rmSync(join(testHomeDir, ".local"), { recursive: true, force: true });
+  setStateSchemaEnsuredPath(null);
   vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
+  setStateSchemaEnsuredPath(null);
   rmSync(join(testHomeDir, ".local"), { recursive: true, force: true });
 });
 

--- a/packages/core/src/state/database.ts
+++ b/packages/core/src/state/database.ts
@@ -15,6 +15,19 @@ const STATE_DB_FILENAME = "state.db";
 const STATE_SCHEMA_VERSION = 2;
 const MEMORY_STATE_STORE = "memory";
 
+// One-shot per-process ensureSchema guard, mirroring the cache side's
+// schemaEnsuredPath (discovery/cache/db.ts). Keyed by dbPath so tests can
+// switch state directories; exported so tests can reset it between runs.
+let stateSchemaEnsuredPath: string | null = null;
+
+export function getStateSchemaEnsuredPath(): string | null {
+  return stateSchemaEnsuredPath;
+}
+
+export function setStateSchemaEnsuredPath(path: string | null): void {
+  stateSchemaEnsuredPath = path;
+}
+
 export class StateStorageUnavailableError extends Error {
   constructor() {
     super("SQLite state database is unavailable");
@@ -144,7 +157,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
     ],
   });
 
-  if (currentVersion <= STATE_SCHEMA_VERSION) {
+  if (currentVersion < STATE_SCHEMA_VERSION) {
     setStateSchemaVersion(db);
   }
 }
@@ -155,7 +168,10 @@ export function withStateDb<T>(fn: (db: SQLiteDatabase) => T): T {
   if (!db) throw new StateStorageUnavailableError();
 
   try {
-    ensureSchema(db, statePath);
+    if (getStateSchemaEnsuredPath() !== statePath) {
+      ensureSchema(db, statePath);
+      setStateSchemaEnsuredPath(statePath);
+    }
     return fn(db);
   } finally {
     db.close();

--- a/packages/core/src/utils/__tests__/sqlite.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite.test.ts
@@ -29,6 +29,31 @@ describe("sqlite migration helpers", () => {
   });
 });
 
+describe("openDb pragmas", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("sets a busy_timeout so lock contention waits instead of failing immediately", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-sqlite-busy-timeout-test-"));
+    tempDirs.push(dir);
+    const dbPath = join(dir, "state.db");
+
+    const db = openDb(dbPath);
+    expect(db).not.toBeNull();
+    try {
+      const pragmaCapable = db as unknown as { pragma(sql: string): unknown };
+      expect(pragmaCapable.pragma("busy_timeout")).toEqual([{ timeout: 5000 }]);
+    } finally {
+      db?.close();
+    }
+  });
+});
+
 describe("sqlite open failures", () => {
   const tempDirs: string[] = [];
 

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -238,6 +238,7 @@ export function openDb(dbPath: string): SQLiteDatabase | null {
       db.pragma("journal_mode = WAL");
       db.pragma("synchronous = NORMAL");
       db.pragma("foreign_keys = ON");
+      db.pragma("busy_timeout = 5000");
     } catch {
       // The database remains usable when SQLite rejects connection-level tuning.
     }


### PR DESCRIPTION
## Summary

Three compounding SQLite connection-layer issues:

1. **state.db wrote on every open**: `ensureSchema` used `currentVersion <= STATE_SCHEMA_VERSION` — always true — so every `withStateDb` re-ran `CREATE TABLE` + `PRAGMA user_version` + an `INSERT`. Since `loadSessionAliasMap()` runs in nearly every API handler, **every read-only API request took a write transaction** on state.db.
2. **No `busy_timeout`**: better-sqlite3 throws `SQLITE_BUSY` immediately under lock contention instead of waiting. cache.db is written concurrently by the search-index worker and the main thread.
3. **Pure reads on a writable connection**: `listCachedProjectGroups` (called per `/api/projects` request) opened cache.db read-write, enlarging the contention surface with the index worker.

## Changes

- `state/database.ts`: fix the version comparison to `<` and add a per-process `stateSchemaEnsuredPath` once-guard, mirroring the cache side's existing `schemaEnsuredPath` pattern (guard set only after `ensureSchema` succeeds, so failures retry).
- `utils/sqlite.ts`: add `busy_timeout = 5000` to `openDb`'s pragma set.
- `discovery/cache/project-groups.ts`: query via `withCacheDbReadOnly` first, falling back to `withCacheDb` only when the read-only path returns null (cold start before the schema exists), following the existing `file-activity.ts` pattern.

## Testing

- New tests: second `withStateDb` open performs no schema writes; `busy_timeout` pragma is applied; project-groups reads take the read-only path when cache exists.
- One existing test (`search-integration.test.ts`) relied on `listCachedProjectGroups` *implicitly* triggering schema migration via its former write path — exactly the side effect this PR removes. Reordered to migrate via `loadCachedSessions` first, then assert the read-only path sees migrated data.
- `pnpm build` / `pnpm test` (core 377, cli 196, web 349 — all green) / `pnpm lint` clean

Issue: CS-71