### PR TITLE
feat: dark mode with theme toggle and persisted preference (CS-89)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,14 +9,49 @@
     />
     <link rel="icon" type="image/svg+xml" href="/logo.svg?v=3" />
     <title>CodeSesh</title>
+    <script>
+      // Sets .dark before first paint, reading the same localStorage key and
+      // envelope shape as useUiPreferences (apps/web/src/hooks/useUiPreferences.ts)
+      // so the pre-hydration skeleton below never flashes the wrong theme.
+      (function () {
+        var theme = "system";
+        try {
+          var raw = window.localStorage.getItem("codesesh.ui-preferences");
+          if (raw) {
+            var envelope = JSON.parse(raw);
+            var stored = envelope && envelope.version === 1 && envelope.state && envelope.state.theme;
+            if (stored === "light" || stored === "dark" || stored === "system") theme = stored;
+          }
+        } catch (e) {
+          theme = "system";
+        }
+        var isDark =
+          theme === "dark" ||
+          (theme === "system" &&
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches);
+        if (isDark) document.documentElement.classList.add("dark");
+      })();
+    </script>
     <style>
       :root {
         --console-bg: #f7f7f7;
         --console-sidebar-bg: #fbfbfb;
+        --console-surface: #ffffff;
         --console-surface-muted: #f5f5f5;
         --console-border: #e5e5e5;
         --console-text: #1a1a1a;
         --console-muted: #666666;
+      }
+
+      .dark {
+        --console-bg: #19191c;
+        --console-sidebar-bg: #1d1d20;
+        --console-surface: #242428;
+        --console-surface-muted: #202023;
+        --console-border: #2e2e32;
+        --console-text: #f2f2f0;
+        --console-muted: #a3a3a8;
       }
 
       body {
@@ -48,6 +83,10 @@
         padding: 0 16px;
       }
 
+      .dark .app-header {
+        background: rgba(36, 36, 40, 0.85);
+      }
+
       .app-brand,
       .app-search,
       .app-pill,
@@ -75,6 +114,10 @@
         max-width: 560px;
         border: 1px solid var(--console-border);
         background: white;
+      }
+
+      .dark .app-search {
+        background: var(--console-surface);
       }
 
       .app-pill {
@@ -114,6 +157,10 @@
         padding: 18px 32px;
       }
 
+      .dark .app-titlebar {
+        background: rgba(36, 36, 40, 0.7);
+      }
+
       .app-title {
         height: 24px;
         width: 220px;
@@ -132,6 +179,10 @@
         border: 1px solid var(--console-border);
         background: rgba(255, 255, 255, 0.8);
         padding: 16px;
+      }
+
+      .dark .app-card {
+        background: rgba(36, 36, 40, 0.8);
       }
 
       .app-line {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,9 +24,11 @@ import { useLiveSync } from "./hooks/useLiveSync";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useTimeWindow } from "./hooks/useTimeWindow";
 import { useUiPreferences } from "./hooks/useUiPreferences";
+import { useTheme } from "./hooks/useTheme";
 import { buildRouteHeaderModel } from "./lib/build-route-header-model";
 import { AppSidebar } from "./components/app/AppSidebar";
 import { ShortcutHelpDialog } from "./components/app/ShortcutHelpDialog";
+import { ThemeToggle } from "./components/app/ThemeToggle";
 import { AppRouteContent } from "./components/app/AppRouteContent";
 import type { BrowseBy } from "./components/app/types";
 import { formatScanStatusLabel, formatSearchSubtitle } from "./lib/scan-format";
