### PR TITLE
perf: track timeline anchors with IntersectionObserver (CS-80)

### DIFF
--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -1,7 +1,38 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionMessageTimeline } from "./session-message-timeline";
 import type { SessionTimelineEntry } from "./timeline";
+
+// Mirrors the ResizeObserverMock pattern used in message-list.test.tsx: a controllable
+// stand-in so tests can drive which anchors are "visible" without a real layout engine.
+class IntersectionObserverMock {
+  static instances: IntersectionObserverMock[] = [];
+
+  readonly targets = new Set<Element>();
+
+  constructor(private readonly callback: IntersectionObserverCallback) {
+    IntersectionObserverMock.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.targets.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.targets.delete(target);
+  }
+
+  disconnect() {
+    this.targets.clear();
+  }
+
+  trigger(changes: Array<{ target: Element; isIntersecting: boolean }>) {
+    this.callback(
+      changes as unknown as IntersectionObserverEntry[],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
 
 const entries: SessionTimelineEntry[] = [
   {
@@ -27,7 +58,10 @@ const entries: SessionTimelineEntry[] = [
   },
 ];
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 function renderTimeline(timelineEntries = entries) {
   const onNavigate = vi.fn();
@@ -249,5 +283,71 @@ describe("SessionMessageTimeline", () => {
     fireEvent.scroll(timeline);
 
     expect(getByRole("tooltip").textContent).toBe("Agent · Second");
+  });
+
+  it("derives the active entry from the IntersectionObserver-tracked visible set", async () => {
+    IntersectionObserverMock.instances = [];
+    vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
+    // Mid-scroll geometry: away from both edges so findTimelineEdgeIndex returns null
+    // and the visible-set-driven activeIndex logic under test actually runs.
+    vi.stubGlobal("innerHeight", 400);
+    vi.stubGlobal("scrollY", 300);
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+      configurable: true,
+      value: 1_000,
+    });
+
+    const detail = document.createElement("div");
+    detail.setAttribute("data-testid", "session-detail");
+    document.body.appendChild(detail);
+
+    const anchorElements = new Map(
+      entries.map((entry) => {
+        const anchor = document.createElement("div");
+        anchor.dataset.sessionTimelineAnchor = entry.anchorId;
+        detail.appendChild(anchor);
+        return [entry.anchorId, anchor] as const;
+      }),
+    );
+
+    render(<SessionMessageTimeline entries={entries} onNavigate={vi.fn()} />, {
+      container: detail,
+    });
+
+    const observer = IntersectionObserverMock.instances[0]!;
+    const agentAnchor = anchorElements.get("agent-1")!;
+    const toolAnchor = anchorElements.get("tool-1")!;
+    agentAnchor.getBoundingClientRect = () => ({ top: 100 }) as DOMRect;
+    toolAnchor.getBoundingClientRect = () => ({ top: 300 }) as DOMRect;
+
+    // Viewport center is 200: only agent-1 (top 100) and tool-1 (top 300) are visible,
+    // and agent-1 is the closest one at-or-above center.
+    act(() => {
+      observer.trigger([
+        { target: agentAnchor, isIntersecting: true },
+        { target: toolAnchor, isIntersecting: true },
+      ]);
+    });
+    await waitFor(() =>
+      expect(document.querySelector('[aria-current="location"]')?.getAttribute("aria-label")).toBe(
+        "Go to Agent · Second",
+      ),
+    );
+
+    // agent-1 scrolls out of view; tool-1 (top 50, now above center) becomes active.
+    toolAnchor.getBoundingClientRect = () => ({ top: 50 }) as DOMRect;
+    act(() => {
+      observer.trigger([
+        { target: agentAnchor, isIntersecting: false },
+        { target: toolAnchor, isIntersecting: true },
+      ]);
+    });
+    await waitFor(() =>
+      expect(document.querySelector('[aria-current="location"]')?.getAttribute("aria-label")).toBe(
+        "Go to Read · Read",
+      ),
+    );
+
+    detail.remove();
   });
 });

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -184,6 +184,26 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
     const detail = root.closest<HTMLElement>('[data-testid="session-detail"]');
     const scrollParent = findScrollParent(root);
     let frame = 0;
+
+    // jsdom (test env) has no IntersectionObserver; fall back to the pre-CS-80 full-scan
+    // path so existing tests keep exercising real layout without a polyfill.
+    const anchorSelector = "[data-session-timeline-anchor]";
+    const readAnchorPosition = (anchor: HTMLElement) => {
+      const anchorId = anchor.dataset.sessionTimelineAnchor;
+      const index = anchorId ? entryIndexes.get(anchorId) : undefined;
+      return index == null ? null : { index, top: anchor.getBoundingClientRect().top };
+    };
+    const scanAllAnchors = () =>
+      Array.from(detail?.querySelectorAll<HTMLElement>(anchorSelector) ?? []).flatMap(
+        (anchor) => readAnchorPosition(anchor) ?? [],
+      );
+
+    // Only intersecting anchors are re-measured per frame; IO keeps this set updated
+    // so scroll frames read O(visible) rects instead of O(total anchors).
+    const visibleAnchors = new Map<string, HTMLElement>();
+    const scanVisibleAnchors = () =>
+      Array.from(visibleAnchors.values()).flatMap((anchor) => readAnchorPosition(anchor) ?? []);
+
     const updateActiveEntry = () => {
       const viewport = getScrollViewport(scrollParent);
       const edgeIndex = findTimelineEdgeIndex(
@@ -192,13 +212,7 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
         viewport.scrollHeight,
         entries.length,
       );
-      const positions = Array.from(
-        detail?.querySelectorAll<HTMLElement>("[data-session-timeline-anchor]") ?? [],
-      ).flatMap((anchor) => {
-        const anchorId = anchor.dataset.sessionTimelineAnchor;
-        const index = anchorId ? entryIndexes.get(anchorId) : undefined;
-        return index == null ? [] : [{ index, top: anchor.getBoundingClientRect().top }];
-      });
+      const positions = intersectionObserver ? scanVisibleAnchors() : scanAllAnchors();
       const nextIndex = edgeIndex ?? findActiveTimelineIndex(positions, viewport.center);
       if (nextIndex != null) {
         setActiveIndex((current) => (current === nextIndex ? current : nextIndex));
@@ -212,6 +226,39 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
       });
     };
 
