### PR TITLE
perf: match aliases directly instead of a second full search (CS-77)

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -466,46 +466,123 @@ describe("handleSearchSessions", () => {
     expect(coreMocks.executeSessionSearch).not.toHaveBeenCalled();
   });
 
-  it("matches aliases while preserving query qualifiers", () => {
-    const aliased = makeSession("s1", { slug: "claudecode/s1" });
+  it("matches aliases while preserving an agent: qualifier embedded in q, calling the search module only once", () => {
+    const cursorSession = makeSession("c1", { slug: "cursor/c1" });
     coreMocks.listSessionAliases.mockReturnValue([
       { agentKey: "claudecode", sessionId: "s1", alias: "Custom cache title", updated_at: 1 },
+      { agentKey: "cursor", sessionId: "c1", alias: "Custom cache from cursor", updated_at: 1 },
     ]);
-    coreMocks.executeSessionSearch.mockImplementation((query) =>
-      query ? [] : [{ agentName: "claudecode", session: aliased }],
-    );
+    coreMocks.executeSessionSearch.mockReturnValue([]);
     const c = makeMockContext({ query: { q: "agent:claudecode custom cache" } });
 
-    handleSearchSessions(c, makeScanSource());
+    handleSearchSessions(
+      c,
+      makeScanSource({
+        sessions: [makeSession("s1", { slug: "claudecode/s1" }), cursorSession],
+        byAgent: {
+          claudecode: [makeSession("s1", { slug: "claudecode/s1" })],
+          cursor: [cursorSession],
+        },
+      }),
+    );
 
+    expect(coreMocks.executeSessionSearch).toHaveBeenCalledTimes(1);
     expect(coreMocks.executeSessionSearch).toHaveBeenCalledWith(
-      "",
-      expect.objectContaining({ agent: "claudecode", limit: 2 }),
+      "agent:claudecode custom cache",
+      expect.anything(),
       expect.anything(),
     );
-    expect(c.json.mock.calls[0]![0].results[0].session.display_title).toBe("Custom cache title");
+    const results = c.json.mock.calls[0]![0].results;
+    expect(results).toHaveLength(1);
+    expect(results[0].session.display_title).toBe("Custom cache title");
+    expect(results[0].matchType).toBe("title");
   });
 
-  it("does not cap alias search candidates at one thousand sessions", () => {
+  it("finds alias matches by scanning the alias map, not the full session list", () => {
     const sessions = Array.from({ length: 1001 }, (_, index) =>
       makeSession(`s${index}`, { slug: `claudecode/s${index}` }),
     );
     coreMocks.listSessionAliases.mockReturnValue([
       { agentKey: "claudecode", sessionId: "s1000", alias: "Old alias", updated_at: 1 },
     ]);
-    coreMocks.executeSessionSearch.mockImplementation((query) =>
-      query ? [] : [{ agentName: "claudecode", session: sessions[1000]! }],
-    );
+    coreMocks.executeSessionSearch.mockReturnValue([]);
     const c = makeMockContext({ query: { q: "old alias" } });
 
     handleSearchSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
 
+    // Only one search call regardless of how many sessions exist -- alias
+    // matching no longer re-runs executeSessionSearch with limit = session count.
+    expect(coreMocks.executeSessionSearch).toHaveBeenCalledTimes(1);
     expect(coreMocks.executeSessionSearch).toHaveBeenCalledWith(
-      "",
-      expect.objectContaining({ limit: 1001 }),
+      "old alias",
+      expect.objectContaining({ limit: 50 }),
       expect.anything(),
     );
     expect(c.json.mock.calls[0]![0].results[0].session.id).toBe("s1000");
+  });
+
+  it("excludes alias hits outside the requested time window", () => {
+    const now = Date.now();
+    const oldSession = makeSession("s1", {
+      slug: "claudecode/s1",
+      time_created: now - 30 * 86400000,
+      time_updated: now - 30 * 86400000,
+    });
+    coreMocks.listSessionAliases.mockReturnValue([
+      { agentKey: "claudecode", sessionId: "s1", alias: "Custom cache title", updated_at: 1 },
+    ]);
+    coreMocks.executeSessionSearch.mockReturnValue([]);
+    const c = makeMockContext({
+      query: {
+        q: "custom cache",
+        from: new Date(now - 86400000).toISOString(),
+        to: new Date(now).toISOString(),
+      },
+    });
+
+    handleSearchSessions(
+      c,
+      makeScanSource({ sessions: [oldSession], byAgent: { claudecode: [oldSession] } }),
+    );
+
+    expect(c.json.mock.calls[0]![0].results).toHaveLength(0);
+  });
+
+  it("excludes alias hits from an agent other than the requested agent filter", () => {
+    coreMocks.listSessionAliases.mockReturnValue([
+      { agentKey: "claudecode", sessionId: "s1", alias: "Custom cache title", updated_at: 1 },
+    ]);
+    coreMocks.executeSessionSearch.mockReturnValue([]);
+    const c = makeMockContext({ query: { q: "custom cache", agent: "cursor" } });
+
+    handleSearchSessions(c, makeScanSource());
+
+    expect(c.json.mock.calls[0]![0].results).toHaveLength(0);
+  });
+
+  it("excludes alias hits outside the requested project identity", () => {
+    const session = makeSession("s1", {
+      slug: "claudecode/s1",
+      project_identity: { kind: "git_remote", key: "github.com/acme/app", displayName: "app" },
+    });
+    coreMocks.listSessionAliases.mockReturnValue([
+      { agentKey: "claudecode", sessionId: "s1", alias: "Custom cache title", updated_at: 1 },
+    ]);
+    coreMocks.executeSessionSearch.mockReturnValue([]);
+    const c = makeMockContext({
+      query: {
+        q: "custom cache",
+        projectKind: "git_remote",
+        projectKey: "github.com/other/app",
+      },
+    });
+
+    handleSearchSessions(
+      c,
+      makeScanSource({ sessions: [session], byAgent: { claudecode: [session] } }),
+    );
+
+    expect(c.json.mock.calls[0]![0].results).toHaveLength(0);
   });
 });
 

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -12,6 +12,7 @@ import type {
   ApiProjectGroup,
   AppConfig,
   ScanStatusEvent,
+  SearchResult,
 } from "@codesesh/core/contract";
 import {
   BookmarkStorageUnavailableError,
@@ -32,6 +33,7 @@ import {
   listCachedProjectGroups,
   listBookmarks,
   listSessionAliases,
+  matchesSessionSearchFilters,
   mergeSearchQueryOptions,
   deleteSessionAlias,
   upsertSessionAlias,
@@ -131,6 +133,16 @@ function withFileActivityDisplayTitle(
   };
 }
 
+function findSessionByAliasKey(scanResult: ScanResult, aliasKey: string): SessionHead | undefined {
+  const separatorIndex = aliasKey.indexOf("\0");
+  const agentName = aliasKey.slice(0, separatorIndex);
+  const sessionId = aliasKey.slice(separatorIndex + 1);
+  return scanResult.byAgent[agentName]?.find((session) => session.id === sessionId);
+}
+
+// Alias hits still have to satisfy the same time-window/project/agent
+// filters as the main search (matchesSessionSearchFilters), otherwise an
+// aliased session could appear in results outside its search scope.
 function findAliasSearchResults(
   query: string,
   options: SearchOptions,
@@ -141,22 +153,24 @@ function findAliasSearchResults(
   const needle = search.text.trim().toLowerCase();
   if (!needle || aliases.size === 0) return [];
 
-  return executeSessionSearch(
-    "",
-    { ...search.options, limit: Math.max(scanResult.sessions.length, 1) },
-    scanResult,
-  ).flatMap((result) => {
-    const alias = aliases.get(getSessionAliasKey(result.agentName, result.session.id));
-    if (!alias || !alias.toLowerCase().includes(needle)) return [];
-    return [
-      {
-        agentName: result.agentName,
-        session: withDisplayTitle(result.session, result.agentName, aliases),
-        snippet: `Alias · ${result.session.directory}`,
-        matchType: "title" as const,
-      },
-    ];
-  });
+  const projectScope = search.options.cwd ? createProjectScopeMatcher(search.options.cwd) : null;
+  const results: SearchResult[] = [];
+  for (const [aliasKey, alias] of aliases) {
+    if (!alias.toLowerCase().includes(needle)) continue;
+    const session = findSessionByAliasKey(scanResult, aliasKey);
+    if (!session) continue;
+    const agentName = aliasKey.slice(0, aliasKey.indexOf("\0"));
+    if (!matchesSessionSearchFilters(agentName, session, search.options, projectScope)) continue;
+    results.push({
+      agentName,
+      session: withDisplayTitle(session, agentName, aliases),
+      snippet: `Alias · ${session.directory}`,
+      matchType: "title",
+    });
+  }
+  return results.sort(
+    (a, b) => getSessionActivityTime(b.session) - getSessionActivityTime(a.session),
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -1,1 +1,5 @@
-export { executeSessionSearch, type SessionSearchSnapshot } from "./session-search.js";
+export {
+  executeSessionSearch,
+  matchesSessionSearchFilters,
+  type SessionSearchSnapshot,
+} from "./session-search.js";

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -48,20 +48,6 @@ function needsIndexedSearch(textQuery: string, options: SearchOptions): boolean 
   return Boolean(textQuery || options.file || options.fileKind || options.tools?.length);
 }
 
-function filterSessionsByActivityWindow(
-  sessions: SessionHead[],
-  from: number | undefined,
-  to: number | undefined,
-): SessionHead[] {
-  if (from == null && to == null) return sessions;
-  return sessions.filter((session) => {
-    const activity = getSessionActivityTime(session);
-    if (from != null && activity < from) return false;
-    if (to != null && activity > to) return false;
-    return true;
-  });
-}
-
 function matchesRecentSearchFilters(
   session: SessionHead,
   options: SearchOptions,
@@ -99,6 +85,22 @@ function matchesRecentSearchFilters(
   return true;
 }
 
+// Single source of truth for "does this session belong in a search result",
+// shared by the recent-sessions path here and by alias matching in the CLI
+// API layer (which looks up individual sessions instead of scanning a list).
+export function matchesSessionSearchFilters(
+  agentName: string,
+  session: SessionHead,
+  options: SearchOptions,
+  projectScope: ProjectScopeMatcher | null = null,
+): boolean {
+  if (options.agent && agentName !== options.agent) return false;
+  const activity = getSessionActivityTime(session);
+  if (options.from != null && activity < options.from) return false;
+  if (options.to != null && activity > options.to) return false;
+  return matchesRecentSearchFilters(session, options, projectScope);
+}
+
 function searchRecentSessions(
   snapshot: SessionSearchSnapshot,
   options: SearchOptions,
@@ -110,8 +112,8 @@ function searchRecentSessions(
 
   return entries
     .flatMap(([agentName, sessions]) =>
-      filterSessionsByActivityWindow(sessions, options.from, options.to)
-        .filter((session) => matchesRecentSearchFilters(session, options, projectScope))
+      sessions
+        .filter((session) => matchesSessionSearchFilters(agentName, session, options, projectScope))
         .map((session) => ({ agentName, session })),
     )
     .sort(


### PR DESCRIPTION
## Summary

With any session alias set, **every** search request (including per-keystroke suggestions) executed `executeSessionSearch` twice: once for the main query, and once more with an empty query and `limit = <total session count>` — pulling **all** sessions through the recent-search path (filter + sort, O(n log n)) just to check which ones had a matching alias. Aliases number in the tens; sessions in the thousands.

## Changes

- `findAliasSearchResults` now iterates the aliases map directly (O(alias count)): substring-match the alias, look up the session by (agentName, sessionId) in the scan snapshot, then validate it against the same search filters as the main query. Result shape (`matchType: "title"`, snippet, display title) is unchanged; hits are sorted by activity time to preserve the previous recency ordering.
- **Shared filter predicate**: extracted `matchesSessionSearchFilters` in core (agent + activity window + the existing `matchesRecentSearchFilters` project/tags/cost checks) as the single source of truth for "does this session belong in a search result". The recent-sessions path now uses it too, so alias matching and main search cannot drift semantically (this replaces the inline `filterSessionsByActivityWindow` + filter chain with the identical predicates).
- `handleSearchSessions` now calls `executeSessionSearch` exactly once per request.

## Testing

- New tests: alias hit appears with correct matchType (incl. `agent:` qualifier disambiguation); `executeSessionSearch` called exactly once (verified with a 1001-session scan); alias hits outside the time window / agent filter / project identity filter are excluded.
- `pnpm build` / `pnpm test` (core 386, cli 202, web 349) / `pnpm lint` clean

Issue: CS-77