### PR TITLE
refactor(api): split handlers into parsing, aliases and analytics (CS-96)

### DIFF
--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -1,23 +1,17 @@
 import type { Context } from "hono";
 import type {
   BookmarkRecord,
-  ProjectGroup,
   ScanResult,
   SessionCacheMeta,
   SessionData,
   SessionHead,
   SmartTag,
 } from "@codesesh/core";
-import type {
-  ApiProjectAgentStat,
-  ApiProjectGroup,
-  AppConfig,
-  ScanStatusEvent,
-  SearchResult,
-} from "@codesesh/core/contract";
+import type { AppConfig, ScanStatusEvent } from "@codesesh/core/contract";
 import {
   BookmarkStorageUnavailableError,
   StateStorageUnavailableError,
+  attachProjectMetrics,
   createProjectScopeMatcher,
   deleteBookmark,
   getAgentInfoMap,
@@ -27,15 +21,11 @@ import {
   extractSessionFileActivity,
   getSmartTagSourceTimestamp,
   importBookmarks,
-  isProjectIdentityKind,
   loadCachedSessionDataEntry,
   listFileActivity,
   listSessionFileActivity,
   listCachedProjectGroups,
   listBookmarks,
-  listSessionAliases,
-  matchesSessionSearchFilters,
-  mergeSearchQueryOptions,
   deleteSessionAlias,
   upsertSessionAlias,
   realFs,
@@ -43,18 +33,29 @@ import {
   matchesProjectScope as sessionMatchesProjectScope,
   matchesProjectIdentity,
   buildDashboard,
-  getSessionAgentName,
-  getSessionActivityTime,
-  getTotalTokens,
   type DashboardData,
   type DashboardScope,
-  type FileActivityKind,
-  type FileActivityResult,
-  type ProjectIdentityRef,
-  type SearchOptions,
 } from "@codesesh/core";
 import { appLogger } from "../logging.js";
-import { resolveTimeWindow, type TimeWindow } from "../time-window-resolution.js";
+import { resolveTimeWindow } from "../time-window-resolution.js";
+import {
+  filterSessionsByActivityWindow,
+  parseDateParam,
+  parseFileActivityKind,
+  parseProjectIdentityFilter,
+  parseSearchOptions,
+  optionalQueryValue,
+  type SessionListDefaults,
+} from "./query-params.js";
+import {
+  decorateBookmark,
+  decorateFileActivity,
+  findAliasSearchResults,
+  getSessionAgentKey,
+  loadAliasView,
+} from "./session-aliases-view.js";
+
+export type { SessionListDefaults };
 
 export interface ScanResultSource {
   getSnapshot(): ScanResult;
@@ -63,8 +64,6 @@ export interface ScanResultSource {
 export interface ScanStatusSource {
   getScanStatus(): ScanStatusEvent;
 }
-
-export type SessionListDefaults = TimeWindow;
 
 interface ClientLogPayload {
   event?: unknown;
@@ -82,105 +81,6 @@ function cacheMatchesCurrentSource(
 
 interface SessionAliasPayload {
   alias?: unknown;
-}
-
-type SessionAliasMap = Map<string, string>;
-
-function getSessionAliasKey(agentKey: string, sessionId: string): string {
-  return `${agentKey.toLowerCase()}\0${sessionId}`;
-}
-
-function getSessionAgentKey(session: Pick<SessionHead, "slug">): string {
-  return session.slug.split("/")[0]?.toLowerCase() ?? "";
-}
-
-function loadSessionAliasMap(): SessionAliasMap {
-  try {
-    return new Map(
-      listSessionAliases().map((alias) => [
-        getSessionAliasKey(alias.agentKey, alias.sessionId),
-        alias.alias,
-      ]),
-    );
-  } catch (error) {
-    if (!(error instanceof StateStorageUnavailableError)) {
-      appLogger.warn("api.session_aliases.load_failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-    return new Map();
-  }
-}
-
-function isStateStorageUnavailable(error: unknown): boolean {
-  return error instanceof StateStorageUnavailableError;
-}
-
-function withDisplayTitle<T extends { id: string; title: string; display_title?: string }>(
-  session: T,
-  agentKey: string,
-  aliases: SessionAliasMap,
-): T {
-  const alias = aliases.get(getSessionAliasKey(agentKey, session.id));
-  return alias ? { ...session, display_title: alias } : session;
-}
-
-function withBookmarkDisplayTitle(
-  bookmark: BookmarkRecord,
-  aliases: SessionAliasMap,
-): BookmarkRecord {
-  const alias = aliases.get(getSessionAliasKey(bookmark.agentKey, bookmark.sessionId));
-  return alias ? { ...bookmark, display_title: alias } : bookmark;
-}
-
-function withFileActivityDisplayTitle(
-  activity: FileActivityResult,
-  aliases: SessionAliasMap,
-): FileActivityResult {
-  return {
-    ...activity,
-    session: withDisplayTitle(activity.session, activity.agent_name, aliases),
-  };
-}
-
-function findSessionByAliasKey(scanResult: ScanResult, aliasKey: string): SessionHead | undefined {
-  const separatorIndex = aliasKey.indexOf("\0");
-  const agentName = aliasKey.slice(0, separatorIndex);
-  const sessionId = aliasKey.slice(separatorIndex + 1);
-  return scanResult.byAgent[agentName]?.find((session) => session.id === sessionId);
-}
-
-// Alias hits still have to satisfy the same time-window/project/agent
-// filters as the main search (matchesSessionSearchFilters), otherwise an
-// aliased session could appear in results outside its search scope.
-function findAliasSearchResults(
-  query: string,
-  options: SearchOptions,
-  scanResult: ScanResult,
-  aliases: SessionAliasMap,
-) {
-  const search = mergeSearchQueryOptions(query, options);
-  const needle = search.text.trim().toLowerCase();
-  if (!needle || aliases.size === 0) return [];
-
-  const projectScope = search.options.cwd ? createProjectScopeMatcher(search.options.cwd) : null;
-  const results: SearchResult[] = [];
-  for (const [aliasKey, alias] of aliases) {
-    if (!alias.toLowerCase().includes(needle)) continue;
-    const session = findSessionByAliasKey(scanResult, aliasKey);
-    if (!session) continue;
-    const agentName = aliasKey.slice(0, aliasKey.indexOf("\0"));
-    if (!matchesSessionSearchFilters(agentName, session, search.options, projectScope)) continue;
-    results.push({
-      agentName,
-      session: withDisplayTitle(session, agentName, aliases),
-      snippet: `Alias · ${session.directory}`,
-      matchType: "title",
-    });
-  }
-  return results.sort(
-    (a, b) => getSessionActivityTime(b.session) - getSessionActivityTime(a.session),
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -225,95 +125,6 @@ function parseBookmarkPayload(value: unknown): Omit<BookmarkRecord, "bookmarked_
   };
 }
 
-function parseDateParam(
-  value: string | undefined,
-  fallback: number | undefined,
-): number | undefined {
-  if (value == null) return fallback;
-  const ts = new Date(value).getTime();
-  return Number.isNaN(ts) ? fallback : ts;
-}
-
-function parseNumberParam(value: string | undefined): number | undefined {
-  if (value == null || !value.trim()) return undefined;
-  const number = Number(value);
-  return Number.isFinite(number) ? number : undefined;
-}
-
-function searchParams(c: Context): URLSearchParams {
-  return new URL(c.req.url ?? "http://localhost/", "http://localhost/").searchParams;
-}
-
-function queryValues(params: URLSearchParams, ...names: string[]): string[] {
-  return names.flatMap((name) =>
-    params
-      .getAll(name)
-      .flatMap((value) => value.split(","))
-      .map((value) => value.trim())
-      .filter(Boolean),
-  );
-}
-
-function parseSmartTags(values: string[]): SmartTag[] | undefined {
-  const tags = values
-    .map((value) => value.toLowerCase())
-    .filter((value): value is SmartTag =>
-      [
-        "bugfix",
-        "refactoring",
-        "feature-dev",
-        "testing",
-        "docs",
-        "git-ops",
-        "build-deploy",
-        "exploration",
-        "planning",
-      ].includes(value),
-    );
-  return tags.length > 0 ? [...new Set(tags)] : undefined;
-}
-
-function parseSearchOptions(
-  c: Context,
-  defaults: SessionListDefaults,
-  projectIdentity?: ProjectIdentityRef,
-): SearchOptions {
-  const params = searchParams(c);
-  const limitValue = parseNumberParam(params.get("limit") ?? undefined);
-  return {
-    agent: optionalQueryValue(params.get("agent") ?? undefined),
-    project: optionalQueryValue(params.get("project") ?? undefined),
-    projectKind: projectIdentity?.kind,
-    projectKey: projectIdentity?.key,
-    cwd: optionalQueryValue(params.get("cwd") ?? undefined),
-    tags: parseSmartTags(queryValues(params, "tag", "tags", "signal")),
-    tools: queryValues(params, "tool", "tools").map((tool) => tool.toLowerCase()),
-    file: optionalQueryValue(params.get("file") ?? params.get("path") ?? undefined),
-    fileKind: parseFileActivityKind(
-      optionalQueryValue(params.get("fileKind") ?? params.get("fileActivity") ?? undefined),
-    ),
-    costMin: parseNumberParam(params.get("costMin") ?? undefined),
-    costMax: parseNumberParam(params.get("costMax") ?? undefined),
-    from: parseDateParam(params.get("from") ?? undefined, defaults.from),
-    to: parseDateParam(params.get("to") ?? undefined, defaults.to),
-    limit: limitValue && limitValue > 0 ? Math.min(limitValue, 100) : 50,
-  };
-}
-
-function filterSessionsByActivityWindow(
-  sessions: SessionHead[],
-  from: number | undefined,
-  to: number | undefined,
-): SessionHead[] {
-  if (from == null && to == null) return sessions;
-  return sessions.filter((session) => {
-    const activity = getSessionActivityTime(session);
-    if (from != null && activity < from) return false;
-    if (to != null && activity > to) return false;
-    return true;
-  });
-}
-
 function sanitizeClientLogData(value: unknown): Record<string, unknown> {
   if (!isRecord(value)) return {};
 
@@ -328,84 +139,6 @@ function sanitizeClientLogData(value: unknown): Record<string, unknown> {
         return [key, String(item).slice(0, 300)];
       }),
   );
-}
-
-function getProjectGroupKey(identityKind: string, identityKey: string): string {
-  return `${identityKind}:${identityKey}`;
-}
-
-function attachProjectMetrics(
-  projects: ProjectGroup[],
-  sessions: SessionHead[],
-): ApiProjectGroup[] {
-  const metrics = new Map<
-    string,
-    {
-      messages: number;
-      tokens: number;
-      cost: number;
-      hasEstimatedCost: boolean;
-      agentStats: Map<string, ApiProjectAgentStat>;
-    }
-  >();
-
-  for (const session of sessions) {
-    const identity = session.project_identity;
-    if (!identity) continue;
-    const key = getProjectGroupKey(identity.kind, identity.key);
-    let current = metrics.get(key);
-    if (!current) {
-      current = {
-        messages: 0,
-        tokens: 0,
-        cost: 0,
-        hasEstimatedCost: false,
-        agentStats: new Map(),
-      };
-      metrics.set(key, current);
-    }
-
-    const tokens = getTotalTokens(session.stats);
-    const cost = session.stats.total_cost ?? 0;
-    current.messages += session.stats.message_count;
-    current.tokens += tokens;
-    current.cost += cost;
-    if (session.stats.cost_source === "estimated") current.hasEstimatedCost = true;
-
-    const agentName = getSessionAgentName(session);
-    const agent = current.agentStats.get(agentName);
-    if (agent) {
-      agent.sessions += 1;
-      agent.messages += session.stats.message_count;
-      agent.tokens += tokens;
-      agent.cost += cost;
-    } else {
-      current.agentStats.set(agentName, {
-        name: agentName,
-        sessions: 1,
-        messages: session.stats.message_count,
-        tokens,
-        cost,
-      });
-    }
-  }
-
-  return projects.map((project) => {
-    const metric = metrics.get(getProjectGroupKey(project.identityKind, project.identityKey));
-    return {
-      ...project,
-      messages: metric?.messages ?? 0,
-      tokens: metric?.tokens ?? 0,
-      cost: metric?.cost ?? 0,
-      cost_source:
-        metric && metric.cost > 0
-          ? metric.hasEstimatedCost
-            ? "estimated"
-            : "recorded"
-          : undefined,
-      agentStats: [...(metric?.agentStats.values() ?? [])].sort((a, b) => b.sessions - a.sessions),
-    };
-  });
 }
 
 export function handleGetConfig(c: Context, defaults: SessionListDefaults) {
@@ -496,17 +229,15 @@ export function handleGetSessions(
     sessions = sessions.filter((s) => s.smart_tags?.includes(tag as SmartTag));
   }
 
-  const aliases = loadSessionAliasMap();
+  const aliases = loadAliasView();
   if (q) {
     sessions = sessions.filter((session) => {
-      const alias = aliases.get(getSessionAliasKey(getSessionAgentKey(session), session.id));
+      const alias = aliases.get(getSessionAgentKey(session), session.id);
       return session.title.toLowerCase().includes(q) || alias?.toLowerCase().includes(q);
     });
   }
   return c.json({
-    sessions: sessions.map((session) =>
-      withDisplayTitle(session, getSessionAgentKey(session), aliases),
-    ),
+    sessions: sessions.map((session) => aliases.decorate(session, getSessionAgentKey(session))),
   });
 }
 
@@ -525,10 +256,10 @@ export function handleSearchSessions(
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
   const searchOptions = parseSearchOptions(c, defaults, projectIdentity);
-  const aliases = loadSessionAliasMap();
+  const aliases = loadAliasView();
   const results = executeSessionSearch(query, searchOptions, scanResult).map((result) => ({
     ...result,
-    session: withDisplayTitle(result.session, result.agentName, aliases),
+    session: aliases.decorate(result.session, result.agentName),
   }));
   const aliasResults = findAliasSearchResults(query, searchOptions, scanResult, aliases);
   const deduped = new Map<string, (typeof results)[number]>();
@@ -536,29 +267,6 @@ export function handleSearchSessions(
     deduped.set(`${result.agentName}\0${result.session.id}`, result);
   }
   return c.json({ results: [...deduped.values()].slice(0, searchOptions.limit ?? 50) });
-}
-
-function parseFileActivityKind(value: string | undefined): FileActivityKind | undefined {
-  if (value === "read" || value === "edit" || value === "write" || value === "delete") {
-    return value;
-  }
-  return undefined;
-}
-
-function optionalQueryValue(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  return normalized ? normalized : undefined;
-}
-
-function parseProjectIdentityFilter(
-  kindValue: string | undefined,
-  keyValue: string | undefined,
-): ProjectIdentityRef | null | undefined {
-  const kind = optionalQueryValue(kindValue);
-  const key = optionalQueryValue(keyValue);
-  if (!kind && !key) return undefined;
-  if (!kind || !key || !isProjectIdentityKind(kind)) return null;
-  return { kind, key };
 }
 
 export function handleGetFileActivity(c: Context, defaults: SessionListDefaults = {}) {
@@ -572,7 +280,7 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
 
-  const aliases = loadSessionAliasMap();
+  const aliases = loadAliasView();
   return c.json({
     activity: listFileActivity({
       agent: optionalQueryValue(c.req.query("agent")),
@@ -586,7 +294,7 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
       from: parseDateParam(c.req.query("from"), defaults.from),
       to: parseDateParam(c.req.query("to"), defaults.to),
       limit,
-    }).map((activity) => withFileActivityDisplayTitle(activity, aliases)),
+    }).map((activity) => decorateFileActivity(activity, aliases)),
   });
 }
 
@@ -653,9 +361,9 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       tag_duration_ms: Math.round(tagDuration),
       duration_ms: Math.round(performance.now() - startedAt),
     });
-    const aliases = loadSessionAliasMap();
+    const aliases = loadAliasView();
     return c.json({
-      ...withDisplayTitle(data, agentName, aliases),
+      ...aliases.decorate(data, agentName),
       project_identity: projectIdentity,
       smart_tags: smartTags,
       smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
@@ -691,9 +399,9 @@ export async function handlePostClientLog(c: Context) {
 
 export function handleGetBookmarks(c: Context) {
   try {
-    const aliases = loadSessionAliasMap();
+    const aliases = loadAliasView();
     return c.json({
-      bookmarks: listBookmarks().map((bookmark) => withBookmarkDisplayTitle(bookmark, aliases)),
+      bookmarks: listBookmarks().map((bookmark) => decorateBookmark(bookmark, aliases)),
       storageAvailable: true,
     });
   } catch (error) {
@@ -776,7 +484,7 @@ export async function handlePutSessionAlias(c: Context) {
     if (error instanceof TypeError) {
       return c.json({ error: "Session alias must be non-empty and at most 160 characters" }, 400);
     }
-    if (isStateStorageUnavailable(error)) {
+    if (error instanceof StateStorageUnavailableError) {
       return c.json({ error: "Session alias storage is unavailable" }, 503);
     }
     throw error;
@@ -794,7 +502,7 @@ export function handleDeleteSessionAlias(c: Context) {
     deleteSessionAlias(agentKey, sessionId);
     return c.json({ ok: true });
   } catch (error) {
-    if (isStateStorageUnavailable(error)) {
+    if (error instanceof StateStorageUnavailableError) {
       return c.json({ error: "Session alias storage is unavailable" }, 503);
     }
     throw error;
@@ -853,14 +561,14 @@ export function handleGetDashboard(
     window: { from, to, days },
   };
 
-  const aliases = loadSessionAliasMap();
+  const aliases = loadAliasView();
   return c.json({
     ...data,
     recentSessions: data.recentSessions.map((session) =>
-      withDisplayTitle(session, session.agentName, aliases),
+      aliases.decorate(session, session.agentName),
     ),
     recentFileActivities: data.recentFileActivities.map((activity) =>
-      withFileActivityDisplayTitle(activity, aliases),
+      decorateFileActivity(activity, aliases),
     ),
   });
 }

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -1,0 +1,139 @@
+/**
+ * Request-parameter parsing for the HTTP API. Everything here turns raw query
+ * strings into the option objects the domain layer expects; no domain logic,
+ * no storage access.
+ */
+import type { Context } from "hono";
+import type { SessionHead, SmartTag } from "@codesesh/core";
+import {
+  getSessionActivityTime,
+  isProjectIdentityKind,
+  type FileActivityKind,
+  type ProjectIdentityRef,
+  type SearchOptions,
+} from "@codesesh/core";
+import type { TimeWindow } from "../time-window-resolution.js";
+
+export type SessionListDefaults = TimeWindow;
+
+const SMART_TAGS: readonly string[] = [
+  "bugfix",
+  "refactoring",
+  "feature-dev",
+  "testing",
+  "docs",
+  "git-ops",
+  "build-deploy",
+  "exploration",
+  "planning",
+];
+
+const SEARCH_LIMIT_MAX = 100;
+const SEARCH_LIMIT_DEFAULT = 50;
+
+export function searchParams(c: Context): URLSearchParams {
+  return new URL(c.req.url ?? "http://localhost/", "http://localhost/").searchParams;
+}
+
+/** Collects repeated and comma-separated values across several parameter names. */
+export function queryValues(params: URLSearchParams, ...names: string[]): string[] {
+  return names.flatMap((name) =>
+    params
+      .getAll(name)
+      .flatMap((value) => value.split(","))
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+}
+
+export function optionalQueryValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+export function parseDateParam(
+  value: string | undefined,
+  fallback: number | undefined,
+): number | undefined {
+  if (value == null) return fallback;
+  const ts = new Date(value).getTime();
+  return Number.isNaN(ts) ? fallback : ts;
+}
+
+export function parseNumberParam(value: string | undefined): number | undefined {
+  if (value == null || !value.trim()) return undefined;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+export function parseSmartTags(values: string[]): SmartTag[] | undefined {
+  const tags = values
+    .map((value) => value.toLowerCase())
+    .filter((value): value is SmartTag => SMART_TAGS.includes(value));
+  return tags.length > 0 ? [...new Set(tags)] : undefined;
+}
+
+export function parseFileActivityKind(value: string | undefined): FileActivityKind | undefined {
+  if (value === "read" || value === "edit" || value === "write" || value === "delete") {
+    return value;
+  }
+  return undefined;
+}
+
+/**
+ * Returns the identity when both halves are present and valid, `undefined` when
+ * neither is supplied, and `null` when the pair is incomplete or malformed —
+ * callers turn that `null` into a 400.
+ */
+export function parseProjectIdentityFilter(
+  kindValue: string | undefined,
+  keyValue: string | undefined,
+): ProjectIdentityRef | null | undefined {
+  const kind = optionalQueryValue(kindValue);
+  const key = optionalQueryValue(keyValue);
+  if (!kind && !key) return undefined;
+  if (!kind || !key || !isProjectIdentityKind(kind)) return null;
+  return { kind, key };
+}
+
+export function parseSearchOptions(
+  c: Context,
+  defaults: SessionListDefaults,
+  projectIdentity?: ProjectIdentityRef,
+): SearchOptions {
+  const params = searchParams(c);
+  const limitValue = parseNumberParam(params.get("limit") ?? undefined);
+  return {
+    agent: optionalQueryValue(params.get("agent") ?? undefined),
+    project: optionalQueryValue(params.get("project") ?? undefined),
+    projectKind: projectIdentity?.kind,
+    projectKey: projectIdentity?.key,
+    cwd: optionalQueryValue(params.get("cwd") ?? undefined),
+    tags: parseSmartTags(queryValues(params, "tag", "tags", "signal")),
+    tools: queryValues(params, "tool", "tools").map((tool) => tool.toLowerCase()),
+    file: optionalQueryValue(params.get("file") ?? params.get("path") ?? undefined),
+    fileKind: parseFileActivityKind(
+      optionalQueryValue(params.get("fileKind") ?? params.get("fileActivity") ?? undefined),
+    ),
+    costMin: parseNumberParam(params.get("costMin") ?? undefined),
+    costMax: parseNumberParam(params.get("costMax") ?? undefined),
+    from: parseDateParam(params.get("from") ?? undefined, defaults.from),
+    to: parseDateParam(params.get("to") ?? undefined, defaults.to),
+    limit:
+      limitValue && limitValue > 0 ? Math.min(limitValue, SEARCH_LIMIT_MAX) : SEARCH_LIMIT_DEFAULT,
+  };
+}
+
+export function filterSessionsByActivityWindow(
+  sessions: SessionHead[],
+  from: number | undefined,
+  to: number | undefined,
+): SessionHead[] {
+  if (from == null && to == null) return sessions;
+  return sessions.filter((session) => {
+    const activity = getSessionActivityTime(session);
+    if (from != null && activity < from) return false;
+    if (to != null && activity > to) return false;
+    return true;
+  });
+}

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -1,0 +1,129 @@
+/**
+ * Session aliases as a read model for the HTTP layer: load the user's local
+ * renames once, then decorate outgoing records with `display_title`.
+ */
+import type { BookmarkRecord, SessionHead } from "@codesesh/core";
+import type { SearchResult } from "@codesesh/core/contract";
+import {
+  createProjectScopeMatcher,
+  getSessionActivityTime,
+  listSessionAliases,
+  matchesSessionSearchFilters,
+  mergeSearchQueryOptions,
+  StateStorageUnavailableError,
+  type FileActivityResult,
+  type ScanResult,
+  type SearchOptions,
+} from "@codesesh/core";
+import { appLogger } from "../logging.js";
+
+/** Anything the API returns that can carry a locally-renamed title. */
+type Titled = { id: string; title: string; display_title?: string };
+
+export interface AliasView {
+  readonly size: number;
+  get(agentKey: string, sessionId: string): string | undefined;
+  /** Returns the record unchanged when no alias applies, so callers can pass through freely. */
+  decorate<T extends Titled>(record: T, agentKey: string): T;
+  entries(): IterableIterator<[string, string]>;
+}
+
+function aliasKey(agentKey: string, sessionId: string): string {
+  return `${agentKey.toLowerCase()}\0${sessionId}`;
+}
+
+function splitAliasKey(key: string): { agentName: string; sessionId: string } {
+  const separatorIndex = key.indexOf("\0");
+  return { agentName: key.slice(0, separatorIndex), sessionId: key.slice(separatorIndex + 1) };
+}
+
+export function getSessionAgentKey(session: Pick<SessionHead, "slug">): string {
+  return session.slug.split("/")[0]?.toLowerCase() ?? "";
+}
+
+function loadAliasMap(): Map<string, string> {
+  try {
+    return new Map(
+      listSessionAliases().map((alias) => [aliasKey(alias.agentKey, alias.sessionId), alias.alias]),
+    );
+  } catch (error) {
+    if (!(error instanceof StateStorageUnavailableError)) {
+      appLogger.warn("api.session_aliases.load_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return new Map();
+  }
+}
+
+export function loadAliasView(): AliasView {
+  const aliases = loadAliasMap();
+  return {
+    size: aliases.size,
+    get: (agentKey, sessionId) => aliases.get(aliasKey(agentKey, sessionId)),
+    decorate(record, agentKey) {
+      const alias = aliases.get(aliasKey(agentKey, record.id));
+      return alias ? { ...record, display_title: alias } : record;
+    },
+    entries: () => aliases.entries(),
+  };
+}
+
+export function decorateBookmark(bookmark: BookmarkRecord, aliases: AliasView): BookmarkRecord {
+  const alias = aliases.get(bookmark.agentKey, bookmark.sessionId);
+  return alias ? { ...bookmark, display_title: alias } : bookmark;
+}
+
+export function decorateFileActivity(
+  activity: FileActivityResult,
+  aliases: AliasView,
+): FileActivityResult {
+  return { ...activity, session: aliases.decorate(activity.session, activity.agent_name) };
+}
+
+/**
+ * Aliases are stored outside the search index, so a query matching only a local
+ * rename has to be resolved here. Hits still have to satisfy the same
+ * time-window / project / agent filters as the main search, otherwise an aliased
+ * session could surface outside its search scope.
+ */
+export function findAliasSearchResults(
+  query: string,
+  options: SearchOptions,
+  scanResult: ScanResult,
+  aliases: AliasView,
+): SearchResult[] {
+  const search = mergeSearchQueryOptions(query, options);
+  const needle = search.text.trim().toLowerCase();
+  if (!needle || aliases.size === 0) return [];
+
+  const projectScope = search.options.cwd ? createProjectScopeMatcher(search.options.cwd) : null;
+  const sessionsByAgent = new Map<string, Map<string, SessionHead>>();
+  const lookupSession = (agentName: string, sessionId: string): SessionHead | undefined => {
+    let byId = sessionsByAgent.get(agentName);
+    if (!byId) {
+      byId = new Map((scanResult.byAgent[agentName] ?? []).map((item) => [item.id, item]));
+      sessionsByAgent.set(agentName, byId);
+    }
+    return byId.get(sessionId);
+  };
+
+  const results: SearchResult[] = [];
+  for (const [key, alias] of aliases.entries()) {
+    if (!alias.toLowerCase().includes(needle)) continue;
+    const { agentName, sessionId } = splitAliasKey(key);
+    const session = lookupSession(agentName, sessionId);
+    if (!session) continue;
+    if (!matchesSessionSearchFilters(agentName, session, search.options, projectScope)) continue;
+    results.push({
+      agentName,
+      session: aliases.decorate(session, agentName),
+      snippet: `Alias · ${session.directory}`,
+      matchType: "title",
+    });
+  }
+
+  return results.sort(
+    (a, b) => getSessionActivityTime(b.session) - getSessionActivityTime(a.session),
+  );
+}

--- a/packages/core/src/analytics/__tests__/projects.test.ts
+++ b/packages/core/src/analytics/__tests__/projects.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { attachProjectMetrics } from "../projects.js";
+import type { ProjectGroup, SessionHead } from "../../types/index.js";
+
+function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
+  return {
+    id,
+    slug: `claudecode/${id}`,
+    title: id,
+    directory: "/home/user/project",
+    time_created: 1_000_000_000_000,
+    time_updated: 1_000_000_000_000,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    project_identity: { kind: "git_remote", key: "repo-a", displayName: "Repo A" },
+    ...overrides,
+  };
+}
+
+function makeGroup(identityKey: string, overrides?: Partial<ProjectGroup>): ProjectGroup {
+  return {
+    identityKind: "git_remote",
+    identityKey,
+    displayName: identityKey,
+    sources: ["claudecode"],
+    sessionCount: 0,
+    lastActivity: null,
+    ...overrides,
+  };
+}
+
+describe("attachProjectMetrics", () => {
+  it("sums messages, tokens and cost per project", () => {
+    const [project] = attachProjectMetrics(
+      [makeGroup("repo-a")],
+      [
+        makeSession("a", {
+          stats: {
+            message_count: 3,
+            total_input_tokens: 100,
+            total_output_tokens: 20,
+            total_cost: 0.5,
+          },
+        }),
+        makeSession("b", {
+          stats: {
+            message_count: 2,
+            total_input_tokens: 10,
+            total_output_tokens: 5,
+            total_cost: 0.25,
+          },
+        }),
+      ],
+    );
+
+    expect(project).toMatchObject({ messages: 5, tokens: 135, cost: 0.75 });
+  });
+
+  it("prefers an explicit total_tokens over the input/output sum", () => {
+    const [project] = attachProjectMetrics(
+      [makeGroup("repo-a")],
+      [
+        makeSession("a", {
+          stats: {
+            message_count: 1,
+            total_input_tokens: 100,
+            total_output_tokens: 20,
+            total_tokens: 999,
+            total_cost: 0,
+          },
+        }),
+      ],
+    );
+
+    expect(project?.tokens).toBe(999);
+  });
+
+  it("marks the project cost estimated when any session's cost is estimated", () => {
+    const recorded = makeSession("a", {
+      stats: {
+        message_count: 1,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 1,
+        cost_source: "recorded",
+      },
+    });
+    const estimated = makeSession("b", {
+      stats: {
+        message_count: 1,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 1,
+        cost_source: "estimated",
+      },
+    });
+
+    expect(attachProjectMetrics([makeGroup("repo-a")], [recorded])[0]?.cost_source).toBe(
+      "recorded",
+    );
+    expect(attachProjectMetrics([makeGroup("repo-a")], [recorded, estimated])[0]?.cost_source).toBe(
+      "estimated",
+    );
+  });
+
+  it("leaves cost_source undefined when a project has no cost", () => {
+    const [project] = attachProjectMetrics([makeGroup("repo-a")], [makeSession("a")]);
+    expect(project?.cost_source).toBeUndefined();
+  });
+
+  it("groups per agent and orders them by session count", () => {
+    const [project] = attachProjectMetrics(
+      [makeGroup("repo-a")],
+      [
+        makeSession("a", { slug: "codex/a" }),
+        makeSession("b", { slug: "claudecode/b" }),
+        makeSession("c", { slug: "claudecode/c" }),
+      ],
+    );
+
+    expect(project?.agentStats.map((stat) => [stat.name, stat.sessions])).toEqual([
+      ["claudecode", 2],
+      ["codex", 1],
+    ]);
+  });
+
+  it("zeroes projects with no matching sessions and ignores sessions with no identity", () => {
+    const projects = attachProjectMetrics(
+      [makeGroup("repo-a"), makeGroup("repo-b")],
+      [makeSession("orphan", { project_identity: undefined })],
+    );
+
+    expect(projects.map((project) => project.messages)).toEqual([0, 0]);
+    expect(projects.every((project) => project.agentStats.length === 0)).toBe(true);
+  });
+
+  it("keys metrics on kind and key together", () => {
+    const projects = attachProjectMetrics(
+      [makeGroup("shared"), makeGroup("shared", { identityKind: "path" })],
+      [
+        makeSession("a", {
+          project_identity: { kind: "git_remote", key: "shared", displayName: "Shared" },
+        }),
+        makeSession("b", {
+          project_identity: { kind: "path", key: "shared", displayName: "Shared" },
+        }),
+        makeSession("c", {
+          project_identity: { kind: "path", key: "shared", displayName: "Shared" },
+        }),
+      ],
+    );
+
+    expect(projects.map((project) => project.messages)).toEqual([1, 2]);
+  });
+});

--- a/packages/core/src/analytics/projects.ts
+++ b/packages/core/src/analytics/projects.ts
@@ -1,0 +1,88 @@
+/**
+ * Project analytics — pure aggregation over SessionHead[], the project-level
+ * counterpart to dashboard.ts. No HTTP, no DB: the caller supplies the groups
+ * and the sessions, this module owns the arithmetic.
+ */
+import type { ProjectGroup, SessionHead } from "../types/index.js";
+import type { ApiProjectAgentStat, ApiProjectGroup } from "../contract/index.js";
+import { getSessionAgentName, getTotalTokens } from "./dashboard.js";
+
+interface ProjectMetrics {
+  messages: number;
+  tokens: number;
+  cost: number;
+  hasEstimatedCost: boolean;
+  agentStats: Map<string, ApiProjectAgentStat>;
+}
+
+function getProjectGroupKey(identityKind: string, identityKey: string): string {
+  return `${identityKind}:${identityKey}`;
+}
+
+function emptyMetrics(): ProjectMetrics {
+  return { messages: 0, tokens: 0, cost: 0, hasEstimatedCost: false, agentStats: new Map() };
+}
+
+/**
+ * Fold per-session totals into the project groups they belong to. Sessions with
+ * no resolved project identity contribute to nothing.
+ */
+export function attachProjectMetrics(
+  projects: ProjectGroup[],
+  sessions: SessionHead[],
+): ApiProjectGroup[] {
+  const metrics = new Map<string, ProjectMetrics>();
+
+  for (const session of sessions) {
+    const identity = session.project_identity;
+    if (!identity) continue;
+
+    const key = getProjectGroupKey(identity.kind, identity.key);
+    let current = metrics.get(key);
+    if (!current) {
+      current = emptyMetrics();
+      metrics.set(key, current);
+    }
+
+    const tokens = getTotalTokens(session.stats);
+    const cost = session.stats.total_cost ?? 0;
+    current.messages += session.stats.message_count;
+    current.tokens += tokens;
+    current.cost += cost;
+    if (session.stats.cost_source === "estimated") current.hasEstimatedCost = true;
+
+    const agentName = getSessionAgentName(session);
+    const agent = current.agentStats.get(agentName);
+    if (agent) {
+      agent.sessions += 1;
+      agent.messages += session.stats.message_count;
+      agent.tokens += tokens;
+      agent.cost += cost;
+    } else {
+      current.agentStats.set(agentName, {
+        name: agentName,
+        sessions: 1,
+        messages: session.stats.message_count,
+        tokens,
+        cost,
+      });
+    }
+  }
+
+  return projects.map((project) => {
+    const metric = metrics.get(getProjectGroupKey(project.identityKind, project.identityKey));
+    return {
+      ...project,
+      messages: metric?.messages ?? 0,
+      tokens: metric?.tokens ?? 0,
+      cost: metric?.cost ?? 0,
+      cost_source:
+        metric && metric.cost > 0
+          ? metric.hasEstimatedCost
+            ? "estimated"
+            : "recorded"
+          : undefined,
+      agentStats: [...(metric?.agentStats.values() ?? [])].sort((a, b) => b.sessions - a.sessions),
+    };
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,4 +9,5 @@ export * from "./state/index.js";
 export * from "./utils/index.js";
 export * from "./pricing/index.js";
 export * from "./analytics/dashboard.js";
+export * from "./analytics/projects.js";
 export * from "./search/index.js";


### PR DESCRIPTION
## Summary

`packages/cli/src/api/handlers.ts` was 866 lines holding four unrelated jobs: query-string parsing, session-alias decoration, project metric aggregation, and the 17 route handlers.

The aggregation was the clearest misplacement. `attachProjectMetrics` is a pure fold over `SessionHead[]` — no `Context`, no storage — while its sibling `buildDashboard` lives in `packages/core/src/analytics/dashboard.ts` under a module comment that states the split explicitly:

> Dashboard analytics — pure aggregation over SessionHead[] with no HTTP or DB coupling. The handler parses request params and supplies file-activity; this module owns the domain math.

So "how project metrics are computed" had two homes: project-level in the CLI, dashboard-level in core. It also re-derived what `getTotalTokens` / `getSessionAgentName` already export.

## Changes

**`packages/core/src/analytics/projects.ts`** (new)
`attachProjectMetrics` moves here beside `buildDashboard` and now reuses `getTotalTokens` and `getSessionAgentName`.

**`packages/cli/src/api/query-params.ts`** (new)
`parseDateParam`, `parseNumberParam`, `searchParams`, `queryValues`, `parseSmartTags`, `parseSearchOptions`, `parseFileActivityKind`, `optionalQueryValue`, `parseProjectIdentityFilter`, `filterSessionsByActivityWindow`. The smart-tag whitelist and the search-limit bounds become named constants instead of literals inside the parser.

**`packages/cli/src/api/session-aliases-view.ts`** (new)
`withDisplayTitle`, `withBookmarkDisplayTitle` and `withFileActivityDisplayTitle` differed only in where the agent key came from. They collapse into one `AliasView` with a `decorate` method plus two thin adapters for the record shapes that carry the key elsewhere.

Its search path also had a real cost: `findSessionByAliasKey` ran `scanResult.byAgent[agent]?.find(...)` **per alias**, i.e. O(aliases × sessions-per-agent). It now builds an id→session `Map` per agent, lazily, on first use.

`handlers.ts`: 866 → 576 lines, now route handlers plus the payload validators they own.

## Behaviour

No API request parameter, response shape or status code changes. Both handler suites (`handlers.test.ts`, `handlers-state.test.ts`, 216 CLI tests) pass **with no edits to their assertions** — that is the main evidence this is a pure move.

## Testing

- New `packages/core/src/analytics/__tests__/projects.test.ts` covers `attachProjectMetrics` where it now lives: per-project sums, explicit `total_tokens` winning over the input/output sum, `cost_source` promotion to `estimated` when any session is estimated, `undefined` when a project has no cost, per-agent grouping ordered by session count, zeroed projects with no sessions, sessions with no identity ignored, and keying on `kind` + `key` together so two groups sharing a key don't merge.
- `pnpm build` / `pnpm test` (core 451, cli 216, web 382) / `pnpm lint` / `pnpm format:check` clean.
- `pnpm test:coverage` exits 0 — the stricter `packages/cli/src/api/**` threshold still holds after the split.

Issue: CS-96