### PR TITLE
perf(live): merge per-agent session shards instead of re-sorting (CS-98)

### DIFF
--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   createRegisteredAgents,
+  mergeSortedSessions,
   scanSessions,
   sortSessions,
   type BaseAgent,
@@ -229,8 +230,12 @@ export class LiveScanStore {
     }, NEW_SESSION_EVENT_WINDOW_MS);
   }
 
+  /**
+   * Every byAgent shard is kept sorted by its two writers (applySessionsChanged
+   * and applyScanResult), so combining them is a merge, not a sort.
+   */
   private rebuildSessions(): void {
-    this.sessions = sortSessions(Object.values(this.byAgent).flat());
+    this.sessions = mergeSortedSessions(Object.values(this.byAgent));
   }
 
   private getSmartTagWorkerUrl(): URL | null {

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -34,6 +34,7 @@ describe("contract browser-safety", () => {
         "getProjectIdentityKey",
         "getSessionAgentKey",
         "getSessionRouteKey",
+        "mergeSortedSessions",
         "sortSessionsByActivity",
         "updateSessionIndex",
       ].sort(),

--- a/packages/core/src/contract/__tests__/session-index.test.ts
+++ b/packages/core/src/contract/__tests__/session-index.test.ts
@@ -5,6 +5,8 @@ import {
   createSessionIndex,
   getProjectAgentKey,
   getSessionRouteKey,
+  mergeSortedSessions,
+  sortSessionsByActivity,
   updateSessionIndex,
 } from "../session-index.js";
 
@@ -123,6 +125,56 @@ describe("canonical session index", () => {
       expect([...index.byProjectIdentityKey.entries()]).toEqual([
         ...rebuilt.byProjectIdentityKey.entries(),
       ]);
+    }
+  });
+});
+
+describe("mergeSortedSessions", () => {
+  /** Deterministic PRNG so a failure is reproducible from the printed seed. */
+  function makeRandom(seed: number): () => number {
+    let state = seed >>> 0;
+    return () => {
+      state = (state * 1664525 + 1013904223) >>> 0;
+      return state / 0x100000000;
+    };
+  }
+
+  function makeShards(random: () => number, shardCount: number): SessionHead[][] {
+    return Array.from({ length: shardCount }, (_unused, shardIndex) => {
+      const size = Math.floor(random() * 6);
+      const shard = Array.from({ length: size }, (_item, index) =>
+        // A small activity range guarantees plenty of cross-shard ties.
+        createSession(`s${shardIndex}-${index}`, Math.floor(random() * 4)),
+      );
+      return sortSessionsByActivity(shard);
+    });
+  }
+
+  it("returns an empty array when every shard is empty", () => {
+    expect(mergeSortedSessions([])).toEqual([]);
+    expect(mergeSortedSessions([[], []])).toEqual([]);
+  });
+
+  it("copies a lone shard rather than returning it", () => {
+    const shard = [createSession("a", 2), createSession("b", 1)];
+    const merged = mergeSortedSessions([shard]);
+
+    expect(merged).toEqual(shard);
+    expect(merged).not.toBe(shard);
+  });
+
+  it("matches sortSessionsByActivity element for element, ties included", () => {
+    for (let seed = 1; seed <= 200; seed += 1) {
+      const shards = makeShards(makeRandom(seed), 2 + (seed % 6));
+      const merged = mergeSortedSessions(shards);
+      const sorted = sortSessionsByActivity(shards.flat());
+
+      // Reference equality, so a tie resolved to a different shard fails here.
+      expect({ seed, ids: merged.map((session) => session.id) }).toEqual({
+        seed,
+        ids: sorted.map((session) => session.id),
+      });
+      expect(merged.every((session, index) => session === sorted[index])).toBe(true);
     }
   });
 });

--- a/packages/core/src/contract/session-index.ts
+++ b/packages/core/src/contract/session-index.ts
@@ -32,6 +32,42 @@ export function sortSessionsByActivity(sessions: SessionHead[]): SessionHead[] {
   return [...sessions];
 }
 
