### PR TITLE
fix(api): distinguish alias validation errors

### DIFF
--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../logging.js", () => ({ appLogger: loggerMocks }));
 
 import {
   BookmarkStorageUnavailableError,
+  SessionAliasValidationError,
   StateStorageUnavailableError,
   type BookmarkRecord,
   type LiveSnapshot,
@@ -54,6 +55,7 @@ import {
   handlePutSessionAlias,
   type ScanResultSource,
 } from "../handlers.js";
+import { createApiRoutes } from "../routes.js";
 import { invalidateAliasView } from "../session-aliases-view.js";
 
 interface ContextOptions {
@@ -470,7 +472,7 @@ describe("session alias handlers", () => {
     );
 
     coreMocks.upsertSessionAlias.mockImplementationOnce(() => {
-      throw new TypeError("invalid alias");
+      throw new SessionAliasValidationError();
     });
     const invalid = makeContext({
       body: { alias: " " },
@@ -481,6 +483,27 @@ describe("session alias handlers", () => {
       { error: "Session alias must be non-empty and at most 160 characters" },
       400,
     );
+  });
+
+  it("lets internal TypeErrors reach the HTTP error boundary", async () => {
+    coreMocks.upsertSessionAlias.mockImplementationOnce(() => {
+      throw new TypeError("Cannot read properties of undefined");
+    });
+    const app = createApiRoutes(scanSource);
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const response = await app.request("http://localhost/session-aliases/codex/s1", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ alias: "Renamed" }),
+      });
+
+      expect(response.status).toBe(500);
+      expect(errorLog).toHaveBeenCalledWith(expect.any(TypeError));
+    } finally {
+      errorLog.mockRestore();
+    }
   });
 
   it("maps unavailable alias storage and rethrows unexpected write failures", async () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -15,7 +15,7 @@ import {
   type SessionReference,
 } from "@codesesh/core/contract";
 import {
-  BookmarkStorageUnavailableError,
+  SessionAliasValidationError,
   StateStorageUnavailableError,
   attachProjectMetrics,
   createProjectScopeMatcher,
@@ -109,6 +109,20 @@ interface ClientLogPayload {
 
 interface SessionAliasPayload {
   alias?: unknown;
+}
+
+function withStorageErrors<TResult, TFallback>(
+  handler: () => TResult,
+  onUnavailable: () => TFallback,
+): TResult | TFallback {
+  try {
+    return handler();
+  } catch (error) {
+    if (error instanceof StateStorageUnavailableError) {
+      return onUnavailable();
+    }
+    throw error;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -520,18 +534,16 @@ export async function handlePostClientLog(c: Context) {
 }
 
 export function handleGetBookmarks(c: Context) {
-  try {
-    const aliases = loadAliasView();
-    return c.json({
-      bookmarks: listBookmarks().map((bookmark) => decorateBookmark(bookmark, aliases)),
-      storageAvailable: true,
-    });
-  } catch (error) {
-    if (error instanceof BookmarkStorageUnavailableError) {
-      return c.json({ bookmarks: [], storageAvailable: false });
-    }
-    throw error;
-  }
+  return withStorageErrors(
+    () => {
+      const aliases = loadAliasView();
+      return c.json({
+        bookmarks: listBookmarks().map((bookmark) => decorateBookmark(bookmark, aliases)),
+        storageAvailable: true,
+      });
+    },
+    () => c.json({ bookmarks: [], storageAvailable: false }),
+  );
 }
 
 export async function handlePutBookmark(c: Context) {
@@ -540,14 +552,10 @@ export async function handlePutBookmark(c: Context) {
     return c.json({ error: "Invalid bookmark payload" }, 400);
   }
 
-  try {
-    return c.json({ bookmark: upsertBookmark(payload), storageAvailable: true });
-  } catch (error) {
-    if (error instanceof BookmarkStorageUnavailableError) {
-      return c.json({ error: "Bookmark storage is unavailable" }, 503);
-    }
-    throw error;
-  }
+  return withStorageErrors(
+    () => c.json({ bookmark: upsertBookmark(payload), storageAvailable: true }),
+    () => c.json({ error: "Bookmark storage is unavailable" }, 503),
+  );
 }
 
 export async function handleImportBookmarks(c: Context) {
@@ -564,14 +572,10 @@ export async function handleImportBookmarks(c: Context) {
     return c.json({ error: "Invalid bookmark payload" }, 400);
   }
 
-  try {
-    return c.json({ bookmarks: importBookmarks(bookmarks), storageAvailable: true });
-  } catch (error) {
-    if (error instanceof BookmarkStorageUnavailableError) {
-      return c.json({ error: "Bookmark storage is unavailable" }, 503);
-    }
-    throw error;
-  }
+  return withStorageErrors(
+    () => c.json({ bookmarks: importBookmarks(bookmarks), storageAvailable: true }),
+    () => c.json({ error: "Bookmark storage is unavailable" }, 503),
+  );
 }
 
 export function handleDeleteBookmark(c: Context) {
@@ -581,35 +585,36 @@ export function handleDeleteBookmark(c: Context) {
     return c.json({ error: "Missing bookmark identifier" }, 400);
   }
 
-  try {
-    deleteBookmark({ agentName: agentKey, sessionId });
-    return c.json({ ok: true, storageAvailable: true });
-  } catch (error) {
-    if (error instanceof BookmarkStorageUnavailableError) {
-      return c.json({ error: "Bookmark storage is unavailable" }, 503);
-    }
-    throw error;
-  }
+  return withStorageErrors(
+    () => {
+      deleteBookmark({ agentName: agentKey, sessionId });
+      return c.json({ ok: true, storageAvailable: true });
+    },
+    () => c.json({ error: "Bookmark storage is unavailable" }, 503),
+  );
 }
 
 export async function handlePutSessionAlias(c: Context) {
   const agentKey = c.req.param("agent");
   const sessionId = c.req.param("id");
   const payload = (await c.req.json().catch(() => null)) as SessionAliasPayload | null;
-  if (!agentKey || !sessionId || typeof payload?.alias !== "string") {
+  const aliasValue = payload?.alias;
+  if (!agentKey || !sessionId || typeof aliasValue !== "string") {
     return c.json({ error: "Invalid session alias payload" }, 400);
   }
 
   try {
-    const alias = upsertSessionAlias({ agentName: agentKey, sessionId }, payload.alias);
-    invalidateAliasView();
-    return c.json({ alias });
+    return withStorageErrors(
+      () => {
+        const alias = upsertSessionAlias({ agentName: agentKey, sessionId }, aliasValue);
+        invalidateAliasView();
+        return c.json({ alias });
+      },
+      () => c.json({ error: "Session alias storage is unavailable" }, 503),
+    );
   } catch (error) {
-    if (error instanceof TypeError) {
+    if (error instanceof SessionAliasValidationError) {
       return c.json({ error: "Session alias must be non-empty and at most 160 characters" }, 400);
-    }
-    if (error instanceof StateStorageUnavailableError) {
-      return c.json({ error: "Session alias storage is unavailable" }, 503);
     }
     throw error;
   }
@@ -622,16 +627,14 @@ export function handleDeleteSessionAlias(c: Context) {
     return c.json({ error: "Missing session alias identifier" }, 400);
   }
 
-  try {
-    deleteSessionAlias({ agentName: agentKey, sessionId });
-    invalidateAliasView();
-    return c.json({ ok: true });
-  } catch (error) {
-    if (error instanceof StateStorageUnavailableError) {
-      return c.json({ error: "Session alias storage is unavailable" }, 503);
-    }
-    throw error;
-  }
+  return withStorageErrors(
+    () => {
+      deleteSessionAlias({ agentName: agentKey, sessionId });
+      invalidateAliasView();
+      return c.json({ ok: true });
+    },
+    () => c.json({ error: "Session alias storage is unavailable" }, 503),
+  );
 }
 
 export function handleGetDashboard(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,6 +75,7 @@ export {
   importBookmarks,
   listBookmarks,
   listSessionAliases,
+  SessionAliasValidationError,
   StateStorageUnavailableError,
   upsertBookmark,
   upsertSessionAlias,

--- a/packages/core/src/state/__tests__/session-aliases.test.ts
+++ b/packages/core/src/state/__tests__/session-aliases.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { join } from "node:path";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { deleteSessionAlias, listSessionAliases, upsertSessionAlias } from "../session-aliases.js";
+import {
+  deleteSessionAlias,
+  listSessionAliases,
+  SessionAliasValidationError,
+  upsertSessionAlias,
+} from "../session-aliases.js";
 import { setStateSchemaEnsuredPath } from "../database.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-aliases-test-"));
@@ -64,5 +69,14 @@ describe("session aliases", () => {
 
     deleteSessionAlias(reference);
     expect(listSessionAliases()).toEqual([]);
+  });
+
+  it("rejects invalid aliases with a named validation error", () => {
+    const reference = { agentName: "codex", sessionId: "s1" };
+
+    expect(() => upsertSessionAlias(reference, " ")).toThrow(SessionAliasValidationError);
+    expect(() => upsertSessionAlias(reference, "x".repeat(161))).toThrow(
+      SessionAliasValidationError,
+    );
   });
 });

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -11,6 +11,7 @@ export {
   listSessionAliases,
   normalizeSessionAlias,
   SESSION_ALIAS_MAX_LENGTH,
+  SessionAliasValidationError,
   StateStorageUnavailableError,
   upsertSessionAlias,
   type SessionAlias,

--- a/packages/core/src/state/session-aliases.ts
+++ b/packages/core/src/state/session-aliases.ts
@@ -4,6 +4,13 @@ import { normalizeSessionReference, type SessionReference } from "../contract/in
 
 export const SESSION_ALIAS_MAX_LENGTH = 160;
 
+export class SessionAliasValidationError extends Error {
+  constructor() {
+    super("Invalid session alias");
+    this.name = "SessionAliasValidationError";
+  }
+}
+
 export interface SessionAlias {
   reference: SessionReference;
   alias: string;
@@ -63,7 +70,7 @@ export function listSessionAliases(): SessionAlias[] {
 export function upsertSessionAlias(reference: SessionReference, alias: string): SessionAlias {
   const normalizedAlias = normalizeSessionAlias(alias);
   if (!normalizedAlias) {
-    throw new TypeError("Invalid session alias");
+    throw new SessionAliasValidationError();
   }
 
   const normalizedReference = normalizeSessionReference(reference);


### PR DESCRIPTION
## Summary

- centralize storage-unavailable handling across bookmark and session-alias handlers while preserving existing response shapes
- introduce `SessionAliasValidationError` instead of using `TypeError` as an input-validation signal
- let unexpected internal `TypeError` failures reach the HTTP 500 boundary

## Testing

- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter codesesh exec vitest run src/api/__tests__/handlers-state.test.ts`