### PR TITLE
test(e2e): improve failure diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,14 @@ jobs:
       - run: pnpm exec playwright install --with-deps chromium
 
       - run: pnpm test:e2e
+
+      - name: Upload Playwright failure artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failure-artifacts
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -14,6 +14,7 @@ const chineseUrl = new URL(localeRoutes.zh, siteUrl).toString();
 const language = locale === "zh" ? "zh-CN" : "en";
 const ogLocale = locale === "zh" ? "zh_CN" : "en_US";
 const ogLocaleAlternate = locale === "zh" ? "en_US" : "zh_CN";
+const analyticsEnabled = import.meta.env.PROD;
 const featureList = t.features.groups.flatMap((group) => group.items.map((item) => item.title));
 const jsonLd = {
   "@context": "https://schema.org",
@@ -220,12 +221,16 @@ const jsonLd = {
 
     <title>{t.meta.title}</title>
     <script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
-    <script
-      is:inline
-      defer
-      src="https://static.cloudflareinsights.com/beacon.min.js"
-      data-cf-beacon='{"token": "c341768d21d44e19b5efbc18d4eb57c6"}'
-    ></script>
+    {
+      analyticsEnabled && (
+        <script
+          is:inline
+          defer
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "c341768d21d44e19b5efbc18d4eb57c6"}'
+        />
+      )
+    }
   </head>
   <body>
     <slot />

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,7 +39,9 @@ export default defineConfig({
     timeout: 10_000,
   },
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  reporter: process.env.CI
+    ? [["github"], ["list"], ["html", { outputFolder: "playwright-report", open: "never" }]]
+    : [["list"]],
   use: {
     screenshot: "only-on-failure",
     trace: "retain-on-failure",

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "playwright/test";
+import { expect, test } from "./test-fixtures.js";
 
 test("keeps project navigation aligned with the overview route", async ({ page }) => {
   await page.goto("/projects");
@@ -33,17 +33,7 @@ test("persists app shell preferences across reloads", async ({ page }) => {
   );
 });
 
-test("covers dashboard, detail, search, projects, and pin flows", async ({ page }) => {
-  const consoleErrors: string[] = [];
-  page.on("console", (message) => {
-    if (message.type() === "error") {
-      consoleErrors.push(message.text());
-    }
-  });
-
-  const resetBookmark = await page.request.delete("/api/bookmarks/claudecode/e2e-dashboard");
-  expect(resetBookmark.ok()).toBe(true);
-
+test("browses the dashboard and project tree with a keyboard", async ({ page }) => {
   await page.goto("/");
   const dashboard = page.getByTestId("dashboard");
   await expect(dashboard).toBeVisible();
@@ -70,6 +60,10 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
   await expect(page.getByRole("menuitem", { name: "Rename" })).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(treeSession).toBeFocused();
+});
+
+test("opens a session detail from the dashboard", async ({ page }) => {
+  await page.goto("/");
 
   await page.getByText("Core browsing smoke session").first().click();
   await expect(page).toHaveURL(/\/claudecode\/e2e-dashboard$/);
@@ -77,7 +71,9 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
     page.getByRole("heading", { level: 1, name: "Core browsing smoke session" }),
   ).toBeVisible();
   await expect(page.getByText("Dashboard path is ready")).toBeVisible();
+});
 
+test("searches indexed messages and opens a result", async ({ page }) => {
   await expect
     .poll(async () => {
       const response = await page.request.get("/api/search?q=needle");
@@ -90,6 +86,7 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
     })
     .toBe(true);
 
+  await page.goto("/");
   await page.getByRole("searchbox", { name: "Search Sessions" }).fill("needle");
   await page.getByRole("button", { name: "Search" }).click();
   const searchHeading = page.getByRole("heading", { level: 1, name: "Search" });
@@ -104,6 +101,11 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
   await searchResult.click();
   await expect(page).toHaveURL(/\/claudecode\/e2e-dashboard$/);
   await expect(page.getByText("needle search target")).toBeVisible();
+});
+
+test("bookmarks a recent session", async ({ page }) => {
+  const resetBookmark = await page.request.delete("/api/bookmarks/claudecode/e2e-dashboard");
+  expect(resetBookmark.ok()).toBe(true);
 
   await page.goto("/");
   const recentSession = page
@@ -136,8 +138,6 @@ test("covers dashboard, detail, search, projects, and pin flows", async ({ page 
   await expect(page.locator("section").filter({ hasText: "BOOKMARKS" })).toContainText(
     "Core browsing smoke session",
   );
-
-  expect(consoleErrors).toEqual([]);
 });
 
 test("persists the selected time range across navigation", async ({ page }) => {

--- a/tests/e2e/live-refresh.spec.ts
+++ b/tests/e2e/live-refresh.spec.ts
@@ -1,5 +1,5 @@
 import { appendFile } from "node:fs/promises";
-import { expect, test } from "playwright/test";
+import { expect, test } from "./test-fixtures.js";
 
 test("refreshes an open session when its source file changes", async ({ page }, testInfo) => {
   const fixtureSessionPath = testInfo.project.metadata.fixtureSessionPath;

--- a/tests/e2e/test-fixtures.ts
+++ b/tests/e2e/test-fixtures.ts
@@ -1,0 +1,27 @@
+import { expect, test as base, type Page } from "playwright/test";
+
+export function monitorBrowserErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(`page: ${error.stack ?? error.message}`));
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(`console: ${message.text()}`);
+  });
+  return errors;
+}
+
+type BrowserErrorFixtures = {
+  browserErrorGate: void;
+};
+
+export const test = base.extend<BrowserErrorFixtures>({
+  browserErrorGate: [
+    async ({ page }, use) => {
+      const errors = monitorBrowserErrors(page);
+      await use();
+      expect(errors, "unexpected browser errors").toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/tests/e2e/www.spec.ts
+++ b/tests/e2e/www.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test } from "playwright/test";
+import { expect, monitorBrowserErrors, test } from "./test-fixtures.js";
+
+test("keeps production analytics out of development", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.locator('script[src*="cloudflareinsights.com"]')).toHaveCount(0);
+});
 
 test("copies the install command with the clipboard API", async ({ page }) => {
   await page.addInitScript(() => {
@@ -16,8 +22,6 @@ test("copies the install command with the clipboard API", async ({ page }) => {
 });
 
 test("reports copy failure without an unhandled rejection", async ({ page }) => {
-  const pageErrors: Error[] = [];
-  page.on("pageerror", (error) => pageErrors.push(error));
   await page.addInitScript(() => {
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -37,7 +41,6 @@ test("reports copy failure without an unhandled rejection", async ({ page }) => 
   await expect(page.locator("[data-copy-status]")).toHaveText(
     "Copy failed. Copy the command manually.",
   );
-  expect(pageErrors).toEqual([]);
 });
 
 test("falls back when the clipboard API rejects", async ({ page }) => {
@@ -93,13 +96,17 @@ test("keeps showcase actions visible on touch", async ({ browser }, testInfo) =>
     viewport: { width: 390, height: 844 },
   });
   const page = await context.newPage();
+  const browserErrors = monitorBrowserErrors(page);
   await page.goto("/");
 
   const expand = page.getByRole("button", { name: "Expand Engineering Memory Overview" });
   await expect(expand).toHaveCSS("opacity", "1");
   await expand.tap();
-  await expect(page.getByRole("dialog", { name: "Engineering Memory Overview preview" })).toBeVisible();
+  await expect(
+    page.getByRole("dialog", { name: "Engineering Memory Overview preview" }),
+  ).toBeVisible();
   await context.close();
+  expect(browserErrors, "unexpected browser errors").toEqual([]);
 });
 
 test("removes showcase transforms for reduced motion", async ({ page }) => {


### PR DESCRIPTION
## Summary
- split the combined browsing smoke flow into focused dashboard, detail, search, and bookmark scenarios
- fail every Playwright page on unhandled errors or console errors, including the custom touch context
- keep Cloudflare analytics production-only so development tests remain free of third-party CORS noise
- generate an HTML report in CI and upload Playwright traces, screenshots, and error context after failures

## Testing
- `pnpm test:e2e` (19 passed)
- `pnpm exec playwright test --project=www-chromium` (7 passed)
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`