### PR TITLE
refactor(cli): split AgentSyncEngine responsibilities

### DIFF
--- a/packages/cli/src/agent-operation-scheduler.test.ts
+++ b/packages/cli/src/agent-operation-scheduler.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentOperationScheduler, type AgentOperationResult } from "./agent-operation-scheduler.js";
+import { appLogger } from "./logging.js";
+
+function deferredResult() {
+  let resolve!: (result: AgentOperationResult) => void;
+  const promise = new Promise<AgentOperationResult>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("AgentOperationScheduler", () => {
+  it("keeps the earliest refresh deadline for repeated signals", async () => {
+    vi.useFakeTimers();
+    const runRefresh = vi.fn(async () => "unchanged" as const);
+    const scheduler = new AgentOperationScheduler(runRefresh);
+
+    scheduler.notify("codex", 200);
+    await vi.advanceTimersByTimeAsync(50);
+    scheduler.notify("codex", 200);
+    await vi.advanceTimersByTimeAsync(149);
+    expect(runRefresh).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runRefresh).toHaveBeenCalledOnce();
+    expect(scheduler.takePendingSignalCount("codex")).toBe(2);
+  });
+
+  it("coalesces signals received while a refresh is running", async () => {
+    vi.useFakeTimers();
+    const first = deferredResult();
+    const runRefresh = vi
+      .fn<(agentName: string) => Promise<AgentOperationResult>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValue("unchanged");
+    const scheduler = new AgentOperationScheduler(runRefresh);
+
+    const active = scheduler.refresh("codex");
+    await vi.waitFor(() => expect(runRefresh).toHaveBeenCalledOnce());
+    await scheduler.refresh("codex");
+    await scheduler.refresh("codex");
+
+    first.resolve("unchanged");
+    await active;
+    await vi.advanceTimersByTimeAsync(99);
+    expect(runRefresh).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies adaptive delay after an expensive refresh", async () => {
+    vi.useFakeTimers();
+    const runRefresh = vi.fn(async () => "unchanged" as const);
+    const scheduler = new AgentOperationScheduler(runRefresh);
+    scheduler.recordRefreshDuration("codex", 5_000);
+
+    scheduler.notify("codex", 200);
+    await vi.advanceTimersByTimeAsync(19_999);
+    expect(runRefresh).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("serializes operations for one agent and advances their generations", async () => {
+    const first = deferredResult();
+    const log = vi.spyOn(appLogger, "info").mockImplementation(() => undefined);
+    const scheduler = new AgentOperationScheduler(async () => "unchanged");
+    const backfill = scheduler.run("codex", "backfill", () => first.promise);
+    const refresh = scheduler.run("codex", "refresh", async () => "committed");
+
+    await Promise.resolve();
+    expect(log).toHaveBeenCalledTimes(1);
+    first.resolve("committed");
+    await Promise.all([backfill, refresh]);
+
+    expect(
+      log.mock.calls
+        .filter(([event]) => String(event).startsWith("scan.agent_operation."))
+        .map(([event, fields]) => [event, fields?.operation, fields?.generation, fields?.result]),
+    ).toEqual([
+      ["scan.agent_operation.started", "backfill", 1, undefined],
+      ["scan.agent_operation.completed", "backfill", 1, "committed"],
+      ["scan.agent_operation.started", "refresh", 2, undefined],
+      ["scan.agent_operation.completed", "refresh", 2, "committed"],
+    ]);
+  });
+
+  it("allows different agents to run concurrently", async () => {
+    const codex = deferredResult();
+    const kimi = deferredResult();
+    const scheduler = new AgentOperationScheduler(async () => "unchanged");
+
+    const codexRun = scheduler.run("codex", "backfill", () => codex.promise);
+    const kimiRun = scheduler.run("kimi", "refresh", () => kimi.promise);
+    await Promise.resolve();
+
+    expect(scheduler.snapshot()).toEqual({ activeOperations: 2, activeRefreshes: 0 });
+    kimi.resolve("committed");
+    await kimiRun;
+    await vi.waitFor(() => expect(scheduler.snapshot().activeOperations).toBe(1));
+
+    codex.resolve("committed");
+    await codexRun;
+  });
+
+  it("continues a serialized queue after an operation fails", async () => {
+    vi.spyOn(appLogger, "info").mockImplementation(() => undefined);
+    const scheduler = new AgentOperationScheduler(async () => "unchanged");
+    const failed = scheduler.run("codex", "backfill", async () => {
+      throw new Error("failed");
+    });
+    const next = scheduler.run("codex", "refresh", async () => "committed");
+
+    await expect(failed).rejects.toThrow("failed");
+    await expect(next).resolves.toBe("committed");
+  });
+
+  it("cancels timers and skips queued operations after stop", async () => {
+    vi.useFakeTimers();
+    const first = deferredResult();
+    const runRefresh = vi.fn(async () => "unchanged" as const);
+    const scheduler = new AgentOperationScheduler(runRefresh);
+    scheduler.notify("codex", 200);
+    const active = scheduler.run("kimi", "backfill", () => first.promise);
+    const queued = scheduler.run("kimi", "refresh", async () => "committed");
+    await Promise.resolve();
+
+    scheduler.stop();
+    first.resolve("committed");
+    await active;
+    await expect(queued).resolves.toBe("skipped");
+    await scheduler.waitForIdle();
+    await vi.advanceTimersByTimeAsync(200);
+    scheduler.notify("codex", 0);
+
+    expect(runRefresh).not.toHaveBeenCalled();
+    expect(scheduler.takePendingSignalCount("codex")).toBe(0);
+    expect(scheduler.snapshot()).toEqual({ activeOperations: 0, activeRefreshes: 0 });
+  });
+});

--- a/packages/cli/src/agent-operation-scheduler.ts
+++ b/packages/cli/src/agent-operation-scheduler.ts
@@ -1,0 +1,194 @@
+import { appLogger } from "./logging.js";
+
+export type AgentOperationKind = "backfill" | "refresh";
+export type AgentOperationResult = "committed" | "failed" | "skipped" | "unchanged";
+
+interface AgentScheduleState {
+  timer: NodeJS.Timeout | null;
+  timerDeadline: number;
+  isRefreshRunning: boolean;
+  hasPendingRefresh: boolean;
+  lastRefreshDurationMs: number;
+  pendingSignalCount: number;
+}
+
+interface AgentOperationLifecycle {
+  agentName: string;
+  kind: AgentOperationKind;
+  generation: number;
+  startedAt: number;
+}
+
+export interface AgentOperationSchedulerSnapshot {
+  activeOperations: number;
+  activeRefreshes: number;
+}
+
+const PENDING_REFRESH_DELAY_MS = 100;
+const MAX_ADAPTIVE_REFRESH_DELAY_MS = 30_000;
+const ADAPTIVE_REFRESH_DELAY_MULTIPLIER = 4;
+
+export class AgentOperationScheduler {
+  private readonly states = new Map<string, AgentScheduleState>();
+  private readonly operationGenerations = new Map<string, number>();
+  private readonly operationTails = new Map<string, Promise<void>>();
+  private isStopped = false;
+
+  constructor(private readonly runRefresh: (agentName: string) => Promise<AgentOperationResult>) {}
+
+  notify(agentName: string, delayMs: number): void {
+    if (this.isStopped) return;
+    this.state(agentName).pendingSignalCount += 1;
+    this.schedule(agentName, delayMs);
+  }
+
+  schedule(agentName: string, delayMs: number): void {
+    if (this.isStopped) return;
+    const state = this.state(agentName);
+    const adaptiveDelayMs = Math.min(
+      state.lastRefreshDurationMs * ADAPTIVE_REFRESH_DELAY_MULTIPLIER,
+      MAX_ADAPTIVE_REFRESH_DELAY_MS,
+    );
+    const effectiveDelayMs = Math.max(delayMs, adaptiveDelayMs);
+    const deadline = Date.now() + effectiveDelayMs;
+    if (state.timer) {
+      if (deadline >= state.timerDeadline) return;
+      clearTimeout(state.timer);
+    }
+
+    appLogger.debug("scan.refresh.schedule", { agent: agentName, delay_ms: effectiveDelayMs });
+    state.timerDeadline = deadline;
+    state.timer = setTimeout(() => {
+      state.timer = null;
+      state.timerDeadline = 0;
+      void this.refresh(agentName);
+    }, effectiveDelayMs);
+  }
+
+  async refresh(agentName: string): Promise<void> {
+    if (this.isStopped) return;
+    const state = this.state(agentName);
+    if (state.isRefreshRunning) {
+      appLogger.debug("scan.refresh.pending", { agent: agentName });
+      state.hasPendingRefresh = true;
+      return;
+    }
+
+    state.isRefreshRunning = true;
+    try {
+      await this.run(agentName, "refresh", () => this.runRefresh(agentName));
+    } finally {
+      state.isRefreshRunning = false;
+      if (state.hasPendingRefresh && !this.isStopped) {
+        state.hasPendingRefresh = false;
+        this.schedule(agentName, PENDING_REFRESH_DELAY_MS);
+      }
+    }
+  }
+
+  run(
+    agentName: string,
+    kind: AgentOperationKind,
+    operation: () => Promise<AgentOperationResult>,
+  ): Promise<AgentOperationResult> {
+    const previous = this.operationTails.get(agentName) ?? Promise.resolve();
+    const run = previous.then(async () => {
+      if (this.isStopped) return "skipped";
+      const lifecycle = this.beginOperation(agentName, kind);
+      try {
+        const result = await operation();
+        this.completeOperation(lifecycle, result);
+        return result;
+      } catch (error) {
+        this.completeOperation(lifecycle, "failed");
+        throw error;
+      }
+    });
+    const tail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.operationTails.set(agentName, tail);
+    void tail.finally(() => {
+      if (this.operationTails.get(agentName) === tail) this.operationTails.delete(agentName);
+    });
+    return run;
+  }
+
+  takePendingSignalCount(agentName: string): number {
+    const state = this.state(agentName);
+    const count = state.pendingSignalCount;
+    state.pendingSignalCount = 0;
+    return count;
+  }
+
+  recordRefreshDuration(agentName: string, durationMs: number): void {
+    this.state(agentName).lastRefreshDurationMs = durationMs;
+  }
+
+  snapshot(): AgentOperationSchedulerSnapshot {
+    return {
+      activeOperations: this.operationTails.size,
+      activeRefreshes: [...this.states.values()].filter((state) => state.isRefreshRunning).length,
+    };
+  }
+
+  stop(): void {
+    this.isStopped = true;
+    for (const state of this.states.values()) {
+      if (state.timer) clearTimeout(state.timer);
+      state.timer = null;
+      state.timerDeadline = 0;
+      state.hasPendingRefresh = false;
+      state.pendingSignalCount = 0;
+    }
+  }
+
+  async waitForIdle(): Promise<void> {
+    await Promise.allSettled(this.operationTails.values());
+  }
+
+  private state(agentName: string): AgentScheduleState {
+    const existing = this.states.get(agentName);
+    if (existing) return existing;
+    const state: AgentScheduleState = {
+      timer: null,
+      timerDeadline: 0,
+      isRefreshRunning: false,
+      hasPendingRefresh: false,
+      lastRefreshDurationMs: 0,
+      pendingSignalCount: 0,
+    };
+    this.states.set(agentName, state);
+    return state;
+  }
+
+  private beginOperation(agentName: string, kind: AgentOperationKind): AgentOperationLifecycle {
+    const generation = (this.operationGenerations.get(agentName) ?? 0) + 1;
+    const startedAt = Date.now();
+    this.operationGenerations.set(agentName, generation);
+    appLogger.info("scan.agent_operation.started", {
+      agent: agentName,
+      operation: kind,
+      generation,
+      started_at: startedAt,
+    });
+    return { agentName, kind, generation, startedAt };
+  }
+
+  private completeOperation(
+    lifecycle: AgentOperationLifecycle,
+    result: AgentOperationResult,
+  ): void {
+    const completedAt = Date.now();
+    appLogger.info("scan.agent_operation.completed", {
+      agent: lifecycle.agentName,
+      operation: lifecycle.kind,
+      generation: lifecycle.generation,
+      started_at: lifecycle.startedAt,
+      completed_at: completedAt,
+      duration_ms: completedAt - lifecycle.startedAt,
+      result,
+    });
+  }
+}

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -116,16 +116,9 @@ function makeEngine(
     byAgent: { [agent.name]: sessions },
     sessions,
   };
-  const engine = new AgentSyncEngine({
-    snapshot: () => state,
-    workerRunner,
-  });
-  engine.subscribeSessionsChanged((change) => {
-    state.byAgent[change.agentName] = change.sessions;
-    state.sessions = Object.values(state.byAgent).flat();
-  });
-  engine.initialize();
-  return { engine, state };
+  const engine = new AgentSyncEngine({ workerRunner });
+  engine.initialize(state);
+  return { engine };
 }
 
 afterEach(() => {
@@ -185,7 +178,7 @@ describe("AgentSyncEngine", () => {
       checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
       incrementalScan: () => [updated],
     });
-    const { engine, state } = makeEngine(agent, [previous]);
+    const { engine } = makeEngine(agent, [previous]);
     const sessionChanges = vi.fn();
     const statusChanges = vi.fn();
     engine.subscribeSessionsChanged(sessionChanges);
@@ -193,7 +186,7 @@ describe("AgentSyncEngine", () => {
 
     await engine.refresh("codex");
 
-    expect(state.sessions[0]?.title).toBe("after");
+    expect(engine.snapshot().sessions[0]?.title).toBe("after");
     expect(sessionChanges).toHaveBeenCalledWith(
       expect.objectContaining({
         agentName: "codex",
@@ -214,7 +207,7 @@ describe("AgentSyncEngine", () => {
     );
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
-    const { engine, state } = makeEngine(
+    const { engine } = makeEngine(
       makeAgent({
         checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
         incrementalScan: () => [updated],
@@ -224,12 +217,12 @@ describe("AgentSyncEngine", () => {
 
     const refresh = engine.refresh("codex");
     await vi.waitFor(() => expect(searchIndex.enqueue).toHaveBeenCalledOnce());
-    expect(state.sessions[0]?.title).toBe("before");
+    expect(engine.snapshot().sessions[0]?.title).toBe("before");
 
     commitIndex();
     await refresh;
 
-    expect(state.sessions[0]?.title).toBe("after");
+    expect(engine.snapshot().sessions[0]?.title).toBe("after");
   });
 
   it("waits for the initial search index commit", async () => {
@@ -309,7 +302,7 @@ describe("AgentSyncEngine", () => {
     searchIndex.enqueue.mockRejectedValueOnce(new Error("index failed"));
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
-    const { engine, state } = makeEngine(
+    const { engine } = makeEngine(
       makeAgent({
         checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
         incrementalScan: () => [updated],
@@ -321,7 +314,7 @@ describe("AgentSyncEngine", () => {
 
     await engine.refresh("codex");
 
-    expect(state.sessions[0]?.title).toBe("before");
+    expect(engine.snapshot().sessions[0]?.title).toBe("before");
     expect(sessionChanges).not.toHaveBeenCalled();
     expect(console.error).toHaveBeenCalledWith(
       "[codex] Session refresh failed:",
@@ -366,7 +359,7 @@ describe("AgentSyncEngine", () => {
     expect(secondRoundCalls).toBeLessThan(firstRoundCalls);
   });
 
-  it("clears cached session signatures when a session is removed", async () => {
+  it("removes sessions from its owned snapshot", async () => {
     const session = makeSession("gone");
     const agent = makeAgent({
       checkForChanges: () => ({ hasChanges: true, timestamp: Date.now() }),
@@ -376,10 +369,8 @@ describe("AgentSyncEngine", () => {
 
     await engine.refresh("codex");
 
-    const signatureCache = (
-      engine as unknown as { state: (name: string) => { signatureCache: Map<string, string> } }
-    ).state("codex").signatureCache;
-    expect(signatureCache.has("gone")).toBe(false);
+    expect(engine.snapshot().byAgent.codex).toEqual([]);
+    expect(engine.snapshot().sessions).toEqual([]);
   });
 
   it("short-circuits source sync when fingerprints and signatures are unchanged", async () => {
@@ -431,12 +422,8 @@ describe("AgentSyncEngine", () => {
       byAgent: { codex: [oldSession] },
       sessions: [oldSession],
     };
-    const engine = new AgentSyncEngine({ snapshot: () => state, workerRunner });
-    engine.subscribeSessionsChanged((change) => {
-      state.byAgent[change.agentName] = change.sessions;
-      state.sessions = Object.values(state.byAgent).flat();
-    });
-    engine.initialize();
+    const engine = new AgentSyncEngine({ workerRunner });
+    engine.initialize(state);
 
     core.loadCachedSessions.mockReturnValue({
       sessions: [oldSession],
@@ -452,6 +439,51 @@ describe("AgentSyncEngine", () => {
     expect(sessionChanges).toHaveBeenCalledWith(
       expect.objectContaining({
         agentName: "codex",
+        event: expect.objectContaining({ updatedSessions: 1 }),
+      }),
+    );
+  });
+
+  it("does not advance signature lineage when search indexing fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    searchIndex.enqueue.mockRejectedValueOnce(new Error("index failed"));
+    const oldSession = { ...makeSession("sess1"), smart_tags_source_updated_at: 1 };
+    const newSession = { ...makeSession("sess1"), smart_tags_source_updated_at: 2 };
+    const agent = new FakeSyncAgent();
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () => ({ sessions: [newSession], meta: {}, changedIds: [] })),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const engine = new AgentSyncEngine({ workerRunner });
+    engine.initialize({
+      agents: [agent],
+      byAgent: { codex: [oldSession] },
+      sessions: [oldSession],
+    });
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [oldSession],
+      meta: {},
+      timestamp: Date.now(),
+    });
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().sessions).toEqual([oldSession]);
+    expect(sessionChanges).not.toHaveBeenCalled();
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().sessions).toEqual([
+      expect.objectContaining({
+        id: newSession.id,
+        smart_tags_source_updated_at: newSession.smart_tags_source_updated_at,
+      }),
+    ]);
+    expect(sessionChanges).toHaveBeenCalledWith(
+      expect.objectContaining({
         event: expect.objectContaining({ updatedSessions: 1 }),
       }),
     );
@@ -485,15 +517,10 @@ describe("AgentSyncEngine", () => {
     };
     const state: LiveSnapshot = { agents: [agent], byAgent: { codex: [] }, sessions: [] };
     const engine = new AgentSyncEngine({
-      snapshot: () => state,
       workerRunner,
       startupScanOptions: { from: 1, to: 2 },
     });
-    engine.subscribeSessionsChanged((change) => {
-      state.byAgent[change.agentName] = change.sessions;
-      state.sessions = Object.values(state.byAgent).flat();
-    });
-    engine.initialize();
+    engine.initialize(state);
 
     await engine.refresh("codex");
     expect(cacheInitialized).toBe(true);

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -20,13 +20,14 @@ import type {
   ScanStatusEvent,
   SessionsUpdatedEvent,
 } from "@codesesh/core/contract";
+import { AgentOperationScheduler, type AgentOperationResult } from "./agent-operation-scheduler.js";
 import { appLogger, logSearchIndexSync } from "./logging.js";
 import { SearchIndexJobRunner } from "./search-index-job-runner.js";
 import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 import { ScanStatusModel } from "./scan-status-model.js";
 import type { WorkerRunner } from "./worker-runner.js";
 
-export type AgentOperationResult = "committed" | "failed" | "skipped" | "unchanged";
+export type { AgentOperationResult } from "./agent-operation-scheduler.js";
 
 export interface AgentSessionsChanged {
   agentName: string;
@@ -42,17 +43,10 @@ export interface AgentSyncEngineOptions {
 
 type SessionsChangedListener = (change: AgentSessionsChanged) => void;
 type StatusChangedListener = (event: ScanStatusEvent) => void;
-type AgentOperationKind = "backfill" | "refresh";
 type CachedSessions = NonNullable<ReturnType<typeof loadCachedSessions>>;
 
 interface AgentRefreshState {
-  timer: NodeJS.Timeout | null;
-  timerDeadline: number;
-  isRunning: boolean;
-  hasPendingRerun: boolean;
   lastRefreshAt: number;
-  lastRefreshDurationMs: number;
-  pendingPathCount: number;
   /**
    * id → sessionSignature, carried across refreshes so unchanged sessions skip
    * re-stringifying. Only ever passed into the runRefresh event-path diff
@@ -65,13 +59,6 @@ interface AgentRefreshState {
    * was already written back by the strategy-path diff.
    */
   signatureCache: Map<string, string>;
-}
-
-interface AgentOperationLifecycle {
-  agentName: string;
-  kind: AgentOperationKind;
-  generation: number;
-  startedAt: number;
 }
 
 interface SessionRefreshDiff {
@@ -100,9 +87,6 @@ interface RefreshStrategyResult {
 
 const REFRESH_DEBOUNCE_MS = 200;
 const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
-const PENDING_REFRESH_DELAY_MS = 100;
-const MAX_ADAPTIVE_REFRESH_DELAY_MS = 30_000;
-const ADAPTIVE_REFRESH_DELAY_MULTIPLIER = 4;
 const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 const BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
@@ -150,8 +134,7 @@ function restoreAgentCacheMeta(agent: BaseAgent, cached: CachedSessions): void {
 
 export class AgentSyncEngine {
   private refreshStates = new Map<string, AgentRefreshState>();
-  private operationGenerations = new Map<string, number>();
-  private operationTails = new Map<string, Promise<void>>();
+  private readonly scheduler: AgentOperationScheduler;
   private backfillQueue: string[] = [];
   private currentBackfillAgent: string | undefined;
   private completedBackfillAgents: string[] = [];
@@ -164,7 +147,9 @@ export class AgentSyncEngine {
   private backgroundRefreshTimer: NodeJS.Timeout | null = null;
   private isShuttingDown = false;
 
-  constructor(private readonly options: AgentSyncEngineOptions) {}
+  constructor(private readonly options: AgentSyncEngineOptions) {
+    this.scheduler = new AgentOperationScheduler((agentName) => this.performRefresh(agentName));
+  }
 
   initialize(cacheTimestamps: Record<string, number> = {}): void {
     for (const agent of this.options.snapshot().agents) {
@@ -197,12 +182,11 @@ export class AgentSyncEngine {
   handleAgentsChanged(agentNames: Iterable<string>): void {
     const snapshot = this.options.snapshot();
     for (const agentName of agentNames) {
-      this.state(agentName).pendingPathCount += 1;
       const delayMs =
         (snapshot.byAgent[agentName]?.length ?? 0) === 0
           ? EMPTY_AGENT_REFRESH_DEBOUNCE_MS
           : REFRESH_DEBOUNCE_MS;
-      this.scheduleRefresh(agentName, delayMs);
+      this.scheduler.notify(agentName, delayMs);
     }
   }
 
@@ -212,32 +196,28 @@ export class AgentSyncEngine {
     this.startScanBatch(agentNames, "scanning");
     this.backgroundRefreshTimer = setTimeout(() => {
       this.backgroundRefreshTimer = null;
-      for (const agentName of agentNames) this.scheduleRefresh(agentName, 0);
+      for (const agentName of agentNames) this.scheduler.schedule(agentName, 0);
       if (agentNames.length === 0) this.finishScanBatch();
     }, 0);
   }
 
   async refresh(agentName: string): Promise<void> {
-    await this.runCoalescedRefresh(agentName);
+    await this.scheduler.refresh(agentName);
   }
 
   async shutdown(): Promise<void> {
     this.isShuttingDown = true;
+    const schedulerSnapshot = this.scheduler.snapshot();
     const activeOperations = {
-      agent_operations: this.operationTails.size,
-      refreshes: [...this.refreshStates.values()].filter((state) => state.isRunning).length,
+      agent_operations: schedulerSnapshot.activeOperations,
+      refreshes: schedulerSnapshot.activeRefreshes,
       backfill_running: this.currentBackfillAgent != null || undefined,
       scan_workers: this.options.workerRunner.activeCount,
     };
     if (activeOperations.agent_operations > 0 || activeOperations.scan_workers > 0) {
       appLogger.warn("scan.shutdown.active_operations", activeOperations);
     }
-    for (const state of this.refreshStates.values()) {
-      if (!state.timer) continue;
-      clearTimeout(state.timer);
-      state.timer = null;
-      state.timerDeadline = 0;
-    }
+    this.scheduler.stop();
     if (this.backgroundRefreshTimer) {
       clearTimeout(this.backgroundRefreshTimer);
       this.backgroundRefreshTimer = null;
@@ -251,7 +231,7 @@ export class AgentSyncEngine {
     });
     await this.searchIndexJobs.shutdown();
     await this.options.workerRunner.shutdown();
-    await Promise.allSettled(this.operationTails.values());
+    await this.scheduler.waitForIdle();
     const stoppedSearchIndexSnapshot = this.searchIndexJobs.snapshot();
     appLogger.info("search_index.shutdown.completed", {
       active_batch_id: searchIndexSnapshot.activeBatchId,
@@ -306,46 +286,6 @@ export class AgentSyncEngine {
     for (const listener of this.sessionsChangedListeners) listener(change);
   }
 
-  private scheduleRefresh(agentName: string, delayMs: number): void {
-    if (this.isShuttingDown) return;
-    const state = this.state(agentName);
-    const adaptiveDelayMs = Math.min(
-      state.lastRefreshDurationMs * ADAPTIVE_REFRESH_DELAY_MULTIPLIER,
-      MAX_ADAPTIVE_REFRESH_DELAY_MS,
-    );
-    const effectiveDelayMs = Math.max(delayMs, adaptiveDelayMs);
-    const deadline = Date.now() + effectiveDelayMs;
-    if (state.timer) {
-      if (deadline >= state.timerDeadline) return;
-      clearTimeout(state.timer);
-    }
-    appLogger.debug("scan.refresh.schedule", { agent: agentName, delay_ms: effectiveDelayMs });
-    state.timerDeadline = deadline;
-    state.timer = setTimeout(() => {
-      state.timer = null;
-      void this.runCoalescedRefresh(agentName);
-    }, effectiveDelayMs);
-  }
-
-  private async runCoalescedRefresh(agentName: string): Promise<void> {
-    const state = this.state(agentName);
-    if (state.isRunning) {
-      appLogger.debug("scan.refresh.pending", { agent: agentName });
-      state.hasPendingRerun = true;
-      return;
-    }
-    state.isRunning = true;
-    try {
-      await this.serialize(agentName, "refresh", () => this.performRefresh(agentName));
-    } finally {
-      state.isRunning = false;
-      if (state.hasPendingRerun && !this.isShuttingDown) {
-        state.hasPendingRerun = false;
-        this.scheduleRefresh(agentName, PENDING_REFRESH_DELAY_MS);
-      }
-    }
-  }
-
   private async performRefresh(agentName: string): Promise<AgentOperationResult> {
     this.beginAgentScan(agentName);
     try {
@@ -364,8 +304,7 @@ export class AgentSyncEngine {
   private async runRefresh(agentName: string): Promise<Exclude<AgentOperationResult, "failed">> {
     const startedAt = performance.now();
     const state = this.state(agentName);
-    const pendingPathCount = state.pendingPathCount;
-    state.pendingPathCount = 0;
+    const pendingPathCount = this.scheduler.takePendingSignalCount(agentName);
     const agent = this.findAgent(agentName);
     if (!agent) {
       appLogger.warn("scan.refresh.missing_agent", { agent: agentName });
@@ -449,7 +388,7 @@ export class AgentSyncEngine {
     logSearchIndexSync("scan.refresh", null, { pending_paths: pendingPathCount });
 
     const totalDurationMs = performance.now() - startedAt;
-    state.lastRefreshDurationMs = totalDurationMs;
+    this.scheduler.recordRefreshDuration(agentName, totalDurationMs);
     appLogger.info("scan.refresh.done", {
       agent: agentName,
       duration_ms: Math.round(totalDurationMs),
@@ -639,24 +578,26 @@ export class AgentSyncEngine {
     if (!agentName) return;
     this.currentBackfillAgent = agentName;
     this.publishBackfillStatus();
-    void this.serialize(agentName, "backfill", () => this.performBackfill(agentName)).then(
-      (result) => {
-        if (this.isShuttingDown) return;
-        this.currentBackfillAgent = undefined;
-        if (result === "committed") {
-          if (!this.completedBackfillAgents.includes(agentName)) {
-            this.completedBackfillAgents.push(agentName);
-          }
-          this.failedBackfillAgents = this.failedBackfillAgents.filter(
-            (failedAgent) => failedAgent !== agentName,
-          );
-        } else if (!this.failedBackfillAgents.includes(agentName)) {
-          this.failedBackfillAgents.push(agentName);
+    void this.runBackfill(agentName).then((result) => {
+      if (this.isShuttingDown) return;
+      this.currentBackfillAgent = undefined;
+      if (result === "committed") {
+        if (!this.completedBackfillAgents.includes(agentName)) {
+          this.completedBackfillAgents.push(agentName);
         }
-        this.publishBackfillStatus();
-        this.pumpBackfillQueue();
-      },
-    );
+        this.failedBackfillAgents = this.failedBackfillAgents.filter(
+          (failedAgent) => failedAgent !== agentName,
+        );
+      } else if (!this.failedBackfillAgents.includes(agentName)) {
+        this.failedBackfillAgents.push(agentName);
+      }
+      this.publishBackfillStatus();
+      this.pumpBackfillQueue();
+    });
+  }
+
+  private runBackfill(agentName: string): Promise<AgentOperationResult> {
+    return this.scheduler.run(agentName, "backfill", () => this.performBackfill(agentName));
   }
 
   private async performBackfill(agentName: string): Promise<AgentOperationResult> {
@@ -716,79 +657,15 @@ export class AgentSyncEngine {
     }
   }
 
-  private serialize(
-    agentName: string,
-    kind: AgentOperationKind,
-    operation: () => Promise<AgentOperationResult>,
-  ): Promise<AgentOperationResult> {
-    const previous = this.operationTails.get(agentName) ?? Promise.resolve();
-    const run = previous.then(async () => {
-      if (this.isShuttingDown) return "skipped";
-      const lifecycle = this.beginOperation(agentName, kind);
-      try {
-        const result = await operation();
-        this.completeOperation(lifecycle, result);
-        return result;
-      } catch (error) {
-        this.completeOperation(lifecycle, "failed");
-        throw error;
-      }
-    });
-    const tail = run.then(
-      () => undefined,
-      () => undefined,
-    );
-    this.operationTails.set(agentName, tail);
-    void tail.finally(() => {
-      if (this.operationTails.get(agentName) === tail) this.operationTails.delete(agentName);
-    });
-    return run;
-  }
-
   private state(agentName: string): AgentRefreshState {
     const existing = this.refreshStates.get(agentName);
     if (existing) return existing;
     const state: AgentRefreshState = {
-      timer: null,
-      timerDeadline: 0,
-      isRunning: false,
-      hasPendingRerun: false,
       lastRefreshAt: 0,
-      lastRefreshDurationMs: 0,
-      pendingPathCount: 0,
       signatureCache: new Map(),
     };
     this.refreshStates.set(agentName, state);
     return state;
-  }
-
-  private beginOperation(agentName: string, kind: AgentOperationKind): AgentOperationLifecycle {
-    const generation = (this.operationGenerations.get(agentName) ?? 0) + 1;
-    const startedAt = Date.now();
-    this.operationGenerations.set(agentName, generation);
-    appLogger.info("scan.agent_operation.started", {
-      agent: agentName,
-      operation: kind,
-      generation,
-      started_at: startedAt,
-    });
-    return { agentName, kind, generation, startedAt };
-  }
-
-  private completeOperation(
-    lifecycle: AgentOperationLifecycle,
-    result: AgentOperationResult,
-  ): void {
-    const completedAt = Date.now();
-    appLogger.info("scan.agent_operation.completed", {
-      agent: lifecycle.agentName,
-      operation: lifecycle.kind,
-      generation: lifecycle.generation,
-      started_at: lifecycle.startedAt,
-      completed_at: completedAt,
-      duration_ms: completedAt - lifecycle.startedAt,
-      result,
-    });
   }
 
   private backfillStatus(): BackfillStatus {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -21,6 +21,7 @@ import type {
   SessionsUpdatedEvent,
 } from "@codesesh/core/contract";
 import { AgentOperationScheduler, type AgentOperationResult } from "./agent-operation-scheduler.js";
+import { LiveSessionIndex, type LiveSessionIndexOptions } from "./live-session-index.js";
 import { appLogger, logSearchIndexSync } from "./logging.js";
 import { SearchIndexJobRunner } from "./search-index-job-runner.js";
 import type { SearchIndexWorkerJob } from "./search-index-worker.js";
@@ -36,33 +37,19 @@ export interface AgentSessionsChanged {
 }
 
 export interface AgentSyncEngineOptions {
-  snapshot: () => LiveSnapshot;
   startupScanOptions?: Pick<ScanOptions, "from" | "to">;
   workerRunner: WorkerRunner;
+}
+
+export interface AgentSyncEngineInitializationOptions extends LiveSessionIndexOptions {
+  cacheTimestamps?: Record<string, number>;
 }
 
 type SessionsChangedListener = (change: AgentSessionsChanged) => void;
 type StatusChangedListener = (event: ScanStatusEvent) => void;
 type CachedSessions = NonNullable<ReturnType<typeof loadCachedSessions>>;
 
-interface AgentRefreshState {
-  lastRefreshAt: number;
-  /**
-   * id → sessionSignature, carried across refreshes so unchanged sessions skip
-   * re-stringifying. Only ever passed into the runRefresh event-path diff
-   * (previousSessions → nextSessions), whose lineage is the in-memory result of
-   * the prior event diff. The strategy-path diffs (DB cached.sessions baseline)
-   * must NOT share this cache: that baseline can lag an in-flight persist job,
-   * and a cache hit there would both mask the self-heal recheck after a failed
-   * persist and, if reused this same cycle, make the event-path diff miss a
-   * signature-only change (e.g. smart-tag reclassification) whose new signature
-   * was already written back by the strategy-path diff.
-   */
-  signatureCache: Map<string, string>;
-}
-
-interface SessionRefreshDiff {
-  event: SessionsUpdatedEvent | null;
+interface SessionPersistenceDiff {
   changedSessions: SessionHeadChange[];
   removedSessionIds: string[];
 }
@@ -71,8 +58,13 @@ interface SessionPublication {
   context: "scan.refresh" | "scan.backfill";
   agentName: string;
   sessions: SessionHead[];
-  event: SessionsUpdatedEvent | null;
+  candidateChangedIds: string[];
   indexJob: SearchIndexWorkerJob;
+}
+
+interface SessionPublicationResult {
+  event: SessionsUpdatedEvent | null;
+  diffDuration: number;
 }
 
 interface RefreshStrategyResult {
@@ -80,7 +72,7 @@ interface RefreshStrategyResult {
   nextSessions: SessionHead[];
   fullScanSessions: SessionHead[] | null;
   preciseChangedIds: string[] | null;
-  persistenceDiff: Pick<SessionRefreshDiff, "changedSessions" | "removedSessionIds"> | null;
+  persistenceDiff: SessionPersistenceDiff | null;
   checkDuration: number;
   scanDuration: number;
 }
@@ -90,42 +82,18 @@ const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 const BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-function buildRefreshDiff(
-  agentName: string,
+function buildPersistenceDiff(
   previousSessions: SessionHead[],
   nextSessions: SessionHead[],
   candidateChangedIds: string[] = [],
-  signatureCache?: Map<string, string>,
-): SessionRefreshDiff {
-  const { changes, removedSessionIds, counts } = computeSessionDiff(
+): SessionPersistenceDiff {
+  const { changes, removedSessionIds } = computeSessionDiff(
     previousSessions,
     nextSessions,
     candidateChangedIds,
     sessionSignature,
-    signatureCache,
   );
-  for (const removedId of removedSessionIds) signatureCache?.delete(removedId);
-  if (counts.new === 0 && counts.updated === 0 && counts.removed === 0) {
-    return { event: null, changedSessions: changes, removedSessionIds };
-  }
-  return {
-    changedSessions: changes,
-    removedSessionIds,
-    event: {
-      type: "sessions-updated",
-      changedAgents: [agentName],
-      newSessions: counts.new,
-      updatedSessions: counts.updated,
-      removedSessions: counts.removed,
-      totalSessions: nextSessions.length,
-      timestamp: Date.now(),
-      changedSessionHeads: changes.map(({ session }) => ({
-        reference: { agentName, sessionId: session.id },
-        session,
-      })),
-      removedSessionRefs: removedSessionIds.map((sessionId) => ({ agentName, sessionId })),
-    },
-  };
+  return { changedSessions: changes, removedSessionIds };
 }
 
 function restoreAgentCacheMeta(agent: BaseAgent, cached: CachedSessions): void {
@@ -133,8 +101,9 @@ function restoreAgentCacheMeta(agent: BaseAgent, cached: CachedSessions): void {
 }
 
 export class AgentSyncEngine {
-  private refreshStates = new Map<string, AgentRefreshState>();
+  private lastRefreshAtByAgent = new Map<string, number>();
   private readonly scheduler: AgentOperationScheduler;
+  private readonly sessionIndex = new LiveSessionIndex();
   private backfillQueue: string[] = [];
   private currentBackfillAgent: string | undefined;
   private completedBackfillAgents: string[] = [];
@@ -151,10 +120,19 @@ export class AgentSyncEngine {
     this.scheduler = new AgentOperationScheduler((agentName) => this.performRefresh(agentName));
   }
 
-  initialize(cacheTimestamps: Record<string, number> = {}): void {
-    for (const agent of this.options.snapshot().agents) {
-      this.state(agent.name).lastRefreshAt = cacheTimestamps[agent.name] ?? Date.now();
+  initialize(snapshot: LiveSnapshot, options: AgentSyncEngineInitializationOptions = {}): void {
+    this.sessionIndex.initialize(snapshot, options);
+    this.lastRefreshAtByAgent.clear();
+    for (const agent of this.sessionIndex.snapshot().agents) {
+      this.lastRefreshAtByAgent.set(
+        agent.name,
+        options.cacheTimestamps?.[agent.name] ?? Date.now(),
+      );
     }
+  }
+
+  snapshot(): LiveSnapshot {
+    return this.sessionIndex.snapshot();
   }
 
   status(): ScanStatusEvent {
@@ -180,7 +158,7 @@ export class AgentSyncEngine {
   }
 
   handleAgentsChanged(agentNames: Iterable<string>): void {
-    const snapshot = this.options.snapshot();
+    const snapshot = this.sessionIndex.snapshot();
     for (const agentName of agentNames) {
       const delayMs =
         (snapshot.byAgent[agentName]?.length ?? 0) === 0
@@ -192,7 +170,7 @@ export class AgentSyncEngine {
 
   startBackgroundRefresh(): void {
     if (this.backgroundRefreshTimer) return;
-    const agentNames = this.options.snapshot().agents.map((agent) => agent.name);
+    const agentNames = this.sessionIndex.snapshot().agents.map((agent) => agent.name);
     this.startScanBatch(agentNames, "scanning");
     this.backgroundRefreshTimer = setTimeout(() => {
       this.backgroundRefreshTimer = null;
@@ -240,7 +218,7 @@ export class AgentSyncEngine {
   }
 
   private startScanBatch(agentNames: string[], phase: ScanStatusEvent["phase"]): void {
-    const snapshot = this.options.snapshot();
+    const snapshot = this.sessionIndex.snapshot();
     const sessionCounts = Object.fromEntries(
       agentNames.map((agentName) => [agentName, snapshot.byAgent[agentName]?.length ?? 0]),
     );
@@ -252,7 +230,7 @@ export class AgentSyncEngine {
   }
 
   private beginAgentScan(agentName: string): void {
-    const snapshot = this.options.snapshot();
+    const snapshot = this.sessionIndex.snapshot();
     if (!this.scanStatus.snapshot().active) this.startScanBatch([agentName], "scanning");
     this.publishStatus(
       this.scanStatus.beginAgent(agentName, snapshot.byAgent[agentName]?.length ?? 0),
@@ -264,7 +242,7 @@ export class AgentSyncEngine {
   }
 
   private finishAgentScan(agentName: string): void {
-    const count = this.options.snapshot().byAgent[agentName]?.length;
+    const count = this.sessionIndex.snapshot().byAgent[agentName]?.length;
     this.publishStatus(this.scanStatus.finishAgent(agentName, count));
   }
 
@@ -303,17 +281,16 @@ export class AgentSyncEngine {
 
   private async runRefresh(agentName: string): Promise<Exclude<AgentOperationResult, "failed">> {
     const startedAt = performance.now();
-    const state = this.state(agentName);
     const pendingPathCount = this.scheduler.takePendingSignalCount(agentName);
     const agent = this.findAgent(agentName);
     if (!agent) {
       appLogger.warn("scan.refresh.missing_agent", { agent: agentName });
       return "skipped";
     }
-    const previousSessions = this.options.snapshot().byAgent[agentName] ?? [];
+    const previousSessions = this.sessionIndex.snapshot().byAgent[agentName] ?? [];
     const cached = loadCachedSessions(agentName);
     const refreshBaseline = cached?.sessions ?? previousSessions;
-    const cacheTimestamp = cached?.timestamp ?? state.lastRefreshAt;
+    const cacheTimestamp = cached?.timestamp ?? this.lastRefreshAtByAgent.get(agentName) ?? 0;
     if (cached) restoreAgentCacheMeta(agent, cached);
     const isInitialized = isAgentCacheInitialized(agentName);
     const availabilityStartedAt = performance.now();
@@ -339,23 +316,11 @@ export class AgentSyncEngine {
     if (strategyResult.status === "unchanged") return "unchanged";
 
     const nextSessions = attachMissingProjectIdentities(strategyResult.nextSessions);
-    const diffStartedAt = performance.now();
-    const diff = buildRefreshDiff(
-      agentName,
-      previousSessions,
-      nextSessions,
-      strategyResult.preciseChangedIds ?? [],
-      state.signatureCache,
-    );
-    const diffDuration = performance.now() - diffStartedAt;
     const searchIndexOptions =
       pendingPathCount >= SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD ? { isBulk: true } : undefined;
     const persistenceDiff = strategyResult.persistenceDiff;
-    const persistentChanges = persistenceDiff?.changedSessions ?? diff.changedSessions;
-    const persistentRemovedSessionIds =
-      persistenceDiff?.removedSessionIds ?? diff.removedSessionIds;
     const changedSessionIds = persistenceDiff
-      ? new Set(persistentChanges.map(({ session }) => session.id))
+      ? new Set(persistenceDiff.changedSessions.map(({ session }) => session.id))
       : undefined;
     const persistStartedAt = performance.now();
     const persistentJob: SearchIndexWorkerJob = persistenceDiff
@@ -363,8 +328,8 @@ export class AgentSyncEngine {
           kind: "changes",
           context: "scan.refresh",
           agentName,
-          changes: persistentChanges,
-          removedSessionIds: persistentRemovedSessionIds,
+          changes: persistenceDiff.changedSessions,
+          removedSessionIds: persistenceDiff.removedSessionIds,
           meta: buildAgentCacheMeta(agent, changedSessionIds),
           ...(searchIndexOptions ? { searchIndexOptions } : {}),
         }
@@ -377,11 +342,11 @@ export class AgentSyncEngine {
           saveCache: true,
           ...(searchIndexOptions ? { searchIndexOptions } : {}),
         };
-    await this.commitSessionPublication({
+    const publication = await this.commitSessionPublication({
       context: "scan.refresh",
       agentName,
       sessions: nextSessions,
-      event: diff.event,
+      candidateChangedIds: strategyResult.preciseChangedIds ?? [],
       indexJob: persistentJob,
     });
     const persistDuration = performance.now() - persistStartedAt;
@@ -393,14 +358,14 @@ export class AgentSyncEngine {
       agent: agentName,
       duration_ms: Math.round(totalDurationMs),
       sessions: nextSessions.length,
-      new_sessions: diff.event?.newSessions ?? 0,
-      updated_sessions: diff.event?.updatedSessions ?? 0,
-      removed_sessions: diff.event?.removedSessions ?? 0,
+      new_sessions: publication.event?.newSessions ?? 0,
+      updated_sessions: publication.event?.updatedSessions ?? 0,
+      removed_sessions: publication.event?.removedSessions ?? 0,
       pending_paths: pendingPathCount,
       availability_ms: Math.round(availabilityDuration),
       check_ms: Math.round(strategyResult.checkDuration),
       scan_ms: Math.round(strategyResult.scanDuration),
-      diff_ms: Math.round(diffDuration),
+      diff_ms: Math.round(publication.diffDuration),
       persist_ms: Math.round(persistDuration),
       search_index_ms: Math.round(persistDuration),
       persistent_index_worker_job: persistentJob.kind,
@@ -409,7 +374,7 @@ export class AgentSyncEngine {
   }
 
   private refreshUnavailableAgent(agentName: string): RefreshStrategyResult {
-    this.state(agentName).lastRefreshAt = Date.now();
+    this.lastRefreshAtByAgent.set(agentName, Date.now());
     return this.refreshStrategyResult([]);
   }
 
@@ -422,7 +387,7 @@ export class AgentSyncEngine {
     const result = await this.runWorker(agent, previousSessions, null, this.startupScanOptions());
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
     const sessions = attachMissingProjectIdentities(result.sessions);
-    this.state(agent.name).lastRefreshAt = Date.now();
+    this.lastRefreshAtByAgent.set(agent.name, Date.now());
     return this.refreshStrategyResult(sessions, {
       fullScanSessions: sessions,
       scanDuration: performance.now() - scanStartedAt,
@@ -442,13 +407,8 @@ export class AgentSyncEngine {
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
     const sessions = attachMissingProjectIdentities(result.sessions);
     const preciseChangedIds = result.changedIds ?? [];
-    const persistenceDiff = buildRefreshDiff(
-      agent.name,
-      cached.sessions,
-      sessions,
-      preciseChangedIds,
-    );
-    this.state(agent.name).lastRefreshAt = Date.now();
+    const persistenceDiff = buildPersistenceDiff(cached.sessions, sessions, preciseChangedIds);
+    this.lastRefreshAtByAgent.set(agent.name, Date.now());
     if (
       persistenceDiff.changedSessions.length === 0 &&
       persistenceDiff.removedSessionIds.length === 0
@@ -475,7 +435,7 @@ export class AgentSyncEngine {
     const checkStartedAt = performance.now();
     const checkResult = await Promise.resolve(agent.checkForChanges(cacheTimestamp, baseline));
     const checkDuration = performance.now() - checkStartedAt;
-    this.state(agent.name).lastRefreshAt = checkResult.timestamp;
+    this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
     if (!checkResult.hasChanges) {
       this.logUnchangedRefresh(agent.name, refreshStartedAt);
       return this.refreshStrategyResult(baseline, { status: "unchanged", checkDuration });
@@ -487,7 +447,7 @@ export class AgentSyncEngine {
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
       return this.refreshStrategyResult(sessions, {
-        persistenceDiff: buildRefreshDiff(agent.name, baseline, sessions),
+        persistenceDiff: buildPersistenceDiff(baseline, sessions),
         checkDuration,
         scanDuration: performance.now() - scanStartedAt,
       });
@@ -497,7 +457,7 @@ export class AgentSyncEngine {
     );
     return this.refreshStrategyResult(sessions, {
       preciseChangedIds,
-      persistenceDiff: buildRefreshDiff(agent.name, baseline, sessions, preciseChangedIds),
+      persistenceDiff: buildPersistenceDiff(baseline, sessions, preciseChangedIds),
       checkDuration,
       scanDuration: performance.now() - scanStartedAt,
     });
@@ -511,7 +471,7 @@ export class AgentSyncEngine {
     const result = await this.runWorker(agent, previousSessions, null, {});
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
     const sessions = attachMissingProjectIdentities(result.sessions);
-    this.state(agent.name).lastRefreshAt = Date.now();
+    this.lastRefreshAtByAgent.set(agent.name, Date.now());
     return this.refreshStrategyResult(sessions, {
       fullScanSessions: sessions,
       scanDuration: performance.now() - scanStartedAt,
@@ -604,7 +564,7 @@ export class AgentSyncEngine {
     const startedAt = performance.now();
     const agent = this.findAgent(agentName);
     if (!agent || !agent.isAvailable()) return "skipped";
-    const snapshot = this.options.snapshot();
+    const snapshot = this.sessionIndex.snapshot();
     const cached = loadCachedSessions(agentName);
     const baseline = cached?.sessions ?? snapshot.byAgent[agentName] ?? [];
     const meta = cached?.meta ?? buildAgentCacheMeta(agent);
@@ -622,17 +582,11 @@ export class AgentSyncEngine {
       );
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const fullSessions = attachMissingProjectIdentities(result.sessions);
-      const diff = buildRefreshDiff(
-        agentName,
-        snapshot.byAgent[agentName] ?? [],
-        fullSessions,
-        result.changedIds ?? [],
-      );
       await this.commitSessionPublication({
         context: "scan.backfill",
         agentName,
         sessions: fullSessions,
-        event: diff.event,
+        candidateChangedIds: result.changedIds ?? [],
         indexJob: {
           kind: "full",
           context: "scan.backfill",
@@ -657,17 +611,6 @@ export class AgentSyncEngine {
     }
   }
 
-  private state(agentName: string): AgentRefreshState {
-    const existing = this.refreshStates.get(agentName);
-    if (existing) return existing;
-    const state: AgentRefreshState = {
-      lastRefreshAt: 0,
-      signatureCache: new Map(),
-    };
-    this.refreshStates.set(agentName, state);
-    return state;
-  }
-
   private backfillStatus(): BackfillStatus {
     return {
       active: this.currentBackfillAgent != null || this.backfillQueue.length > 0,
@@ -679,7 +622,7 @@ export class AgentSyncEngine {
   }
 
   private buildFullSearchIndexJobs(context: string): SearchIndexWorkerJob[] {
-    const snapshot = this.options.snapshot();
+    const snapshot = this.sessionIndex.snapshot();
     return snapshot.agents.map((agent) => {
       const cached = loadCachedSessions(agent.name);
       return cached
@@ -736,28 +679,38 @@ export class AgentSyncEngine {
     });
   }
 
-  private async commitSessionPublication(publication: SessionPublication): Promise<void> {
+  private async commitSessionPublication(
+    publication: SessionPublication,
+  ): Promise<SessionPublicationResult> {
     const publicationId = this.publicationId(publication.context, publication.agentName);
     await this.commitSearchIndex(publication.context, [publication.indexJob], {
       publicationId,
       agent: publication.agentName,
     });
+    const diffStartedAt = performance.now();
+    const event = this.sessionIndex.commitAgentSessions(
+      publication.agentName,
+      publication.sessions,
+      publication.candidateChangedIds,
+    );
+    const diffDuration = performance.now() - diffStartedAt;
     this.emitSessionsChanged({
       agentName: publication.agentName,
-      sessions: publication.sessions,
-      event: publication.event,
+      sessions: this.sessionIndex.snapshot().byAgent[publication.agentName] ?? [],
+      event,
     });
     appLogger.info("session.publication.published", {
       publication_id: publicationId,
       context: publication.context,
       agent: publication.agentName,
       sessions: publication.sessions.length,
-      has_event: publication.event != null,
+      has_event: event != null,
     });
+    return { event, diffDuration };
   }
 
   private findAgent(agentName: string): BaseAgent | undefined {
-    return this.options.snapshot().agents.find((agent) => agent.name === agentName);
+    return this.sessionIndex.findAgent(agentName);
   }
 
   private startupScanOptions(): Pick<ScanOptions, "from" | "to"> {

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -340,21 +340,18 @@ function syncEngineOf(store: LiveScanStore): AgentSyncEngine {
 
 function runBackfill(store: LiveScanStore, agentName: string) {
   const engine = syncEngineOf(store) as unknown as {
-    serialize: (
-      agentName: string,
-      kind: "backfill",
-      operation: () => Promise<unknown>,
-    ) => Promise<unknown>;
-    performBackfill: (agentName: string) => Promise<unknown>;
+    runBackfill: (agentName: string) => Promise<unknown>;
   };
-  return engine.serialize(agentName, "backfill", () => engine.performBackfill(agentName));
+  return engine.runBackfill(agentName);
 }
 
 function setRefreshDuration(store: LiveScanStore, agentName: string, durationMs: number): void {
   const engine = syncEngineOf(store) as unknown as {
-    state: (agentName: string) => { lastRefreshDurationMs: number };
+    scheduler: {
+      recordRefreshDuration: (agentName: string, durationMs: number) => void;
+    };
   };
-  engine.state(agentName).lastRefreshDurationMs = durationMs;
+  engine.scheduler.recordRefreshDuration(agentName, durationMs);
 }
 
 let restoreRuntime: (() => void) | null = null;

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -2,13 +2,9 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   createRegisteredAgents,
-  mergeSortedSessions,
   scanSessions,
-  sortSessions,
-  type BaseAgent,
-  type ScanOptions,
   type LiveSnapshot,
-  type SessionHead,
+  type ScanOptions,
   type SessionReference,
 } from "@codesesh/core";
 import type {
@@ -18,7 +14,7 @@ import type {
   ScanStatusEvent,
   SessionsUpdatedEvent,
 } from "@codesesh/core/contract";
-import { AgentSyncEngine, type AgentSessionsChanged } from "./agent-sync-engine.js";
+import { AgentSyncEngine } from "./agent-sync-engine.js";
 import { appLogger } from "./logging.js";
 import { SessionWatcher } from "./session-watcher.js";
 import { ThreadWorkerRunner, type WorkerRunner } from "./worker-runner.js";
@@ -78,9 +74,6 @@ export class LiveScanStore {
   private readonly startupScanOptions: Pick<ScanOptions, "from" | "to">;
   private readonly deferInitialRefresh: boolean;
   private readonly syncEngine: AgentSyncEngine;
-  private agents: BaseAgent[] = [];
-  private byAgent: Record<string, SessionHead[]> = {};
-  private sessions: SessionHead[] = [];
   private listeners = new Set<StoreListener>();
   private watcher: SessionWatcher | null = null;
   private pendingEvent: SessionsUpdatedEvent | null = null;
@@ -97,11 +90,12 @@ export class LiveScanStore {
       options.workerRunner ??
       new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
     this.syncEngine = new AgentSyncEngine({
-      snapshot: () => this.getSnapshot(),
       startupScanOptions: this.startupScanOptions,
       workerRunner,
     });
-    this.syncEngine.subscribeSessionsChanged((change) => this.applySessionsChanged(change));
+    this.syncEngine.subscribeSessionsChanged((change) => {
+      if (change.event) this.emit(change.event);
+    });
   }
 
   async initialize(): Promise<void> {
@@ -123,8 +117,12 @@ export class LiveScanStore {
       smartTagWorkerUrl: this.getSmartTagWorkerUrl() ?? undefined,
       includeSmartTags: this.deferInitialRefresh ? false : undefined,
     });
-    this.applyScanResult(initialResult);
-    this.syncEngine.initialize(initialResult.cacheTimestamps);
+    this.syncEngine.initialize(initialResult, {
+      cacheTimestamps: initialResult.cacheTimestamps,
+      registeredAgents: createRegisteredAgents(),
+      allowedAgents: this.getAllowedAgents(),
+    });
+    const snapshot = this.getSnapshot();
     const indexStartedAt = performance.now();
     if (!this.deferInitialRefresh) await this.syncEngine.syncInitialIndex();
     const indexDuration = performance.now() - indexStartedAt;
@@ -132,9 +130,9 @@ export class LiveScanStore {
       duration_ms: Math.round(performance.now() - startedAt),
       index_ms: this.deferInitialRefresh ? undefined : Math.round(indexDuration),
       deferred: this.deferInitialRefresh || undefined,
-      sessions: this.sessions.length,
+      sessions: snapshot.sessions.length,
       agents: Object.fromEntries(
-        Object.entries(this.byAgent).map(([key, value]) => [key, value.length]),
+        Object.entries(snapshot.byAgent).map(([key, value]) => [key, value.length]),
       ),
       agent_timings: initialResult.timings
         ? Object.fromEntries(
@@ -156,7 +154,7 @@ export class LiveScanStore {
     if (!this.watchEnabled) return;
     this.watcher = new SessionWatcher();
     this.watcher.onAgentsChanged((agentNames) => this.syncEngine.handleAgentsChanged(agentNames));
-    this.watcher.start(this.agents);
+    this.watcher.start(snapshot.agents);
   }
 
   startBackgroundRefresh(): void {
@@ -164,7 +162,7 @@ export class LiveScanStore {
   }
 
   getSnapshot(): LiveSnapshot {
-    return { sessions: this.sessions, byAgent: this.byAgent, agents: this.agents };
+    return this.syncEngine.snapshot();
   }
 
   getScanStatus(): ScanStatusEvent {
@@ -199,14 +197,6 @@ export class LiveScanStore {
     }
   }
 
-  private applySessionsChanged(change: AgentSessionsChanged): void {
-    this.byAgent[change.agentName] = sortSessions(change.sessions);
-    this.rebuildSessions();
-    if (!change.event) return;
-    change.event.totalSessions = this.sessions.length;
-    this.emit(change.event);
-  }
-
   private emit(event: SessionsUpdatedEvent): void {
     if (this.shuttingDown) return;
     if (this.pendingEvent || event.newSessions > 0) {
@@ -231,34 +221,10 @@ export class LiveScanStore {
     }, NEW_SESSION_EVENT_WINDOW_MS);
   }
 
-  /**
-   * Every byAgent shard is kept sorted by its two writers (applySessionsChanged
-   * and applyScanResult), so combining them is a merge, not a sort.
-   */
-  private rebuildSessions(): void {
-    this.sessions = mergeSortedSessions(Object.values(this.byAgent));
-  }
-
   private getSmartTagWorkerUrl(): URL | null {
     const workerUrl = new URL("./smart-tag-worker.js", import.meta.url);
     if (workerUrl.protocol === "file:" && !existsSync(fileURLToPath(workerUrl))) return null;
     return workerUrl;
-  }
-
-  private applyScanResult(result: LiveSnapshot): void {
-    const agentMap = new Map<string, BaseAgent>();
-    const allowedAgents = this.getAllowedAgents();
-    for (const agent of result.agents) agentMap.set(agent.name, agent);
-    for (const agent of createRegisteredAgents()) {
-      if (!agentMap.has(agent.name)) agentMap.set(agent.name, agent);
-    }
-    this.agents = [...agentMap.values()].filter(
-      (agent) => !allowedAgents || allowedAgents.has(agent.name.toLowerCase()),
-    );
-    this.byAgent = Object.fromEntries(
-      this.agents.map((agent) => [agent.name, sortSessions(result.byAgent[agent.name] ?? [])]),
-    );
-    this.rebuildSessions();
   }
 
   private getAllowedAgents(): Set<string> | null {

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { BaseAgent, LiveSnapshot, SessionHead } from "@codesesh/core";
+import { LiveSessionIndex } from "./live-session-index.js";
+
+function makeAgent(name: string): BaseAgent {
+  return {
+    name,
+    displayName: name,
+  } as BaseAgent;
+}
+
+function makeSession(id: string, updatedAt: number, title = id): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title,
+    directory: "/workspace",
+    time_created: updatedAt,
+    time_updated: updatedAt,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+function snapshot(agents: BaseAgent[], byAgent: Record<string, SessionHead[]>): LiveSnapshot {
+  return { agents, byAgent, sessions: Object.values(byAgent).flat() };
+}
+
+describe("LiveSessionIndex", () => {
+  it("initializes sorted views for the allowed agent catalog", () => {
+    const codex = makeAgent("codex");
+    const kimi = makeAgent("kimi");
+    const cursor = makeAgent("cursor");
+    const older = makeSession("older", 1);
+    const newer = makeSession("newer", 3);
+    const index = new LiveSessionIndex();
+
+    index.initialize(snapshot([codex], { codex: [older, newer] }), {
+      registeredAgents: [codex, kimi, cursor],
+      allowedAgents: new Set(["codex", "kimi"]),
+    });
+
+    expect(index.snapshot()).toEqual({
+      agents: [codex, kimi],
+      byAgent: { codex: [newer, older], kimi: [] },
+      sessions: [newer, older],
+    });
+    expect(index.findAgent("kimi")).toBe(kimi);
+    expect(index.findAgent("cursor")).toBeUndefined();
+  });
+
+  it("commits one agent shard and publishes counts against the global view", () => {
+    const codex = makeAgent("codex");
+    const kimi = makeAgent("kimi");
+    const previous = makeSession("previous", 2, "before");
+    const updated = makeSession("previous", 4, "after");
+    const added = makeSession("added", 1);
+    const other = makeSession("other", 3);
+    const index = new LiveSessionIndex();
+    index.initialize(snapshot([codex, kimi], { codex: [previous], kimi: [other] }));
+
+    const event = index.commitAgentSessions("codex", [added, updated], [updated.id]);
+
+    expect(index.snapshot().byAgent.codex).toEqual([updated, added]);
+    expect(index.snapshot().sessions).toEqual([updated, other, added]);
+    expect(event).toEqual({
+      type: "sessions-updated",
+      changedAgents: ["codex"],
+      newSessions: 1,
+      updatedSessions: 1,
+      removedSessions: 0,
+      totalSessions: 3,
+      timestamp: expect.any(Number),
+      changedSessionHeads: [
+        {
+          reference: { agentName: "codex", sessionId: "added" },
+          session: added,
+        },
+        {
+          reference: { agentName: "codex", sessionId: "previous" },
+          session: updated,
+        },
+      ],
+      removedSessionRefs: [],
+    });
+  });
+
+  it("updates the snapshot even when no event is needed", () => {
+    const codex = makeAgent("codex");
+    const original = makeSession("session", 1);
+    const equivalent = { ...original };
+    const index = new LiveSessionIndex();
+    index.initialize(snapshot([codex], { codex: [original] }));
+
+    expect(index.commitAgentSessions("codex", [equivalent])).toBeNull();
+    expect(index.snapshot().sessions[0]).toBe(equivalent);
+  });
+
+  it("resets signature lineage when a new snapshot is initialized", () => {
+    const codex = makeAgent("codex");
+    const original = makeSession("session", 1, "original");
+    const firstCommit = makeSession("session", 2, "first commit");
+    const reloaded = makeSession("session", 3, "reloaded");
+    const index = new LiveSessionIndex();
+    index.initialize(snapshot([codex], { codex: [original] }));
+    index.commitAgentSessions("codex", [firstCommit]);
+
+    index.initialize(snapshot([codex], { codex: [reloaded] }));
+
+    expect(index.commitAgentSessions("codex", [reloaded])).toBeNull();
+  });
+
+  it("removes sessions from both agent and global views", () => {
+    const codex = makeAgent("codex");
+    const removed = makeSession("removed", 1);
+    const index = new LiveSessionIndex();
+    index.initialize(snapshot([codex], { codex: [removed] }));
+
+    const event = index.commitAgentSessions("codex", []);
+
+    expect(index.snapshot().byAgent.codex).toEqual([]);
+    expect(index.snapshot().sessions).toEqual([]);
+    expect(event).toEqual(
+      expect.objectContaining({
+        newSessions: 0,
+        updatedSessions: 0,
+        removedSessions: 1,
+        totalSessions: 0,
+        changedSessionHeads: [],
+        removedSessionRefs: [{ agentName: "codex", sessionId: "removed" }],
+      }),
+    );
+  });
+});

--- a/packages/cli/src/live-session-index.ts
+++ b/packages/cli/src/live-session-index.ts
@@ -1,0 +1,97 @@
+import {
+  computeSessionDiff,
+  mergeSortedSessions,
+  sessionSignature,
+  sortSessions,
+  type BaseAgent,
+  type LiveSnapshot,
+  type SessionHead,
+} from "@codesesh/core";
+import type { SessionsUpdatedEvent } from "@codesesh/core/contract";
+
+export interface LiveSessionIndexOptions {
+  registeredAgents?: BaseAgent[];
+  allowedAgents?: ReadonlySet<string> | null;
+}
+
+export class LiveSessionIndex {
+  private agents: BaseAgent[] = [];
+  private agentsByName = new Map<string, BaseAgent>();
+  private byAgent: Record<string, SessionHead[]> = {};
+  private sessions: SessionHead[] = [];
+  private signatureCaches = new Map<string, Map<string, string>>();
+
+  initialize(snapshot: LiveSnapshot, options: LiveSessionIndexOptions = {}): void {
+    const agentMap = new Map<string, BaseAgent>();
+    for (const agent of snapshot.agents) agentMap.set(agent.name, agent);
+    for (const agent of options.registeredAgents ?? []) {
+      if (!agentMap.has(agent.name)) agentMap.set(agent.name, agent);
+    }
+
+    this.agents = [...agentMap.values()].filter(
+      (agent) => !options.allowedAgents || options.allowedAgents.has(agent.name.toLowerCase()),
+    );
+    this.agentsByName = new Map(this.agents.map((agent) => [agent.name, agent]));
+    this.byAgent = Object.fromEntries(
+      this.agents.map((agent) => [agent.name, sortSessions(snapshot.byAgent[agent.name] ?? [])]),
+    );
+    this.sessions = mergeSortedSessions(Object.values(this.byAgent));
+    this.signatureCaches.clear();
+  }
+
+  snapshot(): LiveSnapshot {
+    return {
+      agents: this.agents,
+      byAgent: this.byAgent,
+      sessions: this.sessions,
+    };
+  }
+
+  findAgent(agentName: string): BaseAgent | undefined {
+    return this.agentsByName.get(agentName);
+  }
+
+  commitAgentSessions(
+    agentName: string,
+    nextSessions: SessionHead[],
+    candidateChangedIds: string[] = [],
+  ): SessionsUpdatedEvent | null {
+    const previousSessions = this.byAgent[agentName] ?? [];
+    const signatureCache = this.signatureCache(agentName);
+    const { changes, removedSessionIds, counts } = computeSessionDiff(
+      previousSessions,
+      nextSessions,
+      candidateChangedIds,
+      sessionSignature,
+      signatureCache,
+    );
+    for (const removedId of removedSessionIds) signatureCache.delete(removedId);
+
+    this.byAgent[agentName] = sortSessions(nextSessions);
+    this.sessions = mergeSortedSessions(Object.values(this.byAgent));
+    if (counts.new === 0 && counts.updated === 0 && counts.removed === 0) return null;
+
+    return {
+      type: "sessions-updated",
+      changedAgents: [agentName],
+      newSessions: counts.new,
+      updatedSessions: counts.updated,
+      removedSessions: counts.removed,
+      totalSessions: this.sessions.length,
+      timestamp: Date.now(),
+      changedSessionHeads: changes.map(({ session }) => ({
+        reference: { agentName, sessionId: session.id },
+        session,
+      })),
+      removedSessionRefs: removedSessionIds.map((sessionId) => ({ agentName, sessionId })),
+    };
+  }
+
+  private signatureCache(agentName: string): Map<string, string> {
+    const existing = this.signatureCaches.get(agentName);
+    if (existing) return existing;
+    const cache = new Map<string, string>();
+    this.signatureCaches.set(agentName, cache);
+    return cache;
+  }
+}


### PR DESCRIPTION
## Summary

- extract per-agent refresh scheduling, coalescing, generation tracking, and operation serialization into AgentOperationScheduler
- centralize session snapshots, diff events, ordering, and signature-cache lineage in LiveSessionIndex
- make LiveScanStore consume committed events without owning a duplicate session index

## Testing

- pnpm build
- pnpm lint
- pnpm format:check
- pnpm test
- pnpm test:migration
- pnpm test:coverage
- pnpm test:e2e