### PR TITLE
perf: read a session's parts in one query (CS-144)

### DIFF
--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { OpenCodeSqliteAgent } from "../opencode-sqlite.js";
 import { SessionScanError } from "../base.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
@@ -254,5 +254,172 @@ describe("CS-138: unreadable databases are not empty scans", () => {
     db.close();
 
     expect(makeAgent(dbPath).scan({ from: 0 })).toEqual([]);
+  });
+});
+
+describe("CS-144: session detail reads parts in one query", () => {
+  function seedDetail(options: {
+    messages: number;
+    partsEach: number;
+    extra?: (db: Database.Database) => void;
+  }): string {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-detail-batch-"));
+    tempDirs.push(dir);
+    const dbPath = join(dir, "agent.db");
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE session (
+        id TEXT PRIMARY KEY, title TEXT, time_created INTEGER, time_updated INTEGER,
+        slug TEXT, directory TEXT, version TEXT, summary_files TEXT
+      );
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, data TEXT, time_created INTEGER);
+      CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, data TEXT, time_created INTEGER);
+    `);
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory) VALUES (?,?,?,?,?)",
+    ).run("s1", "Detail", 1_000, 2_000, "/workspace/project");
+    const insertMessage = db.prepare(
+      "INSERT INTO message (id, session_id, data, time_created) VALUES (?,?,?,?)",
+    );
+    const insertPart = db.prepare(
+      "INSERT INTO part (id, message_id, data, time_created) VALUES (?,?,?,?)",
+    );
+    db.transaction(() => {
+      for (let index = 0; index < options.messages; index += 1) {
+        const id = `m${String(index).padStart(4, "0")}`;
+        insertMessage.run(
+          id,
+          "s1",
+          JSON.stringify({ role: index % 2 ? "assistant" : "user", modelID: "claude-sonnet-4-6" }),
+          1_000 + index,
+        );
+        for (let part = 0; part < options.partsEach; part += 1) {
+          insertPart.run(
+            `${id}-${part}`,
+            id,
+            JSON.stringify({ type: "text", text: `body ${index}.${part}` }),
+            1_000 + index,
+          );
+        }
+      }
+      options.extra?.(db);
+    })();
+    db.close();
+    return dbPath;
+  }
+
+  function detailAgent(dbPath: string) {
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+      getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
+    });
+    agent.isAvailable();
+    return agent;
+  }
+
+  function countPartQueries(run: () => void): number {
+    let queries = 0;
+    const prepare = Database.prototype.prepare;
+    const spy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+      this: Database.Database,
+      sql: string,
+    ) {
+      if (sql.includes("FROM part")) queries += 1;
+      return prepare.call(this, sql) as ReturnType<Database.Database["prepare"]>;
+    });
+    try {
+      run();
+    } finally {
+      spy.mockRestore();
+    }
+    return queries;
+  }
+
+  // One query per message meant M+2 reads, each scanning the part table when no
+  // index on part(message_id) exists.
+  it.each([5, 200])("issues one part query for %i messages", (messages) => {
+    const agent = detailAgent(seedDetail({ messages, partsEach: 2 }));
+    let detail: ReturnType<typeof agent.getSessionData> | undefined;
+
+    const queries = countPartQueries(() => {
+      detail = agent.getSessionData("s1");
+    });
+
+    expect(detail?.messages).toHaveLength(messages);
+    expect(queries).toBe(1);
+  });
+
+  it("keeps message and part order", () => {
+    const agent = detailAgent(seedDetail({ messages: 3, partsEach: 2 }));
+
+    const detail = agent.getSessionData("s1");
+
+    expect(detail.messages.map((message) => message.id)).toEqual(["m0000", "m0001", "m0002"]);
+    expect(detail.messages[0]?.parts.map((part) => ("text" in part ? part.text : ""))).toEqual([
+      "body 0.0",
+      "body 0.1",
+    ]);
+  });
+
+  it("drops messages whose parts are all internal or malformed", () => {
+    const agent = detailAgent(
+      seedDetail({
+        messages: 1,
+        partsEach: 1,
+        extra: (db) => {
+          db.prepare("INSERT INTO message VALUES (?,?,?,?)").run(
+            "m-internal",
+            "s1",
+            JSON.stringify({ role: "assistant" }),
+            9_000,
+          );
+          db.prepare("INSERT INTO part VALUES (?,?,?,?)").run(
+            "m-internal-0",
+            "m-internal",
+            JSON.stringify({ type: "step-start" }),
+            9_000,
+          );
+          db.prepare("INSERT INTO message VALUES (?,?,?,?)").run(
+            "m-empty",
+            "s1",
+            JSON.stringify({ role: "assistant" }),
+            9_100,
+          );
+        },
+      }),
+    );
+
+    const detail = agent.getSessionData("s1");
+
+    expect(detail.messages.map((message) => message.id)).toEqual(["m0000"]);
+  });
+
+  it("drives the batched read off the message index", () => {
+    const dbPath = seedDetail({ messages: 2, partsEach: 1 });
+    const db = new Database(dbPath, { readonly: true });
+
+    try {
+      const plan = db
+        .prepare(
+          `
+            EXPLAIN QUERY PLAN
+            SELECT p.message_id, p.data, p.time_created
+            FROM part p
+            JOIN message m ON m.id = p.message_id
+            WHERE m.session_id = ?
+            ORDER BY p.message_id, p.time_created ASC, p.id ASC
+          `,
+        )
+        .all("s1")
+        .map((row) => String((row as { detail?: unknown }).detail ?? ""))
+        .join("\n");
+
+      // Whatever the planner picks, it must not re-scan parts per message.
+      expect(plan).not.toContain("CORRELATED");
+    } finally {
+      db.close();
+    }
   });
 });

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -236,7 +236,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
           JOIN message m ON m.id = p.message_id
           JOIN session s ON s.id = m.session_id
           WHERE COALESCE(s.time_updated, s.time_created) >= ?
-          ORDER BY p.message_id, p.time_created ASC
+          ORDER BY p.message_id, p.time_created ASC, p.id ASC
         `,
       )
       .all(cutoffTime) as OpenCodePartRow[];
