### PR TITLE
fix(core): cache session index snapshots

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -126,6 +126,8 @@ describe("ClaudeCodeAgent cache refresh", () => {
       join(projectDir, name),
     );
     for (const file of files) writeFileSync(file, "");
+    const indexFile = join(projectDir, "sessions-index.json");
+    writeFileSync(indexFile, JSON.stringify({ entries: [] }));
 
     const agent = new ClaudeCodeAgent() as any;
     agent.basePath = basePath;
@@ -138,6 +140,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
       expect(callsForFile.length).toBe(1);
     }
+    expect(statSpy.mock.calls.filter((call) => call[0] === indexFile)).toHaveLength(1);
   });
 
   it("parses indexed sessions with assistant tools and tool results", () => {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, mkdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -6,11 +14,15 @@ import { CodexAgent } from "../codex.js";
 import type { Message, MessagePart, SessionHead } from "../../types/index.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
-// Spies on statSync while delegating to the real implementation, so the
-// single-stat regression test can count per-file calls during a live scan.
+// Spies while delegating to the real implementation so regression tests can
+// count filesystem calls during a live scan.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
-  return { ...actual, statSync: vi.fn(actual.statSync) };
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+    statSync: vi.fn(actual.statSync),
+  };
 });
 
 let tempDirs: string[] = [];
