### PR TITLE
fix(jsonl): assemble long records in linear time (CS-99)

### DIFF
--- a/packages/core/src/utils/__tests__/jsonl.test.ts
+++ b/packages/core/src/utils/__tests__/jsonl.test.ts
@@ -113,6 +113,34 @@ describe("readJsonlFileLines", () => {
     const filePath = writeTempFile("");
     expect(collect(readJsonlFileLines(filePath))).toEqual([]);
   });
+
+  it("yields a record that spans many chunks intact", () => {
+    const long = "x".repeat(1000);
+    const filePath = writeTempFile(`{"a":1}\n${long}\n{"b":2}`);
+    expect(collect(readJsonlFileLines(filePath, 8))).toEqual(['{"a":1}', long, '{"b":2}']);
+  });
+
+  it("yields a chunk-spanning record as the tail when the file has no trailing newline", () => {
+    const long = "y".repeat(500);
+    const filePath = writeTempFile(`{"a":1}\n${long}`);
+    expect(collect(readJsonlFileLines(filePath, 8))).toEqual(['{"a":1}', long]);
+  });
+
+  it("assembles long records in linear time rather than per-chunk copies", () => {
+    // One record spanning 2000 chunks. Buffering the partial record in a string
+    // makes every chunk re-flatten it, which measures ~300ms on this fixture and
+    // scales quadratically; buffering in an array and joining once measures
+    // single-digit milliseconds. The bound sits well clear of both.
+    const long = "z".repeat(2_000_000);
+    const filePath = writeTempFile(`${long}\n{"tail":1}`);
+
+    const startedAt = performance.now();
+    const result = collect(readJsonlFileLines(filePath, 1000));
+    const elapsed = performance.now() - startedAt;
+
+    expect(result).toEqual([long, '{"tail":1}']);
+    expect(elapsed).toBeLessThan(250);
+  });
 });
 
 describe("readJsonlFile", () => {

--- a/packages/core/src/utils/jsonl.ts
+++ b/packages/core/src/utils/jsonl.ts
@@ -40,18 +40,30 @@ export function* readJsonlFileLines(
     const buffer = Buffer.alloc(chunkBytes);
     // StringDecoder buffers multi-byte UTF-8 sequences split across chunks.
     const decoder = new StringDecoder("utf8");
-    let remainder = "";
+    // Chunks of the record currently being assembled, joined once when its line
+    // break arrives. Concatenating onto a string instead would re-copy the whole
+    // partial record on every chunk — quadratic on the multi-megabyte single-line
+    // records agent logs routinely contain.
+    let pending: string[] = [];
     let bytesRead = readSync(fd, buffer, 0, chunkBytes, -1);
     while (bytesRead > 0) {
-      const lines = (remainder + decoder.write(buffer.subarray(0, bytesRead))).split("\n");
-      remainder = lines.pop()!;
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (trimmed) yield trimmed;
+      const decoded = decoder.write(buffer.subarray(0, bytesRead));
+      const lastBreak = decoded.lastIndexOf("\n");
+      if (lastBreak === -1) {
+        if (decoded) pending.push(decoded);
+      } else {
+        pending.push(decoded.slice(0, lastBreak));
+        const complete = pending.join("");
+        pending = [decoded.slice(lastBreak + 1)];
+        for (const line of complete.split("\n")) {
+          const trimmed = line.trim();
+          if (trimmed) yield trimmed;
+        }
       }
       bytesRead = readSync(fd, buffer, 0, chunkBytes, -1);
     }
-    const tail = (remainder + decoder.end()).trim();
+    pending.push(decoder.end());
+    const tail = pending.join("").trim();
     if (tail) yield tail;
   } finally {
     closeSync(fd);


### PR DESCRIPTION
## Summary

Found while measuring CS-94. `readJsonlFileLines` exists to avoid holding a whole session log in memory — its own comment says Codex rollout files exceed 400 MB and `readFileSync + split` OOMs the scan-refresh worker. But on the file shape it was written for it is **slower than the whole-file load it replaces**.

The in-flight record was buffered in a string:

```ts
const lines = (remainder + decoder.write(chunk)).split("\n");
remainder = lines.pop()!;
```

V8 makes the `+` cheap (cons string), but `.split()` flattens it. A record of length `L` spanning `k = L / chunkBytes` chunks flattens `chunkBytes`, `2·chunkBytes`, … — O(L·k), quadratic in record length.

Agent logs are exactly this shape: few records, tens of megabytes each.

**Local Pi session, 48.8 MB, 36 lines, longest line 22,867,066 chars:**

| | 3 runs |
|---|---|
| `readFileSync` + `split` + `JSON.parse` | 192 / 174 / 188 ms |
| `readJsonlFile` (before) | 593 / 620 / 674 ms |
| `readJsonlFile` (after) | 204 / 202 / 199 ms |

**Synthetic scaling (single line, 1000 B chunks), before:**

| line length | time |
|---|---|
| 600 K | 33 ms |
| 2 M | 298 ms |
| 5 M | 1773 ms |

8.3× the input, 53× the time.

## Changes

- Buffer the in-flight record in a `string[]` and `join("")` once when its line break arrives, instead of concatenating into a string that gets re-split every chunk.
- Use `lastIndexOf("\n")` so a chunk containing several complete records still costs one join and one split.

Peak memory is unchanged: the array holds the same single record the string did. Output is byte-identical, including multi-byte characters split across chunks, blank-line skipping, and a tail without a trailing newline.

## Why now

CS-94 and CS-95 both migrate agents onto this reader. Landing them first would have made `pi`, `kimi` and `claudecode` parsing ~3× slower. This unblocks both.

## Testing

- Existing four `readJsonlFileLines` cases unchanged and passing.
- New: a record spanning many chunks survives intact, both mid-file and as the untrailed tail.
- New regression guard: 2,000,000-char record with 1000 B chunks must complete in under 250 ms. Verified it **fails on the old implementation** (314 ms) and passes on the new one (single-digit ms).
- `pnpm build` / `pnpm test` (core 428, cli 215, web 382) / `pnpm lint` / `pnpm format:check` all clean.

Issue: CS-99