### PR TITLE
perf(agents): stream transcripts instead of loading whole files (CS-95)

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -554,3 +554,88 @@ describe("ClaudeCodeAgent cache refresh", () => {
     });
   });
 });
+
+describe("ClaudeCodeAgent head parsing", () => {
+  function writeSession(lines: string[]): { agent: ClaudeCodeAgent; sessionFile: string } {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-head-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    mkdirSync(projectDir, { recursive: true });
+    const sessionFile = join(projectDir, "session-1.jsonl");
+    writeFileSync(sessionFile, lines.join("\n"));
+
+    const agent = new ClaudeCodeAgent() as never as { basePath: string };
+    agent.basePath = basePath;
+    return { agent: agent as never as ClaudeCodeAgent, sessionFile };
+  }
+
+  function userLine(text: string, timestamp = "2026-04-20T10:00:00Z"): string {
+    return JSON.stringify({
+      type: "user",
+      timestamp,
+      cwd: "/tmp/project",
+      message: { role: "user", content: text },
+    });
+  }
+
+  it("skips an empty file", () => {
+    expect(writeSession([]).agent.scan()).toEqual([]);
+    expect(writeSession(["", "   ", ""]).agent.scan()).toEqual([]);
+  });
+
+  it("skips a file whose first record is malformed", () => {
+    expect(writeSession(["not json", userLine("Visible")]).agent.scan()).toEqual([]);
+  });
+
+  it("skips a malformed record after the first without dropping the session", () => {
+    const [head] = writeSession([userLine("First"), "not json", userLine("Third")]).agent.scan();
+
+    expect(head?.title).toBe("First");
+    expect(head?.stats.message_count).toBe(2);
+  });
+
+  it("falls back to the file mtime when the first record has no timestamp", () => {
+    const { agent, sessionFile } = writeSession([
+      JSON.stringify({
+        type: "user",
+        cwd: "/tmp/project",
+        message: { role: "user", content: "A" },
+      }),
+    ]);
+
+    const [head] = agent.scan();
+
+    expect(head?.time_created).toBe(statSync(sessionFile).mtimeMs);
+  });
+
+  it("only considers the first 20 records for the fallback title", () => {
+    // Malformed records still advance the window, matching the pre-streaming
+    // behaviour where the index came from the raw non-blank line list.
+    const filler = Array.from({ length: 19 }, () =>
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-04-20T10:00:00Z",
+        cwd: "/tmp/project",
+        message: { role: "assistant", content: [{ type: "text", text: "filler" }] },
+      }),
+    );
+
+    const inWindow = writeSession([...filler, userLine("Twentieth record")]).agent.scan();
+    expect(inWindow[0]?.title).toBe("Twentieth record");
+
+    const outOfWindow = writeSession([
+      ...filler,
+      filler[0]!,
+      userLine("Twenty-first record"),
+    ]).agent.scan();
+    expect(outOfWindow[0]?.title).toBe("project");
+  });
+
+  it("reads records that straddle a read-chunk boundary", () => {
+    const marker = "结束标记";
+    const padding = "x".repeat(1024 * 1024);
+    const [head] = writeSession([userLine(`${padding}${marker}`)]).agent.scan();
+
+    expect(head?.title).toBe(`${padding}${marker}`.slice(0, 100));
+  });
+});

--- a/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
@@ -1,15 +1,21 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-// readFileSync is wrapped (call-through) so the suite can assert *which* files the
-// enumeration path touches. Everything else stays real — the fixtures are real dirs.
+// Both file-read entry points are wrapped (call-through) so the suite can assert
+// *which* files a code path opens: readFileSync for whole-file loads, openSync for
+// the streaming reader. Everything else stays real — the fixtures are real dirs.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
-  return { ...actual, readFileSync: vi.fn(actual.readFileSync) };
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+    openSync: vi.fn(actual.openSync),
+  };
 });
 
 import {
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   rmSync,
   statSync,
@@ -24,6 +30,7 @@ const PROJECT_HASH = "project-hash";
 const PROJECT_DIR = "/tmp/kimi-project";
 
 const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedOpenSync = vi.mocked(openSync);
 
 let tempDirs: string[] = [];
 
@@ -51,17 +58,28 @@ function createSessionDir(basePath: string, id: string, customTitle: string): st
   return sessionDir;
 }
 
