### PR TITLE
refactor: validate external data at adapter parse boundaries (CS-74)

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClaudeCodeAgent } from "../claudecode.js";
 import type { Message, MessagePart, SessionHead } from "../../types/index.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 // Spies on statSync while delegating to the real implementation, so the
 // single-stat regression test can count per-file calls during a live scan.
@@ -37,6 +38,7 @@ afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
   }
   tempDirs = [];
+  setCoreDiagnostics(null);
 });
 
 describe("ClaudeCodeAgent cache refresh", () => {
@@ -451,5 +453,104 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(data.messages[1]?.parts).toEqual([
       expect.objectContaining({ type: "text", text: "Visible answer" }),
     ]);
+  });
+
+  it("falls back to zero and reports a mismatch when a usage field has the wrong type", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-usage-drift-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const sessionId = "usage-drift";
+    const sessionFile = join(projectDir, `${sessionId}.jsonl`);
+
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "user",
+          uuid: "user-1",
+          timestamp: "2026-04-20T10:00:00Z",
+          cwd: "/tmp/project",
+          message: { role: "user", content: "Inspect the repository" },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          uuid: "assistant-1",
+          timestamp: "2026-04-20T10:00:01Z",
+          message: {
+            role: "assistant",
+            model: "claude-sonnet-4-5-20250929",
+            usage: {
+              // Drifted upstream shape: input_tokens sent as a string.
+              input_tokens: "100",
+              cache_read_input_tokens: 10,
+              cache_creation_input_tokens: 5,
+              output_tokens: 20,
+            },
+            content: [{ type: "text", text: "Reading package metadata" }],
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    const [head] = agent.scan();
+
+    // input_tokens falls back to 0 (still counting cache_read + cache_create); other fields unaffected.
+    expect(head?.stats).toMatchObject({
+      total_input_tokens: 15,
+      total_output_tokens: 20,
+      total_cache_read_tokens: 10,
+      total_cache_create_tokens: 5,
+    });
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "claudecode", field: "message.usage.input_tokens" },
+    });
+  });
+
+  it("skips message extraction and reports a mismatch when the message field is not an object", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-message-drift-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const sessionId = "message-drift";
+    const sessionFile = join(projectDir, `${sessionId}.jsonl`);
+
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "user",
+          uuid: "user-1",
+          timestamp: "2026-04-20T10:00:00Z",
+          cwd: "/tmp/project",
+          // Drifted upstream shape: message sent as a plain string, not an object.
+          message: "not-an-object",
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    // No visible messages were extracted, so the session is filtered out entirely.
+    expect(agent.scan()).toEqual([]);
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "claudecode", field: "message" },
+    });
   });
 });

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CodexAgent } from "../codex.js";
 import type { Message, MessagePart, SessionHead } from "../../types/index.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 // Spies on statSync while delegating to the real implementation, so the
 // single-stat regression test can count per-file calls during a live scan.
@@ -1122,6 +1123,89 @@ describe("CodexAgent code-mode exec decoding", () => {
     expect(toolParts[1]).toMatchObject({
       tool: "patch",
       state: { arguments: [{ type: "write_file", path: "a.txt", content: "+hi" }], output: null },
+    });
+  });
+});
+
+describe("CodexAgent field shape mismatches", () => {
+  let diagnosticsCalls: Array<{ event: string; detail?: Record<string, unknown> }>;
+
+  afterEach(() => {
+    setCoreDiagnostics(null);
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  function captureDiagnostics(): void {
+    diagnosticsCalls = [];
+    const sink: CoreDiagnostics = {
+      warn: (event, detail) => diagnosticsCalls.push({ event, detail }),
+    };
+    setCoreDiagnostics(sink);
+  }
+
+  it("falls back to zeroed tokens and reports a mismatch when token_count.info drifts", () => {
+    captureDiagnostics();
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionFile = join(
+      tempDir,
+      "rollout-2026-04-20T10-00-00-019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa.jsonl",
+    );
+
+    writeFileSync(
+      sessionFile,
+      [
+        '{"timestamp":"2026-04-20T10:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/project","model":"gpt-5.5"}}',
+        // "info" has drifted from an object to a string upstream.
+        '{"timestamp":"2026-04-20T10:01:00Z","type":"event_msg","payload":{"type":"token_count","info":"unexpected-string"}}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.sessionIndexCache = new Map();
+
+    const head = agent.parseSessionHead(sessionFile);
+
+    expect(head?.stats.total_input_tokens).toBe(0);
+    expect(head?.stats.total_output_tokens).toBe(0);
+    expect(head?.model_usage).toBeUndefined();
+    expect(diagnosticsCalls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "codex", field: "token_count.info" },
+    });
+  });
+
+  it("skips a response_item and reports a mismatch when payload drifts to a non-object", () => {
+    captureDiagnostics();
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-bbbbbbbbbbbb";
+    const sessionFile = join(tempDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+
+    writeFileSync(
+      sessionFile,
+      [
+        '{"timestamp":"2026-04-20T10:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/project"}}',
+        // "payload" has drifted from an object to a bare string upstream.
+        '{"timestamp":"2026-04-20T10:01:00Z","type":"response_item","payload":"unexpected-string"}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.scan();
+
+    const data = agent.getSessionData(sessionId);
+
+    expect(data.messages).toEqual([]);
+    expect(diagnosticsCalls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "codex", field: "payload" },
     });
   });
 });

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -5,6 +5,11 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { CursorAgent } from "../cursor.js";
 import type { MessagePart } from "../../types/index.js";
+import {
+  getCoreDiagnostics,
+  setCoreDiagnostics,
+  type CoreDiagnostics,
+} from "../../utils/diagnostics.js";
 
 let tempDirs: string[] = [];
 
@@ -103,5 +108,84 @@ describe("CursorAgent parsing", () => {
     const data = agent.getSessionData("composer-1");
 
     expect(data.title).toBe("Untitled Session");
+  });
+
+  it("falls back to zero tokens and reports a mismatch when tokenCount is wrong-typed", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createCursorDb(tempDir);
+
+    insertKv(dbPath, "bubbleId:composer-1:assistant", {
+      type: 2,
+      text: "Assistant reply",
+      createdAt: 1_000,
+      // upstream format drift: tokenCount fields arrive as strings instead of numbers
+      tokenCount: { inputTokens: "100", outputTokens: "50" },
+    });
+
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    try {
+      const agent = new CursorAgent() as any;
+      agent.dbPath = dbPath;
+      agent.composerCache.set("composer-1", {
+        id: "composer-1",
+        createdAt: 1_000,
+        updatedAt: 1_000,
+      });
+
+      const data = agent.getSessionData("composer-1");
+
+      expect(data.messages[0]?.tokens).toEqual({ input: 0, output: 0 });
+      expect(calls).toContainEqual({
+        event: "agent.field_shape_mismatch",
+        detail: { agentName: "cursor", field: "bubble.tokenCount.inputTokens" },
+      });
+      expect(calls).toContainEqual({
+        event: "agent.field_shape_mismatch",
+        detail: { agentName: "cursor", field: "bubble.tokenCount.outputTokens" },
+      });
+    } finally {
+      setCoreDiagnostics(null);
+    }
+  });
+
+  it("skips a subagent chat message with a wrong-typed role and reports a mismatch", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createCursorDb(tempDir);
+
+    // upstream format drift: role arrives as a number instead of "user"/"assistant"
+    insertKv(dbPath, "bubble:sub-1", {
+      chatMessages: [{ role: 42, text: "should be skipped" }],
+    });
+
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    try {
+      const agent = new CursorAgent() as any;
+      agent.dbPath = dbPath;
+      agent.composerCache.set("composer-1", {
+        id: "composer-1",
+        createdAt: 1_000,
+        updatedAt: 1_000,
+        subagentInfos: [{ id: "sub-1", title: "Subagent" }],
+      });
+
+      const data = agent.getSessionData("composer-1");
+
+      expect(data.messages.some((m: { id: string }) => m.id === "cursor-sub-sub-1")).toBe(false);
+      expect(calls).toContainEqual({
+        event: "agent.field_shape_mismatch",
+        detail: { agentName: "cursor", field: "chatMessage.role" },
+      });
+    } finally {
+      setCoreDiagnostics(null);
+      expect(getCoreDiagnostics()).toBeNull();
+    }
   });
 });

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { KimiAgent } from "../kimi.js";
 import type { SessionHead } from "../../types/index.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 const PROJECT_HASH = "project-hash";
 const PROJECT_DIR = "/tmp/kimi-project";
@@ -62,6 +63,7 @@ afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
   }
   tempDirs = [];
