### PR TITLE
docs: stop the PRD from describing a deleted architecture (CS-151)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Verify package versions agree
         run: node scripts/release-preflight.mjs
 
+      - name: Verify documented paths exist
+        run: node scripts/check-docs-paths.mjs
+
       - run: pnpm build
 
       - name: Smoke test CLI on minimum Node version

--- a/README.md
+++ b/README.md
@@ -295,27 +295,37 @@ node --watch packages/cli/dist/index.js --cwd . --days 3
 
 ```
 packages/core       Core library (framework-agnostic)
-  agents/           Agent adapters (one file per agent)
-  discovery/        Session path resolution & file scanning
+  agents/           Agent adapters, registry, and registration
+  analytics/        Dashboard aggregation
+  contract/         Browser-safe types and shared pure logic
+  discovery/        Session scanning, SQLite cache, and search index
+  pricing/          Model price registry and cost estimation
+  projects/         Project identity resolution
+  search/           Session search across sources
+  state/            Bookmarks, aliases, and preferences
   types/            Shared TypeScript types
   utils/            Utility functions
 
 packages/cli        CLI entry point & HTTP server
-  src/commands/     CLI subcommands
-  src/api/          Hono route handlers
+  api/              Hono routes and request handlers
+  *-worker.ts       Scan, search-index and smart-tag worker threads
 
 apps/web            React frontend
-  src/components/   UI components
-  src/lib/          API client & utilities
+  components/       UI components
+  hooks/            Data loading and interaction hooks
+  lib/              API client & utilities
 ```
+
+`docs/architecture.md` describes how a scan flows through these; `docs/sqlite-storage.md` covers
+the cache and search index.
 
 ### Extending
 
 Agent capabilities have one registration point:
 
-1. Create `packages/core/src/agents/youragent.ts`, implement `BaseAgent`, and export its data-root resolver.
+1. Create `packages/core/src/agents/<youragent>.ts`, implement `BaseAgent`, and export its data-root resolver.
 2. Register it in `packages/core/src/agents/register.ts`, explicitly declaring its icon, data root, resume command support (`null` when unsupported), and whether it uses a custom or default tool display strategy.
 3. Add its SVG to `apps/web/public/icon/agent/`.
-4. For a custom tool display strategy, add `apps/web/src/components/session-detail/tool-strategy/youragent.ts` and register its builder in that directory's `index.ts`.
+4. For a custom tool display strategy, add `apps/web/src/components/session-detail/tool-strategy/<youragent>.ts` and register its builder in that directory's `index.ts`.
 
 The registration completeness test rejects missing icons, undeclared resume support, and custom strategy mismatches.

--- a/README_CN.md
+++ b/README_CN.md
@@ -289,12 +289,12 @@ apps/web            React 前端
 
 Agent 能力统一在一个注册点声明：
 
-1. 创建 `packages/core/src/agents/youragent.ts`，实现 `BaseAgent` 并导出数据根目录解析器。
+1. 创建 `packages/core/src/agents/<youragent>.ts`，实现 `BaseAgent` 并导出数据根目录解析器。
 2. 在 `packages/core/src/agents/register.ts` 中注册，显式声明图标、数据根目录、resume
    命令能力（不支持时填 `null`）以及使用自定义还是默认工具展示策略。
 3. 在 `apps/web/public/icon/agent/` 添加 SVG。
 4. 如使用自定义工具展示策略，在
-   `apps/web/src/components/session-detail/tool-strategy/youragent.ts` 实现，并在同目录
+   `apps/web/src/components/session-detail/tool-strategy/<youragent>.ts` 实现，并在同目录
    `index.ts` 注册 builder。
 
 注册完备性测试会拒绝缺失图标、未声明 resume 能力或自定义策略不匹配的注册。

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,5 +1,18 @@
 # CodeSesh - 产品需求文档 (PRD)
 
+> **这是立项时的历史文档，不是当前架构的描述。**
+>
+> 它记录 CodeSesh 从 agent-dump / agent-view 整合而来的初始动机与需求范围。文件树、API 清单
+> 与里程碑均为当时的实现计划，之后已经演进；照此文档定位代码会指向不存在的模块。
+>
+> 当前事实来源：
+>
+> - 产品能力与 CLI 参数：[`README.md`](../README.md)
+> - 扫描与缓存架构：[`docs/architecture.md`](./architecture.md)、[`docs/scanning-and-caching.md`](./scanning-and-caching.md)
+> - SQLite 存储与搜索索引：[`docs/sqlite-storage.md`](./sqlite-storage.md)
+> - 支持的 Agent 清单：`packages/core/src/agents/register.ts`
+> - 发布流程：[`docs/release-guide.md`](./release-guide.md)
+
 ## 1. 概述
 
 ### 1.1 产品定位
