### PR TITLE
fix: never read a failed database scan as an empty agent (CS-138)

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -334,6 +334,58 @@ describe("AgentSyncEngine", () => {
     );
   });
 
+  it("CS-138: keeps the previous snapshot when a scan fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const workerRunner = makeWorkerRunner();
+    workerRunner.run = vi.fn(async () => {
+      throw new Error("codex session scan failed while opening the database");
+    });
+    const previous = makeSession("session", "before");
+    const { engine } = makeEngine(
+      makeAgent({ checkForChanges: () => ({ hasChanges: true, timestamp: 2 }) }),
+      [previous],
+      workerRunner,
+    );
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().byAgent.codex).toEqual([previous]);
+    expect(sessionChanges).not.toHaveBeenCalled();
+    expect(searchIndex.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("CS-138: keeps sessions when the agent becomes unreachable", async () => {
+    const previous = makeSession("session", "before");
+    const { engine } = makeEngine(makeAgent({ isAvailable: () => false }), [previous]);
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().byAgent.codex).toEqual([previous]);
+    expect(sessionChanges).not.toHaveBeenCalled();
+    expect(searchIndex.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("CS-138: still publishes a genuinely empty scan as removals", async () => {
+    const workerRunner = makeWorkerRunner();
+    const previous = makeSession("session", "before");
+    const { engine } = makeEngine(
+      makeAgent({ checkForChanges: () => ({ hasChanges: true, timestamp: 2 }) }),
+      [previous],
+      workerRunner,
+    );
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().byAgent.codex).toEqual([]);
+    expect(sessionChanges).toHaveBeenCalled();
+  });
+
   it("clears pending refresh work during shutdown", async () => {
     vi.useFakeTimers();
     const checkForChanges = vi.fn(() => ({ hasChanges: false, timestamp: Date.now() }));

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -378,8 +378,22 @@ export class AgentSyncEngine {
     return "committed";
   }
 
+  /**
+   * An agent that cannot be reached was never scanned, so there is nothing to
+   * compare against. Publishing an empty result here would diff every known
+   * session into a removal — the same mistake as reading a failed query as an
+   * empty database.
+   */
   private refreshUnavailableAgent(agentName: string): RefreshStrategyResult {
     this.lastRefreshAtByAgent.set(agentName, Date.now());
+    const previousSessions = this.sessionIndex.snapshot().byAgent[agentName] ?? [];
+    if (previousSessions.length > 0) {
+      appLogger.warn("scan.refresh.agent_unavailable", {
+        agent: agentName,
+        retained_sessions: previousSessions.length,
+      });
+      return this.refreshStrategyResult(previousSessions, { status: "unchanged" });
+    }
     return this.refreshStrategyResult([]);
   }
 

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1517,7 +1517,10 @@ describe("LiveScanStore", () => {
     ]);
   });
 
-  it("removes sessions when an agent becomes unavailable", async () => {
+  // CS-138: an unreachable agent was never scanned, so an empty result proves
+  // nothing. Publishing it would delete every session the agent ever had —
+  // a moved database file or an unmounted share would wipe the history.
+  it("keeps sessions when an agent becomes unavailable", async () => {
     const previous = makeSession("session");
     const codex = makeAgent("codex", {
       isAvailable: vi.fn(() => false),
@@ -1538,26 +1541,9 @@ describe("LiveScanStore", () => {
     await syncEngineOf(store).refresh("codex");
 
     expect(core.saveCachedSessions).not.toHaveBeenCalled();
-    expect(workerThreads.workers).toHaveLength(workerCount + 1);
-    expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
-      expect.objectContaining({
-        kind: "full",
-        agentName: "codex",
-        sessions: [],
-        saveCache: true,
-      }),
-    ]);
-    expect(events).toEqual([
-      expect.objectContaining({
-        newSessions: 0,
-        updatedSessions: 0,
-        removedSessions: 1,
-        totalSessions: 0,
-        changedSessionHeads: [],
-        removedSessionRefs: [{ agentName: "codex", sessionId: "session" }],
-      }),
-    ]);
-    expect(store.getSnapshot().sessions).toEqual([]);
+    expect(workerThreads.workers).toHaveLength(workerCount);
+    expect(events).toEqual([]);
+    expect(store.getSnapshot().sessions).toEqual([previous]);
   });
 
   it("uses native recursive watch and waits for appended files to stabilize", async () => {

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { OpenCodeSqliteAgent } from "../opencode-sqlite.js";
+import { SessionScanError } from "../base.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 const tempDirs: string[] = [];
@@ -211,5 +212,47 @@ describe("OpenCodeSqliteAgent", () => {
         },
       ]),
     );
+  });
+});
+
+describe("CS-138: unreadable databases are not empty scans", () => {
+  function makeAgent(dbPath: string) {
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+      getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
+    });
+    agent.isAvailable();
+    return agent;
+  }
+
+  function tempFile(name: string): string {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-scan-failure-"));
+    tempDirs.push(dir);
+    return join(dir, name);
+  }
+
+  it("reports a corrupt database as a failure", () => {
+    const dbPath = tempFile("corrupt.db");
+    writeFileSync(dbPath, "this is not a sqlite file");
+
+    expect(() => makeAgent(dbPath).scan({ from: 0 })).toThrow(SessionScanError);
+  });
+
+  it("reports a missing session table as a failure", () => {
+    const dbPath = tempFile("empty.db");
+    new Database(dbPath).close();
+
+    expect(() => makeAgent(dbPath).scan({ from: 0 })).toThrow(SessionScanError);
+  });
+
+  it("still reports a readable but empty database as an empty scan", () => {
+    const dbPath = createDatabase();
+    const db = new Database(dbPath);
+    db.exec("DELETE FROM part; DELETE FROM message; DELETE FROM session;");
+    db.close();
+
+    expect(makeAgent(dbPath).scan({ from: 0 })).toEqual([]);
   });
 });

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -464,6 +464,25 @@ export abstract class SingleFileSessionSource<
  * 无法做 per-file 指纹，故变更检测退化为"库文件 mtime 是否推进"，
  * 增量扫描退化为全量重扫。
  */
