### PR TITLE
refactor(agents): centralize file sources

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -143,6 +143,38 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(statSpy.mock.calls.filter((call) => call[0] === indexFile)).toHaveLength(1);
   });
 
+  it("keeps source references and fingerprints byte-for-byte stable", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-fingerprint-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const sessionFile = join(projectDir, "session-1.jsonl");
+    const indexFile = join(projectDir, "sessions-index.json");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(sessionFile, "fixture");
+    writeFileSync(indexFile, JSON.stringify({ entries: [] }));
+
+    const sessionTime = new Date(1_700_000_000_000);
+    const indexTime = new Date(1_700_000_001_000);
+    utimesSync(sessionFile, sessionTime, sessionTime);
+    utimesSync(indexFile, indexTime, indexTime);
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    expect(agent.listSessionSources()).toEqual([
+      {
+        sessionId: "session-1",
+        sourcePath: sessionFile,
+        fingerprint: JSON.stringify([
+          "claudecode-head-v2",
+          sessionTime.getTime(),
+          statSync(sessionFile).size,
+          indexTime.getTime(),
+        ]),
+      },
+    ]);
+  });
+
   it("parses indexed sessions with assistant tools and tool results", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-test-"));
     tempDirs.push(basePath);

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -116,7 +116,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(windowed.map((ref: { sessionId: string }) => ref.sessionId)).toEqual(["new-session"]);
   });
 
