### PR TITLE
fix(agents): stop deleting cached sessions outside the scan window (CS-100)

### DIFF
--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -212,8 +212,10 @@ describe("diffSessionSources", () => {
     const unwindowed = diffSessionSources([], cached, entries);
 
     // `old` was never enumerated this pass, so its absence proves nothing.
-    // `undated` has no recorded mtime, so the window cannot exonerate it.
-    expect(windowed.removedIds).toEqual(["recent", "undated"]);
+    // `undated` records no mtime, so we cannot tell either — removing it would
+    // destroy a cached session on a guess, keeping it costs one stale entry.
+    expect(windowed.removedIds).toEqual(["recent"]);
+    // With no window every session was enumerated, so absence does mean deleted.
     expect(unwindowed.removedIds).toEqual(["recent", "old", "undated"]);
   });
 });

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { KimiAgent } from "../kimi.js";
+import { diffSessionSources } from "../base.js";
 import type { SessionHead } from "../../types/index.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
@@ -136,6 +137,44 @@ describe("KimiAgent cache refresh", () => {
 
     const windowed = agent.listSessionSources({ from: Date.now() - 24 * 60 * 60 * 1000 });
     expect(windowed.map((ref) => ref.sessionId)).toEqual(["new-session"]);
+  });
+
+  it("records sourceMtimeMs as the value listSessionSources filters on", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    createSessionDir(basePath, "windowed", "Windowed", 5_000);
+
+    const agent = createAgent(basePath);
+    const [head] = agent.scan();
+    const meta = agent.getSessionMetaMap().get("windowed");
+
+    // diffSessionSources compares this against the scan window to tell
+    // "outside the window" apart from "deleted on disk", so it has to match
+    // the createdAt that listSessionSources filters on.
+    expect(meta?.sourceMtimeMs).toBe(head?.time_created);
+  });
+
+  it("keeps out-of-window sessions out of the change set during a windowed refresh", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    const recent = Date.now();
+    const old = recent - 30 * 24 * 60 * 60 * 1000;
+    createSessionDir(basePath, "recent-session", "Recent", recent);
+    createSessionDir(basePath, "old-session", "Old", old);
+
+    const agent = createAgent(basePath);
+    const cached = agent.scan();
+    expect(cached.map((session) => session.id).sort()).toEqual(["old-session", "recent-session"]);
+
+    const window = { from: recent - 7 * 24 * 60 * 60 * 1000 };
+    const refs = agent.listSessionSources(window);
+    expect(refs.map((ref) => ref.sessionId)).toEqual(["recent-session"]);
+
+    const diff = diffSessionSources(refs, cached, agent.getSessionMetaMap(), window);
+
+    // old-session was simply never enumerated; removing it would delete the
+    // session and its messages from the cache.
+    expect(diff.removedIds).toEqual([]);
   });
 
   it("parses context messages with tool calls and backfilled output", () => {

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -94,13 +94,17 @@ function fingerprintMatches(ref: SessionSourceRef, cached: SessionCacheMeta | un
 }
 
 /**
- * A cached session whose recorded mtime falls outside the current scan window was
- * never enumerated this pass, so its absence from the refs doesn't mean it was
- * deleted on disk.
+ * Decides whether a cached session was in scope for this enumeration pass, which
+ * is what makes its absence from the refs mean "deleted on disk" rather than
+ * "outside the window".
  *
- * A session with no recorded mtime is treated as enumerated, i.e. removable.
- * That is load-bearing for agents whose meta omits `sourceMtimeMs` (kimi) — see
- * CS-100 for whether that default should be inverted.
+ * `sourceMtimeMs` must hold the same quantity the agent's `listSessionSources`
+ * window-filters on, or the two disagree and sessions are dropped or kept wrongly.
+ *
+ * When it is missing we cannot tell, and the two wrong answers are not
+ * symmetric: wrongly removing destroys cached sessions and their messages, while
+ * wrongly keeping leaves a stale entry that the next unwindowed pass clears. So
+ * an unknown mtime means "not enumerated" — keep it.
  */
 function wasEnumeratedThisPass(
   cached: SessionCacheMeta | undefined,
@@ -108,7 +112,7 @@ function wasEnumeratedThisPass(
 ): boolean {
   if (options?.from == null && options?.to == null) return true;
   const mtimeMs = cached?.sourceMtimeMs;
-  return typeof mtimeMs !== "number" || matchesScanWindow(mtimeMs, options);
+  return typeof mtimeMs === "number" && matchesScanWindow(mtimeMs, options);
 }
 
 /**

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -63,6 +63,12 @@ interface SessionSource {
 
 interface SessionMeta extends SessionCacheMeta, SessionSource {
   title: string;
+  /**
+   * Mirrors createdAt, which is what listSessionSources window-filters on.
+   * diffSessionSources compares this against the scan window to tell "outside
+   * the window" apart from "deleted on disk"; the two must be the same quantity.
+   */
+  sourceMtimeMs: number;
 }
 
 /** Reads state/metadata `wire_mtime`; reports drift when the field is present but not a number. */
@@ -318,7 +324,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       normalizeTitleText(source.explicitTitle) ??
       resolveSessionTitle(null, extractFirstUserTitle(source.contextFile, source.wireFile), null);
 
-    return parsedSession({ ...source, title });
+    return parsedSession({ ...source, title, sourceMtimeMs: source.createdAt });
   }
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {


### PR DESCRIPTION
## Summary

Running with a time window (`--days`, `--from`) permanently deletes older Kimi sessions from the local cache.

`wasEnumeratedThisPass` decides whether a cached session was in scope for this enumeration pass — that is what makes its absence from the refs mean "deleted on disk" rather than "outside the window". It read:

```ts
return typeof mtimeMs !== "number" || matchesScanWindow(mtimeMs, options);
```

So an unknown mtime counted as *enumerated*, i.e. removable. `KimiAgent`'s meta never wrote `sourceMtimeMs`, and its `listSessionSources` **does** filter by window (`matchesScanWindow(source.createdAt, options)`). Every Kimi session outside the window was therefore reported as removed.

Its comment claimed the opposite — *"Sessions with no recorded mtime predate this field; keep them too rather than risk a false-positive removal"* — which is how it survived. Spotted while consolidating the two change-detection copies in #194; that PR preserved the behaviour verbatim and filed this.

## Confirming it reaches disk

`diffSessionSources.removedIds` → worker `syncAgentSources` `changedIds` → `agent-sync-engine` `persistenceDiff.removedSessionIds` → `SearchIndexWorkerJob{kind:"changes"}` → `saveCachedSessionChanges`, which runs `DELETE` against `cached_sessions`, `sessions`, `session_documents`, `messages` and `message_tools`. Not just the in-memory snapshot.

Reproduced against a real `KimiAgent` over a temp `KIMI_SHARE_DIR` — two sessions, one recent and one 30 days old, 7-day window:

```
old-session has sourceMtimeMs: false
enumerated in window: [ 'recent-session' ]
removedIds: [ 'old-session' ]
```

## Changes

**1. Kimi records `sourceMtimeMs`.** It holds `createdAt` — the exact value Kimi's own `listSessionSources` window-filters on. The other three agents already satisfy this: claudecode, codex and pi all filter on `stat.mtimeMs` and record that same `stat.mtimeMs`. The invariant ("this field must be the quantity the agent's enumeration filters on") is now written on both the field and the predicate, because a mismatch there is what makes the comparison wrong in either direction.

**2. Unknown mtime now means "not enumerated".**

```ts
return typeof mtimeMs === "number" && matchesScanWindow(mtimeMs, options);
```

The two wrong answers are not symmetric. Wrongly removing destroys cached sessions and their messages. Wrongly keeping leaves one stale entry, which the next unwindowed pass (backfill or full scan) clears — `options.from == null && options.to == null` still short-circuits to `true`, so genuine deletions propagate unchanged.

With fix 1 in place, fix 2 has no caller today. That is what a backstop should look like: an agent that forgets the field gets a stale row, not silent data loss.

## Upgrade behaviour

The fingerprint is unaffected, so existing Kimi cache entries do not rescan. Entries written before this change still lack `sourceMtimeMs` and are kept by the new default until a rescan fills it in — the transition is safe by construction.

## Testing

- `keeps out-of-window sessions out of the change set during a windowed refresh` drives a real `KimiAgent` over temp fixtures: scan both sessions, enumerate with a 7-day window, assert `removedIds` is empty. **Verified it fails on the pre-fix code** with `expected [ 'old-session' ] to deeply equal []`.
- `records sourceMtimeMs as the value listSessionSources filters on` pins the invariant against `head.time_created`, so a future change that stores a file mtime instead of `createdAt` breaks here rather than silently mis-windowing.
- `diffSessionSources`' window case updated: `undated` is now kept under a window and still removed without one.
- `pnpm build` / `pnpm test` (core 456, cli 220, web 382) / `pnpm lint` / `pnpm format:check` clean; `pnpm test:coverage` and `pnpm test:migration` pass.

Issue: CS-100