### PR TITLE
docs: refresh scanning architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,10 +46,10 @@
 
 ┌────────────────────────────────────────────────────────────────┐
 │                          Cache Layer                           │
-│              packages/core/src/discovery/cache.ts               │
+│             packages/core/src/discovery/cache/*.ts              │
 │                                                                │
 │   存储位置: ~/.cache/codesesh/codesesh.db                     │
-│   存储内容: sessions cache + meta + FTS index                 │
+│   存储内容: session heads + materialized details + FTS        │
 └────────────────────────────────────────────────────────────────┘
 
 详细表结构和数据流见 [sqlite-storage.md](./sqlite-storage.md)。
@@ -80,7 +80,7 @@ pnpm bench:perf -- --iterations 3
 1. **并行扫描**: 所有 Agent 同时工作
 2. **快速返回**: 缓存命中时优先返回缓存数据
 3. **智能刷新**: 后台检测变更，增量更新
-4. **数据一致**: 列表用缓存，详情实时读取
+4. **数据一致**: 详情优先读取结构化快照，源指纹失效时回源解析
 
 ## 使用方法
 

--- a/docs/scanning-and-caching.md
+++ b/docs/scanning-and-caching.md
@@ -1,361 +1,204 @@
-# CodeSesh 扫描与缓存机制说明文档
+# CodeSesh 扫描与缓存
 
 ## 概述
 
-本文档详细说明 CodeSesh 的会话扫描、并行处理和缓存机制的设计理念与实现细节。
+CodeSesh 的扫描链路分成两个阶段：
 
-SQLite 表结构和搜索索引数据流见 [sqlite-storage.md](./sqlite-storage.md)。
+1. 尽快从 SQLite 恢复可浏览的会话列表。
+2. 在 worker 中核对真实数据源，将变化持久化到缓存和搜索索引，再发布新快照。
 
-## 1. 整体架构
+SQLite schema 与详情快照说明见 [sqlite-storage.md](./sqlite-storage.md)。
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                        扫描流程                              │
-├─────────────────────────────────────────────────────────────┤
-│  CLI 启动                                                   │
-│     │                                                       │
-│     ▼                                                       │
-│  ┌──────────────────┐    ┌──────────────────┐              │
-│  │   scanSessions   │───▶│  Agent 并行扫描   │              │
-│  │   (入口函数)      │    │  (5个并发)       │              │
-│  └──────────────────┘    └──────────────────┘              │
-│                                   │                         │
-│                    ┌──────────────┼──────────────┐         │
-│                    ▼              ▼              ▼         │
-│              ┌─────────┐   ┌─────────┐   ┌─────────┐      │
-│              │ Claude  │   │  Codex  │   │  Kimi   │      │
-│              │ (文件)  │   │ (文件)  │   │ (文件)  │      │
-│              └─────────┘   └─────────┘   └─────────┘      │
-│                                                    │       │
-│              ┌─────────┐   ┌─────────┐            │       │
-│              │OpenCode │   │ Cursor  │────────────┘       │
-│              │ (SQLite)│   │ (SQLite)│                    │
-│              └─────────┘   └─────────┘                    │
-└─────────────────────────────────────────────────────────────┘
+## 运行时结构
+
+```text
+CLI
+  -> LiveScanStore
+       -> scanSessions() 恢复初始快照
+       -> AgentSyncEngine 协调每个 Agent 的刷新与 backfill
+       -> SessionWatcher 把文件系统事件归并为 Agent 刷新
+            -> scan-refresh worker 读取/解析数据源
+            -> search-index worker 持久化会话、详情与索引
+            -> LiveScanStore 发布内存快照和 SSE 更新
 ```
 
-## 2. 并行扫描机制
+核心边界：
 
-### 2.1 Agent 级别并行
+| 模块 | 职责 |
+|------|------|
+| `packages/core/src/discovery/scanner.ts` | 通用扫描、缓存恢复和同步增量合并 |
+| `packages/core/src/agents/base.ts` | 文件型/数据库型 Agent 的变更检测模板 |
+| `packages/cli/src/live-scan.ts` | 持有当前不可变快照，对外提供订阅 |
+| `packages/cli/src/agent-sync-engine.ts` | 串行化单个 Agent 的 refresh/backfill，并协调发布 |
+| `packages/cli/src/session-watcher.ts` | 跨平台文件监听、写入稳定性等待与事件归并 |
+| `packages/cli/src/scan-refresh-worker.ts` | 在 worker thread 中扫描和解析 |
+| `packages/cli/src/search-index-worker.ts` | 写入缓存、详情和搜索索引 |
 
-所有 Agent 同时扫描，而非串行执行：
+## Agent 并行模型
+
+`scanSessions()` 对所有选中的注册 Agent 调用 `scanAgentSmart()`，并通过 `Promise.all`
+并行等待结果；没有固定“5 个并发”的限制。
+
+当前数据源类型：
+
+- 文件型：Claude Code、Codex、Kimi、Pi
+- 单 SQLite 数据库型：OpenCode、Cursor、ZCode
+
+不同 Agent 可以并行刷新；同一个 Agent 的 refresh 与 backfill 由 `AgentSyncEngine`
+串行化，并为每次 operation 记录 generation。SQLite 搜索写入另由单一 job runner
+排队。
+
+## 启动流程
+
+### 交互式 Web 模式
+
+`LiveScanStore` 以 `deferInitialRefresh: true` 启动：
+
+```text
+loadCachedSessions()
+  -> 从 agent_cache + sessions 恢复 SessionHead[] / SessionCacheMeta
+  -> 启动 HTTP 服务
+  -> startBackgroundRefresh()
+  -> 逐 Agent 核对真实数据源并更新快照
+```
+
+缓存不存在时，初始快照可以为空；服务启动后后台初始化对应 Agent。缓存存在时，UI 先
+看到已持久化快照，再通过 SSE 收到刷新结果。
+
+### JSON 模式
+
+`--json` 不延迟初始刷新。扫描与索引同步完成后才输出 JSON，并在输出阶段应用
+`--days` / `--from` / `--to` 列表窗口。
+
+## 变更检测
+
+### 文件型 Agent：源枚举 + 指纹 diff
+
+`FileSystemSessionSource.checkForChanges()` 不用缓存时间戳判断单个文件是否变化。它先由
+适配器枚举当前 `SessionSourceRef[]`：
 
 ```typescript
-// 并行扫描所有 Agent
-const scanPromises = agentsToScan.map((agent) =>
-  scanAgentSmart(agent, options, onProgress)
-);
-const results = await Promise.all(scanPromises);
-```
-
-**性能对比**：
-- 串行扫描：~10.6s (Agent 一个接一个)
-- 并行扫描：~5s (所有 Agent 同时进行)
-
-### 2.2 会话级别扫描（当前实现）
-
-每个 Agent 内部仍然是串行扫描文件：
-
-```typescript
-// Claude Code - 串行读取项目目录
-for (const projectDir of this.listProjectDirs()) {
-  for (const file of this.listJsonlFiles(projectDir)) {
-    const head = this.parseSessionHead(file, projectDir);
-    // ...
-  }
+interface SessionSourceRef {
+  sessionId: string;
+  sourcePath: string;
+  fingerprint: string;
 }
 ```
 
-**未来优化方向**：
-- 使用 `Promise.all` 并行读取多个文件
-- 使用 Worker Threads 处理 CPU 密集型解析
+`diffSessionSources()` 将当前引用与缓存的会话和 `SessionCacheMeta` 比较：
 
-## 3. 智能刷新机制 (Smart Refresh)
+- 缓存中没有该会话：新增；
+- `sourcePath` 改变或 `sourceFingerprint` 不同：变更；
+- 上次在本次扫描窗口内、现在却没有对应引用：删除；
+- 其余会话保持原对象，不重新解析。
 
-### 3.1 设计理念
+指纹由各适配器生成，并纳入其解析结果所依赖的事实，例如文件大小、mtime、辅助索引
+mtime 或解析器版本。比较采用精确字符串相等；声明版本字段的适配器可通过提升版本主动
+失效旧缓存。
 
-解决缓存的两大痛点：
-1. **启动速度**：缓存可立即返回结果（14ms）
-2. **数据新鲜度**：后台检测变更并增量更新
+`incrementalScan()` 复用本次枚举得到的 refs，只对变更/新增源调用
+`scanSessionSource()`，同时移除已消失的会话。
 
-```
-┌────────────────────────────────────────────────────────────┐
-│                     智能刷新流程                            │
-├────────────────────────────────────────────────────────────┤
-│                                                            │
-│   启动                                                      │
-│     │                                                       │
-│     ▼                                                       │
-│   ┌─────────────┐    是    ┌─────────────┐                │
-│   │  缓存存在？  │────────▶│  立即返回    │ 14ms          │
-│   └─────────────┘         └─────────────┘                │
-│     │ 否                         │                        │
-│     ▼                            ▼                        │
-│   ┌─────────────┐         ┌─────────────┐                │
-│   │  完整扫描    │         │  后台检测    │                │
-│   │  (10.6s)   │         │  文件变更    │                │
-│   └─────────────┘         └─────────────┘                │
-│                                    │                        │
-│                                    ▼                        │
-│                           ┌─────────────┐                 │
-│                           │  增量更新    │                 │
-│                           │  (100-500ms)│                 │
-│                           └─────────────┘                 │
-│                                                            │
-└────────────────────────────────────────────────────────────┘
-```
+### 数据库型 Agent：数据库 mtime + 全量重扫
 
-### 3.2 实现细节
+`DatabaseSessionSource.checkForChanges()` 比较数据库文件 mtime 与 `agent_cache.timestamp`。
+由于多个会话共享一个数据库文件，当前无法从文件状态安全推导行级变化：
 
-#### 3.2.1 变更检测 (checkForChanges)
+- mtime 未推进：保持缓存；
+- mtime 推进：报告数据源变化；
+- `incrementalScan()` 退化为该 Agent 的全量 `scan()`。
 
-**文件系统 Agent**（Claude/Codex/Kimi）：
-```typescript
-checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-  const changedIds: string[] = [];
+这条路径已经实现；它不是待补充的示例逻辑。
 
-  for (const session of cachedSessions) {
-    const meta = this.sessionMetaMap.get(session.id);
-    const stat = statSync(meta.sourcePath);
-    
-    // 通过文件修改时间判断是否变更
-    if (stat.mtimeMs > sinceTimestamp) {
-      changedIds.push(session.id);
-    }
-  }
+## 文件监听与事件归并
 
-  return {
-    hasChanges: changedIds.length > 0,
-    changedIds,
-    timestamp: Date.now(),
-  };
-}
+`SessionWatcher` 根据每个适配器的 `getSessionWatchPlan()` 建立监听：
+
+- 平台支持时使用递归监听；
+- 不支持时遍历目录建立非递归 fallback；
+- 等待写入稳定后，把路径事件归并为 Agent 名称；
+- 普通 Agent 默认 debounce 200ms，空 Agent 使用更长等待，以容纳首次创建目录/数据库。
+
+监听事件只是刷新提示，最终变化仍由指纹或数据库 mtime 验证，因此重复、合并或无关的
+文件事件不会直接修改会话状态。
+
+## 持久化与发布
+
+刷新结果先计算 `changedSessions` 和 `removedSessionIds`，再交给 search-index worker：
+
+```text
+saveCachedSessionChanges()
+  + syncSessionSearchIndexChanges()
+  -> SQLite commit
+  -> LiveScanStore 更新内存快照
+  -> SSE sessions-updated
 ```
 
-**数据库 Agent**（OpenCode/Cursor）：
-```typescript
-// 理论上可以通过 SQL 检测变更
-// 当前未实现，需要补充
+完整初始化/backfill 使用 `saveCachedSessions()` 和 `syncSessionSearchIndex()`。增量路径
+只加载需要重新索引的会话详情；未变化会话不会再次调用 `getSessionData()`。
 
-// 示例实现：
-checkForChanges(sinceTimestamp: number): ChangeCheckResult {
-  const result = db.query(`
-    SELECT COUNT(*) as count, MAX(time_updated) as last_update 
-    FROM session 
-    WHERE time_updated > ?
-  `, [sinceTimestamp]);
-  
-  return {
-    hasChanges: result.count > 0,
-    changedIds: [], // 可以通过 SQL 查询具体变更的 ID
-    timestamp: Date.now(),
-  };
-}
-```
+当变化量达到 `SEARCH_INDEX_BULK_SYNC_THRESHOLD` 时，FTS 使用批量重建；小批量变化由
+触发器增量维护。
 
-#### 3.2.2 增量扫描 (incrementalScan)
+## 详情一致性
 
-只重新扫描变更的文件，而非全部：
+详情请求由 `packages/core/src/discovery/session-detail.ts` 物化：
 
-```typescript
-incrementalScan(cachedSessions: SessionHead[], changedIds: string[]): SessionHead[] {
-  // 1. 创建缓存会话的 Map
-  const sessionMap = new Map(cachedSessions.map(s => [s.id, s]));
+1. 从 `sessions + messages` 读取结构化详情快照。
+2. 快照消息完整且缓存指纹与当前 `SessionCacheMeta` 一致时直接返回。
+3. 指纹不一致、消息缺失或会话待 reindex 时调用适配器 `getSessionData()` 回源。
 
-  // 2. 只重新扫描变更的会话
-  for (const file of this.listJsonlFiles()) {
-    const sessionId = extractSessionId(file);
-    
-    if (changedIds.includes(sessionId)) {
-      const head = this.parseSessionHead(file);
-      sessionMap.set(head.id, head); // 更新缓存
-    }
-  }
+所以一致性模型是“materialized detail + 源指纹失效 + 回源兜底”，不是“详情永远实时
+读取源文件”。完整规则见 [sqlite-storage.md](./sqlite-storage.md#3-读取会话详情)。
 
-  // 3. 检查新文件
-  for (const file of this.listJsonlFiles()) {
-    if (!sessionMap.has(sessionId)) {
-      const head = this.parseSessionHead(file);
-      sessionMap.set(head.id, head); // 添加新会话
-    }
-  }
+## 窗口扫描与 backfill
 
-  return Array.from(sessionMap.values());
-}
-```
+交互式启动可以只扫描当前列表时间窗口，以缩短首次刷新。窗口扫描不会把窗口外、且无法
+确认已被枚举的缓存会话误删。
 
-### 3.3 缓存数据结构
+为了最终覆盖完整历史，`AgentSyncEngine` 会为可用 Agent 安排无窗口 backfill：
 
-当前缓存后端已经切换为 SQLite，位置是 `~/.cache/codesesh/codesesh.db`。
+- 从未完成全历史同步时执行；
+- 距离上次全历史同步超过 24 小时时再次执行；
+- 不同 Agent 的 backfill 排队运行；
+- 同一个 Agent 的 backfill 与 refresh 仍保持串行。
 
-核心表：
+7 天是 CLI 默认列表窗口，不是 SQLite 缓存 TTL。
 
-- `cache_meta`
-- `agent_cache`
-- `cached_sessions`
-- `session_documents`
-- `session_documents_fts`
-
-结构说明见 [sqlite-storage.md](./sqlite-storage.md)。
-
-## 4. 数据一致性保证
-
-### 4.1 会话详情加载
-
-`getSessionData()` 依赖 `sessionMetaMap` 获取文件路径：
-
-```typescript
-getSessionData(sessionId: string): SessionData {
-  // 从缓存恢复的 meta 中获取 sourcePath
-  const meta = this.sessionMetaMap.get(sessionId);
-  
-  // 直接读取文件（不使用缓存，保证内容最新）
-  const content = readFileSync(meta.sourcePath, "utf-8");
-  
-  // 解析并返回
-  return parseMessages(content);
-}
-```
-
-**关键设计**：
-- 会话列表使用缓存（元数据）
-- 会话详情实时读取文件（保证内容最新）
-- 后台刷新只更新元数据，不影响正在查看的详情
-
-### 4.2 缓存失效策略
-
-| 触发条件 | 处理方式 |
-|---------|---------|
-| 缓存不存在 | 执行完整扫描 |
-| 缓存过期 (7天) | 执行完整扫描 |
-| 文件有变更 | 增量更新 |
-| 文件被删除 | 从缓存中移除 |
-| 新文件出现 | 添加到缓存 |
-
-## 5. 性能数据
-
-### 5.1 不同场景对比
-
-| 场景 | 耗时 | 说明 |
-|------|------|------|
-| 首次启动（无缓存） | ~10.6s | 扫描所有文件 |
-| 缓存启动（无变更） | ~14ms | 直接返回缓存 |
-| 缓存启动（有变更） | ~14ms + ~200ms | 先返回缓存，后台增量更新 |
-| 禁用缓存 | ~10.6s | 每次都完整扫描 |
-
-### 5.2 并行加速效果
-
-```
-串行扫描：
-Claude (1.1s) → Codex (3.9s) → Cursor (5.6s) = 10.6s
-
-并行扫描：
-Claude (1.1s) 
-Codex (3.9s)    = ~5s (取决于最慢的 Agent)
-Cursor (5.6s)   
-```
-
-## 6. 配置选项
-
-### 6.1 CLI 参数
+## 缓存控制
 
 ```bash
-# 使用缓存（默认开启）
+# 默认：使用缓存，Web 模式后台刷新
 codesesh
 
-# 禁用缓存
+# 忽略缓存执行扫描
 codesesh --no-cache
 
-# 清除缓存后启动
+# 清空 SQLite 缓存后启动
 codesesh --clear-cache
 
-# 性能追踪
+# 输出扫描性能追踪
 codesesh --trace
 ```
 
-### 6.2 程序化配置
+程序化入口使用 `ScanOptions` 控制 Agent、cwd、时间窗口、缓存读写和 cache-only 行为。
+具体字段以 `packages/core/src/discovery/scanner.ts` 的类型定义为准。
 
-```typescript
-const result = await scanSessions({
-  useCache: true,      // 启用缓存
-  smartRefresh: true,  // 启用智能刷新
-  agents: ['claudecode', 'codex'], // 只扫描特定 Agent
-  from: Date.now() - 7 * 24 * 60 * 60 * 1000, // 只扫描最近7天
-});
+## 性能验证
+
+文档不固化缺少硬件、样本规模和 commit 信息的毫秒数字。当前版本使用仓库基准脚本：
+
+```bash
+pnpm bench:perf -- --iterations 3
 ```
 
-## 7. 监控与调试
+报告性能时至少记录 commit、操作系统、Node 版本、会话规模、缓存冷热状态与迭代次数。
 
-### 7.1 性能追踪
+## 正确性不变量
 
-启用 `--trace` 查看详细耗时：
-
-```
-=== Performance Report ===
-
-scanSessions: 14.60ms
-  agent:claudecode: 3.89ms
-    isAvailable: 0.27ms
-    scan: 0ms (from cache)
-  agent:codex: 2.52ms
-    isAvailable: 0.15ms
-    scan: 0ms (from cache)
-```
-
-### 7.2 缓存信息
-
-```typescript
-import { getCacheInfo } from "@codesesh/core";
-
-const info = getCacheInfo();
-console.log(info);
-// { lastScanTime: 1776241234567, size: 124 }
-```
-
-## 8. 未来优化方向
-
-### 8.1 会话级别并行
-
-```typescript
-// 当前：串行读取文件
-for (const file of files) {
-  await parseFile(file);
-}
-
-// 优化：并行读取
-await Promise.all(files.map(file => parseFile(file)));
-```
-
-### 8.2 文件监听（Watch Mode）
-
-```typescript
-// 使用 fs.watch 实时监控文件变化
-fs.watch(sessionDir, (eventType, filename) => {
-  if (filename.endsWith('.jsonl')) {
-    incrementalUpdate(filename);
-  }
-});
-```
-
-### 8.3 SQLite 存储深化
-
-```typescript
-// 当前已经使用 SQLite 统一持久化缓存和搜索索引
-const db = new Database("~/.cache/codesesh/codesesh.db");
-
-// 后续可以继续深化：
-// - 将首次搜索的按需建索引改成后台预热
-// - 将更多过滤条件前移到 SQLite 查询层
-// - 让搜索索引覆盖更多结构化工具输出
-```
-
-## 9. 总结
-
-CodeSesh 的扫描与缓存机制通过以下方式实现高性能：
-
-1. **并行扫描**：所有 Agent 同时工作
-2. **智能缓存**：先返回缓存，后台增量刷新
-3. **变更检测**：通过文件修改时间精确识别变更
-4. **数据一致性**：元数据缓存 + 内容实时读取
-
-这种设计在保持极速启动（14ms）的同时，确保数据的新鲜度和一致性。
+- 新快照只能在对应 SQLite 写入成功后发布。
+- 文件型会话是否变化由 source fingerprint 决定，不由全局 mtime 截断决定。
+- 数据库型 Agent 检测到数据库变化后必须全量重扫。
+- 未变化会话不重新解析、不重写结构化消息。
+- 缓存详情指纹过期时不得直接返回旧消息。
+- 窗口扫描不能把未枚举的历史会话当作已删除。

--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -1,244 +1,175 @@
-# CodeSesh SQLite 存储说明
+# CodeSesh SQLite 存储
 
 ## 概述
 
-CodeSesh 现在将会话缓存和全文搜索索引统一存储在同一个 SQLite 数据库：
+CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存储在同一个 SQLite 数据库：
 
 - 路径：`~/.cache/codesesh/codesesh.db`
-- 实现：`packages/core/src/discovery/cache.ts`
-- 目标：
-  - 启动时快速恢复 `SessionHead[]`
-  - 为 `getSessionData()` 恢复 `SessionCacheMeta`
-  - 为全文搜索提供 FTS5 索引
-  - 让缓存刷新和搜索索引共享同一条数据生命周期
+- 当前 schema：`CACHE_SCHEMA_VERSION = 16`
+- 稳定导出入口：`packages/core/src/discovery/cache.ts`
+- 实现目录：`packages/core/src/discovery/cache/`
 
-## 表结构
+`cache.ts` 只是公共 barrel。数据库连接、schema、会话持久化和搜索实现分别位于
+`cache/` 下的模块中。
 
-### `cache_meta`
+## 模块职责
 
-用于保存数据库级元信息。
+| 模块 | 职责 |
+|------|------|
+| `cache/db.ts` | 缓存路径、共享查询辅助函数、schema/FTS 进程内检查状态 |
+| `cache/schema.ts` | 建表、迁移、事务边界、FTS 完整性检查 |
+| `cache/sessions.ts` | 会话列表和详情快照的读取、写入与清理 |
+| `cache/messages.ts` | `sessions` / `messages` 行与领域对象之间的转换 |
+| `cache/search-index-writer.ts` | 详情、工具、文件活动与全文索引的同步写入 |
+| `cache/search.ts` | 搜索查询与结构化过滤 |
+| `cache/search-query-parser.ts` | 搜索语法解析 |
+| `cache/file-activity.ts` | 文件活动查询 |
+| `cache/project-groups.ts` | 项目聚合查询 |
 
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `key` | `TEXT PRIMARY KEY` | 元信息键 |
-| `value` | `TEXT NOT NULL` | 元信息值 |
+## Schema 清单
 
-当前主要存储：
+当前 schema 创建 14 张表（其中 3 张是 FTS5 虚表）和 1 个视图。
 
-- `version`：当前 schema 版本，来自 `CACHE_VERSION`
+### 生命周期与同步状态
 
-### `agent_cache`
+| 表 | 用途 |
+|----|------|
+| `cache_meta` | schema 版本与一次性迁移标记 |
+| `agent_cache` | 每个 Agent 最近一次缓存写入时间；数据库型 Agent 以此作为 mtime 比较基准 |
+| `cache_initialization` | 每个 Agent 的缓存初始化版本与最近一次全历史同步时间 |
+| `pending_reindex` | 标记因解析器升级而必须重新物化的会话 |
 
-按 Agent 记录缓存时间戳。
+### 当前会话模型
 
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `agent_name` | `TEXT PRIMARY KEY` | agent 名称，如 `claudecode` |
-| `timestamp` | `INTEGER NOT NULL` | 最近一次成功写入缓存的时间戳 |
+| 表 | 用途 |
+|----|------|
+| `sessions` | `SessionHead`、项目身份、统计数据、源路径与 `SessionCacheMeta` |
+| `messages` | 详情页使用的结构化消息快照 |
+| `message_tools` | 从消息中提取的工具名，用于结构化过滤 |
+| `session_file_activity` | 会话涉及的文件路径、操作类型、次数与最近时间 |
 
-用途：
-
-- `loadCachedSessions()` 用它判断某个 agent 的缓存是否存在
-- 同时用于 7 天 TTL 校验
-- `scanner.ts` 会把这个时间戳作为 `checkForChanges()` 的输入基准
-
-### `cached_sessions`
-
-保存会话列表页需要的轻量元数据和详情恢复所需 meta。
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `agent_name` | `TEXT NOT NULL` | agent 名称 |
-| `session_id` | `TEXT NOT NULL` | 会话 ID |
-| `session_json` | `TEXT NOT NULL` | `SessionHead` 的 JSON 序列化 |
-| `meta_json` | `TEXT` | `SessionCacheMeta` 的 JSON 序列化 |
-
-主键：
-
-- `PRIMARY KEY (agent_name, session_id)`
-
-用途：
-
-- 启动时恢复会话列表
-- 恢复 `sessionMetaMap`
-- 为增量扫描提供上一次已知会话集合
-
-### `session_documents`
-
-保存全文搜索的规范化文档源表。
-
-| 字段 | 类型 | 说明 |
-|------|------|------|
-| `id` | `INTEGER PRIMARY KEY AUTOINCREMENT` | FTS 关联主键 |
-| `agent_name` | `TEXT NOT NULL` | agent 名称 |
-| `session_id` | `TEXT NOT NULL` | 会话 ID |
-| `slug` | `TEXT NOT NULL` | 会话 slug |
-| `title` | `TEXT NOT NULL` | 会话标题 |
-| `directory` | `TEXT NOT NULL` | 会话目录 |
-| `time_created` | `INTEGER NOT NULL` | 创建时间 |
-| `time_updated` | `INTEGER` | 更新时间 |
-| `activity_time` | `INTEGER NOT NULL` | 搜索排序和过滤用活动时间 |
-| `content_text` | `TEXT NOT NULL` | 从 `SessionData.messages` 提取的全文文本 |
-| `content_hash` | `TEXT NOT NULL` | 当前索引版本对应的内容签名 |
-| `indexed_at` | `INTEGER NOT NULL` | 最近一次建索引时间 |
-
-唯一约束：
-
-- `UNIQUE(agent_name, session_id)`
-
-用途：
-
-- 作为 FTS 外部内容表
-- 保存搜索结果展示所需字段
-- 用 `content_hash` 判断是否需要重建某条会话索引
-
-### `session_documents_fts`
-
-FTS5 虚表，挂在 `session_documents` 上。
-
-定义：
-
-```sql
-CREATE VIRTUAL TABLE session_documents_fts USING fts5(
-  title,
-  content_text,
-  content='session_documents',
-  content_rowid='id'
-);
-```
-
-索引字段：
-
-- `title`
-- `content_text`
-
-查询逻辑：
-
-- 使用 `MATCH` 执行全文检索
-- 使用 `bm25(session_documents_fts, 8.0, 1.0)` 排序
-- 使用 `snippet(...)` 生成高亮片段
-
-## 触发器
-
-`session_documents_fts` 通过 3 个触发器和 `session_documents` 保持同步：
-
-- `session_documents_ai`
-  插入 `session_documents` 时向 FTS 插入对应 row
-- `session_documents_ad`
-  删除 `session_documents` 时从 FTS 删除对应 row
-- `session_documents_au`
-  更新 `session_documents` 时先删旧索引，再插入新索引
-
-这套设计让业务代码只需要维护 `session_documents`，FTS 同步由 SQLite 完成。
-
-## 数据流
-
-### 1. 启动扫描
-
-```text
-CLI
-  -> scanSessions()
-  -> scanAgentSmart(agent)
-  -> loadCachedSessions(agent.name)
-  -> 从 agent_cache + cached_sessions 恢复 SessionHead[] 和 meta
-  -> 立即返回会话列表
-```
-
-关键点：
-
-- 启动路径只依赖 `cached_sessions`
-- 搜索索引不会阻塞基础列表恢复
-
-### 2. 完整扫描
-
-```text
-agent.scan()
-  -> heads: SessionHead[]
-  -> saveCachedSessions(agentName, heads, meta)
-  -> 覆盖 agent_cache
-  -> 覆盖 cached_sessions
-```
-
-关键点：
-
-- 这一步只写列表缓存
-- 还没有读取 `SessionData.messages`
-
-### 3. 搜索建索引
-
-```text
-/api/search?q=...
-  -> handleSearchSessions()
-  -> syncSessionSearchIndex(agentName, sessions, agent.getSessionData)
-  -> 对比 session_documents.content_hash
-  -> 只为缺失或变更的会话加载 SessionData
-  -> 写入 session_documents
-  -> 触发器同步 session_documents_fts
-  -> searchSessions()
-  -> 返回 snippet + session metadata
-```
-
-关键点：
-
-- 第一次搜索会按需补齐索引
-- 搜索索引构建和缓存恢复解耦
-- 只有发生变化的会话会重新读取全文内容
-
-### 4. 增量刷新
-
-```text
-LiveScanStore.refreshAgent()
-  -> agent.checkForChanges(...)
-  -> agent.incrementalScan(...)
-  -> saveCachedSessions(...)
-  -> syncSessionSearchIndex(...)
-```
-
-关键点：
-
-- 监听文件变化后，列表缓存和搜索索引一起更新
-- 搜索和列表共享同一份会话集合
-
-## 读写职责
-
-| 场景 | 读取表 | 写入表 |
-|------|--------|--------|
-| 启动恢复列表 | `agent_cache`, `cached_sessions` | 无 |
-| 保存扫描结果 | 无 | `agent_cache`, `cached_sessions` |
-| 构建搜索索引 | `session_documents` | `session_documents` |
-| 执行全文搜索 | `session_documents_fts`, `session_documents` | 无 |
-| 清空缓存 | 全部 | `agent_cache`, `cached_sessions`, `session_documents` |
-
-## 一致性策略
-
-### 列表缓存
-
-- 以 agent 为单位整体覆盖
-- `saveCachedSessions()` 在事务里先删旧数据，再写入新数据
+`messages` 和 `session_file_activity` 通过复合外键关联 `sessions`，删除会话时级联清理。
 
 ### 搜索索引
 
-- 以单会话为单位增量更新
-- `content_hash` 基于 `SessionHead` 核心字段生成
-- 如果 `SessionHead` 没变化，默认跳过全文重建
+| 表 | 类型 | 用途 |
+|----|------|------|
+| `messages_fts` | FTS5 虚表 | 消息级全文匹配 |
+| `session_file_activity_path_fts` | trigram FTS5 虚表 | 文件路径匹配 |
+| `session_documents` | 普通表 | 会话标题、聚合文本、内容签名与已索引消息数 |
+| `session_documents_fts` | FTS5 虚表 | 会话级标题和聚合文本搜索 |
 
-### 详情内容
+三个 FTS 表都由对应内容表的 insert/update/delete 触发器维护。批量变化达到阈值时，
+`runSearchIndexWrite()` 会在写事务中重建会话文档和消息索引；文件路径索引仍由触发器
+增量维护。
 
-- `getSessionData()` 仍然实时读取源文件或源数据库
-- SQLite 当前存的是搜索用规范化文本，不是详情页完整消息快照
+### 项目聚合
 
-## 现阶段边界
+| 对象 | 类型 | 用途 |
+|------|------|------|
+| `project_groups_v` | 视图 | 从 `sessions` 按项目身份聚合来源、会话数与最近活动时间 |
 
-当前实现有两个明确边界：
+### 迁移兼容表
 
-1. 首次搜索某个大库时，索引会按需建立，这次请求会更重
-2. `content_hash` 基于 `SessionHead`，如果底层消息内容变化但 head 未变化，索引刷新依赖增量扫描重新产出新的 head
+| 表 | 状态 |
+|----|------|
+| `cached_sessions` | 旧 JSON 会话缓存；迁移到 `sessions` 时读取，当前运行时不再写入 |
+| `project_sessions` | 旧项目映射；仅供旧 schema 迁移与兼容，当前视图读取 `sessions` |
 
-这两个边界都属于当前设计下的可接受权衡，因为启动速度和实现复杂度更重要。
+这两张表仍由最新 schema 创建，以保证旧数据库可以原地升级；不能据此把它们当作当前
+读写路径。
+
+## 数据流
+
+### 1. 恢复会话列表
+
+```text
+LiveScanStore.initialize()
+  -> scanSessions({ cacheOnly: true })
+  -> loadCachedSessions(agentName)
+  -> agent_cache + sessions
+  -> 恢复 SessionHead[] 与 SessionCacheMeta
+```
+
+交互式 CLI 先发布缓存快照并启动 HTTP 服务，再由 `AgentSyncEngine` 在后台刷新。
+`--json` 路径不采用延迟刷新，会在输出前完成扫描。
+
+### 2. 刷新并持久化
+
+```text
+SessionWatcher / 初始后台刷新
+  -> AgentSyncEngine
+  -> scan-refresh worker
+  -> 计算新增、变更、删除
+  -> search-index worker
+       -> saveCachedSessions() / saveCachedSessionChanges()
+       -> syncSessionSearchIndex() / syncSessionSearchIndexChanges()
+  -> 发布新的内存快照与 SSE 事件
+```
+
+搜索索引 worker 完成对应的 SQLite 写入后，`AgentSyncEngine` 才发布新内存快照。
+
+完整写入会整体协调某个 Agent 的会话集合；精确刷新只 upsert 变更会话并删除已消失
+会话。需要重新索引的会话才会调用适配器的 `getSessionData()`，随后由缓存事务和索引
+事务更新：
+
+- `sessions`
+- `messages`
+- `message_tools`
+- `session_file_activity`
+- `session_documents`
+- 对应 FTS 索引
+
+### 3. 读取会话详情
+
+`packages/core/src/discovery/session-detail.ts` 是详情读取入口：
+
+```text
+materializeSessionDetailResponse()
+  -> loadCachedSessionRawEntry()
+  -> 缓存完整且 sourceFingerprint 与当前 meta 一致
+       -> 从 sessions + messages 流式返回 materialized detail
+     否则
+       -> agent.getSessionData() 回源解析
+```
+
+因此当前一致性语义不是“列表缓存、详情始终实时读取”，而是：
+
+- 默认从结构化详情快照读取；
+- 文件型 Agent 的当前源指纹与缓存指纹不一致时回源；
+- 缓存消息缺失或被 `pending_reindex` 标记时回源；
+- 后续索引同步会重新物化变更后的详情。
+
+## 变更与失效
+
+- 文件型 Agent 将源路径和 `sourceFingerprint` 写入 `SessionCacheMeta`；指纹包含适配器
+  认为会影响解析结果的文件状态与解析版本。
+- 数据库型 Agent 无法按会话建立文件指纹，使用数据库文件 mtime 判断库是否变化；
+  发生变化时执行该 Agent 的全量重扫。
+- `cache_initialization.index_version` 控制缓存是否可用于增量刷新。
+- 窗口化启动后的刷新会检查最近一次全历史同步；从未同步或已超过 24 小时时安排无窗口
+  backfill。这不是缓存 TTL，也不会因为缓存“满 7 天”而丢弃数据。
+- `--clear-cache` 清空会话、搜索内容和 Agent 缓存/初始化状态，并删除旧的
+  `scan-cache.json`。
+
+## 迁移与恢复
+
+`withCacheDb()` 首次打开当前数据库路径时调用 `ensureSchema()`：
+
+1. 读取 `PRAGMA user_version`，旧数据库还会兼容读取 `cache_meta.version`。
+2. 破坏性迁移前备份有数据的缓存。
+3. 按版本顺序运行迁移。
+4. 创建最新 schema，并更新 `user_version` 和 `cache_meta.version`。
+
+迁移实现与目标版本必须以 `cache/schema.ts` 为准；文档不引用易漂移的源码行号。
+搜索边界首次打开数据库时还会检查 FTS 完整性；检查失败则重建对应索引。
 
 ## 相关代码
 
 - `packages/core/src/discovery/cache.ts`
+- `packages/core/src/discovery/cache/`
+- `packages/core/src/discovery/session-detail.ts`
+- `packages/core/src/agents/base.ts`
 - `packages/core/src/discovery/scanner.ts`
-- `packages/cli/src/api/handlers.ts`
-- `packages/cli/src/live-scan.ts`
+- `packages/cli/src/agent-sync-engine.ts`
+- `packages/cli/src/search-index-worker.ts`


### PR DESCRIPTION
## Summary

- document the current schema v16 layout, including all 14 tables, the project view, and the legacy migration tables
- replace stale mtime pseudocode with the implemented file fingerprint and database mtime refresh models
- describe materialized session details, fingerprint invalidation, worker-backed persistence, watchers, and full-history backfill
- point architecture docs at the cache implementation modules and remove obsolete performance and cache-TTL claims

## Validation

- cross-checked every documented table, module path, and key symbol against `main`
- verified the schema contains 14 unique tables plus `project_groups_v`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`