### PR TITLE
feat: landing page dark mode in sync with the product (CS-90)

### DIFF
--- a/apps/www/src/components/Agents.astro
+++ b/apps/www/src/components/Agents.astro
@@ -11,7 +11,7 @@ const t = copy[locale].agents;
 ---
 
 <section
-  class="border-t border-[var(--console-border)] bg-white px-6 py-20"
+  class="border-t border-[var(--console-border)] bg-[var(--console-surface)] px-6 py-20"
   aria-labelledby="agents-heading"
 >
   <div class="mx-auto max-w-4xl text-center">

--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import { copy, localeRoutes, type Locale } from "../data/landing";
+import Icon from "./Icon.astro";
 
 interface Props {
   locale: Locale;
@@ -7,11 +8,20 @@ interface Props {
 
 const { locale } = Astro.props;
 const t = copy[locale].header;
+
+const themes = [
+  { key: "light", icon: "sun", label: t.themeLight },
+  { key: "dark", icon: "moon", label: t.themeDark },
+  { key: "system", icon: "monitor", label: t.themeSystem },
+] as const;
 ---
 
-<header class="sticky top-0 z-50 border-b border-[var(--console-border)] bg-white/88 backdrop-blur-md">
+<header class="sticky top-0 z-50 border-b border-[var(--console-border)] bg-[var(--console-surface)]/88 backdrop-blur-md">
   <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
-    <a href={localeRoutes[locale]} class="flex items-center gap-2 text-[var(--console-text)]">
+    <a
+      href={localeRoutes[locale]}
+      class="flex items-center gap-2 rounded-sm text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
+    >
       <img src="/logo.svg?v=2" alt="CodeSesh" class="h-7 w-7 rounded-sm" />
       <span class="console-mono text-sm font-semibold uppercase tracking-[0.05em]">CodeSesh</span>
     </a>
@@ -20,7 +30,7 @@ const t = copy[locale].header;
         href="https://github.com/xingkaixin/codesesh"
         target="_blank"
         rel="noopener noreferrer"
-        class="console-mono py-2 -my-2 text-xs text-[var(--console-muted)] transition-colors hover:text-[var(--console-text)]"
+        class="console-mono py-2 -my-2 text-xs text-[var(--console-muted)] transition-colors hover:text-[var(--console-text)] focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
       >
         {t.github}
       </a>
@@ -34,9 +44,9 @@ const t = copy[locale].header;
             <a
               href={localeRoutes[item]}
               class:list={[
-                "console-mono rounded-[3px] px-2 py-1.5 text-[10px] font-semibold transition-colors",
+                "console-mono rounded-[3px] px-2 py-1.5 text-[10px] font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]",
                 locale === item
-                  ? "bg-white text-[var(--console-text)] shadow-sm"
+                  ? "bg-[var(--console-surface)] text-[var(--console-text)] shadow-sm"
                   : "text-[var(--console-muted)] hover:text-[var(--console-text)]",
               ]}
               aria-current={locale === item ? "page" : undefined}
@@ -46,6 +56,70 @@ const t = copy[locale].header;
           ))
         }
       </div>
+      <button
+        type="button"
+        data-theme-toggle
+        data-theme-label={t.themeLabel}
+        data-theme-switch-to={t.themeSwitchTo}
+        class="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] p-1.5 text-[var(--console-muted)] transition-colors hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
+      >
+        <span class="copy-icon-stack inline-grid">
+          {
+            themes.map((theme) => (
+              <span data-theme-icon={theme.key} data-theme-text={theme.label} data-active={theme.key === "system" ? "true" : undefined}>
+                <Icon name={theme.icon} class="size-4" />
+              </span>
+            ))
+          }
+        </span>
+        <span class="sr-only" aria-live="polite" data-theme-status>{`${t.themeLabel}: ${t.themeSystem}${t.themeSwitchTo.replace("{next}", t.themeLight)}`}</span>
+      </button>
     </nav>
   </div>
 </header>
