### PR TITLE
fix(web): preserve session reference identity

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# CodeSesh
+
+CodeSesh 将多个本地 AI Coding Agent 的原生历史记录归一为可统一发现、检索和浏览的会话。
+
+## Language
+
+**Agent**:
+产生并持有原生编码会话历史的本地 AI 编码工具。
+_Avoid_: Provider, source type
+
+**Session Source**:
+Agent 持有的一份原生会话记录；它可以是文件、目录或数据库中的记录。
+_Avoid_: Transcript file
+
+**Session**:
+由一个 Agent 产生、经 CodeSesh 归一化后可统一浏览的一段编码对话。
+_Avoid_: Conversation, chat
+
+**Session Reference**:
+在 CodeSesh 中唯一标识 Session 的复合身份，由 Agent 与该 Agent 内的 Session ID 共同构成；Session ID 本身不全局唯一。
+_Avoid_: Bare session ID, session slug
+
+**Session Head**:
+用于列表、分组、搜索和统计的轻量 Session 摘要，不包含完整消息正文。
+_Avoid_: Session metadata
+
+**Session Detail**:
+包含完整归一化消息与工具活动、可用于回放 Session 的详细内容。
+_Avoid_: Full session, transcript
+
+**Project Identity**:
+将不同 Agent 中属于同一代码项目的 Session 聚合起来的复合身份，由 kind 与 key 共同构成。
+_Avoid_: Project path, bare project key
+
+**Live Snapshot**:
+CodeSesh 当前已发布、可供查询和浏览的一组 Session Head 及其派生统计。
+_Avoid_: Cache, session list

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -33,7 +33,12 @@ import { AppRouteContent } from "./components/app/AppRouteContent";
 import type { BrowseBy } from "./components/app/types";
 import { formatScanStatusLabel, formatSearchSubtitle } from "./lib/scan-format";
 import { getProjectIdentityKey, getProjectPath, type ProjectRouteIdentity } from "./lib/projects";
-import { buildSessionIndexes, getSessionAgentKey } from "./lib/session-indexes";
+import {
+  buildSessionIndexes,
+  getSessionAgentKey,
+  getSessionReferenceKey,
+  getSessionRouteKey,
+} from "./lib/session-indexes";
 
 export default function App() {
   const navigate = useNavigate();
@@ -62,7 +67,9 @@ export default function App() {
   const [selectedProjectIdentity, setSelectedProjectIdentity] =
     useState<ProjectRouteIdentity | null>(null);
   const { scanStatus, setScanStatus } = useScanStatus();
-  const [selectedSidebarSessionId, setSelectedSidebarSessionId] = useState<string | null>(null);
+  const [selectedSidebarSessionReference, setSelectedSidebarSessionReference] = useState<
+    string | null
+  >(null);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const {
     shortcutHintDismissed,
@@ -176,14 +183,14 @@ export default function App() {
     selectedProjectNavigation,
     sidebarSessions,
     sidebarSessionLookup,
-    bookmarkedSidebarSessionIds,
+    bookmarkedSidebarSessionReferences,
   } = sidebar;
   const selectedProjectNavigationIdentity = selectedProjectNavigation?.identity ?? null;
   const selectedProjectNavigationId = selectedProjectNavigation?.identityKey ?? null;
 
   const handleSelectFlatSidebarSession = useCallback(
     (sessionItem: SessionHead) => {
-      setSelectedSidebarSessionId(sessionItem.id);
+      setSelectedSidebarSessionReference(getSessionReferenceKey(sessionItem));
       navigate(`/${sessionItem.slug}`);
     },
     [navigate],
@@ -215,12 +222,11 @@ export default function App() {
   }, []);
 
   const handleSelectTreeSidebarSession = useCallback(
-    (sessionId: string) => {
-      setSelectedSidebarSessionId(sessionId);
-      const selected = sidebarSessionLookup.byId.get(sessionId);
-      if (selected) navigate(`/${selected.slug}`);
+    (sessionItem: SessionHead) => {
+      setSelectedSidebarSessionReference(getSessionReferenceKey(sessionItem));
+      navigate(`/${sessionItem.slug}`);
     },
-    [navigate, sidebarSessionLookup],
+    [navigate],
   );
 
   // 可见标签每次渲染直接计算，保证 processed/total 计数实时更新。
@@ -275,17 +281,25 @@ export default function App() {
     if (isSearchMode) return;
 
     if (viewState.mode === "session") {
-      setSelectedSidebarSessionId(viewState.activeSessionSlug);
+      setSelectedSidebarSessionReference(
+        getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionSlug),
+      );
       return;
     }
 
     if (viewState.mode === "agent") {
-      setSelectedSidebarSessionId(null);
+      setSelectedSidebarSessionReference(null);
       return;
     }
 
-    setSelectedSidebarSessionId(null);
-  }, [isSearchMode, viewState.mode, viewState.activeSessionSlug, sidebarSessions]);
+    setSelectedSidebarSessionReference(null);
+  }, [
+    isSearchMode,
+    viewState.mode,
+    viewState.activeAgentKey,
+    viewState.activeSessionSlug,
+    sidebarSessions,
+  ]);
 
   const searchSubtitle =
     searchState.status === "failed"