@@ -62,8 +64,15 @@ export default function App() {
   const { scanStatus, setScanStatus } = useScanStatus();
   const [selectedSidebarSessionId, setSelectedSidebarSessionId] = useState<string | null>(null);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
-  const { shortcutHintDismissed, sidebarCollapsed, dismissShortcutHint, setSidebarCollapsed } =
-    useUiPreferences();
+  const {
+    shortcutHintDismissed,
+    sidebarCollapsed,
+    theme,
+    dismissShortcutHint,
+    setSidebarCollapsed,
+    setTheme,
+  } = useUiPreferences();
+  useTheme(theme);
   const [aliasTarget, setAliasTarget] = useState<SessionAliasTarget | null>(null);
 
   const location = useLocation();
@@ -445,6 +454,7 @@ export default function App() {
             </button>
           </form>
           <div className="flex items-center justify-end gap-2">
+            <ThemeToggle theme={theme} onChange={setTheme} />
             <button
               type="button"
               onClick={() => {

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -174,7 +174,7 @@ function ProjectAgentFilter({
           className={`console-mono rounded-sm border px-2 py-1 text-[10px] motion-hover ${
             activeAgent
               ? "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"
-              : "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
+              : "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white dark:text-[var(--console-bg)]"
           }`}
         >
           All Agents
@@ -189,7 +189,7 @@ function ProjectAgentFilter({
               onClick={() => onChange(active ? undefined : agent.name)}
               className={`console-mono inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-[10px] motion-hover ${
                 active
-                  ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
+                  ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white dark:text-[var(--console-bg)]"
                   : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"
               }`}
             >

--- a/apps/web/src/components/SessionAliasDialog.tsx
+++ b/apps/web/src/components/SessionAliasDialog.tsx
@@ -111,7 +111,7 @@ export function SessionAliasDialog({
                 type="button"
                 disabled={saving}
                 onClick={() => void saveAlias()}
-                className="rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-text)] px-3 py-1.5 text-xs text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                className="rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-text)] px-3 py-1.5 text-xs text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 dark:text-[var(--console-bg)]"
               >
                 {saving ? "Saving…" : "Save title"}
               </button>

--- a/apps/web/src/components/TimeWindowControl.tsx
+++ b/apps/web/src/components/TimeWindowControl.tsx
@@ -116,7 +116,7 @@ export function TimeWindowControl({
                   onSelectCustom(from, to);
                   setCustomOpen(false);
                 }}
-                className="rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-text)] px-3 py-1.5 text-xs text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-text)] px-3 py-1.5 text-xs text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40 dark:text-[var(--console-bg)]"
               >
                 Apply range
               </button>

--- a/apps/web/src/components/app/FilterChip.tsx
+++ b/apps/web/src/components/app/FilterChip.tsx
@@ -13,7 +13,7 @@ export function FilterChip({
       onClick={onClick}
       className={`console-mono rounded-sm border px-2 py-1 text-[10px] motion-hover ${
         active
-          ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white"
+          ? "border-[var(--console-border-strong)] bg-[var(--console-accent)] text-white dark:text-[var(--console-bg)]"
           : "border-[var(--console-border)] bg-[var(--console-surface-muted)] text-[var(--console-muted)] hover:bg-[var(--console-surface)]"
       }`}
     >

--- a/apps/web/src/components/app/SearchResultsPanel.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.tsx
@@ -167,7 +167,7 @@ export function SearchResultsPanel({
             </h2>
             <SmartTagChips tags={result.session.smart_tags} className="mt-2" />
             <p
-              className="console-mono mt-2 text-xs leading-6 text-[var(--console-muted)] [&_mark]:bg-[var(--console-accent)] [&_mark]:px-0.5 [&_mark]:text-white"
+              className="console-mono mt-2 text-xs leading-6 text-[var(--console-muted)] [&_mark]:bg-[var(--console-accent)] [&_mark]:px-0.5 [&_mark]:text-white dark:[&_mark]:text-[var(--console-bg)]"
               dangerouslySetInnerHTML={{
                 __html: toSafeSnippetHtml(result.snippet || getSessionDisplayTitle(result.session)),
               }}

--- a/apps/web/src/components/app/ThemeToggle.test.tsx
+++ b/apps/web/src/components/app/ThemeToggle.test.tsx
@@ -1,0 +1,23 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThemeToggle } from "./ThemeToggle";
+
+afterEach(cleanup);
+
+describe("ThemeToggle", () => {
+  it("labels the button with the current theme", () => {
+    render(<ThemeToggle theme="light" onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: /Theme: Light/ })).toBeTruthy();
+  });
+
+  it.each([
+    ["light", "dark"],
+    ["dark", "system"],
+    ["system", "light"],
+  ] as const)("cycles from %s to %s on click", (theme, next) => {
+    const onChange = vi.fn();
+    render(<ThemeToggle theme={theme} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onChange).toHaveBeenCalledWith(next);
+  });
+});

--- a/apps/web/src/components/app/ThemeToggle.tsx
+++ b/apps/web/src/components/app/ThemeToggle.tsx
@@ -1,0 +1,43 @@
+import { Monitor, Moon, Sun } from "lucide-react";
+import type { Theme } from "../../hooks/useUiPreferences";
+
+const THEME_CYCLE: Record<Theme, Theme> = {
+  light: "dark",
+  dark: "system",
+  system: "light",
+};
+
+const THEME_ICON: Record<Theme, typeof Sun> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+};
+
+const THEME_LABEL: Record<Theme, string> = {
+  light: "Light",
+  dark: "Dark",
+  system: "System",
+};
+
+export function ThemeToggle({
+  theme,
+  onChange,
+}: {
+  theme: Theme;
+  onChange: (next: Theme) => void;
+}) {
+  const Icon = THEME_ICON[theme];
+  const next = THEME_CYCLE[theme];
+
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(next)}
+      aria-label={`Theme: ${THEME_LABEL[theme]}. Switch to ${THEME_LABEL[next]}.`}
+      title={`Theme: ${THEME_LABEL[theme]} (click for ${THEME_LABEL[next]})`}
+      className="console-mono motion-hover motion-press rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1.5 text-[var(--console-muted)] hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--console-accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+    >
+      <Icon aria-hidden="true" className="size-4" />
+    </button>
+  );
+}

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -350,10 +350,21 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
     };
 
     draw();
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(draw);
-    observer.observe(canvas);
-    return () => observer.disconnect();
+    // The palette read above is resolved once per draw; toggling .dark on
+    // <html> changes the resolved --timeline-* values without resizing the
+    // canvas, so redraw must also be triggered by that class flip.
+    const themeObserver = new MutationObserver(draw);
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    if (typeof ResizeObserver === "undefined") return () => themeObserver.disconnect();
+    const resizeObserver = new ResizeObserver(draw);
+    resizeObserver.observe(canvas);
+    return () => {
+      themeObserver.disconnect();
+      resizeObserver.disconnect();
+    };
   }, [entries, minimapVisible]);
 
   const scrollToMinimapRatio = useCallback((ratio: number, grabOffset: number) => {
@@ -550,7 +561,7 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
             <button
               type="button"
               aria-label="Scroll timeline left"
-              className="absolute inset-y-0 left-0 z-10 flex w-8 items-center justify-start bg-[linear-gradient(to_right,#fff_55%,transparent)] pl-0.5 text-[var(--console-muted)] hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--console-text)]"
+              className="absolute inset-y-0 left-0 z-10 flex w-8 items-center justify-start bg-[linear-gradient(to_right,var(--console-surface)_55%,transparent)] pl-0.5 text-[var(--console-muted)] hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--console-text)]"
               onClick={() => scrollTimeline(-1)}
             >
               <ChevronLeft size={14} aria-hidden="true" />
@@ -560,7 +571,7 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
             <button
               type="button"
               aria-label="Scroll timeline right"
-              className="absolute inset-y-0 right-0 z-10 flex w-8 items-center justify-end bg-[linear-gradient(to_left,#fff_55%,transparent)] pr-0.5 text-[var(--console-muted)] hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--console-text)]"
+              className="absolute inset-y-0 right-0 z-10 flex w-8 items-center justify-end bg-[linear-gradient(to_left,var(--console-surface)_55%,transparent)] pr-0.5 text-[var(--console-muted)] hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--console-text)]"
               onClick={() => scrollTimeline(1)}
             >
               <ChevronRight size={14} aria-hidden="true" />

--- a/apps/web/src/components/session-detail/session-toc.tsx
+++ b/apps/web/src/components/session-detail/session-toc.tsx
@@ -92,7 +92,7 @@ function TocCheckbox({
         aria-hidden="true"
         className={`flex size-3.5 items-center justify-center rounded border ${
           checked || indeterminate
-            ? "border-[var(--console-accent-strong)] bg-[var(--console-accent-strong)] text-white"
+            ? "border-[var(--console-accent-strong)] bg-[var(--console-accent-strong)] text-white dark:text-[var(--console-bg)]"
             : "border-[var(--console-border-strong)] bg-[var(--console-surface)] text-transparent"
         }`}
       >

--- a/apps/web/src/components/tool-output/StructuredDiffOutput.tsx
+++ b/apps/web/src/components/tool-output/StructuredDiffOutput.tsx
@@ -9,8 +9,12 @@ function getBlockKey(block: DiffBlock) {
 }
 
 function getStructuredDiffLineClassName(type: DiffLineItem["type"]) {
-  if (type === "add") return "text-[#15803d] bg-[#f0fdf4]";
-  if (type === "remove") return "text-[#b91c1c] bg-[#fef2f2]";
+  if (type === "add") {
+    return "text-[#15803d] bg-[#f0fdf4] dark:text-[var(--console-success)] dark:bg-[var(--console-success-bg)]";
+  }
+  if (type === "remove") {
+    return "text-[#b91c1c] bg-[#fef2f2] dark:text-[var(--console-error)] dark:bg-[var(--console-error-bg)]";
+  }
   return "text-[var(--console-text)]";
 }
 

--- a/apps/web/src/components/tool-output/UnifiedDiffOutput.tsx
+++ b/apps/web/src/components/tool-output/UnifiedDiffOutput.tsx
@@ -8,19 +8,19 @@ function getLineKey(line: string, occurrence: number) {
 
 function getUnifiedDiffLineClassName(line: string) {
   if (/^(Index:|diff\s|===)/.test(line)) {
-    return "text-[var(--console-text)] bg-[#f3f4f6]";
+    return "text-[var(--console-text)] bg-[#f3f4f6] dark:bg-[var(--console-surface-muted)]";
   }
   if (line.startsWith("@@")) {
-    return "text-[#7c3aed] bg-[#f5f3ff]";
+    return "text-[#7c3aed] bg-[#f5f3ff] dark:text-[var(--tag-refactoring-text)] dark:bg-[var(--tag-refactoring-background)]";
   }
   if (line.startsWith("+++ ") || line.startsWith("--- ")) {
-    return "text-[#1d4ed8] bg-[#eff6ff]";
+    return "text-[#1d4ed8] bg-[#eff6ff] dark:text-[var(--tag-feature-dev-text)] dark:bg-[var(--tag-feature-dev-background)]";
   }
   if (line.startsWith("+")) {
-    return "text-[#15803d] bg-[#f0fdf4]";
+    return "text-[#15803d] bg-[#f0fdf4] dark:text-[var(--console-success)] dark:bg-[var(--console-success-bg)]";
   }
   if (line.startsWith("-")) {
-    return "text-[#b91c1c] bg-[#fef2f2]";
+    return "text-[#b91c1c] bg-[#fef2f2] dark:text-[var(--console-error)] dark:bg-[var(--console-error-bg)]";
   }
   return "text-[var(--console-text)]";
 }

--- a/apps/web/src/hooks/useTheme.test.ts
+++ b/apps/web/src/hooks/useTheme.test.ts
@@ -1,0 +1,86 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTheme } from "./useTheme";
+import type { Theme } from "./useUiPreferences";
+
+function mockMatchMedia(initialMatches: boolean) {
+  let changeListener: ((event: MediaQueryListEvent) => void) | null = null;
+  const mediaQueryList = {
+    matches: initialMatches,
+    media: "(prefers-color-scheme: dark)",
+    addEventListener: vi.fn((_event: string, listener: (event: MediaQueryListEvent) => void) => {
+      changeListener = listener;
+    }),
+    removeEventListener: vi.fn(() => {
+      changeListener = null;
+    }),
+  };
+  vi.spyOn(window, "matchMedia").mockReturnValue(mediaQueryList as unknown as MediaQueryList);
+  return {
+    emitChange(matches: boolean) {
+      mediaQueryList.matches = matches;
+      changeListener?.({ matches } as MediaQueryListEvent);
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  document.documentElement.classList.remove("dark");
+});
+
+describe("useTheme", () => {
+  it("applies the .dark class for the dark theme", () => {
+    mockMatchMedia(false);
+    renderHook(() => useTheme("dark"));
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("removes the .dark class for the light theme", () => {
+    mockMatchMedia(true);
+    document.documentElement.classList.add("dark");
+    renderHook(() => useTheme("light"));
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("follows the OS preference for the system theme", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useTheme("system"));
+    expect(result.current).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("reacts to matchMedia change events while on the system theme", () => {
+    const media = mockMatchMedia(false);
+    const { result, rerender } = renderHook(() => useTheme("system"));
+    expect(result.current).toBe("light");
+
+    act(() => media.emitChange(true));
+    rerender();
+
+    expect(result.current).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("ignores matchMedia changes once the theme is no longer system", () => {
+    const media = mockMatchMedia(false);
+    const { rerender, unmount } = renderHook(({ theme }: { theme: Theme }) => useTheme(theme), {
+      initialProps: { theme: "system" },
+    });
+    rerender({ theme: "light" });
+    unmount();
+
+    act(() => media.emitChange(true));
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("returns the effective theme unchanged for explicit light/dark", () => {
+    mockMatchMedia(false);
+    const { result: lightResult } = renderHook(() => useTheme("light"));
+    expect(lightResult.current).toBe("light");
+
+    const { result: darkResult } = renderHook(() => useTheme("dark"));
+    expect(darkResult.current).toBe("dark");
+  });
+});

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import type { Theme } from "./useUiPreferences";
+
+const DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+
+function getSystemPrefersDark(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(DARK_MEDIA_QUERY).matches;
+}
+
+/**
+ * Resolves the effective light/dark theme for `theme` (following the OS
+ * preference when "system"), keeps it synced to `document.documentElement`'s
+ * `.dark` class, and returns it for callers that need it directly.
+ */
+export function useTheme(theme: Theme): "light" | "dark" {
+  const [systemPrefersDark, setSystemPrefersDark] = useState(getSystemPrefersDark);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const media = window.matchMedia(DARK_MEDIA_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => setSystemPrefersDark(event.matches);
+    media.addEventListener("change", handleChange);
+    return () => media.removeEventListener("change", handleChange);
+  }, []);
+
+  const effectiveTheme = theme === "system" ? (systemPrefersDark ? "dark" : "light") : theme;
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", effectiveTheme === "dark");
+  }, [effectiveTheme]);
+
+  return effectiveTheme;
+}

--- a/apps/web/src/hooks/useUiPreferences.test.ts
+++ b/apps/web/src/hooks/useUiPreferences.test.ts
@@ -21,6 +21,7 @@ describe("useUiPreferences", () => {
     const { result } = renderHook(() => useUiPreferences());
     expect(result.current.shortcutHintDismissed).toBe(false);
     expect(result.current.sidebarCollapsed).toBe(false);
+    expect(result.current.theme).toBe("system");
   });
 
   it("hydrates valid preferences synchronously", () => {
@@ -28,13 +29,27 @@ describe("useUiPreferences", () => {
       UI_PREFERENCES_STORAGE_KEY,
       JSON.stringify({
         version: 1,
-        state: { shortcutHintDismissed: true, sidebarCollapsed: true },
+        state: { shortcutHintDismissed: true, sidebarCollapsed: true, theme: "dark" },
       }),
     );
 
     const { result } = renderHook(() => useUiPreferences());
     expect(result.current.shortcutHintDismissed).toBe(true);
     expect(result.current.sidebarCollapsed).toBe(true);
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("defaults theme to system for preferences persisted before CS-89", () => {
+    window.localStorage.setItem(
+      UI_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        state: { shortcutHintDismissed: true, sidebarCollapsed: false },
+      }),
+    );
+
+    const { result } = renderHook(() => useUiPreferences());
+    expect(result.current.theme).toBe("system");
   });
 
   it("persists semantic actions across hook instances", () => {
@@ -42,12 +57,14 @@ describe("useUiPreferences", () => {
     act(() => {
       first.result.current.dismissShortcutHint();
       first.result.current.setSidebarCollapsed(true);
+      first.result.current.setTheme("dark");
     });
     first.unmount();
 
     const second = renderHook(() => useUiPreferences());
     expect(second.result.current.shortcutHintDismissed).toBe(true);
     expect(second.result.current.sidebarCollapsed).toBe(true);
+    expect(second.result.current.theme).toBe("dark");
   });
 
   it("imports the legacy shortcut preference", () => {
@@ -62,6 +79,10 @@ describe("useUiPreferences", () => {
     JSON.stringify({
       version: 1,
       state: { shortcutHintDismissed: "yes", sidebarCollapsed: false },
+    }),
+    JSON.stringify({
+      version: 1,
+      state: { shortcutHintDismissed: true, sidebarCollapsed: false, theme: "blue" },
     }),
   ])("falls back for invalid stored data", (raw) => {
     window.localStorage.setItem(UI_PREFERENCES_STORAGE_KEY, raw);
@@ -94,7 +115,7 @@ describe("useUiPreferences", () => {
 
     expect(JSON.parse(window.localStorage.getItem(UI_PREFERENCES_STORAGE_KEY)!)).toEqual({
       version: 1,
-      state: { shortcutHintDismissed: true, sidebarCollapsed: false },
+      state: { shortcutHintDismissed: true, sidebarCollapsed: false, theme: "system" },
     });
   });
 });
@@ -108,10 +129,11 @@ describe("parseUiPreferences", () => {
           state: {
             shortcutHintDismissed: true,
             sidebarCollapsed: false,
+            theme: "light",
             transientSelection: "session-1",
           },
         }),
       ),
-    ).toEqual({ shortcutHintDismissed: true, sidebarCollapsed: false });
+    ).toEqual({ shortcutHintDismissed: true, sidebarCollapsed: false, theme: "light" });
   });
 });

--- a/apps/web/src/hooks/useUiPreferences.ts
+++ b/apps/web/src/hooks/useUiPreferences.ts
@@ -1,8 +1,13 @@
 import { useCallback, useRef, useState } from "react";
 
+export type Theme = "light" | "dark" | "system";
+
+const THEMES: readonly Theme[] = ["light", "dark", "system"];
+
 export interface UiPreferences {
   shortcutHintDismissed: boolean;
   sidebarCollapsed: boolean;
+  theme: Theme;
 }
 
 interface StoredUiPreferences {
@@ -18,7 +23,12 @@ export const LEGACY_SHORTCUT_HINT_STORAGE_KEY = "codesesh.shortcuts-hint-dismiss
 const DEFAULT_UI_PREFERENCES: UiPreferences = {
   shortcutHintDismissed: false,
   sidebarCollapsed: false,
+  theme: "system",
 };
+
+function isTheme(value: unknown): value is Theme {
+  return typeof value === "string" && THEMES.includes(value as Theme);
+}
 
 function getBrowserStorage(): UiPreferencesStorage | null {
   if (typeof window === "undefined") return null;
@@ -38,11 +48,14 @@ export function parseUiPreferences(raw: string | null): UiPreferences | null {
   try {
     const envelope: unknown = JSON.parse(raw);
     if (!isRecord(envelope) || envelope.version !== 1 || !isRecord(envelope.state)) return null;
-    const { shortcutHintDismissed, sidebarCollapsed } = envelope.state;
+    const { shortcutHintDismissed, sidebarCollapsed, theme } = envelope.state;
     if (typeof shortcutHintDismissed !== "boolean" || typeof sidebarCollapsed !== "boolean") {
       return null;
     }
-    return { shortcutHintDismissed, sidebarCollapsed };
+    // theme predates CS-89: absent in preferences persisted before this field
+    // existed, so treat it as "system" rather than invalidating the envelope.
+    if (theme !== undefined && !isTheme(theme)) return null;
+    return { shortcutHintDismissed, sidebarCollapsed, theme: isTheme(theme) ? theme : "system" };
   } catch {
     return null;
   }
@@ -74,6 +87,7 @@ function persistUiPreferences(
     state: {
       shortcutHintDismissed: preferences.shortcutHintDismissed,
       sidebarCollapsed: preferences.sidebarCollapsed,
+      theme: preferences.theme,
     },
   };
   try {
@@ -105,9 +119,17 @@ export function useUiPreferences() {
     [updatePreferences],
   );
 
+  const setTheme = useCallback(
+    (theme: Theme) => {
+      updatePreferences({ ...preferencesRef.current, theme });
+    },
+    [updatePreferences],
+  );
+
   return {
     ...preferences,
     dismissShortcutHint,
     setSidebarCollapsed,
+    setTheme,
   };
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -189,9 +189,6 @@
     --tt-fg: #2f2f2f;
   }
 
-  /* Dark mode is not implemented: this block only overrides the shadcn base
-     tokens below and does not cover --console-* / --timeline-* / --tag-*,
-     which the product UI actually renders with. */
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
@@ -212,6 +209,73 @@
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
     --ring: 0 0% 83.1%;
+
+    --console-bg: #19191c;
+    --console-sidebar-bg: #1d1d20;
+    --console-surface: #242428;
+    --console-surface-muted: #202023;
+    --console-surface-sunken: #1c1c1f;
+    --console-border: #2e2e32;
+    --console-border-strong: #3d3d42;
+    --console-text: #f2f2f0;
+    --console-muted: #a3a3a8;
+    --console-accent: #ececec;
+    --console-accent-strong: #ffffff;
+    --console-thread: #313135;
+    --console-thinking-bg: #202024;
+    --console-thinking-border: #2c2c30;
+    --console-success: #4ade80;
+    --console-success-bg: #122016;
+    --console-success-border: #20492c;
+    --console-warning: #fbbf24;
+    --console-warning-bg: #241a05;
+    --console-warning-border: #5c3d0a;
+    --console-error: #f87171;
+    --console-error-bg: #241010;
+    --console-error-border: #5c1e1e;
+    --timeline-user: #c98aa8;
+    --timeline-agent: #82aed4;
+    --timeline-tool-read: #6bb3a0;
+    --timeline-tool-write: #d99a5c;
+    --timeline-tool-execute: #a89bc9;
+    --tag-bugfix-text: #f592a0;
+    --tag-bugfix-border: #5c2530;
+    --tag-bugfix-background: #241014;
+    --tag-bugfix-bar: #fb7185;
+    --tag-refactoring-text: #b6a4f7;
+    --tag-refactoring-border: #3a2f63;
+    --tag-refactoring-background: #180f2b;
+    --tag-refactoring-bar: #9b87f0;
+    --tag-feature-dev-text: #8ec1fb;
+    --tag-feature-dev-border: #1f3a5c;
+    --tag-feature-dev-background: #0e1e30;
+    --tag-feature-dev-bar: #5b9df0;
+    --tag-testing-text: #6fdba3;
+    --tag-testing-border: #1c4a30;
+    --tag-testing-background: #0c2318;
+    --tag-testing-bar: #3fbe80;
+    --tag-docs-text: #f6b768;
+    --tag-docs-border: #5c3d10;
+    --tag-docs-background: #2a1a06;
+    --tag-docs-bar: #f0a13f;
+    --tag-git-ops-text: #a9b3f8;
+    --tag-git-ops-border: #332f66;
+    --tag-git-ops-background: #171531;
+    --tag-git-ops-bar: #818cf8;
+    --tag-build-deploy-text: #f6a06a;
+    --tag-build-deploy-border: #5c3416;
+    --tag-build-deploy-background: #2a1708;
+    --tag-build-deploy-bar: #f0813f;
+    --tag-exploration-text: #6fd4e8;
+    --tag-exploration-border: #1c4650;
+    --tag-exploration-background: #0c2126;
+    --tag-exploration-bar: #3fb8d4;
+    --tag-planning-text: #f593cf;
+    --tag-planning-border: #5c2246;
+    --tag-planning-background: #240f1e;
+    --tag-planning-bar: #ef6bc0;
+    --tt-bg: #242428;
+    --tt-fg: #f2f2f0;
   }
 
   * {
@@ -492,10 +556,32 @@
   .session-timeline-segment[aria-current="location"] {
     z-index: 1;
     opacity: 1;
+    /* The inner ring cuts out down to the timeline card's own background
+       (--console-surface), so it must track the surface token rather than
+       a fixed white to keep the cutout illusion in dark mode. */
     box-shadow:
-      0 0 0 2px #ffffff,
+      0 0 0 2px var(--console-surface),
       0 0 0 3px var(--console-text);
   }
+}
+
+/* Tailwind v4's ring-offset utilities fall back to a global #fff inside
+   @layer base; override it here (unlayered, so it wins the cascade) rather
+   than touching every focus-visible:ring-offset-2 call site. */
+.dark,
+.dark * {
+  --tw-ring-offset-color: var(--console-bg);
+}
+
+.dark .bg-grid {
+  background-image:
+    linear-gradient(to right, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+}
+
+.dark .session-timeline-minimap-window {
+  border-color: rgba(255, 255, 255, 0.3);
+  box-shadow: 0 0 0 9999px rgba(12, 12, 14, 0.72);
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -593,6 +679,18 @@
   scrollbar-color: #d1d5db transparent;
 }
 
+.dark .console-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--console-border-strong);
+}
+
+.dark .console-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: var(--console-muted);
+}
+
+.dark .console-scrollbar {
+  scrollbar-color: var(--console-border-strong) transparent;
+}
+
 .console-markdown > * + * {
   margin-top: 0.75rem;
 }
@@ -683,6 +781,10 @@
   text-decoration: underline;
 }
 
+.dark .console-markdown a {
+  color: var(--tag-git-ops-text);
+}
+
 .console-markdown-link {
   color: inherit;
   cursor: text;
@@ -701,6 +803,11 @@
   white-space: pre-wrap;
 }
 
+.dark .console-markdown code {
+  background: var(--console-surface-muted);
+  border-color: var(--console-border);
+}
+
 .console-markdown pre {
   margin: 0;
   max-width: 100%;
@@ -709,6 +816,11 @@
   border-radius: 0.125rem;
   overflow-x: auto;
   padding: 0.75rem;
+}
+
+.dark .console-markdown pre {
+  background: var(--console-surface-sunken);
+  border-color: var(--console-border);
 }
 
 .console-markdown pre code {


### PR DESCRIPTION
## Summary

With CS-81's token consolidation done, this implements dark mode end to end: dark values for all 64 product tokens, a light/dark/system theme toggle, persisted preference, and first-paint FOUC protection. Light theme rendering is byte-identical.

## Palette

Base `#19191c` with the light theme's elevation relationships preserved (`surface #242428` brightest, then sidebar/sunken/bg/muted tiers), near-white accent inversion, desaturated dark backgrounds for the 3 semantic groups, brightened text/bar + deep low-saturation backgrounds for the 5 timeline colors and 9 tag palettes.

**Contrast is script-computed, twice** (implementation + independent review recalculation): text 13.8–15.7:1 across surfaces, muted ≥6.2:1, semantic pairs ≥6.5:1, timeline ≥5.7:1, all 9 tag text/background pairs ≥8.2:1 (safe at 10px).

## Mechanics

- `useUiPreferences` gains `theme: light|dark|system` (default system; legacy stored payloads without the field degrade gracefully). New `useTheme` computes the effective theme (matchMedia + change listener for system) and syncs `.dark` on `documentElement`.
- Header `ThemeToggle`: three-state cycle (Sun/Moon/Monitor), styled like existing header controls with the shared motion classes.
- FOUC guard: inline script in `index.html` parses the same localStorage envelope before first paint (falls back to system on any parse failure).

## Review catches (fixed)

- **Tailwind's `--tw-ring-offset-color` defaults to `#fff`** — all 12 `focus-visible:ring-offset-2` sites would have drawn a white halo on dark backgrounds. Fixed at the root: `.dark` overrides the variable to `var(--console-bg)`.
- `--console-accent` inverting to near-white made 6 hardcoded `text-white`-on-accent buttons white-on-white; each gains `dark:text-[var(--console-bg)]`.
- Chart tooltip / shadcn gray alignment and inline-script strictness asymmetry recorded as accepted deviations.

## Testing

- `useTheme` tests: three states, matchMedia-driven system switching, class sync, persistence round-trip; ThemeToggle cycle tests
- `pnpm build` / `pnpm test` (web 370+, core 421, cli 205) / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-89