### PR TITLE
perf(api): cache the session alias read model (CS-97)

### DIFF
--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -54,6 +54,7 @@ import {
   handlePutSessionAlias,
   type ScanResultSource,
 } from "../handlers.js";
+import { invalidateAliasView } from "../session-aliases-view.js";
 
 interface ContextOptions {
   body?: unknown;
@@ -115,6 +116,9 @@ const scanSource: ScanResultSource = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  // The alias read model is cached for the process lifetime; each test needs a
+  // clean slate or it inherits the previous test's listSessionAliases stub.
+  invalidateAliasView();
   coreMocks.listBookmarks.mockReturnValue([]);
   coreMocks.listFileActivity.mockReturnValue([]);
   coreMocks.listSessionAliases.mockReturnValue([]);
@@ -198,12 +202,15 @@ describe("bookmark handlers", () => {
 
   it("tolerates unavailable alias storage and logs unexpected alias failures", () => {
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
+    // Each failure mode is a separate load: the alias read model caches its
+    // result, so the view has to be invalidated between scenarios.
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw new StateStorageUnavailableError();
     });
     handleGetBookmarks(makeContext() as never);
     expect(loggerMocks.warn).not.toHaveBeenCalled();
 
+    invalidateAliasView();
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw new Error("corrupt aliases");
     });
@@ -212,6 +219,7 @@ describe("bookmark handlers", () => {
       error: "corrupt aliases",
     });
 
+    invalidateAliasView();
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw "invalid aliases";
     });
@@ -576,5 +584,74 @@ describe("query boundary handlers", () => {
       to: Date.now(),
       days: 0,
     });
+  });
+});
+
+describe("session alias caching", () => {
+  const aliasRecord = { agentKey: "codex", sessionId: "s1", alias: "Renamed", updated_at: 1 };
+
+  it("queries alias storage once across repeated reads", () => {
+    coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
+
+    handleGetSessions(makeContext() as never, scanSource);
+    handleGetSessions(makeContext() as never, scanSource);
+    handleGetBookmarks(makeContext() as never);
+
+    expect(coreMocks.listSessionAliases).toHaveBeenCalledTimes(1);
+  });
+
+  it("picks up a stored alias on the next read", async () => {
+    coreMocks.listSessionAliases.mockReturnValue([]);
+    handleGetSessions(makeContext() as never, scanSource);
+
+    coreMocks.upsertSessionAlias.mockReturnValue(aliasRecord);
+    coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
+    await handlePutSessionAlias(
+      makeContext({ body: { alias: "Renamed" }, param: { agent: "codex", id: "s1" } }) as never,
+    );
+
+    coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
+    const after = makeContext();
+    handleGetBookmarks(after as never);
+
+    expect(getResponsePayload<{ bookmarks: BookmarkRecord[] }>(after).bookmarks[0]).toMatchObject({
+      display_title: "Renamed",
+    });
+  });
+
+  it("drops a removed alias on the next read", () => {
+    coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
+    coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
+    handleGetBookmarks(makeContext() as never);
+
+    coreMocks.listSessionAliases.mockReturnValue([]);
+    handleDeleteSessionAlias(makeContext({ param: { agent: "codex", id: "s1" } }) as never);
+
+    const after = makeContext();
+    handleGetBookmarks(after as never);
+
+    expect(
+      getResponsePayload<{ bookmarks: BookmarkRecord[] }>(after).bookmarks[0]?.display_title,
+    ).toBeUndefined();
+  });
+
+  it("caches an unavailable store but retries it after invalidation", () => {
+    coreMocks.listSessionAliases.mockImplementation(() => {
+      throw new StateStorageUnavailableError();
+    });
+
+    handleGetSessions(makeContext() as never, scanSource);
+    handleGetSessions(makeContext() as never, scanSource);
+    expect(coreMocks.listSessionAliases).toHaveBeenCalledTimes(1);
+
+    invalidateAliasView();
+    coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
+    coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
+    const recovered = makeContext();
+    handleGetBookmarks(recovered as never);
+
+    expect(
+      getResponsePayload<{ bookmarks: BookmarkRecord[] }>(recovered).bookmarks[0],
+    ).toMatchObject({ display_title: "Renamed" });
   });
 });

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -49,6 +49,7 @@ import {
   handleSearchSessions,
   type ScanResultSource,
 } from "../handlers.js";