+/**
+ * Merges shards that are each already sorted by activity, newest first.
+ *
+ * Callers must uphold that precondition — this does not re-sort. Ties resolve to
+ * the earlier shard, which is what a stable `Array.sort` over the concatenation
+ * would produce, so the result is element-for-element identical to
+ * `sortSessionsByActivity(shards.flat())` at O(n·k) instead of O(n log n).
+ */
+export function mergeSortedSessions(shards: SessionHead[][]): SessionHead[] {
+  const active = shards.filter((shard) => shard.length > 0);
+  if (active.length === 0) return [];
+  if (active.length === 1) return [...active[0]!];
+
+  const total = active.reduce((sum, shard) => sum + shard.length, 0);
+  const merged: SessionHead[] = [];
+  const cursors = Array.from({ length: active.length }, () => 0);
+
+  for (let position = 0; position < total; position += 1) {
+    let pick = -1;
+    for (let shard = 0; shard < active.length; shard += 1) {
+      const cursor = cursors[shard]!;
+      if (cursor >= active[shard]!.length) continue;
+      if (
+        pick === -1 ||
+        compareSessionActivityDesc(active[shard]![cursor]!, active[pick]![cursors[pick]!]!) < 0
+      ) {
+        pick = shard;
+      }
+    }
+    merged.push(active[pick]![cursors[pick]!]!);
+    cursors[pick]! += 1;
+  }
+
+  return merged;
+}
+
 export function getSessionAgentKey(session: Pick<SessionHead, "slug">): string {
   return session.slug.split("/")[0]?.toLowerCase() || "unknown";
 }

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -14,6 +14,7 @@ export {
   sessionSignature,
   sortSessions,
 } from "./orchestrate.js";
+export { mergeSortedSessions } from "../contract/session-index.js";
 export {
   loadCachedSessions,
   loadCachedSessionData,


### PR DESCRIPTION
## Summary

```ts
private rebuildSessions(): void {
  this.sessions = sortSessions(Object.values(this.byAgent).flat());
}
```

`sortSessionsByActivity` has an already-ordered short-circuit, but the input here is a *concatenation* of sorted shards — it goes out of order at the first shard boundary, so the short-circuit essentially never fires. Every agent refresh commit therefore ran a full `Array.sort` over every session from every agent, plus the array copy.

Both writers of `byAgent` (`applySessionsChanged`, `applyScanResult`) already sort their shard. So the work is a merge, not a sort.

## Changes

- New `mergeSortedSessions(shards)` in `contract/session-index.ts`, beside `sortSessionsByActivity` and `compareSessionActivityDesc`. Straight k-way merge with a linear scan over cursors — k is the agent count (≤ 7), so a heap would cost more than it saves.
- `rebuildSessions` uses it.
- Re-exported through `discovery/index.ts` so the CLI reaches it the same way it already reaches `sortSessions`.

The precondition (each shard sorted) is documented on the function and the two `sortSessions` calls that establish it are left in place — they are what makes the merge valid, not redundant work.

## The tie-break

This is the one place the output could have drifted. `Array.prototype.sort` is stable in V8, so the old code resolved equal activity times by position in the concatenation, i.e. by shard order. The merge picks the earliest shard on a tie (`< 0`, not `<= 0`), which reproduces exactly that.

## Testing

- 200 seeded random cases, deterministic PRNG so a failure reprints its seed. Shard counts 2–7, sizes 0–5, activity values drawn from a range of 4 so ties are dense. Each case asserts the merge is **reference-identical** to `sortSessionsByActivity(shards.flat())` — element identity, not just id order, which is what catches a tie resolved to the wrong shard.
- Empty input and all-empty shards return `[]`.
- A single shard returns a copy, not the same array reference — callers mutate `byAgent` shards.
- `browser-safe.test.ts` pins the contract entry's export list; `mergeSortedSessions` added there (it is pure, no Node built-ins).
- Existing `live-scan-store.test.ts` passes untouched.
- `pnpm build` / `pnpm test` (core 454, cli 220, web 382) / `pnpm lint` / `pnpm format:check` clean; `pnpm test:coverage` exits 0.

Issue: CS-98