+
+<script>
+  const THEMES = ["light", "dark", "system"] as const;
+  type Theme = (typeof THEMES)[number];
+  const NEXT_THEME: Record<Theme, Theme> = { light: "dark", dark: "system", system: "light" };
+
+  function isTheme(value: string | undefined): value is Theme {
+    return !!value && (THEMES as readonly string[]).includes(value as Theme);
+  }
+
+  declare global {
+    interface Window {
+      __wwwTheme?: { get: () => Theme; set: (next: Theme) => void };
+    }
+  }
+
+  document.querySelectorAll<HTMLButtonElement>("[data-theme-toggle]").forEach((button) => {
+    const label = button.dataset.themeLabel ?? "";
+    const switchToTemplate = button.dataset.themeSwitchTo ?? "";
+    const status = button.querySelector<HTMLElement>("[data-theme-status]");
+    const icons = new Map<Theme, HTMLElement>();
+    button.querySelectorAll<HTMLElement>("[data-theme-icon]").forEach((el) => {
+      const key = el.dataset.themeIcon;
+      if (isTheme(key)) icons.set(key, el);
+    });
+
+    function render(theme: Theme) {
+      icons.forEach((el, key) => {
+        el.dataset.active = String(key === theme);
+      });
+      const currentText = icons.get(theme)?.dataset.themeText ?? "";
+      const nextText = icons.get(NEXT_THEME[theme])?.dataset.themeText ?? "";
+      const switchToText = switchToTemplate.replace("{next}", nextText);
+      if (status) status.textContent = `${label}: ${currentText}${switchToText}`;
+    }
+
+    render(window.__wwwTheme?.get() ?? "system");
+
+    button.addEventListener("click", () => {
+      const current = window.__wwwTheme?.get() ?? "system";
+      const nextTheme = NEXT_THEME[current];
+      window.__wwwTheme?.set(nextTheme);
+      render(nextTheme);
+    });
+  });
+</script>

--- a/apps/www/src/components/Hero.astro
+++ b/apps/www/src/components/Hero.astro
@@ -91,7 +91,7 @@ const legend: LaneKey[] = ["user", "agent", "read", "write", "execute"];
           {t.commandTitle}
         </p>
         <div class="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center">
-          <code class="console-mono flex-1 rounded-[2px] border border-[var(--console-border-strong)] bg-white px-4 py-3 text-sm text-[var(--console-text)]">
+          <code class="console-mono flex-1 rounded-[2px] border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-4 py-3 text-sm text-[var(--console-text)]">
             $ {t.command}
           </code>
           <button
@@ -100,7 +100,7 @@ const legend: LaneKey[] = ["user", "agent", "read", "write", "execute"];
             data-copy-label={t.copyCommand}
             data-copied-label={t.copied}
             data-copy-failed-label={t.copyFailed}
-            class="pressable console-mono inline-flex items-center justify-center gap-2 rounded-[2px] bg-[var(--console-accent-strong)] px-4 py-3 text-xs font-semibold text-white hover:bg-black"
+            class="pressable console-mono inline-flex items-center justify-center gap-2 rounded-[2px] bg-[var(--console-accent-strong)] px-4 py-3 text-xs font-semibold text-white hover:bg-black focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)] dark:text-[var(--console-bg)] dark:hover:bg-[var(--console-muted)]"
           >
             <span class="copy-icon-stack inline-grid">
               <span data-copy-icon="idle" data-active="true"><Icon name="copy" class="size-4" /></span>
@@ -117,7 +117,7 @@ const legend: LaneKey[] = ["user", "agent", "read", "write", "execute"];
     <div class="min-w-0">
       <div
         aria-hidden="true"
