### PR TITLE
chore: enable tabular figures for data-dense numerics (CS-83)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -236,6 +236,7 @@
   .console-mono {
     font-family:
       "JetBrains Mono", "IBM Plex Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
+    font-variant-numeric: tabular-nums;
   }
 
   .bg-grid {


### PR DESCRIPTION
## Summary

Numeric data across the dashboard (session/message counts, token detail, hover readouts) rendered with proportional figures — columns didn't align and hover readouts jittered horizontally as digit widths changed.

## Changes

One line: `.console-mono` gains `font-variant-numeric: tabular-nums`.

An audit of every numeric render site (`formatNumber`/`toLocaleString` call sites) confirmed the repo's existing convention already routes all visible data numerics through `.console-mono` ancestors, so the inherited property covers them all. The only two non-mono numeric sites (`Dashboard.tsx:414`, `ui/chart.tsx:231`) already carried explicit `tabular-nums`. Canvas-drawn numbers (InteractiveReceipt) are unaffected by CSS and out of scope; sr-only tables have no visual rendering.

## Testing

- `pnpm build` / `pnpm test` / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-83