### PR TITLE
fix: limit file activity search by session, not row (CS-134)

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -1219,6 +1219,126 @@ describe("searchSessions", () => {
     expect(directWriteResults[0]?.snippet).toContain("write");
   });
 
+  it("CS-134: applies the search limit to sessions, not activity rows", () => {
+    const sessions = [
+      { id: "dense", paths: 6, time: now + 100 },
+      { id: "sparse", paths: 1, time: now },
+    ].map(({ id, paths, time }) => {
+      const session = { ...makeSession(id), time_updated: time };
+      const activityParts = Array.from({ length: paths }, (_, index) => ({
+        type: "tool" as const,
+        tool: "Read",
+        time_created: time + index,
+        state: {
+          status: "completed" as const,
+          input: { file_path: `src/shared/module-${id}-${index}.ts` },
+        },
+      }));
+      return { session, activityParts };
+    });
+
+    saveCachedSessions(
+      "claudecode",
+      sessions.map(({ session }) => session),
+    );
+    syncSessionSearchIndex(
+      "claudecode",
+      sessions.map(({ session }) => session),
+      (sessionId) => {
+        const entry = sessions.find(({ session }) => session.id === sessionId)!;
+        return {
+          ...entry.session,
+          messages: [
+            {
+              id: "m1",
+              role: "assistant",
+              time_created: entry.session.time_updated!,
+              parts: entry.activityParts,
+            },
+          ],
+        } as SessionDetail;
+      },
+    );
+
+    // The denser session owns the six most recent matching rows; a row-level
+    // limit would spend the whole budget there and never reach "sparse".
+    const results = searchFileActivitySessions("src/shared/module", { limit: 2 });
+
+    expect(results.map((result) => result.session.id)).toEqual(["dense", "sparse"]);
+  });
+
+  it("CS-134: keeps same-id sessions from different agents apart", () => {
+    for (const agent of ["claudecode", "codex"]) {
+      const session = { ...makeSession("shared-id"), slug: `${agent}/shared-id` };
+      saveCachedSessions(agent, [session]);
+      syncSessionSearchIndex(
+        agent,
+        [session],
+        () =>
+          ({
+            ...session,
+            messages: [
+              {
+                id: "m1",
+                role: "assistant",
+                time_created: now,
+                parts: [
+                  {
+                    type: "tool" as const,
+                    tool: "Read",
+                    time_created: now,
+                    state: {
+                      status: "completed" as const,
+                      input: { file_path: "src/cross/agent.ts" },
+                    },
+                  },
+                ],
+              },
+            ],
+          }) as SessionDetail,
+      );
+    }
+
+    const results = searchFileActivitySessions("src/cross/agent.ts", { limit: 10 });
+
+    expect(results.map((result) => result.reference.agentName).sort()).toEqual([
+      "claudecode",
+      "codex",
+    ]);
+  });
+
+  it("CS-134: picks the top-ranked row for the snippet on a tie", () => {
+    const session = makeSession("tied");
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex(
+      "claudecode",
+      [session],
+      () =>
+        ({
+          ...session,
+          messages: [
+            {
+              id: "m1",
+              role: "assistant",
+              time_created: now,
+              parts: ["b.ts", "a.ts", "c.ts"].map((name) => ({
+                type: "tool" as const,
+                tool: "Read",
+                time_created: now,
+                state: { status: "completed" as const, input: { file_path: `src/tie/${name}` } },
+              })),
+            },
+          ],
+        }) as SessionDetail,
+    );
+
+    const results = searchFileActivitySessions("src/tie", { limit: 10 });
+
+    expect(results).toHaveLength(1);
+    // Equal latest_time and count, so the path breaks the tie.
+    expect(results[0]?.snippet).toContain("</mark>/a.ts");
+  });
+
   it("uses latest-time indexes for recent file activity query plans", () => {
     saveCachedSessions("claudecode", [makeSession("indexed")]);
 
@@ -1263,6 +1383,41 @@ describe("searchSessions", () => {
       );
       expect(pathPlan).toContain("session_file_activity_path_fts");
       expect(pathPlan).not.toContain("SCAN fa\n");
+
+      // CS-134: ranking one row per session stays a single pass over the FTS
+      // matches — not a correlated lookup per session.
+      const rankedPlan = (
+        db
+          .prepare(
+            `
+              EXPLAIN QUERY PLAN
+              SELECT fa.agent_name, fa.session_id, fa.path
+              FROM (
+                SELECT
+                  fa.rowid AS activity_rowid,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY fa.agent_name, fa.session_id
+                    ORDER BY fa.latest_time DESC, fa.count DESC, fa.path
+                  ) AS session_rank
+                FROM session_file_activity fa
+                JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
+                WHERE fa.rowid IN (SELECT rowid FROM session_file_activity_path_fts WHERE path MATCH ?)
+              ) ranked
+              JOIN session_file_activity fa ON fa.rowid = ranked.activity_rowid
+              JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
+              WHERE ranked.session_rank = 1
+              ORDER BY fa.latest_time DESC, fa.count DESC, fa.path
+              LIMIT ?
+            `,
+          )
+          .all('"src/App"', 50) as Array<{ detail?: string }>
+      )
+        .map((row) => String(row.detail ?? ""))
+        .join("\n");
+
+      expect(rankedPlan).toContain("session_file_activity_path_fts");
+      expect(rankedPlan).not.toContain("CORRELATED");
+      expect(rankedPlan).not.toContain("SCAN fa\n");
     } finally {
       db.close();
     }

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -150,65 +150,113 @@ export function buildFileActivityWhere(options: FileActivityOptions): {
   };
 }
 
+const FILE_ACTIVITY_COLUMNS = `
+  fa.agent_name,
+  fa.session_id,
+  fa.project_identity_key,
+  fa.path,
+  fa.kind,
+  fa.count,
+  fa.latest_time,
+  s.slug,
+  s.title,
+  s.directory,
+  s.project_identity_kind,
+  s.project_display_name,
+  s.time_created,
+  s.time_updated,
+  s.message_count,
+  s.total_input_tokens,
+  s.total_output_tokens,
+  s.total_cache_read_tokens,
+  s.total_cache_create_tokens,
+  s.total_cost,
+  s.cost_source,
+  s.total_tokens,
+  s.model_usage_json,
+  s.smart_tags_json,
+  s.smart_tags_source_updated_at
+`;
+
+const FILE_ACTIVITY_JOIN = `
+  FROM session_file_activity fa
+  JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
+`;
+
+/** Most recent first, then busiest, then path — the tie-break every caller relies on. */
+const FILE_ACTIVITY_ORDER = "fa.latest_time DESC, fa.count DESC, fa.path";
+
 export function listFileActivity(options: FileActivityOptions = {}): FileActivityResult[] {
   return queryFileActivity(options);
+}
+
+interface FileActivityQuery {
+  options: FileActivityOptions;
+  sessionSearchOptions?: SearchOptions;
+  /** Keep only each session's top-ranked row, so the limit counts sessions. */
+  onePerSession?: boolean;
+}
+
+function fileActivityWhere(query: FileActivityQuery): { where: string; params: unknown[] } {
+  const filters = buildFileActivityWhere(query.options);
+  const sessionFilters = query.sessionSearchOptions
+    ? buildSessionSearchFilters(query.sessionSearchOptions)
+    : { where: "", params: [] };
+  const clauses = [
+    filters.where.replace(/^WHERE /, ""),
+    sessionFilters.where.replace(/^ AND /, ""),
+  ].filter(Boolean);
+  return {
+    where: clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "",
+    params: [...filters.params, ...sessionFilters.params],
+  };
+}
+
+function fileActivitySql(query: FileActivityQuery, where: string): string {
+  if (!query.onePerSession) {
+    return `
+      SELECT ${FILE_ACTIVITY_COLUMNS}
+      ${FILE_ACTIVITY_JOIN}
+      ${where}
+      ORDER BY ${FILE_ACTIVITY_ORDER}
+      LIMIT ?
+    `;
+  }
+
+  return `
+    SELECT ${FILE_ACTIVITY_COLUMNS}
+    FROM (
+      SELECT
+        fa.rowid AS activity_rowid,
+        ROW_NUMBER() OVER (
+          PARTITION BY fa.agent_name, fa.session_id
+          ORDER BY ${FILE_ACTIVITY_ORDER}
+        ) AS session_rank
+      ${FILE_ACTIVITY_JOIN}
+      ${where}
+    ) ranked
+    JOIN session_file_activity fa ON fa.rowid = ranked.activity_rowid
+    JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
+    WHERE ranked.session_rank = 1
+    ORDER BY ${FILE_ACTIVITY_ORDER}
+    LIMIT ?
+  `;
 }
 
 function queryFileActivity(
   options: FileActivityOptions,
   sessionSearchOptions?: SearchOptions,
+  onePerSession = false,
 ): FileActivityResult[] {
   if (!hasCacheStorage()) {
     return [];
   }
 
-  const filters = buildFileActivityWhere(options);
-  const sessionFilters = sessionSearchOptions
-    ? buildSessionSearchFilters(sessionSearchOptions)
-    : { where: "", params: [] };
-  const whereClauses = [
-    filters.where.replace(/^WHERE /, ""),
-    sessionFilters.where.replace(/^ AND /, ""),
-  ].filter(Boolean);
-  const where = whereClauses.length > 0 ? `WHERE ${whereClauses.join(" AND ")}` : "";
+  const query: FileActivityQuery = { options, sessionSearchOptions, onePerSession };
+  const { where, params } = fileActivityWhere(query);
+  const sql = fileActivitySql(query, where);
   const queryRows = (db: SQLiteDatabase) =>
-    db
-      .prepare(
-        `
-          SELECT
-            fa.agent_name,
-            fa.session_id,
-            fa.project_identity_key,
-            fa.path,
-            fa.kind,
-            fa.count,
-            fa.latest_time,
-            s.slug,
-            s.title,
-            s.directory,
-            s.project_identity_kind,
-            s.project_display_name,
-            s.time_created,
-            s.time_updated,
-            s.message_count,
-            s.total_input_tokens,
-            s.total_output_tokens,
-            s.total_cache_read_tokens,
-            s.total_cache_create_tokens,
-            s.total_cost,
-            s.cost_source,
-            s.total_tokens,
-            s.model_usage_json,
-            s.smart_tags_json,
-            s.smart_tags_source_updated_at
-          FROM session_file_activity fa
-          JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
-          ${where}
-          ORDER BY fa.latest_time DESC, fa.count DESC, fa.path
-          LIMIT ?
-        `,
-      )
-      .all(...filters.params, ...sessionFilters.params, options.limit ?? 50) as FileActivityRow[];
+    db.prepare(sql).all(...params, options.limit ?? 50) as FileActivityRow[];
 
   let rows = withCacheDbReadOnly(queryRows);
   if (rows == null && options.path) {
@@ -253,25 +301,16 @@ export function searchFileActivitySessions(
     {
       path,
       kind: search.options.fileKind,
-      limit: (search.options.limit ?? 50) * 3,
+      limit: search.options.limit ?? 50,
     },
     search.options,
+    true,
   );
-  const seen = new Set<string>();
-  const results: SearchResult[] = [];
 
-  for (const row of rows) {
-    const key = `${row.reference.agentName}/${row.reference.sessionId}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    results.push({
-      reference: row.reference,
-      session: row.session,
-      snippet: `${row.kind} ${highlightFilePath(row.path, path)} · ${row.count} events`,
-      matchType: "file_path",
-    });
-    if (results.length >= (search.options.limit ?? 50)) break;
-  }
-
-  return results;
+  return rows.map((row) => ({
+    reference: row.reference,
+    session: row.session,
+    snippet: `${row.kind} ${highlightFilePath(row.path, path)} · ${row.count} events`,
+    matchType: "file_path",
+  }));
 }


### PR DESCRIPTION
## Problem

`searchFileActivitySessions()` asked SQLite for three times the requested limit in **activity rows**,
then deduplicated by session reference in TypeScript and truncated. One session with several
matching paths could fill the entire candidate window, so other matching sessions were never
returned.

Reproduced with two sessions — six recent matching paths in the first, one older path in the second,
`limit: 2`: the result was `["dense"]` instead of `["dense", "sparse"]`. Raising the over-fetch
multiplier only moves the threshold; the query granularity is what is wrong.

## Change

- SQLite ranks activity rows per `(agent_name, session_id)` with `ROW_NUMBER()` and keeps the top
  row before the limit applies, so the limit counts sessions
- `searchFileActivitySessions` consumes those candidates directly — no over-fetch multiplier and no
  in-memory dedupe
- the row-level `listFileActivity` path is unchanged; both share the same column list, join and
  ordering, so filters and the recency tie-break stay identical

## Verification

- regression test for the reproduced 6+1 rows at `limit: 2`
- same-id sessions from different agents stay separate — the partition covers both fields
- on an exact tie in time and count, the snippet comes from the path-ordered top row
- `EXPLAIN QUERY PLAN` asserts the ranked query still drives off the path FTS index, with no
  correlated per-session lookup and no scan of the activity table
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 528, cli 280, web 425 passing