### PR TITLE
fix: rebuild sidebar session menu on Base UI Menu (CS-85)

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionHead } from "../lib/api";
-import { buildSessionTreeModel } from "./SessionTreeSidebar";
+import { buildSessionTreeModel, SessionTreeSidebar } from "./SessionTreeSidebar";
 
 function makeSession(overrides: Partial<SessionHead> & { id: string }): SessionHead {
   return {
@@ -88,5 +89,117 @@ describe("buildSessionTreeModel group sorting", () => {
 
     expect(() => buildSessionTreeModel(sessions)).not.toThrow();
     expect(groupOrderOf(paths)).toEqual(["small", "big"]);
+  });
+});
+
+// happy-dom dispatches events into the tree's shadow DOM without retargeting
+// `event.target` for listeners outside the shadow root (unlike real browsers),
+// which breaks React's target-based event delegation. This patches the test
+// environment to match spec behavior so SessionTreeSidebar's onClickCapture /
+// onKeyDownCapture handlers on the light-DOM host receive the events.
+function patchShadowEventRetargeting() {
+  const retarget = (event: Event) => {
+    const root = (event.target as Node | null)?.getRootNode?.();
+    if (root instanceof ShadowRoot) {
+      Object.defineProperty(event, "target", { value: root.host, configurable: true });
+    }
+  };
+  document.addEventListener("click", retarget, true);
+  document.addEventListener("keydown", retarget, true);
+}
+
+function renderSessionTreeSidebar() {
+  const session = makeSession({ id: "s1" });
+  const onToggleBookmark = vi.fn();
+  const onRenameSession = vi.fn();
+  render(
+    <SessionTreeSidebar
+      sessions={[session]}
+      activeSessionId={session.id}
+      selectedSessionId={session.id}
+      onSelectSession={() => {}}
+      bookmarkedSessionIds={new Set()}
+      onToggleBookmark={onToggleBookmark}
+      onRenameSession={onRenameSession}
+    />,
+  );
+  const shadowRoot = document.querySelector("file-tree-container")!.shadowRoot!;
+  const item = shadowRoot.querySelector<HTMLElement>('[data-item-type="file"]')!;
+  const decoration = item.querySelector<HTMLElement>('[data-item-section="decoration"] > span')!;
+  return { session, onToggleBookmark, onRenameSession, shadowRoot, item, decoration };
+}
+
+function dispatch(target: HTMLElement, type: string, init: EventInit & { key?: string } = {}) {
+  const Ctor = type === "keydown" ? KeyboardEvent : MouseEvent;
+  target.dispatchEvent(
+    new Ctor(type, { bubbles: true, cancelable: true, composed: true, ...init }),
+  );
+}
+
+describe("SessionTreeSidebar session options menu", () => {
+  beforeEach(() => {
+    patchShadowEventRetargeting();
+  });
+  afterEach(cleanup);
+
+  it("opens from the row's options button, runs the selected action, and returns focus", async () => {
+    const { session, onToggleBookmark, item, decoration } = renderSessionTreeSidebar();
+
+    dispatch(decoration, "click");
+    await waitFor(() => expect(screen.queryByRole("menu")).not.toBeNull());
+
+    const bookmarkItem = await screen.findByRole("menuitem", { name: "Add bookmark" });
+    dispatch(bookmarkItem, "click");
+
+    expect(onToggleBookmark).toHaveBeenCalledWith(session);
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    await waitFor(() => expect((item.getRootNode() as ShadowRoot).activeElement).toBe(item));
+  });
+
+  it("opens via keyboard (ContextMenu key) with the first item focused, navigates, and executes", async () => {
+    const { session, onToggleBookmark, item } = renderSessionTreeSidebar();
+
+    item.focus();
+    dispatch(item, "keydown", { key: "ContextMenu" });
+    await waitFor(() => expect(screen.queryByRole("menu")).not.toBeNull());
+
+    const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
+    const bookmarkItem = screen.getByRole("menuitem", { name: "Add bookmark" });
+    await waitFor(() => expect(document.activeElement).toBe(renameItem));
+
+    dispatch(renameItem, "keydown", { key: "ArrowDown" });
+    await waitFor(() => expect(document.activeElement).toBe(bookmarkItem));
+
+    dispatch(bookmarkItem, "keydown", { key: "Enter" });
+    expect(onToggleBookmark).toHaveBeenCalledWith(session);
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    await waitFor(() => expect((item.getRootNode() as ShadowRoot).activeElement).toBe(item));
+  });
+
+  it("closes on Escape and returns focus to the row", async () => {
+    const { item, decoration } = renderSessionTreeSidebar();
+
+    dispatch(decoration, "click");
+    const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
+    await waitFor(() => expect(document.activeElement).toBe(renameItem));
+
+    dispatch(renameItem, "keydown", { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    await waitFor(() => expect((item.getRootNode() as ShadowRoot).activeElement).toBe(item));
+  });
+
+  it("closes on an outside pointer press and returns focus to the row", async () => {
+    const { item, decoration } = renderSessionTreeSidebar();
+
+    dispatch(decoration, "click");
+    await waitFor(() => expect(screen.queryByRole("menu")).not.toBeNull());
+
+    document.body.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true, composed: true }),
+    );
+
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    await waitFor(() => expect((item.getRootNode() as ShadowRoot).activeElement).toBe(item));
   });
 });

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -1,3 +1,4 @@
+import { Menu } from "@base-ui/react/menu";
 import type { FileTreeSortEntry } from "@pierre/trees";
 import { FileTree, useFileTree } from "@pierre/trees/react";
 import {
@@ -259,12 +260,10 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   onToggleBookmark,
   onRenameSession,
 }: SessionTreeSidebarProps) {
-  const [options, setOptions] = useState<{
-    session: SessionHead;
-    top: number;
-    right: number;
-    trigger: HTMLElement;
-  } | null>(null);
+  const [menuSession, setMenuSession] = useState<SessionHead | null>(null);
+  const menuAnchorRef = useRef<HTMLElement | null>(null);
+  const menuTriggerRef = useRef<HTMLElement | null>(null);
+  const menuProxyTriggerRef = useRef<HTMLButtonElement>(null);
   const modelData = useMemo(
     () =>
       measureSessionTreeWork("SessionTreeSidebar:buildTreeModel", () =>
@@ -277,7 +276,6 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   const groupCountByPathRef = useRef(modelData.groupCountByPath);
   const sessionByPathRef = useRef(modelData.sessionByPath);
   const bookmarkedSessionIdsRef = useRef(bookmarkedSessionIds);
-  const optionsMenuRef = useRef<HTMLDivElement>(null);
   const onSelectSessionRef = useRef(onSelectSession);
   const onToggleBookmarkRef = useRef(onToggleBookmark);
   const onRenameSessionRef = useRef(onRenameSession);
@@ -333,38 +331,25 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   }, [bookmarkedSessionIds]);
 
   useEffect(() => {
-    if (!options) return;
-
-    const closeOnOutsidePointer = (event: PointerEvent) => {
-      if (!optionsMenuRef.current?.contains(event.target as Node)) setOptions(null);
-    };
-    const closeOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        options.trigger.focus();
-        setOptions(null);
-      }
-    };
-    const closeOnFocusOutside = (event: FocusEvent) => {
-      if (!optionsMenuRef.current?.contains(event.target as Node)) setOptions(null);
-    };
-    document.addEventListener("pointerdown", closeOnOutsidePointer);
-    document.addEventListener("keydown", closeOnEscape);
-    document.addEventListener("focusin", closeOnFocusOutside);
-    optionsMenuRef.current?.querySelector<HTMLButtonElement>("[role='menuitem']")?.focus();
-    return () => {
-      document.removeEventListener("pointerdown", closeOnOutsidePointer);
-      document.removeEventListener("keydown", closeOnEscape);
-      document.removeEventListener("focusin", closeOnFocusOutside);
-    };
-  }, [options]);
-
-  useEffect(() => {
     onToggleBookmarkRef.current = onToggleBookmark;
   }, [onToggleBookmark]);
 
   useEffect(() => {
     onRenameSessionRef.current = onRenameSession;
   }, [onRenameSession]);
