### PR TITLE
refactor: consolidate hardcoded surface colors into design tokens (CS-81)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -365,7 +365,7 @@ export default function App() {
 
   return (
     <div className="console-ui flex h-screen flex-col overflow-hidden bg-[var(--console-bg)] text-[var(--console-text)]">
-      <header className="shrink-0 border-b border-[var(--console-border)] bg-white/85 backdrop-blur-sm">
+      <header className="shrink-0 border-b border-[var(--console-border)] bg-[var(--console-surface)]/85 backdrop-blur-sm">
         <div className="grid min-h-14 grid-cols-[auto_1fr] items-center gap-3 px-4 py-2 sm:grid-cols-[auto_1fr_auto] sm:py-0">
           <div className="flex items-center gap-2">
             <button
@@ -374,7 +374,7 @@ export default function App() {
               aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
               title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
               onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-              className="hidden rounded-sm border border-[var(--console-border)] bg-white p-1.5 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] lg:inline-flex"
+              className="hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1.5 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] lg:inline-flex"
             >
               {sidebarCollapsed ? (
                 <PanelLeftOpen className="size-4" />
@@ -396,7 +396,7 @@ export default function App() {
               submitSearch();
             }}
           >
-            <label className="flex min-w-0 flex-1 items-center rounded-sm border border-[var(--console-border)] bg-white px-2 py-1 focus-within:border-[var(--console-border-strong)] focus-within:ring-2 focus-within:ring-[var(--console-accent)] focus-within:ring-offset-2">
+            <label className="flex min-w-0 flex-1 items-center rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 focus-within:border-[var(--console-border-strong)] focus-within:ring-2 focus-within:ring-[var(--console-accent)] focus-within:ring-offset-2">
               <span className="sr-only">Search Sessions</span>
               <input
                 ref={searchInputRef}
@@ -411,7 +411,7 @@ export default function App() {
             </label>
             <button
               type="submit"
-              className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-white focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+              className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               Search
             </button>
@@ -423,7 +423,7 @@ export default function App() {
                 setShortcutHelpOpen(true);
                 dismissShortcutHint();
               }}
-              className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface-muted)]"
+              className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface-muted)]"
               title="Show keyboard shortcuts"
             >
               ?<span className="hidden sm:inline"> Shortcuts</span>
