### PR TITLE
refactor: unify field narrowing and cover remaining adapters (CS-88)

### DIFF
--- a/packages/core/src/agents/__tests__/opencode.test.ts
+++ b/packages/core/src/agents/__tests__/opencode.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { OpenCodeAgent } from "../opencode.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 let tempDirs: string[] = [];
 
@@ -43,6 +44,7 @@ afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
   }
   tempDirs = [];
+  setCoreDiagnostics(null);
 });
 
 describe("OpenCodeAgent parsing", () => {
@@ -155,5 +157,52 @@ describe("OpenCodeAgent parsing", () => {
         output: "Visible output",
       },
     });
+  });
+
+  it("falls back on a malformed role/tokens shape and reports drift under the opencode agent name", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-opencode-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createOpenCodeDb(tempDir);
+    const db = new Database(dbPath);
+
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory) VALUES (?, ?, ?, ?, ?)",
+    ).run("session-drift", "", 1_000, 2_000, "/tmp/project");
+    db.prepare("INSERT INTO message (id, session_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+      "m1",
+      "session-drift",
+      JSON.stringify({ role: "narrator", tokens: "not-an-object" }),
+      1_000,
+    );
+    db.prepare("INSERT INTO part (id, message_id, data, time_created) VALUES (?, ?, ?, ?)").run(
+      "p1",
+      "m1",
+      JSON.stringify({ type: "text", text: "hello" }),
+      1_000,
+    );
+    db.close();
+
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    const agent = new OpenCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const data = agent.getSessionData("session-drift");
+
+    expect(data.messages[0]).toMatchObject({ role: "assistant", tokens: undefined });
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        {
+          event: "agent.field_shape_mismatch",
+          detail: { agentName: "opencode", field: "message.role" },
+        },
+        {
+          event: "agent.field_shape_mismatch",
+          detail: { agentName: "opencode", field: "message.tokens" },
+        },
+      ]),
+    );
   });
 });

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PiAgent } from "../pi.js";
 import type { MessagePart } from "../../types/index.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 // Spies on statSync while delegating to the real implementation, so the
 // single-stat regression test can count per-file calls during a live scan.
@@ -17,11 +18,19 @@ let tempDirs: string[] = [];
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
+  setCoreDiagnostics(null);
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
   tempDirs = [];
 });
+
+function captureDiagnostics(): Array<{ event: string; detail?: Record<string, unknown> }> {
+  const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+  const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+  setCoreDiagnostics(sink);
+  return calls;
+}
 
 describe("PiAgent", () => {
   it("parses only the current branch path", () => {
@@ -315,6 +324,120 @@ describe("PiAgent", () => {
         input: { path: "package.json" },
         output: [{ type: "text", text: "package output" }],
       },
+    });
+  });
+
+  it("drops a message with a non-string role and reports the drift", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
+    tempDirs.push(tempDir);
+    const piHome = join(tempDir, ".pi");
+    const sessionsDir = join(piHome, "agent", "sessions", "--tmp-project--");
+    const sessionId = "019dcccc-cccc-7ccc-cccc-cccccccccccc";
+    const sessionFile = join(sessionsDir, `2026-04-20T10-00-00_${sessionId}.jsonl`);
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("PI_HOME", piHome);
+
+    writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: sessionId,
+          timestamp: "2026-04-20T10:00:00.000Z",
+          cwd: "/tmp/project",
+        },
+        {
+          type: "message",
+          id: "a1",
+          parentId: null,
+          timestamp: "2026-04-20T10:00:01.000Z",
+          message: { role: "user", content: "Inspect package metadata" },
+        },
+        {
+          type: "message",
+          id: "b1",
+          parentId: "a1",
+          timestamp: "2026-04-20T10:00:02.000Z",
+          message: { role: 42, content: "Malformed role should be dropped" },
+        },
+      ]
+        .map((item) => JSON.stringify(item))
+        .join("\n"),
+    );
+
+    const calls = captureDiagnostics();
+    const agent = new PiAgent();
+    expect(agent.isAvailable()).toBe(true);
+
+    agent.scan();
+    const data = agent.getSessionData(sessionId);
+
+    expect(data.messages).toHaveLength(1);
+    expect(data.messages[0]?.parts[0]).toMatchObject({ text: "Inspect package metadata" });
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "pi", field: "message.role" },
+    });
+  });
+
+  it("falls back to zeroed usage fields and reports drift when usage.input isn't a number", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
+    tempDirs.push(tempDir);
+    const piHome = join(tempDir, ".pi");
+    const sessionsDir = join(piHome, "agent", "sessions", "--tmp-project--");
+    const sessionId = "019dcccc-cccc-7ccc-cccc-dddddddddddd";
+    const sessionFile = join(sessionsDir, `2026-04-20T10-00-00_${sessionId}.jsonl`);
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("PI_HOME", piHome);
+
+    writeFileSync(
+      sessionFile,
+      [
+        {
+          type: "session",
+          version: 3,
+          id: sessionId,
+          timestamp: "2026-04-20T10:00:00.000Z",
+          cwd: "/tmp/project",
+        },
+        {
+          type: "message",
+          id: "a1",
+          parentId: null,
+          timestamp: "2026-04-20T10:00:01.000Z",
+          message: { role: "user", content: "Summarize the repo" },
+        },
+        {
+          type: "message",
+          id: "b1",
+          parentId: "a1",
+          timestamp: "2026-04-20T10:00:02.000Z",
+          message: {
+            role: "assistant",
+            model: "claude-sonnet-4-5",
+            usage: { input: "many", output: 20 },
+            content: [{ type: "text", text: "Here you go." }],
+          },
+        },
+      ]
+        .map((item) => JSON.stringify(item))
+        .join("\n"),
+    );
+
+    const calls = captureDiagnostics();
+    const agent = new PiAgent();
+    expect(agent.isAvailable()).toBe(true);
+
+    agent.scan();
+    const data = agent.getSessionData(sessionId);
+
+    expect(data.messages[1]?.tokens).toMatchObject({ input: 0, output: 20 });
+    expect(data.stats.total_input_tokens).toBe(0);
+    expect(data.stats.total_output_tokens).toBe(20);
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "pi", field: "message.usage.input" },
     });
   });
 });

