### PR TITLE
perf: eliminate redundant enumeration, stat and parse in scan hot path (CS-75)

### DIFF
--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -516,7 +516,9 @@ export class AgentSyncEngine {
     const preciseChangedIds = checkResult.changedIds ?? null;
     const scanStartedAt = performance.now();
     const sessions = attachMissingProjectIdentities(
-      await Promise.resolve(agent.incrementalScan(baseline, checkResult.changedIds ?? [])),
+      await Promise.resolve(
+        agent.incrementalScan(baseline, checkResult.changedIds ?? [], checkResult.refs),
+      ),
     );
     return this.refreshStrategyResult(sessions, {
       preciseChangedIds,

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1037,7 +1037,7 @@ describe("LiveScanStore", () => {
     await vi.advanceTimersByTimeAsync(250);
 
     expect(codex.checkForChanges).toHaveBeenCalledWith(1000, [old, recent]);
-    expect(codex.incrementalScan).toHaveBeenCalledWith([old, recent], ["old"]);
+    expect(codex.incrementalScan).toHaveBeenCalledWith([old, recent], ["old"], undefined);
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent", "old"]);
     expect(events).toEqual([]);
     expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
@@ -1247,10 +1247,11 @@ describe("LiveScanStore", () => {
     await vi.advanceTimersByTimeAsync(250);
 
     expect(codex.checkForChanges).toHaveBeenCalledWith(expect.any(Number), [previous]);
-    expect(codex.incrementalScan).toHaveBeenCalledWith(previous ? [previous] : [], [
-      "session",
-      "added",
-    ]);
+    expect(codex.incrementalScan).toHaveBeenCalledWith(
+      previous ? [previous] : [],
+      ["session", "added"],
+      undefined,
+    );
     expect(core.saveCachedSessions).not.toHaveBeenCalled();
     expect(core.saveCachedSessionChanges).not.toHaveBeenCalled();
     expect(core.syncSessionSearchIndex).not.toHaveBeenCalled();

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DatabaseSessionSource, FileSystemSessionSource } from "../base.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
 import type { SessionData, SessionHead } from "../../types/index.js";
@@ -212,6 +212,15 @@ describe("FileSystemSessionSource.checkForChanges", () => {
     expect(result.hasChanges).toBe(true);
     expect(result.changedIds).toEqual(["a"]);
   });
+
+  it("returns refs matching the listSessionSources enumeration", () => {
+    const agent = new FakeFileSystemSource([source("a"), source("b")]);
+    agent.scanSessionSource("/tmp/a.jsonl");
+    agent.scanSessionSource("/tmp/b.jsonl");
+
+    const result = agent.checkForChanges(Date.now(), [makeSession("a"), makeSession("b")]);
+    expect(result.refs).toEqual(agent.listSessionSources());
+  });
 });
 
 describe("FileSystemSessionSource.incrementalScan", () => {
@@ -237,6 +246,24 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     const updated = agent.incrementalScan([makeSession("a"), makeSession("b")], ["b"]);
     expect(updated.map((s) => s.id)).toEqual(["a"]);
     expect(agent.getSessionMetaMap().has("b")).toBe(false);
+  });
+
+  it("skips listSessionSources when refs are passed explicitly, matching the fallback result", () => {
+    const agent = new FakeFileSystemSource([
+      source("a", "fp-1", { head: makeSession("a") }),
+      source("b", "fp-1", { head: null }),
+    ]);
+    const cached = [makeSession("a"), makeSession("b")];
+    const changedIds = ["a", "b"];
+    const refs = agent.listSessionSources();
+
+    const fallback = agent.incrementalScan(cached, changedIds);
+
+    const listSpy = vi.spyOn(agent, "listSessionSources");
+    const withRefs = agent.incrementalScan(cached, changedIds, refs);
+
+    expect(listSpy).toHaveBeenCalledTimes(0);
+    expect(withRefs.map((s) => s.id).sort()).toEqual(fallback.map((s) => s.id).sort());
   });
 });
 

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -1,9 +1,16 @@
-import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClaudeCodeAgent } from "../claudecode.js";
 import type { Message, MessagePart, SessionHead } from "../../types/index.js";
+
+// Spies on statSync while delegating to the real implementation, so the
+// single-stat regression test can count per-file calls during a live scan.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, statSync: vi.fn(actual.statSync) };
+});
 
 let tempDirs: string[] = [];
 
