### PR TITLE
refactor(domain)!: align public terminology

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,9 +16,13 @@ _Avoid_: Transcript file
 由一个 Agent 产生、经 CodeSesh 归一化后可统一浏览的一段编码对话。
 _Avoid_: Conversation, chat
 
+**Session ID**:
+Agent 在自身命名空间内为 Session 提供的不透明标识；它必须与 Agent 组合后才能唯一定位 Session。
+_Avoid_: Session slug, global session ID
+
 **Session Reference**:
 在 CodeSesh 中唯一标识 Session 的复合身份，由 Agent 与该 Agent 内不透明的 Session ID 共同构成；Session ID 本身不全局唯一，也不应被拆解解释。
-_Avoid_: Bare session ID, session slug
+_Avoid_: Session slug, session path
 
 **Session Head**:
 用于列表、分组、搜索和统计的轻量 Session 摘要，不包含完整消息正文。
@@ -32,6 +36,26 @@ _Avoid_: Full session, transcript
 将不同 Agent 中属于同一代码项目的 Session 聚合起来的复合身份，由 kind 与 key 共同构成。
 _Avoid_: Project path, bare project key
 
+**Project Group**:
+按同一 Project Identity 聚合的一组 Session Head，用于跨 Agent 浏览同一个项目。
+_Avoid_: Project folder, workspace
+
 **Live Snapshot**:
 CodeSesh 当前已发布、可供查询和浏览的一组 Session Head 及其派生统计。
 _Avoid_: Cache, session list
+
+**Session Alias**:
+用户为一个 Session Reference 指定的显示名称；它只改变展示，不改变 Session 的身份。
+_Avoid_: Session title, nickname
+
+**Bookmark**:
+用户标记为稍后访问的 Session；它的身份始终由 Session Reference 决定。
+_Avoid_: Favorite, bookmarked session snapshot
+
+**Smart Tag**:
+CodeSesh 根据 Session 内容自动归纳、用于筛选的一项工作类型分类。
+_Avoid_: Label, manual tag
+
+**File Activity**:
+Session 中对文件路径发生的读取、编辑、写入或删除活动的归一化汇总。
+_Avoid_: File change, tool call

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,7 +3,7 @@ declare const __APP_VERSION__: string;
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { PanelLeftClose, PanelLeftOpen } from "./components/ui/icons";
 import { Link, useLocation, useMatches, useNavigate } from "react-router-dom";
-import type { BookmarkedSessionSnapshot, SessionHead } from "./lib/api";
+import type { BookmarkRecord, SessionHead } from "./lib/api";
 import { logClientEvent } from "./lib/api";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { CopyResumeButton } from "./components/CopyResumeButton";
@@ -98,9 +98,9 @@ export default function App() {
       path: location.pathname,
       mode: viewState.mode,
       agent: viewState.activeAgentKey,
-      session: viewState.activeSessionSlug,
+      session: viewState.activeSessionId,
     });
-  }, [location.pathname, viewState.mode, viewState.activeAgentKey, viewState.activeSessionSlug]);
+  }, [location.pathname, viewState.mode, viewState.activeAgentKey, viewState.activeSessionId]);
 
   useEffect(() => {
     if (viewState.mode !== "project") return;
@@ -213,7 +213,7 @@ export default function App() {
     });
   }, []);
 
