### PR TITLE
refactor(web): unify session detail model

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -10,14 +10,8 @@ import {
   recordRenderProfileEntry,
   RenderProfiler,
 } from "./RenderProfiler";
-import { buildSessionDetailToc, filterSessionMessages } from "./session-detail/toc";
-import { buildMessageDisplayModels } from "./session-detail/display-model";
-import {
-  buildFileChangeSummary,
-  buildFileChangeSummaryFromActivity,
-} from "./session-detail/file-change";
+import { buildSessionDetailDisplayModel } from "./session-detail/display-model";
 import { SessionToc, toggleTocFilter } from "./session-detail/session-toc";
-import { normalizeMessagesForDisplay } from "./session-detail/tool-strategy";
 import {
   MessageList,
   type MessageListHandle,
@@ -33,7 +27,6 @@ import {
   resolveReducedMotionScrollBehavior,
   type SessionAnchorScrollBehavior,
 } from "./session-detail/scroll-behavior";
-import { buildSessionTimelineEntries } from "./session-detail/timeline";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -111,38 +104,18 @@ function measureSessionDetailWork<T>(id: string, compute: () => T): T {
 export function SessionDetail({ session, agentCatalog, highlightQuery }: SessionDetailProps) {
   const sessionAgentKey = getSessionAgentKey({ slug: session.slug ?? "" });
   const sessionAgent = findAgent(agentCatalog, sessionAgentKey);
-  const normalizedMessages = useMemo(
+  const displayModel = useMemo(
     () =>
-      measureSessionDetailWork("SessionDetail:normalizeMessages", () =>
-        normalizeMessagesForDisplay(session.messages, sessionAgentKey),
+      measureSessionDetailWork("SessionDetail:buildDisplayModel", () =>
+        buildSessionDetailDisplayModel({
+          messages: session.messages,
+          agentName: sessionAgentKey,
+          fileActivity: session.file_activity,
+        }),
       ),
-    [session.messages, sessionAgentKey],
+    [session.file_activity, session.messages, sessionAgentKey],
   );
-  const messageModels = useMemo(
-    () =>
-      measureSessionDetailWork("SessionDetail:buildMessageDisplayModels", () =>
-        buildMessageDisplayModels(normalizedMessages),
-      ),
-    [normalizedMessages],
-  );
-  const {
-    toolAnchorIds,
-    anchorMessageIndexes,
-    summary: localFileChangeSummary,
-  } = useMemo(
-    () =>
-      measureSessionDetailWork("SessionDetail:buildFileChangeSummary", () =>
-        buildFileChangeSummary(messageModels),
-      ),
-    [messageModels],
-  );
-  const toc = useMemo(
-    () =>
-      measureSessionDetailWork("SessionDetail:buildSessionDetailToc", () =>
-        buildSessionDetailToc(messageModels),
-      ),
-    [messageModels],
-  );
+  const { messages: messageModels, toc, fileChangeSummary } = displayModel;
   const [selectedFilters, setSelectedFilters] = useState<Set<string>>(() => new Set(toc.filterIds));
   const [openAuxPanel, setOpenAuxPanel] = useState<"toc" | "files" | null>(null);
   const tocSignature = useMemo(() => [...toc.filterIds].toSorted().join("|"), [toc.filterIds]);
@@ -150,40 +123,21 @@ export function SessionDetail({ session, agentCatalog, highlightQuery }: Session
     () => [...selectedFilters].toSorted().join("|"),
     [selectedFilters],
   );
-  const filteredMessages = useMemo(
+  const selection = useMemo(
     () =>
-      measureSessionDetailWork("SessionDetail:filterSessionMessages", () =>
-        filterSessionMessages(messageModels, selectedFilters),
+      measureSessionDetailWork("SessionDetail:selectDisplayModel", () =>
+        displayModel.select(selectedFilters),
       ),
-    [messageModels, selectedFilters],
+    [displayModel, selectedFilters],
   );
+  const { messages: filteredMessages, timelineEntries } = selection;
   const virtualListRef = useRef<MessageListHandle | null>(null);
   const scrollRequestRef = useRef(0);
-  const anchorListIndexes = useMemo(() => {
-    return measureSessionDetailWork("SessionDetail:buildAnchorListIndexes", () => {
-      const indexes = new Map<number, number>();
-      filteredMessages.forEach((item, listIndex) => {
-        indexes.set(item.index, listIndex);
-      });
-      return indexes;
-    });
-  }, [filteredMessages]);
-  const fileChangeSummary = useMemo(
-    () =>
-      measureSessionDetailWork("SessionDetail:mergeFileActivitySummary", () =>
-        buildFileChangeSummaryFromActivity(session.file_activity, localFileChangeSummary),
-      ),
-    [session.file_activity, localFileChangeSummary],
-  );
-  const timelineEntries = useMemo(
-    () => buildSessionTimelineEntries(filteredMessages, toolAnchorIds),
-    [filteredMessages, toolAnchorIds],
-  );
   const handleJumpToMessageAnchor = useCallback(
     (anchorId: string, messageIndex: number | undefined, behavior: SessionAnchorScrollBehavior) => {
       const requestId = scrollRequestRef.current + 1;
       scrollRequestRef.current = requestId;
-      const listIndex = messageIndex == null ? undefined : anchorListIndexes.get(messageIndex);
+      const listIndex = messageIndex == null ? undefined : selection.resolveListIndex(messageIndex);
       scrollToSessionAnchor({
         anchorId,
         behavior,
@@ -192,13 +146,13 @@ export function SessionDetail({ session, agentCatalog, highlightQuery }: Session
         isCurrent: () => scrollRequestRef.current === requestId,
       });
     },
-    [anchorListIndexes],
+    [selection],
   );
   const handleJumpToAnchor = useCallback(
     (anchorId: string, behavior: SessionAnchorScrollBehavior) => {
-      handleJumpToMessageAnchor(anchorId, anchorMessageIndexes.get(anchorId), behavior);
+      handleJumpToMessageAnchor(anchorId, displayModel.resolveMessageIndex(anchorId), behavior);
     },
-    [anchorMessageIndexes, handleJumpToMessageAnchor],
+    [displayModel, handleJumpToMessageAnchor],
   );
 
   useEffect(() => {
@@ -278,7 +232,6 @@ export function SessionDetail({ session, agentCatalog, highlightQuery }: Session
                 <MessageList
                   key={`${session.id}:${selectedFilterSignature}`}
                   messages={filteredMessages}
-                  toolAnchorIds={toolAnchorIds}
                   sessionAgentKey={sessionAgentKey}
                   agent={sessionAgent}
                   baseDirectory={session.directory}

--- a/apps/web/src/components/session-detail/blocks.ts
+++ b/apps/web/src/components/session-detail/blocks.ts
@@ -5,6 +5,7 @@ export type MessageBlockType = "reasoning" | "text" | "tool" | "plan";
 export interface MessageBlock {
   type: MessageBlockType;
   parts: MessagePart[];
+  anchorIds?: string[];
 }
 
 export function extractMessageText(value: unknown): string {

--- a/apps/web/src/components/session-detail/display-model.test.ts
+++ b/apps/web/src/components/session-detail/display-model.test.ts
@@ -1,65 +1,133 @@
 import { describe, expect, it } from "vitest";
-import type { Message, MessagePart } from "../../lib/api";
-import type { MessageBlock } from "./blocks";
-import { buildMessageDisplayModels, type MessageDisplayModel } from "./display-model";
-import { buildSessionDetailToc, filterSessionMessages } from "./toc";
+import type { Message, SessionFileActivity } from "../../lib/api";
+import { buildSessionDetailDisplayModel } from "./display-model";
 
-function message(id: string, role: Message["role"], parts: MessagePart[]): Message {
-  return {
-    id,
-    role,
-    time_created: 1,
-    parts,
-  };
-}
+const messages: Message[] = [
+  {
+    id: "duplicate",
+    role: "user",
+    time_created: 10,
+    parts: [{ type: "text", text: "Inspect these files" }],
+  },
+  {
+    id: "duplicate",
+    role: "assistant",
+    time_created: 20,
+    parts: [
+      { type: "reasoning", text: "Checking" },
+      { type: "text", text: "I will inspect them." },
+      { type: "plan", text: "Read then update" },
+      {
+        type: "tool",
+        tool: "Read",
+        time_created: 21,
+        state: { arguments: { file_path: "src/a.ts" } },
+      },
+      {
+        type: "tool",
+        tool: "Write",
+        time_created: 22,
+        state: { arguments: { file_path: "src/b.ts" } },
+      },
+    ],
+  },
+  {
+    id: "duplicate",
+    role: "assistant",
+    time_created: 30,
+    parts: [
+      {
+        type: "tool",
+        tool: "Read",
+        state: { arguments: { file_path: "src/a.ts" } },
+      },
+      { type: "text", text: "Done." },
+    ],
+  },
+];
+
+const fileActivity: SessionFileActivity[] = [
+  {
+    agent_name: "claudecode",
+    session_id: "s1",
+    project_identity_key: "project",
+    path: "src/a.ts",
+    kind: "read",
+    count: 2,
+    latest_time: 30,
+  },
+  {
+    agent_name: "claudecode",
+    session_id: "s1",
+    project_identity_key: "project",
+    path: "src/b.ts",
+    kind: "write",
+    count: 1,
+    latest_time: 22,
+  },
+];
 
 describe("session detail display model", () => {
-  it("builds visible message models once in display order", () => {
-    const userPart: MessagePart = { type: "text", text: "hello" };
-    const toolPart: MessagePart = { type: "tool", tool: "read" };
-    const models = buildMessageDisplayModels([
-      message("empty", "assistant", [{ type: "text", text: "   " }]),
-      message("user", "user", [userPart]),
-      message("tool", "assistant", [toolPart]),
-    ]);
+  it("prepares filtering, navigation, timeline, and file changes through one interface", () => {
+    const model = buildSessionDetailDisplayModel({
+      messages,
+      agentName: "claudecode",
+      fileActivity,
+    });
 
-    expect(models.map((model) => model.msg.id)).toEqual(["user", "tool"]);
-    expect(models.map((model) => model.index)).toEqual([0, 1]);
-    expect(models[0]?.blocks).toEqual([{ type: "text", parts: [userPart] }]);
-    expect(models[1]?.blocks).toEqual([{ type: "tool", parts: [toolPart] }]);
+    expect(model.messages.map((message) => message.index)).toEqual([0, 1, 2]);
+    expect(model.messages.map((message) => message.msg.id)).toEqual([
+      "duplicate",
+      "duplicate",
+      "duplicate",
+    ]);
+    expect(model.toc.counts).toEqual({
+      user: 1,
+      agent_message: 2,
+      thinking: 1,
+      plan: 1,
+      tools_all: 3,
+    });
+
+    const firstTools = model.messages[1]?.blocks.find((block) => block.type === "tool");
+    const secondTools = model.messages[2]?.blocks.find((block) => block.type === "tool");
+    expect(firstTools?.anchorIds).toEqual(["tool-1-0", "tool-1-1"]);
+    expect(secondTools?.anchorIds).toEqual(["tool-2-0"]);
+
+    expect(model.fileChangeSummary.read).toEqual([
+      expect.objectContaining({
+        path: "src/a.ts",
+        count: 2,
+        latestAnchorId: "tool-2-0",
+        anchors: [
+          expect.objectContaining({ anchorId: "tool-1-0" }),
+          expect.objectContaining({ anchorId: "tool-2-0" }),
+        ],
+      }),
+    ]);
+    expect(model.fileChangeSummary.write).toHaveLength(1);
+
+    const reads = model.select(new Set(["tool:read"]));
+    expect(reads.messages.map((message) => message.index)).toEqual([1, 2]);
+    expect(reads.timelineEntries.map((entry) => entry.anchorId)).toEqual(["tool-1-0", "tool-2-0"]);
+    expect(reads.resolveListIndex(1)).toBe(0);
+    expect(reads.resolveListIndex(2)).toBe(1);
+    expect(model.resolveMessageIndex("tool-2-0")).toBe(2);
+
+    const writes = model.select(new Set(["tool:write"]));
+    expect(writes.messages.map((message) => message.index)).toEqual([1]);
+    expect(writes.timelineEntries.map((entry) => entry.anchorId)).toEqual(["tool-1-1"]);
+    expect(model.resolveMessageIndex("tool-1-1")).toBe(1);
   });
 
-  it("reuses precomputed blocks for toc and filtering", () => {
-    const textPart: MessagePart = { type: "text", text: "precomputed reply" };
-    const readPart: MessagePart = { type: "tool", tool: "Read" };
-    const writePart: MessagePart = { type: "tool", tool: "Write" };
-    const blocks: MessageBlock[] = [
-      { type: "text", parts: [textPart] },
-      { type: "tool", parts: [readPart, writePart] },
-    ];
-    const models: MessageDisplayModel[] = [
-      {
-        msg: message("assistant", "assistant", []),
-        blocks,
-        index: 7,
-      },
-    ];
+  it("returns an empty coherent selection when no messages are visible", () => {
+    const model = buildSessionDetailDisplayModel({
+      messages: [{ id: "empty", role: "assistant", time_created: 1, parts: [] }],
+      agentName: "claudecode",
+    });
 
-    const toc = buildSessionDetailToc(models);
-    expect(toc.counts.agent_message).toBe(1);
-    expect(toc.counts.tools_all).toBe(2);
-    expect(toc.tools.map((tool) => tool.id)).toEqual(["tool:read", "tool:write"]);
-
-    const filtered = filterSessionMessages(
-      models,
-      new Set(["agent_message", "tools_all", "tool:read"]),
-    );
-
-    expect(filtered).toHaveLength(1);
-    expect(filtered[0]?.index).toBe(7);
-    expect(filtered[0]?.blocks).toEqual([
-      { type: "text", parts: [textPart] },
-      { type: "tool", parts: [readPart] },
-    ]);
+    expect(model.messages).toEqual([]);
+    expect(model.toc.filterIds.size).toBe(0);
+    expect(model.select(new Set()).messages).toEqual([]);
   });
 });

--- a/apps/web/src/components/session-detail/display-model.ts
+++ b/apps/web/src/components/session-detail/display-model.ts
@@ -1,5 +1,19 @@
-import type { Message } from "../../lib/api";
+import type { Message, SessionFileActivity } from "../../lib/api";
 import { buildMessageBlocks, type MessageBlock } from "./blocks";
+import {
+  buildFileChangeSummary,
+  buildFileChangeSummaryFromActivity,
+  buildToolAnchorId,
+  type FileChangeSummary,
+} from "./file-change";
+import { buildSessionTimelineEntries, type SessionTimelineEntry } from "./timeline";
+import {
+  buildSessionDetailToc,
+  filterSessionMessages,
+  type FilteredSessionMessage,
+  type SessionDetailToc,
+} from "./toc";
+import { normalizeMessagesForDisplay } from "./tool-strategy";
 
 export interface MessageDisplayModel {
   msg: Message;
@@ -7,15 +21,78 @@ export interface MessageDisplayModel {
   index: number;
 }
 
-export function buildMessageDisplayModels(messages: Message[]): MessageDisplayModel[] {
+export interface SessionDetailSelection {
+  messages: FilteredSessionMessage[];
+  timelineEntries: SessionTimelineEntry[];
+  resolveListIndex(messageIndex: number): number | undefined;
+}
+
+export interface SessionDetailDisplayModel {
+  messages: MessageDisplayModel[];
+  toc: SessionDetailToc;
+  fileChangeSummary: FileChangeSummary;
+  select(selectedFilters: Set<string>): SessionDetailSelection;
+  resolveMessageIndex(anchorId: string): number | undefined;
+}
+
+function attachToolAnchors(blocks: MessageBlock[], messageIndex: number): MessageBlock[] {
+  let toolIndex = 0;
+  return blocks.map((block) => {
+    if (block.type !== "tool") return block;
+    const anchorIds = block.parts.map(() => buildToolAnchorId(messageIndex, toolIndex++));
+    return { ...block, anchorIds };
+  });
+}
+
+function buildMessageDisplayModels(messages: Message[]): MessageDisplayModel[] {
   const models: MessageDisplayModel[] = [];
 
   for (const msg of messages) {
     const blocks = buildMessageBlocks(msg.parts);
     if (blocks.length === 0) continue;
 
-    models.push({ msg, blocks, index: models.length });
+    const index = models.length;
+    models.push({ msg, blocks: attachToolAnchors(blocks, index), index });
   }
 
   return models;
+}
+
+export function buildSessionDetailDisplayModel({
+  messages,
+  agentName,
+  fileActivity,
+}: {
+  messages: Message[];
+  agentName: string;
+  fileActivity?: SessionFileActivity[];
+}): SessionDetailDisplayModel {
+  const displayMessages = buildMessageDisplayModels(
+    normalizeMessagesForDisplay(messages, agentName),
+  );
+  const toc = buildSessionDetailToc(displayMessages);
+  const fileChanges = buildFileChangeSummary(displayMessages);
+  const fileChangeSummary = buildFileChangeSummaryFromActivity(fileActivity, fileChanges.summary);
+
+  return {
+    messages: displayMessages,
+    toc,
+    fileChangeSummary,
+    select(selectedFilters) {
+      const filteredMessages = filterSessionMessages(displayMessages, selectedFilters);
+      const listIndexes = new Map(
+        filteredMessages.map((message, listIndex) => [message.index, listIndex]),
+      );
+      return {
+        messages: filteredMessages,
+        timelineEntries: buildSessionTimelineEntries(filteredMessages),
+        resolveListIndex(messageIndex) {
+          return listIndexes.get(messageIndex);
+        },
+      };
+    },
+    resolveMessageIndex(anchorId) {
+      return fileChanges.anchorMessageIndexes.get(anchorId);
+    },
+  };
 }

--- a/apps/web/src/components/session-detail/file-change.test.ts
+++ b/apps/web/src/components/session-detail/file-change.test.ts
@@ -72,7 +72,7 @@ describe("summarizeFileChangeItems", () => {
 describe("buildFileChangeSummary", () => {
   it("returns empty summary for no messages", () => {
     const result = buildFileChangeSummary([]);
-    expect(result.toolAnchorIds.size).toBe(0);
+    expect(result.anchorMessageIndexes.size).toBe(0);
     expect(result.summary.read).toEqual([]);
   });
 });

--- a/apps/web/src/components/session-detail/file-change.ts
+++ b/apps/web/src/components/session-detail/file-change.ts
@@ -113,11 +113,9 @@ export function summarizeFileChangeItems(records: FileChangeRecord[]): FileChang
 }
 
 export function buildFileChangeSummary(messages: MessageDisplayModel[]): {
-  toolAnchorIds: Map<MessagePart, string>;
   anchorMessageIndexes: Map<string, number>;
   summary: FileChangeSummary;
 } {
-  const toolAnchorIds = new Map<MessagePart, string>();
   const anchorMessageIndexes = new Map<string, number>();
   const fileChanges: Record<FileChangeKind, FileChangeRecord[]> = {
     read: [],
@@ -132,10 +130,9 @@ export function buildFileChangeSummary(messages: MessageDisplayModel[]): {
     for (const block of blocks) {
       if (block.type !== "tool") continue;
 
-      for (const part of block.parts) {
-        const anchorId = buildToolAnchorId(messageIndex, toolIndex);
+      for (const [partIndex, part] of block.parts.entries()) {
+        const anchorId = block.anchorIds?.[partIndex] ?? buildToolAnchorId(messageIndex, toolIndex);
         toolIndex += 1;
-        toolAnchorIds.set(part, anchorId);
         anchorMessageIndexes.set(anchorId, messageIndex);
 
         const inputValue = getToolInputValue(part);
@@ -171,7 +168,6 @@ export function buildFileChangeSummary(messages: MessageDisplayModel[]): {
   });
 
   return {
-    toolAnchorIds,
     anchorMessageIndexes,
     summary: {
       read: summarizeFileChangeItems(fileChanges.read),

--- a/apps/web/src/components/session-detail/message-list.test.tsx
+++ b/apps/web/src/components/session-detail/message-list.test.tsx
@@ -58,7 +58,6 @@ describe("MessageList virtualization", () => {
     const view = render(
       <MessageList
         messages={createMessages().slice(0, 2)}
-        toolAnchorIds={new Map()}
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={apiRef}
@@ -75,7 +74,6 @@ describe("MessageList virtualization", () => {
     render(
       <MessageList
         messages={createMessages()}
-        toolAnchorIds={new Map()}
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}
@@ -92,7 +90,6 @@ describe("MessageList virtualization", () => {
     const view = render(
       <MessageList
         messages={createMessages()}
-        toolAnchorIds={new Map()}
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={apiRef}
@@ -126,7 +123,6 @@ describe("MessageList virtualization", () => {
     render(
       <MessageList
         messages={createMessages()}
-        toolAnchorIds={new Map()}
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={apiRef}
@@ -149,7 +145,6 @@ describe("MessageList virtualization", () => {
     const view = render(
       <MessageList
         messages={createMessages()}
-        toolAnchorIds={new Map()}
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}
@@ -179,7 +174,6 @@ describe("MessageList virtualization", () => {
     const view = render(
       <MessageList
         messages={createMessages()}
-        toolAnchorIds={new Map()}
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}
@@ -205,7 +199,6 @@ describe("MessageList virtualization", () => {
     const view = render(
       <MessageList
         messages={createMessages()}
-        toolAnchorIds={new Map()}
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}

--- a/apps/web/src/components/session-detail/message-list.tsx
+++ b/apps/web/src/components/session-detail/message-list.tsx
@@ -7,7 +7,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import type { AgentInfo, MessagePart } from "../../lib/api";
+import type { AgentInfo } from "../../lib/api";
 import { formatTokens } from "../../lib/format";
 import type { FilteredSessionMessage } from "./toc";
 import { MessageItem } from "./message-rendering";
@@ -23,7 +23,6 @@ export interface MessageListHandle {
 
 interface MessageListProps {
   messages: FilteredSessionMessage[];
-  toolAnchorIds: Map<MessagePart, string>;
   sessionAgentKey: string;
   agent?: AgentInfo;
   baseDirectory: string;
@@ -136,7 +135,6 @@ function scrollParentTo(parent: ScrollParent, top: number) {
 
 export function MessageList({
   messages,
-  toolAnchorIds,
   sessionAgentKey,
   agent,
   baseDirectory,
@@ -153,7 +151,6 @@ export function MessageList({
     return (
       <VirtualizedMessageList
         messages={messages}
-        toolAnchorIds={toolAnchorIds}
         sessionAgentKey={sessionAgentKey}
         agent={agent}
         baseDirectory={baseDirectory}
@@ -171,7 +168,6 @@ export function MessageList({
           messageIndex={index}
           msg={msg}
           blocks={blocks}
-          toolAnchorIds={toolAnchorIds}
           formatTokens={formatTokens}
           sessionAgentKey={sessionAgentKey}
           agent={agent}
@@ -185,7 +181,6 @@ export function MessageList({
 
 function VirtualizedMessageList({
   messages,
-  toolAnchorIds,
   sessionAgentKey,
   agent,
   baseDirectory,
@@ -406,7 +401,6 @@ function VirtualizedMessageList({
               messageIndex={item.index}
               msg={item.msg}
               blocks={item.blocks}
-              toolAnchorIds={toolAnchorIds}
               formatTokens={formatTokens}
               sessionAgentKey={sessionAgentKey}
               agent={agent}

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -90,7 +90,6 @@ export function MessageItem({
   messageIndex,
   msg,
   blocks,
-  toolAnchorIds,
   formatTokens: fmtTokens,
   sessionAgentKey,
   agent,
@@ -100,7 +99,6 @@ export function MessageItem({
   messageIndex: number;
   msg: Message;
   blocks: MessageBlock[];
-  toolAnchorIds: Map<MessagePart, string>;
   formatTokens: (n: number) => string;
   sessionAgentKey: string;
   agent?: AgentInfo;
@@ -198,7 +196,7 @@ export function MessageItem({
                   <ToolsSection
                     key={index}
                     parts={block.parts}
-                    toolAnchorIds={toolAnchorIds}
+                    anchorIds={block.anchorIds}
                     sessionAgentKey={sessionAgentKey}
                     baseDirectory={baseDirectory}
                     highlightQuery={highlightQuery}
@@ -323,13 +321,13 @@ function ReasoningSection({
 
 function ToolsSection({
   parts,
-  toolAnchorIds,
+  anchorIds,
   sessionAgentKey,
   baseDirectory,
   highlightQuery,
 }: {
   parts: MessagePart[];
-  toolAnchorIds: Map<MessagePart, string>;
+  anchorIds?: string[];
   sessionAgentKey: string;
   baseDirectory: string;
   highlightQuery?: string;
@@ -337,11 +335,11 @@ function ToolsSection({
   return (
     <div className="space-y-2">
       <div className="space-y-2">
-        {parts.map((tool, i) => (
+        {parts.map((tool, index) => (
           <ToolItem
-            key={i}
+            key={index}
             tool={tool}
-            anchorId={toolAnchorIds.get(tool)}
+            anchorId={anchorIds?.[index]}
             sessionAgentKey={sessionAgentKey}
             baseDirectory={baseDirectory}
             highlightQuery={highlightQuery}

--- a/apps/web/src/components/session-detail/timeline.test.ts
+++ b/apps/web/src/components/session-detail/timeline.test.ts
@@ -36,12 +36,8 @@ describe("session timeline", () => {
         ],
       },
     ];
-    const toolAnchorIds = new Map<MessagePart, string>([
-      [readTool, "tool-7-0"],
-      [writeTool, "tool-7-1"],
-    ]);
-
-    const entries = buildSessionTimelineEntries(messages, toolAnchorIds);
+    messages[1]!.blocks[1]!.anchorIds = ["tool-7-0", "tool-7-1"];
+    const entries = buildSessionTimelineEntries(messages);
 
     expect(entries.map((entry) => entry.kind)).toEqual([
       "user",

--- a/apps/web/src/components/session-detail/timeline.ts
+++ b/apps/web/src/components/session-detail/timeline.ts
@@ -74,7 +74,6 @@ const TOOL_KIND_LABEL = {
 
 export function buildSessionTimelineEntries(
   messages: FilteredSessionMessage[],
-  toolAnchorIds: Map<MessagePart, string>,
 ): SessionTimelineEntry[] {
   const entries: SessionTimelineEntry[] = [];
 
@@ -94,8 +93,8 @@ export function buildSessionTimelineEntries(
 
     blocks.forEach((block, blockIndex) => {
       if (block.type === "tool") {
-        block.parts.forEach((part) => {
-          const anchorId = toolAnchorIds.get(part);
+        block.parts.forEach((part, partIndex) => {
+          const anchorId = block.anchorIds?.[partIndex];
           if (!anchorId) return;
           const kind = classifyTimelineToolKind(part);
           entries.push({

--- a/apps/web/src/components/session-detail/toc.test.ts
+++ b/apps/web/src/components/session-detail/toc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Message, MessagePart } from "../../lib/api";
-import { buildMessageDisplayModels } from "./display-model";
+import { buildSessionDetailDisplayModel } from "./display-model";
 import { buildSessionDetailToc, filterSessionMessages } from "./toc";
 
 function createMessage(id: string, role: Message["role"], parts: MessagePart[]): Message {
@@ -10,6 +10,10 @@ function createMessage(id: string, role: Message["role"], parts: MessagePart[]):
     time_created: 100,
     parts,
   };
+}
+
+function buildModels(messages: Message[]) {
+  return buildSessionDetailDisplayModel({ messages, agentName: "claudecode" }).messages;
 }
 
 describe("session detail display model", () => {
@@ -23,7 +27,7 @@ describe("session detail display model", () => {
       ]),
     ];
 
-    const models = buildMessageDisplayModels(messages);
+    const models = buildModels(messages);
 
     expect(models).toHaveLength(1);
     expect(models[0]?.index).toBe(0);
@@ -44,7 +48,7 @@ describe("session detail display model", () => {
       tool: "Write",
       state: { input: { path: "a.ts" } },
     } satisfies MessagePart;
-    const models = buildMessageDisplayModels([
+    const models = buildModels([
       createMessage("user", "user", [{ type: "text", text: "open file" }]),
       createMessage("assistant", "assistant", [
         { type: "reasoning", text: "thinking" },
@@ -71,7 +75,7 @@ describe("session detail display model", () => {
     expect(filtered).toHaveLength(1);
     expect(filtered[0]?.index).toBe(1);
     expect(filtered[0]?.msg.id).toBe("assistant");
-    expect(filtered[0]?.blocks).toEqual([{ type: "tool", parts: [readTool] }]);
+    expect(filtered[0]?.blocks).toMatchObject([{ type: "tool", parts: [readTool] }]);
   });
 
   it("filters tool items without requiring the Tools parent filter", () => {
@@ -85,14 +89,12 @@ describe("session detail display model", () => {
       tool: "Write",
       state: { input: { path: "b.ts" } },
     } satisfies MessagePart;
-    const models = buildMessageDisplayModels([
-      createMessage("assistant", "assistant", [readTool, writeTool]),
-    ]);
+    const models = buildModels([createMessage("assistant", "assistant", [readTool, writeTool])]);
 
     const filtered = filterSessionMessages(models, new Set(["tool:read"]));
 
     expect(filtered).toHaveLength(1);
-    expect(filtered[0]?.blocks).toEqual([{ type: "tool", parts: [readTool] }]);
+    expect(filtered[0]?.blocks).toMatchObject([{ type: "tool", parts: [readTool] }]);
   });
 
   it("normalizes legacy leading-dot tool labels", () => {
@@ -101,13 +103,13 @@ describe("session detail display model", () => {
       tool: ".js",
       title: "Tool: .js",
     } satisfies MessagePart;
-    const models = buildMessageDisplayModels([createMessage("assistant", "assistant", [jsTool])]);
+    const models = buildModels([createMessage("assistant", "assistant", [jsTool])]);
 
     const toc = buildSessionDetailToc(models);
     expect(toc.tools).toEqual([{ id: "tool:js", toolKey: "js", label: "js", count: 1 }]);
 
     const filtered = filterSessionMessages(models, new Set(["tools_all", "tool:js"]));
-    expect(filtered[0]?.blocks).toEqual([{ type: "tool", parts: [jsTool] }]);
+    expect(filtered[0]?.blocks).toMatchObject([{ type: "tool", parts: [jsTool] }]);
   });
 
   it("labels Codex node repl js tools as Browser", () => {
@@ -117,9 +119,7 @@ describe("session detail display model", () => {
       title: "Tool: js",
       state: { metadata: { name: "js", namespace: "mcp__node_repl__" } },
     } satisfies MessagePart;
-    const models = buildMessageDisplayModels([
-      createMessage("assistant", "assistant", [browserTool]),
-    ]);
+    const models = buildModels([createMessage("assistant", "assistant", [browserTool])]);
 
     const toc = buildSessionDetailToc(models);
     expect(toc.tools).toEqual([
@@ -127,6 +127,6 @@ describe("session detail display model", () => {
     ]);
 
     const filtered = filterSessionMessages(models, new Set(["tools_all", "tool:browser"]));
-    expect(filtered[0]?.blocks).toEqual([{ type: "tool", parts: [browserTool] }]);
+    expect(filtered[0]?.blocks).toMatchObject([{ type: "tool", parts: [browserTool] }]);
   });
 });

--- a/apps/web/src/components/session-detail/toc.ts
+++ b/apps/web/src/components/session-detail/toc.ts
@@ -143,9 +143,18 @@ function isBlockVisible(
 }
 
 function filterToolBlock(block: MessageBlock, filters: Set<string>): MessageBlock | null {
-  const parts = block.parts.filter((p) => isToolPartVisible(p, filters));
+  const visibleIndexes = block.parts
+    .map((part, index) => (isToolPartVisible(part, filters) ? index : -1))
+    .filter((index) => index >= 0);
+  const parts = visibleIndexes.map((index) => block.parts[index]!);
   if (parts.length === 0) return null;
-  return { ...block, parts };
+  return {
+    ...block,
+    parts,
+    anchorIds: block.anchorIds
+      ? visibleIndexes.map((index) => block.anchorIds![index]!)
+      : undefined,
+  };
 }
 
 export function filterSessionMessages(


### PR DESCRIPTION
## Summary
- centralize session-detail normalization, blocks, anchors, TOC, file activity, filtering, timeline, and virtual index resolution in one display model
- replace `MessagePart` identity maps with stable anchor sequences attached to tool blocks
- reduce `SessionDetail` to display-model construction, selection, interactions, and rendering
- cover the full display preparation chain with duplicate IDs and mixed content

## Validation
- `pnpm test`
- `pnpm --filter @codesesh/web build`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm test:e2e`

Issue: CS-109