@@ -10,7 +23,7 @@ CodeSesh 是一个本地 CLI 工具，用于发现、聚合和可视化多种 AI
 
 当前存在两个独立项目：
 
-- **agent-dump** (Python)：从本地文件系统发现并导出 5 种 Coding Agent（Claude Code、Codex、OpenCode、Cursor、Kimi）的会话记录，统一为 JSON 格式
+- **agent-dump** (Python)：从本地文件系统发现并导出 5 种 Coding Agent（Claude Code、Codex、OpenCode、Cursor、Kimi）的会话记录，统一为 JSON 格式（立项时的范围；当前支持的 Agent 以 `packages/core/src/agents/register.ts` 为准）
 - **agent-view** (React)：将导出的 JSON 会话文件可视化为网页，支持消息时间线、工具输出渲染、TOC 过滤等
 
 CodeSesh 将两者的能力整合为一个 TypeScript monorepo，提供从会话发现到可视化的端到端体验，无需 Python 环境。
@@ -126,158 +139,33 @@ CLI 启动时应有结构化的控制台输出：
 
 ### 3.2 Monorepo 结构
 
-```
-codesesh/
-├── pnpm-workspace.yaml
-├── turbo.json
-├── package.json                 # root scripts, devDeps
-├── tsconfig.base.json
-│
-├── packages/
-│   ├── core/                    # @codesesh/core
-│   │   └── src/
-│   │       ├── types/           # 统一类型定义
-│   │       │   ├── session.ts   # SessionHead, SessionData, Message, MessagePart
-│   │       │   ├── agent.ts     # AgentInfo, ScanOptions
-│   │       │   └── filters.ts   # FilterOptions
-│   │       ├── agents/          # 各 Agent 适配器
-│   │       │   ├── base.ts      # BaseAgent 抽象类
-│   │       │   ├── registry.ts  # Agent 注册表
-│   │       │   ├── claudecode.ts
-│   │       │   ├── codex.ts
-│   │       │   ├── opencode.ts
-│   │       │   ├── cursor.ts
-│   │       │   └── kimi.ts
-│   │       ├── discovery/       # 会话发现
-│   │       │   ├── scanner.ts   # AgentScanner
-│   │       │   └── paths.ts     # 平台路径解析
-│   │       └── utils/           # 工具函数
-│   │           ├── jsonl.ts
-│   │           └── sqlite.ts
-│   │
-│   └── cli/                     # @codesesh/cli（npm bin: codesesh）
-│       └── src/
-│           ├── index.ts         # CLI 入口
-│           ├── commands/
-│           │   └── serve.ts     # 默认命令：发现 + 启动服务
-│           ├── server.ts        # Hono HTTP 服务器
-│           ├── api/
-│           │   ├── routes.ts    # API 路由定义
-│           │   └── handlers.ts  # 请求处理器
-│           └── output.ts        # 控制台输出格式化
-│
-└── apps/
-    └── web/                     # @codesesh/web
-        ├── vite.config.ts
-        ├── index.html
-        └── src/
-            ├── App.tsx          # 基于 agent-view 改造
-            ├── components/      # 从 agent-view 移植
-            ├── config.ts        # Agent 配置
-            └── lib/
-                └── api.ts       # API 客户端
-```
+立项时规划的目录树已不再准确（包名、命令入口与模块划分都已变化）。当前结构见
+[`README.md`](../README.md) 的 Project Structure 一节，扫描链路见
+[`docs/architecture.md`](./architecture.md)。
 
 ### 3.3 数据流
 