@@ -198,6 +210,49 @@ describe("CodexAgent cache refresh", () => {
       const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
       expect(callsForFile.length).toBe(1);
     }
+  });
+
+  it("caches an empty session index and reloads it when the mtime changes", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-empty-index-"));
+    tempDirs.push(tempDir);
+    const codexHome = join(tempDir, ".codex");
+    const sessionsDir = join(codexHome, "sessions");
+    const indexFile = join(codexHome, "session_index.jsonl");
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("CODEX_HOME", codexHome);
+    writeFileSync(indexFile, "");
+
+    for (const id of [
+      "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
+      "019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb",
+      "019dcccc-cccc-7ccc-cccc-cccccccccccc",
+    ]) {
+      writeFileSync(
+        join(sessionsDir, `rollout-2026-04-20T10-00-00-${id}.jsonl`),
+        '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
+      );
+    }
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = sessionsDir;
+    const readSpy = vi.mocked(readFileSync);
+    const statSpy = vi.mocked(statSync);
+    readSpy.mockClear();
+    statSpy.mockClear();
+
+    const initialFingerprint = agent.listSessionSources()[0]?.fingerprint;
+    expect(agent.listSessionSources()[0]?.fingerprint).toBe(initialFingerprint);
+
+    const later = new Date(Date.now() + 2000);
+    writeFileSync(
+      indexFile,
+      '{"id":"019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa","thread_name":"Indexed title"}\n',
+    );
+    utimesSync(indexFile, later, later);
+    expect(agent.listSessionSources()[0]?.fingerprint).not.toBe(initialFingerprint);
+
+    expect(readSpy.mock.calls.filter((call) => call[0] === indexFile)).toHaveLength(2);
+    expect(statSpy.mock.calls.filter((call) => call[0] === indexFile)).toHaveLength(3);
   });
 
   it("uses per-session Codex titles in source fingerprints", () => {

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -146,6 +146,7 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     const refs: SessionSourceRef[] = [];
     for (const projectDir of this.listProjectDirs()) {
       const indexPath = this.getSessionsIndexPath(projectDir);
+      const indexMtime = this.getFileMtimeMs(indexPath);
       for (const file of this.listJsonlFiles(projectDir)) {
         let stat: Stats;
         try {
@@ -158,7 +159,7 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
         refs.push({
           sessionId,
           sourcePath: file,
-          fingerprint: this.sourceFingerprint(stat, indexPath),
+          fingerprint: this.sourceFingerprint(stat, indexMtime),
         });
       }
     }
@@ -234,15 +235,16 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
   private buildSessionMeta(head: SessionHead, file: string, projectDir: string): SessionMeta {
     const indexPath = this.getSessionsIndexPath(projectDir);
+    const indexMtime = this.getFileMtimeMs(indexPath);
     const stat = statSync(file);
     return {
       id: head.id,
       title: head.title,
       sourcePath: file,
-      sourceFingerprint: this.sourceFingerprint(stat, indexPath),
+      sourceFingerprint: this.sourceFingerprint(stat, indexMtime),
       sourceMtimeMs: stat.mtimeMs,
-      indexPath: existsSync(indexPath) ? indexPath : null,
-      indexMtimeMs: this.getFileMtimeMs(indexPath),
+      indexPath: indexMtime === null ? null : indexPath,
+      indexMtimeMs: indexMtime,
       headIndexVersion: HEAD_INDEX_VERSION,
       directory: head.directory,
       model: head.stats.total_tokens ? "unknown" : undefined,
@@ -253,13 +255,11 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   /** Fingerprint depends on an already-fetched stat to avoid re-statting the same file. */
-  private sourceFingerprint(stat: { mtimeMs: number; size: number }, indexPath: string): string {
-    return JSON.stringify([
-      HEAD_INDEX_VERSION,
-      stat.mtimeMs,
-      stat.size,
-      this.getFileMtimeMs(indexPath),
-    ]);
+  private sourceFingerprint(
+    stat: { mtimeMs: number; size: number },
+    indexMtime: number | null,
+  ): string {
+    return JSON.stringify([HEAD_INDEX_VERSION, stat.mtimeMs, stat.size, indexMtime]);
   }
 
   private getSessionsIndexPath(projectDir: string): string {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -338,7 +338,8 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
   private basePath: string | null = null;
   private sessionIndexCache = new Map<string, string>();
-  private sessionIndexMtime: number | null = null;
+  private sessionIndexMtime: number | null | undefined;
+  private sessionIndexPath: string | undefined;
 
   // ---- BaseAgent implementation ----
 
@@ -548,6 +549,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
   private buildSessionMeta(head: SessionHead, file: string): SessionMeta {
     const indexPath = this.getSessionIndexPath();
+    const indexMtime = this.sessionIndexMtime ?? null;
     const stat = statSync(file);
     return {
       id: head.id,
@@ -555,8 +557,8 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       sourcePath: file,
       sourceFingerprint: this.sourceFingerprint(file, stat),
       sourceMtimeMs: stat.mtimeMs,
-      indexPath: existsSync(indexPath) ? indexPath : null,
-      indexMtimeMs: this.getFileMtimeMs(indexPath),
+      indexPath: indexMtime === null ? null : indexPath,
+      indexMtimeMs: indexMtime,
       headIndexVersion: HEAD_INDEX_VERSION,
       parserVersion: PARSER_VERSION,
       directory: head.directory,
@@ -580,8 +582,8 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   private getSessionIndexPath(): string {
-    const roots = resolveProviderRoots();
-    return join(roots.codexRoot, "session_index.jsonl");
+    this.sessionIndexPath ??= join(resolveProviderRoots().codexRoot, "session_index.jsonl");
+    return this.sessionIndexPath;
   }
 
   private getFileMtimeMs(filePath: string): number | null {
@@ -600,28 +602,33 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
     // Invalidate when the index file mtime advances so long-running processes
     // pick up title changes without relying on callers to evict manually.
-    if (this.sessionIndexCache.size > 0 && this.sessionIndexMtime === mtime) return;
+    if (this.sessionIndexMtime !== undefined && this.sessionIndexMtime === mtime) return;
 
-    this.sessionIndexCache.clear();
-    this.sessionIndexMtime = mtime;
-    if (mtime === null) return;
+    if (mtime === null) {
+      this.sessionIndexCache.clear();
+      this.sessionIndexMtime = null;
+      return;
+    }
 
     try {
       const content = readFileSync(indexPath, "utf-8");
+      const cache = new Map<string, string>();
       for (const record of parseJsonlLines(content)) {
         const sid = String(record["id"] ?? "").trim();
         const threadName = String(record["thread_name"] ?? "").trim();
         if (sid && threadName) {
-          this.sessionIndexCache.set(sid, threadName);
+          cache.set(sid, threadName);
         }
       }
+      this.sessionIndexCache = cache;
+      this.sessionIndexMtime = mtime;
     } catch {
-      // ignore
+      this.sessionIndexCache.clear();
+      this.sessionIndexMtime = undefined;
     }
   }
 
   private getTitleForSession(sessionId: string): string | null {
-    this.loadSessionIndex();
     return this.sessionIndexCache.get(sessionId) ?? null;
   }
 


### PR DESCRIPTION
## Summary

- cache the Codex session-index path and distinguish unloaded, missing, and loaded-empty index states
- load Codex titles once per index mtime and reuse them for every rollout fingerprint without changing fingerprint contents
- snapshot each Claude Code project index mtime once per enumeration and reuse it across all session fingerprints
- add filesystem-call regressions for empty-index caching, mtime invalidation, and per-project index stats

## Runtime evidence

Before the fix, enumerating three Codex rollouts twice read an empty index eight times, and enumerating three Claude Code sessions statted the same project index three times. The regression tests now enforce two Codex reads across the initial load plus one mtime change, one index stat per Codex enumeration, and one Claude Code index stat per project enumeration.

## Validation

- `pnpm test` (1,094 tests)
- `pnpm test:coverage` (1,094 tests)
- `pnpm --filter @codesesh/core build`
- `pnpm lint`
- `pnpm format:check`