-function readPathsSince(callIndexFrom: number): string[] {
-  return mockedReadFileSync.mock.calls
-    .slice(callIndexFrom)
+/** Every `.jsonl` path opened for reading since the counters were snapshotted. */
+function transcriptReadsSince(marks: { read: number; open: number }): string[] {
+  return [
+    ...mockedReadFileSync.mock.calls.slice(marks.read),
+    ...mockedOpenSync.mock.calls.slice(marks.open),
+  ]
     .map(([path]) => String(path))
     .filter((path) => path.endsWith(".jsonl"));
+}
+
+function markReads(): { read: number; open: number } {
+  return {
+    read: mockedReadFileSync.mock.calls.length,
+    open: mockedOpenSync.mock.calls.length,
+  };
 }
 
 afterEach(() => {
   for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
   tempDirs = [];
   mockedReadFileSync.mockClear();
+  mockedOpenSync.mockClear();
 });
 
 describe("KimiAgent source enumeration", () => {
@@ -72,11 +90,11 @@ describe("KimiAgent source enumeration", () => {
     createSessionDir(basePath, "session-b", "Session B");
 
     const agent = createAgent(basePath);
-    const before = mockedReadFileSync.mock.calls.length;
+    const marks = markReads();
     const refs = agent.listSessionSources();
 
     expect(refs.map((ref) => ref.sessionId).sort()).toEqual(["session-a", "session-b"]);
-    expect(readPathsSince(before)).toEqual([]);
+    expect(transcriptReadsSince(marks)).toEqual([]);
   });
 
   it("skips the transcript title fallback when state.json carries a title", () => {
@@ -86,11 +104,11 @@ describe("KimiAgent source enumeration", () => {
 
     const agent = createAgent(basePath);
     const sourcePath = join(basePath, PROJECT_HASH, "titled");
-    const before = mockedReadFileSync.mock.calls.length;
+    const marks = markReads();
     const head = agent.scanSessionSource(sourcePath);
 
     expect(head?.title).toBe("Explicit title");
-    expect(readPathsSince(before)).not.toContain(join(sourcePath, "context.jsonl"));
+    expect(transcriptReadsSince(marks)).not.toContain(join(sourcePath, "context.jsonl"));
   });
 
   it("still falls back to the first user message when no explicit title exists", () => {
@@ -125,5 +143,69 @@ describe("KimiAgent source enumeration", () => {
 
     expect(statSync(contextPath).mtimeMs).toBe(pinned.getTime());
     expect(agent.listSessionSources()[0]?.fingerprint).toBe(before);
+  });
+});
+
+describe("KimiAgent stats extraction", () => {
+  function createWireOnlySession(basePath: string, id: string, title: string): string {
+    const sessionDir = join(basePath, PROJECT_HASH, id);
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      join(sessionDir, "state.json"),
+      JSON.stringify({ custom_title: title, wire_mtime: 1_000 }),
+    );
+    writeFileSync(
+      join(sessionDir, "wire.jsonl"),
+      [
+        JSON.stringify({
+          timestamp: 1,
+          message: {
+            type: "ContentPart",
+            payload: { type: "text", text: "hi" },
+            usage: { input_tokens: 12, output_tokens: 5 },
+          },
+        }),
+        JSON.stringify({ role: "_usage", token_count: 999 }),
+        "",
+      ].join("\n"),
+    );
+    return sessionDir;
+  }
+
+  it("walks wire.jsonl once when there is no context.jsonl", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-stats-"));
+    tempDirs.push(basePath);
+    const sourcePath = createWireOnlySession(basePath, "wire-only", "Wire only");
+
+    const agent = createAgent(basePath);
+    const marks = markReads();
+    const head = agent.scanSessionSource(sourcePath);
+
+    expect(head?.stats).toMatchObject({
+      total_input_tokens: 12,
+      total_output_tokens: 5,
+      total_tokens: 999,
+    });
+    expect(transcriptReadsSince(marks)).toEqual([join(sourcePath, "wire.jsonl")]);
+  });
+
+  it("reads the usage total from context.jsonl when it exists", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-stats-"));
+    tempDirs.push(basePath);
+    const sourcePath = createWireOnlySession(basePath, "with-context", "With context");
+    writeFileSync(
+      join(sourcePath, "context.jsonl"),
+      JSON.stringify({ role: "_usage", token_count: 42 }) + "\n",
+    );
+
+    const agent = createAgent(basePath);
+    const head = agent.scanSessionSource(sourcePath);
+
+    // context.jsonl wins over the _usage record sitting in wire.jsonl.
+    expect(head?.stats).toMatchObject({
+      total_input_tokens: 12,
+      total_output_tokens: 5,
+      total_tokens: 42,
+    });
   });
 });

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -11,7 +11,7 @@ import {
 import type { ParseSessionResult } from "./base.js";
 import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
-import { parseJsonlLines } from "../utils/jsonl.js";
+import { readJsonlFile, readJsonlFileLines } from "../utils/jsonl.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
@@ -172,11 +172,10 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
       throw new Error(`Session file missing: ${meta.sourcePath}`);
     }
 
-    const content = readFileSync(meta.sourcePath, "utf-8");
     const builder = new TranscriptBuilder();
     const assistantUuidToToolCalls = new Map<string, string[]>();
     const countedUsageKeys = new Set<string>();
-    for (const record of parseJsonlLines(content)) {
+    for (const record of readJsonlFile(meta.sourcePath)) {
       try {
         this.convertRecord(record, builder, assistantUuidToToolCalls, countedUsageKeys);
       } catch {
@@ -297,29 +296,11 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     return map;
   }
 
-  private parseSessionHead(filePath: string, projectDir: string): SessionHead | null {
-    return getParsedSession(this.parseSessionHeadResult(filePath, projectDir));
-  }
-
   private parseSessionHeadResult(
     filePath: string,
     projectDir: string,
   ): ParseSessionResult<SessionHead> {
-    const content = readFileSync(filePath, "utf-8");
-    const lines = content.split("\n").filter((l) => l.trim());
-
-    if (lines.length === 0) return skippedSession("empty file");
-
     const sessionId = basename(filePath, ".jsonl");
-
-    let firstRecord: Record<string, unknown>;
-    try {
-      firstRecord = JSON.parse(lines[0]!);
-    } catch {
-      return skippedSession("malformed first record");
-    }
-
-    const createdAt = parseTimestampMs(firstRecord) || statSync(filePath).mtimeMs;
 
     // Try to get title from sessions-index.json
     const index = this.loadSessionsIndex(projectDir);
@@ -327,7 +308,9 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     const explicitTitle = indexEntry?.summary ? String(indexEntry.summary) : null;
 
     // Extract lightweight metadata; cwd lives in user-type records, not the first line
-    let updatedAt = createdAt;
+    let createdAt = 0;
+    let updatedAt = 0;
+    let lineIndex = 0;
     let messageCount = 0;
     let model: string | null = null;
     let cwd: string | null = null;
@@ -340,9 +323,26 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     const countedUsageKeys = new Set<string>();
     let messageTitle: string | null = null;
 
-    for (const [lineIndex, line] of lines.entries()) {
+    for (const line of readJsonlFileLines(filePath)) {
+      let data: Record<string, unknown>;
       try {
-        const data = JSON.parse(line);
+        data = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        // A malformed opening record means the file is not a session we can read;
+        // later ones are individually skippable.
+        if (lineIndex === 0) return skippedSession("malformed first record");
+        lineIndex += 1;
+        continue;
+      }
+
+      if (lineIndex === 0) {
+        createdAt = parseTimestampMs(data) || statSync(filePath).mtimeMs;
+        updatedAt = createdAt;
+      }
+      const recordIndex = lineIndex;
+      lineIndex += 1;
+
+      try {
         if (isInternalEventType(data["type"])) continue;
         const ts = parseTimestampMs(data);
         if (ts > updatedAt) updatedAt = ts;
@@ -369,7 +369,7 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
           }
           // Title fallback mirrors the removed extractTitle(): first non-empty
           // visible user text within the first 20 lines.
-          if (messageTitle === null && lineIndex < 20 && role === "user") {
+          if (messageTitle === null && recordIndex < 20 && role === "user") {
             const candidate = this.extractUserMessageTitle(msg["content"]);
             if (candidate) messageTitle = candidate;
           }
@@ -407,6 +407,8 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
         // skip
       }
     }
+
+    if (lineIndex === 0) return skippedSession("empty file");
 
     const directory = cwd ?? projectDir;
     const directoryTitle = basenameTitle(directory) || basenameTitle(projectDir);

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -16,7 +16,7 @@ import type {
 } from "./base.js";
 import type { SessionHead, SessionData, MessagePart } from "../types/index.js";
 import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
-import { parseJsonlLines } from "../utils/jsonl.js";
+import { readJsonlFile } from "../utils/jsonl.js";
 import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
@@ -146,8 +146,7 @@ function kimiContentText(content: unknown): string {
 
 function extractFirstUserTitle(contextFile: string | null, wireFile: string | null): string | null {
   if (contextFile && existsSync(contextFile)) {
-    const content = readFileSync(contextFile, "utf-8");
-    for (const record of parseJsonlLines(content)) {
+    for (const record of readJsonlFile(contextFile)) {
       if (record.role !== "user") continue;
       const title = normalizeTitleText(kimiContentText(record.content));
       if (title) return title;
@@ -155,8 +154,7 @@ function extractFirstUserTitle(contextFile: string | null, wireFile: string | nu
   }
 
   if (wireFile && existsSync(wireFile)) {
-    const content = readFileSync(wireFile, "utf-8");
-    for (const record of parseJsonlLines(content)) {
+    for (const record of readJsonlFile(wireFile)) {
       const message = asRecord(record.message) ?? {};
       if (message.type !== "TurnBegin") continue;
       const payload = asRecord(message.payload) ?? {};
@@ -368,13 +366,12 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
   private getSessionDataFromContext(meta: SessionMeta): SessionData {
     if (!meta.contextFile) throw new Error("context.jsonl is missing");
 
-    const content = readFileSync(meta.contextFile, "utf-8");
     const builder = new TranscriptBuilder();
     const ignoredToolCallIds = new Set<string>();
 
     let seq = 0;
     const fallbackTs = meta.createdAt;
-    for (const record of parseJsonlLines(content)) {
+    for (const record of readJsonlFile(meta.contextFile)) {
       seq++;
       try {
         const role = String(record.role ?? "");
@@ -434,7 +431,6 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     const wirePath = meta.wireFile ?? join(meta.sourcePath, "wire.jsonl");
     if (!existsSync(wirePath)) throw new Error("wire.jsonl is missing");
 
-    const content = readFileSync(wirePath, "utf-8");
     const builder = new TranscriptBuilder();
     const ignoredToolCallIds = new Set<string>();
     const openToolArgumentBuffer = new Map<string, string>();
@@ -442,7 +438,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     let openToolCallId: string | null = null;
     let seq = 0;
 
-    for (const record of parseJsonlLines(content)) {
+    for (const record of readJsonlFile(wirePath)) {
       seq++;
       try {
         const message = asRecord(record.message) ?? {};
@@ -712,6 +708,17 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     return builder.resolveToolCall(callId, { output: [...outputParts] });
   }
 
+  /** Applies a `_usage` record's running total; other records are ignored. */
+  private applyUsageTotal(record: Record<string, unknown>, stats: SessionData["stats"]): void {
+    if (record.role !== "_usage") return;
+    const tokenCount = asNumber(record.token_count);
+    if (tokenCount === undefined) {
+      reportFieldMismatch("kimi", "usage.token_count");
+      return;
+    }
+    stats.total_tokens = tokenCount;
+  }
+
   private extractStats(sessionDir: string): SessionData["stats"] {
     let totalCost = 0;
     const stats: SessionData["stats"] = {
@@ -725,13 +732,16 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     const wirePath = join(sessionDir, "wire.jsonl");
     if (!existsSync(wirePath)) return stats;
 
+    // The `_usage` running total is read from context.jsonl when it exists.
+    // Otherwise it lives in wire.jsonl — the same file this pass already walks,
+    // so fold it in here rather than reading wire.jsonl a second time.
+    const contextPath = join(sessionDir, "context.jsonl");
+    const hasContext = existsSync(contextPath);
+
     try {
-      const content = readFileSync(wirePath, "utf-8");
-      for (const line of content.split("\n").filter((l) => l.trim())) {
-        try {
-          const data = asRecord(JSON.parse(line));
-          const tokenUsage = asRecord(asRecord(data?.message)?.usage);
-          if (!tokenUsage) continue;
+      for (const record of readJsonlFile(wirePath)) {
+        const tokenUsage = asRecord(asRecord(record.message)?.usage);
+        if (tokenUsage) {
           const inputTokens = extractTokenField(tokenUsage, "input_tokens");
           const outputTokens = extractTokenField(tokenUsage, "output_tokens");
           stats.total_input_tokens += inputTokens;
@@ -741,37 +751,19 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
             output: outputTokens,
           });
           if (cost !== null) totalCost += cost;
-        } catch {
-          // skip
         }
+        if (!hasContext) this.applyUsageTotal(record, stats);
       }
     } catch {
-      // skip
+      // skip unreadable wire logs
     }
 
-    // Extract total tokens from context or wire
-    const contextPath = join(sessionDir, "context.jsonl");
-    const rawPath = existsSync(contextPath) ? contextPath : wirePath;
-    if (!existsSync(rawPath)) return stats;
-
-    try {
-      const rawContent = readFileSync(rawPath, "utf-8");
-      for (const line of rawContent.split("\n").filter((l) => l.trim())) {
-        try {
-          const data = asRecord(JSON.parse(line));
-          if (data?.role !== "_usage") continue;
-          const tokenCount = asNumber(data.token_count);
-          if (tokenCount === undefined) {
-            reportFieldMismatch("kimi", "usage.token_count");
-            continue;
-          }
-          stats.total_tokens = tokenCount;
-        } catch {
-          // skip
-        }
+    if (hasContext) {
+      try {
+        for (const record of readJsonlFile(contextPath)) this.applyUsageTotal(record, stats);
+      } catch {
+        // skip unreadable context logs
       }
-    } catch {
-      // skip
     }
 
     stats.total_cost = Number(totalCost.toFixed(8));


### PR DESCRIPTION
## Summary

`utils/jsonl.ts` spells out why session logs must not be loaded whole:

> Codex rollout files can exceed 400 MB; loading them with readFileSync + split doubles that as UTF-16 strings and OOMs the scan-refresh worker.

Only `codex` ever used the streaming reader it provides. `claudecode` and `kimi` still did `readFileSync` on every transcript, on both the head-scan and the session-data path.

Kimi additionally walked the same file twice. `extractStats` read `wire.jsonl` for token usage, then read `contextPath ?? wirePath` for the `_usage` running total — so a session with no `context.jsonl` loaded and split `wire.jsonl` twice in a row.

## Changes

**kimi**
- `extractFirstUserTitle`, `getSessionDataFromContext`, `getSessionDataFromWire` → `readJsonlFile`.
- `extractStats` folds the `_usage` lookup into the `wire.jsonl` pass when there is no `context.jsonl`, and reads `context.jsonl` separately only when it exists. Precedence is unchanged: a `_usage` record in `context.jsonl` still wins over one in `wire.jsonl`.

**claudecode**
- `getSessionData` → `readJsonlFile`.
- `parseSessionHeadResult` → `readJsonlFileLines`. It previously materialized the whole file as a line array for three things: the empty-file check, `JSON.parse(lines[0])` for `createdAt`, and the `lineIndex < 20` title window. All three now run off a record index maintained during the pass, so the opening record is parsed once instead of twice.
- Removed the unused private `parseSessionHead`.

**Diagnostics note:** these paths previously dropped malformed lines silently. Going through `readJsonlFile` means they now emit the same `agent.jsonl_lines_skipped` warning codex already produced — consistent, and no assertion depended on the silence.

## Measurements

Three repeated full `scan()` passes over both agents (61 claudecode + 14 kimi sessions):

| | before | after |
|---|---|---|
| claudecode scan | 964 / 917 / 919 ms | 938 / 909 / 906 ms |
| kimi scan | 33 / 30 / 30 ms | 31 / 30 / 32 ms |
| peak RSS | 610 MB | 251 MB |

Wall clock is unchanged; the win is peak memory. That is the point — this is the path that OOMs the worker on large logs.

Depends on #191: before that fix the streaming reader was ~3× slower than `readFileSync` on long-line files, so this migration would have been a regression.

## Testing

- New claudecode head-parse cases, each targeting something the line-array removal could have broken: empty file (and whitespace-only file), malformed opening record, malformed later record (session survives, count is right), missing first-record timestamp falling back to file mtime, the 20-record title window on both sides of the boundary, and a record straddling the 1 MiB chunk seam.
- **All six new cases were also run against the pre-change implementation and pass there too** — this is a refactor, so identical behaviour is the assertion.
- Kimi: `extractStats` walks `wire.jsonl` exactly once when there is no `context.jsonl`, and `context.jsonl` still wins for the `_usage` total when present.
- The existing kimi enumeration guard was widened to track `openSync` as well as `readFileSync`, otherwise it would have gone vacuously green once the code stopped using `readFileSync`.
- `pnpm build` / `pnpm test` (core 439, cli 215, web 382) / `pnpm lint` / `pnpm format:check` all clean.

Issue: CS-95