@@ -477,7 +477,7 @@ export default function App() {
         />
 
         <main className="flex min-w-0 flex-1 flex-col">
-          <section className="shrink-0 border-b border-[var(--console-border)] bg-white/70 px-4 py-4 backdrop-blur-sm md:px-8">
+          <section className="shrink-0 border-b border-[var(--console-border)] bg-[var(--console-surface)]/70 px-4 py-4 backdrop-blur-sm md:px-8">
             <div>
               <nav
                 aria-label="Breadcrumb"
@@ -514,7 +514,7 @@ export default function App() {
                 {!shortcutHintDismissed ? (
                   <div className="console-mono inline-flex items-center gap-2 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-text)]">
                     <span>Keyboard navigation available</span>
-                    <span className="rounded-sm border border-[var(--console-border)] bg-white px-1">
+                    <span className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1">
                       ?
                     </span>
                     <button

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -41,7 +41,7 @@ function formatCompact(value: number): string {
 
 function StatCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <p className="console-mono text-[11px] uppercase tracking-wider text-[var(--console-muted)]">
         {label}
       </p>
@@ -76,7 +76,7 @@ function DailyActivityChart({ buckets }: { buckets: DashboardDailyBucket[] }) {
   return (
     <section
       aria-labelledby="daily-activity-title"
-      className="rounded-sm border border-[var(--console-border)] bg-white p-4"
+      className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4"
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
@@ -196,7 +196,7 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
   return (
     <section
       aria-labelledby="daily-token-activity-title"
-      className="rounded-sm border border-[var(--console-border)] bg-white p-4"
+      className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4"
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
@@ -359,7 +359,7 @@ function ModelDistribution({ entries }: { entries: ModelDistributionEntry[] }) {
 
   if (visibleEntries.length === 0 || totalTokens === 0) {
     return (
-      <div className="rounded-sm border border-[var(--console-border)] bg-white p-4 text-sm text-[var(--console-muted)]">
+      <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4 text-sm text-[var(--console-muted)]">
         No model data yet
       </div>
     );
@@ -383,7 +383,7 @@ function ModelDistribution({ entries }: { entries: ModelDistributionEntry[] }) {
   return (
     <section
       aria-labelledby="model-distribution-title"
-      className="rounded-sm border border-[var(--console-border)] bg-white p-4"
+      className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4"
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <h3
@@ -464,14 +464,14 @@ function AgentDistribution({ perAgent }: { perAgent: DashboardAgentStat[] }) {
 
   if (total === 0 || perAgent.length === 0) {
     return (
-      <div className="rounded-sm border border-[var(--console-border)] bg-white p-4 text-sm text-[var(--console-muted)]">
+      <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4 text-sm text-[var(--console-muted)]">
         No agent data yet
       </div>
     );
   }
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
         <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Agent Distribution
@@ -531,7 +531,7 @@ function TopProjects({
   if (projects.length === 0) return null;
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
         <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Projects
@@ -566,7 +566,7 @@ function TopProjects({
                     return (
                       <span
                         key={agent.name}
-                        className="console-mono inline-flex items-center gap-1 rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5 text-[10px] text-[var(--console-muted)]"
+                        className="console-mono inline-flex items-center gap-1 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-0.5 text-[10px] text-[var(--console-muted)]"
                       >
                         {agentInfo?.icon ? (
                           <img
@@ -604,7 +604,7 @@ function BookmarkedSessions({
   if (sessions.length === 0) return null;
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between">
         <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Bookmarked Sessions
@@ -660,14 +660,14 @@ function RecentSessions({
 }) {
   if (sessions.length === 0) {
     return (
-      <div className="rounded-sm border border-[var(--console-border)] bg-white p-4 text-sm text-[var(--console-muted)]">
+      <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4 text-sm text-[var(--console-muted)]">
         No sessions yet
       </div>
     );
   }
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between">
         <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Recent Activity
@@ -722,14 +722,14 @@ function RecentSessions({
 function RecentFileActivity({ activity }: { activity: FileActivityResult[] }) {
   if (activity.length === 0) {
     return (
-      <div className="rounded-sm border border-[var(--console-border)] bg-white p-4 text-sm text-[var(--console-muted)]">
+      <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4 text-sm text-[var(--console-muted)]">
         No file activity yet
       </div>
     );
   }
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between">
         <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Recently Touched Files

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -37,7 +37,7 @@ function getSessionTotalTokens(stats: SessionHead["stats"]) {
 
 function LandingCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <p className="console-mono text-[11px] uppercase tracking-wider text-[var(--console-muted)]">
         {label}
       </p>
@@ -76,7 +76,7 @@ function MissingStateHero({
   iconAlt?: string;
 }) {
   return (
-    <div className="rounded-sm border border-[var(--console-border-strong)] bg-white p-5 md:p-6">
+    <div className="rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-5 md:p-6">
       <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
         <div className="max-w-2xl">
           <span className="console-mono inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-[var(--console-muted)]">
@@ -111,7 +111,7 @@ function MissingStateHero({
 
 function RecommendedAgents({ agentItems }: { agentItems: LandingAgentItem[] }) {
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
         <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Known Agents
@@ -155,14 +155,14 @@ function RecentSessions({
 }) {
   if (sessions.length === 0) {
     return (
-      <div className="rounded-sm border border-[var(--console-border)] bg-white p-4 text-sm text-[var(--console-muted)]">
+      <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4 text-sm text-[var(--console-muted)]">
         No sessions yet
       </div>
     );
   }
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between">
         <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Recent Sessions
@@ -305,7 +305,7 @@ export function DetailLanding({
           />
         </div>
 
-        <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+        <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
           <h3 className="console-mono mb-3 text-xs font-bold uppercase text-[var(--console-text)]">
             Agents
           </h3>
@@ -346,7 +346,7 @@ export function DetailLanding({
 
   return (
     <div className="mx-auto max-w-4xl space-y-4">
-      <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+      <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
         <div className="flex items-center gap-3">
           {activeAgent ? (
             <img src={activeAgent.icon} alt={displayName} className="size-6 object-contain" />

--- a/apps/web/src/components/DrawerDialog.tsx
+++ b/apps/web/src/components/DrawerDialog.tsx
@@ -41,7 +41,7 @@ export function DrawerDialog({
             </Dialog.Title>
             <Dialog.Close
               aria-label={`Close ${title.toLowerCase()}`}
-              className="rounded-sm border border-[var(--console-border)] bg-white p-2 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+              className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-2 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               <X className="size-4" aria-hidden="true" />
             </Dialog.Close>

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -22,7 +22,7 @@ function getSessionTotalTokens(session: SessionHead): number {
 
 function StatCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <p className="console-mono text-[11px] uppercase tracking-wider text-[var(--console-muted)]">
         {label}
       </p>
@@ -48,7 +48,7 @@ function AgentPills({
         return (
           <span
             key={agent.name}
-            className="console-mono inline-flex items-center gap-1 rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5 text-[10px] text-[var(--console-muted)]"
+            className="console-mono inline-flex items-center gap-1 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-0.5 text-[10px] text-[var(--console-muted)]"
           >
             {agentInfo?.icon ? (
               <img
@@ -76,7 +76,7 @@ function ProjectListItem({
     <li>
       <Link
         to={getProjectPath({ kind: project.identityKind, key: project.identityKey })}
-        className="block rounded-sm border border-[var(--console-border)] bg-white/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-white"
+        className="block rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-[var(--console-surface)]"
       >
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0">
@@ -119,7 +119,7 @@ export function ProjectsOverview({
 
   if (projects.length === 0) {
     return (
-      <div className="mx-auto max-w-5xl rounded-sm border border-[var(--console-border)] bg-white p-6 text-sm text-[var(--console-muted)]">
+      <div className="mx-auto max-w-5xl rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-6 text-sm text-[var(--console-muted)]">
         No projects found
       </div>
     );
@@ -163,7 +163,7 @@ function ProjectAgentFilter({
   onChange: (agent?: string) => void;
 }) {
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-3">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-3">
       <div className="flex flex-wrap items-center gap-2">
         <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
           Agent
@@ -173,7 +173,7 @@ function ProjectAgentFilter({
           onClick={() => onChange(undefined)}
           className={`console-mono rounded-sm border px-2 py-1 text-[10px] transition-colors ${
             activeAgent
-              ? "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-white"
+              ? "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"
               : "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
           }`}
         >
@@ -190,7 +190,7 @@ function ProjectAgentFilter({
               className={`console-mono inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-[10px] transition-colors ${
                 active
                   ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
-                  : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-white"
+                  : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"
               }`}
             >
               {agentInfo?.icon ? (
@@ -217,7 +217,7 @@ function ProjectHeader({
   agentCatalog: AgentCatalog;
 }) {
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
         <div className="min-w-0">
           <h2 className="console-mono text-base font-semibold text-[var(--console-text)]">
@@ -247,7 +247,7 @@ function TopCostSessions({
     .slice(0, 5);
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white p-4">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
         <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Top Cost
@@ -319,7 +319,7 @@ export function ProjectDashboardView({
 }) {
   if (!project) {
     return (
-      <div className="mx-auto max-w-4xl rounded-sm border border-[var(--console-border)] bg-white p-6">
+      <div className="mx-auto max-w-4xl rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-6">
         <h2 className="console-mono text-sm font-semibold text-[var(--console-text)]">
           Project Not Found
         </h2>
@@ -328,7 +328,7 @@ export function ProjectDashboardView({
         </p>
         <Link
           to="/projects"
-          className="console-mono mt-4 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-white"
+          className="console-mono mt-4 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface)]"
         >
           Back to Projects
         </Link>
@@ -351,7 +351,7 @@ export function ProjectDashboardView({
       />
 
       {loading ? (
-        <div className="rounded-sm border border-[var(--console-border)] bg-white p-6 text-sm text-[var(--console-muted)]">
+        <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-6 text-sm text-[var(--console-muted)]">
           Loading project dashboard
         </div>
       ) : error ? (

--- a/apps/web/src/components/SessionActionsMenu.tsx
+++ b/apps/web/src/components/SessionActionsMenu.tsx
@@ -27,7 +27,7 @@ export function SessionActionsMenu({
         <Menu.Positioner side="bottom" align="end" sideOffset={4} className="z-30">
           <Menu.Popup
             finalFocus={triggerRef}
-            className="w-36 rounded-sm border border-[var(--console-border-strong)] bg-white p-1 shadow-lg focus-visible:outline-none"
+            className="w-36 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-1 shadow-lg focus-visible:outline-none"
           >
             <Menu.Item
               onClick={onRename}

--- a/apps/web/src/components/SessionAliasDialog.tsx
+++ b/apps/web/src/components/SessionAliasDialog.tsx
@@ -64,7 +64,7 @@ export function SessionAliasDialog({
     <Dialog.Root open={target !== null} onOpenChange={(open) => (!open ? onClose() : undefined)}>
       <Dialog.Portal>
         <Dialog.Backdrop className="motion-backdrop fixed inset-0 z-50 bg-black/35" />
-        <Dialog.Popup className="motion-modal fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
+        <Dialog.Popup className="motion-modal fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-5 shadow-2xl outline-none">
           <Dialog.Title className="console-mono text-sm font-semibold text-[var(--console-text)]">
             Rename session
           </Dialog.Title>
@@ -80,7 +80,7 @@ export function SessionAliasDialog({
               onKeyDown={(event) => {
                 if (event.key === "Enter") void saveAlias();
               }}
-              className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-white px-3 py-2 text-sm normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
+              className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 py-2 text-sm normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
             />
           </label>
           {error ? (

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -209,7 +209,7 @@ export function SessionDetail({ session, agentCatalog, highlightQuery }: Session
     return (
       <div
         data-testid="session-detail"
-        className="mx-auto max-w-4xl rounded-sm border border-[var(--console-border)] bg-white p-6 text-sm text-[var(--console-muted)]"
+        className="mx-auto max-w-4xl rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-6 text-sm text-[var(--console-muted)]"
       >
         当前会话暂无可展示的消息内容。
       </div>
@@ -288,7 +288,7 @@ export function SessionDetail({ session, agentCatalog, highlightQuery }: Session
               </RenderProfiler>
             </>
           ) : (
-            <div className="rounded-sm border border-[var(--console-border)] bg-white p-6 text-sm text-[var(--console-muted)]">
+            <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-6 text-sm text-[var(--console-muted)]">
               当前筛选条件下暂无可展示的消息内容。
             </div>
           )}
@@ -318,7 +318,7 @@ export function SessionSummarySection({
   if (!content) return null;
 
   return (
-    <section className="rounded-sm border border-[var(--console-border)] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+    <section className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
       <button
         type="button"
         className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left"

--- a/apps/web/src/components/SessionDetailSkeleton.tsx
+++ b/apps/web/src/components/SessionDetailSkeleton.tsx
@@ -39,7 +39,7 @@ export function SessionDetailSkeleton() {
                     className={`${item.timeWidth} h-2.5 animate-pulse motion-reduce:animate-none`}
                   />
                 </div>
-                <div className="rounded-sm border border-[var(--console-border)] bg-white p-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+                <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
                   <div className="space-y-2">
                     {item.bodyWidths.map((w) => (
                       <SkeletonBlock
@@ -54,7 +54,7 @@ export function SessionDetailSkeleton() {
           </article>
         ))}
       </div>
-      <div className="min-h-24 flex-1 rounded-sm border border-[var(--console-border)] bg-white/60 animate-pulse motion-reduce:animate-none" />
+      <div className="min-h-24 flex-1 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]/60 animate-pulse motion-reduce:animate-none" />
     </div>
   );
 }

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -449,7 +449,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
           ref={optionsMenuRef}
           role="menu"
           style={{ position: "fixed", top: options.top, right: options.right }}
-          className="z-40 w-36 rounded-sm border border-[var(--console-border-strong)] bg-white p-1 shadow-lg"
+          className="z-40 w-36 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-1 shadow-lg"
           onBlur={(event) => {
             if (!event.currentTarget.contains(event.relatedTarget)) setOptions(null);
           }}

--- a/apps/web/src/components/SmartTagChips.tsx
+++ b/apps/web/src/components/SmartTagChips.tsx
@@ -13,65 +13,22 @@ export const SMART_TAG_LABELS: Record<SmartTag, string> = {
   planning: "planning",
 };
 
+// SmartTag values double as the --tag-{tone}-* CSS variable names in
+// index.css, which owns the actual color values.
 export const SMART_TAG_TONES: Record<
   SmartTag,
   { text: string; border: string; background: string; bar: string }
-> = {
-  bugfix: {
-    text: "#B42318",
-    border: "#FECDCA",
-    background: "#FEF3F2",
-    bar: "#F04438",
-  },
-  refactoring: {
-    text: "#6941C6",
-    border: "#D9D6FE",
-    background: "#F4F3FF",
-    bar: "#7A5AF8",
-  },
-  "feature-dev": {
-    text: "#175CD3",
-    border: "#B2DDFF",
-    background: "#EFF8FF",
-    bar: "#2E90FA",
-  },
-  testing: {
-    text: "#027A48",
-    border: "#ABEFC6",
-    background: "#ECFDF3",
-    bar: "#12B76A",
-  },
-  docs: {
-    text: "#B54708",
-    border: "#FEDF89",
-    background: "#FFFAEB",
-    bar: "#F79009",
-  },
-  "git-ops": {
-    text: "#3538CD",
-    border: "#C7D7FE",
-    background: "#EEF4FF",
-    bar: "#444CE7",
-  },
-  "build-deploy": {
-    text: "#C4320A",
-    border: "#F9DBAF",
-    background: "#FEF6EE",
-    bar: "#EF6820",
-  },
-  exploration: {
-    text: "#0E7090",
-    border: "#A5F0FC",
-    background: "#ECFDFF",
-    bar: "#06AED4",
-  },
-  planning: {
-    text: "#C11574",
-    border: "#FCCEEE",
-    background: "#FDF2FA",
-    bar: "#EE46BC",
-  },
-};
+> = Object.fromEntries(
+  (Object.keys(SMART_TAG_LABELS) as SmartTag[]).map((tag) => [
+    tag,
+    {
+      text: `var(--tag-${tag}-text)`,
+      border: `var(--tag-${tag}-border)`,
+      background: `var(--tag-${tag}-background)`,
+      bar: `var(--tag-${tag}-bar)`,
+    },
+  ]),
+) as Record<SmartTag, { text: string; border: string; background: string; bar: string }>;
 
 export function getSmartTagTone(tag: SmartTag) {
   return SMART_TAG_TONES[tag];

--- a/apps/web/src/components/TimeWindowControl.tsx
+++ b/apps/web/src/components/TimeWindowControl.tsx
@@ -50,7 +50,7 @@ export function TimeWindowControl({
               if (next === "custom") openCustom();
               else onSelectPreset(next);
             }}
-            className="console-mono w-24 appearance-none rounded-sm border border-[var(--console-border)] bg-white py-1 pr-6 pl-2 text-xs text-[var(--console-text)] outline-none hover:border-[var(--console-border-strong)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 sm:w-auto sm:max-w-44 sm:pr-7"
+            className="console-mono w-24 appearance-none rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] py-1 pr-6 pl-2 text-xs text-[var(--console-text)] outline-none hover:border-[var(--console-border-strong)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 sm:w-auto sm:max-w-44 sm:pr-7"
           >
             {PRESETS.map((option) => (
               <option key={option.value} value={option.value}>
@@ -68,7 +68,7 @@ export function TimeWindowControl({
             type="button"
             onClick={openCustom}
             aria-label="Edit custom time range"
-            className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-1 text-xs text-[var(--console-muted)] hover:border-[var(--console-border-strong)] hover:text-[var(--console-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2"
+            className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-1 text-xs text-[var(--console-muted)] hover:border-[var(--console-border-strong)] hover:text-[var(--console-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2"
           >
             Edit
           </button>
@@ -78,7 +78,7 @@ export function TimeWindowControl({
       <Dialog.Root open={customOpen} onOpenChange={setCustomOpen}>
         <Dialog.Portal>
           <Dialog.Backdrop className="motion-backdrop fixed inset-0 z-50 bg-black/35" />
-          <Dialog.Popup className="motion-modal fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
+          <Dialog.Popup className="motion-modal fixed top-1/2 left-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-5 shadow-2xl outline-none">
             <Dialog.Title className="console-mono text-sm font-semibold text-[var(--console-text)]">
               Custom time range
             </Dialog.Title>
@@ -91,7 +91,7 @@ export function TimeWindowControl({
                   value={from}
                   max={to || undefined}
                   onChange={(event) => setFrom(event.target.value)}
-                  className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-white px-2 py-2 text-xs normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
+                  className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-2 text-xs normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
                 />
               </label>
               <label className="console-mono text-[11px] uppercase tracking-wide text-[var(--console-muted)]">
@@ -101,7 +101,7 @@ export function TimeWindowControl({
                   value={to}
                   min={from || undefined}
                   onChange={(event) => setTo(event.target.value)}
-                  className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-white px-2 py-2 text-xs normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
+                  className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-2 text-xs normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
                 />
               </label>
             </div>

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -41,7 +41,7 @@ function AgentNavList({
           disabled
             ? "cursor-not-allowed border-transparent text-[var(--console-muted)] opacity-50"
             : isSelected
-              ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+              ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
               : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
         }`;
         const content = (
@@ -112,7 +112,7 @@ function ProjectNavList({
               onClick={() => onSelectProject(projectIdentity)}
               className={`ml-4 flex min-w-0 items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
                 isSelected
-                  ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                  ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
                   : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
               }`}
             >
@@ -226,7 +226,7 @@ export function AppSidebar({
                 className={`flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
                   (browseBy === "agents" && viewState.mode === "root") ||
                   (browseBy === "projects" && viewState.mode === "projects")
-                    ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                    ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
                     : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
                 }`}
               >
@@ -286,7 +286,7 @@ export function AppSidebar({
                     <div
                       className={`flex items-start gap-2 rounded-sm border px-2 py-1.5 transition-colors ${
                         isActive
-                          ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                          ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
                           : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
                       }`}
                     >

--- a/apps/web/src/components/app/BrowseByToggle.tsx
+++ b/apps/web/src/components/app/BrowseByToggle.tsx
@@ -31,7 +31,7 @@ export function BrowseByToggle({
               disabled
                 ? "cursor-not-allowed border-transparent text-[var(--console-muted)] opacity-45"
                 : active
-                  ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+                  ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
                   : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
             }`}
             title={

--- a/apps/web/src/components/app/FilterChip.tsx
+++ b/apps/web/src/components/app/FilterChip.tsx
@@ -14,7 +14,7 @@ export function FilterChip({
       className={`console-mono rounded-sm border px-2 py-1 text-[10px] transition-colors ${
         active
           ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
-          : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-white"
+          : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"
       }`}
     >
       {label}

--- a/apps/web/src/components/app/SearchFilterBar.tsx
+++ b/apps/web/src/components/app/SearchFilterBar.tsx
@@ -57,7 +57,7 @@ export function SearchFilterBar({
   };
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white/85 p-3">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]/85 p-3">
       <div className="flex flex-wrap items-center gap-2">
         <span className="console-mono text-[10px] font-semibold uppercase text-[var(--console-muted)]">
           Scope
@@ -169,7 +169,7 @@ export function SearchFilterBar({
           <button
             type="button"
             onClick={() => onChangeFilters({})}
-            className="console-mono ml-auto rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[10px] text-[var(--console-muted)] transition-colors hover:bg-white"
+            className="console-mono ml-auto rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[10px] text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface)]"
           >
             Clear
           </button>

--- a/apps/web/src/components/app/SearchResultsPanel.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.tsx
@@ -72,7 +72,7 @@ export function SearchResultsPanel({
           {Array.from({ length: 4 }).map((_, index) => (
             <div
               key={index}
-              className="animate-pulse rounded-sm border border-[var(--console-border)] bg-white/80 p-4 motion-reduce:animate-none"
+              className="animate-pulse rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]/80 p-4 motion-reduce:animate-none"
             >
               <div className="h-3 w-32 rounded bg-[var(--console-surface-muted)]" />
               <div className="mt-3 h-4 w-2/3 rounded bg-[var(--console-surface-muted)]" />
@@ -102,7 +102,7 @@ export function SearchResultsPanel({
           <button
             type="button"
             onClick={onRetry}
-            className="console-mono mt-4 rounded-sm border border-[var(--console-error-border)] bg-white px-3 py-1.5 text-xs font-semibold text-[var(--console-error)] transition-colors hover:bg-[var(--console-error-bg)] focus-visible:ring-2 focus-visible:ring-[var(--console-error)] focus-visible:ring-offset-2 focus-visible:outline-none"
+            className="console-mono mt-4 rounded-sm border border-[var(--console-error-border)] bg-[var(--console-surface)] px-3 py-1.5 text-xs font-semibold text-[var(--console-error)] transition-colors hover:bg-[var(--console-error-bg)] focus-visible:ring-2 focus-visible:ring-[var(--console-error)] focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Retry Search
           </button>
@@ -115,7 +115,7 @@ export function SearchResultsPanel({
     return (
       <div className="flex flex-col gap-3">
         {filterBar}
-        <div className="rounded-sm border border-[var(--console-border)] bg-white/80 p-6">
+        <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]/80 p-6">
           <h2 className="console-mono text-sm font-semibold text-[var(--console-text)]">
             {query ? "No matches" : "No recent sessions"}
           </h2>
@@ -145,7 +145,7 @@ export function SearchResultsPanel({
             to={`/${agentKey}/${result.session.id}`}
             state={{ searchQuery: query }}
             onClick={onOpenResult}
-            className={`rounded-sm border bg-white/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-white focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none ${
+            className={`rounded-sm border bg-[var(--console-surface)]/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-[var(--console-surface)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none ${
               index === selectedIndex
                 ? "border-[var(--console-border-strong)]"
                 : "border-[var(--console-border)]"
@@ -155,7 +155,7 @@ export function SearchResultsPanel({
               <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-1.5 py-0.5 text-[10px] uppercase text-[var(--console-muted)]">
                 {agentLabel}
               </span>
-              <span className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5 text-[10px] uppercase text-[var(--console-muted)]">
+              <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-0.5 text-[10px] uppercase text-[var(--console-muted)]">
                 {SEARCH_MATCH_LABELS[result.matchType]}
               </span>
               <span className="console-mono text-[11px] text-[var(--console-muted)]">

--- a/apps/web/src/components/app/ShortcutHelpDialog.tsx
+++ b/apps/web/src/components/app/ShortcutHelpDialog.tsx
@@ -25,7 +25,7 @@ export function ShortcutHelpDialog({ open, onClose }: { open: boolean; onClose: 
     <Dialog.Root open={open} onOpenChange={(next) => (!next ? onClose() : undefined)}>
       <Dialog.Portal>
         <Dialog.Backdrop className="shortcut-overlay fixed inset-0 z-50 bg-black/35" />
-        <Dialog.Popup className="shortcut-content fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-2xl origin-center -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-2xl outline-none">
+        <Dialog.Popup className="shortcut-content fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-2xl origin-center -translate-x-1/2 -translate-y-1/2 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-5 shadow-2xl outline-none">
           <div className="flex items-start justify-between gap-4">
             <div>
               <p className="console-mono text-[11px] uppercase tracking-[0.16em] text-[var(--console-muted)]">
@@ -35,7 +35,7 @@ export function ShortcutHelpDialog({ open, onClose }: { open: boolean; onClose: 
                 Navigate without leaving the keyboard
               </Dialog.Title>
             </div>
-            <Dialog.Close className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-white">
+            <Dialog.Close className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface)]">
               Esc
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/app/SidebarFlatSessionList.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.tsx
@@ -54,7 +54,7 @@ function SessionRow({
     <div
       className={`flex items-start gap-1 rounded-sm border px-2 py-1.5 transition-colors ${
         active || selected
-          ? "border-[var(--console-border-strong)] bg-white text-[var(--console-text)]"
+          ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
           : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
       }`}
     >

--- a/apps/web/src/components/session-detail/file-change-tracker.tsx
+++ b/apps/web/src/components/session-detail/file-change-tracker.tsx
@@ -45,7 +45,7 @@ export function FileChangeTracker({
   if (sections.length === 0) return null;
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
       <div className="flex items-center gap-2 border-b border-[var(--console-border)] px-4 py-3">
         <FileText className="size-3.5 text-[var(--console-accent)]" />
         <span className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">
@@ -84,7 +84,7 @@ function FileTrackerSection({
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-[#fafafa]">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)]">
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
@@ -161,7 +161,7 @@ function FileTrackerItem({
             onClick={(event) =>
               jumpToIndex(currentIndex - 1, getActivationScrollBehavior(event.detail))
             }
-            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-white"
+            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface)]"
           >
             <ChevronUp className="size-3" />
           </button>
@@ -174,7 +174,7 @@ function FileTrackerItem({
             onClick={(event) =>
               jumpToIndex(currentIndex + 1, getActivationScrollBehavior(event.detail))
             }
-            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-white"
+            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface)]"
           >
             <ChevronDown className="size-3" />
           </button>

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -204,7 +204,7 @@ export function MessageItem({
                   key={index}
                   id={timelineAnchorId}
                   data-session-timeline-anchor={timelineAnchorId}
-                  className="scroll-mt-20 rounded-sm border border-[var(--console-border)] bg-white p-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
+                  className="scroll-mt-20 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]"
                 >
                   <div className="console-markdown text-sm leading-relaxed text-[var(--console-text)]">
                     {block.parts.map((part, partIndex) => (
@@ -254,7 +254,7 @@ function AbortToolItem() {
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-start gap-2">
-        <div className="w-full rounded-sm border border-[var(--console-border-strong)] bg-white px-3 py-2 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] md:w-[560px]">
+        <div className="w-full rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-3 py-2 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] md:w-[560px]">
           <div className="flex items-start gap-2">
             <MessageCircleX className="mt-0.5 size-3.5 shrink-0 text-[var(--console-accent)]" />
             <span className="min-w-0 flex-1">
@@ -373,7 +373,7 @@ function PlanItem({ part, highlightQuery }: { part: MessagePart; highlightQuery?
     <div className="space-y-2">
       <div className="flex flex-wrap items-start gap-2">
         <div
-          className={`w-full md:w-[560px] rounded-sm border border-[var(--console-border-strong)] bg-white px-3 py-2 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${
+          className={`w-full md:w-[560px] rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-3 py-2 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${
             display.expandable ? "transition-colors hover:bg-[var(--console-surface-muted)]" : ""
           }`}
         >
@@ -417,7 +417,7 @@ function PlanItem({ part, highlightQuery }: { part: MessagePart; highlightQuery?
       </div>
 
       {display.expandable && expanded ? (
-        <div className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+        <div className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
           <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
             <span className="console-mono text-xs text-[var(--console-muted)]">
               {display.contentLabel}
@@ -459,7 +459,7 @@ function ToolItem({
     <div id={anchorId} data-session-timeline-anchor={anchorId} className="scroll-mt-20 space-y-2">
       <div className="flex flex-wrap items-start gap-2">
         <div
-          className={`w-full max-w-[720px] rounded-sm border border-[var(--console-border-strong)] bg-white px-3 py-2.5 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${
+          className={`w-full max-w-[720px] rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-3 py-2.5 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${
             strategy.expandable ? "transition-colors hover:bg-[var(--console-surface-muted)]" : ""
           }`}
         >
@@ -526,7 +526,7 @@ function ToolItem({
       </div>
 
       {strategy.expandable && expanded ? (
-        <div className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+        <div className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
           <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
             <span className="console-mono text-xs text-[var(--console-muted)]">
               {strategy.contentLabel ?? "Output"}
@@ -534,7 +534,7 @@ function ToolItem({
           </div>
           <div className="space-y-3 p-3">
             {strategy.details.length > 0 ? (
-              <div className="rounded-sm border border-[var(--console-border)] bg-[#fafafa] px-3 py-2">
+              <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] px-3 py-2">
                 <div className="space-y-2">
                   {strategy.details.map((detail) => (
                     <div
@@ -555,7 +555,7 @@ function ToolItem({
             <ToolOutputRenderer outputContent={strategy.outputContent} />
           </div>
           {strategy.showInputPreview ? (
-            <div className="border-t border-[var(--console-border)] bg-[#fafafa] px-3 py-2">
+            <div className="border-t border-[var(--console-border)] bg-[var(--console-surface-sunken)] px-3 py-2">
               <span className="console-mono text-[11px] text-[var(--console-muted)]">
                 Input Preview
               </span>

--- a/apps/web/src/components/session-detail/session-detail-aux.tsx
+++ b/apps/web/src/components/session-detail/session-detail-aux.tsx
@@ -56,7 +56,7 @@ export function DeferredInteractiveReceipt({
         aria-expanded={open}
         aria-label="Open session receipt"
         onClick={() => setOpen(true)}
-        className="console-mono fixed right-0 top-1/2 z-40 hidden h-32 w-10 -translate-y-1/2 items-center justify-center rounded-l-sm border border-r-0 border-[var(--console-border)] bg-white text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--console-text)] shadow-[-2px_4px_14px_rgba(15,23,42,0.14)] transition-colors hover:bg-[var(--console-surface-muted)] min-[1025px]:flex"
+        className="console-mono fixed right-0 top-1/2 z-40 hidden h-32 w-10 -translate-y-1/2 items-center justify-center rounded-l-sm border border-r-0 border-[var(--console-border)] bg-[var(--console-surface)] text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--console-text)] shadow-[-2px_4px_14px_rgba(15,23,42,0.14)] transition-colors hover:bg-[var(--console-surface-muted)] min-[1025px]:flex"
       >
         <span className="[writing-mode:vertical-rl]">Receipt</span>
       </button>
@@ -66,7 +66,7 @@ export function DeferredInteractiveReceipt({
             <InteractiveReceipt key={session.id} session={session} toc={toc} />
           </RenderProfiler>
         ) : (
-          <div className="h-[calc(100dvh-5.5rem)] min-h-[420px] rounded-sm border border-[var(--console-border)] bg-white" />
+          <div className="h-[calc(100dvh-5.5rem)] min-h-[420px] rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]" />
         )}
       </DrawerDialog>
     </>
@@ -89,7 +89,7 @@ export function SessionDetailAuxControls({
       <button
         type="button"
         onClick={() => onOpen("toc")}
-        className="console-mono inline-flex h-9 items-center gap-2 rounded-sm border border-[var(--console-border)] bg-white px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--console-text)] shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-colors hover:bg-[var(--console-surface-muted)]"
+        className="console-mono inline-flex h-9 items-center gap-2 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--console-text)] shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-colors hover:bg-[var(--console-surface-muted)]"
       >
         <Funnel className="size-3.5 text-[var(--console-accent)]" />
         TOC
@@ -99,7 +99,7 @@ export function SessionDetailAuxControls({
         <button
           type="button"
           onClick={() => onOpen("files")}
-          className="console-mono inline-flex h-9 items-center gap-2 rounded-sm border border-[var(--console-border)] bg-white px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--console-text)] shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-colors hover:bg-[var(--console-surface-muted)]"
+          className="console-mono inline-flex h-9 items-center gap-2 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--console-text)] shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-colors hover:bg-[var(--console-surface-muted)]"
         >
           <FileText className="size-3.5 text-[var(--console-accent)]" />
           Files

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -454,7 +454,7 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
     <div className="sticky top-0 z-20 -mx-2 bg-[var(--console-bg)] px-2 py-3">
       <div
         ref={rootRef}
-        className="session-message-timeline relative rounded-sm border border-[var(--console-border)] bg-white px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.05)]"
+        className="session-message-timeline relative rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 py-2.5 shadow-[0_1px_2px_rgba(15,23,42,0.05)]"
       >
         <div className="relative">
           <div

--- a/apps/web/src/components/session-detail/session-toc.tsx
+++ b/apps/web/src/components/session-detail/session-toc.tsx
@@ -93,7 +93,7 @@ function TocCheckbox({
         className={`flex size-3.5 items-center justify-center rounded border ${
           checked || indeterminate
             ? "border-[var(--console-accent-strong)] bg-[var(--console-accent-strong)] text-white"
-            : "border-[var(--console-border-strong)] bg-white text-transparent"
+            : "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-transparent"
         }`}
       >
         {indeterminate ? (
@@ -150,7 +150,7 @@ export function SessionTocFilterPanel({
   const someToolsSelected = selectedToolCount > 0 && selectedToolCount < toolIds.length;
 
   return (
-    <div className="rounded-sm border border-[var(--console-border)] bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+    <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
       <div className="flex items-center gap-2 border-b border-[var(--console-border)] px-4 py-3">
         <Funnel className="size-3.5 text-[var(--console-accent)]" />
         <span className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">

--- a/apps/web/src/components/tool-output/FileSectionsOutput.tsx
+++ b/apps/web/src/components/tool-output/FileSectionsOutput.tsx
@@ -22,7 +22,7 @@ function renderSectionContent(section: FileSectionItem) {
   }
 
   return (
-    <div className="max-h-[420px] overflow-auto bg-[#fafafa]">
+    <div className="max-h-[420px] overflow-auto bg-[var(--console-surface-sunken)]">
       <CodeHighlighter language={section.language} text={outputText} />
     </div>
   );
@@ -34,11 +34,11 @@ export function FileSectionsOutput({ sections }: FileSectionsOutputProps) {
       {sections.map((section) => (
         <div
           key={`${section.operation}:${section.label}:${section.language}`}
-          className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[#fafafa]"
+          className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)]"
         >
           <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
             <div className="flex items-center gap-2">
-              <span className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--console-muted)]">
+              <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--console-muted)]">
                 {section.operation}
               </span>
               <span className="console-mono text-[11px] font-semibold text-[var(--console-muted)]">

--- a/apps/web/src/components/tool-output/MediaOutput.tsx
+++ b/apps/web/src/components/tool-output/MediaOutput.tsx
@@ -24,7 +24,7 @@ export function MediaOutput({ items, text }: { items: MediaItem[]; text?: string
         ))}
       </div>
       {text ? (
-        <pre className="console-mono whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[#fafafa] p-3 text-xs leading-relaxed text-[var(--console-text)]">
+        <pre className="console-mono whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed text-[var(--console-text)]">
           {text}
         </pre>
       ) : null}

--- a/apps/web/src/components/tool-output/PropertyListOutput.tsx
+++ b/apps/web/src/components/tool-output/PropertyListOutput.tsx
@@ -22,7 +22,7 @@ function PropertyValue({ value, depth = 0 }: { value: unknown; depth?: number })
         {value.map((item, index) => (
           <span
             key={index}
-            className="rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5"
+            className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-0.5"
           >
             <PropertyValue value={item} depth={depth + 1} />
           </span>
@@ -52,7 +52,7 @@ function PropertyValue({ value, depth = 0 }: { value: unknown; depth?: number })
 
 export function PropertyListOutput({ items }: { items: PropertyItem[] }) {
   return (
-    <dl className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[#fafafa]">
+    <dl className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)]">
       {items.map((item) => (
         <div
           key={item.label}

--- a/apps/web/src/components/tool-output/QuestionListOutput.tsx
+++ b/apps/web/src/components/tool-output/QuestionListOutput.tsx
@@ -10,12 +10,12 @@ export function QuestionListOutput({ questions }: QuestionListOutputProps) {
       {questions.map((question) => (
         <div
           key={`${question.header ?? "question"}:${question.question}`}
-          className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[#fafafa]"
+          className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)]"
         >
           <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-2">
             <div className="flex flex-wrap items-center gap-2">
               {question.header ? (
-                <span className="console-mono rounded-sm border border-[var(--console-border)] bg-white px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--console-muted)]">
+                <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--console-muted)]">
                   {question.header}
                 </span>
               ) : null}
@@ -42,7 +42,7 @@ export function QuestionListOutput({ questions }: QuestionListOutputProps) {
                   className={`rounded-sm border px-3 py-2 ${
                     isSelected
                       ? "border-[var(--console-success-border)] bg-[var(--console-success-bg)]"
-                      : "border-[var(--console-border)] bg-white"
+                      : "border-[var(--console-border)] bg-[var(--console-surface)]"
                   }`}
                 >
                   <div className="flex flex-wrap items-center gap-2">
@@ -59,7 +59,7 @@ export function QuestionListOutput({ questions }: QuestionListOutputProps) {
                       </span>
                     ) : null}
                     {isSelected ? (
-                      <span className="console-mono rounded-sm border border-[var(--console-success-border)] bg-white px-1.5 py-0.5 text-[10px] text-[var(--console-success)]">
+                      <span className="console-mono rounded-sm border border-[var(--console-success-border)] bg-[var(--console-surface)] px-1.5 py-0.5 text-[10px] text-[var(--console-success)]">
                         Selected
                       </span>
                     ) : null}

--- a/apps/web/src/components/tool-output/StructuredDiffOutput.tsx
+++ b/apps/web/src/components/tool-output/StructuredDiffOutput.tsx
@@ -22,7 +22,7 @@ export function StructuredDiffOutput({ blocks }: StructuredDiffOutputProps) {
         return (
           <div
             key={getBlockKey(block)}
-            className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[#fafafa]"
+            className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)]"
           >
             <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
               <span className="console-mono text-[11px] font-semibold text-[var(--console-muted)]">

--- a/apps/web/src/components/tool-output/TaskListOutput.tsx
+++ b/apps/web/src/components/tool-output/TaskListOutput.tsx
@@ -14,7 +14,7 @@ const STATUS_META = {
 
 export function TaskListOutput({ items }: { items: TaskListItem[] }) {
   return (
-    <ol className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-white">
+    <ol className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]">
       {items.map((item, index) => {
         const meta = STATUS_META[item.status];
         return (

--- a/apps/web/src/components/tool-output/ToolOutputRenderer.tsx
+++ b/apps/web/src/components/tool-output/ToolOutputRenderer.tsx
@@ -41,7 +41,7 @@ export function ToolOutputRenderer({ outputContent }: ToolOutputRendererProps) {
 
   if (!outputContent.isCode || outputContent.language === "text") {
     return (
-      <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[#fafafa] p-3 text-xs leading-relaxed text-[var(--console-text)]">
+      <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed text-[var(--console-text)]">
         {outputText}
       </pre>
     );
@@ -52,7 +52,7 @@ export function ToolOutputRenderer({ outputContent }: ToolOutputRendererProps) {
   }
 
   return (
-    <div className="max-h-[420px] overflow-auto rounded-sm border border-[var(--console-border)] bg-[#fafafa]">
+    <div className="max-h-[420px] overflow-auto rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)]">
       <CodeHighlighter language={outputContent.language} text={outputText} />
     </div>
   );

--- a/apps/web/src/components/tool-output/UnifiedDiffOutput.tsx
+++ b/apps/web/src/components/tool-output/UnifiedDiffOutput.tsx
@@ -30,7 +30,7 @@ export function UnifiedDiffOutput({ text }: UnifiedDiffOutputProps) {
   const lineOccurrences = new Map<string, number>();
 
   return (
-    <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre rounded-sm border border-[var(--console-border)] bg-[#fafafa] p-3 text-xs leading-relaxed">
+    <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed">
       {lines.map((line) => {
         const occurrence = lineOccurrences.get(line) ?? 0;
         lineOccurrences.set(line, occurrence + 1);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -113,7 +113,9 @@
 
     --console-bg: #f7f7f7;
     --console-sidebar-bg: #fbfbfb;
+    --console-surface: #ffffff;
     --console-surface-muted: #f5f5f5;
+    --console-surface-sunken: #fafafa;
     --console-border: #e5e5e5;
     --console-border-strong: #d4d4d4;
     --console-text: #1a1a1a;
@@ -137,6 +139,42 @@
     --timeline-tool-read: #478b7d;
     --timeline-tool-write: #bd7336;
     --timeline-tool-execute: #786ca3;
+    --tag-bugfix-text: #b42318;
+    --tag-bugfix-border: #fecdca;
+    --tag-bugfix-background: #fef3f2;
+    --tag-bugfix-bar: #f04438;
+    --tag-refactoring-text: #6941c6;
+    --tag-refactoring-border: #d9d6fe;
+    --tag-refactoring-background: #f4f3ff;
+    --tag-refactoring-bar: #7a5af8;
+    --tag-feature-dev-text: #175cd3;
+    --tag-feature-dev-border: #b2ddff;
+    --tag-feature-dev-background: #eff8ff;
+    --tag-feature-dev-bar: #2e90fa;
+    --tag-testing-text: #027a48;
+    --tag-testing-border: #abefc6;
+    --tag-testing-background: #ecfdf3;
+    --tag-testing-bar: #12b76a;
+    --tag-docs-text: #b54708;
+    --tag-docs-border: #fedf89;
+    --tag-docs-background: #fffaeb;
+    --tag-docs-bar: #f79009;
+    --tag-git-ops-text: #3538cd;
+    --tag-git-ops-border: #c7d7fe;
+    --tag-git-ops-background: #eef4ff;
+    --tag-git-ops-bar: #444ce7;
+    --tag-build-deploy-text: #c4320a;
+    --tag-build-deploy-border: #f9dbaf;
+    --tag-build-deploy-background: #fef6ee;
+    --tag-build-deploy-bar: #ef6820;
+    --tag-exploration-text: #0e7090;
+    --tag-exploration-border: #a5f0fc;
+    --tag-exploration-background: #ecfdff;
+    --tag-exploration-bar: #06aed4;
+    --tag-planning-text: #c11574;
+    --tag-planning-border: #fcceee;
+    --tag-planning-background: #fdf2fa;
+    --tag-planning-bar: #ee46bc;
     --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
     --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
     --tt-in-dur: 150ms;
@@ -149,6 +187,9 @@
     --tt-fg: #2f2f2f;
   }
 
+  /* Dark mode is not implemented: this block only overrides the shadcn base
+     tokens below and does not cover --console-* / --timeline-* / --tag-*,
+     which the product UI actually renders with. */
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;


### PR DESCRIPTION
## Summary

The web app's color token discipline had a systematic gap: 93 `bg-white` occurrences across 28 components, hardcoded `bg-[#fafafa]` in tool-output renderers, and `SmartTagChips` carrying 36 inline hex values — all bypassing the `--console-*` token system. Any future theming work (dark mode included) would first have to hunt all of these down.

This is a pure tokenization refactor: **light-theme rendering is value-identical**.

## Changes

- **Two new surface tokens** in `index.css`, named consistently with the existing `--console-*` family. Auditing all 105 usage sites showed exactly two semantic tiers:
  - `--console-surface: #ffffff` — cards, popovers, menus, dialogs, inputs
  - `--console-surface-sunken: #fafafa` — nested secondary surfaces (tool output, diffs, file-change blocks)
- **Mechanical replacement** of all 105 sites (93 `bg-white` + 12 `bg-[#fafafa]`), preserving variant prefixes (`hover:`, `data-[...]:`) and opacity modifiers (`bg-white/85` → `bg-[var(--console-surface)]/85`). Zero remaining matches; `apps/www` untouched.
- **SmartTagChips**: the 9-tone × 4-value palette moved to `--tag-{tone}-{text|border|background|bar}` CSS variables; the component builds `var()` references instead of inline hex. Values byte-identical.
- The `.dark` block is left as-is (dark mode is a separate product decision) with a note that it does not yet cover `--console-*`/`--tag-*` tokens.

## Behavior note (review-verified)

Opacity-modified sites compile to the same rendered color in every color-mix-capable browser (2023+ baseline). Only browsers without `color-mix` support see a difference in the fallback branch (opaque white instead of a dropped declaration) — accepted.

## Testing

- `pnpm build` / `pnpm test` (core 389, cli 205, web 357) / `pnpm lint` / `pnpm format:check` all clean
- Grep gates: `bg-white` + `bg-[#fafafa]` = 0 in `apps/web/src`; zero hex literals left in SmartTagChips

Issue: CS-81