### PR TITLE
fix: keep markdown highlights in sync with the query (CS-135)

### DIFF
--- a/apps/web/src/components/MarkdownContent.test.tsx
+++ b/apps/web/src/components/MarkdownContent.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MarkdownContent } from "./MarkdownContent";
+
+afterEach(cleanup);
+
+function marks(container: HTMLElement): string[] {
+  return [...container.querySelectorAll("mark")].map((mark) => mark.textContent ?? "");
+}
+
+describe("MarkdownContent search highlighting", () => {
+  it("CS-135: keeps only the current query highlighted", () => {
+    const view = render(<MarkdownContent text="Alpha Beta" />);
+    expect(marks(view.container)).toEqual([]);
+
+    view.rerender(<MarkdownContent text="Alpha Beta" highlightQuery="Alpha" />);
+    expect(marks(view.container)).toEqual(["Alpha"]);
+
+    view.rerender(<MarkdownContent text="Alpha Beta" highlightQuery="Beta" />);
+    expect(marks(view.container)).toEqual(["Beta"]);
+
+    view.rerender(<MarkdownContent text="Alpha Beta" highlightQuery="" />);
+    expect(marks(view.container)).toEqual([]);
+
+    view.rerender(<MarkdownContent text="Alpha Beta" highlightQuery="Alpha" />);
+    expect(marks(view.container)).toEqual(["Alpha"]);
+    expect(view.container.textContent).toBe("Alpha Beta");
+  });
+
+  it("CS-135: highlights every term of a multi-term query", () => {
+    const view = render(<MarkdownContent text="Alpha Beta Gamma" highlightQuery="gamma alpha" />);
+
+    expect(marks(view.container)).toEqual(["Alpha", "Gamma"]);
+  });
+
+  it("CS-135: treats a quoted phrase as one term", () => {
+    const view = render(
+      <MarkdownContent text="the quick brown fox" highlightQuery='"quick brown"' />,
+    );
+
+    expect(marks(view.container)).toEqual(["quick brown"]);
+  });
+
+  it("CS-135: highlights inside emphasis and link text", () => {
+    const view = render(
+      <MarkdownContent
+        text="**Alpha** and [Alpha docs](https://example.com)"
+        highlightQuery="alpha"
+      />,
+    );
+
+    expect(marks(view.container)).toEqual(["Alpha", "Alpha"]);
+    expect(view.container.querySelector("strong mark")).not.toBeNull();
+  });
+
+  it("CS-135: leaves code and preformatted text untouched", () => {
+    const view = render(
+      <MarkdownContent text={"`alpha()` and\n\n```\nalpha\n```"} highlightQuery="alpha" />,
+    );
+
+    expect(marks(view.container)).toEqual([]);
+  });
+
+  it("CS-135: does not disturb a mark written in the markdown itself", () => {
+    const view = render(<MarkdownContent text="plain text" highlightQuery="missing" />);
+
+    expect(marks(view.container)).toEqual([]);
+    expect(view.container.textContent).toBe("plain text");
+  });
+});

--- a/apps/web/src/components/MarkdownContent.tsx
+++ b/apps/web/src/components/MarkdownContent.tsx
@@ -1,6 +1,6 @@
-import { memo, useEffect, useMemo, useRef } from "react";
+import { memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
-import type { Components } from "react-markdown";
+import type { Components, Options } from "react-markdown";
 
 const markdownComponents: Components = {
   a: ({ children }) => <span className="console-markdown-link">{children}</span>,
@@ -10,6 +10,18 @@ interface MarkdownContentProps {
   text: string;
   highlightQuery?: string;
 }
+
+/** Minimal shape of the hast nodes this plugin walks. */
+interface HastNode {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+}
+
+/** Elements whose text is shown verbatim, so search must not rewrite it. */
+const OPAQUE_TAG_NAMES = new Set(["code", "pre", "mark"]);
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -32,64 +44,76 @@ function buildHighlightPattern(query?: string): RegExp | null {
   return new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
 }
 
+/** Splits a text node around matches, or returns null when nothing matched. */
+function splitHighlighted(value: string, pattern: RegExp): HastNode[] | null {
+  const nodes: HastNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of value.matchAll(pattern)) {
+    const start = match.index ?? 0;
+    const matched = match[0] ?? "";
+    if (!matched) continue;
+    if (start > lastIndex) nodes.push({ type: "text", value: value.slice(lastIndex, start) });
+    nodes.push({
+      type: "element",
+      tagName: "mark",
+      properties: {},
+      children: [{ type: "text", value: matched }],
+    });
+    lastIndex = start + matched.length;
+  }
+
+  if (nodes.length === 0) return null;
+  if (lastIndex < value.length) nodes.push({ type: "text", value: value.slice(lastIndex) });
+  return nodes;
+}
+
+function highlightChildren(node: HastNode, pattern: RegExp): void {
+  if (!node.children) return;
+
+  const next: HastNode[] = [];
+  let changed = false;
+
+  for (const child of node.children) {
+    if (child.type === "text") {
+      const split = splitHighlighted(child.value ?? "", pattern);
+      if (split) {
+        next.push(...split);
+        changed = true;
+        continue;
+      }
+    } else if (!(child.tagName && OPAQUE_TAG_NAMES.has(child.tagName))) {
+      highlightChildren(child, pattern);
+    }
+    next.push(child);
+  }
+
+  if (changed) node.children = next;
+}
+
+/**
+ * Emits `<mark>` as part of the rendered tree. Rewriting the DOM after React
+ * renders would leave stale highlights behind whenever the query changed, since
+ * React would keep reusing the nodes it still believes are plain text.
+ */
+function rehypeHighlightTerms(pattern: RegExp) {
+  return (tree: HastNode) => highlightChildren(tree, pattern);
+}
+
 export const MarkdownContent = memo(function MarkdownContent({
   text,
   highlightQuery,
 }: MarkdownContentProps) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const highlightPattern = useMemo(() => buildHighlightPattern(highlightQuery), [highlightQuery]);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || !highlightPattern) {
-      return;
-    }
-
-    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-    const textNodes: Text[] = [];
-
-    while (walker.nextNode()) {
-      const node = walker.currentNode;
-      if (!(node instanceof Text)) continue;
-      const parent = node.parentElement;
-      if (!parent) continue;
-      if (parent.closest("mark, pre, code")) continue;
-      if (!node.textContent?.trim()) continue;
-      textNodes.push(node);
-    }
-
-    for (const node of textNodes) {
-      const source = node.textContent ?? "";
-      highlightPattern.lastIndex = 0;
-      if (!highlightPattern.test(source)) continue;
-
-      const fragment = document.createDocumentFragment();
-      let lastIndex = 0;
-      highlightPattern.lastIndex = 0;
-
-      for (const match of source.matchAll(highlightPattern)) {
-        const start = match.index ?? 0;
-        const matched = match[0] ?? "";
-        if (start > lastIndex) {
-          fragment.append(source.slice(lastIndex, start));
-        }
-        const mark = document.createElement("mark");
-        mark.textContent = matched;
-        fragment.append(mark);
-        lastIndex = start + matched.length;
-      }
-
-      if (lastIndex < source.length) {
-        fragment.append(source.slice(lastIndex));
-      }
-
-      node.parentNode?.replaceChild(fragment, node);
-    }
-  }, [highlightPattern, text]);
+  const rehypePlugins = useMemo<Options["rehypePlugins"]>(() => {
+    const pattern = buildHighlightPattern(highlightQuery);
+    return pattern ? [[rehypeHighlightTerms, pattern]] : undefined;
+  }, [highlightQuery]);
 
   return (
-    <div ref={containerRef}>
-      <ReactMarkdown components={markdownComponents}>{text}</ReactMarkdown>
+    <div>
+      <ReactMarkdown components={markdownComponents} rehypePlugins={rehypePlugins}>
+        {text}
+      </ReactMarkdown>
     </div>
   );
 });