+  setCoreDiagnostics(null);
 });
 
 describe("KimiAgent cache refresh", () => {
@@ -263,5 +265,69 @@ describe("KimiAgent cache refresh", () => {
     expect(data.messages[1]?.parts).toEqual([
       expect.objectContaining({ type: "text", text: "Visible answer" }),
     ]);
+  });
+
+  it("falls back to zero tokens and reports drift when wire usage fields are non-numeric", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    const sessionDir = createSessionDir(basePath, "usage-drift", "Usage drift", 1_000);
+    writeFileSync(
+      join(sessionDir, "wire.jsonl"),
+      JSON.stringify({
+        timestamp: 1,
+        message: {
+          type: "ContentPart",
+          payload: { type: "text", text: "hi" },
+          usage: { input_tokens: "5", output_tokens: "3" },
+        },
+      }) + "\n",
+    );
+
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    const agent = createAgent(basePath);
+    const [head] = agent.scan();
+
+    expect(head?.stats.total_input_tokens).toBe(0);
+    expect(head?.stats.total_output_tokens).toBe(0);
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "kimi", field: "usage.input_tokens" },
+    });
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "kimi", field: "usage.output_tokens" },
+    });
+  });
+
+  it("falls back to file mtime and reports drift when state.json wire_mtime is not a number", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    const sessionDir = join(basePath, PROJECT_HASH, "mtime-drift");
+    mkdirSync(sessionDir, { recursive: true });
+    const statePath = join(sessionDir, "state.json");
+    writeFileSync(
+      statePath,
+      JSON.stringify({ custom_title: "Mtime drift", wire_mtime: "not-a-number" }),
+    );
+    writeFileSync(
+      join(sessionDir, "context.jsonl"),
+      JSON.stringify({ role: "user", content: "Mtime drift" }) + "\n",
+    );
+
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    const agent = createAgent(basePath);
+    const [head] = agent.scan();
+
+    expect(head?.time_created).toBe(statSync(statePath).mtimeMs);
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "kimi", field: "session.wire_mtime" },
+    });
   });
 });

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { OpenCodeSqliteAgent } from "../opencode-sqlite.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 const tempDirs: string[] = [];
 
@@ -60,10 +61,59 @@ function createDatabase(): string {
   return dbPath;
 }
 
