### PR TITLE
feat: encrypt remote access transport (CS-140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ npx codesesh -j
 | `--port` | `-p` | `4521` | HTTP server starting port; falls back to the next available port if busy |
 | `--host` | — | `127.0.0.1` | HTTP server bind address; default is local-only, set explicitly (e.g. `0.0.0.0`) to expose on the network |
 | `--remote-access` | — | `false` | Enable token-protected access for a non-loopback `--host`; anyone with the startup URL can read session data |
+| `--tls-cert` | — | — | Path to a TLS certificate; serves remote access over HTTPS |
+| `--tls-key` | — | — | Path to the private key matching `--tls-cert` |
+| `--trust-proxy` | — | `false` | A reverse proxy in front of CodeSesh terminates TLS |
 | `--days` | `-d` | `7` | Only include sessions active in the last N days (`0` = all time) |
 | `--cwd` | — | — | Filter to sessions from a project directory (`.` = current dir) |
 | `--agent` | `-a` | all | Filter to specific agent(s), comma-separated |
@@ -184,6 +187,25 @@ npx codesesh -j
 Non-loopback binding is rejected unless `--remote-access` is also present. CodeSesh generates a
 new access token for every process and includes it in the printed startup URL. Treat that URL as a
 password: do not publish it or place it in shared shell history.
+
+A token proves who is asking; it does not hide the answer. Without TLS the token and the full
+session content travel the network in the clear, and the token in the URL can end up in reverse
+proxy access logs. Pick one of:
+
+```bash
+# CodeSesh terminates TLS
+npx codesesh --host 0.0.0.0 --remote-access --tls-cert ./cert.pem --tls-key ./key.pem
+
+# A reverse proxy terminates TLS and forwards to CodeSesh
+npx codesesh --host 0.0.0.0 --remote-access --trust-proxy
+```
+
+`--trust-proxy` requires every API request to arrive with `X-Forwarded-Proto: https`, and refuses
+it otherwise — so a request that bypassed the proxy is rejected before authentication. This assumes
+the deployment makes CodeSesh unreachable except through that proxy.
+
+Binding to a non-loopback address without either option still starts, and prints a warning that the
+transport is unencrypted.
 
 ---
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,11 @@ import { LiveScanStore } from "./live-scan.js";
 import { printScanResults } from "./output.js";
 import { VERSION } from "./version.js";
 import { appLogger } from "./logging.js";
-import { isLoopbackHostname } from "./remote-access.js";
+import {
+  isLoopbackHostname,
+  resolveRemoteTransport,
+  type RemoteTransport,
+} from "./remote-access.js";
 import {
   buildCliRuntimePlan,
   parseSessionUri,
@@ -41,6 +45,19 @@ const main = defineCommand({
     "remote-access": {
       type: "boolean",
       description: "Allow authenticated access when binding to a non-loopback address",
+      default: false,
+    },
+    "tls-cert": {
+      type: "string",
+      description: "Path to a TLS certificate; serve remote access over HTTPS",
+    },
+    "tls-key": {
+      type: "string",
+      description: "Path to the TLS private key matching --tls-cert",
+    },
+    "trust-proxy": {
+      type: "boolean",
+      description: "A reverse proxy in front of CodeSesh terminates TLS",
       default: false,
     },
     agent: {
@@ -114,6 +131,19 @@ const main = defineCommand({
       console.error(
         `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
       );
+      process.exit(1);
+    }
+
+    let transport: RemoteTransport;
+    try {
+      transport = resolveRemoteTransport({
+        hostname,
+        tlsCertPath: args["tls-cert"] as string | undefined,
+        tlsKeyPath: args["tls-key"] as string | undefined,
+        trustProxy: args["trust-proxy"] as boolean,
+      });
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
       process.exit(1);
     }
 
@@ -229,6 +259,7 @@ const main = defineCommand({
         portFallbackAttempts: explicitPort ? 1 : DEFAULT_PORT_FALLBACK_ATTEMPTS,
         hostname,
         remoteAccess,
+        transport,
       });
     } catch (error) {
       console.error(getServerStartupErrorMessage(error, port));

--- a/packages/cli/src/remote-access.test.ts
+++ b/packages/cli/src/remote-access.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
-import { createRemoteAccessToken, isLoopbackHostname } from "./remote-access.js";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createRemoteAccessToken,
+  isConfidentialTransport,
+  isLoopbackHostname,
+  RemoteTransportError,
+  resolveRemoteTransport,
+} from "./remote-access.js";
 
 describe("remote access", () => {
   it.each(["localhost", "LOCALHOST", "127.0.0.1", "127.20.30.40", "::1", "[::1]"])(
@@ -22,5 +31,87 @@ describe("remote access", () => {
 
     expect(first).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(second).not.toBe(first);
+  });
+});
+
+describe("CS-140: remote transport", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeKeyPair() {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-tls-"));
+    tempDirs.push(dir);
+    const certPath = join(dir, "cert.pem");
+    const keyPath = join(dir, "key.pem");
+    writeFileSync(certPath, "certificate");
+    writeFileSync(keyPath, "private key");
+    return { certPath, keyPath };
+  }
+
+  it("treats a loopback host as protected without configuration", () => {
+    expect(resolveRemoteTransport({ hostname: "127.0.0.1" })).toEqual({ kind: "loopback" });
+    expect(isConfidentialTransport({ kind: "loopback" })).toBe(true);
+  });
+
+  it("reports a plaintext non-loopback listener as unprotected", () => {
+    const transport = resolveRemoteTransport({ hostname: "0.0.0.0" });
+
+    expect(transport).toEqual({ kind: "plaintext" });
+    expect(isConfidentialTransport(transport)).toBe(false);
+  });
+
+  it("loads a certificate and key for direct TLS", () => {
+    const { certPath, keyPath } = writeKeyPair();
+
+    const transport = resolveRemoteTransport({
+      hostname: "0.0.0.0",
+      tlsCertPath: certPath,
+      tlsKeyPath: keyPath,
+    });
+
+    expect(transport.kind).toBe("tls");
+    expect(isConfidentialTransport(transport)).toBe(true);
+  });
+
+  it.each([
+    ["only a certificate", { tlsCertPath: "cert.pem" }],
+    ["only a key", { tlsKeyPath: "key.pem" }],
+  ])("rejects %s", (_name, partial) => {
+    expect(() => resolveRemoteTransport({ hostname: "0.0.0.0", ...partial })).toThrow(
+      RemoteTransportError,
+    );
+  });
+
+  it("rejects TLS and a trusted proxy together", () => {
+    const { certPath, keyPath } = writeKeyPair();
+
+    expect(() =>
+      resolveRemoteTransport({
+        hostname: "0.0.0.0",
+        tlsCertPath: certPath,
+        tlsKeyPath: keyPath,
+        trustProxy: true,
+      }),
+    ).toThrow(RemoteTransportError);
+  });
+
+  it("reports an unreadable certificate instead of starting", () => {
+    expect(() =>
+      resolveRemoteTransport({
+        hostname: "0.0.0.0",
+        tlsCertPath: join(tmpdir(), "codesesh-missing-cert.pem"),
+        tlsKeyPath: join(tmpdir(), "codesesh-missing-key.pem"),
+      }),
+    ).toThrow(RemoteTransportError);
+  });
+
+  it("accepts a trusted proxy as protected", () => {
+    const transport = resolveRemoteTransport({ hostname: "0.0.0.0", trustProxy: true });
+
+    expect(transport).toEqual({ kind: "trusted-proxy" });
+    expect(isConfidentialTransport(transport)).toBe(true);
   });
 });

--- a/packages/cli/src/remote-access.ts
+++ b/packages/cli/src/remote-access.ts
@@ -1,8 +1,89 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { isIP } from "node:net";
 import type { Context, MiddlewareHandler } from "hono";
 
 export const REMOTE_ACCESS_QUERY_PARAM = "access_token";
+
+/**
+ * How a remote listener's traffic is protected. A token proves who is asking;
+ * it says nothing about who else can read the answer, so confidentiality is
+ * modelled separately from authentication.
+ */
+export type RemoteTransport =
+  | { kind: "loopback" }
+  /** CodeSesh terminates TLS itself. */
+  | { kind: "tls"; cert: Buffer; key: Buffer }
+  /** A reverse proxy in front of CodeSesh terminates TLS. */
+  | { kind: "trusted-proxy" }
+  /** The operator accepted plaintext on an untrusted network. */
+  | { kind: "plaintext" };
+
+export interface RemoteTransportRequest {
+  hostname: string;
+  tlsCertPath?: string;
+  tlsKeyPath?: string;
+  trustProxy?: boolean;
+}
+
+export class RemoteTransportError extends Error {}
+
+/**
+ * Resolves the transport from the CLI flags. Loopback stays plaintext without
+ * ceremony: nothing leaves the machine.
+ */
+export function resolveRemoteTransport(request: RemoteTransportRequest): RemoteTransport {
+  const hasCert = Boolean(request.tlsCertPath);
+  const hasKey = Boolean(request.tlsKeyPath);
+  if (hasCert !== hasKey) {
+    throw new RemoteTransportError("TLS requires both --tls-cert and --tls-key.");
+  }
+  if (hasCert && request.trustProxy) {
+    throw new RemoteTransportError(
+      "Use either --tls-cert/--tls-key or --trust-proxy, not both: only one of them terminates TLS.",
+    );
+  }
+
+  if (hasCert) {
+    try {
+      return {
+        kind: "tls",
+        cert: readFileSync(request.tlsCertPath!),
+        key: readFileSync(request.tlsKeyPath!),
+      };
+    } catch (error) {
+      throw new RemoteTransportError(
+        `Unable to read the TLS certificate or key: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  if (request.trustProxy) return { kind: "trusted-proxy" };
+  return isLoopbackHostname(request.hostname) ? { kind: "loopback" } : { kind: "plaintext" };
+}
+
+/** Whether the transport keeps request and response bodies off the wire in the clear. */
+export function isConfidentialTransport(transport: RemoteTransport): boolean {
+  return transport.kind !== "plaintext";
+}
+
+const FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
+
+/**
+ * Behind a trusted proxy, a request arriving without the proxy's own
+ * `X-Forwarded-Proto: https` did not come through it. Trusting the header is
+ * only sound because the deployment is expected to make CodeSesh unreachable
+ * except via that proxy — which is what --trust-proxy asserts.
+ */
+export function requireProxyTls(): MiddlewareHandler {
+  return async (c, next) => {
+    const proto = c.req.header(FORWARDED_PROTO_HEADER)?.split(",")[0]?.trim().toLowerCase();
+    if (proto !== "https") {
+      return c.json({ error: "Requests must arrive over TLS through the trusted proxy" }, 403);
+    }
+    await next();
+  };
+}
 
 export function createRemoteAccessToken(): string {
   return randomBytes(32).toString("base64url");

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -1,12 +1,17 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { get as httpsGet } from "node:https";
 import { createServer as createNodeServer, type Server as NodeServer } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
 import { createServer } from "./server.js";
+import { resolveRemoteTransport } from "./remote-access.js";
 
-const serveOptionsLog = vi.hoisted(() => [] as { hostname?: string; port?: number }[]);
+const serveOptionsLog = vi.hoisted(
+  () => [] as { hostname?: string; port?: number; hasCreateServer: boolean }[],
+);
 
 vi.mock("@hono/node-server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@hono/node-server")>();
@@ -16,11 +21,74 @@ vi.mock("@hono/node-server", async (importOriginal) => {
       serveOptionsLog.push({
         hostname: (options as { hostname?: string }).hostname,
         port: (options as { port?: number }).port,
+        hasCreateServer: "createServer" in (options as object),
       });
       return actual.serve(options);
     },
   };
 });
+
+/** Requests a self-signed listener; Node's fetch has no per-call trust override. */
+function httpsRequest(
+  url: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; contentType: string | undefined }> {
+  return new Promise((resolvePromise, reject) => {
+    // agent:false so no keep-alive socket outlives the request and stalls close().
+    const request = httpsGet(
+      url,
+      { headers, rejectUnauthorized: false, agent: false },
+      (response) => {
+        resolvePromise({
+          status: response.statusCode ?? 0,
+          contentType: response.headers["content-type"],
+        });
+        // The SSE route never ends on its own, so drop the socket rather than
+        // waiting for a body.
+        response.destroy();
+        request.destroy();
+      },
+    );
+    request.on("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "ECONNRESET") return;
+      reject(error);
+    });
+  });
+}
+
+/** Self-signed material for the TLS listener; requires openssl on PATH. */
+function createTestCertificate(): { certPath: string; keyPath: string } | null {
+  const dir = mkdtempSync(join(tmpdir(), "codesesh-tls-server-"));
+  const certPath = join(dir, "cert.pem");
+  const keyPath = join(dir, "key.pem");
+  try {
+    execFileSync(
+      "openssl",
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "ec",
+        "-pkeyopt",
+        "ec_paramgen_curve:prime256v1",
+        "-nodes",
+        "-keyout",
+        keyPath,
+        "-out",
+        certPath,
+        "-days",
+        "1",
+        "-subj",
+        "/CN=localhost",
+      ],
+      { stdio: "ignore" },
+    );
+    return { certPath, keyPath };
+  } catch {
+    rmSync(dir, { recursive: true, force: true });
+    return null;
+  }
+}
 
 function createStore() {
   return {
@@ -247,6 +315,99 @@ describe("createServer", () => {
     } finally {
       await app.shutdown();
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CS-140: serves remote access over TLS when a certificate is supplied", async () => {
+    const material = createTestCertificate();
+    if (!material) return; // openssl unavailable on this runner
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const transport = resolveRemoteTransport({
+      hostname: "0.0.0.0",
+      tlsCertPath: material.certPath,
+      tlsKeyPath: material.keyPath,
+    });
+    const app = await createServer(0, createStore(), {
+      hostname: "0.0.0.0",
+      remoteAccessToken: "tls-token",
+      transport,
+    });
+
+    try {
+      expect(app.url.startsWith("https://")).toBe(true);
+      expect(serveOptionsLog.at(-1)?.hasCreateServer).toBe(true);
+
+      const origin = `https://127.0.0.1:${new URL(app.url).port}`;
+
+      expect((await httpsRequest(`${origin}/api/agents`)).status).toBe(401);
+      expect(
+        (await httpsRequest(`${origin}/api/agents`, { Authorization: "Bearer tls-token" })).status,
+      ).toBe(200);
+
+      const events = await httpsRequest(`${origin}/api/events?access_token=tls-token`);
+      expect(events.contentType).toContain("text/event-stream");
+
+      const shell = await httpsRequest(`${origin}/app.js`);
+      expect(shell.status).toBeGreaterThan(0);
+    } finally {
+      await app.shutdown();
+      warnSpy.mockRestore();
+      rmSync(dirname(material.certPath), { recursive: true, force: true });
+    }
+    // Node builds its TLS context on the first https server in a process, which
+    // can take tens of seconds while it loads the system trust store.
+  }, 60_000);
+
+  it("CS-140: warns that a plaintext remote listener is unprotected", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = await createServer(0, createStore(), {
+      hostname: "0.0.0.0",
+      remoteAccessToken: "plaintext-token",
+      transport: { kind: "plaintext" },
+    });
+
+    try {
+      expect(app.url.startsWith("http://")).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("传输未加密"));
+    } finally {
+      await app.shutdown();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("CS-140: refuses requests that bypassed the trusted proxy", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = await createServer(0, createStore(), {
+      hostname: "0.0.0.0",
+      remoteAccessToken: "proxy-token",
+      transport: { kind: "trusted-proxy" },
+    });
+    const origin = `http://127.0.0.1:${new URL(app.url).port}`;
+    const authorized = { Authorization: "Bearer proxy-token" };
+
+    try {
+      expect((await fetch(`${origin}/api/agents`, { headers: authorized })).status).toBe(403);
+      expect(
+        (
+          await fetch(`${origin}/api/agents`, {
+            headers: { ...authorized, "X-Forwarded-Proto": "http" },
+          })
+        ).status,
+      ).toBe(403);
+      expect(
+        (
+          await fetch(`${origin}/api/agents`, {
+            headers: { ...authorized, "X-Forwarded-Proto": "https, http" },
+          })
+        ).status,
+      ).toBe(200);
+      // The proxy check runs first, so a bypassed request never reaches auth.
+      expect(
+        (await fetch(`${origin}/api/agents`, { headers: { "X-Forwarded-Proto": "https" } })).status,
+      ).toBe(401);
+    } finally {
+      await app.shutdown();
+      warnSpy.mockRestore();
     }
   });
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -5,6 +5,7 @@ import { serve } from "@hono/node-server";
 import type { ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { existsSync } from "node:fs";
+import { createServer as createHttpsServer } from "node:https";
 import type { AddressInfo } from "node:net";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,6 +17,8 @@ import {
   isLoopbackHostname,
   REMOTE_ACCESS_QUERY_PARAM,
   remoteAccessAuth,
+  requireProxyTls,
+  type RemoteTransport,
 } from "./remote-access.js";
 import type { ScanEventSource } from "./scan-source.js";
 
@@ -29,6 +32,8 @@ export interface CreateServerOptions {
   hostname?: string;
   remoteAccess?: boolean;
   remoteAccessToken?: string;
+  /** How the listener is protected; defaults to plaintext for a non-loopback host. */
+  transport?: RemoteTransport;
   /** Overrides the auto-detected web build directory; used to pin the static root in tests. */
   webDistPath?: string;
 }
@@ -99,6 +104,8 @@ export async function createServer(
   const app = new Hono();
   const hostname = options.hostname ?? "127.0.0.1";
   const isLoopback = isLoopbackHostname(hostname);
+  const transport: RemoteTransport =
+    options.transport ?? (isLoopback ? { kind: "loopback" } : { kind: "plaintext" });
   const remoteAccessToken = !isLoopback
     ? (options.remoteAccessToken ?? (options.remoteAccess ? createRemoteAccessToken() : null))
     : null;
@@ -131,6 +138,11 @@ export async function createServer(
     }
   });
 
+  // Ordered before authentication: a request that bypassed the proxy must be
+  // refused outright, not given a chance to present a token in the clear.
+  if (transport.kind === "trusted-proxy") {
+    app.use("/api/*", requireProxyTls());
+  }
   if (remoteAccessToken) {
     app.use("/api/*", remoteAccessAuth(remoteAccessToken));
   }
@@ -167,7 +179,17 @@ export async function createServer(
 
   for (let offset = 0; offset < attempts; offset += 1) {
     const candidatePort = port + offset;
-    server = serve({ fetch: app.fetch, port: candidatePort, hostname });
+    server = serve({
+      fetch: app.fetch,
+      port: candidatePort,
+      hostname,
+      ...(transport.kind === "tls"
+        ? {
+            createServer: createHttpsServer,
+            serverOptions: { cert: transport.cert, key: transport.key },
+          }
+        : {}),
+    });
 
     try {
       await waitForListening(server);
@@ -193,9 +215,12 @@ export async function createServer(
     }
   }
 
+  // A trusted proxy publishes its own https origin, so only direct TLS changes
+  // the scheme CodeSesh prints for itself.
+  const scheme = transport.kind === "tls" ? "https" : "http";
   const baseUrl = isLoopback
-    ? `http://localhost:${actualPort}`
-    : `http://${hostname}:${actualPort}`;
+    ? `${scheme}://localhost:${actualPort}`
+    : `${scheme}://${hostname}:${actualPort}`;
   const url = remoteAccessToken
     ? `${baseUrl}/?${REMOTE_ACCESS_QUERY_PARAM}=${encodeURIComponent(remoteAccessToken)}`
     : baseUrl;
@@ -204,11 +229,23 @@ export async function createServer(
     requested_port: port,
     hostname,
     remote_access: Boolean(remoteAccessToken),
+    transport: transport.kind,
   });
 
   if (!isLoopback) {
-    appLogger.warn("server.listen.remote_access", { hostname, port: actualPort });
+    appLogger.warn("server.listen.remote_access", {
+      hostname,
+      port: actualPort,
+      transport: transport.kind,
+    });
     console.warn(`\n⚠ 远程访问已启用。任何持有启动 URL 的人都可以读取你的 AI 会话记录。\n`);
+    if (transport.kind === "plaintext") {
+      appLogger.warn("server.listen.plaintext", { hostname, port: actualPort });
+      console.warn(
+        `⚠ 传输未加密。访问令牌与完整会话内容以明文经过网络，URL 中的令牌还可能写入代理访问日志。\n` +
+          `  使用 --tls-cert/--tls-key 直接启用 TLS，或在受信反向代理后使用 --trust-proxy。\n`,
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
## Problem

`--remote-access` required a token but still started a plain HTTP server and printed an `http://`
URL. The middleware only verified the token — it provided no confidentiality. On shared Wi-Fi or an
untrusted LAN a passive listener could read the Bearer token, the SSE query token, and the full
session content; a token in the URL can also land in reverse proxy access logs.

CS-33 closed unauthenticated non-loopback access. This is the transport half of the same exposure.

## Change

Authentication and confidentiality are now modelled separately. `RemoteTransport` distinguishes
loopback, direct TLS, a trusted proxy, and plaintext, and the server acts on it:

- `--tls-cert` / `--tls-key` terminate TLS in CodeSesh; the startup URL becomes `https://`
- `--trust-proxy` defers to a reverse proxy, and requires `X-Forwarded-Proto: https` on every API
  request — a request that bypassed the proxy is refused with 403 *before* authentication runs, so
  it never gets to present a token in the clear
- the two options are mutually exclusive, and a certificate without its key (or vice versa) fails at
  startup rather than silently falling back
- a plaintext non-loopback listener prints an explicit warning naming both risks: the token and
  session content travel in the clear, and the URL token can reach proxy access logs

Loopback is unchanged and needs no configuration — nothing leaves the machine.

## Scope note

The issue proposed refusing a plaintext non-loopback listener unless an explicit `--insecure-http`
override was given. Per your call, this ships the encrypted paths and warns instead of blocking, so
existing `--remote-access --host 0.0.0.0` setups keep working; there is no `--insecure-http` flag as
a result. The consequence — query tokens are still accepted on a plaintext transport, because
EventSource cannot send an `Authorization` header — is recorded in the issue's notes.

## Verification

- transport resolution: loopback, plaintext, direct TLS, trusted proxy, a cert without a key, both
  TLS and proxy together, and an unreadable certificate
- a real TLS listener built from a self-signed certificate: `https://` URL, rejected without a
  token, accepted with Bearer, SSE content type, and static assets (skipped when openssl is absent)
- trusted proxy: rejected with no `X-Forwarded-Proto`, rejected on `http`, accepted on
  `https, http`, and 401 rather than 200 when the header is right but the token is missing
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 535, cli 295, web 448 passing