### PR TITLE
test(cli): cover runtime plan

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,40 +6,19 @@ import { printScanResults } from "./output.js";
 import { VERSION } from "./version.js";
 import { appLogger } from "./logging.js";
 import { isLoopbackHostname } from "./remote-access.js";
-import { resolveTimeWindow } from "./time-window-resolution.js";
+import {
+  buildCliRuntimePlan,
+  parseSessionUri,
+  redactStartupUrl,
+  resolveStartupUrl,
+} from "./runtime-plan.js";
 import {
   DEFAULT_PORT,
   DEFAULT_PORT_FALLBACK_ATTEMPTS,
   hasExplicitPortArg,
   parsePort,
 } from "./ports.js";
-import {
-  createRegisteredAgents,
-  getAgentInfoMap,
-  refreshPricingCache,
-  type ScanOptions,
-  perf,
-} from "@codesesh/core";
-
-function parseSessionUri(uri: string): { agent: string; sessionId: string } | null {
-  const match = uri.match(/^([a-z]+):\/\/(.+)$/i);
-  if (!match) return null;
-  return { agent: match[1]!, sessionId: match[2]! };
-}
-
-function appendStartupPath(startupUrl: string, path: string): string {
-  const url = new URL(startupUrl);
-  url.pathname = path;
-  return url.toString();
-}
-
-function redactStartupUrl(startupUrl: string): string {
-  const url = new URL(startupUrl);
-  for (const key of url.searchParams.keys()) {
-    url.searchParams.set(key, "[redacted]");
-  }
-  return url.toString();
-}
+import { createRegisteredAgents, getAgentInfoMap, refreshPricingCache, perf } from "@codesesh/core";
 
 const main = defineCommand({
   meta: {
@@ -171,34 +150,20 @@ const main = defineCommand({
       }
     }
 
-    // Resolve cwd filter: '.' => process.cwd()
-    let cwdFilter = args.cwd as string | undefined;
-    if (cwdFilter === ".") {
-      cwdFilter = process.cwd();
-    }
-
-    const {
-      from: listDefaultFrom,
-      to: listDefaultTo,
-      days: listDefaultDays,
-    } = resolveTimeWindow({
-      mode: "cli",
-      from: args.from as string | undefined,
-      to: args.to as string | undefined,
-      days: args.days as string | undefined,
-    });
-
-    const scanOptions: ScanOptions = {
-      agents: targetSession
-        ? [targetSession.agent]
-        : args.agent
-          ? (args.agent as string).split(",").map((a) => a.trim())
-          : undefined,
-      cwd: cwdFilter,
-      useCache: useCache,
-    };
-    const startupScanOptions =
-      targetSession || jsonOnly ? {} : { from: listDefaultFrom, to: listDefaultTo };
+    const { listWindow, scanOptions, startupScanOptions } = buildCliRuntimePlan(
+      {
+        agent: args.agent as string | undefined,
+        cwd: args.cwd as string | undefined,
+        from: args.from as string | undefined,
+        to: args.to as string | undefined,
+        days: args.days as string | undefined,
+        jsonOnly,
+        targetSession,
+        useCache,
+      },
+      { currentWorkingDirectory: process.cwd() },
+    );
+    const { from: listDefaultFrom, to: listDefaultTo, days: listDefaultDays } = listWindow;
 
     const store = new LiveScanStore({
       watchEnabled: !jsonOnly,
@@ -299,9 +264,7 @@ const main = defineCommand({
 
     if (!noOpen) {
       const open = (await import("open")).default;
-      const targetUrl = targetSession
-        ? appendStartupPath(url, `/${targetSession.agent.toLowerCase()}/${targetSession.sessionId}`)
-        : url;
+      const targetUrl = resolveStartupUrl(url, targetSession);
       appLogger.info("browser.open", { url: redactStartupUrl(targetUrl) });
       await open(targetUrl);
     }

--- a/packages/cli/src/runtime-plan.test.ts
+++ b/packages/cli/src/runtime-plan.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCliRuntimePlan,
+  parseSessionUri,
+  redactStartupUrl,
+  resolveStartupUrl,
+  type TargetSession,
+} from "./runtime-plan.js";
+
+const NOW = new Date("2026-07-17T08:00:00.000Z").getTime();
+const DAY_MS = 24 * 60 * 60 * 1000;
+const ENVIRONMENT = {
+  currentWorkingDirectory: "/workspace/project",
+  now: NOW,
+};
+
+describe("CLI runtime plan", () => {
+  it("builds the default rolling scan plan", () => {
+    expect(
+      buildCliRuntimePlan(
+        {
+          days: "7",
+          jsonOnly: false,
+          targetSession: null,
+          useCache: true,
+        },
+        ENVIRONMENT,
+      ),
+    ).toEqual({
+      listWindow: { from: NOW - 7 * DAY_MS, to: undefined, days: 7 },
+      scanOptions: { agents: undefined, cwd: undefined, useCache: true },
+      startupScanOptions: { from: NOW - 7 * DAY_MS, to: undefined },
+    });
+  });
+
+  it("normalizes agent filters and the current directory", () => {
+    const plan = buildCliRuntimePlan(
+      {
+        agent: "claudecode, codex",
+        cwd: ".",
+        jsonOnly: false,
+        targetSession: null,
+        useCache: false,
+      },
+      ENVIRONMENT,
+    );
+
+    expect(plan.scanOptions).toEqual({
+      agents: ["claudecode", "codex"],
+      cwd: "/workspace/project",
+      useCache: false,
+    });
+  });
+
+  it("scans only the direct session agent without limiting startup discovery", () => {
+    const targetSession = parseSessionUri("Codex://session-123");
+    const plan = buildCliRuntimePlan(
+      {
+        agent: "claudecode",
+        days: "7",
+        jsonOnly: false,
+        targetSession,
+        useCache: true,
+      },
+      ENVIRONMENT,
+    );
+
+    expect(targetSession).toEqual({ agent: "Codex", sessionId: "session-123" });
+    expect(plan.scanOptions.agents).toEqual(["Codex"]);
+    expect(plan.startupScanOptions).toEqual({});
+  });
+
+  it("keeps JSON output windowing out of startup discovery", () => {
+    const plan = buildCliRuntimePlan(
+      {
+        from: "2026-07-01",
+        to: "2026-07-10",
+        jsonOnly: true,
+        targetSession: null,
+        useCache: true,
+      },
+      ENVIRONMENT,
+    );
+
+    expect(plan.listWindow).toEqual({
+      from: new Date("2026-07-01").getTime(),
+      to: new Date("2026-07-10").getTime(),
+    });
+    expect(plan.startupScanOptions).toEqual({});
+  });
+
+  it.each(["codex/session-123", "codex://", "://session-123"])(
+    "rejects invalid session URI %s",
+    (uri) => {
+      expect(parseSessionUri(uri)).toBeNull();
+    },
+  );
+
+  it("resolves direct session browser routes", () => {
+    const targetSession: TargetSession = { agent: "Codex", sessionId: "session-123" };
+
+    expect(resolveStartupUrl("http://0.0.0.0:8080/?access_token=secret", targetSession)).toBe(
+      "http://0.0.0.0:8080/codex/session-123?access_token=secret",
+    );
+    expect(resolveStartupUrl("http://127.0.0.1:4521/", null)).toBe("http://127.0.0.1:4521/");
+  });
+
+  it("redacts every startup URL query value", () => {
+    const redacted = new URL(
+      redactStartupUrl("http://0.0.0.0:4521/?access_token=secret&mode=remote"),
+    );
+
+    expect(Object.fromEntries(redacted.searchParams)).toEqual({
+      access_token: "[redacted]",
+      mode: "[redacted]",
+    });
+  });
+});

--- a/packages/cli/src/runtime-plan.ts
+++ b/packages/cli/src/runtime-plan.ts
@@ -1,0 +1,76 @@
+import type { ScanOptions } from "@codesesh/core";
+import { resolveTimeWindow, type TimeWindow } from "./time-window-resolution.js";
+
+export interface TargetSession {
+  agent: string;
+  sessionId: string;
+}
+
+interface CliRuntimePlanInput {
+  agent?: string;
+  cwd?: string;
+  from?: string;
+  to?: string;
+  days?: string;
+  jsonOnly: boolean;
+  useCache: boolean;
+  targetSession: TargetSession | null;
+}
+
+interface CliRuntimeEnvironment {
+  currentWorkingDirectory: string;
+  now?: number;
+}
+
+export interface CliRuntimePlan {
+  listWindow: TimeWindow;
+  scanOptions: ScanOptions;
+  startupScanOptions: Pick<ScanOptions, "from" | "to">;
+}
+
+export function parseSessionUri(uri: string): TargetSession | null {
+  const match = uri.match(/^([a-z]+):\/\/(.+)$/i);
+  if (!match) return null;
+  return { agent: match[1]!, sessionId: match[2]! };
+}
+
+export function buildCliRuntimePlan(
+  input: CliRuntimePlanInput,
+  environment: CliRuntimeEnvironment,
+): CliRuntimePlan {
+  const listWindow = resolveTimeWindow({
+    mode: "cli",
+    from: input.from,
+    to: input.to,
+    days: input.days,
+    now: environment.now,
+  });
+  const cwd = input.cwd === "." ? environment.currentWorkingDirectory : input.cwd;
+  const agents = input.targetSession
+    ? [input.targetSession.agent]
+    : input.agent
+      ? input.agent.split(",").map((agent) => agent.trim())
+      : undefined;
+
+  return {
+    listWindow,
+    scanOptions: { agents, cwd, useCache: input.useCache },
+    startupScanOptions:
+      input.targetSession || input.jsonOnly ? {} : { from: listWindow.from, to: listWindow.to },
+  };
+}
+
+export function resolveStartupUrl(startupUrl: string, targetSession: TargetSession | null): string {
+  if (!targetSession) return startupUrl;
+  const url = new URL(startupUrl);
+  url.pathname = `/${targetSession.agent.toLowerCase()}/${targetSession.sessionId}`;
+  return url.toString();
+}
+
+export function redactStartupUrl(startupUrl: string): string {
+  const url = new URL(startupUrl);
+  for (const key of url.searchParams.keys()) {
+    url.searchParams.set(key, "[redacted]");
+  }
+  return url.toString();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ const CORE_CRITICAL_SCOPE =
   "{packages/core/src/utils/**,packages/core/src/discovery/**,packages/core/src/agents/base.ts,packages/cli/src/api/**}";
 const CLI_RUNTIME_SCOPE =
   "{packages/cli/src/live-scan.ts,packages/cli/src/session-watcher.ts,packages/cli/src/*-coordinator.ts,packages/cli/src/*-worker.ts,packages/cli/src/pending-search-index-jobs.ts,packages/cli/src/scan-status-model.ts}";
+const CLI_RUNTIME_PLAN_SCOPE = "packages/cli/src/runtime-plan.ts";
 const WEB_HOOKS_SCOPE = "apps/web/src/hooks/**";
 const WEB_INTERACTIONS_SCOPE =
   "{apps/web/src/components/Dashboard.tsx,apps/web/src/components/app/SearchResultsPanel.tsx,apps/web/src/components/session-detail/message-list.tsx,apps/web/src/components/session-detail/session-message-timeline.tsx}";
@@ -28,7 +29,7 @@ export default defineConfig({
       thresholds: {
         statements: 70,
         branches: 59,
-        functions: 73,
+        functions: 74,
         lines: 72,
         [CORE_SOURCE_SCOPE]: {
           statements: 79,
@@ -53,6 +54,12 @@ export default defineConfig({
         },
         [CLI_RUNTIME_SCOPE]: {
           lines: 91,
+        },
+        [CLI_RUNTIME_PLAN_SCOPE]: {
+          statements: 100,
+          branches: 100,
+          functions: 100,
+          lines: 100,
         },
         [WEB_HOOKS_SCOPE]: {
           lines: 95,


### PR DESCRIPTION
## Summary
- extract CLI argument normalization and startup URL decisions into a pure runtime plan
- characterize default, filtered, JSON-only, direct-session, remote URL, and redaction behavior
- require 100% coverage for the runtime plan and raise the global function threshold to 74%

## Testing
- `pnpm exec vitest run packages/cli/src/runtime-plan.test.ts packages/cli/src/time-window-resolution.test.ts packages/cli/src/ports.test.ts packages/cli/src/remote-access.test.ts`
- `pnpm --filter codesesh build`
- `pnpm test:coverage`
- `pnpm exec oxlint packages/cli/src/index.ts packages/cli/src/runtime-plan.ts packages/cli/src/runtime-plan.test.ts vitest.config.ts`
- `pnpm exec oxfmt --check packages/cli/src/index.ts packages/cli/src/runtime-plan.ts packages/cli/src/runtime-plan.test.ts vitest.config.ts`