+function createDatabaseWithMessageData(messageData: string): string {
+  const tempDir = mkdtempSync(join(tmpdir(), "codesesh-opencode-sqlite-test-"));
+  tempDirs.push(tempDir);
+  const dbPath = join(tempDir, "agent.db");
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      time_created INTEGER,
+      time_updated INTEGER,
+      slug TEXT,
+      directory TEXT,
+      version TEXT,
+      summary_files TEXT
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      data TEXT,
+      time_created INTEGER
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT,
+      data TEXT,
+      time_created INTEGER
+    );
+  `);
+  db.prepare(
+    "INSERT INTO session (id, title, time_created, time_updated, directory) VALUES (?, ?, ?, ?, ?)",
+  ).run("s1", "", 1_000, 2_000, "/workspace/project");
+  db.prepare("INSERT INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+    "m1",
+    "s1",
+    messageData,
+    1_100,
+  );
+  db.prepare("INSERT INTO part (id, message_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+    "p1",
+    "m1",
+    JSON.stringify({ type: "text", text: "Implement cache tests" }),
+    1_100,
+  );
+  db.close();
+  return dbPath;
+}
+
 afterEach(() => {
   for (const tempDir of tempDirs.splice(0)) {
     rmSync(tempDir, { recursive: true, force: true });
   }
+  setCoreDiagnostics(null);
 });
 
 describe("OpenCodeSqliteAgent", () => {
@@ -102,5 +152,61 @@ describe("OpenCodeSqliteAgent", () => {
         },
       ],
     });
+  });
+
+  it("falls back to an empty message record and reports drift when message data isn't a JSON object", () => {
+    const dbPath = createDatabaseWithMessageData("null");
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent-data-drift",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+    });
+
+    expect(agent.getSessionData("s1")).toMatchObject({
+      messages: [{ role: "assistant", model: null, tokens: undefined, cost: 0 }],
+    });
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "test-agent-data-drift", field: "message.data" },
+    });
+  });
+
+  it("falls back on per-field type drift (role/model/tokens) and reports each mismatch once", () => {
+    const dbPath = createDatabaseWithMessageData(
+      JSON.stringify({ role: "system", modelID: 42, tokens: "not-an-object" }),
+    );
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent-field-drift",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+    });
+
+    expect(agent.getSessionData("s1")).toMatchObject({
+      messages: [{ role: "assistant", model: null, tokens: undefined }],
+    });
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        {
+          event: "agent.field_shape_mismatch",
+          detail: { agentName: "test-agent-field-drift", field: "message.role" },
+        },
+        {
+          event: "agent.field_shape_mismatch",
+          detail: { agentName: "test-agent-field-drift", field: "message.modelID" },
+        },
+        {
+          event: "agent.field_shape_mismatch",
+          detail: { agentName: "test-agent-field-drift", field: "message.tokens" },
+        },
+      ]),
+    );
   });
 });

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -16,6 +16,7 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "./base.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
@@ -45,27 +46,46 @@ interface SessionMeta extends SessionCacheMeta {
 }
 
 function parseTimestampMs(data: Record<string, unknown>): number {
-  const raw = String(data["timestamp"] ?? "").trim();
-  if (!raw) return 0;
+  const raw = data["timestamp"];
+  const value = asString(raw);
+  if (value === undefined) {
+    if (raw !== undefined && raw !== null) reportFieldMismatch("claudecode", "timestamp");
+    return 0;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
   try {
-    return new Date(raw.includes("Z") ? raw : raw + "Z").getTime();
+    return new Date(trimmed.includes("Z") ? trimmed : trimmed + "Z").getTime();
   } catch {
     return 0;
   }
 }
 
-function numericUsage(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+/** Reads a numeric usage field; a present-but-wrong-typed field is a schema drift signal. */
+function readUsageNumber(usage: Record<string, unknown>, field: string): number {
+  const raw = usage[field];
+  if (raw === undefined) return 0;
+  const value = asNumber(raw);
+  if (value === undefined) {
+    reportFieldMismatch("claudecode", `message.usage.${field}`);
+    return 0;
+  }
+  return value;
 }
 
 function extractClaudeUsage(
   data: Record<string, unknown>,
   msg: Record<string, unknown>,
 ): ClaudeUsage | null {
-  const usage = msg["usage"];
-  if (!usage || typeof usage !== "object") return null;
+  const rawUsage = msg["usage"];
+  if (rawUsage === undefined || rawUsage === null) return null;
 
-  const u = usage as Record<string, unknown>;
+  const usage = asRecord(rawUsage);
+  if (!usage) {
+    reportFieldMismatch("claudecode", "message.usage");
+    return null;
+  }
+
   const requestId = typeof data["requestId"] === "string" ? data["requestId"].trim() : "";
   const uuid = typeof data["uuid"] === "string" ? data["uuid"].trim() : "";
   const key = requestId || uuid;
@@ -73,10 +93,10 @@ function extractClaudeUsage(
 
   return {
     key,
-    input: numericUsage(u["input_tokens"]),
-    output: numericUsage(u["output_tokens"]),
-    cacheRead: numericUsage(u["cache_read_input_tokens"]),
-    cacheCreate: numericUsage(u["cache_creation_input_tokens"]),
+    input: readUsageNumber(usage, "input_tokens"),
+    output: readUsageNumber(usage, "output_tokens"),
+    cacheRead: readUsageNumber(usage, "cache_read_input_tokens"),
+    cacheCreate: readUsageNumber(usage, "cache_creation_input_tokens"),
   };
 }
 
@@ -331,26 +351,30 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
           cwd = data["cwd"];
         }
 
-        const msg = data["message"];
-        if (msg && typeof msg === "object") {
-          const role = (msg as Record<string, unknown>)["role"];
-          if (typeof role === "string" && role.trim()) {
+        const msg = asRecord(data["message"]);
+        if (!msg && data["message"] !== undefined && data["message"] !== null) {
+          reportFieldMismatch("claudecode", "message");
+        }
+        if (msg) {
+          const role = asString(msg["role"]);
+          if (msg["role"] !== undefined && role === undefined) {
+            reportFieldMismatch("claudecode", "message.role");
+          }
+          if (role?.trim()) {
             messageCount++;
           }
           if (!model) {
-            const m = (msg as Record<string, unknown>)["model"];
-            if (typeof m === "string" && m.trim()) model = m.trim();
+            const m = asString(msg["model"]);
+            if (m?.trim()) model = m.trim();
           }
           // Title fallback mirrors the removed extractTitle(): first non-empty
           // visible user text within the first 20 lines.
           if (messageTitle === null && lineIndex < 20 && role === "user") {
-            const candidate = this.extractUserMessageTitle(
-              (msg as Record<string, unknown>)["content"],
-            );
+            const candidate = this.extractUserMessageTitle(msg["content"]);
             if (candidate) messageTitle = candidate;
           }
           if (role === "assistant") {
-            const usage = extractClaudeUsage(data, msg as Record<string, unknown>);
+            const usage = extractClaudeUsage(data, msg);
             if (usage && !countedUsageKeys.has(usage.key)) {
               countedUsageKeys.add(usage.key);
               const inputTokens = usage.input;
@@ -363,8 +387,8 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
               totalCacheReadTokens += cacheRead;
               totalCacheCreateTokens += cacheCreate;
 
-              const m = (msg as Record<string, unknown>)["model"];
-              if (typeof m === "string" && m.trim()) {
+              const m = asString(msg["model"]);
+              if (m?.trim()) {
                 const name = m.trim();
                 const msgTotal = inputTokens + cacheRead + cacheCreate + outputTokens;
                 modelUsageMap[name] = (modelUsageMap[name] ?? 0) + msgTotal;
@@ -422,8 +446,11 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     }
     if (Array.isArray(content)) {
       const texts = content
-        .filter((item) => typeof item === "object" && item !== null && "text" in item)
-        .map((item) => String((item as Record<string, unknown>)["text"] ?? ""))
+        .filter((item): item is Record<string, unknown> => {
+          const record = asRecord(item);
+          return record !== undefined && "text" in record;
+        })
+        .map((item) => String(item["text"] ?? ""))
         .join(" ");
       const title = normalizeTitleText(texts);
       return title || null;
@@ -459,62 +486,60 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     assistantUuidToToolCalls: Map<string, string[]>,
     countedUsageKeys: Set<string>,
   ): void {
-    const msg = (data["message"] ?? {}) as Record<string, unknown>;
+    const msg = asRecord(data["message"]) ?? {};
     const timestampMs = parseTimestampMs(data);
-    const rawContent = (msg["content"] ?? []) as unknown[];
+    const rawContent = asArray(msg["content"]) ?? [];
     const uuid = String(data["uuid"] ?? "");
 
     const toolCallIds: string[] = [];
-    if (Array.isArray(rawContent)) {
-      for (const item of rawContent) {
-        if (!item || typeof item !== "object") continue;
-        const part = item as Record<string, unknown>;
-        const partType = String(part["type"] ?? "");
+    for (const item of rawContent) {
+      const part = asRecord(item);
+      if (!part) continue;
+      const partType = String(part["type"] ?? "");
 
-        if (partType === "thinking") {
-          const text = cleanInternalText(String(part["thinking"] ?? ""));
-          if (text) {
-            const message = builder.appendAssistantPart(
-              this.buildReasoningPart(text, timestampMs),
-              { id: uuid, timestampMs, agent: "claude" },
-              { deduplicateTail: true },
-            );
-            this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
-          }
-          continue;
+      if (partType === "thinking") {
+        const text = cleanInternalText(String(part["thinking"] ?? ""));
+        if (text) {
+          const message = builder.appendAssistantPart(
+            this.buildReasoningPart(text, timestampMs),
+            { id: uuid, timestampMs, agent: "claude" },
+            { deduplicateTail: true },
+          );
+          this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
         }
+        continue;
+      }
 
-        if (partType === "text") {
-          const text = cleanInternalText(String(part["text"] ?? ""));
-          if (text) {
-            const message = builder.appendAssistantPart(
-              this.buildTextPart(text, timestampMs),
-              {
-                id: uuid,
-                timestampMs,
-                agent: "claude",
-              },
-              { deduplicateTail: true },
-            );
-            this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
-          }
-          continue;
+      if (partType === "text") {
+        const text = cleanInternalText(String(part["text"] ?? ""));
+        if (text) {
+          const message = builder.appendAssistantPart(
+            this.buildTextPart(text, timestampMs),
+            {
+              id: uuid,
+              timestampMs,
+              agent: "claude",
+            },
+            { deduplicateTail: true },
+          );
+          this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
         }
+        continue;
+      }
 
-        if (partType !== "tool_use") continue;
+      if (partType !== "tool_use") continue;
 
-        const toolCallId = String(part["id"] ?? "").trim();
+      const toolCallId = String(part["id"] ?? "").trim();
 
-        const toolPart = this.buildToolPart(part, timestampMs);
-        const message = builder.appendToolCall(
-          toolPart,
-          { id: uuid, timestampMs, agent: "claude" },
-          { modeOnCreate: "tool" },
-        );
-        this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
-        if (toolCallId) {
-          toolCallIds.push(toolCallId);
-        }
+      const toolPart = this.buildToolPart(part, timestampMs);
+      const message = builder.appendToolCall(
+        toolPart,
+        { id: uuid, timestampMs, agent: "claude" },
+        { modeOnCreate: "tool" },
+      );
+      this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
+      if (toolCallId) {
+        toolCallIds.push(toolCallId);
       }
     }
 
@@ -528,7 +553,7 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     builder: TranscriptBuilder,
     assistantUuidToToolCalls: Map<string, string[]>,
   ): void {
-    const msg = (data["message"] ?? {}) as Record<string, unknown>;
+    const msg = asRecord(data["message"]) ?? {};
     const timestampMs = parseTimestampMs(data);
     const content = msg["content"] ?? "";
     const uuid = String(data["uuid"] ?? "");
@@ -553,9 +578,8 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     const toolStateUpdates = this.extractToolStateUpdates(data["toolUseResult"]);
 
     for (const item of content) {
-      if (!item || typeof item !== "object") continue;
-      const ci = item as Record<string, unknown>;
-      if (ci["type"] !== "tool_result") continue;
+      const ci = asRecord(item);
+      if (!ci || ci["type"] !== "tool_result") continue;
 
       const toolCallId = this.resolveToolCallId(data, ci, assistantUuidToToolCalls);
 
@@ -582,7 +606,7 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
   private convertToolResultRecord(data: Record<string, unknown>, builder: TranscriptBuilder): void {
     const timestampMs = parseTimestampMs(data);
-    const msg = (data["message"] ?? {}) as Record<string, unknown>;
+    const msg = asRecord(data["message"]) ?? {};
     const outputParts = this.normalizeClaudeToolOutput(msg["content"], timestampMs);
     const uuid = String(data["uuid"] ?? "");
 
@@ -657,8 +681,8 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
     const parts: MessagePart[] = [];
     for (const item of content) {
-      if (typeof item === "object" && item !== null) {
-        const ci = item as Record<string, unknown>;
+      const ci = asRecord(item);
+      if (ci) {
         if (ci["type"] === "tool_result") continue;
         const text = cleanInternalText(String(ci["text"] ?? ""));
         if (text) parts.push(this.buildTextPart(text, timestampMs));
@@ -680,12 +704,13 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     if (Array.isArray(content)) {
       const parts: MessagePart[] = [];
       for (const item of content) {
-        if (typeof item === "object" && item !== null) {
-          const itemRecord = item as Record<string, unknown>;
-          const source = itemRecord["source"] as Record<string, unknown> | undefined;
-          if (itemRecord["type"] === "image" && source) {
-            const data = typeof source["data"] === "string" ? source["data"] : "";
-            const mimeType = typeof source["media_type"] === "string" ? source["media_type"] : "";
+        const itemRecord = asRecord(item);
+        if (itemRecord) {
+          const rawSource = itemRecord["source"];
+          if (itemRecord["type"] === "image" && rawSource) {
+            const source = asRecord(rawSource);
+            const data = asString(source?.["data"]) ?? "";
+            const mimeType = asString(source?.["media_type"]) ?? "";
             if (data && mimeType.startsWith("image/")) {
               parts.push({ type: "image", data, mime_type: mimeType, time_created: timestampMs });
             }
@@ -746,9 +771,9 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   private extractToolStateUpdates(toolUseResult: unknown): Record<string, unknown> {
-    if (!toolUseResult || typeof toolUseResult !== "object") return {};
+    const result = asRecord(toolUseResult);
+    if (!result) return {};
 
-    const result = toolUseResult as Record<string, unknown>;
     const updates: Record<string, unknown> = {};
 
     const success = result["success"];

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -24,6 +24,7 @@ import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../utils/jso
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
 import {
   type ExecInnerCall,
@@ -107,6 +108,37 @@ function extractCachedInputTokens(usage: Record<string, unknown> | undefined): n
   return Number(usage["cached_input_tokens"] ?? usage["cache_read_input_tokens"] ?? 0);
 }
 
+/**
+ * Narrows to a record, reporting a field-shape mismatch only when the value
+ * is present but not an object — absent (undefined/null) is a normal, not a
+ * drifted, shape and stays silent.
+ */
+function narrowRecordField(value: unknown, field: string): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined;
+  const record = asRecord(value);
+  if (!record) reportFieldMismatch("codex", field);
+  return record;
+}
+
+function extractPayload(data: Record<string, unknown>): Record<string, unknown> {
+  return narrowRecordField(data["payload"], "payload") ?? {};
+}
+
+function extractTokenUsage(payload: Record<string, unknown>): {
+  totalUsage: Record<string, unknown> | undefined;
+  lastUsage: Record<string, unknown> | undefined;
+} {
+  const info = narrowRecordField(payload["info"], "token_count.info");
+  return {
+    totalUsage: info
+      ? narrowRecordField(info["total_token_usage"], "token_count.total_token_usage")
+      : undefined,
+    lastUsage: info
+      ? narrowRecordField(info["last_token_usage"], "token_count.last_token_usage")
+      : undefined,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tool helpers
 // ---------------------------------------------------------------------------
@@ -164,11 +196,8 @@ function flattenOutputText(output: unknown): string {
     return output
       .map((item) => {
         if (typeof item === "string") return item;
-        if (item && typeof item === "object") {
-          const text = (item as Record<string, unknown>)["text"];
-          if (typeof text === "string") return text;
-        }
-        return "";
+        const record = asRecord(item);
+        return record ? (asString(record["text"]) ?? "") : "";
       })
       .join("");
   }
@@ -383,7 +412,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       try {
         const recordType = String(record["type"] ?? "");
         if (recordType === "turn_context") {
-          const payload = (record["payload"] ?? {}) as Record<string, unknown>;
+          const payload = extractPayload(record);
           activeModel = extractModelName(payload["model"]) ?? activeModel;
         }
 
@@ -391,10 +420,9 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
         // Process Codex token_count events
         if (recordType === "event_msg") {
-          const payload = (record["payload"] ?? {}) as Record<string, unknown>;
+          const payload = extractPayload(record);
           if (String(payload["type"] ?? "") === "token_count") {
-            const info = payload["info"] as Record<string, unknown> | undefined;
-            const totalUsage = info?.["total_token_usage"] as Record<string, unknown> | undefined;
+            const { totalUsage, lastUsage } = extractTokenUsage(payload);
             const cumulativeTotal = Number(totalUsage?.["total_tokens"] ?? 0);
 
             if (cumulativeTotal > 0 && cumulativeTotal === prevCumulativeTotal) {
@@ -402,7 +430,6 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
             } else {
               prevCumulativeTotal = cumulativeTotal;
 
-              const lastUsage = info?.["last_token_usage"] as Record<string, unknown> | undefined;
               let inputTokens = 0;
               let outputTokens = 0;
               let reasoningTokens = 0;
@@ -658,7 +685,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
         } catch {
           return skippedSession("malformed first record");
         }
-        firstPayload = (firstRecord["payload"] ?? {}) as Record<string, unknown>;
+        firstPayload = extractPayload(firstRecord);
         createdAt =
           parseTimestampMs(firstRecord) ||
           parseTimestampMs(firstPayload) ||
@@ -669,13 +696,11 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       try {
         const data = JSON.parse(line);
         const recordType = String(data["type"] ?? "");
-        const payload = (data["payload"] ?? {}) as Record<string, unknown>;
+        const payload = extractPayload(data);
         const payloadType = String(payload["type"] ?? "");
         if (isInternalEventType(recordType) || isInternalEventType(payloadType)) continue;
         hasNonInternalRecord = true;
-        const recordTs =
-          parseTimestampMs(data) ||
-          parseTimestampMs((data["payload"] ?? {}) as Record<string, unknown>);
+        const recordTs = parseTimestampMs(data) || parseTimestampMs(payload);
         if (recordTs > updatedAt) updatedAt = recordTs;
 
         // Title fallback mirrors the removed extractTitleFromLines(): first
@@ -701,7 +726,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
             messageCount++;
           }
           // Extract model from response_item
-          const info = p["info"] as Record<string, unknown> | undefined;
+          const info = narrowRecordField(p["info"], "response_item.info");
           const m = info?.["model"] ?? p["model"];
           if (typeof m === "string" && m.trim()) {
             activeModel = m.trim();
@@ -710,16 +735,13 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
         }
 
         if (recordType === "event_msg") {
-          const p = (data["payload"] ?? {}) as Record<string, unknown>;
-          if (String(p["type"] ?? "") === "token_count") {
-            const info = p["info"] as Record<string, unknown> | undefined;
-            const totalUsage = info?.["total_token_usage"] as Record<string, unknown> | undefined;
+          if (String(payload["type"] ?? "") === "token_count") {
+            const { totalUsage, lastUsage } = extractTokenUsage(payload);
             const cumulativeTotal = Number(totalUsage?.["total_tokens"] ?? 0);
 
             if (cumulativeTotal > 0 && cumulativeTotal !== scanPrevCumulativeTotal) {
               scanPrevCumulativeTotal = cumulativeTotal;
 
-              const lastUsage = info?.["last_token_usage"] as Record<string, unknown> | undefined;
               let inputTokens = 0;
               let outputTokens = 0;
               let reasoningTokens = 0;
@@ -811,7 +833,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       return skippedSession("malformed first record");
     }
 
-    const payload = (firstRecord["payload"] ?? {}) as Record<string, unknown>;
+    const payload = extractPayload(firstRecord);
     const stat = statSync(filePath);
     const createdAt = parseTimestampMs(firstRecord) || parseTimestampMs(payload) || stat.mtimeMs;
     const indexTitle = this.getTitleForSession(sessionId);
@@ -858,7 +880,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     const recordType = String(data["type"] ?? "");
     if (recordType !== "response_item" || isInternalEventType(recordType)) return null;
 
-    const payload = (data["payload"] ?? {}) as Record<string, unknown>;
+    const payload = extractPayload(data);
     const pType = String(payload["type"] ?? "");
     if (pType !== "message" || isInternalEventType(pType)) return null;
     if (String(payload["role"] ?? "") !== "user") return null;
@@ -867,8 +889,10 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     let text: string | null = null;
     if (Array.isArray(content)) {
       text = content
-        .filter((item) => typeof item === "object" && item !== null && "text" in item)
-        .map((item) => String((item as Record<string, unknown>)["text"] ?? ""))
+        .map((item) => {
+          const record = asRecord(item);
+          return record ? String(record["text"] ?? "") : "";
+        })
         .join(" ");
     } else if (typeof content === "string") {
       text = content;
@@ -894,7 +918,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
     if (recordType !== "response_item") return pendingPlan;
 
-    const payload = (data["payload"] ?? {}) as Record<string, unknown>;
+    const payload = extractPayload(data);
     const payloadType = String(payload["type"] ?? "");
     if (isInternalEventType(payloadType)) return pendingPlan;
     const timestampMs = parseTimestampMs(data) || parseTimestampMs(payload);
@@ -955,8 +979,8 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
     const textParts: string[] = [];
     for (const item of content) {
-      if (typeof item !== "object" || item === null) continue;
-      const ci = item as Record<string, unknown>;
+      const ci = asRecord(item);
+      if (!ci) continue;
       if (String(ci["type"] ?? "") === "output_text") {
         const text = String(ci["text"] ?? "");
         if (text.trim()) textParts.push(text);
@@ -1003,11 +1027,11 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     const content = payload["content"];
     const text = Array.isArray(content)
       ? content
-          .map((c) =>
-            typeof c === "object" && c !== null
-              ? String((c as Record<string, unknown>)["text"] ?? "")
-              : String(c ?? ""),
-          )
+          .map((c) => {
+            if (Array.isArray(c)) return "";
+            const record = asRecord(c);
+            return record ? String(record["text"] ?? "") : String(c ?? "");
+          })
           .join(" ")
       : String(content ?? "");
 
@@ -1029,8 +1053,16 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
     const subagentMatch = visibleText.match(SUBAGENT_NOTIFICATION_PATTERN);
     if (subagentMatch) {
+      // Malformed or non-object notification payloads fall through and are
+      // treated as normal user messages below.
+      let notifPayload: Record<string, unknown> | undefined;
       try {
-        const notifPayload = JSON.parse(subagentMatch[1]!) as Record<string, unknown>;
+        notifPayload = asRecord(JSON.parse(subagentMatch[1]!));
+      } catch {
+        notifPayload = undefined;
+      }
+
+      if (notifPayload) {
         const agentId = String(notifPayload["agent_id"] ?? "");
         const nickname = String(notifPayload["nickname"] ?? "");
         const completedText = String(notifPayload["completed"] ?? "");
@@ -1052,8 +1084,6 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
         });
         transcript.beginTurn();
         return pendingPlan;
-      } catch {
-        // Treat malformed notification payloads as normal user messages.
       }
     }
 
@@ -1079,12 +1109,11 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
     const texts: string[] = [];
     for (const item of summary) {
-      if (typeof item === "object" && item !== null) {
-        const ci = item as Record<string, unknown>;
-        if (String(ci["type"] ?? "") === "summary_text") {
-          const text = String(ci["text"] ?? "");
-          if (text.trim()) texts.push(text);
-        }
+      const ci = asRecord(item);
+      if (!ci) continue;
+      if (String(ci["type"] ?? "") === "summary_text") {
+        const text = String(ci["text"] ?? "");
+        if (text.trim()) texts.push(text);
       }
     }
 

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -20,6 +20,7 @@ import {
 } from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
 
 // ---------------------------------------------------------------------------
 // Cursor data model interfaces
@@ -107,6 +108,152 @@ interface ActionEntry {
 }
 
 // ---------------------------------------------------------------------------
+// Safe parsing of external rows — cursorDiskKV values and workspace.json are
+// untrusted (cross Cursor-version drift), so their fields are narrowed
+// individually instead of blindly cast. A field that's absent behaves like
+// today's optional-field fallback (?? 0 / skip); a field that's present but
+// wrong-typed additionally reports once via diagnostics.
+// ---------------------------------------------------------------------------
+
+function narrowString(field: string, value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  const str = asString(value);
+  if (str === undefined) reportFieldMismatch("cursor", field);
+  return str;
+}
+
+function narrowNumber(field: string, value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  const num = asNumber(value);
+  if (num === undefined) reportFieldMismatch("cursor", field);
+  return num;
+}
+
+function parseJsonRecord(json: string): Record<string, unknown> | undefined {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+  return asRecord(raw);
+}
+
+function parseSubagentInfos(value: unknown): SubagentInfo[] | undefined {
+  const arr = asArray(value);
+  if (arr === undefined) return undefined;
+  const infos: SubagentInfo[] = [];
+  for (const item of arr) {
+    const record = asRecord(item);
+    if (!record) continue;
+    infos.push({
+      id: narrowString("subagentInfo.id", record.id),
+      composerId: narrowString("subagentInfo.composerId", record.composerId),
+      title: narrowString("subagentInfo.title", record.title),
+      nickname: narrowString("subagentInfo.nickname", record.nickname),
+    });
+  }
+  return infos;
+}
+
+function parseChatMessages(value: unknown): ChatMessage[] | undefined {
+  const arr = asArray(value);
+  if (arr === undefined) return undefined;
+  const messages: ChatMessage[] = [];
+  for (const item of arr) {
+    const record = asRecord(item);
+    if (!record) continue;
+    const role = narrowString("chatMessage.role", record.role);
+    if (role === undefined) continue;
+    messages.push({ ...record, role, text: narrowString("chatMessage.text", record.text) });
+  }
+  return messages;
+}
+
+/** Parse a `composerData:*` row value into a field-validated ComposerData. */
+function parseComposerRow(value: string): ComposerData | null {
+  const record = parseJsonRecord(value);
+  if (!record) return null;
+
+  const modelConfig = asRecord(record.modelConfig);
+
+  return {
+    id: narrowString("composer.id", record.id),
+    composerId: narrowString("composer.composerId", record.composerId),
+    text: narrowString("composer.text", record.text),
+    name: narrowString("composer.name", record.name),
+    title: narrowString("composer.title", record.title),
+    createdAt: narrowNumber("composer.createdAt", record.createdAt),
+    updatedAt: narrowNumber("composer.updatedAt", record.updatedAt),
+    lastSendTime: narrowNumber("composer.lastSendTime", record.lastSendTime),
+    lastUpdatedAt: narrowNumber("composer.lastUpdatedAt", record.lastUpdatedAt),
+    model: narrowString("composer.model", record.model),
+    modelConfig: modelConfig
+      ? { modelName: narrowString("composer.modelConfig.modelName", modelConfig.modelName) }
+      : undefined,
+    inputTokenCount: narrowNumber("composer.inputTokenCount", record.inputTokenCount),
+    outputTokenCount: narrowNumber("composer.outputTokenCount", record.outputTokenCount),
+    subagentInfos: parseSubagentInfos(record.subagentInfos),
+    chatMessages: parseChatMessages(record.chatMessages),
+  };
+}
+
+/** Parse a `bubbleId:*` / `bubble:*` row value into a field-validated BubbleData. */
+function parseBubbleRow(value: string): BubbleData | null {
+  const record = parseJsonRecord(value);
+  if (!record) return null;
+
+  const timingInfo = asRecord(record.timingInfo);
+  const tokenCount = asRecord(record.tokenCount);
+  const modelInfo = asRecord(record.modelInfo);
+  const toolFormerData = asRecord(record.toolFormerData);
+
+  return {
+    ...record,
+    id: narrowString("bubble.id", record.id),
+    composerId: narrowString("bubble.composerId", record.composerId),
+    chatMessages: parseChatMessages(record.chatMessages),
+    type: narrowNumber("bubble.type", record.type),
+    text: narrowString("bubble.text", record.text),
+    requestId: narrowString("bubble.requestId", record.requestId),
+    createdAt: narrowNumber("bubble.createdAt", record.createdAt),
+    timestamp: narrowNumber("bubble.timestamp", record.timestamp),
+    timingInfo: timingInfo
+      ? {
+          clientRpcSendTime: narrowNumber(
+            "bubble.timingInfo.clientRpcSendTime",
+            timingInfo.clientRpcSendTime,
+          ),
+          clientSettleTime: narrowNumber(
+            "bubble.timingInfo.clientSettleTime",
+            timingInfo.clientSettleTime,
+          ),
+          clientEndTime: narrowNumber("bubble.timingInfo.clientEndTime", timingInfo.clientEndTime),
+        }
+      : undefined,
+    tokenCount: tokenCount
+      ? {
+          inputTokens: narrowNumber("bubble.tokenCount.inputTokens", tokenCount.inputTokens),
+          outputTokens: narrowNumber("bubble.tokenCount.outputTokens", tokenCount.outputTokens),
+        }
+      : undefined,
+    modelInfo: modelInfo
+      ? { modelName: narrowString("bubble.modelInfo.modelName", modelInfo.modelName) }
+      : undefined,
+    toolFormerData: toolFormerData
+      ? {
+          name: narrowString("bubble.toolFormerData.name", toolFormerData.name),
+          toolCallId: narrowString("bubble.toolFormerData.toolCallId", toolFormerData.toolCallId),
+          status: narrowString("bubble.toolFormerData.status", toolFormerData.status),
+          params: toolFormerData.params,
+          result: toolFormerData.result,
+          additionalData: asRecord(toolFormerData.additionalData),
+        }
+      : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -135,9 +282,8 @@ function normalizeToolOutputParts(output: unknown, timestampMs: number): Message
     const parts: MessagePart[] = [];
     for (const item of output) {
       if (typeof item === "object" && item !== null) {
-        const text = String(
-          (item as Record<string, unknown>).text ?? (item as Record<string, unknown>).content ?? "",
-        );
+        const record = asRecord(item);
+        const text = String(record?.text ?? record?.content ?? "");
         const cleaned = cleanInternalText(text);
         if (cleaned) parts.push({ type: "text", text: cleaned, time_created: timestampMs });
       } else if (typeof item === "string") {
@@ -192,9 +338,9 @@ function buildToolState(action: ActionEntry): MessagePart["state"] {
   // Derive status from output shape if not set
   if (!state.status) {
     if (typeof action.output === "object" && action.output !== null) {
-      const out = action.output as Record<string, unknown>;
-      if (out.success === true) state.status = "completed";
-      else if (out.success === false) state.status = "error";
+      const out = asRecord(action.output);
+      if (out?.success === true) state.status = "completed";
+      else if (out?.success === false) state.status = "error";
       else state.status = "completed";
     } else if (action.output != null) {
       state.status = "completed";
@@ -314,11 +460,11 @@ export class CursorAgent extends DatabaseSessionSource {
       // Parse workspace.json to get the project folder path
       let workspacePath: string;
       try {
-        const data = JSON.parse(readFileSync(wsJsonPath, "utf-8")) as {
-          folder?: string;
-          workspace?: string;
-        };
-        const uri = data.folder ?? data.workspace ?? "";
+        const data = asRecord(JSON.parse(readFileSync(wsJsonPath, "utf-8")));
+        const uri =
+          narrowString("workspaceJson.folder", data?.folder) ??
+          narrowString("workspaceJson.workspace", data?.workspace) ??
+          "";
         if (!uri) continue;
         workspacePath = normalize(decodeURIComponent(uri.replace(/^file:\/\//, "")));
       } catch {
@@ -338,25 +484,15 @@ export class CursorAgent extends DatabaseSessionSource {
           .get() as { value: string } | undefined;
         if (!row?.value) continue;
 
-        const parsed = JSON.parse(row.value) as unknown;
-        let composers: Array<{ composerId?: string; id?: string }>;
+        const parsed: unknown = JSON.parse(row.value);
+        const composers = asArray(asRecord(parsed)?.allComposers) ?? asArray(parsed) ?? [];
 
-        if (
-          parsed !== null &&
-          typeof parsed === "object" &&
-          "allComposers" in (parsed as Record<string, unknown>) &&
-          Array.isArray((parsed as Record<string, unknown>)["allComposers"])
-        ) {
-          composers = (parsed as { allComposers: Array<{ composerId?: string; id?: string }> })
-            .allComposers;
-        } else if (Array.isArray(parsed)) {
-          composers = parsed as Array<{ composerId?: string; id?: string }>;
-        } else {
-          continue;
-        }
-
-        for (const c of composers) {
-          const id = c.composerId ?? c.id;
+        for (const item of composers) {
+          const composer = asRecord(item);
+          if (!composer) continue;
+          const id =
+            narrowString("workspaceComposer.composerId", composer.composerId) ??
+            narrowString("workspaceComposer.id", composer.id);
           if (id) map.set(id, workspacePath);
         }
       } catch {
@@ -401,8 +537,8 @@ export class CursorAgent extends DatabaseSessionSource {
 
       for (const row of rows) {
         try {
-          const composer = JSON.parse(row.value) as ComposerData;
-          if (!composer.id && !composer.composerId) continue;
+          const composer = parseComposerRow(row.value);
+          if (!composer || (!composer.id && !composer.composerId)) continue;
 
           const composerId = composer.id || composer.composerId || "";
           const createdAt = composer.createdAt ?? 0;
@@ -659,8 +795,8 @@ export class CursorAgent extends DatabaseSessionSource {
 
       for (const row of rows) {
         try {
-          const bubble = JSON.parse(row.value) as BubbleData;
-          if (bubble.requestId && typeof bubble.requestId === "string" && bubble.requestId.trim()) {
+          const bubble = parseBubbleRow(row.value);
+          if (bubble?.requestId?.trim()) {
             return bubble.requestId.trim();
           }
         } catch {
@@ -682,8 +818,8 @@ export class CursorAgent extends DatabaseSessionSource {
 
       for (const row of rows) {
         try {
-          const bubble = JSON.parse(row.value) as BubbleData;
-          if (bubble.requestId === requestId) {
+          const bubble = parseBubbleRow(row.value);
+          if (bubble?.requestId === requestId) {
             // Extract composerId from key (bubbleId:{composerId}:{bubbleId})
             const keyParts = row.key.split(":");
             if (keyParts.length >= 2 && keyParts[1]) {
@@ -717,9 +853,9 @@ export class CursorAgent extends DatabaseSessionSource {
       let count = 0;
       for (const row of rows) {
         try {
-          const bubble = JSON.parse(row.value) as BubbleData;
+          const bubble = parseBubbleRow(row.value);
           // type 1 = user, type 2 = assistant
-          if (bubble.type === 1 || bubble.type === 2) {
+          if (bubble?.type === 1 || bubble?.type === 2) {
             count++;
           }
         } catch {
@@ -751,8 +887,8 @@ export class CursorAgent extends DatabaseSessionSource {
 
       for (const row of rows) {
         try {
-          const bubble = JSON.parse(row.value) as BubbleData;
-          if (isInternalBubble(bubble)) continue;
+          const bubble = parseBubbleRow(row.value);
+          if (!bubble || isInternalBubble(bubble)) continue;
           const bubbleId = row.key.split(":").pop() || String(messageIndex);
 
           // Determine role: type 2 = assistant, otherwise user
@@ -876,10 +1012,7 @@ export class CursorAgent extends DatabaseSessionSource {
 
     // Handle plan tool specially
     if (toolName === "create_plan") {
-      const planText =
-        typeof state.input === "object" && state.input !== null
-          ? (state.input as Record<string, unknown>).plan
-          : undefined;
+      const planText = asRecord(state.input)?.plan;
       return {
         type: "plan",
         title: "Plan",
@@ -907,11 +1040,7 @@ export class CursorAgent extends DatabaseSessionSource {
 
     if (!row) return null;
 
-    try {
-      return JSON.parse(row.value) as ComposerData;
-    } catch {
-      return null;
-    }
+    return parseComposerRow(row.value);
   }
 
   private loadBubble(db: SQLiteDatabase, sessionId: string): BubbleData | null {
@@ -921,11 +1050,7 @@ export class CursorAgent extends DatabaseSessionSource {
 
     if (!row) return null;
 
-    try {
-      return JSON.parse(row.value) as BubbleData;
-    } catch {
-      return null;
-    }
+    return parseBubbleRow(row.value);
   }
 
   private appendSubagentMessages(
@@ -957,7 +1082,7 @@ export class CursorAgent extends DatabaseSessionSource {
         if (role === "assistant" && Array.isArray(chatMsg.actions)) {
           for (const action of chatMsg.actions) {
             if (isInternalEventType(action.type) || isInternalEventType(action.tool)) continue;
-            const part = convertActionToPart(action as ActionEntry, timestampMs);
+            const part = convertActionToPart(action, timestampMs);
             if (part) parts.push(part);
           }
         }

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -21,6 +21,7 @@ import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const KIMI_TOOL_TITLE_MAP: Record<string, string> = {
@@ -49,9 +50,40 @@ interface SessionMeta extends SessionCacheMeta {
   metaFile: string;
 }
 
-interface KimiWorkDir {
-  path: string;
-  last_session_id: string | null;
+/** Reads state/metadata `wire_mtime`; reports drift when the field is present but not a number. */
+function readWireMtime(record: Record<string, unknown>): number | null {
+  const raw = record.wire_mtime;
+  if (raw === undefined || raw === null) return null;
+  const value = asNumber(raw);
+  if (value === undefined) {
+    reportFieldMismatch("kimi", "session.wire_mtime");
+    return null;
+  }
+  return value;
+}
+
+/** Reads a wire record's `timestamp`; reports drift when the field is present but not a number. */
+function readWireTimestamp(record: Record<string, unknown>): number {
+  const raw = record.timestamp;
+  if (raw === undefined || raw === null) return 0;
+  const value = asNumber(raw);
+  if (value === undefined) {
+    reportFieldMismatch("kimi", "wire.timestamp");
+    return 0;
+  }
+  return value;
+}
+
+/** Reads a token count from a usage record; reports drift when the field is present but not a number. */
+function extractTokenField(usage: Record<string, unknown>, field: string): number {
+  const raw = usage[field];
+  if (raw === undefined || raw === null) return 0;
+  const value = asNumber(raw);
+  if (value === undefined) {
+    reportFieldMismatch("kimi", `usage.${field}`);
+    return 0;
+  }
+  return value;
 }
 
 function normalizeToolArguments(raw: unknown): unknown {
@@ -73,8 +105,9 @@ function normalizeToolOutputParts(content: unknown, timestampMs: number): Messag
   if (Array.isArray(content)) {
     const parts: MessagePart[] = [];
     for (const item of content) {
-      if (typeof item === "object" && item !== null && "text" in item) {
-        const text = String((item as Record<string, unknown>).text ?? "");
+      const record = asRecord(item);
+      if (record && "text" in record) {
+        const text = String(record.text ?? "");
         const cleaned = cleanInternalText(text);
         if (cleaned) parts.push({ type: "text", text: cleaned, time_created: timestampMs });
       } else if (typeof item === "string") {
@@ -110,10 +143,8 @@ function kimiContentText(content: unknown): string {
   return content
     .map((item) => {
       if (typeof item === "string") return item;
-      if (typeof item === "object" && item !== null) {
-        const record = item as Record<string, unknown>;
-        return String(record.text ?? record.content ?? "");
-      }
+      const record = asRecord(item);
+      if (record) return String(record.text ?? record.content ?? "");
       return "";
     })
     .join(" ");
@@ -132,9 +163,9 @@ function extractFirstUserTitle(contextFile: string | null, wireFile: string | nu
   if (wireFile && existsSync(wireFile)) {
     const content = readFileSync(wireFile, "utf-8");
     for (const record of parseJsonlLines(content)) {
-      const message = (record.message ?? {}) as Record<string, unknown>;
+      const message = asRecord(record.message) ?? {};
       if (message.type !== "TurnBegin") continue;
-      const payload = (message.payload ?? {}) as Record<string, unknown>;
+      const payload = asRecord(message.payload) ?? {};
       const userInput = payload.user_input;
       if (!Array.isArray(userInput)) continue;
       const title = normalizeTitleText(kimiContentText(userInput));
@@ -169,12 +200,12 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     }
     if (!existsSync(configPath)) return;
     try {
-      const raw = JSON.parse(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
-      const workDirs = raw?.work_dirs;
-      if (!Array.isArray(workDirs)) return;
+      const raw = asRecord(JSON.parse(readFileSync(configPath, "utf-8")));
+      const workDirs = asArray(raw?.work_dirs);
+      if (!workDirs) return;
       for (const wd of workDirs) {
-        const path = (wd as KimiWorkDir).path;
-        if (typeof path !== "string") continue;
+        const path = asString(asRecord(wd)?.path);
+        if (!path) continue;
         const hash = createHash("md5").update(path).digest("hex");
         this.projectMap.set(hash, path);
       }
@@ -248,14 +279,14 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       let metaFile = "";
 
       if (existsSync(statePath)) {
-        const state = JSON.parse(readFileSync(statePath, "utf-8")) as Record<string, unknown>;
+        const state = asRecord(JSON.parse(readFileSync(statePath, "utf-8"))) ?? {};
         title = String(state.custom_title ?? "");
-        wireMtime = typeof state.wire_mtime === "number" ? state.wire_mtime : null;
+        wireMtime = readWireMtime(state);
         metaFile = statePath;
       } else if (existsSync(metaPath)) {
-        const meta = JSON.parse(readFileSync(metaPath, "utf-8")) as Record<string, unknown>;
+        const meta = asRecord(JSON.parse(readFileSync(metaPath, "utf-8"))) ?? {};
         title = String(meta.title ?? "");
-        wireMtime = typeof meta.wire_mtime === "number" ? meta.wire_mtime : null;
+        wireMtime = readWireMtime(meta);
         metaFile = metaPath;
       }
 
@@ -407,18 +438,17 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     for (const record of parseJsonlLines(content)) {
       seq++;
       try {
-        const message = (record.message ?? {}) as Record<string, unknown>;
-        const msgType = String(message.type ?? "");
+        const message = asRecord(record.message) ?? {};
+        const msgType = asString(message.type) ?? "";
         if (isInternalEventType(msgType)) continue;
-        const payload = (message.payload ?? {}) as Record<string, unknown>;
-        const timestamp = Number(record.timestamp ?? 0);
-        const timestampMs = Number.isFinite(timestamp) ? Math.floor(timestamp * 1000) : 0;
+        const payload = asRecord(message.payload) ?? {};
+        const timestampMs = Math.floor(readWireTimestamp(record) * 1000);
 
         // Bind usage to the most recent assistant message without tokens
-        const usage = message["usage"] as Record<string, unknown> | undefined;
-        if (usage && typeof usage === "object") {
-          const inputTokens = Number(usage["input_tokens"] ?? 0);
-          const outputTokens = Number(usage["output_tokens"] ?? 0);
+        const usage = asRecord(message["usage"]);
+        if (usage) {
+          const inputTokens = extractTokenField(usage, "input_tokens");
+          const outputTokens = extractTokenField(usage, "output_tokens");
           if (inputTokens || outputTokens) {
             const tokens = { input: inputTokens, output: outputTokens };
             const cost = estimateTokenCost(this.defaultModel, tokens);
@@ -473,7 +503,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
         }
 
         if (msgType === "ToolCall") {
-          const function_ = payload.function as Record<string, unknown> | undefined;
+          const function_ = asRecord(payload.function);
           const toolName = String(function_?.name ?? "").trim();
           const callId = String(payload.id ?? "").trim();
 
@@ -581,8 +611,8 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     const content = record.content;
     if (Array.isArray(content)) {
       for (const item of content) {
-        if (typeof item !== "object" || item === null) continue;
-        const ci = item as Record<string, unknown>;
+        const ci = asRecord(item);
+        if (!ci) continue;
         const partType = String(ci.type ?? "");
 
         if (partType === "think") {
@@ -595,16 +625,15 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       }
     }
 
-    const toolCalls = record.tool_calls;
-    if (Array.isArray(toolCalls)) {
+    const toolCalls = asArray(record.tool_calls);
+    if (toolCalls) {
       for (const tc of toolCalls) {
-        if (typeof tc !== "object" || tc === null) continue;
-        const tcRecord = tc as Record<string, unknown>;
-        const function_ = tcRecord.function as Record<string, unknown> | undefined;
+        const tcRecord = asRecord(tc);
+        const function_ = asRecord(tcRecord?.function);
 
         if (!function_) continue;
         const toolName = String(function_.name ?? "").trim();
-        const callId = String(tcRecord.id ?? "").trim();
+        const callId = String(tcRecord?.id ?? "").trim();
 
         if (toolName && callId && KIMI_IGNORED_TOOLS.has(toolName)) {
           ignoredToolCallIds.add(callId);
@@ -652,7 +681,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     const combined = existing + argumentsPart;
 
     try {
-      const parsed = JSON.parse(combined) as unknown;
+      const parsed: unknown = JSON.parse(combined);
       if (
         builder.updateToolCall(openCallId, (part) => {
           const state = part.state ?? (part.state = {});
@@ -693,13 +722,11 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       const content = readFileSync(wirePath, "utf-8");
       for (const line of content.split("\n").filter((l) => l.trim())) {
         try {
-          const data = JSON.parse(line) as Record<string, unknown>;
-          const tokenUsage = (data.message as Record<string, unknown>)?.usage as
-            | Record<string, unknown>
-            | undefined;
+          const data = asRecord(JSON.parse(line));
+          const tokenUsage = asRecord(asRecord(data?.message)?.usage);
           if (!tokenUsage) continue;
-          const inputTokens = Number(tokenUsage.input_tokens ?? 0);
-          const outputTokens = Number(tokenUsage.output_tokens ?? 0);
+          const inputTokens = extractTokenField(tokenUsage, "input_tokens");
+          const outputTokens = extractTokenField(tokenUsage, "output_tokens");
           stats.total_input_tokens += inputTokens;
           stats.total_output_tokens += outputTokens;
           const cost = estimateTokenCost(this.defaultModel, {
@@ -724,10 +751,14 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       const rawContent = readFileSync(rawPath, "utf-8");
       for (const line of rawContent.split("\n").filter((l) => l.trim())) {
         try {
-          const data = JSON.parse(line) as Record<string, unknown>;
-          if (data.role === "_usage" && typeof data.token_count === "number") {
-            stats.total_tokens = data.token_count;
+          const data = asRecord(JSON.parse(line));
+          if (data?.role !== "_usage") continue;
+          const tokenCount = asNumber(data.token_count);
+          if (tokenCount === undefined) {
+            reportFieldMismatch("kimi", "usage.token_count");
+            continue;
           }
+          stats.total_tokens = tokenCount;
         } catch {
           // skip
         }

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -11,6 +11,7 @@ import { openDbReadOnly, type SQLiteDatabase } from "../utils/sqlite.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
+import { asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
 import {
   cleanInternalText,
   cleanParsedMessages,
@@ -39,6 +40,41 @@ interface OpenCodeSqliteAgentConfig {
   name: string;
   displayName: string;
   findDbPath: () => string | null;
+}
+
+const MESSAGE_ROLES = new Set<Message["role"]>(["user", "assistant", "tool"]);
+
+/** Parses a SQLite `data` JSON column; non-object payloads fall back to `{}` (reported as drift). */
+function parseJsonRecord(raw: unknown, agentName: string, field: string): Record<string, unknown> {
+  const parsed = asRecord(JSON.parse(String(raw ?? "{}")));
+  if (parsed) return parsed;
+  reportFieldMismatch(agentName, field);
+  return {};
+}
+
+function parseMessageRole(value: unknown, agentName: string): Message["role"] {
+  const role = asString(value);
+  if (role !== undefined && (MESSAGE_ROLES as Set<string>).has(role)) {
+    return role as Message["role"];
+  }
+  if (value !== undefined && value !== null) reportFieldMismatch(agentName, "message.role");
+  return "assistant";
+}
+
+function parseTokens(value: unknown, agentName: string): Record<string, unknown> | undefined {
+  const tokens = asRecord(value);
+  if (tokens === undefined && value !== undefined) reportFieldMismatch(agentName, "message.tokens");
+  return tokens;
+}
+
+function parseModel(value: unknown, agentName: string): string | null {
+  if (value === null || value === undefined) return null;
+  const model = asString(value);
+  if (model === undefined) {
+    reportFieldMismatch(agentName, "message.modelID");
+    return null;
+  }
+  return model;
 }
 
 export class OpenCodeSqliteAgent extends DatabaseSessionSource {
@@ -208,7 +244,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
   private parsePartRow(
     partRow: Pick<OpenCodePartRow, "data" | "time_created">,
   ): MessagePart | null {
-    const partData = JSON.parse(String(partRow.data ?? "{}")) as Record<string, unknown>;
+    const partData = parseJsonRecord(partRow.data, this.name, "part.data");
     const partType = String(partData.type ?? "");
     if (isInternalEventType(partType)) return null;
 
@@ -228,7 +264,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
         tool: String(partData.tool ?? ""),
         callID: String(partData.callID ?? ""),
         title: cleanInternalText(String(partData.title ?? "")),
-        state: (partData.state ?? {}) as MessagePart["state"],
+        state: asRecord(partData.state) ?? {},
         time_created: Number(partRow.time_created ?? 0),
       };
     }
@@ -272,7 +308,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
     for (const row of messageRows) {
       const sessionId = String(row.session_id ?? "");
       if (!sessionId) continue;
-      const msgData = JSON.parse(String(row.data ?? "{}")) as Record<string, unknown>;
+      const msgData = parseJsonRecord(row.data, this.name, "message.data");
       if (isInternalEventType(msgData.type)) continue;
       const parts = partsByMessage.get(String(row.id ?? "")) ?? [];
       if (parts.length === 0) continue;
@@ -292,10 +328,10 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
       }
 
       const cost = Number(msgData.cost ?? 0);
-      const tokens = msgData.tokens as Record<string, unknown> | undefined;
+      const tokens = parseTokens(msgData.tokens, this.name);
       const inputTokens = Number(tokens?.input ?? 0);
       const outputTokens = Number(tokens?.output ?? 0);
-      const model = (msgData.modelID as string | null) ?? null;
+      const model = parseModel(msgData.modelID, this.name);
       const estimatedCost =
         cost > 0 ? null : estimateTokenCost(model, { input: inputTokens, output: outputTokens });
 
@@ -368,14 +404,14 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
         .all(sessionId) as Record<string, unknown>[];
 
       for (const msgRow of msgRows) {
-        const msgData = JSON.parse(String(msgRow.data ?? "{}")) as Record<string, unknown>;
+        const msgData = parseJsonRecord(msgRow.data, this.name, "message.data");
         if (isInternalEventType(msgData.type)) continue;
 
         const cost = Number(msgData.cost ?? 0);
-        const tokens = msgData.tokens as Record<string, unknown> | undefined;
+        const tokens = parseTokens(msgData.tokens, this.name);
         const inputTokens = Number(tokens?.input ?? 0);
         const outputTokens = Number(tokens?.output ?? 0);
-        const model = (msgData.modelID as string | null) ?? null;
+        const model = parseModel(msgData.modelID, this.name);
         const estimatedCost =
           cost > 0 ? null : estimateTokenCost(model, { input: inputTokens, output: outputTokens });
         const resolvedCost = cost || estimatedCost || 0;
@@ -385,11 +421,11 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
 
         messages.push({
           id: String(msgRow.id ?? ""),
-          role: String(msgData.role ?? "assistant") as Message["role"],
-          agent: (msgData.agent as string | null) ?? null,
-          mode: (msgData.mode as string | null) ?? null,
+          role: parseMessageRole(msgData.role, this.name),
+          agent: asString(msgData.agent) ?? null,
+          mode: asString(msgData.mode) ?? null,
           model,
-          provider: (msgData.providerID as string | null) ?? null,
+          provider: asString(msgData.providerID) ?? null,
           time_created: Number(msgRow.time_created ?? 0),
           tokens: tokens ? { input: inputTokens, output: outputTokens } : undefined,
           cost: resolvedCost,
@@ -416,7 +452,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
         title,
         slug,
         directory,
-        version: (sessionRow.version as string | null) ?? undefined,
+        version: asString(sessionRow.version) ?? undefined,
         time_created: timeCreated,
         time_updated: timeUpdated,
         summary_files: sessionRow.summary_files ?? undefined,

--- a/packages/core/src/utils/__tests__/narrow.test.ts
+++ b/packages/core/src/utils/__tests__/narrow.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../narrow.js";
+import { getCoreDiagnostics, setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
+
+afterEach(() => {
+  setCoreDiagnostics(null);
+});
+
+describe("asRecord", () => {
+  it("narrows plain objects", () => {
+    expect(asRecord({ a: 1 })).toEqual({ a: 1 });
+  });
+
+  it("rejects null, arrays, and primitives", () => {
+    expect(asRecord(null)).toBeUndefined();
+    expect(asRecord([1, 2])).toBeUndefined();
+    expect(asRecord("record")).toBeUndefined();
+    expect(asRecord(1)).toBeUndefined();
+    expect(asRecord(undefined)).toBeUndefined();
+  });
+});
+
+describe("asString", () => {
+  it("narrows strings, including empty ones", () => {
+    expect(asString("hello")).toBe("hello");
+    expect(asString("")).toBe("");
+  });
+
+  it("rejects non-strings", () => {
+    expect(asString(1)).toBeUndefined();
+    expect(asString(null)).toBeUndefined();
+    expect(asString(undefined)).toBeUndefined();
+    expect(asString({})).toBeUndefined();
+  });
+});
+
+describe("asNumber", () => {
+  it("narrows finite numbers, including zero", () => {
+    expect(asNumber(42)).toBe(42);
+    expect(asNumber(0)).toBe(0);
+    expect(asNumber(-3.5)).toBe(-3.5);
+  });
+
+  it("rejects NaN, Infinity, and non-numbers", () => {
+    expect(asNumber(Number.NaN)).toBeUndefined();
+    expect(asNumber(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(asNumber("1")).toBeUndefined();
+    expect(asNumber(null)).toBeUndefined();
+    expect(asNumber(undefined)).toBeUndefined();
+  });
+});
+
+describe("asArray", () => {
+  it("narrows arrays, including empty ones", () => {
+    expect(asArray([1, 2, 3])).toEqual([1, 2, 3]);
+    expect(asArray([])).toEqual([]);
+  });
+
+  it("rejects non-arrays", () => {
+    expect(asArray({ length: 0 })).toBeUndefined();
+    expect(asArray("array")).toBeUndefined();
+    expect(asArray(null)).toBeUndefined();
+    expect(asArray(undefined)).toBeUndefined();
+  });
+});
+
+describe("reportFieldMismatch", () => {
+  it("forwards agentName and field to the diagnostics sink", () => {
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    reportFieldMismatch("cursor", "usage.tokens");
+
+    expect(calls).toEqual([
+      {
+        event: "agent.field_shape_mismatch",
+        detail: { agentName: "cursor", field: "usage.tokens" },
+      },
+    ]);
+  });
+
+  it("dedupes repeated reports for the same agent+field", () => {
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    reportFieldMismatch("kimi", "message.role");
+    reportFieldMismatch("kimi", "message.role");
+    reportFieldMismatch("kimi", "message.role");
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("reports distinct field keys for the same agent separately", () => {
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    reportFieldMismatch("codex", "usage.input_tokens");
+    reportFieldMismatch("codex", "usage.output_tokens");
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("is a no-op when no diagnostics sink is injected", () => {
+    expect(getCoreDiagnostics()).toBeNull();
+    expect(() => reportFieldMismatch("pi", "unset-sink-field")).not.toThrow();
+  });
+});

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { parseJsonlLines, readJsonlFile } from "./jsonl.js";
 export { setCoreDiagnostics, type CoreDiagnostics } from "./diagnostics.js";
+export { asRecord, asString, asNumber, asArray, reportFieldMismatch } from "./narrow.js";
 export { basenameTitle, resolveSessionTitle, normalizeTitleText } from "./title-fallback.js";
 export { cleanDisplayText, firstVisibleLine } from "./parse-cleanup.js";
 export { openDb, openDbReadOnly, isSqliteAvailable } from "./sqlite.js";

--- a/packages/core/src/utils/narrow.ts
+++ b/packages/core/src/utils/narrow.ts
@@ -1,0 +1,38 @@
+import { getCoreDiagnostics } from "./diagnostics.js";
+
+/** Narrow to a plain object (excludes arrays and null); undefined on mismatch. */
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+/** Narrow to a string; undefined on mismatch. */
+export function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Narrow to a finite number (rejects NaN/Infinity); undefined on mismatch. */
+export function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/** Narrow to an array; undefined on mismatch. */
+export function asArray(value: unknown): unknown[] | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+const reportedFieldMismatches = new Set<string>();
+
+/**
+ * Reports a field shape mismatch once per (agentName, field) for the life of
+ * the process — an upstream format drift hits every line of a session file,
+ * and warning per line would flood the diagnostics sink for no added signal.
+ */
+export function reportFieldMismatch(agentName: string, field: string): void {
+  const key = `${agentName}\0${field}`;
+  if (reportedFieldMismatches.has(key)) return;
+  reportedFieldMismatches.add(key);
+  getCoreDiagnostics()?.warn("agent.field_shape_mismatch", { agentName, field });
+}


### PR DESCRIPTION
## Summary

The seven agent adapters parse **untrusted external data** (other tools' JSONL/SQLite files, which drift across versions) yet asserted shapes with bare `as` casts — 116 across the five densest adapters. Each cast is a point where upstream drift produces silently wrong data (miscounted tokens/cost, dropped messages) instead of a signal.

## Changes

- **`utils/narrow.ts`** (new): `asRecord` / `asString` / `asNumber` (rejects NaN/Infinity) / `asArray`, all returning `undefined` on mismatch (no throwing, zero dependencies), plus `reportFieldMismatch` emitting `agent.field_shape_mismatch` through the CS-72 diagnostics channel — deduplicated per (agent, field) so one drifted field can't flood logs across a thousand-line file.
- **Five adapters converted** (cursor, codex, kimi, claudecode, opencode-sqlite): key extraction points (usage/tokens, message role/content, timestamps, model, ids) now narrow through the helpers. Mismatches keep each site's existing fallback semantics (`?? 0`, skip, continue) and report the drift. Remaining `as` casts (`116 → 29`) are the out-of-scope categories: `as const`, SQLite driver row-shape annotations over already-`unknown` columns, and branch-guaranteed literal narrowing.
- **Deliberate behavior tightenings** (covered by new negative tests): numeric fields that previously let non-numbers propagate as NaN now fall back to 0 + report; `null` is uniformly treated as normal absence (silent), aligned across all five adapters after review.
- Fixture suites pass unmodified — the byte-identical regression net for all parsing output.

## Not included (recorded in the issue)

- The remaining low-density adapters (pi/opencode/zcode) and a unified `narrowField` combinator to replace each adapter's thin report-wrapper — review recommended deferring both to a follow-up batch rather than blocking this one.

## Testing

- New: narrow-helper unit tests (positive/negative, report dedupe) + 1-2 negative drift tests per adapter (type-drifted sample rows → fallback + report)
- `pnpm build` / `pnpm test` (core 411, cli 205, web 362) / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-74