### PR TITLE
perf: cache project identity resolution per process (CS-79)

### DIFF
--- a/packages/core/src/discovery/__tests__/orchestrate.test.ts
+++ b/packages/core/src/discovery/__tests__/orchestrate.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionCacheMeta } from "../../agents/base.js";
 import { BaseAgent } from "../../agents/base.js";
 import type { SessionHead } from "../../types/index.js";
+import { clearIdentityCache } from "../../projects/index.js";
 import {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
@@ -9,6 +10,13 @@ import {
   sessionSignature,
   sortSessions,
 } from "../orchestrate.js";
+
+// attachMissingProjectIdentities resolves through the process-lifetime
+// identity cache (identity.ts); clear it so directories reused across tests
+// don't leak cached results between cases.
+beforeEach(() => {
+  clearIdentityCache();
+});
 
 function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
   const timeCreated = overrides?.time_created ?? 1000;

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -9,28 +9,15 @@
  */
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import { sortSessionsByActivity } from "../contract/session-index.js";
-import type { ProjectIdentity, SessionHead } from "../types/index.js";
+import type { SessionHead } from "../types/index.js";
 import type { SessionHeadChange } from "./cache.js";
 import { computeIdentity, realFs } from "../projects/index.js";
 
-function createIdentityResolver() {
-  const cache = new Map<string, ProjectIdentity>();
-  return (directory: string | null | undefined) => {
-    const key = directory || "";
-    const cached = cache.get(key);
-    if (cached) return cached;
-    const identity = computeIdentity(directory, realFs);
-    cache.set(key, identity);
-    return identity;
-  };
-}
-
 /** Attach a project identity to sessions that don't already have one. */
 export function attachMissingProjectIdentities(sessions: SessionHead[]): SessionHead[] {
-  const resolveIdentity = createIdentityResolver();
   return sessions.map((session) => {
     if (session.project_identity) return session;
-    return { ...session, project_identity: resolveIdentity(session.directory) };
+    return { ...session, project_identity: computeIdentity(session.directory, realFs) };
   });
 }
 

--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -1,12 +1,16 @@
-import { homedir } from "node:os";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clearIdentityCache,
   computeIdentity,
   getProjectIdentityKey,
   matchesProjectIdentity,
   normalizeGitRemote,
   type IdentityFs,
 } from "./identity.js";
+import { realFs } from "./fs.js";
 
 vi.mock("node:os", async () => {
   const actual = await vi.importActual<typeof import("node:os")>("node:os");
@@ -190,5 +194,61 @@ describe("computeIdentity", () => {
       key: "github.com/acme/real-project",
       displayName: "real-project",
     });
+  });
+});
+
+// The module-level cache only activates for fs === realFs (see identity.ts);
+// custom IdentityFs fakes above always bypass it, so these tests use a real
+// temp directory to exercise the cached path without polluting other tests.
+describe("computeIdentity caching (realFs)", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), "codesesh-identity-cache-"));
+    // An empty .git dir makes findGitRoot succeed so computeIdentity spawns
+    // git; the spawns themselves fail fast since it isn't a real repository.
+    mkdirSync(join(repoDir, ".git"));
+    clearIdentityCache();
+  });
+
+  afterEach(() => {
+    rmSync(repoDir, { recursive: true, force: true });
+    clearIdentityCache();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("spawns git only once for repeated resolution of the same directory", () => {
+    const spawnSpy = vi.spyOn(realFs, "spawn");
+
+    computeIdentity(repoDir, realFs);
+    const spawnsAfterFirstCall = spawnSpy.mock.calls.length;
+    expect(spawnsAfterFirstCall).toBeGreaterThan(0);
+
+    computeIdentity(repoDir, realFs);
+    expect(spawnSpy).toHaveBeenCalledTimes(spawnsAfterFirstCall);
+  });
+
+  it("re-spawns after clearIdentityCache", () => {
+    const spawnSpy = vi.spyOn(realFs, "spawn");
+
+    computeIdentity(repoDir, realFs);
+    const spawnsAfterFirstCall = spawnSpy.mock.calls.length;
+
+    clearIdentityCache();
+    computeIdentity(repoDir, realFs);
+    expect(spawnSpy).toHaveBeenCalledTimes(spawnsAfterFirstCall * 2);
+  });
+
+  it("re-spawns once the TTL has elapsed", () => {
+    vi.useFakeTimers();
+    const spawnSpy = vi.spyOn(realFs, "spawn");
+
+    computeIdentity(repoDir, realFs);
+    const spawnsAfterFirstCall = spawnSpy.mock.calls.length;
+
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    computeIdentity(repoDir, realFs);
+    expect(spawnSpy).toHaveBeenCalledTimes(spawnsAfterFirstCall * 2);
   });
 });

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -2,6 +2,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ProjectIdentity, ProjectIdentityKind, ProjectIdentityRef } from "../types/index.js";
 import { fallbackDisplayName } from "./display-name.js";
