### PR TITLE
docs: describe --json as a session index (CS-150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,15 @@ npx codesesh --session claudecode://3b0e4ead-eba9-43e7-9fac-b30647e189f8
 ### JSON Output (for scripting)
 
 ```bash
-# Dump all session data as JSON instead of starting the server
+# Print the session index as JSON instead of starting the server
 npx codesesh --json
 npx codesesh -j
 ```
+
+The output is an index, not an archive: an `agents` summary and a `sessions` array of session
+metadata — id, slug, title, directory, project identity, timestamps, token/cost stats and smart
+tags. It does **not** include messages, tool calls, reasoning or file activity, so it is not a
+backup of your history. Session content stays in each agent's own data directory.
 
 ### CLI Options Reference
 
@@ -176,7 +181,7 @@ npx codesesh -j
 | `--from` | — | — | Sessions active after this date `YYYY-MM-DD` (overrides `--days`) |
 | `--to` | — | — | Sessions active before this date `YYYY-MM-DD` |
 | `--session` | `-s` | — | Directly open a session (`agent://session-id`) |
-| `--json` | `-j` | `false` | Output JSON and exit (no server) |
+| `--json` | `-j` | `false` | Print the session index as JSON and exit (metadata only, no messages) |
 | `--no-open` | — | `false` | Don't auto-open the browser |
 | `--trace` | — | `false` | Print performance trace logs |
 | `--cache` | — | `true` | Use cached scan results when available |

--- a/README_CN.md
+++ b/README_CN.md
@@ -155,10 +155,14 @@ npx codesesh --session claudecode://3b0e4ead-eba9-43e7-9fac-b30647e189f8
 ### JSON 输出（用于脚本）
 
 ```bash
-# 以 JSON 格式输出所有会话数据，不启动服务器
+# 以 JSON 格式输出会话索引，不启动服务器
 npx codesesh --json
 npx codesesh -j
 ```
+
+输出是索引而非归档：包含 `agents` 摘要与 `sessions` 数组（id、slug、标题、目录、项目身份、
+时间戳、token/成本统计与智能标签），**不包含**消息、工具调用、推理过程与文件活动，因此
+不能作为历史记录的备份。会话内容仍保存在各 Agent 自己的数据目录中。
 
 ### CLI 参数一览
 
@@ -173,7 +177,7 @@ npx codesesh -j
 | `--from` | — | — | 指定日期之后有活动的会话 `YYYY-MM-DD`（覆盖 `--days`） |
 | `--to` | — | — | 指定日期之前有活动的会话 `YYYY-MM-DD` |
 | `--session` | `-s` | — | 直接打开某个会话（`agent://session-id`） |
-| `--json` | `-j` | `false` | 输出 JSON 后退出（不启动服务器） |
+| `--json` | `-j` | `false` | 输出会话索引 JSON 后退出（仅元数据，不含消息） |
 | `--no-open` | — | `false` | 不自动打开浏览器 |
 | `--trace` | — | `false` | 打印性能追踪日志 |
 | `--cache` | — | `true` | 优先使用缓存扫描结果 |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,7 +71,7 @@ npx codesesh --cwd .
 # Only show specific agent
 npx codesesh --agent claudecode
 
-# Output JSON instead of starting server
+# Print the session index as JSON instead of starting the server
 npx codesesh --json
 
 # Show performance trace logs
@@ -91,7 +91,7 @@ npx codesesh --trace
 | `--from`    | —     | —       | Sessions active after this date `YYYY-MM-DD`                |
 | `--to`      | —     | —       | Sessions active before this date `YYYY-MM-DD`               |
 | `--session` | `-s`  | —       | Directly open a session (`agent://session-id`)              |
-| `--json`    | `-j`  | `false` | Output JSON and exit (no server)                            |
+| `--json`    | `-j`  | `false` | Print the session index as JSON and exit (metadata only)    |
 | `--no-open` | —     | `false` | Don't auto-open the browser                                 |
 | `--trace`   | —     | `false` | Print performance trace logs                                |
 | `--cache`   | —     | `true`  | Use cached scan results when available                      |

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { LiveScanStore } from "./live-scan.js";
 import { printScanResults } from "./output.js";
 import { VERSION } from "./version.js";
 import { appLogger } from "./logging.js";
+import { buildSessionIndexOutput } from "./session-index-output.js";
 import {
   isLoopbackHostname,
   resolveRemoteTransport,
@@ -22,7 +23,7 @@ import {
   hasExplicitPortArg,
   parsePort,
 } from "./ports.js";
-import { createRegisteredAgents, getAgentInfoMap, refreshPricingCache, perf } from "@codesesh/core";
+import { createRegisteredAgents, refreshPricingCache, perf } from "@codesesh/core";
 
 const main = defineCommand({
   meta: {
@@ -218,27 +219,9 @@ const main = defineCommand({
     }
 
     if (jsonOnly) {
-      // Apply --days/--from/--to window to the JSON output so CLI semantics are preserved.
-      const windowed = result.sessions.filter((s) => {
-        const activity = s.time_updated ?? s.time_created;
-        if (listDefaultFrom != null && activity < listDefaultFrom) return false;
-        if (listDefaultTo != null && activity > listDefaultTo) return false;
-        return true;
-      });
-      const info = getAgentInfoMap(
-        Object.fromEntries(Object.entries(result.byAgent).map(([k, v]) => [k, v.length])),
-      );
-      const output = {
-        agents: info.map(({ name, displayName, count }) => ({
-          name,
-          displayName,
-          count,
-          available: count > 0,
-        })),
-        sessions: windowed,
-      };
+      const output = buildSessionIndexOutput(result, { from: listDefaultFrom, to: listDefaultTo });
       appLogger.info("cli.json_output", {
-        sessions: windowed.length,
+        sessions: output.sessions.length,
         duration_ms: Math.round(performance.now() - startedAt),
       });
       console.log(JSON.stringify(output, null, 2));

--- a/packages/cli/src/session-index-output.test.ts
+++ b/packages/cli/src/session-index-output.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { LiveSnapshot, SessionHead } from "@codesesh/core";
+import { buildSessionIndexOutput } from "./session-index-output.js";
+
+function makeSession(id: string, activity: number): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: id,
+    directory: "/workspace",
+    time_created: activity,
+    time_updated: activity,
+    stats: {
+      message_count: 3,
+      total_input_tokens: 10,
+      total_output_tokens: 5,
+      total_cost: 0.01,
+    },
+  };
+}
+
+function makeSnapshot(sessions: SessionHead[]): Pick<LiveSnapshot, "sessions" | "byAgent"> {
+  return { sessions, byAgent: { codex: sessions } };
+}
+
+/** Fields the README promises; anything beyond this would make --json an archive. */
+const DOCUMENTED_SESSION_FIELDS = [
+  "directory",
+  "id",
+  "slug",
+  "stats",
+  "time_created",
+  "time_updated",
+  "title",
+];
+
+describe("CS-150: --json is a session index", () => {
+  it("reports agents and session heads only", () => {
+    const output = buildSessionIndexOutput(makeSnapshot([makeSession("s1", 100)]));
+
+    expect(Object.keys(output).sort()).toEqual(["agents", "sessions"]);
+    expect(output.agents.find((agent) => agent.name === "codex")).toMatchObject({
+      count: 1,
+      available: true,
+    });
+    expect(Object.keys(output.sessions[0]!).sort()).toEqual(DOCUMENTED_SESSION_FIELDS);
+  });
+
+  it.each(["messages", "file_activity", "parts", "reasoning"])("does not carry %s", (field) => {
+    const output = buildSessionIndexOutput(makeSnapshot([makeSession("s1", 100)]));
+
+    expect(output.sessions[0]).not.toHaveProperty(field);
+  });
+
+  it("applies the time window to the index", () => {
+    const output = buildSessionIndexOutput(
+      makeSnapshot([makeSession("old", 100), makeSession("new", 5_000)]),
+      { from: 1_000 },
+    );
+
+    expect(output.sessions.map((session) => session.id)).toEqual(["new"]);
+  });
+
+  it("reports an agent with no sessions as unavailable", () => {
+    const output = buildSessionIndexOutput({ sessions: [], byAgent: { codex: [] } });
+
+    expect(output.agents.find((agent) => agent.name === "codex")).toMatchObject({
+      count: 0,
+      available: false,
+    });
+  });
+});

--- a/packages/cli/src/session-index-output.ts
+++ b/packages/cli/src/session-index-output.ts
@@ -1,0 +1,49 @@
+/**
+ * Shape of `--json`: an index of what exists, not an archive of what was said.
+ *
+ * Sessions are reported as heads — metadata only. Messages, tool calls,
+ * reasoning and file activity stay in each agent's own data directory, so this
+ * output is deliberately not a backup, and must not quietly grow into one.
+ */
+import { getAgentInfoMap, type LiveSnapshot, type SessionHead } from "@codesesh/core";
+
+export interface SessionIndexAgent {
+  name: string;
+  displayName: string;
+  count: number;
+  available: boolean;
+}
+
+export interface SessionIndexOutput {
+  agents: SessionIndexAgent[];
+  sessions: SessionHead[];
+}
+
+export interface SessionIndexWindow {
+  from?: number;
+  to?: number;
+}
+
+export function buildSessionIndexOutput(
+  snapshot: Pick<LiveSnapshot, "sessions" | "byAgent">,
+  window: SessionIndexWindow = {},
+): SessionIndexOutput {
+  // Keep --days/--from/--to meaningful for the JSON output too.
+  const sessions = snapshot.sessions.filter((session) => {
+    const activity = session.time_updated ?? session.time_created;
+    if (window.from != null && activity < window.from) return false;
+    if (window.to != null && activity > window.to) return false;
+    return true;
+  });
+
+  const agents = getAgentInfoMap(
+    Object.fromEntries(Object.entries(snapshot.byAgent).map(([name, list]) => [name, list.length])),
+  ).map(({ name, displayName, count }) => ({
+    name,
+    displayName,
+    count,
+    available: count > 0,
+  }));
+
+  return { agents, sessions };
+}


### PR DESCRIPTION
## Problem

The README introduced `--json` with "Dump all session data as JSON", which reads like a full export.
The command actually prints an agent summary and a time-windowed `SessionHead[]` — it never reads
messages, tool calls, reasoning or file activity.

Verified against the built CLI: the output has exactly `agents` and `sessions`, and a session
carries only `id`, `slug`, `title`, `directory`, `project_identity`, timestamps, `stats`,
`model_usage` and smart tags. Someone treating it as a backup could delete an agent's data and only
then discover the content was not recoverable.

## Change

- README, README_CN and the CLI README describe it as a session index, list what the output does
  contain, and state plainly that it is not a backup — session content stays in each agent's own
  data directory
- the flag row in all three option tables says metadata only
- the assembly moved into `session-index-output.ts`, so the promise is covered by tests rather than
  living only in prose

Widening `--json` into a real archive would be a separate, deliberate feature; this change does not
alter the output.

## Verification

- tests assert the output has exactly `agents` and `sessions`, that a session carries only the
  documented fields, and that `messages`, `file_activity`, `parts` and `reasoning` are absent
- the time window still applies to the index, and an agent with no sessions is reported unavailable
- the built CLI produces the same `{agents, sessions}` output as before
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 544, cli 302, web 463 passing