### PR TITLE
fix: keep session storage and logs owner-only (CS-141)

### DIFF
--- a/packages/cli/src/logging.test.ts
+++ b/packages/cli/src/logging.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -45,5 +53,38 @@ describe("AppLogger", () => {
     const files = readdirSync(logDir).filter((name) => name.endsWith(".log"));
     expect(files.length).toBeLessThanOrEqual(2);
     expect(files).toContain("codesesh.log");
+  });
+});
+
+describe("CS-141: log permissions", () => {
+  const isPosix = process.platform !== "win32";
+
+  it.runIf(isPosix)("tightens logs a previous run left readable", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-log-existing-"));
+    try {
+      const stale = join(dir, "codesesh-2026-01-01T000000-000Z-1-1.log");
+      writeFileSync(stale, "old entry");
+      chmodSync(stale, 0o644);
+
+      new AppLogger({ logDir: dir }).info("permissions.check", { ok: true });
+
+      expect(statSync(stale).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.runIf(isPosix)("keeps the log directory and file owner-only", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-log-perms-"));
+    try {
+      const logger = new AppLogger({ logDir: dir });
+      logger.info("permissions.check", { ok: true });
+      const logPath = logger.getLogPath();
+
+      expect(statSync(dir).mode & 0o777).toBe(0o700);
+      expect(statSync(logPath!).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -1,14 +1,11 @@
-import {
-  appendFileSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  renameSync,
-  statSync,
-  unlinkSync,
-} from "node:fs";
+import { appendFileSync, existsSync, readdirSync, renameSync, statSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+  ensurePrivateDirectory,
+  restrictExistingPrivateFiles,
+  restrictPrivateFile,
+} from "@codesesh/core";
 import type { SearchIndexSyncResult } from "@codesesh/core";
 
 type LogLevel = "debug" | "info" | "warn" | "error";
@@ -79,6 +76,7 @@ export class AppLogger {
   private readonly maxFiles: number;
   private readonly currentPath: string;
   private rotationIndex = 0;
+  private restrictedExistingLogs = false;
 
   constructor(options: LoggerOptions = {}) {
     this.logDir = options.logDir ?? process.env.CODESESH_LOG_DIR ?? getDefaultLogDir();
@@ -113,7 +111,8 @@ export class AppLogger {
     if (LEVEL_WEIGHT[level] < LEVEL_WEIGHT[this.level]) return;
 
     try {
-      mkdirSync(this.logDir, { recursive: true });
+      ensurePrivateDirectory(this.logDir);
+      this.restrictExistingLogs();
       const line = `${JSON.stringify({
         ts: new Date().toISOString(),
         level,
@@ -123,7 +122,19 @@ export class AppLogger {
       })}\n`;
       this.rotateIfNeeded(Buffer.byteLength(line));
       appendFileSync(this.currentPath, line, "utf8");
+      // Logs carry project paths and error detail.
+      restrictPrivateFile(this.currentPath);
     } catch {}
+  }
+
+  /** Logs rotated by an earlier run predate the owner-only policy. */
+  private restrictExistingLogs(): void {
+    if (this.restrictedExistingLogs) return;
+    this.restrictedExistingLogs = true;
+    restrictExistingPrivateFiles(
+      this.logDir,
+      (name) => name.startsWith("codesesh") && name.endsWith(".log"),
+    );
   }
 
   private rotateIfNeeded(nextBytes: number): void {
@@ -141,6 +152,7 @@ export class AppLogger {
       `codesesh-${timestampForFile()}-${process.pid}-${this.rotationIndex}.log`,
     );
     renameSync(this.currentPath, rotatedPath);
+    restrictPrivateFile(rotatedPath);
     this.removeExpiredLogs();
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,8 +82,11 @@ export {
 export type { BookmarkRecord, SessionAlias } from "./state/index.js";
 export {
   classifySessionTags,
+  ensurePrivateDirectory,
   getSmartTagSourceTimestamp,
   perf,
+  restrictExistingPrivateFiles,
+  restrictPrivateFile,
   setCoreDiagnostics,
 } from "./utils/index.js";
 export { refreshPricingCache } from "./pricing/index.js";

--- a/packages/core/src/utils/__tests__/private-storage.test.ts
+++ b/packages/core/src/utils/__tests__/private-storage.test.ts
@@ -1,0 +1,131 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  PRIVATE_DIR_MODE,
+  PRIVATE_FILE_MODE,
+  ensurePrivateDirectory,
+  restrictPrivateDatabase,
+  restrictPrivateFile,
+} from "../private-storage.js";
+import { backupDatabase, openDb } from "../sqlite.js";
+
+const isPosix = process.platform !== "win32";
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function workspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), "codesesh-private-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function mode(path: string): number {
+  return statSync(path).mode & 0o777;
+}
+
+describe("CS-141: private storage", () => {
+  it.runIf(isPosix)("creates a directory only its owner can enter", () => {
+    const dir = join(workspace(), "nested", "cache");
+
+    ensurePrivateDirectory(dir);
+
+    expect(mode(dir)).toBe(PRIVATE_DIR_MODE);
+  });
+
+  it.runIf(isPosix)("tightens a directory that already existed too openly", () => {
+    const dir = join(workspace(), "cache");
+    mkdirSync(dir, { recursive: true });
+    chmodSync(dir, 0o755);
+
+    ensurePrivateDirectory(dir);
+
+    expect(mode(dir)).toBe(PRIVATE_DIR_MODE);
+  });
+
+  it.runIf(isPosix)("tightens an existing world-readable file", () => {
+    const path = join(workspace(), "codesesh.log");
+    writeFileSync(path, "entry");
+    chmodSync(path, 0o644);
+
+    restrictPrivateFile(path);
+
+    expect(mode(path)).toBe(PRIVATE_FILE_MODE);
+  });
+
+  it.runIf(isPosix)("tightens a database and every sidecar", () => {
+    const dir = workspace();
+    const dbPath = join(dir, "state.db");
+    for (const suffix of ["", "-wal", "-shm"]) {
+      writeFileSync(`${dbPath}${suffix}`, "");
+      chmodSync(`${dbPath}${suffix}`, 0o644);
+    }
+
+    restrictPrivateDatabase(dbPath);
+
+    for (const suffix of ["", "-wal", "-shm"]) {
+      expect(mode(`${dbPath}${suffix}`), suffix || "main").toBe(PRIVATE_FILE_MODE);
+    }
+  });
+
+  it.runIf(isPosix)("opens a database with private permissions", () => {
+    const dbPath = join(workspace(), "nested", "cache.db");
+
+    const db = openDb(dbPath);
+    db?.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    db?.close();
+
+    expect(mode(join(dbPath, ".."))).toBe(PRIVATE_DIR_MODE);
+    expect(mode(dbPath)).toBe(PRIVATE_FILE_MODE);
+  });
+
+  it.runIf(isPosix)("keeps a migration backup private", () => {
+    const dir = workspace();
+    const dbPath = join(dir, "source.db");
+    const source = new Database(dbPath);
+    source.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
+    source.prepare("INSERT INTO t (id) VALUES (1)").run();
+
+    const backupPath = backupDatabase(source as never, dbPath, "test");
+    source.close();
+
+    expect(backupPath).not.toBeNull();
+    expect(mode(backupPath!)).toBe(PRIVATE_FILE_MODE);
+  });
+
+  it.runIf(isPosix)("tightens a backup left beside the database", () => {
+    const dir = workspace();
+    const dbPath = join(dir, "cache.db");
+    const backupPath = `${dbPath}.2026-01-01T000000-000Z.migration.bak`;
+    const unrelated = join(dir, "other.db.2026-01-01T000000-000Z.migration.bak");
+    for (const path of [dbPath, backupPath, unrelated]) {
+      writeFileSync(path, "");
+      chmodSync(path, 0o644);
+    }
+
+    restrictPrivateDatabase(dbPath);
+
+    expect(mode(backupPath)).toBe(PRIVATE_FILE_MODE);
+    // Scoped to this database's own backups.
+    expect(mode(unrelated)).toBe(0o644);
+  });
+
+  it("does not throw for a missing path", () => {
+    const missing = join(workspace(), "absent.db");
+
+    expect(() => restrictPrivateFile(missing)).not.toThrow();
+    expect(() => restrictPrivateDatabase(missing)).not.toThrow();
+  });
+
+  it.runIf(!isPosix)("is a no-op on Windows", () => {
+    const dir = join(workspace(), "cache");
+
+    expect(() => ensurePrivateDirectory(dir)).not.toThrow();
+    expect(() => restrictPrivateFile(join(dir, "file.log"))).not.toThrow();
+  });
+});

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,11 @@
+export {
+  PRIVATE_DIR_MODE,
+  PRIVATE_FILE_MODE,
+  ensurePrivateDirectory,
+  restrictExistingPrivateFiles,
+  restrictPrivateDatabase,
+  restrictPrivateFile,
+} from "./private-storage.js";
 export { parseJsonlLines, readJsonlFile } from "./jsonl.js";
 export { setCoreDiagnostics, type CoreDiagnostics } from "./diagnostics.js";
 export { asRecord, asString, asNumber, asArray, reportFieldMismatch } from "./narrow.js";

--- a/packages/core/src/utils/private-storage.ts
+++ b/packages/core/src/utils/private-storage.ts
@@ -1,0 +1,105 @@
+/**
+ * Owner-only permissions for the files CodeSesh writes.
+ *
+ * The session cache holds full transcripts; state holds bookmarks and aliases;
+ * logs hold project paths and error detail. All of them were created under the
+ * process umask, which is commonly 022 — so 0755 directories and 0644 files. On
+ * a shared machine with a traversable home, another user could read them.
+ *
+ * POSIX modes do not apply on Windows, where `chmod` is a no-op; access there is
+ * governed by the profile directory's ACL.
+ */
+import { chmodSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { getCoreDiagnostics } from "./diagnostics.js";
+
+/** Owner read/write/execute. */
+export const PRIVATE_DIR_MODE = 0o700;
+/** Owner read/write. */
+export const PRIVATE_FILE_MODE = 0o600;
+
+/** Sidecars SQLite creates next to a database, which carry the same data. */
+const SQLITE_SIDECAR_SUFFIXES = ["-wal", "-shm", "-journal"];
+
+const isPosix = process.platform !== "win32";
+
+function reportChmodFailure(path: string, error: unknown): void {
+  getCoreDiagnostics()?.warn("storage.permissions_failed", {
+    path,
+    message: error instanceof Error ? error.message : String(error),
+  });
+}
+
+/** Narrows an existing path's permissions, reporting rather than throwing. */
+function restrict(path: string, mode: number): void {
+  if (!isPosix || !existsSync(path)) return;
+  try {
+    // Skip the syscall when it would not change anything.
+    if ((statSync(path).mode & 0o777) === mode) return;
+    chmodSync(path, mode);
+  } catch (error) {
+    reportChmodFailure(path, error);
+  }
+}
+
+/**
+ * Creates a directory only its owner can enter, and tightens it if it existed.
+ *
+ * A failed mkdir propagates — the caller has nowhere to store anything. A failed
+ * chmod does not: the directory is usable, just not as private as intended, and
+ * that is reported instead.
+ */
+export function ensurePrivateDirectory(path: string): void {
+  mkdirSync(path, { recursive: true, mode: PRIVATE_DIR_MODE });
+  // `recursive` skips the mode for a directory that already existed.
+  restrict(path, PRIVATE_DIR_MODE);
+}
+
+/** Narrows a file CodeSesh owns to owner-only. */
+export function restrictPrivateFile(path: string): void {
+  restrict(path, PRIVATE_FILE_MODE);
+}
+
+/**
+ * Tightens files already in a directory — those written before this policy
+ * existed, or by an older version. The caller names exactly what it owns, so
+ * the sweep never reaches beyond CodeSesh's own files.
+ */
+export function restrictExistingPrivateFiles(
+  directory: string,
+  owns: (name: string) => boolean,
+): void {
+  try {
+    for (const entry of readdirSync(directory)) {
+      if (owns(entry)) restrictPrivateFile(join(directory, entry));
+    }
+  } catch (error) {
+    reportChmodFailure(directory, error);
+  }
+}
+
+/** Databases whose neighbouring backups have already been swept this process. */
+const sweptBackupsFor = new Set<string>();
+
+/** A backup holds the same rows as the database it came from. */
+function restrictExistingBackups(dbPath: string): void {
+  if (sweptBackupsFor.has(dbPath)) return;
+  sweptBackupsFor.add(dbPath);
+
+  const prefix = `${basename(dbPath)}.`;
+  restrictExistingPrivateFiles(
+    dirname(dbPath),
+    (name) => name.startsWith(prefix) && name.endsWith(".bak"),
+  );
+}
+
+/**
+ * Narrows a database, any sidecar SQLite has created, and backups left beside
+ * it. Call after opening: the sidecars do not exist until the connection is
+ * established.
+ */
+export function restrictPrivateDatabase(dbPath: string): void {
+  restrictPrivateFile(dbPath);
+  for (const suffix of SQLITE_SIDECAR_SUFFIXES) restrictPrivateFile(`${dbPath}${suffix}`);
+  restrictExistingBackups(dbPath);
+}

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -2,10 +2,15 @@
  * SQLite helper — graceful degradation if better-sqlite3 is unavailable.
  */
 
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { createRequire } from "node:module";
 import { getCoreDiagnostics } from "./diagnostics.js";
+import {
+  ensurePrivateDirectory,
+  restrictPrivateDatabase,
+  restrictPrivateFile,
+} from "./private-storage.js";
 
 interface SQLiteStatement {
   all(...params: unknown[]): DatabaseRow[];
@@ -148,6 +153,8 @@ export function backupDatabase(db: SQLiteDatabase, dbPath: string, label: string
     backupPath = join(dirname(dbPath), `${basename(dbPath)}.${timestamp}.${label}.${counter}.bak`);
   }
   db.exec(`VACUUM INTO ${quoteSqlString(backupPath)}`);
+  // A fresh inode does not inherit the source database's mode.
+  restrictPrivateFile(backupPath);
   return backupPath;
 }
 
@@ -265,8 +272,10 @@ export function openDb(dbPath: string): SQLiteDatabase | null {
     return null;
   }
   try {
-    mkdirSync(dirname(dbPath), { recursive: true });
+    ensurePrivateDirectory(dirname(dbPath));
     const db = DatabaseConstructor(dbPath);
+    // The sidecars only exist once the connection is established.
+    restrictPrivateDatabase(dbPath);
     try {
       db.pragma("journal_mode = WAL");
       db.pragma("synchronous = NORMAL");


### PR DESCRIPTION
## Problem

CodeSesh stores full session details in a local SQLite cache, plus a state database for bookmarks
and aliases, logs, and migration backups. All of them were created under the process umask with no
explicit mode and no follow-up `chmod`. Under a common `umask 022` that means 0755 directories and
0644 files.

Confirmed on this machine before the change: the cache directory was 755, `codesesh.db` was 644, and
both a migration backup and rotated logs were 644. If the home or XDG parent is traversable, another
local user could read message bodies, project paths, bookmarks and error detail.

## Change

One module owns the policy — directories 0700, files 0600 — and the cache, state and logging
adapters use it instead of each passing modes at their own call sites:

- `openDb` creates its directory privately and tightens the database plus every `-wal` / `-shm` /
  `-journal` sidecar *after* connecting, since those do not exist until then
- `VACUUM INTO` backups are tightened on creation — a new inode does not inherit the source mode —
  and backups left by earlier versions are swept, scoped to that database's own backup names in its
  own directory
- log directories and files are tightened, including rotated files and ones a previous run left
  readable

A failed `mkdir` still propagates: the caller has nowhere to store anything. A failed `chmod` does
not — the storage is usable, just not as private as intended — and is reported as
`storage.permissions_failed`.

POSIX modes do not apply on Windows, where `chmod` is a no-op and access follows the profile
directory's ACL; the helpers are no-ops there rather than throwing.

## Verification

- tests assert 0700 directories and 0600 files for new storage, and that an existing over-permissive
  directory, file, database, sidecar set and backup are all tightened
- the backup sweep is scoped: a backup belonging to a different database in the same directory is
  left alone
- a log left at 0644 by a previous run is tightened on the next write
- Windows skips the POSIX assertions and is checked not to throw
- after this change, the real cache directory is 700, `codesesh.db` and its backup are 600, and all
  five log files are 600
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 557, cli 304, web 467 passing