### PR TITLE
chore: widen timeline segment and minimap hit targets to 24px (CS-87)

### DIFF
--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -611,19 +611,21 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
               minimapDragRef.current = null;
             }}
           >
-            <canvas
-              ref={minimapCanvasRef}
-              aria-hidden="true"
-              className="absolute inset-0 h-full w-full"
-            />
-            <div
-              data-testid="session-timeline-minimap-window"
-              className="session-timeline-minimap-window absolute inset-y-0"
-              style={{
-                left: `${minimapWindow.start * 100}%`,
-                width: `${minimapWindow.size * 100}%`,
-              }}
-            />
+            <div className="relative h-full w-full overflow-hidden rounded-[2px]">
+              <canvas
+                ref={minimapCanvasRef}
+                aria-hidden="true"
+                className="absolute inset-0 h-full w-full"
+              />
+              <div
+                data-testid="session-timeline-minimap-window"
+                className="session-timeline-minimap-window absolute inset-y-0"
+                style={{
+                  left: `${minimapWindow.start * 100}%`,
+                  width: `${minimapWindow.size * 100}%`,
+                }}
+              />
+            </div>
           </div>
         )}
         {tooltip &&

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -450,8 +450,16 @@
   }
 
   .session-timeline-minimap {
-    overflow: hidden;
     border-radius: 2px;
+  }
+
+  /* Transparent hit-area extension: 10px visual track -> >=24px pointer target,
+     without affecting layout flow (position: absolute) or the focus ring (drawn on the
+     real element, not this pseudo box). */
+  .session-timeline-minimap::before {
+    content: "";
+    position: absolute;
+    inset: -7px 0;
   }
 
   .session-timeline-minimap canvas {
@@ -467,12 +475,21 @@
   }
 
   .session-timeline-segment {
+    position: relative;
     opacity: 0.58;
     transition: opacity 100ms ease;
   }
 
+  /* Transparent hit-area extension: 20px (h-5) visual segment -> 24px pointer target.
+     Vertical only -- horizontal stays column-width so adjacent segments stay mutually
+     exclusive (WCAG 2.5.8 spacing exception). */
+  .session-timeline-segment::before {
+    content: "";
+    position: absolute;
+    inset: -2px 0;
+  }
+
   .session-timeline-segment[aria-current="location"] {
-    position: relative;
     z-index: 1;
     opacity: 1;
     box-shadow:


### PR DESCRIPTION
## Summary

The session timeline's interactive targets were below the 24px minimum: segment buttons ~10×20px, the minimap track ~10px tall — hard to hit on touch or with reduced pointer precision. Density is the component's deliberate design, so this expands **hit areas only**, with zero visual change.

## Changes

- **Segments**: transparent `::before` with `inset: -2px 0` → 24px vertical hit box. Horizontal untouched — adjacent segments are mutually exclusive, covered by WCAG 2.5.8's spacing exception. The `position: relative` previously applied only to the active segment moves to the base rule.
- **Minimap**: `::before` with `inset: -7px 0` → 24px hit box. The track's `overflow: hidden` (which clips the window overlay's 9999px dimming shadow) would have clipped the pseudo-element, so clipping moves to a new inner wrapper holding the canvas + window overlay; the outer interactive element keeps the pointer/keyboard handlers whose math is horizontal-only and unaffected.
- Pseudo-elements are `position: absolute` → no layout flow change (padding-based expansion was rejected for exactly that reason). Occlusion budgets verified: segment expansion absorbed by the viewport's `py-1` + `overflow-y-hidden`; minimap expansion fits inside the 8px gap above and 10px card padding below.
- Focus rings stay on the real elements (pseudo-elements can't host outline), so ring geometry is unchanged.

## Testing

- Full timeline suite passes unchanged (minimap drag / keyboard / window-percentage assertions — testids preserved).
- `pnpm build` / `pnpm test` / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-87