### PR TITLE
fix: gate session publication on successful persistence (CS-137)

### DIFF
--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -124,7 +124,13 @@ export class LiveScanStore {
     });
     const snapshot = this.getSnapshot();
     const indexStartedAt = performance.now();
-    if (!this.deferInitialRefresh) await this.syncEngine.syncInitialIndex();
+    if (!this.deferInitialRefresh) {
+      // The snapshot is already served from memory, so an index-write failure
+      // degrades search freshness rather than startup.
+      await this.syncEngine.syncInitialIndex().catch((error: unknown) => {
+        appLogger.error("scan.initial.index_failed", { error });
+      });
+    }
     const indexDuration = performance.now() - indexStartedAt;
     appLogger.info("scan.initial.done", {
       duration_ms: Math.round(performance.now() - startedAt),

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SearchIndexWorkerJob, SearchIndexWorkerMessage } from "./search-index-worker.js";
+
+const workerMocks = vi.hoisted(() => {
+  type Handler = (arg: never) => void;
+  class FakeWorker {
+    private handlers = new Map<string, Handler>();
+
+    constructor() {
+      workers.push(this);
+    }
+
+    on(event: string, handler: Handler): this {
+      this.handlers.set(event, handler);
+      return this;
+    }
+
+    unref(): void {}
+
+    async terminate(): Promise<number> {
+      return 0;
+    }
+
+    post(message: SearchIndexWorkerMessage): void {
+      (this.handlers.get("message") as ((arg: SearchIndexWorkerMessage) => void) | undefined)?.(
+        message,
+      );
+    }
+  }
+  const workers: FakeWorker[] = [];
+  return { workers, FakeWorker };
+});
+
+vi.mock("node:worker_threads", () => ({ Worker: workerMocks.FakeWorker }));
+vi.mock("node:fs", () => ({ existsSync: () => true }));
+vi.mock("./logging.js", () => ({
+  appLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logSearchIndexSync: vi.fn(),
+}));
+
+import { SearchIndexJobRunner } from "./search-index-job-runner.js";
+
+function makeJob(): SearchIndexWorkerJob {
+  return {
+    kind: "changes",
+    context: "scan.refresh",
+    agentName: "codex",
+    changes: [],
+    removedSessionIds: ["gone"],
+    meta: {},
+  };
+}
+
+function startedWorker() {
+  const worker = workerMocks.workers.at(-1);
+  if (!worker) throw new Error("no search index worker was started");
+  return worker;
+}
+
+beforeEach(() => {
+  workerMocks.workers.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("SearchIndexJobRunner", () => {
+  it("resolves the batch when the worker reports done", async () => {
+    const runner = new SearchIndexJobRunner();
+    const completion = runner.enqueue("scan.refresh", [makeJob()]);
+
+    startedWorker().post({
+      type: "done",
+      context: "scan.refresh",
+      durationMs: 1,
+      sessions: 1,
+    });
+
+    await expect(completion).resolves.toBeUndefined();
+  });
+
+  it("CS-137: rejects the batch when the worker reports a persistence failure", async () => {
+    const runner = new SearchIndexJobRunner();
+    const completion = runner.enqueue("scan.refresh", [makeJob()]);
+
+    startedWorker().post({
+      type: "persist-failed",
+      context: "scan.refresh",
+      stage: "cache",
+      agentName: "codex",
+      sessions: 1,
+    });
+
+    await expect(completion).rejects.toThrow(/failed to persist cache for codex/);
+  });
+});

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -114,6 +114,22 @@ export class SearchIndexJobRunner {
         logSearchIndexSync(message.context, message.result);
         return;
       }
+      if (message.type === "persist-failed") {
+        appLogger.error("search_index.persist_failed", {
+          batch_id: batch.id,
+          context: message.context,
+          stage: message.stage,
+          agent: message.agentName,
+          sessions: message.sessions,
+        });
+        this.settle(
+          batch,
+          new Error(
+            `Search index worker failed to persist ${message.stage} for ${message.agentName}`,
+          ),
+        );
+        return;
+      }
       if (message.type !== "done") return;
 
       appLogger.info(`${message.context}.done`, {

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   syncSessionSearchIndex: vi.fn(),
   syncSessionSearchIndexChanges: vi.fn(),
   appLoggerWarn: vi.fn(),
+  appLoggerError: vi.fn(),
 }));
 
 vi.mock("node:worker_threads", () => ({
@@ -31,7 +32,7 @@ vi.mock("@codesesh/core", () => ({
 }));
 
 vi.mock("./logging.js", () => ({
-  appLogger: { warn: mocks.appLoggerWarn },
+  appLogger: { warn: mocks.appLoggerWarn, error: mocks.appLoggerError },
 }));
 
 function makeAgent() {
@@ -49,6 +50,8 @@ async function runWorker() {
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
+  mocks.saveCachedSessions.mockReturnValue(true);
+  mocks.saveCachedSessionChanges.mockReturnValue(true);
   mocks.workerData = {
     context: "refresh",
     agentNames: [],
@@ -211,5 +214,80 @@ describe("search index worker", () => {
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: "done", sessions: 1 }),
     );
+  });
+
+  it("CS-137: reports a failed cache write instead of settling the batch as done", async () => {
+    const agent = makeAgent();
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.saveCachedSessionChanges.mockReturnValue(false);
+    mocks.workerData = {
+      context: "scan.refresh",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [
+        {
+          kind: "changes",
+          context: "scan.refresh",
+          agentName: "codex",
+          changes: [{ session: { id: "s1" }, sortIndex: 0 }],
+          removedSessionIds: [],
+          meta: {},
+        },
+      ],
+    };
+
+    await runWorker();
+
+    expect(mocks.syncSessionSearchIndexChanges).not.toHaveBeenCalled();
+    expect(mocks.postMessage).toHaveBeenCalledExactlyOnceWith({
+      type: "persist-failed",
+      context: "scan.refresh",
+      stage: "cache",
+      agentName: "codex",
+      sessions: 1,
+    });
+  });
+
+  it("CS-137: reports a failed index write and skips the remaining jobs", async () => {
+    const agent = makeAgent();
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.syncSessionSearchIndex.mockReturnValue(null);
+    mocks.workerData = {
+      context: "scan.refresh",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [
+        {
+          kind: "full",
+          context: "scan.refresh",
+          agentName: "codex",
+          sessions: [{ id: "s1" }, { id: "s2" }],
+          meta: {},
+          saveCache: true,
+        },
+        {
+          kind: "full",
+          context: "scan.refresh",
+          agentName: "codex",
+          sessions: [{ id: "s3" }],
+          meta: {},
+          saveCache: true,
+        },
+      ],
+    };
+
+    await runWorker();
+
+    expect(mocks.markAgentCacheInitialized).not.toHaveBeenCalled();
+    expect(mocks.syncSessionSearchIndex).toHaveBeenCalledOnce();
+    expect(mocks.postMessage).toHaveBeenCalledExactlyOnceWith({
+      type: "persist-failed",
+      context: "scan.refresh",
+      stage: "search_index",
+      agentName: "codex",
+      sessions: 2,
+    });
   });
 });

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -15,11 +15,20 @@ import {
 } from "@codesesh/core";
 import { appLogger } from "./logging.js";
 
+export type SearchIndexPersistStage = "cache" | "search_index";
+
 export type SearchIndexWorkerMessage =
   | {
       type: "sync-result";
       context: string;
       result: SearchIndexSyncResult | null;
+    }
+  | {
+      type: "persist-failed";
+      context: string;
+      stage: SearchIndexPersistStage;
+      agentName: string;
+      sessions: number;
     }
   | {
       type: "done";
@@ -56,6 +65,8 @@ interface SearchIndexWorkerData {
   metaByAgent: Record<string, Record<string, SessionCacheMeta>>;
 }
 
+type WorkerAgent = ReturnType<typeof createRegisteredAgents>[number];
+
 const data = workerData as SearchIndexWorkerData;
 const startedAt = performance.now();
 const agents = createRegisteredAgents();
@@ -71,6 +82,83 @@ const jobs =
     }),
   );
 
+function jobSessionCount(job: SearchIndexWorkerJob): number {
+  return job.kind === "full" ? job.sessions.length : job.changes.length;
+}
+
+/**
+ * Reports a persistence failure so the batch is rejected instead of settling as
+ * `done`; the caller keeps its previously published snapshot and can retry.
+ */
+function reportPersistFailure(job: SearchIndexWorkerJob, stage: SearchIndexPersistStage): void {
+  appLogger.error("search_index.persist_failed", {
+    context: job.context,
+    stage,
+    agent: job.agentName,
+    sessions: jobSessionCount(job),
+  });
+  parentPort?.postMessage({
+    type: "persist-failed",
+    context: job.context,
+    stage,
+    agentName: job.agentName,
+    sessions: jobSessionCount(job),
+  } satisfies SearchIndexWorkerMessage);
+}
+
+function runJob(job: SearchIndexWorkerJob, agent: WorkerAgent): SearchIndexPersistStage | null {
+  if (job.kind === "changes") {
+    if (!saveCachedSessionChanges(job.agentName, job.changes, job.removedSessionIds, job.meta)) {
+      return "cache";
+    }
+    const result = syncSessionSearchIndexChanges(
+      job.agentName,
+      job.changes,
+      job.removedSessionIds,
+      (sessionId) => agent.getSessionData(sessionId),
+      job.searchIndexOptions,
+    );
+    if (!result) return "search_index";
+    postSyncResult(job.context, result);
+    return null;
+  }
+
+  if (job.saveCache && !saveCachedSessions(job.agentName, job.sessions, job.meta)) {
+    return "cache";
+  }
+  const result = syncSessionSearchIndex(
+    job.agentName,
+    job.sessions,
+    (sessionId) => agent.getSessionData(sessionId),
+    job.searchIndexOptions,
+  );
+  if (!result) return "search_index";
+  // Head cache init is decoupled from search-index completeness (CS-73): a
+  // session that fails to load must not permanently block markAgentCacheInitialized,
+  // or every future refresh would fall back to a full initializeAgent scan.
+  // The skip is still surfaced as a warning so it stays visible.
+  if (job.saveCache) {
+    markAgentCacheInitialized(job.agentName);
+    if (result.skipped > 0) {
+      appLogger.warn("search_index.sync_incomplete", {
+        agent: job.agentName,
+        skipped: result.skipped,
+      });
+    }
+  }
+  postSyncResult(job.context, result);
+  return null;
+}
+
+function postSyncResult(context: string, result: SearchIndexSyncResult): void {
+  parentPort?.postMessage({
+    type: "sync-result",
+    context,
+    result,
+  } satisfies SearchIndexWorkerMessage);
+}
+
+let persistFailed = false;
 for (const job of jobs) {
   const agent = agents.find((item) => item.name === job.agentName);
   if (!agent) continue;
@@ -79,53 +167,19 @@ for (const job of jobs) {
     agent.setSessionMetaMap(new Map(Object.entries(job.meta)));
   }
 
-  let result: SearchIndexSyncResult | null;
-  if (job.kind === "changes") {
-    saveCachedSessionChanges(job.agentName, job.changes, job.removedSessionIds, job.meta);
-    result = syncSessionSearchIndexChanges(
-      job.agentName,
-      job.changes,
-      job.removedSessionIds,
-      (sessionId) => agent.getSessionData(sessionId),
-      job.searchIndexOptions,
-    );
-  } else {
-    if (job.saveCache) {
-      saveCachedSessions(job.agentName, job.sessions, job.meta);
-    }
-    result = syncSessionSearchIndex(
-      job.agentName,
-      job.sessions,
-      (sessionId) => agent.getSessionData(sessionId),
-      job.searchIndexOptions,
-    );
-    // Head cache init is decoupled from search-index completeness (CS-73): a
-    // session that fails to load must not permanently block markAgentCacheInitialized,
-    // or every future refresh would fall back to a full initializeAgent scan.
-    // The skip is still surfaced as a warning so it stays visible.
-    if (job.saveCache && result) {
-      markAgentCacheInitialized(job.agentName);
-      if (result.skipped > 0) {
-        appLogger.warn("search_index.sync_incomplete", {
-          agent: job.agentName,
-          skipped: result.skipped,
-        });
-      }
-    }
+  const failedStage = runJob(job, agent);
+  if (failedStage) {
+    reportPersistFailure(job, failedStage);
+    persistFailed = true;
+    break;
   }
-  parentPort?.postMessage({
-    type: "sync-result",
-    context: job.context,
-    result,
-  } satisfies SearchIndexWorkerMessage);
 }
 
-parentPort?.postMessage({
-  type: "done",
-  context: data.context,
-  durationMs: performance.now() - startedAt,
-  sessions: jobs.reduce(
-    (total, job) => total + (job.kind === "full" ? job.sessions.length : job.changes.length),
-    0,
-  ),
-} satisfies SearchIndexWorkerMessage);
+if (!persistFailed) {
+  parentPort?.postMessage({
+    type: "done",
+    context: data.context,
+    durationMs: performance.now() - startedAt,
+    sessions: jobs.reduce((total, job) => total + jobSessionCount(job), 0),
+  } satisfies SearchIndexWorkerMessage);
+}

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -10,6 +10,7 @@ import {
   saveCachedSessions,
 } from "../sessions.js";
 import { setSchemaEnsuredPath } from "../db.js";
+import { withCacheDb } from "../schema.js";
 import { makeSessionHead } from "./fixtures.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-sessions-test-"));
