### PR TITLE
fix: keep transcript media local (CS-136)

### DIFF
--- a/apps/web/src/components/MarkdownContent.test.tsx
+++ b/apps/web/src/components/MarkdownContent.test.tsx
@@ -68,3 +68,31 @@ describe("MarkdownContent search highlighting", () => {
     expect(view.container.textContent).toBe("plain text");
   });
 });
+
+describe("CS-136: markdown media stays local", () => {
+  it.each([
+    ["remote https", "https://tracker.example.com/pixel.png"],
+    ["protocol relative", "//tracker.example.com/pixel.png"],
+  ])("does not emit a requestable src for a %s image", (_name, url) => {
+    const view = render(<MarkdownContent text={`![shot](${url})`} />);
+
+    expect(view.container.querySelectorAll("img")).toHaveLength(0);
+    expect(view.container.textContent).toContain("Remote image not loaded");
+    expect(view.container.textContent).toContain("shot");
+  });
+
+  it("renders inline image data", () => {
+    const src = "data:image/png;base64,iVBORw0KGgo=";
+    const view = render(<MarkdownContent text={`![local](${src})`} />);
+
+    expect(view.container.querySelector("img")?.getAttribute("src")).toBe(src);
+  });
+
+  it("renders a same-origin asset path", () => {
+    const view = render(<MarkdownContent text="![asset](/api/assets/a.png)" />);
+
+    expect(view.container.querySelector("img")?.getAttribute("src")).toBe(
+      `${window.location.origin}/api/assets/a.png`,
+    );
+  });
+});

--- a/apps/web/src/components/MarkdownContent.tsx
+++ b/apps/web/src/components/MarkdownContent.tsx
@@ -1,10 +1,39 @@
 import { memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components, Options } from "react-markdown";
+import { resolveLocalMediaSource } from "../lib/local-media-policy";
 
 const markdownComponents: Components = {
   a: ({ children }) => <span className="console-markdown-link">{children}</span>,
+  img: ({ src, alt, title }) => {
+    const safeSrc = resolveLocalMediaSource(typeof src === "string" ? src : undefined);
+    if (!safeSrc) {
+      return (
+        <span className="console-mono inline-block rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-muted)]">
+          Remote image not loaded{alt ? `: ${alt}` : ""}
+        </span>
+      );
+    }
+    return (
+      <img
+        src={safeSrc}
+        alt={alt ?? ""}
+        title={title}
+        loading="lazy"
+        className="max-h-[520px] max-w-full object-contain"
+      />
+    );
+  },
 };