-        class="rounded-sm border border-[var(--console-border-strong)] bg-white p-5 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
+        class="rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] p-5 shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
       >
         <div class="flex flex-wrap items-center gap-x-4 gap-y-2 border-b border-[var(--console-border)] pb-4">
           {

--- a/apps/www/src/components/Icon.astro
+++ b/apps/www/src/components/Icon.astro
@@ -1,7 +1,16 @@
 ---
 import type { IconName } from "../data/landing";
 
-type UiIconName = IconName | "check" | "chevron-left" | "chevron-right" | "copy" | "expand";
+type UiIconName =
+  | IconName
+  | "check"
+  | "chevron-left"
+  | "chevron-right"
+  | "copy"
+  | "expand"
+  | "sun"
+  | "moon"
+  | "monitor";
 
 interface Props {
   name: UiIconName;
@@ -27,11 +36,15 @@ const paths = {
     '<rect width="20" height="16" x="2" y="4" rx="2"/><path d="M6 8h.01"/><path d="M10 8h.01"/><path d="M14 8h.01"/><path d="M18 8h.01"/><path d="M8 12h.01"/><path d="M12 12h.01"/><path d="M16 12h.01"/><path d="M7 16h10"/>',
   "list-tree":
     '<path d="M21 12h-8"/><path d="M21 6H8"/><path d="M21 18h-8"/><path d="M3 6v4c0 1.1.9 2 2 2h3"/><path d="M3 10v4c0 1.1.9 2 2 2h3"/>',
+  monitor:
+    '<rect width="20" height="14" x="2" y="3" rx="2"/><line x1="8" x2="16" y1="21" y2="21"/><line x1="12" x2="12" y1="17" y2="21"/>',
+  moon: '<path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401"/>',
   search: '<circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>',
   settings:
     '<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/>',
   shield:
     '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.68 0C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.5 3.8 17 5 19 5a1 1 0 0 1 1 1z"/>',
+  sun: '<circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>',
   tags: '<path d="M13.172 2a2 2 0 0 1 1.414.586l6.71 6.71a2.4 2.4 0 0 1 0 3.408l-4.592 4.592a2.4 2.4 0 0 1-3.408 0l-6.71-6.71A2 2 0 0 1 6 9.172V3a1 1 0 0 1 1-1z"/><path d="M2 7v6.172a2 2 0 0 0 .586 1.414l6.71 6.71a2.4 2.4 0 0 0 3.191.193"/><circle cx="10.5" cy="6.5" r=".5" fill="currentColor"/>',
   terminal: '<path d="m4 17 6-6-6-6"/><path d="M12 19h8"/>',
   timer: '<line x1="10" x2="14" y1="2" y2="2"/><line x1="12" x2="15" y1="14" y2="11"/><circle cx="12" cy="14" r="8"/>',

--- a/apps/www/src/components/ProductShowcase.astro
+++ b/apps/www/src/components/ProductShowcase.astro
@@ -12,7 +12,7 @@ const t = copy[locale].tour;
 const scenes = copy[locale].scenes;
 ---
 
-<section class="border-y border-[var(--console-border)] bg-white px-6 py-24">
+<section class="border-y border-[var(--console-border)] bg-[var(--console-surface)] px-6 py-24">
   <div class="mx-auto max-w-6xl">
     <p class="console-mono text-xs font-semibold uppercase tracking-[0.14em] text-[var(--console-muted)]">
       {t.label}
@@ -25,14 +25,14 @@ const scenes = copy[locale].scenes;
     {
       scenes[0] && (
         <div class="mt-12">
-          <article class="product-showcase-card card-lift group relative overflow-hidden rounded-sm border border-[var(--console-border)] bg-white text-left">
-            <div class="border-b border-[var(--console-border)] bg-white px-6 py-5">
+          <article class="product-showcase-card card-lift group relative overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] text-left">
+            <div class="border-b border-[var(--console-border)] bg-[var(--console-surface)] px-6 py-5">
               <h3 class="text-sm font-semibold text-[var(--console-text)]">{scenes[0].title}</h3>
               <p class="mt-1.5 text-sm leading-6 text-[var(--console-muted)]">{scenes[0].description}</p>
             </div>
 
             <div class="bg-[var(--console-surface-muted)] p-4">
-              <div class="overflow-hidden rounded-[2px] border border-[var(--console-border)] bg-[#f8f8f8]">
+              <div class="overflow-hidden rounded-[2px] border border-[var(--console-border)] bg-[#f8f8f8] dark:border-[var(--console-border-strong)]">
                 <img
                   src={scenes[0].image}
                   alt={scenes[0].description}
@@ -48,7 +48,7 @@ const scenes = copy[locale].scenes;
             <button
               type="button"
               data-scene-open="0"
-              class="product-showcase-expand pressable absolute right-5 bottom-5 inline-flex items-center gap-2 rounded-[2px] border border-[var(--console-border)] bg-white/92 px-3 py-2 text-xs font-medium text-[var(--console-text)] shadow-[0_1px_2px_rgba(0,0,0,0.08)]"
+              class="product-showcase-expand pressable absolute right-5 bottom-5 inline-flex items-center gap-2 rounded-[2px] border border-[var(--console-border)] bg-[var(--console-surface)]/92 px-3 py-2 text-xs font-medium text-[var(--console-text)] shadow-[0_1px_2px_rgba(0,0,0,0.08)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
               aria-label={`${t.expand} ${scenes[0].title}`}
             >
               <Icon name="expand" class="size-3.5" />
@@ -64,14 +64,14 @@ const scenes = copy[locale].scenes;
         scenes.slice(1).map((scene, i) => {
           const index = i + 1;
           return (
-            <article class="product-showcase-card card-lift group relative overflow-hidden rounded-sm border border-[var(--console-border)] bg-white text-left">
-              <div class="border-b border-[var(--console-border)] bg-white px-6 py-5">
+            <article class="product-showcase-card card-lift group relative overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] text-left">
+              <div class="border-b border-[var(--console-border)] bg-[var(--console-surface)] px-6 py-5">
                 <h3 class="text-sm font-semibold text-[var(--console-text)]">{scene.title}</h3>
                 <p class="mt-1.5 text-sm leading-6 text-[var(--console-muted)]">{scene.description}</p>
               </div>
 
               <div class="bg-[var(--console-surface-muted)] p-4">
-                <div class="overflow-hidden rounded-[2px] border border-[var(--console-border)] bg-[#f8f8f8]">
+                <div class="overflow-hidden rounded-[2px] border border-[var(--console-border)] bg-[#f8f8f8] dark:border-[var(--console-border-strong)]">
                   <img
                     src={scene.image}
                     alt={scene.description}
@@ -86,7 +86,7 @@ const scenes = copy[locale].scenes;
               <button
                 type="button"
                 data-scene-open={String(index)}
-                class="product-showcase-expand pressable absolute right-5 bottom-5 inline-flex items-center gap-2 rounded-[2px] border border-[var(--console-border)] bg-white/92 px-3 py-2 text-xs font-medium text-[var(--console-text)] shadow-[0_1px_2px_rgba(0,0,0,0.08)]"
+                class="product-showcase-expand pressable absolute right-5 bottom-5 inline-flex items-center gap-2 rounded-[2px] border border-[var(--console-border)] bg-[var(--console-surface)]/92 px-3 py-2 text-xs font-medium text-[var(--console-text)] shadow-[0_1px_2px_rgba(0,0,0,0.08)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
                 aria-label={`${t.expand} ${scene.title}`}
               >
                 <Icon name="expand" class="size-3.5" />
@@ -110,8 +110,8 @@ const scenes = copy[locale].scenes;
       aria-label={`${scene.title} preview`}
     >
       <div class="flex min-h-dvh items-center justify-center p-4" data-scene-backdrop>
-        <div class="relative flex max-h-[92dvh] w-full max-w-7xl flex-col overflow-hidden rounded-sm border border-white/20 bg-[#f7f7f7] shadow-[0_24px_64px_rgba(0,0,0,0.24)]">
-          <div class="flex items-start justify-between gap-4 border-b border-[var(--console-border)] bg-white px-5 py-4">
+        <div class="relative flex max-h-[92dvh] w-full max-w-7xl flex-col overflow-hidden rounded-sm border border-white/20 bg-[var(--console-bg)] shadow-[0_24px_64px_rgba(0,0,0,0.24)]">
+          <div class="flex items-start justify-between gap-4 border-b border-[var(--console-border)] bg-[var(--console-surface)] px-5 py-4">
             <div>
               <p class="text-sm font-semibold text-[var(--console-text)]">
                 {scene.title}
@@ -123,17 +123,17 @@ const scenes = copy[locale].scenes;
             <button
               type="button"
               data-scene-close
-              class="pressable rounded-[2px] border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5 text-xs font-medium text-[var(--console-text)] hover:bg-white"
+              class="pressable rounded-[2px] border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5 text-xs font-medium text-[var(--console-text)] hover:bg-[var(--console-surface)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
             >
               {t.close}
             </button>
           </div>
 
-          <div class="flex items-center justify-between gap-3 border-b border-[var(--console-border)] bg-[rgba(255,255,255,0.82)] px-4 py-3">
+          <div class="flex items-center justify-between gap-3 border-b border-[var(--console-border)] bg-[var(--console-surface)]/82 px-4 py-3">
             <button
               type="button"
               data-scene-prev
-              class="pressable inline-flex items-center gap-2 rounded-[2px] border border-[var(--console-border)] bg-white px-3 py-2 text-xs font-medium text-[var(--console-text)] hover:bg-[var(--console-surface-muted)]"
+              class="pressable inline-flex items-center gap-2 rounded-[2px] border border-[var(--console-border)] bg-[var(--console-surface)] px-3 py-2 text-xs font-medium text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
             >
               <Icon name="chevron-left" class="size-4" />
               {t.previous}
@@ -144,7 +144,7 @@ const scenes = copy[locale].scenes;
             <button
               type="button"
               data-scene-next
-              class="pressable inline-flex items-center gap-2 rounded-[2px] border border-[var(--console-border)] bg-white px-3 py-2 text-xs font-medium text-[var(--console-text)] hover:bg-[var(--console-surface-muted)]"
+              class="pressable inline-flex items-center gap-2 rounded-[2px] border border-[var(--console-border)] bg-[var(--console-surface)] px-3 py-2 text-xs font-medium text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--console-accent)]"
             >
               {t.next}
               <Icon name="chevron-right" class="size-4" />
@@ -156,7 +156,7 @@ const scenes = copy[locale].scenes;
             tabindex="0"
             aria-label={scene.title}
           >
-            <div class="mx-auto min-w-[56rem] overflow-hidden rounded-[2px] border border-[var(--console-border)] bg-white">
+            <div class="mx-auto min-w-[56rem] overflow-hidden rounded-[2px] border border-[var(--console-border)] bg-white dark:border-[var(--console-border-strong)]">
               <img
                 src={scene.image}
                 alt={scene.title}

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -47,6 +47,11 @@ interface LandingCopy {
   header: {
     github: string;
     languageLabel: string;
+    themeLabel: string;
+    themeLight: string;
+    themeDark: string;
+    themeSystem: string;
+    themeSwitchTo: string;
   };
   hero: {
     title: HeadingCopy;
@@ -116,6 +121,11 @@ export const copy = {
     header: {
       github: "GitHub",
       languageLabel: "语言",
+      themeLabel: "主题",
+      themeLight: "浅色",
+      themeDark: "深色",
+      themeSystem: "跟随系统",
+      themeSwitchTo: "，点击切换到{next}",
     },
     hero: {
       title: ["把 AI 编码历史，", "变成可复用的工程记忆。"],
@@ -308,6 +318,11 @@ export const copy = {
     header: {
       github: "GitHub",
       languageLabel: "Language",
+      themeLabel: "Theme",
+      themeLight: "Light",
+      themeDark: "Dark",
+      themeSystem: "System",
+      themeSwitchTo: ". Switch to {next}.",
     },
     hero: {
       title: ["Turn AI coding history", "into reusable engineering memory."],

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -84,6 +84,103 @@ const jsonLd = {
 <html lang={language}>
   <head>
     <meta charset="UTF-8" />
+    <script is:inline>
+      // Applies the persisted theme before first paint to avoid a light->dark
+      // flash. Key ("www-theme") is independent from apps/web's
+      // "codesesh.ui-preferences" since the two apps ship separately.
+      // Exposes window.__wwwTheme so Header.astro's toggle can read/update the
+      // same state without re-deriving the light/dark computation.
+      (function () {
+        var KEY = "www-theme";
+        var MEDIA = "(prefers-color-scheme: dark)";
+
+        function getStored() {
+          try {
+            var value = window.localStorage.getItem(KEY);
+            return value === "light" || value === "dark" || value === "system" ? value : "system";
+          } catch (e) {
+            return "system";
+          }
+        }
+
+        function systemPrefersDark() {
+          return typeof window.matchMedia === "function" && window.matchMedia(MEDIA).matches;
+        }
+
+        function apply(theme) {
+          var isDark = theme === "dark" || (theme === "system" && systemPrefersDark());
+          document.documentElement.classList.toggle("dark", isDark);
+        }
+
+        var initialTheme = getStored();
+        apply(initialTheme);
+
+        if (typeof window.matchMedia === "function") {
+          window.matchMedia(MEDIA).addEventListener("change", function () {
+            if (getStored() === "system") apply("system");
+          });
+        }
+
+        window.__wwwTheme = {
+          get: getStored,
+          set: function (next) {
+            try {
+              window.localStorage.setItem(KEY, next);
+            } catch (e) {
+              // ignore write failures (private mode, storage disabled, etc.)
+            }
+            apply(next);
+          },
+        };
+      })();
+    </script>
+    <noscript>
+      <style>
+        /* No-JS fallback: follow the OS preference via a plain media query
+           (the `.dark` class-based `dark:` variant never activates without
+           the script above). Covers the two spots that aren't already driven
+           by the --console-* custom properties. */
+        @media (prefers-color-scheme: dark) {
+          :root {
+            --console-bg: #19191c;
+            --console-sidebar-bg: #1d1d20;
+            --console-surface: #242428;
+            --console-surface-muted: #202023;
+            --console-border: #2e2e32;
+            --console-border-strong: #3d3d42;
+            --console-text: #f2f2f0;
+            --console-muted: #a3a3a8;
+            --console-accent: #ececec;
+            --console-accent-strong: #ffffff;
+            --timeline-user: #c98aa8;
+            --timeline-agent: #82aed4;
+            --timeline-tool-read: #6bb3a0;
+            --timeline-tool-write: #d99a5c;
+            --timeline-tool-execute: #a89bc9;
+          }
+
+          [data-copy-command] {
+            color: var(--console-bg);
+          }
+
+          [data-copy-command]:hover {
+            background: var(--console-muted);
+          }
+
+          .bg-grid {
+            background-image:
+              linear-gradient(to right, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+              linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+          }
+        }
+
+        /* The toggle only works via the inline script above; without JS it's
+           inert, so hide it rather than ship a dead control. */
+        [data-theme-toggle] {
+          display: none;
+        }
+      </style>
+    </noscript>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={t.meta.description} />
     <meta

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -63,6 +63,7 @@
 
     --console-bg: #f7f7f7;
     --console-sidebar-bg: #fbfbfb;
+    --console-surface: #ffffff;
     --console-surface-muted: #f5f5f5;
     --console-border: #e5e5e5;
     --console-border-strong: #d4d4d4;
@@ -90,6 +91,58 @@
     --timeline-tool-execute: #786ca3;
     --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
     --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+  }
+
+  /* Dark tone values copied from apps/web/src/index.css `.dark` block (CS-89)
+     to keep the landing page's dark palette aligned with the product app. */
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
+
+    --console-bg: #19191c;
+    --console-sidebar-bg: #1d1d20;
+    --console-surface: #242428;
+    --console-surface-muted: #202023;
+    --console-border: #2e2e32;
+    --console-border-strong: #3d3d42;
+    --console-text: #f2f2f0;
+    --console-muted: #a3a3a8;
+    --console-accent: #ececec;
+    --console-accent-strong: #ffffff;
+    --console-thread: #313135;
+    --console-thinking-bg: #202024;
+    --console-thinking-border: #2c2c30;
+    --console-success: #4ade80;
+    --console-success-bg: #122016;
+    --console-success-border: #20492c;
+    --console-warning: #fbbf24;
+    --console-warning-bg: #241a05;
+    --console-warning-border: #5c3d0a;
+    --console-error: #f87171;
+    --console-error-bg: #241010;
+    --console-error-border: #5c1e1e;
+    --timeline-user: #c98aa8;
+    --timeline-agent: #82aed4;
+    --timeline-tool-read: #6bb3a0;
+    --timeline-tool-write: #d99a5c;
+    --timeline-tool-execute: #a89bc9;
   }
 
   * {
@@ -195,6 +248,15 @@
   .card-lift:hover {
     transform: translateY(-2px);
   }
+}
+
+/* .bg-grid bakes its line color into an rgba() background-image, which the
+   `dark:` variant can't reach; override it directly, matching
+   apps/web/src/index.css's `.dark .bg-grid` rule. */
+.dark .bg-grid {
+  background-image:
+    linear-gradient(to right, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
 }
 
 .scene-dialog {


### PR DESCRIPTION
## Summary

With the product's dark mode landed (CS-89 / #178), the landing page follows suit: full dark support across every section, defaulting to the system preference, with a manual light/dark/system toggle matching the product's — same base palette (`#19191c` ground, `#242428` surfaces), so the brand experience stays consistent from landing to app.

## Approach

- The landing already ran on `--console-*`/`--timeline-*` variables — the bulk of dark support is a variable-level `.dark` block in `global.css` reusing CS-89's contrast-verified hex values (source-annotated). Of 24 hardcoded literals, 21 "surface"-semantic ones were converted to a new `--console-surface` variable (light value byte-identical to `bg-white`), 3 got targeted `dark:` overrides.
- **FOUC guard**: `is:inline` head script reads its own `www-theme` key + `prefers-color-scheme` and sets `.dark` before first paint; system mode listens for `matchMedia` changes. `<noscript>` styles follow the system preference and hide the (script-dependent) toggle.
- **Header toggle**: three-state cycle using the existing icon-stack animation pattern; sr-only status with `aria-live="polite"` and a "Theme: Light. Switch to Dark." accessible name matching the product's `ThemeToggle` (bilingual copy via `landing.ts`).
- **Product screenshots** stay light per the issue's decision — dark containers get strengthened borders to frame them; swapping in dark screenshots is a follow-up once real dark UI ships.
- Light theme is byte-identical (review verified every hunk is dark-prefixed, `.dark`-scoped, or new toggle/script code).

## Contrast

Script-computed (same values as the product side): body text 13.8–15.7:1, muted ≥6.2:1, inverse CTA 17.5:1, focus outline ≥13:1.

## Testing

- `pnpm build` (astro check 0/0/0) / `pnpm test` (web 374, cli 205, core 421) / `pnpm lint` / `pnpm format:check` all clean

Issue: CS-90