### PR TITLE
chore: form error association, skip link, heading hierarchy (CS-86)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -387,6 +387,12 @@ export default function App() {
 
   return (
     <div className="console-ui flex h-screen flex-col overflow-hidden bg-[var(--console-bg)] text-[var(--console-text)]">
+      <a
+        href="#main"
+        className="console-mono sr-only rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-3 py-1.5 text-xs text-[var(--console-text)] focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
+        Skip to content
+      </a>
       <header className="shrink-0 border-b border-[var(--console-border)] bg-[var(--console-surface)]/85 backdrop-blur-sm">
         <div className="grid min-h-14 grid-cols-[auto_1fr] items-center gap-3 px-4 py-2 sm:grid-cols-[auto_1fr_auto] sm:py-0">
           <div className="flex items-center gap-2">
@@ -498,7 +504,7 @@ export default function App() {
           }}
         />
 
-        <main className="flex min-w-0 flex-1 flex-col">
+        <main id="main" tabIndex={-1} className="flex min-w-0 flex-1 flex-col outline-none">
           <section className="shrink-0 border-b border-[var(--console-border)] bg-[var(--console-surface)]/70 px-4 py-4 backdrop-blur-sm md:px-8">
             <div>
               <nav

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -80,12 +80,12 @@ function DailyActivityChart({ buckets }: { buckets: DashboardDailyBucket[] }) {
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
-          <h3
+          <h2
             id="daily-activity-title"
             className="console-mono text-xs font-bold uppercase text-[var(--console-text)]"
           >
             Daily Activity
-          </h3>
+          </h2>
           <p className="console-mono mt-1 text-[11px] text-[var(--console-muted)]">
             Session activity · last {buckets.length} days
           </p>
@@ -200,12 +200,12 @@ function DailyTokenChart({ buckets }: { buckets: DailyTokenBucket[] }) {
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <div>
-          <h3
+          <h2
             id="daily-token-activity-title"
             className="console-mono text-xs font-bold uppercase text-[var(--console-text)]"
           >
             Daily Token Activity
-          </h3>
+          </h2>
           <p className="console-mono mt-1 text-[11px] text-[var(--console-muted)]">
             Token breakdown · last {buckets.length} days
           </p>
@@ -386,12 +386,12 @@ function ModelDistribution({ entries }: { entries: ModelDistributionEntry[] }) {
       className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4"
     >
       <div className="mb-3 flex items-center justify-between gap-3">
-        <h3
+        <h2
           id="model-distribution-title"
           className="console-mono text-xs font-bold uppercase text-[var(--console-text)]"
         >
           Model Distribution
-        </h3>
+        </h2>
         <span className="console-mono text-[11px] text-[var(--console-muted)]">
           {visibleEntries.length} models
         </span>
@@ -473,9 +473,9 @@ function AgentDistribution({ perAgent }: { perAgent: DashboardAgentStat[] }) {
   return (
     <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+        <h2 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Agent Distribution
-        </h3>
+        </h2>
         <span className="console-mono text-[11px] text-[var(--console-muted)]">
           {perAgent.length} agents
         </span>
@@ -533,9 +533,9 @@ function TopProjects({
   return (
     <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+        <h2 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Projects
-        </h3>
+        </h2>
         <Link
           to="/projects"
           className="console-mono text-[11px] text-[var(--console-muted)] motion-hover hover:text-[var(--console-text)]"
@@ -606,9 +606,9 @@ function BookmarkedSessions({
   return (
     <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+        <h2 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Bookmarked Sessions
-        </h3>
+        </h2>
         <span className="console-mono text-[11px] text-[var(--console-muted)]">
           {sessions.length} items
         </span>
@@ -669,9 +669,9 @@ function RecentSessions({
   return (
     <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+        <h2 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Recent Activity
-        </h3>
+        </h2>
         <span className="console-mono text-[11px] text-[var(--console-muted)]">
           {sessions.length} items
         </span>
@@ -731,9 +731,9 @@ function RecentFileActivity({ activity }: { activity: FileActivityResult[] }) {
   return (
     <div className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-4">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
+        <h2 className="console-mono text-xs font-bold uppercase text-[var(--console-text)]">
           Recently Touched Files
-        </h3>
+        </h2>
         <span className="console-mono text-[11px] text-[var(--console-muted)]">
           {activity.length} files
         </span>

--- a/apps/web/src/components/SessionAliasDialog.test.tsx
+++ b/apps/web/src/components/SessionAliasDialog.test.tsx
@@ -68,4 +68,30 @@ describe("SessionAliasDialog", () => {
     await waitFor(() => expect(onRemove).toHaveBeenCalledOnce());
     expect(onSave).not.toHaveBeenCalled();
   });
+
+  it("associates a save error with the title input for screen readers", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("Title already in use"));
+    render(
+      <SessionAliasDialog
+        target={{ agentKey: "codex", sessionId: "session-1", title: "Source title" }}
+        onClose={vi.fn()}
+        onSave={onSave}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Session title" });
+    expect(input.getAttribute("aria-invalid")).toBeNull();
+    expect(input.getAttribute("aria-describedby")).toBeNull();
+
+    fireEvent.change(input, { target: { value: "New title" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save title" }));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce());
+
+    const errorMessage = await screen.findByText("Title already in use");
+    expect(errorMessage.id).toBe("session-alias-error");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.getAttribute("aria-describedby")).toBe("session-alias-error");
+  });
 });

--- a/apps/web/src/components/SessionAliasDialog.tsx
+++ b/apps/web/src/components/SessionAliasDialog.tsx
@@ -80,11 +80,17 @@ export function SessionAliasDialog({
               onKeyDown={(event) => {
                 if (event.key === "Enter") void saveAlias();
               }}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? "session-alias-error" : undefined}
               className="mt-1.5 w-full rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-3 py-2 text-sm normal-case tracking-normal text-[var(--console-text)] outline-none focus:border-[var(--console-accent)] focus:ring-2 focus:ring-[var(--console-accent)]/25"
             />
           </label>
           {error ? (
-            <p aria-live="polite" className="mt-2 text-xs text-[var(--console-error)]">
+            <p
+              id="session-alias-error"
+              aria-live="polite"
+              className="mt-2 text-xs text-[var(--console-error)]"
+            >
               {error}
             </p>
           ) : null}


### PR DESCRIPTION
## Summary

Three small semantic gaps:

1. `SessionAliasDialog`'s error text was announced once (`aria-live`) but never programmatically associated with the input — refocusing the field gave no error context.
2. No skip link: after every navigation, keyboard users tabbed through the whole header (collapse toggle, logo, search, shortcuts, time window) and the entire sidebar to reach content.
3. Heading outline jumped h1 → h3 (Dashboard cards; zero `h2` in the file).

## Changes

- **Error association**: error `<p>` gets `id="session-alias-error"`; the input carries `aria-invalid` + `aria-describedby` only while an error exists (`undefined` otherwise, so the attributes don't render).
- **Skip link**: first child of the shell — `sr-only` until focused (`focus:not-sr-only focus:fixed`), styled with the repo's standard focus ring. The existing `<main>` landmark (already correctly excludes header/sidebar) gains `id="main"` + `tabIndex={-1}` + `outline-none`.
- **Headings**: all 8 Dashboard card `<h3>` → `<h2>` (classes untouched). Verified non-issues left alone: the TOC panel label is a `<span>` (no heading gap), and `ShortcutHelpDialog`'s group `<h3>`s correctly nest under Base UI `Dialog.Title`'s default `<h2>`.

## Testing

- New test: input gains `aria-invalid`/`aria-describedby` after a failed save, and the referenced element contains the error text; both absent before.
- Full-App mount test for the skip link skipped — no App-level test harness exists (would require QueryClient/router scaffolding disproportionate to this chore); verified by inspection.
- `pnpm build` / `pnpm test` (web 362) / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-86