### PR TITLE
perf(cli): reuse refresh workers and return deltas

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -73,6 +73,31 @@ function makeAgent(overrides: Partial<BaseAgent> = {}): BaseAgent {
   } as BaseAgent;
 }
 
+class FakeSyncAgent extends FileSystemSessionSource {
+  readonly name = "codex";
+  readonly displayName = "Codex";
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  listSessionSources() {
+    return [];
+  }
+
+  scanSessionSource() {
+    return null;
+  }
+
+  getSessionData() {
+    return { messages: [] } as never;
+  }
+
+  getSessionWatchPlan() {
+    return { status: "not-needed" as const, reason: "sync test adapter" };
+  }
+}
+
 function makeWorkerRunner(): WorkerRunner {
   return {
     activeCount: 0,
@@ -357,6 +382,30 @@ describe("AgentSyncEngine", () => {
     expect(signatureCache.has("gone")).toBe(false);
   });
 
+  it("short-circuits source sync when fingerprints and signatures are unchanged", async () => {
+    const session = makeSession("steady");
+    const agent = new FakeSyncAgent();
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () => ({ sessions: [session], meta: {}, changedIds: [] })),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(agent, [session], workerRunner);
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [session],
+      meta: {},
+      timestamp: Date.now(),
+    });
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(workerRunner.run).toHaveBeenCalledOnce();
+    expect(searchIndex.enqueue).not.toHaveBeenCalled();
+    expect(sessionChanges).not.toHaveBeenCalled();
+  });
+
   it("still emits a changed event for a signature-only update reported via the DB-baseline (sync) path", async () => {
     // Regression test for a bug where the strategy-path diff (DB `cached.sessions`
     // baseline) and the event-path diff (in-memory `previousSessions` baseline)
@@ -366,26 +415,6 @@ describe("AgentSyncEngine", () => {
     // no reported changedIds (e.g. smart-tag reclassification) looked like no
     // change at all and the UI event was dropped. Only the event path may use the
     // cache now — this asserts the event still fires in that scenario.
-    class FakeSyncAgent extends FileSystemSessionSource {
-      readonly name = "codex";
-      readonly displayName = "Codex";
-      isAvailable(): boolean {
-        return true;
-      }
-      listSessionSources() {
-        return [];
-      }
-      scanSessionSource() {
-        return null;
-      }
-      getSessionData() {
-        return { messages: [] } as never;
-      }
-      getSessionWatchPlan() {
-        return { status: "not-needed" as const, reason: "sync test adapter" };
-      }
-    }
-
     const oldSession = { ...makeSession("sess1"), smart_tags_source_updated_at: 1 };
     const newSession = { ...makeSession("sess1"), smart_tags_source_updated_at: 2 };
     const agent = new FakeSyncAgent();

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -507,7 +507,16 @@ export class AgentSyncEngine {
       preciseChangedIds,
     );
     this.state(agent.name).lastRefreshAt = Date.now();
-    if (preciseChangedIds.length === 0) this.logUnchangedRefresh(agent.name, refreshStartedAt);
+    if (
+      persistenceDiff.changedSessions.length === 0 &&
+      persistenceDiff.removedSessionIds.length === 0
+    ) {
+      this.logUnchangedRefresh(agent.name, refreshStartedAt);
+      return this.refreshStrategyResult(sessions, {
+        status: "unchanged",
+        scanDuration: performance.now() - scanStartedAt,
+      });
+    }
     return this.refreshStrategyResult(sessions, {
       preciseChangedIds,
       persistenceDiff,

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -135,6 +135,45 @@ const workerThreads = vi.hoisted(() => ({
     };
     const serializeMeta = (agent: any) =>
       Object.fromEntries(agent.getSessionMetaMap?.()?.entries?.() ?? []);
+    const computeDelta = (
+      data: any,
+      sessions: SessionHead[],
+      changedIds: string[] | undefined,
+      meta: Record<string, SessionCacheMeta>,
+    ) => {
+      const previousById = new Map(
+        (data.previousSessions ?? []).map((session: SessionHead) => [session.id, session]),
+      );
+      const updatedIds = new Set(sessions.map((session) => session.id));
+      const nextMeta = Object.fromEntries(
+        Object.entries(meta).filter(([sessionId]) => updatedIds.has(sessionId)),
+      ) as Record<string, SessionCacheMeta>;
+      const changedMeta = Object.fromEntries(
+        Object.entries(nextMeta).filter(
+          ([sessionId, value]) => JSON.stringify(data.meta?.[sessionId]) !== JSON.stringify(value),
+        ),
+      );
+      const removedMetaIds = Object.keys(data.meta ?? {}).filter(
+        (sessionId) => !Object.hasOwn(nextMeta, sessionId),
+      );
+      const changedIdSet = new Set([
+        ...(changedIds ?? []),
+        ...Object.keys(changedMeta),
+        ...removedMetaIds,
+      ]);
+      const changes = sessions.flatMap((session, sortIndex) => {
+        const previous = previousById.get(session.id);
+        return !previous ||
+          changedIdSet.has(session.id) ||
+          JSON.stringify(previous) !== JSON.stringify(session)
+          ? [{ session, sortIndex }]
+          : [];
+      });
+      const removedSessionIds = (data.previousSessions ?? [])
+        .filter((session: SessionHead) => !updatedIds.has(session.id))
+        .map((session: SessionHead) => session.id);
+      return { changes, removedSessionIds, meta: changedMeta, removedMetaIds };
+    };
     const dispatch = (data: any) => {
       queueMicrotask(() => {
         for (const handler of messageHandlers) {
@@ -160,12 +199,11 @@ const workerThreads = vi.hoisted(() => ({
                   });
                 }
               }
+              const delta = computeDelta(data, sessions, changedIds, serializeMeta(agent));
               handler({
                 type: "done",
                 requestId: data.requestId,
-                sessions,
-                meta: serializeMeta(agent),
-                changedIds,
+                ...delta,
                 durationMs: 0,
               });
               continue;
@@ -1002,6 +1040,49 @@ describe("LiveScanStore", () => {
       meta: {},
       changedIds: undefined,
     });
+  });
+
+  it("reconstructs an ordered snapshot from a scan worker delta", async () => {
+    const removed = makeSession("removed");
+    const retained = makeSession("retained");
+    const added = makeSession("added", { time_updated: 2000 });
+    let meta = new Map<string, SessionCacheMeta>();
+    const agent = makeAgent("codex", {
+      scan: vi.fn(() => {
+        meta = new Map([
+          ["added", { id: "added", sourcePath: "/added" }],
+          ["retained", { id: "retained", sourcePath: "/retained" }],
+        ]);
+        return [added, retained];
+      }),
+      getSessionMetaMap: vi.fn(() => meta),
+      setSessionMetaMap: vi.fn((next: Map<string, SessionCacheMeta>) => {
+        meta = new Map(next);
+      }),
+    });
+    core.createRegisteredAgents.mockReturnValue([agent]);
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+
+    const result = await runner.run("codex", {
+      previousSessions: [removed, retained],
+      changedIds: null,
+      scanOptions: {},
+      meta: {
+        removed: { id: "removed", sourcePath: "/removed" },
+        retained: { id: "retained", sourcePath: "/retained" },
+      },
+    });
+
+    expect(result).toEqual({
+      sessions: [added, retained],
+      meta: {
+        added: { id: "added", sourcePath: "/added" },
+        retained: { id: "retained", sourcePath: "/retained" },
+      },
+      changedIds: undefined,
+    });
+    expect(runner.activeCount).toBe(0);
+    await runner.shutdown();
   });
 
   it("persists incremental changes outside the startup time window", async () => {

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -65,6 +65,7 @@ const workerThreads = vi.hoisted(() => ({
     workerData: any;
     on: ReturnType<typeof vi.fn>;
     once: ReturnType<typeof vi.fn>;
+    postMessage: ReturnType<typeof vi.fn>;
     unref: ReturnType<typeof vi.fn>;
     terminate: ReturnType<typeof vi.fn>;
     emitDone: () => void;
@@ -72,13 +73,16 @@ const workerThreads = vi.hoisted(() => ({
     emitExit: (code: number) => void;
   }>,
   Worker: vi.fn(function (this: unknown, url: URL, options?: { workerData?: unknown }) {
-    const workerData = options?.workerData as any;
-    const deferredSearchWorker = workerThreads.deferSearchIndexWorkers && workerData?.jobs;
-    const deferredScanWorker = workerThreads.deferScanRefreshWorkers && workerData?.agentName;
-    const deferredMessageHandlers: Array<(message: unknown) => void> = [];
-    const deferredExitHandlers: Array<(code: number) => void> = [];
-    const deferredErrorHandlers: Array<(error: Error) => void> = [];
-    const runSourceSync = (agent: any) => {
+    const workerData = (options?.workerData ?? {}) as any;
+    const isSearchWorker = Boolean(workerData.jobs);
+    const isScanWorker = Boolean(workerData.agentName);
+    const deferMessages =
+      (isSearchWorker && workerThreads.deferSearchIndexWorkers) ||
+      (isScanWorker && workerThreads.deferScanRefreshWorkers);
+    const messageHandlers: Array<(message: unknown) => void> = [];
+    const exitHandlers: Array<(code: number) => void> = [];
+    const errorHandlers: Array<(error: Error) => void> = [];
+    const runSourceSync = (data: any, agent: any) => {
       const parseSourceFingerprint = (fingerprint: string) => {
         try {
           const parsed = JSON.parse(fingerprint);
@@ -98,7 +102,7 @@ const workerThreads = vi.hoisted(() => ({
         );
       };
       const sessionMap = new Map(
-        (workerData.previousSessions ?? []).map((session: SessionHead) => [session.id, session]),
+        (data.previousSessions ?? []).map((session: SessionHead) => [session.id, session]),
       );
       const changedIds = new Set<string>();
       const sources = agent.listSessionSources();
@@ -106,7 +110,7 @@ const workerThreads = vi.hoisted(() => ({
 
       for (const source of sources) {
         const cachedSession = sessionMap.get(source.sessionId);
-        const cached = workerData.meta?.[source.sessionId];
+        const cached = data.meta?.[source.sessionId];
         if (
           cachedSession &&
           cached?.sourcePath === source.sourcePath &&
@@ -120,7 +124,7 @@ const workerThreads = vi.hoisted(() => ({
         else sessionMap.delete(source.sessionId);
       }
 
-      for (const session of workerData.previousSessions ?? []) {
+      for (const session of data.previousSessions ?? []) {
         if (!currentIds.has(session.id)) {
           sessionMap.delete(session.id);
           changedIds.add(session.id);
@@ -131,93 +135,96 @@ const workerThreads = vi.hoisted(() => ({
     };
     const serializeMeta = (agent: any) =>
       Object.fromEntries(agent.getSessionMetaMap?.()?.entries?.() ?? []);
+    const dispatch = (data: any) => {
+      queueMicrotask(() => {
+        for (const handler of messageHandlers) {
+          try {
+            if (data?.agentName) {
+              const agent = core
+                .createRegisteredAgents()
+                .find((item: any) => item.name === data.agentName);
+              agent?.setSessionMetaMap?.(new Map(Object.entries(data.meta ?? {})));
+              let sessions: SessionHead[] = [];
+              let changedIds: string[] | undefined;
+              if (agent?.isAvailable?.() !== false) {
+                if (data.sourceSync && agent?.listSessionSources && agent?.scanSessionSource) {
+                  const result = runSourceSync(data, agent);
+                  sessions = result.sessions as SessionHead[];
+                  changedIds = result.changedIds;
+                } else if (data.changedIds && agent?.incrementalScan) {
+                  sessions = agent.incrementalScan(data.previousSessions, data.changedIds);
+                } else {
+                  sessions = agent?.scan?.({
+                    ...data.scanOptions,
+                    onProgress: () => undefined,
+                  });
+                }
+              }
+              handler({
+                type: "done",
+                requestId: data.requestId,
+                sessions,
+                meta: serializeMeta(agent),
+                changedIds,
+                durationMs: 0,
+              });
+              continue;
+            }
+          } catch (error) {
+            handler({
+              type: "error",
+              requestId: data.requestId,
+              error: error instanceof Error ? error.message : String(error),
+              durationMs: 0,
+            });
+            continue;
+          }
+          const jobs = data?.jobs ?? [];
+          handler({
+            type: "done",
+            context: data?.context ?? "",
+            durationMs: 0,
+            sessions: jobs.length,
+          });
+        }
+      });
+    };
     const worker = {
       url,
       workerData,
       on: vi.fn((event: string, handler: (message: unknown) => void) => {
         if (event === "message") {
-          if (deferredSearchWorker || deferredScanWorker) {
-            deferredMessageHandlers.push(handler);
-            return worker;
-          }
-          queueMicrotask(() => {
-            try {
-              if (workerData?.agentName) {
-                const agent = core
-                  .createRegisteredAgents()
-                  .find((item: any) => item.name === workerData.agentName);
-                agent?.setSessionMetaMap?.(new Map(Object.entries(workerData.meta ?? {})));
-                let sessions: SessionHead[] = [];
-                let changedIds: string[] | undefined;
-                if (agent?.isAvailable?.() !== false) {
-                  if (
-                    workerData.sourceSync &&
-                    agent?.listSessionSources &&
-                    agent?.scanSessionSource
-                  ) {
-                    const result = runSourceSync(agent);
-                    sessions = result.sessions as SessionHead[];
-                    changedIds = result.changedIds;
-                  } else if (workerData.changedIds && agent?.incrementalScan) {
-                    sessions = agent.incrementalScan(
-                      workerData.previousSessions,
-                      workerData.changedIds,
-                    );
-                  } else {
-                    sessions = agent?.scan?.({
-                      ...workerData.scanOptions,
-                      onProgress: () => undefined,
-                    });
-                  }
-                }
-                handler({
-                  type: "done",
-                  sessions,
-                  meta: serializeMeta(agent),
-                  changedIds,
-                  durationMs: 0,
-                });
-                return;
-              }
-            } catch (error) {
-              handler({
-                type: "error",
-                error: error instanceof Error ? error.message : String(error),
-                durationMs: 0,
-              });
-              return;
-            }
-            const jobs = workerData?.jobs ?? [];
-            handler({
-              type: "done",
-              context: workerData?.context ?? "",
-              durationMs: 0,
-              sessions: jobs.length,
-            });
-          });
+          messageHandlers.push(handler);
+          if (!deferMessages) dispatch(workerData);
         }
         if (event === "exit") {
-          if (deferredSearchWorker || deferredScanWorker) deferredExitHandlers.push(handler);
-          else queueMicrotask(() => handler(0));
+          exitHandlers.push(handler);
+          if (isSearchWorker && !workerThreads.deferSearchIndexWorkers) {
+            queueMicrotask(() => handler(0));
+          }
         }
-        if (event === "error" && (deferredSearchWorker || deferredScanWorker)) {
-          deferredErrorHandlers.push(handler);
-        }
+        if (event === "error") errorHandlers.push(handler as (error: Error) => void);
         return worker;
       }),
       once: vi.fn((event: string, handler: (message: unknown) => void) => {
         if (event === "exit") {
-          if (deferredSearchWorker || deferredScanWorker) deferredExitHandlers.push(handler);
-          else queueMicrotask(() => handler(0));
+          exitHandlers.push(handler);
+          if (isSearchWorker && !workerThreads.deferSearchIndexWorkers) {
+            queueMicrotask(() => handler(0));
+          }
         }
         return worker;
       }),
+      postMessage: vi.fn((data: unknown) => {
+        Object.assign(workerData, data);
+        if (!workerThreads.deferScanRefreshWorkers) dispatch(workerData);
+      }),
       unref: vi.fn(),
       terminate: vi.fn(async () => {
-        for (const handler of deferredExitHandlers) handler(0);
+        for (const handler of exitHandlers) handler(0);
       }),
       emitDone: () => {
-        for (const handler of deferredMessageHandlers) {
+        for (const handler of messageHandlers) {
           handler({
             type: "done",
             context: workerData?.context ?? "",
@@ -225,13 +232,13 @@ const workerThreads = vi.hoisted(() => ({
             sessions: workerData?.jobs?.length ?? 0,
           });
         }
-        for (const handler of deferredExitHandlers) handler(0);
+        for (const handler of exitHandlers) handler(0);
       },
       emitError: (error: Error) => {
-        for (const handler of deferredErrorHandlers) handler(error);
+        for (const handler of errorHandlers) handler(error);
       },
       emitExit: (code: number) => {
-        for (const handler of deferredExitHandlers) handler(code);
+        for (const handler of exitHandlers) handler(code);
       },
     };
     workerThreads.workers.push(worker);
@@ -758,7 +765,11 @@ describe("LiveScanStore", () => {
         saveCache: true,
       }),
     ]);
-    expect(workerThreads.workers).toHaveLength(4);
+    const scanWorkers = workerThreads.workers.filter(
+      (worker) => worker.workerData.agentName === "codex",
+    );
+    expect(scanWorkers).toHaveLength(1);
+    expect(scanWorkers[0]?.postMessage).toHaveBeenCalledTimes(1);
   });
 
   it("serializes refresh behind an in-flight backfill for the same agent", async () => {

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1214,16 +1214,12 @@ describe("LiveScanStore", () => {
 
     const store = new LiveScanStore({ watchEnabled: false });
     await store.initialize();
+    const workerCountBeforeRefresh = workerThreads.workers.length;
     await syncEngineOf(store).refresh("codex");
 
     expect(scanSessionSource).not.toHaveBeenCalled();
-    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
-      expect.objectContaining({
-        kind: "changes",
-        changes: [],
-        removedSessionIds: [],
-      }),
-    ]);
+    expect(workerThreads.workers).toHaveLength(workerCountBeforeRefresh + 1);
+    expect(workerThreads.workers.at(-1)?.workerData.agentName).toBe("codex");
   });
 
   it("emits refresh events and persists changed agent sessions", async () => {

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -1,4 +1,4 @@
-import type { BaseAgent, SessionHead, SessionSourceRef } from "@codesesh/core";
+import type { BaseAgent, SessionCacheMeta, SessionHead, SessionSourceRef } from "@codesesh/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -28,6 +28,9 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     createRegisteredAgents: mocks.createRegisteredAgents,
     ensureSessionTagsSync: mocks.ensureSessionTagsSync,
     FileSystemSessionSource: mocks.FileSystemSessionSource,
+    buildAgentCacheMeta: actual.buildAgentCacheMeta,
+    computeSessionDiff: actual.computeSessionDiff,
+    sessionSignature: actual.sessionSignature,
     // The change decision is shared with FileSystemSessionSource.checkForChanges;
     // stubbing it would stop this suite from covering the wiring it exists to test.
     diffSessionSources: actual.diffSessionSources,
@@ -55,6 +58,7 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
 }
 
 function makeAgent(overrides: Record<string, unknown> = {}) {
+  let sessionMetaMap = new Map<string, SessionCacheMeta>();
   return Object.assign(new mocks.FileSystemSessionSource(), {
     name: "codex",
     isAvailable: vi.fn(() => true),
@@ -63,8 +67,10 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
     listSessionSources: vi.fn(() => []),
     scanSessionSource: vi.fn(() => null),
     getSessionData: vi.fn(),
-    getSessionMetaMap: vi.fn(() => new Map()),
-    setSessionMetaMap: vi.fn(),
+    getSessionMetaMap: vi.fn(() => sessionMetaMap),
+    setSessionMetaMap: vi.fn((next: Map<string, SessionCacheMeta>) => {
+      sessionMetaMap = new Map(next);
+    }),
     ...overrides,
   });
 }
@@ -113,7 +119,13 @@ describe("scan refresh worker entry", () => {
 
     expect(agent.setSessionMetaMap).toHaveBeenCalledWith(new Map());
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
-      expect.objectContaining({ type: "done", sessions: [], meta: {} }),
+      expect.objectContaining({
+        type: "done",
+        changes: [],
+        removedSessionIds: [],
+        meta: {},
+        removedMetaIds: [],
+      }),
     );
   });
 
@@ -141,8 +153,58 @@ describe("scan refresh worker entry", () => {
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: "done",
-        sessions: [session],
+        changes: [{ session, sortIndex: 0 }],
+        removedSessionIds: [],
         meta: { fresh: { id: "fresh", sourcePath: "/fresh" } },
+        removedMetaIds: [],
+      }),
+    );
+  });
+
+  it("returns a head when only its metadata changes", async () => {
+    const session = makeSession("same");
+    let meta = new Map<string, SessionCacheMeta>();
+    const agent = makeAgent({
+      scan: vi.fn(() => {
+        meta.set("same", {
+          id: "same",
+          sourcePath: "/same",
+          sourceFingerprint: "new",
+        });
+        return [session];
+      }),
+      getSessionMetaMap: vi.fn(() => meta),
+      setSessionMetaMap: vi.fn((next: Map<string, SessionCacheMeta>) => {
+        meta = new Map(next);
+      }),
+    });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    setWorkerData({
+      previousSessions: [session],
+      meta: {
+        same: {
+          id: "same",
+          sourcePath: "/same",
+          sourceFingerprint: "old",
+        },
+      },
+    });
+
+    await runWorker();
+
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "done",
+        changes: [{ session, sortIndex: 0 }],
+        removedSessionIds: [],
+        meta: {
+          same: {
+            id: "same",
+            sourcePath: "/same",
+            sourceFingerprint: "new",
+          },
+        },
+        removedMetaIds: [],
       }),
     );
   });
@@ -159,7 +221,48 @@ describe("scan refresh worker entry", () => {
 
     expect(incrementalScan).toHaveBeenCalledWith([previous], ["previous"]);
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
-      expect.objectContaining({ type: "done", sessions: [updated] }),
+      expect.objectContaining({
+        type: "done",
+        changes: [{ session: updated, sortIndex: 0 }],
+        removedSessionIds: ["previous"],
+        removedMetaIds: [],
+      }),
+    );
+  });
+
+  it("returns an empty delta when source heads and metadata are unchanged", async () => {
+    const session = makeSession("unchanged");
+    const scanSessionSource = vi.fn();
+    const agent = makeAgent({
+      listSessionSources: vi.fn(() => [
+        { sessionId: "unchanged", sourcePath: "/unchanged", fingerprint: "same" },
+      ]),
+      scanSessionSource,
+    });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    setWorkerData({
+      sourceSync: true,
+      previousSessions: [session],
+      meta: {
+        unchanged: {
+          id: "unchanged",
+          sourcePath: "/unchanged",
+          sourceFingerprint: "same",
+        },
+      },
+    });
+
+    await runWorker();
+
+    expect(scanSessionSource).not.toHaveBeenCalled();
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "done",
+        changes: [],
+        removedSessionIds: [],
+        meta: {},
+        removedMetaIds: [],
+      }),
     );
   });
 
@@ -225,8 +328,9 @@ describe("scan refresh worker entry", () => {
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: "done",
-        sessions: [unchanged, updated, outsideWindow],
-        changedIds: ["changed", "moved", "missing", "removed"],
+        changes: [{ session: updated, sortIndex: 1 }],
+        removedSessionIds: ["removed", "moved"],
+        removedMetaIds: ["removed", "moved"],
       }),
     );
   });
@@ -261,7 +365,12 @@ describe("scan refresh worker entry", () => {
 
     expect(scanSessionSource).toHaveBeenCalledWith("/legacy");
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
-      expect.objectContaining({ type: "done", sessions: [reparsed], changedIds: ["legacy"] }),
+      expect.objectContaining({
+        type: "done",
+        changes: [{ session: reparsed, sortIndex: 0 }],
+        removedSessionIds: [],
+        removedMetaIds: [],
+      }),
     );
   });
 });

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock("node:worker_threads", () => ({
-  parentPort: { postMessage: mocks.postMessage },
+  parentPort: { postMessage: mocks.postMessage, on: vi.fn() },
   get workerData() {
     return mocks.workerData;
   },
@@ -71,6 +71,8 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
 
 function setWorkerData(overrides: Record<string, unknown> = {}) {
   mocks.workerData = {
+    type: "run",
+    requestId: 1,
     agentName: "codex",
     previousSessions: [],
     changedIds: null,
@@ -133,6 +135,7 @@ describe("scan refresh worker entry", () => {
 
     expect(mocks.postMessage).toHaveBeenNthCalledWith(1, {
       type: "progress",
+      requestId: 1,
       progress: { agent: "codex", current: 1 },
     });
     expect(mocks.postMessage).toHaveBeenLastCalledWith(

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -1,16 +1,21 @@
 import "./diagnostics-bridge.js";
 import { parentPort, workerData } from "node:worker_threads";
+import { isDeepStrictEqual } from "node:util";
 import {
   attachMissingProjectIdentities,
+  buildAgentCacheMeta,
+  computeSessionDiff,
   createRegisteredAgents,
   diffSessionSources,
   ensureSessionTagsSync,
   FileSystemSessionSource,
+  sessionSignature,
   type AgentScanProgress,
   type BaseAgent,
   type ScanOptions,
   type SessionCacheMeta,
   type SessionHead,
+  type SessionHeadChange,
 } from "@codesesh/core";
 
 export type ScanRefreshWorkerMessage =
@@ -22,9 +27,10 @@ export type ScanRefreshWorkerMessage =
   | {
       type: "done";
       requestId: number;
-      sessions: SessionHead[];
+      changes: SessionHeadChange[];
+      removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
-      changedIds?: string[];
+      removedMetaIds: string[];
       durationMs: number;
     }
   | {
@@ -45,15 +51,24 @@ export interface ScanRefreshWorkerRequest {
   meta: Record<string, SessionCacheMeta>;
 }
 
-function serializeMeta(agent: {
-  getSessionMetaMap: () => Map<string, SessionCacheMeta>;
-}): Record<string, SessionCacheMeta> {
-  const metaMap = agent.getSessionMetaMap();
-  const meta: Record<string, SessionCacheMeta> = {};
-  for (const [id, data] of metaMap.entries()) {
-    meta[id] = { id, ...(data as Record<string, unknown>) } as SessionCacheMeta;
+interface CacheMetaDiff {
+  changes: Record<string, SessionCacheMeta>;
+  removedIds: string[];
+}
+
+function computeCacheMetaDiff(
+  previous: Record<string, SessionCacheMeta>,
+  next: Record<string, SessionCacheMeta>,
+): CacheMetaDiff {
+  const changes: Record<string, SessionCacheMeta> = {};
+  const removedIds: string[] = [];
+  for (const [id, meta] of Object.entries(next)) {
+    if (!isDeepStrictEqual(previous[id], meta)) changes[id] = meta;
   }
-  return meta;
+  for (const id of Object.keys(previous)) {
+    if (!Object.hasOwn(next, id)) removedIds.push(id);
+  }
+  return { changes, removedIds };
 }
 
 /**
@@ -162,13 +177,22 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
   }
 
   sessions = finalizeSessions(agent, sessions);
+  const nextMeta = buildAgentCacheMeta(agent, new Set(sessions.map((session) => session.id)));
+  const metaDiff = computeCacheMetaDiff(data.meta, nextMeta);
+  const diff = computeSessionDiff(
+    data.previousSessions,
+    sessions,
+    [...(changedIds ?? []), ...Object.keys(metaDiff.changes), ...metaDiff.removedIds],
+    sessionSignature,
+  );
 
   parentPort?.postMessage({
     type: "done",
     requestId: data.requestId,
-    sessions,
-    meta: serializeMeta(agent),
-    changedIds,
+    changes: diff.changes,
+    removedSessionIds: diff.removedSessionIds,
+    meta: metaDiff.changes,
+    removedMetaIds: metaDiff.removedIds,
     durationMs: performance.now() - startedAt,
   } satisfies ScanRefreshWorkerMessage);
 }

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -16,10 +16,12 @@ import {
 export type ScanRefreshWorkerMessage =
   | {
       type: "progress";
+      requestId: number;
       progress: AgentScanProgress;
     }
   | {
       type: "done";
+      requestId: number;
       sessions: SessionHead[];
       meta: Record<string, SessionCacheMeta>;
       changedIds?: string[];
@@ -27,11 +29,14 @@ export type ScanRefreshWorkerMessage =
     }
   | {
       type: "error";
+      requestId: number;
       error: string;
       durationMs: number;
     };
 
-interface ScanRefreshWorkerData {
+export interface ScanRefreshWorkerRequest {
+  type: "run";
+  requestId: number;
   agentName: string;
   previousSessions: SessionHead[];
   changedIds: string[] | null;
@@ -120,10 +125,8 @@ export function finalizeSessions(agent: BaseAgent, sessions: SessionHead[]): Ses
   return withIdentity.map((session) => taggedById.get(session.id) ?? session);
 }
 
-const data = workerData as ScanRefreshWorkerData;
-const startedAt = performance.now();
-
-async function run(): Promise<void> {
+async function run(data: ScanRefreshWorkerRequest): Promise<void> {
+  const startedAt = performance.now();
   const agent = createRegisteredAgents().find((item) => item.name === data.agentName);
   if (!agent) {
     throw new Error(`Unknown agent: ${data.agentName}`);
@@ -150,6 +153,7 @@ async function run(): Promise<void> {
         onProgress: (progress) => {
           parentPort?.postMessage({
             type: "progress",
+            requestId: data.requestId,
             progress,
           } satisfies ScanRefreshWorkerMessage);
         },
@@ -161,6 +165,7 @@ async function run(): Promise<void> {
 
   parentPort?.postMessage({
     type: "done",
+    requestId: data.requestId,
     sessions,
     meta: serializeMeta(agent),
     changedIds,
@@ -168,12 +173,36 @@ async function run(): Promise<void> {
   } satisfies ScanRefreshWorkerMessage);
 }
 
-try {
-  await run();
-} catch (error) {
-  parentPort?.postMessage({
-    type: "error",
-    error: error instanceof Error ? error.message : String(error),
-    durationMs: performance.now() - startedAt,
-  } satisfies ScanRefreshWorkerMessage);
+async function handleRequest(data: ScanRefreshWorkerRequest): Promise<void> {
+  const startedAt = performance.now();
+  try {
+    await run(data);
+  } catch (error) {
+    parentPort?.postMessage({
+      type: "error",
+      requestId: data.requestId,
+      error: error instanceof Error ? error.message : String(error),
+      durationMs: performance.now() - startedAt,
+    } satisfies ScanRefreshWorkerMessage);
+  }
 }
+
+let requestTail = Promise.resolve();
+
+function enqueueRequest(data: ScanRefreshWorkerRequest): void {
+  requestTail = requestTail.then(() => handleRequest(data));
+}
+
+const initialRequest = workerData as Partial<ScanRefreshWorkerRequest> | undefined;
+if (
+  initialRequest?.type === "run" &&
+  typeof initialRequest.requestId === "number" &&
+  typeof initialRequest.agentName === "string" &&
+  Array.isArray(initialRequest.previousSessions)
+) {
+  enqueueRequest(initialRequest as ScanRefreshWorkerRequest);
+}
+
+parentPort?.on("message", (message: ScanRefreshWorkerRequest) => {
+  if (message.type === "run") enqueueRequest(message);
+});

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -1,7 +1,7 @@
 import { Worker } from "node:worker_threads";
 import type { AgentScanProgress, ScanOptions, SessionCacheMeta, SessionHead } from "@codesesh/core";
 import { appLogger } from "./logging.js";
-import type { ScanRefreshWorkerMessage } from "./scan-refresh-worker.js";
+import type { ScanRefreshWorkerMessage, ScanRefreshWorkerRequest } from "./scan-refresh-worker.js";
 
 export interface WorkerPayload {
   previousSessions: SessionHead[];
@@ -24,73 +24,136 @@ export interface WorkerRunner {
   shutdown(): Promise<void>;
 }
 
+interface PendingRequest {
+  resolve: (result: WorkerResult) => void;
+  reject: (error: Error) => void;
+  onProgress?: (progress: AgentScanProgress) => void;
+}
+
+interface WorkerSlot {
+  worker: Worker;
+  pending: Map<number, PendingRequest>;
+  closed: boolean;
+}
+
+const SHUTDOWN_ERROR_MESSAGE = "Scan refresh worker shut down";
+
 export class ThreadWorkerRunner implements WorkerRunner {
-  private workers = new Set<Worker>();
+  private workers = new Map<string, WorkerSlot>();
+  private nextRequestId = 1;
+  private isShuttingDown = false;
 
   constructor(private readonly workerUrl: URL) {}
 
   get activeCount(): number {
-    return this.workers.size;
+    let count = 0;
+    for (const slot of this.workers.values()) count += slot.pending.size;
+    return count;
   }
 
   run(agentName: string, payload: WorkerPayload): Promise<WorkerResult> {
+    if (this.isShuttingDown) return Promise.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
+
+    const request: ScanRefreshWorkerRequest = {
+      type: "run",
+      requestId: this.nextRequestId++,
+      agentName,
+      previousSessions: payload.previousSessions,
+      changedIds: payload.changedIds,
+      sourceSync: payload.sourceSync,
+      scanOptions: payload.scanOptions,
+      meta: payload.meta,
+    };
+
     return new Promise((resolve, reject) => {
-      const worker = new Worker(this.workerUrl, {
-        workerData: {
-          agentName,
-          previousSessions: payload.previousSessions,
-          changedIds: payload.changedIds,
-          sourceSync: payload.sourceSync,
-          scanOptions: payload.scanOptions,
-          meta: payload.meta,
-        },
-      });
-      worker.unref();
-      this.workers.add(worker);
-
-      let settled = false;
-      const finish = (callback: () => void, terminate = true) => {
-        if (settled) return;
-        settled = true;
-        this.workers.delete(worker);
-        if (terminate) void worker.terminate();
-        callback();
-      };
-
-      worker.on("message", (message: ScanRefreshWorkerMessage) => {
-        if (message.type === "progress") {
-          payload.onProgress?.(message.progress);
+      let slot = this.workers.get(agentName);
+      const isNewWorker = !slot;
+      if (!slot) {
+        try {
+          slot = this.createWorker(agentName, request);
+        } catch (error) {
+          reject(error instanceof Error ? error : new Error(String(error)));
           return;
         }
-        if (message.type === "done") {
-          finish(() =>
-            resolve({
-              sessions: message.sessions,
-              meta: message.meta,
-              changedIds: message.changedIds,
-            }),
-          );
-          return;
+      }
+
+      slot.pending.set(request.requestId, {
+        resolve,
+        reject,
+        onProgress: payload.onProgress,
+      });
+
+      if (!isNewWorker) {
+        try {
+          slot.worker.postMessage(request);
+        } catch (error) {
+          slot.pending.delete(request.requestId);
+          reject(error instanceof Error ? error : new Error(String(error)));
         }
-        finish(() => reject(new Error(message.error)));
-      });
-      worker.once("error", (error) => {
-        finish(() => reject(error));
-      });
-      worker.once("exit", (code) => {
-        if (settled) return;
-        appLogger.warn("scan.refresh_worker.exit_before_done", { agent: agentName, code });
-        finish(
-          () => reject(new Error(`Scan refresh worker exited before completing (code ${code})`)),
-          false,
-        );
-      });
+      }
     });
   }
 
   async shutdown(): Promise<void> {
-    const workers = [...this.workers];
-    await Promise.allSettled(workers.map((worker) => worker.terminate()));
+    this.isShuttingDown = true;
+    const slots = [...this.workers.values()];
     this.workers.clear();
+    const shutdownError = new Error(SHUTDOWN_ERROR_MESSAGE);
+    for (const slot of slots) {
+      slot.closed = true;
+      for (const pending of slot.pending.values()) pending.reject(shutdownError);
+      slot.pending.clear();
+    }
+    await Promise.allSettled(slots.map((slot) => slot.worker.terminate()));
+  }
+
+  private createWorker(agentName: string, request: ScanRefreshWorkerRequest): WorkerSlot {
+    const worker = new Worker(this.workerUrl, { workerData: request });
+    const slot: WorkerSlot = { worker, pending: new Map(), closed: false };
+    worker.unref();
+    this.workers.set(agentName, slot);
+    worker.on("message", (message: ScanRefreshWorkerMessage) => {
+      this.handleMessage(slot, message);
+    });
+    worker.on("error", (error) => {
+      this.closeWorker(agentName, slot, error);
+    });
+    worker.on("exit", (code) => {
+      if (slot.closed) return;
+      const error = new Error(`Scan refresh worker exited before completing (code ${code})`);
+      if (slot.pending.size > 0) {
+        appLogger.warn("scan.refresh_worker.exit_before_done", { agent: agentName, code });
+      }
+      this.closeWorker(agentName, slot, error);
+    });
+    return slot;
+  }
+
+  private handleMessage(slot: WorkerSlot, message: ScanRefreshWorkerMessage): void {
+    const pending = slot.pending.get(message.requestId);
+    if (!pending) return;
+    if (message.type === "progress") {
+      pending.onProgress?.(message.progress);
+      return;
+    }
+
+    slot.pending.delete(message.requestId);
+    if (message.type === "error") {
+      pending.reject(new Error(message.error));
+      return;
+    }
+    pending.resolve({
+      sessions: message.sessions,
+      meta: message.meta,
+      changedIds: message.changedIds,
+    });
+  }
+
+  private closeWorker(agentName: string, slot: WorkerSlot, error: Error): void {
+    if (slot.closed) return;
+    slot.closed = true;
+    if (this.workers.get(agentName) === slot) this.workers.delete(agentName);
+    for (const pending of slot.pending.values()) pending.reject(error);
+    slot.pending.clear();
   }
 }

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -1,5 +1,11 @@
 import { Worker } from "node:worker_threads";
-import type { AgentScanProgress, ScanOptions, SessionCacheMeta, SessionHead } from "@codesesh/core";
+import type {
+  AgentScanProgress,
+  ScanOptions,
+  SessionCacheMeta,
+  SessionHead,
+  SessionHeadChange,
+} from "@codesesh/core";
 import { appLogger } from "./logging.js";
 import type { ScanRefreshWorkerMessage, ScanRefreshWorkerRequest } from "./scan-refresh-worker.js";
 
@@ -27,6 +33,7 @@ export interface WorkerRunner {
 interface PendingRequest {
   resolve: (result: WorkerResult) => void;
   reject: (error: Error) => void;
+  payload: WorkerPayload;
   onProgress?: (progress: AgentScanProgress) => void;
 }
 
@@ -37,6 +44,45 @@ interface WorkerSlot {
 }
 
 const SHUTDOWN_ERROR_MESSAGE = "Scan refresh worker shut down";
+
+function applySessionChanges(
+  previousSessions: SessionHead[],
+  changes: SessionHeadChange[],
+  removedSessionIds: string[],
+): SessionHead[] {
+  const replacedIds = new Set(removedSessionIds);
+  for (const { session } of changes) replacedIds.add(session.id);
+  const retained = previousSessions.filter((session) => !replacedIds.has(session.id));
+  const next: Array<SessionHead | undefined> = Array.from({
+    length: retained.length + changes.length,
+  });
+
+  for (const { session, sortIndex } of changes) {
+    if (sortIndex < 0 || sortIndex >= next.length || next[sortIndex]) {
+      throw new Error(`Invalid scan refresh sort index: ${sortIndex}`);
+    }
+    next[sortIndex] = session;
+  }
+
+  let retainedIndex = 0;
+  for (let index = 0; index < next.length; index += 1) {
+    if (!next[index]) next[index] = retained[retainedIndex++];
+  }
+  if (retainedIndex !== retained.length || next.some((session) => !session)) {
+    throw new Error("Invalid scan refresh delta");
+  }
+  return next as SessionHead[];
+}
+
+function applyMetaChanges(
+  previous: Record<string, SessionCacheMeta>,
+  changed: Record<string, SessionCacheMeta>,
+  replacedSessionIds: Iterable<string>,
+): Record<string, SessionCacheMeta> {
+  const next = { ...previous };
+  for (const id of replacedSessionIds) delete next[id];
+  return Object.assign(next, changed);
+}
 
 export class ThreadWorkerRunner implements WorkerRunner {
   private workers = new Map<string, WorkerSlot>();
@@ -80,6 +126,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       slot.pending.set(request.requestId, {
         resolve,
         reject,
+        payload,
         onProgress: payload.onProgress,
       });
 
@@ -142,11 +189,22 @@ export class ThreadWorkerRunner implements WorkerRunner {
       pending.reject(new Error(message.error));
       return;
     }
-    pending.resolve({
-      sessions: message.sessions,
-      meta: message.meta,
-      changedIds: message.changedIds,
-    });
+    const changedIds = message.changes.map(({ session }) => session.id);
+    const replacedSessionIds = [...changedIds, ...message.removedSessionIds];
+    const removedMetaIds = [...message.removedSessionIds, ...message.removedMetaIds];
+    try {
+      pending.resolve({
+        sessions: applySessionChanges(
+          pending.payload.previousSessions,
+          message.changes,
+          message.removedSessionIds,
+        ),
+        meta: applyMetaChanges(pending.payload.meta, message.meta, removedMetaIds),
+        changedIds: pending.payload.sourceSync ? replacedSessionIds : undefined,
+      });
+    } catch (error) {
+      pending.reject(error instanceof Error ? error : new Error(String(error)));
+    }
   }
 
   private closeWorker(agentName: string, slot: WorkerSlot, error: Error): void {


### PR DESCRIPTION
## Summary

- short-circuit unchanged source refreshes before publication and search indexing
- reuse one long-lived scan worker per agent and terminate it explicitly on shutdown
- return session and metadata deltas across the worker boundary while preserving the existing full-snapshot runner contract

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage` (1,092 tests)
- `pnpm test:migration`
- `pnpm test:e2e` (21 tests)
- `pnpm bench:perf -- --iterations 3`

Local issue: CS-111