@@ -105,6 +112,30 @@ describe("ClaudeCodeAgent cache refresh", () => {
 
     const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
     expect(windowed.map((ref: { sessionId: string }) => ref.sessionId)).toEqual(["new-session"]);
+  });
+
+  it("stats each session file at most once per listSessionSources call", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-stat-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    mkdirSync(projectDir, { recursive: true });
+
+    const files = ["session-a.jsonl", "session-b.jsonl", "session-c.jsonl"].map((name) =>
+      join(projectDir, name),
+    );
+    for (const file of files) writeFileSync(file, "");
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    const statSpy = vi.mocked(statSync);
+    statSpy.mockClear();
+    agent.listSessionSources();
+
+    for (const file of files) {
+      const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
+      expect(callsForFile.length).toBe(1);
+    }
   });
 
   it("parses indexed sessions with assistant tools and tool results", () => {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -5,6 +5,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CodexAgent } from "../codex.js";
 import type { Message, MessagePart, SessionHead } from "../../types/index.js";
 
+// Spies on statSync while delegating to the real implementation, so the
+// single-stat regression test can count per-file calls during a live scan.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, statSync: vi.fn(actual.statSync) };
+});
+
 let tempDirs: string[] = [];
 
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
@@ -64,7 +71,10 @@ describe("CodexAgent cache refresh", () => {
         },
       ],
     ]);
-    agent.listRolloutFiles = () => [oldA, newC];
+    agent.listRolloutFiles = () => [
+      { file: oldA, stat: statSync(oldA) },
+      { file: newC, stat: statSync(newC) },
+    ];
 
     const result = agent.checkForChanges(Date.now(), [
       makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
@@ -159,6 +169,36 @@ describe("CodexAgent cache refresh", () => {
     expect(windowed.map((ref: { sourcePath: string }) => ref.sourcePath)).toEqual([newFile]);
   });
 
+  it("stats each rollout file at most once per listSessionSources call", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+
+    const sessionIds = [
+      "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
+      "019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb",
+      "019dcccc-cccc-7ccc-cccc-cccccccccccc",
+    ];
+    const files = sessionIds.map((id) => join(tempDir, `rollout-2026-04-20T10-00-00-${id}.jsonl`));
+    for (const file of files) {
+      writeFileSync(
+        file,
+        '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
+      );
+    }
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+
+    const statSpy = vi.mocked(statSync);
+    statSpy.mockClear();
+    agent.listSessionSources();
+
+    for (const file of files) {
+      const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
+      expect(callsForFile.length).toBe(1);
+    }
+  });
+
   it("uses per-session Codex titles in source fingerprints", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     tempDirs.push(tempDir);
@@ -230,7 +270,7 @@ describe("CodexAgent cache refresh", () => {
         },
       ],
     ]);
-    agent.listRolloutFiles = () => [sessionFile];
+    agent.listRolloutFiles = () => [{ file: sessionFile, stat: statSync(sessionFile) }];
 
     const result = agent.checkForChanges(Date.now(), [
       makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -1,9 +1,16 @@
-import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PiAgent } from "../pi.js";
 import type { MessagePart } from "../../types/index.js";
+
+// Spies on statSync while delegating to the real implementation, so the
+// single-stat regression test can count per-file calls during a live scan.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, statSync: vi.fn(actual.statSync) };
+});
 
 let tempDirs: string[] = [];
 
