### PR TITLE
refactor(core): remove cache shadow writes

### DIFF
--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -283,7 +283,22 @@ describe("sqlite migration smoke", () => {
         bookmarked_at: now - 500,
       },
     ]);
-    expect(getUserVersion(getCachePath())).toBe(14);
+    const migratedCache = new Database(getCachePath(), { readonly: true });
+    const documentColumns = (
+      migratedCache.prepare("PRAGMA table_info(session_documents)").all() as Array<{ name: string }>
+    ).map((row) => row.name);
+    migratedCache.close();
+    expect(documentColumns).toEqual([
+      "id",
+      "agent_name",
+      "session_id",
+      "title",
+      "content_text",
+      "content_hash",
+      "indexed_message_count",
+      "indexed_at",
+    ]);
+    expect(getUserVersion(getCachePath())).toBe(15);
     expect(getUserVersion(getStatePath())).toBe(2);
   }, 30_000);
 });

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -32,6 +32,9 @@ describe("cache schema boundary", () => {
         .all() as Array<{ name: string }>;
       return {
         names: new Set(objects.map((row) => row.name)),
+        documentColumns: (
+          db.prepare("PRAGMA table_info(session_documents)").all() as Array<{ name: string }>
+        ).map((row) => row.name),
         version: Number(
           (db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined)
             ?.user_version ?? 0,
@@ -48,7 +51,17 @@ describe("cache schema boundary", () => {
     ]) {
       expect(state?.names.has(name)).toBe(true);
     }
-    expect(state?.version).toBe(14);
+    expect(state?.documentColumns).toEqual([
+      "id",
+      "agent_name",
+      "session_id",
+      "title",
+      "content_text",
+      "content_hash",
+      "indexed_message_count",
+      "indexed_at",
+    ]);
+    expect(state?.version).toBe(15);
   });
 
   it("exposes capabilities instead of migration steps", () => {

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -677,7 +677,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(14);
+    expect(getUserVersion(getCachePath())).toBe(15);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -1297,7 +1297,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(14);
+    expect(getUserVersion(getCachePath())).toBe(15);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -201,18 +201,18 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(14);
+    expect(getUserVersion(getCachePath())).toBe(15);
 
     const db = new Database(getCachePath());
-    db.pragma("user_version = 5");
+    db.pragma("user_version = 14");
     db.close();
 
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(5);
+    expect(getUserVersion(getCachePath())).toBe(14);
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(14);
+    expect(getUserVersion(getCachePath())).toBe(15);
   });
 });
 
@@ -220,7 +220,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(14);
+    expect(getUserVersion(getCachePath())).toBe(15);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -265,12 +265,43 @@ describe("saveCachedSessions", () => {
     }
   });
 
