### PR TITLE
fix: detect WAL-mode database commits (CS-139)

### DIFF
--- a/packages/cli/src/session-watcher.test.ts
+++ b/packages/cli/src/session-watcher.test.ts
@@ -282,6 +282,45 @@ describe("SessionWatcher", () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it("CS-139: emits a database agent change for its WAL sidecar", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "watcher-db-wal-"));
+    try {
+      const dbPath = join(tempDir, "opencode.db");
+      writeFileSync(dbPath, "main");
+      writeFileSync(`${dbPath}-wal`, "commit");
+      writeFileSync(join(tempDir, "unrelated.db-wal"), "other");
+      writeFileSync(`${dbPath}.bak`, "backup");
+      const watcher = new SessionWatcher();
+      const changed = vi.fn();
+      watcher.onAgentsChanged(changed);
+      watcher.start([
+        source("database-agent", {
+          status: "supported",
+          targets: [{ root: tempDir, path: dbPath }],
+        }),
+      ]);
+
+      // A WAL-mode commit appends here and leaves the main file alone.
+      fsWatch.watchers[0]!.listener("change", "opencode.db-wal");
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(changed).toHaveBeenCalledWith(new Set(["database-agent"]));
+
+      changed.mockClear();
+      for (const filename of ["unrelated.db-wal", "opencode.db.bak", "opencode.db-shm"]) {
+        fsWatch.watchers[0]!.listener("change", filename);
+      }
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(changed).not.toHaveBeenCalled();
+      await watcher.dispose();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("isRecursiveWatchSupported", () => {

--- a/packages/cli/src/session-watcher.ts
+++ b/packages/cli/src/session-watcher.ts
@@ -95,8 +95,23 @@ function isSameOrChildPath(parentPath: string, childPath: string): boolean {
   return path === "" || (!path.startsWith("..") && !isAbsolute(path));
 }
 
+/**
+ * Sidecars a SQLite commit writes. `-shm` is excluded because a read-only open
+ * rewrites it, which would make every scan look like a new change.
+ */
+const SQLITE_SIDECAR_SUFFIXES = ["-wal", "-journal"];
+
+/** True for `foo.db-wal` against `foo.db`, but not for `foo.db.bak`. */
+function isSqliteSidecarOf(changedPath: string, targetPath: string): boolean {
+  return SQLITE_SIDECAR_SUFFIXES.some((suffix) => changedPath === `${targetPath}${suffix}`);
+}
+
 function isRelatedPath(changedPath: string, targetPath: string): boolean {
-  return isSameOrChildPath(targetPath, changedPath) || isSameOrChildPath(changedPath, targetPath);
+  return (
+    isSameOrChildPath(targetPath, changedPath) ||
+    isSameOrChildPath(changedPath, targetPath) ||
+    isSqliteSidecarOf(changedPath, targetPath)
+  );
 }
 
 function mergeScopes(target: WatchScope[], scopes: WatchScope[]): void {

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import Database from "better-sqlite3";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -434,5 +435,102 @@ describe("DatabaseSessionSource", () => {
     agent.rememberSession("db-1");
     const meta: SessionCacheMeta | undefined = agent.getSessionMetaMap().get("db-1");
     expect(meta?.sourcePath).toBe("/tmp/fake.db");
+  });
+});
+
+describe("CS-139: WAL-mode change detection", () => {
+  const dbDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dbDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  class WalDatabaseSource extends DatabaseSessionSource {
+    readonly name = "waldb";
+    readonly displayName = "WAL DB";
+
+    constructor(private readonly dbPath: string) {
+      super();
+    }
+
+    isAvailable(): boolean {
+      return true;
+    }
+
+    getSessionWatchPlan() {
+      return { status: "not-needed" as const, reason: "temporary test database" };
+    }
+
+    scan(): SessionHead[] {
+      const db = new Database(this.dbPath, { readonly: true });
+      try {
+        db.prepare("SELECT id FROM session").all();
+        return [];
+      } finally {
+        db.close();
+      }
+    }
+
+    getSessionData(): SessionDetail {
+      return {} as SessionDetail;
+    }
+
+    protected getDatabasePath(): string {
+      return this.dbPath;
+    }
+  }
+
+  function createWalDatabase() {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-wal-test-"));
+    dbDirs.push(dir);
+    const dbPath = join(dir, "opencode.db");
+    const db = new Database(dbPath);
+    db.pragma("journal_mode = WAL");
+    db.exec("CREATE TABLE session (id TEXT PRIMARY KEY)");
+    db.prepare("INSERT INTO session VALUES (?)").run("s1");
+    return { dbPath, db, agent: new WalDatabaseSource(dbPath) };
+  }
+
+  it("sees a commit that has not been checkpointed", () => {
+    const { db, agent } = createWalDatabase();
+    // Establish the baseline the way a running server would.
+    agent.checkForChanges(0, []);
+    expect(agent.checkForChanges(0, []).hasChanges).toBe(false);
+
+    db.prepare("INSERT INTO session VALUES (?)").run("s2");
+
+    expect(agent.checkForChanges(0, []).hasChanges).toBe(true);
+    db.close();
+  });
+
+  it("does not report a change caused by its own read-only scan", () => {
+    const { db, agent } = createWalDatabase();
+    agent.checkForChanges(0, []);
+
+    agent.scan();
+
+    expect(agent.checkForChanges(0, []).hasChanges).toBe(false);
+    db.close();
+  });
+
+  it("sees a checkpoint and the sidecar removal that follows", () => {
+    const { db, agent } = createWalDatabase();
+    db.prepare("INSERT INTO session VALUES (?)").run("s2");
+    agent.checkForChanges(0, []);
+
+    db.pragma("wal_checkpoint(TRUNCATE)");
+    expect(agent.checkForChanges(0, []).hasChanges).toBe(true);
+
+    db.close();
+    expect(agent.checkForChanges(0, []).hasChanges).toBe(true);
+  });
+
+  it("uses the newest sidecar time on the first check after startup", () => {
+    const { db, agent } = createWalDatabase();
+    const before = Date.now() - 60_000;
+
+    // A WAL written while the process was down leaves the main file untouched.
+    expect(agent.checkForChanges(before, []).hasChanges).toBe(true);
+    db.close();
   });
 });

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -483,8 +483,43 @@ export class SessionScanError extends Error {
   }
 }
 
+/**
+ * Files that reflect committed data. `-shm` is deliberately absent: opening the
+ * database read-only rewrites it, so including it would report a change after
+ * every scan.
+ */
+export function sqliteSourceFiles(dbPath: string): string[] {
+  return [dbPath, `${dbPath}-wal`];
+}
+
+function statOrNull(path: string): { size: number; mtimeMs: number } | null {
+  try {
+    return statSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/** Changes whenever committed data changes, and only then. */
+function sqliteSourceFingerprint(dbPath: string): string {
+  return sqliteSourceFiles(dbPath)
+    .map((path) => {
+      const stats = statOrNull(path);
+      return stats ? `${stats.size}:${Math.round(stats.mtimeMs)}` : "-";
+    })
+    .join("|");
+}
+
+function latestSqliteSourceMtime(dbPath: string): number {
+  return sqliteSourceFiles(dbPath).reduce((latest, path) => {
+    const stats = statOrNull(path);
+    return stats && stats.mtimeMs > latest ? stats.mtimeMs : latest;
+  }, 0);
+}
+
 export abstract class DatabaseSessionSource extends BaseAgent {
   protected sessionMetaMap = new Map<string, SessionCacheMeta>();
+  private lastSourceFingerprint: string | null = null;
 
   /** 返回数据库文件路径（供 mtime 检测）。 */
   protected abstract getDatabasePath(): string | null;
@@ -505,7 +540,12 @@ export abstract class DatabaseSessionSource extends BaseAgent {
   }
 
   /**
-   * 变更检测：数据库内部变更难以按行定位，按库文件 mtime 判定。
+   * 变更检测：数据库内部变更难以按行定位，按库文件集合的指纹判定。
+   *
+   * In WAL mode a commit appends to the sidecar and leaves the main file
+   * untouched until checkpoint, so watching the database alone misses recent
+   * writes entirely. Size is part of the fingerprint because an uncheckpointed
+   * commit may land in the same millisecond as the previous one.
    */
   checkForChanges(sinceTimestamp: number, _cachedSessions: SessionHead[]): ChangeCheckResult {
     const dbPath = this.getDatabasePath();
@@ -514,7 +554,15 @@ export abstract class DatabaseSessionSource extends BaseAgent {
     }
 
     try {
-      const hasChanges = statSync(dbPath).mtimeMs > sinceTimestamp;
+      const fingerprint = sqliteSourceFingerprint(dbPath);
+      const previous = this.lastSourceFingerprint;
+      this.lastSourceFingerprint = fingerprint;
+      // Nothing to compare against on the first pass — fall back to the caller's
+      // baseline, which also covers a WAL written while the process was down.
+      const hasChanges =
+        previous == null
+          ? latestSqliteSourceMtime(dbPath) > sinceTimestamp
+          : fingerprint !== previous;
       return {
         hasChanges,
         timestamp: Date.now(),


### PR DESCRIPTION
## Problem

Database change detection read the main database file's mtime, and the watcher only accepted the
main path. In WAL mode a commit appends to `<db>-wal` and leaves the main file untouched until a
checkpoint, so new sessions and messages could stay invisible indefinitely.

Measured on a real WAL-mode database:

| step | main (size, mtime) | `-wal` (size, mtime) |
|---|---|---|
| commit, no checkpoint | unchanged | 20632 → 28872 |
| read-only scan | unchanged | unchanged |
| checkpoint | both change | size → 0 |

## Change

- the database source is now a file set — the database plus its WAL — fingerprinted by size and
  mtime, which covers WAL creation, growth, truncation, checkpoint and removal
- size matters, not just mtime: an uncheckpointed commit can land in the same millisecond as the
  previous one, and checkpoint truncation is a size change
- the first check after startup falls back to the newest mtime across the set, so a WAL written
  while the process was down is still noticed
- the watcher accepts `<db>-wal` and `<db>-journal` for a database target

`-shm` is deliberately excluded from both: a read-only open rewrites it, so including it would
report a change after every scan. That is the experiment the issue asked for; the numbers above are
from it.

## Verification

- tests drive a real WAL-mode database: an uncheckpointed commit is seen, the agent's own read-only
  scan is not mistaken for one, and a checkpoint followed by sidecar removal is seen
- the first check after startup reports a change from the sidecar's mtime alone
- watcher test: a `-wal` event reaches the database agent, while `unrelated.db-wal`,
  `opencode.db.bak` and `opencode.db-shm` do not
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 535, cli 284, web 448 passing