+import { invalidateAliasView } from "../session-aliases-view.js";
 import type {
   CachedSessionDataEntry,
   ChangeCheckResult,
@@ -191,6 +192,9 @@ afterEach(() => {
   coreMocks.listSessionFileActivity.mockReturnValue([]);
   coreMocks.listSessionAliases.mockReset();
   coreMocks.listSessionAliases.mockReturnValue([]);
+  // The alias read model caches for the process lifetime; tests stub
+  // listSessionAliases per case and need a fresh load each time.
+  invalidateAliasView();
   coreMocks.executeSessionSearch.mockReset();
   coreMocks.executeSessionSearch.mockReturnValue([]);
   vi.useRealTimers();

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -52,6 +52,7 @@ import {
   decorateFileActivity,
   findAliasSearchResults,
   getSessionAgentKey,
+  invalidateAliasView,
   loadAliasView,
 } from "./session-aliases-view.js";
 
@@ -479,7 +480,9 @@ export async function handlePutSessionAlias(c: Context) {
   }
 
   try {
-    return c.json({ alias: upsertSessionAlias(agentKey, sessionId, payload.alias) });
+    const alias = upsertSessionAlias(agentKey, sessionId, payload.alias);
+    invalidateAliasView();
+    return c.json({ alias });
   } catch (error) {
     if (error instanceof TypeError) {
       return c.json({ error: "Session alias must be non-empty and at most 160 characters" }, 400);
@@ -500,6 +503,7 @@ export function handleDeleteSessionAlias(c: Context) {
 
   try {
     deleteSessionAlias(agentKey, sessionId);
+    invalidateAliasView();
     return c.json({ ok: true });
   } catch (error) {
     if (error instanceof StateStorageUnavailableError) {

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -56,7 +56,7 @@ function loadAliasMap(): Map<string, string> {
   }
 }
 
-export function loadAliasView(): AliasView {
+function buildAliasView(): AliasView {
   const aliases = loadAliasMap();
   return {
     size: aliases.size,
@@ -67,6 +67,23 @@ export function loadAliasView(): AliasView {
     },
     entries: () => aliases.entries(),
   };
+}
+
+/**
+ * Aliases change only through this process's own PUT/DELETE handlers, so the
+ * read model is built once and reused until one of them invalidates it. Six read
+ * handlers call this per request; without the cache each one re-queries the whole
+ * table. A storage failure is cached too — it does not heal between requests, and
+ * invalidateAliasView() is what lets a recovered store be retried.
+ */
+let cachedView: AliasView | null = null;
+
+export function loadAliasView(): AliasView {
+  return (cachedView ??= buildAliasView());
+}
+
+export function invalidateAliasView(): void {
+  cachedView = null;
 }
 
 export function decorateBookmark(bookmark: BookmarkRecord, aliases: AliasView): BookmarkRecord {


### PR DESCRIPTION
## Summary

`loadAliasView()` is called by six read handlers — `handleGetSessions`, `handleSearchSessions`, `handleGetFileActivity`, `handleGetSessionData`, `handleGetBookmarks`, `handleGetDashboard` — and each call ran `SELECT agent_name, session_id, alias, updated_at FROM session_aliases ORDER BY updated_at DESC` and rebuilt the lookup map from scratch.

Aliases only change through two endpoints in this same process (`PUT`/`DELETE /session-aliases/:agent/:id`). Read-heavy, single-writer, writer fully in-process — so the read model can simply be built once and dropped when a write lands.

## Changes

- `session-aliases-view.ts` holds the built view in a module-level `cachedView`; `loadAliasView()` returns it, `invalidateAliasView()` clears it.
- `handlePutSessionAlias` and `handleDeleteSessionAlias` invalidate **after** the write succeeds, so a failed write leaves the cache intact.

Invalidation rather than incremental map maintenance: writes are rare, and keeping two update paths for one map is how they drift.

No TTL: the only writer is in this process, so there is no "someone else changed the DB" case a TTL would cover — it would add an inconsistency window for nothing.

A failed load is cached too. `StateStorageUnavailableError` does not resolve itself between two consecutive requests, and re-querying a broken store on every read is exactly the cost this removes. `invalidateAliasView()` is the escape hatch for a recovered store.

## Testing

New `session alias caching` suite:
- repeated reads across different handlers query storage once
- a stored alias shows up on the next read
- a deleted alias disappears on the next read
- an unavailable store is cached, and invalidation lets a recovered store be picked up

Two existing suites needed setup changes, both forced by the cache being real rather than by any behaviour change:
- `beforeEach` in both handler suites now calls `invalidateAliasView()`, otherwise a test inherits the previous test's `listSessionAliases` stub.
- `tolerates unavailable alias storage and logs unexpected alias failures` walks three failure modes through three consecutive `handleGetBookmarks` calls; it now invalidates between them, since in production each of those is a separate process state rather than three requests in a row.

No assertion in either suite changed.

- `pnpm build` / `pnpm test` (core 451, cli 220, web 382) / `pnpm lint` / `pnpm format:check` clean.
- `pnpm test:coverage` exits 0.

Issue: CS-97