### PR TITLE
fix: close the Windows static path traversal (CS-131)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@codesesh/core": "workspace:*",
-    "@hono/node-server": "^1.14.0",
+    "@hono/node-server": "^2.0.12",
     "better-sqlite3": "^12.11.1",
     "citty": "^0.1.6",
     "consola": "^3.4.2",

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -1,4 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer as createNodeServer, type Server as NodeServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
 import { createServer } from "./server.js";
@@ -212,6 +215,38 @@ describe("createServer", () => {
       await eventsResponse.body?.cancel();
     } finally {
       await app.shutdown();
+    }
+  });
+
+  it("CS-131: serves the web build without reading outside its root", async () => {
+    const root = mkdtempSync(join(tmpdir(), "codesesh-static-root-"));
+    const webDist = join(root, "web");
+    mkdirSync(webDist);
+    writeFileSync(join(webDist, "index.html"), "<html>app shell</html>");
+    writeFileSync(join(webDist, "app.js"), "console.log('bundle')");
+    // Only reachable by escaping the static root.
+    const outsideMarker = "outside-static-root-marker";
+    writeFileSync(join(root, "private.txt"), outsideMarker);
+
+    const app = await createServer(0, createStore(), { webDistPath: webDist });
+    const encodedDot = "%2e";
+    const separators = ["/", "\\", "%2f", "%5c"];
+
+    try {
+      expect(await (await fetch(`${app.url}/app.js`)).text()).toContain("bundle");
+      // SPA fallback still resolves unknown routes to the app shell.
+      expect(await (await fetch(`${app.url}/sessions/anything`)).text()).toContain("app shell");
+
+      for (const separator of separators) {
+        for (const dots of ["..", `${encodedDot}${encodedDot}`]) {
+          const escape = `${dots}${separator}`.repeat(4);
+          const response = await fetch(`${app.url}/${escape}private.txt`);
+          expect(await response.text()).not.toContain(outsideMarker);
+        }
+      }
+    } finally {
+      await app.shutdown();
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -29,6 +29,8 @@ export interface CreateServerOptions {
   hostname?: string;
   remoteAccess?: boolean;
   remoteAccessToken?: string;
+  /** Overrides the auto-detected web build directory; used to pin the static root in tests. */
+  webDistPath?: string;
 }
 
 function findWebDistPath(): string | null {
@@ -152,7 +154,7 @@ export async function createServer(
   app.route("/api", createApiRoutes(store, store, routeOptions));
 
   // Serve static files from web dist (if available)
-  const webDistPath = findWebDistPath();
+  const webDistPath = options.webDistPath ?? findWebDistPath();
 
   if (webDistPath) {
     app.use("/*", serveStatic({ root: webDistPath }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,8 +167,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@hono/node-server':
-        specifier: ^1.14.0
-        version: 1.19.14(hono@4.12.29)
+        specifier: ^2.0.12
+        version: 2.0.12(hono@4.12.29)
       better-sqlite3:
         specifier: ^12.11.1
         version: 12.11.1
@@ -545,9 +545,9 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.12':
+    resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -4441,7 +4441,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.29)':
+  '@hono/node-server@2.0.12(hono@4.12.29)':
     dependencies:
       hono: 4.12.29
 
@@ -5924,6 +5924,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   file-uri-to-path@1.0.0: {}
 
@@ -7546,8 +7550,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@2.1.0: {}
 


### PR DESCRIPTION
## Problem

`packages/cli/src/server.ts` serves the web build with `@hono/node-server`'s `serveStatic()`,
and the lockfile resolved to 1.19.14 — affected by
[GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9), a Windows
`serve-static` path-normalization traversal.

This is a directly exercised runtime path, not an unreachable transitive warning: remote access
mounts its token check on `/api/*` only, so static requests are unauthenticated.

## Change

- upgrade `@hono/node-server` to `^2.0.12` (first fixed release is 2.0.5)
- add an optional `webDistPath` option to `createServer` so the static root can be pinned in
  tests; production still auto-detects the packaged or monorepo build directory
- regression test hosts a known directory and asserts that no combination of separator
  (`/`, `\`, and their encoded forms) reaches a file outside the root, while assets and the SPA
  fallback keep serving

The traversal assertions run on the Windows CI matrix, where the advisory applies.

## Verification

- `pnpm audit --prod --audit-level moderate` no longer reports GHSA-frvp-7c67-39w9
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 507, cli 253 passing
- `pnpm test:e2e` — 21 passing