### PR TITLE
feat: unify motion system — collapse transitions, menu animation, motion tokens (CS-82)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -374,7 +374,7 @@ export default function App() {
               aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
               title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
               onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-              className="hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1.5 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] lg:inline-flex"
+              className="hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1.5 text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] lg:inline-flex"
             >
               {sidebarCollapsed ? (
                 <PanelLeftOpen className="size-4" />
@@ -411,7 +411,7 @@ export default function App() {
             </label>
             <button
               type="submit"
-              className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+              className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               Search
             </button>
@@ -423,7 +423,7 @@ export default function App() {
                 setShortcutHelpOpen(true);
                 dismissShortcutHint();
               }}
-              className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface-muted)]"
+              className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 text-xs text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface-muted)]"
               title="Show keyboard shortcuts"
             >
               ?<span className="hidden sm:inline"> Shortcuts</span>
@@ -486,10 +486,7 @@ export default function App() {
                 {routeHeader.breadcrumbs.map((item, index) => (
                   <span key={`${item.label}-${index}`} className="flex items-center gap-1">
                     {item.to ? (
-                      <Link
-                        to={item.to}
-                        className="transition-colors hover:text-[var(--console-text)]"
-                      >
+                      <Link to={item.to} className="motion-hover hover:text-[var(--console-text)]">
                         {item.label}
                       </Link>
                     ) : (
@@ -520,7 +517,7 @@ export default function App() {
                     <button
                       type="button"
                       onClick={dismissShortcutHint}
-                      className="text-[var(--console-muted)] transition-colors hover:text-[var(--console-text)]"
+                      className="text-[var(--console-muted)] motion-hover hover:text-[var(--console-text)]"
                       aria-label="Dismiss keyboard shortcuts hint"
                     >
                       ×

--- a/apps/web/src/components/BookmarkButton.tsx
+++ b/apps/web/src/components/BookmarkButton.tsx
@@ -17,7 +17,7 @@ export function BookmarkButton({ active, onToggle, className = "" }: BookmarkBut
       }}
       aria-label={active ? "Remove bookmark" : "Add bookmark"}
       title={active ? "Remove bookmark" : "Add bookmark"}
-      className={`inline-flex size-6 shrink-0 items-center justify-center rounded-sm border transition-colors ${className} ${
+      className={`motion-hover motion-press inline-flex size-6 shrink-0 items-center justify-center rounded-sm border ${className} ${
         active
           ? "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-text)]"
           : "border-transparent text-[var(--console-muted)] opacity-70 hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] hover:opacity-100"

--- a/apps/web/src/components/CopyResumeButton.tsx
+++ b/apps/web/src/components/CopyResumeButton.tsx
@@ -76,7 +76,7 @@ export function CopyResumeButton({
       }}
       aria-label={copied ? `Resume command copied: ${command}` : `Copy resume command: ${command}`}
       title={copied ? `Copied: ${command}` : `Copy: ${command}`}
-      className={`console-mono inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-[11px] transition-colors ${className} ${
+      className={`console-mono motion-hover motion-press inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 text-[11px] ${className} ${
         copied
           ? "border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] text-[var(--console-text)]"
           : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:border-[var(--console-border-strong)] hover:text-[var(--console-text)]"

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -488,7 +488,7 @@ function AgentDistribution({ perAgent }: { perAgent: DashboardAgentStat[] }) {
             <li key={agent.name}>
               <Link
                 to={`/${agent.name.toLowerCase()}`}
-                className="block rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                className="block rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
               >
                 <div className="flex items-center gap-2">
                   {agent.icon ? (
@@ -538,7 +538,7 @@ function TopProjects({
         </h3>
         <Link
           to="/projects"
-          className="console-mono text-[11px] text-[var(--console-muted)] transition-colors hover:text-[var(--console-text)]"
+          className="console-mono text-[11px] text-[var(--console-muted)] motion-hover hover:text-[var(--console-text)]"
         >
           View all
         </Link>
@@ -550,7 +550,7 @@ function TopProjects({
             <li key={`${project.identityKind}:${project.identityKey}`}>
               <Link
                 to={getProjectPath({ kind: project.identityKind, key: project.identityKey })}
-                className="block rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                className="block rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
               >
                 <div className="flex items-center gap-2">
                   <span className="console-mono min-w-0 flex-1 truncate text-xs text-[var(--console-text)]">
@@ -619,7 +619,7 @@ function BookmarkedSessions({
           const updated = session.time_updated ?? session.time_created;
           return (
             <li key={getSessionBookmarkKey(session.agentKey, session.sessionId)}>
-              <div className="flex items-start gap-2 rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]">
+              <div className="flex items-start gap-2 rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]">
                 <Link to={`/${session.fullPath}`} className="flex min-w-0 flex-1 items-start gap-2">
                   {agent?.icon ? (
                     <img
@@ -684,7 +684,7 @@ function RecentSessions({
           const bookmarked = isBookmarked(agentKey, session.id);
           return (
             <li key={session.id}>
-              <div className="flex items-start gap-2 rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]">
+              <div className="flex items-start gap-2 rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]">
                 <Link to={`/${session.slug}`} className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     {agent?.icon ? (
@@ -745,7 +745,7 @@ function RecentFileActivity({ activity }: { activity: FileActivityResult[] }) {
             <li key={`${item.agent_name}/${item.session_id}/${item.kind}/${item.path}`}>
               <Link
                 to={`/${item.session.slug}`}
-                className="block rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                className="block rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
               >
                 <div className="flex items-center gap-2">
                   <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-1.5 py-0.5 text-[10px] uppercase text-[var(--console-muted)]">

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -125,7 +125,7 @@ function RecommendedAgents({ agentItems }: { agentItems: LandingAgentItem[] }) {
           <li key={agent.key}>
             <Link
               to={`/${agent.key}`}
-              className="flex min-h-11 items-center gap-2 rounded-sm border border-transparent px-3 py-2 transition-colors duration-200 hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
+              className="flex min-h-11 items-center gap-2 rounded-sm border border-transparent px-3 py-2 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
             >
               {agent.icon ? (
                 <img src={agent.icon} alt={agent.name} className="size-4 object-contain" />
@@ -176,7 +176,7 @@ function RecentSessions({
           const bookmarked = isBookmarked(session.agentKey, session.id);
           return (
             <li key={session.id}>
-              <div className="flex items-start gap-2 rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]">
+              <div className="flex items-start gap-2 rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]">
                 <Link to={`/${session.fullPath}`} className="min-w-0 flex-1">
                   <p className="line-clamp-1 text-sm text-[var(--console-text)]">
                     {getSessionDisplayTitle(session)}
@@ -314,7 +314,7 @@ export function DetailLanding({
               <li key={agent.key}>
                 <Link
                   to={`/${agent.key}`}
-                  className="flex items-center gap-2 rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                  className="flex items-center gap-2 rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
                 >
                   {agent.icon ? (
                     <img src={agent.icon} alt={agent.name} className="size-4 object-contain" />

--- a/apps/web/src/components/DrawerDialog.tsx
+++ b/apps/web/src/components/DrawerDialog.tsx
@@ -41,7 +41,7 @@ export function DrawerDialog({
             </Dialog.Title>
             <Dialog.Close
               aria-label={`Close ${title.toLowerCase()}`}
-              className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-2 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+              className="motion-hover motion-press rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-2 text-[var(--console-muted)] hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               <X className="size-4" aria-hidden="true" />
             </Dialog.Close>

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -76,7 +76,7 @@ function ProjectListItem({
     <li>
       <Link
         to={getProjectPath({ kind: project.identityKind, key: project.identityKey })}
-        className="block rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-[var(--console-surface)]"
+        className="block rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]/85 p-4 motion-hover hover:border-[var(--console-border-strong)] hover:bg-[var(--console-surface)]"
       >
         <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
           <div className="min-w-0">
@@ -171,7 +171,7 @@ function ProjectAgentFilter({
         <button
           type="button"
           onClick={() => onChange(undefined)}
-          className={`console-mono rounded-sm border px-2 py-1 text-[10px] transition-colors ${
+          className={`console-mono rounded-sm border px-2 py-1 text-[10px] motion-hover ${
             activeAgent
               ? "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"
               : "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
@@ -187,7 +187,7 @@ function ProjectAgentFilter({
               key={agent.name}
               type="button"
               onClick={() => onChange(active ? undefined : agent.name)}
-              className={`console-mono inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-[10px] transition-colors ${
+              className={`console-mono inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-[10px] motion-hover ${
                 active
                   ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
                   : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"
@@ -263,7 +263,7 @@ function TopCostSessions({
             <li key={session.fullPath}>
               <Link
                 to={`/${session.fullPath}`}
-                className="block rounded-sm border border-transparent px-2 py-1.5 transition-colors hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
+                className="block rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
               >
                 <div className="flex items-center gap-2">
                   {agent?.icon ? (
@@ -328,7 +328,7 @@ export function ProjectDashboardView({
         </p>
         <Link
           to="/projects"
-          className="console-mono mt-4 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface)]"
+          className="console-mono mt-4 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface)]"
         >
           Back to Projects
         </Link>

--- a/apps/web/src/components/SessionActionsMenu.tsx
+++ b/apps/web/src/components/SessionActionsMenu.tsx
@@ -19,7 +19,7 @@ export function SessionActionsMenu({
         ref={triggerRef}
         aria-label="Session options"
         onClick={(event) => event.stopPropagation()}
-        className="inline-flex size-6 shrink-0 items-center justify-center rounded-sm border border-transparent text-[var(--console-muted)] transition-[background-color,border-color,color,transform] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] active:scale-[0.97] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+        className="motion-hover motion-press inline-flex size-6 shrink-0 items-center justify-center rounded-sm border border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         <MoreHorizontal className="size-3.5" aria-hidden="true" />
       </Menu.Trigger>
@@ -27,18 +27,18 @@ export function SessionActionsMenu({
         <Menu.Positioner side="bottom" align="end" sideOffset={4} className="z-30">
           <Menu.Popup
             finalFocus={triggerRef}
-            className="w-36 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-1 shadow-lg focus-visible:outline-none"
+            className="motion-menu w-36 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-1 shadow-lg focus-visible:outline-none"
           >
             <Menu.Item
               onClick={onRename}
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+              className="motion-hover motion-press flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
             >
               <Pencil className="size-3" aria-hidden="true" />
               Rename
             </Menu.Item>
             <Menu.Item
               onClick={onToggleBookmark}
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+              className="motion-hover motion-press flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
             >
               <Star
                 className="size-3"

--- a/apps/web/src/components/TimeWindowControl.tsx
+++ b/apps/web/src/components/TimeWindowControl.tsx
@@ -68,7 +68,7 @@ export function TimeWindowControl({
             type="button"
             onClick={openCustom}
             aria-label="Edit custom time range"
-            className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-1 text-xs text-[var(--console-muted)] hover:border-[var(--console-border-strong)] hover:text-[var(--console-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2"
+            className="console-mono motion-hover motion-press rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-1.5 py-1 text-xs text-[var(--console-muted)] hover:border-[var(--console-border-strong)] hover:text-[var(--console-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2"
           >
             Edit
           </button>

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -37,7 +37,7 @@ function AgentNavList({
         const isSelected = key === activeAgentKey;
         const agentProgress = formatAgentScanProgress(scanStatus, agent.name);
         const disabled = isScanActive && agentProgress !== null;
-        const className = `ml-4 flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
+        const className = `ml-4 flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left motion-hover ${
           disabled
             ? "cursor-not-allowed border-transparent text-[var(--console-muted)] opacity-50"
             : isSelected
@@ -110,7 +110,7 @@ function ProjectNavList({
             <Link
               to={getProjectPath(projectIdentity)}
               onClick={() => onSelectProject(projectIdentity)}
-              className={`ml-4 flex min-w-0 items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
+              className={`ml-4 flex min-w-0 items-center gap-2 rounded-sm border px-3 py-1.5 text-left motion-hover ${
                 isSelected
                   ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
                   : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
@@ -223,7 +223,7 @@ export function AppSidebar({
             <li>
               <Link
                 to={browseBy === "projects" ? "/projects" : "/"}
-                className={`flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left transition-colors ${
+                className={`flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left motion-hover ${
                   (browseBy === "agents" && viewState.mode === "root") ||
                   (browseBy === "projects" && viewState.mode === "projects")
                     ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
@@ -284,7 +284,7 @@ export function AppSidebar({
                 return (
                   <li key={getSessionBookmarkKey(session.agentKey, session.sessionId)}>
                     <div
-                      className={`flex items-start gap-2 rounded-sm border px-2 py-1.5 transition-colors ${
+                      className={`flex items-start gap-2 rounded-sm border px-2 py-1.5 motion-hover ${
                         isActive
                           ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
                           : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"

--- a/apps/web/src/components/app/BrowseByToggle.tsx
+++ b/apps/web/src/components/app/BrowseByToggle.tsx
@@ -27,7 +27,7 @@ export function BrowseByToggle({
             aria-checked={active}
             disabled={disabled}
             onClick={() => onChange(option.value)}
-            className={`console-mono flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left text-xs transition-colors ${
+            className={`console-mono flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left text-xs motion-hover ${
               disabled
                 ? "cursor-not-allowed border-transparent text-[var(--console-muted)] opacity-45"
                 : active

--- a/apps/web/src/components/app/FilterChip.tsx
+++ b/apps/web/src/components/app/FilterChip.tsx
@@ -11,7 +11,7 @@ export function FilterChip({
     <button
       type="button"
       onClick={onClick}
-      className={`console-mono rounded-sm border px-2 py-1 text-[10px] transition-colors ${
+      className={`console-mono rounded-sm border px-2 py-1 text-[10px] motion-hover ${
         active
           ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
           : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"

--- a/apps/web/src/components/app/SearchFilterBar.tsx
+++ b/apps/web/src/components/app/SearchFilterBar.tsx
@@ -169,7 +169,7 @@ export function SearchFilterBar({
           <button
             type="button"
             onClick={() => onChangeFilters({})}
-            className="console-mono ml-auto rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[10px] text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface)]"
+            className="console-mono ml-auto rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[10px] text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface)]"
           >
             Clear
           </button>

--- a/apps/web/src/components/app/SearchResultsPanel.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.tsx
@@ -102,7 +102,7 @@ export function SearchResultsPanel({
           <button
             type="button"
             onClick={onRetry}
-            className="console-mono mt-4 rounded-sm border border-[var(--console-error-border)] bg-[var(--console-surface)] px-3 py-1.5 text-xs font-semibold text-[var(--console-error)] transition-colors hover:bg-[var(--console-error-bg)] focus-visible:ring-2 focus-visible:ring-[var(--console-error)] focus-visible:ring-offset-2 focus-visible:outline-none"
+            className="console-mono motion-hover motion-press mt-4 rounded-sm border border-[var(--console-error-border)] bg-[var(--console-surface)] px-3 py-1.5 text-xs font-semibold text-[var(--console-error)] hover:bg-[var(--console-error-bg)] focus-visible:ring-2 focus-visible:ring-[var(--console-error)] focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             Retry Search
           </button>
@@ -145,7 +145,7 @@ export function SearchResultsPanel({
             to={`/${agentKey}/${result.session.id}`}
             state={{ searchQuery: query }}
             onClick={onOpenResult}
-            className={`rounded-sm border bg-[var(--console-surface)]/85 p-4 transition-colors hover:border-[var(--console-border-strong)] hover:bg-[var(--console-surface)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none ${
+            className={`rounded-sm border bg-[var(--console-surface)]/85 p-4 motion-hover hover:border-[var(--console-border-strong)] hover:bg-[var(--console-surface)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none ${
               index === selectedIndex
                 ? "border-[var(--console-border-strong)]"
                 : "border-[var(--console-border)]"

--- a/apps/web/src/components/app/ShortcutHelpDialog.tsx
+++ b/apps/web/src/components/app/ShortcutHelpDialog.tsx
@@ -35,7 +35,7 @@ export function ShortcutHelpDialog({ open, onClose }: { open: boolean; onClose: 
                 Navigate without leaving the keyboard
               </Dialog.Title>
             </div>
-            <Dialog.Close className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] transition-colors hover:bg-[var(--console-surface)]">
+            <Dialog.Close className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-xs text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface)]">
               Esc
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/app/SidebarFlatSessionList.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.tsx
@@ -52,7 +52,7 @@ function SessionRow({
   const agent = findAgent(agentCatalog, agentKey);
   return (
     <div
-      className={`flex items-start gap-1 rounded-sm border px-2 py-1.5 transition-colors ${
+      className={`flex items-start gap-1 rounded-sm border px-2 py-1.5 motion-hover ${
         active || selected
           ? "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-[var(--console-text)]"
           : "border-transparent text-[var(--console-muted)] hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"

--- a/apps/web/src/components/session-detail/file-change-tracker.tsx
+++ b/apps/web/src/components/session-detail/file-change-tracker.tsx
@@ -9,6 +9,7 @@ import {
   NotebookPen,
   XCircle,
 } from "lucide-react";
+import { Collapsible } from "../ui/Collapsible";
 import type { FileChangeKind, FileChangeSummary, FileChangeSummaryItem } from "./file-change";
 import { formatTrackedPath } from "./path-extract";
 import {
@@ -88,7 +89,7 @@ function FileTrackerSection({
       <button
         type="button"
         onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--console-surface-muted)]"
+        className="motion-hover flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-[var(--console-surface-muted)]"
       >
         <Icon className="size-3.5 shrink-0 text-[var(--console-accent)]" />
         <span className="console-mono min-w-0 flex-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--console-muted)]">
@@ -97,24 +98,25 @@ function FileTrackerSection({
         <span className="console-mono shrink-0 text-[10px] text-[var(--console-muted)]">
           {items.length}
         </span>
-        {expanded ? (
-          <ChevronUp className="size-3.5 shrink-0 text-[var(--console-muted)]" />
-        ) : (
-          <ChevronDown className="size-3.5 shrink-0 text-[var(--console-muted)]" />
-        )}
+        <ChevronDown
+          className="motion-chevron size-3.5 shrink-0 text-[var(--console-muted)]"
+          data-open={expanded || undefined}
+        />
       </button>
-      {expanded ? (
-        <div className="space-y-1 border-t border-[var(--console-border)] p-2">
-          {items.map((item) => (
-            <FileTrackerItem
-              key={`${item.path}:${item.latestAnchorId || item.latestTime}`}
-              item={item}
-              baseDirectory={baseDirectory}
-              onJumpToAnchor={onJumpToAnchor}
-            />
-          ))}
-        </div>
-      ) : null}
+      <Collapsible open={expanded}>
+        {() => (
+          <div className="space-y-1 border-t border-[var(--console-border)] p-2">
+            {items.map((item) => (
+              <FileTrackerItem
+                key={`${item.path}:${item.latestAnchorId || item.latestTime}`}
+                item={item}
+                baseDirectory={baseDirectory}
+                onJumpToAnchor={onJumpToAnchor}
+              />
+            ))}
+          </div>
+        )}
+      </Collapsible>
     </div>
   );
 }
@@ -142,7 +144,7 @@ function FileTrackerItem({
   }
 
   return (
-    <div className="flex items-start gap-2 rounded-sm px-2 py-2 transition-colors hover:bg-[var(--console-surface-muted)]">
+    <div className="flex items-start gap-2 rounded-sm px-2 py-2 motion-hover hover:bg-[var(--console-surface-muted)]">
       <button
         type="button"
         title={item.path}
@@ -161,7 +163,7 @@ function FileTrackerItem({
             onClick={(event) =>
               jumpToIndex(currentIndex - 1, getActivationScrollBehavior(event.detail))
             }
-            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface)]"
+            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface)]"
           >
             <ChevronUp className="size-3" />
           </button>
@@ -174,7 +176,7 @@ function FileTrackerItem({
             onClick={(event) =>
               jumpToIndex(currentIndex + 1, getActivationScrollBehavior(event.detail))
             }
-            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] transition-colors hover:bg-[var(--console-surface)]"
+            className="rounded-sm border border-[var(--console-border)] p-1 text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface)]"
           >
             <ChevronDown className="size-3" />
           </button>

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -4,7 +4,6 @@ import {
   CalendarRange,
   CheckCircle2,
   ChevronDown,
-  ChevronUp,
   Lightbulb,
   LoaderCircle,
   MessageCircleX,
@@ -15,6 +14,7 @@ import type { AgentInfo, Message, MessagePart } from "../../lib/api";
 import { formatMessageTime } from "../../lib/format";
 import { MarkdownContent } from "../MarkdownContent";
 import { ToolOutputRenderer } from "../tool-output/ToolOutputRenderer";
+import { Collapsible } from "../ui/Collapsible";
 import { extractMessageText, type MessageBlock } from "./blocks";
 import { isCodexTurnAbortedMessage } from "./codex-abort";
 import { buildCodexPlanDisplay } from "./codex-plan";
@@ -299,16 +299,18 @@ function ReasoningSection({
           Thinking
         </span>
         <span className="text-[var(--console-muted)]">
-          {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+          <ChevronDown className="motion-chevron w-4 h-4" data-open={expanded || undefined} />
         </span>
       </div>
-      {expanded && (
-        <div className="border-t border-dashed border-[var(--console-thinking-border)] px-4 py-3">
-          <div className="console-mono whitespace-pre-wrap text-xs leading-relaxed text-[var(--console-muted)]">
-            {renderHighlightedText(fullText, highlightQuery)}
+      <Collapsible open={expanded}>
+        {() => (
+          <div className="border-t border-dashed border-[var(--console-thinking-border)] px-4 py-3">
+            <div className="console-mono whitespace-pre-wrap text-xs leading-relaxed text-[var(--console-muted)]">
+              {renderHighlightedText(fullText, highlightQuery)}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </Collapsible>
     </div>
   );
 }
@@ -370,11 +372,11 @@ function PlanItem({ part, highlightQuery }: { part: MessagePart; highlightQuery?
   const StatusIcon = statusMeta.icon;
 
   return (
-    <div className="space-y-2">
+    <div>
       <div className="flex flex-wrap items-start gap-2">
         <div
           className={`w-full md:w-[560px] rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-3 py-2 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${
-            display.expandable ? "transition-colors hover:bg-[var(--console-surface-muted)]" : ""
+            display.expandable ? "motion-hover hover:bg-[var(--console-surface-muted)]" : ""
           }`}
         >
           {display.expandable ? (
@@ -390,11 +392,10 @@ function PlanItem({ part, highlightQuery }: { part: MessagePart; highlightQuery?
                 </span>
               </span>
               <span className="mt-0.5 shrink-0 text-[var(--console-muted)]">
-                {expanded ? (
-                  <ChevronUp className="size-3.5" />
-                ) : (
-                  <ChevronDown className="size-3.5" />
-                )}
+                <ChevronDown
+                  className="motion-chevron size-3.5"
+                  data-open={expanded || undefined}
+                />
               </span>
             </button>
           ) : (
@@ -416,20 +417,22 @@ function PlanItem({ part, highlightQuery }: { part: MessagePart; highlightQuery?
         </span>
       </div>
 
-      {display.expandable && expanded ? (
-        <div className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
-            <span className="console-mono text-xs text-[var(--console-muted)]">
-              {display.contentLabel}
-            </span>
-          </div>
-          <div className="p-4">
-            <div className="console-markdown text-sm leading-relaxed text-[var(--console-text)]">
-              <MessageMarkdown text={display.contentMarkdown} highlightQuery={highlightQuery} />
+      <Collapsible open={display.expandable && expanded}>
+        {() => (
+          <div className="mt-2 overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+            <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
+              <span className="console-mono text-xs text-[var(--console-muted)]">
+                {display.contentLabel}
+              </span>
+            </div>
+            <div className="p-4">
+              <div className="console-markdown text-sm leading-relaxed text-[var(--console-text)]">
+                <MessageMarkdown text={display.contentMarkdown} highlightQuery={highlightQuery} />
+              </div>
             </div>
           </div>
-        </div>
-      ) : null}
+        )}
+      </Collapsible>
     </div>
   );
 }
@@ -456,11 +459,11 @@ function ToolItem({
   const ToolIcon = strategy.Icon;
 
   return (
-    <div id={anchorId} data-session-timeline-anchor={anchorId} className="scroll-mt-20 space-y-2">
+    <div id={anchorId} data-session-timeline-anchor={anchorId} className="scroll-mt-20">
       <div className="flex flex-wrap items-start gap-2">
         <div
           className={`w-full max-w-[720px] rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-3 py-2.5 text-left shadow-[2px_2px_0_0_rgba(15,23,42,0.05)] ${
-            strategy.expandable ? "transition-colors hover:bg-[var(--console-surface-muted)]" : ""
+            strategy.expandable ? "motion-hover hover:bg-[var(--console-surface-muted)]" : ""
           }`}
         >
           {strategy.expandable ? (
@@ -492,11 +495,10 @@ function ToolItem({
                 {statusMeta.label}
               </span>
               <span className="mt-0.5 shrink-0 text-[var(--console-muted)]">
-                {expanded ? (
-                  <ChevronUp className="size-3.5" />
-                ) : (
-                  <ChevronDown className="size-3.5" />
-                )}
+                <ChevronDown
+                  className="motion-chevron size-3.5"
+                  data-open={expanded || undefined}
+                />
               </span>
             </button>
           ) : (
@@ -525,47 +527,49 @@ function ToolItem({
         </div>
       </div>
 
-      {strategy.expandable && expanded ? (
-        <div className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-          <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
-            <span className="console-mono text-xs text-[var(--console-muted)]">
-              {strategy.contentLabel ?? "Output"}
-            </span>
-          </div>
-          <div className="space-y-3 p-3">
-            {strategy.details.length > 0 ? (
-              <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] px-3 py-2">
-                <div className="space-y-2">
-                  {strategy.details.map((detail) => (
-                    <div
-                      key={`${detail.label}:${detail.value}`}
-                      className="flex flex-col gap-1 md:flex-row md:items-start md:gap-3"
-                    >
-                      <span className="console-mono shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[var(--console-muted)] md:w-24">
-                        {detail.label}
-                      </span>
-                      <span className="console-mono whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-text)]">
-                        {renderHighlightedText(detail.value, highlightQuery)}
-                      </span>
-                    </div>
-                  ))}
+      <Collapsible open={strategy.expandable && expanded}>
+        {() => (
+          <div className="mt-2 overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+            <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
+              <span className="console-mono text-xs text-[var(--console-muted)]">
+                {strategy.contentLabel ?? "Output"}
+              </span>
+            </div>
+            <div className="space-y-3 p-3">
+              {strategy.details.length > 0 ? (
+                <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] px-3 py-2">
+                  <div className="space-y-2">
+                    {strategy.details.map((detail) => (
+                      <div
+                        key={`${detail.label}:${detail.value}`}
+                        className="flex flex-col gap-1 md:flex-row md:items-start md:gap-3"
+                      >
+                        <span className="console-mono shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[var(--console-muted)] md:w-24">
+                          {detail.label}
+                        </span>
+                        <span className="console-mono whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-text)]">
+                          {renderHighlightedText(detail.value, highlightQuery)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
                 </div>
+              ) : null}
+              <ToolOutputRenderer outputContent={strategy.outputContent} />
+            </div>
+            {strategy.showInputPreview ? (
+              <div className="border-t border-[var(--console-border)] bg-[var(--console-surface-sunken)] px-3 py-2">
+                <span className="console-mono text-[11px] text-[var(--console-muted)]">
+                  Input Preview
+                </span>
+                <pre className="console-mono mt-1 max-h-[200px] overflow-x-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-muted)]">
+                  {renderHighlightedText(inputPreviewText, highlightQuery)}
+                </pre>
               </div>
             ) : null}
-            <ToolOutputRenderer outputContent={strategy.outputContent} />
           </div>
-          {strategy.showInputPreview ? (
-            <div className="border-t border-[var(--console-border)] bg-[var(--console-surface-sunken)] px-3 py-2">
-              <span className="console-mono text-[11px] text-[var(--console-muted)]">
-                Input Preview
-              </span>
-              <pre className="console-mono mt-1 max-h-[200px] overflow-x-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-muted)]">
-                {renderHighlightedText(inputPreviewText, highlightQuery)}
-              </pre>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+        )}
+      </Collapsible>
     </div>
   );
 }

--- a/apps/web/src/components/session-detail/session-detail-aux.tsx
+++ b/apps/web/src/components/session-detail/session-detail-aux.tsx
@@ -56,7 +56,7 @@ export function DeferredInteractiveReceipt({
         aria-expanded={open}
         aria-label="Open session receipt"
         onClick={() => setOpen(true)}
-        className="console-mono fixed right-0 top-1/2 z-40 hidden h-32 w-10 -translate-y-1/2 items-center justify-center rounded-l-sm border border-r-0 border-[var(--console-border)] bg-[var(--console-surface)] text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--console-text)] shadow-[-2px_4px_14px_rgba(15,23,42,0.14)] transition-colors hover:bg-[var(--console-surface-muted)] min-[1025px]:flex"
+        className="console-mono fixed right-0 top-1/2 z-40 hidden h-32 w-10 -translate-y-1/2 items-center justify-center rounded-l-sm border border-r-0 border-[var(--console-border)] bg-[var(--console-surface)] text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--console-text)] shadow-[-2px_4px_14px_rgba(15,23,42,0.14)] motion-hover hover:bg-[var(--console-surface-muted)] min-[1025px]:flex"
       >
         <span className="[writing-mode:vertical-rl]">Receipt</span>
       </button>
@@ -89,7 +89,7 @@ export function SessionDetailAuxControls({
       <button
         type="button"
         onClick={() => onOpen("toc")}
-        className="console-mono inline-flex h-9 items-center gap-2 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--console-text)] shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-colors hover:bg-[var(--console-surface-muted)]"
+        className="console-mono inline-flex h-9 items-center gap-2 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--console-text)] shadow-[0_1px_2px_rgba(15,23,42,0.04)] motion-hover hover:bg-[var(--console-surface-muted)]"
       >
         <Funnel className="size-3.5 text-[var(--console-accent)]" />
         TOC
@@ -99,7 +99,7 @@ export function SessionDetailAuxControls({
         <button
           type="button"
           onClick={() => onOpen("files")}
-          className="console-mono inline-flex h-9 items-center gap-2 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--console-text)] shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-colors hover:bg-[var(--console-surface-muted)]"
+          className="console-mono inline-flex h-9 items-center gap-2 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--console-text)] shadow-[0_1px_2px_rgba(15,23,42,0.04)] motion-hover hover:bg-[var(--console-surface-muted)]"
         >
           <FileText className="size-3.5 text-[var(--console-accent)]" />
           Files

--- a/apps/web/src/components/session-detail/session-toc.tsx
+++ b/apps/web/src/components/session-detail/session-toc.tsx
@@ -161,7 +161,7 @@ export function SessionTocFilterPanel({
         {TOC_META.filter(({ id }) => toc.counts[id] > 0).map(({ id, label }) => (
           <label
             key={id}
-            className="flex cursor-pointer items-start gap-3 rounded-sm px-2 py-2 transition-colors hover:bg-[var(--console-surface-muted)]"
+            className="flex cursor-pointer items-start gap-3 rounded-sm px-2 py-2 motion-hover hover:bg-[var(--console-surface-muted)]"
           >
             <TocCheckbox
               checked={id === "tools_all" ? allToolsSelected : selectedFilters.has(id)}
@@ -181,7 +181,7 @@ export function SessionTocFilterPanel({
             {toc.tools.map((tool) => (
               <label
                 key={tool.id}
-                className="flex cursor-pointer items-start gap-3 rounded-sm px-2 py-2 transition-colors hover:bg-[var(--console-surface-muted)]"
+                className="flex cursor-pointer items-start gap-3 rounded-sm px-2 py-2 motion-hover hover:bg-[var(--console-surface-muted)]"
               >
                 <TocCheckbox
                   checked={selectedFilters.has(tool.id)}

--- a/apps/web/src/components/ui/Collapsible.tsx
+++ b/apps/web/src/components/ui/Collapsible.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+
+/**
+ * Animates open with a grid-rows 0fr -> 1fr + opacity transition. Closing is
+ * instant: content unmounts immediately so heavy children (e.g. full
+ * thinking text) never stay rendered while collapsed, matching the previous
+ * `{open && children}` lazy-render semantics. `children` is a render prop so
+ * the caller's JSX isn't evaluated at all while closed.
+ */
+export function Collapsible({
+  open,
+  children,
+  className,
+}: {
+  open: boolean;
+  children: () => ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("motion-collapsible", className)} data-open={open || undefined}>
+      <div className="motion-collapsible-inner">{open ? children() : null}</div>
+    </div>
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -177,6 +177,8 @@
     --tag-planning-bar: #ee46bc;
     --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
     --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+    --dur-fast: 120ms;
+    --dur-base: 180ms;
     --tt-in-dur: 150ms;
     --tt-out-dur: 50ms;
     --tt-scale: 0.98;
@@ -310,6 +312,78 @@
     transition-duration: 180ms;
   }
 
+  .motion-menu {
+    opacity: 1;
+    scale: 1;
+    transform-origin: var(--transform-origin);
+    transition:
+      opacity var(--dur-fast) var(--ease-out),
+      scale var(--dur-fast) var(--ease-out);
+  }
+
+  .motion-menu[data-starting-style],
+  .motion-menu[data-ending-style] {
+    opacity: 0;
+    scale: 0.96;
+  }
+
+  .motion-hover {
+    transition:
+      color var(--dur-fast) var(--ease-out),
+      background-color var(--dur-fast) var(--ease-out),
+      border-color var(--dur-fast) var(--ease-out);
+  }
+
+  .motion-press {
+    transition: transform var(--dur-fast) var(--ease-out);
+  }
+
+  .motion-press:active {
+    transform: scale(0.97);
+  }
+
+  /* Both use the `transition` shorthand at equal specificity, so combining
+     them on one element needs an explicit merged rule; otherwise source
+     order lets .motion-press silently drop .motion-hover's color/bg/border
+     transitions. */
+  .motion-hover.motion-press {
+    transition:
+      color var(--dur-fast) var(--ease-out),
+      background-color var(--dur-fast) var(--ease-out),
+      border-color var(--dur-fast) var(--ease-out),
+      transform var(--dur-fast) var(--ease-out);
+  }
+
+  /* Grid-rows 0fr -> 1fr trick: animates to the content's intrinsic height
+     without measuring it in JS. Requires the row content to stay mounted
+     for the duration of the transition (see Collapsible.tsx). */
+  .motion-collapsible {
+    display: grid;
+    grid-template-rows: 0fr;
+    opacity: 0;
+    transition:
+      grid-template-rows var(--dur-base) var(--ease-out),
+      opacity var(--dur-base) var(--ease-out);
+  }
+
+  .motion-collapsible[data-open] {
+    grid-template-rows: 1fr;
+    opacity: 1;
+  }
+
+  .motion-collapsible-inner {
+    overflow: hidden;
+    min-height: 0;
+  }
+
+  .motion-chevron {
+    transition: transform var(--dur-fast) var(--ease-out);
+  }
+
+  .motion-chevron[data-open] {
+    transform: rotate(180deg);
+  }
+
   .t-tt-wrap {
     position: relative;
     display: inline-block;
@@ -415,7 +489,8 @@
 @media (prefers-reduced-motion: reduce) {
   .motion-backdrop,
   .motion-modal,
-  .motion-drawer {
+  .motion-drawer,
+  .motion-menu {
     transition: opacity 150ms var(--ease-out);
   }
 
@@ -429,6 +504,35 @@
   .motion-drawer[data-starting-style],
   .motion-drawer[data-ending-style] {
     transform: none;
+  }
+
+  .motion-menu,
+  .motion-menu[data-starting-style],
+  .motion-menu[data-ending-style] {
+    scale: 1;
+  }
+
+  .motion-collapsible {
+    transition: none;
+  }
+
+  .motion-chevron {
+    transition: none;
+  }
+
+  .motion-press {
+    transition: none;
+  }
+
+  .motion-press:active {
+    transform: none;
+  }
+
+  .motion-hover.motion-press {
+    transition:
+      color var(--dur-fast) var(--ease-out),
+      background-color var(--dur-fast) var(--ease-out),
+      border-color var(--dur-fast) var(--ease-out);
   }
 
   .shortcut-content[data-open] {


### PR DESCRIPTION
## Summary

The CSS layer had motion primitives (`--ease-out`/`--ease-drawer`, `motion-backdrop/modal/drawer`) wired into dialogs, but the system stopped there:

- Expand/collapse in the message timeline (the most frequent interaction) snapped instantly, with chevron icons swapped instead of rotated
- `Menu.Popup` appeared with no enter/exit animation, unlike every dialog
- 44 bare `transition-colors` fell back to Tailwind's default duration/easing, never touching the tokens
- `active:scale` press feedback existed on only 6 controls

## Changes

- **Duration tokens** `--dur-fast: 120ms` / `--dur-base: 180ms` + utility classes: `motion-hover` (color/bg/border), `motion-press` (transform + `:active` scale), `motion-chevron` (180° rotate), `motion-menu` (origin-aware opacity+scale via Base UI's `data-[starting-style]`/`data-[ending-style]` and `var(--transform-origin)`), `motion-collapsible` (grid-rows `0fr→1fr` + opacity).
- **New `ui/Collapsible`** applied to the Thinking/Plan/Tool sections and the file-change tracker. Children are a **render prop**, so collapsed content is neither mounted nor evaluated (search-highlight splitting of full thinking text stays lazy — review caught the eager-JSX version). Expand animates; collapse unmounts instantly — deliberate trade-off to keep the lazy-render semantics without a transitionend state machine.
- **44 `transition-colors` → `motion-hover`** (zero remaining), press feedback added to high-frequency buttons, SessionActionsMenu's hand-rolled transition list migrated to the shared classes.
- **Reduced motion**: all new classes covered in the existing `prefers-reduced-motion` block, including an explicit `.motion-hover.motion-press` combined rule — review caught that the `transition` shorthand on both classes silently dropped hover color transitions on the 8 elements using both.
- Review also caught an 8px layout regression from the always-rendered collapse container inside `space-y-2` parents — fixed by moving spacing into the collapsible content (`mt-2`), keeping collapsed state at exactly zero height.

## Testing

- `pnpm build` / `pnpm test` (core 389, cli 205, web 357+) / `pnpm lint` / `pnpm format:check` all clean
- Grep gates: `transition-colors` = 0 in apps/web

Issue: CS-82