### PR TITLE
fix(cli): offload database refresh scans

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -81,7 +81,11 @@ function makeWorkerRunner(): WorkerRunner {
   };
 }
 
-function makeEngine(agent: BaseAgent, sessions: SessionHead[] = []) {
+function makeEngine(
+  agent: BaseAgent,
+  sessions: SessionHead[] = [],
+  workerRunner: WorkerRunner = makeWorkerRunner(),
+) {
   const state: ScanResult = {
     agents: [agent],
     byAgent: { [agent.name]: sessions },
@@ -89,7 +93,7 @@ function makeEngine(agent: BaseAgent, sessions: SessionHead[] = []) {
   };
   const engine = new AgentSyncEngine({
     snapshot: () => state,
-    workerRunner: makeWorkerRunner(),
+    workerRunner,
   });
   engine.subscribeSessionsChanged((change) => {
     state.byAgent[change.agentName] = change.sessions;
@@ -225,24 +229,52 @@ describe("AgentSyncEngine", () => {
     expect(completed).toBe(true);
   });
 
-  it("commits a full search-index job when change detection cannot identify sessions", async () => {
-    const updated = makeSession("session", "after");
+  it("rescans imprecise changes in a worker and persists only the signature diff", async () => {
+    const steady = makeSession("steady");
+    const previous = makeSession("changed", "before");
+    const updated = makeSession("changed", "after");
+    const incrementalScan = vi.fn(() => [updated]);
+    const runWorker = vi.fn(async () => ({
+      sessions: [steady, updated],
+      meta: {
+        steady: { id: "steady", sourcePath: "/database" },
+        changed: { id: "changed", sourcePath: "/database" },
+      },
+    }));
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: runWorker,
+      shutdown: vi.fn(async () => undefined),
+    };
     const { engine } = makeEngine(
       makeAgent({
         checkForChanges: () => ({ hasChanges: true, timestamp: 2 }),
-        incrementalScan: () => [updated],
+        incrementalScan,
       }),
-      [makeSession("session", "before")],
+      [steady, previous],
+      workerRunner,
     );
 
     await engine.refresh("codex");
 
+    expect(incrementalScan).not.toHaveBeenCalled();
+    expect(runWorker).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({
+        previousSessions: [steady, previous],
+        changedIds: null,
+      }),
+    );
     expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.refresh", [
       expect.objectContaining({
-        kind: "full",
+        kind: "changes",
         agentName: "codex",
-        sessions: [expect.objectContaining({ id: "session", title: "after" })],
-        saveCache: true,
+        changes: [
+          expect.objectContaining({
+            session: expect.objectContaining({ id: "changed", title: "after" }),
+          }),
+        ],
+        removedSessionIds: [],
       }),
     ]);
   });
@@ -287,7 +319,11 @@ describe("AgentSyncEngine", () => {
   it("reuses cached session signatures across refreshes for an unchanged session", async () => {
     const session = makeSession("steady", "same-title");
     const agent = makeAgent({
-      checkForChanges: () => ({ hasChanges: true, timestamp: Date.now() }),
+      checkForChanges: () => ({
+        hasChanges: true,
+        changedIds: [session.id],
+        timestamp: Date.now(),
+      }),
       incrementalScan: () => [session],
     });
     const { engine } = makeEngine(agent, [session]);

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -93,7 +93,6 @@ interface RefreshStrategyResult {
   nextSessions: SessionHead[];
   fullScanSessions: SessionHead[] | null;
   preciseChangedIds: string[] | null;
-  usedIncrementalScan: boolean;
   persistenceDiff: Pick<SessionRefreshDiff, "changedSessions" | "removedSessionIds"> | null;
   checkDuration: number;
   scanDuration: number;
@@ -409,15 +408,15 @@ export class AgentSyncEngine {
     const diffDuration = performance.now() - diffStartedAt;
     const searchIndexOptions =
       pendingPathCount >= SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD ? { isBulk: true } : undefined;
-    const persistentChanges =
-      strategyResult.persistenceDiff?.changedSessions ?? diff.changedSessions;
+    const persistenceDiff = strategyResult.persistenceDiff;
+    const persistentChanges = persistenceDiff?.changedSessions ?? diff.changedSessions;
     const persistentRemovedSessionIds =
-      strategyResult.persistenceDiff?.removedSessionIds ?? diff.removedSessionIds;
-    const changedSessionIds = strategyResult.usedIncrementalScan
+      persistenceDiff?.removedSessionIds ?? diff.removedSessionIds;
+    const changedSessionIds = persistenceDiff
       ? new Set(persistentChanges.map(({ session }) => session.id))
       : undefined;
     const persistStartedAt = performance.now();
-    const persistentJob: SearchIndexWorkerJob = strategyResult.usedIncrementalScan
+    const persistentJob: SearchIndexWorkerJob = persistenceDiff
       ? {
           kind: "changes",
           context: "scan.refresh",
@@ -511,7 +510,6 @@ export class AgentSyncEngine {
     if (preciseChangedIds.length === 0) this.logUnchangedRefresh(agent.name, refreshStartedAt);
     return this.refreshStrategyResult(sessions, {
       preciseChangedIds,
-      usedIncrementalScan: true,
       persistenceDiff,
       scanDuration: performance.now() - scanStartedAt,
     });
@@ -533,15 +531,22 @@ export class AgentSyncEngine {
     }
     const preciseChangedIds = checkResult.changedIds ?? null;
     const scanStartedAt = performance.now();
+    if (preciseChangedIds === null) {
+      const result = await this.runWorker(agent, baseline, null, {});
+      agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
+      const sessions = attachMissingProjectIdentities(result.sessions);
+      return this.refreshStrategyResult(sessions, {
+        persistenceDiff: buildRefreshDiff(agent.name, baseline, sessions),
+        checkDuration,
+        scanDuration: performance.now() - scanStartedAt,
+      });
+    }
     const sessions = attachMissingProjectIdentities(
-      await Promise.resolve(
-        agent.incrementalScan(baseline, checkResult.changedIds ?? [], checkResult.refs),
-      ),
+      await Promise.resolve(agent.incrementalScan(baseline, preciseChangedIds, checkResult.refs)),
     );
     return this.refreshStrategyResult(sessions, {
       preciseChangedIds,
-      usedIncrementalScan: Array.isArray(checkResult.changedIds),
-      persistenceDiff: buildRefreshDiff(agent.name, baseline, sessions, preciseChangedIds ?? []),
+      persistenceDiff: buildRefreshDiff(agent.name, baseline, sessions, preciseChangedIds),
       checkDuration,
       scanDuration: performance.now() - scanStartedAt,
     });
@@ -571,7 +576,6 @@ export class AgentSyncEngine {
       nextSessions,
       fullScanSessions: null,
       preciseChangedIds: null,
-      usedIncrementalScan: false,
       persistenceDiff: null,
       checkDuration: 0,
       scanDuration: 0,

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1839,7 +1839,9 @@ describe("LiveScanStore", () => {
   it("queues a refresh requested while one is in flight and runs it after completion", async () => {
     vi.useFakeTimers();
     const existing = makeSession("existing");
-    let resolveCheck: ((result: { hasChanges: boolean; timestamp: number }) => void) | null = null;
+    let resolveCheck:
+      | ((result: { hasChanges: boolean; changedIds: string[]; timestamp: number }) => void)
+      | null = null;
     const checkForChanges = vi
       .fn()
       .mockImplementationOnce(
@@ -1874,7 +1876,7 @@ describe("LiveScanStore", () => {
     await Promise.resolve();
     expect(checkForChanges).toHaveBeenCalledTimes(1);
 
-    resolveCheck!({ hasChanges: true, timestamp: 3500 });
+    resolveCheck!({ hasChanges: true, changedIds: [existing.id], timestamp: 3500 });
     await firstRefresh;
     await secondRefresh;
     expect(checkForChanges).toHaveBeenCalledTimes(1);

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -393,7 +393,7 @@ describe("DatabaseSessionSource", () => {
     }
   }
 
-  it("flags all sessions as changed when db mtime advances past since", () => {
+  it("reports no changes when db mtime has not advanced", () => {
     const dbPath = makeDb();
     const agent = new FakeDatabaseSource(dbPath);
     const cached = [makeSession("db-1")];
@@ -401,17 +401,17 @@ describe("DatabaseSessionSource", () => {
     // since far in the future → no changes
     const fresh = agent.checkForChanges(Date.now() + 1_000_000, cached);
     expect(fresh.hasChanges).toBe(false);
-    expect(fresh.changedIds).toEqual([]);
+    expect(fresh).not.toHaveProperty("changedIds");
   });
 
-  it("reports changes when db mtime is newer than since", () => {
+  it("reports an imprecise change when db mtime is newer than since", () => {
     const dbPath = makeDb();
     const agent = new FakeDatabaseSource(dbPath);
     const cached = [makeSession("db-1"), makeSession("db-2")];
 
     const stale = agent.checkForChanges(0, cached);
     expect(stale.hasChanges).toBe(true);
-    expect(stale.changedIds).toEqual(["db-1", "db-2"]);
+    expect(stale).not.toHaveProperty("changedIds");
   });
 
   it("reports no changes when database path is missing", () => {

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -49,7 +49,7 @@ export function matchesScanWindow(activityTime: number, options?: AgentScanOptio
 export interface ChangeCheckResult {
   /** 是否有变更 */
   hasChanges: boolean;
-  /** 变更的会话 ID 列表（可选，用于精确更新） */
+  /** 可精确定位时的变更会话 ID；省略表示只能确认数据源发生过变化 */
   changedIds?: string[];
   /** 检测时间戳 */
   timestamp: number;
@@ -357,10 +357,9 @@ export abstract class DatabaseSessionSource extends BaseAgent {
   }
 
   /**
-   * 变更检测：数据库内部变更难以按行定位，简单起见按库文件 mtime 判定。
-   * 库有变更则标记全部缓存会话刷新。
+   * 变更检测：数据库内部变更难以按行定位，按库文件 mtime 判定。
    */
-  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
+  checkForChanges(sinceTimestamp: number, _cachedSessions: SessionHead[]): ChangeCheckResult {
     const dbPath = this.getDatabasePath();
     if (!dbPath || !existsSync(dbPath)) {
       return { hasChanges: false, timestamp: Date.now() };
@@ -370,7 +369,6 @@ export abstract class DatabaseSessionSource extends BaseAgent {
       const hasChanges = statSync(dbPath).mtimeMs > sinceTimestamp;
       return {
         hasChanges,
-        changedIds: hasChanges ? cachedSessions.map((session) => session.id) : [],
         timestamp: Date.now(),
       };
     } catch {


### PR DESCRIPTION
## Summary
- represent database mtime changes as imprecise changes instead of marking every cached session ID as changed
- run imprecise full rescans in the scan refresh worker rather than on the HTTP event loop
- derive change-only persistence from the computed persistence diff so only sessions with changed signatures are rewritten
- cover worker routing, differential persistence, database change detection, and queued refresh scheduling

## Root cause
`DatabaseSessionSource.checkForChanges` converted a database mtime change into the full cached ID list. `AgentSyncEngine` treated that synthetic list as a precise incremental change set, ran the database full scan on the main thread, and forced every cached session row into the persistence job.

## Impact
Database-backed agents still perform a full source scan when their database changes, but the scan runs off the server event loop and cache writes are proportional to the real session churn.

## Validation
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage` (1,088 tests)
- `pnpm test:migration`
- `pnpm test:e2e` (21 tests)
- `pnpm bench:perf -- --iterations 3`

Issue: CS-110