+/**
+ * A scan that could not prove its result complete — the database would not
+ * open, a table was missing, or a top-level query failed.
+ *
+ * This is not the same as an agent with no sessions. Callers must keep the last
+ * successful snapshot: treating it as an empty result would diff every known
+ * session into a removal and wipe the agent from cache, search and the UI.
+ */
+export class SessionScanError extends Error {
+  constructor(
+    readonly agentName: string,
+    readonly stage: string,
+    options?: { cause?: unknown },
+  ) {
+    super(`${agentName} session scan failed while ${stage}`, options);
+    this.name = "SessionScanError";
+  }
+}
+
 export abstract class DatabaseSessionSource extends BaseAgent {
   protected sessionMetaMap = new Map<string, SessionCacheMeta>();
 

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -7,6 +7,7 @@ import {
   getParsedSession,
   matchesScanWindow,
   parsedSession,
+  SessionScanError,
 } from "./base.js";
 import type { AgentScanOptions } from "./base.js";
 import type {
@@ -539,7 +540,7 @@ export class CursorAgent extends DatabaseSessionSource {
     const db = this.openDatabase();
     perf.end(dbMarker);
 
-    if (!db) return [];
+    if (!db) throw new SessionScanError(this.name, "opening the database");
 
     // Build composerId → workspace path map from workspaceStorage
     const wsMarker = perf.start("buildWorkspacePathMap");
@@ -688,8 +689,8 @@ export class CursorAgent extends DatabaseSessionSource {
 
       perf.end(scanMarker);
       return heads;
-    } catch {
-      return [];
+    } catch (error) {
+      throw new SessionScanError(this.name, "reading composers", { cause: error });
     } finally {
       db.close();
     }

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -2,6 +2,7 @@ export {
   BaseAgent,
   DatabaseSessionSource,
   FileSystemSessionSource,
+  SessionScanError,
   SingleFileSessionSource,
 } from "./base.js";
 export {

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -1,5 +1,6 @@
 import {
   DatabaseSessionSource,
+  SessionScanError,
   filteredSession,
   getParsedSession,
   parsedSession,
@@ -109,7 +110,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
     if (!this.dbPath) return [];
 
     const db = openDbReadOnly(this.dbPath);
-    if (!db) return [];
+    if (!db) throw new SessionScanError(this.name, "opening the database");
 
     try {
       const cutoffTime = options?.from ?? Date.now() - 3650 * 24 * 60 * 60 * 1000;
@@ -173,8 +174,8 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
       }
 
       return heads;
-    } catch {
-      return [];
+    } catch (error) {
+      throw new SessionScanError(this.name, "reading sessions", { cause: error });
     } finally {
       db.close();
     }


### PR DESCRIPTION
## Problem

`openDbReadOnly` returns null when it cannot open a database, and the Cursor and OpenCode adapters
(ZCode inherits the latter) turned that — along with a missing table or a throwing top-level query —
into `[]`.

`scan-refresh-worker` cannot distinguish "scanned successfully, found nothing" from "could not
scan", so it diffed the empty result against the baseline and produced a full removal for the agent.
`AgentSyncEngine` then persisted it and broadcast it over SSE: a brief I/O error or a schema drift
emptied the cache, the search index and the UI.

Reproduced: a corrupt database file and a database missing the `session` table both returned `[]`.

## Change

- `SessionScanError` marks a scan that cannot prove its result complete; the adapters raise it
  instead of returning an empty array when the database will not open or a top-level query fails
- per-row tolerance is unchanged — a single malformed entry is still skipped
- the existing worker `error` channel carries it, so the runner rejects, the engine keeps its last
  snapshot, emits no SSE, and the agent retries on the next cycle
- an agent failing `isAvailable()` no longer publishes an empty result either: it was never scanned,
  so there is nothing to diff against

## Behavior change

An unreachable agent previously had all of its sessions removed. It now keeps them and logs
`scan.refresh.agent_unavailable`. A moved database file or an unmounted share was enough to delete
the history, which is not recoverable without a full rescan; keeping stale entries is. The existing
`removes sessions when an agent becomes unavailable` test became
`keeps sessions when an agent becomes unavailable`.

A readable but genuinely empty database still publishes its removals — covered by a test so the two
cases cannot be conflated again.

## Verification

- adapter tests for a corrupt file, a missing session table, and a readable-but-empty database
- engine tests: a failing scan and an unreachable agent both keep the snapshot, emit no session
  change and enqueue no index job; a real empty scan still publishes removals
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 531, cli 283, web 448 passing
- `pnpm test:e2e` — 22 passing