### PR TITLE
refactor(web): share file tool strategies

### DIFF
--- a/apps/web/src/components/session-detail/tool-strategy.test.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.test.ts
@@ -17,6 +17,26 @@ function part(overrides?: Partial<ToolPart>): ToolPart {
   };
 }
 
+const FILE_TOOL_CASES = [
+  ["claudecode", "Read", "read"],
+  ["claudecode", "Edit", "edit"],
+  ["claudecode", "Write", "write"],
+  ["opencode", "Read", "read"],
+  ["opencode", "Edit", "edit"],
+  ["opencode", "Write", "write"],
+  ["pi", "Read", "read"],
+  ["pi", "Edit", "edit"],
+  ["pi", "Write", "write"],
+  ["zcode", "Read", "read"],
+  ["zcode", "Edit", "edit"],
+  ["zcode", "Write", "write"],
+  ["kimi", "ReadFile", "read"],
+  ["kimi", "StrReplaceFile", "edit"],
+  ["kimi", "WriteFile", "write"],
+  ["cursor", "read_file_v2", "read"],
+  ["cursor", "edit_file_v2", "edit"],
+] as const;
+
 describe("normalizeToolState", () => {
   it("extracts input/output/error from tool state", () => {
     const state = normalizeToolState(
@@ -50,6 +70,42 @@ describe("getToolDisplayStrategy", () => {
     expect(strategy).toBeDefined();
     expect(strategy.title).toBeTruthy();
   });
+
+  it.each(FILE_TOOL_CASES)(
+    "normalizes %s %s to the canonical %s file strategy",
+    (agentName, toolName, title) => {
+      const tool = part({
+        tool: toolName,
+        title: agentName === "zcode" ? "" : "Agent-specific title",
+        state: {
+          status: "completed",
+          input: {
+            file_path: "/repo/src/example.ts",
+            old_string: "old",
+            new_string: "new",
+            streamingContent: "-old\n+new",
+            content: "new",
+          },
+          output: agentName === "cursor" ? { contents: "const value = 1;" } : "updated",
+        },
+      });
+
+      const strategy = getToolDisplayStrategy(agentName, tool, normalizeToolState(tool), "/repo");
+
+      expect(strategy).toMatchObject({
+        title,
+        secondaryText: "src/example.ts",
+        showInputPreview: false,
+      });
+      if (title !== "edit") {
+        expect(strategy.outputContent).toMatchObject({
+          kind: "plain",
+          language: "typescript",
+          isCode: true,
+        });
+      }
+    },
+  );
 
   it("renders ZCode edit metadata as a structured diff", () => {
     const tool = part({

--- a/apps/web/src/components/session-detail/tool-strategy/claudecode.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/claudecode.ts
@@ -4,7 +4,6 @@
  * Pure logic — no React. Consumed by ./index's TOOL_STRATEGY_BUILDERS.
  */
 import type { ToolPart } from "../../../lib/api";
-import { detectLanguageByFilePath } from "../../tool-output/language";
 import type { TaskListItem } from "../../tool-output/types";
 import { buildStructuredDiffFromTexts } from "../diff";
 import { getDisplayPath, getFilePathFromInput } from "../path-extract";
@@ -20,16 +19,18 @@ import {
   toStringValue,
 } from "../tool-normalize";
 import { getDisplayTextWithRelativePaths } from "../path-extract";
-import { buildDefaultToolStrategy, extractReadContent, extractWriteContent } from "./shared";
+import {
+  buildDefaultToolStrategy,
+  buildFileEditStrategy,
+  buildFileReadStrategy,
+  buildFileWriteStrategy,
+} from "./shared";
 import {
   Bot,
-  BookOpenText,
   CircleHelp,
-  FilePenLine,
   FileSearch,
   ListTodo,
   MessageSquareMore,
-  NotebookPen,
   PanelsTopLeft,
   Search,
   SquareTerminal,
@@ -127,55 +128,37 @@ export function buildClaudeToolStrategy(
   const displayPath = getDisplayPath(filePath, baseDirectory);
 
   if (toolKey === "read") {
-    const semanticOutput = buildSemanticOutputContent(state.outputValue);
-    return {
-      ...defaultStrategy,
-      Icon: BookOpenText,
-      title: "read",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent:
-        semanticOutput ??
-        ({
-          kind: "plain",
-          text: extractReadContent(state.outputValue),
-          language: detectLanguageByFilePath(filePath),
-          isCode: true,
-        } as const),
-    };
+    return buildFileReadStrategy({
+      defaultStrategy,
+      state,
+      filePath,
+      displayPath,
+      outputContent: buildSemanticOutputContent(state.outputValue),
+    });
   }
 
   if (toolKey === "edit") {
     const oldValue = toStringValue(input.old_string);
     const newValue = toStringValue(input.new_string);
     const diffBlocks = buildStructuredDiffFromTexts(displayPath || filePath, oldValue, newValue);
-    return {
-      ...defaultStrategy,
-      Icon: FilePenLine,
-      title: "edit",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
+    return buildFileEditStrategy({
+      defaultStrategy,
+      displayPath,
       outputContent:
         diffBlocks.length > 0
           ? { kind: "structured-diff", blocks: diffBlocks }
           : { kind: "plain", text: getOutputOrErrorText(state), language: "text", isCode: false },
-    };
+    });
   }
 
   if (toolKey === "write") {
-    return {
-      ...defaultStrategy,
-      Icon: NotebookPen,
-      title: "write",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractWriteContent(state),
-        language: detectLanguageByFilePath(filePath),
-        isCode: true,
-      },
-    };
+    return buildFileWriteStrategy({
+      defaultStrategy,
+      state,
+      filePath,
+      displayPath,
+      isCode: true,
+    });
   }
 
   if (toolKey === "bash" || toolKey === "workflow") {

--- a/apps/web/src/components/session-detail/tool-strategy/cursor.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/cursor.ts
@@ -4,7 +4,6 @@
  * Pure logic — no React. Consumed by ./index's TOOL_STRATEGY_BUILDERS.
  */
 import type { ToolPart } from "../../../lib/api";
-import { detectLanguageByFilePath } from "../../tool-output/language";
 import {
   getDisplayPath,
   getDisplayTextWithRelativePaths,
@@ -22,8 +21,8 @@ import {
   toStringValue,
 } from "../tool-normalize";
 import { parseJsonText } from "../utils";
-import { buildDefaultToolStrategy } from "./shared";
-import { BookOpenText, FilePenLine, FileSearch, SquareTerminal } from "../../ui/icons";
+import { buildDefaultToolStrategy, buildFileEditStrategy, buildFileReadStrategy } from "./shared";
+import { FileSearch, SquareTerminal } from "../../ui/icons";
 
 export function getCursorOutputRecord(rawOutput: unknown) {
   if (rawOutput && typeof rawOutput === "object" && !Array.isArray(rawOutput)) {
@@ -76,11 +75,12 @@ export function buildCursorToolStrategy(
 
   if (toolKey === "read_file_v2") {
     const content = extractCursorReadContent(state.outputValue);
-    return {
-      ...defaultStrategy,
-      Icon: BookOpenText,
-      title: "read",
-      secondaryText: displayPath || undefined,
+    return buildFileReadStrategy({
+      defaultStrategy,
+      state,
+      filePath,
+      displayPath,
+      text: content,
       details:
         content === "No output captured."
           ? [
@@ -90,31 +90,22 @@ export function buildCursorToolStrategy(
               },
             ]
           : [],
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: content,
-        language: detectLanguageByFilePath(filePath),
-        isCode: content !== "No output captured.",
-      },
-    };
+      isCode: content !== "No output captured.",
+    });
   }
 
   if (toolKey === "edit_file_v2") {
     const diffText = normalizeEscapedNewlines(toStringValue(input.streamingContent));
-    return {
-      ...defaultStrategy,
-      Icon: FilePenLine,
-      title: "edit",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
+    return buildFileEditStrategy({
+      defaultStrategy,
+      displayPath,
       outputContent: {
         kind: "plain",
         text: diffText || getOutputOrErrorText(state),
         language: diffText ? "diff" : "text",
         isCode: Boolean(diffText),
       },
-    };
+    });
   }
 
   if (toolKey === "ripgrep_raw_search") {

--- a/apps/web/src/components/session-detail/tool-strategy/index.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/index.ts
@@ -4,9 +4,10 @@
  *
  * This is the registry entry point: getToolDisplayStrategy dispatches by
  * agentKey to the builder in the matching ./<agent>.ts file. Common
- * infrastructure lives in ./shared.ts (default/skill strategies, extractors
- * shared by 2+ agents); agent-agnostic normalization (normalizeToolState,
- * normalizeMessagesForDisplay) lives in ../tool-normalize.ts.
+ * infrastructure lives in ./shared.ts (default/skill/file strategies and
+ * extractors shared by 2+ agents); agent-agnostic normalization
+ * (normalizeToolState, normalizeMessagesForDisplay) lives in
+ * ../tool-normalize.ts.
  *
  * Pure logic — no React. Consumed by SessionDetail's ToolItem / MessageItem.
  */

--- a/apps/web/src/components/session-detail/tool-strategy/kimi.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/kimi.ts
@@ -4,7 +4,6 @@
  * Pure logic — no React. Consumed by ./index's TOOL_STRATEGY_BUILDERS.
  */
 import type { ToolPart } from "../../../lib/api";
-import { detectLanguageByFilePath } from "../../tool-output/language";
 import { buildKimiEditDiffBlocks, extractEditDiff } from "../diff";
 import {
   getDisplayPath,
@@ -18,8 +17,13 @@ import {
   toPlainText,
   toRecord,
 } from "../tool-normalize";
-import { buildDefaultToolStrategy, extractReadContent, extractWriteContent } from "./shared";
-import { BookOpenText, FilePenLine, FileSearch, NotebookPen, SquareTerminal } from "../../ui/icons";
+import {
+  buildDefaultToolStrategy,
+  buildFileEditStrategy,
+  buildFileReadStrategy,
+  buildFileWriteStrategy,
+} from "./shared";
+import { FileSearch, SquareTerminal } from "../../ui/icons";
 
 export function buildKimiToolStrategy(
   tool: ToolPart,
@@ -29,6 +33,8 @@ export function buildKimiToolStrategy(
   const defaultStrategy = buildDefaultToolStrategy(tool, state, baseDirectory);
   const toolKey = tool.tool.toLowerCase();
   const input = toRecord(state.inputValue);
+  const filePath = getFilePathFromInput(state.inputValue);
+  const displayPath = getDisplayPath(filePath, baseDirectory);
 
   if (toolKey === "glob") {
     const pattern = toPlainText(input.pattern);
@@ -85,56 +91,23 @@ export function buildKimiToolStrategy(
   }
 
   if (toolKey === "readfile") {
-    const filePath = getFilePathFromInput(state.inputValue);
-    const displayPath = getDisplayPath(filePath, baseDirectory);
-    return {
-      ...defaultStrategy,
-      Icon: BookOpenText,
-      title: tool.title || "read",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractReadContent(state.outputValue),
-        language: detectLanguageByFilePath(filePath),
-        isCode: true,
-      },
-    };
+    return buildFileReadStrategy({ defaultStrategy, state, filePath, displayPath });
   }
 
   if (toolKey === "strreplacefile") {
-    const filePath = getFilePathFromInput(state.inputValue);
-    const displayPath = getDisplayPath(filePath, baseDirectory);
     const diffBlocks = buildKimiEditDiffBlocks(state, displayPath || filePath);
-    return {
-      ...defaultStrategy,
-      Icon: FilePenLine,
-      title: tool.title || "edit",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
+    return buildFileEditStrategy({
+      defaultStrategy,
+      displayPath,
       outputContent:
         diffBlocks.length > 0
           ? { kind: "structured-diff", blocks: diffBlocks }
           : { kind: "plain", text: extractEditDiff(state), language: "diff", isCode: true },
-    };
+    });
   }
 
   if (toolKey === "writefile") {
-    const filePath = getFilePathFromInput(state.inputValue);
-    const displayPath = getDisplayPath(filePath, baseDirectory);
-    return {
-      ...defaultStrategy,
-      Icon: NotebookPen,
-      title: tool.title || "write",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractWriteContent(state),
-        language: detectLanguageByFilePath(filePath),
-        isCode: state.status === "completed",
-      },
-    };
+    return buildFileWriteStrategy({ defaultStrategy, state, filePath, displayPath });
   }
 
   return defaultStrategy;

--- a/apps/web/src/components/session-detail/tool-strategy/opencode.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/opencode.ts
@@ -4,7 +4,6 @@
  * Pure logic — no React. Consumed by ./index's TOOL_STRATEGY_BUILDERS.
  */
 import type { ToolPart } from "../../../lib/api";
-import { detectLanguageByFilePath } from "../../tool-output/language";
 import { extractEditDiff } from "../diff";
 import {
   getDisplayPath,
@@ -20,11 +19,12 @@ import {
 } from "../tool-normalize";
 import {
   buildDefaultToolStrategy,
+  buildFileEditStrategy,
+  buildFileReadStrategy,
+  buildFileWriteStrategy,
   buildSkillToolStrategy,
-  extractReadContent,
-  extractWriteContent,
 } from "./shared";
-import { BookOpenText, FilePenLine, FileSearch, NotebookPen, SquareTerminal } from "../../ui/icons";
+import { FileSearch, SquareTerminal } from "../../ui/icons";
 
 export function buildOpencodeToolStrategy(
   tool: ToolPart,
@@ -34,6 +34,8 @@ export function buildOpencodeToolStrategy(
   const defaultStrategy = buildDefaultToolStrategy(tool, state, baseDirectory);
   const toolKey = tool.tool.toLowerCase();
   const input = toRecord(state.inputValue);
+  const filePath = getFilePathFromInput(state.inputValue);
+  const displayPath = getDisplayPath(filePath, baseDirectory);
 
   if (toolKey === "glob") {
     const pattern = toPlainText(input.pattern);
@@ -96,58 +98,24 @@ export function buildOpencodeToolStrategy(
   }
 
   if (toolKey === "read") {
-    const filePath = getFilePathFromInput(state.inputValue);
-    const displayPath = getDisplayPath(filePath, baseDirectory);
-    return {
-      ...defaultStrategy,
-      Icon: BookOpenText,
-      title: tool.tool || "read",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractReadContent(state.outputValue),
-        language: detectLanguageByFilePath(filePath),
-        isCode: true,
-      },
-    };
+    return buildFileReadStrategy({ defaultStrategy, state, filePath, displayPath });
   }
 
   if (toolKey === "edit") {
-    const filePath = getFilePathFromInput(state.inputValue);
-    const displayPath = getDisplayPath(filePath, baseDirectory);
-    return {
-      ...defaultStrategy,
-      Icon: FilePenLine,
-      title: tool.tool || "edit",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
+    return buildFileEditStrategy({
+      defaultStrategy,
+      displayPath,
       outputContent: {
         kind: "plain",
         text: extractEditDiff(state),
         language: "diff",
         isCode: true,
       },
-    };
+    });
   }
 
   if (toolKey === "write") {
-    const filePath = getFilePathFromInput(state.inputValue);
-    const displayPath = getDisplayPath(filePath, baseDirectory);
-    const isSuccessfulWrite = state.status === "completed";
-    return {
-      ...defaultStrategy,
-      Icon: NotebookPen,
-      title: tool.tool || "write",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractWriteContent(state),
-        language: detectLanguageByFilePath(filePath),
-        isCode: isSuccessfulWrite,
-      },
-    };
+    return buildFileWriteStrategy({ defaultStrategy, state, filePath, displayPath });
   }
 
   if (toolKey === "skill") {

--- a/apps/web/src/components/session-detail/tool-strategy/pi.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/pi.ts
@@ -4,7 +4,6 @@
  * Pure logic — no React. Consumed by ./index's TOOL_STRATEGY_BUILDERS.
  */
 import type { ToolPart } from "../../../lib/api";
-import { detectLanguageByFilePath } from "../../tool-output/language";
 import type { ToolDetailItem } from "../codex-tool";
 import { buildPiEditDiffBlocks } from "../diff";
 import {
@@ -20,16 +19,13 @@ import {
   toRecord,
   toStringValue,
 } from "../tool-normalize";
-import { buildDefaultToolStrategy, extractReadContent, extractWriteContent } from "./shared";
 import {
-  Bot,
-  BookOpenText,
-  FilePenLine,
-  FilePlus2,
-  Image as ImageIcon,
-  ListTodo,
-  SquareTerminal,
-} from "../../ui/icons";
+  buildDefaultToolStrategy,
+  buildFileEditStrategy,
+  buildFileReadStrategy,
+  buildFileWriteStrategy,
+} from "./shared";
+import { Bot, FilePlus2, Image as ImageIcon, ListTodo, SquareTerminal } from "../../ui/icons";
 
 export function getPiTodoTaskFromDetails(state: NormalizedToolState) {
   const input = toRecord(state.inputValue);
@@ -108,35 +104,17 @@ export function buildPiToolStrategy(
   }
 
   if (toolKey === "read") {
-    return {
-      ...defaultStrategy,
-      Icon: BookOpenText,
-      title: "read",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractReadContent(state.outputValue),
-        language: detectLanguageByFilePath(filePath),
-        isCode: true,
-      },
-    };
+    return buildFileReadStrategy({ defaultStrategy, state, filePath, displayPath });
   }
 
   if (toolKey === "write") {
-    return {
-      ...defaultStrategy,
+    return buildFileWriteStrategy({
+      defaultStrategy,
+      state,
+      filePath,
+      displayPath,
       Icon: FilePlus2,
-      title: "write",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractWriteContent(state),
-        language: detectLanguageByFilePath(filePath),
-        isCode: state.status === "completed",
-      },
-    };
+    });
   }
 
   if (toolKey === "edit") {
@@ -145,18 +123,15 @@ export function buildPiToolStrategy(
       typeof metadata.firstChangedLine === "number"
         ? String(metadata.firstChangedLine)
         : toStringValue(metadata.firstChangedLine);
-    return {
-      ...defaultStrategy,
-      Icon: FilePenLine,
-      title: "edit",
-      secondaryText: displayPath || undefined,
+    return buildFileEditStrategy({
+      defaultStrategy,
+      displayPath,
       details: firstChangedLine ? [{ label: "Line", value: firstChangedLine }] : [],
-      showInputPreview: false,
       outputContent:
         diffBlocks.length > 0
           ? { kind: "structured-diff", blocks: diffBlocks }
           : { kind: "plain", text: getOutputOrErrorText(state), language: "text", isCode: false },
-    };
+    });
   }
 
   if (toolKey === "agent") {

--- a/apps/web/src/components/session-detail/tool-strategy/shared.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/shared.ts
@@ -1,11 +1,13 @@
 /**
- * Cross-agent tool-strategy infrastructure: the default/skill strategy
- * builders and extractors reused by 2+ agent builders (claudecode, opencode,
- * kimi, pi, zcode).
+ * Cross-agent tool-strategy infrastructure: the default, skill, and file
+ * strategy builders reused by 2+ agent builders.
  *
  * Pure logic — no React. Consumed by the per-agent builders in this folder.
  */
 import type { ToolPart } from "../../../lib/api";
+import { detectLanguageByFilePath } from "../../tool-output/language";
+import type { ToolOutputContent } from "../../tool-output/types";
+import type { ToolDetailItem } from "../codex-tool";
 import {
   type NormalizedToolState,
   type ToolDisplayStrategy,
@@ -21,7 +23,7 @@ import {
   toStringValue,
 } from "../tool-normalize";
 import { getDisplayTextWithRelativePaths } from "../path-extract";
-import { SquareTerminal, Wrench } from "../../ui/icons";
+import { BookOpenText, FilePenLine, NotebookPen, SquareTerminal, Wrench } from "../../ui/icons";
 
 export type { NormalizedToolState, ToolDisplayStrategy, ToolStatus };
 
@@ -51,6 +53,87 @@ export function extractWriteContent(state: NormalizedToolState) {
     if (contentText.trim()) return normalizeEscapedNewlines(contentText);
   }
   return getOutputOrErrorText(state);
+}
+
+interface FileStrategyContext {
+  defaultStrategy: ToolDisplayStrategy;
+  displayPath: string;
+}
+
+interface FileToolStrategyOptions extends FileStrategyContext {
+  outputContent: ToolOutputContent;
+  Icon: ToolDisplayStrategy["Icon"];
+  title: "read" | "write" | "edit";
+  details?: ToolDetailItem[];
+}
+
+interface FileReadStrategyOptions extends FileStrategyContext {
+  state: NormalizedToolState;
+  filePath: string;
+  outputContent?: ToolOutputContent | null;
+  text?: string;
+  isCode?: boolean;
+  details?: ToolDetailItem[];
+}
+
+interface FileWriteStrategyOptions extends FileStrategyContext {
+  state: NormalizedToolState;
+  filePath: string;
+  Icon?: ToolDisplayStrategy["Icon"];
+  isCode?: boolean;
+}
+
+interface FileEditStrategyOptions extends FileStrategyContext {
+  outputContent: ToolOutputContent;
+  details?: ToolDetailItem[];
+}
+
+function buildFileToolStrategy(options: FileToolStrategyOptions): ToolDisplayStrategy {
+  return {
+    ...options.defaultStrategy,
+    Icon: options.Icon,
+    title: options.title,
+    secondaryText: options.displayPath || undefined,
+    details: options.details ?? options.defaultStrategy.details,
+    showInputPreview: false,
+    outputContent: options.outputContent,
+  };
+}
+
+export function buildFileReadStrategy(options: FileReadStrategyOptions): ToolDisplayStrategy {
+  return buildFileToolStrategy({
+    ...options,
+    Icon: BookOpenText,
+    title: "read",
+    outputContent: options.outputContent ?? {
+      kind: "plain",
+      text: options.text ?? extractReadContent(options.state.outputValue),
+      language: detectLanguageByFilePath(options.filePath),
+      isCode: options.isCode ?? true,
+    },
+  });
+}
+
+export function buildFileWriteStrategy(options: FileWriteStrategyOptions): ToolDisplayStrategy {
+  return buildFileToolStrategy({
+    ...options,
+    Icon: options.Icon ?? NotebookPen,
+    title: "write",
+    outputContent: {
+      kind: "plain",
+      text: extractWriteContent(options.state),
+      language: detectLanguageByFilePath(options.filePath),
+      isCode: options.isCode ?? options.state.status === "completed",
+    },
+  });
+}
+
+export function buildFileEditStrategy(options: FileEditStrategyOptions): ToolDisplayStrategy {
+  return buildFileToolStrategy({
+    ...options,
+    Icon: FilePenLine,
+    title: "edit",
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/session-detail/tool-strategy/zcode.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/zcode.ts
@@ -4,7 +4,6 @@
  * Pure logic — no React. Consumed by ./index's TOOL_STRATEGY_BUILDERS.
  */
 import type { ToolPart } from "../../../lib/api";
-import { detectLanguageByFilePath } from "../../tool-output/language";
 import type { ToolDetailItem } from "../codex-tool";
 import { buildStructuredDiffFromTexts, buildZCodeEditDiffBlocks } from "../diff";
 import {
@@ -21,12 +20,15 @@ import {
   toRecord,
   toStringValue,
 } from "../tool-normalize";
-import { buildDefaultToolStrategy, extractReadContent, extractWriteContent } from "./shared";
+import {
+  buildDefaultToolStrategy,
+  buildFileEditStrategy,
+  buildFileReadStrategy,
+  buildFileWriteStrategy,
+} from "./shared";
 import {
   Bot,
-  BookOpenText,
   CircleHelp,
-  FilePenLine,
   FilePlus2,
   FileSearch,
   ListTodo,
@@ -160,19 +162,7 @@ export function buildZCodeToolStrategy(
   }
 
   if (toolKey === "read") {
-    return {
-      ...defaultStrategy,
-      Icon: BookOpenText,
-      title: "read",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractReadContent(state.outputValue),
-        language: detectLanguageByFilePath(filePath),
-        isCode: true,
-      },
-    };
+    return buildFileReadStrategy({ defaultStrategy, state, filePath, displayPath });
   }
 
   if (toolKey === "edit") {
@@ -186,11 +176,9 @@ export function buildZCodeToolStrategy(
     );
     const blocks = diffBlocks.length > 0 ? diffBlocks : fallbackDiffBlocks;
     const display = toRecord(metadata.display);
-    return {
-      ...defaultStrategy,
-      Icon: FilePenLine,
-      title: "edit",
-      secondaryText: displayPath || undefined,
+    return buildFileEditStrategy({
+      defaultStrategy,
+      displayPath,
       details: [
         typeof display.additions === "number"
           ? { label: "Additions", value: String(display.additions) }
@@ -199,28 +187,21 @@ export function buildZCodeToolStrategy(
           ? { label: "Deletions", value: String(display.deletions) }
           : null,
       ].filter((item): item is ToolDetailItem => item != null),
-      showInputPreview: false,
       outputContent:
         blocks.length > 0
           ? { kind: "structured-diff", blocks }
           : { kind: "plain", text: outputText, language: "text", isCode: false },
-    };
+    });
   }
 
   if (toolKey === "write") {
-    return {
-      ...defaultStrategy,
+    return buildFileWriteStrategy({
+      defaultStrategy,
+      state,
+      filePath,
+      displayPath,
       Icon: FilePlus2,
-      title: "write",
-      secondaryText: displayPath || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: extractWriteContent(state),
-        language: detectLanguageByFilePath(filePath),
-        isCode: state.status === "completed",
-      },
-    };
+    });
   }
 
   if (toolKey === "glob" || toolKey === "grep") {


### PR DESCRIPTION
## Summary

- centralize the common read, write, and edit display shape for Claude Code, OpenCode, Pi, ZCode, Kimi, and Cursor
- keep semantic output, structured diffs, metadata, icons, and Cursor extraction as explicit agent-specific inputs
- cover the shared contract with cross-agent read, edit, and write cases

## Behavior change

OpenCode and Kimi file-tool labels now use the canonical lowercase read, edit, and write titles instead of preserving agent-specific casing or titles.

## Testing

- pnpm build
- pnpm lint
- pnpm format:check
- pnpm test
- pnpm test:migration
- pnpm test:coverage
- pnpm test:e2e