@@ -46,6 +47,21 @@ describe("cached sessions", () => {
     expect(loadCachedSessions("codex")?.sessions).toEqual([
       expect.objectContaining({ id: "keep", title: "Updated" }),
     ]);
+  });
+
+  it("CS-137: reports whether the write reached disk", () => {
+    expect(saveCachedSessions("codex", [makeSessionHead("one")])).toBe(true);
+    expect(
+      saveCachedSessionChanges("codex", [{ session: makeSessionHead("one"), sortIndex: 0 }], []),
+    ).toBe(true);
+    expect(saveCachedSessionChanges("codex", [], [])).toBe(true);
+
+    withCacheDb((db) => db.exec("DROP TABLE sessions"));
+
+    expect(saveCachedSessions("codex", [makeSessionHead("two")])).toBe(false);
+    expect(
+      saveCachedSessionChanges("codex", [{ session: makeSessionHead("two"), sortIndex: 0 }], []),
+    ).toBe(false);
   });
 
   it("clears persisted rows without leaving stale state", () => {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -341,12 +341,13 @@ export function loadCachedSessionData(agentName: string, sessionId: string): Ses
   return loadCachedSessionDataEntry(agentName, sessionId)?.data ?? null;
 }
 
+/** Returns whether the write reached disk; callers must not publish on `false`. */
 export function saveCachedSessions(
   agentName: string,
   sessions: SessionHead[],
   meta: Record<string, SessionCacheMeta> = {},
-): void {
-  withCacheDb((db) => {
+): boolean {
+  const persisted = withCacheDb((db) => {
     const deleteSession = db.prepare(
       "DELETE FROM sessions WHERE agent_name = ? AND session_id = ?",
     );
@@ -404,20 +405,24 @@ export function saveCachedSessions(
 
     write();
     deleteLegacyCacheFile();
+    return true;
   });
+
+  return persisted ?? false;
 }
 
+/** Returns whether the write reached disk; callers must not publish on `false`. */
 export function saveCachedSessionChanges(
   agentName: string,
   changes: SessionHeadChange[],
   removedSessionIds: string[],
   meta: Record<string, SessionCacheMeta> = {},
-): void {
+): boolean {
   if (changes.length === 0 && removedSessionIds.length === 0) {
-    return;
+    return true;
   }
 
-  withCacheDb((db) => {
+  const persisted = withCacheDb((db) => {
     const deleteSession = db.prepare(
       "DELETE FROM sessions WHERE agent_name = ? AND session_id = ?",
     );
@@ -467,7 +472,10 @@ export function saveCachedSessionChanges(
 
     write();
     deleteLegacyCacheFile();
+    return true;
   });
+
+  return persisted ?? false;
 }
 
 export function clearCache(): void {

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -5,6 +5,7 @@ import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import { createRegisteredAgents } from "../agents/index.js";
 import { filterSessionsByProjectScope } from "../projects/index.js";
 import { classifySessionTags, getSmartTagSourceTimestamp, perf } from "../utils/index.js";
+import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import {
   loadCachedSessions,
   markAgentCacheInitialized,
@@ -471,12 +472,19 @@ async function scanAgentFull(
 
     if (options.writeCache !== false) {
       // 全量（无时间窗）扫描才落盘完整会话列表并记录一次全量同步，用于 backfill 节流判断
-      if (options.from == null && options.to == null) {
-        saveCachedSessions(agent.name, tagged.sessions, meta);
-        markAgentFullSyncCompleted(agent.name);
+      const isFullWindow = options.from == null && options.to == null;
+      // 落盘失败时不得标记缓存已建立，否则后续刷新会基于不存在的缓存走增量路径
+      const persisted = isFullWindow ? saveCachedSessions(agent.name, tagged.sessions, meta) : true;
+      if (persisted) {
+        if (isFullWindow) markAgentFullSyncCompleted(agent.name);
+        // head 缓存是否建立与搜索索引是否完整是两回事，带时间窗的扫描同样应当标记
+        markAgentCacheInitialized(agent.name);
+      } else {
+        getCoreDiagnostics()?.warn("cache.save_failed", {
+          agent: agent.name,
+          sessions: tagged.sessions.length,
+        });
       }
-      // head 缓存是否建立与搜索索引是否完整是两回事，带时间窗的扫描同样应当标记
-      markAgentCacheInitialized(agent.name);
     }
 
     onProgress?.({ agent: agent.name, phase: "complete", newCount: tagged.sessions.length });


### PR DESCRIPTION
## Problem

The publication pipeline's success signal was disconnected from what actually reached disk:

- `withCacheDb()` catches write exceptions and returns `null`
- `saveCachedSessions` / `saveCachedSessionChanges` returned `void`, so callers could not tell
- the search index worker posted `done` regardless of the cache/index result
- `SearchIndexJobRunner` resolved on `done`, and `AgentSyncEngine` then committed the new
  in-memory index and broadcast SSE

On a full disk, a permission error, a lock timeout or a corrupted database, the UI saw
"committed" data that no longer existed after a restart, and list / detail / search could diverge.

## Change

- `saveCachedSessions` and `saveCachedSessionChanges` now return whether the write reached disk
- a full scan only marks the agent cache initialized when its sessions were actually persisted,
  and reports `cache.save_failed` otherwise
- the worker checks every persistence step, posts `persist-failed` with the failing stage, agent
  and session count, and stops instead of posting `done`
- `SearchIndexJobRunner` rejects the batch on `persist-failed`, so `AgentSyncEngine` keeps the
  previously published snapshot and emits no SSE update
- an initial index failure degrades search freshness rather than blocking startup

Logs carry stage / agent / session counts only — no transcript content.

## Verification

- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 507, web 415, cli 252 passing
- new regression tests: cache-write failure and index-write failure both stop the batch
  (`search-index-worker.test.ts`), the runner rejects on `persist-failed`
  (`search-index-job-runner.test.ts`), and the save APIs report a failed write
  (`sessions.test.ts`)
- the existing `keeps the previous snapshot when search indexing fails` engine test covers the
  resulting commit gate