-  const handleRenameBookmarkedSession = useCallback((bookmark: BookmarkedSessionSnapshot) => {
+  const handleRenameBookmarkedSession = useCallback((bookmark: BookmarkRecord) => {
     setAliasTarget({
       agentKey: bookmark.reference.agentName,
       sessionId: bookmark.reference.sessionId,
@@ -284,7 +284,7 @@ export default function App() {
 
     if (viewState.mode === "session") {
       setSelectedSidebarSessionReference(
-        getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionSlug),
+        getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionId),
       );
       return;
     }
@@ -299,7 +299,7 @@ export default function App() {
     isSearchMode,
     viewState.mode,
     viewState.activeAgentKey,
-    viewState.activeSessionSlug,
+    viewState.activeSessionId,
     sidebarSessions,
   ]);
 

--- a/apps/web/src/components/Dashboard.test.tsx
+++ b/apps/web/src/components/Dashboard.test.tsx
@@ -2,10 +2,10 @@ import { cleanup, fireEvent, render, screen, within } from "@testing-library/rea
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import type {
-  BookmarkedSessionSnapshot,
+  BookmarkRecord,
   DashboardData,
   DashboardRecentSession,
-  ProjectGroup,
+  ApiProjectGroup,
   SessionHead,
 } from "../lib/api";
 import { createAgentCatalog } from "../lib/agents";
@@ -69,7 +69,7 @@ const recentSession: DashboardRecentSession = {
   session: recentSessionHead,
 };
 
-const bookmarkedSession: BookmarkedSessionSnapshot = {
+const bookmarkedSession: BookmarkRecord = {
   reference: { agentName: "codex", sessionId: "saved" },
   session: {
     ...makeSession("saved"),
@@ -85,7 +85,7 @@ const bookmarkedSession: BookmarkedSessionSnapshot = {
   bookmarkedAt: Date.now(),
 };
 
-const project: ProjectGroup = {
+const project: ApiProjectGroup = {
   identityKind: "path",
   identityKey: "/workspace",
   displayName: "CodeSesh",

--- a/apps/web/src/components/Dashboard.tsx
+++ b/apps/web/src/components/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { Pie, PieChart } from "recharts";
 import type {
-  BookmarkedSessionSnapshot,
+  BookmarkRecord,
   DashboardData,
   DashboardAgentStat,
   DashboardDailyBucket,
@@ -10,7 +10,7 @@ import type {
   FileActivityResult,
   ModelDistributionEntry,
   DashboardRecentSession,
-  ProjectGroup,
+  ApiProjectGroup,
 } from "../lib/api";
 import { findAgent, type AgentCatalog } from "../lib/agents";
 import { getSessionBookmarkKey } from "../lib/bookmarks";
@@ -25,10 +25,10 @@ import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } f
 interface DashboardProps {
   data: DashboardData;
   agentCatalog: AgentCatalog;
-  projects?: ProjectGroup[];
-  bookmarkedSessions: BookmarkedSessionSnapshot[];
+  projects?: ApiProjectGroup[];
+  bookmarkedSessions: BookmarkRecord[];
   isBookmarked: (agentKey: string, sessionId: string) => boolean;
-  onToggleBookmark: (session: DashboardRecentSession | BookmarkedSessionSnapshot) => void;
+  onToggleBookmark: (session: DashboardRecentSession | BookmarkRecord) => void;
 }
 
 function formatCompact(value: number): string {
@@ -524,7 +524,7 @@ function TopProjects({
   projects,
   agentCatalog,
 }: {
-  projects: ProjectGroup[];
+  projects: ApiProjectGroup[];
   agentCatalog: AgentCatalog;
 }) {
   if (projects.length === 0) return null;
@@ -597,9 +597,9 @@ function BookmarkedSessions({
   agentCatalog,
   onToggleBookmark,
 }: {
-  sessions: BookmarkedSessionSnapshot[];
+  sessions: BookmarkRecord[];
   agentCatalog: AgentCatalog;
-  onToggleBookmark: (session: BookmarkedSessionSnapshot) => void;
+  onToggleBookmark: (session: BookmarkRecord) => void;
 }) {
   if (sessions.length === 0) return null;
 

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -9,8 +9,8 @@ import { SmartTagChips } from "./SmartTagChips";
 
 export interface LandingSession extends SessionHead {
   agentKey: string;
-  sessionSlug: string;
-  fullPath: string;
+  sessionId: string;
+  reference: string;
 }
 
 export interface LandingAgentItem {
@@ -28,7 +28,7 @@ interface DetailLandingProps {
   agentItems: LandingAgentItem[];
   activeAgentKey?: string;
   attemptedAgentKey?: string;
-  attemptedSessionSlug?: string | null;
+  attemptedSessionId?: string | null;
   isBookmarked: (agentKey: string, sessionId: string) => boolean;
   onToggleBookmark: (session: LandingSession) => void;
 }
@@ -187,12 +187,12 @@ function RecentSessions({
           return (
             <li key={session.id}>
               <div className="flex items-start gap-2 rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]">
-                <Link to={`/${session.fullPath}`} className="min-w-0 flex-1">
+                <Link to={`/${session.reference}`} className="min-w-0 flex-1">
                   <p className="line-clamp-1 text-sm text-[var(--console-text)]">
                     {getSessionDisplayTitle(session)}
                   </p>
                   <p className="console-mono mt-0.5 text-[11px] text-[var(--console-muted)]">
-                    /{session.fullPath} ·{" "}
+                    /{session.reference} ·{" "}
                     {formatRelativeTime(session.time_updated || session.time_created)}
                   </p>
                   <SmartTagChips tags={session.smart_tags} className="mt-1.5" />
@@ -214,7 +214,7 @@ export function DetailLanding({
   agentItems,
   activeAgentKey,
   attemptedAgentKey,
-  attemptedSessionSlug,
+  attemptedSessionId,
   isBookmarked,
   onToggleBookmark,
 }: DetailLandingProps) {
@@ -235,7 +235,7 @@ export function DetailLanding({
   const latestUpdatedAt = sortedSessions[0]?.time_updated || sortedSessions[0]?.time_created;
 
   if (type === "missing-agent") {
-    const requestedPath = `/${attemptedAgentKey || "unknown"}${attemptedSessionSlug ? `/${attemptedSessionSlug}` : ""}`;
+    const requestedPath = `/${attemptedAgentKey || "unknown"}${attemptedSessionId ? `/${attemptedSessionId}` : ""}`;
 
     return (
       <div className="mx-auto max-w-4xl space-y-4">
@@ -249,8 +249,8 @@ export function DetailLanding({
         <div className="grid gap-3 md:grid-cols-3">
           <DiagnosticItem label="Requested Agent" value={attemptedAgentKey || "unknown"} />
           <DiagnosticItem label="Requested Path" value={requestedPath} />
-          {attemptedSessionSlug ? (
-            <DiagnosticItem label="Requested Session" value={attemptedSessionSlug} />
+          {attemptedSessionId ? (
+            <DiagnosticItem label="Requested Session" value={attemptedSessionId} />
           ) : null}
         </div>
 
@@ -263,14 +263,14 @@ export function DetailLanding({
     const agent = activeAgentKey ? findAgent(agentCatalog, activeAgentKey) : undefined;
     const displayName = agent?.displayName ?? activeAgentKey ?? "Unknown Agent";
     const agentIcon = agent?.icon;
-    const sessionSlug = attemptedSessionSlug || "unknown-session";
+    const sessionId = attemptedSessionId || "unknown-session";
 
     return (
       <div className="mx-auto max-w-4xl space-y-4">
         <MissingStateHero
           code="404 / SESSION"
           title="This session isn't in the index."
-          description={`${displayName} is available, but the session you're looking for does not exist in the current index. The slug may be incorrect, or the record may never have been part of this dataset.`}
+          description={`${displayName} is available, but the session you're looking for does not exist in the current index. The session ID may be incorrect, or the record may never have been part of this dataset.`}
           aside="We checked the current path, but nothing matched. The session list on the left is still available."
           iconSrc={agentIcon}
           iconColored={agent?.iconColored}
@@ -296,7 +296,7 @@ export function DetailLanding({
               </p>
             </div>
           </div>
-          <DiagnosticItem label="Session" value={sessionSlug} />
+          <DiagnosticItem label="Session" value={sessionId} />
         </div>
 
         <RecentSessions

--- a/apps/web/src/components/InteractiveReceipt.tsx
+++ b/apps/web/src/components/InteractiveReceipt.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useMemo, useRef } from "react";
-import type { SessionData } from "../lib/api";
+import type { SessionDetail } from "../lib/api";
 import { getSessionDisplayTitle } from "../lib/session-title";
 import {
   isReceiptSettled,
@@ -11,7 +11,7 @@ import { SMART_TAG_LABELS } from "./SmartTagChips";
 import type { SessionDetailToc } from "./session-detail/toc";
 
 interface InteractiveReceiptProps {
-  session: SessionData;
+  session: SessionDetail;
   toc: SessionDetailToc;
   minWidthQuery?: string;
 }
@@ -21,8 +21,8 @@ interface ReceiptPayload {
   title: string;
   agent: string;
   updatedAt: number;
-  tags?: SessionData["smart_tags"];
-  stats: SessionData["stats"];
+  tags?: SessionDetail["smart_tags"];
+  stats: SessionDetail["stats"];
   items: ReceiptLineItem[];
 }
 
@@ -141,12 +141,12 @@ function buildReceiptItems(toc: SessionDetailToc): ReceiptLineItem[] {
   return [...baseItems, ...visibleToolItems].slice(0, maxItems);
 }
 
-function formatReceiptSubtitle(tags?: SessionData["smart_tags"]) {
+function formatReceiptSubtitle(tags?: SessionDetail["smart_tags"]) {
   if (!tags || tags.length === 0) return "SESSION ACTIVITY RECEIPT";
   return tags.map((tag) => SMART_TAG_LABELS[tag]).join(" / ");
 }
 
-function createReceiptPayload(session: SessionData, toc: SessionDetailToc): ReceiptPayload {
+function createReceiptPayload(session: SessionDetail, toc: SessionDetailToc): ReceiptPayload {
   const agent = session.slug?.split("/")[0] || "codesesh";
   return {
     id: session.id,

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import type { DashboardData, ProjectAgentStat, ProjectGroup, SessionHead } from "../lib/api";
+import type { DashboardData, ApiProjectAgentStat, ApiProjectGroup, SessionHead } from "../lib/api";
 import { findAgent, type AgentCatalog } from "../lib/agents";
 import { formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
 import { getProjectPath } from "../lib/projects";
@@ -37,7 +37,7 @@ function AgentPills({
   agents,
   agentCatalog,
 }: {
-  agents: ProjectAgentStat[];
+  agents: ApiProjectAgentStat[];
   agentCatalog: AgentCatalog;
 }) {
   if (agents.length === 0) return null;
@@ -71,7 +71,7 @@ function ProjectListItem({
   project,
   agentCatalog,
 }: {
-  project: ProjectGroup;
+  project: ApiProjectGroup;
   agentCatalog: AgentCatalog;
 }) {
   return (
@@ -111,7 +111,7 @@ export function ProjectsOverview({
   projects,
   agentCatalog,
 }: {
-  projects: ProjectGroup[];
+  projects: ApiProjectGroup[];
   agentCatalog: AgentCatalog;
 }) {
   const totalSessions = projects.reduce((sum, project) => sum + project.sessionCount, 0);
@@ -159,7 +159,7 @@ function ProjectAgentFilter({
   activeAgent,
   onChange,
 }: {
-  agents: ProjectAgentStat[];
+  agents: ApiProjectAgentStat[];
   agentCatalog: AgentCatalog;
   activeAgent?: string;
   onChange: (agent?: string) => void;
@@ -216,7 +216,7 @@ function ProjectHeader({
   project,
   agentCatalog,
 }: {
-  project: ProjectGroup;
+  project: ApiProjectGroup;
   agentCatalog: AgentCatalog;
 }) {
   return (
@@ -263,9 +263,9 @@ function TopCostSessions({
         {topSessions.map((session) => {
           const agent = findAgent(agentCatalog, session.agentKey);
           return (
-            <li key={session.fullPath}>
+            <li key={session.reference}>
               <Link
-                to={`/${session.fullPath}`}
+                to={`/${session.reference}`}
                 className="block rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
               >
                 <div className="flex items-center gap-2">
@@ -285,7 +285,7 @@ function TopCostSessions({
                   </span>
                 </div>
                 <p className="console-mono mt-1 text-[11px] text-[var(--console-muted)]">
-                  /{session.fullPath} · {formatCompact(getSessionTotalTokens(session))} tokens
+                  /{session.reference} · {formatCompact(getSessionTotalTokens(session))} tokens
                 </p>
               </Link>
             </li>
@@ -309,7 +309,7 @@ export function ProjectDashboardView({
   isBookmarked,
   onToggleSessionBookmark,
 }: {
-  project: ProjectGroup | null;
+  project: ApiProjectGroup | null;
   agentCatalog: AgentCatalog;
   projectKey: string;
   dashboard: DashboardData | null;

--- a/apps/web/src/components/SessionDetail.test.tsx
+++ b/apps/web/src/components/SessionDetail.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { SessionData } from "../lib/api";
+import type * as Api from "../lib/api";
 import { createAgentCatalog } from "../lib/agents";
 
 const displayModelMocks = vi.hoisted(() => ({
@@ -27,7 +27,7 @@ describe("SessionDetail identity", () => {
       resolveMessageIndex: vi.fn(),
       select: vi.fn(() => ({ messages: [], timelineEntries: [], resolveListIndex: vi.fn() })),
     });
-    const session: SessionData = {
+    const session: Api.SessionDetail = {
       reference: { agentName: "codex", sessionId: "s1" },
       id: "s1",
       slug: null,

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -2,7 +2,7 @@
 import { ChevronDown, ChevronUp, FileText } from "./ui/icons";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { findAgent, type AgentCatalog } from "../lib/agents";
-import type { SessionData } from "../lib/api";
+import type { SessionDetail } from "../lib/api";
 import { MarkdownContent } from "./MarkdownContent";
 import {
   isRenderProfilerEnabled,
@@ -32,7 +32,7 @@ import {
 // ---------------------------------------------------------------------------
 
 interface SessionDetailProps {
-  session: SessionData;
+  session: SessionDetail;
   agentCatalog: AgentCatalog;
   highlightQuery?: string;
 }

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ProjectGroup } from "../../lib/api";
+import type { ApiProjectGroup } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
 import { AppRouteContent } from "./AppRouteContent";
 
@@ -16,7 +16,7 @@ const project = {
   tokens: 0,
   cost: 0,
   agentStats: [],
-} satisfies ProjectGroup;
+} satisfies ApiProjectGroup;
 
 function makeProps(): Parameters<typeof AppRouteContent>[0] {
   return {
@@ -25,7 +25,7 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
     viewState: {
       mode: "root",
       activeAgentKey: null,
-      activeSessionSlug: null,
+      activeSessionId: null,
     },
     detailHighlightQuery: "",
     agents: [],
@@ -73,7 +73,7 @@ describe("AppRouteContent", () => {
     props.viewState = {
       mode: "project",
       activeAgentKey: null,
-      activeSessionSlug: null,
+      activeSessionId: null,
       activeProjectKind: "git_remote",
       activeProjectKey: project.identityKey,
     };

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -7,19 +7,19 @@ import { SessionDetail } from "../SessionDetail";
 import { SessionDetailSkeleton } from "../SessionDetailSkeleton";
 import type {
   AgentInfo,
-  BookmarkedSessionSnapshot,
+  BookmarkRecord,
   DashboardData,
-  ProjectGroup,
-  SessionData,
+  ApiProjectGroup,
   SessionHead,
 } from "../../lib/api";
+import type * as Api from "../../lib/api";
 import type { AgentCatalog } from "../../lib/agents";
 import type { ViewState } from "../../lib/view-state";
 import { SearchResultsPanel } from "./SearchResultsPanel";
 import type { SearchFilterState, SearchLoadState, SearchProjectOption } from "./types";
 
 interface SessionDetailModel {
-  session: SessionData | null;
+  session: Api.SessionDetail | null;
   loading: boolean;
   error: string | null;
 }
@@ -46,9 +46,9 @@ interface SearchContentModel {
 }
 
 interface BookmarkContentModel {
-  sessions: BookmarkedSessionSnapshot[];
+  sessions: BookmarkRecord[];
   isBookmarked: (agentKey: string, sessionId: string) => boolean;
-  toggleBookmark: (session: BookmarkedSessionSnapshot) => void;
+  toggleBookmark: (session: BookmarkRecord) => void;
   toggleSessionBookmark: (session: SessionHead, agentKey: string) => void;
 }
 
@@ -60,10 +60,10 @@ interface AppRouteContentProps {
   agents: AgentInfo[];
   agentCatalog: AgentCatalog;
   agentNameMap: ReadonlyMap<string, string>;
-  projects: ProjectGroup[];
+  projects: ApiProjectGroup[];
   landingSessions: LandingSession[];
   sessionsByAgent: Map<string, LandingSession[]>;
-  activeProject: ProjectGroup | null;
+  activeProject: ApiProjectGroup | null;
   activeProjectSessions: LandingSession[];
   dashboard: DashboardData | null;
   sessionDetail: SessionDetailModel;
@@ -208,7 +208,7 @@ export function AppRouteContent({
           sessions={sessionsByAgent.get(viewState.activeAgentKey) ?? []}
           agentItems={landingAgentItems}
           activeAgentKey={viewState.activeAgentKey}
-          attemptedSessionSlug={viewState.activeSessionSlug}
+          attemptedSessionId={viewState.activeSessionId}
           isBookmarked={bookmarks.isBookmarked}
           onToggleBookmark={(session) => bookmarks.toggleSessionBookmark(session, session.agentKey)}
         />

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -35,7 +35,7 @@ describe("AppSidebar agent counts", () => {
             sidebarCollapsed: false,
             browseBy: "agents",
             isScanActive: false,
-            viewState: { mode: "root", activeAgentKey: null, activeSessionSlug: null },
+            viewState: { mode: "root", activeAgentKey: null, activeSessionId: null },
             agents,
             agentCatalog: createAgentCatalog(agents),
             activeAgentKey: null,

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -1,7 +1,7 @@
 import type {
   AgentInfo,
-  BookmarkedSessionSnapshot,
-  ProjectGroup,
+  BookmarkRecord,
+  ApiProjectGroup,
   ScanStatusEvent,
   SessionHead,
 } from "../../lib/api";
@@ -103,7 +103,7 @@ function ProjectNavList({
   selectedProjectNavigationId,
   onSelectProject,
 }: {
-  projects: ProjectGroup[];
+  projects: ApiProjectGroup[];
   selectedProjectNavigationId: string | null;
   onSelectProject: (identity: ReturnType<typeof getProjectGroupIdentity>) => void;
 }) {
@@ -146,10 +146,10 @@ export interface AppSidebarViewModel {
   agentCatalog: AgentCatalog;
   activeAgentKey: string | null;
   scanStatus: ScanStatusEvent | null;
-  projects: ProjectGroup[];
+  projects: ApiProjectGroup[];
   selectedProjectNavigationId: string | null;
   loading: boolean;
-  bookmarkedSessions: BookmarkedSessionSnapshot[];
+  bookmarkedSessions: BookmarkRecord[];
   sidebarSessions: SessionHead[];
   selectedSidebarSessionReference: string | null;
   bookmarkedSidebarSessionReferences: Set<string>;
@@ -158,11 +158,11 @@ export interface AppSidebarViewModel {
 export interface AppSidebarActions {
   onChangeBrowseBy: (value: BrowseBy) => void;
   onSelectProject: (identity: ReturnType<typeof getProjectGroupIdentity>) => void;
-  onToggleBookmark: (session: BookmarkedSessionSnapshot) => void;
+  onToggleBookmark: (session: BookmarkRecord) => void;
   onSelectFlatSidebarSession: (session: SessionHead) => void;
   onToggleSidebarSessionBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
-  onRenameBookmarkedSession: (session: BookmarkedSessionSnapshot) => void;
+  onRenameBookmarkedSession: (session: BookmarkRecord) => void;
   onSelectTreeSidebarSession: (session: SessionHead) => void;
 }
 
@@ -200,7 +200,7 @@ export function AppSidebar({
 }) {
   const activeSessionReference =
     viewState.mode === "session"
-      ? getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionSlug)
+      ? getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionId)
       : null;
 
   return (
@@ -292,7 +292,7 @@ export function AppSidebar({
                 const isActive =
                   viewState.mode === "session" &&
                   viewState.activeAgentKey === reference.agentName &&
-                  viewState.activeSessionSlug === reference.sessionId;
+                  viewState.activeSessionId === reference.sessionId;
                 const agent = findAgent(agentCatalog, reference.agentName);
                 return (
                   <li key={getSessionBookmarkKey(reference)}>

--- a/apps/web/src/components/session-detail/session-detail-aux.tsx
+++ b/apps/web/src/components/session-detail/session-detail-aux.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { FileText, Funnel } from "../ui/icons";
-import type { SessionData } from "../../lib/api";
+import type { SessionDetail } from "../../lib/api";
 import { InteractiveReceipt } from "../InteractiveReceipt";
 import { RenderProfiler } from "../RenderProfiler";
 import { DrawerDialog } from "../DrawerDialog";
@@ -14,7 +14,7 @@ export function DeferredInteractiveReceipt({
   session,
   toc,
 }: {
-  session: SessionData;
+  session: SessionDetail;
   toc: SessionDetailToc;
 }) {
   const [open, setOpen] = useState(false);

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import type { BookmarkedSessionSnapshot, SessionHead } from "../lib/api";
+import type { BookmarkRecord, SessionHead } from "../lib/api";
 import * as api from "../lib/api";
 import * as bookmarkUtils from "../lib/bookmarks";
 import { createQueryWrapper } from "../test/query-wrapper";
@@ -24,7 +24,7 @@ vi.mock("../lib/bookmarks", async (importOriginal) => {
   };
 });
 
-const snap = (id: string, updated = 1): BookmarkedSessionSnapshot => ({
+const snap = (id: string, updated = 1): BookmarkRecord => ({
   reference: { agentName: "cc", sessionId: id },
   session: {
     id,
@@ -174,7 +174,7 @@ describe("useBookmarks", () => {
   });
 
   it("does not apply the initial response after unmount", async () => {
-    const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
+    const request = deferred<{ bookmarks: BookmarkRecord[] }>();
     vi.mocked(api.fetchBookmarks).mockReturnValueOnce(request.promise);
     const { unmount } = renderBookmarks();
 
@@ -225,7 +225,7 @@ describe("useBookmarks", () => {
   });
 
   it("does not report snapshot sync failures after unmount", async () => {
-    const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
+    const request = deferred<{ bookmarks: BookmarkRecord[] }>();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
     vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
@@ -266,7 +266,7 @@ describe("useBookmarks", () => {
 
   it("does not apply a completed legacy migration after unmount", async () => {
     const legacy = snap("legacy");
-    const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
+    const request = deferred<{ bookmarks: BookmarkRecord[] }>();
     vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([legacy]);
     vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
     const { unmount } = renderBookmarks();
@@ -294,7 +294,7 @@ describe("useBookmarks", () => {
   });
 
   it("does not report legacy migration failures after unmount", async () => {
-    const request = deferred<{ bookmarks: BookmarkedSessionSnapshot[] }>();
+    const request = deferred<{ bookmarks: BookmarkRecord[] }>();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([snap("legacy")]);
     vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import {
-  type BookmarkedSessionSnapshot,
+  type BookmarkRecord,
   type SessionHead,
   deleteBookmark,
   fetchBookmarks,
@@ -14,26 +14,26 @@ import {
   getSessionBookmarkKey,
   loadLegacyBookmarks,
   mergeBookmarksWithSessions,
-  toBookmarkedSessionSnapshot,
+  toBookmarkRecord,
 } from "../lib/bookmarks";
 import { queryKeys } from "../lib/query-keys";
 
 interface ToggleBookmarkVariables {
-  snapshot: BookmarkedSessionSnapshot;
+  snapshot: BookmarkRecord;
   isBookmarked: boolean;
 }
 
-const EMPTY_BOOKMARKS: BookmarkedSessionSnapshot[] = [];
+const EMPTY_BOOKMARKS: BookmarkRecord[] = [];
 
-function withoutBookmarkTimestamp(bookmarks: BookmarkedSessionSnapshot[]) {
+function withoutBookmarkTimestamp(bookmarks: BookmarkRecord[]) {
   return bookmarks.map(({ bookmarkedAt: _bookmarkedAt, ...bookmark }) => bookmark);
 }
 
 function toggledBookmarks(
-  bookmarks: BookmarkedSessionSnapshot[],
-  snapshot: BookmarkedSessionSnapshot,
+  bookmarks: BookmarkRecord[],
+  snapshot: BookmarkRecord,
   isBookmarked: boolean,
-): BookmarkedSessionSnapshot[] {
+): BookmarkRecord[] {
   const key = getSessionBookmarkKey(snapshot.reference);
   if (isBookmarked) {
     return bookmarks.filter((bookmark) => getSessionBookmarkKey(bookmark.reference) !== key);
@@ -45,10 +45,7 @@ function toggledBookmarks(
   });
 }
 
-function sameBookmarks(
-  left: BookmarkedSessionSnapshot[],
-  right: BookmarkedSessionSnapshot[],
-): boolean {
+function sameBookmarks(left: BookmarkRecord[], right: BookmarkRecord[]): boolean {
   return left.length === right.length && left.every((bookmark, index) => bookmark === right[index]);
 }
 
@@ -68,7 +65,7 @@ export function useBookmarks(sessions: SessionHead[]) {
   const bookmarks = bookmarksQuery.data?.bookmarks ?? EMPTY_BOOKMARKS;
 
   const setBookmarks = useCallback(
-    (next: BookmarkedSessionSnapshot[]) => {
+    (next: BookmarkRecord[]) => {
       queryClient.setQueryData(queryKeys.bookmarks, { bookmarks: next });
     },
     [queryClient],
@@ -85,7 +82,7 @@ export function useBookmarks(sessions: SessionHead[]) {
     },
     onMutate: async ({ snapshot, isBookmarked }) => {
       const cancellation = queryClient.cancelQueries({ queryKey: queryKeys.bookmarks });
-      const previous = queryClient.getQueryData<{ bookmarks: BookmarkedSessionSnapshot[] }>(
+      const previous = queryClient.getQueryData<{ bookmarks: BookmarkRecord[] }>(
         queryKeys.bookmarks,
       );
       setBookmarks(toggledBookmarks(previous?.bookmarks ?? [], snapshot, isBookmarked));
@@ -103,12 +100,10 @@ export function useBookmarks(sessions: SessionHead[]) {
   });
 
   const { mutate: syncBookmarks } = useMutation({
-    mutationFn: (bookmarks: Omit<BookmarkedSessionSnapshot, "bookmarkedAt">[]) =>
-      importBookmarks(bookmarks),
+    mutationFn: (bookmarks: Omit<BookmarkRecord, "bookmarkedAt">[]) => importBookmarks(bookmarks),
   });
   const { mutate: migrateBookmarks } = useMutation({
-    mutationFn: (bookmarks: Omit<BookmarkedSessionSnapshot, "bookmarkedAt">[]) =>
-      importBookmarks(bookmarks),
+    mutationFn: (bookmarks: Omit<BookmarkRecord, "bookmarkedAt">[]) => importBookmarks(bookmarks),
   });
 
   useEffect(() => {
@@ -145,7 +140,7 @@ export function useBookmarks(sessions: SessionHead[]) {
   );
 
   const toggleBookmark = useCallback(
-    (snapshot: BookmarkedSessionSnapshot) => {
+    (snapshot: BookmarkRecord) => {
       const key = getSessionBookmarkKey(snapshot.reference);
       mutateBookmark({ snapshot, isBookmarked: bookmarkKeySet.has(key) });
     },
@@ -154,7 +149,7 @@ export function useBookmarks(sessions: SessionHead[]) {
 
   const toggleSessionBookmark = useCallback(
     (session: SessionHead, agentKey: string) => {
-      toggleBookmark(toBookmarkedSessionSnapshot(session, agentKey));
+      toggleBookmark(toBookmarkRecord(session, agentKey));
     },
     [toggleBookmark],
   );

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
@@ -37,7 +37,7 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
     viewState: {
       mode: "root",
       activeAgentKey: null,
-      activeSessionSlug: null,
+      activeSessionId: null,
     } satisfies ViewState,
     browseBy: "agents" as const,
     navigate: vi.fn() as unknown as NavigateFunction,
@@ -136,7 +136,7 @@ describe("useKeyboardShortcuts", () => {
       viewState: {
         mode: "session",
         activeAgentKey: "codex",
-        activeSessionSlug: "s1",
+        activeSessionId: "s1",
       } satisfies ViewState,
       selectedProjectNavigationIdentity: { kind: "path" as const, key: "/workspace" },
     });
@@ -149,7 +149,7 @@ describe("useKeyboardShortcuts", () => {
       viewState: {
         mode: "session",
         activeAgentKey: "codex",
-        activeSessionSlug: "s1",
+        activeSessionId: "s1",
       } satisfies ViewState,
     });
     renderHook(() => useKeyboardShortcuts(agentDeps));

--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import type { SessionData } from "../lib/api";
+import type { SessionDetail } from "../lib/api";
 import type { ViewState } from "../lib/view-state";
 import * as api from "../lib/api";
 import { createQueryWrapper } from "../test/query-wrapper";
@@ -14,10 +14,10 @@ vi.mock("../lib/api", () => ({
 const sessionView: ViewState = {
   mode: "session",
   activeAgentKey: "claudecode",
-  activeSessionSlug: "claudecode/abc",
+  activeSessionId: "claudecode/abc",
 };
 
-const sample = { id: "abc", messages: [] } as unknown as SessionData;
+const sample = { id: "abc", messages: [] } as unknown as SessionDetail;
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -65,7 +65,7 @@ describe("useSessionDetail", () => {
   });
 
   it("does not fetch for a non-session route", () => {
-    const rootView: ViewState = { mode: "root", activeAgentKey: null, activeSessionSlug: null };
+    const rootView: ViewState = { mode: "root", activeAgentKey: null, activeSessionId: null };
     const { result } = renderSessionDetail(rootView);
 
     expect(result.current.session).toBeNull();
@@ -77,7 +77,7 @@ describe("useSessionDetail", () => {
     const { result } = renderSessionDetail();
     await waitFor(() => expect(result.current.session).toEqual(sample));
 
-    const updated = { id: "abc", messages: [1] } as unknown as SessionData;
+    const updated = { id: "abc", messages: [1] } as unknown as SessionDetail;
     vi.mocked(api.fetchSessionData).mockResolvedValue(updated);
     await act(async () => {
       await result.current.refresh();
@@ -86,18 +86,18 @@ describe("useSessionDetail", () => {
   });
 
   it("keeps the current route when an older request resolves last", async () => {
-    const requestA = deferred<SessionData>();
-    const requestB = deferred<SessionData>();
+    const requestA = deferred<SessionDetail>();
+    const requestB = deferred<SessionDetail>();
     const viewA = sessionView;
     const viewB: ViewState = {
       mode: "session",
       activeAgentKey: "codex",
-      activeSessionSlug: "def",
+      activeSessionId: "def",
     };
-    const sessionA = { id: "a", messages: [] } as unknown as SessionData;
-    const sessionB = { id: "b", messages: [] } as unknown as SessionData;
+    const sessionA = { id: "a", messages: [] } as unknown as SessionDetail;
+    const sessionB = { id: "b", messages: [] } as unknown as SessionDetail;
     vi.mocked(api.fetchSessionData).mockImplementation((_agent, sessionId) =>
-      sessionId === viewA.activeSessionSlug ? requestA.promise : requestB.promise,
+      sessionId === viewA.activeSessionId ? requestA.promise : requestB.promise,
     );
     const { result, rerender } = renderSessionDetail(viewA);
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
@@ -128,9 +128,9 @@ describe("useSessionDetail", () => {
     const viewB: ViewState = {
       mode: "session",
       activeAgentKey: "codex",
-      activeSessionSlug: "def",
+      activeSessionId: "def",
     };
-    const sessionB = { id: "b", messages: [] } as unknown as SessionData;
+    const sessionB = { id: "b", messages: [] } as unknown as SessionDetail;
     vi.mocked(api.fetchSessionData).mockImplementation((agent, _sessionId, options) => {
       if (agent === "codex") return Promise.resolve(sessionB);
       return new Promise((_resolve, reject) => {
@@ -155,16 +155,16 @@ describe("useSessionDetail", () => {
   });
 
   it("does not let a stale failure clear loading for the current request", async () => {
-    const requestA = deferred<SessionData>();
-    const requestB = deferred<SessionData>();
+    const requestA = deferred<SessionDetail>();
+    const requestB = deferred<SessionDetail>();
     const viewB: ViewState = {
       mode: "session",
       activeAgentKey: "codex",
-      activeSessionSlug: "def",
+      activeSessionId: "def",
     };
-    const sessionB = { id: "b", messages: [] } as unknown as SessionData;
+    const sessionB = { id: "b", messages: [] } as unknown as SessionDetail;
     vi.mocked(api.fetchSessionData).mockImplementation((_agent, sessionId) =>
-      sessionId === sessionView.activeSessionSlug ? requestA.promise : requestB.promise,
+      sessionId === sessionView.activeSessionId ? requestA.promise : requestB.promise,
     );
     const { result, rerender } = renderSessionDetail();
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
@@ -181,7 +181,7 @@ describe("useSessionDetail", () => {
   });
 
   it("aborts without committing state after unmount", async () => {
-    const request = deferred<SessionData>();
+    const request = deferred<SessionDetail>();
     vi.mocked(api.fetchSessionData).mockReturnValue(request.promise);
     const { unmount } = renderSessionDetail();
     await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledTimes(1));
@@ -202,13 +202,13 @@ describe("useSessionDetail", () => {
   });
 
   it("does not let an old refresh overwrite a navigated session", async () => {
-    const refreshRequest = deferred<SessionData>();
-    const refreshedA = { id: "a-refreshed", messages: [] } as unknown as SessionData;
-    const sessionB = { id: "b", messages: [] } as unknown as SessionData;
+    const refreshRequest = deferred<SessionDetail>();
+    const refreshedA = { id: "a-refreshed", messages: [] } as unknown as SessionDetail;
+    const sessionB = { id: "b", messages: [] } as unknown as SessionDetail;
     const viewB: ViewState = {
       mode: "session",
       activeAgentKey: "codex",
-      activeSessionSlug: "def",
+      activeSessionId: "def",
     };
     vi.mocked(api.fetchSessionData)
       .mockResolvedValueOnce(sample)

--- a/apps/web/src/hooks/useSessionDetail.ts
+++ b/apps/web/src/hooks/useSessionDetail.ts
@@ -10,19 +10,19 @@ function sessionRoute(viewState: ViewState) {
   if (viewState.mode !== "session") return null;
   return {
     agent: viewState.activeAgentKey,
-    sessionSlug: viewState.activeSessionSlug,
+    sessionId: viewState.activeSessionId,
   };
 }
 
 export function useSessionDetail(viewState: ViewState) {
   const route = sessionRoute(viewState);
   const query = useQuery({
-    queryKey: queryKeys.sessionDetail(route?.agent ?? "", route?.sessionSlug ?? ""),
+    queryKey: queryKeys.sessionDetail(route?.agent ?? "", route?.sessionId ?? ""),
     enabled: route !== null,
     queryFn: async ({ signal }) => {
       if (!route) throw new Error("Session route is required");
       const requestId = nextSessionRequestId++;
-      const requestKey = `${route.agent}/${route.sessionSlug}`;
+      const requestKey = `${route.agent}/${route.sessionId}`;
       const startedAt = performance.now();
       let didLogCancellation = false;
       const logCancellation = () => {
@@ -40,18 +40,18 @@ export function useSessionDetail(viewState: ViewState) {
         request_key: requestKey,
         trigger: "route",
         agent: route.agent,
-        session: route.sessionSlug,
+        session: route.sessionId,
       });
 
       try {
-        const data = await fetchSessionData(route.agent, route.sessionSlug, { signal });
+        const data = await fetchSessionData(route.agent, route.sessionId, { signal });
         if (signal.aborted) throw new DOMException("Aborted", "AbortError");
         logClientEvent("session.open.done", {
           request_id: requestId,
           request_key: requestKey,
           trigger: "route",
           agent: route.agent,
-          session: route.sessionSlug,
+          session: route.sessionId,
           duration_ms: Math.round(performance.now() - startedAt),
           messages: data.messages.length,
         });
@@ -66,7 +66,7 @@ export function useSessionDetail(viewState: ViewState) {
           request_key: requestKey,
           trigger: "route",
           agent: route.agent,
-          session: route.sessionSlug,
+          session: route.sessionId,
           duration_ms: Math.round(performance.now() - startedAt),
           error: error instanceof Error ? error.message : String(error),
         });

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@codesesh/core/contract";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentInfo, AppConfig, ProjectGroup } from "../lib/api";
+import type { AgentInfo, AppConfig, ApiProjectGroup } from "../lib/api";
 import * as api from "../lib/api";
 import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
@@ -24,7 +24,7 @@ const agents = [
   { name: "ClaudeCode", displayName: "Claude Code", count: 1 },
   { name: "Codex", displayName: "Codex", count: 0 },
 ] as unknown as AgentInfo[];
-const projects = [{ identityKind: "path", identityKey: "p1" }] as unknown as ProjectGroup[];
+const projects = [{ identityKind: "path", identityKey: "p1" }] as unknown as ApiProjectGroup[];
 
 function deferred<T>() {
   let resolve!: (value: T) => void;

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -5,7 +5,7 @@ import {
   type AgentInfo,
   type AppConfig,
   type DashboardData,
-  type ProjectGroup,
+  type ApiProjectGroup,
   type SessionHead,
   type SessionsUpdatedEvent,
   fetchAgents,
@@ -22,7 +22,7 @@ export interface SessionStoreSnapshot {
   window: AppConfig["window"];
   agents: AgentInfo[];
   sessions: SessionHead[];
-  projects: ProjectGroup[];
+  projects: ApiProjectGroup[];
   dashboard: DashboardData;
 }
 
@@ -31,14 +31,14 @@ type SnapshotAggregates = Pick<SessionStoreSnapshot, "agents" | "projects" | "da
 const EMPTY_SNAPSHOT = {
   agents: [] satisfies AgentInfo[],
   sessions: [] satisfies SessionHead[],
-  projects: [] satisfies ProjectGroup[],
+  projects: [] satisfies ApiProjectGroup[],
   dashboard: null,
 };
 
 async function loadProjects(
   window: AppConfig["window"],
   signal: AbortSignal,
-): Promise<ProjectGroup[]> {
+): Promise<ApiProjectGroup[]> {
   try {
     return (await fetchProjects(window, { signal })).projects;
   } catch (error) {

--- a/apps/web/src/hooks/useSidebarModel.test.ts
+++ b/apps/web/src/hooks/useSidebarModel.test.ts
@@ -1,7 +1,7 @@
 import { SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AgentInfo, ProjectGroup, SessionHead } from "../lib/api";
+import type { AgentInfo, ApiProjectGroup, SessionHead } from "../lib/api";
 import { buildSessionIndexes, getSessionReferenceKey } from "../lib/session-indexes";
 import type { ViewState } from "../lib/view-state";
 import { useSidebarModel } from "./useSidebarModel";
@@ -28,7 +28,7 @@ const projects = [
     cost: 0,
     agentStats: [],
   },
-] as ProjectGroup[];
+] as ApiProjectGroup[];
 const codexSession = {
   ...SAMPLE_SESSION_HEAD,
   id: "codex-session",
@@ -46,19 +46,19 @@ const sessionIndexes = buildSessionIndexes([codexSession, claudeSession], agents
 const rootView = {
   mode: "root",
   activeAgentKey: null,
-  activeSessionSlug: null,
+  activeSessionId: null,
 } satisfies ViewState;
 const projectView = {
   mode: "project",
   activeAgentKey: null,
-  activeSessionSlug: null,
+  activeSessionId: null,
   activeProjectKind: projectIdentity.kind,
   activeProjectKey: projectIdentity.key,
 } satisfies ViewState;
 const sessionView = {
   mode: "session",
   activeAgentKey: "codex",
-  activeSessionSlug: codexSession.id,
+  activeSessionId: codexSession.id,
 } satisfies ViewState;
 
 afterEach(cleanup);
@@ -92,7 +92,7 @@ describe("useSidebarModel", () => {
     const agentView = {
       mode: "agent",
       activeAgentKey: "codex",
-      activeSessionSlug: null,
+      activeSessionId: null,
     } satisfies ViewState;
     const { result } = renderModel(agentView);
 

--- a/apps/web/src/hooks/useSidebarModel.ts
+++ b/apps/web/src/hooks/useSidebarModel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { AgentInfo, ProjectGroup, SessionData, SessionHead } from "../lib/api";
+import type { AgentInfo, ApiProjectGroup, SessionDetail, SessionHead } from "../lib/api";
 import {
   getProjectGroupIdentity,
   getProjectIdentityKey,
@@ -19,9 +19,9 @@ import type { BrowseBy } from "../components/app/types";
 interface UseSidebarModelOptions {
   viewState: ViewState;
   sessionIndexes: SessionIndexes;
-  session: SessionData | null;
+  session: SessionDetail | null;
   agents: AgentInfo[];
-  projects: ProjectGroup[];
+  projects: ApiProjectGroup[];
   selectedProjectAgent?: string;
   isSessionBookmarked: (agentKey: string, sessionId: string) => boolean;
 }
@@ -29,7 +29,7 @@ interface UseSidebarModelOptions {
 export interface ProjectNavigationModel {
   identity: ProjectRouteIdentity;
   identityKey: string;
-  project: ProjectGroup | null;
+  project: ApiProjectGroup | null;
 }
 
 function browseByForRoute(viewState: ViewState): BrowseBy | null {
@@ -39,7 +39,7 @@ function browseByForRoute(viewState: ViewState): BrowseBy | null {
 }
 
 function findProject(
-  projects: ProjectGroup[],
+  projects: ApiProjectGroup[],
   identityKey: string,
 ): ProjectNavigationModel["project"] {
   return (
@@ -109,11 +109,11 @@ export function useSidebarModel({
     const openedSessionHead =
       viewState.mode === "session"
         ? (sessionIndexes.byRouteKey.get(
-            getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionSlug),
+            getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionId),
           ) ?? null)
         : null;
     const openedSessionData =
-      viewState.mode === "session" && session?.id === viewState.activeSessionSlug ? session : null;
+      viewState.mode === "session" && session?.id === viewState.activeSessionId ? session : null;
     const openedSessionProjectIdentity =
       openedSessionData?.project_identity ?? openedSessionHead?.project_identity ?? null;
     const selectedProjectIdentity =

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -20,7 +20,7 @@ export type {
   ToolPart,
   MessagePart,
   Message,
-  SessionData,
+  SessionDetail,
   SessionReference,
   ScanStatusEvent,
   BackfillStatus,
@@ -35,22 +35,22 @@ export type {
   AppConfig,
   SearchResult,
   SessionsUpdatedEvent,
-  ApiProjectGroup as ProjectGroup,
-  ApiProjectAgentStat as ProjectAgentStat,
-  BookmarkRecord as BookmarkedSessionSnapshot,
+  ApiProjectGroup,
+  ApiProjectAgentStat,
+  BookmarkRecord,
 } from "@codesesh/core/contract";
 
 import type {
   AgentInfo,
   ApiProjectGroup,
   AppConfig,
-  BookmarkRecord as BookmarkedSessionSnapshot,
+  BookmarkRecord,
   DashboardData,
   FileActivityKind,
   ProjectIdentityKind,
   ScanStatusEvent,
   SearchResult,
-  SessionData,
+  SessionDetail,
   SessionReference,
   SessionHead,
   SessionsUpdatedEvent,
@@ -180,7 +180,7 @@ export async function fetchSessionData(
   agent: string,
   sessionId: string,
   options?: FetchOptions,
-): Promise<SessionData> {
+): Promise<SessionDetail> {
   return fetchJson(`/api/sessions/${agent}/${sessionId}`, options);
 }
 
@@ -220,13 +220,13 @@ export async function fetchSearchResults(
 
 export async function fetchBookmarks(
   options?: FetchOptions,
-): Promise<{ bookmarks: BookmarkedSessionSnapshot[] }> {
+): Promise<{ bookmarks: BookmarkRecord[] }> {
   return fetchJson("/api/bookmarks", options);
 }
 
 export async function upsertBookmark(
-  bookmark: Omit<BookmarkedSessionSnapshot, "bookmarkedAt">,
-): Promise<{ bookmark: BookmarkedSessionSnapshot }> {
+  bookmark: Omit<BookmarkRecord, "bookmarkedAt">,
+): Promise<{ bookmark: BookmarkRecord }> {
   return fetchJson("/api/bookmarks", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -235,8 +235,8 @@ export async function upsertBookmark(
 }
 
 export async function importBookmarks(
-  bookmarks: Omit<BookmarkedSessionSnapshot, "bookmarkedAt">[],
-): Promise<{ bookmarks: BookmarkedSessionSnapshot[] }> {
+  bookmarks: Omit<BookmarkRecord, "bookmarkedAt">[],
+): Promise<{ bookmarks: BookmarkRecord[] }> {
   return fetchJson("/api/bookmarks/import", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/web/src/lib/app-routes.ts
+++ b/apps/web/src/lib/app-routes.ts
@@ -21,7 +21,7 @@ export const appRouteChildren: RouteObject[] = [
   {
     path: ":agentKey",
     id: APP_ROUTE_IDS.agent,
-    children: [{ path: ":sessionSlug", id: APP_ROUTE_IDS.session }],
+    children: [{ path: ":sessionId", id: APP_ROUTE_IDS.session }],
   },
   { path: "*", id: APP_ROUTE_IDS.notFound },
 ];

--- a/apps/web/src/lib/bookmarks.test.ts
+++ b/apps/web/src/lib/bookmarks.test.ts
@@ -5,8 +5,8 @@ import {
   getSessionBookmarkKey,
   loadLegacyBookmarks,
   mergeBookmarksWithSessions,
-  sortBookmarkedSessions,
-  toBookmarkedSessionSnapshot,
+  sortBookmarks,
+  toBookmarkRecord,
 } from "./bookmarks";
 
 function createSession(
@@ -45,7 +45,7 @@ describe("bookmarks", () => {
       time_updated: 200,
     });
 
-    expect(toBookmarkedSessionSnapshot(session, "codex")).toEqual({
+    expect(toBookmarkRecord(session, "codex")).toEqual({
       reference: { agentName: "codex", sessionId: "s1" },
       session,
       bookmarkedAt: expect.any(Number),
@@ -53,7 +53,7 @@ describe("bookmarks", () => {
   });
 
   it("refreshes stored snapshots when live sessions change", () => {
-    const bookmark = toBookmarkedSessionSnapshot(
+    const bookmark = toBookmarkRecord(
       createSession({
         id: "s1",
         slug: "codex/s1",
@@ -88,11 +88,11 @@ describe("bookmarks", () => {
   });
 
   it("loads valid legacy bookmarks and drops invalid entries", () => {
-    const older = toBookmarkedSessionSnapshot(
+    const older = toBookmarkRecord(
       createSession({ id: "old", slug: "codex/old", title: "Old", time_updated: 100 }),
       "codex",
     );
-    const newer = toBookmarkedSessionSnapshot(
+    const newer = toBookmarkRecord(
       createSession({ id: "new", slug: "codex/new", title: "New", time_updated: 300 }),
       "codex",
     );
@@ -153,7 +153,7 @@ describe("bookmarks", () => {
   });
 
   it("keeps bookmark arrays unchanged when live sessions add no new data", () => {
-    const bookmark = toBookmarkedSessionSnapshot(
+    const bookmark = toBookmarkRecord(
       createSession({ id: "s1", slug: "codex/s1", title: "Same", time_updated: 100 }),
       "codex",
     );
@@ -174,19 +174,17 @@ describe("bookmarks", () => {
   });
 
   it("sorts bookmarks by updated time with created time fallback", () => {
-    const createdOnly = toBookmarkedSessionSnapshot(
+    const createdOnly = toBookmarkRecord(
       createSession({ id: "created", slug: "codex/created", title: "Created", time_created: 200 }),
       "codex",
     );
-    const updated = toBookmarkedSessionSnapshot(
+    const updated = toBookmarkRecord(
       createSession({ id: "updated", slug: "codex/updated", title: "Updated", time_updated: 300 }),
       "codex",
     );
 
     expect(
-      [createdOnly, updated]
-        .toSorted(sortBookmarkedSessions)
-        .map((item) => item.reference.sessionId),
+      [createdOnly, updated].toSorted(sortBookmarks).map((item) => item.reference.sessionId),
     ).toEqual(["updated", "created"]);
   });
 });

--- a/apps/web/src/lib/bookmarks.ts
+++ b/apps/web/src/lib/bookmarks.ts
@@ -1,4 +1,4 @@
-import type { BookmarkedSessionSnapshot, SessionHead } from "./api";
+import type { BookmarkRecord, SessionHead } from "./api";
 import {
   formatSessionReference,
   getSessionAgentKey,
@@ -23,7 +23,7 @@ function isStats(value: unknown): value is SessionHead["stats"] {
   );
 }
 
-function parseLegacyBookmark(value: unknown): BookmarkedSessionSnapshot | null {
+function parseLegacyBookmark(value: unknown): BookmarkRecord | null {
   if (!isRecord(value)) return null;
   if (
     typeof value.sessionId === "string" &&
@@ -65,10 +65,7 @@ export function getSessionBookmarkKey(reference: SessionReference): string {
   return JSON.stringify([normalized.agentName, normalized.sessionId]);
 }
 
-export function toBookmarkedSessionSnapshot(
-  session: SessionHead,
-  agentKey: string,
-): BookmarkedSessionSnapshot {
+export function toBookmarkRecord(session: SessionHead, agentKey: string): BookmarkRecord {
   const reference = normalizeSessionReference({
     agentName: agentKey,
     sessionId: session.id,
@@ -84,7 +81,7 @@ export function toBookmarkedSessionSnapshot(
   };
 }
 
-export function loadLegacyBookmarks(): BookmarkedSessionSnapshot[] {
+export function loadLegacyBookmarks(): BookmarkRecord[] {
   if (typeof window === "undefined") return [];
 
   try {
@@ -94,8 +91,8 @@ export function loadLegacyBookmarks(): BookmarkedSessionSnapshot[] {
     if (!Array.isArray(parsed)) return [];
     return parsed
       .map(parseLegacyBookmark)
-      .filter((bookmark): bookmark is BookmarkedSessionSnapshot => bookmark !== null)
-      .toSorted(sortBookmarkedSessions);
+      .filter((bookmark): bookmark is BookmarkRecord => bookmark !== null)
+      .toSorted(sortBookmarks);
   } catch {
     return [];
   }
@@ -106,25 +103,22 @@ export function clearLegacyBookmarks(): void {
   window.localStorage.removeItem(LEGACY_BOOKMARK_STORAGE_KEY);
 }
 
-export function sortBookmarkedSessions(
-  a: BookmarkedSessionSnapshot,
-  b: BookmarkedSessionSnapshot,
-): number {
+export function sortBookmarks(a: BookmarkRecord, b: BookmarkRecord): number {
   const aTime = a.session.time_updated ?? a.session.time_created;
   const bTime = b.session.time_updated ?? b.session.time_created;
   return bTime - aTime;
 }
 
 export function mergeBookmarksWithSessions(
-  bookmarks: BookmarkedSessionSnapshot[],
+  bookmarks: BookmarkRecord[],
   sessions: SessionHead[],
-): BookmarkedSessionSnapshot[] {
+): BookmarkRecord[] {
   if (bookmarks.length === 0 || sessions.length === 0) return bookmarks;
 
   const liveSnapshots = new Map(
     sessions.map((session) => {
       const agentKey = getSessionAgentKey(session);
-      const snapshot = toBookmarkedSessionSnapshot(session, agentKey);
+      const snapshot = toBookmarkRecord(session, agentKey);
       return [getSessionBookmarkKey(snapshot.reference), snapshot] as const;
     }),
   );
@@ -152,5 +146,5 @@ export function mergeBookmarksWithSessions(
     };
   });
 
-  return changed ? next.toSorted(sortBookmarkedSessions) : bookmarks;
+  return changed ? next.toSorted(sortBookmarks) : bookmarks;
 }

--- a/apps/web/src/lib/build-route-header-model.test.tsx
+++ b/apps/web/src/lib/build-route-header-model.test.tsx
@@ -32,12 +32,12 @@ describe("buildRouteHeaderModel", () => {
     {
       mode: "session",
       activeAgentKey: "claudecode",
-      activeSessionSlug: "session-1",
+      activeSessionId: "session-1",
     } as const,
     {
       mode: "project",
       activeAgentKey: null,
-      activeSessionSlug: null,
+      activeSessionId: null,
       activeProjectKind: "path",
       activeProjectKey: "/tmp/codesesh",
     } as const,
@@ -56,13 +56,13 @@ describe("buildRouteHeaderModel", () => {
   });
 
   it.each([
-    [{ mode: "root", activeAgentKey: null, activeSessionSlug: null } as const, "Dashboard"],
-    [{ mode: "projects", activeAgentKey: null, activeSessionSlug: null } as const, "Projects"],
+    [{ mode: "root", activeAgentKey: null, activeSessionId: null } as const, "Dashboard"],
+    [{ mode: "projects", activeAgentKey: null, activeSessionId: null } as const, "Projects"],
     [
       {
         mode: "project",
         activeAgentKey: null,
-        activeSessionSlug: null,
+        activeSessionId: null,
         activeProjectKind: "path",
         activeProjectKey: "/tmp/codesesh",
       } as const,
@@ -72,11 +72,11 @@ describe("buildRouteHeaderModel", () => {
       {
         mode: "session",
         activeAgentKey: "claudecode",
-        activeSessionSlug: "session-1",
+        activeSessionId: "session-1",
       } as const,
       "Session",
     ],
-    [{ mode: "agent", activeAgentKey: "claudecode", activeSessionSlug: null } as const, "Landing"],
+    [{ mode: "agent", activeAgentKey: "claudecode", activeSessionId: null } as const, "Landing"],
   ])("keeps the existing $1 context for non-search routes", (viewState, expected) => {
     expect(buildRouteHeaderModel(createInput(viewState)).contextLabel).toBe(expected);
   });

--- a/apps/web/src/lib/build-route-header-model.tsx
+++ b/apps/web/src/lib/build-route-header-model.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { AgentInfo, DashboardData, ProjectGroup, SessionData } from "../lib/api";
+import type { AgentInfo, DashboardData, ApiProjectGroup, SessionDetail } from "../lib/api";
 import { formatRelativeTime } from "../lib/format";
 import { getProjectPath, type ProjectRouteIdentity } from "../lib/projects";
 import { getSessionDisplayTitle } from "./session-title";
@@ -18,15 +18,15 @@ interface RouteHeaderInput {
   isSearchMode: boolean;
   searchSubtitle: string;
   dashboard: DashboardData | null;
-  projects: ProjectGroup[];
+  projects: ApiProjectGroup[];
   sessionCount: number;
-  activeProject: ProjectGroup | null;
+  activeProject: ApiProjectGroup | null;
   activeAgent: AgentInfo | null;
   sidebarSessionCount: number;
-  session: SessionData | null;
+  session: SessionDetail | null;
   sessionError: string | null;
   selectedProjectIdentity: ProjectRouteIdentity | null;
-  selectedProject: ProjectGroup | null;
+  selectedProject: ApiProjectGroup | null;
 }
 
 export function buildRouteHeaderModel(input: RouteHeaderInput): {
@@ -98,13 +98,13 @@ function routeTitleAndSubtitle(input: RouteHeaderInput): {
     if (input.sessionError) {
       return {
         title: "Session Not Found",
-        subtitle: `Requested /${viewState.activeAgentKey}/${viewState.activeSessionSlug}`,
+        subtitle: `Requested /${viewState.activeAgentKey}/${viewState.activeSessionId}`,
       };
     }
     if (input.session) {
       const updated = input.session.time_updated ?? input.session.time_created;
       return {
-        title: getSessionDisplayTitle(input.session) || "Conversation",
+        title: getSessionDisplayTitle(input.session) || "Session",
         subtitle: (
           <>
             <span>ID: #{input.session.id.slice(0, 8)}</span>
@@ -166,7 +166,7 @@ function routeBreadcrumbs(input: RouteHeaderInput): BreadcrumbItem[] {
       {
         label: input.session
           ? getSessionDisplayTitle(input.session)
-          : viewState.activeSessionSlug || "Conversation",
+          : viewState.activeSessionId || "Session",
       },
     ];
   }
@@ -181,7 +181,7 @@ function routeBreadcrumbs(input: RouteHeaderInput): BreadcrumbItem[] {
   };
   if (viewState.mode === "agent") return [dashboard, { label: agentLabel }];
   if (viewState.mode === "missingSession") {
-    return [dashboard, agent, { label: viewState.attemptedSessionSlug }];
+    return [dashboard, agent, { label: viewState.attemptedSessionId }];
   }
   if (viewState.mode === "session") {
     return [
@@ -190,7 +190,7 @@ function routeBreadcrumbs(input: RouteHeaderInput): BreadcrumbItem[] {
       {
         label: input.session
           ? getSessionDisplayTitle(input.session)
-          : viewState.activeSessionSlug || "Conversation",
+          : viewState.activeSessionId || "Session",
       },
     ];
   }

--- a/apps/web/src/lib/projects.ts
+++ b/apps/web/src/lib/projects.ts
@@ -1,11 +1,11 @@
-import type { ProjectGroup, ProjectIdentityKind } from "./api";
+import type { ApiProjectGroup, ProjectIdentityKind } from "./api";
 
 export interface ProjectRouteIdentity {
   kind: ProjectIdentityKind;
   key: string;
 }
 
-export function getProjectGroupIdentity(project: ProjectGroup): ProjectRouteIdentity {
+export function getProjectGroupIdentity(project: ApiProjectGroup): ProjectRouteIdentity {
   return { kind: project.identityKind, key: project.identityKey };
 }
 

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -25,8 +25,8 @@ export const queryKeys = {
   search: (query: string, options: SearchRequestOptions) => ["search", query, options] as const,
   searches: ["search"] as const,
   sessionDetails: ["session-detail"] as const,
-  sessionDetail: (agent: string, sessionSlug: string) =>
-    ["session-detail", agent, sessionSlug] as const,
+  sessionDetail: (agent: string, sessionId: string) =>
+    ["session-detail", agent, sessionId] as const,
   sessionSnapshots: ["session-snapshot"] as const,
   sessionSnapshot: (window: TimeWindow) => ["session-snapshot", normalizeWindow(window)] as const,
   sessionSnapshotAggregateQueries: ["session-snapshot-aggregates"] as const,

--- a/apps/web/src/lib/session-indexes.ts
+++ b/apps/web/src/lib/session-indexes.ts
@@ -9,8 +9,8 @@ import { getProjectIdentityKey } from "./projects";
 
 export interface IndexedSession extends SessionHead {
   agentKey: string;
-  sessionSlug: string;
-  fullPath: string;
+  sessionId: string;
+  reference: string;
 }
 
 export interface SessionProjectOption {
@@ -72,8 +72,8 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
     const indexedSession: IndexedSession = {
       ...session,
       agentKey,
-      sessionSlug: session.id,
-      fullPath: session.slug,
+      sessionId: session.id,
+      reference: session.slug,
     };
 
     landingSessions.push(indexedSession);

--- a/apps/web/src/lib/view-state.test.ts
+++ b/apps/web/src/lib/view-state.test.ts
@@ -21,18 +21,18 @@ describe("viewStateFromRouteMatches", () => {
     expect(viewState("/")).toEqual({
       mode: "root",
       activeAgentKey: null,
-      activeSessionSlug: null,
+      activeSessionId: null,
     });
     expect(viewState("/projects").mode).toBe("projects");
     expect(viewState("/claudecode")).toEqual({
       mode: "agent",
       activeAgentKey: "claudecode",
-      activeSessionSlug: null,
+      activeSessionId: null,
     });
     expect(viewState("/codex/abc-123")).toEqual({
       mode: "session",
       activeAgentKey: "codex",
-      activeSessionSlug: "abc-123",
+      activeSessionId: "abc-123",
     });
   });
 
@@ -46,7 +46,7 @@ describe("viewStateFromRouteMatches", () => {
     expect(viewState(path)).toEqual({
       mode: "project",
       activeAgentKey: null,
-      activeSessionSlug: null,
+      activeSessionId: null,
       activeProjectKind: "git_remote",
       activeProjectKey: "github.com/acme/app",
     });
@@ -56,7 +56,7 @@ describe("viewStateFromRouteMatches", () => {
     expect(viewState("/unknown")).toEqual({
       mode: "missingAgent",
       activeAgentKey: null,
-      activeSessionSlug: null,
+      activeSessionId: null,
       attemptedKey: "unknown",
     });
   });

--- a/apps/web/src/lib/view-state.ts
+++ b/apps/web/src/lib/view-state.ts
@@ -3,25 +3,25 @@ import type { ProjectIdentityKind } from "./api";
 import { isProjectIdentityKind } from "./projects";
 
 export type ViewState =
-  | { mode: "root"; activeAgentKey: null; activeSessionSlug: null }
-  | { mode: "projects"; activeAgentKey: null; activeSessionSlug: null }
+  | { mode: "root"; activeAgentKey: null; activeSessionId: null }
+  | { mode: "projects"; activeAgentKey: null; activeSessionId: null }
   | {
       mode: "project";
       activeAgentKey: null;
-      activeSessionSlug: null;
+      activeSessionId: null;
       activeProjectKind: ProjectIdentityKind;
       activeProjectKey: string;
     }
-  | { mode: "agent"; activeAgentKey: string; activeSessionSlug: null }
-  | { mode: "session"; activeAgentKey: string; activeSessionSlug: string }
-  | { mode: "missingAgent"; activeAgentKey: null; activeSessionSlug: null; attemptedKey: string }
+  | { mode: "agent"; activeAgentKey: string; activeSessionId: null }
+  | { mode: "session"; activeAgentKey: string; activeSessionId: string }
+  | { mode: "missingAgent"; activeAgentKey: null; activeSessionId: null; attemptedKey: string }
   | {
       mode: "missingSession";
       activeAgentKey: string;
-      activeSessionSlug: string;
-      attemptedSessionSlug: string;
+      activeSessionId: string;
+      attemptedSessionId: string;
     }
-  | { mode: "invalidRoute"; activeAgentKey: null; activeSessionSlug: null };
+  | { mode: "invalidRoute"; activeAgentKey: null; activeSessionId: null };
 
 export interface ViewRouteMatch {
   id: string;
@@ -31,7 +31,7 @@ export interface ViewRouteMatch {
 const invalidRoute: ViewState = {
   mode: "invalidRoute",
   activeAgentKey: null,
-  activeSessionSlug: null,
+  activeSessionId: null,
 };
 
 export function viewStateFromRouteMatches(
@@ -42,10 +42,10 @@ export function viewStateFromRouteMatches(
   if (!match) return invalidRoute;
 
   if (match.id === APP_ROUTE_IDS.root) {
-    return { mode: "root", activeAgentKey: null, activeSessionSlug: null };
+    return { mode: "root", activeAgentKey: null, activeSessionId: null };
   }
   if (match.id === APP_ROUTE_IDS.projects) {
-    return { mode: "projects", activeAgentKey: null, activeSessionSlug: null };
+    return { mode: "projects", activeAgentKey: null, activeSessionId: null };
   }
   if (match.id === APP_ROUTE_IDS.project) {
     const kind = match.params.projectKind;
@@ -54,7 +54,7 @@ export function viewStateFromRouteMatches(
     return {
       mode: "project",
       activeAgentKey: null,
-      activeSessionSlug: null,
+      activeSessionId: null,
       activeProjectKind: kind,
       activeProjectKey: key,
     };
@@ -65,16 +65,16 @@ export function viewStateFromRouteMatches(
       return {
         mode: "missingAgent",
         activeAgentKey: null,
-        activeSessionSlug: null,
+        activeSessionId: null,
         attemptedKey: agentKey ?? "",
       };
     }
     if (match.id === APP_ROUTE_IDS.agent) {
-      return { mode: "agent", activeAgentKey: agentKey, activeSessionSlug: null };
+      return { mode: "agent", activeAgentKey: agentKey, activeSessionId: null };
     }
-    const sessionSlug = match.params.sessionSlug;
-    if (!sessionSlug) return invalidRoute;
-    return { mode: "session", activeAgentKey: agentKey, activeSessionSlug: sessionSlug };
+    const sessionId = match.params.sessionId;
+    if (!sessionId) return invalidRoute;
+    return { mode: "session", activeAgentKey: agentKey, activeSessionId: sessionId };
   }
   return invalidRoute;
 }

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FileSystemSessionSource } from "@codesesh/core";
-import type { BaseAgent, loadCachedSessions, ScanResult, SessionHead } from "@codesesh/core";
+import type { BaseAgent, loadCachedSessions, LiveSnapshot, SessionHead } from "@codesesh/core";
 import type { WorkerRunner } from "./worker-runner.js";
 
 const core = vi.hoisted(() => ({
@@ -111,7 +111,7 @@ function makeEngine(
   sessions: SessionHead[] = [],
   workerRunner: WorkerRunner = makeWorkerRunner(),
 ) {
-  const state: ScanResult = {
+  const state: LiveSnapshot = {
     agents: [agent],
     byAgent: { [agent.name]: sessions },
     sessions,
@@ -426,7 +426,7 @@ describe("AgentSyncEngine", () => {
       run: vi.fn(async () => ({ sessions: [newSession], meta: {}, changedIds: [] })),
       shutdown: vi.fn(async () => undefined),
     };
-    const state: ScanResult = {
+    const state: LiveSnapshot = {
       agents: [agent],
       byAgent: { codex: [oldSession] },
       sessions: [oldSession],
@@ -483,7 +483,7 @@ describe("AgentSyncEngine", () => {
       run: vi.fn(async () => ({ sessions: scanResult, meta: {} })),
       shutdown: vi.fn(async () => undefined),
     };
-    const state: ScanResult = { agents: [agent], byAgent: { codex: [] }, sessions: [] };
+    const state: LiveSnapshot = { agents: [agent], byAgent: { codex: [] }, sessions: [] };
     const engine = new AgentSyncEngine({
       snapshot: () => state,
       workerRunner,

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -11,7 +11,7 @@ import {
   type AgentScanProgress,
   type BaseAgent,
   type ScanOptions,
-  type ScanResult,
+  type LiveSnapshot,
   type SessionHead,
   type SessionHeadChange,
 } from "@codesesh/core";
@@ -35,7 +35,7 @@ export interface AgentSessionsChanged {
 }
 
 export interface AgentSyncEngineOptions {
-  snapshot: () => ScanResult;
+  snapshot: () => LiveSnapshot;
   startupScanOptions?: Pick<ScanOptions, "from" | "to">;
   workerRunner: WorkerRunner;
 }

--- a/packages/cli/src/api/__tests__/contract.test.ts
+++ b/packages/cli/src/api/__tests__/contract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { SAMPLE_SCAN_STATUS_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
-import type { ScanResult } from "@codesesh/core";
+import type { LiveSnapshot } from "@codesesh/core";
 import { createApiRoutes } from "../routes.js";
 import type { ScanResultSource } from "../handlers.js";
 import type { ScanEventSource } from "../../scan-source.js";
@@ -12,7 +12,7 @@ function makeScanSource(): ScanResultSource {
         sessions: [SAMPLE_SESSION_HEAD],
         byAgent: { claudecode: [SAMPLE_SESSION_HEAD] },
         agents: [],
-      }) as ScanResult,
+      }) as LiveSnapshot,
   };
 }
 

--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -39,7 +39,7 @@ import {
   BookmarkStorageUnavailableError,
   StateStorageUnavailableError,
   type BookmarkRecord,
-  type ScanResult,
+  type LiveSnapshot,
 } from "@codesesh/core";
 import {
   handleDeleteBookmark,
@@ -130,7 +130,7 @@ const scanSource: ScanResultSource = {
       sessions: [],
       byAgent: {},
       agents: [],
-    }) as ScanResult,
+    }) as LiveSnapshot,
 };
 
 beforeEach(() => {

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -60,10 +60,10 @@ import { invalidateAliasView } from "../session-aliases-view.js";
 import type {
   ChangeCheckResult,
   FileActivityResult,
-  ScanResult,
+  LiveSnapshot,
   SessionCacheMeta,
   SessionHead,
-  SessionData,
+  SessionDetail,
 } from "@codesesh/core";
 import { BaseAgent } from "@codesesh/core";
 
@@ -125,7 +125,7 @@ class MockAgent extends BaseAgent {
     return [];
   }
 
-  getSessionData(_sessionId: string): SessionData {
+  getSessionData(_sessionId: string): SessionDetail {
     return {
       reference: { agentName: "claudecode", sessionId: "s1" },
       id: "s1",
@@ -163,7 +163,7 @@ class MockAgent extends BaseAgent {
   setSessionMetaMap(): void {}
 }
 
-function makeScanResult(overrides?: Partial<ScanResult>): ScanResult {
+function makeScanResult(overrides?: Partial<LiveSnapshot>): LiveSnapshot {
   const agent = new MockAgent();
   const sessions = [
     makeSession("s1", { slug: "claudecode/s1" }),
@@ -177,7 +177,7 @@ function makeScanResult(overrides?: Partial<ScanResult>): ScanResult {
   };
 }
 
-function makeScanSource(overrides?: Partial<ScanResult>): ScanResultSource {
+function makeScanSource(overrides?: Partial<LiveSnapshot>): ScanResultSource {
   const result = makeScanResult(overrides);
   return {
     getSnapshot() {
@@ -1187,7 +1187,7 @@ describe("handleGetDashboard", () => {
 });
 
 describe("handleGetSessionData", () => {
-  const detail: SessionData = {
+  const detail: SessionDetail = {
     reference: { agentName: "claudecode", sessionId: "s1" },
     id: "s1",
     slug: "claudecode/s1",

--- a/packages/cli/src/api/__tests__/routes.test.ts
+++ b/packages/cli/src/api/__tests__/routes.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
 import { createApiRoutes } from "../routes.js";
-import type { ScanResult } from "@codesesh/core";
+import type { LiveSnapshot } from "@codesesh/core";
 import type { ScanResultSource } from "../handlers.js";
 import type { ScanEventSource } from "../../scan-source.js";
 
@@ -13,7 +13,7 @@ describe("createApiRoutes", () => {
           sessions: [],
           byAgent: {},
           agents: [],
-        } as unknown as ScanResult;
+        } as unknown as LiveSnapshot;
       },
     };
     const app = createApiRoutes(scanSource);

--- a/packages/cli/src/api/__tests__/search-transport.test.ts
+++ b/packages/cli/src/api/__tests__/search-transport.test.ts
@@ -13,7 +13,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
-import type { ScanResult, SessionHead } from "@codesesh/core";
+import type { LiveSnapshot, SessionHead } from "@codesesh/core";
 import type { ScanResultSource } from "../handlers.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-search-transport-"));
@@ -65,7 +65,7 @@ function makeScanSource(): ScanResultSource {
         sessions,
         byAgent: { claudecode: sessions },
         agents: [],
-      }) as ScanResult,
+      }) as LiveSnapshot,
   };
 }
 

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -1,8 +1,8 @@
 import type { Context } from "hono";
 import type {
   BookmarkRecord,
-  ScanResult,
-  SessionData,
+  LiveSnapshot,
+  SessionDetail,
   SessionHead,
   SmartTag,
 } from "@codesesh/core";
@@ -59,7 +59,7 @@ import {
 export type { SessionListDefaults };
 
 export interface ScanResultSource {
-  getSnapshot(): ScanResult;
+  getSnapshot(): LiveSnapshot;
 }
 
 export interface ScanStatusSource {
@@ -236,7 +236,7 @@ function getSessionHeadReference(session: SessionHead): SessionReference {
 }
 
 function createSessionDetailJsonResponse(
-  data: Omit<SessionData, "messages">,
+  data: Omit<SessionDetail, "messages">,
   messages: Iterable<string>,
 ): Response {
   const encoder = new TextEncoder();

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -11,7 +11,7 @@ import {
   mergeSearchQueryOptions,
   StateStorageUnavailableError,
   type FileActivityResult,
-  type ScanResult,
+  type LiveSnapshot,
   type SearchOptions,
 } from "@codesesh/core";
 import { appLogger } from "../logging.js";
@@ -100,7 +100,7 @@ export function decorateFileActivity(
 export function findAliasSearchResults(
   query: string,
   options: SearchOptions,
-  scanResult: ScanResult,
+  scanResult: LiveSnapshot,
   aliases: AliasView,
 ): SearchResult[] {
   const search = mergeSearchQueryOptions(query, options);

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -6,10 +6,10 @@ import {
   FileSystemSessionSource,
   type AgentScanOptions,
   type ChangeCheckResult,
-  type ProviderRoots,
+  type AgentRoots,
   type ScanOptions,
   type SessionCacheMeta,
-  type SessionData,
+  type SessionDetail,
   type SessionHead,
   type SessionSourceRef,
 } from "@codesesh/core";
@@ -36,8 +36,8 @@ const core = vi.hoisted(() => ({
   filterSessions: vi.fn((sessions: SessionHead[], _options: ScanOptions) => sessions),
   getCursorDataPath: vi.fn(() => "/tmp/cursor"),
   getAgentLastFullSyncAt: vi.fn(),
-  resolveProviderRoots: vi.fn(
-    (): ProviderRoots => ({
+  resolveAgentRoots: vi.fn(
+    (): AgentRoots => ({
       claudeRoot: "/tmp/claude",
       codexRoot: "/tmp/codex",
       kimiRoot: "/tmp/kimi",
@@ -308,7 +308,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     loadCachedSessions: core.loadCachedSessions,
     markAgentCacheInitialized: core.markAgentCacheInitialized,
     markAgentFullSyncCompleted: core.markAgentFullSyncCompleted,
-    resolveProviderRoots: core.resolveProviderRoots,
+    resolveAgentRoots: core.resolveAgentRoots,
     scanSessions: core.scanSessions,
     saveCachedSessions: core.saveCachedSessions,
     saveCachedSessionChanges: core.saveCachedSessionChanges,
@@ -422,7 +422,7 @@ const projectIdentity = {
 };
 
 function watchPlanFor(name: string) {
-  const roots = core.resolveProviderRoots();
+  const roots = core.resolveAgentRoots();
   return {
     status: "supported" as const,
     targets:
@@ -491,7 +491,7 @@ function makeFileSystemAgent(
   Object.defineProperty(agent, "displayName", { value: name, configurable: true });
   agent.isAvailable = vi.fn(() => true);
   agent.scan = vi.fn(() => []);
-  agent.getSessionData = vi.fn(() => ({}) as SessionData);
+  agent.getSessionData = vi.fn(() => ({}) as SessionDetail);
   agent.getSessionWatchPlan = vi.fn(() => watchPlanFor(name));
   agent.listSessionSources = overrides.listSessionSources ?? vi.fn(() => []);
   agent.scanSessionSource = overrides.scanSessionSource ?? vi.fn(() => null);
@@ -523,7 +523,7 @@ describe("LiveScanStore", () => {
     core.isAgentCacheInitialized.mockReturnValue(true);
     core.loadCachedSessions.mockReturnValue(null);
     core.markAgentCacheInitialized.mockReset();
-    core.resolveProviderRoots.mockReturnValue({
+    core.resolveAgentRoots.mockReturnValue({
       claudeRoot: "/tmp/claude",
       codexRoot: "/tmp/codex",
       kimiRoot: "/tmp/kimi",
@@ -1572,7 +1572,7 @@ describe("LiveScanStore", () => {
     const sessionsDir = join(codexRoot, "sessions");
     const sessionFile = join(sessionsDir, "new.jsonl");
     mkdirSync(sessionsDir, { recursive: true });
-    core.resolveProviderRoots.mockReturnValue({
+    core.resolveAgentRoots.mockReturnValue({
       claudeRoot: join(tempDir, "claude"),
       codexRoot,
       kimiRoot: join(tempDir, "kimi"),
@@ -1646,7 +1646,7 @@ describe("LiveScanStore", () => {
     const dayDir = join(sessionsDir, "2026", "05", "10");
     const sessionFile = join(dayDir, "new.jsonl");
     mkdirSync(dayDir, { recursive: true });
-    core.resolveProviderRoots.mockReturnValue({
+    core.resolveAgentRoots.mockReturnValue({
       claudeRoot: join(tempDir, "claude"),
       codexRoot,
       kimiRoot: join(tempDir, "kimi"),
@@ -1697,7 +1697,7 @@ describe("LiveScanStore", () => {
     const sessionFile = join(sessionsDir, "new.jsonl");
     mkdirSync(sessionsDir, { recursive: true });
     writeFileSync(sessionFile, "session");
-    core.resolveProviderRoots.mockReturnValue({
+    core.resolveAgentRoots.mockReturnValue({
       claudeRoot: join(tempDir, "claude"),
       codexRoot,
       kimiRoot: join(tempDir, "kimi"),

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -7,7 +7,7 @@ import {
   sortSessions,
   type BaseAgent,
   type ScanOptions,
-  type ScanResult,
+  type LiveSnapshot,
   type SessionHead,
   type SessionReference,
 } from "@codesesh/core";
@@ -163,7 +163,7 @@ export class LiveScanStore {
     this.syncEngine.startBackgroundRefresh();
   }
 
-  getSnapshot(): ScanResult {
+  getSnapshot(): LiveSnapshot {
     return { sessions: this.sessions, byAgent: this.byAgent, agents: this.agents };
   }
 
@@ -245,7 +245,7 @@ export class LiveScanStore {
     return workerUrl;
   }
 
-  private applyScanResult(result: ScanResult): void {
+  private applyScanResult(result: LiveSnapshot): void {
     const agentMap = new Map<string, BaseAgent>();
     const allowedAgents = this.getAllowedAgents();
     for (const agent of result.agents) agentMap.set(agent.name, agent);

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DatabaseSessionSource, diffSessionSources, FileSystemSessionSource } from "../base.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
-import type { SessionData, SessionHead } from "../../types/index.js";
+import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 interface FakeSource {
@@ -40,8 +40,8 @@ class FakeFileSystemSource extends FileSystemSessionSource {
     return { status: "not-needed" as const, reason: "in-memory test source" };
   }
 
-  getSessionData(_sessionId: string): SessionData {
-    return {} as SessionData;
+  getSessionData(_sessionId: string): SessionDetail {
+    return {} as SessionDetail;
   }
 
   listSessionSources(): SessionSourceRef[] {
@@ -384,8 +384,8 @@ describe("DatabaseSessionSource", () => {
       return [makeSession("db-1")];
     }
 
-    getSessionData(_sessionId: string): SessionData {
-      return {} as SessionData;
+    getSessionData(_sessionId: string): SessionDetail {
+      return {} as SessionDetail;
     }
 
     protected getDatabasePath(): string | null {

--- a/packages/core/src/agents/__tests__/watch-plan.test.ts
+++ b/packages/core/src/agents/__tests__/watch-plan.test.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getCursorDataPath, resolveProviderRoots } from "../../discovery/paths.js";
+import { getCursorDataPath, resolveAgentRoots } from "../../discovery/paths.js";
 import "../register.js";
 import { createRegisteredAgents } from "../registry.js";
 
@@ -36,7 +36,7 @@ describe("registered agent session watch plans", () => {
     vi.stubEnv("CURSOR_DATA_PATH", "/tmp/cursor-home");
     vi.stubEnv("XDG_DATA_HOME", "/tmp/data-home");
     const agents = new Map(createRegisteredAgents().map((agent) => [agent.name, agent]));
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
 
     expect(agents.get("claudecode")?.getSessionWatchPlan()).toEqual({
       status: "supported",

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync } from "node:fs";
-import type { SessionHead, SessionData, ParseSessionResult } from "../types/index.js";
+import type { SessionHead, SessionDetail, ParseSessionResult } from "../types/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 
 export type { ParseSessionResult };
@@ -177,7 +177,7 @@ export abstract class BaseAgent {
   abstract scan(options?: AgentScanOptions): SessionHead[];
 
   /** Load full session data including all messages. */
-  abstract getSessionData(sessionId: string): SessionData;
+  abstract getSessionData(sessionId: string): SessionDetail;
 
   /** Describe how changes to this agent's session sources can be observed. */
   abstract getSessionWatchPlan(): SessionWatchPlan;

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -11,13 +11,13 @@ import {
 import type { ParseSessionResult } from "./base.js";
 import type {
   SessionHead,
-  SessionData,
+  SessionDetail,
   Message,
   MessagePart,
   ToolPart,
   ToolPartState,
 } from "../types/index.js";
-import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
+import { resolveAgentRoots, firstExisting } from "../discovery/paths.js";
 import { readJsonlFile, readJsonlFileLines } from "../utils/jsonl.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
@@ -117,12 +117,12 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
   private sessionsIndexMtime: Record<string, number | null> = {};
 
   private findBasePath(): string | null {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     return firstExisting(join(roots.claudeRoot, "projects"), "data/claudecode");
   }
 
   getSessionWatchPlan() {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     return {
       status: "supported" as const,
       targets: [
@@ -182,7 +182,7 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     return head;
   }
 
-  getSessionData(sessionId: string): SessionData {
+  getSessionData(sessionId: string): SessionDetail {
     const meta = this.sessionMetaMap.get(sessionId);
     if (!meta) {
       throw new Error(`Session not found: ${sessionId}`);

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -18,8 +18,8 @@ import {
   skippedSession,
 } from "./base.js";
 import type { ParseSessionResult } from "./base.js";
-import type { SessionHead, SessionData, MessagePart } from "../types/index.js";
-import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
+import type { SessionHead, SessionDetail, MessagePart } from "../types/index.js";
+import { resolveAgentRoots, firstExisting } from "../discovery/paths.js";
 import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../utils/jsonl.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
@@ -344,12 +344,12 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
   // ---- BaseAgent implementation ----
 
   private findBasePath(): string | null {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     return firstExisting(join(roots.codexRoot, "sessions"));
   }
 
   getSessionWatchPlan() {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     return {
       status: "supported" as const,
       targets: [
@@ -390,7 +390,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     return head;
   }
 
-  getSessionData(sessionId: string): SessionData {
+  getSessionData(sessionId: string): SessionDetail {
     const meta = this.sessionMetaMap.get(sessionId);
     if (!meta) throw new Error(`Session not found: ${sessionId}`);
     if (!existsSync(meta.sourcePath)) throw new Error(`Session file missing: ${meta.sourcePath}`);
@@ -583,7 +583,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   private getSessionIndexPath(): string {
-    this.sessionIndexPath ??= join(resolveProviderRoots().codexRoot, "session_index.jsonl");
+    this.sessionIndexPath ??= join(resolveAgentRoots().codexRoot, "session_index.jsonl");
     return this.sessionIndexPath;
   }
 

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -10,7 +10,7 @@ import {
 import type { AgentScanOptions } from "./base.js";
 import type {
   SessionHead,
-  SessionData,
+  SessionDetail,
   Message,
   MessagePart,
   ToolPartState,
@@ -675,7 +675,7 @@ export class CursorAgent extends DatabaseSessionSource {
     }
   }
 
-  getSessionData(sessionId: string): SessionData {
+  getSessionData(sessionId: string): SessionDetail {
     // Ensure dbPath is set
     if (!this.dbPath) {
       this.dbPath = this.findDbPath();

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -14,8 +14,8 @@ import type {
   SessionCacheMeta,
   SessionSourceRef,
 } from "./base.js";
-import type { SessionHead, SessionData, MessagePart } from "../types/index.js";
-import { resolveProviderRoots, firstExisting } from "../discovery/paths.js";
+import type { SessionHead, SessionDetail, MessagePart } from "../types/index.js";
+import { resolveAgentRoots, firstExisting } from "../discovery/paths.js";
 import { readJsonlFile } from "../utils/jsonl.js";
 import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
@@ -183,12 +183,12 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
   private defaultModel: string | null = null;
 
   private findBasePath(): string | null {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     return firstExisting(join(roots.kimiRoot, "sessions"), "data/kimi");
   }
 
   getSessionWatchPlan() {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     return {
       status: "supported" as const,
       targets: [
@@ -200,7 +200,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
 
   /** Parse kimi.json and build md5(project_path) → cwd mapping */
   private loadKimiConfig(): void {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     const configPath = join(roots.kimiRoot, "kimi.json");
     const tomlPath = join(roots.kimiRoot, "config.toml");
     if (existsSync(tomlPath)) {
@@ -370,7 +370,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     };
   }
 
-  getSessionData(sessionId: string): SessionData {
+  getSessionData(sessionId: string): SessionDetail {
     const meta = this.sessionMetaMap.get(sessionId);
     if (!meta) throw new Error(`Session not found: ${sessionId}`);
 
@@ -380,7 +380,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     return this.getSessionDataFromWire(meta);
   }
 
-  private getSessionDataFromContext(meta: SessionMeta): SessionData {
+  private getSessionDataFromContext(meta: SessionMeta): SessionDetail {
     if (!meta.contextFile) throw new Error("context.jsonl is missing");
 
     const builder = new TranscriptBuilder();
@@ -444,7 +444,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     return this.buildSessionData(meta, builder, stats);
   }
 
-  private getSessionDataFromWire(meta: SessionMeta): SessionData {
+  private getSessionDataFromWire(meta: SessionMeta): SessionDetail {
     const wirePath = meta.wireFile ?? join(meta.sourcePath, "wire.jsonl");
     if (!existsSync(wirePath)) throw new Error("wire.jsonl is missing");
 
@@ -729,7 +729,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   /** Applies a `_usage` record's running total; other records are ignored. */
-  private applyUsageTotal(record: Record<string, unknown>, stats: SessionData["stats"]): void {
+  private applyUsageTotal(record: Record<string, unknown>, stats: SessionDetail["stats"]): void {
     if (record.role !== "_usage") return;
     const tokenCount = asNumber(record.token_count);
     if (tokenCount === undefined) {
@@ -739,9 +739,9 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     stats.total_tokens = tokenCount;
   }
 
-  private extractStats(sessionDir: string): SessionData["stats"] {
+  private extractStats(sessionDir: string): SessionDetail["stats"] {
     let totalCost = 0;
-    const stats: SessionData["stats"] = {
+    const stats: SessionDetail["stats"] = {
       total_cost: 0,
       total_input_tokens: 0,
       total_output_tokens: 0,
@@ -797,8 +797,8 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
   private buildSessionData(
     meta: SessionMeta,
     builder: TranscriptBuilder,
-    stats: SessionData["stats"],
-  ): SessionData {
+    stats: SessionDetail["stats"],
+  ): SessionDetail {
     const transcript = builder.finish(stats);
     return {
       reference: { agentName: this.name, sessionId: meta.id },

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -6,7 +6,7 @@ import {
   skippedSession,
 } from "./base.js";
 import type { AgentScanOptions, ParseSessionResult, SessionWatchPlan } from "./base.js";
-import type { SessionHead, SessionData, Message, MessagePart } from "../types/index.js";
+import type { SessionHead, SessionDetail, Message, MessagePart } from "../types/index.js";
 import { normalizeMessageParts } from "../contract/message-part.js";
 import { openDbReadOnly, type SQLiteDatabase } from "../utils/sqlite.js";
 import { estimateTokenCost } from "../utils/cost.js";
@@ -344,7 +344,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
     return contexts;
   }
 
-  getSessionData(sessionId: string): SessionData {
+  getSessionData(sessionId: string): SessionDetail {
     // Ensure dbPath is set
     if (!this.dbPath) {
       this.dbPath = this.findDbPath();

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -1,16 +1,16 @@
 import { join } from "node:path";
-import { firstExisting, resolveProviderRoots } from "../discovery/paths.js";
+import { firstExisting, resolveAgentRoots } from "../discovery/paths.js";
 import { isSqliteAvailable } from "../utils/sqlite.js";
 import { OpenCodeSqliteAgent } from "./opencode-sqlite.js";
 
 function findOpenCodeDbPath(): string | null {
   if (!isSqliteAvailable()) return null;
-  const roots = resolveProviderRoots();
+  const roots = resolveAgentRoots();
   return firstExisting(join(roots.opencodeRoot, "opencode.db"), "data/opencode/opencode.db");
 }
 
 function getOpenCodeSessionWatchPlan() {
-  const roots = resolveProviderRoots();
+  const roots = resolveAgentRoots();
   return {
     status: "supported" as const,
     targets: [

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -13,8 +13,8 @@ import type {
   SessionCacheMeta,
   SessionSourceRef,
 } from "./base.js";
-import type { Message, MessagePart, SessionData, SessionHead } from "../types/index.js";
-import { firstExisting, resolveProviderRoots } from "../discovery/paths.js";
+import type { Message, MessagePart, SessionDetail, SessionHead } from "../types/index.js";
+import { firstExisting, resolveAgentRoots } from "../discovery/paths.js";
 import { readJsonlFile } from "../utils/jsonl.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { asNumber, asRecord, asString, narrowField } from "../utils/narrow.js";
@@ -147,12 +147,12 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
   private basePath: string | null = null;
 
   private findBasePath(): string | null {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     return firstExisting(join(roots.piRoot, "agent", "sessions"), "data/pi");
   }
 
   getSessionWatchPlan() {
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     return {
       status: "supported" as const,
       targets: [
@@ -185,7 +185,7 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     return head;
   }
 
-  getSessionData(sessionId: string): SessionData {
+  getSessionData(sessionId: string): SessionDetail {
     const meta = this.sessionMetaMap.get(sessionId);
     if (!meta) throw new Error(`Session not found: ${sessionId}`);
     if (!existsSync(meta.sourcePath)) throw new Error(`Session file missing: ${meta.sourcePath}`);

--- a/packages/core/src/agents/zcode.ts
+++ b/packages/core/src/agents/zcode.ts
@@ -1,17 +1,17 @@
 import { join } from "node:path";
-import { firstExisting, resolveProviderRoots } from "../discovery/paths.js";
+import { firstExisting, resolveAgentRoots } from "../discovery/paths.js";
 import { isSqliteAvailable } from "../utils/sqlite.js";
 import { OpenCodeSqliteAgent } from "./opencode-sqlite.js";
 
 function findZCodeDbPath(): string | null {
   if (!isSqliteAvailable()) return null;
-  const roots = resolveProviderRoots();
+  const roots = resolveAgentRoots();
   if (!roots.zcodeRoot) return null;
   return firstExisting(join(roots.zcodeRoot, "cli", "db", "db.sqlite"));
 }
 
 function getZCodeSessionWatchPlan() {
-  const roots = resolveProviderRoots();
+  const roots = resolveAgentRoots();
   return {
     status: "supported" as const,
     targets: roots.zcodeRoot

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -173,8 +173,8 @@ export interface ReferencedSessionHead {
   session: SessionHead;
 }
 
-/** Full session data for detail view */
-export interface SessionData {
+/** Complete normalized content for replaying a Session */
+export interface SessionDetail {
   reference: SessionReference;
   id: string;
   title: string;

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -10,7 +10,7 @@ import {
   syncSessionSearchIndex,
 } from "../cache.js";
 import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../cache/db.js";
-import type { SessionData, SessionHead } from "../../types/index.js";
+import type { SessionDetail, SessionHead } from "../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-smoke-test-"));
 
@@ -46,7 +46,7 @@ describe("session cache integration", () => {
         total_cost: 0,
       },
     };
-    const data: SessionData = {
+    const data: SessionDetail = {
       ...session,
       reference: { agentName: "codex", sessionId: session.id },
       messages: [

--- a/packages/core/src/discovery/__tests__/paths.test.ts
+++ b/packages/core/src/discovery/__tests__/paths.test.ts
@@ -19,7 +19,7 @@ vi.mock("node:fs", async (importOriginal) => {
 
 import { homedir, platform } from "node:os";
 import { existsSync } from "node:fs";
-import { resolveProviderRoots, getCursorDataPath, getZCodeDataPath } from "../paths.js";
+import { resolveAgentRoots, getCursorDataPath, getZCodeDataPath } from "../paths.js";
 
 /** Normalize path separators so tests work on both Unix and Windows */
 const expectPath = (actual: string) => expect(actual.replace(/\\/g, "/"));
@@ -44,10 +44,10 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("resolveProviderRoots", () => {
+describe("resolveAgentRoots", () => {
   it("uses default paths when no env vars are set", () => {
     mockedHomedir.mockReturnValue("/home/user");
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     expectPath(roots.codexRoot).toBe("/home/user/.codex");
     expectPath(roots.claudeRoot).toBe("/home/user/.claude");
     expectPath(roots.kimiRoot).toBe("/home/user/.kimi");
@@ -58,28 +58,28 @@ describe("resolveProviderRoots", () => {
   it("respects CODEX_HOME override", () => {
     vi.stubEnv("CODEX_HOME", "/custom/codex");
     mockedHomedir.mockReturnValue("/home/user");
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     expectPath(roots.codexRoot).toBe("/custom/codex");
   });
 
   it("respects CLAUDE_CONFIG_DIR override", () => {
     vi.stubEnv("CLAUDE_CONFIG_DIR", "/custom/claude");
     mockedHomedir.mockReturnValue("/home/user");
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     expectPath(roots.claudeRoot).toBe("/custom/claude");
   });
 
   it("respects KIMI_SHARE_DIR override", () => {
     vi.stubEnv("KIMI_SHARE_DIR", "/custom/kimi");
     mockedHomedir.mockReturnValue("/home/user");
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     expectPath(roots.kimiRoot).toBe("/custom/kimi");
   });
 
   it("respects PI_HOME override", () => {
     vi.stubEnv("PI_HOME", "/custom/pi");
     mockedHomedir.mockReturnValue("/home/user");
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     expectPath(roots.piRoot).toBe("/custom/pi");
   });
 
@@ -87,7 +87,7 @@ describe("resolveProviderRoots", () => {
     mockedHomedir.mockReturnValue("/home/user");
     mockedPlatform.mockReturnValue("linux");
     vi.stubEnv("XDG_DATA_HOME", "/custom/data");
-    const roots = resolveProviderRoots();
+    const roots = resolveAgentRoots();
     expectPath(roots.opencodeRoot).toBe("/custom/data/opencode");
   });
 });

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { SessionHead, SessionData } from "../../types/index.js";
+import type { SessionHead, SessionDetail } from "../../types/index.js";
 import { BaseAgent, type SessionCacheMeta, type ChangeCheckResult } from "../../agents/base.js";
 import { filterSessions } from "../scanner.js";
 
@@ -36,8 +36,8 @@ class TestAgent extends BaseAgent {
     return [];
   }
 
-  getSessionData(): SessionData {
-    return {} as SessionData;
+  getSessionData(): SessionDetail {
+    return {} as SessionDetail;
   }
 
   getSessionWatchPlan() {

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -8,9 +8,9 @@ import {
   saveCachedSessions,
   syncSessionSearchIndex,
   type ChangeCheckResult,
-  type ScanResult,
+  type LiveSnapshot,
   type SessionCacheMeta,
-  type SessionData,
+  type SessionDetail,
   type SessionHead,
 } from "../../index.js";
 import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../cache/db.js";
@@ -35,7 +35,7 @@ class TestAgent extends BaseAgent {
   reads = 0;
 
   constructor(
-    private readonly detail: SessionData,
+    private readonly detail: SessionDetail,
     private readonly meta: Map<string, SessionCacheMeta>,
   ) {
     super();
@@ -49,7 +49,7 @@ class TestAgent extends BaseAgent {
     return [];
   }
 
-  getSessionData(): SessionData {
+  getSessionData(): SessionDetail {
     this.reads += 1;
     return this.detail;
   }
@@ -92,7 +92,7 @@ function makeHead(overrides: Partial<SessionHead> = {}): SessionHead {
   };
 }
 
-function makeDetail(title = "Source Session"): SessionData {
+function makeDetail(title = "Source Session"): SessionDetail {
   return {
     ...makeHead({ title }),
     reference: { agentName: "test", sessionId: "s1" },
@@ -121,7 +121,7 @@ function makeMeta(fingerprint: string): SessionCacheMeta {
   };
 }
 
-function makeScanResult(agent: TestAgent, head = makeHead()): ScanResult {
+function makeScanResult(agent: TestAgent, head = makeHead()): LiveSnapshot {
   return {
     sessions: [head],
     byAgent: { test: [head] },
@@ -129,7 +129,7 @@ function makeScanResult(agent: TestAgent, head = makeHead()): ScanResult {
   };
 }
 
-function persistDetail(head: SessionHead, detail: SessionData, fingerprint: string): void {
+function persistDetail(head: SessionHead, detail: SessionDetail, fingerprint: string): void {
   saveCachedSessions("test", [head], { [head.id]: makeMeta(fingerprint) });
   syncSessionSearchIndex("test", [head], () => detail);
 }

--- a/packages/core/src/discovery/cache/__tests__/fixtures.ts
+++ b/packages/core/src/discovery/cache/__tests__/fixtures.ts
@@ -1,11 +1,11 @@
-import type { SessionData, SessionHead } from "../../../types/index.js";
+import type { SessionDetail, SessionHead } from "../../../types/index.js";
 
 export const TEST_NOW = 1_700_000_000_000;
 
 export function makeSessionHead(
   id: string,
   overrides: Partial<SessionHead> = {},
-): SessionHead & Pick<SessionData, "reference"> {
+): SessionHead & Pick<SessionDetail, "reference"> {
   return {
     reference: { agentName: "codex", sessionId: id },
     id,
@@ -30,7 +30,7 @@ export function makeSessionHead(
   };
 }
 
-export function makeSessionData(id: string, text = "visible text"): SessionData {
+export function makeSessionData(id: string, text = "visible text"): SessionDetail {
   const head = makeSessionHead(id);
   return {
     ...head,

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../../cache.js";
 import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
 import { withCacheDb } from "../schema.js";
-import type { SessionData, SessionHead } from "../../../types/index.js";
+import type { SessionDetail, SessionHead } from "../../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
 const SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS = 30_000;
@@ -45,7 +45,7 @@ function getCachePath(): string {
 // resolves to a "path" identity regardless of what manifests exist in /tmp.
 const FIXTURE_DIR = mkdtempSync(join(tmpdir(), "codesesh-identity-"));
 
-function makeSession(id: string): SessionHead & Pick<SessionData, "reference"> {
+function makeSession(id: string): SessionHead & Pick<SessionDetail, "reference"> {
   return {
     reference: { agentName: "agent", sessionId: id },
     id,
@@ -63,7 +63,7 @@ function makeSession(id: string): SessionHead & Pick<SessionData, "reference"> {
   };
 }
 
-function makeSessionData(id: string, text: string): SessionData {
+function makeSessionData(id: string, text: string): SessionDetail {
   const session = makeSession(id);
   return {
     ...session,
@@ -123,7 +123,7 @@ afterEach(() => {
 });
 
 describe("session detail re-indexing", () => {
-  function toolSessionData(id: string, tool: string): SessionData {
+  function toolSessionData(id: string, tool: string): SessionDetail {
     const session = makeSession(id);
     return {
       ...session,
@@ -366,7 +366,7 @@ describe("searchSessions", () => {
       stats: { ...makeSession("or-first").stats, message_count: 2 },
     };
     const sessions = [title, user, assistant, tool, quoted, orFirst];
-    const dataById = new Map<string, SessionData>([
+    const dataById = new Map<string, SessionDetail>([
       [
         "title",
         {
@@ -737,7 +737,7 @@ describe("searchSessions", () => {
     };
     const sessions = [keep, changed, removed];
     const sessionMap = new Map(sessions.map((session) => [session.id, session]));
-    const makeIndexedData = (session: SessionHead, text: string, path: string): SessionData => ({
+    const makeIndexedData = (session: SessionHead, text: string, path: string): SessionDetail => ({
       ...session,
       reference: { agentName: "claudecode", sessionId: session.id },
       messages: [

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -7,7 +7,7 @@ import type {
   Message,
   MessagePart,
   ProjectIdentityKind,
-  SessionData,
+  SessionDetail,
   SessionFileActivity,
   SessionHead,
   ToolPart,
@@ -532,7 +532,7 @@ export function buildMessageText(message: Message): string {
   return chunks.join("\n");
 }
 
-export function normalizeMessages(session: SessionData): StructuredMessageRecord[] {
+export function normalizeMessages(session: SessionDetail): StructuredMessageRecord[] {
   return session.messages.map((message, index) => {
     const toolMetadata = message.parts
       .filter((part): part is ToolPart => part.type === "tool")

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -1,4 +1,4 @@
-import type { SessionData, SessionFileActivity, SessionHead } from "../../types/index.js";
+import type { SessionDetail, SessionFileActivity, SessionHead } from "../../types/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
@@ -167,7 +167,7 @@ function searchIndexEntryNeedsUpdate(state: SearchIndexState, session: SessionHe
 function loadSearchIndexEntry(
   agentName: string,
   change: SessionHeadChange,
-  loadSessionData: (sessionId: string) => SessionData,
+  loadSessionData: (sessionId: string) => SessionDetail,
 ): LoadedSearchIndexEntry | null {
   try {
     const data = loadSessionData(change.session.id);
@@ -197,7 +197,7 @@ function loadSearchIndexEntry(
 function* loadSearchIndexEntries(
   agentName: string,
   changes: Iterable<SessionHeadChange>,
-  loadSessionData: (sessionId: string) => SessionData,
+  loadSessionData: (sessionId: string) => SessionDetail,
 ): Generator<LoadedSearchIndexEntry> {
   for (const change of changes) {
     const entry = loadSearchIndexEntry(agentName, change, loadSessionData);
@@ -347,7 +347,7 @@ function writeSearchIndexRows(
 export function syncSessionSearchIndex(
   agentName: string,
   sessions: SessionHead[],
-  loadSessionData: (sessionId: string) => SessionData,
+  loadSessionData: (sessionId: string) => SessionDetail,
   options: SearchIndexSyncOptions = {},
 ): SearchIndexSyncResult | null {
   return withSearchIndexDb((db) => {
@@ -413,7 +413,7 @@ export function syncSessionSearchIndexChanges(
   agentName: string,
   changes: SessionHeadChange[],
   removedSessionIds: string[],
-  loadSessionData: (sessionId: string) => SessionData,
+  loadSessionData: (sessionId: string) => SessionDetail,
   options: SearchIndexSyncOptions = {},
 ): SearchIndexSyncResult | null {
   if (changes.length === 0 && removedSessionIds.length === 0) {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -3,7 +3,7 @@
  */
 import { existsSync, rmSync, unlinkSync } from "node:fs";
 import type { SessionCacheMeta } from "../../agents/base.js";
-import type { SessionData, SessionHead } from "../../types/index.js";
+import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { tableExists } from "../../utils/sqlite.js";
 import {
   getCachePath,
@@ -34,12 +34,12 @@ export interface CachedResult {
 }
 
 export interface CachedSessionDataEntry {
-  data: SessionData;
+  data: SessionDetail;
   meta: SessionCacheMeta | null;
 }
 
 export interface CachedSessionRawEntry {
-  data: Omit<SessionData, "messages">;
+  data: Omit<SessionDetail, "messages">;
   messageRows: CachedMessageRow[];
   meta: SessionCacheMeta | null;
 }
@@ -338,7 +338,7 @@ export function loadCachedSessionDataEntry(
   };
 }
 
-export function loadCachedSessionData(agentName: string, sessionId: string): SessionData | null {
+export function loadCachedSessionData(agentName: string, sessionId: string): SessionDetail | null {
   return loadCachedSessionDataEntry(agentName, sessionId)?.data ?? null;
 }
 

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -1,12 +1,12 @@
-export { resolveProviderRoots, getCursorDataPath, firstExisting } from "./paths.js";
-export type { ProviderRoots } from "./paths.js";
+export { resolveAgentRoots, getCursorDataPath, firstExisting } from "./paths.js";
+export type { AgentRoots } from "./paths.js";
 export {
   ensureSessionTagsSync,
   filterSessions,
   scanSessions,
   scanSessionsAsync,
 } from "./scanner.js";
-export type { ScanResult, ScanOptions } from "./scanner.js";
+export type { LiveSnapshot, ScanOptions } from "./scanner.js";
 export {
   materializeSessionDetail,
   materializeSessionDetailResponse,

--- a/packages/core/src/discovery/paths.ts
+++ b/packages/core/src/discovery/paths.ts
@@ -28,7 +28,7 @@ function getDataHome(): string {
   return join(homedir(), ".local", "share");
 }
 
-export interface ProviderRoots {
+export interface AgentRoots {
   codexRoot: string;
   claudeRoot: string;
   kimiRoot: string;
@@ -37,7 +37,7 @@ export interface ProviderRoots {
   zcodeRoot: string | null;
 }
 
-export function resolveProviderRoots(): ProviderRoots {
+export function resolveAgentRoots(): AgentRoots {
   const home = homedir();
   return {
     codexRoot: envPath("CODEX_HOME") ?? join(home, ".codex"),

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -45,7 +45,7 @@ export interface ScanOptions {
   smartTagWorkerUrl?: URL | string;
 }
 
-export interface ScanResult {
+export interface LiveSnapshot {
   sessions: SessionHead[];
   byAgent: Record<string, SessionHead[]>;
   agents: BaseAgent[];
@@ -496,7 +496,7 @@ async function scanAgentFull(
 export async function scanSessions(
   options: ScanOptions = {},
   onProgress?: (progress: ScanProgress) => void,
-): Promise<ScanResult> {
+): Promise<LiveSnapshot> {
   const scanMarker = perf.start("scanSessions");
   const agents = createRegisteredAgents();
   const byAgent: Record<string, SessionHead[]> = {};
@@ -553,6 +553,6 @@ export async function scanSessions(
 export async function scanSessionsAsync(
   options: ScanOptions = {},
   onProgress?: (progress: ScanProgress) => void,
-): Promise<ScanResult> {
+): Promise<LiveSnapshot> {
   return scanSessions(options, onProgress);
 }

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -1,6 +1,6 @@
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import type { SessionReference } from "../contract/index.js";
-import type { SessionData, SessionHead } from "../types/index.js";
+import type { SessionDetail, SessionHead } from "../types/index.js";
 import { computeIdentity, realFs } from "../projects/index.js";
 import {
   classifySessionTags,
@@ -10,10 +10,10 @@ import {
 import { listSessionFileActivity } from "./cache.js";
 import { loadCachedSessionRawEntry, type CachedSessionRawEntry } from "./cache/sessions.js";
 import { messageFromCachedRow, messageJsonFromCachedRow } from "./cache/messages.js";
-import type { ScanResult } from "./scanner.js";
+import type { LiveSnapshot } from "./scanner.js";
 
 export type SessionDetailResult =
-  | { status: "found"; data: SessionData }
+  | { status: "found"; data: SessionDetail }
   | { status: "unknown-agent" }
   | { status: "not-ready" };
 
@@ -21,7 +21,7 @@ export type SessionDetailResponseResult =
   | SessionDetailResult
   | {
       status: "found-json";
-      data: Omit<SessionData, "messages">;
+      data: Omit<SessionDetail, "messages">;
       messages: Iterable<string>;
       messageCount: number;
     };
@@ -46,7 +46,7 @@ function sessionReferenceKey(agentName: string, sessionId: string): string {
  * The canonical sessions array is replaced atomically with each scan snapshot,
  * so its identity also versions this lazily built lookup.
  */
-function getSessionDetailLookup(scanResult: ScanResult): SessionDetailLookup {
+function getSessionDetailLookup(scanResult: LiveSnapshot): SessionDetailLookup {
   const cached = sessionDetailLookups.get(scanResult.sessions);
   if (cached) return cached;
 
@@ -68,7 +68,7 @@ function getSessionDetailLookup(scanResult: ScanResult): SessionDetailLookup {
 }
 
 function getSessionDetailContext(
-  scanResult: ScanResult,
+  scanResult: LiveSnapshot,
   reference: SessionReference,
 ): SessionDetailContext | null {
   const lookup = getSessionDetailLookup(scanResult);
@@ -103,7 +103,7 @@ function cacheHasCompleteDetail(
 }
 
 function getProjectIdentity(
-  data: Pick<SessionData, "directory" | "project_identity">,
+  data: Pick<SessionDetail, "directory" | "project_identity">,
   head: SessionHead | undefined,
 ) {
   return data.project_identity ?? head?.project_identity ?? computeIdentity(data.directory, realFs);
@@ -162,7 +162,7 @@ function* serializeCachedMessages(entry: CachedSessionRawEntry): IterableIterato
 }
 
 export function materializeSessionDetail(
-  scanResult: ScanResult,
+  scanResult: LiveSnapshot,
   reference: SessionReference,
 ): SessionDetailResult {
   const context = getSessionDetailContext(scanResult, reference);
@@ -171,7 +171,7 @@ export function materializeSessionDetail(
 }
 
 export function materializeSessionDetailResponse(
-  scanResult: ScanResult,
+  scanResult: LiveSnapshot,
   reference: SessionReference,
 ): SessionDetailResponseResult {
   const context = getSessionDetailContext(scanResult, reference);

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -20,7 +20,7 @@ import { beforeAll, afterAll, describe, expect, it, vi } from "vitest";
 import type {
   Message,
   ProjectIdentity,
-  SessionData,
+  SessionDetail,
   SessionHead,
   SmartTag,
 } from "../../types/index.js";
@@ -122,7 +122,7 @@ function makeSessionHead(spec: FixtureSpec): SessionHead {
   };
 }
 
-function makeSessionData(spec: FixtureSpec): SessionData {
+function makeSessionData(spec: FixtureSpec): SessionDetail {
   return {
     ...makeSessionHead(spec),
     reference: { agentName: spec.agent, sessionId: spec.id },

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -1,6 +1,6 @@
 /**
  * Deep session search: single owner for search-query interpretation
- * (qualifier parsing/merging), source selection between the live ScanResult
+ * (qualifier parsing/merging), source selection between the live LiveSnapshot
  * snapshot ("recent" path) and the SQLite search index (FTS / file-activity
  * paths), and cross-source result merging.
  */

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -22,7 +22,7 @@ export type {
   MessagePart,
   Message,
   SessionHead,
-  SessionData,
+  SessionDetail,
 } from "../contract/session.js";
 export type { SessionReference } from "../contract/session-reference.js";
 

--- a/packages/core/src/utils/__tests__/smart-tags.test.ts
+++ b/packages/core/src/utils/__tests__/smart-tags.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { classifySessionTags } from "../smart-tags.js";
-import type { SessionData } from "../../types/index.js";
+import type { SessionDetail } from "../../types/index.js";
 
-function makeSession(messages: SessionData["messages"]): SessionData {
+function makeSession(messages: SessionDetail["messages"]): SessionDetail {
   return {
     reference: { agentName: "test", sessionId: "s1" },
     id: "s1",

--- a/packages/core/src/utils/smart-tags.ts
+++ b/packages/core/src/utils/smart-tags.ts
@@ -1,4 +1,4 @@
-import type { MessagePart, SessionData, SmartTag, ToolPart } from "../types/index.js";
+import type { MessagePart, SessionDetail, SmartTag, ToolPart } from "../types/index.js";
 
 const TAG_ORDER: SmartTag[] = [
   "bugfix",
@@ -29,12 +29,12 @@ const EDIT_TOOL_RE = /\b(edit|write|apply_patch|patch|multiedit|notebookedit)\b/
 const PLAN_TOOL_RE = /\b(enterplanmode|taskcreate|update_plan|plan)\b/i;
 
 export function getSmartTagSourceTimestamp(
-  session: Pick<SessionData, "time_created" | "time_updated">,
+  session: Pick<SessionDetail, "time_created" | "time_updated">,
 ): number {
   return session.time_updated ?? session.time_created;
 }
 
-export function classifySessionTags(session: Pick<SessionData, "messages">): SmartTag[] {
+export function classifySessionTags(session: Pick<SessionDetail, "messages">): SmartTag[] {
   const tags = new Set<SmartTag>();
   let readToolCount = 0;
   let editToolCount = 0;


### PR DESCRIPTION
## Summary

- align public contract names with the project domain language
- distinguish Session IDs from Session References throughout web routing and indexes
- use canonical project and bookmark contract names without web-only aliases
- expand `CONTEXT.md` with the exported domain concepts

## Breaking changes

- rename `ProviderRoots` / `resolveProviderRoots` to `AgentRoots` / `resolveAgentRoots`
- rename `ScanResult` to `LiveSnapshot`
- rename `SessionData` to `SessionDetail`
- rename web view-state and indexed-session fields to `sessionId` and `reference`

Persisted `SessionHead.slug` and the legacy bookmark `fullPath` field remain unchanged.

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm test:migration`
- `pnpm test:e2e`