### PR TITLE
perf: index virtual list heights logarithmically (CS-143)

### DIFF
--- a/apps/web/src/components/session-detail/height-index.test.ts
+++ b/apps/web/src/components/session-detail/height-index.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { HeightIndex } from "./height-index";
+
+const ESTIMATE = 280;
+const GAP = 16;
+
+/** Straightforward O(N) model of the same layout, used as the oracle. */
+function referenceOffsets(heights: Array<number | undefined>): {
+  starts: number[];
+  ends: number[];
+  total: number;
+} {
+  const starts: number[] = [];
+  const ends: number[] = [];
+  let offset = 0;
+  for (let index = 0; index < heights.length; index += 1) {
+    const height = heights[index] ?? ESTIMATE;
+    starts.push(offset);
+    ends.push(offset + height);
+    offset += height + (index === heights.length - 1 ? 0 : GAP);
+  }
+  return { starts, ends, total: offset };
+}
+
+describe("CS-143: HeightIndex", () => {
+  it("matches the reference layout while heights are unmeasured", () => {
+    const index = new HeightIndex(5, ESTIMATE, GAP);
+    const reference = referenceOffsets(Array.from({ length: 5 }));
+
+    expect([0, 1, 2, 3, 4].map((i) => index.startAt(i))).toEqual(reference.starts);
+    expect([0, 1, 2, 3, 4].map((i) => index.endAt(i))).toEqual(reference.ends);
+    expect(index.totalSize).toBe(reference.total);
+  });
+
+  it("matches the reference layout after arbitrary measurements", () => {
+    const heights = [120, undefined, 640, 90, undefined, 310];
+    const index = new HeightIndex(heights.length, ESTIMATE, GAP);
+    heights.forEach((height, position) => {
+      if (height != null) index.setHeight(position, height);
+    });
+    const reference = referenceOffsets(heights);
+
+    expect(heights.map((_, i) => index.startAt(i))).toEqual(reference.starts);
+    expect(heights.map((_, i) => index.endAt(i))).toEqual(reference.ends);
+    expect(index.totalSize).toBe(reference.total);
+  });
+
+  it("ignores a repeat measurement within a pixel", () => {
+    const index = new HeightIndex(3, ESTIMATE, GAP);
+
+    expect(index.setHeight(1, 300)).toBe(true);
+    expect(index.setHeight(1, 300.4)).toBe(false);
+    expect(index.setHeight(1, 340)).toBe(true);
+  });
+
+  it.each([
+    ["out of range low", -1],
+    ["out of range high", 99],
+  ])("ignores a measurement %s", (_name, position) => {
+    const index = new HeightIndex(3, ESTIMATE, GAP);
+
+    expect(index.setHeight(position, 200)).toBe(false);
+    expect(index.totalSize).toBe(referenceOffsets(Array.from({ length: 3 })).total);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["not a number", Number.NaN],
+  ])("ignores a %s height", (_name, height) => {
+    const index = new HeightIndex(3, ESTIMATE, GAP);
+
+    expect(index.setHeight(0, height)).toBe(false);
+  });
+
+  it("locates the items overlapping a viewport", () => {
+    const heights = [100, 200, 300, 400];
+    const index = new HeightIndex(heights.length, ESTIMATE, GAP);
+    heights.forEach((height, position) => index.setHeight(position, height));
+    const reference = referenceOffsets(heights);
+
+    // Viewport starting inside item 1 and ending inside item 2.
+    const start = reference.starts[1]! + 10;
+    const end = reference.starts[2]! + 10;
+
+    expect(index.firstEndAfter(start)).toBe(1);
+    expect(index.firstStartAfter(end)).toBe(3);
+  });
+
+  it("keeps offsets correct for a large list with scattered measurements", () => {
+    const count = 10_000;
+    const heights: Array<number | undefined> = Array.from({ length: count });
+    const index = new HeightIndex(count, ESTIMATE, GAP);
+
+    for (let position = 0; position < count; position += 7) {
+      const height = 100 + (position % 500);
+      heights[position] = height;
+      index.setHeight(position, height);
+    }
+    const reference = referenceOffsets(heights);
+
+    expect(index.totalSize).toBe(reference.total);
+    for (const position of [0, 1, 7, 1234, 5000, 9998, 9999]) {
+      expect(index.startAt(position)).toBe(reference.starts[position]);
+      expect(index.endAt(position)).toBe(reference.ends[position]);
+    }
+  });
+
+  // Rebuilding a prefix array per measurement is O(N) each, so measuring every
+  // row of a 10k transcript costs O(N²) — around 10^8 operations. A logarithmic
+  // update finishes this in milliseconds; the bound is loose on purpose.
+  it("measures every row of a 10k list without quadratic work", () => {
+    const count = 10_000;
+    const index = new HeightIndex(count, ESTIMATE, GAP);
+    const heights: number[] = [];
+
+    const started = performance.now();
+    for (let position = 0; position < count; position += 1) {
+      const height = 80 + (position % 400);
+      heights.push(height);
+      index.setHeight(position, height);
+    }
+    const durationMs = performance.now() - started;
+
+    expect(index.totalSize).toBe(referenceOffsets(heights).total);
+    expect(durationMs).toBeLessThan(1_000);
+  });
+});

