### PR TITLE
perf: sidebar scalability — list virtualization, sort fix, API compression (CS-78)

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { SessionHead } from "../lib/api";
+import { buildSessionTreeModel } from "./SessionTreeSidebar";
+
+function makeSession(overrides: Partial<SessionHead> & { id: string }): SessionHead {
+  return {
+    slug: `codex/${overrides.id}`,
+    title: overrides.id,
+    directory: "/repo/unused",
+    time_created: 0,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+function groupOrderOf(paths: string[]) {
+  const seen: string[] = [];
+  for (const path of paths) {
+    const group = path.split("/")[0]!;
+    if (!seen.includes(group)) seen.push(group);
+  }
+  return seen;
+}
+
+describe("buildSessionTreeModel group sorting", () => {
+  it("orders groups by most recent session time, descending", () => {
+    const sessions = [
+      makeSession({
+        id: "old-1",
+        directory: "/repo/old",
+        time_created: 100,
+      }),
+      makeSession({
+        id: "new-1",
+        directory: "/repo/new",
+        time_created: 300,
+      }),
+      makeSession({
+        id: "mid-1",
+        directory: "/repo/mid",
+        time_created: 200,
+      }),
+      // A second, older session in the "new" group should not pull its maxTime down.
+      makeSession({
+        id: "new-2",
+        directory: "/repo/new",
+        time_created: 10,
+      }),
+    ];
+
+    const { paths } = buildSessionTreeModel(sessions);
+
+    expect(groupOrderOf(paths)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("always places the unknown group last, regardless of session recency", () => {
+    const sessions = [
+      makeSession({ id: "known-1", directory: "/repo/known", time_created: 10 }),
+      makeSession({ id: "unknown-1", directory: "", time_created: 9999 }),
+    ];
+
+    const { paths } = buildSessionTreeModel(sessions);
+
+    expect(groupOrderOf(paths)).toEqual(["known", "(unknown)"]);
+  });
+
+  it("sorts a huge group against another group without throwing (no Math.max spread)", () => {
+    // 200k sessions in one group reliably overflows `Math.max(...arr)`'s call
+    // stack, so this only passes if the comparator avoids spreading.
+    const bigGroup: SessionHead[] = Array.from({ length: 200_000 }, (_, index) =>
+      makeSession({
+        id: `big-${index}`,
+        directory: "/repo/big",
+        time_created: index,
+      }),
+    );
+    const sessions = [
+      ...bigGroup,
+      makeSession({ id: "small-1", directory: "/repo/small", time_created: 999_999 }),
+    ];
+
+    const { paths } = buildSessionTreeModel(sessions);
+
+    expect(() => buildSessionTreeModel(sessions)).not.toThrow();
+    expect(groupOrderOf(paths)).toEqual(["small", "big"]);
+  });
+});

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -144,7 +144,7 @@ function compareTreeOrder(
   return left.path.localeCompare(right.path);
 }
 
-function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel {
+export function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel {
   const sortOrderByPath = new Map<string, number>();
   const pathBySessionId = new Map<string, string>();
   const groupPathBySessionId = new Map<string, string>();
@@ -153,24 +153,24 @@ function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel {
   const sessionByPath = new Map<string, SessionHead>();
   const usedPaths = new Set<string>();
   const paths: string[] = [];
-  const groups = new Map<string, { label: string; sessions: SessionHead[] }>();
+  const groups = new Map<string, { label: string; sessions: SessionHead[]; maxTime: number }>();
 
   for (const session of sessions) {
     const { key, label } = getProjectGroup(session);
+    const time = getSessionTime(session);
     const group = groups.get(key);
     if (group) {
       group.sessions.push(session);
+      if (time > group.maxTime) group.maxTime = time;
     } else {
-      groups.set(key, { label, sessions: [session] });
+      groups.set(key, { label, sessions: [session], maxTime: time });
     }
   }
 
   const sortedGroups = [...groups.entries()].sort(([, a], [, b]) => {
     if (a.label === "(unknown)") return 1;
     if (b.label === "(unknown)") return -1;
-    const aTime = Math.max(...a.sessions.map(getSessionTime));
-    const bTime = Math.max(...b.sessions.map(getSessionTime));
-    return bTime - aTime;
+    return b.maxTime - a.maxTime;
   });
 
   let order = 0;

--- a/apps/web/src/components/app/SidebarFlatSessionList.test.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionHead } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
-import { SidebarFlatSessionList } from "./SidebarFlatSessionList";
+import { SidebarFlatSessionList, VIRTUALIZED_SESSION_THRESHOLD } from "./SidebarFlatSessionList";
 
 afterEach(cleanup);
 
@@ -19,6 +19,22 @@ const session: SessionHead = {
     total_cost: 0,
   },
 };
+
+function makeSessions(count: number): SessionHead[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `session-${index}`,
+    slug: `codex/session-${index}`,
+    title: `Session ${index}`,
+    directory: "/repo",
+    time_created: index,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  }));
+}
 
 describe("SidebarFlatSessionList", () => {
   it("forwards session menu actions without selecting the row", () => {
@@ -47,5 +63,71 @@ describe("SidebarFlatSessionList", () => {
     fireEvent.click(screen.getByRole("menuitem", { name: "Add bookmark" }));
     expect(onToggleBookmark).toHaveBeenCalledWith(session);
     expect(onSelectSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("SidebarFlatSessionList virtualization", () => {
+  it("renders every row when at or below the threshold", () => {
+    const sessions = makeSessions(VIRTUALIZED_SESSION_THRESHOLD);
+
+    render(
+      <SidebarFlatSessionList
+        sessions={sessions}
+        agentCatalog={createAgentCatalog([])}
+        activeSessionId={null}
+        selectedSessionId={null}
+        bookmarkedSessionIds={new Set()}
+        onSelectSession={vi.fn()}
+        onRenameSession={vi.fn()}
+        onToggleBookmark={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(VIRTUALIZED_SESSION_THRESHOLD);
+  });
+
+  it("keeps the rendered DOM node count bounded once past the threshold", () => {
+    const sessions = makeSessions(VIRTUALIZED_SESSION_THRESHOLD * 20);
+
+    const view = render(
+      <SidebarFlatSessionList
+        sessions={sessions}
+        agentCatalog={createAgentCatalog([])}
+        activeSessionId={null}
+        selectedSessionId={null}
+        bookmarkedSessionIds={new Set()}
+        onSelectSession={vi.fn()}
+        onRenameSession={vi.fn()}
+        onToggleBookmark={vi.fn()}
+      />,
+    );
+
+    const rendered = view.container.querySelectorAll("li").length;
+    expect(rendered).toBeGreaterThan(0);
+    expect(rendered).toBeLessThan(sessions.length / 2);
+  });
+
+  it("still reflects selection and forwards actions for a virtualized row that is scrolled into view", () => {
+    const sessions = makeSessions(VIRTUALIZED_SESSION_THRESHOLD * 5);
+    const onSelectSession = vi.fn();
+    const onRenameSession = vi.fn();
+    const targetSession = sessions[0]!;
+
+    render(
+      <SidebarFlatSessionList
+        sessions={sessions}
+        agentCatalog={createAgentCatalog([])}
+        activeSessionId={targetSession.id}
+        selectedSessionId={targetSession.id}
+        bookmarkedSessionIds={new Set()}
+        onSelectSession={onSelectSession}
+        onRenameSession={onRenameSession}
+        onToggleBookmark={vi.fn()}
+      />,
+    );
+
+    const title = screen.getByText("Session 0");
+    fireEvent.click(title);
+    expect(onSelectSession).toHaveBeenCalledWith(targetSession);
   });
 });

--- a/apps/web/src/components/app/SidebarFlatSessionList.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { SessionHead } from "../../lib/api";
 import { findAgent, type AgentCatalog } from "../../lib/agents";
 import { getSessionAgentKey } from "../../lib/session-indexes";
@@ -5,16 +6,19 @@ import { formatRelativeTime } from "../../lib/format";
 import { getSessionDisplayTitle } from "../../lib/session-title";
 import { SessionActionsMenu } from "../SessionActionsMenu";
 
-export function SidebarFlatSessionList({
-  sessions,
-  agentCatalog,
-  activeSessionId,
-  selectedSessionId,
-  bookmarkedSessionIds,
-  onSelectSession,
-  onToggleBookmark,
-  onRenameSession,
-}: {
+// Rows render a single-line, truncated title/timestamp with a fixed-size icon, so
+// (unlike chat messages) every row has the same height and doesn't need per-row
+// measurement — a constant span plus overscan absorbs any small estimation error.
+export const VIRTUALIZED_SESSION_THRESHOLD = 80;
+const SESSION_ROW_GAP_PX = 4;
+// SessionRow height, measured from rendered output: py-1.5 (12) + border (2)
+// + title line (text-xs line-height, 16) + mt-0.5 (2) + timestamp line
+// (text-[10px] * line-height 1.5, 15) = 47.
+const SESSION_ROW_SPAN_PX = 47;
+const SESSION_LIST_OVERSCAN = 8;
+const SESSION_LIST_HEIGHT_CLASS = "h-[min(560px,calc(100vh-410px))] min-h-56";
+
+interface SidebarFlatSessionListProps {
   sessions: SessionHead[];
   agentCatalog: AgentCatalog;
   activeSessionId: string | null;
@@ -23,51 +27,195 @@ export function SidebarFlatSessionList({
   onSelectSession: (session: SessionHead) => void;
   onToggleBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
+}
+
+function SessionRow({
+  session,
+  agentCatalog,
+  active,
+  selected,
+  onSelectSession,
+  onToggleBookmark,
+  onRenameSession,
+  bookmarkedSessionIds,
+}: {
+  session: SessionHead;
+  agentCatalog: AgentCatalog;
+  active: boolean;
+  selected: boolean;
+  onSelectSession: (session: SessionHead) => void;
+  onToggleBookmark: (session: SessionHead) => void;
+  onRenameSession: (session: SessionHead) => void;
+  bookmarkedSessionIds: Set<string>;
 }) {
+  const agentKey = getSessionAgentKey(session);
+  const agent = findAgent(agentCatalog, agentKey);
   return (
-    <div className="console-scrollbar h-[min(560px,calc(100vh-410px))] min-h-56 overflow-y-auto">
+    <div
+      className={`flex items-start gap-1 rounded-sm border px-2 py-1.5 transition-colors ${
+        active || selected
+          ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+          : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => onSelectSession(session)}
+        className="min-w-0 flex-1 text-left"
+      >
+        <span className="flex min-w-0 items-center gap-1.5">
+          {agent?.icon ? (
+            <img
+              src={agent.icon}
+              alt={agent.displayName}
+              className="size-3.5 shrink-0 object-contain"
+            />
+          ) : null}
+          <span className="console-mono line-clamp-1 text-xs text-[var(--console-text)]">
+            {getSessionDisplayTitle(session)}
+          </span>
+        </span>
+        <span className="console-mono mt-0.5 block truncate text-[10px] text-[var(--console-muted)]">
+          {formatRelativeTime(session.time_updated ?? session.time_created)}
+        </span>
+      </button>
+      <SessionActionsMenu
+        bookmarked={bookmarkedSessionIds.has(session.id)}
+        onRename={() => onRenameSession(session)}
+        onToggleBookmark={() => onToggleBookmark(session)}
+      />
+    </div>
+  );
+}
+
+export function SidebarFlatSessionList(props: SidebarFlatSessionListProps) {
+  if (props.sessions.length > VIRTUALIZED_SESSION_THRESHOLD) {
+    return <VirtualizedSidebarFlatSessionList {...props} />;
+  }
+
+  const {
+    sessions,
+    agentCatalog,
+    activeSessionId,
+    selectedSessionId,
+    bookmarkedSessionIds,
+    onSelectSession,
+    onToggleBookmark,
+    onRenameSession,
+  } = props;
+
+  return (
+    <div className={`console-scrollbar ${SESSION_LIST_HEIGHT_CLASS} overflow-y-auto`}>
       <ul className="space-y-1">
-        {sessions.map((sessionItem) => {
-          const agentKey = getSessionAgentKey(sessionItem);
-          const agent = findAgent(agentCatalog, agentKey);
-          const active = activeSessionId === sessionItem.id;
-          const selected = selectedSessionId === sessionItem.id;
+        {sessions.map((sessionItem) => (
+          <li key={sessionItem.slug}>
+            <SessionRow
+              session={sessionItem}
+              agentCatalog={agentCatalog}
+              active={activeSessionId === sessionItem.id}
+              selected={selectedSessionId === sessionItem.id}
+              bookmarkedSessionIds={bookmarkedSessionIds}
+              onSelectSession={onSelectSession}
+              onToggleBookmark={onToggleBookmark}
+              onRenameSession={onRenameSession}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function VirtualizedSidebarFlatSessionList({
+  sessions,
+  agentCatalog,
+  activeSessionId,
+  selectedSessionId,
+  bookmarkedSessionIds,
+  onSelectSession,
+  onToggleBookmark,
+  onRenameSession,
+}: SidebarFlatSessionListProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 });
+  const viewportRef = useRef(viewport);
+
+  const updateViewport = useCallback(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const next = { scrollTop: node.scrollTop, height: node.clientHeight };
+    const current = viewportRef.current;
+    if (
+      Math.abs(current.scrollTop - next.scrollTop) < 1 &&
+      Math.abs(current.height - next.height) < 1
+    ) {
+      return;
+    }
+
+    viewportRef.current = next;
+    setViewport(next);
+  }, []);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    let frame = 0;
+    const scheduleUpdate = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        updateViewport();
+      });
+    };
+
+    node.addEventListener("scroll", scheduleUpdate, { passive: true });
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(scheduleUpdate) : null;
+    resizeObserver?.observe(node);
+    updateViewport();
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      node.removeEventListener("scroll", scheduleUpdate);
+      resizeObserver?.disconnect();
+    };
+  }, [updateViewport]);
+
+  const rowSpan = SESSION_ROW_SPAN_PX + SESSION_ROW_GAP_PX;
+  const startIndex = Math.max(0, Math.floor(viewport.scrollTop / rowSpan) - SESSION_LIST_OVERSCAN);
+  const endIndex = Math.min(
+    sessions.length,
+    Math.ceil((viewport.scrollTop + viewport.height) / rowSpan) + SESSION_LIST_OVERSCAN,
+  );
+  const visibleSessions = sessions.slice(startIndex, endIndex);
+  const totalHeight = Math.max(0, sessions.length * rowSpan - SESSION_ROW_GAP_PX);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`console-scrollbar ${SESSION_LIST_HEIGHT_CLASS} overflow-y-auto`}
+    >
+      <ul className="relative" style={{ height: totalHeight }}>
+        {visibleSessions.map((sessionItem, offset) => {
+          const index = startIndex + offset;
           return (
-            <li key={sessionItem.slug}>
-              <div
-                className={`flex items-start gap-1 rounded-sm border px-2 py-1.5 transition-colors ${
-                  active || selected
-                    ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
-                    : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
-                }`}
-              >
-                <button
-                  type="button"
-                  onClick={() => onSelectSession(sessionItem)}
-                  className="min-w-0 flex-1 text-left"
-                >
-                  <span className="flex min-w-0 items-center gap-1.5">
-                    {agent?.icon ? (
-                      <img
-                        src={agent.icon}
-                        alt={agent.displayName}
-                        className="size-3.5 shrink-0 object-contain"
-                      />
-                    ) : null}
-                    <span className="console-mono line-clamp-1 text-xs text-[var(--console-text)]">
-                      {getSessionDisplayTitle(sessionItem)}
-                    </span>
-                  </span>
-                  <span className="console-mono mt-0.5 block truncate text-[10px] text-[var(--console-muted)]">
-                    {formatRelativeTime(sessionItem.time_updated ?? sessionItem.time_created)}
-                  </span>
-                </button>
-                <SessionActionsMenu
-                  bookmarked={bookmarkedSessionIds.has(sessionItem.id)}
-                  onRename={() => onRenameSession(sessionItem)}
-                  onToggleBookmark={() => onToggleBookmark(sessionItem)}
-                />
-              </div>
+            <li
+              key={sessionItem.slug}
+              className="absolute inset-x-0 top-0"
+              style={{ transform: `translateY(${index * rowSpan}px)` }}
+            >
+              <SessionRow
+                session={sessionItem}
+                agentCatalog={agentCatalog}
+                active={activeSessionId === sessionItem.id}
+                selected={selectedSessionId === sessionItem.id}
+                bookmarkedSessionIds={bookmarkedSessionIds}
+                onSelectSession={onSelectSession}
+                onToggleBookmark={onToggleBookmark}
+                onRenameSession={onRenameSession}
+              />
             </li>
           );
         })}

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -29,6 +29,29 @@ function createStore() {
   };
 }
 
+function createLargeSessionsStore() {
+  const sessions = Array.from({ length: 200 }, (_, index) => ({
+    id: `session-${index}`,
+    slug: `codex/session-${index}`,
+    title: `Session with a reasonably descriptive title ${index}`,
+    directory: "/repo/some/nested/project/directory",
+    time_created: index,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  }));
+  return {
+    getSnapshot: () => ({ sessions, byAgent: { codex: sessions }, agents: [] }),
+    getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
+    subscribe: () => () => {},
+    subscribeScanStatus: () => () => {},
+    shutdown: vi.fn(),
+  };
+}
+
 async function listen(server: NodeServer, port: number): Promise<number> {
   return new Promise((resolve, reject) => {
     server.once("error", reject);
@@ -169,6 +192,26 @@ describe("createServer", () => {
     } finally {
       await app.shutdown();
       warnSpy.mockRestore();
+    }
+  });
+
+  it("compresses large JSON API responses but leaves the SSE stream untouched", async () => {
+    const app = await createServer(0, createLargeSessionsStore());
+
+    try {
+      const sessionsResponse = await fetch(`${app.url}/api/sessions`, {
+        headers: { "Accept-Encoding": "gzip" },
+      });
+      expect(sessionsResponse.headers.get("Content-Encoding")).toBe("gzip");
+
+      const eventsResponse = await fetch(`${app.url}/api/events`, {
+        headers: { "Accept-Encoding": "gzip" },
+      });
+      expect(eventsResponse.headers.get("Content-Encoding")).toBeNull();
+      expect(eventsResponse.headers.get("Content-Type")).toContain("text/event-stream");
+      await eventsResponse.body?.cancel();
+    } finally {
+      await app.shutdown();
     }
   });
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
+import { compress } from "hono/compress";
 import { serve } from "@hono/node-server";
 import type { ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
@@ -138,6 +139,9 @@ export async function createServer(
       onError: (c) => c.json({ error: "Request body too large" }, 413),
     }),
   );
+  // Hono's default filter already excludes text/event-stream, so this does not
+  // interfere with the /api/events SSE stream.
+  app.use("/api/*", compress());
 
   // API routes
   const routeOptions: ApiRouteOptions = {


### PR DESCRIPTION
## Summary

Three scalability gaps in the sidebar when session counts grow into the thousands:

1. **Group-sort comparator recomputed `Math.max(...sessions.map(...))` on every comparison** — O(total sessions × log groups) redundant scans, plus a real `RangeError: Maximum call stack size exceeded` crash risk from spreading large arrays (reproducible around 200k elements).
2. **`SidebarFlatSessionList` rendered every session as a DOM node** with no virtualization.
3. **`/api/sessions` responses were uncompressed** (and unbounded — see below).

## Changes

- **Sort fix**: each group's `maxTime` is accumulated (no spread) during the existing group-building pass; the comparator reads the precomputed value. Ordering — including the "(unknown)"-last rule — is unchanged, verified by tests incl. a 200k-session regression case that crashes the old implementation.
- **Virtualization**: fixed-row-height windowing (threshold 80, same semantics as `message-list.tsx`'s `VIRTUALIZED_MESSAGE_THRESHOLD`; overscan; rAF-merged scroll/resize). Deliberately simpler than message-list's measured-row machinery: session rows are single-line-clamped title + timestamp, so row height is a constant (47px, derived from padding/border/line-heights and pixel-matched against the non-virtualized path — review caught the original 56px estimate causing a visible spacing jump at the 80→81 boundary). Rows are extracted into a shared `SessionRow` so both paths render identically. Keyboard selection lives in app state (`useKeyboardShortcuts` never scrolled the DOM), so no interaction regression.
- **API compression**: `hono/compress` on `/api/*`. Verified against hono 4.12's source that `COMPRESSIBLE_CONTENT_TYPE_REGEX` explicitly excludes `text/event-stream` (negative lookahead), so the `/api/events` SSE stream is untouched while JSON payloads compress.
- **Pagination deliberately not added** (per the issue's escape clause): the web app's session store fetches the full window once and derives sidebar/tree/dashboard views client-side — a server-side limit would break the tree grouping. Recorded in the issue.

## Testing

- New: sort equivalence + 200k no-crash; DOM node bound above threshold; full render below threshold; selection/click forwarding under virtualization; compression smoke in server tests.
- `pnpm build` / `pnpm test` (core 389, cli 204, web 356) / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-78