### PR TITLE
refactor(core): materialize session details

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1,17 +1,9 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
 
 const coreMocks = vi.hoisted(() => {
-  const loadCachedSessionData = vi.fn();
   return {
-    loadCachedSessionData,
-    loadCachedSessionDataEntry: vi.fn(
-      (agentName: string, sessionId: string): CachedSessionDataEntry | null => {
-        const data = loadCachedSessionData(agentName, sessionId) as SessionData | null;
-        return data ? { data, meta: null } : null;
-      },
-    ),
+    materializeSessionDetail: vi.fn(),
     listFileActivity: vi.fn((): FileActivityResult[] => []),
-    listSessionFileActivity: vi.fn(() => []),
     listSessionAliases: vi.fn<
       () => Array<{ agentKey: string; sessionId: string; alias: string; updated_at: number }>
     >(() => []),
@@ -29,10 +21,8 @@ vi.mock("@codesesh/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core")>();
   return {
     ...actual,
-    loadCachedSessionData: coreMocks.loadCachedSessionData,
-    loadCachedSessionDataEntry: coreMocks.loadCachedSessionDataEntry,
+    materializeSessionDetail: coreMocks.materializeSessionDetail,
     listFileActivity: coreMocks.listFileActivity,
-    listSessionFileActivity: coreMocks.listSessionFileActivity,
     listSessionAliases: coreMocks.listSessionAliases,
     executeSessionSearch: coreMocks.executeSessionSearch,
   };
@@ -51,7 +41,6 @@ import {
 } from "../handlers.js";
 import { invalidateAliasView } from "../session-aliases-view.js";
 import type {
-  CachedSessionDataEntry,
   ChangeCheckResult,
   FileActivityResult,
   ScanResult,
@@ -182,18 +171,9 @@ function toLocalDateKey(ts: number): string {
 // --- Tests ---
 
 afterEach(() => {
-  coreMocks.loadCachedSessionData.mockReset();
-  coreMocks.loadCachedSessionDataEntry.mockReset();
-  coreMocks.loadCachedSessionDataEntry.mockImplementation(
-    (agentName: string, sessionId: string): CachedSessionDataEntry | null => {
-      const data = coreMocks.loadCachedSessionData(agentName, sessionId) as SessionData | null;
-      return data ? { data, meta: null } : null;
-    },
-  );
+  coreMocks.materializeSessionDetail.mockReset();
   coreMocks.listFileActivity.mockReset();
   coreMocks.listFileActivity.mockReturnValue([]);
-  coreMocks.listSessionFileActivity.mockReset();
-  coreMocks.listSessionFileActivity.mockReturnValue([]);
   coreMocks.listSessionAliases.mockReset();
   coreMocks.listSessionAliases.mockReturnValue([]);
   // The alias read model caches for the process lifetime; tests stub
@@ -1096,209 +1076,84 @@ describe("handleGetDashboard", () => {
 });
 
 describe("handleGetSessionData", () => {
-  it("returns session data for valid agent and id", async () => {
-    coreMocks.loadCachedSessionData.mockReturnValue({
-      id: "s1",
-      slug: "claudecode/s1",
-      title: "Test Session",
-      directory: "/home/user/project",
-      time_created: 1000,
-      time_updated: 1000,
-      messages: [],
-      stats: {
-        message_count: 0,
-        total_input_tokens: 0,
-        total_output_tokens: 0,
-        total_cost: 0,
-      },
-    });
+  const detail: SessionData = {
+    id: "s1",
+    slug: "claudecode/s1",
+    title: "Test Session",
+    directory: "/home/user/project",
+    time_created: 1000,
+    time_updated: 1000,
+    messages: [],
+    stats: {
+      message_count: 0,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    project_identity: {
+      kind: "path",
+      key: "/home/user/project",
+      displayName: "project",
+    },
+    smart_tags: [],
+    smart_tags_source_updated_at: 1000,
+    file_activity: [],
+  };
+
+  it("maps materialized session data to JSON", async () => {
+    coreMocks.materializeSessionDetail.mockReturnValue({ status: "found", data: detail });
+    const scanSource = makeScanSource();
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+
+    await handleGetSessionData(c, scanSource);
+
+    expect(coreMocks.materializeSessionDetail).toHaveBeenCalledWith(scanSource.getSnapshot(), {
+      agentName: "claudecode",
+      sessionId: "s1",
+    });
+    expect(c.json).toHaveBeenCalledWith(detail);
+  });
+
+  it("returns 400 when agent name is missing", async () => {
+    const c = makeMockContext({ param: { agent: "", id: "s1" } });
     await handleGetSessionData(c, makeScanSource());
-    expect(c.json).toHaveBeenCalled();
-    const response = c.json.mock.calls[0]![0];
-    expect(response.title).toBe("Test Session");
-    expect(coreMocks.loadCachedSessionData).toHaveBeenCalledWith("claudecode", "s1");
+    expect(c.json).toHaveBeenCalledWith({ error: "Missing agent name" }, 400);
+    expect(coreMocks.materializeSessionDetail).not.toHaveBeenCalled();
   });
 
   it("returns 400 when session ID is missing", async () => {
     const c = makeMockContext({ param: { agent: "claudecode", id: "" } });
     await handleGetSessionData(c, makeScanSource());
     expect(c.json).toHaveBeenCalledWith({ error: "Missing session ID" }, 400);
+    expect(coreMocks.materializeSessionDetail).not.toHaveBeenCalled();
   });
 
-  it("returns 404 for unknown agent", async () => {
+  it("maps an unknown agent to 404", async () => {
+    coreMocks.materializeSessionDetail.mockReturnValue({ status: "unknown-agent" });
     const c = makeMockContext({ param: { agent: "unknown", id: "s1" } });
+
     await handleGetSessionData(c, makeScanSource());
+
     expect(c.json).toHaveBeenCalledWith({ error: "Unknown agent: unknown" }, 404);
   });
 
-  it("returns 404 when the SQLite session cache is missing", async () => {
-    coreMocks.loadCachedSessionData.mockReturnValue(null);
+  it("maps unavailable detail to 404", async () => {
+    coreMocks.materializeSessionDetail.mockReturnValue({ status: "not-ready" });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-    await handleGetSessionData(
-      c,
-      makeScanSource({
-        sessions: [],
-        byAgent: { claudecode: [] },
-      }),
-    );
+
+    await handleGetSessionData(c, makeScanSource());
+
     expect(c.json).toHaveBeenCalledWith({ error: "Session cache not ready" }, 404);
   });
 
-  it("loads session data from the current agent index when SQLite cache is empty", async () => {
-    coreMocks.loadCachedSessionData.mockReturnValue(null);
-    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-
-    await handleGetSessionData(c, makeScanSource());
-
-    const response = c.json.mock.calls[0]![0];
-    expect(response.title).toBe("Test Session");
-    expect(response.project_identity).toMatchObject({
-      kind: "path",
-      key: "/home/user/project",
-    });
-    expect(response.file_activity).toEqual([]);
-  });
-
-  it("falls back to the current agent index when cached messages are missing", async () => {
-    coreMocks.loadCachedSessionData.mockReturnValue({
-      id: "s1",
-      slug: "claudecode/s1",
-      title: "Cached Session",
-      directory: "/home/user/project",
-      time_created: 1000,
-      time_updated: 1000,
-      messages: [],
-      stats: {
-        message_count: 1,
-        total_input_tokens: 0,
-        total_output_tokens: 0,
-        total_cost: 0,
-      },
-    });
-
-    class AgentWithDetail extends MockAgent {
-      override getSessionData(_sessionId: string): SessionData {
-        return {
-          id: "s1",
-          slug: "claudecode/s1",
-          title: "Source Session",
-          directory: "/home/user/project",
-          time_created: 1000,
-          time_updated: 1000,
-          messages: [
-            {
-              id: "m1",
-              role: "user",
-              time_created: 1000,
-              parts: [{ type: "text", text: "hello" }],
-            },
-          ],
-          stats: {
-            message_count: 1,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cost: 0,
-          },
-        };
-      }
-    }
-
-    const sessions = [makeSession("s1", { slug: "claudecode/s1" })];
-    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-
-    await handleGetSessionData(
-      c,
-      makeScanSource({
-        sessions,
-        byAgent: { claudecode: sessions },
-        agents: [new AgentWithDetail()],
-      }),
-    );
-
-    const response = c.json.mock.calls[0]![0];
-    expect(response.title).toBe("Source Session");
-    expect(response.messages).toHaveLength(1);
-    expect(coreMocks.listSessionFileActivity).not.toHaveBeenCalled();
-  });
-
-  it("bypasses cached detail when the source fingerprint changes", async () => {
-    coreMocks.loadCachedSessionDataEntry.mockReturnValue({
-      data: {
-        id: "s1",
-        slug: "claudecode/s1",
-        title: "Cached Session",
-        directory: "/home/user/project",
-        time_created: 1000,
-        time_updated: 1000,
-        messages: [
-          {
-            id: "stale",
-            role: "assistant",
-            time_created: 1000,
-            parts: [{ type: "text", text: "stale detail" }],
-          },
-        ],
-        stats: {
-          message_count: 1,
-          total_input_tokens: 0,
-          total_output_tokens: 0,
-          total_cost: 0,
-        },
-      },
-      meta: { id: "s1", sourcePath: "/session.jsonl", sourceFingerprint: "old" },
-    });
-
-    class AgentWithChangedSource extends MockAgent {
-      override getSessionMetaMap(): Map<string, SessionCacheMeta> {
-        return new Map([
-          ["s1", { id: "s1", sourcePath: "/session.jsonl", sourceFingerprint: "current" }],
-        ]);
-      }
-
-      override getSessionData(_sessionId: string): SessionData {
-        return {
-          ...super.getSessionData(_sessionId),
-          messages: [
-            {
-              id: "fresh",
-              role: "assistant",
-              time_created: 1000,
-              parts: [{ type: "text", text: "fresh detail" }],
-            },
-          ],
-          stats: {
-            message_count: 1,
-            total_input_tokens: 0,
-            total_output_tokens: 0,
-            total_cost: 0,
-          },
-        };
-      }
-    }
-
-    const sessions = [makeSession("s1", { slug: "claudecode/s1" })];
-    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-
-    await handleGetSessionData(
-      c,
-      makeScanSource({
-        sessions,
-        byAgent: { claudecode: sessions },
-        agents: [new AgentWithChangedSource()],
-      }),
-    );
-
-    const response = c.json.mock.calls[0]![0];
-    expect(response.messages[0].parts[0].text).toBe("fresh detail");
-  });
-
-  it("returns 500 when SQLite cache loading throws", async () => {
-    coreMocks.loadCachedSessionData.mockImplementation(() => {
+  it("maps materialization errors to 500", async () => {
+    coreMocks.materializeSessionDetail.mockImplementation(() => {
       throw new Error("DB not found");
     });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+
     await handleGetSessionData(c, makeScanSource());
+
     expect(c.json).toHaveBeenCalledWith({ error: "DB not found" }, 500);
   });
 });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -1,12 +1,5 @@
 import type { Context } from "hono";
-import type {
-  BookmarkRecord,
-  ScanResult,
-  SessionCacheMeta,
-  SessionData,
-  SessionHead,
-  SmartTag,
-} from "@codesesh/core";
+import type { BookmarkRecord, ScanResult, SessionHead, SmartTag } from "@codesesh/core";
 import type { AppConfig, ScanStatusEvent } from "@codesesh/core/contract";
 import {
   BookmarkStorageUnavailableError,
@@ -15,20 +8,14 @@ import {
   createProjectScopeMatcher,
   deleteBookmark,
   getAgentInfoMap,
-  classifySessionTags,
-  computeIdentity,
   executeSessionSearch,
-  extractSessionFileActivity,
-  getSmartTagSourceTimestamp,
   importBookmarks,
-  loadCachedSessionDataEntry,
   listFileActivity,
-  listSessionFileActivity,
   listCachedProjectGroups,
   listBookmarks,
   deleteSessionAlias,
+  materializeSessionDetail,
   upsertSessionAlias,
-  realFs,
   upsertBookmark,
   matchesProjectScope as sessionMatchesProjectScope,
   matchesProjectIdentity,
@@ -69,15 +56,6 @@ export interface ScanStatusSource {
 interface ClientLogPayload {
   event?: unknown;
   data?: unknown;
-}
-
-function cacheMatchesCurrentSource(
-  cachedMeta: SessionCacheMeta | null,
-  currentMeta: SessionCacheMeta | undefined,
-) {
-  const currentFingerprint = currentMeta?.sourceFingerprint;
-  if (typeof currentFingerprint !== "string") return true;
-  return cachedMeta?.sourceFingerprint === currentFingerprint;
 }
 
 interface SessionAliasPayload {
@@ -301,7 +279,6 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
 
 export async function handleGetSessionData(c: Context, scanSource: ScanResultSource) {
   const startedAt = performance.now();
-  const scanResult = scanSource.getSnapshot();
   const agentName = c.req.param("agent");
   const sessionId = c.req.param("id");
 
@@ -313,30 +290,12 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
     return c.json({ error: "Missing session ID" }, 400);
   }
 
-  const agent = scanResult.agents.find((a) => a.name === agentName);
-
-  if (!agent) {
-    return c.json({ error: `Unknown agent: ${agentName}` }, 404);
-  }
-
   try {
-    const head = scanResult.byAgent[agentName]?.find((item) => item.id === sessionId);
-    const loadStartedAt = performance.now();
-    const cachedEntry = loadCachedSessionDataEntry(agentName, sessionId);
-    const cachedData = cachedEntry?.data ?? null;
-    const cachedMessageCount = cachedData?.stats.message_count ?? 0;
-    const currentMeta = head ? agent.getSessionMetaMap().get(sessionId) : undefined;
-    const cacheHasExpectedMessages =
-      cachedData !== null &&
-      cacheMatchesCurrentSource(cachedEntry?.meta ?? null, currentMeta) &&
-      (cachedData.messages.length > 0 || cachedMessageCount === 0);
-    const data: SessionData | null = cacheHasExpectedMessages
-      ? cachedData
-      : head
-        ? agent.getSessionData(sessionId)
-        : null;
-    const loadDuration = performance.now() - loadStartedAt;
-    if (!data) {
+    const result = materializeSessionDetail(scanSource.getSnapshot(), { agentName, sessionId });
+    if (result.status === "unknown-agent") {
+      return c.json({ error: `Unknown agent: ${agentName}` }, 404);
+    }
+    if (result.status === "not-ready") {
       appLogger.warn("api.session_data.cache_miss", {
         agent: agentName,
         session_id: sessionId,
@@ -344,32 +303,15 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       });
       return c.json({ error: "Session cache not ready" }, 404);
     }
-    const tagStartedAt = performance.now();
-    const smartTags = data.smart_tags ?? classifySessionTags(data);
-    const tagDuration = performance.now() - tagStartedAt;
-    const projectIdentity =
-      data.project_identity ?? head?.project_identity ?? computeIdentity(data.directory, realFs);
-    const fileActivity =
-      data.file_activity ??
-      (cacheHasExpectedMessages && cachedData
-        ? listSessionFileActivity(agentName, sessionId)
-        : extractSessionFileActivity(agentName, sessionId, projectIdentity.key, data.messages));
+
     appLogger.info("api.session_data", {
       agent: agentName,
       session_id: sessionId,
-      messages: data.messages.length,
-      load_duration_ms: Math.round(loadDuration),
-      tag_duration_ms: Math.round(tagDuration),
+      messages: result.data.messages.length,
       duration_ms: Math.round(performance.now() - startedAt),
     });
     const aliases = loadAliasView();
-    return c.json({
-      ...aliases.decorate(data, agentName),
-      project_identity: projectIdentity,
-      smart_tags: smartTags,
-      smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
-      file_activity: fileActivity,
-    });
+    return c.json(aliases.decorate(result.data, agentName));
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to load session";
     appLogger.error("api.session_data.error", {

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -1,0 +1,233 @@
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BaseAgent,
+  materializeSessionDetail,
+  saveCachedSessions,
+  syncSessionSearchIndex,
+  type ChangeCheckResult,
+  type ScanResult,
+  type SessionCacheMeta,
+  type SessionData,
+  type SessionHead,
+} from "../../index.js";
+import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../cache/db.js";
+
+const { testHomeDir } = vi.hoisted(() => ({
+  testHomeDir: `/tmp/codesesh-session-detail-test-${process.pid}`,
+}));
+const projectIdentity = {
+  kind: "path" as const,
+  key: "/workspace/project",
+  displayName: "project",
+};
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(() => testHomeDir) };
+});
+
+class TestAgent extends BaseAgent {
+  readonly name = "test";
+  readonly displayName = "Test";
+  reads = 0;
+
+  constructor(
+    private readonly detail: SessionData,
+    private readonly meta: Map<string, SessionCacheMeta>,
+  ) {
+    super();
+  }
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  scan(): SessionHead[] {
+    return [];
+  }
+
+  getSessionData(): SessionData {
+    this.reads += 1;
+    return this.detail;
+  }
+
+  getSessionWatchPlan() {
+    return { status: "not-needed" as const, reason: "Test adapter" };
+  }
+
+  checkForChanges(): ChangeCheckResult {
+    return { hasChanges: false, timestamp: 0 };
+  }
+
+  incrementalScan(sessions: SessionHead[]): SessionHead[] {
+    return sessions;
+  }
+
+  getSessionMetaMap(): Map<string, SessionCacheMeta> {
+    return this.meta;
+  }
+
+  setSessionMetaMap(): void {}
+}
+
+function makeHead(overrides: Partial<SessionHead> = {}): SessionHead {
+  return {
+    id: "s1",
+    slug: "test/s1",
+    title: "Cached Session",
+    directory: "/workspace/project",
+    project_identity: projectIdentity,
+    time_created: 1000,
+    time_updated: 2000,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    ...overrides,
+  };
+}
+
+function makeDetail(title = "Source Session"): SessionData {
+  return {
+    ...makeHead({ title }),
+    messages: [
+      {
+        id: "m1",
+        role: "assistant",
+        time_created: 1500,
+        parts: [
+          {
+            type: "tool",
+            tool: "Read",
+            state: { arguments: { file_path: "src/index.ts" } },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function makeMeta(fingerprint: string): SessionCacheMeta {
+  return {
+    id: "s1",
+    sourcePath: "/sessions/s1.jsonl",
+    sourceFingerprint: fingerprint,
+  };
+}
+
+function makeScanResult(agent: TestAgent, head = makeHead()): ScanResult {
+  return {
+    sessions: [head],
+    byAgent: { test: [head] },
+    agents: [agent],
+  };
+}
+
+function persistDetail(head: SessionHead, detail: SessionData, fingerprint: string): void {
+  saveCachedSessions("test", [head], { [head.id]: makeMeta(fingerprint) });
+  syncSessionSearchIndex("test", [head], () => detail);
+}
+
+beforeEach(() => {
+  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
+  setFtsIntegrityCheckedPath(null);
+  setSchemaEnsuredPath(null);
+});
+
+afterEach(() => {
+  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
+  setFtsIntegrityCheckedPath(null);
+  setSchemaEnsuredPath(null);
+});
+
+describe("materializeSessionDetail", () => {
+  it("returns a complete matching cache entry without reading the source", () => {
+    const head = makeHead();
+    persistDetail(head, makeDetail("Cached Session"), "same");
+    const agent = new TestAgent(makeDetail(), new Map([["s1", makeMeta("same")]]));
+
+    const result = materializeSessionDetail(makeScanResult(agent, head), {
+      agentName: "test",
+      sessionId: "s1",
+    });
+
+    expect(result.status).toBe("found");
+    if (result.status !== "found") return;
+    expect(result.data.title).toBe("Cached Session");
+    expect(result.data.project_identity).toEqual(projectIdentity);
+    expect(result.data.smart_tags_source_updated_at).toBe(2000);
+    expect(result.data.file_activity).toEqual([
+      expect.objectContaining({ path: "src/index.ts", kind: "read", count: 1 }),
+    ]);
+    expect(agent.reads).toBe(0);
+  });
+
+  it("reads the source when cached messages are incomplete", () => {
+    const head = makeHead();
+    saveCachedSessions("test", [head], { s1: makeMeta("same") });
+    const agent = new TestAgent(makeDetail(), new Map([["s1", makeMeta("same")]]));
+
+    const result = materializeSessionDetail(makeScanResult(agent, head), {
+      agentName: "test",
+      sessionId: "s1",
+    });
+
+    expect(result).toMatchObject({
+      status: "found",
+      data: { title: "Source Session", messages: [{ id: "m1" }] },
+    });
+    expect(agent.reads).toBe(1);
+  });
+
+  it("reads the source when its fingerprint no longer matches the cache", () => {
+    const head = makeHead();
+    persistDetail(head, makeDetail("Cached Session"), "old");
+    const agent = new TestAgent(makeDetail(), new Map([["s1", makeMeta("current")]]));
+
+    const result = materializeSessionDetail(makeScanResult(agent, head), {
+      agentName: "test",
+      sessionId: "s1",
+    });
+
+    expect(result).toMatchObject({ status: "found", data: { title: "Source Session" } });
+    expect(agent.reads).toBe(1);
+  });
+
+  it("derives the same file activity for cached and source details", () => {
+    const head = makeHead();
+    const detail = makeDetail();
+    persistDetail(head, detail, "cached");
+    const cachedAgent = new TestAgent(detail, new Map([["s1", makeMeta("cached")]]));
+    const sourceAgent = new TestAgent(detail, new Map([["s1", makeMeta("source")]]));
+
+    const cached = materializeSessionDetail(makeScanResult(cachedAgent, head), {
+      agentName: "test",
+      sessionId: "s1",
+    });
+    const source = materializeSessionDetail(makeScanResult(sourceAgent, head), {
+      agentName: "test",
+      sessionId: "s1",
+    });
+
+    expect(cached.status).toBe("found");
+    expect(source.status).toBe("found");
+    if (cached.status !== "found" || source.status !== "found") return;
+    expect(source.data.file_activity).toEqual(cached.data.file_activity);
+  });
+
+  it("returns explicit lookup outcomes when no detail can be materialized", () => {
+    const agent = new TestAgent(makeDetail(), new Map());
+    const emptyScan = { sessions: [], byAgent: { test: [] }, agents: [agent] };
+
+    expect(materializeSessionDetail(emptyScan, { agentName: "missing", sessionId: "s1" })).toEqual({
+      status: "unknown-agent",
+    });
+    expect(materializeSessionDetail(emptyScan, { agentName: "test", sessionId: "s1" })).toEqual({
+      status: "not-ready",
+    });
+  });
+});

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -8,6 +8,11 @@ export {
 } from "./scanner.js";
 export type { ScanResult, ScanOptions } from "./scanner.js";
 export {
+  materializeSessionDetail,
+  type SessionDetailResult,
+  type SessionReference,
+} from "./session-detail.js";
+export {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
   computeSessionDiff,

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -1,0 +1,88 @@
+import type { SessionCacheMeta } from "../agents/index.js";
+import type { SessionData } from "../types/index.js";
+import { computeIdentity, realFs } from "../projects/index.js";
+import {
+  classifySessionTags,
+  extractSessionFileActivity,
+  getSmartTagSourceTimestamp,
+} from "../utils/index.js";
+import { listSessionFileActivity, loadCachedSessionDataEntry } from "./cache.js";
+import type { ScanResult } from "./scanner.js";
+
+export interface SessionReference {
+  agentName: string;
+  sessionId: string;
+}
+
+export type SessionDetailResult =
+  | { status: "found"; data: SessionData }
+  | { status: "unknown-agent" }
+  | { status: "not-ready" };
+
+function cacheMatchesCurrentSource(
+  cachedMeta: SessionCacheMeta | null,
+  currentMeta: SessionCacheMeta | undefined,
+): boolean {
+  const currentFingerprint = currentMeta?.sourceFingerprint;
+  if (typeof currentFingerprint !== "string") return true;
+  return cachedMeta?.sourceFingerprint === currentFingerprint;
+}
+
+function cacheHasCompleteDetail(
+  cachedData: SessionData | null,
+  cachedMeta: SessionCacheMeta | null,
+  currentMeta: SessionCacheMeta | undefined,
+): cachedData is SessionData {
+  if (!cachedData || !cacheMatchesCurrentSource(cachedMeta, currentMeta)) {
+    return false;
+  }
+
+  return cachedData.messages.length > 0 || cachedData.stats.message_count === 0;
+}
+
+export function materializeSessionDetail(
+  scanResult: ScanResult,
+  reference: SessionReference,
+): SessionDetailResult {
+  const agent = scanResult.agents.find((item) => item.name === reference.agentName);
+  if (!agent) {
+    return { status: "unknown-agent" };
+  }
+
+  const head = scanResult.byAgent[reference.agentName]?.find(
+    (item) => item.id === reference.sessionId,
+  );
+  const cachedEntry = loadCachedSessionDataEntry(reference.agentName, reference.sessionId);
+  const cachedData = cachedEntry?.data ?? null;
+  const currentMeta = head ? agent.getSessionMetaMap().get(reference.sessionId) : undefined;
+  const useCache = cacheHasCompleteDetail(cachedData, cachedEntry?.meta ?? null, currentMeta);
+  const data = useCache ? cachedData : head ? agent.getSessionData(reference.sessionId) : null;
+
+  if (!data) {
+    return { status: "not-ready" };
+  }
+
+  const projectIdentity =
+    data.project_identity ?? head?.project_identity ?? computeIdentity(data.directory, realFs);
+  const fileActivity =
+    data.file_activity ??
+    (useCache
+      ? listSessionFileActivity(reference.agentName, reference.sessionId)
+      : extractSessionFileActivity(
+          reference.agentName,
+          reference.sessionId,
+          projectIdentity.key,
+          data.messages,
+        ));
+
+  return {
+    status: "found",
+    data: {
+      ...data,
+      project_identity: projectIdentity,
+      smart_tags: data.smart_tags ?? classifySessionTags(data),
+      smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
+      file_activity: fileActivity,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a Core session-detail materializer that owns cache validation, source fallback, and enrichment
- return explicit domain outcomes for found, unknown-agent, and not-ready cases
- reduce the HTTP handler to parameter validation, response mapping, presentation, and logging
- move fallback coverage to real SQLite and local-agent module tests

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`
- `pnpm exec playwright test tests/e2e/browsing.spec.ts --grep "opens a session detail from the dashboard"`

Issue: CS-108