### PR TITLE
fix: add aria-live regions for scan status and copy feedback (CS-84)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -214,7 +214,29 @@ export default function App() {
     [navigate, sidebarSessionLookup],
   );
 
+  // 可见标签每次渲染直接计算，保证 processed/total 计数实时更新。
   const scanStatusLabel = formatScanStatusLabel(scanStatus);
+
+  // 播报文本节流：processed/total 逐条 tick 高频变化，仅当 phase/当前 agent/完成数
+  // 等里程碑信息变化时才重算，避免 aria-live 区域被逐条计数刷屏。
+  const scanStatusMilestoneKey = scanStatus
+    ? [
+        scanStatus.phase,
+        scanStatus.scanningAgents[0] ?? "",
+        scanStatus.completedAgents.length,
+        scanStatus.totalAgents,
+        scanStatus.backfill.active,
+        scanStatus.backfill.currentAgent ?? "",
+        scanStatus.backfill.pendingAgents.length,
+        scanStatus.backfill.failedAgents.length,
+      ].join("|")
+    : null;
+  const [announcedScanKey, setAnnouncedScanKey] = useState(scanStatusMilestoneKey);
+  const [announcedScanLabel, setAnnouncedScanLabel] = useState(scanStatusLabel);
+  if (scanStatusMilestoneKey !== announcedScanKey) {
+    setAnnouncedScanKey(scanStatusMilestoneKey);
+    setAnnouncedScanLabel(scanStatusLabel);
+  }
   const isScanActive = scanStatus?.active === true;
 
   const { liveNotice } = useLiveSync({
@@ -537,16 +559,23 @@ export default function App() {
                   />
                 ) : null}
               </div>
-              {liveNotice ? (
-                <p className="console-mono mt-2 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-text)]">
-                  {liveNotice}
-                </p>
-              ) : null}
-              {scanStatusLabel && viewState.mode === "root" ? (
-                <p className="console-mono mt-2 inline-flex max-w-4xl rounded-sm border border-[var(--console-warning-border)] bg-[var(--console-warning-bg)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-warning)]">
-                  {scanStatusLabel}
-                </p>
-              ) : null}
+              <div aria-live="polite">
+                {liveNotice ? (
+                  <p className="console-mono mt-2 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-text)]">
+                    {liveNotice}
+                  </p>
+                ) : null}
+              </div>
+              <div>
+                {scanStatusLabel && viewState.mode === "root" ? (
+                  <p className="console-mono mt-2 inline-flex max-w-4xl rounded-sm border border-[var(--console-warning-border)] bg-[var(--console-warning-bg)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-warning)]">
+                    {scanStatusLabel}
+                  </p>
+                ) : null}
+              </div>
+              <div className="sr-only" aria-live="polite" aria-atomic="true">
+                {viewState.mode === "root" ? announcedScanLabel : null}
+              </div>
             </div>
           </section>
 

--- a/apps/web/src/components/CopyResumeButton.test.tsx
+++ b/apps/web/src/components/CopyResumeButton.test.tsx
@@ -1,0 +1,40 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CopyResumeButton } from "./CopyResumeButton";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("CopyResumeButton", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  it("announces and resets the copy confirmation via the live region", async () => {
+    vi.useFakeTimers();
+    render(
+      <CopyResumeButton agentName="claudecode" sessionId="abc-123" directory="/tmp/project" />,
+    );
+
+    const button = screen.getByRole("button", { name: /Copy resume command/ });
+    const liveRegion = button.querySelector('[aria-live="polite"]');
+    expect(liveRegion?.textContent).toBe("");
+
+    await act(async () => {
+      fireEvent.click(button);
+      await Promise.resolve();
+    });
+
+    expect(liveRegion?.textContent).toBe("Resume command copied");
+    expect(screen.getByRole("button", { name: /Resume command copied/ })).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(1500));
+
+    expect(liveRegion?.textContent).toBe("");
+  });
+});

--- a/apps/web/src/components/CopyResumeButton.tsx
+++ b/apps/web/src/components/CopyResumeButton.tsx
@@ -88,6 +88,9 @@ export function CopyResumeButton({
         <Copy className="size-3" strokeWidth={1.8} />
       )}
       <span>{copied ? "Copied" : "Copy resume"}</span>
+      <span className="sr-only" aria-live="polite">
+        {copied ? "Resume command copied" : ""}
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary

Two async state changes were completely silent to screen readers:

- **Scan progress / live sync notices**: `liveNotice` and `scanStatusLabel` rendered as plain `<p>` elements — background indexing is this tool's core feedback channel, and its state changes were imperceptible to AT users.
- **Copy feedback**: `CopyResumeButton` only swapped its `aria-label` on success, which most screen readers don't reliably announce for an already-focused button.

## Changes

- `liveNotice` and the scan status now sit inside **persistently mounted** `aria-live="polite"` containers (a live region must exist before content appears to announce reliably; spacing classes stay on the inner content so the empty state adds no layout).
- **Announcements are throttled, the visible label is not.** Investigation confirmed scan progress ticks once per file with no batching — thousands of updates per full scan. The visible counter keeps updating per tick (as before), while a separate sr-only region announces only on milestone transitions (phase / current agent / completed count / backfill state), using the render-time state-adjustment pattern (oxlint's exhaustive-deps rejects the useMemo variant).
- `CopyResumeButton` gains a persistent sr-only polite region set to "Resume command copied" on success and cleared by the existing 1500ms reset timer.

## Testing

- New `CopyResumeButton` test: live region empty → announces after click → clears after reset (fake timers).
- `pnpm build` / `pnpm test` (web 357, cli 205, core 389) / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-84