+
+  function openSessionMenu(session: SessionHead, anchor: HTMLElement, trigger: HTMLElement) {
+    menuAnchorRef.current = anchor;
+    menuTriggerRef.current = trigger;
+    setMenuSession(session);
+    // The tree row is the visual/focus trigger, but Base UI's roving-focus and
+    // open-interaction tracking are wired to its own <Menu.Trigger>. Dispatching
+    // ArrowDown at the hidden proxy trigger opens the menu through that wiring so
+    // the first item is focused, matching native menu keyboard behavior.
+    menuProxyTriggerRef.current?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }),
+    );
+  }
 
   function handleTreeClickCapture(event: MouseEvent<HTMLDivElement>) {
     const path = event.nativeEvent.composedPath();
@@ -384,13 +369,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     if (!decoration || !item || !session) return;
     event.preventDefault();
     event.stopPropagation();
-    const rect = decoration.getBoundingClientRect();
-    setOptions({
-      session,
-      top: rect.bottom + 4,
-      right: window.innerWidth - rect.right,
-      trigger: item,
-    });
+    openSessionMenu(session, decoration, item);
   }
 
   function handleTreeKeyDownCapture(event: ReactKeyboardEvent<HTMLDivElement>) {
@@ -410,13 +389,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     event.stopPropagation();
     const anchor =
       item.querySelector<HTMLElement>("[data-item-section='decoration'] > span") ?? item;
-    const rect = anchor.getBoundingClientRect();
-    setOptions({
-      session,
-      top: rect.bottom + 4,
-      right: window.innerWidth - rect.right,
-      trigger: item,
-    });
+    openSessionMenu(session, anchor, item);
   }
 
   useEffect(() => {
@@ -444,42 +417,47 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
       onKeyDownCapture={handleTreeKeyDownCapture}
     >
       <FileTree model={model} style={{ height: "100%" }} aria-label="Sessions" />
-      {options ? (
-        <div
-          ref={optionsMenuRef}
-          role="menu"
-          style={{ position: "fixed", top: options.top, right: options.right }}
-          className="z-40 w-36 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-1 shadow-lg"
-          onBlur={(event) => {
-            if (!event.currentTarget.contains(event.relatedTarget)) setOptions(null);
-          }}
-        >
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              onRenameSessionRef.current(options.session);
-              setOptions(null);
-            }}
-            className="block w-full rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] focus-visible:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+      <Menu.Root modal={false}>
+        <Menu.Trigger
+          ref={menuProxyTriggerRef}
+          tabIndex={-1}
+          aria-hidden="true"
+          className="pointer-events-none absolute size-0 opacity-0"
+        />
+        <Menu.Portal>
+          <Menu.Positioner
+            anchor={menuAnchorRef}
+            side="bottom"
+            align="end"
+            sideOffset={4}
+            className="z-40"
           >
-            Rename
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            onClick={() => {
-              onToggleBookmarkRef.current(options.session);
-              setOptions(null);
-            }}
-            className="block w-full rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] active:scale-[0.97] focus-visible:bg-[var(--console-surface-muted)] focus-visible:outline-none"
-          >
-            {bookmarkedSessionIdsRef.current.has(options.session.id)
-              ? "Remove bookmark"
-              : "Add bookmark"}
-          </button>
-        </div>
-      ) : null}
+            <Menu.Popup
+              finalFocus={menuTriggerRef}
+              className="motion-menu w-36 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-1 shadow-lg focus-visible:outline-none"
+            >
+              {menuSession ? (
+                <>
+                  <Menu.Item
+                    onClick={() => onRenameSessionRef.current(menuSession)}
+                    className="motion-hover motion-press block w-full rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+                  >
+                    Rename
+                  </Menu.Item>
+                  <Menu.Item
+                    onClick={() => onToggleBookmarkRef.current(menuSession)}
+                    className="motion-hover motion-press block w-full rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+                  >
+                    {bookmarkedSessionIdsRef.current.has(menuSession.id)
+                      ? "Remove bookmark"
+                      : "Add bookmark"}
+                  </Menu.Item>
+                </>
+              ) : null}
+            </Menu.Popup>
+          </Menu.Positioner>
+        </Menu.Portal>
+      </Menu.Root>
     </div>
   );
 });


