### PR TITLE
refactor(agents): share one source change-detection pass (CS-93)

### DIFF
--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -10,7 +10,6 @@ const mocks = vi.hoisted(() => {
     attachMissingProjectIdentities: vi.fn((sessions: SessionHead[]) => sessions),
     createRegisteredAgents: vi.fn(),
     ensureSessionTagsSync: vi.fn((_agent: BaseAgent, sessions: SessionHead[]) => ({ sessions })),
-    matchesScanWindow: vi.fn((_mtimeMs: number) => true),
     FileSystemSessionSource,
   };
 });
@@ -22,15 +21,20 @@ vi.mock("node:worker_threads", () => ({
   },
 }));
 
-vi.mock("@codesesh/core", () => ({
-  attachMissingProjectIdentities: mocks.attachMissingProjectIdentities,
-  createRegisteredAgents: mocks.createRegisteredAgents,
-  ensureSessionTagsSync: mocks.ensureSessionTagsSync,
-  FileSystemSessionSource: mocks.FileSystemSessionSource,
-  matchesScanWindow: mocks.matchesScanWindow,
-  // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
-  setCoreDiagnostics: vi.fn(),
-}));
+vi.mock("@codesesh/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codesesh/core")>();
+  return {
+    attachMissingProjectIdentities: mocks.attachMissingProjectIdentities,
+    createRegisteredAgents: mocks.createRegisteredAgents,
+    ensureSessionTagsSync: mocks.ensureSessionTagsSync,
+    FileSystemSessionSource: mocks.FileSystemSessionSource,
+    // The change decision is shared with FileSystemSessionSource.checkForChanges;
+    // stubbing it would stop this suite from covering the wiring it exists to test.
+    diffSessionSources: actual.diffSessionSources,
+    // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
+    setCoreDiagnostics: vi.fn(),
+  };
+});
 
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
@@ -85,7 +89,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.attachMissingProjectIdentities.mockImplementation((sessions) => sessions);
   mocks.ensureSessionTagsSync.mockImplementation((_agent, sessions) => ({ sessions }));
-  mocks.matchesScanWindow.mockReturnValue(true);
   setWorkerData();
 });
 