@@ -162,6 +169,32 @@ describe("PiAgent", () => {
 
     const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
     expect(windowed.map((ref) => ref.sourcePath)).toEqual([newFile]);
+  });
+
+  it("stats each session file at most once per listSessionSources call", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
+    tempDirs.push(tempDir);
+    const piHome = join(tempDir, ".pi");
+    const sessionsDir = join(piHome, "agent", "sessions", "--tmp-project--");
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("PI_HOME", piHome);
+
+    const files = ["a", "b", "c"].map((name) =>
+      join(sessionsDir, `2026-04-20T10-00-00_${name}.jsonl`),
+    );
+    for (const file of files) writeFileSync(file, "");
+
+    const agent = new PiAgent();
+    agent.isAvailable();
+
+    const statSpy = vi.mocked(statSync);
+    statSpy.mockClear();
+    agent.listSessionSources();
+
+    for (const file of files) {
+      const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
+      expect(callsForFile.length).toBe(1);
+    }
   });
 
   it("uses session names and parses assistant tools on the selected leaf", () => {

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -53,6 +53,8 @@ export interface ChangeCheckResult {
   changedIds?: string[];
   /** 检测时间戳 */
   timestamp: number;
+  /** 检测过程中已枚举的会话源（可选），供 incrementalScan 复用以避免二次枚举 */
+  refs?: SessionSourceRef[];
 }
 
 export interface SessionSourceRef {
@@ -94,6 +96,7 @@ export abstract class BaseAgent {
   abstract incrementalScan(
     cachedSessions: SessionHead[],
     changedIds: string[],
+    refs?: SessionSourceRef[],
   ): Promise<SessionHead[]> | SessionHead[];
 
   /** Get session metadata for caching. */
@@ -192,19 +195,25 @@ export abstract class FileSystemSessionSource<
       hasChanges: changedIdList.length > 0,
       changedIds: changedIdList,
       timestamp: Date.now(),
+      refs: currentRefs,
     };
   }
 
   /**
    * 增量扫描：对变更/新增源调用 scanSessionSource 重解析，
    * 删除已消失的源，合并回 cachedSessions。
+   * refs 未传时回退为自行枚举，供独立调用方（如测试）沿用旧行为。
    */
-  incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
+  incrementalScan(
+    cachedSessions: SessionHead[],
+    changedIds: string[],
+    refs?: SessionSourceRef[],
+  ): SessionHead[] {
     const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
     const changedSet = new Set(changedIds);
     const currentIds = new Set<string>();
 
-    for (const ref of this.listSessionSources()) {
+    for (const ref of refs ?? this.listSessionSources()) {
       currentIds.add(ref.sessionId);
       if (!changedSet.has(ref.sessionId)) continue;
       const head = this.scanSessionSource(ref.sourcePath);

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, type Stats } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import {
   FileSystemSessionSource,
@@ -114,17 +114,20 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     if (!this.basePath) return [];
     const refs: SessionSourceRef[] = [];
     for (const projectDir of this.listProjectDirs()) {
+      const indexPath = this.getSessionsIndexPath(projectDir);
       for (const file of this.listJsonlFiles(projectDir)) {
+        let stat: Stats;
         try {
-          if (!matchesScanWindow(statSync(file).mtimeMs, options)) continue;
+          stat = statSync(file);
         } catch {
           continue;
         }
+        if (!matchesScanWindow(stat.mtimeMs, options)) continue;
         const sessionId = basename(file, ".jsonl");
         refs.push({
           sessionId,
           sourcePath: file,
-          fingerprint: this.sourceFingerprint(file, projectDir),
+          fingerprint: this.sourceFingerprint(stat, indexPath),
         });
       }
     }
@@ -201,12 +204,13 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
   private buildSessionMeta(head: SessionHead, file: string, projectDir: string): SessionMeta {
     const indexPath = this.getSessionsIndexPath(projectDir);
+    const stat = statSync(file);
     return {
       id: head.id,
       title: head.title,
       sourcePath: file,
-      sourceFingerprint: this.sourceFingerprint(file, projectDir),
-      sourceMtimeMs: statSync(file).mtimeMs,
+      sourceFingerprint: this.sourceFingerprint(stat, indexPath),
+      sourceMtimeMs: stat.mtimeMs,
       indexPath: existsSync(indexPath) ? indexPath : null,
       indexMtimeMs: this.getFileMtimeMs(indexPath),
       headIndexVersion: HEAD_INDEX_VERSION,
@@ -218,9 +222,8 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     };
   }
 
-  private sourceFingerprint(file: string, projectDir: string): string {
-    const stat = statSync(file);
-    const indexPath = this.getSessionsIndexPath(projectDir);
+  /** Fingerprint depends on an already-fetched stat to avoid re-statting the same file. */
+  private sourceFingerprint(stat: { mtimeMs: number; size: number }, indexPath: string): string {
     return JSON.stringify([
       HEAD_INDEX_VERSION,
       stat.mtimeMs,
@@ -315,8 +318,9 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     let totalCost = 0;
     const modelUsageMap: Record<string, number> = {};
     const countedUsageKeys = new Set<string>();
+    let messageTitle: string | null = null;
 
-    for (const line of lines) {
+    for (const [lineIndex, line] of lines.entries()) {
       try {
         const data = JSON.parse(line);
         if (isInternalEventType(data["type"])) continue;
@@ -336,6 +340,14 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
           if (!model) {
             const m = (msg as Record<string, unknown>)["model"];
             if (typeof m === "string" && m.trim()) model = m.trim();
+          }
+          // Title fallback mirrors the removed extractTitle(): first non-empty
+          // visible user text within the first 20 lines.
+          if (messageTitle === null && lineIndex < 20 && role === "user") {
+            const candidate = this.extractUserMessageTitle(
+              (msg as Record<string, unknown>)["content"],
+            );
+            if (candidate) messageTitle = candidate;
           }
           if (role === "assistant") {
             const usage = extractClaudeUsage(data, msg as Record<string, unknown>);
@@ -373,9 +385,6 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     }
 
     const directory = cwd ?? projectDir;
-
-    // Extract first user message as fallback title
-    const messageTitle = this.extractTitle(lines);
     const directoryTitle = basenameTitle(directory) || basenameTitle(projectDir);
 
     const title = resolveSessionTitle(explicitTitle, messageTitle, directoryTitle);
@@ -403,33 +412,21 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     });
   }
 
-  private extractTitle(lines: string[]): string | null {
-    for (const line of lines.slice(0, 20)) {
-      try {
-        const data = JSON.parse(line);
-        if (isInternalEventType(data["type"])) continue;
-        const msg = data["message"];
-        if (!msg || typeof msg !== "object") continue;
-        if ((msg as Record<string, unknown>)["role"] !== "user") continue;
+  /** Mirrors the title-candidate extraction previously done in a second JSON.parse pass. */
+  private extractUserMessageTitle(content: unknown): string | null {
+    if (!content) return null;
 
-        const content = (msg as Record<string, unknown>)["content"];
-        if (!content) continue;
-
-        if (typeof content === "string") {
-          const title = normalizeTitleText(content);
-          if (title) return title;
-        }
-        if (Array.isArray(content)) {
-          const texts = content
-            .filter((item) => typeof item === "object" && item !== null && "text" in item)
-            .map((item) => String((item as Record<string, unknown>)["text"] ?? ""))
-            .join(" ");
-          const title = normalizeTitleText(texts);
-          if (title) return title;
-        }
-      } catch {
-        // skip
-      }
+    if (typeof content === "string") {
+      const title = normalizeTitleText(content);
+      return title || null;
+    }
+    if (Array.isArray(content)) {
+      const texts = content
+        .filter((item) => typeof item === "object" && item !== null && "text" in item)
+        .map((item) => String((item as Record<string, unknown>)["text"] ?? ""))
+        .join(" ");
+      const title = normalizeTitleText(texts);
+      return title || null;
     }
     return null;
   }

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -6,6 +6,7 @@ import {
   readSync,
   readdirSync,
   statSync,
+  type Stats,
 } from "node:fs";
 import { join, basename } from "node:path";
 import {
@@ -340,10 +341,10 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
     this.loadSessionIndex();
-    return this.listRolloutFiles(options).map((file) => ({
+    return this.listRolloutFiles(options).map(({ file, stat }) => ({
       sessionId: extractSessionId(file),
       sourcePath: file,
-      fingerprint: this.sourceFingerprint(file),
+      fingerprint: this.sourceFingerprint(file, stat),
     }));
   }
 
@@ -478,7 +479,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
   // ---- File listing ----
 
-  private listRolloutFiles(options?: AgentScanOptions): string[] {
+  private listRolloutFiles(options?: AgentScanOptions): { file: string; stat: Stats }[] {
     if (!this.basePath) return [];
     try {
       return this.walkDirForRolloutFiles(this.basePath, options);
@@ -487,22 +488,26 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     }
   }
 
-  private walkDirForRolloutFiles(dir: string, options?: AgentScanOptions): string[] {
-    const files: string[] = [];
+  /** Stats each rollout file once during the walk; caller reuses it for the scan window check and the fingerprint. */
+  private walkDirForRolloutFiles(
+    dir: string,
+    options?: AgentScanOptions,
+  ): { file: string; stat: Stats }[] {
+    const files: { file: string; stat: Stats }[] = [];
     try {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const fullPath = join(dir, entry.name);
         if (entry.isDirectory()) {
           files.push(...this.walkDirForRolloutFiles(fullPath, options));
         } else if (entry.name.endsWith(".jsonl") && entry.name.startsWith("rollout-")) {
-          if (options?.from != null || options?.to != null) {
-            try {
-              if (!matchesScanWindow(statSync(fullPath).mtimeMs, options)) continue;
-            } catch {
-              continue;
-            }
+          let stat: Stats;
+          try {
+            stat = statSync(fullPath);
+          } catch {
+            continue;
           }
-          files.push(fullPath);
+          if (!matchesScanWindow(stat.mtimeMs, options)) continue;
+          files.push({ file: fullPath, stat });
         }
       }
     } catch {
@@ -513,12 +518,13 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
   private buildSessionMeta(head: SessionHead, file: string): SessionMeta {
     const indexPath = this.getSessionIndexPath();
+    const stat = statSync(file);
     return {
       id: head.id,
       title: head.title,
       sourcePath: file,
-      sourceFingerprint: this.sourceFingerprint(file),
-      sourceMtimeMs: statSync(file).mtimeMs,
+      sourceFingerprint: this.sourceFingerprint(file, stat),
+      sourceMtimeMs: stat.mtimeMs,
       indexPath: existsSync(indexPath) ? indexPath : null,
       indexMtimeMs: this.getFileMtimeMs(indexPath),
       headIndexVersion: HEAD_INDEX_VERSION,
@@ -531,8 +537,8 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     };
   }
 
-  private sourceFingerprint(file: string): string {
-    const stat = statSync(file);
+  /** Fingerprint depends on an already-fetched stat to avoid re-statting the same file. */
+  private sourceFingerprint(file: string, stat: { mtimeMs: number; size: number }): string {
     const sessionId = extractSessionId(file);
     return JSON.stringify([
       HEAD_INDEX_VERSION,
@@ -619,10 +625,10 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     let firstPayload: Record<string, unknown> = {};
     let createdAt = 0;
     let lineCount = 0;
-    const titleLines: string[] = [];
+    let messageTitle: string | null = null;
 
-    // Single streaming pass: read the first record, buffer title candidates,
-    // count messages, extract models, and pre-accumulate tokens.
+    // Single streaming pass: read the first record, extract the title
+    // candidate, count messages, extract models, and pre-accumulate tokens.
     let updatedAt = 0;
     let messageCount = 0;
     let model: string | null = null;
@@ -659,7 +665,6 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
           statSync(filePath).mtimeMs;
         updatedAt = createdAt;
       }
-      if (titleLines.length < 20) titleLines.push(line);
 
       try {
         const data = JSON.parse(line);
@@ -672,6 +677,13 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
           parseTimestampMs(data) ||
           parseTimestampMs((data["payload"] ?? {}) as Record<string, unknown>);
         if (recordTs > updatedAt) updatedAt = recordTs;
+
+        // Title fallback mirrors the removed extractTitleFromLines(): first
+        // visible user message within the first 20 lines.
+        if (messageTitle === null && lineCount <= 20) {
+          const candidate = this.extractCodexRecordTitle(data);
+          if (candidate) messageTitle = candidate;
+        }
 
         if (recordType === "session_meta" || recordType === "turn_context") {
           const nextModel = extractModelName(payload["model"]);
@@ -759,7 +771,6 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     if (!hasNonInternalRecord) return filteredSession("internal events only");
 
     const indexTitle = this.getTitleForSession(sessionId);
-    const messageTitle = this.extractTitleFromLines(titleLines);
     const directory = firstPayload["cwd"] ? String(firstPayload["cwd"]) : "";
     const title = resolveSessionTitle(indexTitle, messageTitle, basenameTitle(directory || null));
 
@@ -825,36 +836,45 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     });
   }
 
+  /** Fast path only: parses each of the first 20 lines to find a title (no full stats pass available). */
   private extractTitleFromLines(lines: string[]): string | null {
     for (const line of lines.slice(0, 20)) {
       try {
-        const data = JSON.parse(line);
-        const recordType = String(data["type"] ?? "");
-        if (recordType !== "response_item" || isInternalEventType(recordType)) continue;
-
-        const payload = (data["payload"] ?? {}) as Record<string, unknown>;
-        const pType = String(payload["type"] ?? "");
-        if (pType !== "message" || isInternalEventType(pType)) continue;
-        if (String(payload["role"] ?? "") !== "user") continue;
-
-        const content = payload["content"];
-        let text: string | null = null;
-        if (Array.isArray(content)) {
-          text = content
-            .filter((item) => typeof item === "object" && item !== null && "text" in item)
-            .map((item) => String((item as Record<string, unknown>)["text"] ?? ""))
-            .join(" ");
-        } else if (typeof content === "string") {
-          text = content;
-        }
-        if (!text || isDeveloperLikeUserMessage(text)) continue;
-        const title = normalizeTitleText(text);
+        const title = this.extractCodexRecordTitle(JSON.parse(line));
         if (title) return title;
       } catch {
         // skip
       }
     }
     return null;
+  }
+
+  /**
+   * Title candidate from a single already-parsed record, if it's a visible
+   * user message. Shared by the main streaming pass (which parses every line
+   * once) and the fast path's extractTitleFromLines().
+   */
+  private extractCodexRecordTitle(data: Record<string, unknown>): string | null {
+    const recordType = String(data["type"] ?? "");
+    if (recordType !== "response_item" || isInternalEventType(recordType)) return null;
+
+    const payload = (data["payload"] ?? {}) as Record<string, unknown>;
+    const pType = String(payload["type"] ?? "");
+    if (pType !== "message" || isInternalEventType(pType)) return null;
+    if (String(payload["role"] ?? "") !== "user") return null;
+
+    const content = payload["content"];
+    let text: string | null = null;
+    if (Array.isArray(content)) {
+      text = content
+        .filter((item) => typeof item === "object" && item !== null && "text" in item)
+        .map((item) => String((item as Record<string, unknown>)["text"] ?? ""))
+        .join(" ");
+    } else if (typeof content === "string") {
+      text = content;
+    }
+    if (!text || isDeveloperLikeUserMessage(text)) return null;
+    return normalizeTitleText(text) || null;
   }
 
   // ---- Record conversion ----

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync, type Stats } from "node:fs";
 import { basename, join } from "node:path";
 import {
   FileSystemSessionSource,
@@ -138,10 +138,10 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
-    return this.listSessionFiles(options).map((file) => ({
+    return this.walkJsonlFiles(this.basePath, options).map(({ file, stat }) => ({
       sessionId: extractSessionIdFromFilename(file),
       sourcePath: file,
-      fingerprint: this.sourceFingerprint(file),
+      fingerprint: this.sourceFingerprint(stat),
     }));
   }
 
@@ -183,11 +183,12 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
 
   private listSessionFiles(options?: AgentScanOptions): string[] {
     if (!this.basePath) return [];
-    return this.walkJsonlFiles(this.basePath, options);
+    return this.walkJsonlFiles(this.basePath, options).map(({ file }) => file);
   }
 
-  private walkJsonlFiles(dir: string, options?: AgentScanOptions): string[] {
-    const files: string[] = [];
+  /** Stats each file once during the walk; caller reuses it for both the scan window check and the fingerprint. */
+  private walkJsonlFiles(dir: string, options?: AgentScanOptions): { file: string; stat: Stats }[] {
+    const files: { file: string; stat: Stats }[] = [];
     try {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const fullPath = join(dir, entry.name);
@@ -196,8 +197,14 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
           continue;
         }
         if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
-        if (!matchesScanWindow(statSync(fullPath).mtimeMs, options)) continue;
-        files.push(fullPath);
+        let stat: Stats;
+        try {
+          stat = statSync(fullPath);
+        } catch {
+          continue;
+        }
+        if (!matchesScanWindow(stat.mtimeMs, options)) continue;
+        files.push({ file: fullPath, stat });
       }
     } catch {
       // skip inaccessible dirs
@@ -206,12 +213,13 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   private buildSessionMeta(head: SessionHead, file: string): SessionMeta {
+    const stat = statSync(file);
     return {
       id: head.id,
       title: head.title,
       sourcePath: file,
-      sourceFingerprint: this.sourceFingerprint(file),
-      sourceMtimeMs: statSync(file).mtimeMs,
+      sourceFingerprint: this.sourceFingerprint(stat),
+      sourceMtimeMs: stat.mtimeMs,
       headIndexVersion: HEAD_INDEX_VERSION,
       parserVersion: PARSER_VERSION,
       directory: head.directory,
@@ -221,8 +229,8 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     };
   }
 
-  private sourceFingerprint(file: string): string {
-    const stat = statSync(file);
+  /** Fingerprint depends on an already-fetched stat to avoid re-statting the same file. */
+  private sourceFingerprint(stat: { mtimeMs: number; size: number }): string {
     return JSON.stringify([HEAD_INDEX_VERSION, PARSER_VERSION, stat.mtimeMs, stat.size]);
   }
 

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -380,7 +380,7 @@ async function scanAgentSmart(
 
         const t2 = performance.now();
         const updatedSessions = await Promise.resolve(
-          agent.incrementalScan(cached.sessions, checkResult.changedIds || []),
+          agent.incrementalScan(cached.sessions, checkResult.changedIds || [], checkResult.refs),
         );
         timing.scan = performance.now() - t2;
 


### PR DESCRIPTION
## Summary

Every watcher-triggered incremental refresh paid three layers of redundant I/O. With thousands of JSONL sessions this meant tens of thousands of wasted syscalls per refresh:

1. **Directory tree walked twice**: `checkForChanges` and `incrementalScan` each called `listSessionSources()` within the same refresh cycle.
2. **Every file statted twice**: once for the scan-window check, once more inside `sourceFingerprint`.
3. **First 20 lines JSON-parsed twice**: the head parser's main loop parsed every line, then `extractTitle` re-parsed the first 20 lines to find a title candidate.

## Changes

- **Enumeration reuse**: `ChangeCheckResult` gains an optional `refs` field carrying the enumerated `SessionSourceRef[]`; `incrementalScan` accepts an optional `refs` parameter (falls back to self-enumeration when absent, so existing callers are unaffected). `scanAgentSmart` and the CLI's `refreshChangedAgent` both pass it through.
- **Single stat per file**: `claudecode` and `codex` adapters stat each file once, feeding `mtimeMs`/`size` to both the scan-window check and the fingerprint. `sourceFingerprint` now takes the already-fetched stat. **Fingerprint output format is byte-for-byte unchanged** — no cache invalidation on upgrade.
- **`pi` adapter** (separate commit): had the identical double-stat pattern; proactively applied the same fix. Not in the original issue scope — flagged here for review.
- **Title extraction inline**: title candidates are captured during the main parse loop (same 20-line window, same internal-event filtering, same string/array content handling); the second-pass `extractTitle`/`extractTitleFromLines` paths are removed (codex keeps `extractTitleFromLines` for the `fast` head path, which reads only a file prefix and never double-parsed).

## Testing

- New tests: each adapter stats a file at most once per `listSessionSources` call (spy on `statSync`); `checkForChanges` returns refs matching enumeration; `incrementalScan` with explicit refs skips re-enumeration and matches the fallback path's results.
- Existing fixture tests (unchanged titles, fingerprints, session heads) all pass — the regression net for behavior equivalence.
- `pnpm build` / `pnpm test` (core 382, cli 196, web 349) / `pnpm lint` clean

Issue: CS-75