### PR TITLE
fix(cache): avoid blocking startup on message migration

### DIFF
--- a/packages/cli/src/diagnostics-bridge.ts
+++ b/packages/cli/src/diagnostics-bridge.ts
@@ -9,6 +9,9 @@ import { appLogger } from "./logging.js";
  * diagnostics singleton is per-thread, not shared across workers.
  */
 setCoreDiagnostics({
+  info(event, detail) {
+    appLogger.info(event, detail);
+  },
   warn(event, detail) {
     appLogger.warn(event, detail);
   },

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -302,7 +302,7 @@ describe("sqlite migration smoke", () => {
       "indexed_message_count",
       "indexed_at",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(16);
+    expect(getUserVersion(getCachePath())).toBe(17);
     expect(getUserVersion(getStatePath())).toBe(2);
   }, 30_000);
 });

--- a/packages/core/src/discovery/cache/__tests__/messages.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/messages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildMessageText,
   buildSessionContentFromMessages,
+  MESSAGE_PARTS_FORMAT_VERSION,
   messageFromCachedRow,
   messageJsonFromCachedRow,
   normalizeMessages,
@@ -41,7 +42,7 @@ describe("cached messages", () => {
       role: "assistant" as const,
       time_created: 10,
       time_completed: 11,
-      cache_version: 16,
+      parts_format_version: MESSAGE_PARTS_FORMAT_VERSION,
       parts_json: JSON.stringify([{ type: "text", text: "done" }]),
       tokens_json: JSON.stringify({ input: 2, output: 3 }),
       cost: 0.4,
@@ -64,7 +65,7 @@ describe("cached messages", () => {
       message_id: "m1",
       role: "assistant" as const,
       time_created: 10,
-      cache_version: 15,
+      parts_format_version: 0,
       parts_json: JSON.stringify([
         {
           type: "tool",

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -36,6 +36,9 @@ describe("cache schema boundary", () => {
         documentColumns: (
           db.prepare("PRAGMA table_info(session_documents)").all() as Array<{ name: string }>
         ).map((row) => row.name),
+        messageColumns: (
+          db.prepare("PRAGMA table_info(messages)").all() as Array<{ name: string }>
+        ).map((row) => row.name),
         version: Number(
           (db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined)
             ?.user_version ?? 0,
@@ -62,7 +65,8 @@ describe("cache schema boundary", () => {
       "indexed_message_count",
       "indexed_at",
     ]);
-    expect(state?.version).toBe(16);
+    expect(state?.messageColumns).toContain("parts_format_version");
+    expect(state?.version).toBe(17);
   });
 
   it("exposes capabilities instead of migration steps", () => {
@@ -75,76 +79,73 @@ describe("cache schema boundary", () => {
     ]);
   });
 
-  it("normalizes legacy message parts once during migration", () => {
-    schema.withCacheDb(() => undefined);
+  it.each([15, 16])(
+    "upgrades a v%s cache without rewriting legacy message payloads",
+    (legacyVersion) => {
+      schema.withCacheDb(() => undefined);
 
-    const legacyDb = new Database(getCachePath());
-    legacyDb.pragma("foreign_keys = OFF");
-    legacyDb
-      .prepare(
-        `
-          INSERT INTO messages(
-            agent_name,
-            session_id,
-            message_index,
-            message_id,
-            role,
-            time_created,
-            parts_json,
-            content_text
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        `,
-      )
-      .run(
-        "codex",
-        "legacy",
-        0,
-        "m1",
-        "assistant",
-        1,
-        JSON.stringify([
-          {
-            type: "tool",
-            tool: "Read",
-            state: { status: "success", arguments: { path: "src/a.ts" }, result: "done" },
-          },
-        ]),
-        "legacy",
-      );
-    legacyDb.pragma("user_version = 15");
-    legacyDb.prepare("UPDATE cache_meta SET value = '15' WHERE key = 'version'").run();
-    legacyDb.close();
-    setSchemaEnsuredPath(null);
-
-    const migrated = schema.withCacheDb((db) => ({
-      version: Number(
-        (db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined)
-          ?.user_version ?? 0,
-      ),
-      parts: JSON.parse(
-        String(
-          (
-            db.prepare("SELECT parts_json FROM messages WHERE message_id = 'm1'").get() as {
-              parts_json?: string;
-            }
-          ).parts_json,
-        ),
-      ) as unknown,
-    }));
-
-    expect(migrated).toEqual({
-      version: 16,
-      parts: [
+      const legacyDb = new Database(getCachePath());
+      legacyDb.pragma("foreign_keys = OFF");
+      legacyDb.exec("ALTER TABLE messages DROP COLUMN parts_format_version");
+      const legacyPartsJson = JSON.stringify([
         {
           type: "tool",
           tool: "Read",
-          state: {
-            status: "completed",
-            input: { path: "src/a.ts" },
-            output: "done",
-          },
+          state: { status: "success", arguments: { path: "src/a.ts" }, result: "done" },
         },
-      ],
-    });
-  });
+      ]);
+      legacyDb
+        .prepare(
+          `
+            INSERT INTO messages(
+              agent_name,
+              session_id,
+              message_index,
+              message_id,
+              role,
+              time_created,
+              parts_json,
+              content_text
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+          `,
+        )
+        .run("codex", "legacy", 0, "m1", "assistant", 1, legacyPartsJson, "legacy");
+      legacyDb.exec(`
+        CREATE TRIGGER reject_message_parts_rewrite
+        BEFORE UPDATE OF parts_json ON messages
+        BEGIN
+          SELECT RAISE(ABORT, 'legacy message payload must not be rewritten');
+        END;
+      `);
+      legacyDb.pragma(`user_version = ${legacyVersion}`);
+      legacyDb
+        .prepare("UPDATE cache_meta SET value = ? WHERE key = 'version'")
+        .run(String(legacyVersion));
+      legacyDb.close();
+      setSchemaEnsuredPath(null);
+
+      const migrated = schema.withCacheDb((db) => {
+        const row = db
+          .prepare("SELECT parts_json, parts_format_version FROM messages WHERE message_id = 'm1'")
+          .get() as {
+          parts_json?: string;
+          parts_format_version?: number;
+        };
+        return {
+          version: Number(
+            (db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined)
+              ?.user_version ?? 0,
+          ),
+          partsJson: row.parts_json,
+          partsFormatVersion: Number(row.parts_format_version),
+        };
+      });
+
+      expect(migrated).toEqual({
+        version: 17,
+        partsJson: legacyPartsJson,
+        partsFormatVersion: 0,
+      });
+    },
+  );
 });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -17,6 +17,7 @@ import {
   syncSessionSearchIndexChanges,
 } from "../search.js";
 import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
+import { MESSAGE_PARTS_FORMAT_VERSION } from "../messages.js";
 import { withCacheDb } from "../schema.js";
 import type { SessionDetail, SessionHead } from "../../../types/index.js";
 
@@ -679,7 +680,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(16);
+    expect(getUserVersion(getCachePath())).toBe(17);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -1042,19 +1043,21 @@ describe("searchSessions", () => {
     try {
       const rows = db
         .prepare(
-          "SELECT message_id, role, content_text, tool_metadata_json FROM messages ORDER BY message_index",
+          "SELECT message_id, role, content_text, tool_metadata_json, parts_format_version FROM messages ORDER BY message_index",
         )
         .all() as Array<{
         message_id?: string;
         role?: string;
         content_text?: string;
         tool_metadata_json?: string | null;
+        parts_format_version?: number;
       }>;
 
       expect(rows).toHaveLength(1);
       expect(rows[0]?.message_id).toBe("m1-updated");
       expect(rows[0]?.role).toBe("user");
       expect(rows[0]?.content_text).toContain("updated sqlite message");
+      expect(rows[0]?.parts_format_version).toBe(MESSAGE_PARTS_FORMAT_VERSION);
     } finally {
       db.close();
     }
@@ -1310,7 +1313,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(16);
+    expect(getUserVersion(getCachePath())).toBe(17);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -201,7 +201,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(16);
+    expect(getUserVersion(getCachePath())).toBe(17);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -212,7 +212,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(16);
+    expect(getUserVersion(getCachePath())).toBe(17);
   });
 });
 
@@ -220,7 +220,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(16);
+    expect(getUserVersion(getCachePath())).toBe(17);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -408,7 +408,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(16);
+    expect(getUserVersion(getCachePath())).toBe(17);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -17,7 +17,7 @@ import { computeIdentity, realFs } from "../../projects/index.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import type { SQLiteStatement } from "./db.js";
 
-const NORMALIZED_MESSAGE_PARTS_CACHE_VERSION = 16;
+export const MESSAGE_PARTS_FORMAT_VERSION = 1;
 
 export interface SessionRow extends DatabaseRow {
   agent_name?: string;
@@ -62,7 +62,7 @@ export interface MessageBackfillRow extends DatabaseRow {
 }
 
 export interface CachedMessageRow extends MessageBackfillRow {
-  cache_version?: number | string;
+  parts_format_version?: number | string;
   tokens_json?: string | null;
   cost?: number | null;
   cost_source?: SessionHead["stats"]["cost_source"] | null;
@@ -421,7 +421,7 @@ export function messageJsonFromCachedRow(row: CachedMessageRow): string {
     fields.push(`"cost_source":${JSON.stringify(row.cost_source)}`);
   }
   const partsJson =
-    Number(row.cache_version) >= NORMALIZED_MESSAGE_PARTS_CACHE_VERSION
+    Number(row.parts_format_version) >= MESSAGE_PARTS_FORMAT_VERSION
       ? String(row.parts_json ?? "[]")
       : normalizeMessagePartsJson(row.parts_json);
   fields.push(`"parts":${partsJson}`);

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -27,7 +27,6 @@ import {
 } from "./db.js";
 import {
   messageFromBackfillRow,
-  normalizeMessagePartsJson,
   prepareInsertFileActivity,
   prepareInsertMessageTool,
   prepareUpsertSession,
@@ -39,17 +38,12 @@ import {
   type SessionRow,
 } from "./messages.js";
 
-const CACHE_SCHEMA_VERSION = 16;
+const CACHE_SCHEMA_VERSION = 17;
 interface MessageToolBackfillRow extends DatabaseRow {
   agent_name?: string;
   session_id?: string;
   message_index?: number;
   tool_metadata_json?: string | null;
-}
-
-interface MessagePartsMigrationRow extends DatabaseRow {
-  rowid?: number;
-  parts_json?: string;
 }
 
 interface ProjectBackfillSessionRow extends DatabaseRow {
@@ -250,6 +244,7 @@ function createSessionTables(db: SQLiteDatabase): void {
       cost REAL,
       cost_source TEXT,
       parts_json TEXT NOT NULL,
+      parts_format_version INTEGER NOT NULL DEFAULT 0,
       subagent_id TEXT,
       nickname TEXT,
       content_text TEXT NOT NULL,
@@ -1038,17 +1033,11 @@ function compactSessionDocuments(db: SQLiteDatabase): void {
   `);
 }
 
-function normalizeCachedMessageParts(db: SQLiteDatabase): void {
-  if (!tableExists(db, "messages")) return;
-
-  const rows = db
-    .prepare("SELECT rowid, parts_json FROM messages")
-    .all() as MessagePartsMigrationRow[];
-  const update = db.prepare("UPDATE messages SET parts_json = ? WHERE rowid = ?");
-  for (const row of rows) {
-    if (row.rowid == null) continue;
-    update.run(normalizeMessagePartsJson(row.parts_json), row.rowid);
+function addMessagePartsFormatVersion(db: SQLiteDatabase): void {
+  if (!tableExists(db, "messages") || columnExists(db, "messages", "parts_format_version")) {
+    return;
   }
+  db.exec("ALTER TABLE messages ADD COLUMN parts_format_version INTEGER NOT NULL DEFAULT 0");
 }
 
 const CODEX_EXEC_DECODE_MIGRATION_KEY = "codex_exec_decode_migrated_v3";
@@ -1210,7 +1199,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 13, migrate: createCacheTables },
       { version: 14, migrate: addIndexedMessageCount },
       { version: 15, destructive: true, migrate: compactSessionDocuments },
-      { version: 16, migrate: normalizeCachedMessageParts },
+      { version: 17, migrate: addMessagePartsFormatVersion },
     ],
   });
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -5,6 +5,7 @@ import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { SEARCH_INDEX_BULK_SYNC_THRESHOLD, type SessionHeadChange } from "./db.js";
 import {
   buildSessionContentFromMessages,
+  MESSAGE_PARTS_FORMAT_VERSION,
   normalizeMessages,
   prepareInsertFileActivity,
   prepareInsertMessageTool,
@@ -243,11 +244,12 @@ function writeSearchIndexRows(
       cost,
       cost_source,
       parts_json,
+      parts_format_version,
       subagent_id,
       nickname,
       content_text,
       tool_metadata_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id, message_index) DO UPDATE SET
       message_id = excluded.message_id,
       role = excluded.role,
@@ -261,6 +263,7 @@ function writeSearchIndexRows(
       cost = excluded.cost,
       cost_source = excluded.cost_source,
       parts_json = excluded.parts_json,
+      parts_format_version = excluded.parts_format_version,
       subagent_id = excluded.subagent_id,
       nickname = excluded.nickname,
       content_text = excluded.content_text,
@@ -320,6 +323,7 @@ function writeSearchIndexRows(
         message.cost ?? null,
         message.costSource ?? null,
         message.partsJson,
+        MESSAGE_PARTS_FORMAT_VERSION,
         message.subagentId ?? null,
         message.nickname ?? null,
         message.contentText,

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -288,7 +288,7 @@ export function loadCachedSessionRawEntry(
             cost,
             cost_source,
             parts_json,
-            (SELECT value FROM cache_meta WHERE key = 'version') AS cache_version,
+            parts_format_version,
             subagent_id,
             nickname
           FROM messages

--- a/packages/core/src/utils/__tests__/diagnostics.test.ts
+++ b/packages/core/src/utils/__tests__/diagnostics.test.ts
@@ -11,12 +11,23 @@ describe("core diagnostics", () => {
   });
 
   it("returns a sink that forwards to the injected one until reset", () => {
-    const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];
-    const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
+    const calls: Array<{
+      level: "info" | "warn";
+      event: string;
+      detail?: Record<string, unknown>;
+    }> = [];
+    const sink: CoreDiagnostics = {
+      info: (event, detail) => calls.push({ level: "info", event, detail }),
+      warn: (event, detail) => calls.push({ level: "warn", event, detail }),
+    };
     setCoreDiagnostics(sink);
 
+    getCoreDiagnostics()?.info?.("test.started", { version: 1 });
     getCoreDiagnostics()?.warn("test.event", { a: 1 });
-    expect(calls).toEqual([{ event: "test.event", detail: { a: 1 } }]);
+    expect(calls).toEqual([
+      { level: "info", event: "test.started", detail: { version: 1 } },
+      { level: "warn", event: "test.event", detail: { a: 1 } },
+    ]);
 
     setCoreDiagnostics(null);
     expect(getCoreDiagnostics()).toBeNull();
@@ -24,12 +35,16 @@ describe("core diagnostics", () => {
 
   it("swallows exceptions thrown by an injected sink", () => {
     const sink: CoreDiagnostics = {
+      info: () => {
+        throw new Error("sink boom");
+      },
       warn: () => {
         throw new Error("sink boom");
       },
     };
     setCoreDiagnostics(sink);
 
+    expect(() => getCoreDiagnostics()?.info?.("test.event")).not.toThrow();
     expect(() => getCoreDiagnostics()?.warn("test.event")).not.toThrow();
   });
 });

--- a/packages/core/src/utils/__tests__/sqlite.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite.test.ts
@@ -7,11 +7,33 @@ import {
   backupDatabaseIfPopulated,
   openDb,
   openDbReadOnly,
+  runSchemaMigrations,
   type SQLiteDatabase,
 } from "../sqlite.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
 
 describe("sqlite migration helpers", () => {
+  afterEach(() => {
+    setCoreDiagnostics(null);
+  });
+
+  function collectMigrationDiagnostics(): Array<{
+    level: "info" | "warn";
+    event: string;
+    detail?: Record<string, unknown>;
+  }> {
+    const events: Array<{
+      level: "info" | "warn";
+      event: string;
+      detail?: Record<string, unknown>;
+    }> = [];
+    setCoreDiagnostics({
+      info: (event, detail) => events.push({ level: "info", event, detail }),
+      warn: (event, detail) => events.push({ level: "warn", event, detail }),
+    });
+    return events;
+  }
+
   it("skips backups for in-memory databases", () => {
     const db = new Database(":memory:") as unknown as SQLiteDatabase;
     try {
@@ -23,6 +45,87 @@ describe("sqlite migration helpers", () => {
       `);
 
       expect(backupDatabaseIfPopulated(db, ":memory:", "migration", ["rows"])).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("reports migration start and completion", () => {
+    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    const events = collectMigrationDiagnostics();
+    try {
+      runSchemaMigrations(db, {
+        dbPath: ":memory:",
+        currentVersion: 0,
+        targetVersion: 1,
+        migrations: [{ version: 1, migrate: (database) => database.exec("CREATE TABLE rows(id)") }],
+        backupTables: [],
+        backupLabel: "test-migration",
+      });
+
+      expect(events).toEqual([
+        {
+          level: "info",
+          event: "sqlite.migration.started",
+          detail: {
+            label: "test-migration",
+            from_version: 0,
+            to_version: 1,
+            destructive: false,
+          },
+        },
+        {
+          level: "info",
+          event: "sqlite.migration.completed",
+          detail: expect.objectContaining({
+            label: "test-migration",
+            from_version: 0,
+            to_version: 1,
+            destructive: false,
+            backup_created: false,
+            duration_ms: expect.any(Number),
+          }),
+        },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("reports migration failures before rethrowing", () => {
+    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    const events = collectMigrationDiagnostics();
+    try {
+      expect(() =>
+        runSchemaMigrations(db, {
+          dbPath: ":memory:",
+          currentVersion: 0,
+          targetVersion: 1,
+          migrations: [
+            {
+              version: 1,
+              migrate() {
+                throw new Error("migration boom");
+              },
+            },
+          ],
+          backupTables: [],
+          backupLabel: "test-migration",
+        }),
+      ).toThrow("migration boom");
+
+      expect(events.map(({ level, event }) => ({ level, event }))).toEqual([
+        { level: "info", event: "sqlite.migration.started" },
+        { level: "warn", event: "sqlite.migration.failed" },
+      ]);
+      expect(events[1]?.detail).toEqual(
+        expect.objectContaining({
+          from_version: 0,
+          to_version: 1,
+          message: "migration boom",
+          duration_ms: expect.any(Number),
+        }),
+      );
     } finally {
       db.close();
     }

--- a/packages/core/src/utils/diagnostics.ts
+++ b/packages/core/src/utils/diagnostics.ts
@@ -6,6 +6,7 @@
  */
 
 export interface CoreDiagnostics {
+  info?(event: string, detail?: Record<string, unknown>): void;
   warn(event: string, detail?: Record<string, unknown>): void;
 }
 
@@ -19,6 +20,11 @@ let diagnostics: CoreDiagnostics | null = null;
  */
 function toSafeSink(sink: CoreDiagnostics): CoreDiagnostics {
   return {
+    info(event, detail) {
+      try {
+        sink.info?.(event, detail);
+      } catch {}
+    },
     warn(event, detail) {
       try {
         sink.warn(event, detail);

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -177,24 +177,55 @@ export function runSchemaMigrations(
       break;
     }
 
-    if (migration.destructive) {
-      const backupPath = backupDatabaseIfPopulated(
-        db,
-        options.dbPath,
-        options.backupLabel,
-        options.backupTables,
-      );
-      if (backupPath) {
-        backups.push(backupPath);
-      }
-    }
-
-    const apply = db.transaction(() => {
-      migration.migrate(db);
-      setUserVersion(db, migration.version);
+    const fromVersion = currentVersion;
+    const startedAt = performance.now();
+    getCoreDiagnostics()?.info?.("sqlite.migration.started", {
+      label: options.backupLabel,
+      from_version: fromVersion,
+      to_version: migration.version,
+      destructive: migration.destructive ?? false,
     });
-    apply();
-    currentVersion = migration.version;
+
+    try {
+      let backupCreated = false;
+      if (migration.destructive) {
+        const backupPath = backupDatabaseIfPopulated(
+          db,
+          options.dbPath,
+          options.backupLabel,
+          options.backupTables,
+        );
+        if (backupPath) {
+          backups.push(backupPath);
+          backupCreated = true;
+        }
+      }
+
+      const apply = db.transaction(() => {
+        migration.migrate(db);
+        setUserVersion(db, migration.version);
+      });
+      apply();
+      currentVersion = migration.version;
+      getCoreDiagnostics()?.info?.("sqlite.migration.completed", {
+        label: options.backupLabel,
+        from_version: fromVersion,
+        to_version: migration.version,
+        destructive: migration.destructive ?? false,
+        backup_created: backupCreated,
+        duration_ms: Math.round(performance.now() - startedAt),
+      });
+    } catch (error) {
+      getCoreDiagnostics()?.warn("sqlite.migration.failed", {
+        label: options.backupLabel,
+        from_version: fromVersion,
+        to_version: migration.version,
+        destructive: migration.destructive ?? false,
+        duration_ms: Math.round(performance.now() - startedAt),
+        message: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
   }
 
   if (currentVersion < options.targetVersion) {


### PR DESCRIPTION
## Summary

- replace the eager v16 `messages.parts_json` rewrite with a metadata-only v17 schema migration
- track the message-parts format per row so legacy payloads normalize at the read boundary while new rows keep the zero-parse streaming path
- log SQLite migration start, completion, failure, version boundaries, and duration

## Root cause

The v16 migration loaded every cached message payload with `.all()` and rewrote every row inside one startup transaction. On a 5.1 GB cache, this blocked the CLI before the HTTP server started and produced a 1.2 GB WAL. Interrupting the process rolled back the schema version to v15, so every restart repeated the full migration.

## Impact

Legacy v15 caches and caches that already completed the old v16 migration now upgrade through the same v17 compatibility path. Historical payloads are not read or rewritten during migration. They remain compatible through boundary normalization and are naturally replaced when sessions are re-indexed.

## Validation

- `pnpm test` — core 502, CLI 248, web 413 tests passed
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- 100,000-row legacy fixture migrated in 2 ms with a trigger rejecting any `parts_json` update
- the original 5.1 GB cache migrated in 1 ms and the CLI reached `ready` in 152 ms; all 110,334 messages were preserved and the WAL returned from 1.2 GB to 0 B

## Tracking

CS-129 — v0.17.0