### PR TITLE
chore: make pnpm clean work on Windows (CS-152)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,16 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == 22
         run: node packages/cli/dist/index.js --version
 
+      # `pnpm clean` is a documented command, so it has to work on every OS we
+      # claim to support — including a shell with no `rm`.
+      - name: Smoke test clean and rebuild
+        if: matrix.node-version == 24
+        run: |
+          node -e "require('node:fs').writeFileSync('packages/core/dist/clean-sentinel.txt','x')"
+          pnpm clean
+          node -e "if (require('node:fs').existsSync('packages/core/dist')) { console.error('dist survived pnpm clean'); process.exit(1) }"
+          pnpm build
+
       - run: pnpm test
 
   smoke:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "clean": "rm -rf dist",
+    "clean": "node ../../scripts/clean.mjs",
     "lint": "oxlint src/",
     "lint:fix": "oxlint src/ --fix",
     "format": "oxfmt --write src/",

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -5,6 +5,8 @@ import type { ApiProjectGroup } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
 import { AppRouteContent } from "./AppRouteContent";
 
+const LAZY_SURFACE_TIMEOUT_MS = 5_000;
+
 const project = {
   identityKind: "git_remote",
   identityKey: "github.com/acme/app",
@@ -68,7 +70,8 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
 afterEach(cleanup);
 
 describe("AppRouteContent", () => {
-  // The route surfaces load on demand, so the assertion waits for the chunk.
+  // The route surfaces load on demand, so these assertions wait for the chunk.
+  // The default 1s query timeout is tight when the suite runs under load.
   it("renders a project from the resolved project model", async () => {
     const props = makeProps();
     props.viewState = {
@@ -86,7 +89,13 @@ describe("AppRouteContent", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole("heading", { name: "acme/app" })).toBeTruthy();
+    expect(
+      await screen.findByRole(
+        "heading",
+        { name: "acme/app" },
+        { timeout: LAZY_SURFACE_TIMEOUT_MS },
+      ),
+    ).toBeTruthy();
   });
 
   it("renders search content from the explicit search contract", async () => {
@@ -99,6 +108,12 @@ describe("AppRouteContent", () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole("heading", { name: "No recent sessions" })).toBeTruthy();
+    expect(
+      await screen.findByRole(
+        "heading",
+        { name: "No recent sessions" },
+        { timeout: LAZY_SURFACE_TIMEOUT_MS },
+      ),
+    ).toBeTruthy();
   });
 });

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -7,7 +7,7 @@
     "dev": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "clean": "rm -rf dist",
+    "clean": "node ../../scripts/clean.mjs",
     "deploy:cf": "pnpm build && wrangler pages deploy dist --project-name codesesh"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "build": "tsc --noEmit && tsup && node scripts/copy-web-dist.js",
     "release": "tsc --noEmit && tsup && node scripts/copy-web-dist.js",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "node ../../scripts/clean.mjs",
     "start": "node dist/index.js",
     "lint": "oxlint src/",
     "lint:fix": "oxlint src/ --fix",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsup && tsc6 --emitDeclarationOnly",
     "dev": "tsup --watch",
-    "clean": "rm -rf dist",
+    "clean": "node ../../scripts/clean.mjs",
     "lint": "oxlint src/",
     "lint:fix": "oxlint src/ --fix",
     "format": "oxfmt --write src/",

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,52 @@
+/**
+ * Cross-platform build-output cleanup.
+ *
+ * `rm -rf` is not available in cmd.exe, so the documented `pnpm clean` failed on
+ * a plain Windows Node/pnpm setup. Targets come from a fixed manifest and are
+ * verified to live inside the workspace that asked for them — a mistyped or
+ * expanded path cannot reach outside it.
+ *
+ * Usage (from a workspace directory): node ../../scripts/clean.mjs
+ */
+import { rmSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Build outputs a workspace may remove. Deliberately just the published output:
+ * clearing Turbo's cache here would make the next build slower for no reason.
+ */
+export const CLEANABLE_DIRECTORIES = ["dist"];
+
+/** Resolves the targets a workspace is allowed to delete, rejecting any escape. */
+export function resolveCleanTargets(workspaceDir, names = CLEANABLE_DIRECTORIES) {
+  const workspace = resolve(workspaceDir);
+  const targets = [];
+
+  for (const name of names) {
+    const target = resolve(workspace, name);
+    const location = relative(workspace, target);
+    if (location === "" || location.startsWith("..") || resolve(workspace, location) !== target) {
+      throw new Error(`Refusing to clean ${name}: outside ${workspace}`);
+    }
+    targets.push(target);
+  }
+
+  return targets;
+}
+
+function main() {
+  const workspaceDir = process.cwd();
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  if (relative(repoRoot, resolve(workspaceDir)).startsWith("..")) {
+    console.error(`Refusing to clean ${workspaceDir}: outside ${repoRoot}`);
+    process.exit(1);
+  }
+
+  for (const target of resolveCleanTargets(workspaceDir)) {
+    // Repeat runs are fine: a missing directory is already clean.
+    rmSync(target, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/clean.test.mjs
+++ b/scripts/clean.test.mjs
@@ -1,0 +1,66 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CLEANABLE_DIRECTORIES, resolveCleanTargets } from "./clean.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function workspace() {
+  const dir = mkdtempSync(join(tmpdir(), "codesesh-clean-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("CS-152: clean targets", () => {
+  it("resolves every build output inside the workspace", () => {
+    const dir = workspace();
+
+    const targets = resolveCleanTargets(dir);
+
+    expect(targets).toEqual(CLEANABLE_DIRECTORIES.map((name) => join(dir, name)));
+  });
+
+  it.each([
+    ["a parent escape", "../dist"],
+    ["the workspace itself", "."],
+    ["an absolute path", join(tmpdir(), "elsewhere")],
+  ])("refuses %s", (_name, target) => {
+    const dir = workspace();
+
+    expect(() => resolveCleanTargets(dir, [target])).toThrow(/Refusing to clean/);
+  });
+
+  it("removes only the declared outputs", async () => {
+    const dir = workspace();
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    writeFileSync(join(dir, "dist", "bundle.js"), "output");
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "index.ts"), "source");
+    writeFileSync(join(dir, "package.json"), "{}");
+
+    const { rmSync: remove } = await import("node:fs");
+    for (const target of resolveCleanTargets(dir)) remove(target, { recursive: true, force: true });
+
+    expect(existsSync(join(dir, "dist"))).toBe(false);
+    expect(existsSync(join(dir, "src", "index.ts"))).toBe(true);
+    expect(existsSync(join(dir, "package.json"))).toBe(true);
+  });
+
+  it("succeeds when the outputs are already gone", async () => {
+    const dir = workspace();
+    const { rmSync: remove } = await import("node:fs");
+
+    for (const pass of [1, 2]) {
+      expect(() => {
+        for (const target of resolveCleanTargets(dir)) {
+          remove(target, { recursive: true, force: true });
+        }
+      }, `pass ${pass}`).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

All four workspaces ran `"clean": "rm -rf dist"`. The README lists `pnpm clean` as a standard
command and the project claims Windows support, but `cmd.exe` has no `rm`. Windows CI only ran
install / lint / format / build / test, so it never executed clean and the drift stayed invisible.

## Change

- `scripts/clean.mjs` removes build output through Node, so it behaves the same on macOS, Linux and
  Windows; all four workspaces call it
- targets come from a fixed manifest and each is verified to resolve inside the workspace that asked
  for it — a `..` segment or an absolute path is refused rather than deleted
- the scope stays exactly what it was: `dist` only. Clearing Turbo's cache here would slow the next
  build for no reason.
- CI writes a sentinel into `dist`, runs `pnpm clean`, asserts the directory is gone, and builds
  again — on every OS in the matrix

Repeat runs succeed: a missing directory is already clean.

## Verification

- tests cover the resolved target list, refusal of a parent escape / the workspace itself / an
  absolute path, that only declared outputs are removed while sources and manifests survive, and
  that a second pass does not throw
- locally: `pnpm build && pnpm clean && pnpm build` removes every `dist` and leaves the Turbo cache
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 544, cli 302, web 463 passing

Also included: the two `AppRouteContent` assertions that became async in CS-146 now allow more than
the default 1s for their chunk. They failed intermittently when the suite ran under load, which is
unrelated to what they assert.