### PR TITLE
fix: decouple head cache init from search-index completeness (CS-73)

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -12,7 +12,7 @@ const core = vi.hoisted(() => ({
 }));
 
 const searchIndex = vi.hoisted(() => ({
-  enqueue: vi.fn(async () => undefined),
+  enqueue: vi.fn<(...args: unknown[]) => Promise<undefined>>(async () => undefined),
   shutdown: vi.fn(async () => undefined),
   snapshot: vi.fn(() => ({ activeBatchId: undefined, pendingBatches: 0 })),
 }));
@@ -105,6 +105,7 @@ afterEach(() => {
   core.getAgentLastFullSyncAt.mockReturnValue(Date.now());
   core.isAgentCacheInitialized.mockReturnValue(true);
   core.loadCachedSessions.mockReturnValue(null);
+  searchIndex.enqueue.mockImplementation(async () => undefined);
 });
 
 describe("AgentSyncEngine", () => {
@@ -290,5 +291,55 @@ describe("AgentSyncEngine", () => {
         event: expect.objectContaining({ updatedSessions: 1 }),
       }),
     );
+  });
+
+  it("CS-73 regression: a windowed startup scan with one unindexed session still switches to the incremental refresh path", async () => {
+    // Mirrors the fixed search-index-worker.ts:108 (`job.saveCache && result`,
+    // no more `skipped === 0` gate): the head cache is marked initialized as
+    // soon as it's saved, even if `getSessionData` couldn't load "broken" and
+    // syncSessionSearchIndex reports skipped > 0 for it. Before the fix, that
+    // skip permanently blocked markAgentCacheInitialized, so isInitialized
+    // stayed false and every later refresh re-ran the full initializeAgent
+    // scan instead of the incremental checkForChanges path.
+    let cacheInitialized = false;
+    core.isAgentCacheInitialized.mockImplementation(() => cacheInitialized);
+    searchIndex.enqueue.mockImplementation(async (...args: unknown[]) => {
+      const jobs = args[1] as Array<{ kind: string; saveCache?: boolean }>;
+      for (const job of jobs) {
+        if (job.kind === "full" && job.saveCache) cacheInitialized = true;
+      }
+      return undefined;
+    });
+
+    const checkForChanges = vi.fn(() => ({ hasChanges: false, timestamp: Date.now() }));
+    const agent = makeAgent({ checkForChanges });
+    const scanResult = [makeSession("broken")];
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () => ({ sessions: scanResult, meta: {} })),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const state: ScanResult = { agents: [agent], byAgent: { codex: [] }, sessions: [] };
+    const engine = new AgentSyncEngine({
+      snapshot: () => state,
+      workerRunner,
+      startupScanOptions: { from: 1, to: 2 },
+    });
+    engine.subscribeSessionsChanged((change) => {
+      state.byAgent[change.agentName] = change.sessions;
+      state.sessions = Object.values(state.byAgent).flat();
+    });
+    engine.initialize();
+
+    await engine.refresh("codex");
+    expect(cacheInitialized).toBe(true);
+    expect(workerRunner.run).toHaveBeenCalledTimes(1);
+
+    await engine.refresh("codex");
+
+    // The second refresh takes the incremental path (checkForChanges), not
+    // another windowed initializeAgent full scan.
+    expect(checkForChanges).toHaveBeenCalledTimes(1);
+    expect(workerRunner.run).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   setFtsIntegrityCheckedPath: vi.fn(),
   syncSessionSearchIndex: vi.fn(),
   syncSessionSearchIndexChanges: vi.fn(),
+  appLoggerWarn: vi.fn(),
 }));
 
 vi.mock("node:worker_threads", () => ({
@@ -31,6 +32,10 @@ vi.mock("@codesesh/core", () => ({
   syncSessionSearchIndexChanges: mocks.syncSessionSearchIndexChanges,
   // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
   setCoreDiagnostics: vi.fn(),
+}));
+
+vi.mock("./logging.js", () => ({
+  appLogger: { warn: mocks.appLoggerWarn },
 }));
 
 function makeAgent() {
@@ -122,6 +127,42 @@ describe("search index worker", () => {
       { force: true },
     );
     expect(mocks.markAgentCacheInitialized).toHaveBeenCalledWith("codex");
+    expect(mocks.appLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it("CS-73 regression: still marks the agent initialized when a session couldn't be indexed, but warns", async () => {
+    const agent = makeAgent();
+    const sessions = [{ id: "s1" }, { id: "broken" }];
+    const meta = { s1: { id: "s1" } };
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    // One session (e.g. its data failed to load) is left unindexed.
+    mocks.syncSessionSearchIndex.mockReturnValue({ indexed: 1, skipped: 1 });
+    mocks.workerData = {
+      context: "refresh",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [
+        {
+          kind: "full",
+          context: "codex-full",
+          agentName: "codex",
+          sessions,
+          meta,
+          saveCache: true,
+        },
+      ],
+    };
+
+    await runWorker();
+
+    // Head cache init must not be blocked by an incomplete search index —
+    // otherwise every later refresh falls back to a full initializeAgent scan.
+    expect(mocks.markAgentCacheInitialized).toHaveBeenCalledWith("codex");
+    expect(mocks.appLoggerWarn).toHaveBeenCalledWith("search_index.sync_incomplete", {
+      agent: "codex",
+      skipped: 1,
+    });
   });
 
   it("applies incremental index changes and reports processed sessions", async () => {

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -15,6 +15,7 @@ import {
   type SessionHeadChange,
   type SessionHead,
 } from "@codesesh/core";
+import { appLogger } from "./logging.js";
 
 export type SearchIndexWorkerMessage =
   | {
@@ -105,8 +106,18 @@ for (const job of jobs) {
       (sessionId) => agent.getSessionData(sessionId),
       job.searchIndexOptions,
     );
-    if (job.saveCache && result?.skipped === 0) {
+    // Head cache init is decoupled from search-index completeness (CS-73): a
+    // session that fails to load must not permanently block markAgentCacheInitialized,
+    // or every future refresh would fall back to a full initializeAgent scan.
+    // The skip is still surfaced as a warning so it stays visible.
+    if (job.saveCache && result) {
       markAgentCacheInitialized(job.agentName);
+      if (result.skipped > 0) {
+        appLogger.warn("search_index.sync_incomplete", {
+          agent: job.agentName,
+          skipped: result.skipped,
+        });
+      }
     }
   }
   parentPort?.postMessage({

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -469,11 +469,14 @@ async function scanAgentFull(
     // 收集元数据
     const meta = buildAgentCacheMeta(agent);
 
-    // 保存到缓存
-    if (options.writeCache !== false && options.from == null && options.to == null) {
-      saveCachedSessions(agent.name, tagged.sessions, meta);
+    if (options.writeCache !== false) {
+      // 全量（无时间窗）扫描才落盘完整会话列表并记录一次全量同步，用于 backfill 节流判断
+      if (options.from == null && options.to == null) {
+        saveCachedSessions(agent.name, tagged.sessions, meta);
+        markAgentFullSyncCompleted(agent.name);
+      }
+      // head 缓存是否建立与搜索索引是否完整是两回事，带时间窗的扫描同样应当标记
       markAgentCacheInitialized(agent.name);
-      markAgentFullSyncCompleted(agent.name);
     }
 
     onProgress?.({ agent: agent.name, phase: "complete", newCount: tagged.sessions.length });


### PR DESCRIPTION
## Summary

`markAgentCacheInitialized` had two inconsistent gates:

- `scanner.ts` only marked it for **unwindowed** full scans (`from`/`to` both null)
- `search-index-worker.ts` only marked it when `result.skipped === 0`

Consequence (**reproduced with a deterministic test before fixing**): start the CLI with a time window (the backfill norm) plus a single session whose `loadSessionData` fails → the agent is never marked initialized → `isAgentCacheInitialized` stays false forever → **every refresh degenerates into a full `initializeAgent` scan**, permanently disabling the incremental path.

## Root cause & trade-off

`git blame` shows both gates landed together in the original cache-init commit. The worker's `skipped === 0` gate had a real motivation: incremental refreshes only re-index *changed* sessions, so entering incremental mode with unindexed sessions leaves them without a retry trigger. But the retry mechanism it effectively provided was the bug itself — a full rescan of everything on every refresh. This PR keeps the incompleteness *signal* (a `search_index.sync_incomplete` warn with agent + skipped count) without the pathological blocking behavior. A permanently unloadable session now stays unindexed-but-logged; if its file ever changes, the fingerprint diff re-indexes it naturally.

## Changes

- `search-index-worker.ts`: mark head cache initialized on any real sync result; warn when `skipped > 0`.
- `scanner.ts`: mark head cache initialized for windowed scans too. `saveCachedSessions` / `markAgentFullSyncCompleted` stay gated to unwindowed scans (they mean "full history persisted", a genuinely different concept). After a windowed startup, the next refresh runs incrementally against an empty cache baseline — one full re-parse that persists everything, then true incremental from there.

## Testing

- Regression test encoding the fixed contract: windowed startup + one unindexable session → round 2 takes the incremental path (`checkForChanges` called, no second full scan). Mutation-verified (fails against the pre-fix gates).
- Unit test: `skipped: 1` still marks initialized and emits the warn.
- `pnpm build` / `pnpm test` / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-73