+
+/**
+ * react-markdown's default transform drops inline image data and keeps remote
+ * URLs — the opposite of what a local-only reader wants. The media policy makes
+ * that call instead, for every URL the tree carries.
+ */
+function transformMediaUrl(url: string): string {
+  return resolveLocalMediaSource(url) ?? "";
+}
 
 interface MarkdownContentProps {
   text: string;
@@ -111,7 +140,11 @@ export const MarkdownContent = memo(function MarkdownContent({
 
   return (
     <div>
-      <ReactMarkdown components={markdownComponents} rehypePlugins={rehypePlugins}>
+      <ReactMarkdown
+        components={markdownComponents}
+        rehypePlugins={rehypePlugins}
+        urlTransform={transformMediaUrl}
+      >
         {text}
       </ReactMarkdown>
     </div>

--- a/apps/web/src/components/session-detail/tool-normalize.ts
+++ b/apps/web/src/components/session-detail/tool-normalize.ts
@@ -9,6 +9,7 @@ import type { LoaderCircle } from "../ui/icons";
 import type { Message, ToolPart } from "../../lib/api";
 import type { ToolOutputContent } from "../tool-output/types";
 import type { ToolDetailItem } from "./codex-tool";
+import { inlineImageSource, resolveLocalMediaSource } from "../../lib/local-media-policy";
 import {
   compactText,
   normalizeEscapedNewlines,
@@ -42,13 +43,9 @@ export interface ToolDisplayStrategy {
 }
 
 function toSafeImageSource(part: Record<string, unknown>) {
-  const mimeType = toPlainText(part.mime_type);
-  const data = toPlainText(part.data);
-  if (mimeType.startsWith("image/") && data) return `data:${mimeType};base64,${data}`;
-
-  const url = toPlainText(part.url);
-  if (/^data:image\//i.test(url)) return url;
-  return "";
+  const inline = inlineImageSource(toPlainText(part.mime_type), toPlainText(part.data));
+  if (inline) return inline;
+  return resolveLocalMediaSource(toPlainText(part.url)) ?? "";
 }
 
 export function extractToolMedia(value: unknown) {

--- a/apps/web/src/lib/local-media-policy.test.ts
+++ b/apps/web/src/lib/local-media-policy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { inlineImageSource, resolveLocalMediaSource } from "./local-media-policy";
+
+describe("CS-136: local media policy", () => {
+  it.each([
+    ["remote https", "https://tracker.example.com/pixel.png"],
+    ["remote http", "http://tracker.example.com/pixel.png"],
+    ["protocol relative", "//tracker.example.com/pixel.png"],
+    ["remote with credentials", "https://user:pw@tracker.example.com/a.png"],
+    ["blob reference", "blob:https://tracker.example.com/9f2b"],
+    ["javascript url", "javascript:alert(1)"],
+    ["non-image data url", "data:text/html;base64,PHNjcmlwdD4="],
+    ["malformed", "https://"],
+    ["empty", "   "],
+  ])("refuses %s", (_name, value) => {
+    expect(resolveLocalMediaSource(value)).toBeNull();
+  });
+
+  it("allows inline image data", () => {
+    const src = "data:image/png;base64,iVBORw0KGgo=";
+    expect(resolveLocalMediaSource(src)).toBe(src);
+  });
+
+  it("allows a same-origin path served by CodeSesh", () => {
+    const resolved = resolveLocalMediaSource("/api/sessions/codex/s1/asset.png");
+    expect(resolved).toBe(`${window.location.origin}/api/sessions/codex/s1/asset.png`);
+  });
+
+  it("refuses an oversized inline payload", () => {
+    const huge = `data:image/png;base64,${"A".repeat(13 * 1024 * 1024)}`;
+    expect(resolveLocalMediaSource(huge)).toBeNull();
+  });
+
+  it("builds inline sources only for image mime types", () => {
+    expect(inlineImageSource("image/png", "iVBORw0KGgo=")).toBe(
+      "data:image/png;base64,iVBORw0KGgo=",
+    );
+    expect(inlineImageSource("text/html", "PHNjcmlwdD4=")).toBeNull();
+    expect(inlineImageSource("image/png", "")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/local-media-policy.ts
+++ b/apps/web/src/lib/local-media-policy.ts
@@ -1,0 +1,62 @@
+/**
+ * What transcript content is allowed to display without touching the network.
+ *
+ * Everything CodeSesh renders was produced by an agent, so any URL inside it is
+ * untrusted input. Fetching one would tell a third party the reader's IP and
+ * when they opened the session — which is exactly what "100% local" rules out.
+ * Callers ask for a displayable source and get nothing back when the policy
+ * refuses; protocol, origin and size limits stay in here.
+ */
+
+/**
+ * Roughly 9 MB of image data once base64 is decoded. Large enough for a
+ * full-resolution screenshot, small enough that a malformed payload cannot
+ * stall the renderer.
+ */
+const MAX_INLINE_IMAGE_CHARS = 12 * 1024 * 1024;
+
+const INLINE_IMAGE_PATTERN = /^data:image\/[a-z0-9.+-]+(?:;[a-z0-9-]+=[^,;]*)*(?:;base64)?,/i;
+
+function appOrigin(): string | null {
+  return typeof window === "undefined" ? null : window.location.origin;
+}
+
+/** Resolves against the app origin so `//host/x` is judged by its target, not its prefix. */
+function resolveAgainstApp(value: string): URL | null {
+  const origin = appOrigin();
+  try {
+    return origin ? new URL(value, origin) : new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function isInlineImage(value: string): boolean {
+  if (!INLINE_IMAGE_PATTERN.test(value)) return false;
+  return value.length <= MAX_INLINE_IMAGE_CHARS;
+}
+
+/**
+ * Returns a source safe to put in `src`, or null when the policy refuses it.
+ * Accepts inline image data and same-origin paths served by CodeSesh itself.
+ */
+export function resolveLocalMediaSource(value: string | null | undefined): string | null {
+  const raw = value?.trim();
+  if (!raw) return null;
+  if (isInlineImage(raw)) return raw;
+
+  const url = resolveAgainstApp(raw);
+  if (!url) return null;
+  // A blob URL only refers to something the current page created, so one stored
+  // in a transcript is either stale or forged.
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+
+  const origin = appOrigin();
+  return origin && url.origin === origin ? url.href : null;
+}
+
+/** Builds an inline image source from a mime type and base64 payload. */
+export function inlineImageSource(mimeType: string, base64Data: string): string | null {
+  if (!mimeType.startsWith("image/") || !base64Data) return null;
+  return resolveLocalMediaSource(`data:${mimeType};base64,${base64Data}`);
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -83,7 +83,12 @@ export default defineConfig({
   projects: [
     {
       name: "web-chromium",
-      testMatch: ["aggregation.spec.ts", "browsing.spec.ts", "live-refresh.spec.ts"],
+      testMatch: [
+        "aggregation.spec.ts",
+        "browsing.spec.ts",
+        "live-refresh.spec.ts",
+        "local-media.spec.ts",
+      ],
       metadata: { fixtureSessionPath },
       use: { ...devices["Desktop Chrome"], baseURL: `http://127.0.0.1:${port}` },
     },

--- a/tests/e2e/local-media.spec.ts
+++ b/tests/e2e/local-media.spec.ts
@@ -1,0 +1,73 @@
+import { appendFile } from "node:fs/promises";
+import { expect, test } from "./test-fixtures.js";
+
+const REMOTE_HOST = "tracker.invalid";
+
+/**
+ * CodeSesh renders transcripts an agent produced, so a remote URL inside one is
+ * untrusted. Loading it would hand a third party the reader's IP and the time
+ * they opened the session.
+ */
+test("never requests remote media referenced by a transcript", async ({ page }, testInfo) => {
+  const fixtureSessionPath = testInfo.project.metadata.fixtureSessionPath;
+  if (typeof fixtureSessionPath !== "string") {
+    throw new Error("Missing staged session fixture path");
+  }
+
+  const marker = `localmedia${testInfo.retry}`;
+  const record = {
+    type: "assistant",
+    uuid: `assistant-media-${testInfo.retry}`,
+    timestamp: "2026-04-20T10:00:04Z",
+    message: {
+      role: "assistant",
+      model: "claude-sonnet-4-5-20250929",
+      usage: {
+        input_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: 12,
+      },
+      content: [
+        {
+          type: "text",
+          text: [
+            `Report ${marker}`,
+            `![screenshot](https://${REMOTE_HOST}/pixel.png)`,
+            `![protocol relative](//${REMOTE_HOST}/beacon.png)`,
+            `[link](https://${REMOTE_HOST}/page)`,
+          ].join("\n\n"),
+        },
+        {
+          type: "image",
+          source: { type: "url", url: `https://${REMOTE_HOST}/tool-output.png` },
+        },
+      ],
+    },
+  };
+
+  const offOrigin: string[] = [];
+  await page.route("**/*", async (route) => {
+    const host = new URL(route.request().url()).hostname;
+    if (host === "localhost" || host === "127.0.0.1") {
+      await route.continue();
+      return;
+    }
+    offOrigin.push(route.request().url());
+    await route.abort();
+  });
+
+  await appendFile(fixtureSessionPath, `${JSON.stringify(record)}\n`, "utf8");
+
+  await page.goto("/claudecode/e2e-dashboard");
+  await expect(page.getByTestId("session-detail")).toBeVisible();
+  await expect(page.getByText(`Report ${marker}`)).toBeVisible();
+  // The SSE stream stays open, so idle never fires; give any image request
+  // the renderer might have issued a chance to reach the route handler.
+  await page.waitForTimeout(500);
+
+  expect(offOrigin).toEqual([]);
+  expect(await page.locator(`img[src*="${REMOTE_HOST}"]`).count()).toBe(0);
+  expect(await page.locator(`link[href*="${REMOTE_HOST}"]`).count()).toBe(0);
+  await expect(page.getByText("Remote image not loaded").first()).toBeVisible();
+});


### PR DESCRIPTION
## Problem

Tool output already refused remote image URLs, but `MarkdownContent` had no image handling at all.
react-markdown 10 allows HTTP(S) URLs by default, so a session containing a markdown image rendered
a real `<img src="https://…">` — and React 19's static render even emitted a preload for it.

Opening a locally stored session therefore told a third party the reader's IP address and when they
read it, which contradicts the "100% Local & Private / no cloud telemetry" claim in the README and
on the site.

Reproduced against the component: both `https://…` and protocol-relative `//host/…` image URLs
reached the DOM as requestable `src` attributes.

## Change

- new `local-media-policy` module decides what transcript content may be displayed: inline image
  data within a size bound, and same-origin paths CodeSesh itself serves
- candidates are resolved against the app origin rather than prefix-matched, so `//host/x` is judged
  by where it actually points; a `blob:` URL stored in a transcript is refused, since it can only
  ever refer to something the current page created
- markdown images and tool media both consume the policy — markdown through `urlTransform` and a
  dedicated `img` component, tool output through its existing source builder
- a refused image renders a labelled placeholder instead of disappearing silently

Remote URLs stay unfetched by default. Opting into them would be a separate, visible product
decision.

## Verification

- policy tests cover remote http/https, protocol-relative, credentialed, `blob:`, `javascript:`,
  non-image data URLs, malformed input, an oversized inline payload, and the allowed inline and
  same-origin cases
- component tests assert no requestable `src` reaches the DOM for remote markdown images, while
  inline data and same-origin asset paths still render
- Playwright test aborts and records every off-origin request, opens a session whose transcript
  carries remote markdown images, a remote link and a remote tool image, and asserts zero such
  requests — verified to fail without the policy in place
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 528, cli 280, web 448 passing
- `pnpm test:e2e` — 22 passing