+import { realFs } from "./fs.js";
 
 export interface IdentityFs {
   exists(path: string): boolean;
@@ -61,7 +62,38 @@ export function normalizeGitRemote(url: string): string | null {
   return value.toLowerCase();
 }
 
+// Process-lifetime identity cache, keyed by directory. Only used for the real
+// filesystem (fs === realFs); tests inject fake IdentityFs implementations and
+// must bypass the cache to stay isolated from each other. git remotes change
+// rarely, so a coarse TTL is enough — no file-watch invalidation needed.
+const IDENTITY_CACHE_TTL_MS = 10 * 60 * 1000;
+
+interface IdentityCacheEntry {
+  identity: ProjectIdentity;
+  resolvedAt: number;
+}
+
+const identityCache = new Map<string, IdentityCacheEntry>();
+
+/** Clears the process-lifetime identity cache. For tests and explicit invalidation. */
+export function clearIdentityCache(): void {
+  identityCache.clear();
+}
+
 export function computeIdentity(cwd: string | null | undefined, fs: IdentityFs): ProjectIdentity {
+  if (fs !== realFs) return resolveIdentity(cwd, fs);
+
+  const key = cwd ?? "";
+  const cached = identityCache.get(key);
+  if (cached && Date.now() - cached.resolvedAt < IDENTITY_CACHE_TTL_MS) {
+    return cached.identity;
+  }
+  const identity = resolveIdentity(cwd, fs);
+  identityCache.set(key, { identity, resolvedAt: Date.now() });
+  return identity;
+}
+
+function resolveIdentity(cwd: string | null | undefined, fs: IdentityFs): ProjectIdentity {
   if (!cwd) return loose();
 
   const pathOps = getPathOps(cwd);


### PR DESCRIPTION
## Summary

`attachMissingProjectIdentities` created a fresh identity-resolver cache on every call, so its memoization never survived a single refresh cycle. Each cache miss synchronously spawns git (up to twice: `git config --get remote.origin.url`, then `git rev-parse --git-common-dir`), blocking the event loop — repeatedly re-paid on every refresh and full scan for the same directories, and even inside the HTTP request path via `handleGetSessionData`'s fallback.

## Changes

- `computeIdentity` now consults a **process-lifetime, TTL'd (10 min) module-level cache** keyed by directory. Git remotes change rarely; a coarse TTL beats file-watch invalidation complexity.
- The cache only engages for `fs === realFs` (reference equality — all production call sites pass the same singleton). Tests injecting fake `IdentityFs` implementations bypass it automatically, keeping them isolated.
- `clearIdentityCache()` exported for tests and explicit invalidation.
- `createIdentityResolver` (private per-call memo in `orchestrate.ts`) deleted — a second cache layer on top of the module-level one would be redundant; `attachMissingProjectIdentities` calls `computeIdentity` directly.
- `handleGetSessionData`'s fallback path benefits automatically, no changes needed.

## Testing

- New tests against real temp dirs (empty `.git` so git exits fast without a real repo) with a call-through spy on `realFs.spawn`: same directory resolves with one spawn; `clearIdentityCache()` forces re-resolution; TTL expiry (fake timers) forces re-resolution.
- `beforeEach` cache clearing added where tests exercise `attachMissingProjectIdentities` directly.
- `pnpm build` / `pnpm test` (core 389, cli 204, web 349) / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-79