### PR TITLE
perf: optimize session detail responses

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -4,7 +4,7 @@ const coreMocks = vi.hoisted(() => {
   return {
     attachProjectMetrics: vi.fn(),
     buildDashboard: vi.fn(),
-    materializeSessionDetail: vi.fn(),
+    materializeSessionDetailResponse: vi.fn(),
     listFileActivity: vi.fn((): FileActivityResult[] => []),
     listSessionAliases: vi.fn<
       () => Array<{ agentKey: string; sessionId: string; alias: string; updated_at: number }>
@@ -31,7 +31,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
       coreMocks.buildDashboard(...args);
       return actual.buildDashboard(...args);
     },
-    materializeSessionDetail: coreMocks.materializeSessionDetail,
+    materializeSessionDetailResponse: coreMocks.materializeSessionDetailResponse,
     listFileActivity: coreMocks.listFileActivity,
     listSessionAliases: coreMocks.listSessionAliases,
     executeSessionSearch: coreMocks.executeSessionSearch,
@@ -183,7 +183,7 @@ function toLocalDateKey(ts: number): string {
 afterEach(() => {
   coreMocks.attachProjectMetrics.mockClear();
   coreMocks.buildDashboard.mockClear();
-  coreMocks.materializeSessionDetail.mockReset();
+  coreMocks.materializeSessionDetailResponse.mockReset();
   coreMocks.listFileActivity.mockReset();
   coreMocks.listFileActivity.mockReturnValue([]);
   coreMocks.listSessionAliases.mockReset();
@@ -1181,35 +1181,85 @@ describe("handleGetSessionData", () => {
   };
 
   it("maps materialized session data to JSON", async () => {
-    coreMocks.materializeSessionDetail.mockReturnValue({ status: "found", data: detail });
+    coreMocks.materializeSessionDetailResponse.mockReturnValue({ status: "found", data: detail });
     const scanSource = makeScanSource();
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
 
     await handleGetSessionData(c, scanSource);
 
-    expect(coreMocks.materializeSessionDetail).toHaveBeenCalledWith(scanSource.getSnapshot(), {
-      agentName: "claudecode",
-      sessionId: "s1",
-    });
+    expect(coreMocks.materializeSessionDetailResponse).toHaveBeenCalledWith(
+      scanSource.getSnapshot(),
+      {
+        agentName: "claudecode",
+        sessionId: "s1",
+      },
+    );
     expect(c.json).toHaveBeenCalledWith(detail);
+  });
+
+  it("streams cached message JSON lazily while preserving aliases", async () => {
+    const { messages: _messages, ...detailHeader } = detail;
+    let serializedMessages = 0;
+    function* messages() {
+      serializedMessages += 1;
+      yield JSON.stringify({
+        id: "m1",
+        role: "assistant",
+        agent: null,
+        time_created: 1000,
+        time_completed: null,
+        mode: null,
+        model: null,
+        provider: null,
+        parts: [{ type: "text", text: "cached" }],
+      });
+    }
+    coreMocks.listSessionAliases.mockReturnValue([
+      {
+        agentKey: "claudecode",
+        sessionId: "s1",
+        alias: "Local Alias",
+        updated_at: 1000,
+      },
+    ]);
+    coreMocks.materializeSessionDetailResponse.mockReturnValue({
+      status: "found-json",
+      data: detailHeader,
+      messages: messages(),
+      messageCount: 1,
+    });
+    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+
+    const response = await handleGetSessionData(c, makeScanSource());
+
+    expect(response).toBeInstanceOf(Response);
+    expect(serializedMessages).toBe(0);
+    expect(c.json).not.toHaveBeenCalled();
+    const payload = await (response as Response).json();
+    expect(payload).toMatchObject({
+      id: "s1",
+      display_title: "Local Alias",
+      messages: [{ id: "m1", parts: [{ type: "text", text: "cached" }] }],
+    });
+    expect(serializedMessages).toBe(1);
   });
 
   it("returns 400 when agent name is missing", async () => {
     const c = makeMockContext({ param: { agent: "", id: "s1" } });
     await handleGetSessionData(c, makeScanSource());
     expect(c.json).toHaveBeenCalledWith({ error: "Missing agent name" }, 400);
-    expect(coreMocks.materializeSessionDetail).not.toHaveBeenCalled();
+    expect(coreMocks.materializeSessionDetailResponse).not.toHaveBeenCalled();
   });
 
   it("returns 400 when session ID is missing", async () => {
     const c = makeMockContext({ param: { agent: "claudecode", id: "" } });
     await handleGetSessionData(c, makeScanSource());
     expect(c.json).toHaveBeenCalledWith({ error: "Missing session ID" }, 400);
-    expect(coreMocks.materializeSessionDetail).not.toHaveBeenCalled();
+    expect(coreMocks.materializeSessionDetailResponse).not.toHaveBeenCalled();
   });
 
   it("maps an unknown agent to 404", async () => {
-    coreMocks.materializeSessionDetail.mockReturnValue({ status: "unknown-agent" });
+    coreMocks.materializeSessionDetailResponse.mockReturnValue({ status: "unknown-agent" });
     const c = makeMockContext({ param: { agent: "unknown", id: "s1" } });
 
     await handleGetSessionData(c, makeScanSource());
@@ -1218,7 +1268,7 @@ describe("handleGetSessionData", () => {
   });
 
   it("maps unavailable detail to 404", async () => {
-    coreMocks.materializeSessionDetail.mockReturnValue({ status: "not-ready" });
+    coreMocks.materializeSessionDetailResponse.mockReturnValue({ status: "not-ready" });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
 
     await handleGetSessionData(c, makeScanSource());
@@ -1227,7 +1277,7 @@ describe("handleGetSessionData", () => {
   });
 
   it("maps materialization errors to 500", async () => {
-    coreMocks.materializeSessionDetail.mockImplementation(() => {
+    coreMocks.materializeSessionDetailResponse.mockImplementation(() => {
       throw new Error("DB not found");
     });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -1,5 +1,11 @@
 import type { Context } from "hono";
-import type { BookmarkRecord, ScanResult, SessionHead, SmartTag } from "@codesesh/core";
+import type {
+  BookmarkRecord,
+  ScanResult,
+  SessionData,
+  SessionHead,
+  SmartTag,
+} from "@codesesh/core";
 import type { AppConfig, ScanStatusEvent } from "@codesesh/core/contract";
 import {
   BookmarkStorageUnavailableError,
@@ -14,7 +20,7 @@ import {
   listCachedProjectGroups,
   listBookmarks,
   deleteSessionAlias,
-  materializeSessionDetail,
+  materializeSessionDetailResponse,
   upsertSessionAlias,
   upsertBookmark,
   matchesProjectScope as sessionMatchesProjectScope,
@@ -162,6 +168,43 @@ function toSessionListItem(session: SessionHead): SessionHead {
   const item = { ...session };
   delete item.model_usage;
   return item;
+}
+
+function createSessionDetailJsonResponse(
+  data: Omit<SessionData, "messages">,
+  messages: Iterable<string>,
+): Response {
+  const encoder = new TextEncoder();
+  const headerJson = JSON.stringify(data);
+  const iterator = messages[Symbol.iterator]();
+  let wroteHeader = false;
+  let wroteMessage = false;
+
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!wroteHeader) {
+          controller.enqueue(encoder.encode(`${headerJson.slice(0, -1)},"messages":[`));
+          wroteHeader = true;
+          return;
+        }
+
+        const next = iterator.next();
+        if (!next.done) {
+          controller.enqueue(encoder.encode(`${wroteMessage ? "," : ""}${next.value}`));
+          wroteMessage = true;
+          return;
+        }
+
+        controller.enqueue(encoder.encode("]}"));
+        controller.close();
+      },
+      cancel() {
+        iterator.return?.();
+      },
+    }),
+    { headers: { "Content-Type": "application/json; charset=UTF-8" } },
+  );
 }
 
 export function handleGetConfig(c: Context, defaults: SessionListDefaults) {
@@ -353,7 +396,10 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
   }
 
   try {
-    const result = materializeSessionDetail(scanSource.getSnapshot(), { agentName, sessionId });
+    const result = materializeSessionDetailResponse(scanSource.getSnapshot(), {
+      agentName,
+      sessionId,
+    });
     if (result.status === "unknown-agent") {
       return c.json({ error: `Unknown agent: ${agentName}` }, 404);
     }
@@ -369,10 +415,16 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
     appLogger.info("api.session_data", {
       agent: agentName,
       session_id: sessionId,
-      messages: result.data.messages.length,
+      messages: result.status === "found-json" ? result.messageCount : result.data.messages.length,
       duration_ms: Math.round(performance.now() - startedAt),
     });
     const aliases = loadAliasView();
+    if (result.status === "found-json") {
+      return createSessionDetailJsonResponse(
+        aliases.decorate(result.data, agentName),
+        result.messages,
+      );
+    }
     return c.json(aliases.decorate(result.data, agentName));
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to load session";

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BaseAgent,
   materializeSessionDetail,
+  materializeSessionDetailResponse,
   saveCachedSessions,
   syncSessionSearchIndex,
   type ChangeCheckResult,
@@ -217,6 +218,60 @@ describe("materializeSessionDetail", () => {
     expect(source.status).toBe("found");
     if (cached.status !== "found" || source.status !== "found") return;
     expect(source.data.file_activity).toEqual(cached.data.file_activity);
+  });
+
+  it("returns cached messages as lazy JSON without reading the source", () => {
+    const head = makeHead({ smart_tags: [] });
+    const detail = { ...makeDetail("Cached Session"), smart_tags: [] };
+    persistDetail(head, detail, "same");
+    const agent = new TestAgent(makeDetail(), new Map([["s1", makeMeta("same")]]));
+    const scanResult = makeScanResult(agent, head);
+
+    const result = materializeSessionDetailResponse(scanResult, {
+      agentName: "test",
+      sessionId: "s1",
+    });
+    const structured = materializeSessionDetail(scanResult, {
+      agentName: "test",
+      sessionId: "s1",
+    });
+
+    expect(result.status).toBe("found-json");
+    expect(structured.status).toBe("found");
+    if (result.status !== "found-json" || structured.status !== "found") return;
+    expect(result.data.title).toBe("Cached Session");
+    expect(result.messageCount).toBe(1);
+    expect([...result.messages].map((message) => JSON.parse(message))).toEqual(
+      structured.data.messages,
+    );
+    expect(agent.reads).toBe(0);
+  });
+
+  it("indexes heads once per scan snapshot instead of calling Array.find", () => {
+    const heads = Array.from({ length: 100 }, (_, index) =>
+      makeHead({ id: `s${index}`, slug: `test/s${index}` }),
+    );
+    const target = heads.at(-1)!;
+    const agent = new TestAgent({ ...makeDetail(), id: target.id, slug: target.slug }, new Map());
+    const scanResult = {
+      sessions: heads,
+      byAgent: { test: heads },
+      agents: [agent],
+    };
+    const find = vi.spyOn(heads, "find");
+
+    const first = materializeSessionDetail(scanResult, {
+      agentName: "test",
+      sessionId: target.id,
+    });
+    const second = materializeSessionDetail(scanResult, {
+      agentName: "test",
+      sessionId: target.id,
+    });
+
+    expect(first.status).toBe("found");
+    expect(second.status).toBe("found");
+    expect(find).not.toHaveBeenCalled();
   });
 
   it("returns explicit lookup outcomes when no detail can be materialized", () => {

--- a/packages/core/src/discovery/cache/__tests__/messages.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/messages.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildMessageText,
   buildSessionContentFromMessages,
   messageFromCachedRow,
+  messageJsonFromCachedRow,
   normalizeMessages,
   toolNamesFromMetadataJson,
 } from "../messages.js";
@@ -32,6 +33,29 @@ describe("cached messages", () => {
       subagent_id: "sub-1",
       nickname: "worker",
     });
+  });
+
+  it("serializes owned JSON fields without parsing them", () => {
+    const row = {
+      message_id: "m1",
+      role: "assistant" as const,
+      time_created: 10,
+      time_completed: 11,
+      parts_json: JSON.stringify([{ type: "text", text: "done" }]),
+      tokens_json: JSON.stringify({ input: 2, output: 3 }),
+      cost: 0.4,
+      cost_source: "recorded" as const,
+      subagent_id: "sub-1",
+      nickname: "worker",
+    };
+    const parse = vi.spyOn(JSON, "parse");
+
+    const json = messageJsonFromCachedRow(row);
+    const parseCalls = parse.mock.calls.length;
+    parse.mockRestore();
+
+    expect(parseCalls).toBe(0);
+    expect(JSON.parse(json)).toEqual(messageFromCachedRow(row));
   });
 
   it("normalizes searchable content and unique tool names", () => {

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -346,7 +346,7 @@ export function sessionFromRow(row: SessionRow): SessionHead {
   return session;
 }
 
-export function messageFromBackfillRow(row: MessageBackfillRow): Message {
+function messageMetadataFromBackfillRow(row: MessageBackfillRow): Omit<Message, "parts"> {
   const role = row.role === "assistant" || row.role === "tool" ? row.role : "user";
   return {
     id: String(row.message_id ?? ""),
@@ -357,14 +357,13 @@ export function messageFromBackfillRow(row: MessageBackfillRow): Message {
     mode: row.mode ?? null,
     model: row.model ?? null,
     provider: row.provider ?? null,
-    parts: JSON.parse(String(row.parts_json ?? "[]")) as MessagePart[],
     subagent_id: row.subagent_id ?? undefined,
     nickname: row.nickname ?? undefined,
   };
 }
 
-export function messageFromCachedRow(row: CachedMessageRow): Message {
-  const message = messageFromBackfillRow(row);
+function messageMetadataFromCachedRow(row: CachedMessageRow): Omit<Message, "parts"> {
+  const message = messageMetadataFromBackfillRow(row);
   const tokens = parseOptionalJson<Message["tokens"]>(row.tokens_json);
   if (tokens) {
     message.tokens = tokens;
@@ -376,6 +375,36 @@ export function messageFromCachedRow(row: CachedMessageRow): Message {
     message.cost_source = row.cost_source;
   }
   return message;
+}
+
+export function messageFromBackfillRow(row: MessageBackfillRow): Message {
+  return {
+    ...messageMetadataFromBackfillRow(row),
+    parts: JSON.parse(String(row.parts_json ?? "[]")) as MessagePart[],
+  };
+}
+
+export function messageFromCachedRow(row: CachedMessageRow): Message {
+  return {
+    ...messageMetadataFromCachedRow(row),
+    parts: JSON.parse(String(row.parts_json ?? "[]")) as MessagePart[],
+  };
+}
+
+export function messageJsonFromCachedRow(row: CachedMessageRow): string {
+  const metadataJson = JSON.stringify(messageMetadataFromBackfillRow(row));
+  const fields: string[] = [];
+  if (row.tokens_json != null) {
+    fields.push(`"tokens":${String(row.tokens_json)}`);
+  }
+  if (row.cost != null) {
+    fields.push(`"cost":${JSON.stringify(Number(row.cost))}`);
+  }
+  if (row.cost_source) {
+    fields.push(`"cost_source":${JSON.stringify(row.cost_source)}`);
+  }
+  fields.push(`"parts":${String(row.parts_json ?? "[]")}`);
+  return `${metadataJson.slice(0, -1)},${fields.join(",")}}`;
 }
 
 export function appendPlainText(value: unknown, chunks: string[]): void {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -38,6 +38,12 @@ export interface CachedSessionDataEntry {
   meta: SessionCacheMeta | null;
 }
 
+export interface CachedSessionRawEntry {
+  data: Omit<SessionData, "messages">;
+  messageRows: CachedMessageRow[];
+  meta: SessionCacheMeta | null;
+}
+
 function parseCachedSessionMeta(value: string | null | undefined): SessionCacheMeta | null {
   if (!value) return null;
   try {
@@ -209,10 +215,10 @@ export function markAgentFullSyncCompleted(agentName: string): void {
   });
 }
 
-export function loadCachedSessionDataEntry(
+export function loadCachedSessionRawEntry(
   agentName: string,
   sessionId: string,
-): CachedSessionDataEntry | null {
+): CachedSessionRawEntry | null {
   if (!hasCacheStorage()) {
     return null;
   }
@@ -307,12 +313,27 @@ export function loadCachedSessionDataEntry(
     return {
       data: {
         ...head,
-        messages: messageRows.map((messageRow) => messageFromCachedRow(messageRow)),
         file_activity: fileActivityRows.map((activityRow) => fileActivityFromRow(activityRow)),
       },
+      messageRows,
       meta: parseCachedSessionMeta(row.meta_json),
     };
   });
+}
+
+export function loadCachedSessionDataEntry(
+  agentName: string,
+  sessionId: string,
+): CachedSessionDataEntry | null {
+  const entry = loadCachedSessionRawEntry(agentName, sessionId);
+  if (!entry) return null;
+  return {
+    data: {
+      ...entry.data,
+      messages: entry.messageRows.map((messageRow) => messageFromCachedRow(messageRow)),
+    },
+    meta: entry.meta,
+  };
 }
 
 export function loadCachedSessionData(agentName: string, sessionId: string): SessionData | null {

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -9,6 +9,8 @@ export {
 export type { ScanResult, ScanOptions } from "./scanner.js";
 export {
   materializeSessionDetail,
+  materializeSessionDetailResponse,
+  type SessionDetailResponseResult,
   type SessionDetailResult,
   type SessionReference,
 } from "./session-detail.js";

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -1,12 +1,14 @@
-import type { SessionCacheMeta } from "../agents/index.js";
-import type { SessionData } from "../types/index.js";
+import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
+import type { SessionData, SessionHead } from "../types/index.js";
 import { computeIdentity, realFs } from "../projects/index.js";
 import {
   classifySessionTags,
   extractSessionFileActivity,
   getSmartTagSourceTimestamp,
 } from "../utils/index.js";
-import { listSessionFileActivity, loadCachedSessionDataEntry } from "./cache.js";
+import { listSessionFileActivity } from "./cache.js";
+import { loadCachedSessionRawEntry, type CachedSessionRawEntry } from "./cache/sessions.js";
+import { messageFromCachedRow, messageJsonFromCachedRow } from "./cache/messages.js";
 import type { ScanResult } from "./scanner.js";
 
 export interface SessionReference {
@@ -19,6 +21,71 @@ export type SessionDetailResult =
   | { status: "unknown-agent" }
   | { status: "not-ready" };
 
+export type SessionDetailResponseResult =
+  | SessionDetailResult
+  | {
+      status: "found-json";
+      data: Omit<SessionData, "messages">;
+      messages: Iterable<string>;
+      messageCount: number;
+    };
+
+interface SessionDetailLookup {
+  agentsByName: Map<string, BaseAgent>;
+  headsByReference: Map<string, SessionHead>;
+}
+
+interface SessionDetailContext {
+  agent: BaseAgent;
+  head: SessionHead | undefined;
+}
+
+const sessionDetailLookups = new WeakMap<SessionHead[], SessionDetailLookup>();
+
+function sessionReferenceKey(agentName: string, sessionId: string): string {
+  return `${agentName}\0${sessionId}`;
+}
+
+/**
+ * The canonical sessions array is replaced atomically with each scan snapshot,
+ * so its identity also versions this lazily built lookup.
+ */
+function getSessionDetailLookup(scanResult: ScanResult): SessionDetailLookup {
+  const cached = sessionDetailLookups.get(scanResult.sessions);
+  if (cached) return cached;
+
+  const agentsByName = new Map<string, BaseAgent>();
+  for (const agent of scanResult.agents) {
+    if (!agentsByName.has(agent.name)) agentsByName.set(agent.name, agent);
+  }
+  const headsByReference = new Map<string, SessionHead>();
+  for (const [agentName, sessions] of Object.entries(scanResult.byAgent)) {
+    for (const session of sessions) {
+      const key = sessionReferenceKey(agentName, session.id);
+      if (!headsByReference.has(key)) headsByReference.set(key, session);
+    }
+  }
+
+  const lookup = { agentsByName, headsByReference };
+  sessionDetailLookups.set(scanResult.sessions, lookup);
+  return lookup;
+}
+
+function getSessionDetailContext(
+  scanResult: ScanResult,
+  reference: SessionReference,
+): SessionDetailContext | null {
+  const lookup = getSessionDetailLookup(scanResult);
+  const agent = lookup.agentsByName.get(reference.agentName);
+  if (!agent) return null;
+  return {
+    agent,
+    head: lookup.headsByReference.get(
+      sessionReferenceKey(reference.agentName, reference.sessionId),
+    ),
+  };
+}
+
 function cacheMatchesCurrentSource(
   cachedMeta: SessionCacheMeta | null,
   currentMeta: SessionCacheMeta | undefined,
@@ -29,41 +96,45 @@ function cacheMatchesCurrentSource(
 }
 
 function cacheHasCompleteDetail(
-  cachedData: SessionData | null,
-  cachedMeta: SessionCacheMeta | null,
+  cachedEntry: CachedSessionRawEntry | null,
   currentMeta: SessionCacheMeta | undefined,
-): cachedData is SessionData {
-  if (!cachedData || !cacheMatchesCurrentSource(cachedMeta, currentMeta)) {
+): cachedEntry is CachedSessionRawEntry {
+  if (!cachedEntry || !cacheMatchesCurrentSource(cachedEntry.meta, currentMeta)) {
     return false;
   }
 
-  return cachedData.messages.length > 0 || cachedData.stats.message_count === 0;
+  return cachedEntry.messageRows.length > 0 || cachedEntry.data.stats.message_count === 0;
 }
 
-export function materializeSessionDetail(
-  scanResult: ScanResult,
-  reference: SessionReference,
-): SessionDetailResult {
-  const agent = scanResult.agents.find((item) => item.name === reference.agentName);
-  if (!agent) {
-    return { status: "unknown-agent" };
-  }
+function getProjectIdentity(
+  data: Pick<SessionData, "directory" | "project_identity">,
+  head: SessionHead | undefined,
+) {
+  return data.project_identity ?? head?.project_identity ?? computeIdentity(data.directory, realFs);
+}
 
-  const head = scanResult.byAgent[reference.agentName]?.find(
-    (item) => item.id === reference.sessionId,
-  );
-  const cachedEntry = loadCachedSessionDataEntry(reference.agentName, reference.sessionId);
-  const cachedData = cachedEntry?.data ?? null;
+function materializeStructuredSessionDetail(
+  context: SessionDetailContext,
+  reference: SessionReference,
+  cachedEntry = loadCachedSessionRawEntry(reference.agentName, reference.sessionId),
+): SessionDetailResult {
+  const { agent, head } = context;
   const currentMeta = head ? agent.getSessionMetaMap().get(reference.sessionId) : undefined;
-  const useCache = cacheHasCompleteDetail(cachedData, cachedEntry?.meta ?? null, currentMeta);
-  const data = useCache ? cachedData : head ? agent.getSessionData(reference.sessionId) : null;
+  const useCache = cacheHasCompleteDetail(cachedEntry, currentMeta);
+  const data = useCache
+    ? {
+        ...cachedEntry.data,
+        messages: cachedEntry.messageRows.map((messageRow) => messageFromCachedRow(messageRow)),
+      }
+    : head
+      ? agent.getSessionData(reference.sessionId)
+      : null;
 
   if (!data) {
     return { status: "not-ready" };
   }
 
-  const projectIdentity =
-    data.project_identity ?? head?.project_identity ?? computeIdentity(data.directory, realFs);
+  const projectIdentity = getProjectIdentity(data, head);
   const fileActivity =
     data.file_activity ??
     (useCache
@@ -84,5 +155,51 @@ export function materializeSessionDetail(
       smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
       file_activity: fileActivity,
     },
+  };
+}
+
+function* serializeCachedMessages(entry: CachedSessionRawEntry): IterableIterator<string> {
+  for (const messageRow of entry.messageRows) {
+    yield messageJsonFromCachedRow(messageRow);
+  }
+}
+
+export function materializeSessionDetail(
+  scanResult: ScanResult,
+  reference: SessionReference,
+): SessionDetailResult {
+  const context = getSessionDetailContext(scanResult, reference);
+  if (!context) return { status: "unknown-agent" };
+  return materializeStructuredSessionDetail(context, reference);
+}
+
+export function materializeSessionDetailResponse(
+  scanResult: ScanResult,
+  reference: SessionReference,
+): SessionDetailResponseResult {
+  const context = getSessionDetailContext(scanResult, reference);
+  if (!context) return { status: "unknown-agent" };
+
+  const cachedEntry = loadCachedSessionRawEntry(reference.agentName, reference.sessionId);
+  const currentMeta = context.head
+    ? context.agent.getSessionMetaMap().get(reference.sessionId)
+    : undefined;
+  const useCache = cacheHasCompleteDetail(cachedEntry, currentMeta);
+  if (!useCache || cachedEntry.data.smart_tags == null) {
+    return materializeStructuredSessionDetail(context, reference, cachedEntry);
+  }
+
+  const data = cachedEntry.data;
+  return {
+    status: "found-json",
+    data: {
+      ...data,
+      project_identity: getProjectIdentity(data, context.head),
+      smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
+      file_activity:
+        data.file_activity ?? listSessionFileActivity(reference.agentName, reference.sessionId),
+    },
+    messages: serializeCachedMessages(cachedEntry),
+    messageCount: cachedEntry.messageRows.length,
   };
 }


### PR DESCRIPTION
## Summary

- index agents and session heads once per scan snapshot for O(1) detail lookup
- preserve cache-owned `parts_json` and `tokens_json` instead of parsing and re-stringifying them
- stream cached messages while preserving the existing `SessionData` JSON contract, aliases, fingerprint invalidation, and structured fallbacks

## Performance

For a 5,019,561-byte cached transcript (20-run median):

- structured parse/stringify: 6.47 ms
- raw JSON path: 0.88 ms (7.34x faster)

For 100,000 session heads:

- one-time index build: 12.79 ms
- 100 tail `Array.find` lookups: 82.74 ms
- 100 indexed lookups: 0.006 ms

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` (1,108 tests)
- `pnpm test:coverage`
- `pnpm test:e2e` (21 tests)