### PR TITLE
perf: read Cursor bubbles once per scan (CS-142)

### DIFF
--- a/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
@@ -1,0 +1,230 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CursorAgent } from "../cursor.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+interface BubbleSpec {
+  suffix: string;
+  bubble: Record<string, unknown>;
+}
+
+function createDb(entries: Array<[string, unknown]>): string {
+  const dir = mkdtempSync(join(tmpdir(), "codesesh-cursor-shape-"));
+  tempDirs.push(dir);
+  const dbPath = join(dir, "state.vscdb");
+  const db = new Database(dbPath);
+  db.exec("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+  const insert = db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)");
+  const write = db.transaction((rows: Array<[string, unknown]>) => {
+    for (const [key, value] of rows) insert.run(key, JSON.stringify(value));
+  });
+  write(entries);
+  db.close();
+  return dbPath;
+}
+
+function composer(id: string, overrides: Record<string, unknown> = {}) {
+  return [
+    `composerData:${id}`,
+    { composerId: id, createdAt: 1_000, lastUpdatedAt: 2_000, ...overrides },
+  ] as [string, unknown];
+}
+
+function bubbles(composerId: string, specs: BubbleSpec[]): Array<[string, unknown]> {
+  return specs.map(({ suffix, bubble }) => [`bubbleId:${composerId}:${suffix}`, bubble]);
+}
+
+function makeAgent(dbPath: string) {
+  const agent = new CursorAgent();
+  (agent as unknown as { dbPath: string }).dbPath = dbPath;
+  return agent;
+}
+
+function textOf(agent: CursorAgent, sessionId: string): string[] {
+  return agent
+    .getSessionData(sessionId)
+    .messages.flatMap((message) =>
+      message.parts.filter((part) => part.type === "text").map((part) => part.text),
+    );
+}
+
+describe("CS-142: Cursor scan shape", () => {
+  it("takes the request id from the key-ordered bubbles", () => {
+    const dbPath = createDb([
+      composer("c1"),
+      // Inserted out of key order on purpose: "b" sorts before "c".
+      ...bubbles("c1", [
+        { suffix: "c", bubble: { type: 1, text: "second", requestId: "req-from-c" } },
+        { suffix: "b", bubble: { type: 1, text: "first", requestId: "req-from-b" } },
+      ]),
+    ]);
+
+    const heads = makeAgent(dbPath).scan({ from: 0 });
+
+    expect(heads.map((head) => head.id)).toEqual(["req-from-b"]);
+  });
+
+  it("keeps message order by insertion, not by key", () => {
+    const dbPath = createDb([
+      composer("c1"),
+      ...bubbles("c1", [
+        { suffix: "z", bubble: { type: 1, text: "written first" } },
+        { suffix: "a", bubble: { type: 2, text: "written second" } },
+      ]),
+    ]);
+    const agent = makeAgent(dbPath);
+
+    const heads = agent.scan({ from: 0 });
+
+    expect(textOf(agent, heads[0]!.id)).toEqual(["written first", "written second"]);
+  });
+
+  it("drops a composer whose bubbles are all malformed or internal", () => {
+    const dbPath = createDb([
+      composer("empty"),
+      composer("kept"),
+      ["bubbleId:empty:a", "{not json"],
+      ...bubbles("kept", [{ suffix: "a", bubble: { type: 1, text: "visible" } }]),
+    ]);
+
+    const heads = makeAgent(dbPath).scan({ from: 0 });
+
+    expect(heads.map((head) => head.id)).toEqual(["kept"]);
+  });
+
+  it("keeps a composer that only has subagents", () => {
+    const dbPath = createDb([composer("sub", { subagentInfos: [{ name: "explorer" }] })]);
+
+    const heads = makeAgent(dbPath).scan({ from: 0 });
+
+    expect(heads.map((head) => head.id)).toEqual(["sub"]);
+  });
+
+  it("applies the scan window to the composer's update time", () => {
+    const dbPath = createDb([
+      composer("old", { createdAt: 100, lastUpdatedAt: 200 }),
+      composer("new", { createdAt: 5_000, lastUpdatedAt: 6_000 }),
+      ...bubbles("old", [{ suffix: "a", bubble: { type: 1, text: "old" } }]),
+      ...bubbles("new", [{ suffix: "a", bubble: { type: 1, text: "new" } }]),
+    ]);
+
+    const heads = makeAgent(dbPath).scan({ from: 1_000 });
+
+    expect(heads.map((head) => head.id)).toEqual(["new"]);
+  });
+
+  it("counts messages and totals from the bubbles it parsed", () => {
+    const dbPath = createDb([
+      composer("c1", { model: "gpt-4" }),
+      ...bubbles("c1", [
+        {
+          suffix: "a",
+          bubble: {
+            type: 1,
+            text: "question",
+            tokenCount: { inputTokens: 10, outputTokens: 0 },
+          },
+        },
+        {
+          suffix: "b",
+          bubble: {
+            type: 2,
+            text: "answer",
+            tokenCount: { inputTokens: 0, outputTokens: 5 },
+          },
+        },
+      ]),
+    ]);
+
+    const heads = makeAgent(dbPath).scan({ from: 0 });
+
+    expect(heads[0]?.stats.message_count).toBe(2);
+  });
+});
+
+describe("CS-142: Cursor scan reads bubbles once", () => {
+  function seedComposers(composerCount: number, bubblesEach: number): string {
+    const entries: Array<[string, unknown]> = [];
+    for (let index = 0; index < composerCount; index += 1) {
+      const id = `composer-${String(index).padStart(4, "0")}`;
+      entries.push(composer(id));
+      for (let bubble = 0; bubble < bubblesEach; bubble += 1) {
+        entries.push([
+          `bubbleId:${id}:${String(bubble).padStart(3, "0")}`,
+          { type: bubble % 2 === 0 ? 1 : 2, text: `message ${bubble}`, requestId: `req-${index}` },
+        ]);
+      }
+    }
+    return createDb(entries);
+  }
+
+  function countBubbleQueries(run: () => void): number {
+    let queries = 0;
+    const prepare = Database.prototype.prepare;
+    const spy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+      this: Database.Database,
+      sql: string,
+    ) {
+      if (sql.includes("bubbleId:")) queries += 1;
+      return prepare.call(this, sql) as ReturnType<Database.Database["prepare"]>;
+    });
+    try {
+      run();
+    } finally {
+      spy.mockRestore();
+    }
+    return queries;
+  }
+
+  // The old scan issued two full-table queries per composer, so the count grew
+  // with the number of composers rather than staying flat.
+  it.each([
+    [10, 3],
+    [200, 3],
+  ])("issues one bubble query for %i composers", (composerCount, bubblesEach) => {
+    const dbPath = seedComposers(composerCount, bubblesEach);
+    const agent = makeAgent(dbPath);
+    let heads: ReturnType<typeof agent.scan> = [];
+
+    const queries = countBubbleQueries(() => {
+      heads = agent.scan({ from: 0 });
+    });
+
+    expect(heads).toHaveLength(composerCount);
+    expect(queries).toBe(1);
+  });
+
+  it("reads bubbles in primary key order instead of scanning unordered", () => {
+    const dbPath = seedComposers(2, 2);
+    const db = new Database(dbPath, { readonly: true });
+
+    try {
+      const plan = db
+        .prepare(
+          `
+            EXPLAIN QUERY PLAN
+            SELECT rowid AS row_id, key, value
+            FROM cursorDiskKV
+            WHERE key LIKE 'bubbleId:%'
+            ORDER BY key
+          `,
+        )
+        .all()
+        .map((row) => String((row as { detail?: unknown }).detail ?? ""))
+        .join("\n");
+
+      expect(plan).toContain("USING INDEX");
+      expect(plan).not.toContain("TEMP B-TREE");
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -19,7 +19,12 @@ import type {
 } from "../types/index.js";
 import { normalizeMessageParts } from "../contract/message-part.js";
 import { firstExisting, readEnvPath } from "../discovery/paths.js";
-import { openDbReadOnly, isSqliteAvailable, type SQLiteDatabase } from "../utils/sqlite.js";
+import {
+  openDbReadOnly,
+  isSqliteAvailable,
+  type DatabaseRow,
+  type SQLiteDatabase,
+} from "../utils/sqlite.js";
 import { resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import {
@@ -214,6 +219,59 @@ function parseComposerRow(value: string): ComposerData | null {
     outputTokenCount: narrowNumber("composer.outputTokenCount", record.outputTokenCount),
     subagentInfos: parseSubagentInfos(record.subagentInfos),
     chatMessages: parseChatMessages(record.chatMessages),
+  };
+}
+
+interface BubbleRow extends DatabaseRow {
+  row_id: number;
+  key: string;
+  value: string;
+}
+
+interface BubbleEntry {
+  rowId: number;
+  key: string;
+  bubble: BubbleData;
+}
+
+/**
+ * One composer's bubbles, parsed once and offered in both orders the readers
+ * need: request ids come from the key-ordered view, messages from insertion
+ * order.
+ */
+interface ComposerBubbles {
+  composerId: string;
+  byKey: BubbleEntry[];
+  byRowId: BubbleEntry[];
+}
+
+/** A composer waiting for its bubbles in the second phase of a scan. */
+interface PendingComposer {
+  composer: ComposerData;
+  composerId: string;
+  createdAt: number;
+  updatedAt: number;
+  hasSubagents: boolean;
+  order: number;
+}
+
+function composerIdFromBubbleKey(key: string): string {
+  const start = key.indexOf(":") + 1;
+  const end = key.indexOf(":", start);
+  return end === -1 ? key.slice(start) : key.slice(start, end);
+}
+
+function groupBubbleRows(rows: BubbleRow[]): ComposerBubbles {
+  const byKey: BubbleEntry[] = [];
+  for (const row of rows) {
+    const bubble = parseBubbleRow(row.value);
+    if (bubble) byKey.push({ rowId: row.row_id, key: row.key, bubble });
+  }
+  byKey.sort((left, right) => left.key.localeCompare(right.key));
+  return {
+    composerId: rows.length > 0 ? composerIdFromBubbleKey(rows[0]!.key) : "",
+    byKey,
+    byRowId: [...byKey].sort((left, right) => left.rowId - right.rowId),
   };
 }
 
@@ -552,7 +610,11 @@ export class CursorAgent extends DatabaseSessionSource {
         .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")
         .all() as Array<{ key: string; value: string }>;
 
-      const heads: SessionHead[] = [];
+      // Heads are emitted by composer order regardless of which phase produced
+      // them, so the scan output does not depend on how bubbles are read.
+      const emitted = new Map<number, SessionHead>();
+      const pending: PendingComposer[] = [];
+      let order = 0;
       options?.onProgress?.({ total: rows.length, processed: 0, sessions: 0 });
       let processed = 0;
 
@@ -599,7 +661,8 @@ export class CursorAgent extends DatabaseSessionSource {
                   }),
             );
             if (!head) continue;
-            heads.push(head);
+            emitted.set(order, head);
+            order += 1;
             this.composerCache.set(composerId, composer);
             this.sessionMetaMap.set(composerId, {
               id: composerId,
@@ -608,84 +671,43 @@ export class CursorAgent extends DatabaseSessionSource {
             continue;
           }
 
-          // Try to extract requestId from bubbles (like agent-dump does)
-          const requestId = this.extractRequestIdFromBubbles(db, composerId);
-          const sessionId = requestId || composerId;
-
-          // Load actual messages to filter out empty composers
-          const parsedMessages = cleanParsedMessages(
-            this.loadMessagesFromBubbles(
-              db,
-              composerId,
-              sessionId,
-              composer.modelConfig?.modelName ?? composer.model ?? null,
-            ),
-          );
-          const messages = getParsedSession(
-            parsedMessages.length === 0 && !hasSubagents
-              ? filteredSession<Message[]>("no visible messages")
-              : parsedSession(parsedMessages),
-          );
-          if (!messages) continue;
-          const messageCount = messages.length;
-          const title = this.extractTitle(composer, messages);
-
-          const directory = workspacePathMap.get(composerId) ?? "";
-
-          const modelUsageMap: Record<string, number> = {};
-          let totalCost = 0;
-          for (const msg of messages) {
-            totalCost += msg.cost ?? 0;
-            if (msg.model) {
-              const msgTokens = (msg.tokens?.input ?? 0) + (msg.tokens?.output ?? 0);
-              if (msgTokens > 0) {
-                modelUsageMap[msg.model] = (modelUsageMap[msg.model] ?? 0) + msgTokens;
-              }
-            }
-          }
-          const hasModelUsage = Object.keys(modelUsageMap).length > 0;
-
-          heads.push({
-            id: sessionId,
-            slug: `cursor/${sessionId}`,
-            title,
-            directory,
-            time_created: createdAt,
-            time_updated: updatedAt || undefined,
-            stats: {
-              message_count: messageCount,
-              total_input_tokens: composer.inputTokenCount ?? 0,
-              total_output_tokens: composer.outputTokenCount ?? 0,
-              total_cost: totalCost,
-              cost_source: totalCost > 0 ? "estimated" : undefined,
-            },
-            model_usage: hasModelUsage ? modelUsageMap : undefined,
-          });
-
-          // Cache with sessionId (requestId) as key
-          this.composerCache.set(sessionId, composer);
-          // Also cache composerId -> sessionId mapping and directory
-          this.composerCache.set(`__mapping__${composerId}`, {
-            sessionId,
-          } as unknown as ComposerData);
-          if (directory) {
-            this.composerCache.set(`__dir__${composerId}`, {
-              directory,
-            } as unknown as ComposerData);
-          }
-
-          // Store session metadata for caching
-          this.sessionMetaMap.set(sessionId, {
-            id: sessionId,
-            sourcePath: this.dbPath || "",
-          });
+          pending.push({ composer, composerId, createdAt, updatedAt, hasSubagents, order });
+          order += 1;
         } catch {
           // skip malformed entries
         } finally {
           processed += 1;
-          options?.onProgress?.({ total: rows.length, processed, sessions: heads.length });
+          options?.onProgress?.({ total: rows.length, processed, sessions: emitted.size });
         }
       }
+
+      // Second phase: one ordered pass over every bubble row. Keys share the
+      // composer prefix, so each group arrives contiguously and only one group
+      // is held at a time — replacing two full scans per composer.
+      const bubbleMarker = perf.start("cursor:bubbles");
+      const wanted = new Map(pending.map((entry) => [entry.composerId, entry]));
+      this.forEachComposerBubbles(db, wanted, (bubbles) => {
+        const entry = wanted.get(bubbles.composerId);
+        if (!entry) return;
+        wanted.delete(bubbles.composerId);
+        const head = this.buildScanHead(entry, bubbles, workspacePathMap);
+        if (head) emitted.set(entry.order, head);
+      });
+      // Composers with no bubbles at all still go through the same builder.
+      for (const entry of wanted.values()) {
+        const head = this.buildScanHead(
+          entry,
+          { composerId: entry.composerId, byKey: [], byRowId: [] },
+          workspacePathMap,
+        );
+        if (head) emitted.set(entry.order, head);
+      }
+      perf.end(bubbleMarker);
+
+      const heads = [...emitted.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([, head]) => head);
+      options?.onProgress?.({ total: rows.length, processed, sessions: heads.length });
 
       perf.end(scanMarker);
       return heads;
@@ -808,25 +830,111 @@ export class CursorAgent extends DatabaseSessionSource {
     return openDbReadOnly(this.dbPath);
   }
 
-  /** Extract requestId from bubbles for a composer (like agent-dump) */
-  private extractRequestIdFromBubbles(db: SQLiteDatabase, composerId: string): string | null {
-    try {
-      const rows = db
-        .prepare("SELECT value FROM cursorDiskKV WHERE key LIKE ? ORDER BY key")
-        .all(`bubbleId:${composerId}:%`) as Array<{ value: string }>;
+  /**
+   * Streams every bubble row once, in key order, handing each composer's group
+   * to the caller. A key-ordered scan keeps a composer's bubbles contiguous, so
+   * only one group is materialized at a time.
+   */
+  private forEachComposerBubbles(
+    db: SQLiteDatabase,
+    wanted: Map<string, PendingComposer>,
+    onGroup: (bubbles: ComposerBubbles) => void,
+  ): void {
+    if (wanted.size === 0) return;
 
-      for (const row of rows) {
-        try {
-          const bubble = parseBubbleRow(row.value);
-          if (bubble?.requestId?.trim()) {
-            return bubble.requestId.trim();
-          }
-        } catch {
-          // skip malformed bubbles
+    let currentId: string | null = null;
+    let group: BubbleRow[] = [];
+    const flush = () => {
+      if (currentId != null && group.length > 0) onGroup(groupBubbleRows(group));
+      group = [];
+    };
+
+    const rows = db
+      .prepare(
+        "SELECT rowid AS row_id, key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:%' ORDER BY key",
+      )
+      .iterate() as Iterable<BubbleRow>;
+    for (const row of rows) {
+      const composerId = composerIdFromBubbleKey(row.key);
+      if (composerId !== currentId) {
+        flush();
+        currentId = composerId;
+      }
+      if (wanted.has(composerId)) group.push(row);
+    }
+    flush();
+  }
+
+  /** Builds the head for one composer from bubbles that were parsed once. */
+  private buildScanHead(
+    entry: PendingComposer,
+    bubbles: ComposerBubbles,
+    workspacePathMap: Map<string, string>,
+  ): SessionHead | null {
+    const { composer, composerId, createdAt, updatedAt, hasSubagents } = entry;
+    const requestId = this.requestIdFromBubbles(bubbles);
+    const sessionId = requestId || composerId;
+
+    const parsedMessages = cleanParsedMessages(
+      this.messagesFromBubbles(bubbles, composer.modelConfig?.modelName ?? composer.model ?? null),
+    );
+    const messages = getParsedSession(
+      parsedMessages.length === 0 && !hasSubagents
+        ? filteredSession<Message[]>("no visible messages")
+        : parsedSession(parsedMessages),
+    );
+    if (!messages) return null;
+
+    const title = this.extractTitle(composer, messages);
+    const directory = workspacePathMap.get(composerId) ?? "";
+
+    const modelUsageMap: Record<string, number> = {};
+    let totalCost = 0;
+    for (const msg of messages) {
+      totalCost += msg.cost ?? 0;
+      if (msg.model) {
+        const msgTokens = (msg.tokens?.input ?? 0) + (msg.tokens?.output ?? 0);
+        if (msgTokens > 0) {
+          modelUsageMap[msg.model] = (modelUsageMap[msg.model] ?? 0) + msgTokens;
         }
       }
-    } catch {
-      // ignore errors
+    }
+    const hasModelUsage = Object.keys(modelUsageMap).length > 0;
+
+    this.composerCache.set(sessionId, composer);
+    this.composerCache.set(`__mapping__${composerId}`, {
+      sessionId,
+    } as unknown as ComposerData);
+    if (directory) {
+      this.composerCache.set(`__dir__${composerId}`, {
+        directory,
+      } as unknown as ComposerData);
+    }
+    this.sessionMetaMap.set(sessionId, { id: sessionId, sourcePath: this.dbPath || "" });
+
+    return {
+      id: sessionId,
+      slug: `cursor/${sessionId}`,
+      title,
+      directory,
+      time_created: createdAt,
+      time_updated: updatedAt || undefined,
+      stats: {
+        message_count: messages.length,
+        total_input_tokens: composer.inputTokenCount ?? 0,
+        total_output_tokens: composer.outputTokenCount ?? 0,
+        total_cost: totalCost,
+        cost_source: totalCost > 0 ? "estimated" : undefined,
+      },
+      model_usage: hasModelUsage ? modelUsageMap : undefined,
+    };
+  }
+
+  /** First request id in key order, matching what agent-dump reports. */
+  private requestIdFromBubbles(bubbles: ComposerBubbles): string | null {
+    for (const entry of bubbles.byKey) {
+      const requestId = entry.bubble.requestId?.trim();
+      if (requestId) return requestId;
     }
     return null;
   }
@@ -890,28 +998,39 @@ export class CursorAgent extends DatabaseSessionSource {
     }
   }
 
-  /** Load messages from bubbles (like agent-dump) */
+  /** Load one composer's bubbles, for the detail path that only needs a single session. */
   private loadMessagesFromBubbles(
     db: SQLiteDatabase,
     composerId: string,
     _sessionId: string,
     initialModelName: string | null,
   ): Message[] {
-    const messages: Message[] = [];
-
     try {
       const rows = db
-        .prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE ? ORDER BY rowid ASC")
-        .all(`bubbleId:${composerId}:%`) as Array<{ key: string; value: string }>;
+        .prepare("SELECT rowid AS row_id, key, value FROM cursorDiskKV WHERE key LIKE ?")
+        .all(`bubbleId:${composerId}:%`) as BubbleRow[];
+      return this.messagesFromBubbles(groupBubbleRows(rows), initialModelName);
+    } catch {
+      return [];
+    }
+  }
 
+  /** Build messages from bubbles already parsed once, in insertion order. */
+  private messagesFromBubbles(
+    bubbles: ComposerBubbles,
+    initialModelName: string | null,
+  ): Message[] {
+    const messages: Message[] = [];
+
+    {
       let activeModelName: string | null = initialModelName;
       let messageIndex = 0;
 
-      for (const row of rows) {
-        try {
-          const bubble = parseBubbleRow(row.value);
-          if (!bubble || isInternalBubble(bubble)) continue;
-          const bubbleId = row.key.split(":").pop() || String(messageIndex);
+      for (const entry of bubbles.byRowId) {
+        {
+          const bubble = entry.bubble;
+          if (isInternalBubble(bubble)) continue;
+          const bubbleId = entry.key.split(":").pop() || String(messageIndex);
 
           // Determine role: type 2 = assistant, otherwise user
           const role = bubble.type === 2 ? "assistant" : "user";
@@ -960,7 +1079,7 @@ export class CursorAgent extends DatabaseSessionSource {
           const cost = estimateTokenCost(modelName, tokens);
 
           messages.push({
-            id: `cursor-${composerId}-${bubbleId}`,
+            id: `cursor-${bubbles.composerId}-${bubbleId}`,
             role: role as Message["role"],
             agent: "cursor",
             time_created: timestampMs,
@@ -975,12 +1094,8 @@ export class CursorAgent extends DatabaseSessionSource {
           });
 
           messageIndex++;
-        } catch {
-          // skip malformed bubbles
         }
       }
-    } catch {
-      // ignore errors
     }
 
     return messages;

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -10,6 +10,8 @@ import { getCoreDiagnostics } from "./diagnostics.js";
 interface SQLiteStatement {
   all(...params: unknown[]): DatabaseRow[];
   get(...params: unknown[]): DatabaseRow | undefined;
+  /** Streams rows so a large result set never has to be materialized at once. */
+  iterate(...params: unknown[]): IterableIterator<DatabaseRow>;
   run(...params: unknown[]): unknown;
 }
 


### PR DESCRIPTION
## Problem

A full Cursor scan called `extractRequestIdFromBubbles()` and then `loadMessagesFromBubbles()` for
every composer. Both ran `key LIKE 'bubbleId:<composer>:%'`, and `EXPLAIN QUERY PLAN` answered both
with `SCAN cursorDiskKV` — so with C composers over K rows the scan was O(C·K), and every bubble was
JSON-parsed twice.

Measured on 3 bubbles per composer:

| composers | before | after |
|---:|---:|---:|
| 100 | 21.5 ms | 17.2 ms |
| 500 | 228.1 ms | 31.2 ms |
| 1,000 | 714.6 ms | 55.0 ms |
| 2,000 | 2,385.8 ms | 106.9 ms |

Doubling the composers used to cost ~3.3× the time; it now costs ~2×.

## Change

The scan runs in two phases. The first reads composer metadata and decides which composers still
need bubbles (fast mode and out-of-window composers need none). The second streams every bubble row
once in key order — keys carry the composer prefix, so each group arrives contiguously and only one
group is materialized at a time, rather than loading the whole table.

- each bubble is parsed once and serves both the request id and the messages
- the group exposes both orders the readers rely on: request ids come from the key-ordered view,
  messages from insertion order
- heads are emitted by composer order regardless of which phase produced them, so scan output does
  not depend on how bubbles are read
- the detail path keeps its single-composer query and shares the same message builder

`SQLiteStatement` gained `iterate` so a large result set never has to be materialized at once.

## Verification

- characterization tests landed first, pinning request id selection by key order, message order by
  insertion, the scan window, and malformed / subagent-only composers — all still pass unchanged
- a complexity test asserts exactly one bubble query for both 10 and 200 composers; the old shape
  issued two per composer
- `EXPLAIN QUERY PLAN` asserts the new read walks the primary key index with no temp B-tree sort
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 544, cli 295, web 448 passing