### PR TITLE
perf: bound the session detail cache (CS-147)

### DIFF
--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
+import { installSessionDetailCachePolicy } from "./session-detail-cache";
 
 export function createQueryClient(): QueryClient {
   return new QueryClient({
@@ -16,3 +17,4 @@ export function createQueryClient(): QueryClient {
 }
 
 export const queryClient = createQueryClient();
+installSessionDetailCachePolicy(queryClient);

--- a/apps/web/src/lib/session-detail-cache.test.ts
+++ b/apps/web/src/lib/session-detail-cache.test.ts
@@ -1,0 +1,114 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, describe, expect, it } from "vitest";
+import { queryKeys } from "./query-keys";
+import {
+  RETAINED_INACTIVE_SESSION_DETAILS,
+  installSessionDetailCachePolicy,
+  pruneSessionDetailCache,
+} from "./session-detail-cache";
+
+let unsubscribe: (() => void) | null = null;
+let client: QueryClient | null = null;
+
+afterEach(() => {
+  unsubscribe?.();
+  unsubscribe = null;
+  client?.clear();
+  client = null;
+});
+
+function makeClient() {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  unsubscribe = installSessionDetailCachePolicy(client);
+  return client;
+}
+
+/** Stand-in for a full transcript; only its identity matters here. */
+function transcript(id: string) {
+  return { id, messages: [{ id: `${id}-m1`, parts: [] }] };
+}
+
+async function openDetail(active: QueryClient, sessionId: string) {
+  await active.fetchQuery({
+    queryKey: queryKeys.sessionDetail("codex", sessionId),
+    queryFn: async () => transcript(sessionId),
+  });
+}
+
+function cachedDetailIds(active: QueryClient): string[] {
+  return active
+    .getQueryCache()
+    .getAll()
+    .filter((query) => query.queryKey[0] === queryKeys.sessionDetails[0])
+    .map((query) => String(query.queryKey[2]));
+}
+
+describe("CS-147: session detail cache is bounded", () => {
+  it("keeps only the most recent inactive details", async () => {
+    const active = makeClient();
+
+    for (let index = 0; index < 10; index += 1) {
+      await openDetail(active, `s${index}`);
+    }
+    pruneSessionDetailCache(active);
+
+    const cached = cachedDetailIds(active);
+    expect(cached).toHaveLength(RETAINED_INACTIVE_SESSION_DETAILS);
+    expect(cached.sort()).toEqual(["s8", "s9"]);
+  });
+
+  it("never evicts a detail something is still watching", async () => {
+    const active = makeClient();
+    await openDetail(active, "watched");
+    const observed = active
+      .getQueryCache()
+      .find({ queryKey: queryKeys.sessionDetail("codex", "watched") })!;
+    const observer = { onQueryUpdate: () => {} };
+    // Simulate a mounted component holding this query.
+    observed.addObserver(observer as never);
+
+    for (let index = 0; index < 5; index += 1) {
+      await openDetail(active, `other-${index}`);
+    }
+    pruneSessionDetailCache(active);
+
+    expect(cachedDetailIds(active)).toContain("watched");
+    observed.removeObserver(observer as never);
+  });
+
+  it("leaves other resources alone", async () => {
+    const active = makeClient();
+    for (const key of [queryKeys.bookmarks, queryKeys.config, queryKeys.dashboards]) {
+      await active.fetchQuery({ queryKey: key, queryFn: async () => ({ ok: true }) });
+    }
+    for (let index = 0; index < 5; index += 1) {
+      await openDetail(active, `s${index}`);
+    }
+    pruneSessionDetailCache(active);
+
+    const remaining = active
+      .getQueryCache()
+      .getAll()
+      .map((query) => String(query.queryKey[0]));
+    expect(remaining).toContain("bookmarks");
+    expect(remaining).toContain("config");
+    expect(remaining).toContain("dashboard");
+  });
+
+  it("applies the bound when a detail stops being displayed", async () => {
+    const active = makeClient();
+
+    // Each session is watched while open, then released on navigation.
+    for (let index = 0; index < 6; index += 1) {
+      await openDetail(active, `s${index}`);
+      const query = active
+        .getQueryCache()
+        .find({ queryKey: queryKeys.sessionDetail("codex", `s${index}`) })!;
+      const observer = { onQueryUpdate: () => {} };
+      query.addObserver(observer as never);
+      query.removeObserver(observer as never);
+    }
+
+    expect(cachedDetailIds(active)).toHaveLength(RETAINED_INACTIVE_SESSION_DETAILS);
+  });
+});

--- a/apps/web/src/lib/session-detail-cache.ts
+++ b/apps/web/src/lib/session-detail-cache.ts
@@ -1,0 +1,50 @@
+/**
+ * Bounds how many full transcripts the browser keeps.
+ *
+ * A session detail carries every message and part; parsed, it costs more heap
+ * than the response did bytes. TanStack Query's default keeps an inactive query
+ * for five minutes, so browsing ten large sessions in a row held all ten — the
+ * cache was bounded by how fast someone clicked, not by anything structural.
+ *
+ * The bound here is a count, not a shorter timeout: the active detail plus a
+ * couple of recent ones, so going back one session is still instant.
+ */
+import type { QueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./query-keys";
+
+export const RETAINED_INACTIVE_SESSION_DETAILS = 2;
+
+const SESSION_DETAIL_PREFIX = queryKeys.sessionDetails[0];
+
+/** Drops the least recently used inactive details beyond the retained count. */
+export function pruneSessionDetailCache(client: QueryClient): void {
+  const cache = client.getQueryCache();
+  const inactive = cache
+    .getAll()
+    .map((query, position) => ({ query, position }))
+    .filter(
+      ({ query }) => query.queryKey[0] === SESSION_DETAIL_PREFIX && query.getObserversCount() === 0,
+    )
+    // Newest first. Two details fetched in the same millisecond tie on
+    // dataUpdatedAt, so cache insertion order breaks it.
+    .sort(
+      (left, right) =>
+        right.query.state.dataUpdatedAt - left.query.state.dataUpdatedAt ||
+        right.position - left.position,
+    );
+
+  for (const { query } of inactive.slice(RETAINED_INACTIVE_SESSION_DETAILS)) {
+    cache.remove(query);
+  }
+}
+
+/**
+ * Applies the bound when a detail stops being observed — the moment a
+ * transcript becomes retained rather than displayed. Returns an unsubscribe.
+ */
+export function installSessionDetailCachePolicy(client: QueryClient): () => void {
+  return client.getQueryCache().subscribe((event) => {
+    if (event.type !== "observerRemoved") return;
+    pruneSessionDetailCache(client);
+  });
+}


### PR DESCRIPTION
## Problem

`useSessionDetail` keys each transcript by agent + session id, and `query-client.ts` set only
stale / refetch / retry — no `gcTime` for the resource and no removal. TanStack Query's default
keeps an inactive query for five minutes, so ten large sessions opened in a row were all retained:
memory was `O(Σ transcriptSize)` over a time window, bounded by how fast someone clicked rather than
by anything structural. Each entry is a full messages/parts object tree, which costs more heap
parsed than the response did in bytes.

## Change

- a dedicated policy for the `session-detail` resource keeps the displayed detail plus the two most
  recent ones and removes the rest
- the bound is a count, not a shorter timeout — the issue explicitly rules out swapping five minutes
  for another long constant, and a count is what can be asserted
- pruning runs when a detail stops being observed, which is the moment a transcript goes from
  displayed to merely retained
- least-recently-updated is evicted first; details fetched in the same millisecond tie on
  `dataUpdatedAt`, so cache insertion order breaks it

Nothing else is touched: dashboards, config, bookmarks and session heads keep their lifetimes, and a
detail with a live observer is never evicted, so an in-flight request or a mounted view is safe.

## Verification

- opening ten sessions leaves exactly the two most recent inactive details
- a detail with an observer survives five later sessions
- bookmarks, config and dashboard entries are untouched by the prune
- the bound applies on its own as sessions are opened and released, without an explicit call
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 544, cli 302, web 467 passing
- `pnpm test:e2e` — 24 passing