### PR TITLE
perf(kimi): keep source enumeration off transcripts (CS-92)

### DIFF
--- a/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// readFileSync is wrapped (call-through) so the suite can assert *which* files the
+// enumeration path touches. Everything else stays real — the fixtures are real dirs.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+});
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { KimiAgent } from "../kimi.js";
+
+const PROJECT_HASH = "project-hash";
+const PROJECT_DIR = "/tmp/kimi-project";
+
+const mockedReadFileSync = vi.mocked(readFileSync);
+
+let tempDirs: string[] = [];
+
+function createAgent(basePath: string): KimiAgent {
+  const agent = new KimiAgent() as never as {
+    basePath: string;
+    projectMap: Map<string, string>;
+  };
+  agent.basePath = basePath;
+  agent.projectMap = new Map([[PROJECT_HASH, PROJECT_DIR]]);
+  return agent as never as KimiAgent;
+}
+
+function createSessionDir(basePath: string, id: string, customTitle: string): string {
+  const sessionDir = join(basePath, PROJECT_HASH, id);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, "state.json"),
+    JSON.stringify({ custom_title: customTitle, wire_mtime: 1_000 }),
+  );
+  writeFileSync(
+    join(sessionDir, "context.jsonl"),
+    JSON.stringify({ role: "user", content: `first message of ${id}` }) + "\n",
+  );
+  return sessionDir;
+}
+
+function readPathsSince(callIndexFrom: number): string[] {
+  return mockedReadFileSync.mock.calls
+    .slice(callIndexFrom)
+    .map(([path]) => String(path))
+    .filter((path) => path.endsWith(".jsonl"));
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs = [];
+  mockedReadFileSync.mockClear();
+});
+
+describe("KimiAgent source enumeration", () => {
+  it("does not read transcripts while enumerating sources", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
+    tempDirs.push(basePath);
+    createSessionDir(basePath, "session-a", "Session A");
+    createSessionDir(basePath, "session-b", "Session B");
+
+    const agent = createAgent(basePath);
+    const before = mockedReadFileSync.mock.calls.length;
+    const refs = agent.listSessionSources();
+
+    expect(refs.map((ref) => ref.sessionId).sort()).toEqual(["session-a", "session-b"]);
+    expect(readPathsSince(before)).toEqual([]);
+  });
+
+  it("skips the transcript title fallback when state.json carries a title", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
+    tempDirs.push(basePath);
+    createSessionDir(basePath, "titled", "Explicit title");
+
+    const agent = createAgent(basePath);
+    const sourcePath = join(basePath, PROJECT_HASH, "titled");
+    const before = mockedReadFileSync.mock.calls.length;
+    const head = agent.scanSessionSource(sourcePath);
+
+    expect(head?.title).toBe("Explicit title");
+    expect(readPathsSince(before)).not.toContain(join(sourcePath, "context.jsonl"));
+  });
+
+  it("still falls back to the first user message when no explicit title exists", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
+    tempDirs.push(basePath);
+    const sourcePath = createSessionDir(basePath, "untitled", "");
+
+    const agent = createAgent(basePath);
+    const head = agent.scanSessionSource(sourcePath);
+
+    expect(head?.title).toBe("first message of untitled");
+  });
+
+  it("keeps the fingerprint bound to metadata and transcript mtimes only", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
+    tempDirs.push(basePath);
+    const sourcePath = createSessionDir(basePath, "fingerprint", "Fingerprint");
+
+    // Pin the mtime so the rewrite below can restore it exactly — statSync
+    // reports sub-millisecond precision that a Date round-trip would truncate.
+    const contextPath = join(sourcePath, "context.jsonl");
+    const pinned = new Date(1_700_000_000_000);
+    utimesSync(contextPath, pinned, pinned);
+
+    const agent = createAgent(basePath);
+    const before = agent.listSessionSources()[0]?.fingerprint;
+
+    // Rewriting the transcript body without moving its mtime must not move the
+    // fingerprint: enumeration only observes mtimes, never content.
+    writeFileSync(contextPath, JSON.stringify({ role: "user", content: "rewritten" }) + "\n");
+    utimesSync(contextPath, pinned, pinned);
+
+    expect(statSync(contextPath).mtimeMs).toBe(pinned.getTime());
+    expect(agent.listSessionSources()[0]?.fingerprint).toBe(before);
+  });
+});

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -46,15 +46,23 @@ function mapToolTitle(toolName: string): string {
   return KIMI_TOOL_TITLE_MAP[toolName] ?? toolName;
 }
 
