### PR TITLE
fix(cache): avoid startup FTS integrity checks

### DIFF
--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -57,4 +57,84 @@ describe("AppSidebar agent counts", () => {
     expect(codexLink.textContent).toContain("5");
     expect(codexLink.textContent).not.toContain("1856");
   });
+
+  it("uses indeterminate progress for indexing and determinate progress for known totals", () => {
+    const agents = [
+      { name: "codex", displayName: "Codex", count: 5 },
+      { name: "claudecode", displayName: "Claude Code", count: 8 },
+    ] as AgentInfo[];
+    const scanStatus = {
+      type: "scan-status",
+      active: true,
+      phase: "scanning",
+      pendingAgents: [],
+      scanningAgents: ["codex", "claudecode"],
+      completedAgents: [],
+      totalAgents: 2,
+      updatedAt: 1,
+      backfill: {
+        active: false,
+        pendingAgents: [],
+        completedAgents: [],
+        failedAgents: [],
+      },
+      agentStatuses: {
+        codex: {
+          agentName: "codex",
+          status: "indexing",
+          processed: 5,
+          total: 5,
+          updatedAt: 1,
+        },
+        claudecode: {
+          agentName: "claudecode",
+          status: "scanning",
+          processed: 4,
+          total: 10,
+          updatedAt: 1,
+        },
+      },
+    } satisfies ScanStatusEvent;
+
+    render(
+      <MemoryRouter>
+        <AppSidebar
+          model={{
+            sidebarCollapsed: false,
+            browseBy: "agents",
+            isScanActive: true,
+            viewState: { mode: "root", activeAgentKey: null, activeSessionId: null },
+            agents,
+            agentCatalog: createAgentCatalog(agents),
+            activeAgentKey: null,
+            scanStatus,
+            projects: [],
+            selectedProjectNavigationId: null,
+            loading: false,
+            bookmarkedSessions: [],
+            sidebarSessions: [],
+            selectedSidebarSessionReference: null,
+            bookmarkedSidebarSessionReferences: new Set(),
+          }}
+          actions={actions}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Indexing")).toBeTruthy();
+    const indexingProgress = screen.getByRole("progressbar", {
+      name: "Codex indexing progress",
+    });
+    expect(indexingProgress.getAttribute("aria-valuenow")).toBeNull();
+    expect(
+      indexingProgress.firstElementChild?.classList.contains("scan-progress-indeterminate"),
+    ).toBe(true);
+
+    expect(screen.getByText("4/10")).toBeTruthy();
+    const scanningProgress = screen.getByRole("progressbar", {
+      name: "Claude Code scan progress",
+    });
+    expect(scanningProgress.getAttribute("aria-valuenow")).toBe("40");
+    expect((scanningProgress.firstElementChild as HTMLElement).style.width).toBe("40%");
+  });
 });

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -1,4 +1,5 @@
 import type {
+  AgentScanStatus,
   AgentInfo,
   BookmarkRecord,
   ApiProjectGroup,
@@ -21,6 +22,20 @@ import { BrowseByToggle } from "./BrowseByToggle";
 import { SidebarFlatSessionList } from "./SidebarFlatSessionList";
 import type { BrowseBy } from "./types";
 
+function agentProgressPercent(status: AgentScanStatus | undefined): number | null {
+  if (
+    status?.status !== "scanning" ||
+    typeof status.total !== "number" ||
+    !Number.isFinite(status.total) ||
+    status.total <= 0 ||
+    typeof status.processed !== "number" ||
+    !Number.isFinite(status.processed)
+  ) {
+    return null;
+  }
+  return Math.min(100, Math.max(0, Math.round((status.processed / status.total) * 100)));
+}
+
 function AgentNavList({
   agents,
   activeAgentKey,
@@ -37,7 +52,9 @@ function AgentNavList({
       {agents.map((agent) => {
         const key = agent.name.toLowerCase();
         const isSelected = key === activeAgentKey;
+        const agentStatus = scanStatus?.agentStatuses[agent.name];
         const agentProgress = formatAgentScanProgress(scanStatus, agent.name);
+        const progressPercent = agentProgressPercent(agentStatus);
         const disabled = isScanActive && agentProgress !== null;
         const className = `ml-4 flex items-center gap-2 rounded-sm border px-3 py-1.5 text-left motion-hover ${
           disabled
@@ -74,20 +91,22 @@ function AgentNavList({
               </Link>
             )}
             {agentProgress ? (
-              <span className="ml-4 mt-1 block h-1 overflow-hidden rounded-sm bg-[var(--console-surface-muted)]">
+              <span
+                className="ml-4 mt-1 block h-1 overflow-hidden rounded-sm bg-[var(--console-surface-muted)]"
+                role="progressbar"
+                aria-label={`${agent.displayName} ${
+                  agentStatus?.status === "indexing" ? "indexing" : "scan"
+                } progress`}
+                aria-valuemin={progressPercent == null ? undefined : 0}
+                aria-valuemax={progressPercent == null ? undefined : 100}
+                aria-valuenow={progressPercent ?? undefined}
+                aria-valuetext={progressPercent == null ? agentProgress : undefined}
+              >
                 <span
-                  className="block h-full bg-[var(--console-accent)]"
-                  style={{
-                    width: `${
-                      scanStatus?.agentStatuses[agent.name]?.total
-                        ? Math.round(
-                            ((scanStatus.agentStatuses[agent.name]?.processed ?? 0) /
-                              scanStatus.agentStatuses[agent.name]!.total!) *
-                              100,
-                          )
-                        : 8
-                    }%`,
-                  }}
+                  className={`block h-full bg-[var(--console-accent)] ${
+                    progressPercent == null ? "scan-progress-indeterminate" : ""
+                  }`}
+                  style={progressPercent == null ? undefined : { width: `${progressPercent}%` }}
                 />
               </span>
             ) : null}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -86,6 +86,16 @@
       scale: 0.96;
     }
   }
+
+  @keyframes scan-progress-indeterminate {
+    from {
+      transform: translateX(-100%);
+    }
+
+    to {
+      transform: translateX(250%);
+    }
+  }
 }
 
 @layer base {
@@ -179,6 +189,7 @@
     --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
     --dur-fast: 120ms;
     --dur-base: 180ms;
+    --scan-progress-duration: 1.2s;
     --tt-in-dur: 150ms;
     --tt-out-dur: 50ms;
     --tt-scale: 0.98;
@@ -308,6 +319,13 @@
     background-image:
       linear-gradient(to right, rgba(0, 0, 0, 0.04) 1px, transparent 1px),
       linear-gradient(to bottom, rgba(0, 0, 0, 0.04) 1px, transparent 1px);
+  }
+
+  .scan-progress-indeterminate {
+    width: 40%;
+    transform: translateX(-100%);
+    animation: scan-progress-indeterminate var(--scan-progress-duration) linear infinite;
+    will-change: transform;
   }
 
   .shortcut-overlay[data-open] {
@@ -653,6 +671,13 @@
 
   .session-timeline-segment {
     transition: none;
+  }
+
+  .scan-progress-indeterminate {
+    width: 40%;
+    transform: translateX(75%);
+    animation: none;
+    opacity: 0.65;
   }
 }
 

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -73,4 +73,18 @@ describe("formatAgentScanProgress", () => {
   it("returns null for complete or missing agent", () => {
     expect(formatAgentScanProgress(null, "codex")).toBeNull();
   });
+
+  it("distinguishes indexing from scanning and pending", () => {
+    const status = {
+      agentStatuses: {
+        codex: { status: "indexing" },
+        claude: { status: "scanning" },
+        kimi: { status: "pending" },
+      },
+    } as unknown as ScanStatusEvent;
+
+    expect(formatAgentScanProgress(status, "codex")).toBe("Indexing");
+    expect(formatAgentScanProgress(status, "claude")).toBe("Scanning");
+    expect(formatAgentScanProgress(status, "kimi")).toBe("Pending");
+  });
 });

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -75,6 +75,7 @@ export function formatAgentScanProgress(
 ): string | null {
   const agentStatus = status?.agentStatuses[agentName];
   if (!agentStatus || agentStatus.status === "complete") return null;
+  if (agentStatus.status === "indexing") return "Indexing";
   if (agentStatus.total && agentStatus.processed != null) {
     return `${agentStatus.processed}/${agentStatus.total}`;
   }

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FileSystemSessionSource } from "@codesesh/core";
 import type { BaseAgent, loadCachedSessions, LiveSnapshot, SessionHead } from "@codesesh/core";
+import type { ScanStatusEvent } from "@codesesh/core/contract";
 import type { WorkerRunner } from "./worker-runner.js";
 
 const core = vi.hoisted(() => ({
@@ -214,10 +215,21 @@ describe("AgentSyncEngine", () => {
       }),
       [previous],
     );
+    const statuses: ScanStatusEvent[] = [];
+    engine.subscribeStatusChanged((status) => statuses.push(status));
 
     const refresh = engine.refresh("codex");
     await vi.waitFor(() => expect(searchIndex.enqueue).toHaveBeenCalledOnce());
     expect(engine.snapshot().sessions[0]?.title).toBe("before");
+    expect(statuses.at(-1)).toEqual(
+      expect.objectContaining({
+        active: true,
+        phase: "indexing",
+        agentStatuses: {
+          codex: expect.objectContaining({ status: "indexing" }),
+        },
+      }),
+    );
 
     commitIndex();
     await refresh;

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -241,6 +241,10 @@ export class AgentSyncEngine {
     this.publishStatus(this.scanStatus.updateAgent(agentName, progress));
   }
 
+  private beginAgentIndexing(agentName: string): void {
+    this.publishStatus(this.scanStatus.indexAgent(agentName));
+  }
+
   private finishAgentScan(agentName: string): void {
     const count = this.sessionIndex.snapshot().byAgent[agentName]?.length;
     this.publishStatus(this.scanStatus.finishAgent(agentName, count));
@@ -342,6 +346,7 @@ export class AgentSyncEngine {
           saveCache: true,
           ...(searchIndexOptions ? { searchIndexOptions } : {}),
         };
+    this.beginAgentIndexing(agentName);
     const publication = await this.commitSessionPublication({
       context: "scan.refresh",
       agentName,

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -2217,22 +2217,4 @@ describe("LiveScanStore", () => {
     expect(worker.terminate).toHaveBeenCalledTimes(1);
     expect(workerThreads.workers.filter((item) => item.workerData.jobs)).toHaveLength(1);
   });
-
-  it("skips the FTS integrity check on search-index batches after the first one completes", async () => {
-    const runner = new SearchIndexJobRunner();
-    const job = {
-      kind: "full" as const,
-      context: "scan.refresh",
-      agentName: "codex",
-      sessions: [],
-      meta: {},
-    };
-    await runner.enqueue("scan.refresh", [job]);
-    await runner.enqueue("scan.refresh", [job]);
-
-    const searchIndexWorkers = workerThreads.workers.filter((worker) => worker.workerData.jobs);
-    expect(searchIndexWorkers).toHaveLength(2);
-    expect(searchIndexWorkers[0]?.workerData.skipFtsIntegrityCheck).toBe(false);
-    expect(searchIndexWorkers[1]?.workerData.skipFtsIntegrityCheck).toBe(true);
-  });
 });

--- a/packages/cli/src/scan-status-model.test.ts
+++ b/packages/cli/src/scan-status-model.test.ts
@@ -85,6 +85,30 @@ describe("ScanStatusModel", () => {
     expect(model.updateAgent("codex", { processed: 2 })).toBeNull();
   });
 
+  it("moves agents from scanning to indexing before completion", () => {
+    const model = new ScanStatusModel();
+    model.startBatch(["codex", "claude"], "scanning", {});
+    model.beginAgent("codex", 2);
+
+    const codexIndexing = model.indexAgent("codex");
+
+    expect(codexIndexing).toEqual(
+      expect.objectContaining({
+        phase: "scanning",
+        pendingAgents: ["claude"],
+      }),
+    );
+    expect(codexIndexing?.agentStatuses.codex?.status).toBe("indexing");
+
+    model.beginAgent("claude", 3);
+    const allIndexing = model.indexAgent("claude");
+    expect(allIndexing?.phase).toBe("indexing");
+
+    const oneRemaining = model.finishAgent("codex");
+    expect(oneRemaining.phase).toBe("indexing");
+    expect(model.updateAgent("claude", { processed: 1 })).toBeNull();
+  });
+
   it("completes unseen agents and normalizes unfinished statuses at batch end", () => {
     const model = new ScanStatusModel();
     const unseen = model.finishAgent("codex");

--- a/packages/cli/src/scan-status-model.ts
+++ b/packages/cli/src/scan-status-model.ts
@@ -131,6 +131,23 @@ export class ScanStatusModel {
     });
   }
 
+  indexAgent(agentName: string): ScanStatusEvent | null {
+    const status = this.status.agentStatuses[agentName];
+    if (!this.status.active || !status || status.status !== "scanning") return null;
+
+    const now = Date.now();
+    const agentStatuses = {
+      ...this.status.agentStatuses,
+      [agentName]: { ...status, status: "indexing" as const, updatedAt: now },
+    };
+    return this.set({
+      ...this.status,
+      phase: this.activePhase(this.status.pendingAgents, this.status.scanningAgents, agentStatuses),
+      agentStatuses,
+      updatedAt: now,
+    });
+  }
+
   finishAgent(agentName: string, sessionCount?: number): ScanStatusEvent {
     const pendingAgents = this.status.pendingAgents.filter((agent) => agent !== agentName);
     const scanningAgents = this.status.scanningAgents.filter((agent) => agent !== agentName);
@@ -139,27 +156,28 @@ export class ScanStatusModel {
     const now = Date.now();
     const previousStatus = this.status.agentStatuses[agentName];
     const total = previousStatus?.total ?? previousStatus?.processed;
+    const agentStatuses = {
+      ...this.status.agentStatuses,
+      [agentName]: {
+        agentName,
+        status: "complete" as const,
+        total,
+        processed: total,
+        sessions: sessionCount ?? previousStatus?.sessions ?? 0,
+        startedAt: previousStatus?.startedAt,
+        updatedAt: now,
+        completedAt: now,
+      },
+    };
 
     return this.set({
       ...this.status,
       active: isActive,
-      phase: isActive ? "scanning" : "idle",
+      phase: isActive ? this.activePhase(pendingAgents, scanningAgents, agentStatuses) : "idle",
       pendingAgents,
       scanningAgents,
       completedAgents,
-      agentStatuses: {
-        ...this.status.agentStatuses,
-        [agentName]: {
-          agentName,
-          status: "complete",
-          total,
-          processed: total,
-          sessions: sessionCount ?? previousStatus?.sessions ?? 0,
-          startedAt: previousStatus?.startedAt,
-          updatedAt: now,
-          completedAt: now,
-        },
-      },
+      agentStatuses,
       updatedAt: now,
       completedAt: isActive ? undefined : now,
     });
@@ -190,6 +208,21 @@ export class ScanStatusModel {
       backfill: { ...this.status.backfill, ...patch },
       updatedAt: Date.now(),
     });
+  }
+
+  private activePhase(
+    pendingAgents: string[],
+    scanningAgents: string[],
+    agentStatuses: ScanStatus["agentStatuses"],
+  ): ScanStatusEvent["phase"] {
+    if (
+      pendingAgents.length === 0 &&
+      scanningAgents.length > 0 &&
+      scanningAgents.every((agentName) => agentStatuses[agentName]?.status === "indexing")
+    ) {
+      return "indexing";
+    }
+    return this.status.phase === "initializing" ? "initializing" : "scanning";
   }
 
   private set(status: ScanStatus): ScanStatusEvent {

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -20,7 +20,6 @@ export class SearchIndexJobRunner {
   private nextBatchId = 1;
   private pendingJobs = new PendingSearchIndexJobs();
   private isShuttingDown = false;
-  private hasCheckedFtsIntegrity = false;
 
   enqueue(context: string, jobs: SearchIndexWorkerJob[]): Promise<void> {
     if (jobs.length === 0) return Promise.resolve();
@@ -104,7 +103,6 @@ export class SearchIndexJobRunner {
         agentNames: [],
         sessionsByAgent: {},
         metaByAgent: {},
-        skipFtsIntegrityCheck: this.hasCheckedFtsIntegrity,
       },
     });
     worker.unref();
@@ -122,7 +120,6 @@ export class SearchIndexJobRunner {
         duration_ms: Math.round(message.durationMs),
         sessions: message.sessions,
       });
-      this.hasCheckedFtsIntegrity = true;
       this.settle(batch);
     });
     worker.on("error", (error) => {

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -4,11 +4,9 @@ const mocks = vi.hoisted(() => ({
   workerData: {} as Record<string, unknown>,
   postMessage: vi.fn(),
   createRegisteredAgents: vi.fn(),
-  getCachePath: vi.fn(() => "/cache"),
   markAgentCacheInitialized: vi.fn(),
   saveCachedSessionChanges: vi.fn(),
   saveCachedSessions: vi.fn(),
-  setFtsIntegrityCheckedPath: vi.fn(),
   syncSessionSearchIndex: vi.fn(),
   syncSessionSearchIndexChanges: vi.fn(),
   appLoggerWarn: vi.fn(),
@@ -23,11 +21,9 @@ vi.mock("node:worker_threads", () => ({
 
 vi.mock("@codesesh/core", () => ({
   createRegisteredAgents: mocks.createRegisteredAgents,
-  getCachePath: mocks.getCachePath,
   markAgentCacheInitialized: mocks.markAgentCacheInitialized,
   saveCachedSessionChanges: mocks.saveCachedSessionChanges,
   saveCachedSessions: mocks.saveCachedSessions,
-  setFtsIntegrityCheckedPath: mocks.setFtsIntegrityCheckedPath,
   syncSessionSearchIndex: mocks.syncSessionSearchIndex,
   syncSessionSearchIndexChanges: mocks.syncSessionSearchIndexChanges,
   // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
@@ -62,7 +58,7 @@ beforeEach(() => {
 });
 
 describe("search index worker", () => {
-  it("builds legacy full jobs and preserves the integrity-check state", async () => {
+  it("builds legacy full jobs", async () => {
     const agent = makeAgent();
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     mocks.syncSessionSearchIndex.mockImplementation(
@@ -76,12 +72,10 @@ describe("search index worker", () => {
       agentNames: ["codex", "unknown"],
       sessionsByAgent: { codex: [{ id: "s1" }] },
       metaByAgent: { codex: { s1: { id: "s1" } } },
-      skipFtsIntegrityCheck: true,
     };
 
     await runWorker();
 
-    expect(mocks.setFtsIntegrityCheckedPath).toHaveBeenCalledWith("/cache");
     expect(agent.setSessionMetaMap).toHaveBeenCalledWith(new Map([["s1", { id: "s1" }]]));
     expect(mocks.postMessage).toHaveBeenNthCalledWith(1, {
       type: "sync-result",

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -2,11 +2,9 @@ import "./diagnostics-bridge.js";
 import { parentPort, workerData } from "node:worker_threads";
 import {
   createRegisteredAgents,
-  getCachePath,
   markAgentCacheInitialized,
   saveCachedSessionChanges,
   saveCachedSessions,
-  setFtsIntegrityCheckedPath,
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,
   type SearchIndexSyncResult,
@@ -56,14 +54,9 @@ interface SearchIndexWorkerData {
   agentNames: string[];
   sessionsByAgent: Record<string, SessionHead[]>;
   metaByAgent: Record<string, Record<string, SessionCacheMeta>>;
-  /** Set once this process has already run the FTS integrity check in an earlier batch. */
-  skipFtsIntegrityCheck?: boolean;
 }
 
 const data = workerData as SearchIndexWorkerData;
-if (data.skipFtsIntegrityCheck) {
-  setFtsIntegrityCheckedPath(getCachePath());
-}
 const startedAt = performance.now();
 const agents = createRegisteredAgents();
 const jobs =

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -15,7 +15,7 @@ export interface SessionsUpdatedEvent {
 
 export interface AgentScanStatus {
   agentName: string;
-  status: "pending" | "scanning" | "complete";
+  status: "pending" | "scanning" | "indexing" | "complete";
   total?: number;
   processed?: number;
   sessions?: number;

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearCache, loadCachedSessionData, saveCachedSessions } from "../cache/sessions.js";
 import { searchSessions, syncSessionSearchIndex } from "../cache/search.js";
-import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../cache/db.js";
+import { setSchemaEnsuredPath } from "../cache/db.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-smoke-test-"));
@@ -17,7 +17,6 @@ vi.mock("node:os", async (importOriginal) => {
 afterEach(() => {
   clearCache();
   rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -7,7 +7,7 @@ import { saveCachedSessions } from "../cache/sessions.js";
 import { syncSessionSearchIndex } from "../cache/search.js";
 import { materializeSessionDetail, materializeSessionDetailResponse } from "../session-detail.js";
 import type { LiveSnapshot } from "../scanner.js";
-import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../cache/db.js";
+import { setSchemaEnsuredPath } from "../cache/db.js";
 
 const { testHomeDir } = vi.hoisted(() => ({
   testHomeDir: `/tmp/codesesh-session-detail-test-${process.pid}`,
@@ -130,13 +130,11 @@ function persistDetail(head: SessionHead, detail: SessionDetail, fingerprint: st
 
 beforeEach(() => {
   rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
   rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 

--- a/packages/core/src/discovery/cache/__tests__/db.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/db.test.ts
@@ -2,12 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   escapeRegExp,
   filePathFtsQuery,
+  getSchemaEnsuredPath,
   likePattern,
   normalizeFilePathSearch,
-  setFtsIntegrityCheckedPath,
   setSchemaEnsuredPath,
-  getFtsIntegrityCheckedPath,
-  getSchemaEnsuredPath,
 } from "../db.js";
 
 describe("cache db helpers", () => {
@@ -19,14 +17,11 @@ describe("cache db helpers", () => {
     expect(escapeRegExp("a+b?.ts")).toBe("a\\+b\\?\\.ts");
   });
 
-  it("owns the process-local schema guards", () => {
-    setFtsIntegrityCheckedPath("/cache/a.db");
+  it("owns the process-local schema guard", () => {
     setSchemaEnsuredPath("/cache/b.db");
 
-    expect(getFtsIntegrityCheckedPath()).toBe("/cache/a.db");
     expect(getSchemaEnsuredPath()).toBe("/cache/b.db");
 
-    setFtsIntegrityCheckedPath(null);
     setSchemaEnsuredPath(null);
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../../utils/diagnostics.js";
-import { withCacheDb } from "../schema.js";
+import { withCacheDb, withSearchIndexDb } from "../schema.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-diag-test-"));
 
@@ -16,9 +16,12 @@ afterEach(() => {
   setCoreDiagnostics(null);
 });
 
-function collectDiagnostics(): Array<{ event: string; detail?: Record<string, unknown> }> {
+function collectDiagnostics(
+  includeInfo = false,
+): Array<{ event: string; detail?: Record<string, unknown> }> {
   const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
   const diagnostics: CoreDiagnostics = {
+    info: includeInfo ? (event, detail) => events.push({ event, detail }) : undefined,
     warn: (event, detail) => events.push({ event, detail }),
   };
   setCoreDiagnostics(diagnostics);
@@ -43,5 +46,12 @@ describe("withCacheDb diagnostics", () => {
         throw new Error("boom");
       }),
     ).not.toThrow();
+  });
+
+  it("does not run a full FTS integrity check during a normal index write", () => {
+    const events = collectDiagnostics(true);
+
+    expect(withSearchIndexDb(() => "ready")).toBe("ready");
+    expect(events.some(({ event }) => event === "sqlite.fts_integrity.started")).toBe(false);
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
@@ -23,7 +23,7 @@ vi.mock("../schema.js", async (importOriginal) => {
 import { listCachedProjectGroups } from "../project-groups.js";
 import { saveCachedSessions } from "../sessions.js";
 import { withCacheDb } from "../schema.js";
-import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
+import { setSchemaEnsuredPath } from "../db.js";
 import { makeSessionHead, TEST_NOW } from "./fixtures.js";
 
 const mockedWithCacheDb = vi.mocked(withCacheDb);
@@ -35,14 +35,12 @@ function getCacheDir(): string {
 beforeEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
-  setFtsIntegrityCheckedPath(null);
   mockedWithCacheDb.mockClear();
 });
 
 afterEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
-  setFtsIntegrityCheckedPath(null);
 });
 
 describe("cached project groups", () => {

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getCachePath, setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
+import { getCachePath, setSchemaEnsuredPath } from "../db.js";
 import * as schema from "../schema.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-schema-test-"));
@@ -15,13 +15,11 @@ vi.mock("node:os", async (importOriginal) => {
 
 beforeEach(() => {
   rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
   rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { searchSessions } from "../search.js";
 import { syncSessionSearchIndex, syncSessionSearchIndexChanges } from "../search-index-writer.js";
-import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
+import { setSchemaEnsuredPath } from "../db.js";
 import { makeSessionData, makeSessionHead } from "./fixtures.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-search-writer-test-"));
@@ -16,7 +16,6 @@ vi.mock("node:os", async (importOriginal) => {
 
 afterEach(() => {
   rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -16,9 +16,9 @@ import {
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,
 } from "../search.js";
-import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
+import { setSchemaEnsuredPath } from "../db.js";
 import { MESSAGE_PARTS_FORMAT_VERSION } from "../messages.js";
-import { withCacheDb } from "../schema.js";
+import { withCacheDb, withSearchDb } from "../schema.js";
 import type { SessionDetail, SessionHead } from "../../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
@@ -114,13 +114,11 @@ function getUserVersion(dbPath: string): number {
 beforeEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   dateNowSpy.mockReturnValue(now);
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 
@@ -1584,5 +1582,101 @@ describe("searchSessions", () => {
     expect(results).toHaveLength(1);
     expect(results[0]?.session.id).toBe("fts-empty");
     expect(results[0]?.snippet).toContain("<mark>orphan</mark>");
+  });
+
+  it("rebuilds affected FTS indexes when update triggers are missing", () => {
+    const session = makeSession("missing-fts-triggers");
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex("claudecode", [session], (sessionId) =>
+      makeSessionData(sessionId, "original indexed content"),
+    );
+
+    const db = new Database(getCachePath());
+    try {
+      db.exec(`
+        DROP TRIGGER session_documents_au;
+        DROP TRIGGER messages_au;
+      `);
+      db.prepare(
+        "UPDATE session_documents SET content_text = ? WHERE agent_name = ? AND session_id = ?",
+      ).run("documentrepairneedle", "claudecode", session.id);
+      db.prepare(
+        "UPDATE messages SET content_text = ? WHERE agent_name = ? AND session_id = ?",
+      ).run("messagerepairneedle", "claudecode", session.id);
+    } finally {
+      db.close();
+    }
+
+    const matches = withSearchDb((searchDb) => ({
+      documents: searchDb
+        .prepare(
+          "SELECT COUNT(*) AS value FROM session_documents_fts WHERE session_documents_fts MATCH ?",
+        )
+        .get("documentrepairneedle") as { value: number },
+      messages: searchDb
+        .prepare("SELECT COUNT(*) AS value FROM messages_fts WHERE messages_fts MATCH ?")
+        .get("messagerepairneedle") as { value: number },
+    }));
+
+    expect(matches?.documents.value).toBe(1);
+    expect(matches?.messages.value).toBe(1);
+  });
+
+  it("recreates and rebuilds a missing FTS table", () => {
+    const session = makeSession("missing-fts-table");
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex("claudecode", [session], (sessionId) =>
+      makeSessionData(sessionId, "tablerepairneedle"),
+    );
+
+    const db = new Database(getCachePath());
+    try {
+      db.exec("DROP TABLE session_documents_fts");
+    } finally {
+      db.close();
+    }
+
+    expect(searchSessions("tablerepairneedle")[0]?.session.id).toBe(session.id);
+  });
+
+  it("validates and rebuilds FTS indexes after SQLite reports corruption", () => {
+    const session = makeSession("corrupt-fts");
+    const content = Array.from({ length: 200 }, (_, index) => `recoverytoken${index}`).join(" ");
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex("claudecode", [session], (sessionId) =>
+      makeSessionData(sessionId, content),
+    );
+
+    const db = new Database(getCachePath());
+    try {
+      const row = db
+        .prepare(
+          "SELECT id, block FROM session_documents_fts_data WHERE id > 10 AND length(block) > 4 LIMIT 1",
+        )
+        .get() as { id: number; block: Buffer } | undefined;
+      if (!row) throw new Error("Expected an FTS segment block");
+
+      const corruptBlock = Buffer.from(row.block);
+      const corruptIndex = Math.floor(corruptBlock.length / 2);
+      corruptBlock[corruptIndex] = (corruptBlock[corruptIndex] ?? 0) ^ 0xff;
+      db.unsafeMode(true);
+      db.prepare("UPDATE session_documents_fts_data SET block = ? WHERE id = ?").run(
+        corruptBlock,
+        row.id,
+      );
+      db.unsafeMode(false);
+    } finally {
+      db.close();
+    }
+
+    const result = withSearchDb((searchDb) => {
+      searchDb.exec(
+        "INSERT INTO session_documents_fts(session_documents_fts, rank) VALUES ('integrity-check', 1)",
+      );
+      return "recovered";
+    });
+
+    expect(result).toBe("recovered");
+    expect(searchSessions("recoverytoken42")[0]?.session.id).toBe(session.id);
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -17,12 +17,7 @@ import {
 import { listCachedProjectGroups } from "../project-groups.js";
 import type { SessionCacheMeta } from "../../../agents/base.js";
 import { withCacheDb, withSearchIndexDb } from "../schema.js";
-import {
-  getFtsIntegrityCheckedPath,
-  getSchemaEnsuredPath,
-  setFtsIntegrityCheckedPath,
-  setSchemaEnsuredPath,
-} from "../db.js";
+import { getSchemaEnsuredPath, setSchemaEnsuredPath } from "../db.js";
 import type { SessionHead } from "../../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
@@ -131,13 +126,11 @@ function getMigrationBackups(): string[] {
 beforeEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   dateNowSpy.mockReturnValue(now);
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 describe("loadCachedSessions", () => {
@@ -183,7 +176,7 @@ describe("loadCachedSessions", () => {
 });
 
 describe("withSearchIndexDb", () => {
-  it("provides a consistent search index and records readiness", () => {
+  it("provides ready search-index tables", () => {
     const tables = withSearchIndexDb((db) =>
       db
         .prepare(
@@ -193,7 +186,6 @@ describe("withSearchIndexDb", () => {
     );
 
     expect(tables).toHaveLength(2);
-    expect(getFtsIntegrityCheckedPath()).toBe(getCachePath());
   });
 });
 

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -9,7 +9,7 @@ import {
   saveCachedSessionChanges,
   saveCachedSessions,
 } from "../sessions.js";
-import { setFtsIntegrityCheckedPath, setSchemaEnsuredPath } from "../db.js";
+import { setSchemaEnsuredPath } from "../db.js";
 import { makeSessionHead } from "./fixtures.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-sessions-test-"));
@@ -21,7 +21,6 @@ vi.mock("node:os", async (importOriginal) => {
 
 afterEach(() => {
   rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
 });
 

--- a/packages/core/src/discovery/cache/db.ts
+++ b/packages/core/src/discovery/cache/db.ts
@@ -1,6 +1,6 @@
 /**
- * Cache infrastructure: cache paths, shared query helpers, and the FTS
- * integrity-check guard. Lower-level than schema.ts — no DB handles here.
+ * Cache infrastructure: cache paths and shared query helpers.
+ * Lower-level than schema.ts — no DB handles here.
  */
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -30,17 +30,6 @@ export interface CacheRow extends DatabaseRow {
 }
 
 export type SQLiteStatement = ReturnType<SQLiteDatabase["prepare"]>;
-
-// One-shot per-process FTS integrity check guard; reset by clearCache.
-let ftsIntegrityCheckedPath: string | null = null;
-
-export function getFtsIntegrityCheckedPath(): string | null {
-  return ftsIntegrityCheckedPath;
-}
-
-export function setFtsIntegrityCheckedPath(path: string | null): void {
-  ftsIntegrityCheckedPath = path;
-}
 
 // One-shot per-process ensureSchema guard; reset by clearCache. Once a path
 // has been schema-checked, withCacheDb skips ensureSchema's DDL exec (which

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -17,14 +17,7 @@ import {
   type DatabaseRow,
   type SQLiteDatabase,
 } from "../../utils/sqlite.js";
-import {
-  getCachePath,
-  getFtsIntegrityCheckedPath,
-  getSchemaEnsuredPath,
-  setFtsIntegrityCheckedPath,
-  setSchemaEnsuredPath,
-  type CacheRow,
-} from "./db.js";
+import { getCachePath, getSchemaEnsuredPath, setSchemaEnsuredPath, type CacheRow } from "./db.js";
 import {
   messageFromBackfillRow,
   prepareInsertFileActivity,
@@ -111,17 +104,11 @@ export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): T | null 
 }
 
 export function withSearchDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
-  return withCacheDb((db) => {
-    ensureFtsReady(db);
-    return fn(db);
-  });
+  return withCacheDb((db) => runWithFtsRecovery(db, fn));
 }
 
 export function withSearchIndexDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
-  return withCacheDb((db) => {
-    ensureFtsConsistency(db);
-    return fn(db);
-  });
+  return withCacheDb((db) => runWithFtsRecovery(db, fn));
 }
 
 interface SearchIndexWriteResult<T> {
@@ -565,10 +552,9 @@ function recreateProjectGroupsView(db: SQLiteDatabase): void {
 function createLatestCacheSchema(db: SQLiteDatabase): void {
   createCacheTables(db);
   createSessionTables(db);
-  createMessageSearchTables(db);
   createFileActivityTables(db);
-  createSearchTables(db);
   createProjectTables(db);
+  ensureFtsReady(db);
 }
 
 function recreateSearchIndexSchema(db: SQLiteDatabase): void {
@@ -1085,26 +1071,70 @@ function rebuildMessageSearchIndex(db: SQLiteDatabase): void {
   db.exec("INSERT INTO messages_fts(messages_fts) VALUES ('rebuild')");
 }
 
-function ensureFtsReady(db: SQLiteDatabase): void {
-  if (!tableExists(db, "session_documents_fts")) {
-    createSearchTables(db);
-  }
-  createSearchTriggers(db);
+const SEARCH_FTS_INDEXES = ["session_documents_fts", "messages_fts"] as const;
 
-  const needsMessageSearchRebuild = !tableExists(db, "messages_fts");
-  createMessageSearchTables(db);
-  if (needsMessageSearchRebuild) {
-    rebuildMessageSearchIndex(db);
+type SearchFtsIndex = (typeof SEARCH_FTS_INDEXES)[number];
+
+function triggerExists(db: SQLiteDatabase, triggerName: string): boolean {
+  return (
+    db
+      .prepare("SELECT 1 AS value FROM sqlite_master WHERE name = ? AND type = 'trigger' LIMIT 1")
+      .get(triggerName) !== undefined
+  );
+}
+
+function hasAllTriggers(db: SQLiteDatabase, triggerNames: string[]): boolean {
+  return triggerNames.every((triggerName) => triggerExists(db, triggerName));
+}
+
+function rebuildSearchFtsIndexes(
+  db: SQLiteDatabase,
+  indexes: SearchFtsIndex[],
+  reason: "corruption" | "schema_missing",
+): void {
+  if (indexes.length === 0) return;
+
+  const startedAt = performance.now();
+  getCoreDiagnostics()?.info?.("sqlite.fts_rebuild.started", { indexes, reason });
+  try {
+    for (const index of indexes) {
+      if (index === "session_documents_fts") rebuildSearchIndex(db);
+      else rebuildMessageSearchIndex(db);
+    }
+    getCoreDiagnostics()?.info?.("sqlite.fts_rebuild.completed", {
+      indexes,
+      reason,
+      duration_ms: Math.round(performance.now() - startedAt),
+    });
+  } catch (error) {
+    getCoreDiagnostics()?.warn("sqlite.fts_rebuild.failed", {
+      indexes,
+      reason,
+      duration_ms: Math.round(performance.now() - startedAt),
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
   }
 }
 
-function ensureFtsConsistency(db: SQLiteDatabase): void {
-  ensureFtsReady(db);
-  const cachePath = getCachePath();
-  if (getFtsIntegrityCheckedPath() === cachePath) {
-    return;
-  }
+function ensureFtsReady(db: SQLiteDatabase): void {
+  const needsSearchRebuild =
+    !tableExists(db, "session_documents_fts") ||
+    !hasAllTriggers(db, ["session_documents_ai", "session_documents_ad", "session_documents_au"]);
+  const needsMessageSearchRebuild =
+    !tableExists(db, "messages_fts") ||
+    !hasAllTriggers(db, ["messages_ai", "messages_ad", "messages_au"]);
 
+  createSearchTables(db);
+  createMessageSearchTables(db);
+
+  const indexes: SearchFtsIndex[] = [];
+  if (needsSearchRebuild) indexes.push("session_documents_fts");
+  if (needsMessageSearchRebuild) indexes.push("messages_fts");
+  rebuildSearchFtsIndexes(db, indexes, "schema_missing");
+}
+
+function ensureFtsConsistency(db: SQLiteDatabase): void {
   const startedAt = performance.now();
   getCoreDiagnostics()?.info?.("sqlite.fts_integrity.started", {
     indexes: 2,
@@ -1114,7 +1144,6 @@ function ensureFtsConsistency(db: SQLiteDatabase): void {
       "INSERT INTO session_documents_fts(session_documents_fts, rank) VALUES ('integrity-check', 1)",
     );
     db.exec("INSERT INTO messages_fts(messages_fts, rank) VALUES ('integrity-check', 1)");
-    setFtsIntegrityCheckedPath(cachePath);
     getCoreDiagnostics()?.info?.("sqlite.fts_integrity.completed", {
       indexes: 2,
       duration_ms: Math.round(performance.now() - startedAt),
@@ -1125,14 +1154,30 @@ function ensureFtsConsistency(db: SQLiteDatabase): void {
       duration_ms: Math.round(performance.now() - startedAt),
       message: error instanceof Error ? error.message : String(error),
     });
-    const rebuildStartedAt = performance.now();
-    rebuildSearchIndex(db);
-    rebuildMessageSearchIndex(db);
-    setFtsIntegrityCheckedPath(cachePath);
-    getCoreDiagnostics()?.info?.("sqlite.fts_integrity.rebuilt", {
-      indexes: 2,
-      duration_ms: Math.round(performance.now() - rebuildStartedAt),
+    rebuildSearchFtsIndexes(db, [...SEARCH_FTS_INDEXES], "corruption");
+  }
+}
+
+function isFtsCorruptionError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "SQLITE_CORRUPT_VTAB"
+  );
+}
+
+function runWithFtsRecovery<T>(db: SQLiteDatabase, fn: (db: SQLiteDatabase) => T): T {
+  ensureFtsReady(db);
+  try {
+    return fn(db);
+  } catch (error) {
+    if (!isFtsCorruptionError(error)) throw error;
+    getCoreDiagnostics()?.warn("sqlite.fts_corruption.detected", {
+      message: error instanceof Error ? error.message : String(error),
     });
+    ensureFtsConsistency(db);
+    return fn(db);
   }
 }
 

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -1105,16 +1105,34 @@ function ensureFtsConsistency(db: SQLiteDatabase): void {
     return;
   }
 
+  const startedAt = performance.now();
+  getCoreDiagnostics()?.info?.("sqlite.fts_integrity.started", {
+    indexes: 2,
+  });
   try {
     db.exec(
       "INSERT INTO session_documents_fts(session_documents_fts, rank) VALUES ('integrity-check', 1)",
     );
     db.exec("INSERT INTO messages_fts(messages_fts, rank) VALUES ('integrity-check', 1)");
     setFtsIntegrityCheckedPath(cachePath);
-  } catch {
+    getCoreDiagnostics()?.info?.("sqlite.fts_integrity.completed", {
+      indexes: 2,
+      duration_ms: Math.round(performance.now() - startedAt),
+    });
+  } catch (error) {
+    getCoreDiagnostics()?.warn("sqlite.fts_integrity.failed", {
+      indexes: 2,
+      duration_ms: Math.round(performance.now() - startedAt),
+      message: error instanceof Error ? error.message : String(error),
+    });
+    const rebuildStartedAt = performance.now();
     rebuildSearchIndex(db);
     rebuildMessageSearchIndex(db);
     setFtsIntegrityCheckedPath(cachePath);
+    getCoreDiagnostics()?.info?.("sqlite.fts_integrity.rebuilt", {
+      indexes: 2,
+      duration_ms: Math.round(performance.now() - rebuildStartedAt),
+    });
   }
 }
 

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -9,7 +9,6 @@ import {
   getCachePath,
   getLegacyCachePath,
   hasCacheStorage,
-  setFtsIntegrityCheckedPath,
   setSchemaEnsuredPath,
   type ScalarRow,
   type SessionHeadChange,
@@ -472,7 +471,6 @@ export function saveCachedSessionChanges(
 }
 
 export function clearCache(): void {
-  setFtsIntegrityCheckedPath(null);
   setSchemaEnsuredPath(null);
   if (!hasCacheStorage()) {
     deleteLegacyCacheFile();

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -30,7 +30,7 @@ export {
   saveCachedSessions,
 } from "./cache/sessions.js";
 export type { CachedSessionDataEntry } from "./cache/sessions.js";
-export { getCachePath, setFtsIntegrityCheckedPath } from "./cache/db.js";
+export { getCachePath } from "./cache/db.js";
 export type { SessionHeadChange } from "./cache/db.js";
 export { listCachedProjectGroups } from "./cache/project-groups.js";
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,7 +48,6 @@ export {
   saveCachedSessions,
   scanSessions,
   sessionSignature,
-  setFtsIntegrityCheckedPath,
   sortSessions,
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,


### PR DESCRIPTION
## Summary

- remove the process-local startup integrity guard and keep full FTS validation out of normal search and index opens
- rebuild only the affected FTS index when its table or synchronization triggers are missing
- recover from `SQLITE_CORRUPT_VTAB` by validating, rebuilding, and retrying the original operation once
- report the per-agent indexing phase and render accessible indeterminate progress when the total is unknown

## Root cause

The first search-index write in every Node.js process synchronously ran FTS5 `integrity-check` against both search indexes. On the reported 5.1 GB cache, this check took 36.794 seconds and serialized every pending session publication. The sidebar continued to label that wait as `Scanning` and rendered a fixed 8% bar when no total was available.

## Impact

With the same cache, the HTTP server became ready in 180 ms. The first Claude Code operation dropped from about 44.5 seconds to 1.627 seconds, and Codex dropped from about 43.2 seconds to 2.123 seconds. The normal startup emitted no integrity, rebuild, or corruption events.

## Validation

- `pnpm test` — 1,169 tests passed (Core 506, CLI 248, Web 415)
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- smoke-tested startup against the original 5.1 GB cache

Issue: CS-130