### PR TITLE
perf: load route surfaces on demand (CS-146)

### DIFF
--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -68,7 +68,8 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
 afterEach(cleanup);
 
 describe("AppRouteContent", () => {
-  it("renders a project from the resolved project model", () => {
+  // The route surfaces load on demand, so the assertion waits for the chunk.
+  it("renders a project from the resolved project model", async () => {
     const props = makeProps();
     props.viewState = {
       mode: "project",
@@ -85,10 +86,10 @@ describe("AppRouteContent", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: "acme/app" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "acme/app" })).toBeTruthy();
   });
 
-  it("renders search content from the explicit search contract", () => {
+  it("renders search content from the explicit search contract", async () => {
     const props = makeProps();
     props.search.active = true;
 
@@ -98,6 +99,6 @@ describe("AppRouteContent", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("heading", { name: "No recent sessions" })).toBeTruthy();
+    expect(await screen.findByRole("heading", { name: "No recent sessions" })).toBeTruthy();
   });
 });

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -1,10 +1,33 @@
-import { useMemo, type Dispatch, type SetStateAction } from "react";
-import { Dashboard } from "../Dashboard";
+import { lazy, Suspense, useMemo, type Dispatch, type ReactNode, type SetStateAction } from "react";
 import { DetailLanding, type LandingAgentItem, type LandingSession } from "../DetailLanding";
-import { ProjectDashboardView, ProjectsOverview } from "../Projects";
+import { ErrorBoundary } from "../ErrorBoundary";
 import { RenderProfiler } from "../RenderProfiler";
-import { SessionDetail } from "../SessionDetail";
 import { SessionDetailSkeleton } from "../SessionDetailSkeleton";
+
+// Each surface owns its heavy dependencies — markdown, syntax highlighting and
+// the receipt reach the browser when their route does, not on first paint.
+const Dashboard = lazy(() => import("../Dashboard").then((m) => ({ default: m.Dashboard })));
+const ProjectsOverview = lazy(() =>
+  import("../Projects").then((m) => ({ default: m.ProjectsOverview })),
+);
+const ProjectDashboardView = lazy(() =>
+  import("../Projects").then((m) => ({ default: m.ProjectDashboardView })),
+);
+const SessionDetail = lazy(() =>
+  import("../SessionDetail").then((m) => ({ default: m.SessionDetail })),
+);
+const SearchResultsPanel = lazy(() =>
+  import("./SearchResultsPanel").then((m) => ({ default: m.SearchResultsPanel })),
+);
+
+/** Keeps a failed chunk load contained to the surface that needed it. */
+function LazySurface({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<SessionDetailSkeleton />}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}
 import type {
   AgentInfo,
   BookmarkRecord,
@@ -15,7 +38,6 @@ import type {
 import type * as Api from "../../lib/api";
 import type { AgentCatalog } from "../../lib/agents";
 import type { ViewState } from "../../lib/view-state";
-import { SearchResultsPanel } from "./SearchResultsPanel";
 import type { SearchFilterState, SearchLoadState, SearchProjectOption } from "./types";
 
 interface SessionDetailModel {
@@ -110,19 +132,21 @@ export function AppRouteContent({
         id="SearchResultsPanel"
         detail={{ results: resultCount, loading: search.state.status === "loading" }}
       >
-        <SearchResultsPanel
-          query={search.query}
-          state={search.state}
-          agentNameMap={agentNameMap}
-          agents={agents}
-          projects={search.projectOptions}
-          filters={search.filters}
-          onChangeFilters={search.onChangeFilters}
-          onOpenResult={search.onClose}
-          onRetry={search.onRetry}
-          selectedIndex={search.selectedIndex}
-          registerResultRef={search.registerResultRef}
-        />
+        <LazySurface>
+          <SearchResultsPanel
+            query={search.query}
+            state={search.state}
+            agentNameMap={agentNameMap}
+            agents={agents}
+            projects={search.projectOptions}
+            filters={search.filters}
+            onChangeFilters={search.onChangeFilters}
+            onOpenResult={search.onClose}
+            onRetry={search.onRetry}
+            selectedIndex={search.selectedIndex}
+            registerResultRef={search.registerResultRef}
+          />
+        </LazySurface>
       </RenderProfiler>
     );
   }
@@ -139,20 +163,22 @@ export function AppRouteContent({
         id="Dashboard"
         detail={{ sessions: dashboard.totals.sessions, projects: projects.length }}
       >
-        <Dashboard
-          data={dashboard}
-          agentCatalog={agentCatalog}
-          projects={projects}
-          bookmarkedSessions={bookmarks.sessions}
-          isBookmarked={bookmarks.isBookmarked}
-          onToggleBookmark={(item) => {
-            if (!("bookmarkedAt" in item)) {
-              bookmarks.toggleSessionBookmark(item.session, item.reference.agentName);
-              return;
-            }
-            bookmarks.toggleBookmark(item);
-          }}
-        />
+        <LazySurface>
+          <Dashboard
+            data={dashboard}
+            agentCatalog={agentCatalog}
+            projects={projects}
+            bookmarkedSessions={bookmarks.sessions}
+            isBookmarked={bookmarks.isBookmarked}
+            onToggleBookmark={(item) => {
+              if (!("bookmarkedAt" in item)) {
+                bookmarks.toggleSessionBookmark(item.session, item.reference.agentName);
+                return;
+              }
+              bookmarks.toggleBookmark(item);
+            }}
+          />
+        </LazySurface>
       </RenderProfiler>
     ) : (
       <DetailLanding
@@ -166,23 +192,29 @@ export function AppRouteContent({
     );
   }
   if (viewState.mode === "projects") {
-    return <ProjectsOverview projects={projects} agentCatalog={agentCatalog} />;
+    return (
+      <LazySurface>
+        <ProjectsOverview projects={projects} agentCatalog={agentCatalog} />
+      </LazySurface>
+    );
   }
   if (viewState.mode === "project") {
     return (
-      <ProjectDashboardView
-        project={activeProject}
-        agentCatalog={agentCatalog}
-        projectKey={viewState.activeProjectKey}
-        dashboard={projectDashboard.dashboard}
-        loading={projectDashboard.loading}
-        error={projectDashboard.error}
-        sessions={activeProjectSessions}
-        activeAgent={projectDashboard.selectedAgent}
-        onChangeAgent={projectDashboard.onChangeAgent}
-        isBookmarked={bookmarks.isBookmarked}
-        onToggleSessionBookmark={bookmarks.toggleSessionBookmark}
-      />
+      <LazySurface>
+        <ProjectDashboardView
+          project={activeProject}
+          agentCatalog={agentCatalog}
+          projectKey={viewState.activeProjectKey}
+          dashboard={projectDashboard.dashboard}
+          loading={projectDashboard.loading}
+          error={projectDashboard.error}
+          sessions={activeProjectSessions}
+          activeAgent={projectDashboard.selectedAgent}
+          onChangeAgent={projectDashboard.onChangeAgent}
+          isBookmarked={bookmarks.isBookmarked}
+          onToggleSessionBookmark={bookmarks.toggleSessionBookmark}
+        />
+      </LazySurface>
     );
   }
   if (viewState.mode === "agent") {
@@ -222,11 +254,13 @@ export function AppRouteContent({
           session: sessionDetail.session.id,
         }}
       >
-        <SessionDetail
-          session={sessionDetail.session}
-          agentCatalog={agentCatalog}
-          highlightQuery={detailHighlightQuery}
-        />
+        <LazySurface>
+          <SessionDetail
+            session={sessionDetail.session}
+            agentCatalog={agentCatalog}
+            highlightQuery={detailHighlightQuery}
+          />
+        </LazySurface>
       </RenderProfiler>
     );
   }

--- a/apps/web/src/components/session-detail/session-detail-aux.tsx
+++ b/apps/web/src/components/session-detail/session-detail-aux.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { FileText, Funnel } from "../ui/icons";
 import type { SessionDetail } from "../../lib/api";
-import { InteractiveReceipt } from "../InteractiveReceipt";
+import { ErrorBoundary } from "../ErrorBoundary";
 import { RenderProfiler } from "../RenderProfiler";
 import { DrawerDialog } from "../DrawerDialog";
 import type { SessionDetailToc } from "./toc";
@@ -9,6 +9,17 @@ import type { FileChangeSummary } from "./file-change";
 import { FileChangeTracker, getFileTrackerItemCount } from "./file-change-tracker";
 import type { SessionAnchorScrollHandler } from "./scroll-behavior";
 import { SessionTocFilterPanel } from "./session-toc";
+
+// The receipt is only reachable from its drawer, so it downloads on open.
+const InteractiveReceipt = lazy(() =>
+  import("../InteractiveReceipt").then((m) => ({ default: m.InteractiveReceipt })),
+);
+
+function ReceiptPlaceholder() {
+  return (
+    <div className="h-[calc(100dvh-5.5rem)] min-h-[420px] rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]" />
+  );
+}
 
 export function DeferredInteractiveReceipt({
   session,
@@ -63,10 +74,14 @@ export function DeferredInteractiveReceipt({
       <DrawerDialog open={open} onOpenChange={setOpen} title="Session Receipt" variant="desktop">
         {ready ? (
           <RenderProfiler id="InteractiveReceipt">
-            <InteractiveReceipt key={session.id} session={session} toc={toc} />
+            <ErrorBoundary>
+              <Suspense fallback={<ReceiptPlaceholder />}>
+                <InteractiveReceipt key={session.id} session={session} toc={toc} />
+              </Suspense>
+            </ErrorBoundary>
           </RenderProfiler>
         ) : (
-          <div className="h-[calc(100dvh-5.5rem)] min-h-[420px] rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)]" />
+          <ReceiptPlaceholder />
         )}
       </DrawerDialog>
     </>

--- a/apps/web/src/components/tool-output/CodeHighlighter.tsx
+++ b/apps/web/src/components/tool-output/CodeHighlighter.tsx
@@ -1,80 +1,35 @@
-import SyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism-light";
-import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
-import c from "react-syntax-highlighter/dist/esm/languages/prism/c";
-import cpp from "react-syntax-highlighter/dist/esm/languages/prism/cpp";
-import csharp from "react-syntax-highlighter/dist/esm/languages/prism/csharp";
-import css from "react-syntax-highlighter/dist/esm/languages/prism/css";
-import docker from "react-syntax-highlighter/dist/esm/languages/prism/docker";
-import go from "react-syntax-highlighter/dist/esm/languages/prism/go";
-import ini from "react-syntax-highlighter/dist/esm/languages/prism/ini";
-import java from "react-syntax-highlighter/dist/esm/languages/prism/java";
-import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
-import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
-import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
-import markdown from "react-syntax-highlighter/dist/esm/languages/prism/markdown";
-import markup from "react-syntax-highlighter/dist/esm/languages/prism/markup";
-import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
-import rust from "react-syntax-highlighter/dist/esm/languages/prism/rust";
-import sql from "react-syntax-highlighter/dist/esm/languages/prism/sql";
-import toml from "react-syntax-highlighter/dist/esm/languages/prism/toml";
-import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
-import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
-import yaml from "react-syntax-highlighter/dist/esm/languages/prism/yaml";
-import oneDark from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
-import oneLight from "react-syntax-highlighter/dist/esm/styles/prism/one-light";
-import { useContext } from "react";
-import { ResolvedThemeContext } from "../../hooks/useTheme";
+import { lazy, Suspense } from "react";
+import { ErrorBoundary } from "../ErrorBoundary";
 
-SyntaxHighlighter.registerLanguage("bash", bash);
-SyntaxHighlighter.registerLanguage("c", c);
-SyntaxHighlighter.registerLanguage("cpp", cpp);
-SyntaxHighlighter.registerLanguage("csharp", csharp);
-SyntaxHighlighter.registerLanguage("css", css);
-SyntaxHighlighter.registerLanguage("docker", docker);
-SyntaxHighlighter.registerLanguage("go", go);
-SyntaxHighlighter.registerLanguage("ini", ini);
-SyntaxHighlighter.registerLanguage("java", java);
-SyntaxHighlighter.registerLanguage("javascript", javascript);
-SyntaxHighlighter.registerLanguage("jsx", jsx);
-SyntaxHighlighter.registerLanguage("json", json);
-SyntaxHighlighter.registerLanguage("markdown", markdown);
-SyntaxHighlighter.registerLanguage("markup", markup);
-SyntaxHighlighter.registerLanguage("python", python);
-SyntaxHighlighter.registerLanguage("rust", rust);
-SyntaxHighlighter.registerLanguage("sql", sql);
-SyntaxHighlighter.registerLanguage("toml", toml);
-SyntaxHighlighter.registerLanguage("tsx", tsx);
-SyntaxHighlighter.registerLanguage("typescript", typescript);
-SyntaxHighlighter.registerLanguage("yaml", yaml);
-
-interface CodeHighlighterProps {
+export interface CodeHighlighterProps {
   language: string;
   text: string;
 }
 
-function normalizeLanguage(language: string) {
-  if (language === "html" || language === "xml") return "markup";
-  return language;
+// Prism and its language grammars are the largest thing a session detail pulls
+// in, and plenty of sessions never show a code block — so it loads on the first
+// one, behind a fallback that already shows the code.
+const PrismHighlighter = lazy(() =>
+  import("./PrismHighlighter").then((m) => ({ default: m.PrismHighlighter })),
+);
+
+function PlainCode({ text }: { text: string }) {
+  return (
+    <pre
+      className="console-mono m-0 overflow-x-auto whitespace-pre-wrap break-words p-3 text-xs leading-relaxed"
+      style={{ background: "transparent" }}
+    >
+      {text}
+    </pre>
+  );
 }
 
 export function CodeHighlighter({ language, text }: CodeHighlighterProps) {
-  const resolvedTheme = useContext(ResolvedThemeContext);
   return (
-    <SyntaxHighlighter
-      language={normalizeLanguage(language)}
-      style={resolvedTheme === "dark" ? oneDark : oneLight}
-      customStyle={{
-        margin: 0,
-        padding: "0.75rem",
-        borderRadius: 0,
-        background: "transparent",
-        fontSize: "0.75rem",
-        lineHeight: 1.55,
-      }}
-      codeTagProps={{ className: "console-mono" }}
-      wrapLongLines
-    >
-      {text}
-    </SyntaxHighlighter>
+    <ErrorBoundary fallback={<PlainCode text={text} />}>
+      <Suspense fallback={<PlainCode text={text} />}>
+        <PrismHighlighter language={language} text={text} />
+      </Suspense>
+    </ErrorBoundary>
   );
 }

--- a/apps/web/src/components/tool-output/PrismHighlighter.tsx
+++ b/apps/web/src/components/tool-output/PrismHighlighter.tsx
@@ -1,0 +1,77 @@
+import SyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism-light";
+import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
+import c from "react-syntax-highlighter/dist/esm/languages/prism/c";
+import cpp from "react-syntax-highlighter/dist/esm/languages/prism/cpp";
+import csharp from "react-syntax-highlighter/dist/esm/languages/prism/csharp";
+import css from "react-syntax-highlighter/dist/esm/languages/prism/css";
+import docker from "react-syntax-highlighter/dist/esm/languages/prism/docker";
+import go from "react-syntax-highlighter/dist/esm/languages/prism/go";
+import ini from "react-syntax-highlighter/dist/esm/languages/prism/ini";
+import java from "react-syntax-highlighter/dist/esm/languages/prism/java";
+import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
+import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
+import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
+import markdown from "react-syntax-highlighter/dist/esm/languages/prism/markdown";
+import markup from "react-syntax-highlighter/dist/esm/languages/prism/markup";
+import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
+import rust from "react-syntax-highlighter/dist/esm/languages/prism/rust";
+import sql from "react-syntax-highlighter/dist/esm/languages/prism/sql";
+import toml from "react-syntax-highlighter/dist/esm/languages/prism/toml";
+import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
+import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
+import yaml from "react-syntax-highlighter/dist/esm/languages/prism/yaml";
+import oneDark from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
+import oneLight from "react-syntax-highlighter/dist/esm/styles/prism/one-light";
+import { useContext } from "react";
+import { ResolvedThemeContext } from "../../hooks/useTheme";
+
+SyntaxHighlighter.registerLanguage("bash", bash);
+SyntaxHighlighter.registerLanguage("c", c);
+SyntaxHighlighter.registerLanguage("cpp", cpp);
+SyntaxHighlighter.registerLanguage("csharp", csharp);
+SyntaxHighlighter.registerLanguage("css", css);
+SyntaxHighlighter.registerLanguage("docker", docker);
+SyntaxHighlighter.registerLanguage("go", go);
+SyntaxHighlighter.registerLanguage("ini", ini);
+SyntaxHighlighter.registerLanguage("java", java);
+SyntaxHighlighter.registerLanguage("javascript", javascript);
+SyntaxHighlighter.registerLanguage("jsx", jsx);
+SyntaxHighlighter.registerLanguage("json", json);
+SyntaxHighlighter.registerLanguage("markdown", markdown);
+SyntaxHighlighter.registerLanguage("markup", markup);
+SyntaxHighlighter.registerLanguage("python", python);
+SyntaxHighlighter.registerLanguage("rust", rust);
+SyntaxHighlighter.registerLanguage("sql", sql);
+SyntaxHighlighter.registerLanguage("toml", toml);
+SyntaxHighlighter.registerLanguage("tsx", tsx);
+SyntaxHighlighter.registerLanguage("typescript", typescript);
+SyntaxHighlighter.registerLanguage("yaml", yaml);
+
+import type { CodeHighlighterProps } from "./CodeHighlighter";
+
+function normalizeLanguage(language: string) {
+  if (language === "html" || language === "xml") return "markup";
+  return language;
+}
+
+export function PrismHighlighter({ language, text }: CodeHighlighterProps) {
+  const resolvedTheme = useContext(ResolvedThemeContext);
+  return (
+    <SyntaxHighlighter
+      language={normalizeLanguage(language)}
+      style={resolvedTheme === "dark" ? oneDark : oneLight}
+      customStyle={{
+        margin: 0,
+        padding: "0.75rem",
+        borderRadius: 0,
+        background: "transparent",
+        fontSize: "0.75rem",
+        lineHeight: 1.55,
+      }}
+      codeTagProps={{ className: "console-mono" }}
+      wrapLongLines
+    >
+      {text}
+    </SyntaxHighlighter>
+  );
+}

--- a/apps/web/tests/initial-bundle.test.ts
+++ b/apps/web/tests/initial-bundle.test.ts
@@ -1,0 +1,58 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+
+const distDir = join(dirname(fileURLToPath(import.meta.url)), "../dist");
+const indexHtmlPath = join(distDir, "index.html");
+const distExists = existsSync(indexHtmlPath);
+
+/**
+ * Budget for what a first paint costs, in gzipped JavaScript. Generous enough
+ * not to fail on ordinary feature work, tight enough that pulling a route's
+ * heavy dependencies back into the entry trips it.
+ */
+const INITIAL_JS_GZIP_BUDGET_BYTES = 300_000;
+
+/** Markers for dependencies that must only arrive with the route that needs them. */
+const DEFERRED_DEPENDENCY_MARKERS = ["micromark", "mdast", "prism", "remark"];
+
+function initialScripts(): string[] {
+  const html = readFileSync(indexHtmlPath, "utf8");
+  return [...html.matchAll(/(?:src|href)="(\/assets\/[^"]+\.js)"/g)].map((match) => match[1]!);
+}
+
+// Requires `pnpm --filter @codesesh/web build` to have run first.
+describe.skipIf(!distExists)("CS-146: initial bundle", () => {
+  it("stays within the gzipped budget", () => {
+    const total = initialScripts().reduce(
+      (bytes, path) => bytes + gzipSync(readFileSync(join(distDir, path.slice(1)))).length,
+      0,
+    );
+
+    expect(total).toBeLessThan(INITIAL_JS_GZIP_BUDGET_BYTES);
+  });
+
+  it("does not preload markdown, syntax highlighting or the receipt", () => {
+    const combined = initialScripts()
+      .map((path) => readFileSync(join(distDir, path.slice(1)), "utf8").toLowerCase())
+      .join("");
+
+    for (const marker of DEFERRED_DEPENDENCY_MARKERS) {
+      expect(combined).not.toContain(marker);
+    }
+  });
+
+  it("still ships those dependencies in on-demand chunks", () => {
+    const initial = new Set(initialScripts().map((path) => path.slice("/assets/".length)));
+    const deferred = readdirSync(join(distDir, "assets"))
+      .filter((file) => file.endsWith(".js") && !initial.has(file))
+      .map((file) => readFileSync(join(distDir, "assets", file), "utf8").toLowerCase());
+
+    // Deferred, not dropped: each marker still ships in some non-initial chunk.
+    for (const marker of DEFERRED_DEPENDENCY_MARKERS) {
+      expect(deferred.some((source) => source.includes(marker))).toBe(true);
+    }
+  });
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,21 +9,13 @@ const pkg = await import("./package.json", { with: { type: "json" } });
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   build: {
+    // No manual chunk map: naming chunks does not make a static dependency
+    // async, and pinning vendors into shared chunks pulls them into the entry
+    // as soon as one member is reachable synchronously. The dynamic imports in
+    // AppRouteContent define the boundaries instead.
     rolldownOptions: {
       output: {
-        manualChunks(id) {
-          if (!id.includes("node_modules")) return;
-          if (id.includes("/react/") || id.includes("/react-dom/") || id.includes("/scheduler/")) {
-            return "react";
-          }
-          if (id.includes("/react-syntax-highlighter/") || id.includes("/refractor/")) {
-            return "syntax";
-          }
-          if (id.includes("/react-markdown/") || id.includes("/remark-") || id.includes("/mdast-")) {
-            return "markdown";
-          }
-          return "vendor";
-        },
+        codeSplitting: true,
       },
     },
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -86,6 +86,7 @@ export default defineConfig({
       testMatch: [
         "aggregation.spec.ts",
         "browsing.spec.ts",
+        "code-splitting.spec.ts",
         "live-refresh.spec.ts",
         "local-media.spec.ts",
       ],

--- a/tests/e2e/code-splitting.spec.ts
+++ b/tests/e2e/code-splitting.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "./test-fixtures.js";
+
+function jsRequests(page: import("playwright/test").Page): string[] {
+  const requested: string[] = [];
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname;
+    if (path.endsWith(".js")) requested.push(path);
+  });
+  return requested;
+}
+
+/**
+ * The dashboard must not pay for the session detail's markdown, syntax
+ * highlighting or receipt — those arrive with the surface that needs them.
+ */
+test("loads detail-only chunks on demand", async ({ page }) => {
+  const requested = jsRequests(page);
+
+  await page.goto("/");
+  await expect(page.getByTestId("dashboard")).toBeVisible();
+  const dashboardChunks = [...requested];
+
+  await page.goto("/claudecode/e2e-dashboard");
+  await expect(page.getByTestId("session-detail")).toBeVisible();
+  await expect(page.getByText("Dashboard path is ready")).toBeVisible();
+
+  const detailChunks = requested.filter((path) => !dashboardChunks.includes(path));
+
+  // The dashboard never asked for the detail surface.
+  expect(dashboardChunks.some((path) => /SessionDetail/i.test(path))).toBe(false);
+  expect(dashboardChunks.some((path) => /PrismHighlighter/i.test(path))).toBe(false);
+  expect(dashboardChunks.some((path) => /InteractiveReceipt/i.test(path))).toBe(false);
+  // Opening it did.
+  expect(detailChunks.some((path) => /SessionDetail/i.test(path))).toBe(true);
+});
+
+test("loads the receipt when its drawer opens", async ({ page }) => {
+  const requested = jsRequests(page);
+
+  await page.goto("/claudecode/e2e-dashboard");
+  await expect(page.getByTestId("session-detail")).toBeVisible();
+  expect(requested.some((path) => /InteractiveReceipt/i.test(path))).toBe(false);
+
+  await page.getByRole("button", { name: "Open session receipt" }).click();
+
+  await expect
+    .poll(() => requested.some((path) => /InteractiveReceipt/i.test(path)))
+    .toBe(true);
+});


### PR DESCRIPTION
## Problem

`AppRouteContent` statically imported Dashboard, Projects, SessionDetail and Search, and the detail
chain pulled in markdown, Prism languages and themes, and the 902-line InteractiveReceipt. The
`manualChunks` map only renamed files — it cannot turn a static dependency into an async one.

Every first paint, including the dashboard and an invalid route, downloaded and parsed all of it:

| | before | after |
|---|---:|---:|
| Initial JS (minified) | 1,567,205 B | 850,807 B |
| Initial JS (gzip) | 458,900 B | 259,389 B |

## Change

- each route surface is a dynamic import behind its own error boundary, so a failed chunk load
  degrades one surface instead of blanking the app
- the receipt loads when its drawer opens; it was already deferred in rendering, just not in bundling
- the syntax highlighter loads on the first code output, behind a fallback that already renders the
  code as plain text — so nothing is hidden while it arrives
- the manual chunk map is gone: pinning vendors into shared chunks pulled markdown into the entry as
  soon as one member of that chunk was reachable synchronously

## Verification

- a build gate asserts the initial JS stays under a 300KB gzip budget, that no initial chunk contains
  markdown or Prism markers, and that those markers still ship in non-initial chunks — deferred, not
  dropped. It reads `dist/index.html` rather than hardcoding chunk names or hashes.
- Playwright records every JS request: the dashboard asks for no detail, highlighter or receipt
  chunk; opening a session pulls the detail chunk; opening the receipt drawer pulls the receipt chunk
- two `AppRouteContent` tests became async, which is the visible consequence of the surfaces loading
  on demand
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 544, cli 295, web 463 passing
- `pnpm test:e2e` — 24 passing