### PR TITLE
fix(web): reuse message markdown while scrolling

### DIFF
--- a/apps/web/src/components/MarkdownContent.tsx
+++ b/apps/web/src/components/MarkdownContent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 
@@ -32,7 +32,10 @@ function buildHighlightPattern(query?: string): RegExp | null {
   return new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
 }
 
-export function MarkdownContent({ text, highlightQuery }: MarkdownContentProps) {
+export const MarkdownContent = memo(function MarkdownContent({
+  text,
+  highlightQuery,
+}: MarkdownContentProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const highlightPattern = useMemo(() => buildHighlightPattern(highlightQuery), [highlightQuery]);
 
@@ -89,4 +92,4 @@ export function MarkdownContent({ text, highlightQuery }: MarkdownContentProps) 
       <ReactMarkdown components={markdownComponents}>{text}</ReactMarkdown>
     </div>
   );
-}
+});

--- a/apps/web/src/components/session-detail/message-markdown-memo.test.tsx
+++ b/apps/web/src/components/session-detail/message-markdown-memo.test.tsx
@@ -1,0 +1,103 @@
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MarkdownContent } from "../MarkdownContent";
+import { MessageList, VIRTUALIZED_MESSAGE_THRESHOLD } from "./message-list";
+import type { FilteredSessionMessage } from "./toc";
+
+const { markdownRender } = vi.hoisted(() => ({
+  markdownRender: vi.fn(),
+}));
+
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => {
+    markdownRender(children);
+    return <span>{children}</span>;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  markdownRender.mockClear();
+  vi.restoreAllMocks();
+});
+
+function createMessages(): FilteredSessionMessage[] {
+  return Array.from({ length: VIRTUALIZED_MESSAGE_THRESHOLD + 1 }, (_, index) => ({
+    msg: {
+      id: `message-${index}`,
+      role: "user",
+      time_created: index,
+      parts: [],
+    } as FilteredSessionMessage["msg"],
+    blocks: [
+      {
+        type: "text",
+        parts: [{ type: "text", text: `Message ${index}` }],
+      },
+    ],
+    index,
+  }));
+}
+
+describe("message markdown memoization", () => {
+  it("reuses parsed markdown until its text or highlight changes", () => {
+    const view = render(<MarkdownContent text="Memoized markdown" />);
+    expect(markdownRender).toHaveBeenCalledOnce();
+
+    view.rerender(<MarkdownContent text="Memoized markdown" />);
+    expect(markdownRender).toHaveBeenCalledOnce();
+
+    view.rerender(<MarkdownContent text="Memoized markdown" highlightQuery="memoized" />);
+    expect(markdownRender).toHaveBeenCalledTimes(2);
+    expect(view.container.querySelector("mark")?.textContent).toBe("Memoized");
+  });
+
+  it("does not reparse stable visible messages on viewport updates", () => {
+    let scheduledFrame: FrameRequestCallback | undefined;
+    const requestFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        scheduledFrame = callback;
+        return 1;
+      });
+    const scrollContainer = document.createElement("div");
+    scrollContainer.style.overflowY = "auto";
+    document.body.append(scrollContainer);
+    Object.defineProperty(scrollContainer, "clientHeight", {
+      configurable: true,
+      value: 300,
+    });
+    const messages = createMessages();
+    const view = render(
+      <MessageList
+        messages={messages}
+        sessionAgentKey="codex"
+        baseDirectory="/tmp/project"
+        apiRef={{ current: null }}
+      />,
+      { container: scrollContainer },
+    );
+    const initialRenderCount = markdownRender.mock.calls.length;
+    expect(initialRenderCount).toBeGreaterThan(0);
+
+    scrollContainer.scrollTop = 1;
+    fireEvent.scroll(scrollContainer);
+    expect(requestFrame).toHaveBeenCalledOnce();
+    act(() => scheduledFrame?.(0));
+
+    expect(markdownRender).toHaveBeenCalledTimes(initialRenderCount);
+
+    view.rerender(
+      <MessageList
+        messages={messages}
+        sessionAgentKey="codex"
+        baseDirectory="/tmp/project"
+        highlightQuery="Message"
+        apiRef={{ current: null }}
+      />,
+    );
+    expect(markdownRender.mock.calls.length).toBeGreaterThan(initialRenderCount);
+    expect(view.container.querySelectorAll("mark").length).toBeGreaterThan(0);
+    scrollContainer.remove();
+  });
+});

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import {
   Bot,
   CalendarRange,
@@ -86,7 +86,7 @@ function MessageMarkdown({ text, highlightQuery }: { text: string; highlightQuer
   return <MarkdownContent text={text} highlightQuery={highlightQuery} />;
 }
 
-export function MessageItem({
+export const MessageItem = memo(function MessageItem({
   messageIndex,
   msg,
   blocks,
@@ -252,7 +252,7 @@ export function MessageItem({
       </div>
     </article>
   );
-}
+});
 
 function AbortToolItem() {
   return (


### PR DESCRIPTION
## Summary

- memoize stable `MessageItem` rows so virtual viewport updates only render entering or changed messages
- memoize `MarkdownContent` so unchanged text is not reparsed by `react-markdown` during parent updates
- preserve search highlighting by allowing `highlightQuery` changes through both memo boundaries
- add regressions for parser reuse, viewport updates, and highlight refreshes

## Performance evidence

Using the existing React `RenderProfiler` on a 756-message detail view while scrolling 2,400px produced the same 18 commits before and after the change:

- total render duration: 181.0ms → 11.2ms
- mean commit duration: 10.06ms → 0.62ms
- median commit duration: 11.7ms → 0.2ms
- total reduction: 93.8%

A browser smoke test also reopened the session from an `e2e` search result and verified 20 visible `e2e` / `E2E` highlights.

## Validation

- `pnpm exec turbo run build --force`
- `pnpm test` (1,096 tests)
- `pnpm test:coverage` (1,096 tests)
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:e2e` (21 tests)