### PR TITLE
chore: verify release versions before publishing (CS-149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
 
       - run: pnpm format:check
 
+      - name: Verify package versions agree
+        run: node scripts/release-preflight.mjs
+
       - run: pnpm build
 
       - name: Smoke test CLI on minimum Node version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Before anything is built, rewritten or published: the tag and all four
+      # manifests must already agree.
+      - name: Verify release versions
+        run: node scripts/release-preflight.mjs "${GITHUB_REF_NAME}"
+
       - run: pnpm build
 
       # Build CLI with @codesesh/core bundled in (self-contained)

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -43,6 +43,16 @@ CLI 运行时版本来自 `packages/cli/src/version.ts`，读取 **同目录** `
   - `packages/core/package.json`
   - `apps/web/package.json`
   - `apps/www/package.json`
+
+  改完后本地自检（与 CI、Release workflow 用的是同一个脚本）：
+
+  ```bash
+  node scripts/release-preflight.mjs vX.Y.Z
+  ```
+
+  常规 CI 只做包与包之间的一致性检查（不带参数）；Release workflow 在 build 与
+  publish 之前用 tag 再校验一次，任何一处漂移都会在改动 `packages/cli/package.json`
+  之前失败。
 - [ ] **README（按需）**：若本版有用户可见的新能力、Agent 列表或 CLI 行为变化，更新：
   - `README.md`
   - `README_CN.md`

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,0 +1,73 @@
+/**
+ * Read-only check that every published version agrees before a release mutates
+ * anything. A release rewrites the CLI manifest and publishes to npm; a manifest
+ * missed during preparation would otherwise ship a package whose version
+ * disagrees with the tag, the web `__APP_VERSION__` and the site.
+ *
+ * Usage:
+ *   node scripts/release-preflight.mjs            # manifests agree with each other
+ *   node scripts/release-preflight.mjs v1.2.3     # ...and with the tag
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const VERSIONED_MANIFESTS = [
+  "packages/cli/package.json",
+  "packages/core/package.json",
+  "apps/web/package.json",
+  "apps/www/package.json",
+];
+
+const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+
+/** Strips exactly one leading `v`; anything else is not a release tag. */
+export function versionFromTag(tag) {
+  if (typeof tag !== "string" || !tag.startsWith("v")) return null;
+  const version = tag.slice(1);
+  return SEMVER.test(version) ? version : null;
+}
+
+export function checkReleaseVersions({ tag, manifests }) {
+  const problems = [];
+  const expected = tag == null ? manifests[0]?.version : versionFromTag(tag);
+
+  if (tag != null && expected == null) {
+    return { ok: false, expected: null, problems: [`Tag ${tag} is not a v-prefixed semver tag`] };
+  }
+
+  for (const manifest of manifests) {
+    if (!SEMVER.test(manifest.version ?? "")) {
+      problems.push(`${manifest.path} has a non-semver version: ${manifest.version ?? "(missing)"}`);
+      continue;
+    }
+    if (manifest.version !== expected) {
+      problems.push(`${manifest.path} is ${manifest.version}, expected ${expected}`);
+    }
+  }
+
+  return { ok: problems.length === 0, expected, problems };
+}
+
+function readManifests(repoRoot) {
+  return VERSIONED_MANIFESTS.map((path) => ({
+    path,
+    version: JSON.parse(readFileSync(join(repoRoot, path), "utf8")).version,
+  }));
+}
+
+function main() {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const tag = process.argv[2];
+  const result = checkReleaseVersions({ tag: tag ?? null, manifests: readManifests(repoRoot) });
+
+  if (!result.ok) {
+    console.error("Release preflight failed:");
+    for (const problem of result.problems) console.error(`  - ${problem}`);
+    process.exit(1);
+  }
+
+  console.log(`Release preflight passed: every manifest is ${result.expected}`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/release-preflight.test.mjs
+++ b/scripts/release-preflight.test.mjs
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  VERSIONED_MANIFESTS,
+  checkReleaseVersions,
+  versionFromTag,
+} from "./release-preflight.mjs";
+
+function manifests(versions) {
+  return VERSIONED_MANIFESTS.map((path, index) => ({
+    path,
+    version: versions[index] ?? versions[0],
+  }));
+}
+
+describe("CS-149: release preflight", () => {
+  it.each([
+    ["v1.2.3", "1.2.3"],
+    ["v0.17.0", "0.17.0"],
+    ["v1.2.3-rc.1", "1.2.3-rc.1"],
+    ["v1.2.3+build.5", "1.2.3+build.5"],
+  ])("reads %s as %s", (tag, expected) => {
+    expect(versionFromTag(tag)).toBe(expected);
+  });
+
+  it.each([
+    ["no prefix", "1.2.3"],
+    ["double prefix", "vv1.2.3"],
+    ["incomplete", "v1.2"],
+    ["not a version", "vlatest"],
+    ["empty", ""],
+  ])("rejects a %s tag", (_name, tag) => {
+    expect(versionFromTag(tag)).toBeNull();
+  });
+
+  it("passes when the tag and every manifest agree", () => {
+    const result = checkReleaseVersions({ tag: "v1.2.3", manifests: manifests(["1.2.3"]) });
+
+    expect(result).toEqual({ ok: true, expected: "1.2.3", problems: [] });
+  });
+
+  it("names the manifest that drifted", () => {
+    const result = checkReleaseVersions({
+      tag: "v1.2.3",
+      manifests: manifests(["1.2.3", "1.2.3", "1.2.2", "1.2.3"]),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.problems).toEqual(["apps/web/package.json is 1.2.2, expected 1.2.3"]);
+  });
+
+  it("reports every manifest when the tag itself drifted", () => {
+    const result = checkReleaseVersions({ tag: "v1.3.0", manifests: manifests(["1.2.3"]) });
+
+    expect(result.ok).toBe(false);
+    expect(result.problems).toHaveLength(VERSIONED_MANIFESTS.length);
+  });
+
+  it("fails on a malformed tag without inspecting manifests", () => {
+    const result = checkReleaseVersions({ tag: "release-1.2.3", manifests: manifests(["1.2.3"]) });
+
+    expect(result.ok).toBe(false);
+    expect(result.problems).toEqual(["Tag release-1.2.3 is not a v-prefixed semver tag"]);
+  });
+
+  it("checks manifests against each other when there is no tag", () => {
+    expect(checkReleaseVersions({ tag: null, manifests: manifests(["1.2.3"]) }).ok).toBe(true);
+    expect(
+      checkReleaseVersions({ tag: null, manifests: manifests(["1.2.3", "1.2.3", "1.2.3", "0.9.0"]) })
+        .problems,
+    ).toEqual(["apps/www/package.json is 0.9.0, expected 1.2.3"]);
+  });
+
+  it("rejects a non-semver manifest version", () => {
+    const result = checkReleaseVersions({
+      tag: "v1.2.3",
+      manifests: manifests(["1.2.3", "next", "1.2.3", "1.2.3"]),
+    });
+
+    expect(result.problems).toEqual([
+      "packages/core/package.json has a non-semver version: next",
+    ]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,12 @@ const WEB_INTERACTIONS_SCOPE =
 
 export default defineConfig({
   test: {
-    projects: ["packages/core", "packages/cli", "apps/web"],
+    projects: [
+      "packages/core",
+      "packages/cli",
+      "apps/web",
+      { test: { name: "scripts", include: ["scripts/**/*.test.mjs"] } },
+    ],
     coverage: {
       provider: "v8",
       include: [CORE_SOURCE_SCOPE, CLI_SOURCE_SCOPE, WEB_SOURCE_SCOPE],


### PR DESCRIPTION
## Problem

`release.yml` ran on any `v*` tag and went straight to build, rewriting
`packages/cli/package.json` and publishing to npm. Nothing checked that the tag matched the four
manifests the release guide asks a human to keep in sync:

- `packages/cli/package.json` — the published npm version
- `packages/core/package.json`
- `apps/web/package.json` — the web `__APP_VERSION__`
- `apps/www/package.json` — the version shown on the site

A missed bump publishes a package whose version disagrees with the tag, the web build and the site;
a stale one fails only at the publish step, after the manifest has already been rewritten.

## Change

- `scripts/release-preflight.mjs` is a read-only check that parses the tag and all four manifests
  and reports every mismatch by path and expected value
- the release job runs it right after install and before build, so a drift fails ahead of any
  mutation
- regular CI runs the same script with no tag, checking the manifests against each other
- the release guide points at the same command for local preparation

Exactly one leading `v` is stripped; `1.2.3`, `vv1.2.3`, `v1.2` and `vlatest` are all rejected as
release tags rather than being coerced.

## Verification

- table-driven tests: all four in sync, one manifest drifted, the tag drifted, a malformed tag, a
  non-semver manifest version, and the no-tag package-to-package mode; prerelease and build-metadata
  tags are accepted
- the script passes against the current `v0.17.0` manifests, and reports all four when given a tag
  that does not match
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 544, cli 295, web 463 passing
- `pnpm test:coverage` — 1317 passing, including the new script tests