--- a/apps/web/src/components/session-detail/height-index.ts
+++ b/apps/web/src/components/session-detail/height-index.ts
@@ -1,0 +1,121 @@
+/**
+ * Offsets for a vertically stacked list whose items are measured as they render.
+ *
+ * A plain prefix array has to be rebuilt from the first changed item, so one
+ * resize costs O(N) and a frame of V resizes costs O(V·N). A Fenwick tree keeps
+ * every update and lookup at O(log N), which is what makes a 10k transcript
+ * usable while heights are still settling.
+ */
+export class HeightIndex {
+  /** Item extent including the gap that follows it; the last item has no gap. */
+  private readonly sizes: Float64Array;
+  private readonly measured: Uint8Array;
+  /** Fenwick tree over `sizes`, 1-indexed. */
+  private readonly tree: Float64Array;
+
+  constructor(
+    readonly count: number,
+    estimate: number,
+    private readonly gap: number,
+  ) {
+    this.sizes = new Float64Array(count);
+    this.measured = new Uint8Array(count);
+    this.tree = new Float64Array(count + 1);
+    for (let index = 0; index < count; index += 1) {
+      this.sizes[index] = this.extentOf(estimate, index);
+    }
+    this.buildTree();
+  }
+
+  /** Measured height of an item, or the estimate while it is unmeasured. */
+  heightAt(index: number): number {
+    if (index < 0 || index >= this.count) return 0;
+    return this.sizes[index]! - this.gapAfter(index);
+  }
+
+  /** Records a height. Returns false when it does not move the layout. */
+  setHeight(index: number, height: number): boolean {
+    if (index < 0 || index >= this.count) return false;
+    if (!Number.isFinite(height) || height <= 0) return false;
+
+    const rounded = Math.ceil(height);
+    if (this.measured[index] === 1 && Math.abs(this.heightAt(index) - rounded) <= 1) return false;
+
+    const next = this.extentOf(rounded, index);
+    const delta = next - this.sizes[index]!;
+    this.sizes[index] = next;
+    this.measured[index] = 1;
+    if (delta !== 0) this.addToTree(index, delta);
+    return true;
+  }
+
+  /** Offset of an item's top edge. */
+  startAt(index: number): number {
+    return this.prefixSum(Math.max(0, Math.min(index, this.count)));
+  }
+
+  /** Offset of an item's bottom edge, excluding the gap after it. */
+  endAt(index: number): number {
+    return this.startAt(index) + this.heightAt(index);
+  }
+
+  get totalSize(): number {
+    return this.prefixSum(this.count);
+  }
+
+  /** First item whose bottom edge is at or past `offset`. */
+  firstEndAfter(offset: number): number {
+    let low = 0;
+    let high = this.count;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (this.endAt(mid) < offset) low = mid + 1;
+      else high = mid;
+    }
+    return low;
+  }
+
+  /** First item whose top edge is past `offset`. */
+  firstStartAfter(offset: number): number {
+    let low = 0;
+    let high = this.count;
+    while (low < high) {
+      const mid = (low + high) >> 1;
+      if (this.startAt(mid) <= offset) low = mid + 1;
+      else high = mid;
+    }
+    return low;
+  }
+
+  private gapAfter(index: number): number {
+    return index === this.count - 1 ? 0 : this.gap;
+  }
+
+  private extentOf(height: number, index: number): number {
+    return height + this.gapAfter(index);
+  }
+
+  private buildTree(): void {
+    for (let index = 0; index < this.count; index += 1) {
+      const node = index + 1;
+      this.tree[node]! += this.sizes[index]!;
+      const parent = node + (node & -node);
+      if (parent <= this.count) this.tree[parent]! += this.tree[node]!;
+    }
+  }
+
+  private addToTree(index: number, delta: number): void {
+    for (let node = index + 1; node <= this.count; node += node & -node) {
+      this.tree[node]! += delta;
+    }
+  }
+
+  /** Sum of the first `count` extents. */
+  private prefixSum(count: number): number {
+    let total = 0;
+    for (let node = count; node > 0; node -= node & -node) {
+      total += this.tree[node]!;
+    }
+    return total;
+  }
+}

