### PR TITLE
fix(web): unify live cache invalidation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -58,6 +58,7 @@ export default function App() {
     error,
     reload,
     applyLiveEvent,
+    resyncLiveState,
   } = sessionStore;
   useWindowedDataLoad({
     window: timeWindow,
@@ -256,6 +257,7 @@ export default function App() {
 
   const { liveNotice } = useLiveSync({
     applyLiveEvent,
+    resyncLiveState,
     setScanStatus,
   });
 

--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -27,6 +27,7 @@ vi.mock("../lib/api", () => ({
 function makeDeps() {
   return {
     applyLiveEvent: vi.fn().mockResolvedValue({}),
+    resyncLiveState: vi.fn().mockResolvedValue({}),
     setScanStatus: vi.fn(),
   };
 }
@@ -76,7 +77,7 @@ describe("useLiveSync", () => {
     expect(result.current.liveNotice).toBe("实时更新已断开，重连中…");
   });
 
-  it("clears the notice and asks the store for a full reload on reconnect", async () => {
+  it("clears the notice and explicitly resyncs the store on reconnect", async () => {
     const deps = makeDeps();
     const { result } = renderHook(() => useLiveSync(deps));
     act(() => disconnectCallback?.());
@@ -87,8 +88,7 @@ describe("useLiveSync", () => {
     });
 
     expect(result.current.liveNotice).toBeNull();
-    expect(deps.applyLiveEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "sessions-updated" }),
-    );
+    expect(deps.resyncLiveState).toHaveBeenCalledOnce();
+    expect(deps.applyLiveEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -1,17 +1,22 @@
 import { useEffect, useEffectEvent, useState } from "react";
-import { type ScanStatusEvent, subscribeSessionUpdates } from "../lib/api";
-import type { LiveSessionsUpdate, SessionStoreSnapshot } from "./useSessionStore";
+import {
+  type ScanStatusEvent,
+  type SessionsUpdatedEvent,
+  subscribeSessionUpdates,
+} from "../lib/api";
+import type { SessionStoreSnapshot } from "./useSessionStore";
 
 interface LiveSyncDeps {
-  applyLiveEvent: (event: LiveSessionsUpdate) => Promise<SessionStoreSnapshot | null>;
+  applyLiveEvent: (event: SessionsUpdatedEvent) => Promise<SessionStoreSnapshot | null>;
+  resyncLiveState: () => Promise<SessionStoreSnapshot | null>;
   setScanStatus: (event: ScanStatusEvent) => void;
 }
 
-export function useLiveSync({ applyLiveEvent, setScanStatus }: LiveSyncDeps) {
+export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: LiveSyncDeps) {
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [connectionNotice, setConnectionNotice] = useState<string | null>(null);
 
-  const syncLiveUpdate = useEffectEvent(async (event: LiveSessionsUpdate) => {
+  const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
     try {
       const snapshot = await applyLiveEvent(event);
       if (snapshot && event.newSessions > 0) {
@@ -22,17 +27,13 @@ export function useLiveSync({ applyLiveEvent, setScanStatus }: LiveSyncDeps) {
     }
   });
 
-  const handleReconnect = useEffectEvent(() => {
+  const handleReconnect = useEffectEvent(async () => {
     setConnectionNotice(null);
-    void syncLiveUpdate({
-      type: "sessions-updated",
-      changedAgents: [],
-      newSessions: 0,
-      updatedSessions: 0,
-      removedSessions: 0,
-      totalSessions: 0,
-      timestamp: Date.now(),
-    });
+    try {
+      await resyncLiveState();
+    } catch (error) {
+      console.error("Failed to resync live session state:", error);
+    }
   });
 
   useEffect(() => {
@@ -41,7 +42,7 @@ export function useLiveSync({ applyLiveEvent, setScanStatus }: LiveSyncDeps) {
         void syncLiveUpdate(event);
       },
       setScanStatus,
-      handleReconnect,
+      () => void handleReconnect(),
       () => {
         setConnectionNotice("实时更新已断开，重连中…");
       },

--- a/apps/web/src/hooks/useSessionAliasMutations.ts
+++ b/apps/web/src/hooks/useSessionAliasMutations.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { deleteSessionAlias, upsertSessionAlias } from "../lib/api";
-import { queryKeys } from "../lib/query-keys";
+import { invalidateSessionDerivedQueries } from "../lib/session-query-consistency";
 
 export interface SessionAliasIdentity {
   agentKey: string;
@@ -16,12 +16,7 @@ export function useSessionAliasMutations(refreshSessionSnapshot: () => Promise<v
   const queryClient = useQueryClient();
 
   const refreshAliasConsumers = useCallback(async () => {
-    await Promise.all([
-      refreshSessionSnapshot(),
-      queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.dashboards }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
-    ]);
+    await Promise.all([refreshSessionSnapshot(), invalidateSessionDerivedQueries(queryClient)]);
   }, [queryClient, refreshSessionSnapshot]);
 
   const { mutateAsync: mutateAlias } = useMutation({

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -7,8 +7,9 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentInfo, AppConfig, ProjectGroup } from "../lib/api";
 import * as api from "../lib/api";
+import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
-import { useSessionStore } from "./useSessionStore";
+import { useSessionStore, type SessionStoreSnapshot } from "./useSessionStore";
 
 vi.mock("../lib/api", () => ({
   fetchAgents: vi.fn(),
@@ -47,10 +48,10 @@ afterEach(() => {
 });
 
 async function renderStore() {
-  const { Wrapper } = createQueryWrapper();
+  const { client, Wrapper } = createQueryWrapper();
   const hook = renderHook(() => useSessionStore(), { wrapper: Wrapper });
   await waitFor(() => expect(hook.result.current.config).toEqual(config));
-  return hook;
+  return { ...hook, client };
 }
 
 describe("useSessionStore", () => {
@@ -76,7 +77,7 @@ describe("useSessionStore", () => {
     expect(console.error).toHaveBeenCalledWith("Failed to load config:", error);
   });
 
-  it("ignores live events until a window has loaded", async () => {
+  it("ignores live events until a window has been selected", async () => {
     const { result } = await renderStore();
     let snapshot: Awaited<ReturnType<typeof result.current.applyLiveEvent>> | undefined;
 
@@ -86,6 +87,25 @@ describe("useSessionStore", () => {
 
     expect(snapshot).toBeNull();
     expect(api.fetchAgents).not.toHaveBeenCalled();
+  });
+
+  it("handles a live event that arrives before the first window load completes", async () => {
+    const { result } = await renderStore();
+    let initialLoad!: ReturnType<typeof result.current.reload>;
+    let liveUpdate!: ReturnType<typeof result.current.applyLiveEvent>;
+
+    act(() => {
+      initialLoad = result.current.reload(config.window);
+      liveUpdate = result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
+    });
+    let snapshots!: [SessionStoreSnapshot | null, SessionStoreSnapshot | null];
+    await act(async () => {
+      snapshots = await Promise.all([liveUpdate, initialLoad]);
+    });
+    const [liveSnapshot] = snapshots;
+
+    expect(liveSnapshot?.window).toEqual(config.window);
+    await waitFor(() => expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]));
   });
 
   it("commits all window data as one snapshot", async () => {
@@ -129,6 +149,28 @@ describe("useSessionStore", () => {
     expect(result.current.version).toBeGreaterThan(0);
   });
 
+  it("applies live events to the latest window after a rapid switch", async () => {
+    const { result, client } = await renderStore();
+    const firstWindow = { from: 1, to: 2 };
+    const latestWindow = { from: 3, to: 4 };
+    await act(() => result.current.reload(firstWindow));
+    await act(() => result.current.reload(latestWindow));
+    const changedSession = { ...SAMPLE_SESSION_HEAD, display_title: "Latest window" };
+
+    await act(() =>
+      result.current.applyLiveEvent({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        changedSessionHeads: [{ agentName: "claudecode", session: changedSession }],
+      }),
+    );
+
+    expect(result.current.window).toEqual(latestWindow);
+    await waitFor(() => expect(result.current.sessions).toEqual([changedSession]));
+    expect(
+      client.getQueryData<SessionStoreSnapshot>(queryKeys.sessionSnapshot(firstWindow))?.sessions,
+    ).toEqual([SAMPLE_SESSION_HEAD]);
+  });
+
   it("applies an incremental live session diff without re-fetching sessions", async () => {
     const { result } = await renderStore();
     await act(() => result.current.reload(config.window));
@@ -148,22 +190,36 @@ describe("useSessionStore", () => {
     expect(result.current.version).toBeGreaterThan(0);
   });
 
-  it("falls back to a full reload for reconnect events without a diff", async () => {
+  it("invalidates project dashboards, server searches, and inactive aggregate caches", async () => {
+    const { result, client } = await renderStore();
+    await act(() => result.current.reload(config.window));
+    const projectDashboardKey = queryKeys.dashboard(config.window, {
+      projectKind: "path",
+      projectKey: "p1",
+    });
+    const searchKey = queryKeys.search("needle", {});
+    const inactiveAggregateKey = queryKeys.sessionSnapshotAggregates({ from: 10, to: 20 });
+    client.setQueryData(projectDashboardKey, SAMPLE_DASHBOARD_DATA);
+    client.setQueryData(searchKey, []);
+    client.setQueryData(inactiveAggregateKey, {
+      agents,
+      projects,
+      dashboard: SAMPLE_DASHBOARD_DATA,
+    });
+
+    await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
+
+    expect(client.getQueryState(projectDashboardKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(searchKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(inactiveAggregateKey)?.isInvalidated).toBe(true);
+  });
+
+  it("performs an explicit full reload when live state reconnects", async () => {
     const { result } = await renderStore();
     await act(() => result.current.reload(config.window));
     vi.mocked(api.fetchSessions).mockClear();
 
-    await act(() =>
-      result.current.applyLiveEvent({
-        type: "sessions-updated",
-        changedAgents: [],
-        newSessions: 0,
-        updatedSessions: 0,
-        removedSessions: 0,
-        totalSessions: 0,
-        timestamp: Date.now(),
-      }),
-    );
+    await act(() => result.current.resyncLiveState());
 
     expect(api.fetchSessions).toHaveBeenCalledOnce();
     expect(result.current.version).toBeGreaterThan(0);

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -1,6 +1,6 @@
 import { applySessionChanges } from "@codesesh/core/contract";
 import { isCancelledError, queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   type AgentInfo,
   type AppConfig,
@@ -16,12 +16,7 @@ import {
 } from "../lib/api";
 import { createAgentCatalog } from "../lib/agents";
 import { queryKeys } from "../lib/query-keys";
-
-export type LiveSessionsUpdate = Omit<
-  SessionsUpdatedEvent,
-  "changedSessionHeads" | "removedSessionRefs"
-> &
-  Partial<Pick<SessionsUpdatedEvent, "changedSessionHeads" | "removedSessionRefs">>;
+import { invalidateSessionDerivedQueries } from "../lib/session-query-consistency";
 
 export interface SessionStoreSnapshot {
   window: AppConfig["window"];
@@ -94,6 +89,7 @@ function sessionSnapshotOptions(window: AppConfig["window"]) {
 export function useSessionStore() {
   const queryClient = useQueryClient();
   const [requestedWindow, setRequestedWindow] = useState<AppConfig["window"] | null>(null);
+  const requestedWindowRef = useRef<AppConfig["window"] | null>(null);
   const configQuery = useQuery({
     queryKey: queryKeys.config,
     queryFn: async ({ signal }) => {
@@ -113,6 +109,7 @@ export function useSessionStore() {
 
   const reload = useCallback(
     async (window: AppConfig["window"]): Promise<SessionStoreSnapshot | null> => {
+      requestedWindowRef.current = window;
       setRequestedWindow(window);
       try {
         await queryClient.cancelQueries({ queryKey: queryKeys.sessionSnapshots });
@@ -131,18 +128,14 @@ export function useSessionStore() {
   );
 
   const applyLiveEvent = useCallback(
-    async (event: LiveSessionsUpdate): Promise<SessionStoreSnapshot | null> => {
-      if (!requestedWindow) return null;
-      const snapshotKey = queryKeys.sessionSnapshot(requestedWindow);
+    async (event: SessionsUpdatedEvent): Promise<SessionStoreSnapshot | null> => {
+      const activeWindow = requestedWindowRef.current;
+      if (!activeWindow) return null;
+      const snapshotKey = queryKeys.sessionSnapshot(activeWindow);
       const current = queryClient.getQueryData<SessionStoreSnapshot>(snapshotKey);
-      if (!current || !event.changedSessionHeads || !event.removedSessionRefs) {
-        await queryClient.invalidateQueries({
-          queryKey: snapshotKey,
-          exact: true,
-          refetchType: "none",
-        });
-        const refreshed = await queryClient.fetchQuery(sessionSnapshotOptions(requestedWindow));
-        await queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails });
+      if (!current) {
+        const refreshed = await reload(activeWindow);
+        await invalidateSessionDerivedQueries(queryClient);
         return refreshed;
       }
 
@@ -154,16 +147,24 @@ export function useSessionStore() {
           event.removedSessionRefs,
         ),
       });
-      const aggregates = await queryClient.fetchQuery(snapshotAggregatesOptions(requestedWindow));
+      await invalidateSessionDerivedQueries(queryClient);
+      const aggregates = await queryClient.fetchQuery(snapshotAggregatesOptions(activeWindow));
       const updated =
         queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, (latest) =>
           latest ? { ...latest, ...aggregates } : latest,
         ) ?? null;
-      await queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails });
       return updated;
     },
-    [queryClient, requestedWindow],
+    [queryClient, reload],
   );
+
+  const resyncLiveState = useCallback(async (): Promise<SessionStoreSnapshot | null> => {
+    const activeWindow = requestedWindowRef.current;
+    if (!activeWindow) return null;
+    const refreshed = await reload(activeWindow);
+    await invalidateSessionDerivedQueries(queryClient);
+    return refreshed;
+  }, [queryClient, reload]);
 
   const agents = snapshot?.agents ?? EMPTY_SNAPSHOT.agents;
   const agentCatalog = useMemo(() => createAgentCatalog(agents), [agents]);
@@ -191,5 +192,6 @@ export function useSessionStore() {
     agentNameMap: agentCatalog.displayNameByKey,
     reload,
     applyLiveEvent,
+    resyncLiveState,
   };
 }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -29,6 +29,7 @@ export const queryKeys = {
     ["session-detail", agent, sessionSlug] as const,
   sessionSnapshots: ["session-snapshot"] as const,
   sessionSnapshot: (window: TimeWindow) => ["session-snapshot", normalizeWindow(window)] as const,
+  sessionSnapshotAggregateQueries: ["session-snapshot-aggregates"] as const,
   sessionSnapshotAggregates: (window: TimeWindow) =>
     ["session-snapshot-aggregates", normalizeWindow(window)] as const,
 } as const;

--- a/apps/web/src/lib/session-query-consistency.ts
+++ b/apps/web/src/lib/session-query-consistency.ts
@@ -1,0 +1,11 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./query-keys";
+
+export async function invalidateSessionDerivedQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.sessionSnapshotAggregateQueries }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.dashboards }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
+  ]);
+}


### PR DESCRIPTION
## Summary
- centralize invalidation for session-derived aggregates, details, dashboards, and server searches
- reuse the same consistency policy for SSE updates, reconnect recovery, and alias mutations
- model reconnect as an explicit full resync instead of an incomplete wire event
- track the active window synchronously so early live events and rapid switches target the correct snapshot
- add coverage for stale project/search caches, first-load ordering, rapid window changes, reconnects, and overlapping events

## Root cause
Live updates only patched the active session snapshot and invalidated session details. Project dashboards, server searches, and cached snapshot aggregates were independent TanStack Query entries and remained valid indefinitely.

A client diagnostic reproduced the stale state before the fix:
`live.session_consumer_cache_state { dashboards: [{ invalidated: false }], searches: [{ invalidated: false }] }`

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e`

Issue: CS-104