### PR TITLE
fix(search): unify cross-source filters

### DIFF
--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -5,10 +5,9 @@
 import type { BookmarkRecord, SessionHead } from "@codesesh/core";
 import type { SearchResult } from "@codesesh/core/contract";
 import {
-  createProjectScopeMatcher,
+  filterSessionSearchCandidates,
   getSessionActivityTime,
   listSessionAliases,
-  matchesSessionSearchFilters,
   mergeSearchQueryOptions,
   StateStorageUnavailableError,
   type FileActivityResult,
@@ -114,7 +113,6 @@ export function findAliasSearchResults(
   const needle = search.text.trim().toLowerCase();
   if (!needle || aliases.size === 0) return [];
 
-  const projectScope = search.options.cwd ? createProjectScopeMatcher(search.options.cwd) : null;
   const sessionsByAgent = new Map<string, Map<string, SessionHead>>();
   const lookupSession = (agentName: string, sessionId: string): SessionHead | undefined => {
     let byId = sessionsByAgent.get(agentName);
@@ -131,7 +129,6 @@ export function findAliasSearchResults(
     const { agentName, sessionId } = splitAliasKey(key);
     const session = lookupSession(agentName, sessionId);
     if (!session) continue;
-    if (!matchesSessionSearchFilters(agentName, session, search.options, projectScope)) continue;
     results.push({
       agentName,
       session: aliases.decorate(session, agentName),
@@ -140,7 +137,7 @@ export function findAliasSearchResults(
     });
   }
 
-  return results.sort(
+  return filterSessionSearchCandidates(results, search.options).sort(
     (a, b) => getSessionActivityTime(b.session) - getSessionActivityTime(a.session),
   );
 }

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -13,9 +13,9 @@ import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { filePathFtsQuery, hasCacheStorage, likePattern, normalizeFilePathSearch } from "./db.js";
 import { withCacheDb, withCacheDbReadOnly } from "./schema.js";
 import {
+  buildSessionSearchFilters,
   mergeSearchQueryOptions,
   sessionHeadFromSearchRow,
-  sessionMatchesSearchCost,
   type SearchOptions,
   type SearchResult,
   type SearchResultRow,
@@ -149,11 +149,26 @@ export function buildFileActivityWhere(options: FileActivityOptions): {
 }
 
 export function listFileActivity(options: FileActivityOptions = {}): FileActivityResult[] {
+  return queryFileActivity(options);
+}
+
+function queryFileActivity(
+  options: FileActivityOptions,
+  sessionSearchOptions?: SearchOptions,
+): FileActivityResult[] {
   if (!hasCacheStorage()) {
     return [];
   }
 
   const filters = buildFileActivityWhere(options);
+  const sessionFilters = sessionSearchOptions
+    ? buildSessionSearchFilters(sessionSearchOptions)
+    : { where: "", params: [] };
+  const whereClauses = [
+    filters.where.replace(/^WHERE /, ""),
+    sessionFilters.where.replace(/^ AND /, ""),
+  ].filter(Boolean);
+  const where = whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
   const queryRows = (db: SQLiteDatabase) =>
     db
       .prepare(
@@ -180,15 +195,18 @@ export function listFileActivity(options: FileActivityOptions = {}): FileActivit
             s.total_cache_create_tokens,
             s.total_cost,
             s.cost_source,
-            s.total_tokens
+            s.total_tokens,
+            s.model_usage_json,
+            s.smart_tags_json,
+            s.smart_tags_source_updated_at
           FROM session_file_activity fa
           JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
-          ${filters.where}
+          ${where}
           ORDER BY fa.latest_time DESC, fa.count DESC, fa.path
           LIMIT ?
         `,
       )
-      .all(...filters.params, options.limit ?? 50) as FileActivityRow[];
+      .all(...filters.params, ...sessionFilters.params, options.limit ?? 50) as FileActivityRow[];
 
   let rows = withCacheDbReadOnly(queryRows);
   if (rows == null && options.path) {
@@ -229,25 +247,20 @@ export function searchFileActivitySessions(
   const path = normalizeFilePathSearch(search.options.file ?? search.text);
   if (!path) return [];
 
-  const rows = listFileActivity({
-    agent: search.options.agent,
-    projectKind: search.options.projectKind,
-    projectKey: search.options.projectKey,
-    project: search.options.project,
-    cwd: search.options.cwd,
-    path,
-    kind: search.options.fileKind,
-    from: search.options.from,
-    to: search.options.to,
-    limit: (search.options.limit ?? 50) * 3,
-  });
+  const rows = queryFileActivity(
+    {
+      path,
+      kind: search.options.fileKind,
+      limit: (search.options.limit ?? 50) * 3,
+    },
+    search.options,
+  );
   const seen = new Set<string>();
   const results: SearchResult[] = [];
 
   for (const row of rows) {
     const key = `${row.agent_name}/${row.session_id}`;
     if (seen.has(key)) continue;
-    if (!sessionMatchesSearchCost(row.session, search.options)) continue;
     seen.add(key);
     results.push({
       agentName: row.agent_name,

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -139,7 +139,7 @@ export function sessionMatchesSearchCost(session: SessionHead, options: SearchOp
   return true;
 }
 
-function buildSessionSearchFilters(options: SearchOptions): {
+export function buildSessionSearchFilters(options: SearchOptions): {
   where: string;
   params: unknown[];
 } {
@@ -227,6 +227,50 @@ function buildSessionSearchFilters(options: SearchOptions): {
     where: clauses.length > 0 ? ` AND ${clauses.join(" AND ")}` : "",
     params,
   };
+}
+
+export interface SessionSearchReference {
+  agentName: string;
+  sessionId: string;
+}
+
+const SQLITE_REFERENCE_BATCH_SIZE = 200;
+
+export function filterIndexedSessionReferences(
+  references: SessionSearchReference[],
+  options: SearchOptions,
+): Set<string> {
+  if (references.length === 0 || !hasCacheStorage()) return new Set();
+
+  const matches = withCacheDb((db) => {
+    ensureFtsReady(db);
+    const filters = buildSessionSearchFilters(options);
+    const result = new Set<string>();
+
+    for (let offset = 0; offset < references.length; offset += SQLITE_REFERENCE_BATCH_SIZE) {
+      const batch = references.slice(offset, offset + SQLITE_REFERENCE_BATCH_SIZE);
+      const referenceClauses = batch.map(() => "(s.agent_name = ? AND s.session_id = ?)");
+      const referenceParams = batch.flatMap(({ agentName, sessionId }) => [agentName, sessionId]);
+      const rows = db
+        .prepare(
+          `
+            SELECT s.agent_name, s.session_id
+            FROM sessions s
+            WHERE (${referenceClauses.join(" OR ")})
+              ${filters.where}
+          `,
+        )
+        .all(...referenceParams, ...filters.params) as SearchResultRow[];
+
+      for (const row of rows) {
+        result.add(searchResultRowKey(row));
+      }
+    }
+
+    return result;
+  });
+
+  return matches ?? new Set();
 }
 
 function searchSessionColumns(): string {

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -20,7 +20,11 @@ import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
 import type { Message, ProjectIdentity, SessionHead, SmartTag } from "../../types/index.js";
 import type { SearchOptions } from "../../discovery/cache/search.js";
 import { searchSessions, syncSessionSearchIndex } from "../../discovery/cache.js";
-import { executeSessionSearch, type SessionSearchSnapshot } from "../session-search.js";
+import {
+  executeSessionSearch,
+  filterSessionSearchCandidates,
+  type SessionSearchSnapshot,
+} from "../session-search.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-session-search-"));
 
@@ -276,6 +280,29 @@ const fileTagPlanningMismatch: FixtureSpec = {
   messages: [fileToolMessage("file-tag-planning-m1", "edit", "src/tagcheck.ts")],
 };
 
+const fileQualifierMatch: FixtureSpec = {
+  id: "file-qualifier-match",
+  agent: "claudecode",
+  cost: 2,
+  tags: ["docs"],
+  project: PROJ_APP,
+  timeUpdated: now - 15_500,
+  messages: [
+    fileToolMessage("file-qualifier-match-m1", "edit", "src/qualifier-matrix.ts"),
+    toolOutputMessage("file-qualifier-match-m2", "bash", "matrixtextneedle"),
+  ],
+};
+
+const fileQualifierMismatch: FixtureSpec = {
+  id: "file-qualifier-mismatch",
+  agent: "claudecode",
+  cost: 0.1,
+  tags: ["planning"],
+  project: PROJ_OTHER,
+  timeUpdated: now - 15_600,
+  messages: [fileToolMessage("file-qualifier-mismatch-m1", "edit", "src/qualifier-matrix.ts")],
+};
+
 const recentOld: FixtureSpec = {
   id: "recent-old",
   agent: "claudecode",
@@ -304,6 +331,8 @@ const syncedFixtures: FixtureSpec[] = [
   tagMergeFeatDevOnly,
   fileTagDocsMatch,
   fileTagPlanningMismatch,
+  fileQualifierMatch,
+  fileQualifierMismatch,
   ...limitSessions,
 ];
 
@@ -379,7 +408,7 @@ describe("search characterization: source selection", () => {
     // just like the recent path -- except results now come from the SQLite
     // index instead of the snapshot.
     const results = search("", { tools: ["bash"], limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["fts-tool"]);
+    expect(results.map((r) => r.session.id)).toEqual(["fts-tool", "file-qualifier-match"]);
     expect(results[0]!.matchType).toBe("recent");
   });
 
@@ -418,7 +447,7 @@ describe("search characterization: recent (empty-query) path", () => {
       limit: 50,
     });
     expect(results.map((r) => r.session.id).sort()).toEqual(
-      ["recent-mid", "lagging-session"].sort(),
+      ["recent-mid", "lagging-session", "file-qualifier-mismatch"].sort(),
     );
   });
 
@@ -430,7 +459,7 @@ describe("search characterization: recent (empty-query) path", () => {
   it("filters by costMin", () => {
     const results = search("", { costMin: 1, limit: 50 });
     expect(results.map((r) => r.session.id).sort()).toEqual(
-      ["recent-mid", "lagging-session"].sort(),
+      ["recent-mid", "lagging-session", "file-qualifier-match"].sort(),
     );
   });
 });
@@ -496,6 +525,83 @@ describe("search characterization: file activity path", () => {
     expect(matches).toHaveLength(1);
     expect(matches[0]!.matchType).toBe("file_path");
   });
+
+  it.each([
+    ["file", { file: "qualifier-matrix.ts" }, ["file-qualifier-match", "file-qualifier-mismatch"]],
+    [
+      "file + file kind",
+      { file: "qualifier-matrix.ts", fileKind: "edit" as const },
+      ["file-qualifier-match", "file-qualifier-mismatch"],
+    ],
+    ["file + tool", { file: "qualifier-matrix.ts", tools: ["bash"] }, ["file-qualifier-match"]],
+    [
+      "file + tag",
+      { file: "qualifier-matrix.ts", tags: ["docs"] as SmartTag[] },
+      ["file-qualifier-match"],
+    ],
+    ["file + cost", { file: "qualifier-matrix.ts", costMin: 1 }, ["file-qualifier-match"]],
+    ["file + time", { file: "qualifier-matrix.ts", from: now - 15_550 }, ["file-qualifier-match"]],
+    [
+      "file + project",
+      {
+        file: "qualifier-matrix.ts",
+        projectKind: PROJ_APP.kind,
+        projectKey: PROJ_APP.key,
+      },
+      ["file-qualifier-match"],
+    ],
+    [
+      "file + cwd",
+      { file: "qualifier-matrix.ts", cwd: `/projects/${PROJ_APP.key}` },
+      ["file-qualifier-match"],
+    ],
+    [
+      "all qualifiers",
+      {
+        file: "qualifier-matrix.ts",
+        fileKind: "edit" as const,
+        tools: ["bash"],
+        tags: ["docs"] as SmartTag[],
+        costMin: 1,
+        from: now - 15_550,
+        projectKind: PROJ_APP.kind,
+        projectKey: PROJ_APP.key,
+        cwd: `/projects/${PROJ_APP.key}`,
+      },
+      ["file-qualifier-match"],
+    ],
+  ])("applies complete search semantics for %s", (_label, options, expectedIds) => {
+    expect(search("", { ...options, limit: 50 }).map((result) => result.session.id)).toEqual(
+      expectedIds,
+    );
+  });
+
+  it("requires both text and an explicit file qualifier to match", () => {
+    const results = search("matrixtextneedle", {
+      file: "qualifier-matrix.ts",
+      limit: 50,
+    });
+    expect(results.map((result) => result.session.id)).toEqual(["file-qualifier-match"]);
+  });
+});
+
+describe("search candidate filtering", () => {
+  it("keeps alias-style candidates subject to indexed file and tool qualifiers", () => {
+    const snapshot = makeSnapshot();
+    const candidates = [fileQualifierMatch, fileQualifierMismatch].map((spec) => ({
+      agentName: spec.agent,
+      session: snapshot.byAgent[spec.agent]!.find((session) => session.id === spec.id)!,
+      snippet: "Alias",
+      matchType: "title" as const,
+    }));
+
+    const results = filterSessionSearchCandidates(candidates, {
+      file: "qualifier-matrix.ts",
+      tools: ["bash"],
+    });
+
+    expect(results.map((result) => result.session.id)).toEqual(["file-qualifier-match"]);
+  });
 });
 
 describe("search characterization: limit", () => {
@@ -507,6 +613,23 @@ describe("search characterization: limit", () => {
 });
 
 describe("search characterization: recent vs SQLite-indexed equivalence (tag filter, empty query)", () => {
+  it.each([
+    ["tag", { tags: ["docs"] as SmartTag[] }],
+    ["agent", { agent: "codex" }],
+    ["project", { projectKind: PROJ_APP.kind, projectKey: PROJ_APP.key }],
+    ["cost", { costMax: 0.05 }],
+    ["time", { to: now - 1_500 }],
+  ])("returns the same synced result set for a %s filter", (_label, options) => {
+    const liveIds = search("", { ...options, limit: 100 })
+      .map((result) => `${result.agentName}/${result.session.id}`)
+      .sort();
+    const indexedIds = searchSessions("", { ...options, limit: 100 })
+      .map((result) => `${result.agentName}/${result.session.id}`)
+      .sort();
+
+    expect(liveIds).toEqual(indexedIds);
+  });
+
   it("diverges when the SQLite index lags behind the live snapshot", () => {
     // Both fixtures are tagged "bugfix": recent-mid was synced to SQLite,
     // lagging-session was deliberately left out to model index lag. The
@@ -571,24 +694,19 @@ describe("search characterization: skip redundant sessions query for file-only s
     expect(ranSearchSessions(sql)).toBe(true);
   });
 
-  it("still queries the sessions table when tags are combined with a file filter", () => {
+  it("applies tags inside the file adapter without a broad sessions query", () => {
     const { result, sql } = withPreparedSqlCapture(() =>
       search("", { file: "tagcheck.ts", tags: ["docs"], limit: 50 }),
     );
-    // Quirk: searchFileActivitySessions ignores the tags option, and its
-    // (tag-blind) hits win the first-write-wins dedupe over searchSessions's
-    // (tag-filtered) hits -- so a file match with a mismatched tag still
-    // surfaces even though searchSessions did run with the tag filter.
-    expect(result.map((r) => r.session.id).sort()).toEqual(
-      ["file-tag-docs", "file-tag-planning"].sort(),
-    );
-    expect(ranSearchSessions(sql)).toBe(true);
+    expect(result.map((r) => r.session.id)).toEqual(["file-tag-docs"]);
+    expect(result[0]?.session.smart_tags).toEqual(["docs"]);
+    expect(ranSearchSessions(sql)).toBe(false);
   });
 
-  it("still queries the sessions table when a from/to window is combined with a file filter", () => {
+  it("applies the session activity window inside the file adapter", () => {
     const { sql } = withPreparedSqlCapture(() =>
       search("", { file: "app.tsx", from: now - 20_000, limit: 50 }),
     );
-    expect(ranSearchSessions(sql)).toBe(true);
+    expect(ranSearchSessions(sql)).toBe(false);
   });
 });

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -1,5 +1,6 @@
 export {
   executeSessionSearch,
+  filterSessionSearchCandidates,
   matchesSessionSearchFilters,
   type SessionSearchSnapshot,
 } from "./session-search.js";

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -7,6 +7,7 @@
 import type { SessionHead } from "../types/index.js";
 import type { SearchResult } from "../contract/index.js";
 import {
+  filterIndexedSessionReferences,
   mergeSearchQueryOptions,
   searchSessions,
   sessionMatchesSearchCost,
@@ -85,9 +86,8 @@ function matchesRecentSearchFilters(
   return true;
 }
 
-// Single source of truth for "does this session belong in a search result",
-// shared by the recent-sessions path here and by alias matching in the CLI
-// API layer (which looks up individual sessions instead of scanning a list).
+// Evaluates filters answerable from SessionHead. File and tool predicates
+// require the indexed batch seam in filterSessionSearchCandidates.
 export function matchesSessionSearchFilters(
   agentName: string,
   session: SessionHead,
@@ -99,6 +99,36 @@ export function matchesSessionSearchFilters(
   if (options.from != null && activity < options.from) return false;
   if (options.to != null && activity > options.to) return false;
   return matchesRecentSearchFilters(session, options, projectScope);
+}
+
+function sessionReferenceKey(agentName: string, sessionId: string): string {
+  return `${agentName}\u0000${sessionId}`;
+}
+
+export function filterSessionSearchCandidates(
+  candidates: SearchResult[],
+  options: SearchOptions,
+): SearchResult[] {
+  const projectScope = options.cwd ? createProjectScopeMatcher(options.cwd) : null;
+  const headMatches = candidates.filter((candidate) =>
+    matchesSessionSearchFilters(candidate.agentName, candidate.session, options, projectScope),
+  );
+  if (!options.file && !options.fileKind && !options.tools?.length) return headMatches;
+
+  const indexedMatches = filterIndexedSessionReferences(
+    headMatches.map((candidate) => ({
+      agentName: candidate.agentName,
+      sessionId: candidate.session.id,
+    })),
+    {
+      file: options.file,
+      fileKind: options.fileKind,
+      tools: options.tools,
+    },
+  );
+  return headMatches.filter((candidate) =>
+    indexedMatches.has(sessionReferenceKey(candidate.agentName, candidate.session.id)),
+  );
 }
 
 function searchRecentSessions(
@@ -149,7 +179,7 @@ function mergeSearchResultSources(results: SearchResult[], limit: number): Searc
   const merged: SearchResult[] = [];
 
   for (const result of results) {
-    const key = `${result.agentName}/${result.session.id}`;
+    const key = sessionReferenceKey(result.agentName, result.session.id);
     if (seen.has(key)) continue;
     seen.add(key);
     merged.push(result);
@@ -159,26 +189,8 @@ function mergeSearchResultSources(results: SearchResult[], limit: number): Searc
   return merged;
 }
 
-// searchSessions is the only source when: there's text (FTS is the primary
-// source), tools are filtered (its empty-query SQL branch is the sole source
-// for tool-only queries), tags are filtered (listFileActivity has no tag
-// clause), or a from/to window is set (file-activity filters by
-// fa.latest_time, not the session's activity_time, so it can't stand in).
-// Otherwise, once a file path narrowed the results, the file-activity path
-// already covers everything and re-querying sessions is redundant.
-function canSkipSessionsSearch(
-  fileQuery: string,
-  textQuery: string,
-  options: SearchOptions,
-): boolean {
-  return Boolean(
-    fileQuery &&
-    !textQuery &&
-    !options.tools?.length &&
-    !options.tags?.length &&
-    options.from == null &&
-    options.to == null,
-  );
+function canSkipSessionsSearch(fileQuery: string, textQuery: string): boolean {
+  return Boolean(fileQuery && !textQuery);
 }
 
 function searchIndexedSessions(
@@ -189,9 +201,20 @@ function searchIndexedSessions(
 ): SearchResult[] {
   const fileQuery = deriveFileQuery(query, parsed, options);
   const fileResults = fileQuery ? searchFileActivitySessions(fileQuery, options) : [];
-  const sessionResults = canSkipSessionsSearch(fileQuery, textQuery, options)
+  const sessionResults = canSkipSessionsSearch(fileQuery, textQuery)
     ? []
     : searchSessions(query, options);
+  const textMatchReferences =
+    textQuery && options.file
+      ? new Set(
+          sessionResults.map((result) => sessionReferenceKey(result.agentName, result.session.id)),
+        )
+      : null;
+  const matchingFileResults = textMatchReferences
+    ? fileResults.filter((result) =>
+        textMatchReferences.has(sessionReferenceKey(result.agentName, result.session.id)),
+      )
+    : fileResults;
 
-  return mergeSearchResultSources([...fileResults, ...sessionResults], options.limit ?? 50);
+  return mergeSearchResultSources([...matchingFileResults, ...sessionResults], options.limit ?? 50);
 }


### PR DESCRIPTION
## Summary
- apply one complete filter contract to live, SQLite, file-activity, and alias candidates
- reuse the session SQL filter builder from the file-activity adapter
- interpret search time windows with session activity time instead of file-event time
- keep explicit text + file queries conjunctive while preserving bare-text path matches
- add a qualifier matrix and synced live/SQLite equivalence coverage

## Root cause
The file-activity adapter projected incomplete session heads and only applied a subset of search qualifiers before first-write-wins merging. A runtime diagnostic confirmed both matching and mismatching file candidates arrived with `candidate_tags: undefined`, so merge order could admit a false positive.

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- core search and cache integration tests
- CLI search transport and handler tests

Issue: CS-103