-interface SessionMeta extends SessionCacheMeta {
+/**
+ * 会话源的轻量视图：只需要目录遍历 + 小 JSON 文件（state/metadata）即可得出，
+ * 不触碰 transcript。枚举路径（listSessionSources）每次刷新都会跑，只用这一层。
+ */
+interface SessionSource {
   id: string;
-  title: string;
   sourcePath: string;
   cwd: string;
   contextFile: string | null;
   wireFile: string | null;
   createdAt: number;
   metaFile: string;
+  explicitTitle: string;
+}
+
+interface SessionMeta extends SessionCacheMeta, SessionSource {
+  title: string;
 }
 
 /** Reads state/metadata `wire_mtime`; reports drift when the field is present but not a number. */
@@ -241,45 +249,42 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     return dirs;
   }
 
-  /** Parse session directory, preferring state.json over metadata.json */
-  private parseSessionDir(sessionDir: string): SessionMeta | null {
-    return getParsedSession(this.parseSessionDirResult(sessionDir));
-  }
-
-  private parseSessionDirResult(sessionDir: string): ParseSessionResult<SessionMeta> {
+  /**
+   * 解析会话源，优先 state.json 而非 metadata.json。
+   * 只读小 JSON 文件与 statSync，不触碰 transcript——枚举路径依赖这一点。
+   */
+  private resolveSessionSourceResult(sessionDir: string): ParseSessionResult<SessionSource> {
     try {
       const sessionId = basename(sessionDir);
       const projectHash = basename(dirname(sessionDir));
       const contextFile = join(sessionDir, "context.jsonl");
       const wireFile = join(sessionDir, "wire.jsonl");
 
-      if (!existsSync(contextFile) && !existsSync(wireFile)) {
+      const existingContextFile = existsSync(contextFile) ? contextFile : null;
+      const existingWireFile = existsSync(wireFile) ? wireFile : null;
+      if (!existingContextFile && !existingWireFile) {
         return skippedSession("missing transcript");
       }
 
       const statePath = join(sessionDir, "state.json");
       const metaPath = join(sessionDir, "metadata.json");
 
-      let title = "";
+      let explicitTitle = "";
       let wireMtime: number | null = null;
       let metaFile = "";
 
       if (existsSync(statePath)) {
         const state = asRecord(JSON.parse(readFileSync(statePath, "utf-8"))) ?? {};
-        title = String(state.custom_title ?? "");
+        explicitTitle = String(state.custom_title ?? "");
         wireMtime = readWireMtime(state);
         metaFile = statePath;
       } else if (existsSync(metaPath)) {
         const meta = asRecord(JSON.parse(readFileSync(metaPath, "utf-8"))) ?? {};
-        title = String(meta.title ?? "");
+        explicitTitle = String(meta.title ?? "");
         wireMtime = readWireMtime(meta);
         metaFile = metaPath;
       }
 
-      const cwd = this.projectMap.get(projectHash) || "";
-      const existingContextFile = existsSync(contextFile) ? contextFile : null;
-      const existingWireFile = existsSync(wireFile) ? wireFile : null;
-      const messageTitle = extractFirstUserTitle(existingContextFile, existingWireFile);
       const createdAt =
         wireMtime !== null
           ? wireMtime * 1000
@@ -289,29 +294,45 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
 
       return parsedSession({
         id: sessionId,
-        title: resolveSessionTitle(title, messageTitle, null),
         sourcePath: sessionDir,
-        cwd,
+        cwd: this.projectMap.get(projectHash) || "",
         contextFile: existingContextFile,
         wireFile: existingWireFile,
         createdAt,
         metaFile,
+        explicitTitle,
       });
     } catch {
       return skippedSession("malformed metadata");
     }
   }
 
+  /**
+   * 在会话源之上补齐 title。仅当 state/metadata 里没有可用标题时才回退去读
+   * transcript 找首条用户消息，所以标题解析的成本只在真正需要重解析时付出。
+   */
+  private parseSessionDirResult(sessionDir: string): ParseSessionResult<SessionMeta> {
+    const result = this.resolveSessionSourceResult(sessionDir);
+    if (result.status !== "parsed") return result;
+
+    const source = result.data;
+    const title =
+      normalizeTitleText(source.explicitTitle) ??
+      resolveSessionTitle(null, extractFirstUserTitle(source.contextFile, source.wireFile), null);
+
+    return parsedSession({ ...source, title });
+  }
+
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
     const refs: SessionSourceRef[] = [];
     for (const dir of this.listSessionDirs()) {
-      const meta = getParsedSession(this.parseSessionDirResult(dir));
-      if (!meta || !matchesScanWindow(meta.createdAt, options)) continue;
+      const source = getParsedSession(this.resolveSessionSourceResult(dir));
+      if (!source || !matchesScanWindow(source.createdAt, options)) continue;
       refs.push({
-        sessionId: meta.id,
-        sourcePath: meta.sourcePath,
-        fingerprint: this.sourceFingerprint(meta),
+        sessionId: source.id,
+        sourcePath: source.sourcePath,
+        fingerprint: this.sourceFingerprint(source),
       });
     }
     return refs;
@@ -570,7 +591,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
 
   // --- Helpers ---
 
-  private sourceFingerprint(meta: SessionMeta): string {
+  private sourceFingerprint(meta: Pick<SessionSource, "metaFile" | "contextFile" | "wireFile">) {
     const fileMtime = (path: string | null) => {
       if (!path) return null;
       try {


### PR DESCRIPTION
## Summary

`FileSystemSessionSource` splits scanning into two primitives: `listSessionSources` (enumerate + fingerprint) and `scanSessionSource` (parse one source). The enumeration primitive is meant to be cheap — change detection calls it on every refresh cycle.

Kimi's implementation ran the *full* session parse for every directory during enumeration, and that parse called `extractFirstUserTitle`, which reads an entire `context.jsonl` (then `wire.jsonl` if needed) into memory and JSON-parses line by line. The resulting title was then thrown away: `sourceFingerprint` is built from three file mtimes and never includes it.

Every file-watch tick therefore re-read every Kimi transcript on disk. `claudecode`, `codex` and `pi` all enumerate with `statSync` only.

## Changes

- Split `parseSessionDirResult` into two layers:
  - `resolveSessionSourceResult` — directory entries, the small `state.json`/`metadata.json`, and `statSync`. No transcript I/O. `listSessionSources` uses only this.
  - `parseSessionDirResult` — layers `title` on top, used by `scanSessionSource` / `getSessionData`.
- Title resolution is now lazy: `normalizeTitleText(explicitTitle)` first, and the transcript fallback runs only when that yields nothing. Previously the fallback was computed eagerly even when `custom_title` was present.
- New `SessionSource` interface holds the cheap view; `SessionMeta` extends it with `title`.
- `sourceFingerprint` takes the three paths it actually needs instead of a full `SessionMeta`.

Fingerprint composition, the `matchesScanWindow(createdAt)` filter and the resolved title are all unchanged.

## Testing

- New `kimi-enumeration.test.ts` wraps `readFileSync` (call-through) to assert what the enumeration path touches:
  - `listSessionSources()` performs zero `.jsonl` reads
  - `scanSessionSource()` skips the transcript when `state.json` carries a title
  - the first-user-message fallback still resolves when it does not
  - rewriting a transcript body without moving its mtime leaves the fingerprint unchanged
- Existing `kimi.test.ts` untouched and passing, including the `listSessionSources` scan-window case.
- `pnpm build` / `pnpm test` (core 393, cli 204, web 382) / `pnpm lint` / `pnpm format:check` all clean.
- Measured against the local `~/.kimi/sessions` (14 sessions, 12 MB): enumeration 22.8ms → 1.2ms.

Issue: CS-92