@@ -360,7 +374,7 @@ export default function App() {
   function changeBrowseBy(next: BrowseBy) {
     if (next === "projects" && isScanActive) return;
     selectBrowseBy(next);
-    setSelectedSidebarSessionId(null);
+    setSelectedSidebarSessionReference(null);
     if (next === "projects") {
       const project =
         openedSessionProjectIdentity ??
@@ -378,8 +392,8 @@ export default function App() {
     activeAgentKey,
     sidebarSessions,
     sidebarSessionLookup,
-    selectedSidebarSessionId,
-    setSelectedSidebarSessionId,
+    selectedSidebarSessionReference,
+    setSelectedSidebarSessionReference,
     selectedProjectNavigationIdentity,
     shortcutHelpOpen,
     setShortcutHelpOpen,
@@ -500,8 +514,8 @@ export default function App() {
               loading,
               bookmarkedSessions,
               sidebarSessions,
-              selectedSidebarSessionId,
-              bookmarkedSidebarSessionIds,
+              selectedSidebarSessionReference,
+              bookmarkedSidebarSessionReferences,
             }}
             actions={{
               onChangeBrowseBy: changeBrowseBy,

--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionHead } from "../lib/api";
+import { getSessionReferenceKey } from "../lib/session-indexes";
 import { buildSessionTreeModel, SessionTreeSidebar } from "./SessionTreeSidebar";
 
 function makeSession(overrides: Partial<SessionHead> & { id: string }): SessionHead {
@@ -90,6 +91,16 @@ describe("buildSessionTreeModel group sorting", () => {
     expect(() => buildSessionTreeModel(sessions)).not.toThrow();
     expect(groupOrderOf(paths)).toEqual(["small", "big"]);
   });
+
+  it("keeps paths for equal session ids from different agents", () => {
+    const codex = makeSession({ id: "same", slug: "codex/same" });
+    const claude = makeSession({ id: "same", slug: "claude/same" });
+
+    const model = buildSessionTreeModel([codex, claude]);
+
+    expect(model.pathBySessionReference.get(getSessionReferenceKey(codex))).toBeDefined();
+    expect(model.pathBySessionReference.get(getSessionReferenceKey(claude))).toBeDefined();
+  });
 });
 
 // happy-dom dispatches events into the tree's shadow DOM without retargeting
@@ -115,10 +126,10 @@ function renderSessionTreeSidebar() {
   render(
     <SessionTreeSidebar
       sessions={[session]}
-      activeSessionId={session.id}
-      selectedSessionId={session.id}
+      activeSessionReference={getSessionReferenceKey(session)}
+      selectedSessionReference={getSessionReferenceKey(session)}
       onSelectSession={() => {}}
-      bookmarkedSessionIds={new Set()}
+      bookmarkedSessionReferences={new Set()}
       onToggleBookmark={onToggleBookmark}
       onRenameSession={onRenameSession}
     />,

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -12,15 +12,16 @@ import {
   type MouseEvent,
 } from "react";
 import type { SessionHead } from "../lib/api";
+import { getSessionReferenceKey } from "../lib/session-indexes";
 import { getSessionDisplayTitle } from "../lib/session-title";
 import { isRenderProfilerEnabled, recordRenderProfileEntry } from "./RenderProfiler";
 
 interface SessionTreeSidebarProps {
   sessions: SessionHead[];
-  activeSessionId: string | null;
-  selectedSessionId: string | null;
-  onSelectSession: (sessionId: string) => void;
-  bookmarkedSessionIds: Set<string>;
+  activeSessionReference: string | null;
+  selectedSessionReference: string | null;
+  onSelectSession: (session: SessionHead) => void;
+  bookmarkedSessionReferences: Set<string>;
   onToggleBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
 }
@@ -28,9 +29,8 @@ interface SessionTreeSidebarProps {
 interface SessionTreeModel {
   paths: string[];
   sortOrderByPath: Map<string, number>;
-  pathBySessionId: Map<string, string>;
-  groupPathBySessionId: Map<string, string>;
-  sessionIdByPath: Map<string, string>;
+  pathBySessionReference: Map<string, string>;
+  groupPathBySessionReference: Map<string, string>;
   groupCountByPath: Map<string, string>;
   sessionByPath: Map<string, SessionHead>;
 }
@@ -147,9 +147,8 @@ function compareTreeOrder(
 
 export function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel {
   const sortOrderByPath = new Map<string, number>();
-  const pathBySessionId = new Map<string, string>();
-  const groupPathBySessionId = new Map<string, string>();
-  const sessionIdByPath = new Map<string, string>();
+  const pathBySessionReference = new Map<string, string>();
+  const groupPathBySessionReference = new Map<string, string>();
   const groupCountByPath = new Map<string, string>();
   const sessionByPath = new Map<string, SessionHead>();
   const usedPaths = new Set<string>();
@@ -215,9 +214,9 @@ export function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel
       paths.push(path);
       sortOrderByPath.set(path, order);
       order += 1;
-      pathBySessionId.set(session.id, path);
-      groupPathBySessionId.set(session.id, groupPath);
-      sessionIdByPath.set(path, session.id);
+      const reference = getSessionReferenceKey(session);
+      pathBySessionReference.set(reference, path);
+      groupPathBySessionReference.set(reference, groupPath);
       sessionByPath.set(path, session);
     }
   }
@@ -225,9 +224,8 @@ export function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel
   return {
     paths,
     sortOrderByPath,
-    pathBySessionId,
-    groupPathBySessionId,
-    sessionIdByPath,
+    pathBySessionReference,
+    groupPathBySessionReference,
     groupCountByPath,
     sessionByPath,
   };
@@ -253,10 +251,10 @@ function measureSessionTreeWork<T>(id: string, compute: () => T): T {
 
 export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   sessions,
-  activeSessionId,
-  selectedSessionId,
+  activeSessionReference,
+  selectedSessionReference,
   onSelectSession,
-  bookmarkedSessionIds,
+  bookmarkedSessionReferences,
   onToggleBookmark,
   onRenameSession,
 }: SessionTreeSidebarProps) {
@@ -272,10 +270,9 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     [sessions],
   );
   const sortOrderRef = useRef(modelData.sortOrderByPath);
-  const sessionIdByPathRef = useRef(modelData.sessionIdByPath);
   const groupCountByPathRef = useRef(modelData.groupCountByPath);
   const sessionByPathRef = useRef(modelData.sessionByPath);
-  const bookmarkedSessionIdsRef = useRef(bookmarkedSessionIds);
+  const bookmarkedSessionReferencesRef = useRef(bookmarkedSessionReferences);
   const onSelectSessionRef = useRef(onSelectSession);
   const onToggleBookmarkRef = useRef(onToggleBookmark);
   const onRenameSessionRef = useRef(onRenameSession);
@@ -300,8 +297,8 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     density: "compact",
     unsafeCSS: SESSION_TREE_CSS,
     onSelectionChange(paths) {
-      const sessionId = sessionIdByPathRef.current.get(paths[0] ?? "");
-      if (sessionId) onSelectSessionRef.current(sessionId);
+      const session = sessionByPathRef.current.get(paths[0] ?? "");
+      if (session) onSelectSessionRef.current(session);
     },
     renderRowDecoration({ item }) {
       const session = sessionByPathRef.current.get(item.path);
@@ -316,7 +313,6 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
 
   useEffect(() => {
     sortOrderRef.current = modelData.sortOrderByPath;
-    sessionIdByPathRef.current = modelData.sessionIdByPath;
     groupCountByPathRef.current = modelData.groupCountByPath;
     sessionByPathRef.current = modelData.sessionByPath;
     model.resetPaths(modelData.paths);
@@ -327,8 +323,8 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   }, [onSelectSession]);
 
   useEffect(() => {
-    bookmarkedSessionIdsRef.current = bookmarkedSessionIds;
-  }, [bookmarkedSessionIds]);
+    bookmarkedSessionReferencesRef.current = bookmarkedSessionReferences;
+  }, [bookmarkedSessionReferences]);
 
   useEffect(() => {
     onToggleBookmarkRef.current = onToggleBookmark;
@@ -393,21 +389,21 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   }
 
   useEffect(() => {
-    const activePath = modelData.pathBySessionId.get(activeSessionId ?? "");
-    const selectedPath = modelData.pathBySessionId.get(selectedSessionId ?? "");
+    const activePath = modelData.pathBySessionReference.get(activeSessionReference ?? "");
+    const selectedPath = modelData.pathBySessionReference.get(selectedSessionReference ?? "");
     const focusedPath = selectedPath ?? activePath;
-    const focusedSessionId = selectedSessionId ?? activeSessionId ?? "";
-    const focusedGroupPath = modelData.groupPathBySessionId.get(focusedSessionId);
+    const focusedSessionReference = selectedSessionReference ?? activeSessionReference ?? "";
+    const focusedGroupPath = modelData.groupPathBySessionReference.get(focusedSessionReference);
 
     if (activePath) model.getItem(activePath)?.select();
-    if (focusedPath && activeSessionId) {
+    if (focusedPath && activeSessionReference) {
       const focusedGroup = focusedGroupPath ? model.getItem(focusedGroupPath) : null;
       if (focusedGroup && "expand" in focusedGroup) focusedGroup.expand();
       model.focusPath(focusedPath);
       return;
     }
     if (focusedGroupPath) model.focusPath(focusedGroupPath);
-  }, [activeSessionId, model, modelData, selectedSessionId]);
+  }, [activeSessionReference, model, modelData, selectedSessionReference]);
 
   return (
     <div
@@ -448,7 +444,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
                     onClick={() => onToggleBookmarkRef.current(menuSession)}
                     className="motion-hover motion-press block w-full rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
                   >
-                    {bookmarkedSessionIdsRef.current.has(menuSession.id)
+                    {bookmarkedSessionReferencesRef.current.has(getSessionReferenceKey(menuSession))
                       ? "Remove bookmark"
                       : "Add bookmark"}
                   </Menu.Item>

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -45,8 +45,8 @@ describe("AppSidebar agent counts", () => {
             loading: false,
             bookmarkedSessions: [],
             sidebarSessions: [],
-            selectedSidebarSessionId: null,
-            bookmarkedSidebarSessionIds: new Set(),
+            selectedSidebarSessionReference: null,
+            bookmarkedSidebarSessionReferences: new Set(),
           }}
           actions={actions}
         />

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -7,6 +7,7 @@ import type {
 } from "../../lib/api";
 import { findAgent, type AgentCatalog } from "../../lib/agents";
 import { getSessionBookmarkKey } from "../../lib/bookmarks";
+import { getSessionRouteKey } from "../../lib/session-indexes";
 import { getSessionDisplayTitle } from "../../lib/session-title";
 import { formatAgentScanProgress } from "../../lib/scan-format";
 import { getProjectGroupIdentity, getProjectIdentityKey, getProjectPath } from "../../lib/projects";
@@ -150,8 +151,8 @@ export interface AppSidebarViewModel {
   loading: boolean;
   bookmarkedSessions: BookmarkedSessionSnapshot[];
   sidebarSessions: SessionHead[];
-  selectedSidebarSessionId: string | null;
-  bookmarkedSidebarSessionIds: Set<string>;
+  selectedSidebarSessionReference: string | null;
+  bookmarkedSidebarSessionReferences: Set<string>;
 }
 
 export interface AppSidebarActions {
@@ -162,7 +163,7 @@ export interface AppSidebarActions {
   onToggleSidebarSessionBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
   onRenameBookmarkedSession: (session: BookmarkedSessionSnapshot) => void;
-  onSelectTreeSidebarSession: (sessionId: string) => void;
+  onSelectTreeSidebarSession: (session: SessionHead) => void;
 }
 
 export function AppSidebar({
@@ -180,8 +181,8 @@ export function AppSidebar({
     loading,
     bookmarkedSessions,
     sidebarSessions,
-    selectedSidebarSessionId,
-    bookmarkedSidebarSessionIds,
+    selectedSidebarSessionReference,
+    bookmarkedSidebarSessionReferences,
   },
   actions: {
     onChangeBrowseBy,
@@ -197,6 +198,11 @@ export function AppSidebar({
   model: AppSidebarViewModel;
   actions: AppSidebarActions;
 }) {
+  const activeSessionReference =
+    viewState.mode === "session"
+      ? getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionSlug)
+      : null;
+
   return (
     <aside
       className={`w-64 shrink-0 flex-col border-r border-[var(--console-border)] bg-[var(--console-sidebar-bg)] ${
@@ -355,9 +361,9 @@ export function AppSidebar({
             <SidebarFlatSessionList
               sessions={sidebarSessions}
               agentCatalog={agentCatalog}
-              activeSessionId={viewState.mode === "session" ? viewState.activeSessionSlug : null}
-              selectedSessionId={selectedSidebarSessionId}
-              bookmarkedSessionIds={bookmarkedSidebarSessionIds}
+              activeSessionReference={activeSessionReference}
+              selectedSessionReference={selectedSidebarSessionReference}
+              bookmarkedSessionReferences={bookmarkedSidebarSessionReferences}
               onSelectSession={onSelectFlatSidebarSession}
               onToggleBookmark={onToggleSidebarSessionBookmark}
               onRenameSession={onRenameSession}
@@ -366,10 +372,10 @@ export function AppSidebar({
             <RenderProfiler id="SessionTreeSidebar" detail={{ sessions: sidebarSessions.length }}>
               <SessionTreeSidebar
                 sessions={sidebarSessions}
-                activeSessionId={viewState.mode === "session" ? viewState.activeSessionSlug : null}
-                selectedSessionId={selectedSidebarSessionId}
+                activeSessionReference={activeSessionReference}
+                selectedSessionReference={selectedSidebarSessionReference}
                 onSelectSession={onSelectTreeSidebarSession}
-                bookmarkedSessionIds={bookmarkedSidebarSessionIds}
+                bookmarkedSessionReferences={bookmarkedSidebarSessionReferences}
                 onToggleBookmark={onToggleSidebarSessionBookmark}
                 onRenameSession={onRenameSession}
               />

--- a/apps/web/src/components/app/SidebarFlatSessionList.test.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionHead } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
+import { getSessionReferenceKey } from "../../lib/session-indexes";
 import { SidebarFlatSessionList, VIRTUALIZED_SESSION_THRESHOLD } from "./SidebarFlatSessionList";
 
 afterEach(cleanup);
@@ -46,9 +47,9 @@ describe("SidebarFlatSessionList", () => {
       <SidebarFlatSessionList
         sessions={[session]}
         agentCatalog={createAgentCatalog([])}
-        activeSessionId={null}
-        selectedSessionId={null}
-        bookmarkedSessionIds={new Set()}
+        activeSessionReference={null}
+        selectedSessionReference={null}
+        bookmarkedSessionReferences={new Set()}
         onSelectSession={onSelectSession}
         onRenameSession={onRenameSession}
         onToggleBookmark={onToggleBookmark}
@@ -74,9 +75,9 @@ describe("SidebarFlatSessionList virtualization", () => {
       <SidebarFlatSessionList
         sessions={sessions}
         agentCatalog={createAgentCatalog([])}
-        activeSessionId={null}
-        selectedSessionId={null}
-        bookmarkedSessionIds={new Set()}
+        activeSessionReference={null}
+        selectedSessionReference={null}
+        bookmarkedSessionReferences={new Set()}
         onSelectSession={vi.fn()}
         onRenameSession={vi.fn()}
         onToggleBookmark={vi.fn()}
@@ -93,9 +94,9 @@ describe("SidebarFlatSessionList virtualization", () => {
       <SidebarFlatSessionList
         sessions={sessions}
         agentCatalog={createAgentCatalog([])}
-        activeSessionId={null}
-        selectedSessionId={null}
-        bookmarkedSessionIds={new Set()}
+        activeSessionReference={null}
+        selectedSessionReference={null}
+        bookmarkedSessionReferences={new Set()}
         onSelectSession={vi.fn()}
         onRenameSession={vi.fn()}
         onToggleBookmark={vi.fn()}
@@ -117,9 +118,9 @@ describe("SidebarFlatSessionList virtualization", () => {
       <SidebarFlatSessionList
         sessions={sessions}
         agentCatalog={createAgentCatalog([])}
-        activeSessionId={targetSession.id}
-        selectedSessionId={targetSession.id}
-        bookmarkedSessionIds={new Set()}
+        activeSessionReference={getSessionReferenceKey(targetSession)}
+        selectedSessionReference={getSessionReferenceKey(targetSession)}
+        bookmarkedSessionReferences={new Set()}
         onSelectSession={onSelectSession}
         onRenameSession={onRenameSession}
         onToggleBookmark={vi.fn()}

--- a/apps/web/src/components/app/SidebarFlatSessionList.tsx
+++ b/apps/web/src/components/app/SidebarFlatSessionList.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SessionHead } from "../../lib/api";
 import { findAgent, type AgentCatalog } from "../../lib/agents";
-import { getSessionAgentKey } from "../../lib/session-indexes";
+import { getSessionAgentKey, getSessionReferenceKey } from "../../lib/session-indexes";
 import { formatRelativeTime } from "../../lib/format";
 import { getSessionDisplayTitle } from "../../lib/session-title";
 import { AgentIcon } from "../AgentIcon";
@@ -22,9 +22,9 @@ const SESSION_LIST_HEIGHT_CLASS = "h-[min(560px,calc(100vh-410px))] min-h-56";
 interface SidebarFlatSessionListProps {
   sessions: SessionHead[];
   agentCatalog: AgentCatalog;
-  activeSessionId: string | null;
-  selectedSessionId: string | null;
-  bookmarkedSessionIds: Set<string>;
+  activeSessionReference: string | null;
+  selectedSessionReference: string | null;
+  bookmarkedSessionReferences: Set<string>;
   onSelectSession: (session: SessionHead) => void;
   onToggleBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
@@ -38,7 +38,7 @@ function SessionRow({
   onSelectSession,
   onToggleBookmark,
   onRenameSession,
-  bookmarkedSessionIds,
+  bookmarkedSessionReferences,
 }: {
   session: SessionHead;
   agentCatalog: AgentCatalog;
@@ -47,7 +47,7 @@ function SessionRow({
   onSelectSession: (session: SessionHead) => void;
   onToggleBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
-  bookmarkedSessionIds: Set<string>;
+  bookmarkedSessionReferences: Set<string>;
 }) {
   const agentKey = getSessionAgentKey(session);
   const agent = findAgent(agentCatalog, agentKey);
@@ -82,7 +82,7 @@ function SessionRow({
         </span>
       </button>
       <SessionActionsMenu
-        bookmarked={bookmarkedSessionIds.has(session.id)}
+        bookmarked={bookmarkedSessionReferences.has(getSessionReferenceKey(session))}
         onRename={() => onRenameSession(session)}
         onToggleBookmark={() => onToggleBookmark(session)}
       />
@@ -98,9 +98,9 @@ export function SidebarFlatSessionList(props: SidebarFlatSessionListProps) {
   const {
     sessions,
     agentCatalog,
-    activeSessionId,
-    selectedSessionId,
-    bookmarkedSessionIds,
+    activeSessionReference,
+    selectedSessionReference,
+    bookmarkedSessionReferences,
     onSelectSession,
     onToggleBookmark,
     onRenameSession,
@@ -114,9 +114,9 @@ export function SidebarFlatSessionList(props: SidebarFlatSessionListProps) {
             <SessionRow
               session={sessionItem}
               agentCatalog={agentCatalog}
-              active={activeSessionId === sessionItem.id}
-              selected={selectedSessionId === sessionItem.id}
-              bookmarkedSessionIds={bookmarkedSessionIds}
+              active={activeSessionReference === getSessionReferenceKey(sessionItem)}
+              selected={selectedSessionReference === getSessionReferenceKey(sessionItem)}
+              bookmarkedSessionReferences={bookmarkedSessionReferences}
               onSelectSession={onSelectSession}
               onToggleBookmark={onToggleBookmark}
               onRenameSession={onRenameSession}
@@ -131,9 +131,9 @@ export function SidebarFlatSessionList(props: SidebarFlatSessionListProps) {
 function VirtualizedSidebarFlatSessionList({
   sessions,
   agentCatalog,
-  activeSessionId,
-  selectedSessionId,
-  bookmarkedSessionIds,
+  activeSessionReference,
+  selectedSessionReference,
+  bookmarkedSessionReferences,
   onSelectSession,
   onToggleBookmark,
   onRenameSession,
@@ -211,9 +211,9 @@ function VirtualizedSidebarFlatSessionList({
               <SessionRow
                 session={sessionItem}
                 agentCatalog={agentCatalog}
-                active={activeSessionId === sessionItem.id}
-                selected={selectedSessionId === sessionItem.id}
-                bookmarkedSessionIds={bookmarkedSessionIds}
+                active={activeSessionReference === getSessionReferenceKey(sessionItem)}
+                selected={selectedSessionReference === getSessionReferenceKey(sessionItem)}
+                bookmarkedSessionReferences={bookmarkedSessionReferences}
                 onSelectSession={onSelectSession}
                 onToggleBookmark={onToggleBookmark}
                 onRenameSession={onRenameSession}

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, renderHook } from "@testing-library/react";
 import type { NavigateFunction } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SearchResult, SessionHead } from "../lib/api";
-import { buildSidebarSessionLookup } from "../lib/session-indexes";
+import { buildSidebarSessionLookup, getSessionReferenceKey } from "../lib/session-indexes";
 import type { ViewState } from "../lib/view-state";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 
@@ -44,8 +44,8 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
     activeAgentKey: "codex",
     sidebarSessions: sessions,
     sidebarSessionLookup: buildSidebarSessionLookup(sessions),
-    selectedSidebarSessionId: null,
-    setSelectedSidebarSessionId: vi.fn(),
+    selectedSidebarSessionReference: null,
+    setSelectedSidebarSessionReference: vi.fn(),
     selectedProjectNavigationIdentity: null,
     shortcutHelpOpen: false,
     setShortcutHelpOpen: vi.fn(),
@@ -104,7 +104,7 @@ describe("useKeyboardShortcuts", () => {
     const { unmount } = renderHook(() => useKeyboardShortcuts(helpDeps));
 
     dispatchKey("j");
-    expect(helpDeps.setSelectedSidebarSessionId).not.toHaveBeenCalled();
+    expect(helpDeps.setSelectedSidebarSessionReference).not.toHaveBeenCalled();
     expect(dispatchKey("Escape").defaultPrevented).toBe(true);
     expect(helpDeps.setShortcutHelpOpen).toHaveBeenCalledWith(false);
     unmount();
@@ -116,7 +116,7 @@ describe("useKeyboardShortcuts", () => {
     input.focus();
 
     fireEvent.keyDown(input, { key: "j" });
-    expect(editableDeps.setSelectedSidebarSessionId).not.toHaveBeenCalled();
+    expect(editableDeps.setSelectedSidebarSessionReference).not.toHaveBeenCalled();
     fireEvent.keyDown(input, { key: "Escape" });
     expect(document.activeElement).not.toBe(input);
     input.remove();
@@ -184,16 +184,16 @@ describe("useKeyboardShortcuts", () => {
     const { unmount } = renderHook(() => useKeyboardShortcuts(deps));
 
     dispatchKey("j");
-    expect(deps.setSelectedSidebarSessionId).toHaveBeenNthCalledWith(1, "s1");
+    expect(deps.setSelectedSidebarSessionReference).toHaveBeenNthCalledWith(1, "codex/s1");
     dispatchKey("k");
-    expect(deps.setSelectedSidebarSessionId).toHaveBeenNthCalledWith(2, "s3");
+    expect(deps.setSelectedSidebarSessionReference).toHaveBeenNthCalledWith(2, "codex/s3");
     dispatchKey("g");
-    expect(deps.setSelectedSidebarSessionId).toHaveBeenNthCalledWith(3, "s1");
+    expect(deps.setSelectedSidebarSessionReference).toHaveBeenNthCalledWith(3, "codex/s1");
     dispatchKey("G");
-    expect(deps.setSelectedSidebarSessionId).toHaveBeenNthCalledWith(4, "s3");
+    expect(deps.setSelectedSidebarSessionReference).toHaveBeenNthCalledWith(4, "codex/s3");
     unmount();
 
-    const agentDeps = makeDeps({ selectedSidebarSessionId: "s2" });
+    const agentDeps = makeDeps({ selectedSidebarSessionReference: "codex/s2" });
     const agentHook = renderHook(() => useKeyboardShortcuts(agentDeps));
     dispatchKey("Enter");
     expect(agentDeps.navigate).toHaveBeenCalledWith("/codex/s2");
@@ -201,7 +201,7 @@ describe("useKeyboardShortcuts", () => {
 
     const projectDeps = makeDeps({
       browseBy: "projects" as const,
-      selectedSidebarSessionId: "s2",
+      selectedSidebarSessionReference: "codex/s2",
     });
     renderHook(() => useKeyboardShortcuts(projectDeps));
     dispatchKey("Enter");
@@ -226,6 +226,23 @@ describe("useKeyboardShortcuts", () => {
     const sidebarDeps = makeDeps({ activeAgentKey: null });
     renderHook(() => useKeyboardShortcuts(sidebarDeps));
     dispatchKey("j");
-    expect(sidebarDeps.setSelectedSidebarSessionId).not.toHaveBeenCalled();
+    expect(sidebarDeps.setSelectedSidebarSessionReference).not.toHaveBeenCalled();
+  });
+
+  it("opens the selected agent when project sessions share a native id", () => {
+    const codex = makeSession("same");
+    const claude = { ...makeSession("same"), slug: "claude/same" };
+    const projectSessions = [codex, claude];
+    const deps = makeDeps({
+      browseBy: "projects" as const,
+      sidebarSessions: projectSessions,
+      sidebarSessionLookup: buildSidebarSessionLookup(projectSessions),
+      selectedSidebarSessionReference: getSessionReferenceKey(claude),
+    });
+    renderHook(() => useKeyboardShortcuts(deps));
+
+    dispatchKey("Enter");
+
+    expect(deps.navigate).toHaveBeenCalledWith("/claude/same");
   });
 });

--- a/apps/web/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,7 +1,7 @@
 import { useEffect, useEffectEvent } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import type { SearchResult, SessionHead } from "../lib/api";
-import type { SidebarSessionLookup } from "../lib/session-indexes";
+import { getSessionReferenceKey, type SidebarSessionLookup } from "../lib/session-indexes";
 import { getProjectPath, type ProjectRouteIdentity } from "../lib/projects";
 import type { ViewState } from "../lib/view-state";
 import type { BrowseBy } from "../components/app/types";
@@ -13,8 +13,8 @@ interface KeyboardShortcutsDeps {
   activeAgentKey: string | null;
   sidebarSessions: SessionHead[];
   sidebarSessionLookup: SidebarSessionLookup;
-  selectedSidebarSessionId: string | null;
-  setSelectedSidebarSessionId: (id: string | null) => void;
+  selectedSidebarSessionReference: string | null;
+  setSelectedSidebarSessionReference: (reference: string | null) => void;
   selectedProjectNavigationIdentity: ProjectRouteIdentity | null;
   shortcutHelpOpen: boolean;
   setShortcutHelpOpen: (open: boolean) => void;
@@ -54,8 +54,8 @@ export function useKeyboardShortcuts(deps: KeyboardShortcutsDeps) {
     activeAgentKey,
     sidebarSessions,
     sidebarSessionLookup,
-    selectedSidebarSessionId,
-    setSelectedSidebarSessionId,
+    selectedSidebarSessionReference,
+    setSelectedSidebarSessionReference,
     selectedProjectNavigationIdentity,
     shortcutHelpOpen,
     setShortcutHelpOpen,
@@ -178,13 +178,14 @@ export function useKeyboardShortcuts(deps: KeyboardShortcutsDeps) {
     const moveSidebarSelection = (offset: number) => {
       dismissShortcutHint();
       const currentIndex =
-        selectedSidebarSessionId != null
-          ? (sidebarSessionLookup.indexById.get(selectedSidebarSessionId) ?? -1)
+        selectedSidebarSessionReference != null
+          ? (sidebarSessionLookup.indexByReference.get(selectedSidebarSessionReference) ?? -1)
           : -1;
       const baseIndex =
         currentIndex >= 0 ? currentIndex : offset >= 0 ? -1 : sidebarSessions.length;
       const nextIndex = Math.max(0, Math.min(baseIndex + offset, sidebarSessions.length - 1));
-      setSelectedSidebarSessionId(sidebarSessions[nextIndex]?.id ?? null);
+      const nextSession = sidebarSessions[nextIndex];
+      setSelectedSidebarSessionReference(nextSession ? getSessionReferenceKey(nextSession) : null);
     };
 
     if (key === "j") {
@@ -200,19 +201,21 @@ export function useKeyboardShortcuts(deps: KeyboardShortcutsDeps) {
     if (key === "g") {
       event.preventDefault();
       dismissShortcutHint();
-      setSelectedSidebarSessionId(sidebarSessions[0]?.id ?? null);
+      const first = sidebarSessions[0];
+      setSelectedSidebarSessionReference(first ? getSessionReferenceKey(first) : null);
       return;
     }
     if (key === "G") {
       event.preventDefault();
       dismissShortcutHint();
-      setSelectedSidebarSessionId(sidebarSessions.at(-1)?.id ?? null);
+      const last = sidebarSessions.at(-1);
+      setSelectedSidebarSessionReference(last ? getSessionReferenceKey(last) : null);
       return;
     }
     if (key === "Enter") {
       const selected =
-        selectedSidebarSessionId != null
-          ? sidebarSessionLookup.byId.get(selectedSidebarSessionId)
+        selectedSidebarSessionReference != null
+          ? sidebarSessionLookup.byReference.get(selectedSidebarSessionReference)
           : null;
       if (!selected) return;
       event.preventDefault();

--- a/apps/web/src/hooks/useSidebarModel.test.ts
+++ b/apps/web/src/hooks/useSidebarModel.test.ts
@@ -2,7 +2,7 @@ import { SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentInfo, ProjectGroup, SessionHead } from "../lib/api";
-import { buildSessionIndexes } from "../lib/session-indexes";
+import { buildSessionIndexes, getSessionReferenceKey } from "../lib/session-indexes";
 import type { ViewState } from "../lib/view-state";
 import { useSidebarModel } from "./useSidebarModel";
 
@@ -63,7 +63,7 @@ const sessionView = {
 
 afterEach(cleanup);
 
-function renderModel(initialViewState: ViewState = rootView) {
+function renderModel(initialViewState: ViewState = rootView, indexes = sessionIndexes) {
   const isSessionBookmarked = vi.fn((agentKey, sessionId) => {
     return agentKey === "codex" && sessionId === codexSession.id;
   });
@@ -71,7 +71,7 @@ function renderModel(initialViewState: ViewState = rootView) {
     ({ viewState, selectedProjectAgent }) =>
       useSidebarModel({
         viewState,
-        sessionIndexes,
+        sessionIndexes: indexes,
         session: null,
         agents,
         projects,
@@ -129,8 +129,25 @@ describe("useSidebarModel", () => {
     rerender({ viewState: projectView, selectedProjectAgent: "codex" });
 
     expect(result.current.sidebarSessions).toEqual([codexSession]);
-    expect(result.current.bookmarkedSidebarSessionIds).toEqual(new Set([codexSession.id]));
-    expect(result.current.sidebarSessionLookup.byId.get(codexSession.id)).toBe(codexSession);
+    const reference = getSessionReferenceKey(codexSession);
+    expect(result.current.bookmarkedSidebarSessionReferences).toEqual(new Set([reference]));
+    expect(result.current.sidebarSessionLookup.byReference.get(reference)).toBe(codexSession);
+  });
+
+  it("keeps bookmark and lookup identity separate across agents with the same session id", () => {
+    const sameIdClaude = {
+      ...claudeSession,
+      id: codexSession.id,
+      slug: `claudecode/${codexSession.id}`,
+    };
+    const indexes = buildSessionIndexes([codexSession, sameIdClaude], agents);
+    const { result } = renderModel(projectView, indexes);
+    const codexReference = getSessionReferenceKey(codexSession);
+    const claudeReference = getSessionReferenceKey(sameIdClaude);
+
+    expect(result.current.bookmarkedSidebarSessionReferences).toEqual(new Set([codexReference]));
+    expect(result.current.sidebarSessionLookup.byReference.get(codexReference)).toBe(codexSession);
+    expect(result.current.sidebarSessionLookup.byReference.get(claudeReference)).toBe(sameIdClaude);
   });
 
   it("resolves the active project once for route consumers", () => {

--- a/apps/web/src/hooks/useSidebarModel.ts
+++ b/apps/web/src/hooks/useSidebarModel.ts
@@ -9,6 +9,7 @@ import {
   buildSidebarSessionLookup,
   getProjectAgentKey,
   getSessionAgentKey,
+  getSessionReferenceKey,
   getSessionRouteKey,
   type SessionIndexes,
 } from "../lib/session-indexes";
@@ -146,12 +147,12 @@ export function useSidebarModel({
     );
     const sidebarSessions = browseBy === "projects" ? projectSessions : agentSessions;
     const sidebarSessionLookup = buildSidebarSessionLookup(sidebarSessions);
-    const bookmarkedSidebarSessionIds = new Set(
+    const bookmarkedSidebarSessionReferences = new Set(
       sidebarSessions
         .filter((sessionItem) =>
           isSessionBookmarked(getSessionAgentKey(sessionItem), sessionItem.id),
         )
-        .map((sessionItem) => sessionItem.id),
+        .map(getSessionReferenceKey),
     );
 
     return {
@@ -163,7 +164,7 @@ export function useSidebarModel({
       selectedProjectNavigation,
       sidebarSessions,
       sidebarSessionLookup,
-      bookmarkedSidebarSessionIds,
+      bookmarkedSidebarSessionReferences,
     };
   }, [
     agents,

--- a/apps/web/src/lib/session-indexes.test.ts
+++ b/apps/web/src/lib/session-indexes.test.ts
@@ -4,6 +4,7 @@ import {
   buildSessionIndexes,
   buildSidebarSessionLookup,
   getProjectAgentKey,
+  getSessionReferenceKey,
   getSessionRouteKey,
 } from "./session-indexes";
 
@@ -150,17 +151,19 @@ describe("session indexes", () => {
     ]);
   });
 
-  it("keeps sidebar lookup compatible with first-match selection", () => {
+  it("keeps equal session ids from different agents in separate sidebar entries", () => {
     const first = createSession({ id: "same", slug: "codex/same", title: "First" });
     const duplicate = createSession({ id: "same", slug: "claude/same", title: "Duplicate" });
     const next = createSession({ id: "next", slug: "codex/next", title: "Next" });
 
     const lookup = buildSidebarSessionLookup([first, duplicate, next]);
 
-    expect(lookup.byId.get("same")).toBe(first);
-    expect(lookup.indexById.get("same")).toBe(0);
-    expect(lookup.byId.get("next")).toBe(next);
-    expect(lookup.indexById.get("next")).toBe(2);
+    expect(lookup.byReference.get(getSessionReferenceKey(first))).toBe(first);
+    expect(lookup.indexByReference.get(getSessionReferenceKey(first))).toBe(0);
+    expect(lookup.byReference.get(getSessionReferenceKey(duplicate))).toBe(duplicate);
+    expect(lookup.indexByReference.get(getSessionReferenceKey(duplicate))).toBe(1);
+    expect(lookup.byReference.get(getSessionReferenceKey(next))).toBe(next);
+    expect(lookup.indexByReference.get(getSessionReferenceKey(next))).toBe(2);
   });
 
   it("keeps route lookup compatible with first-match session search", () => {

--- a/apps/web/src/lib/session-indexes.ts
+++ b/apps/web/src/lib/session-indexes.ts
@@ -34,11 +34,15 @@ export interface SessionIndexes {
 }
 
 export interface SidebarSessionLookup {
-  byId: Map<string, SessionHead>;
-  indexById: Map<string, number>;
+  byReference: Map<string, SessionHead>;
+  indexByReference: Map<string, number>;
 }
 
 export { getProjectAgentKey, getSessionAgentKey, getSessionRouteKey };
+
+export function getSessionReferenceKey(session: Pick<SessionHead, "id" | "slug">): string {
+  return getSessionRouteKey(getSessionAgentKey(session), session.id);
+}
 
 function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
   const current = map.get(key);
@@ -117,15 +121,16 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
 }
 
 export function buildSidebarSessionLookup(sessions: SessionHead[]): SidebarSessionLookup {
-  const byId = new Map<string, SessionHead>();
-  const indexById = new Map<string, number>();
+  const byReference = new Map<string, SessionHead>();
+  const indexByReference = new Map<string, number>();
 
   for (let index = 0; index < sessions.length; index += 1) {
     const session = sessions[index]!;
-    if (byId.has(session.id)) continue;
-    byId.set(session.id, session);
-    indexById.set(session.id, index);
+    const reference = getSessionReferenceKey(session);
+    if (byReference.has(reference)) continue;
+    byReference.set(reference, session);
+    indexByReference.set(reference, index);
   }
 
-  return { byId, indexById };
+  return { byReference, indexByReference };
 }


### PR DESCRIPTION
## Summary
- preserve the canonical `(agent, native session ID)` identity throughout sidebar state
- keep cross-agent sessions with the same native ID independently selectable and bookmarkable
- document the project domain vocabulary in `CONTEXT.md`
- add regression coverage for click, keyboard, tree, active, and bookmark flows

## Root cause
The web sidebar reduced a Session Reference to a bare native ID. Project views can contain sessions from multiple agents, so identical native IDs collided and the first entry silently won.

A temporary structured diagnostic reproduced the collision before implementation:
`sidebar.session_identity_collision { session_id: "same", kept_route: "codex/same", dropped_route: "claude/same" }`

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e`

Issue: CS-102