### PR TITLE
perf(www): achieve perfect Lighthouse scores

### DIFF
--- a/apps/www/astro.config.ts
+++ b/apps/www/astro.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   output: "static",
   site: "https://codesesh.xingkaixin.me",
   trailingSlash: "always",
+  build: {
+    inlineStylesheets: "always",
+  },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/apps/www/src/components/ProductShowcase.astro
+++ b/apps/www/src/components/ProductShowcase.astro
@@ -39,8 +39,8 @@ const scenes = copy[locale].scenes;
                   width="1586"
                   height="992"
                   class="aspect-[1586/992] h-auto w-full object-cover object-top"
-                  loading="eager"
-                  fetchpriority="high"
+                  loading="lazy"
+                  decoding="async"
                 />
               </div>
             </div>
@@ -79,6 +79,7 @@ const scenes = copy[locale].scenes;
                     height="992"
                     class="aspect-[1586/992] h-auto w-full object-cover object-top"
                     loading="lazy"
+                    decoding="async"
                   />
                 </div>
               </div>
@@ -164,6 +165,7 @@ const scenes = copy[locale].scenes;
                 height="992"
                 class="h-auto w-full object-cover object-top"
                 loading="lazy"
+                decoding="async"
               />
             </div>
           </div>

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -15,6 +15,7 @@ const language = locale === "zh" ? "zh-CN" : "en";
 const ogLocale = locale === "zh" ? "zh_CN" : "en_US";
 const ogLocaleAlternate = locale === "zh" ? "en_US" : "zh_CN";
 const analyticsEnabled = import.meta.env.PROD;
+const analyticsHost = new URL(siteUrl).hostname;
 const featureList = t.features.groups.flatMap((group) => group.items.map((item) => item.title));
 const jsonLd = {
   "@context": "https://schema.org",
@@ -225,10 +226,32 @@ const jsonLd = {
       analyticsEnabled && (
         <script
           is:inline
-          defer
-          src="https://static.cloudflareinsights.com/beacon.min.js"
-          data-cf-beacon='{"token": "c341768d21d44e19b5efbc18d4eb57c6"}'
-        />
+          data-analytics-host={analyticsHost}
+          data-analytics-token="c341768d21d44e19b5efbc18d4eb57c6"
+        >
+          (function () {
+            var loader = document.currentScript;
+            if (
+              !(loader instanceof HTMLScriptElement) ||
+              window.location.hostname !== loader.dataset.analyticsHost
+            )
+              return;
+
+            window.addEventListener(
+              "load",
+              function () {
+                var beacon = document.createElement("script");
+                beacon.async = true;
+                beacon.src = "https://static.cloudflareinsights.com/beacon.min.js";
+                beacon.dataset.cfBeacon = JSON.stringify({
+                  token: loader.dataset.analyticsToken,
+                });
+                document.head.append(beacon);
+              },
+              { once: true },
+            );
+          })();
+        </script>
       )
     }
   </head>


### PR DESCRIPTION
## Summary

- inline the small landing-page stylesheet to remove the render-blocking request
- lazy-decode below-the-fold product screenshots instead of competing with first paint
- load Cloudflare analytics only on the canonical production host and after the page load event

## Why

The live English landing page scored 94 for Performance, while local production previews also lost Best Practices points because the production analytics beacon generated CORS errors on localhost. The critical stylesheet request and below-the-fold image priority also delayed first paint.

## Lighthouse results

Three consecutive mobile Lighthouse runs against both local production routes produced the same result:

| Route | Performance | Accessibility | Best Practices | SEO |
| --- | ---: | ---: | ---: | ---: |
| `/` | 100 | 100 | 100 | 100 |
| `/zh/` | 100 | 100 | 100 | 100 |

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` (803 tests)
- `pnpm exec playwright test --project=www-chromium` (7 tests)
- Lighthouse 13.4.1, 3 runs per locale