### PR DESCRIPTION
## Summary

`SessionTreeSidebar` hand-rolled a `role="menu"` popover with three defects: no arrow-key navigation (violating the WAI-ARIA menu keyboard contract its role declares), focus dropped to `<body>` after toggling a bookmark (the only close path without `trigger.focus()` restore), and it duplicated — more weakly — the Base UI `Menu` already used by `SessionActionsMenu`.

## Changes

Replaced the hand-rolled popover with Base UI `Menu` in controlled mode:

- `Menu.Positioner` anchors to the actual tree-row "⋯" element (same `side/align/offset` as `SessionActionsMenu`), so positioning matches the old fixed-coordinate behavior across all three open paths (click, right-click ContextMenu, Shift+F10).
- **Hidden proxy trigger**: Base UI's roving focus is wired to its own `Menu.Trigger` interactions, which a purely-controlled open bypasses (menu container gets focused instead of the first item). A visually hidden `tabIndex={-1}` proxy trigger receives a synthetic ArrowDown, driving Base UI's own interaction chain so the first item is focused per the ARIA menu pattern. Anchor (positioning) and `finalFocus` (restore target = the real tree row) stay decoupled from the proxy.
- All four close paths now restore focus to the triggering row: item activation (incl. bookmark), Escape, outside press, and keyboard activation — previously only Escape restored.
- Deleted the hand-rolled `onBlur` close, manual Escape effect, and `role` markup; Base UI semantics take over. Menu items, callbacks, and the CS-82 `motion-menu` animation are shared with `SessionActionsMenu`.

## Testing

- 4 new render-level tests: mouse open → activate → focus restore; keyboard (ContextMenu key) open → first-item auto-focus → ArrowDown → Enter → focus restore; Escape close; outside-press close. All assert `activeElement` through the tree's shadow root (with a test-only shadow event retargeting patch for happy-dom).
- `pnpm build` / `pnpm test` (web 361) / `pnpm lint` / `pnpm format:check` all clean

Known intentional difference: mouse-opening also focuses the first item (APG-permitted; cost of the proxy-trigger approach), unlike `SessionActionsMenu`.

Issue: CS-85