### PR TITLE
perf: cache event-path session signatures per agent (CS-76)

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { BaseAgent, ScanResult, SessionHead } from "@codesesh/core";
+import { FileSystemSessionSource } from "@codesesh/core";
+import type { BaseAgent, loadCachedSessions, ScanResult, SessionHead } from "@codesesh/core";
 import type { WorkerRunner } from "./worker-runner.js";
 
 const core = vi.hoisted(() => ({
   getAgentLastFullSyncAt: vi.fn(() => Date.now()),
   isAgentCacheInitialized: vi.fn(() => true),
-  loadCachedSessions: vi.fn(() => null),
+  loadCachedSessions: vi.fn((): ReturnType<typeof loadCachedSessions> => null),
   markAgentFullSyncCompleted: vi.fn(),
+  sessionSignature: vi.fn(),
 }));
 
 const searchIndex = vi.hoisted(() => ({
@@ -15,13 +17,19 @@ const searchIndex = vi.hoisted(() => ({
   snapshot: vi.fn(() => ({ activeBatchId: undefined, pendingBatches: 0 })),
 }));
 
-vi.mock("@codesesh/core", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@codesesh/core")>()),
-  getAgentLastFullSyncAt: core.getAgentLastFullSyncAt,
-  isAgentCacheInitialized: core.isAgentCacheInitialized,
-  loadCachedSessions: core.loadCachedSessions,
-  markAgentFullSyncCompleted: core.markAgentFullSyncCompleted,
-}));
+vi.mock("@codesesh/core", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@codesesh/core")>();
+  // Spy that still delegates to the real implementation, so diff behavior is unchanged.
+  core.sessionSignature.mockImplementation(original.sessionSignature);
+  return {
+    ...original,
+    getAgentLastFullSyncAt: core.getAgentLastFullSyncAt,
+    isAgentCacheInitialized: core.isAgentCacheInitialized,
+    loadCachedSessions: core.loadCachedSessions,
+    markAgentFullSyncCompleted: core.markAgentFullSyncCompleted,
+    sessionSignature: core.sessionSignature,
+  };
+});
 
 vi.mock("./search-index-job-runner.js", () => ({
   SearchIndexJobRunner: class {
@@ -177,5 +185,110 @@ describe("AgentSyncEngine", () => {
     await vi.advanceTimersByTimeAsync(1_000);
 
     expect(checkForChanges).not.toHaveBeenCalled();
+  });
+
+  it("reuses cached session signatures across refreshes for an unchanged session", async () => {
+    const session = makeSession("steady", "same-title");
+    const agent = makeAgent({
+      checkForChanges: () => ({ hasChanges: true, timestamp: Date.now() }),
+      incrementalScan: () => [session],
+    });
+    const { engine } = makeEngine(agent, [session]);
+
+    await engine.refresh("codex");
+    const firstRoundCalls = core.sessionSignature.mock.calls.length;
+    expect(firstRoundCalls).toBeGreaterThan(0);
+
+    core.sessionSignature.mockClear();
+    await engine.refresh("codex");
+    const secondRoundCalls = core.sessionSignature.mock.calls.length;
+
+    // The cached-side signature is served from the per-agent cache on the second
+    // round, so fewer sessionSignature calls are needed than on the cold-cache round.
+    expect(secondRoundCalls).toBeLessThan(firstRoundCalls);
+  });
+
+  it("clears cached session signatures when a session is removed", async () => {
+    const session = makeSession("gone");
+    const agent = makeAgent({
+      checkForChanges: () => ({ hasChanges: true, timestamp: Date.now() }),
+      incrementalScan: () => [],
+    });
+    const { engine } = makeEngine(agent, [session]);
+
+    await engine.refresh("codex");
+
+    const signatureCache = (
+      engine as unknown as { state: (name: string) => { signatureCache: Map<string, string> } }
+    ).state("codex").signatureCache;
+    expect(signatureCache.has("gone")).toBe(false);
+  });
+
+  it("still emits a changed event for a signature-only update reported via the DB-baseline (sync) path", async () => {
+    // Regression test for a bug where the strategy-path diff (DB `cached.sessions`
+    // baseline) and the event-path diff (in-memory `previousSessions` baseline)
+    // shared one signature cache within a single refresh. The strategy-path diff
+    // ran first and wrote the *new* signature into the cache; the event-path diff
+    // then read that new signature back for the cached side too, so a change with
+    // no reported changedIds (e.g. smart-tag reclassification) looked like no
+    // change at all and the UI event was dropped. Only the event path may use the
+    // cache now — this asserts the event still fires in that scenario.
+    class FakeSyncAgent extends FileSystemSessionSource {
+      readonly name = "codex";
+      readonly displayName = "Codex";
+      isAvailable(): boolean {
+        return true;
+      }
+      listSessionSources() {
+        return [];
+      }
+      scanSessionSource() {
+        return null;
+      }
+      getSessionData() {
+        return { messages: [] } as never;
+      }
+    }
+
+    const oldSession = { ...makeSession("sess1"), smart_tags_source_updated_at: 1 };
+    const newSession = { ...makeSession("sess1"), smart_tags_source_updated_at: 2 };
+    const agent = new FakeSyncAgent();
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      // The sync worker reports no changedIds even though the session content
+      // changed — mirrors an out-of-band reclassification the file-fingerprint
+      // check can't see.
+      run: vi.fn(async () => ({ sessions: [newSession], meta: {}, changedIds: [] })),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const state: ScanResult = {
+      agents: [agent],
+      byAgent: { codex: [oldSession] },
+      sessions: [oldSession],
+    };
+    const engine = new AgentSyncEngine({ snapshot: () => state, workerRunner });
+    engine.subscribeSessionsChanged((change) => {
+      state.byAgent[change.agentName] = change.sessions;
+      state.sessions = Object.values(state.byAgent).flat();
+    });
+    engine.initialize();
+
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [oldSession],
+      meta: {},
+      timestamp: Date.now(),
+    });
+
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(sessionChanges).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: "codex",
+        event: expect.objectContaining({ updatedSessions: 1 }),
+      }),
+    );
   });
 });

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -53,6 +53,18 @@ interface AgentRefreshState {
   lastRefreshAt: number;
   lastRefreshDurationMs: number;
   pendingPathCount: number;
+  /**
+   * id → sessionSignature, carried across refreshes so unchanged sessions skip
+   * re-stringifying. Only ever passed into the runRefresh event-path diff
+   * (previousSessions → nextSessions), whose lineage is the in-memory result of
+   * the prior event diff. The strategy-path diffs (DB cached.sessions baseline)
+   * must NOT share this cache: that baseline can lag an in-flight persist job,
+   * and a cache hit there would both mask the self-heal recheck after a failed
+   * persist and, if reused this same cycle, make the event-path diff miss a
+   * signature-only change (e.g. smart-tag reclassification) whose new signature
+   * was already written back by the strategy-path diff.
+   */
+  signatureCache: Map<string, string>;
 }
 
 interface AgentOperationLifecycle {
@@ -92,13 +104,16 @@ function buildRefreshDiff(
   previousSessions: SessionHead[],
   nextSessions: SessionHead[],
   candidateChangedIds: string[] = [],
+  signatureCache?: Map<string, string>,
 ): SessionRefreshDiff {
   const { changes, removedSessionIds, counts } = computeSessionDiff(
     previousSessions,
     nextSessions,
     candidateChangedIds,
     sessionSignature,
+    signatureCache,
   );
+  for (const removedId of removedSessionIds) signatureCache?.delete(removedId);
   if (counts.new === 0 && counts.updated === 0 && counts.removed === 0) {
     return { event: null, changedSessions: changes, removedSessionIds };
   }
@@ -379,6 +394,7 @@ export class AgentSyncEngine {
       previousSessions,
       nextSessions,
       strategyResult.preciseChangedIds ?? [],
+      state.signatureCache,
     );
     const diffDuration = performance.now() - diffStartedAt;
     const searchIndexOptions =
@@ -719,6 +735,7 @@ export class AgentSyncEngine {
       lastRefreshAt: 0,
       lastRefreshDurationMs: 0,
       pendingPathCount: 0,
+      signatureCache: new Map(),
     };
     this.refreshStates.set(agentName, state);
     return state;

--- a/packages/core/src/discovery/__tests__/orchestrate.test.ts
+++ b/packages/core/src/discovery/__tests__/orchestrate.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SessionCacheMeta } from "../../agents/base.js";
 import { BaseAgent } from "../../agents/base.js";
 import type { SessionHead } from "../../types/index.js";
@@ -192,5 +192,49 @@ describe("computeSessionDiff", () => {
     expect(computeSessionDiff(cached, updated).counts.updated).toBe(0);
     // Custom signature that includes slug detects the change.
     expect(computeSessionDiff(cached, updated, [], (s) => s.slug).counts.updated).toBe(1);
+  });
+
+  describe("signatureCache", () => {
+    it("skips recomputing the cached-side signature on a warm cache", () => {
+      const session = makeSession("a");
+      const signatureCache = new Map<string, string>();
+      const signature = vi.fn((s: SessionHead) => sessionSignature(s));
+
+      computeSessionDiff([session], [session], [], signature, signatureCache);
+      expect(signature).toHaveBeenCalledTimes(2); // cached-side miss + updated-side
+
+      signature.mockClear();
+      computeSessionDiff([session], [session], [], signature, signatureCache);
+      expect(signature).toHaveBeenCalledTimes(1); // cached-side hit, only updated-side computed
+    });
+
+    it("backfills the cache with the updated session's signature", () => {
+      const cachedVersion = makeSession("a", { title: "old" });
+      const updatedVersion = makeSession("a", { title: "new" });
+      const signatureCache = new Map<string, string>();
+
+      computeSessionDiff([cachedVersion], [updatedVersion], [], sessionSignature, signatureCache);
+
+      expect(signatureCache.get("a")).toBe(sessionSignature(updatedVersion));
+    });
+
+    it("backfills new sessions too", () => {
+      const signatureCache = new Map<string, string>();
+      const session = makeSession("a");
+
+      computeSessionDiff([], [session], [], sessionSignature, signatureCache);
+
+      expect(signatureCache.get("a")).toBe(sessionSignature(session));
+    });
+
+    it("still detects a real change even when the cache holds a stale entry", () => {
+      const signatureCache = new Map<string, string>([["a", "stale-signature"]]);
+      const cached = [makeSession("a", { title: "old" })];
+      const updated = [makeSession("a", { title: "new" })];
+
+      const diff = computeSessionDiff(cached, updated, [], sessionSignature, signatureCache);
+
+      expect(diff.counts.updated).toBe(1);
+    });
   });
 });

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -90,12 +90,24 @@ export interface SessionDiffResult {
  * as "changed" if it is new, if its id is in `changedIds`, or if its signature
  * differs from the cached copy. The algorithm is pure — event assembly and
  * no-op short-circuiting stay with the caller.
+ *
+ * `signatureCache` is an optional id→signature memo the caller owns across
+ * calls (e.g. across refresh cycles). On the cached side it's consulted before
+ * falling back to `signature(cached)`; every updated session's signature is
+ * written back into it, so the next call's cached-side lookups for unchanged
+ * sessions can skip recomputation entirely. Mutating this caller-supplied map
+ * is the only side effect — there's no module-level state. Callers must only
+ * pass a cache whose lineage matches `cachedSessions`: if `cachedSessions` can
+ * be a baseline the cache was never populated from (e.g. a DB snapshot instead
+ * of the previous call's `updatedSessions`), a stale or mismatched hit will
+ * silently suppress a real change.
  */
 export function computeSessionDiff(
   cachedSessions: SessionHead[],
   updatedSessions: SessionHead[],
   changedIds: string[] = [],
   signature: (session: SessionHead) => string = sessionSignature,
+  signatureCache?: Map<string, string>,
 ): SessionDiffResult {
   const cachedMap = new Map(cachedSessions.map((session) => [session.id, session]));
   const updatedIds = new Set(updatedSessions.map((session) => session.id));
@@ -110,10 +122,13 @@ export function computeSessionDiff(
     if (!cached) {
       newCount += 1;
       changes.push({ session, sortIndex });
+      signatureCache?.set(session.id, signature(session));
       return;
     }
-    const hasSignatureChange = signature(cached) !== signature(session);
-    if (changedIdSet.has(session.id) || hasSignatureChange) {
+    const cachedSignature = signatureCache?.get(cached.id) ?? signature(cached);
+    const updatedSignature = signature(session);
+    signatureCache?.set(session.id, updatedSignature);
+    if (changedIdSet.has(session.id) || cachedSignature !== updatedSignature) {
       updatedCount += 1;
       changes.push({ session, sortIndex });
     }


### PR DESCRIPTION
## Summary

Each refresh cycle recomputed `sessionSignature` (a `JSON.stringify` over 9 fields) for every session on both sides of every diff. This PR memoizes the one place where caching is provably behavior-identical: the event-path diff in `runRefresh`, whose baseline (`previousSessions`, the in-memory snapshot) shares lineage with the previous round's diffed sessions.

## Scope reduction from the original issue (CS-76)

Investigation during implementation invalidated both of the issue's stronger premises — details recorded in the issue's notes:

1. **Diff reuse was not implemented.** The two `buildRefreshDiff` calls per refresh are not duplicates: the strategy-path diff baselines against DB `cached.sessions` (written by a fire-and-forget worker job, can lag) and drives persistence; the event-path diff baselines against the in-memory snapshot and drives UI events. Collapsing them would change behavior under persist/read races.
2. **The signature cache is deliberately NOT shared with the strategy/backfill paths.** A shared cache lets the strategy diff backfill new signatures within the same round, after which the event diff sees "no signature change" for changedIds-empty, signature-only updates (e.g. smart-tag reclassification — the exact case `sessionSignature` includes `smart_tags_source_updated_at` for), permanently dropping the UI event. Caching the DB baseline would also mask the re-detection that self-heals failed persist jobs.

## Changes

- `computeSessionDiff` (core): optional caller-owned `signatureCache: Map<id, signature>`; cached-side lookups consult it, updated-side signatures are written back. Doc comment states the lineage requirement.
- `AgentSyncEngine` (cli): per-agent `signatureCache` injected **only** at the `runRefresh` event-path diff; entries for removed sessions are cleaned up.
- Regression test that a signature-only update still emits a UI changed event — mutation-verified (re-introducing the shared cache makes it fail).

## Testing

- 4 new pure-function cache tests (orchestrate), 3 new engine tests incl. the regression guard
- `pnpm build` / `pnpm test` (core 386, cli 199, web 349) / `pnpm lint` clean

Issue: CS-76