--- a/apps/web/src/components/session-detail/message-markdown-memo.test.tsx
+++ b/apps/web/src/components/session-detail/message-markdown-memo.test.tsx
@@ -8,12 +8,18 @@ const { markdownRender } = vi.hoisted(() => ({
   markdownRender: vi.fn(),
 }));
 
+// Stubbed so the assertions count parses rather than markdown output; the
+// rendered highlight itself is covered by MarkdownContent.test.tsx.
 vi.mock("react-markdown", () => ({
-  default: ({ children }: { children: string }) => {
-    markdownRender(children);
+  default: ({ children, rehypePlugins }: { children: string; rehypePlugins?: unknown[] }) => {
+    markdownRender(children, rehypePlugins);
     return <span>{children}</span>;
   },
 }));
+
+function lastHighlightPlugins(): unknown[] | undefined {
+  return markdownRender.mock.calls.at(-1)?.[1] as unknown[] | undefined;
+}
 
 afterEach(() => {
   cleanup();
@@ -49,7 +55,11 @@ describe("message markdown memoization", () => {
 
     view.rerender(<MarkdownContent text="Memoized markdown" highlightQuery="memoized" />);
     expect(markdownRender).toHaveBeenCalledTimes(2);
-    expect(view.container.querySelector("mark")?.textContent).toBe("Memoized");
+    expect(lastHighlightPlugins()).toHaveLength(1);
+
+    view.rerender(<MarkdownContent text="Memoized markdown" highlightQuery="" />);
+    expect(markdownRender).toHaveBeenCalledTimes(3);
+    expect(lastHighlightPlugins()).toBeUndefined();
   });
 
   it("does not reparse stable visible messages on viewport updates", () => {
@@ -97,7 +107,7 @@ describe("message markdown memoization", () => {
       />,
     );
     expect(markdownRender.mock.calls.length).toBeGreaterThan(initialRenderCount);
-    expect(view.container.querySelectorAll("mark").length).toBeGreaterThan(0);
+    expect(lastHighlightPlugins()).toHaveLength(1);
     scrollContainer.remove();
   });
 });


### PR DESCRIPTION
## Problem

`MarkdownContent` walked the rendered DOM and replaced React-managed `Text` nodes with `<mark>`
fragments. The effect had no cleanup and returned early on an empty query, so React went on reusing
nodes it still believed were plain text.

Reproduced against the real component: rendering `"Alpha Beta"` highlighted for `Alpha`, then
re-rendering for `Beta`, left `["Alpha", "Beta"]` marked instead of `["Beta"]`. Clearing the query
left the previous highlight in place. This is the update path CS-114 asked for but did not cover.

## Change

Highlighting became a rehype plugin, so the `<mark>` elements are part of the tree React renders
rather than something applied to the DOM afterwards. There is nothing to clean up: a changed or
empty query simply produces a different tree.

- terms, quoted phrases and the `OR` filtering are unchanged
- `code`, `pre` and any `mark` already in the source are still skipped
- the plugin array is only built when there is a query, so an unhighlighted render is untouched

## Verification

- regression sequence over no query → Alpha → Beta → empty → Alpha, asserting mark text and count at
  each step, plus that the visible text is unchanged
- multi-term and quoted-phrase queries, highlighting inside emphasis and link text, and code/pre
  exclusion
- the memoization tests still assert that stable text and query do not reparse, and now check that
  the highlight reaches the render pipeline rather than inspecting stub output
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm --filter @codesesh/web test` — 431 passing
- `pnpm test:e2e` — 21 passing