--- a/apps/web/src/components/session-detail/message-list.test.tsx
+++ b/apps/web/src/components/session-detail/message-list.test.tsx
@@ -1,3 +1,4 @@
+import { Profiler } from "react";
 import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FilteredSessionMessage } from "./toc";
@@ -219,5 +220,49 @@ describe("MessageList virtualization", () => {
 
     ResizeObserverMock.instances.forEach((observer) => observer.trigger(row));
     expect(Number.parseInt(list.style.height, 10)).toBe(initialHeight + 320);
+  });
+
+  it("CS-143: commits one update for a frame of measurements", async () => {
+    ResizeObserverMock.instances = [];
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const commits: number[] = [];
+    const view = render(
+      <Profiler id="message-list" onRender={(_id, _phase, duration) => commits.push(duration)}>
+        <MessageList
+          messages={createMessages()}
+          sessionAgentKey="claudecode"
+          baseDirectory="/tmp/project"
+          apiRef={{ current: null }}
+        />
+      </Profiler>,
+    );
+    const list = view.container.firstElementChild as HTMLElement;
+    const initialHeight = Number.parseInt(list.style.height, 10);
+    const rows = [...view.container.querySelectorAll("[data-message-index]")].map(
+      (node) => node.parentElement as HTMLElement,
+    );
+    expect(rows.length).toBeGreaterThan(1);
+
+    for (const row of rows) {
+      vi.spyOn(row, "getBoundingClientRect").mockReturnValue({
+        ...row.getBoundingClientRect(),
+        bottom: 600,
+        height: 600,
+      });
+    }
+
+    const before = commits.length;
+    // Every visible row resizing in the same frame is one layout change, so it
+    // must not cost one commit per row.
+    act(() => {
+      for (const row of rows) {
+        ResizeObserverMock.instances.forEach((observer) => observer.trigger(row));
+      }
+    });
+
+    await waitFor(() =>
+      expect(Number.parseInt(list.style.height, 10)).toBeGreaterThan(initialHeight),
+    );
+    expect(commits.length - before).toBe(1);
   });
 });

--- a/apps/web/src/components/session-detail/message-list.tsx
+++ b/apps/web/src/components/session-detail/message-list.tsx
@@ -11,6 +11,7 @@ import type { AgentInfo } from "../../lib/api";
 import { formatTokens } from "../../lib/format";
 import type { FilteredSessionMessage } from "./toc";
 import { MessageItem } from "./message-rendering";
+import { HeightIndex } from "./height-index";
 
 const MESSAGE_LIST_GAP_PX = 32;
 export const VIRTUALIZED_MESSAGE_THRESHOLD = 80;
@@ -30,70 +31,10 @@ interface MessageListProps {
   apiRef: { current: MessageListHandle | null };
 }
 
