### PR TITLE
fix: make pricing refreshes deterministic (CS-148)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,7 +23,8 @@ import {
   hasExplicitPortArg,
   parsePort,
 } from "./ports.js";
-import { createRegisteredAgents, refreshPricingCache, perf } from "@codesesh/core";
+import { createRegisteredAgents, perf } from "@codesesh/core";
+import { startPricingRefresh } from "./pricing-refresh.js";
 
 const main = defineCommand({
   meta: {
@@ -169,7 +170,9 @@ const main = defineCommand({
       console.log("Cache cleared.");
     }
 
-    void refreshPricingCache();
+    // Owns the refresh: bounded, cancellable, and published only between scans
+    // so a scan never spans two price generations.
+    const pricingRefresh = startPricingRefresh();
 
     // Parse session URI if provided
     let targetSession: { agent: string; sessionId: string } | null = null;
@@ -219,6 +222,8 @@ const main = defineCommand({
     }
 
     if (jsonOnly) {
+      // Nothing will consume a later generation, so stop waiting for it.
+      await pricingRefresh.cancel();
       const output = buildSessionIndexOutput(result, { from: listDefaultFrom, to: listDefaultTo });
       appLogger.info("cli.json_output", {
         sessions: output.sessions.length,
@@ -251,6 +256,8 @@ const main = defineCommand({
 
     const { url } = app;
     if (!jsonOnly) {
+      // The startup scan has finished and background scans have not begun.
+      pricingRefresh.publish();
       store.startBackgroundRefresh();
     }
     let shuttingDown = false;
@@ -258,6 +265,7 @@ const main = defineCommand({
       if (shuttingDown) return;
       shuttingDown = true;
       appLogger.info("cli.shutdown", { signal });
+      await pricingRefresh.cancel();
       await app.shutdown();
       process.exit(0);
     };

--- a/packages/cli/src/pricing-refresh.ts
+++ b/packages/cli/src/pricing-refresh.ts
@@ -1,0 +1,40 @@
+/**
+ * Lifecycle owner for the background price refresh.
+ *
+ * The refresh used to be fired and forgotten: no timeout, no cancellation, and
+ * it replaced the live prices the moment it returned — so one scan could price
+ * its first sessions differently from its last. Here it is bounded, cancellable
+ * on shutdown, and published only at a point where no scan is running.
+ */
+import { publishPendingPricing, refreshPricingCache } from "@codesesh/core";
+import { appLogger } from "./logging.js";
+
+/** Long enough for a cold network, short enough not to outlive a --json run. */
+const REFRESH_TIMEOUT_MS = 10_000;
+
+export interface PricingRefresh {
+  /** Makes a completed refresh current. Safe to call more than once. */
+  publish(): void;
+  /** Cancels an in-flight refresh and waits for it to settle. */
+  cancel(): Promise<void>;
+}
+
+export function startPricingRefresh(timeoutMs = REFRESH_TIMEOUT_MS): PricingRefresh {
+  const controller = new AbortController();
+  const completion = refreshPricingCache({ signal: controller.signal, timeoutMs }).catch(
+    (error: unknown) => {
+      appLogger.warn("pricing.refresh.error", { error });
+      return false;
+    },
+  );
+
+  return {
+    publish() {
+      if (publishPendingPricing()) appLogger.info("pricing.refresh.published", {});
+    },
+    async cancel() {
+      controller.abort();
+      await completion;
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,7 +89,13 @@ export {
   restrictPrivateFile,
   setCoreDiagnostics,
 } from "./utils/index.js";
-export { refreshPricingCache } from "./pricing/index.js";
+export {
+  getPricingGeneration,
+  hasPendingPricing,
+  publishPendingPricing,
+  refreshPricingCache,
+  type PricingGeneration,
+} from "./pricing/index.js";
 export { buildDashboard, getSessionActivityTime } from "./analytics/dashboard.js";
 export type { DashboardData, DashboardScope } from "./analytics/dashboard.js";
 export { attachProjectMetrics } from "./analytics/projects.js";

--- a/packages/core/src/pricing/__tests__/refresh-generation.test.ts
+++ b/packages/core/src/pricing/__tests__/refresh-generation.test.ts
@@ -1,0 +1,163 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testHome = mkdtempSync(join(tmpdir(), "codesesh-pricing-refresh-"));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: () => testHome };
+});
+
+const { setCoreDiagnostics } = await import("../../utils/diagnostics.js");
+const { estimateTokenCost } = await import("../../utils/cost.js");
+const { getPricingGeneration, hasPendingPricing, publishPendingPricing, refreshPricingCache } =
+  await import("../fetcher.js");
+
+const MODEL = "claude-sonnet-4-5";
+const MILLION_INPUT = { input: 1_000_000, output: 0 };
+const cachePath = join(testHome, ".cache", "codesesh", "litellm-pricing.json");
+
+/** A remote payload that moves this model's price to an unmistakable value. */
+function remotePricing(inputCost: number) {
+  return {
+    [MODEL]: { input_cost_per_token: inputCost, output_cost_per_token: inputCost },
+  };
+}
+
+function stubFetch(handler: (url: string, init?: RequestInit) => Promise<unknown>) {
+  vi.stubGlobal("fetch", handler);
+}
+
+beforeEach(() => {
+  rmSync(cachePath, { force: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  publishPendingPricing();
+});
+
+describe("CS-148: pricing generations", () => {
+  it("does not change live prices until the refresh is published", async () => {
+    const before = estimateTokenCost(MODEL, MILLION_INPUT);
+    const generationBefore = getPricingGeneration().id;
+    stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000999) }));
+
+    expect(await refreshPricingCache()).toBe(true);
+
+    // A scan in flight keeps the prices it started with.
+    expect(estimateTokenCost(MODEL, MILLION_INPUT)).toBe(before);
+    expect(getPricingGeneration().id).toBe(generationBefore);
+    expect(hasPendingPricing()).toBe(true);
+
+    expect(publishPendingPricing()).toBe(true);
+    expect(estimateTokenCost(MODEL, MILLION_INPUT)).toBe(999);
+    expect(getPricingGeneration().id).toBe(generationBefore + 1);
+  });
+
+  it("reports nothing to publish when no refresh completed", () => {
+    expect(hasPendingPricing()).toBe(false);
+    expect(publishPendingPricing()).toBe(false);
+  });
+
+  it.each([
+    ["an HTTP failure", async () => ({ ok: false, json: async () => ({}) })],
+    ["an empty payload", async () => ({ ok: true, json: async () => ({}) })],
+    [
+      "a malformed payload",
+      async () => ({
+        ok: true,
+        json: async () => {
+          throw new SyntaxError("Unexpected token");
+        },
+      }),
+    ],
+    [
+      "a network error",
+      async () => {
+        throw new TypeError("fetch failed");
+      },
+    ],
+  ])("leaves the current generation alone after %s", async (_name, handler) => {
+    const before = estimateTokenCost(MODEL, MILLION_INPUT);
+    const generationBefore = getPricingGeneration().id;
+    stubFetch(handler as never);
+
+    expect(await refreshPricingCache()).toBe(false);
+
+    expect(hasPendingPricing()).toBe(false);
+    expect(estimateTokenCost(MODEL, MILLION_INPUT)).toBe(before);
+    expect(getPricingGeneration().id).toBe(generationBefore);
+  });
+
+  it("gives up on a request that never answers", async () => {
+    stubFetch(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    );
+
+    const started = performance.now();
+    expect(await refreshPricingCache({ timeoutMs: 50 })).toBe(false);
+
+    expect(performance.now() - started).toBeLessThan(2_000);
+    expect(hasPendingPricing()).toBe(false);
+  });
+
+  it("abandons a refresh its caller cancelled", async () => {
+    const controller = new AbortController();
+    stubFetch(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    );
+
+    const refresh = refreshPricingCache({ signal: controller.signal });
+    controller.abort();
+
+    expect(await refresh).toBe(false);
+    expect(hasPendingPricing()).toBe(false);
+  });
+
+  it("replaces the disk cache in one step", async () => {
+    stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000123) }));
+
+    await refreshPricingCache();
+
+    const raw = readFileSync(cachePath, "utf8");
+    // A truncated write would not parse.
+    const parsed = JSON.parse(raw) as { timestamp: number; data: Record<string, unknown> };
+    expect(typeof parsed.timestamp).toBe("number");
+    expect(Object.keys(parsed.data).length).toBeGreaterThan(0);
+    expect(existsSync(`${cachePath}.${process.pid}.tmp`)).toBe(false);
+  });
+
+  it("reports a failed disk write and leaves no partial file", async () => {
+    // A non-empty directory in the cache file's place makes the rename fail.
+    rmSync(cachePath, { force: true });
+    mkdirSync(cachePath, { recursive: true });
+    writeFileSync(join(cachePath, "blocker"), "x");
+    const events: string[] = [];
+    setCoreDiagnostics({ warn: (event) => events.push(event) });
+    stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000321) }));
+
+    try {
+      // The in-memory refresh still succeeds; only the cache write fails.
+      expect(await refreshPricingCache()).toBe(true);
+    } finally {
+      setCoreDiagnostics(null);
+      rmSync(cachePath, { recursive: true, force: true });
+    }
+
+    expect(events).toContain("pricing.cache_write_failed");
+    expect(existsSync(`${cachePath}.${process.pid}.tmp`)).toBe(false);
+  });
+});

--- a/packages/core/src/pricing/fetcher.ts
+++ b/packages/core/src/pricing/fetcher.ts
@@ -1,6 +1,8 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { ensurePrivateDirectory, restrictPrivateFile } from "../utils/private-storage.js";
+import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import snapshotData from "./data/snapshot.json";
 
 export interface ModelPricing {
@@ -28,8 +30,21 @@ const LITELLM_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const WEB_SEARCH_COST = 0.01;
+const REFRESH_TIMEOUT_MS = 10_000;
 
-let pricingCache = loadSnapshot();
+/**
+ * A published set of prices. Estimates read one generation for as long as they
+ * need it: a refresh landing mid-scan used to mean the first sessions of a scan
+ * were priced differently from the last, with no record of which applied.
+ */
+export interface PricingGeneration {
+  id: number;
+  pricing: Map<string, ModelPricing>;
+}
+
+let published: PricingGeneration = { id: 1, pricing: loadSnapshot() };
+/** A completed refresh waiting for a safe point to become current. */
+let pending: Map<string, ModelPricing> | null = null;
 loadDiskCache();
 
 function normalizeKey(key: string): string {
@@ -134,7 +149,7 @@ function loadDiskCache() {
         if (!pricing) continue;
         next.set(normalizeKey(name), pricing);
       }
-      pricingCache = next;
+      published = { id: published.id + 1, pricing: next };
     }
   } catch {
     // ignore malformed cache
@@ -142,7 +157,32 @@ function loadDiskCache() {
 }
 
 export function getPricingRegistry(): Map<string, ModelPricing> {
-  return pricingCache;
+  return published.pricing;
+}
+
+/** The generation estimates are currently reading. */
+export function getPricingGeneration(): PricingGeneration {
+  return published;
+}
+
+/**
+ * Makes a completed refresh current. Owners call this between scans, never
+ * during one, so a scan cannot span two generations.
+ */
+export function publishPendingPricing(): boolean {
+  if (!pending) return false;
+  published = { id: published.id + 1, pricing: pending };
+  pending = null;
+  getCoreDiagnostics()?.info?.("pricing.generation.published", {
+    generation: published.id,
+    models: published.pricing.size,
+  });
+  return true;
+}
+
+/** Whether a refresh is waiting to be published. */
+export function hasPendingPricing(): boolean {
+  return pending !== null;
 }
 
 export function hasBillablePricing(pricing: ModelPricing): boolean {
@@ -154,7 +194,35 @@ export function hasBillablePricing(pricing: ModelPricing): boolean {
   );
 }
 
-export async function refreshPricingCache(): Promise<boolean> {
+/** Replaces the cache in one step, so an interrupted write cannot truncate it. */
+function writeDiskCacheAtomically(path: string, pricing: Map<string, ModelPricing>): void {
+  const temporaryPath = `${path}.${process.pid}.tmp`;
+  const payload = JSON.stringify({ timestamp: Date.now(), data: Object.fromEntries(pricing) });
+  try {
+    ensurePrivateDirectory(getCacheDir());
+    writeFileSync(temporaryPath, payload);
+    restrictPrivateFile(temporaryPath);
+    renameSync(temporaryPath, path);
+  } catch (error) {
+    rmSync(temporaryPath, { force: true });
+    getCoreDiagnostics()?.warn("pricing.cache_write_failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export interface RefreshPricingOptions {
+  /** Abort the request when it outlives a startup's patience. */
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+/**
+ * Fetches prices into a pending generation. It does not become current until
+ * {@link publishPendingPricing}, so an in-flight scan keeps the prices it
+ * started with.
+ */
+export async function refreshPricingCache(options: RefreshPricingOptions = {}): Promise<boolean> {
   const path = getCachePath();
   if (existsSync(path)) {
     try {
@@ -167,8 +235,12 @@ export async function refreshPricingCache(): Promise<boolean> {
     }
   }
 
+  const timeout = AbortSignal.timeout(options.timeoutMs ?? REFRESH_TIMEOUT_MS);
+  const signal = options.signal ? AbortSignal.any([options.signal, timeout]) : timeout;
+
+  getCoreDiagnostics()?.info?.("pricing.refresh.started", { generation: published.id });
   try {
-    const response = await fetch(LITELLM_URL);
+    const response = await fetch(LITELLM_URL, { signal });
     if (!response.ok) return false;
     const data = (await response.json()) as Record<string, LiteLLMEntry>;
     const remote = parseLiteLLMData(data);
@@ -179,11 +251,19 @@ export async function refreshPricingCache(): Promise<boolean> {
       next.set(name, pricing);
     }
 
-    pricingCache = next;
-    mkdirSync(getCacheDir(), { recursive: true });
-    writeFileSync(path, JSON.stringify({ timestamp: Date.now(), data: Object.fromEntries(next) }));
+    pending = next;
+    writeDiskCacheAtomically(path, next);
+    getCoreDiagnostics()?.info?.("pricing.refresh.completed", {
+      generation: published.id,
+      models: next.size,
+    });
     return true;
-  } catch {
+  } catch (error) {
+    getCoreDiagnostics()?.warn("pricing.refresh.failed", {
+      generation: published.id,
+      aborted: signal.aborted,
+      message: error instanceof Error ? error.message : String(error),
+    });
     return false;
   }
 }


### PR DESCRIPTION
## Problem

`refreshPricingCache()` replaced the global price map as soon as it returned, and the CLI fired it
with `void` before the initial scan — no wait, no timeout, no cancellation, no owner.

Reproduced: the same model and usage cost 3 before a refresh and 999 after, with no scan boundary
between them. A scan that straddles a refresh prices its early sessions from one generation and its
later ones from another, and the estimates it already persisted are never revisited. The disk cache
was written with a plain `writeFileSync`, so an interrupted or concurrent run could leave truncated
JSON, and `--json` could exit with the promise still outstanding.

## Change

- prices are published as a generation. A refresh lands in a *pending* generation and only becomes
  current when an owner calls `publishPendingPricing()`, so a scan in flight keeps the prices it
  started with.
- the CLI owns that lifecycle: it publishes between the startup scan and the background scans,
  cancels on shutdown, and abandons the refresh before `--json` exits
- the fetch takes an `AbortSignal` and a timeout, both belonging to the module rather than assembled
  by each caller
- the disk cache is written to a temporary file and renamed into place, so a reader sees either the
  complete old file or the complete new one

Recorded costs are untouched; this only concerns estimates.

## Verification

- a completed refresh does not move live prices until published, and the generation id only advances
  on publish
- HTTP failure, an empty payload, malformed JSON and a network error all leave the current
  generation and its prices alone, with nothing pending
- a request that never answers is given up on within its timeout, and a caller's `AbortSignal`
  abandons it
- the written cache parses and leaves no temporary file behind; a failed replacement is reported as
  `pricing.cache_write_failed` and leaves no partial file
- `--json` returns promptly rather than waiting on the network
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 567, cli 304, web 467 passing