### PR TITLE
test(web): cover semantic tool outputs

### DIFF
--- a/apps/web/src/components/tool-output/ToolOutputRenderer.test.tsx
+++ b/apps/web/src/components/tool-output/ToolOutputRenderer.test.tsx
@@ -1,0 +1,183 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildSemanticOutputContent } from "../session-detail/tool-normalize";
+import { ToolOutputRenderer } from "./ToolOutputRenderer";
+import type { ToolOutputContent } from "./types";
+
+afterEach(cleanup);
+
+function renderOutput(outputContent: ToolOutputContent) {
+  return render(<ToolOutputRenderer outputContent={outputContent} />);
+}
+
+describe("ToolOutputRenderer", () => {
+  it("renders plain, highlighted code, and unified diff output", () => {
+    const plain = renderOutput({
+      kind: "plain",
+      text: "plain result",
+      language: "text",
+      isCode: false,
+    });
+    expect(plain.getByText("plain result")).toBeTruthy();
+    plain.unmount();
+
+    const code = renderOutput({
+      kind: "plain",
+      text: "const answer = 42;",
+      language: "typescript",
+      isCode: true,
+    });
+    expect(code.container.textContent).toContain("const answer = 42;");
+    code.unmount();
+
+    const diff = renderOutput({
+      kind: "plain",
+      text: "@@ -1 +1 @@\n-before\n+after",
+      language: "diff",
+      isCode: true,
+    });
+    expect(diff.getByText("@@ -1 +1 @@")).toBeTruthy();
+    expect(diff.getByText("-before")).toBeTruthy();
+    expect(diff.getByText("+after")).toBeTruthy();
+  });
+
+  it("uses a visible fallback when plain output is empty", () => {
+    const view = renderOutput({ kind: "plain", text: "", language: "text", isCode: false });
+
+    expect(view.getByText("No output captured.")).toBeTruthy();
+  });
+
+  it("renders structured diff blocks with line prefixes", () => {
+    const view = renderOutput({
+      kind: "structured-diff",
+      blocks: [
+        {
+          label: "src/example.ts",
+          lines: [
+            { type: "context", text: "unchanged" },
+            { type: "remove", text: "old value" },
+            { type: "add", text: "new value" },
+          ],
+        },
+      ],
+    });
+
+    expect(view.getByText("src/example.ts")).toBeTruthy();
+    expect(view.getByText("-old value")).toBeTruthy();
+    expect(view.getByText("+new value")).toBeTruthy();
+  });
+
+  it("renders file sections according to their content type", () => {
+    const view = renderOutput({
+      kind: "file-sections",
+      sections: [
+        {
+          label: "notes.txt",
+          operation: "write",
+          language: "text",
+          isCode: false,
+          text: "release notes",
+        },
+        {
+          label: "change.diff",
+          operation: "edit",
+          language: "diff",
+          isCode: true,
+          text: "+added line",
+        },
+        {
+          label: "main.ts",
+          operation: "edit",
+          language: "typescript",
+          isCode: true,
+          text: "export const ready = true;",
+        },
+      ],
+    });
+
+    expect(view.getByText("notes.txt")).toBeTruthy();
+    expect(view.getByText("release notes")).toBeTruthy();
+    expect(view.getByText("+added line")).toBeTruthy();
+    expect(view.container.textContent).toContain("export const ready = true;");
+  });
+
+  it("shows question state, recommendations, and selected answers", () => {
+    const view = renderOutput({
+      kind: "question-list",
+      questions: [
+        {
+          header: "Runtime",
+          question: "Which runtime should CI use?",
+          options: [
+            { label: "Node 24", description: "Current LTS", recommended: true },
+            { label: "Node 22" },
+          ],
+          answers: ["Node 24"],
+        },
+        {
+          question: "Deploy now?",
+          options: [{ label: "Wait" }],
+          answers: [],
+        },
+      ],
+    });
+
+    expect(view.getByText("Answered")).toBeTruthy();
+    expect(view.getByText("Pending")).toBeTruthy();
+    expect(view.getByText("Recommended")).toBeTruthy();
+    expect(view.getByText("Selected")).toBeTruthy();
+    expect(view.getByText("Current LTS")).toBeTruthy();
+  });
+
+  it("renders every task status and optional detail", () => {
+    const view = renderOutput({
+      kind: "task-list",
+      items: [
+        { label: "Queued task", status: "pending" },
+        { label: "Active task", status: "in_progress", detail: "Running checks" },
+        { label: "Finished task", status: "completed" },
+        { label: "Broken task", status: "error" },
+      ],
+    });
+
+    expect(view.getByText("Pending")).toBeTruthy();
+    expect(view.getByText("In progress")).toBeTruthy();
+    expect(view.getByText("Done")).toBeTruthy();
+    expect(view.getByText("Failed")).toBeTruthy();
+    expect(view.getByText("Running checks")).toBeTruthy();
+  });
+
+  it("renders semantic media output produced by normalization", () => {
+    const outputContent = buildSemanticOutputContent([
+      { type: "image", mime_type: "image/png", data: "iVBORw0KGgo=" },
+      { type: "text", text: "Browser screenshot" },
+    ]);
+    if (!outputContent) throw new Error("Expected semantic media output");
+
+    const view = renderOutput(outputContent);
+    const image = view.getByRole("img", { name: "Tool output image 1" }) as HTMLImageElement;
+
+    expect(image.src).toBe("data:image/png;base64,iVBORw0KGgo=");
+    expect(view.getByText("Browser screenshot")).toBeTruthy();
+  });
+
+  it("renders semantic property output produced by normalization", () => {
+    const outputContent = buildSemanticOutputContent({
+      status: "complete",
+      enabled: true,
+      missing: null,
+      metadata: { owner: "agent", tags: ["test", "coverage"] },
+    });
+    if (!outputContent) throw new Error("Expected semantic property output");
+
+    const view = renderOutput(outputContent);
+
+    expect(view.getByText("status")).toBeTruthy();
+    expect(view.getByText("complete")).toBeTruthy();
+    expect(view.getByText("Yes")).toBeTruthy();
+    expect(view.getByText("—")).toBeTruthy();
+    expect(view.getByText("owner")).toBeTruthy();
+    expect(view.getByText("agent")).toBeTruthy();
+    expect(view.getByText("coverage")).toBeTruthy();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,10 +26,10 @@ export default defineConfig({
       ],
       reporter: ["text", "html"],
       thresholds: {
-        statements: 69,
-        branches: 58,
-        functions: 72,
-        lines: 71,
+        statements: 70,
+        branches: 59,
+        functions: 73,
+        lines: 72,
         [CORE_SOURCE_SCOPE]: {
           statements: 79,
           branches: 66,
@@ -43,10 +43,10 @@ export default defineConfig({
           lines: 87,
         },
         [WEB_SOURCE_SCOPE]: {
-          statements: 54,
-          branches: 43,
-          functions: 56,
-          lines: 55,
+          statements: 55,
+          branches: 45,
+          functions: 58,
+          lines: 56,
         },
         [CORE_CRITICAL_SCOPE]: {
           lines: 90,


### PR DESCRIPTION
## Summary

- render every semantic tool output kind through the real React component tree
- verify user-visible plain, code, diff, file, question, task, media, and property output
- connect media and property normalization to their rendered DOM behavior
- raise the global and Web coverage floors to preserve the added coverage

## Why

The semantic tool output renderer and its leaf components were production-critical but had no direct rendering coverage. Existing normalization tests could pass even if the UI dispatched or displayed normalized content incorrectly.

## Validation

- `pnpm exec vitest run --project web apps/web/src/components/tool-output/ToolOutputRenderer.test.tsx` (8 tests passed)
- `pnpm test:coverage` (127 files, 1008 tests passed)
- `pnpm --filter @codesesh/web build`
- `pnpm exec oxfmt --check vitest.config.ts apps/web/src/components/tool-output/ToolOutputRenderer.test.tsx`
- `pnpm exec oxlint vitest.config.ts apps/web/src/components/tool-output/ToolOutputRenderer.test.tsx`
- full-source coverage: 70.40% statements, 59.71% branches, 73.99% functions, 72.56% lines