### PR TITLE
fix(live): refresh changed session details

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1,26 +1,36 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
 
-const coreMocks = vi.hoisted(() => ({
-  loadCachedSessionData: vi.fn(),
-  listFileActivity: vi.fn((): FileActivityResult[] => []),
-  listSessionFileActivity: vi.fn(() => []),
-  listSessionAliases: vi.fn<
-    () => Array<{ agentKey: string; sessionId: string; alias: string; updated_at: number }>
-  >(() => []),
-  executeSessionSearch: vi.fn(
-    (
-      _query: string,
-      _options?: unknown,
-      _scanResult?: unknown,
-    ): Array<{ agentName: string; session: SessionHead }> => [],
-  ),
-}));
+const coreMocks = vi.hoisted(() => {
+  const loadCachedSessionData = vi.fn();
+  return {
+    loadCachedSessionData,
+    loadCachedSessionDataEntry: vi.fn(
+      (agentName: string, sessionId: string): CachedSessionDataEntry | null => {
+        const data = loadCachedSessionData(agentName, sessionId) as SessionData | null;
+        return data ? { data, meta: null } : null;
+      },
+    ),
+    listFileActivity: vi.fn((): FileActivityResult[] => []),
+    listSessionFileActivity: vi.fn(() => []),
+    listSessionAliases: vi.fn<
+      () => Array<{ agentKey: string; sessionId: string; alias: string; updated_at: number }>
+    >(() => []),
+    executeSessionSearch: vi.fn(
+      (
+        _query: string,
+        _options?: unknown,
+        _scanResult?: unknown,
+      ): Array<{ agentName: string; session: SessionHead }> => [],
+    ),
+  };
+});
 
 vi.mock("@codesesh/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core")>();
   return {
     ...actual,
     loadCachedSessionData: coreMocks.loadCachedSessionData,
+    loadCachedSessionDataEntry: coreMocks.loadCachedSessionDataEntry,
     listFileActivity: coreMocks.listFileActivity,
     listSessionFileActivity: coreMocks.listSessionFileActivity,
     listSessionAliases: coreMocks.listSessionAliases,
@@ -40,6 +50,7 @@ import {
   type ScanResultSource,
 } from "../handlers.js";
 import type {
+  CachedSessionDataEntry,
   ChangeCheckResult,
   FileActivityResult,
   ScanResult,
@@ -167,6 +178,13 @@ function toLocalDateKey(ts: number): string {
 
 afterEach(() => {
   coreMocks.loadCachedSessionData.mockReset();
+  coreMocks.loadCachedSessionDataEntry.mockReset();
+  coreMocks.loadCachedSessionDataEntry.mockImplementation(
+    (agentName: string, sessionId: string): CachedSessionDataEntry | null => {
+      const data = coreMocks.loadCachedSessionData(agentName, sessionId) as SessionData | null;
+      return data ? { data, meta: null } : null;
+    },
+  );
   coreMocks.listFileActivity.mockReset();
   coreMocks.listFileActivity.mockReturnValue([]);
   coreMocks.listSessionFileActivity.mockReset();
@@ -1194,6 +1212,77 @@ describe("handleGetSessionData", () => {
     expect(response.title).toBe("Source Session");
     expect(response.messages).toHaveLength(1);
     expect(coreMocks.listSessionFileActivity).not.toHaveBeenCalled();
+  });
+
+  it("bypasses cached detail when the source fingerprint changes", async () => {
+    coreMocks.loadCachedSessionDataEntry.mockReturnValue({
+      data: {
+        id: "s1",
+        slug: "claudecode/s1",
+        title: "Cached Session",
+        directory: "/home/user/project",
+        time_created: 1000,
+        time_updated: 1000,
+        messages: [
+          {
+            id: "stale",
+            role: "assistant",
+            time_created: 1000,
+            parts: [{ type: "text", text: "stale detail" }],
+          },
+        ],
+        stats: {
+          message_count: 1,
+          total_input_tokens: 0,
+          total_output_tokens: 0,
+          total_cost: 0,
+        },
+      },
+      meta: { id: "s1", sourcePath: "/session.jsonl", sourceFingerprint: "old" },
+    });
+
+    class AgentWithChangedSource extends MockAgent {
+      override getSessionMetaMap(): Map<string, SessionCacheMeta> {
+        return new Map([
+          ["s1", { id: "s1", sourcePath: "/session.jsonl", sourceFingerprint: "current" }],
+        ]);
+      }
+
+      override getSessionData(_sessionId: string): SessionData {
+        return {
+          ...super.getSessionData(_sessionId),
+          messages: [
+            {
+              id: "fresh",
+              role: "assistant",
+              time_created: 1000,
+              parts: [{ type: "text", text: "fresh detail" }],
+            },
+          ],
+          stats: {
+            message_count: 1,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cost: 0,
+          },
+        };
+      }
+    }
+
+    const sessions = [makeSession("s1", { slug: "claudecode/s1" })];
+    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+
+    await handleGetSessionData(
+      c,
+      makeScanSource({
+        sessions,
+        byAgent: { claudecode: sessions },
+        agents: [new AgentWithChangedSource()],
+      }),
+    );
+
+    const response = c.json.mock.calls[0]![0];
+    expect(response.messages[0].parts[0].text).toBe("fresh detail");
   });
 
   it("returns 500 when SQLite cache loading throws", async () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -3,6 +3,7 @@ import type {
   BookmarkRecord,
   ProjectGroup,
   ScanResult,
+  SessionCacheMeta,
   SessionData,
   SessionHead,
   SmartTag,
@@ -27,7 +28,7 @@ import {
   getSmartTagSourceTimestamp,
   importBookmarks,
   isProjectIdentityKind,
-  loadCachedSessionData,
+  loadCachedSessionDataEntry,
   listFileActivity,
   listSessionFileActivity,
   listCachedProjectGroups,
@@ -68,6 +69,15 @@ export type SessionListDefaults = TimeWindow;
 interface ClientLogPayload {
   event?: unknown;
   data?: unknown;
+}
+
+function cacheMatchesCurrentSource(
+  cachedMeta: SessionCacheMeta | null,
+  currentMeta: SessionCacheMeta | undefined,
+) {
+  const currentFingerprint = currentMeta?.sourceFingerprint;
+  if (typeof currentFingerprint !== "string") return true;
+  return cachedMeta?.sourceFingerprint === currentFingerprint;
 }
 
 interface SessionAliasPayload {
@@ -603,10 +613,14 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
   try {
     const head = scanResult.byAgent[agentName]?.find((item) => item.id === sessionId);
     const loadStartedAt = performance.now();
-    const cachedData = loadCachedSessionData(agentName, sessionId);
+    const cachedEntry = loadCachedSessionDataEntry(agentName, sessionId);
+    const cachedData = cachedEntry?.data ?? null;
     const cachedMessageCount = cachedData?.stats.message_count ?? 0;
+    const currentMeta = head ? agent.getSessionMetaMap().get(sessionId) : undefined;
     const cacheHasExpectedMessages =
-      cachedData !== null && (cachedData.messages.length > 0 || cachedMessageCount === 0);
+      cachedData !== null &&
+      cacheMatchesCurrentSource(cachedEntry?.meta ?? null, currentMeta) &&
+      (cachedData.messages.length > 0 || cachedMessageCount === 0);
     const data: SessionData | null = cacheHasExpectedMessages
       ? cachedData
       : head

--- a/packages/core/src/discovery/cache.ts
+++ b/packages/core/src/discovery/cache.ts
@@ -19,12 +19,14 @@ export {
   getCacheInfo,
   isAgentCacheInitialized,
   loadCachedSessionData,
+  loadCachedSessionDataEntry,
   loadCachedSessions,
   markAgentCacheInitialized,
   markAgentFullSyncCompleted,
   saveCachedSessionChanges,
   saveCachedSessions,
   type CachedResult,
+  type CachedSessionDataEntry,
 } from "./cache/sessions.js";
 
 export {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -37,6 +37,20 @@ export interface CachedResult {
   timestamp: number;
 }
 
+export interface CachedSessionDataEntry {
+  data: SessionData;
+  meta: SessionCacheMeta | null;
+}
+
+function parseCachedSessionMeta(value: string | null | undefined): SessionCacheMeta | null {
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as SessionCacheMeta;
+  } catch {
+    return null;
+  }
+}
+
 export function deleteLegacyCacheFile(): void {
   const legacyPath = getLegacyCachePath();
   if (!existsSync(legacyPath)) {
@@ -199,7 +213,10 @@ export function markAgentFullSyncCompleted(agentName: string): void {
   });
 }
 
-export function loadCachedSessionData(agentName: string, sessionId: string): SessionData | null {
+export function loadCachedSessionDataEntry(
+  agentName: string,
+  sessionId: string,
+): CachedSessionDataEntry | null {
   if (!hasCacheStorage()) {
     return null;
   }
@@ -292,11 +309,18 @@ export function loadCachedSessionData(agentName: string, sessionId: string): Ses
       .all(agentName, sessionId) as FileActivityRow[];
 
     return {
-      ...head,
-      messages: messageRows.map((messageRow) => messageFromCachedRow(messageRow)),
-      file_activity: fileActivityRows.map((activityRow) => fileActivityFromRow(activityRow)),
+      data: {
+        ...head,
+        messages: messageRows.map((messageRow) => messageFromCachedRow(messageRow)),
+        file_activity: fileActivityRows.map((activityRow) => fileActivityFromRow(activityRow)),
+      },
+      meta: parseCachedSessionMeta(row.meta_json),
     };
   });
+}
+
+export function loadCachedSessionData(agentName: string, sessionId: string): SessionData | null {
+  return loadCachedSessionDataEntry(agentName, sessionId)?.data ?? null;
 }
 
 export function saveCachedSessions(

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -17,6 +17,7 @@ export {
 export {
   loadCachedSessions,
   loadCachedSessionData,
+  loadCachedSessionDataEntry,
   isAgentCacheInitialized,
   markAgentCacheInitialized,
   getAgentLastFullSyncAt,
@@ -47,6 +48,7 @@ export type {
   SearchOptions,
   SearchQueryFilters,
   SessionHeadChange,
+  CachedSessionDataEntry,
 } from "./cache.js";
 export { perf } from "../utils/index.js";
 export type { PerfMarker } from "../utils/index.js";

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,26 +4,31 @@ import { join, resolve } from "node:path";
 import { defineConfig, devices } from "playwright/test";
 
 const FIXTURE_PROJECT_DIR_TOKEN = "__E2E_PROJECT_DIR__";
+const E2E_HOME_ENV = "CODESESH_PLAYWRIGHT_HOME";
 const port = Number(process.env.CODESESH_E2E_PORT ?? 4387);
 const wwwPort = Number(process.env.CODESESH_WWW_E2E_PORT ?? 4388);
-const e2eHome = mkdtempSync(join(tmpdir(), "codesesh-e2e-home-"));
+const inheritedE2eHome = process.env[E2E_HOME_ENV];
+const e2eHome = inheritedE2eHome ?? mkdtempSync(join(tmpdir(), "codesesh-e2e-home-"));
 const fixtureTemplateRoot = resolve("tests/e2e/fixtures");
 const fixtureRoot = join(e2eHome, "fixtures");
-
-cpSync(fixtureTemplateRoot, fixtureRoot, { recursive: true });
-process.once("exit", () => rmSync(e2eHome, { recursive: true, force: true }));
-
 const e2eProjectDir = join(e2eHome, "codesesh-e2e");
-mkdirSync(e2eProjectDir, { recursive: true });
 const fixtureSessionPath = join(fixtureRoot, "claude/projects/codesesh-e2e/e2e-dashboard.jsonl");
-const fixtureSessionTemplate = readFileSync(fixtureSessionPath, "utf8");
-if (!fixtureSessionTemplate.includes(FIXTURE_PROJECT_DIR_TOKEN)) {
-  throw new Error(`E2E fixture is missing ${FIXTURE_PROJECT_DIR_TOKEN}`);
+
+if (!inheritedE2eHome) {
+  process.env[E2E_HOME_ENV] = e2eHome;
+  cpSync(fixtureTemplateRoot, fixtureRoot, { recursive: true });
+  process.once("exit", () => rmSync(e2eHome, { recursive: true, force: true }));
+
+  mkdirSync(e2eProjectDir, { recursive: true });
+  const fixtureSessionTemplate = readFileSync(fixtureSessionPath, "utf8");
+  if (!fixtureSessionTemplate.includes(FIXTURE_PROJECT_DIR_TOKEN)) {
+    throw new Error(`E2E fixture is missing ${FIXTURE_PROJECT_DIR_TOKEN}`);
+  }
+  writeFileSync(
+    fixtureSessionPath,
+    fixtureSessionTemplate.replaceAll(FIXTURE_PROJECT_DIR_TOKEN, e2eProjectDir),
+  );
 }
-writeFileSync(
-  fixtureSessionPath,
-  fixtureSessionTemplate.replaceAll(FIXTURE_PROJECT_DIR_TOKEN, e2eProjectDir),
-);
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -70,7 +75,8 @@ export default defineConfig({
   projects: [
     {
       name: "web-chromium",
-      testMatch: "browsing.spec.ts",
+      testMatch: ["browsing.spec.ts", "live-refresh.spec.ts"],
+      metadata: { fixtureSessionPath },
       use: { ...devices["Desktop Chrome"], baseURL: `http://127.0.0.1:${port}` },
     },
     {

--- a/tests/e2e/live-refresh.spec.ts
+++ b/tests/e2e/live-refresh.spec.ts
@@ -1,0 +1,41 @@
+import { appendFile } from "node:fs/promises";
+import { expect, test } from "playwright/test";
+
+test("refreshes an open session when its source file changes", async ({ page }, testInfo) => {
+  const fixtureSessionPath = testInfo.project.metadata.fixtureSessionPath;
+  if (typeof fixtureSessionPath !== "string") {
+    throw new Error("Missing staged session fixture path");
+  }
+
+  await page.goto("/claudecode/e2e-dashboard");
+  await expect(page.getByTestId("session-detail")).toBeVisible();
+  await expect(page.getByText("Dashboard path is ready")).toBeVisible();
+
+  let mainFrameNavigations = 0;
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) mainFrameNavigations += 1;
+  });
+
+  const liveMessage = `Live refresh reached the browser on attempt ${testInfo.retry}.`;
+  const record = {
+    type: "assistant",
+    uuid: `assistant-live-${testInfo.retry}`,
+    timestamp: "2026-04-20T10:00:03Z",
+    message: {
+      role: "assistant",
+      model: "claude-sonnet-4-5-20250929",
+      usage: {
+        input_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: 12,
+      },
+      content: [{ type: "text", text: liveMessage }],
+    },
+  };
+
+  await appendFile(fixtureSessionPath, `${JSON.stringify(record)}\n`, "utf8");
+
+  await expect(page.getByText(liveMessage)).toBeVisible();
+  expect(mainFrameNavigations).toBe(0);
+});


### PR DESCRIPTION
## Summary

- share one isolated fixture directory across Playwright runner and worker processes
- add an E2E test that appends to a staged Claude session and verifies the open detail updates without navigation or reload
- expose cached session metadata alongside cached detail data
- bypass stale cached detail whenever its source fingerprint differs from the current agent fingerprint
- add a handler regression test for the stale-cache race

## Why

The session watcher emitted the live event before the asynchronous detail-cache update completed. The browser immediately refetched the open session and received stale cached messages, with no later event to trigger another request. Comparing source fingerprints keeps the source file authoritative without delaying list refreshes on search-index persistence.

## Validation

- `pnpm exec vitest run --project cli packages/cli/src/api/__tests__/handlers.test.ts` (44 tests passed)
- `pnpm exec vitest run --project core packages/core/src/discovery/cache/__tests__/search-integration.test.ts` (29 tests passed)
- `pnpm test:coverage` (127 test files passed)
- `pnpm --filter codesesh build`
- `pnpm exec playwright test tests/e2e/live-refresh.spec.ts --project web-chromium`
- `pnpm test:e2e` (15 tests passed)
- targeted `oxfmt`, `oxlint`, and `git diff --check`