### PR TITLE
perf(pi): parse session files in one streaming pass (CS-94)

### DIFF
--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -25,6 +25,28 @@ afterEach(() => {
   tempDirs = [];
 });
 
+const TS = "2026-04-20T10:00:00.000Z";
+
+/** Writes a one-session PI_HOME fixture and returns an agent bound to it. */
+function writePiSession(
+  sessionId: string,
+  records: Record<string, unknown>[],
+): { agent: PiAgent; sessionFile: string; sessionId: string } {
+  const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
+  tempDirs.push(tempDir);
+  const piHome = join(tempDir, ".pi");
+  const sessionsDir = join(piHome, "agent", "sessions", "--tmp-project--");
+  mkdirSync(sessionsDir, { recursive: true });
+  vi.stubEnv("PI_HOME", piHome);
+
+  const sessionFile = join(sessionsDir, `2026-04-20T10-00-00_${sessionId}.jsonl`);
+  writeFileSync(sessionFile, records.map((record) => JSON.stringify(record)).join("\n"));
+
+  const agent = new PiAgent();
+  agent.isAvailable();
+  return { agent, sessionFile, sessionId };
+}
+
 function captureDiagnostics(): Array<{ event: string; detail?: Record<string, unknown> }> {
   const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
   const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
@@ -439,5 +461,76 @@ describe("PiAgent", () => {
       event: "agent.field_shape_mismatch",
       detail: { agentName: "pi", field: "message.usage.input" },
     });
+  });
+
+  it("takes the first session record as the header when several are present", () => {
+    const { agent, sessionId } = writePiSession("019deeee-eeee-7eee-eeee-eeeeeeeeeeee", [
+      { type: "session", version: 3, id: "first", timestamp: TS, cwd: "/tmp/first" },
+      { type: "session", version: 3, id: "second", timestamp: TS, cwd: "/tmp/second" },
+      {
+        type: "message",
+        id: "a1",
+        parentId: null,
+        timestamp: TS,
+        message: { role: "user", content: "Hello" },
+      },
+    ]);
+
+    const [head] = agent.scan();
+
+    expect(head?.id).toBe("first");
+    expect(head?.directory).toBe("/tmp/first");
+    expect(sessionId).toBeTruthy();
+  });
+
+  it("skips files that are empty or missing a session header", () => {
+    const empty = writePiSession("019deeee-eeee-7eee-eeee-ffffffffffff", []);
+    expect(empty.agent.scan()).toEqual([]);
+
+    const headerless = writePiSession("019deeee-eeee-7eee-eeee-000000000000", [
+      {
+        type: "message",
+        id: "a1",
+        parentId: null,
+        timestamp: TS,
+        message: { role: "user", content: "Orphan" },
+      },
+    ]);
+    expect(headerless.agent.scan()).toEqual([]);
+  });
+
+  it("reassembles records that straddle a read-chunk boundary", () => {
+    // readJsonlFileLines decodes in 1 MiB chunks. Sweep the padding so both a
+    // line break and a multi-byte character land on either side of the seam.
+    const CHUNK_BYTES = 1024 * 1024;
+    const MARKER = "结束标记";
+
+    for (const delta of [-1, 0, 1]) {
+      const sessionId = `019deeee-eeee-7eee-eeee-11111111000${delta + 1}`;
+      const prefix = JSON.stringify({
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: TS,
+        cwd: "/tmp/project",
+      }).length;
+      const padding = "x".repeat(Math.max(0, CHUNK_BYTES + delta - prefix - 120));
+      const { agent } = writePiSession(sessionId, [
+        { type: "session", version: 3, id: sessionId, timestamp: TS, cwd: "/tmp/project" },
+        {
+          type: "message",
+          id: "a1",
+          parentId: null,
+          timestamp: TS,
+          message: { role: "user", content: `${padding}${MARKER}` },
+        },
+      ]);
+
+      agent.scan();
+      const text = String(agent.getSessionData(sessionId).messages[0]?.parts[0]?.text ?? "");
+
+      expect(text).toHaveLength(padding.length + MARKER.length);
+      expect(text.endsWith(MARKER)).toBe(true);
+    }
   });
 });

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync, type Stats } from "node:fs";
+import { existsSync, readdirSync, statSync, type Stats } from "node:fs";
 import { basename, join } from "node:path";
 import {
   FileSystemSessionSource,
@@ -15,7 +15,7 @@ import type {
 } from "./base.js";
 import type { Message, MessagePart, SessionData, SessionHead } from "../types/index.js";
 import { firstExisting, resolveProviderRoots } from "../discovery/paths.js";
-import { parseJsonlLines } from "../utils/jsonl.js";
+import { readJsonlFile } from "../utils/jsonl.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { asNumber, asRecord, asString, narrowField } from "../utils/narrow.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
@@ -283,13 +283,24 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   private parsePiFile(filePath: string): ParsedPiFile {
-    const records = Array.from(parseJsonlLines(readFileSync(filePath, "utf-8")));
-    if (records.length === 0) throw new Error("empty file");
+    // Single streaming pass: the file is never held as a string, and header
+    // selection happens inline instead of scanning a materialized record array.
+    let header: Record<string, unknown> | null = null;
+    let recordCount = 0;
+    const entries: Record<string, unknown>[] = [];
 
-    const header = records.find((record) => record["type"] === "session");
+    for (const record of readJsonlFile(filePath)) {
+      recordCount += 1;
+      if (record["type"] === "session") {
+        header ??= record;
+        continue;
+      }
+      entries.push(record);
+    }
+
+    if (recordCount === 0) throw new Error("empty file");
     if (!header) throw new Error("missing session header");
 
-    const entries = records.filter((record) => record["type"] !== "session");
     const pathEntries = buildCurrentPathEntries(entries);
     if (pathEntries.length === 0) throw new Error("empty session tree");
 


### PR DESCRIPTION
## Summary

`parsePiFile` materialized the same file three times:

```ts
const records = Array.from(parseJsonlLines(readFileSync(filePath, "utf-8")));  // string + array
const header = records.find((r) => r["type"] === "session");                   // O(n) scan
const entries = records.filter((r) => r["type"] !== "session");                // second array
```

All three are live at once. The local Pi corpus is 72 files / 79 MB, with a single session file at 48.8 MB — that one produces a ~49 MB string plus two arrays of fully parsed records.

Both `parseSessionHeadResult` and `getSessionData` go through this function, so every scan and every incremental re-parse pays it.

## Changes

- Read with `readJsonlFile` (streaming) and select the header inline during the same pass. Only the `entries` array survives.
- Behaviour preserved exactly: the **first** `type: "session"` record wins (matching `find`), and **all** session-typed records are excluded from `entries` (matching `filter`). `recordCount === 0` reproduces the old `records.length === 0` empty-file error.
- `buildCurrentPathEntries` needs the full entry list to walk the parent chain, so the `entries` array itself stays.

Measured on the local corpus, full `scan()` of 72 sessions:

| | before | after |
|---|---|---|
| wall clock | 2382 ms | 2112 ms |
| peak RSS | 301 MB | 218 MB |

## Scope note

The issue also proposed a lightweight head path that skips building `Message` objects. That turned out not to be viable: `message_count` comes from `TranscriptBuilder.finish()` → `cleanParsedMessages`, which drops messages whose parts all clean away. Reproducing that count without building parts means reimplementing `cleanMessagePart`, and building parts is the bulk of the cost. Head and detail still share `convertEntries`; that architectural split needs a separate change to how `message_count` is defined, which would move a user-visible number and does not belong in a performance patch.

Depends on #191 — before that fix the streaming reader was ~3× slower than `readFileSync` on this exact file shape.

## Testing

- New: the first of several `session` records is used as the header (id and cwd come from it).
- New: empty files and files with no session header are skipped by `scan()` rather than throwing out.
- New: a record straddling the 1 MiB read-chunk seam survives intact — swept across three padding offsets with a multi-byte marker at the end.
- Existing six `pi.test.ts` cases unchanged and passing.
- `pnpm build` / `pnpm test` (core 431, cli 215, web 382) / `pnpm lint` / `pnpm format:check` all clean.

Issue: CS-94