### PR TITLE
fix(cli): unify session publication commits

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -176,6 +176,102 @@ describe("AgentSyncEngine", () => {
     );
   });
 
+  it("publishes an ordinary refresh only after the search index commits", async () => {
+    let commitIndex!: () => void;
+    searchIndex.enqueue.mockReturnValueOnce(
+      new Promise<undefined>((resolve) => {
+        commitIndex = () => resolve(undefined);
+      }),
+    );
+    const previous = makeSession("session", "before");
+    const updated = makeSession("session", "after");
+    const { engine, state } = makeEngine(
+      makeAgent({
+        checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
+        incrementalScan: () => [updated],
+      }),
+      [previous],
+    );
+
+    const refresh = engine.refresh("codex");
+    await vi.waitFor(() => expect(searchIndex.enqueue).toHaveBeenCalledOnce());
+    expect(state.sessions[0]?.title).toBe("before");
+
+    commitIndex();
+    await refresh;
+
+    expect(state.sessions[0]?.title).toBe("after");
+  });
+
+  it("waits for the initial search index commit", async () => {
+    let commitIndex!: () => void;
+    searchIndex.enqueue.mockReturnValueOnce(
+      new Promise<undefined>((resolve) => {
+        commitIndex = () => resolve(undefined);
+      }),
+    );
+    const { engine } = makeEngine(makeAgent(), [makeSession("session")]);
+    let completed = false;
+
+    const initialIndex = engine.syncInitialIndex().then(() => {
+      completed = true;
+    });
+    await vi.waitFor(() => expect(searchIndex.enqueue).toHaveBeenCalledOnce());
+    expect(completed).toBe(false);
+
+    commitIndex();
+    await initialIndex;
+
+    expect(completed).toBe(true);
+  });
+
+  it("commits a full search-index job when change detection cannot identify sessions", async () => {
+    const updated = makeSession("session", "after");
+    const { engine } = makeEngine(
+      makeAgent({
+        checkForChanges: () => ({ hasChanges: true, timestamp: 2 }),
+        incrementalScan: () => [updated],
+      }),
+      [makeSession("session", "before")],
+    );
+
+    await engine.refresh("codex");
+
+    expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.refresh", [
+      expect.objectContaining({
+        kind: "full",
+        agentName: "codex",
+        sessions: [expect.objectContaining({ id: "session", title: "after" })],
+        saveCache: true,
+      }),
+    ]);
+  });
+
+  it("keeps the previous snapshot when search indexing fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    searchIndex.enqueue.mockRejectedValueOnce(new Error("index failed"));
+    const previous = makeSession("session", "before");
+    const updated = makeSession("session", "after");
+    const { engine, state } = makeEngine(
+      makeAgent({
+        checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
+        incrementalScan: () => [updated],
+      }),
+      [previous],
+    );
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(state.sessions[0]?.title).toBe("before");
+    expect(sessionChanges).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "[codex] Session refresh failed:",
+      expect.objectContaining({ message: "index failed" }),
+    );
+  });
+
   it("clears pending refresh work during shutdown", async () => {
     vi.useFakeTimers();
     const checkForChanges = vi.fn(() => ({ hasChanges: false, timestamp: Date.now() }));

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -80,6 +80,14 @@ interface SessionRefreshDiff {
   removedSessionIds: string[];
 }
 
+interface SessionPublication {
+  context: "scan.refresh" | "scan.backfill";
+  agentName: string;
+  sessions: SessionHead[];
+  event: SessionsUpdatedEvent | null;
+  indexJob: SearchIndexWorkerJob;
+}
+
 interface RefreshStrategyResult {
   status: "continue" | "unchanged";
   nextSessions: SessionHead[];
@@ -150,6 +158,7 @@ export class AgentSyncEngine {
   private statusChangedListeners = new Set<StatusChangedListener>();
   private scanStatus = new ScanStatusModel();
   private searchIndexJobs = new SearchIndexJobRunner();
+  private nextPublicationId = 1;
   private backgroundRefreshTimer: NodeJS.Timeout | null = null;
   private isShuttingDown = false;
 
@@ -176,10 +185,11 @@ export class AgentSyncEngine {
   }
 
   async syncInitialIndex(): Promise<void> {
-    await this.searchIndexJobs.enqueue(
-      "scan.initial",
-      this.buildFullSearchIndexJobs("scan.initial"),
-    );
+    const jobs = this.buildFullSearchIndexJobs("scan.initial");
+    await this.commitSearchIndex("scan.initial", jobs, {
+      publicationId: this.publicationId("scan.initial"),
+      agents: jobs.map((job) => job.agentName),
+    });
   }
 
   handleAgentsChanged(agentNames: Iterable<string>): void {
@@ -407,7 +417,7 @@ export class AgentSyncEngine {
       ? new Set(persistentChanges.map(({ session }) => session.id))
       : undefined;
     const persistStartedAt = performance.now();
-    const persistentJob: SearchIndexWorkerJob | null = strategyResult.usedIncrementalScan
+    const persistentJob: SearchIndexWorkerJob = strategyResult.usedIncrementalScan
       ? {
           kind: "changes",
           context: "scan.refresh",
@@ -417,31 +427,24 @@ export class AgentSyncEngine {
           meta: buildAgentCacheMeta(agent, changedSessionIds),
           ...(searchIndexOptions ? { searchIndexOptions } : {}),
         }
-      : strategyResult.fullScanSessions
-        ? {
-            kind: "full",
-            context: "scan.refresh",
-            agentName,
-            sessions: strategyResult.fullScanSessions,
-            meta: buildAgentCacheMeta(agent),
-            saveCache: true,
-            ...(searchIndexOptions ? { searchIndexOptions } : {}),
-          }
-        : null;
-    if (persistentJob) {
-      const persist = this.searchIndexJobs.enqueue("scan.refresh", [persistentJob]);
-      if (!isInitialized && persistentJob.kind === "full") {
-        await persist;
-      } else {
-        void persist.catch((error) => {
-          appLogger.error("scan.refresh.persist.error", { agent: agentName, error });
-          console.error(`[${agentName}] Session persistence failed:`, error);
-        });
-      }
-    }
+      : {
+          kind: "full",
+          context: "scan.refresh",
+          agentName,
+          sessions: strategyResult.fullScanSessions ?? nextSessions,
+          meta: buildAgentCacheMeta(agent),
+          saveCache: true,
+          ...(searchIndexOptions ? { searchIndexOptions } : {}),
+        };
+    await this.commitSessionPublication({
+      context: "scan.refresh",
+      agentName,
+      sessions: nextSessions,
+      event: diff.event,
+      indexJob: persistentJob,
+    });
     const persistDuration = performance.now() - persistStartedAt;
     logSearchIndexSync("scan.refresh", null, { pending_paths: pendingPathCount });
-    this.emitSessionsChanged({ agentName, sessions: nextSessions, event: diff.event });
 
     const totalDurationMs = performance.now() - startedAt;
     state.lastRefreshDurationMs = totalDurationMs;
@@ -458,9 +461,8 @@ export class AgentSyncEngine {
       scan_ms: Math.round(strategyResult.scanDuration),
       diff_ms: Math.round(diffDuration),
       persist_ms: Math.round(persistDuration),
-      search_index_ms: 0,
-      persistent_index_worker_job: persistentJob?.kind,
-      persistent_index_skipped: !persistentJob || undefined,
+      search_index_ms: Math.round(persistDuration),
+      persistent_index_worker_job: persistentJob.kind,
     });
     return "committed";
   }
@@ -669,8 +671,12 @@ export class AgentSyncEngine {
         fullSessions,
         result.changedIds ?? [],
       );
-      await this.searchIndexJobs.enqueue("scan.backfill", [
-        {
+      await this.commitSessionPublication({
+        context: "scan.backfill",
+        agentName,
+        sessions: fullSessions,
+        event: diff.event,
+        indexJob: {
           kind: "full",
           context: "scan.backfill",
           agentName,
@@ -678,9 +684,8 @@ export class AgentSyncEngine {
           meta: buildAgentCacheMeta(agent),
           saveCache: true,
         },
-      ]);
+      });
       markAgentFullSyncCompleted(agentName);
-      this.emitSessionsChanged({ agentName, sessions: fullSessions, event: diff.event });
       appLogger.info("scan.backfill.done", {
         agent: agentName,
         duration_ms: Math.round(performance.now() - startedAt),
@@ -799,6 +804,62 @@ export class AgentSyncEngine {
             sessions: snapshot.byAgent[agent.name] ?? [],
             meta: buildAgentCacheMeta(agent),
           };
+    });
+  }
+
+  private publicationId(context: string, agentName?: string): string {
+    const id = this.nextPublicationId++;
+    return agentName ? `${context}:${agentName}:${id}` : `${context}:${id}`;
+  }
+
+  private async commitSearchIndex(
+    context: string,
+    jobs: SearchIndexWorkerJob[],
+    details: { publicationId: string; agent?: string; agents?: string[] },
+  ): Promise<void> {
+    appLogger.info("session.publication.prepared", {
+      publication_id: details.publicationId,
+      context,
+      agent: details.agent,
+      agents: details.agents,
+      jobs: jobs.length,
+    });
+    try {
+      await this.searchIndexJobs.enqueue(context, jobs);
+    } catch (error) {
+      appLogger.error("session.publication.failed", {
+        publication_id: details.publicationId,
+        context,
+        agent: details.agent,
+        stage: "search_index",
+        error,
+      });
+      throw error;
+    }
+    appLogger.info("session.publication.index_committed", {
+      publication_id: details.publicationId,
+      context,
+      agent: details.agent,
+    });
+  }
+
+  private async commitSessionPublication(publication: SessionPublication): Promise<void> {
+    const publicationId = this.publicationId(publication.context, publication.agentName);
+    await this.commitSearchIndex(publication.context, [publication.indexJob], {
+      publicationId,
+      agent: publication.agentName,
+    });
+    this.emitSessionsChanged({
+      agentName: publication.agentName,
+      sessions: publication.sessions,
+      event: publication.event,
+    });
+    appLogger.info("session.publication.published", {
+      publication_id: publicationId,
+      context: publication.context,
+      agent: publication.agentName,
+      sessions: publication.sessions.length,
+      has_event: publication.event != null,
     });
   }
 

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -279,6 +279,7 @@ vi.mock("node:worker_threads", () => ({
 import { LiveScanStore, resolveAgentWatchTargets, type SessionsUpdatedEvent } from "./live-scan.js";
 import { AgentSyncEngine } from "./agent-sync-engine.js";
 import { appLogger } from "./logging.js";
+import { SearchIndexJobRunner } from "./search-index-job-runner.js";
 import { ThreadWorkerRunner, type WorkerResult, type WorkerRunner } from "./worker-runner.js";
 
 function makeWorkerRunner() {
@@ -1287,6 +1288,54 @@ describe("LiveScanStore", () => {
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["session", "added"]);
   });
 
+  it("keeps the previous snapshot private until the refresh index commits", async () => {
+    const previous = makeSession("session", { title: "old", time_updated: 1000 });
+    const updated = makeSession("session", { title: "new", time_updated: 2000 });
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["session"],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [updated]),
+    });
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [previous],
+      byAgent: { codex: [previous] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore({ watchEnabled: false });
+    await store.initialize();
+    workerThreads.deferSearchIndexWorkers = true;
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    const refresh = syncEngineOf(store).refresh("codex");
+    await vi.waitFor(() =>
+      expect(
+        workerThreads.workers.some(
+          (worker) => worker.workerData.jobs?.[0]?.context === "scan.refresh",
+        ),
+      ).toBe(true),
+    );
+    const refreshWorker = workerThreads.workers.find(
+      (worker) => worker.workerData.jobs?.[0]?.context === "scan.refresh",
+    )!;
+
+    expect(store.getSnapshot().sessions[0]?.title).toBe("old");
+    expect(listener).not.toHaveBeenCalled();
+
+    refreshWorker.emitDone();
+    await refresh;
+
+    expect(store.getSnapshot().sessions[0]?.title).toBe("new");
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "sessions-updated", updatedSessions: 1 }),
+    );
+  });
+
   it("marks search index sync as bulk when many paths are pending", async () => {
     const previous = makeSession("session", { title: "old", time_updated: 1000 });
     const updated = makeSession("session", { title: "new", time_updated: 2000 });
@@ -1378,7 +1427,15 @@ describe("LiveScanStore", () => {
     await syncEngineOf(store).refresh("codex");
 
     expect(core.saveCachedSessions).not.toHaveBeenCalled();
-    expect(workerThreads.workers).toHaveLength(workerCount);
+    expect(workerThreads.workers).toHaveLength(workerCount + 1);
+    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
+      expect.objectContaining({
+        kind: "full",
+        agentName: "codex",
+        sessions: [],
+        saveCache: true,
+      }),
+    ]);
     expect(events).toEqual([
       expect.objectContaining({
         newSessions: 0,
@@ -1877,45 +1934,68 @@ describe("LiveScanStore", () => {
   });
 
   it("does not start a pending search-index batch while shutting down", async () => {
-    core.createRegisteredAgents.mockReturnValue([]);
-    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
-
+    const codexBefore = makeSession("codex-session", { title: "codex before" });
+    const codexAfter = makeSession("codex-session", { title: "codex after" });
+    const kimiBefore = makeSession("kimi-session", { title: "kimi before" });
+    const kimiAfter = makeSession("kimi-session", { title: "kimi after" });
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: [codexAfter.id],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [codexAfter]),
+    });
+    const kimi = makeAgent("kimi", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: [kimiAfter.id],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [kimiAfter]),
+    });
+    core.createRegisteredAgents.mockReturnValue([codex, kimi]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [codexBefore, kimiBefore],
+      byAgent: { codex: [codexBefore], kimi: [kimiBefore] },
+      agents: [codex, kimi],
+    });
+    vi.spyOn(appLogger, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
     const store = new LiveScanStore({ watchEnabled: false });
     await store.initialize();
+    const initialSearchWorkerCount = workerThreads.workers.filter(
+      (worker) => worker.workerData.jobs,
+    ).length;
     workerThreads.deferSearchIndexWorkers = true;
-    const job = {
-      kind: "full" as const,
-      context: "scan.refresh",
-      agentName: "codex",
-      sessions: [],
-      meta: {},
-    };
-
-    const current = (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [job]);
-    const pending = (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [job]);
-    const outcomes = Promise.allSettled([current, pending]);
-    expect(workerThreads.workers.filter((worker) => worker.workerData.jobs)).toHaveLength(1);
+    const listener = vi.fn();
+    store.subscribe(listener);
+    const current = syncEngineOf(store).refresh("codex");
+    await vi.waitFor(() =>
+      expect(workerThreads.workers.filter((worker) => worker.workerData.jobs)).toHaveLength(
+        initialSearchWorkerCount + 1,
+      ),
+    );
+    const pending = syncEngineOf(store).refresh("kimi");
+    await vi.waitFor(() => expect(kimi.incrementalScan).toHaveBeenCalledOnce());
 
     await store.shutdown();
+    await Promise.all([current, pending]);
 
-    expect(workerThreads.workers.filter((worker) => worker.workerData.jobs)).toHaveLength(1);
-    expect(await outcomes).toEqual([
-      expect.objectContaining({ status: "rejected", reason: expect.any(Error) }),
-      expect.objectContaining({ status: "rejected", reason: expect.any(Error) }),
-    ]);
-    expect((syncEngineOf(store) as any).searchIndexJobs.snapshot()).toEqual(
-      expect.objectContaining({ activeBatchId: undefined, pendingBatches: 0 }),
+    expect(workerThreads.workers.filter((worker) => worker.workerData.jobs)).toHaveLength(
+      initialSearchWorkerCount + 1,
     );
+    expect(store.getSnapshot().sessions.map((session) => session.title)).toEqual([
+      "codex before",
+      "kimi before",
+    ]);
+    expect(listener).not.toHaveBeenCalled();
   });
 
   it("coalesces pending search-index changes to the latest session state", async () => {
-    core.createRegisteredAgents.mockReturnValue([]);
-    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
-
-    const store = new LiveScanStore({ watchEnabled: false, deferInitialRefresh: true });
-    await store.initialize();
     workerThreads.deferSearchIndexWorkers = true;
-    const active = (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [
+    const runner = new SearchIndexJobRunner();
+    const active = runner.enqueue("scan.refresh", [
       {
         kind: "full",
         context: "scan.refresh",
@@ -1925,7 +2005,7 @@ describe("LiveScanStore", () => {
       },
     ]);
     const pending = [1, 2, 3].map((version) =>
-      (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [
+      runner.enqueue("scan.refresh", [
         {
           kind: "changes",
           context: "scan.refresh",
@@ -1969,12 +2049,8 @@ describe("LiveScanStore", () => {
   });
 
   it("makes repeated shutdown calls share one worker termination", async () => {
-    core.createRegisteredAgents.mockReturnValue([]);
-    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
-
-    const store = new LiveScanStore({ watchEnabled: false });
-    await store.initialize();
     workerThreads.deferSearchIndexWorkers = true;
+    const runner = new SearchIndexJobRunner();
     const job = {
       kind: "full" as const,
       context: "scan.refresh",
@@ -1982,26 +2058,22 @@ describe("LiveScanStore", () => {
       sessions: [],
       meta: {},
     };
-    const batch = (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [job]);
+    const batch = runner.enqueue("scan.refresh", [job]);
     const outcome = batch.catch((error: Error) => error);
     const worker = workerThreads.workers.at(-1)!;
 
-    await Promise.all([store.shutdown(), store.shutdown()]);
+    await Promise.all([runner.shutdown(), runner.shutdown()]);
 
     expect(worker.terminate).toHaveBeenCalledTimes(1);
     expect(await outcome).toBeInstanceOf(Error);
-    await expect(
-      (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [job]),
-    ).rejects.toThrow("Live scan store shut down");
+    await expect(runner.enqueue("scan.refresh", [job])).rejects.toThrow(
+      "Live scan store shut down",
+    );
   });
 
   it("settles a worker error once when shutdown follows", async () => {
-    core.createRegisteredAgents.mockReturnValue([]);
-    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
-
-    const store = new LiveScanStore({ watchEnabled: false });
-    await store.initialize();
     workerThreads.deferSearchIndexWorkers = true;
+    const runner = new SearchIndexJobRunner();
     const job = {
       kind: "full" as const,
       context: "scan.refresh",
@@ -2009,12 +2081,12 @@ describe("LiveScanStore", () => {
       sessions: [],
       meta: {},
     };
-    const batch = (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [job]);
+    const batch = runner.enqueue("scan.refresh", [job]);
     const outcome = Promise.allSettled([batch]);
     const worker = workerThreads.workers.at(-1)!;
 
     worker.emitError(new Error("index failed"));
-    await store.shutdown();
+    await runner.shutdown();
 
     expect(await outcome).toEqual([
       expect.objectContaining({ status: "rejected", reason: new Error("index failed") }),
@@ -2024,12 +2096,7 @@ describe("LiveScanStore", () => {
   });
 
   it("skips the FTS integrity check on search-index batches after the first one completes", async () => {
-    core.createRegisteredAgents.mockReturnValue([]);
-    core.scanSessions.mockResolvedValue({ sessions: [], byAgent: {}, agents: [] });
-
-    const store = new LiveScanStore({ watchEnabled: false });
-    await store.initialize();
-
+    const runner = new SearchIndexJobRunner();
     const job = {
       kind: "full" as const,
       context: "scan.refresh",
@@ -2037,8 +2104,8 @@ describe("LiveScanStore", () => {
       sessions: [],
       meta: {},
     };
-    await (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [job]);
-    await (syncEngineOf(store) as any).searchIndexJobs.enqueue("scan.refresh", [job]);
+    await runner.enqueue("scan.refresh", [job]);
+    await runner.enqueue("scan.refresh", [job]);
 
     const searchIndexWorkers = workerThreads.workers.filter((worker) => worker.workerData.jobs);
     expect(searchIndexWorkers).toHaveLength(2);

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1962,19 +1962,18 @@ describe("LiveScanStore", () => {
     });
     vi.spyOn(appLogger, "error").mockImplementation(() => undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const store = new LiveScanStore({ watchEnabled: false });
+    const store = new LiveScanStore({ watchEnabled: false, deferInitialRefresh: true });
     await store.initialize();
-    const initialSearchWorkerCount = workerThreads.workers.filter(
-      (worker) => worker.workerData.jobs,
-    ).length;
     workerThreads.deferSearchIndexWorkers = true;
     const listener = vi.fn();
     store.subscribe(listener);
     const current = syncEngineOf(store).refresh("codex");
     await vi.waitFor(() =>
-      expect(workerThreads.workers.filter((worker) => worker.workerData.jobs)).toHaveLength(
-        initialSearchWorkerCount + 1,
-      ),
+      expect(
+        workerThreads.workers.some((worker) =>
+          worker.workerData.jobs?.some((job: { agentName?: string }) => job.agentName === "codex"),
+        ),
+      ).toBe(true),
     );
     const pending = syncEngineOf(store).refresh("kimi");
     await vi.waitFor(() => expect(kimi.incrementalScan).toHaveBeenCalledOnce());
@@ -1982,9 +1981,11 @@ describe("LiveScanStore", () => {
     await store.shutdown();
     await Promise.all([current, pending]);
 
-    expect(workerThreads.workers.filter((worker) => worker.workerData.jobs)).toHaveLength(
-      initialSearchWorkerCount + 1,
-    );
+    expect(
+      workerThreads.workers.some((worker) =>
+        worker.workerData.jobs?.some((job: { agentName?: string }) => job.agentName === "kimi"),
+      ),
+    ).toBe(false);
     expect(store.getSnapshot().sessions.map((session) => session.title)).toEqual([
       "codex before",
       "kimi before",

--- a/tests/e2e/live-refresh.spec.ts
+++ b/tests/e2e/live-refresh.spec.ts
@@ -16,7 +16,8 @@ test("refreshes an open session when its source file changes", async ({ page }, 
     if (frame === page.mainFrame()) mainFrameNavigations += 1;
   });
 
-  const liveMessage = `Live refresh reached the browser on attempt ${testInfo.retry}.`;
+  const searchNeedle = `liveindexneedle${testInfo.retry}`;
+  const liveMessage = `Live refresh reached the browser on attempt ${testInfo.retry}: ${searchNeedle}.`;
   const record = {
     type: "assistant",
     uuid: `assistant-live-${testInfo.retry}`,
@@ -37,5 +38,11 @@ test("refreshes an open session when its source file changes", async ({ page }, 
   await appendFile(fixtureSessionPath, `${JSON.stringify(record)}\n`, "utf8");
 
   await expect(page.getByText(liveMessage)).toBeVisible();
+  const searchResponse = await page.request.get(`/api/search?q=${searchNeedle}`);
+  expect(searchResponse.ok()).toBe(true);
+  const searchBody = (await searchResponse.json()) as {
+    results?: Array<{ session?: { id?: string } }>;
+  };
+  expect(searchBody.results?.some((result) => result.session?.id === "e2e-dashboard")).toBe(true);
   expect(mainFrameNavigations).toBe(0);
 });


### PR DESCRIPTION
## Summary
- commit refresh and backfill search-index updates before exposing the new live snapshot or SSE event
- keep the previous snapshot when indexing fails and add correlated publication-stage logs
- cover initial, full, incremental, failure, shutdown, and live indexed-search ordering without private engine access

## Validation
- `pnpm --filter codesesh test`
- `pnpm --filter @codesesh/core test -- --runInBand`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh exec tsc --noEmit`
- `pnpm build`
- `pnpm test:e2e`