-interface VirtualMeasurement {
-  start: number;
-  end: number;
-}
-
 type ScrollParent = HTMLElement | Window;
 
 function isWindowScrollParent(parent: ScrollParent): parent is Window {
   return parent === window;
-}
-
-function buildVirtualMeasurements(
-  count: number,
-  heights: Array<number | undefined>,
-): {
-  items: VirtualMeasurement[];
-  totalSize: number;
-} {
-  const items: VirtualMeasurement[] = [];
-  let offset = 0;
-
-  for (let index = 0; index < count; index += 1) {
-    const height = heights[index] ?? VIRTUALIZED_MESSAGE_ESTIMATE_PX;
-    const start = offset;
-    const end = start + height;
-    items.push({ start, end });
-    offset = end + (index === count - 1 ? 0 : MESSAGE_LIST_GAP_PX);
-  }
-
-  return { items, totalSize: offset };
-}
-
-function findFirstEndAfter(items: VirtualMeasurement[], offset: number) {
-  let low = 0;
-  let high = items.length;
-
-  while (low < high) {
-    const mid = Math.floor((low + high) / 2);
-    const item = items[mid];
-    if (item && item.end < offset) {
-      low = mid + 1;
-    } else {
-      high = mid;
-    }
-  }
-
-  return low;
-}
-
-function findFirstStartAfter(items: VirtualMeasurement[], offset: number) {
-  let low = 0;
-  let high = items.length;
-
-  while (low < high) {
-    const mid = Math.floor((low + high) / 2);
-    const item = items[mid];
-    if (item && item.start <= offset) {
-      low = mid + 1;
-    } else {
-      high = mid;
-    }
-  }
-
-  return low;
 }
 
 function findScrollParent(node: HTMLElement): ScrollParent {
@@ -189,7 +130,11 @@ function VirtualizedMessageList({
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const scrollParentRef = useRef<ScrollParent | null>(null);
-  const [measuredHeights, setMeasuredHeights] = useState<Array<number | undefined>>([]);
+  // Heights live outside React state: a measurement mutates the index in place
+  // and a single version bump per frame tells the view to re-read it.
+  const heightIndexRef = useRef<HeightIndex | null>(null);
+  const [measurementVersion, setMeasurementVersion] = useState(0);
+  const pendingMeasureFrameRef = useRef(0);
   const [forcedIndex, setForcedIndex] = useState<number | null>(null);
   const [viewport, setViewport] = useState(() => ({
     scrollTop: 0,
@@ -293,74 +238,80 @@ function VirtualizedMessageList({
     };
   }, [updateViewport]);
 
+  const heightIndex = useMemo(() => {
+    const index = new HeightIndex(
+      messages.length,
+      VIRTUALIZED_MESSAGE_ESTIMATE_PX,
+      MESSAGE_LIST_GAP_PX,
+    );
+    heightIndexRef.current = index;
+    return index;
+  }, [messages]);
+
   useEffect(() => {
-    setMeasuredHeights([]);
     setForcedIndex(null);
+    setMeasurementVersion(0);
     updateViewport();
   }, [messages, updateViewport]);
 
-  const measurements = useMemo(
-    () => buildVirtualMeasurements(messages.length, measuredHeights),
-    [measuredHeights, messages.length],
-  );
+  useEffect(() => {
+    return () => {
+      if (pendingMeasureFrameRef.current) cancelAnimationFrame(pendingMeasureFrameRef.current);
+      pendingMeasureFrameRef.current = 0;
+    };
+  }, []);
 
   const measureItem = useCallback((index: number, height: number) => {
-    const nextHeight = Math.ceil(height);
-    if (!Number.isFinite(nextHeight) || nextHeight <= 0) return;
-
-    setMeasuredHeights((current) => {
-      const currentHeight = current[index];
-      if (currentHeight != null && Math.abs(currentHeight - nextHeight) <= 1) return current;
-
-      const next = [...current];
-      next[index] = nextHeight;
-      return next;
+    if (!heightIndexRef.current?.setHeight(index, height)) return;
+    // Every row mounting in one frame would otherwise commit its own render.
+    if (pendingMeasureFrameRef.current) return;
+    pendingMeasureFrameRef.current = requestAnimationFrame(() => {
+      pendingMeasureFrameRef.current = 0;
+      setMeasurementVersion((version) => version + 1);
     });
   }, []);
 
   const virtualItems = useMemo(() => {
     if (messages.length === 0) return [];
+    void measurementVersion;
 
     const localStart = Math.max(0, viewport.scrollTop - viewport.listTop);
     const localEnd = localStart + viewport.height;
     const startIndex = Math.max(
       0,
-      findFirstEndAfter(measurements.items, localStart) - VIRTUALIZED_MESSAGE_OVERSCAN,
+      heightIndex.firstEndAfter(localStart) - VIRTUALIZED_MESSAGE_OVERSCAN,
     );
     const endIndex = Math.min(
       messages.length,
-      findFirstStartAfter(measurements.items, localEnd) + VIRTUALIZED_MESSAGE_OVERSCAN,
+      heightIndex.firstStartAfter(localEnd) + VIRTUALIZED_MESSAGE_OVERSCAN,
     );
 
     const items: Array<{ index: number; start: number }> = [];
     for (let index = startIndex; index < endIndex; index += 1) {
-      const measurement = measurements.items[index];
-      if (measurement) items.push({ index, start: measurement.start });
+      items.push({ index, start: heightIndex.startAt(index) });
     }
 
     if (forcedIndex != null && forcedIndex >= 0 && forcedIndex < messages.length) {
-      const measurement = measurements.items[forcedIndex];
-      if (measurement && !items.some((item) => item.index === forcedIndex)) {
-        items.push({ index: forcedIndex, start: measurement.start });
+      if (!items.some((item) => item.index === forcedIndex)) {
+        items.push({ index: forcedIndex, start: heightIndex.startAt(forcedIndex) });
         items.sort((a, b) => a.start - b.start);
       }
     }
 
     return items;
-  }, [forcedIndex, measurements, messages.length, viewport]);
+  }, [forcedIndex, heightIndex, measurementVersion, messages.length, viewport]);
 
   const scrollToIndex = useCallback(
     (index: number) => {
       if (typeof window === "undefined") return;
-      const measurement = measurements.items[index];
-      if (!measurement) return;
+      if (index < 0 || index >= messages.length) return;
 
       setForcedIndex(index);
       const node = containerRef.current;
       const scrollParent = node ? findScrollParent(node) : (scrollParentRef.current ?? window);
       scrollParentRef.current = scrollParent;
       const listTop = node ? getListTop(node, scrollParent) : 0;
-      const nextTop = Math.max(0, listTop + measurement.start - 24);
+      const nextTop = Math.max(0, listTop + heightIndex.startAt(index) - 24);
       scrollParentTo(scrollParent, nextTop);
       const nextViewport = {
         scrollTop: nextTop,
@@ -370,7 +321,7 @@ function VirtualizedMessageList({
       viewportRef.current = nextViewport;
       setViewport(nextViewport);
     },
-    [measurements.items],
+    [heightIndex, messages.length],
   );
 
   useEffect(() => {
@@ -384,7 +335,7 @@ function VirtualizedMessageList({
     <div
       ref={containerRef}
       className="relative min-w-0"
-      style={{ height: Math.max(1, measurements.totalSize) }}
+      style={{ height: Math.max(1, heightIndex.totalSize) }}
     >
       {virtualItems.map(({ index, start }) => {
         const item = messages[index];


### PR DESCRIPTION
## Problem

The message list was virtualized, but its dynamic-height index still did whole-list work on every
measurement:

- `measureItem()` copied the entire sparse `measuredHeights` array
- `buildVirtualMeasurements()` then allocated a fresh `{start, end}` for all N messages
- each newly mounted row and each `ResizeObserver` change submitted its own update

One measurement was O(N) in both time and allocation, so a frame with V changes was O(V·N). Only
lookups after the heights had settled were O(log N). The existing tests topped out at 81 messages,
so no 10k variable-height transcript was ever exercised.

## Change

- `height-index.ts` owns the layout: a Fenwick tree over per-item extents, exposing only
  `setHeight`, `startAt` / `endAt`, `totalSize`, and the two viewport searches. Updates and lookups
  are O(log N); the component never touches sparse-array arithmetic.
- heights live outside React state — a measurement mutates the index in place and one version bump
  per frame tells the view to re-read it, instead of a state copy per row
- the gap between items is folded into each item's extent, so offsets are a plain prefix sum

Anchor jumps, forced indices, async height growth and scroll-container behavior are unchanged.

## Verification

- the index is checked against a straightforward O(N) model of the same layout: unmeasured,
  partially measured, and a 10k list with scattered measurements all agree on every start, end and
  total
- repeat measurements within a pixel, out-of-range indices and non-positive heights are rejected
- a 10k scale test measures every row; the old per-measurement rebuild is ~10^8 operations there,
  the tree finishes in milliseconds
- a Profiler test asserts a frame of resizes across all visible rows produces a single commit
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 544, cli 295, web 460 passing
- `pnpm test:e2e` — 22 passing (covers TOC anchors and search filtering)