-```
-┌─────────────┐     ┌──────────────┐     ┌──────────────┐
-│   本地文件    │────▶│  Core 适配器  │────▶│  CLI 服务器   │
-│ JSONL/SQLite │     │  发现 + 转换  │     │  Hono API    │
-└─────────────┘     └──────────────┘     └──────┬───────┘
-                                                │ HTTP
-                                         ┌──────▼───────┐
-                                         │   Web UI     │
-                                         │  React SPA   │
-                                         └──────────────┘
-```
-
-1. **发现阶段**（Core）：Scanner 遍历所有已注册的 Agent 适配器，调用 `isAvailable()` 和 `scan()` 收集 `SessionHead`（轻量元数据：id、title、cwd、时间、消息数）
-2. **服务阶段**（CLI）：启动 Hono HTTP 服务器，暴露 API 并托管 Web 静态资源
-3. **展示阶段**（Web）：SPA 通过 API 获取会话列表和详情，按需加载完整消息数据
+见 [`docs/architecture.md`](./architecture.md) 与
+[`docs/scanning-and-caching.md`](./scanning-and-caching.md)。
 
 ### 3.4 API 设计
 
-```
-GET /api/agents
-  → [{ name, displayName, count, icon }]
-
-GET /api/sessions?agent=X&cwd=Y&from=Z&to=W&q=keyword
-  → { sessions: SessionHead[] }
-
-GET /api/sessions/:agent/:sessionId
-  → SessionData（含完整 messages）
-```
-
-会话列表只返回元数据，完整消息数据按需加载，避免一次性传输大量数据。
+立项时只规划了 3 条路由。当前 API 以 `packages/cli/src/api/routes.ts` 为准。
 
 ### 3.5 核心类型
 
-```typescript
-// 会话元数据（列表展示用）
-interface SessionHead {
-  id: string;
-  agent: string;            // "claudecode" | "codex" | "opencode" | "cursor" | "kimi"
-  agentDisplayName: string;
-  title: string;
-  cwd: string;
-  createdAt: number;        // ms epoch
-  updatedAt: number;
-  model?: string;
-  messageCount?: number;
-}
-
-// 完整会话数据（详情展示用）
-interface SessionData {
-  id: string;
-  title: string;
-  directory: string;
-  timeCreated: number;
-  timeUpdated?: number;
-  stats: SessionStats;
-  messages: Message[];
-}
-
-// Agent 适配器接口
-abstract class BaseAgent {
-  abstract name: string;
-  abstract displayName: string;
-  abstract isAvailable(): Promise<boolean>;
-  abstract scan(options?: ScanOptions): Promise<SessionHead[]>;
-  abstract getSessionData(sessionId: string): Promise<SessionData>;
-}
-```
-
-消息和消息片段类型（Message、MessagePart）复用 agent-view 已有定义。
+当前类型定义以 `packages/core/src/types/` 与 `packages/core/src/contract/` 为准。
 
 ### 3.6 构建与发布
 
-**构建顺序**（Turborepo 管理依赖）：
-
-1. `@codesesh/core` → tsc 编译
-2. `@codesesh/web` → vite build（依赖 core 类型）
-3. `@codesesh/cli` → tsup 打包（依赖 core；将 web dist 嵌入到产物中）
-
-**发布**：
-
-仅发布 `codesesh` CLI 包到 npm。CLI 包内嵌 Web 构建产物，用户 `npx codesesh` 即可使用，无需额外安装。
-
-```json
-{
-  "name": "codesesh",
-  "bin": { "codesesh": "dist/cli.mjs" },
-  "files": ["dist/"],
-  "dependencies": {
-    "better-sqlite3": "^11.0.0",
-    "hono": "^4.0.0",
-    "@hono/node-server": "^1.0.0"
-  }
-}
-```
+见 [`docs/release-guide.md`](./release-guide.md)。
 
 ---
 
-## 4. 里程碑
+## 4. 里程碑（立项计划）
+
+以下为立项时的阶段划分，仅作历史记录；当前进度见 `CHANGELOG.md` 与 `.issues/`。
+
 
 ### M1: 项目骨架
 

