### PR TITLE
test(coverage): gate all production source

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,10 @@ pnpm --filter @codesesh/www deploy:cf
 ```
 
 `test:coverage` runs the Core and CLI suites in Node and the Web suite in
-`happy-dom`. The 75% line threshold applies to the configured Core
-discovery/utils/base modules and CLI API modules, not every monorepo source file.
+`happy-dom`. Coverage includes all production TypeScript in Core, CLI, and Web.
+Package-level baselines prevent coverage regressions, while stricter targeted
+thresholds protect the scanning, API, live runtime, hook, and interaction paths.
+The Astro landing page is covered by Playwright rather than Vitest.
 
 ### Performance Benchmark
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -233,8 +233,9 @@ pnpm --filter @codesesh/www deploy:cf
 ```
 
 `test:coverage` 会在 Node 环境运行 Core、CLI 测试，在 `happy-dom` 环境运行 Web 测试。
-75% 行覆盖率门槛只应用于配置中指定的 Core discovery/utils/base 模块与 CLI API 模块，
-不代表 monorepo 全部源码的覆盖率。
+覆盖率统计包括 Core、CLI、Web 的全部生产 TypeScript。各包的基线门槛用于防止覆盖率回退，
+扫描、API、实时运行时、Hook 和交互路径继续使用更严格的定向门槛。
+Astro 落地页由 Playwright 覆盖，不计入 Vitest 覆盖率。
 
 ### 性能 Benchmark
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitest/config";
 
-const COVERAGE_THRESHOLD_SCOPE =
+const CORE_SOURCE_SCOPE = "packages/core/src/**/*.ts";
+const CLI_SOURCE_SCOPE = "packages/cli/src/**/*.ts";
+const WEB_SOURCE_SCOPE = "apps/web/src/**/*.{ts,tsx}";
+const CORE_CRITICAL_SCOPE =
   "{packages/core/src/utils/**,packages/core/src/discovery/**,packages/core/src/agents/base.ts,packages/cli/src/api/**}";
 const CLI_RUNTIME_SCOPE =
   "{packages/cli/src/live-scan.ts,packages/cli/src/session-watcher.ts,packages/cli/src/*-coordinator.ts,packages/cli/src/*-worker.ts,packages/cli/src/pending-search-index-jobs.ts,packages/cli/src/scan-status-model.ts}";
@@ -13,20 +16,39 @@ export default defineConfig({
     projects: ["packages/core", "packages/cli", "apps/web"],
     coverage: {
       provider: "v8",
-      include: [
-        COVERAGE_THRESHOLD_SCOPE,
-        CLI_RUNTIME_SCOPE,
-        WEB_HOOKS_SCOPE,
-        WEB_INTERACTIONS_SCOPE,
+      include: [CORE_SOURCE_SCOPE, CLI_SOURCE_SCOPE, WEB_SOURCE_SCOPE],
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/*.test.{ts,tsx}",
+        "**/__tests__/**",
+        "**/*.d.ts",
       ],
-      exclude: ["**/node_modules/**", "**/dist/**", "packages/core/src/utils/sqlite.ts"],
       reporter: ["text", "html"],
       thresholds: {
-        statements: 88,
-        branches: 80,
-        functions: 88,
-        lines: 91,
-        [COVERAGE_THRESHOLD_SCOPE]: {
+        statements: 69,
+        branches: 58,
+        functions: 72,
+        lines: 71,
+        [CORE_SOURCE_SCOPE]: {
+          statements: 79,
+          branches: 66,
+          functions: 89,
+          lines: 82,
+        },
+        [CLI_SOURCE_SCOPE]: {
+          statements: 85,
+          branches: 82,
+          functions: 85,
+          lines: 87,
+        },
+        [WEB_SOURCE_SCOPE]: {
+          statements: 54,
+          branches: 43,
+          functions: 56,
+          lines: 55,
+        },
+        [CORE_CRITICAL_SCOPE]: {
           lines: 90,
         },
         [CLI_RUNTIME_SCOPE]: {


### PR DESCRIPTION
## Summary

- include all production TypeScript from Core, CLI, and Web in Vitest coverage
- add package-level baseline thresholds while retaining stricter critical-path line gates
- exclude tests, declarations, dependencies, and build output from the production report
- update the English and Chinese coverage documentation

## Why

The previous 93% line result only described selected critical files. Untested production modules outside those globs could regress without affecting the CI gate. This change records the current full-source baseline and prevents it from moving backward while later PRs raise targeted coverage.

## Validation

- `pnpm exec oxfmt --check vitest.config.ts`
- `pnpm exec oxlint vitest.config.ts`
- `pnpm test:coverage` (126 files, 1000 tests passed)
- full-source coverage: 69.65% statements, 58.67% branches, 72.70% functions, 71.75% lines