+    const intersectionObserver =
+      typeof IntersectionObserver === "undefined"
+        ? null
+        : new IntersectionObserver(
+            (ioEntries) => {
+              for (const entry of ioEntries) {
+                const anchor = entry.target as HTMLElement;
+                const anchorId = anchor.dataset.sessionTimelineAnchor;
+                if (!anchorId) continue;
+                if (entry.isIntersecting) visibleAnchors.set(anchorId, anchor);
+                else visibleAnchors.delete(anchorId);
+              }
+              scheduleUpdate();
+            },
+            { root: isWindowScrollParent(scrollParent) ? null : scrollParent, threshold: 0 },
+          );
+
+    const observeAnchor = (anchor: HTMLElement) => intersectionObserver?.observe(anchor);
+    const unobserveAnchor = (anchor: HTMLElement) => {
+      intersectionObserver?.unobserve(anchor);
+      const anchorId = anchor.dataset.sessionTimelineAnchor;
+      if (anchorId) visibleAnchors.delete(anchorId);
+    };
+    const forEachAnchorIn = (node: Node, visit: (anchor: HTMLElement) => void) => {
+      if (!(node instanceof HTMLElement)) return;
+      if (node.matches(anchorSelector)) visit(node);
+      node.querySelectorAll<HTMLElement>(anchorSelector).forEach(visit);
+    };
+
+    if (intersectionObserver && detail) {
+      detail.querySelectorAll<HTMLElement>(anchorSelector).forEach(observeAnchor);
+    }
+
     scheduleUpdate();
     scrollParent.addEventListener("scroll", scheduleUpdate, { passive: true });
     window.addEventListener("resize", scheduleUpdate);
@@ -220,12 +267,27 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
       typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleUpdate);
     if (detail) resizeObserver?.observe(detail);
 
+    // Converged to registration bookkeeping only: mutations register/unregister IO targets
+    // for added/removed anchors instead of forcing a full-scan recompute on every DOM change.
     const mutationObserver =
-      typeof MutationObserver === "undefined" ? null : new MutationObserver(scheduleUpdate);
+      typeof MutationObserver === "undefined"
+        ? null
+        : new MutationObserver((records) => {
+            if (!intersectionObserver) {
+              scheduleUpdate();
+              return;
+            }
+            for (const record of records) {
+              record.addedNodes.forEach((node) => forEachAnchorIn(node, observeAnchor));
+              record.removedNodes.forEach((node) => forEachAnchorIn(node, unobserveAnchor));
+            }
+            scheduleUpdate();
+          });
     if (detail) mutationObserver?.observe(detail, { childList: true, subtree: true });
 
     return () => {
       if (frame) cancelAnimationFrame(frame);
+      intersectionObserver?.disconnect();
       resizeObserver?.disconnect();
       mutationObserver?.disconnect();
       scrollParent.removeEventListener("scroll", scheduleUpdate);


### PR DESCRIPTION
## Summary

The session timeline's active-entry tracking did, on every scroll/update frame: `querySelectorAll` over **all** `[data-session-timeline-anchor]` elements followed by a `getBoundingClientRect` per anchor — a forced layout read scaling with message count. On top of that, a `childList+subtree` MutationObserver over the whole session-detail tree re-triggered this full scan on *any* DOM change (virtualized row mount/unmount, async code-highlight, image loads), amplifying layout thrash on long sessions.

## Changes

- An `IntersectionObserver` (root = the scroll container, or viewport when window-scrolled) maintains the set of currently visible anchors. Scroll frames now measure **O(visible)** rects (typically <10) instead of O(total).
- The MutationObserver is converged to registration bookkeeping: added/removed nodes are walked for anchors (both the node itself and descendants — React inserts subtree roots) to `observe`/`unobserve`, instead of forcing a recompute on every mutation.
- Semantics preserved: `edgeIndex` top/bottom forcing, `setActiveIndex` dedupe, rAF throttling, the anchor `data-` protocol, and all cleanup paths.
- Environments without `IntersectionObserver` (jsdom/happy-dom tests) fall back to the previous full-scan path unchanged.

## Testing

- New test drives activeIndex through a stubbed IntersectionObserver's visible-set changes (same stubbing pattern as the existing `ResizeObserverMock`).
- All existing timeline tests pass via the fallback path, byte-identical behavior.
- `pnpm build` / `pnpm test` (core 389, cli 205, web 357) / `pnpm lint` / `pnpm format:check` clean

Issue: CS-80