--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 - 当前 schema：`CACHE_SCHEMA_VERSION = 16`
-- 稳定导出入口：`packages/core/src/discovery/cache.ts`
+- 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`
 
 `cache.ts` 只是公共 barrel。数据库连接、schema、会话持久化和搜索实现分别位于
@@ -166,7 +166,7 @@ materializeSessionDetailResponse()
 
 ## 相关代码
 
-- `packages/core/src/discovery/cache.ts`
+- `packages/core/src/discovery/index.ts`
 - `packages/core/src/discovery/cache/`
 - `packages/core/src/discovery/session-detail.ts`
 - `packages/core/src/agents/base.ts`

--- a/scripts/check-docs-paths.mjs
+++ b/scripts/check-docs-paths.mjs
@@ -1,0 +1,74 @@
+/**
+ * Verifies that repository paths quoted in documentation still exist.
+ *
+ * Docs drifted silently once code moved: `discovery/cache.ts` was deleted while
+ * two documents still called it the stable entry point. This only checks
+ * backticked paths that look like repository files or directories — prose,
+ * commands and external references are left alone.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CHECKED_DOCUMENTS = [
+  "README.md",
+  "README_CN.md",
+  "packages/cli/README.md",
+  "docs/PRD.md",
+  "docs/architecture.md",
+  "docs/scanning-and-caching.md",
+  "docs/sqlite-storage.md",
+  "docs/release-guide.md",
+];
+
+/** Directories a repository path must start with to be checked. */
+const REPO_ROOTS = ["packages/", "apps/", "docs/", "scripts/", ".github/"];
+
+/** Paths that stand for a pattern or a placeholder rather than a file. */
+function isTemplate(path) {
+  return path.includes("*") || path.includes("<");
+}
+
+export function extractRepositoryPaths(markdown) {
+  const quoted = markdown.match(/`[^`\n]+`/g) ?? [];
+  return [
+    ...new Set(
+      quoted
+        .map((token) => token.slice(1, -1).trim())
+        .filter((token) => REPO_ROOTS.some((root) => token.startsWith(root)))
+        .filter((token) => !isTemplate(token)),
+    ),
+  ];
+}
+
+export function findMissingPaths(repoRoot, documents) {
+  const missing = [];
+  for (const document of documents) {
+    const fullPath = join(repoRoot, document);
+    if (!existsSync(fullPath)) {
+      missing.push({ document, path: document, reason: "document not found" });
+      continue;
+    }
+    for (const path of extractRepositoryPaths(readFileSync(fullPath, "utf8"))) {
+      if (!existsSync(join(repoRoot, path))) missing.push({ document, path });
+    }
+  }
+  return missing;
+}
+
+function main() {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const missing = findMissingPaths(repoRoot, CHECKED_DOCUMENTS);
+
+  if (missing.length > 0) {
+    console.error("Documentation references paths that do not exist:");
+    for (const entry of missing) {
+      console.error(`  - ${entry.document}: ${entry.path}${entry.reason ? ` (${entry.reason})` : ""}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Documentation paths resolve in ${CHECKED_DOCUMENTS.length} files`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/check-docs-paths.mjs
+++ b/scripts/check-docs-paths.mjs
@@ -29,6 +29,14 @@ function isTemplate(path) {
   return path.includes("*") || path.includes("<");
 }
 
+/**
+ * Build output. Whether it exists depends on whether anything has been built,
+ * not on whether the documentation is accurate.
+ */
+function isBuildOutput(path) {
+  return path.includes("/dist/") || path.endsWith("/dist");
+}
+
 export function extractRepositoryPaths(markdown) {
   const quoted = markdown.match(/`[^`\n]+`/g) ?? [];
   return [
@@ -36,7 +44,7 @@ export function extractRepositoryPaths(markdown) {
       quoted
         .map((token) => token.slice(1, -1).trim())
         .filter((token) => REPO_ROOTS.some((root) => token.startsWith(root)))
-        .filter((token) => !isTemplate(token)),
+        .filter((token) => !isTemplate(token) && !isBuildOutput(token)),
     ),
   ];
 }

--- a/scripts/check-docs-paths.test.mjs
+++ b/scripts/check-docs-paths.test.mjs
@@ -1,0 +1,76 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { CHECKED_DOCUMENTS, extractRepositoryPaths, findMissingPaths } from "./check-docs-paths.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function repo(files) {
+  const dir = mkdtempSync(join(tmpdir(), "codesesh-docs-check-"));
+  tempDirs.push(dir);
+  for (const [path, contents] of Object.entries(files)) {
+    const full = join(dir, path);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return dir;
+}
+
+describe("CS-151: documentation path check", () => {
+  it("picks out repository paths and ignores everything else", () => {
+    const paths = extractRepositoryPaths(
+      [
+        "Run `pnpm build` then read `packages/core/src/index.ts`.",
+        "See `docs/architecture.md` and `apps/web/src/App.tsx`.",
+        "Data lives in `~/.claude/projects/**/*.jsonl`.",
+        "Create `packages/core/src/agents/<youragent>.ts`.",
+        "Sources match `packages/core/src/**/*.ts`.",
+      ].join("\n"),
+    );
+
+    expect(paths).toEqual([
+      "packages/core/src/index.ts",
+      "docs/architecture.md",
+      "apps/web/src/App.tsx",
+    ]);
+  });
+
+  it("reports a path that no longer exists", () => {
+    const dir = repo({
+      "docs/guide.md": "Entry point: `packages/core/src/discovery/cache.ts`",
+      "packages/core/src/index.ts": "",
+    });
+
+    expect(findMissingPaths(dir, ["docs/guide.md"])).toEqual([
+      { document: "docs/guide.md", path: "packages/core/src/discovery/cache.ts" },
+    ]);
+  });
+
+  it("accepts a directory reference", () => {
+    const dir = repo({
+      "docs/guide.md": "Cache modules live in `packages/core/src/discovery/cache/`",
+      "packages/core/src/discovery/cache/db.ts": "",
+    });
+
+    expect(findMissingPaths(dir, ["docs/guide.md"])).toEqual([]);
+  });
+
+  it("reports a document that is not there at all", () => {
+    const dir = repo({ "README.md": "" });
+
+    expect(findMissingPaths(dir, ["docs/absent.md"])).toEqual([
+      { document: "docs/absent.md", path: "docs/absent.md", reason: "document not found" },
+    ]);
+  });
+
+  it("checks the documents that describe the repository", () => {
+    expect(CHECKED_DOCUMENTS).toContain("README.md");
+    expect(CHECKED_DOCUMENTS).toContain("docs/PRD.md");
+    expect(CHECKED_DOCUMENTS).toContain("docs/sqlite-storage.md");
+  });
+});

--- a/scripts/check-docs-paths.test.mjs
+++ b/scripts/check-docs-paths.test.mjs
@@ -30,6 +30,7 @@ describe("CS-151: documentation path check", () => {
         "Data lives in `~/.claude/projects/**/*.jsonl`.",
         "Create `packages/core/src/agents/<youragent>.ts`.",
         "Sources match `packages/core/src/**/*.ts`.",
+        "Run `node packages/cli/dist/index.js --version`.",
       ].join("\n"),
     );
 


### PR DESCRIPTION
## Problem

CS-124 refreshed three architecture documents but not `docs/PRD.md` or the READMEs, and a later
`refactor(core): tighten public exports` deleted `packages/core/src/discovery/cache.ts` — which two
documents still named as the stable entry point.

Confirmed drift:

- the PRD presents the agent-dump / agent-view consolidation as current and lists five agents; the
  registry has seven
- its monorepo tree contains `commands/serve.ts`, `apps/web/src/config.ts`, the old `@codesesh/cli`
  package name and `dist/cli.mjs`, none of which exist
- its API section lists three early routes, and its type list predates `contract/`
- the README's structure omits `analytics/`, `contract/`, `pricing/`, `projects/`, `search/` and
  `state/`, and still shows a `src/commands/` directory that was removed
- `docs/sqlite-storage.md` referenced the deleted `discovery/cache.ts` twice

## Change

- the PRD says up front that it is the inception document, and links to what is authoritative for
  each fact: the README for capabilities, `architecture.md` and `scanning-and-caching.md` for the
  scan, `sqlite-storage.md` for storage, `register.ts` for the agent list, `release-guide.md` for
  releases. Its structure tree, API list and type list are replaced by those pointers rather than
  updated — they rot every time the code moves. The milestones stay, marked as the original plan.
- the README structure matches the current packages
- `sqlite-storage.md` points at `discovery/index.ts`, the entry point that actually exports the cache
- placeholder paths in the extension guide are written as `<youragent>.ts`, so they read as templates

`scripts/check-docs-paths.mjs` resolves every backticked repository path in the eight documents that
describe the repo, and CI runs it — the drift that started this cannot recur silently.

## Verification

- the checker reports the deleted `discovery/cache.ts` as missing, accepts directory references, and
  ignores globs, placeholders, shell commands and home-directory paths
- a missing document is reported rather than skipped
- all eight documents resolve after the change
- the README's seven agents match `register.ts`
- `pnpm lint`, `pnpm format:check`
- `pnpm test` — core 567, cli 304, web 467 passing; 26 script tests