### PR TITLE
test(e2e): cover cross-agent aggregation

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,10 @@ const fixtureTemplateRoot = resolve("tests/e2e/fixtures");
 const fixtureRoot = join(e2eHome, "fixtures");
 const e2eProjectDir = join(e2eHome, "codesesh-e2e");
 const fixtureSessionPath = join(fixtureRoot, "claude/projects/codesesh-e2e/e2e-dashboard.jsonl");
+const codexFixtureSessionPath = join(
+  fixtureRoot,
+  "codex/sessions/2026/04/20/rollout-2026-04-20T10-05-00-019daaaa-bbbb-7bbb-8bbb-bbbbbbbbbbbb.jsonl",
+);
 
 if (!inheritedE2eHome) {
   process.env[E2E_HOME_ENV] = e2eHome;
@@ -20,14 +24,16 @@ if (!inheritedE2eHome) {
   process.once("exit", () => rmSync(e2eHome, { recursive: true, force: true }));
 
   mkdirSync(e2eProjectDir, { recursive: true });
-  const fixtureSessionTemplate = readFileSync(fixtureSessionPath, "utf8");
-  if (!fixtureSessionTemplate.includes(FIXTURE_PROJECT_DIR_TOKEN)) {
-    throw new Error(`E2E fixture is missing ${FIXTURE_PROJECT_DIR_TOKEN}`);
+  for (const tokenizedFixturePath of [fixtureSessionPath, codexFixtureSessionPath]) {
+    const fixtureSessionTemplate = readFileSync(tokenizedFixturePath, "utf8");
+    if (!fixtureSessionTemplate.includes(FIXTURE_PROJECT_DIR_TOKEN)) {
+      throw new Error(`E2E fixture is missing ${FIXTURE_PROJECT_DIR_TOKEN}`);
+    }
+    writeFileSync(
+      tokenizedFixturePath,
+      fixtureSessionTemplate.replaceAll(FIXTURE_PROJECT_DIR_TOKEN, e2eProjectDir),
+    );
   }
-  writeFileSync(
-    fixtureSessionPath,
-    fixtureSessionTemplate.replaceAll(FIXTURE_PROJECT_DIR_TOKEN, e2eProjectDir),
-  );
 }
 
 export default defineConfig({
@@ -48,7 +54,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `pnpm build && node packages/cli/dist/index.js --port ${port} --agent claudecode --days 0 --noOpen --cache false`,
+      command: `pnpm build && node packages/cli/dist/index.js --port ${port} --agent claudecode,codex --days 0 --noOpen --cache false`,
       url: `http://127.0.0.1:${port}/api/config`,
       reuseExistingServer: false,
       timeout: 60_000,
@@ -62,7 +68,7 @@ export default defineConfig({
         CODESESH_STATE_STORE: "memory",
         CODESESH_STATE_DIR: join(e2eHome, "state"),
         CLAUDE_CONFIG_DIR: join(fixtureRoot, "claude"),
-        CODEX_HOME: join(e2eHome, ".codex"),
+        CODEX_HOME: join(fixtureRoot, "codex"),
         KIMI_SHARE_DIR: join(e2eHome, ".kimi"),
         CURSOR_DATA_PATH: join(e2eHome, "cursor"),
       },
@@ -77,7 +83,7 @@ export default defineConfig({
   projects: [
     {
       name: "web-chromium",
-      testMatch: ["browsing.spec.ts", "live-refresh.spec.ts"],
+      testMatch: ["aggregation.spec.ts", "browsing.spec.ts", "live-refresh.spec.ts"],
       metadata: { fixtureSessionPath },
       use: { ...devices["Desktop Chrome"], baseURL: `http://127.0.0.1:${port}` },
     },

--- a/tests/e2e/aggregation.spec.ts
+++ b/tests/e2e/aggregation.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "./test-fixtures.js";
+
+const CODEX_SESSION_ID = "019daaaa-bbbb-7bbb-8bbb-bbbbbbbbbbbb";
+
+test("aggregates Claude and Codex sessions under one project", async ({ page }) => {
+  await page.goto("/");
+
+  const dashboard = page.getByTestId("dashboard");
+  await expect(dashboard.getByText("Total Sessions").locator("..")).toContainText("2");
+  const distribution = dashboard.getByText("Agent Distribution").locator("../..");
+  await expect(distribution).toContainText("2 agents");
+  await expect(distribution.getByRole("link", { name: /Claude Code/ })).toContainText("1 · 50.0%");
+  await expect(distribution.getByRole("link", { name: /Codex/ })).toContainText("1 · 50.0%");
+
+  await page.goto("/projects");
+  const project = page.locator("main").getByRole("link", { name: /codesesh-e2e/ });
+  await expect(project).toContainText("2 sessions");
+  await expect(project).toContainText("Claude Code · 1");
+  await expect(project).toContainText("Codex · 1");
+  await project.click();
+
+  await expect(page.getByRole("heading", { level: 1, name: "codesesh-e2e" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Claude Code · 1" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Codex · 1" })).toBeVisible();
+  await expect(
+    page.getByTestId("dashboard").getByText("Total Sessions").locator(".."),
+  ).toContainText("2");
+});
+
+test("searches and opens the aggregated Codex session", async ({ page }) => {
+  await expect
+    .poll(async () => {
+      const response = await page.request.get("/api/search?q=codex-shared-needle");
+      const body = (await response.json()) as {
+        results?: Array<{ session?: { id?: string } }>;
+      };
+      return body.results?.some((result) => result.session?.id === CODEX_SESSION_ID);
+    })
+    .toBe(true);
+
+  await page.goto("/");
+  await page.getByRole("searchbox", { name: "Search Sessions" }).fill("codex-shared-needle");
+  await page.getByRole("button", { name: "Search" }).click();
+
+  const result = page
+    .getByRole("link")
+    .filter({ hasText: "Codex aggregation smoke session" })
+    .first();
+  await expect(result).toContainText("codex-shared-needle");
+  await result.click();
+
+  await expect(page).toHaveURL(new RegExp(`/codex/${CODEX_SESSION_ID}$`));
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Codex aggregation smoke session" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Codex joined the shared project with codex-shared-needle."),
+  ).toBeVisible();
+});

--- a/tests/e2e/fixtures/codex/sessions/2026/04/20/rollout-2026-04-20T10-05-00-019daaaa-bbbb-7bbb-8bbb-bbbbbbbbbbbb.jsonl
+++ b/tests/e2e/fixtures/codex/sessions/2026/04/20/rollout-2026-04-20T10-05-00-019daaaa-bbbb-7bbb-8bbb-bbbbbbbbbbbb.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-04-20T10:05:00Z","type":"session_meta","payload":{"cwd":"__E2E_PROJECT_DIR__","model":"gpt-5.4"}}
+{"timestamp":"2026-04-20T10:05:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Codex aggregation smoke session"}]}}
+{"timestamp":"2026-04-20T10:05:02Z","type":"response_item","payload":{"type":"message","role":"assistant","model":"gpt-5.4","content":[{"type":"output_text","text":"Codex joined the shared project with codex-shared-needle."}]}}
+{"timestamp":"2026-04-20T10:05:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":60,"output_tokens":20},"total_token_usage":{"total_tokens":80}}}}


### PR DESCRIPTION
## Summary
- stage an isolated Codex rollout alongside the existing Claude Code fixture
- scan both providers against the same temporary project directory
- verify dashboard agent distribution and project aggregation across providers
- verify global search opens the Codex session through its real detail route

## Testing
- `pnpm exec playwright test tests/e2e/aggregation.spec.ts --project=web-chromium` (2 passed)
- `pnpm test:e2e` (21 passed)
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`