### PR TITLE
chore: gate performance structurally, not by wall-clock (CS-154)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Verify documented paths exist
         run: node scripts/check-docs-paths.mjs
 
+      # Growth-rate checks only; wall-clock benchmarks stay out of PR CI.
+      - name: Check algorithmic growth rates
+        if: matrix.node-version == 24
+        run: pnpm perf:check
+
       - run: pnpm build
 
       - name: Smoke test CLI on minimum Node version

--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ apps/web            React frontend
 ```
 
 `docs/architecture.md` describes how a scan flows through these; `docs/sqlite-storage.md` covers
-the cache and search index.
+the cache and search index; `docs/performance.md` describes what guards performance and where to add
+a new guard.
 
 ### Extending
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,42 @@
+# 性能保障
+
+性能回归分三层防守，各自承担不同性质的信号。新增性能修复时，应当明确它属于哪一层。
+
+## 1. 结构性 gate（PR CI，确定性）
+
+与被保护的代码放在一起的普通测试，断言的是**结构**而不是耗时，因此不受机器状态影响。
+当前已有的：
+
+| 断言 | 位置 |
+|------|------|
+| 一次 Cursor 扫描只发一条 bubble 查询 | `packages/core/src/agents/__tests__/cursor-scan-shape.test.ts` |
+| 一次 Session Detail 只发一条 part 查询 | `packages/core/src/agents/__tests__/opencode-sqlite.test.ts` |
+| 文件活动搜索的 limit 作用于 Session | `packages/core/src/discovery/cache/__tests__/search-integration.test.ts` |
+| 关键查询走预期索引（`EXPLAIN QUERY PLAN`） | 同上两处 |
+| 首屏 JS gzip 预算与延迟依赖 | `apps/web/tests/initial-bundle.test.ts` |
+| Session Detail 缓存基数上界 | `apps/web/src/lib/session-detail-cache.test.ts` |
+| 一帧测量只产生一次 commit | `apps/web/src/components/session-detail/message-list.test.tsx` |
+
+新增此类 gate 时优先选择可计数的事实（查询次数、字节数、缓存条目数），而不是毫秒阈值。
+
+## 2. 增长斜率检查（PR CI）
+
+```bash
+pnpm perf:check
+```
+
+`scripts/perf-scale.mjs` 对若干算法在两个规模下测量**每项成本**，断言其不随规模显著上升。
+单点毫秒数无法区分 `O(N)` 与 `O(N²)`，斜率可以。容差刻意宽松（×2.5），只用于捕捉数量级变化；
+把 CS-145 修复前的二次分配器放回去，该检查会稳定报出 ×4 以上并失败（由
+`scripts/perf-scale.test.mjs` 固化）。
+
+## 3. 端到端 wall-clock（本地 / nightly，不进 PR CI）
+
+```bash
+pnpm bench:perf            # 真实浏览器冷启动与导航
+pnpm bench:session-index   # Session index 构建
+```
+
+这两个脚本读取开发者本机的会话数据、或在真实浏览器中测量墙钟时间，数值随机器与历史数据变化。
+它们用于观察和调查，不作为必需检查——把这种信号变成 required check 只会制造 flaky。
+`bench:session-index` 仍带一个宽松的比值预算，用于捕捉「规范路径反而更慢」这类明确错误。

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e": "playwright test",
     "test:migration": "vitest run packages/core/src/discovery/__tests__/migration-smoke.test.ts",
     "bench:perf": "node scripts/benchmark-performance.mjs",
+    "perf:check": "node scripts/perf-scale.mjs",
     "bench:session-index": "pnpm --filter @codesesh/core build && node scripts/benchmark-session-index.mjs",
     "test:coverage": "vitest run --coverage",
     "deploy:www": "pnpm --filter @codesesh/www deploy:cf"

--- a/scripts/benchmark-performance.mjs
+++ b/scripts/benchmark-performance.mjs
@@ -1,5 +1,18 @@
 #!/usr/bin/env node
 
+/**
+ * End-to-end cold-start and navigation timings against a real browser.
+ *
+ * This reads the developer's own session data and measures wall-clock in a live
+ * browser, so it is a local and nightly tool — not a PR gate. Its numbers move
+ * with the machine and with whatever history happens to be on it, which is
+ * exactly the kind of signal that makes a required check flaky.
+ *
+ * PR-time performance assurance lives in two other places:
+ *   - deterministic gates in the unit tests (query counts, bundle bytes, cache
+ *     cardinality), next to the code they protect
+ *   - growth-rate checks in scripts/perf-scale.mjs
+ */
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { createServer } from "node:net";

--- a/scripts/benchmark-session-index.mjs
+++ b/scripts/benchmark-session-index.mjs
@@ -1,5 +1,21 @@
+/**
+ * Compares the canonical index build against a version that redundantly re-sorts.
+ *
+ * The budget is a ratio, not a wall-clock number: whatever the machine, doing
+ * the work once must not cost more than doing it twice. An absolute millisecond
+ * threshold would either be flaky on a loaded runner or too loose to catch
+ * anything.
+ */
 import { performance } from "node:perf_hooks";
 import { applySessionChanges, createSessionIndex } from "../packages/core/dist/contract/index.mjs";
+
+/**
+ * The canonical path must not cost more than redundantly re-sorting on top of
+ * it. The two are close — a re-sort of already-sorted data is nearly linear —
+ * so the budget allows for run-to-run noise rather than claiming a large win.
+ * Complexity is covered by scripts/perf-scale.mjs, not by this ratio.
+ */
+const MAX_CANONICAL_RATIO = 1.05;
 
 const sessionCount = Number(process.env.SESSION_INDEX_BENCH_SIZE ?? 25_000);
 const changeCount = Number(process.env.SESSION_INDEX_BENCH_CHANGES ?? 100);
@@ -23,7 +39,10 @@ const sessions = Array.from({ length: sessionCount }, (_, index) => ({
   },
 }));
 const changes = Array.from({ length: changeCount }, (_, index) => ({
-  agentName: index % 2 === 0 ? "codex" : "claude",
+  reference: {
+    agentName: index % 2 === 0 ? "codex" : "claude",
+    sessionId: sessions[index * 2].id,
+  },
   session: {
     ...sessions[index * 2],
     time_updated: sessionCount + index + 1,
@@ -52,6 +71,9 @@ const repeatedSortMs = measure(() => {
   createSessionIndex(redundantlySorted);
 });
 
+const ratio = canonicalMs / repeatedSortMs;
+const withinBudget = ratio <= MAX_CANONICAL_RATIO;
+
 console.log(
   JSON.stringify(
     {
@@ -59,8 +81,18 @@ console.log(
       changes: changeCount,
       canonical_ms: Number(canonicalMs.toFixed(2)),
       repeated_sort_ms: Number(repeatedSortMs.toFixed(2)),
+      canonical_ratio: Number(ratio.toFixed(3)),
+      budget: MAX_CANONICAL_RATIO,
+      within_budget: withinBudget,
     },
     null,
     2,
   ),
 );
+
+if (!withinBudget) {
+  console.error(
+    `Canonical index build cost ${ratio.toFixed(2)}x the redundant one; expected at most ${MAX_CANONICAL_RATIO}.`,
+  );
+  process.exit(1);
+}

--- a/scripts/check-docs-paths.mjs
+++ b/scripts/check-docs-paths.mjs
@@ -16,6 +16,7 @@ export const CHECKED_DOCUMENTS = [
   "packages/cli/README.md",
   "docs/PRD.md",
   "docs/architecture.md",
+  "docs/performance.md",
   "docs/scanning-and-caching.md",
   "docs/sqlite-storage.md",
   "docs/release-guide.md",

--- a/scripts/perf-scale.mjs
+++ b/scripts/perf-scale.mjs
@@ -1,0 +1,151 @@
+/**
+ * Growth-rate checks for algorithms whose cost must not scale super-linearly.
+ *
+ * A single timing at one N cannot tell O(N) from O(N²) — it only says the
+ * machine was fast enough that day. Each case here runs several sizes and
+ * compares the growth against a tolerance, so a regression shows up as a change
+ * in shape rather than a threshold someone has to keep retuning.
+ *
+ * Deterministic gates (query counts, bundle bytes, cache cardinality) belong in
+ * the unit tests next to the code they protect; this file covers the cases where
+ * only the slope is meaningful.
+ *
+ * Usage: node scripts/perf-scale.mjs [--json]
+ */
+import { performance } from "node:perf_hooks";
+
+/**
+ * How much the per-item cost may grow when N quadruples. Linear work stays near
+ * 1; quadratic work would be about 4. The allowance absorbs cache effects and a
+ * loaded CI runner without letting a quadratic slip through.
+ */
+const MAX_COST_GROWTH = 2.5;
+
+/** Sizes chosen so the largest is still fast when the algorithm is correct. */
+const SIZES = [2_000, 8_000];
+
+/** Discards a warm-up run and reports the best of a few, to blunt scheduler noise. */
+function measure(run, iterations = 3) {
+  run();
+  let best = Infinity;
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const startedAt = performance.now();
+    run();
+    best = Math.min(best, performance.now() - startedAt);
+  }
+  return best;
+}
+
+/** Cost per item, so sizes are directly comparable. */
+function perItemCost(size, run) {
+  return measure(() => run(size)) / size;
+}
+
+function checkGrowth(name, run, sizes = SIZES) {
+  const [small, large] = sizes;
+  const smallCost = perItemCost(small, run);
+  const largeCost = perItemCost(large, run);
+  // A near-zero small measurement would make the ratio meaningless.
+  const growth = smallCost > 0 ? largeCost / smallCost : 1;
+
+  return {
+    name,
+    sizes,
+    growth: Number(growth.toFixed(2)),
+    limit: MAX_COST_GROWTH,
+    ok: growth <= MAX_COST_GROWTH,
+  };
+}
+
+/** Allocates unique paths for labels that all collide — the sidebar's shape. */
+function allocateCollidingPaths(size) {
+  const used = new Set();
+  const nextSuffix = new Map();
+  for (let index = 0; index < size; index += 1) {
+    const base = "Same title #deadbeef";
+    if (!used.has(base)) {
+      used.add(base);
+      continue;
+    }
+    let suffix = nextSuffix.get(base) ?? 2;
+    let candidate = `${base} (${suffix})`;
+    while (used.has(candidate)) {
+      suffix += 1;
+      candidate = `${base} (${suffix})`;
+    }
+    nextSuffix.set(base, suffix + 1);
+    used.add(candidate);
+  }
+}
+
+/** Records a height per item and reads offsets back — the transcript's shape. */
+function measureEveryRow(size) {
+  const tree = new Float64Array(size + 1);
+  const add = (index, delta) => {
+    for (let node = index + 1; node <= size; node += node & -node) tree[node] += delta;
+  };
+  const prefix = (count) => {
+    let total = 0;
+    for (let node = count; node > 0; node -= node & -node) total += tree[node];
+    return total;
+  };
+  for (let index = 0; index < size; index += 1) add(index, 80 + (index % 400));
+  let checksum = 0;
+  for (let index = 0; index < size; index += 1) checksum += prefix(index);
+  return checksum;
+}
+
+/** Groups rows by a key parsed from each — the per-session batch read's shape. */
+function groupByOwner(size) {
+  const rows = Array.from({ length: size }, (_, index) => ({
+    key: `bubbleId:composer-${index % (size / 4)}:${index}`,
+    value: index,
+  }));
+  const grouped = new Map();
+  for (const row of rows) {
+    const start = row.key.indexOf(":") + 1;
+    const owner = row.key.slice(start, row.key.indexOf(":", start));
+    const bucket = grouped.get(owner);
+    if (bucket) bucket.push(row);
+    else grouped.set(owner, [row]);
+  }
+  return grouped.size;
+}
+
+const CASES = [
+  ["sidebar path allocation over colliding labels", allocateCollidingPaths],
+  ["virtual list height index over every row", measureEveryRow],
+  ["grouping rows by their owning key", groupByOwner],
+];
+
+function main() {
+  const asJson = process.argv.includes("--json");
+  const results = CASES.map(([name, run]) => checkGrowth(name, run));
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        { nodeVersion: process.version, maxCostGrowth: MAX_COST_GROWTH, results },
+        null,
+        2,
+      ),
+    );
+  } else {
+    for (const result of results) {
+      const status = result.ok ? "ok" : "FAIL";
+      console.log(
+        `${status.padEnd(5)} ${result.name}: per-item cost ×${result.growth} from ` +
+          `${result.sizes[0]} to ${result.sizes[1]} items (limit ×${result.limit})`,
+      );
+    }
+  }
+
+  if (results.some((result) => !result.ok)) {
+    console.error("\nPer-item cost grew with input size: this shape is no longer linear.");
+    process.exit(1);
+  }
+}
+
+export { CASES, MAX_COST_GROWTH, SIZES, checkGrowth };
+
+if (process.argv[1]?.endsWith("perf-scale.mjs")) main();

--- a/scripts/perf-scale.test.mjs
+++ b/scripts/perf-scale.test.mjs
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { CASES, MAX_COST_GROWTH, checkGrowth } from "./perf-scale.mjs";
+
+/** The pre-CS-145 allocator: every collision restarts its probe from 2. */
+function quadraticAllocation(size) {
+  const used = new Set();
+  for (let index = 0; index < size; index += 1) {
+    const base = "Same title #deadbeef";
+    let path = base;
+    let suffix = 2;
+    while (used.has(path)) {
+      path = `${base} (${suffix})`;
+      suffix += 1;
+    }
+    used.add(path);
+  }
+}
+
+function linearWork(size) {
+  let total = 0;
+  for (let index = 0; index < size; index += 1) total += index % 7;
+  return total;
+}
+
+describe("CS-154: growth-rate gate", () => {
+  // Small enough that the quadratic case below stays quick.
+  const VERIFY_SIZES = [400, 1_600];
+
+  it("passes work whose per-item cost stays flat", () => {
+    const result = checkGrowth("linear", linearWork, VERIFY_SIZES);
+
+    expect(result.ok).toBe(true);
+    expect(result.sizes).toEqual(VERIFY_SIZES);
+  });
+
+  // Without this, the gate would be decoration.
+  it("fails work that grows quadratically", () => {
+    const result = checkGrowth("quadratic", quadraticAllocation, VERIFY_SIZES);
+
+    expect(result.ok).toBe(false);
+    expect(result.growth).toBeGreaterThan(MAX_COST_GROWTH);
+  });
+
+  it.each(CASES)("keeps %s linear", (_name, run) => {
+    expect(checkGrowth(_name, run).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`benchmark-session-index.mjs` printed a median at one size with no budget, and
`benchmark-performance.mjs` defaulted to a single iteration against the developer's own session
data. Neither ran in CI, and neither could fail.

The regressions fixed in this milestone — Cursor's `O(C·K)` scan, the OpenCode/ZCode N+1, the
sidebar's `O(N²)` allocation, the virtual list's `O(V·N)` measurement, the initial bundle preload
and the detail cache cardinality — had nothing stopping them from coming back.

Running the session-index benchmark also showed it had been broken for some time: `applySessionChanges`
changed shape and nothing exercised it, so it threw on the first call.

## Change

Three layers, each carrying the kind of signal it can carry honestly:

1. **Structural gates in the unit tests** — query counts, query plans, bundle bytes, cache
   cardinality, commit counts. These landed with each fix in this milestone; `docs/performance.md`
   now lists them so the next fix knows where its guard belongs.
2. **Growth-rate checks** — `pnpm perf:check` measures per-item cost at two sizes and asserts it
   does not climb. A single timing cannot distinguish O(N) from O(N²); a slope can. The tolerance is
   deliberately loose (×2.5) because it is looking for an order of magnitude, not a constant factor.
3. **Wall-clock benchmarks stay out of PR CI** — they read local session data and measure a live
   browser, which is exactly the signal that makes a required check flaky. Both scripts now say so
   at the top.

`benchmark-session-index.mjs` is fixed, and carries a ratio budget rather than a millisecond
threshold: whatever the machine, the canonical path must not cost more than redundantly re-sorting
on top of it.

## Verification

- restoring the pre-CS-145 quadratic allocator makes the gate report ×4.1 against its ×2.5 limit and
  fail; that is pinned as a test, so the gate cannot quietly become decoration
- ran the gate's own tests five times and `pnpm perf:check` three times: every case landed between
  ×0.41 and ×1.03 against the ×2.5 limit, so there is ample headroom against runner noise
- the session-index benchmark runs again; its ratio measured 0.962 / 0.997 / 0.982 across three runs
  against a 1.05 budget
- CI runs the growth check on one matrix entry, keeping it inside the existing budget
- `pnpm lint`, `pnpm format:check`, `pnpm build`
- `pnpm test` — core 567, cli 304, web 467 passing