-  it("stats each session file at most once per listSessionSources call", () => {
+  it("stats each session file once during a scan", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-stat-"));
     tempDirs.push(basePath);
     const projectDir = join(basePath, "project");
@@ -125,7 +125,17 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const files = ["session-a.jsonl", "session-b.jsonl", "session-c.jsonl"].map((name) =>
       join(projectDir, name),
     );
-    for (const file of files) writeFileSync(file, "");
+    for (const file of files) {
+      writeFileSync(
+        file,
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-04-20T10:00:00Z",
+          cwd: "/tmp/project",
+          message: { role: "user", content: `Inspect ${file}` },
+        }),
+      );
+    }
     const indexFile = join(projectDir, "sessions-index.json");
     writeFileSync(indexFile, JSON.stringify({ entries: [] }));
 
@@ -134,13 +144,12 @@ describe("ClaudeCodeAgent cache refresh", () => {
 
     const statSpy = vi.mocked(statSync);
     statSpy.mockClear();
-    agent.listSessionSources();
+    expect(agent.scan()).toHaveLength(files.length);
 
     for (const file of files) {
       const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
       expect(callsForFile.length).toBe(1);
     }
-    expect(statSpy.mock.calls.filter((call) => call[0] === indexFile)).toHaveLength(1);
   });
 
   it("keeps source references and fingerprints byte-for-byte stable", () => {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -182,7 +182,7 @@ describe("CodexAgent cache refresh", () => {
     expect(windowed.map((ref: { sourcePath: string }) => ref.sourcePath)).toEqual([newFile]);
   });
 
-  it("stats each rollout file at most once per listSessionSources call", () => {
+  it("stats each rollout file once during a scan", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     tempDirs.push(tempDir);
 
@@ -191,11 +191,26 @@ describe("CodexAgent cache refresh", () => {
       "019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb",
       "019dcccc-cccc-7ccc-cccc-cccccccccccc",
     ];
-    const files = sessionIds.map((id) => join(tempDir, `rollout-2026-04-20T10-00-00-${id}.jsonl`));
-    for (const file of files) {
+    const files = sessionIds.map((id) => ({
+      id,
+      file: join(tempDir, `rollout-2026-04-20T10-00-00-${id}.jsonl`),
+    }));
+    for (const { id, file } of files) {
       writeFileSync(
         file,
-        '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
+        [
+          JSON.stringify({
+            timestamp: "2026-04-20T10:00:00Z",
+            type: "session_meta",
+            payload: { id, cwd: "/tmp/project" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-20T10:00:01Z",
+            type: "response_item",
+            payload: { type: "message", role: "user", content: `Inspect ${id}` },
+          }),
+          "",
+        ].join("\n"),
       );
     }
 
@@ -204,9 +219,9 @@ describe("CodexAgent cache refresh", () => {
 
     const statSpy = vi.mocked(statSync);
     statSpy.mockClear();
-    agent.listSessionSources();
+    expect(agent.scan()).toHaveLength(files.length);
 
-    for (const file of files) {
+    for (const { file } of files) {
       const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
       expect(callsForFile.length).toBe(1);
     }

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -212,6 +212,42 @@ describe("CodexAgent cache refresh", () => {
     }
   });
 
+  it("keeps source references and fingerprints byte-for-byte stable", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-fingerprint-"));
+    tempDirs.push(tempDir);
+    const codexHome = join(tempDir, ".codex");
+    const sessionsDir = join(codexHome, "sessions");
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const sessionFile = join(sessionsDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("CODEX_HOME", codexHome);
+    writeFileSync(sessionFile, "fixture");
+    writeFileSync(
+      join(codexHome, "session_index.jsonl"),
+      `${JSON.stringify({ id: sessionId, thread_name: "Indexed title" })}\n`,
+    );
+
+    const sessionTime = new Date(1_700_000_000_000);
+    utimesSync(sessionFile, sessionTime, sessionTime);
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = sessionsDir;
+
+    expect(agent.listSessionSources()).toEqual([
+      {
+        sessionId,
+        sourcePath: sessionFile,
+        fingerprint: JSON.stringify([
+          "codex-head-v1",
+          "codex-parser-v4",
+          sessionTime.getTime(),
+          statSync(sessionFile).size,
+          "Indexed title",
+        ]),
+      },
+    ]);
+  });
+
   it("caches an empty session index and reloads it when the mtime changes", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-empty-index-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
@@ -129,12 +129,20 @@ describe("KimiAgent source enumeration", () => {
 
     // Pin the mtime so the rewrite below can restore it exactly — statSync
     // reports sub-millisecond precision that a Date round-trip would truncate.
+    const statePath = join(sourcePath, "state.json");
     const contextPath = join(sourcePath, "context.jsonl");
+    const stateTime = new Date(1_699_999_999_000);
     const pinned = new Date(1_700_000_000_000);
+    utimesSync(statePath, stateTime, stateTime);
     utimesSync(contextPath, pinned, pinned);
 
     const agent = createAgent(basePath);
-    const before = agent.listSessionSources()[0]?.fingerprint;
+    const [before] = agent.listSessionSources();
+    expect(before).toEqual({
+      sessionId: "fingerprint",
+      sourcePath,
+      fingerprint: JSON.stringify([stateTime.getTime(), pinned.getTime(), null]),
+    });
 
     // Rewriting the transcript body without moving its mtime must not move the
     // fingerprint: enumeration only observes mtimes, never content.
@@ -142,7 +150,7 @@ describe("KimiAgent source enumeration", () => {
     utimesSync(contextPath, pinned, pinned);
 
     expect(statSync(contextPath).mtimeMs).toBe(pinned.getTime());
-    expect(agent.listSessionSources()[0]?.fingerprint).toBe(before);
+    expect(agent.listSessionSources()[0]?.fingerprint).toBe(before?.fingerprint);
   });
 });
 

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -202,7 +202,7 @@ describe("PiAgent", () => {
     expect(windowed.map((ref) => ref.sourcePath)).toEqual([newFile]);
   });
 
-  it("stats each session file at most once per listSessionSources call", () => {
+  it("stats each session file once during a scan", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
     tempDirs.push(tempDir);
     const piHome = join(tempDir, ".pi");
@@ -210,19 +210,40 @@ describe("PiAgent", () => {
     mkdirSync(sessionsDir, { recursive: true });
     vi.stubEnv("PI_HOME", piHome);
 
-    const files = ["a", "b", "c"].map((name) =>
-      join(sessionsDir, `2026-04-20T10-00-00_${name}.jsonl`),
-    );
-    for (const file of files) writeFileSync(file, "");
+    const files = ["a", "b", "c"].map((id) => ({
+      id,
+      file: join(sessionsDir, `2026-04-20T10-00-00_${id}.jsonl`),
+    }));
+    for (const { id, file } of files) {
+      writeFileSync(
+        file,
+        [
+          JSON.stringify({
+            type: "session",
+            version: 3,
+            id,
+            timestamp: "2026-04-20T10:00:00.000Z",
+            cwd: "/tmp/project",
+          }),
+          JSON.stringify({
+            type: "message",
+            id: `message-${id}`,
+            parentId: null,
+            timestamp: "2026-04-20T10:00:01.000Z",
+            message: { role: "user", content: `Inspect ${id}` },
+          }),
+        ].join("\n"),
+      );
+    }
 
     const agent = new PiAgent();
     agent.isAvailable();
 
     const statSpy = vi.mocked(statSync);
     statSpy.mockClear();
-    agent.listSessionSources();
+    expect(agent.scan()).toHaveLength(files.length);
 
-    for (const file of files) {
+    for (const { file } of files) {
       const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
       expect(callsForFile.length).toBe(1);
     }

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -228,6 +228,37 @@ describe("PiAgent", () => {
     }
   });
 
+  it("keeps source references and fingerprints byte-for-byte stable", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-fingerprint-"));
+    tempDirs.push(tempDir);
+    const piHome = join(tempDir, ".pi");
+    const sessionsDir = join(piHome, "agent", "sessions", "--tmp-project--");
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const sessionFile = join(sessionsDir, `2026-04-20T10-00-00_${sessionId}.jsonl`);
+    mkdirSync(sessionsDir, { recursive: true });
+    vi.stubEnv("PI_HOME", piHome);
+    writeFileSync(sessionFile, "fixture");
+
+    const sessionTime = new Date(1_700_000_000_000);
+    utimesSync(sessionFile, sessionTime, sessionTime);
+
+    const agent = new PiAgent();
+    agent.isAvailable();
+
+    expect(agent.listSessionSources()).toEqual([
+      {
+        sessionId,
+        sourcePath: sessionFile,
+        fingerprint: JSON.stringify([
+          "pi-head-v1",
+          "pi-parser-v1",
+          sessionTime.getTime(),
+          statSync(sessionFile).size,
+        ]),
+      },
+    ]);
+  });
+
   it("uses session names and parses assistant tools on the selected leaf", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,4 +1,5 @@
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readdirSync, statSync, type Dirent, type Stats } from "node:fs";
+import { join } from "node:path";
 import type { SessionHead, SessionDetail, ParseSessionResult } from "../types/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 
@@ -39,6 +40,11 @@ export interface AgentScanProgress {
   sessions?: number;
 }
 
+export interface FileWalkOptions {
+  recursive?: boolean;
+  scanWindow?: Pick<AgentScanOptions, "from" | "to">;
+}
+
 export function matchesScanWindow(activityTime: number, options?: AgentScanOptions): boolean {
   if (options?.from != null && activityTime < options.from) return false;
   if (options?.to != null && activityTime > options.to) return false;
@@ -61,6 +67,23 @@ export interface SessionSourceRef {
   sessionId: string;
   sourcePath: string;
   fingerprint: string;
+}
+
+export interface SessionSourceFile {
+  file: string;
+  stat: Stats;
+}
+
+export interface FileSessionMeta extends SessionCacheMeta {
+  id: string;
+  title: string;
+  sourcePath: string;
+  sourceFingerprint: string;
+  sourceMtimeMs: number;
+  directory: string;
+  messageCount: number;
+  createdAt: number;
+  updatedAt: number;
 }
 
 export interface SessionWatchTarget {
@@ -232,6 +255,7 @@ export abstract class FileSystemSessionSource<
   TMeta extends SessionCacheMeta = SessionCacheMeta,
 > extends BaseAgent {
   protected sessionMetaMap = new Map<string, TMeta>();
+  private sourceFileStats = new Map<string, Stats>();
 
   /** 枚举所有会话源及其指纹。传入 options 时按 mtime 限定扫描窗口。 */
   abstract listSessionSources(options?: AgentScanOptions): SessionSourceRef[];
@@ -273,6 +297,63 @@ export abstract class FileSystemSessionSource<
 
   setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
     this.sessionMetaMap = meta as Map<string, TMeta>;
+  }
+
+  protected walkFiles(
+    roots: string | readonly string[],
+    isSessionFile: (entry: Dirent) => boolean,
+    options: FileWalkOptions = {},
+  ): SessionSourceFile[] {
+    const files: SessionSourceFile[] = [];
+    this.sourceFileStats.clear();
+
+    const walk = (directory: string): void => {
+      let entries: Dirent[];
+      try {
+        entries = readdirSync(directory, { withFileTypes: true });
+      } catch {
+        return;
+      }
+
+      for (const entry of entries) {
+        const filePath = join(directory, entry.name);
+        if (entry.isDirectory()) {
+          if (options.recursive !== false) walk(filePath);
+          continue;
+        }
+        if (!isSessionFile(entry)) continue;
+
+        let stat: Stats;
+        try {
+          stat = statSync(filePath);
+        } catch {
+          continue;
+        }
+        if (!matchesScanWindow(stat.mtimeMs, options.scanWindow)) continue;
+
+        files.push({ file: filePath, stat });
+        this.sourceFileStats.set(filePath, stat);
+      }
+    };
+
+    for (const root of typeof roots === "string" ? [roots] : roots) walk(root);
+    return files;
+  }
+
+  protected sessionSourceFile(sourcePath: string): SessionSourceFile {
+    return {
+      file: sourcePath,
+      stat: this.sourceFileStats.get(sourcePath) ?? statSync(sourcePath),
+    };
+  }
+
+  protected readFileMtimeMs(filePath: string | null): number | null {
+    if (!filePath) return null;
+    try {
+      return statSync(filePath).mtimeMs;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -327,6 +408,54 @@ export abstract class FileSystemSessionSource<
     }
 
     return [...sessionMap.values()];
+  }
+}
+
+/** Shared scan template for agents whose session source is a single stat-able file. */
+export abstract class SingleFileSessionSource<
+  TMeta extends FileSessionMeta = FileSessionMeta,
+> extends FileSystemSessionSource<TMeta> {
+  protected abstract parseFileSessionHead(
+    sourcePath: string,
+    options?: AgentScanOptions,
+  ): SessionHead | null;
+
+  protected abstract createFileSessionMeta(head: SessionHead, source: SessionSourceFile): TMeta;
+
+  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
+    const head = this.parseFileSessionHead(sourcePath, options);
+    if (head) {
+      this.sessionMetaMap.set(
+        head.id,
+        this.createFileSessionMeta(head, this.sessionSourceFile(sourcePath)),
+      );
+    }
+    return head;
+  }
+
+  protected buildFileSessionMeta<TExtra extends object>({
+    head,
+    source,
+    fingerprint,
+    extras,
+  }: {
+    head: SessionHead;
+    source: SessionSourceFile;
+    fingerprint: string;
+    extras: TExtra;
+  }): FileSessionMeta & TExtra {
+    return {
+      ...extras,
+      id: head.id,
+      title: head.title,
+      sourcePath: source.file,
+      sourceFingerprint: fingerprint,
+      sourceMtimeMs: source.stat.mtimeMs,
+      directory: head.directory,
+      messageCount: head.stats.message_count,
+      createdAt: head.time_created,
+      updatedAt: head.time_updated ?? head.time_created,
+    };
   }
 }
 

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -1,10 +1,9 @@
-import { existsSync, readdirSync, readFileSync, statSync, type Stats } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import {
-  FileSystemSessionSource,
+  SingleFileSessionSource,
   filteredSession,
   getParsedSession,
-  matchesScanWindow,
   parsedSession,
   skippedSession,
 } from "./base.js";
@@ -24,7 +23,12 @@ import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
-import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "./base.js";
+import type {
+  AgentScanOptions,
+  FileSessionMeta,
+  SessionSourceFile,
+  SessionSourceRef,
+} from "./base.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const HEAD_INDEX_VERSION = "claudecode-head-v2";
@@ -37,19 +41,11 @@ interface ClaudeUsage {
   cacheCreate: number;
 }
 
-interface SessionMeta extends SessionCacheMeta {
-  id: string;
-  title: string;
-  sourcePath: string;
-  sourceMtimeMs: number;
+interface SessionMeta extends FileSessionMeta {
   indexPath: string | null;
   indexMtimeMs: number | null;
   headIndexVersion: string;
-  directory: string;
   model: string | null | undefined;
-  messageCount: number;
-  createdAt: number;
-  updatedAt: number;
 }
 
 function parseTimestampMs(data: Record<string, unknown>): number {
@@ -107,7 +103,7 @@ function extractClaudeUsage(
   };
 }
 
-export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
+export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   readonly name = "claudecode";
   readonly displayName = "Claude Code";
 
@@ -150,36 +146,26 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
-    const refs: SessionSourceRef[] = [];
-    for (const projectDir of this.listProjectDirs()) {
+    const projectDirs = this.listProjectDirs();
+    const indexMtimes = new Map<string, number | null>();
+    for (const projectDir of projectDirs) {
       const indexPath = this.getSessionsIndexPath(projectDir);
-      const indexMtime = this.getFileMtimeMs(indexPath);
-      for (const file of this.listJsonlFiles(projectDir)) {
-        let stat: Stats;
-        try {
-          stat = statSync(file);
-        } catch {
-          continue;
-        }
-        if (!matchesScanWindow(stat.mtimeMs, options)) continue;
-        const sessionId = basename(file, ".jsonl");
-        refs.push({
-          sessionId,
-          sourcePath: file,
-          fingerprint: this.sourceFingerprint(stat, indexMtime),
-        });
-      }
+      indexMtimes.set(projectDir, this.readFileMtimeMs(indexPath));
     }
-    return refs;
+
+    return this.walkFiles(projectDirs, (entry) => entry.name.endsWith(".jsonl"), {
+      recursive: false,
+      scanWindow: options,
+    }).map(({ file, stat }) => ({
+      sessionId: basename(file, ".jsonl"),
+      sourcePath: file,
+      fingerprint: this.sourceFingerprint(stat, indexMtimes.get(dirname(file)) ?? null),
+    }));
   }
 
-  scanSessionSource(sourcePath: string): SessionHead | null {
+  protected parseFileSessionHead(sourcePath: string): SessionHead | null {
     const projectDir = dirname(sourcePath);
-    const head = getParsedSession(this.parseSessionHeadResult(sourcePath, projectDir));
-    if (head) {
-      this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath, projectDir));
-    }
-    return head;
+    return getParsedSession(this.parseSessionHeadResult(sourcePath, projectDir));
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -231,35 +217,21 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     }
   }
 
-  private listJsonlFiles(dir: string): string[] {
-    try {
-      return readdirSync(dir)
-        .filter((f) => f.endsWith(".jsonl") && f !== "sessions-index.json")
-        .map((f) => join(dir, f));
-    } catch {
-      return [];
-    }
-  }
-
-  private buildSessionMeta(head: SessionHead, file: string, projectDir: string): SessionMeta {
+  protected createFileSessionMeta(head: SessionHead, source: SessionSourceFile): SessionMeta {
+    const projectDir = dirname(source.file);
     const indexPath = this.getSessionsIndexPath(projectDir);
-    const indexMtime = this.getFileMtimeMs(indexPath);
-    const stat = statSync(file);
-    return {
-      id: head.id,
-      title: head.title,
-      sourcePath: file,
-      sourceFingerprint: this.sourceFingerprint(stat, indexMtime),
-      sourceMtimeMs: stat.mtimeMs,
-      indexPath: indexMtime === null ? null : indexPath,
-      indexMtimeMs: indexMtime,
-      headIndexVersion: HEAD_INDEX_VERSION,
-      directory: head.directory,
-      model: head.stats.total_tokens ? "unknown" : undefined,
-      messageCount: head.stats.message_count,
-      createdAt: head.time_created,
-      updatedAt: head.time_updated ?? head.time_created,
-    };
+    const indexMtime = this.readFileMtimeMs(indexPath);
+    return this.buildFileSessionMeta({
+      head,
+      source,
+      fingerprint: this.sourceFingerprint(source.stat, indexMtime),
+      extras: {
+        indexPath: indexMtime === null ? null : indexPath,
+        indexMtimeMs: indexMtime,
+        headIndexVersion: HEAD_INDEX_VERSION,
+        model: head.stats.total_tokens ? "unknown" : undefined,
+      },
+    });
   }
 
   /** Fingerprint depends on an already-fetched stat to avoid re-statting the same file. */
@@ -274,18 +246,10 @@ export class ClaudeCodeAgent extends FileSystemSessionSource<SessionMeta> {
     return join(projectDir, "sessions-index.json");
   }
 
-  private getFileMtimeMs(filePath: string): number | null {
-    try {
-      return statSync(filePath).mtimeMs;
-    } catch {
-      return null;
-    }
-  }
-
   private loadSessionsIndex(projectDir: string): Map<string, Record<string, unknown>> {
     const cacheKey = basename(projectDir);
     const indexPath = this.getSessionsIndexPath(projectDir);
-    const mtime = this.getFileMtimeMs(indexPath);
+    const mtime = this.readFileMtimeMs(indexPath);
 
     // Invalidate when the index file mtime advances so long-running processes
     // pick up title changes without relying on callers to evict manually.

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1,19 +1,9 @@
-import {
-  closeSync,
-  existsSync,
-  openSync,
-  readFileSync,
-  readSync,
-  readdirSync,
-  statSync,
-  type Stats,
-} from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import {
-  FileSystemSessionSource,
+  SingleFileSessionSource,
   filteredSession,
   getParsedSession,
-  matchesScanWindow,
   parsedSession,
   skippedSession,
 } from "./base.js";
@@ -310,29 +300,26 @@ function extractPatchContent(
 // Session meta
 // ---------------------------------------------------------------------------
 
-import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "./base.js";
+import type {
+  AgentScanOptions,
+  FileSessionMeta,
+  SessionSourceFile,
+  SessionSourceRef,
+} from "./base.js";
 
-interface SessionMeta extends SessionCacheMeta {
-  id: string;
-  title: string;
-  sourcePath: string;
-  sourceMtimeMs: number;
+interface SessionMeta extends FileSessionMeta {
   indexPath: string | null;
   indexMtimeMs: number | null;
   headIndexVersion: string;
   parserVersion: string;
-  directory: string;
   model: string | null;
-  messageCount: number;
-  createdAt: number;
-  updatedAt: number;
 }
 
 // ---------------------------------------------------------------------------
 // CodexAgent
 // ---------------------------------------------------------------------------
 
-export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
+export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   readonly name = "codex";
   readonly displayName = "Codex";
 
@@ -362,13 +349,7 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
   isAvailable(): boolean {
     this.basePath = this.findBasePath();
     if (!this.basePath) return false;
-    try {
-      // Check recursively for rollout jsonl files
-      const files = this.walkDirForRolloutFiles(this.basePath);
-      return files.length > 0;
-    } catch {
-      return false;
-    }
+    return this.listRolloutFiles().length > 0;
   }
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
@@ -379,15 +360,6 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
       sourcePath: file,
       fingerprint: this.sourceFingerprint(file, stat),
     }));
-  }
-
-  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
-    this.loadSessionIndex();
-    const head = getParsedSession(this.parseSessionHeadResult(sourcePath, options));
-    if (head) {
-      this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath));
-    }
-    return head;
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -511,63 +483,30 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
 
   // ---- File listing ----
 
-  private listRolloutFiles(options?: AgentScanOptions): { file: string; stat: Stats }[] {
+  private listRolloutFiles(options?: AgentScanOptions): SessionSourceFile[] {
     if (!this.basePath) return [];
-    try {
-      return this.walkDirForRolloutFiles(this.basePath, options);
-    } catch {
-      return [];
-    }
+    return this.walkFiles(
+      this.basePath,
+      (entry) => entry.name.endsWith(".jsonl") && entry.name.startsWith("rollout-"),
+      { scanWindow: options },
+    );
   }
 
-  /** Stats each rollout file once during the walk; caller reuses it for the scan window check and the fingerprint. */
-  private walkDirForRolloutFiles(
-    dir: string,
-    options?: AgentScanOptions,
-  ): { file: string; stat: Stats }[] {
-    const files: { file: string; stat: Stats }[] = [];
-    try {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const fullPath = join(dir, entry.name);
-        if (entry.isDirectory()) {
-          files.push(...this.walkDirForRolloutFiles(fullPath, options));
-        } else if (entry.name.endsWith(".jsonl") && entry.name.startsWith("rollout-")) {
-          let stat: Stats;
-          try {
-            stat = statSync(fullPath);
-          } catch {
-            continue;
-          }
-          if (!matchesScanWindow(stat.mtimeMs, options)) continue;
-          files.push({ file: fullPath, stat });
-        }
-      }
-    } catch {
-      // skip permission errors
-    }
-    return files;
-  }
-
-  private buildSessionMeta(head: SessionHead, file: string): SessionMeta {
+  protected createFileSessionMeta(head: SessionHead, source: SessionSourceFile): SessionMeta {
     const indexPath = this.getSessionIndexPath();
     const indexMtime = this.sessionIndexMtime ?? null;
-    const stat = statSync(file);
-    return {
-      id: head.id,
-      title: head.title,
-      sourcePath: file,
-      sourceFingerprint: this.sourceFingerprint(file, stat),
-      sourceMtimeMs: stat.mtimeMs,
-      indexPath: indexMtime === null ? null : indexPath,
-      indexMtimeMs: indexMtime,
-      headIndexVersion: HEAD_INDEX_VERSION,
-      parserVersion: PARSER_VERSION,
-      directory: head.directory,
-      model: null,
-      messageCount: head.stats.message_count,
-      createdAt: head.time_created,
-      updatedAt: head.time_updated ?? head.time_created,
-    };
+    return this.buildFileSessionMeta({
+      head,
+      source,
+      fingerprint: this.sourceFingerprint(source.file, source.stat),
+      extras: {
+        indexPath: indexMtime === null ? null : indexPath,
+        indexMtimeMs: indexMtime,
+        headIndexVersion: HEAD_INDEX_VERSION,
+        parserVersion: PARSER_VERSION,
+        model: null,
+      },
+    });
   }
 
   /** Fingerprint depends on an already-fetched stat to avoid re-statting the same file. */
@@ -587,19 +526,11 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     return this.sessionIndexPath;
   }
 
-  private getFileMtimeMs(filePath: string): number | null {
-    try {
-      return statSync(filePath).mtimeMs;
-    } catch {
-      return null;
-    }
-  }
-
   // ---- Session index ----
 
   private loadSessionIndex(): void {
     const indexPath = this.getSessionIndexPath();
-    const mtime = this.getFileMtimeMs(indexPath);
+    const mtime = this.readFileMtimeMs(indexPath);
 
     // Invalidate when the index file mtime advances so long-running processes
     // pick up title changes without relying on callers to evict manually.
@@ -644,6 +575,11 @@ export class CodexAgent extends FileSystemSessionSource<SessionMeta> {
     } finally {
       closeSync(fd);
     }
+  }
+
+  protected parseFileSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {
+    this.loadSessionIndex();
+    return this.parseSessionHead(filePath, options);
   }
 
   private parseSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,4 +1,9 @@
-export { BaseAgent, FileSystemSessionSource, DatabaseSessionSource } from "./base.js";
+export {
+  BaseAgent,
+  DatabaseSessionSource,
+  FileSystemSessionSource,
+  SingleFileSessionSource,
+} from "./base.js";
 export {
   diffSessionSources,
   filteredSession,
@@ -12,7 +17,10 @@ export type {
   AgentScanProgress,
   CachedMetaLookup,
   ChangeCheckResult,
+  FileSessionMeta,
+  FileWalkOptions,
   SessionCacheMeta,
+  SessionSourceFile,
   SessionSourceDiff,
   SessionSourceRef,
   SessionWatchPlan,

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -605,18 +605,10 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
   // --- Helpers ---
 
   private sourceFingerprint(meta: Pick<SessionSource, "metaFile" | "contextFile" | "wireFile">) {
-    const fileMtime = (path: string | null) => {
-      if (!path) return null;
-      try {
-        return statSync(path).mtimeMs;
-      } catch {
-        return null;
-      }
-    };
     return JSON.stringify([
-      fileMtime(meta.metaFile),
-      fileMtime(meta.contextFile),
-      fileMtime(meta.wireFile),
+      this.readFileMtimeMs(meta.metaFile),
+      this.readFileMtimeMs(meta.contextFile),
+      this.readFileMtimeMs(meta.wireFile),
     ]);
   }
 

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,16 +1,16 @@
-import { existsSync, readdirSync, statSync, type Stats } from "node:fs";
+import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
 import {
-  FileSystemSessionSource,
+  SingleFileSessionSource,
   filteredSession,
   getParsedSession,
-  matchesScanWindow,
   parsedSession,
 } from "./base.js";
 import type {
   AgentScanOptions,
+  FileSessionMeta,
   ParseSessionResult,
-  SessionCacheMeta,
+  SessionSourceFile,
   SessionSourceRef,
 } from "./base.js";
 import type { Message, MessagePart, SessionDetail, SessionHead } from "../types/index.js";
@@ -25,17 +25,9 @@ import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-bui
 const HEAD_INDEX_VERSION = "pi-head-v1";
 const PARSER_VERSION = "pi-parser-v1";
 
-interface SessionMeta extends SessionCacheMeta {
-  id: string;
-  title: string;
-  sourcePath: string;
-  sourceMtimeMs: number;
+interface SessionMeta extends FileSessionMeta {
   headIndexVersion: string;
   parserVersion: string;
-  directory: string;
-  messageCount: number;
-  createdAt: number;
-  updatedAt: number;
 }
 
 interface ParsedPiFile {
@@ -140,7 +132,7 @@ function buildCurrentPathEntries(entries: Record<string, unknown>[]): Record<str
   return path.reverse();
 }
 
-export class PiAgent extends FileSystemSessionSource<SessionMeta> {
+export class PiAgent extends SingleFileSessionSource<SessionMeta> {
   readonly name = "pi";
   readonly displayName = "Pi";
 
@@ -170,19 +162,11 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
     if (!this.basePath) return [];
-    return this.walkJsonlFiles(this.basePath, options).map(({ file, stat }) => ({
+    return this.listSessionFiles(options).map(({ file, stat }) => ({
       sessionId: extractSessionIdFromFilename(file),
       sourcePath: file,
       fingerprint: this.sourceFingerprint(stat),
     }));
-  }
-
-  scanSessionSource(sourcePath: string): SessionHead | null {
-    const head = getParsedSession(this.parseSessionHeadResult(sourcePath));
-    if (head) {
-      this.sessionMetaMap.set(head.id, this.buildSessionMeta(head, sourcePath));
-    }
-    return head;
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -214,57 +198,34 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     };
   }
 
-  private listSessionFiles(options?: AgentScanOptions): string[] {
+  private listSessionFiles(options?: AgentScanOptions): SessionSourceFile[] {
     if (!this.basePath) return [];
-    return this.walkJsonlFiles(this.basePath, options).map(({ file }) => file);
+    return this.walkFiles(
+      this.basePath,
+      (entry) => entry.isFile() && entry.name.endsWith(".jsonl"),
+      { scanWindow: options },
+    );
   }
 
-  /** Stats each file once during the walk; caller reuses it for both the scan window check and the fingerprint. */
-  private walkJsonlFiles(dir: string, options?: AgentScanOptions): { file: string; stat: Stats }[] {
-    const files: { file: string; stat: Stats }[] = [];
-    try {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const fullPath = join(dir, entry.name);
-        if (entry.isDirectory()) {
-          files.push(...this.walkJsonlFiles(fullPath, options));
-          continue;
-        }
-        if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
-        let stat: Stats;
-        try {
-          stat = statSync(fullPath);
-        } catch {
-          continue;
-        }
-        if (!matchesScanWindow(stat.mtimeMs, options)) continue;
-        files.push({ file: fullPath, stat });
-      }
-    } catch {
-      // skip inaccessible dirs
-    }
-    return files;
-  }
-
-  private buildSessionMeta(head: SessionHead, file: string): SessionMeta {
-    const stat = statSync(file);
-    return {
-      id: head.id,
-      title: head.title,
-      sourcePath: file,
-      sourceFingerprint: this.sourceFingerprint(stat),
-      sourceMtimeMs: stat.mtimeMs,
-      headIndexVersion: HEAD_INDEX_VERSION,
-      parserVersion: PARSER_VERSION,
-      directory: head.directory,
-      messageCount: head.stats.message_count,
-      createdAt: head.time_created,
-      updatedAt: head.time_updated ?? head.time_created,
-    };
+  protected createFileSessionMeta(head: SessionHead, source: SessionSourceFile): SessionMeta {
+    return this.buildFileSessionMeta({
+      head,
+      source,
+      fingerprint: this.sourceFingerprint(source.stat),
+      extras: {
+        headIndexVersion: HEAD_INDEX_VERSION,
+        parserVersion: PARSER_VERSION,
+      },
+    });
   }
 
   /** Fingerprint depends on an already-fetched stat to avoid re-statting the same file. */
   private sourceFingerprint(stat: { mtimeMs: number; size: number }): string {
     return JSON.stringify([HEAD_INDEX_VERSION, PARSER_VERSION, stat.mtimeMs, stat.size]);
+  }
+
+  protected parseFileSessionHead(filePath: string): SessionHead | null {
+    return getParsedSession(this.parseSessionHeadResult(filePath));
   }
 
   private parseSessionHeadResult(filePath: string): ParseSessionResult<SessionHead> {
@@ -319,7 +280,7 @@ export class PiAgent extends FileSystemSessionSource<SessionMeta> {
     const sessionId = String(header["id"] ?? extractSessionIdFromFilename(filePath)).trim();
     if (!sessionId) throw new Error("missing session id");
 
-    const stat = statSync(filePath);
+    const stat = this.sessionSourceFile(filePath).stat;
     const directory = String(header["cwd"] ?? "").trim() || basename(filePath, ".jsonl");
     const createdAt = narrowTimestampMs("session.timestamp", header["timestamp"]) || stat.mtimeMs;
     const updatedAt = pathEntries.reduce(


### PR DESCRIPTION
## Summary

- add shared recursive file enumeration, scan-window filtering, and nullable mtime primitives for file-system session sources
- add a single-file session source template that centralizes scan metadata construction while preserving adapter-specific parsing and fingerprint extras
- migrate Claude Code, Codex, and Pi to the template, while keeping Kimi's directory-based enumeration
- lock Claude Code, Codex, Pi, and Kimi source references and fingerprints with characterization tests

## Impact

File-backed adapters now share one implementation for source walking, stat reuse, metadata construction, and scan orchestration. Existing source fingerprints remain byte-for-byte unchanged, so cached session heads are not invalidated by this refactor.

## Testing

- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm test:migration`
- `pnpm test:coverage`
- `pnpm test:e2e`