@@ -254,13 +254,23 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
     return part ? cleanMessagePart(part) : null;
   }
 
-  private readMessageParts(db: SQLiteDatabase, messageId: unknown): MessagePart[] {
-    const partRows = db
-      .prepare("SELECT data, time_created FROM part WHERE message_id = ? ORDER BY time_created ASC")
-      .all(messageId) as OpenCodePartRow[];
-    return partRows
-      .map((partRow) => this.parsePartRow(partRow))
-      .filter((part): part is MessagePart => part !== null);
+  /**
+   * Every part of one session in a single read. Fetching per message turned a
+   * detail into M+2 queries, and without an index on part(message_id) each one
+   * scanned the whole table.
+   */
+  private readSessionPartRows(db: SQLiteDatabase, sessionId: string): OpenCodePartRow[] {
+    return db
+      .prepare(
+        `
+          SELECT p.message_id, p.data, p.time_created
+          FROM part p
+          JOIN message m ON m.id = p.message_id
+          WHERE m.session_id = ?
+          ORDER BY p.message_id, p.time_created ASC, p.id ASC
+        `,
+      )
+      .all(sessionId) as OpenCodePartRow[];
   }
 
   private buildPartsByMessage(partRows: OpenCodePartRow[]): Map<string, MessagePart[]> {
@@ -382,8 +392,9 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
 
       // Get messages
       const msgRows = db
-        .prepare("SELECT * FROM message WHERE session_id = ? ORDER BY time_created ASC")
+        .prepare("SELECT * FROM message WHERE session_id = ? ORDER BY time_created ASC, id ASC")
         .all(sessionId) as Record<string, unknown>[];
+      const partsByMessage = this.buildPartsByMessage(this.readSessionPartRows(db, sessionId));
 
       for (const msgRow of msgRows) {
         const msgData = parseJsonRecord(msgRow.data, this.name, "message.data");
@@ -398,7 +409,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
           cost > 0 ? null : estimateTokenCost(model, { input: inputTokens, output: outputTokens });
         const resolvedCost = cost || estimatedCost || 0;
 
-        const parts = this.readMessageParts(db, msgRow.id);
+        const parts = partsByMessage.get(String(msgRow.id ?? "")) ?? [];
         if (parts.length === 0) continue;
 
         messages.push({


### PR DESCRIPTION
## Problem

`getSessionData()` read a session's messages, then called `readMessageParts()` inside the loop —
one query per message, so `M+2` reads for a detail. The compatibility schema used by tests has no
index on `part(message_id)`, so each of those scanned all `P` parts, making the read `O(M·P)`.

The head scan already batched this with `readHeadPartRows()` and `buildPartsByMessage()`; the detail
path did not reuse it. The search index and smart-tag worker also read details across sessions, so
the cost compounds.

Measured on the reads themselves, 3 parts per message:

| messages / parts | per-message | batched |
|---:|---:|---:|
| 100 / 300 | 1.68 ms | 0.19 ms |
| 500 / 1,500 | 28.79 ms | 0.85 ms |
| 1,000 / 3,000 | 110.41 ms | 2.09 ms |
| 2,000 / 6,000 | 428.61 ms | 4.09 ms |

Doubling the messages quadrupled the per-message time; the batched read scales linearly.

## Change

- one `part` read per session, joined through `message`, assembled by the existing
  `buildPartsByMessage()`
- both the detail and head reads order by `p.id` after `time_created`, so parts written in the same
  millisecond have a defined order instead of inheriting SQLite's current one; messages likewise
  tie-break on `id`
- ZCode inherits the adapter, so it gets the same read

A failed batch read fails the whole detail, as before — it cannot produce a partially populated
session.

## Verification

- query-count tests assert exactly one part query for both 5 and 200 messages
- message and part order are pinned, and messages whose parts are all internal events or missing are
  still dropped
- `EXPLAIN QUERY PLAN` asserts the batched read is not a correlated per-message lookup
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 549, cli 302, web 463 passing