### PR TITLE
Fix session timeline rendering and loading stalls

### DIFF
--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -1,10 +1,15 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ApiProjectGroup } from "../../lib/api";
-import type { SessionDetail } from "../../lib/api";
+import type { ApiProjectGroup, SessionDetail } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
 import { AppRouteContent } from "./AppRouteContent";
+
+vi.mock("../SessionDetail", () => ({
+  SessionDetail: ({ session }: { session: SessionDetail }) => (
+    <div data-testid="session-detail">{session.id}</div>
+  ),
+}));
 
 const LAZY_SURFACE_TIMEOUT_MS = 5_000;
 

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiProjectGroup } from "../../lib/api";
+import type { SessionDetail } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
 import { AppRouteContent } from "./AppRouteContent";
 
@@ -67,6 +68,24 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
   };
 }
 
+function makeSession(id: string): SessionDetail {
+  return {
+    reference: { agentName: "claudecode", sessionId: id },
+    id,
+    slug: `claudecode/${id}`,
+    title: `Session ${id}`,
+    directory: "/repo",
+    time_created: 1,
+    stats: {
+      message_count: 0,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    messages: [],
+  };
+}
+
 afterEach(cleanup);
 
 describe("AppRouteContent", () => {
@@ -115,5 +134,39 @@ describe("AppRouteContent", () => {
         { timeout: LAZY_SURFACE_TIMEOUT_MS },
       ),
     ).toBeTruthy();
+  });
+
+  it("remounts session-scoped UI when the route changes to another session", async () => {
+    const props = makeProps();
+    props.viewState = {
+      mode: "session",
+      activeAgentKey: "claudecode",
+      activeSessionId: "session-a",
+    };
+    props.sessionDetail.session = makeSession("session-a");
+    const view = render(
+      <MemoryRouter>
+        <AppRouteContent {...props} />
+      </MemoryRouter>,
+    );
+    const firstDetail = await screen.findByTestId(
+      "session-detail",
+      {},
+      { timeout: LAZY_SURFACE_TIMEOUT_MS },
+    );
+
+    props.viewState = {
+      mode: "session",
+      activeAgentKey: "claudecode",
+      activeSessionId: "session-b",
+    };
+    props.sessionDetail.session = makeSession("session-b");
+    view.rerender(
+      <MemoryRouter>
+        <AppRouteContent {...props} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId("session-detail")).not.toBe(firstDetail);
   });
 });

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -256,6 +256,7 @@ export function AppRouteContent({
       >
         <LazySurface>
           <SessionDetail
+            key={`${sessionDetail.session.reference.agentName}/${sessionDetail.session.reference.sessionId}`}
             session={sessionDetail.session}
             agentCatalog={agentCatalog}
             highlightQuery={detailHighlightQuery}

--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -173,7 +173,11 @@ describe("SessionMessageTimeline", () => {
     expect(track.style.minWidth).toBe("1099px");
     expect(track.style.gridTemplateColumns).toBe("");
     expect(track.querySelectorAll("[data-timeline-index]")).toHaveLength(34);
-    expect((track.firstElementChild as HTMLElement).style.width).toBe("calc(1% - 0.99px)");
+    const firstSegment = track.firstElementChild as HTMLElement;
+    expect(firstSegment.style.position).toBe("absolute");
+    expect(firstSegment.style.top).toBe("0px");
+    expect(firstSegment.style.bottom).toBe("0px");
+    expect(firstSegment.style.width).toBe("calc(1% - 0.99px)");
 
     fireEvent.click(getByRole("button", { name: "Scroll timeline right" }));
 

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -124,6 +124,9 @@ function getVirtualizedSegmentStyle(
 ): CSSProperties {
   const segmentWidth = 100 / entryCount;
   return {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
     left: `calc(${index * segmentWidth}% + ${(index * gapWidth) / entryCount}px)`,
     width: `calc(${segmentWidth}% - ${((entryCount - 1) * gapWidth) / entryCount}px)`,
   };
@@ -143,7 +146,7 @@ const TimelineSegment = memo(function TimelineSegment({
   const tooltipId = `timeline-tooltip-${entry.id}`;
   return (
     <span
-      className={`t-tt-wrap session-timeline-item min-w-0 ${virtualized ? "absolute inset-y-0" : ""}`}
+      className="session-timeline-item min-w-0"
       style={virtualized ? getVirtualizedSegmentStyle(index, entryCount, gapWidth) : undefined}
     >
       <button

--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -1,4 +1,5 @@
-import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { SAMPLE_SESSIONS_UPDATED_EVENT } from "@codesesh/core/contract";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionsUpdatedEvent } from "../lib/api";
 import * as api from "../lib/api";
@@ -48,27 +49,53 @@ describe("useLiveSync", () => {
   });
 
   it("forwards session events to the store", async () => {
+    vi.useFakeTimers();
     const deps = makeDeps();
     renderHook(() => useLiveSync(deps));
-    const event = { newSessions: 0 } as SessionsUpdatedEvent;
+    const event = SAMPLE_SESSIONS_UPDATED_EVENT;
 
     await act(async () => {
       sessionsCallback?.(event);
-      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(500);
     });
 
     expect(deps.applyLiveEvent).toHaveBeenCalledWith(event);
   });
 
   it("surfaces a notice when new sessions arrive", async () => {
+    vi.useFakeTimers();
     const { result } = renderHook(() => useLiveSync(makeDeps()));
 
     await act(async () => {
-      sessionsCallback?.({ newSessions: 3 } as SessionsUpdatedEvent);
-      await Promise.resolve();
+      sessionsCallback?.({ ...SAMPLE_SESSIONS_UPDATED_EVENT, newSessions: 3 });
+      await vi.advanceTimersByTimeAsync(500);
     });
 
-    await waitFor(() => expect(result.current.liveNotice).toContain("3"));
+    expect(result.current.liveNotice).toContain("3");
+  });
+
+  it("merges burst updates into one store refresh", async () => {
+    vi.useFakeTimers();
+    const deps = makeDeps();
+    renderHook(() => useLiveSync(deps));
+
+    await act(async () => {
+      sessionsCallback?.({ ...SAMPLE_SESSIONS_UPDATED_EVENT, newSessions: 1 });
+      sessionsCallback?.({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        newSessions: 2,
+        timestamp: SAMPLE_SESSIONS_UPDATED_EVENT.timestamp + 1,
+      });
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(deps.applyLiveEvent).toHaveBeenCalledOnce();
+    expect(deps.applyLiveEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        newSessions: 3,
+        timestamp: SAMPLE_SESSIONS_UPDATED_EVENT.timestamp + 1,
+      }),
+    );
   });
 
   it("shows a persistent connection notice on disconnect", () => {

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -1,4 +1,5 @@
-import { useEffect, useEffectEvent, useState } from "react";
+import { mergeSessionsUpdatedEvents } from "@codesesh/core/contract";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import {
   type ScanStatusEvent,
   type SessionsUpdatedEvent,
@@ -12,9 +13,14 @@ interface LiveSyncDeps {
   setScanStatus: (event: ScanStatusEvent) => void;
 }
 
+const LIVE_UPDATE_WINDOW_MS = 500;
+
 export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: LiveSyncDeps) {
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [connectionNotice, setConnectionNotice] = useState<string | null>(null);
+  const pendingEventRef = useRef<SessionsUpdatedEvent | null>(null);
+  const pendingTimerRef = useRef<number | null>(null);
+  const updateChainRef = useRef(Promise.resolve());
 
   const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
     try {
@@ -27,9 +33,26 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
     }
   });
 
+  const flushLiveUpdate = useEffectEvent(() => {
+    pendingTimerRef.current = null;
+    const event = pendingEventRef.current;
+    pendingEventRef.current = null;
+    if (!event) return;
+    updateChainRef.current = updateChainRef.current.then(() => syncLiveUpdate(event));
+  });
+
+  const clearPendingLiveUpdate = useEffectEvent(() => {
+    pendingEventRef.current = null;
+    if (pendingTimerRef.current === null) return;
+    window.clearTimeout(pendingTimerRef.current);
+    pendingTimerRef.current = null;
+  });
+
   const handleReconnect = useEffectEvent(async () => {
+    clearPendingLiveUpdate();
     setConnectionNotice(null);
     try {
+      await updateChainRef.current;
       await resyncLiveState();
     } catch (error) {
       console.error("Failed to resync live session state:", error);
@@ -39,7 +62,13 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
   useEffect(() => {
     return subscribeSessionUpdates(
       (event) => {
-        void syncLiveUpdate(event);
+        pendingEventRef.current = pendingEventRef.current
+          ? mergeSessionsUpdatedEvents(pendingEventRef.current, event)
+          : event;
+        pendingTimerRef.current ??= window.setTimeout(
+          () => flushLiveUpdate(),
+          LIVE_UPDATE_WINDOW_MS,
+        );
       },
       setScanStatus,
       () => void handleReconnect(),
@@ -48,6 +77,8 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
       },
     );
   }, [setScanStatus]);
+
+  useEffect(() => () => clearPendingLiveUpdate(), []);
 
   useEffect(() => {
     if (!liveNotice) return;

--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { SessionDetail } from "../lib/api";
 import type { ViewState } from "../lib/view-state";
 import * as api from "../lib/api";
+import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionDetail } from "./useSessionDetail";
 
@@ -30,11 +31,14 @@ function deferred<T>() {
 }
 
 function renderSessionDetail(view: ViewState = sessionView) {
-  const { Wrapper } = createQueryWrapper();
-  return renderHook(({ currentView }) => useSessionDetail(currentView), {
-    initialProps: { currentView: view },
-    wrapper: Wrapper,
-  });
+  const { client, Wrapper } = createQueryWrapper();
+  return {
+    client,
+    ...renderHook(({ currentView }) => useSessionDetail(currentView), {
+      initialProps: { currentView: view },
+      wrapper: Wrapper,
+    }),
+  };
 }
 
 afterEach(() => {
@@ -83,6 +87,34 @@ describe("useSessionDetail", () => {
       await result.current.refresh();
     });
     await waitFor(() => expect(result.current.session).toEqual(updated));
+  });
+
+  it("reuses a cached detail when returning to a session route", async () => {
+    vi.mocked(api.fetchSessionData).mockResolvedValue(sample);
+    const rootView: ViewState = { mode: "root", activeAgentKey: null, activeSessionId: null };
+    const { result, rerender } = renderSessionDetail();
+    await waitFor(() => expect(result.current.session).toEqual(sample));
+
+    rerender({ currentView: rootView });
+    rerender({ currentView: sessionView });
+    await waitFor(() => expect(result.current.session).toEqual(sample));
+
+    expect(api.fetchSessionData).toHaveBeenCalledOnce();
+  });
+
+  it("re-fetches a cached detail when a live update invalidates it", async () => {
+    vi.mocked(api.fetchSessionData).mockResolvedValue(sample);
+    const { client, result } = renderSessionDetail();
+    await waitFor(() => expect(result.current.session).toEqual(sample));
+
+    await act(() =>
+      client.invalidateQueries({
+        queryKey: queryKeys.sessionDetail("claudecode", "claudecode/abc"),
+        exact: true,
+      }),
+    );
+
+    expect(api.fetchSessionData).toHaveBeenCalledTimes(2);
   });
 
   it("keeps the current route when an older request resolves last", async () => {

--- a/apps/web/src/hooks/useSessionDetail.ts
+++ b/apps/web/src/hooks/useSessionDetail.ts
@@ -19,6 +19,7 @@ export function useSessionDetail(viewState: ViewState) {
   const query = useQuery({
     queryKey: queryKeys.sessionDetail(route?.agent ?? "", route?.sessionId ?? ""),
     enabled: route !== null,
+    staleTime: Infinity,
     queryFn: async ({ signal }) => {
       if (!route) throw new Error("Session route is required");
       const requestId = nextSessionRequestId++;
@@ -31,7 +32,7 @@ export function useSessionDetail(viewState: ViewState) {
         logClientEvent("session.open.cancel", {
           request_id: requestId,
           request_key: requestKey,
-          reason: "route-change",
+          reason: "query-cancelled",
         });
       };
       signal.addEventListener("abort", logCancellation, { once: true });

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -224,6 +224,20 @@ describe("useSessionStore", () => {
     expect(client.getQueryState(inactiveAggregateKey)?.isInvalidated).toBe(true);
   });
 
+  it("invalidates only session details changed by a live event", async () => {
+    const { result, client } = await renderStore();
+    await act(() => result.current.reload(config.window));
+    const changedDetailKey = queryKeys.sessionDetail("claudecode", SAMPLE_SESSION_HEAD.id);
+    const unchangedDetailKey = queryKeys.sessionDetail("claudecode", "unchanged-session");
+    client.setQueryData(changedDetailKey, { id: SAMPLE_SESSION_HEAD.id });
+    client.setQueryData(unchangedDetailKey, { id: "unchanged-session" });
+
+    await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
+
+    expect(client.getQueryState(changedDetailKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(unchangedDetailKey)?.isInvalidated).toBe(false);
+  });
+
   it("performs an explicit full reload when live state reconnects", async () => {
     const { result } = await renderStore();
     await act(() => result.current.reload(config.window));

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -16,7 +16,10 @@ import {
 } from "../lib/api";
 import { createAgentCatalog } from "../lib/agents";
 import { queryKeys } from "../lib/query-keys";
-import { invalidateSessionDerivedQueries } from "../lib/session-query-consistency";
+import {
+  invalidateLiveSessionDerivedQueries,
+  invalidateSessionDerivedQueries,
+} from "../lib/session-query-consistency";
 
 export interface SessionStoreSnapshot {
   window: AppConfig["window"];
@@ -135,7 +138,7 @@ export function useSessionStore() {
       const current = queryClient.getQueryData<SessionStoreSnapshot>(snapshotKey);
       if (!current) {
         const refreshed = await reload(activeWindow);
-        await invalidateSessionDerivedQueries(queryClient);
+        await invalidateLiveSessionDerivedQueries(queryClient, event);
         return refreshed;
       }
 
@@ -147,7 +150,7 @@ export function useSessionStore() {
           event.removedSessionRefs,
         ),
       });
-      await invalidateSessionDerivedQueries(queryClient);
+      await invalidateLiveSessionDerivedQueries(queryClient, event);
       const aggregates = await queryClient.fetchQuery(snapshotAggregatesOptions(activeWindow));
       const updated =
         queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, (latest) =>

--- a/apps/web/src/lib/session-detail-cache.test.ts
+++ b/apps/web/src/lib/session-detail-cache.test.ts
@@ -76,6 +76,28 @@ describe("CS-147: session detail cache is bounded", () => {
     observed.removeObserver(observer as never);
   });
 
+  it("keeps a newly created detail during observer handoff", async () => {
+    const active = makeClient();
+    await openDetail(active, "previous-1");
+    await openDetail(active, "previous-2");
+
+    const previous = active
+      .getQueryCache()
+      .find({ queryKey: queryKeys.sessionDetail("codex", "previous-2") })!;
+    const observer = { onQueryUpdate: () => {} };
+    previous.addObserver(observer as never);
+
+    const pendingKey = queryKeys.sessionDetail("codex", "pending");
+    const pending = active.getQueryCache().build(active, {
+      queryKey: pendingKey,
+      queryFn: async () => transcript("pending"),
+    });
+
+    previous.removeObserver(observer as never);
+
+    expect(active.getQueryCache().find({ queryKey: pendingKey })).toBe(pending);
+  });
+
   it("leaves other resources alone", async () => {
     const active = makeClient();
     for (const key of [queryKeys.bookmarks, queryKeys.config, queryKeys.dashboards]) {

--- a/apps/web/src/lib/session-detail-cache.ts
+++ b/apps/web/src/lib/session-detail-cache.ts
@@ -23,7 +23,10 @@ export function pruneSessionDetailCache(client: QueryClient): void {
     .getAll()
     .map((query, position) => ({ query, position }))
     .filter(
-      ({ query }) => query.queryKey[0] === SESSION_DETAIL_PREFIX && query.getObserversCount() === 0,
+      ({ query }) =>
+        query.queryKey[0] === SESSION_DETAIL_PREFIX &&
+        query.state.status === "success" &&
+        query.getObserversCount() === 0,
     )
     // Newest first. Two details fetched in the same millisecond tie on
     // dataUpdatedAt, so cache insertion order breaks it.

--- a/apps/web/src/lib/session-query-consistency.ts
+++ b/apps/web/src/lib/session-query-consistency.ts
@@ -1,11 +1,45 @@
 import type { QueryClient } from "@tanstack/react-query";
+import type { SessionsUpdatedEvent } from "./api";
 import { queryKeys } from "./query-keys";
+
+function invalidateSessionCollections(queryClient: QueryClient) {
+  return [
+    queryClient.invalidateQueries({ queryKey: queryKeys.sessionSnapshotAggregateQueries }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.dashboards }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
+  ];
+}
 
 export async function invalidateSessionDerivedQueries(queryClient: QueryClient): Promise<void> {
   await Promise.all([
-    queryClient.invalidateQueries({ queryKey: queryKeys.sessionSnapshotAggregateQueries }),
+    ...invalidateSessionCollections(queryClient),
     queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails }),
-    queryClient.invalidateQueries({ queryKey: queryKeys.dashboards }),
-    queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
+  ]);
+}
+
+export async function invalidateLiveSessionDerivedQueries(
+  queryClient: QueryClient,
+  event: SessionsUpdatedEvent,
+): Promise<void> {
+  const changedDetailKeys = new Map<string, readonly unknown[]>();
+  for (const item of event.changedSessionHeads) {
+    const { agentName, sessionId } = item.reference;
+    changedDetailKeys.set(
+      `${agentName.toLowerCase()}\0${sessionId}`,
+      queryKeys.sessionDetail(agentName.toLowerCase(), sessionId),
+    );
+  }
+  for (const { agentName, sessionId } of event.removedSessionRefs) {
+    changedDetailKeys.set(
+      `${agentName.toLowerCase()}\0${sessionId}`,
+      queryKeys.sessionDetail(agentName.toLowerCase(), sessionId),
+    );
+  }
+
+  await Promise.all([
+    ...invalidateSessionCollections(queryClient),
+    ...Array.from(changedDetailKeys.values(), (queryKey) =>
+      queryClient.invalidateQueries({ queryKey, exact: true }),
+    ),
   ]);
 }

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1238,18 +1238,20 @@ describe("handleGetSessionData", () => {
     const { messages: _messages, ...detailHeader } = detail;
     let serializedMessages = 0;
     function* messages() {
-      serializedMessages += 1;
-      yield JSON.stringify({
-        id: "m1",
-        role: "assistant",
-        agent: null,
-        time_created: 1000,
-        time_completed: null,
-        mode: null,
-        model: null,
-        provider: null,
-        parts: [{ type: "text", text: "cached" }],
-      });
+      for (let index = 0; index < 200; index += 1) {
+        serializedMessages += 1;
+        yield JSON.stringify({
+          id: `m${index}`,
+          role: "assistant",
+          agent: null,
+          time_created: 1000,
+          time_completed: null,
+          mode: null,
+          model: null,
+          provider: null,
+          parts: [{ type: "text", text: "cached".repeat(100) }],
+        });
+      }
     }
     coreMocks.listSessionAliases.mockReturnValue([
       {
@@ -1262,7 +1264,7 @@ describe("handleGetSessionData", () => {
       status: "found-json",
       data: detailHeader,
       messages: messages(),
-      messageCount: 1,
+      messageCount: 200,
     });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
 
@@ -1271,13 +1273,24 @@ describe("handleGetSessionData", () => {
     expect(response).toBeInstanceOf(Response);
     expect(serializedMessages).toBe(0);
     expect(c.json).not.toHaveBeenCalled();
-    const payload = await (response as Response).json();
-    expect(payload).toMatchObject({
-      id: "s1",
-      display_title: "Local Alias",
-      messages: [{ id: "m1", parts: [{ type: "text", text: "cached" }] }],
-    });
-    expect(serializedMessages).toBe(1);
+    const reader = (response as Response).body!.getReader();
+    const decoder = new TextDecoder();
+    const chunks: Uint8Array[] = [];
+    let json = "";
+    for (;;) {
+      const result = await reader.read();
+      if (result.done) break;
+      chunks.push(result.value);
+      json += decoder.decode(result.value, { stream: true });
+    }
+    json += decoder.decode();
+    const payload = JSON.parse(json);
+    expect(payload.id).toBe("s1");
+    expect(payload.display_title).toBe("Local Alias");
+    expect(payload.messages[0].id).toBe("m0");
+    expect(payload.messages).toHaveLength(200);
+    expect(chunks.length).toBeLessThan(10);
+    expect(serializedMessages).toBe(200);
   });
 
   it("returns 400 when agent name is missing", async () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -249,6 +249,8 @@ function getSessionHeadReference(session: SessionHead): SessionReference {
   };
 }
 
+const SESSION_DETAIL_STREAM_BATCH_CHARS = 64 * 1024;
+
 function createSessionDetailJsonResponse(
   data: Omit<SessionDetail, "messages">,
   messages: Iterable<string>,
@@ -268,15 +270,26 @@ function createSessionDetailJsonResponse(
           return;
         }
 
-        const next = iterator.next();
-        if (!next.done) {
-          controller.enqueue(encoder.encode(`${wroteMessage ? "," : ""}${next.value}`));
+        const batch: string[] = [];
+        let batchLength = 0;
+        let next = iterator.next();
+        while (!next.done) {
+          const prefix = wroteMessage ? "," : "";
+          batch.push(prefix, next.value);
+          batchLength += prefix.length + next.value.length;
           wroteMessage = true;
+          if (batchLength >= SESSION_DETAIL_STREAM_BATCH_CHARS) break;
+          next = iterator.next();
+        }
+
+        if (next.done) {
+          batch.push("]}");
+          controller.enqueue(encoder.encode(batch.join("")));
+          controller.close();
           return;
         }
 
-        controller.enqueue(encoder.encode("]}"));
-        controller.close();
+        controller.enqueue(encoder.encode(batch.join("")));
       },
       cancel() {
         iterator.return?.();

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -5,15 +5,14 @@ import {
   scanSessions,
   type LiveSnapshot,
   type ScanOptions,
-  type SessionReference,
 } from "@codesesh/core";
 import type {
   AgentScanStatus,
   BackfillStatus,
-  ReferencedSessionHead,
   ScanStatusEvent,
   SessionsUpdatedEvent,
 } from "@codesesh/core/contract";
+import { mergeSessionsUpdatedEvents } from "@codesesh/core/contract";
 import { AgentSyncEngine } from "./agent-sync-engine.js";
 import { appLogger } from "./logging.js";
 import { SessionWatcher } from "./session-watcher.js";
@@ -33,40 +32,6 @@ export interface LiveScanStoreOptions {
 }
 
 const NEW_SESSION_EVENT_WINDOW_MS = 250;
-
-function mergeEvents(
-  previous: SessionsUpdatedEvent,
-  next: SessionsUpdatedEvent,
-): SessionsUpdatedEvent {
-  const changedSessionHeads = new Map<string, ReferencedSessionHead>();
-  const removedSessionRefs = new Map<string, SessionReference>();
-  const sessionKey = (agentName: string, sessionId: string) => `${agentName}\0${sessionId}`;
-  const addChanged = (item: ReferencedSessionHead) => {
-    const key = sessionKey(item.reference.agentName, item.reference.sessionId);
-    removedSessionRefs.delete(key);
-    changedSessionHeads.set(key, item);
-  };
-  const addRemoved = (item: SessionReference) => {
-    const key = sessionKey(item.agentName, item.sessionId);
-    changedSessionHeads.delete(key);
-    removedSessionRefs.set(key, item);
-  };
-  for (const item of previous.changedSessionHeads) addChanged(item);
-  for (const item of previous.removedSessionRefs) addRemoved(item);
-  for (const item of next.changedSessionHeads) addChanged(item);
-  for (const item of next.removedSessionRefs) addRemoved(item);
-  return {
-    type: "sessions-updated",
-    changedAgents: Array.from(new Set([...previous.changedAgents, ...next.changedAgents])),
-    newSessions: previous.newSessions + next.newSessions,
-    updatedSessions: previous.updatedSessions + next.updatedSessions,
-    removedSessions: previous.removedSessions + next.removedSessions,
-    totalSessions: next.totalSessions,
-    timestamp: next.timestamp,
-    changedSessionHeads: [...changedSessionHeads.values()],
-    removedSessionRefs: [...removedSessionRefs.values()],
-  };
-}
 
 export class LiveScanStore {
   private readonly watchEnabled: boolean;
@@ -217,7 +182,9 @@ export class LiveScanStore {
   }
 
   private queueEvent(event: SessionsUpdatedEvent): void {
-    this.pendingEvent = this.pendingEvent ? mergeEvents(this.pendingEvent, event) : event;
+    this.pendingEvent = this.pendingEvent
+      ? mergeSessionsUpdatedEvents(this.pendingEvent, event)
+      : event;
     if (this.pendingEventTimer) return;
     this.pendingEventTimer = setTimeout(() => {
       const pending = this.pendingEvent;

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -43,6 +43,7 @@ describe("contract browser-safety", () => {
         "getSessionRoutePath",
         "isProjectIdentityKind",
         "matchesProjectIdentity",
+        "mergeSessionsUpdatedEvents",
         "mergeSortedSessions",
         "normalizeMessageParts",
         "normalizeSessionReference",

--- a/packages/core/src/contract/__tests__/events.test.ts
+++ b/packages/core/src/contract/__tests__/events.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { mergeSessionsUpdatedEvents, type SessionsUpdatedEvent } from "../events.js";
+import type { ReferencedSessionHead } from "../session.js";
+
+function event(
+  changedSessionHeads: ReferencedSessionHead[],
+  removedSessionRefs: SessionsUpdatedEvent["removedSessionRefs"] = [],
+): SessionsUpdatedEvent {
+  return {
+    type: "sessions-updated",
+    changedAgents: ["claudecode"],
+    newSessions: 0,
+    updatedSessions: changedSessionHeads.length,
+    removedSessions: removedSessionRefs.length,
+    totalSessions: 2,
+    timestamp: 1,
+    changedSessionHeads,
+    removedSessionRefs,
+  };
+}
+
+describe("mergeSessionsUpdatedEvents", () => {
+  it("keeps the latest change for each session", () => {
+    const reference = { agentName: "claudecode", sessionId: "session-1" };
+    const first = {
+      reference,
+      session: { id: "session-1", display_title: "Before" },
+    } as ReferencedSessionHead;
+    const latest = {
+      reference,
+      session: { id: "session-1", display_title: "After" },
+    } as ReferencedSessionHead;
+
+    const merged = mergeSessionsUpdatedEvents(event([first]), event([latest]));
+
+    expect(merged.changedSessionHeads).toEqual([latest]);
+  });
+
+  it("lets the latest removal replace an earlier change", () => {
+    const reference = { agentName: "claudecode", sessionId: "session-1" };
+    const changed = { reference, session: { id: "session-1" } } as ReferencedSessionHead;
+
+    const merged = mergeSessionsUpdatedEvents(event([changed]), event([], [reference]));
+
+    expect(merged.changedSessionHeads).toEqual([]);
+    expect(merged.removedSessionRefs).toEqual([reference]);
+  });
+});

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -13,6 +13,42 @@ export interface SessionsUpdatedEvent {
   removedSessionRefs: SessionReference[];
 }
 
+export function mergeSessionsUpdatedEvents(
+  previous: SessionsUpdatedEvent,
+  next: SessionsUpdatedEvent,
+): SessionsUpdatedEvent {
+  const changedSessionHeads = new Map<string, ReferencedSessionHead>();
+  const removedSessionRefs = new Map<string, SessionReference>();
+  const sessionKey = (agentName: string, sessionId: string) => `${agentName}\0${sessionId}`;
+  const addChanged = (item: ReferencedSessionHead) => {
+    const key = sessionKey(item.reference.agentName, item.reference.sessionId);
+    removedSessionRefs.delete(key);
+    changedSessionHeads.set(key, item);
+  };
+  const addRemoved = (item: SessionReference) => {
+    const key = sessionKey(item.agentName, item.sessionId);
+    changedSessionHeads.delete(key);
+    removedSessionRefs.set(key, item);
+  };
+
+  for (const item of previous.changedSessionHeads) addChanged(item);
+  for (const item of previous.removedSessionRefs) addRemoved(item);
+  for (const item of next.changedSessionHeads) addChanged(item);
+  for (const item of next.removedSessionRefs) addRemoved(item);
+
+  return {
+    type: "sessions-updated",
+    changedAgents: Array.from(new Set([...previous.changedAgents, ...next.changedAgents])),
+    newSessions: previous.newSessions + next.newSessions,
+    updatedSessions: previous.updatedSessions + next.updatedSessions,
+    removedSessions: previous.removedSessions + next.removedSessions,
+    totalSessions: next.totalSessions,
+    timestamp: next.timestamp,
+    changedSessionHeads: [...changedSessionHeads.values()],
+    removedSessionRefs: [...removedSessionRefs.values()],
+  };
+}
+
 export interface AgentScanStatus {
   agentName: string;
   status: "pending" | "scanning" | "indexing" | "complete";

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -5,7 +5,7 @@ export type * from "./file-activity.js";
 export type * from "./search.js";
 export type * from "./bookmarks.js";
 export type * from "./dashboard.js";
-export type * from "./events.js";
+export * from "./events.js";
 export * from "./calendar-day.js";
 export * from "./project-identity.js";
 export * from "./session-reference.js";


### PR DESCRIPTION
## Summary

- reset session-scoped UI on route changes and explicitly position virtualized timeline segments
- keep pending session-detail queries out of inactive-cache eviction while reusing completed cached details
- coalesce bursty live updates and invalidate only the session details that actually changed
- batch streamed session JSON into bounded chunks instead of emitting one chunk per message

## Root cause

The timeline could retain route-scoped layout state, while virtualized segment positioning depended on a wrapper class that was not reliable during the initial render.

The loading stall was a query-cache race. During observer handoff, a newly created detail query briefly had no observer and no data. The inactive-detail retention policy evicted that pending query, so TanStack Query recreated it and entered a repeated request loop. Runtime diagnostics reproduced 45 loads and 89 pending-query evictions for one navigation in roughly two seconds.

Live scan bursts also invalidated every cached detail independently, and the server emitted one stream chunk per message. Those behaviors amplified background work and response overhead.

## Impact

Opening successive sessions now preserves the in-flight query, bounds only completed inactive transcripts, and avoids unrelated detail refetches. Timeline blocks render correctly on first navigation without requiring a page refresh.

## Validation

- `pnpm test` — core: 590 passed, web: 473 passed, CLI: 304 passed
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- production UI verification across four successive sessions: one load request per session; the third session loaded 781 messages in 166 ms and the fourth loaded 201 messages in 32 ms