### PR TITLE
perf: allocate sidebar paths in amortized constant time (CS-145)

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -88,7 +88,6 @@ describe("buildSessionTreeModel group sorting", () => {
 
     const { paths } = buildSessionTreeModel(sessions);
 
-    expect(() => buildSessionTreeModel(sessions)).not.toThrow();
     expect(groupOrderOf(paths)).toEqual(["small", "big"]);
   });
 
@@ -100,6 +99,53 @@ describe("buildSessionTreeModel group sorting", () => {
 
     expect(model.pathBySessionReference.get(getSessionReferenceKey(codex))).toBeDefined();
     expect(model.pathBySessionReference.get(getSessionReferenceKey(claude))).toBeDefined();
+  });
+});
+
+describe("buildSessionTreeModel path allocation", () => {
+  it("CS-145: allocates unique paths for fully colliding titles and id prefixes", () => {
+    // Same title and same first 8 id characters: every leaf lands on one base
+    // path. A restart-from-2 probe is O(N²) here and cannot finish in time.
+    const sessions = Array.from({ length: 20_000 }, (_, index) =>
+      makeSession({
+        id: `deadbeef-${index}`,
+        title: "Same title",
+        directory: "/repo/one",
+      }),
+    );
+
+    const model = buildSessionTreeModel(sessions);
+
+    expect(model.paths).toHaveLength(sessions.length);
+    expect(new Set(model.paths).size).toBe(sessions.length);
+    for (const session of sessions) {
+      const path = model.pathBySessionReference.get(getSessionReferenceKey(session));
+      expect(model.sessionByPath.get(path ?? "")).toBe(session);
+    }
+  });
+
+  it("CS-145: keeps groups with the same label distinct", () => {
+    const sessions = [
+      makeSession({ id: "a", directory: "/repo/one/shared" }),
+      makeSession({ id: "b", directory: "/repo/two/shared" }),
+      makeSession({ id: "c", directory: "/repo/three/shared" }),
+    ];
+
+    const { paths } = buildSessionTreeModel(sessions);
+
+    expect(groupOrderOf(paths)).toEqual(["shared", "shared (2)", "shared (3)"]);
+  });
+
+  it("CS-145: does not reuse a numbered label already taken by another title", () => {
+    const sessions = [
+      makeSession({ id: "a", title: "Report (2)" }),
+      makeSession({ id: "b", title: "Report" }),
+      makeSession({ id: "c", title: "Report" }),
+    ];
+
+    const { paths } = buildSessionTreeModel(sessions);
+
+    expect(new Set(paths).size).toBe(sessions.length);
   });
 });
 

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -145,13 +145,41 @@ function compareTreeOrder(
   return left.path.localeCompare(right.path);
 }
 
+/**
+ * Hands out unique paths for repeated labels. Each base resumes its suffix
+ * search where the last collision left off, so a run of N identical labels
+ * costs O(N) probes instead of O(N²).
+ */
+function createPathAllocator() {
+  const used = new Set<string>();
+  const nextSuffix = new Map<string, number>();
+
+  return function allocate(base: string): string {
+    if (!used.has(base)) {
+      used.add(base);
+      return base;
+    }
+
+    let suffix = nextSuffix.get(base) ?? 2;
+    let path = `${base} (${suffix})`;
+    // A distinct base may already own this exact numbered label.
+    while (used.has(path)) {
+      suffix += 1;
+      path = `${base} (${suffix})`;
+    }
+    nextSuffix.set(base, suffix + 1);
+    used.add(path);
+    return path;
+  };
+}
+
 export function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel {
   const sortOrderByPath = new Map<string, number>();
   const pathBySessionReference = new Map<string, string>();
   const groupPathBySessionReference = new Map<string, string>();
   const groupCountByPath = new Map<string, string>();
   const sessionByPath = new Map<string, SessionHead>();
-  const usedPaths = new Set<string>();
+  const allocateSessionPath = createPathAllocator();
   const paths: string[] = [];
   const groups = new Map<string, { label: string; sessions: SessionHead[]; maxTime: number }>();
 
@@ -174,17 +202,10 @@ export function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel
   });
 
   let order = 0;
-  const usedGroupPaths = new Set<string>();
+  const allocateGroupPath = createPathAllocator();
   for (const [, group] of sortedGroups) {
-    const groupLeaf = sanitizeSegment(group.label);
-    let groupPath = `${groupLeaf}/`;
-    let groupSuffix = 2;
-    while (usedGroupPaths.has(groupPath)) {
-      groupPath = `${groupLeaf} (${groupSuffix})/`;
-      groupSuffix += 1;
-    }
-    usedGroupPaths.add(groupPath);
-    const bareGroupPath = groupPath.slice(0, -1);
+    const bareGroupPath = allocateGroupPath(sanitizeSegment(group.label));
+    const groupPath = `${bareGroupPath}/`;
     const titleCounts = new Map<string, number>();
 
     sortOrderByPath.set(groupPath, order);
@@ -203,14 +224,8 @@ export function buildSessionTreeModel(sessions: SessionHead[]): SessionTreeModel
       const leaf = needsDisambiguation
         ? `${sanitizeSegment(title)} #${session.id.slice(0, 8)}`
         : sanitizeSegment(title);
-      let path = `${groupPath}${leaf}`;
-      let suffix = 2;
-      while (usedPaths.has(path)) {
-        path = `${groupPath}${leaf} (${suffix})`;
-        suffix += 1;
-      }
+      const path = allocateSessionPath(`${groupPath}${leaf}`);
 
-      usedPaths.add(path);
       paths.push(path);
       sortOrderByPath.set(path, order);
       order += 1;


### PR DESCRIPTION
## Problem

`buildSessionTreeModel` disambiguated duplicate labels by restarting the suffix probe at `2` for
every colliding leaf, so a run of N sessions sharing a base path cost O(N²) set lookups. Group
labels used the same shape.

Measured on the equivalent allocator:

| conflicts | before |
|---:|---:|
| 1,000 | 79.7 ms |
| 2,000 | 319.2 ms |
| 4,000 | 1,348.7 ms |
| 8,000 | 5,307.9 ms |

Opaque session ids allow this distribution: sessions with the same title and the same first 8 id
characters all land on one base path.

## Change

- extract a `createPathAllocator` primitive that records the next suffix per base, so each base
  resumes its probe instead of restarting; a run of N identical labels costs O(N) probes
- leaf paths and group paths share the primitive
- the allocator still verifies the candidate against the used set, so a numbered label already
  owned by a different title is not handed out twice

Labels are unchanged for the ordinary no-conflict case.

## Verification

- new tests: 20,000 fully colliding sessions (same title, same id prefix) allocate unique paths
  and round-trip every reference back to its session — the old probe cannot finish this within the
  test timeout; same-label project groups stay distinct; a title that already looks like
  `Report (2)` does not collide with a generated suffix
- dropped a redundant second 200k model build in the existing CS-78 sort test, which was pushing
  that test to its timeout on slower CI runners
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm --filter @codesesh/web test` — 418 passing