### PR TITLE
refactor: give project identity one owner (CS-153)

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -12,6 +12,7 @@ import {
   type MouseEvent,
 } from "react";
 import type { SessionHead } from "../lib/api";
+import { getProjectIdentityKey } from "../lib/projects";
 import { getSessionReferenceKey } from "../lib/session-indexes";
 import { getSessionDisplayTitle } from "../lib/session-title";
 import { isRenderProfilerEnabled, recordRenderProfileEntry } from "./RenderProfiler";
@@ -119,7 +120,7 @@ function getProjectGroup(session: SessionHead) {
   const identity = session.project_identity;
   if (identity) {
     return {
-      key: `${identity.kind}:${identity.key}`,
+      key: getProjectIdentityKey(identity),
       label: identity.displayName || getDirectoryLabel(session.directory),
     };
   }

--- a/apps/web/src/lib/projects.ts
+++ b/apps/web/src/lib/projects.ts
@@ -1,29 +1,17 @@
-import type { ApiProjectGroup, ProjectIdentityKind } from "./api";
+import {
+  getProjectIdentityKey,
+  isProjectIdentityKind,
+  type ProjectIdentityRef,
+} from "@codesesh/core/contract";
+import type { ApiProjectGroup } from "./api";
 
-export interface ProjectRouteIdentity {
-  kind: ProjectIdentityKind;
-  key: string;
-}
+// Identity semantics come from the contract; this module only turns them into
+// URLs and back. A route key is percent-encoded, an identity key is not.
+export { getProjectIdentityKey, isProjectIdentityKind };
+export type ProjectRouteIdentity = ProjectIdentityRef;
 
 export function getProjectGroupIdentity(project: ApiProjectGroup): ProjectRouteIdentity {
   return { kind: project.identityKind, key: project.identityKey };
-}
-
-const projectIdentityKinds = new Set<string>([
-  "git_remote",
-  "git_common_dir",
-  "manifest_path",
-  "synthetic",
-  "path",
-  "loose",
-]);
-
-export function isProjectIdentityKind(value: string): value is ProjectIdentityKind {
-  return projectIdentityKinds.has(value);
-}
-
-export function getProjectIdentityKey(project: ProjectRouteIdentity): string {
-  return `${project.kind}:${project.key}`;
 }
 
 export function decodeProjectRouteKey(value: string): string {

--- a/packages/core/src/analytics/projects.ts
+++ b/packages/core/src/analytics/projects.ts
@@ -5,6 +5,7 @@
  */
 import type { ProjectGroup, SessionHead } from "../types/index.js";
 import type { ApiProjectAgentStat, ApiProjectGroup } from "../contract/index.js";
+import { getProjectIdentityKey } from "../contract/project-identity.js";
 import { getSessionAgentName, getTotalTokens } from "./dashboard.js";
 
 interface ProjectMetrics {
@@ -13,10 +14,6 @@ interface ProjectMetrics {
   cost: number;
   hasEstimatedCost: boolean;
   agentStats: Map<string, ApiProjectAgentStat>;
-}
-
-function getProjectGroupKey(identityKind: string, identityKey: string): string {
-  return `${identityKind}:${identityKey}`;
 }
 
 function emptyMetrics(): ProjectMetrics {
@@ -37,7 +34,7 @@ export function attachProjectMetrics(
     const identity = session.project_identity;
     if (!identity) continue;
 
-    const key = getProjectGroupKey(identity.kind, identity.key);
+    const key = getProjectIdentityKey(identity);
     let current = metrics.get(key);
     if (!current) {
       current = emptyMetrics();
@@ -70,7 +67,9 @@ export function attachProjectMetrics(
   }
 
   return projects.map((project) => {
-    const metric = metrics.get(getProjectGroupKey(project.identityKind, project.identityKey));
+    const metric = metrics.get(
+      getProjectIdentityKey({ kind: project.identityKind, key: project.identityKey }),
+    );
     return {
       ...project,
       messages: metric?.messages ?? 0,

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -23,6 +23,7 @@ describe("contract browser-safety", () => {
     const contract = await import(distEntry);
     expect(Object.keys(contract).sort()).toEqual(
       [
+        "PROJECT_IDENTITY_KINDS",
         "SAMPLE_DASHBOARD_DATA",
         "SAMPLE_SCAN_STATUS_EVENT",
         "SAMPLE_SESSIONS_UPDATED_EVENT",
@@ -40,6 +41,8 @@ describe("contract browser-safety", () => {
         "getSessionAgentKey",
         "getSessionRouteKey",
         "getSessionRoutePath",
+        "isProjectIdentityKind",
+        "matchesProjectIdentity",
         "mergeSortedSessions",
         "normalizeMessageParts",
         "normalizeSessionReference",

--- a/packages/core/src/contract/__tests__/project-identity.test.ts
+++ b/packages/core/src/contract/__tests__/project-identity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROJECT_IDENTITY_KINDS,
+  getProjectAgentKey,
+  getProjectIdentityKey,
+  isProjectIdentityKind,
+  matchesProjectIdentity,
+} from "../project-identity.js";
+
+/** A representative key per kind, including ones with URL-significant characters. */
+const KEY_BY_KIND = {
+  git_remote: "github.com/acme/app",
+  git_common_dir: "/Users/dev/work/app/.git",
+  manifest_path: "/Users/dev/work/app/package.json",
+  synthetic: "app@2",
+  path: "/Users/dev/scratch/a b",
+  loose: "~/Downloads",
+} as const;
+
+describe("CS-153: project identity", () => {
+  it("covers every kind in the closed set", () => {
+    expect(Object.keys(KEY_BY_KIND).sort()).toEqual([...PROJECT_IDENTITY_KINDS].sort());
+  });
+
+  // These strings reach SQLite rows and API responses, so they are wire format.
+  it.each(PROJECT_IDENTITY_KINDS)("encodes a %s identity key unchanged", (kind) => {
+    const key = KEY_BY_KIND[kind];
+
+    expect(getProjectIdentityKey({ kind, key })).toBe(`${kind}:${key}`);
+  });
+
+  it.each(PROJECT_IDENTITY_KINDS)("recognizes %s as a kind", (kind) => {
+    expect(isProjectIdentityKind(kind)).toBe(true);
+  });
+
+  it.each(["", "git", "GIT_REMOTE", "unknown", "path:extra"])("rejects %j as a kind", (value) => {
+    expect(isProjectIdentityKind(value)).toBe(false);
+  });
+
+  it("matches only on both fields", () => {
+    const identity = { kind: "path", key: "/repo" } as const;
+
+    expect(matchesProjectIdentity(identity, { kind: "path", key: "/repo" })).toBe(true);
+    expect(matchesProjectIdentity(identity, { kind: "loose", key: "/repo" })).toBe(false);
+    expect(matchesProjectIdentity(identity, { kind: "path", key: "/other" })).toBe(false);
+    expect(matchesProjectIdentity(null, { kind: "path", key: "/repo" })).toBe(false);
+    expect(matchesProjectIdentity(undefined, { kind: "path", key: "/repo" })).toBe(false);
+  });
+
+  it("keeps two identities distinct when one key is a prefix of the other", () => {
+    const shorter = getProjectIdentityKey({ kind: "path", key: "/repo" });
+    const longer = getProjectIdentityKey({ kind: "path", key: "/repo/nested" });
+
+    expect(shorter).not.toBe(longer);
+  });
+
+  it("scopes a project key to one agent, case-insensitively", () => {
+    const projectKey = getProjectIdentityKey({ kind: "path", key: "/repo" });
+
+    expect(getProjectAgentKey(projectKey, "Codex")).toBe(getProjectAgentKey(projectKey, "codex"));
+    expect(getProjectAgentKey(projectKey, "codex")).not.toBe(
+      getProjectAgentKey(projectKey, "claudecode"),
+    );
+    // The separator cannot appear in an agent name, so keys stay unambiguous.
+    expect(getProjectAgentKey(projectKey, "codex")).toContain("\0");
+  });
+});

--- a/packages/core/src/contract/__tests__/session-index.test.ts
+++ b/packages/core/src/contract/__tests__/session-index.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { SessionHead } from "../session.js";
+import { getProjectAgentKey } from "../project-identity.js";
 import {
   applySessionChanges,
   createSessionIndex,
-  getProjectAgentKey,
   getSessionRouteKey,
   mergeSortedSessions,
   sortSessionsByActivity,

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -7,6 +7,7 @@ export type * from "./bookmarks.js";
 export type * from "./dashboard.js";
 export type * from "./events.js";
 export * from "./calendar-day.js";
+export * from "./project-identity.js";
 export * from "./session-reference.js";
 export * from "./session-index.js";
 export type * from "./api.js";

--- a/packages/core/src/contract/project-identity.ts
+++ b/packages/core/src/contract/project-identity.ts
@@ -1,0 +1,60 @@
+/**
+ * What a project identity is, independent of how it is discovered or displayed.
+ *
+ * The same facts used to be restated in five places: the kind union here, a kind
+ * Set and `kind:key` encoding in the Node resolver, another `getProjectIdentityKey`
+ * in the session index, a private group key in analytics, and a third copy in the
+ * web adapter. Adding a kind meant editing all of them, and nothing failed if one
+ * was missed.
+ *
+ * This module owns the closed set, the identity key, and identity comparison.
+ * Discovering identities from the filesystem lives in `projects/identity.ts`;
+ * encoding them into URLs lives in the web adapter. Both sit outside this one.
+ */
+
+/**
+ * Every kind of project identity, most specific first. The order is documentation,
+ * not behavior. These values appear in SQLite rows and API responses, so they
+ * cannot be renamed without a migration.
+ */
+export const PROJECT_IDENTITY_KINDS = [
+  "git_remote",
+  "git_common_dir",
+  "manifest_path",
+  "synthetic",
+  "path",
+  "loose",
+] as const;
+
+export type ProjectIdentityKind = (typeof PROJECT_IDENTITY_KINDS)[number];
+
+export interface ProjectIdentityRef {
+  kind: ProjectIdentityKind;
+  key: string;
+}
+
+const KIND_LOOKUP = new Set<string>(PROJECT_IDENTITY_KINDS);
+
+export function isProjectIdentityKind(value: string): value is ProjectIdentityKind {
+  return KIND_LOOKUP.has(value);
+}
+
+/**
+ * Stable key for grouping and lookup. This is not a URL: route encoding is a
+ * separate adapter, and conflating the two would put an escaped key in storage.
+ */
+export function getProjectIdentityKey(identity: ProjectIdentityRef): string {
+  return `${identity.kind}:${identity.key}`;
+}
+
+export function matchesProjectIdentity(
+  identity: ProjectIdentityRef | null | undefined,
+  expected: ProjectIdentityRef,
+): boolean {
+  return identity?.kind === expected.kind && identity.key === expected.key;
+}
+
+/** Key for one agent's slice of a project. */
+export function getProjectAgentKey(projectIdentityKey: string, agentName: string): string {
+  return `${projectIdentityKey}\0${agentName.toLowerCase()}`;
+}

--- a/packages/core/src/contract/session-index.ts
+++ b/packages/core/src/contract/session-index.ts
@@ -1,4 +1,5 @@
-import type { ProjectIdentity, ReferencedSessionHead, SessionHead } from "./session.js";
+import type { ReferencedSessionHead, SessionHead } from "./session.js";
+import { getProjectAgentKey, getProjectIdentityKey } from "./project-identity.js";
 import {
   formatSessionReference,
   getSessionAgentKey,
@@ -69,14 +70,6 @@ export function mergeSortedSessions(shards: SessionHead[][]): SessionHead[] {
 
 export function getSessionRouteKey(agentName: string, sessionId: string): string {
   return formatSessionReference({ agentName, sessionId });
-}
-
-export function getProjectIdentityKey(identity: Pick<ProjectIdentity, "kind" | "key">): string {
-  return `${identity.kind}:${identity.key}`;
-}
-
-export function getProjectAgentKey(projectIdentityKey: string, agentName: string): string {
-  return `${projectIdentityKey}\0${agentName.toLowerCase()}`;
 }
 
 function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -1,3 +1,4 @@
+import type { ProjectIdentityKind } from "./project-identity.js";
 import type { SessionReference } from "./session-reference.js";
 
 export interface SessionStats {
@@ -44,21 +45,13 @@ export interface SessionFileActivityOccurrence {
   tool_index: number;
 }
 
-export type ProjectIdentityKind =
-  | "git_remote"
-  | "git_common_dir"
-  | "manifest_path"
-  | "synthetic"
-  | "path"
-  | "loose";
+export type { ProjectIdentityKind, ProjectIdentityRef } from "./project-identity.js";
 
 export interface ProjectIdentity {
   kind: ProjectIdentityKind;
   key: string;
   displayName: string;
 }
-
-export type ProjectIdentityRef = Pick<ProjectIdentity, "kind" | "key">;
 
 export interface ProjectGroup {
   identityKind: ProjectIdentityKind;

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -1,6 +1,6 @@
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ProjectIdentity, ProjectIdentityKind, ProjectIdentityRef } from "../types/index.js";
+import type { ProjectIdentity, ProjectIdentityKind } from "../types/index.js";
 import { fallbackDisplayName } from "./display-name.js";
 import { realFs } from "./fs.js";
 
@@ -24,33 +24,18 @@ const PARSEABLE_MANIFESTS = ["package.json", "Cargo.toml", "pyproject.toml"] as 
 
 const LOOSE_DIRS = new Set(["/tmp", "/private/tmp"]);
 const LOOSE_HOME_DIRS = ["Desktop", "Downloads", "Documents"];
-const PROJECT_IDENTITY_KINDS = new Set<ProjectIdentityKind>([
-  "git_remote",
-  "git_common_dir",
-  "manifest_path",
-  "synthetic",
-  "path",
-  "loose",
-]);
 type PathOps = Pick<
   typeof path.posix,
   "dirname" | "isAbsolute" | "join" | "relative" | "resolve" | "sep"
 >;
 
-export function isProjectIdentityKind(value: string): value is ProjectIdentityKind {
-  return PROJECT_IDENTITY_KINDS.has(value as ProjectIdentityKind);
-}
-
-export function getProjectIdentityKey(identity: ProjectIdentityRef): string {
-  return `${identity.kind}:${identity.key}`;
-}
-
-export function matchesProjectIdentity(
-  identity: ProjectIdentityRef | null | undefined,
-  expected: ProjectIdentityRef,
-): boolean {
-  return identity?.kind === expected.kind && identity.key === expected.key;
-}
+// Identity semantics live in the contract; this module only discovers them
+// from the filesystem and git.
+export {
+  getProjectIdentityKey,
+  isProjectIdentityKind,
+  matchesProjectIdentity,
+} from "../contract/project-identity.js";
 
 export function normalizeGitRemote(url: string): string | null {
   if (!url) return null;


### PR DESCRIPTION
## Problem

The same identity facts were restated across five modules:

- `contract/session.ts` declared the kind union
- `projects/identity.ts` kept its own kind Set plus `kind:key` encoding and comparison
- `contract/session-index.ts` re-implemented `getProjectIdentityKey()`
- `analytics/projects.ts` had a private group-key encoding
- `apps/web/src/lib/projects.ts` kept a third kind Set and a third key encoding, and
  `SessionTreeSidebar` inlined the format again

Adding a kind or changing the key rule meant editing Node, the browser-safe contract, analytics and
the web app — and nothing failed if one was missed.

## Change

`contract/project-identity.ts` owns the closed kind set, the identity key, identity comparison and
the project-agent key. The union is derived from that set, so a new kind is declared once.

What sits outside it stays outside:

- `projects/identity.ts` keeps only the filesystem and git work that *discovers* an identity, and
  re-exports the semantics rather than restating them
- the web adapter keeps only URL encoding — a route key is percent-encoded, an identity key is not,
  and conflating them would put an escaped key into storage
- analytics and the session index consume the canonical key instead of building their own

No wire or SQLite meaning changes: the kind strings and `kind:key` format are byte-for-byte what
they were.

## Verification

- a characterization matrix covers all six kinds, including keys with spaces, `@` and `.git`
  suffixes, asserting the encoded key is unchanged per kind
- kind recognition rejects empty strings, wrong case and near-misses
- comparison requires both fields and treats null/undefined as no match; a key that is a prefix of
  another stays distinct
- the agent key is case-insensitive on the agent name and keeps its unambiguous separator
- `rg` confirms `kind:key` is now built in exactly one place
- the browser-safe contract test covers the new exports
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 588, cli 304, web 467 passing
- `pnpm test:e2e` — 24 passing