--- a/packages/core/src/agents/__tests__/zcode.test.ts
+++ b/packages/core/src/agents/__tests__/zcode.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { ZCodeAgent } from "../zcode.js";
+import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 let tempDirs: string[] = [];
 
@@ -47,6 +48,7 @@ afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
   }
   tempDirs = [];
+  setCoreDiagnostics(null);
 });
 
 describe("ZCodeAgent parsing", () => {
@@ -152,6 +154,46 @@ describe("ZCodeAgent parsing", () => {
       tool: "Bash",
       callID: "call_1",
       state: { status: "completed", output: "ok" },
+    });
+  });
+
+  it("falls back to null and reports drift under the zcode agent name when modelID isn't a string", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-zcode-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createZCodeDb(tempDir);
+    const db = new Database(dbPath);
+
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run("sess_drift", "", 1_000, 2_000, "/tmp/project", "/tmp/project", "0.14.8", 0);
+    db.prepare(
+      "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+    ).run("msg_user", "sess_drift", 1_000, 1_000, JSON.stringify({ role: "user", modelID: 12345 }));
+    db.prepare(
+      "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(
+      "part_user",
+      "msg_user",
+      "sess_drift",
+      1_000,
+      1_000,
+      JSON.stringify({ type: "text", text: "hello" }),
+    );
+    db.close();
+
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    const agent = new ZCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const data = agent.getSessionData("sess_drift");
+
+    expect(data.messages[0]).toMatchObject({ role: "user", model: null });
+    expect(calls).toContainEqual({
+      event: "agent.field_shape_mismatch",
+      detail: { agentName: "zcode", field: "message.modelID" },
     });
   });
 });

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -24,7 +24,7 @@ import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../utils/jso
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import { asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
+import { asRecord, asString, narrowField } from "../utils/narrow.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
 import {
   type ExecInnerCall,
@@ -108,16 +108,8 @@ function extractCachedInputTokens(usage: Record<string, unknown> | undefined): n
   return Number(usage["cached_input_tokens"] ?? usage["cache_read_input_tokens"] ?? 0);
 }
 
-/**
- * Narrows to a record, reporting a field-shape mismatch only when the value
- * is present but not an object — absent (undefined/null) is a normal, not a
- * drifted, shape and stays silent.
- */
 function narrowRecordField(value: unknown, field: string): Record<string, unknown> | undefined {
-  if (value === undefined || value === null) return undefined;
-  const record = asRecord(value);
-  if (!record) reportFieldMismatch("codex", field);
-  return record;
+  return narrowField("codex", field, value, asRecord);
 }
 
 function extractPayload(data: Record<string, unknown>): Record<string, unknown> {

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -20,7 +20,14 @@ import {
 } from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
+import {
+  asArray,
+  asNumber,
+  asRecord,
+  asString,
+  narrowField,
+  safeParseJsonRecord,
+} from "../utils/narrow.js";
 
 // ---------------------------------------------------------------------------
 // Cursor data model interfaces
@@ -116,27 +123,11 @@ interface ActionEntry {
 // ---------------------------------------------------------------------------
 
 function narrowString(field: string, value: unknown): string | undefined {
-  if (value === undefined) return undefined;
-  const str = asString(value);
-  if (str === undefined) reportFieldMismatch("cursor", field);
-  return str;
+  return narrowField("cursor", field, value, asString);
 }
 
 function narrowNumber(field: string, value: unknown): number | undefined {
-  if (value === undefined) return undefined;
-  const num = asNumber(value);
-  if (num === undefined) reportFieldMismatch("cursor", field);
-  return num;
-}
-
-function parseJsonRecord(json: string): Record<string, unknown> | undefined {
-  let raw: unknown;
-  try {
-    raw = JSON.parse(json);
-  } catch {
-    return undefined;
-  }
-  return asRecord(raw);
+  return narrowField("cursor", field, value, asNumber);
 }
 
 function parseSubagentInfos(value: unknown): SubagentInfo[] | undefined {
@@ -172,7 +163,7 @@ function parseChatMessages(value: unknown): ChatMessage[] | undefined {
 
 /** Parse a `composerData:*` row value into a field-validated ComposerData. */
 function parseComposerRow(value: string): ComposerData | null {
-  const record = parseJsonRecord(value);
+  const record = safeParseJsonRecord(value);
   if (!record) return null;
 
   const modelConfig = asRecord(record.modelConfig);
@@ -200,7 +191,7 @@ function parseComposerRow(value: string): ComposerData | null {
 
 /** Parse a `bubbleId:*` / `bubble:*` row value into a field-validated BubbleData. */
 function parseBubbleRow(value: string): BubbleData | null {
-  const record = parseJsonRecord(value);
+  const record = safeParseJsonRecord(value);
   if (!record) return null;
 
   const timingInfo = asRecord(record.timingInfo);

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -21,7 +21,14 @@ import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
+import {
+  asArray,
+  asNumber,
+  asRecord,
+  asString,
+  narrowField,
+  reportFieldMismatch,
+} from "../utils/narrow.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const KIMI_TOOL_TITLE_MAP: Record<string, string> = {
@@ -52,38 +59,17 @@ interface SessionMeta extends SessionCacheMeta {
 
 /** Reads state/metadata `wire_mtime`; reports drift when the field is present but not a number. */
 function readWireMtime(record: Record<string, unknown>): number | null {
-  const raw = record.wire_mtime;
-  if (raw === undefined || raw === null) return null;
-  const value = asNumber(raw);
-  if (value === undefined) {
-    reportFieldMismatch("kimi", "session.wire_mtime");
-    return null;
-  }
-  return value;
+  return narrowField("kimi", "session.wire_mtime", record.wire_mtime, asNumber) ?? null;
 }
 
 /** Reads a wire record's `timestamp`; reports drift when the field is present but not a number. */
 function readWireTimestamp(record: Record<string, unknown>): number {
-  const raw = record.timestamp;
-  if (raw === undefined || raw === null) return 0;
-  const value = asNumber(raw);
-  if (value === undefined) {
-    reportFieldMismatch("kimi", "wire.timestamp");
-    return 0;
-  }
-  return value;
+  return narrowField("kimi", "wire.timestamp", record.timestamp, asNumber) ?? 0;
 }
 
 /** Reads a token count from a usage record; reports drift when the field is present but not a number. */
 function extractTokenField(usage: Record<string, unknown>, field: string): number {
-  const raw = usage[field];
-  if (raw === undefined || raw === null) return 0;
-  const value = asNumber(raw);
-  if (value === undefined) {
-    reportFieldMismatch("kimi", `usage.${field}`);
-    return 0;
-  }
-  return value;
+  return narrowField("kimi", `usage.${field}`, usage[field], asNumber) ?? 0;
 }
 
 function normalizeToolArguments(raw: unknown): unknown {

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -11,7 +11,7 @@ import { openDbReadOnly, type SQLiteDatabase } from "../utils/sqlite.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
-import { asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
+import { asRecord, asString, narrowField, reportFieldMismatch } from "../utils/narrow.js";
 import {
   cleanInternalText,
   cleanParsedMessages,
@@ -52,29 +52,23 @@ function parseJsonRecord(raw: unknown, agentName: string, field: string): Record
   return {};
 }
 
-function parseMessageRole(value: unknown, agentName: string): Message["role"] {
+function narrowMessageRole(value: unknown): Message["role"] | undefined {
   const role = asString(value);
-  if (role !== undefined && (MESSAGE_ROLES as Set<string>).has(role)) {
-    return role as Message["role"];
-  }
-  if (value !== undefined && value !== null) reportFieldMismatch(agentName, "message.role");
-  return "assistant";
+  return role !== undefined && (MESSAGE_ROLES as Set<string>).has(role)
+    ? (role as Message["role"])
+    : undefined;
+}
+
+function parseMessageRole(value: unknown, agentName: string): Message["role"] {
+  return narrowField(agentName, "message.role", value, narrowMessageRole) ?? "assistant";
 }
 
 function parseTokens(value: unknown, agentName: string): Record<string, unknown> | undefined {
-  const tokens = asRecord(value);
-  if (tokens === undefined && value !== undefined) reportFieldMismatch(agentName, "message.tokens");
-  return tokens;
+  return narrowField(agentName, "message.tokens", value, asRecord);
 }
 
 function parseModel(value: unknown, agentName: string): string | null {
-  if (value === null || value === undefined) return null;
-  const model = asString(value);
-  if (model === undefined) {
-    reportFieldMismatch(agentName, "message.modelID");
-    return null;
-  }
-  return model;
+  return narrowField(agentName, "message.modelID", value, asString) ?? null;
 }
 
 export class OpenCodeSqliteAgent extends DatabaseSessionSource {

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -17,6 +17,7 @@ import type { Message, MessagePart, SessionData, SessionHead } from "../types/in
 import { firstExisting, resolveProviderRoots } from "../discovery/paths.js";
 import { parseJsonlLines } from "../utils/jsonl.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { asNumber, asRecord, asString, narrowField } from "../utils/narrow.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
@@ -54,6 +55,26 @@ function parseTimestampMs(value: unknown): number {
   return Number.isNaN(ts) ? 0 : ts;
 }
 
+function narrowPiField<T>(
+  field: string,
+  value: unknown,
+  narrow: (v: unknown) => T | undefined,
+): T | undefined {
+  return narrowField("pi", field, value, narrow);
+}
+
+/**
+ * Reports drift only when the timestamp is present but neither a number nor
+ * a string (e.g. an object) — actual date parsing (and its silent-0
+ * fallback for unparseable text) is unchanged, via `parseTimestampMs`.
+ */
+function narrowTimestampMs(field: string, value: unknown): number {
+  const shaped = narrowPiField(field, value, (v) =>
+    typeof v === "number" || typeof v === "string" ? v : undefined,
+  );
+  return shaped === undefined ? 0 : parseTimestampMs(shaped);
+}
+
 function extractSessionIdFromFilename(filePath: string): string {
   const stem = basename(filePath, ".jsonl");
   const underscore = stem.indexOf("_");
@@ -84,7 +105,7 @@ function normalizeTextParts(content: unknown, timestampMs: number): MessagePart[
 }
 
 function getEntryTimestamp(entry: Record<string, unknown>): number {
-  return parseTimestampMs(entry["timestamp"]);
+  return narrowTimestampMs("entry.timestamp", entry["timestamp"]);
 }
 
 function chooseLeafEntry(entries: Record<string, unknown>[]): Record<string, unknown> | null {
@@ -277,7 +298,7 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
 
     const stat = statSync(filePath);
     const directory = String(header["cwd"] ?? "").trim() || basename(filePath, ".jsonl");
-    const createdAt = parseTimestampMs(header["timestamp"]) || stat.mtimeMs;
+    const createdAt = narrowTimestampMs("session.timestamp", header["timestamp"]) || stat.mtimeMs;
     const updatedAt = pathEntries.reduce(
       (max, entry) => Math.max(max, getEntryTimestamp(entry)),
       createdAt,
@@ -334,8 +355,8 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
       const type = String(entry["type"] ?? "");
 
       if (type === "message") {
-        const message = entry["message"];
-        if (!isObject(message)) continue;
+        const message = narrowPiField("entry.message", entry["message"], asRecord);
+        if (!message) continue;
         const result = this.convertAgentMessage(entry, message, timestampMs, builder);
         if (!result) continue;
         if (result.message) builder.appendMessage(result.message);
@@ -372,8 +393,8 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     totalTokens: number;
     model: string | null;
   } | null {
-    const id = String(entry["id"] ?? "");
-    const role = String(message["role"] ?? "");
+    const id = narrowPiField("message.id", entry["id"], asString) ?? "";
+    const role = narrowPiField("message.role", message["role"], asString) ?? "";
 
     if (role === "user") {
       const parts = normalizeTextParts(message["content"], timestampMs);
@@ -543,7 +564,7 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     if (!text) return null;
 
     return {
-      id: String(entry["id"] ?? ""),
+      id: narrowPiField("summary.id", entry["id"], asString) ?? "",
       role: type === "custom_message" ? "user" : "assistant",
       agent: type === "custom_message" ? undefined : "pi",
       timestampMs,
@@ -560,14 +581,16 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     cost: number | null;
     tokens: Message["tokens"];
   } {
-    const usage = isObject(raw) ? raw : {};
-    const inputTokens = Number(usage["input"] ?? 0);
-    const outputTokens = Number(usage["output"] ?? 0);
-    const cacheReadTokens = Number(usage["cacheRead"] ?? 0);
-    const cacheCreateTokens = Number(usage["cacheWrite"] ?? 0);
-    const totalTokens = Number(
-      usage["totalTokens"] ?? inputTokens + outputTokens + cacheReadTokens + cacheCreateTokens,
-    );
+    const usage = narrowPiField("message.usage", raw, asRecord) ?? {};
+    const inputTokens = narrowPiField("message.usage.input", usage["input"], asNumber) ?? 0;
+    const outputTokens = narrowPiField("message.usage.output", usage["output"], asNumber) ?? 0;
+    const cacheReadTokens =
+      narrowPiField("message.usage.cacheRead", usage["cacheRead"], asNumber) ?? 0;
+    const cacheCreateTokens =
+      narrowPiField("message.usage.cacheWrite", usage["cacheWrite"], asNumber) ?? 0;
+    const totalTokens =
+      narrowPiField("message.usage.totalTokens", usage["totalTokens"], asNumber) ??
+      inputTokens + outputTokens + cacheReadTokens + cacheCreateTokens;
     const cost = isObject(usage["cost"]) ? Number(usage["cost"]["total"] ?? 0) : null;
 
     return {

--- a/packages/core/src/utils/__tests__/narrow.test.ts
+++ b/packages/core/src/utils/__tests__/narrow.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../narrow.js";
+import {
+  asArray,
+  asNumber,
+  asRecord,
+  asString,
+  narrowField,
+  reportFieldMismatch,
+  safeParseJsonRecord,
+} from "../narrow.js";
 import { getCoreDiagnostics, setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
 
 afterEach(() => {
@@ -106,5 +114,55 @@ describe("reportFieldMismatch", () => {
   it("is a no-op when no diagnostics sink is injected", () => {
     expect(getCoreDiagnostics()).toBeNull();
     expect(() => reportFieldMismatch("pi", "unset-sink-field")).not.toThrow();
+  });
+});
+
+describe("narrowField", () => {
+  it("returns the narrowed value on success", () => {
+    expect(narrowField("test-agent", "field.string", "hello", asString)).toBe("hello");
+    expect(narrowField("test-agent", "field.number", 42, asNumber)).toBe(42);
+  });
+
+  it("returns undefined silently for undefined and null (null-as-absent)", () => {
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    expect(narrowField("test-agent", "field.absent", undefined, asString)).toBeUndefined();
+    expect(narrowField("test-agent", "field.null", null, asString)).toBeUndefined();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("reports once when the field is present but narrowing fails", () => {
+    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    setCoreDiagnostics(sink);
+
+    expect(narrowField("test-agent", "field.mismatch", 123, asString)).toBeUndefined();
+    expect(narrowField("test-agent", "field.mismatch", 123, asString)).toBeUndefined();
+
+    expect(calls).toEqual([
+      {
+        event: "agent.field_shape_mismatch",
+        detail: { agentName: "test-agent", field: "field.mismatch" },
+      },
+    ]);
+  });
+});
+
+describe("safeParseJsonRecord", () => {
+  it("parses valid JSON objects", () => {
+    expect(safeParseJsonRecord('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("returns undefined for malformed JSON without throwing", () => {
+    expect(() => safeParseJsonRecord("{not json")).not.toThrow();
+    expect(safeParseJsonRecord("{not json")).toBeUndefined();
+  });
+
+  it("returns undefined for valid JSON that isn't an object (array, null, primitive)", () => {
+    expect(safeParseJsonRecord("[1,2]")).toBeUndefined();
+    expect(safeParseJsonRecord("null")).toBeUndefined();
+    expect(safeParseJsonRecord('"text"')).toBeUndefined();
   });
 });

--- a/packages/core/src/utils/narrow.ts
+++ b/packages/core/src/utils/narrow.ts
@@ -23,6 +23,21 @@ export function asArray(value: unknown): unknown[] | undefined {
   return Array.isArray(value) ? value : undefined;
 }
 
+/**
+ * Parses JSON text to a plain object; undefined on parse failure or a
+ * non-object shape (e.g. array, string, null). Callers that need drift
+ * reporting compose this with `narrowField`.
+ */
+export function safeParseJsonRecord(json: string): Record<string, unknown> | undefined {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+  return asRecord(raw);
+}
+
 const reportedFieldMismatches = new Set<string>();
 
 /**
@@ -35,4 +50,22 @@ export function reportFieldMismatch(agentName: string, field: string): void {
   if (reportedFieldMismatches.has(key)) return;
   reportedFieldMismatches.add(key);
   getCoreDiagnostics()?.warn("agent.field_shape_mismatch", { agentName, field });
+}
+
+/**
+ * Narrows a field's value with `narrow`, reporting once via
+ * `reportFieldMismatch` when the field is present but narrowing fails.
+ * `undefined`/`null` mean the field is absent (null-as-absent) and return
+ * undefined silently — that's a normal shape, not drift.
+ */
+export function narrowField<T>(
+  agent: string,
+  field: string,
+  value: unknown,
+  narrow: (v: unknown) => T | undefined,
+): T | undefined {
+  if (value === undefined || value === null) return undefined;
+  const result = narrow(value);
+  if (result === undefined) reportFieldMismatch(agent, field);
+  return result;
 }


### PR DESCRIPTION
## Summary

Follow-up to CS-74 (#176), addressing the two items its review deferred:

1. The "narrow-and-report" combinator was reimplemented by four adapters with inconsistent signatures (`narrowString(field, value)` vs `narrowRecordField(value, field)` vs bespoke readers), plus two same-named `parseJsonRecord` functions with different exception semantics.
2. The low-density adapters (pi/opencode/zcode) hadn't been audited.

## Changes

- **`narrowField<T>(agent, field, value, narrow)`** in `narrow.ts`: `undefined`/`null` → silent absence; present-but-mismatched → deduplicated `agent.field_shape_mismatch` report. The four adapters' wrappers collapse onto it (call-site fallback semantics unchanged; fixtures byte-identical). Two spots previously reported on literal `null` (cursor strings, opencode token objects) now follow the null-as-absent convention — unexercised by any fixture, verified.
- **`safeParseJsonRecord`**: cursor's exception-swallowing JSON parse renamed and promoted to `narrow.ts`; opencode-sqlite's throwing variant stays put (equivalent to its original behavior).
- **pi/opencode/zcode audit**: all three had **zero** `as` casts (opencode/zcode are pure config wrappers over `OpenCodeSqliteAgent`). `pi.ts` gains narrowing + drift reporting at its representative extraction points (message shape, id/role, usage subfields, timestamps); its `cost: 0` coercion quirk deliberately untouched. New negative tests drive drift through the concrete `OpenCodeAgent`/`ZCodeAgent` classes to prove agent-name plumbing end to end.

## Testing

- +3 `narrowField` and +3 `safeParseJsonRecord` unit tests; +2 pi negative tests; +1 each for opencode/zcode
- `pnpm build` / `pnpm test` (core 421, cli 205, web 362) / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-88