-  it("restores session heads from structured rows when snapshot json is malformed", () => {
+  it("writes session heads only to the canonical sessions table", () => {
+    saveCachedSessions("claudecode", [makeSession("s1")]);
+    saveCachedSessionChanges(
+      "claudecode",
+      [{ session: { ...makeSession("s1"), title: "Updated" }, sortIndex: 0 }],
+      [],
+    );
+
+    const db = new Database(getCachePath(), { readonly: true });
+    try {
+      const rowCounts = Object.fromEntries(
+        ["sessions", "cached_sessions", "project_sessions"].map((table) => {
+          const row = db.prepare(`SELECT COUNT(*) AS value FROM ${table}`).get() as {
+            value?: number;
+          };
+          return [table, Number(row.value ?? 0)];
+        }),
+      );
+      expect(rowCounts).toEqual({
+        sessions: 1,
+        cached_sessions: 0,
+        project_sessions: 0,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("ignores malformed legacy snapshot rows when restoring structured heads", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
 
     const db = new Database(getCachePath());
     try {
-      db.prepare("UPDATE cached_sessions SET session_json = ? WHERE session_id = ?").run("{", "s1");
+      db.prepare(
+        `INSERT INTO cached_sessions(agent_name, session_id, session_json)
+         VALUES (?, ?, ?)`,
+      ).run("claudecode", "s1", "{");
     } finally {
       db.close();
     }
@@ -377,7 +408,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(14);
+    expect(getUserVersion(getCachePath())).toBe(15);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -6,7 +6,6 @@ import type { SessionCacheMeta } from "../../agents/base.js";
 import type {
   Message,
   MessagePart,
-  ProjectIdentity,
   ProjectIdentityKind,
   SessionData,
   SessionFileActivity,
@@ -101,36 +100,6 @@ export function sourcePathFromMetaJson(metaJson: string | null | undefined): str
   if (!metaJson) return null;
   const meta = JSON.parse(metaJson) as SessionCacheMeta;
   return sourcePathFromMeta(meta);
-}
-
-export function prepareUpsertCachedSession(db: SQLiteDatabase): SQLiteStatement {
-  return db.prepare(`
-    INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json)
-    VALUES (?, ?, ?, ?)
-    ON CONFLICT(agent_name, session_id) DO UPDATE SET
-      session_json = excluded.session_json,
-      meta_json = excluded.meta_json
-  `);
-}
-
-export function prepareUpsertProjectSession(db: SQLiteDatabase): SQLiteStatement {
-  return db.prepare(`
-    INSERT INTO project_sessions(
-      agent_name,
-      session_id,
-      identity_kind,
-      identity_key,
-      display_name,
-      directory,
-      activity_time
-    ) VALUES (?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(agent_name, session_id) DO UPDATE SET
-      identity_kind = excluded.identity_kind,
-      identity_key = excluded.identity_key,
-      display_name = excluded.display_name,
-      directory = excluded.directory,
-      activity_time = excluded.activity_time
-  `);
 }
 
 export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
@@ -321,23 +290,6 @@ export function writeFileActivityRows(
       activity.latest_time,
     );
   }
-}
-
-export function writeProjectSessionRow(
-  statement: SQLiteStatement,
-  agentName: string,
-  session: SessionHead,
-  identity: ProjectIdentity,
-): void {
-  statement.run(
-    agentName,
-    session.id,
-    identity.kind,
-    identity.key,
-    identity.displayName,
-    session.directory,
-    session.time_updated ?? session.time_created,
-  );
 }
 
 export function sessionFromRow(row: SessionRow): SessionHead {

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -38,7 +38,7 @@ import {
   type SessionRow,
 } from "./messages.js";
 
-const CACHE_SCHEMA_VERSION = 14;
+const CACHE_SCHEMA_VERSION = 15;
 interface MessageToolBackfillRow extends DatabaseRow {
   agent_name?: string;
   session_id?: string;
@@ -414,12 +414,7 @@ function createSearchTables(db: SQLiteDatabase): void {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       agent_name TEXT NOT NULL,
       session_id TEXT NOT NULL,
-      slug TEXT NOT NULL,
       title TEXT NOT NULL,
-      directory TEXT NOT NULL,
-      time_created INTEGER NOT NULL,
-      time_updated INTEGER,
-      activity_time INTEGER NOT NULL,
       content_text TEXT NOT NULL,
       content_hash TEXT NOT NULL,
       indexed_message_count INTEGER NOT NULL,
@@ -488,30 +483,30 @@ function dropSearchTriggers(db: SQLiteDatabase): void {
   `);
 }
 
-function ensureProjectColumns(db: SQLiteDatabase): void {
+const LEGACY_SESSION_DOCUMENT_COLUMNS = [
+  ["slug", "TEXT NOT NULL DEFAULT ''"],
+  ["directory", "TEXT NOT NULL DEFAULT ''"],
+  ["time_created", "INTEGER NOT NULL DEFAULT 0"],
+  ["time_updated", "INTEGER"],
+  ["activity_time", "INTEGER NOT NULL DEFAULT 0"],
+  ["project_identity_kind", "TEXT NOT NULL DEFAULT 'path'"],
+  ["project_identity_key", "TEXT NOT NULL DEFAULT ''"],
+  ["project_display_name", "TEXT NOT NULL DEFAULT ''"],
+] as const;
+
+function ensureLegacySessionDocumentColumns(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents")) {
     return;
   }
 
-  if (!columnExists(db, "session_documents", "project_identity_kind")) {
-    db.exec(
-      "ALTER TABLE session_documents ADD COLUMN project_identity_kind TEXT NOT NULL DEFAULT 'path'",
-    );
-  }
-  if (!columnExists(db, "session_documents", "project_identity_key")) {
-    db.exec(
-      "ALTER TABLE session_documents ADD COLUMN project_identity_key TEXT NOT NULL DEFAULT ''",
-    );
-  }
-  if (!columnExists(db, "session_documents", "project_display_name")) {
-    db.exec(
-      "ALTER TABLE session_documents ADD COLUMN project_display_name TEXT NOT NULL DEFAULT ''",
-    );
+  for (const [name, definition] of LEGACY_SESSION_DOCUMENT_COLUMNS) {
+    if (!columnExists(db, "session_documents", name)) {
+      db.exec(`ALTER TABLE session_documents ADD COLUMN ${name} ${definition}`);
+    }
   }
 }
 
 function createProjectTables(db: SQLiteDatabase): void {
-  ensureProjectColumns(db);
   db.exec(`
     CREATE TABLE IF NOT EXISTS project_sessions (
       agent_name TEXT NOT NULL,
@@ -603,7 +598,7 @@ function readLegacyCacheVersion(db: SQLiteDatabase): number {
 
 function inferCacheSchemaVersion(db: SQLiteDatabase): number {
   if (columnExists(db, "session_documents", "indexed_message_count")) {
-    return 14;
+    return columnExists(db, "session_documents", "slug") ? 14 : 15;
   }
   if (tableExists(db, "message_tools")) {
     return 11;
@@ -737,6 +732,7 @@ function backfillSessionDocumentProjects(db: SQLiteDatabase): void {
 }
 
 function migrateProjectIdentity(db: SQLiteDatabase): void {
+  ensureLegacySessionDocumentColumns(db);
   createProjectTables(db);
   backfillProjectSessions(db);
   backfillSessionDocumentProjects(db);
@@ -997,6 +993,45 @@ function invalidateSearchContentHashes(db: SQLiteDatabase): void {
   }
 }
 
+function compactSessionDocuments(db: SQLiteDatabase): void {
+  if (!tableExists(db, "session_documents")) {
+    createSearchTables(db);
+    return;
+  }
+
+  dropSearchTriggers(db);
+  db.exec(`
+    DROP TABLE IF EXISTS session_documents_fts;
+    DROP TABLE IF EXISTS session_documents_legacy_v14;
+    ALTER TABLE session_documents RENAME TO session_documents_legacy_v14;
+  `);
+  createSearchTables(db);
+  db.exec(`
+    INSERT INTO session_documents(
+      id,
+      agent_name,
+      session_id,
+      title,
+      content_text,
+      content_hash,
+      indexed_message_count,
+      indexed_at
+    )
+    SELECT
+      id,
+      agent_name,
+      session_id,
+      title,
+      content_text,
+      content_hash,
+      indexed_message_count,
+      indexed_at
+    FROM session_documents_legacy_v14;
+
+    DROP TABLE session_documents_legacy_v14;
+  `);
+}
+
 const CODEX_EXEC_DECODE_MIGRATION_KEY = "codex_exec_decode_migrated_v3";
 
 /**
@@ -1155,6 +1190,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       },
       { version: 13, migrate: createCacheTables },
       { version: 14, migrate: addIndexedMessageCount },
+      { version: 15, destructive: true, migrate: compactSessionDocuments },
     ],
   });
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -1,9 +1,4 @@
-import type {
-  ProjectIdentity,
-  SessionData,
-  SessionFileActivity,
-  SessionHead,
-} from "../../types/index.js";
+import type { SessionData, SessionFileActivity, SessionHead } from "../../types/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
@@ -68,7 +63,6 @@ const SEARCH_INDEX_STATE_BATCH_SIZE = 900;
 
 interface LoadedSearchIndexEntry {
   session: SessionHead;
-  identity: ProjectIdentity;
   messages: StructuredMessageRecord[];
   contentText: string;
   contentHash: string;
@@ -184,7 +178,6 @@ function loadSearchIndexEntry(
       computeIdentity(change.session.directory, realFs);
     return {
       session: change.session,
-      identity,
       messages,
       contentText: buildSessionContentFromMessages(data.title ?? change.session.title, messages),
       contentHash: sessionContentHash(change.session),
@@ -277,30 +270,14 @@ function writeSearchIndexRows(
     INSERT INTO session_documents(
       agent_name,
       session_id,
-      slug,
       title,
-      directory,
-      project_identity_kind,
-      project_identity_key,
-      project_display_name,
-      time_created,
-      time_updated,
-      activity_time,
       content_text,
       content_hash,
       indexed_message_count,
       indexed_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id) DO UPDATE SET
-      slug = excluded.slug,
       title = excluded.title,
-      directory = excluded.directory,
-      project_identity_kind = excluded.project_identity_kind,
-      project_identity_key = excluded.project_identity_key,
-      project_display_name = excluded.project_display_name,
-      time_created = excluded.time_created,
-      time_updated = excluded.time_updated,
-      activity_time = excluded.activity_time,
       content_text = excluded.content_text,
       content_hash = excluded.content_hash,
       indexed_message_count = excluded.indexed_message_count,
@@ -321,7 +298,6 @@ function writeSearchIndexRows(
 
   let indexed = 0;
   for (const entry of entries) {
-    const activityTime = entry.session.time_updated ?? entry.session.time_created;
     upsertSessionRow(upsertIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
     deleteFileActivity.run(agentName, entry.session.id);
     deleteMessageTools.run(agentName, entry.session.id, 0);
@@ -357,15 +333,7 @@ function writeSearchIndexRows(
     upsertRow.run(
       agentName,
       entry.session.id,
-      entry.session.slug,
       entry.session.title,
-      entry.session.directory,
-      entry.identity.kind,
-      entry.identity.key,
-      entry.identity.displayName,
-      entry.session.time_created,
-      entry.session.time_updated ?? null,
-      activityTime,
       entry.contentText,
       entry.contentHash,
       entry.messages.length,

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -4,7 +4,6 @@
 import { existsSync, rmSync, unlinkSync } from "node:fs";
 import type { SessionCacheMeta } from "../../agents/base.js";
 import type { SessionData, SessionHead } from "../../types/index.js";
-import { computeIdentity, realFs } from "../../projects/index.js";
 import { tableExists } from "../../utils/sqlite.js";
 import {
   getCachePath,
@@ -18,13 +17,10 @@ import {
 import { withCacheDb, withCacheDbReadOnly } from "./schema.js";
 import {
   messageFromCachedRow,
-  prepareUpsertCachedSession,
-  prepareUpsertProjectSession,
   prepareUpsertSession,
   sessionFromRow,
   sourcePathFromMeta,
   upsertSessionRow,
-  writeProjectSessionRow,
   type CachedMessageRow,
   type SessionRow,
 } from "./messages.js";
@@ -329,8 +325,6 @@ export function saveCachedSessions(
   meta: Record<string, SessionCacheMeta> = {},
 ): void {
   withCacheDb((db) => {
-    const deleteAgent = db.prepare("DELETE FROM agent_cache WHERE agent_name = ?");
-    const deleteLegacySessions = db.prepare("DELETE FROM cached_sessions WHERE agent_name = ?");
     const deleteSession = db.prepare(
       "DELETE FROM sessions WHERE agent_name = ? AND session_id = ?",
     );
@@ -346,18 +340,12 @@ export function saveCachedSessions(
     const deleteFileActivity = db.prepare(
       "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
     );
-    const deleteProjectSession = db.prepare(
-      "DELETE FROM project_sessions WHERE agent_name = ? AND session_id = ?",
-    );
-    const deleteProjectSessions = db.prepare("DELETE FROM project_sessions WHERE agent_name = ?");
     const upsertAgent = db.prepare(`
       INSERT INTO agent_cache(agent_name, timestamp)
       VALUES (?, ?)
       ON CONFLICT(agent_name) DO UPDATE SET timestamp = excluded.timestamp
     `);
-    const upsertCachedSession = prepareUpsertCachedSession(db);
     const upsertSession = prepareUpsertSession(db);
-    const upsertProjectSession = prepareUpsertProjectSession(db);
 
     const write = db.transaction(() => {
       const timestamp = Date.now();
@@ -365,9 +353,6 @@ export function saveCachedSessions(
       const existingSessionIds = db
         .prepare("SELECT session_id FROM sessions WHERE agent_name = ?")
         .all(agentName) as SessionRow[];
-      deleteAgent.run(agentName);
-      deleteLegacySessions.run(agentName);
-      deleteProjectSessions.run(agentName);
       upsertAgent.run(agentName, timestamp);
 
       for (const row of existingSessionIds) {
@@ -377,16 +362,13 @@ export function saveCachedSessions(
           deleteMessageTools.run(agentName, sessionId);
           deleteMessages.run(agentName, sessionId);
           deleteFileActivity.run(agentName, sessionId);
-          deleteProjectSession.run(agentName, sessionId);
           deleteSession.run(agentName, sessionId);
         }
       }
 
       sessions.forEach((session, index) => {
-        const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
         const sessionMeta = meta[session.id];
         const metaJson = sessionMeta ? JSON.stringify(sessionMeta) : null;
-        upsertCachedSession.run(agentName, session.id, JSON.stringify(session), metaJson);
         upsertSessionRow(
           upsertSession,
           agentName,
@@ -395,7 +377,6 @@ export function saveCachedSessions(
           index,
           sourcePathFromMeta(sessionMeta),
         );
-        writeProjectSessionRow(upsertProjectSession, agentName, session, identity);
       });
     });
 
@@ -415,9 +396,6 @@ export function saveCachedSessionChanges(
   }
 
   withCacheDb((db) => {
-    const deleteLegacySession = db.prepare(
-      "DELETE FROM cached_sessions WHERE agent_name = ? AND session_id = ?",
-    );
     const deleteSession = db.prepare(
       "DELETE FROM sessions WHERE agent_name = ? AND session_id = ?",
     );
@@ -433,36 +411,27 @@ export function saveCachedSessionChanges(
     const deleteFileActivity = db.prepare(
       "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
     );
-    const deleteProjectSession = db.prepare(
-      "DELETE FROM project_sessions WHERE agent_name = ? AND session_id = ?",
-    );
     const upsertAgent = db.prepare(`
       INSERT INTO agent_cache(agent_name, timestamp)
       VALUES (?, ?)
       ON CONFLICT(agent_name) DO UPDATE SET timestamp = excluded.timestamp
     `);
-    const upsertCachedSession = prepareUpsertCachedSession(db);
     const upsertSession = prepareUpsertSession(db);
-    const upsertProjectSession = prepareUpsertProjectSession(db);
 
     const write = db.transaction(() => {
       upsertAgent.run(agentName, Date.now());
 
       for (const sessionId of new Set(removedSessionIds)) {
-        deleteLegacySession.run(agentName, sessionId);
         deleteSearchDocument.run(agentName, sessionId);
         deleteMessageTools.run(agentName, sessionId);
         deleteMessages.run(agentName, sessionId);
         deleteFileActivity.run(agentName, sessionId);
-        deleteProjectSession.run(agentName, sessionId);
         deleteSession.run(agentName, sessionId);
       }
 
       for (const { session, sortIndex } of changes) {
-        const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
         const sessionMeta = meta[session.id];
         const metaJson = sessionMeta ? JSON.stringify(sessionMeta) : null;
-        upsertCachedSession.run(agentName, session.id, JSON.stringify(session), metaJson);
         upsertSessionRow(
           upsertSession,
           agentName,
@@ -471,7 +440,6 @@ export function saveCachedSessionChanges(
           sortIndex,
           sourcePathFromMeta(sessionMeta),
         );
-        writeProjectSessionRow(upsertProjectSession, agentName, session, identity);
       }
     });
 


### PR DESCRIPTION
## Summary

- make `sessions` the only stable SessionHead write target and stop maintaining `cached_sessions` / `project_sessions` shadow rows
- compact `session_documents` to the columns required by search, joins, hashes, and indexed counts through schema v15
- preserve legacy cache migration and fallback readers while keeping fresh databases free of redundant columns

## Validation

- `pnpm exec turbo run build --force`
- `pnpm test` (1,093 tests)
- `pnpm test:coverage` (1,093 tests)
- `pnpm lint`
- `pnpm format:check`
- migration suite (60 tests)
- E2E suite (21 tests)
- `pnpm bench:perf -- --iterations 3`

The first benchmark iteration included the one-time migration and safety backup of the existing large local cache (~70.5s). Subsequent server readiness was 218–248ms and dashboard readiness was 1.10–1.23s.