@@ -162,7 +165,7 @@ describe("scan refresh worker entry", () => {
     const changed = makeSession("changed", { title: "old" });
     const removed = makeSession("removed");
     const outsideWindow = makeSession("outside");
-    const compatible = makeSession("compatible", { title: "same title" });
+    const moved = makeSession("moved");
     const updated = makeSession("changed", { title: "new" });
     const refs: SessionSourceRef[] = [
       {
@@ -176,9 +179,9 @@ describe("scan refresh worker entry", () => {
         fingerprint: "different",
       },
       {
-        sessionId: "compatible",
-        sourcePath: "/compatible",
-        fingerprint: JSON.stringify(["v2", 1, 42, null, "same title"]),
+        sessionId: "moved",
+        sourcePath: "/moved-to",
+        fingerprint: "same",
       },
       {
         sessionId: "missing",
@@ -194,20 +197,58 @@ describe("scan refresh worker entry", () => {
       scanSessionSource,
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
-    mocks.matchesScanWindow.mockImplementation((mtimeMs) => mtimeMs !== 5);
     setWorkerData({
       sourceSync: true,
-      previousSessions: [unchanged, changed, removed, outsideWindow, compatible],
-      scanOptions: { from: 1, fast: true },
+      previousSessions: [unchanged, changed, removed, outsideWindow, moved],
+      // from: 5 puts `outside` (mtime 0) before the window and `removed`
+      // (mtime 10) inside it, so only the latter counts as deleted on disk.
+      scanOptions: { from: 5, fast: true },
       meta: {
         unchanged: { id: "unchanged", sourcePath: "/unchanged", sourceFingerprint: "same" },
         changed: { id: "changed", sourcePath: "/changed", sourceFingerprint: "old" },
         removed: { id: "removed", sourcePath: "/removed", sourceMtimeMs: 10 },
-        outside: { id: "outside", sourcePath: "/outside", sourceMtimeMs: 5 },
-        compatible: {
-          id: "compatible",
-          sourcePath: "/compatible",
-          sourceFingerprint: "legacy",
+        outside: { id: "outside", sourcePath: "/outside", sourceMtimeMs: 0 },
+        // Same fingerprint, different path — a relocated file still needs re-parsing.
+        moved: { id: "moved", sourcePath: "/moved-from", sourceFingerprint: "same" },
+      },
+    });
+
+    await runWorker();
+
+    expect(scanSessionSource).toHaveBeenCalledTimes(3);
+    expect(scanSessionSource).toHaveBeenCalledWith("/changed");
+    expect(scanSessionSource).toHaveBeenCalledWith("/moved-to");
+    expect(scanSessionSource).toHaveBeenCalledWith("/missing");
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "done",
+        sessions: [unchanged, updated, outsideWindow],
+        changedIds: ["changed", "moved", "missing", "removed"],
+      }),
+    );
+  });
+
+  it("re-parses a cached session whose fingerprint format changed", async () => {
+    const cached = makeSession("legacy");
+    const reparsed = makeSession("legacy", { title: "reparsed" });
+    const scanSessionSource = vi.fn(() => reparsed);
+    const agent = makeAgent({
+      listSessionSources: vi.fn(() => [
+        { sessionId: "legacy", sourcePath: "/legacy", fingerprint: '["v2",2,42,7,null]' },
+      ]),
+      scanSessionSource,
+    });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    setWorkerData({
+      sourceSync: true,
+      previousSessions: [cached],
+      meta: {
+        // Written by an older parser version: same file, but the head it produced
+        // is no longer what the current parser would produce.
+        legacy: {
+          id: "legacy",
+          sourcePath: "/legacy",
+          sourceFingerprint: '["v2",1,42,7,null]',
           sourceMtimeMs: 42,
         },
       },
@@ -215,15 +256,9 @@ describe("scan refresh worker entry", () => {
 
     await runWorker();
 
-    expect(scanSessionSource).toHaveBeenCalledTimes(2);
-    expect(scanSessionSource).toHaveBeenCalledWith("/changed");
-    expect(scanSessionSource).toHaveBeenCalledWith("/missing");
+    expect(scanSessionSource).toHaveBeenCalledWith("/legacy");
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        type: "done",
-        sessions: [unchanged, updated, outsideWindow, compatible],
-        changedIds: ["changed", "missing", "removed"],
-      }),
+      expect.objectContaining({ type: "done", sessions: [reparsed], changedIds: ["legacy"] }),
     );
   });
 });

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -3,15 +3,14 @@ import { parentPort, workerData } from "node:worker_threads";
 import {
   attachMissingProjectIdentities,
   createRegisteredAgents,
+  diffSessionSources,
   ensureSessionTagsSync,
   FileSystemSessionSource,
-  matchesScanWindow,
   type AgentScanProgress,
   type BaseAgent,
   type ScanOptions,
   type SessionCacheMeta,
   type SessionHead,
-  type SessionSourceRef,
 } from "@codesesh/core";
 
 export type ScanRefreshWorkerMessage =
@@ -52,65 +51,11 @@ function serializeMeta(agent: {
   return meta;
 }
 
-function sourceFingerprintFromMeta(meta: SessionCacheMeta | undefined): string | null {
-  return typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : null;
-}
-
-function parseSourceFingerprint(fingerprint: string): unknown[] | null {
-  try {
-    const parsed = JSON.parse(fingerprint);
-    return Array.isArray(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
 /**
- * Compare a live source fingerprint against the cached meta. A direct string
- * match is the fast path; the fallback tolerates older cache entries written by
- * a different fingerprint format as long as the underlying mtime (array slot 2)
- * is unchanged, so a fingerprint-format bump does not force a full rescan.
- */
-function sourceFingerprintMatches(
-  source: SessionSourceRef,
-  cachedSession: SessionHead,
-  cached: SessionCacheMeta | undefined,
-): boolean {
-  if (sourceFingerprintFromMeta(cached) === source.fingerprint) return true;
-
-  const current = parseSourceFingerprint(source.fingerprint);
-  if (!current || current.length < 5) return false;
-
-  return (
-    typeof cached?.sourceMtimeMs === "number" &&
-    cached.sourceMtimeMs === current[2] &&
-    (current[4] == null || cachedSession.title === current[4])
-  );
-}
-
-function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string | null {
-  return typeof meta?.sourcePath === "string" ? meta.sourcePath : null;
-}
-
-/**
- * A cached session outside the current scan window was never enumerated this
- * pass, so its absence from sourceRefs doesn't mean it was deleted on disk —
- * treat it as still present. Sessions with no recorded mtime predate this
- * field; keep them too rather than risk a false-positive removal.
- */
-function wasEnumeratedThisPass(
-  cached: SessionCacheMeta | undefined,
-  windowOptions: Pick<ScanOptions, "from" | "to"> | undefined,
-): boolean {
-  if (windowOptions?.from == null && windowOptions?.to == null) return true;
-  const mtimeMs = cached?.sourceMtimeMs;
-  return typeof mtimeMs !== "number" || matchesScanWindow(mtimeMs, windowOptions);
-}
-
-/**
- * Source-level incremental sync, mirroring FileSystemSessionSource.incrementalScan.
- * Kept standalone because the worker cannot share the agent's live metaMap with
- * the main thread — it receives cached meta via workerData instead.
+ * Source-level incremental sync. The change decision itself lives in
+ * diffSessionSources so this path and FileSystemSessionSource.checkForChanges
+ * cannot drift; only the re-parse and merge are local, because the worker holds
+ * cached meta received over workerData rather than the agent's live metaMap.
  */
 function syncAgentSources(
   agent: FileSystemSessionSource,
@@ -120,34 +65,31 @@ function syncAgentSources(
 ): { sessions: SessionHead[]; changedIds: string[] } {
   const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
   const sourceRefs = agent.listSessionSources(windowOptions);
-  const currentIds = new Set(sourceRefs.map((source) => source.sessionId));
-  const changedIds = new Set<string>();
+  const sourceById = new Map(sourceRefs.map((source) => [source.sessionId, source]));
+  const { changedIds, removedIds } = diffSessionSources(
+    sourceRefs,
+    cachedSessions,
+    cachedMeta,
+    windowOptions,
+  );
 
-  for (const source of sourceRefs) {
-    const cachedSession = sessionMap.get(source.sessionId);
-    const cached = cachedMeta[source.sessionId];
-    const sameSource = sourcePathFromMeta(cached) === source.sourcePath;
-    const sameFingerprint =
-      cachedSession && sourceFingerprintMatches(source, cachedSession, cached);
-    if (cachedSession && sameSource && sameFingerprint) continue;
-
+  for (const sessionId of changedIds) {
+    const source = sourceById.get(sessionId);
+    if (!source) continue;
     const next = agent.scanSessionSource(source.sourcePath);
-    changedIds.add(source.sessionId);
     if (next) {
       sessionMap.set(next.id, next);
     } else {
-      sessionMap.delete(source.sessionId);
+      sessionMap.delete(sessionId);
     }
   }
 
-  for (const session of cachedSessions) {
-    if (currentIds.has(session.id)) continue;
-    if (!wasEnumeratedThisPass(cachedMeta[session.id], windowOptions)) continue;
-    sessionMap.delete(session.id);
-    changedIds.add(session.id);
-  }
+  for (const sessionId of removedIds) sessionMap.delete(sessionId);
 
-  return { sessions: [...sessionMap.values()], changedIds: [...changedIds] };
+  return {
+    sessions: [...sessionMap.values()],
+    changedIds: [...new Set([...changedIds, ...removedIds])],
+  };
 }
 
 /**

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DatabaseSessionSource, FileSystemSessionSource } from "../base.js";
+import { DatabaseSessionSource, diffSessionSources, FileSystemSessionSource } from "../base.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
 import type { SessionData, SessionHead } from "../../types/index.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
@@ -144,6 +144,77 @@ describe("FileSystemSessionSource.scan", () => {
     } finally {
       setCoreDiagnostics(null);
     }
+  });
+});
+
+describe("diffSessionSources", () => {
+  function ref(
+    id: string,
+    fingerprint = "fp-1",
+    sourcePath = `/tmp/${id}.jsonl`,
+  ): SessionSourceRef {
+    return { sessionId: id, sourcePath, fingerprint };
+  }
+
+  function meta(id: string, overrides: Partial<SessionCacheMeta> = {}): SessionCacheMeta {
+    return { id, sourcePath: `/tmp/${id}.jsonl`, sourceFingerprint: "fp-1", ...overrides };
+  }
+
+  it("reads cached meta from a Map and from a plain object identically", () => {
+    const refs = [ref("a"), ref("b", "fp-2")];
+    const cached = [makeSession("a"), makeSession("b")];
+    const entries = { a: meta("a"), b: meta("b") };
+
+    const fromObject = diffSessionSources(refs, cached, entries);
+    const fromMap = diffSessionSources(refs, cached, new Map(Object.entries(entries)));
+
+    expect(fromObject).toEqual({ changedIds: ["b"], removedIds: [] });
+    expect(fromMap).toEqual(fromObject);
+  });
+
+  it("treats a differing fingerprint as changed even when the mtime is unchanged", () => {
+    // Agents put their head-index and parser versions in the fingerprint so a
+    // version bump invalidates cached heads; matching mtimes must not override it.
+    const diff = diffSessionSources(
+      [ref("a", '["head-v1","parser-v2",42,7,null]')],
+      [makeSession("a")],
+      {
+        a: meta("a", { sourceFingerprint: '["head-v1","parser-v1",42,7,null]', sourceMtimeMs: 42 }),
+      },
+    );
+
+    expect(diff).toEqual({ changedIds: ["a"], removedIds: [] });
+  });
+
+  it("treats a ref with no cached session as changed even when its meta matches", () => {
+    const diff = diffSessionSources([ref("a")], [], { a: meta("a") });
+    expect(diff).toEqual({ changedIds: ["a"], removedIds: [] });
+  });
+
+  it("separates removed sessions from changed ones", () => {
+    const diff = diffSessionSources([ref("a")], [makeSession("a"), makeSession("gone")], {
+      a: meta("a"),
+      gone: meta("gone"),
+    });
+
+    expect(diff).toEqual({ changedIds: [], removedIds: ["gone"] });
+  });
+
+  it("keeps sessions whose mtime falls outside the scan window", () => {
+    const cached = [makeSession("recent"), makeSession("old"), makeSession("undated")];
+    const entries = {
+      recent: meta("recent", { sourceMtimeMs: 500 }),
+      old: meta("old", { sourceMtimeMs: 10 }),
+      undated: meta("undated"),
+    };
+
+    const windowed = diffSessionSources([], cached, entries, { from: 100 });
+    const unwindowed = diffSessionSources([], cached, entries);
+
+    // `old` was never enumerated this pass, so its absence proves nothing.
+    // `undated` has no recorded mtime, so the window cannot exonerate it.
+    expect(windowed.removedIds).toEqual(["recent", "undated"]);
+    expect(unwindowed.removedIds).toEqual(["recent", "old", "undated"]);
   });
 });
 

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -63,6 +63,92 @@ export interface SessionSourceRef {
   fingerprint: string;
 }
 
+/** What a source enumeration says needs re-parsing and what disappeared. */
+export interface SessionSourceDiff {
+  changedIds: string[];
+  removedIds: string[];
+}
+
+/**
+ * Cached meta reaches this comparison as a live Map on the main thread and as a
+ * plain object over the worker's structured-clone boundary.
+ */
+export type CachedMetaLookup =
+  | ReadonlyMap<string, SessionCacheMeta>
+  | Record<string, SessionCacheMeta>;
+
+function readCachedMeta(meta: CachedMetaLookup, sessionId: string): SessionCacheMeta | undefined {
+  if (meta instanceof Map) return meta.get(sessionId);
+  return (meta as Record<string, SessionCacheMeta>)[sessionId];
+}
+
+/**
+ * Fingerprints compare by exact string equality. Agents encode their head-index
+ * and parser versions into the fingerprint precisely so that bumping either one
+ * invalidates every cached head — a tolerant comparison would defeat that.
+ */
+function fingerprintMatches(ref: SessionSourceRef, cached: SessionCacheMeta | undefined): boolean {
+  return (
+    typeof cached?.sourceFingerprint === "string" && cached.sourceFingerprint === ref.fingerprint
+  );
+}
+
+/**
+ * A cached session whose recorded mtime falls outside the current scan window was
+ * never enumerated this pass, so its absence from the refs doesn't mean it was
+ * deleted on disk.
+ *
+ * A session with no recorded mtime is treated as enumerated, i.e. removable.
+ * That is load-bearing for agents whose meta omits `sourceMtimeMs` (kimi) — see
+ * CS-100 for whether that default should be inverted.
+ */
+function wasEnumeratedThisPass(
+  cached: SessionCacheMeta | undefined,
+  options: AgentScanOptions | undefined,
+): boolean {
+  if (options?.from == null && options?.to == null) return true;
+  const mtimeMs = cached?.sourceMtimeMs;
+  return typeof mtimeMs !== "number" || matchesScanWindow(mtimeMs, options);
+}
+
+/**
+ * Single owner of "which sources changed" for file-backed agents. The main
+ * thread reaches it through FileSystemSessionSource.checkForChanges; the
+ * scan-refresh worker calls it directly, because it holds cached meta received
+ * over workerData rather than a live agent metaMap.
+ */
+export function diffSessionSources(
+  refs: SessionSourceRef[],
+  cachedSessions: SessionHead[],
+  cachedMeta: CachedMetaLookup,
+  options?: AgentScanOptions,
+): SessionSourceDiff {
+  const cachedIds = new Set(cachedSessions.map((session) => session.id));
+  const enumeratedIds = new Set<string>();
+  const changedIds: string[] = [];
+
+  for (const ref of refs) {
+    enumeratedIds.add(ref.sessionId);
+    const meta = readCachedMeta(cachedMeta, ref.sessionId);
+    // A ref with no cached session has to be parsed even when its meta matches:
+    // the caller's session list is what the refresh merges into.
+    const unchanged =
+      cachedIds.has(ref.sessionId) &&
+      meta?.sourcePath === ref.sourcePath &&
+      fingerprintMatches(ref, meta);
+    if (!unchanged) changedIds.push(ref.sessionId);
+  }
+
+  const removedIds: string[] = [];
+  for (const session of cachedSessions) {
+    if (enumeratedIds.has(session.id)) continue;
+    if (!wasEnumeratedThisPass(readCachedMeta(cachedMeta, session.id), options)) continue;
+    removedIds.push(session.id);
+  }
+
+  return { changedIds, removedIds };
+}
+
 export abstract class BaseAgent {
   abstract readonly name: string;
   abstract readonly displayName: string;
@@ -170,30 +256,17 @@ export abstract class FileSystemSessionSource<
   }
 
   /**
-   * 变更检测：枚举当前源 → 与缓存 metaMap 的指纹/路径比对。
+   * 变更检测：枚举当前源 → 交给 diffSessionSources 比对。
    * 新增、变更、删除三类统一产出 changedIds。
    */
   checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
     const currentRefs = this.listSessionSources();
-    const currentIds = new Set(currentRefs.map((ref) => ref.sessionId));
-    const changedIds = new Set<string>();
+    const diff = diffSessionSources(currentRefs, cachedSessions, this.sessionMetaMap);
+    const changedIds = [...new Set([...diff.changedIds, ...diff.removedIds])];
 
-    for (const ref of currentRefs) {
-      const meta = this.sessionMetaMap.get(ref.sessionId);
-      const samePath = meta?.sourcePath === ref.sourcePath;
-      const sameFingerprint =
-        typeof meta?.sourceFingerprint === "string" && meta.sourceFingerprint === ref.fingerprint;
-      if (!samePath || !sameFingerprint) changedIds.add(ref.sessionId);
-    }
-
-    for (const session of cachedSessions) {
-      if (!currentIds.has(session.id)) changedIds.add(session.id);
-    }
-
-    const changedIdList = [...changedIds];
     return {
-      hasChanges: changedIdList.length > 0,
-      changedIds: changedIdList,
+      hasChanges: changedIds.length > 0,
+      changedIds,
       timestamp: Date.now(),
       refs: currentRefs,
     };

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,5 +1,6 @@
 export { BaseAgent, FileSystemSessionSource, DatabaseSessionSource } from "./base.js";
 export {
+  diffSessionSources,
   filteredSession,
   getParsedSession,
   matchesScanWindow,
@@ -9,8 +10,10 @@ export {
 export type {
   AgentScanOptions,
   AgentScanProgress,
+  CachedMetaLookup,
   ChangeCheckResult,
   SessionCacheMeta,
+  SessionSourceDiff,
   SessionSourceRef,
 } from "./base.js";
 export type { ParseSessionResult } from "../types/index.js";


### PR DESCRIPTION
## Summary

"Which sources changed since the last refresh" was implemented twice:

- `FileSystemSessionSource.checkForChanges` (`packages/core/src/agents/base.ts`)
- `syncAgentSources` in `packages/cli/src/scan-refresh-worker.ts`, whose own comment said *"Kept standalone because the worker cannot share the agent's live metaMap"*

Only the worker copy runs on the server path: `index.ts` passes `deferInitialRefresh: !jsonOnly`, so the startup scan is `cacheOnly` and returns before `checkForChanges`. The base copy only runs under `--json`.

**They disagreed on a case that matters.** The worker treated a *differing* fingerprint as unchanged whenever the cached `sourceMtimeMs` and title still matched:

```ts
if (sourceFingerprintFromMeta(cached) === source.fingerprint) return true;
const current = parseSourceFingerprint(source.fingerprint);
if (!current || current.length < 5) return false;
return cached?.sourceMtimeMs === current[2] && (current[4] == null || cachedSession.title === current[4]);
```

Agents encode `HEAD_INDEX_VERSION` and `PARSER_VERSION` into the fingerprint precisely so that bumping either one invalidates every cached head. That fallback compares only slots 2 and 4 — mtime and title — so on the server path **a parser-version bump never invalidated anything**. `packages/core/src/agents/__tests__/codex.test.ts:244` already asserted the opposite for the base path.

`git log -S sourceFingerprintMatches` traces the fallback to #43, whose description states its purpose:

> Keep legacy fingerprint compatibility so the first refresh after this change does not rescan every cached Codex session.

A one-time migration shim for that specific format change. Caches have long since been rewritten in the new format; what remains is a permanent hole in version-based invalidation.

## Changes

- New exported `diffSessionSources(refs, cachedSessions, cachedMeta, options)` in `base.ts`, returning `{ changedIds, removedIds }`. It accepts cached meta as either a `Map` (main thread) or a plain object (worker's `workerData`), which is the only reason the two copies existed.
- `checkForChanges` and the worker's `syncAgentSources` both delegate to it. The worker keeps only its re-parse-and-merge loop.
- **Fingerprint comparison is now exact string equality**, dropping the shim. Cost: one full rescan per agent after a fingerprint-format or parser-version change — which is the point of those fields.
- A ref with no corresponding cached session is now always parsed. The old base copy compared meta only, so such a session could be silently omitted from the refresh result.

Placed in `base.ts` rather than a new module: the helper needs `matchesScanWindow`, `SessionSourceRef`, `SessionCacheMeta` and `AgentScanOptions`, all defined there, and a separate file would need either a runtime import cycle or a much larger type migration.

## Deliberately not changed

`wasEnumeratedThisPass` returns `true` for cached entries with no `sourceMtimeMs`, i.e. treats them as removable — while its comment claimed it keeps them "rather than risk a false-positive removal". `KimiAgent`'s meta happens not to write that field, so windowed refreshes may be dropping out-of-window Kimi sessions today.

This PR preserves that behaviour byte for byte and only corrects the comment. Changing deletion semantics inside a refactor would be the wrong place for it — filed as **CS-100** with the two candidate fixes and the verification needed to choose between them.

## Testing

- New `diffSessionSources` unit tests: Map and object meta produce identical results; a differing fingerprint with matching mtime counts as changed (the behaviour this PR restores); a ref with no cached session counts as changed; removals are reported separately from changes; the scan-window guard.
- Worker integration: the `compatible` case encoded the removed shim, so it is replaced by `moved` (same fingerprint, different path → re-parse) plus a new case asserting a parser-version bump does trigger a re-parse.
- The suite's `@codesesh/core` mock now passes through the real `diffSessionSources` — stubbing it would leave this suite unable to cover the wiring it exists to test. Its `matchesScanWindow` stub is gone; the window case now drives real timestamps.
- `pnpm build` / `pnpm test` (core 444, cli 216, web 382) / `pnpm lint` / `pnpm format:check` all clean.

Issue: CS-93