### PR TITLE
feat(core): fold ZCode subagent sessions into parent

### DIFF
--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -423,3 +423,31 @@ describe("CS-144: session detail reads parts in one query", () => {
     }
   });
 });
+
+describe("subagent folding degrades when task_type/parent_id are absent", () => {
+  it("scans a database without task_type/parent_id columns without error", () => {
+    const dbPath = createDatabase();
+    const agent = new OpenCodeSqliteAgent({
+      name: "opencode",
+      displayName: "OpenCode",
+      findDbPath: () => dbPath,
+      getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
+    });
+    agent.isAvailable();
+
+    const heads = agent.scan({ from: 0 });
+    expect(heads).toHaveLength(1);
+    expect(heads[0]).toMatchObject({
+      id: "s1",
+      stats: expect.objectContaining({
+        message_count: 1,
+        total_input_tokens: 1_000,
+        total_output_tokens: 500,
+      }),
+    });
+
+    const detail = agent.getSessionData("s1");
+    expect(detail.stats.total_input_tokens).toBe(1_000);
+    expect(detail.messages).toHaveLength(1);
+  });
+});

--- a/packages/core/src/agents/__tests__/zcode.test.ts
+++ b/packages/core/src/agents/__tests__/zcode.test.ts
@@ -51,6 +51,68 @@ afterEach(() => {
   setCoreDiagnostics(null);
 });
 
+function createZCodeDbWithSubagent(tempDir: string): string {
+  const dbPath = join(tempDir, "db.sqlite");
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      title TEXT,
+      time_created INTEGER,
+      time_updated INTEGER,
+      slug TEXT,
+      directory TEXT,
+      path TEXT,
+      version TEXT,
+      summary_files INTEGER,
+      task_type TEXT,
+      parent_id TEXT
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      time_created INTEGER,
+      time_updated INTEGER,
+      data TEXT
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT,
+      session_id TEXT,
+      time_created INTEGER,
+      time_updated INTEGER,
+      data TEXT
+    );
+  `);
+  db.close();
+  return dbPath;
+}
+
+function insertMessage(
+  db: Database.Database,
+  id: string,
+  sessionId: string,
+  data: Record<string, unknown>,
+  timeCreated: number,
+) {
+  db.prepare(
+    "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+  ).run(id, sessionId, timeCreated, timeCreated, JSON.stringify(data));
+}
+
+function insertTextPart(
+  db: Database.Database,
+  id: string,
+  messageId: string,
+  sessionId: string,
+  text: string,
+  timeCreated: number,
+) {
+  db.prepare(
+    "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(id, messageId, sessionId, timeCreated, timeCreated, JSON.stringify({ type: "text", text }));
+}
+
 describe("ZCodeAgent parsing", () => {
   it("reads ZCode SQLite sessions through the OpenCode-compatible schema", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-zcode-test-"));
@@ -195,5 +257,258 @@ describe("ZCodeAgent parsing", () => {
       event: "agent.field_shape_mismatch",
       detail: { agentName: "zcode", field: "message.modelID" },
     });
+  });
+});
+
+describe("ZCodeAgent subagent folding", () => {
+  it("filters subagent_child sessions out of the top-level list and folds their tokens", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-zcode-subagent-"));
+    tempDirs.push(tempDir);
+    const dbPath = createZCodeDbWithSubagent(tempDir);
+    const db = new Database(dbPath);
+
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files, task_type, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "parent",
+      "",
+      1_000,
+      2_000,
+      "/tmp/project",
+      "/tmp/project",
+      "0.14.8",
+      1,
+      "interactive",
+      null,
+    );
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files, task_type, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "child",
+      "",
+      1_100,
+      1_500,
+      "/tmp/project",
+      "/tmp/project",
+      "0.14.8",
+      0,
+      "subagent_child",
+      "parent",
+    );
+
+    insertMessage(
+      db,
+      "msg_parent",
+      "parent",
+      { role: "user", tokens: { input: 10, output: 0 } },
+      1_000,
+    );
+    insertTextPart(db, "part_parent", "msg_parent", "parent", "hi", 1_000);
+    insertMessage(
+      db,
+      "msg_child",
+      "child",
+      { role: "assistant", tokens: { input: 40, output: 60 } },
+      1_200,
+    );
+    insertTextPart(db, "part_child", "msg_child", "child", "working", 1_200);
+    db.close();
+
+    const agent = new ZCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const heads = agent.scan({ from: 0 });
+    expect(heads.map((h: any) => h.id)).toEqual(["parent"]);
+    const [head] = heads;
+    expect(head.stats).toMatchObject({
+      message_count: 1,
+      total_input_tokens: 50,
+      total_output_tokens: 60,
+    });
+  });
+
+  it("folds child tokens into getSessionData detail stats without surfacing child messages", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-zcode-subagent-"));
+    tempDirs.push(tempDir);
+    const dbPath = createZCodeDbWithSubagent(tempDir);
+    const db = new Database(dbPath);
+
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files, task_type, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "parent",
+      "",
+      1_000,
+      2_000,
+      "/tmp/project",
+      "/tmp/project",
+      "0.14.8",
+      1,
+      "interactive",
+      null,
+    );
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files, task_type, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "child",
+      "",
+      1_100,
+      1_500,
+      "/tmp/project",
+      "/tmp/project",
+      "0.14.8",
+      0,
+      "subagent_child",
+      "parent",
+    );
+
+    insertMessage(
+      db,
+      "msg_parent",
+      "parent",
+      { role: "user", tokens: { input: 10, output: 0 } },
+      1_000,
+    );
+    insertTextPart(db, "part_parent", "msg_parent", "parent", "hi", 1_000);
+    insertMessage(
+      db,
+      "msg_child",
+      "child",
+      { role: "assistant", tokens: { input: 40, output: 60 } },
+      1_200,
+    );
+    insertTextPart(db, "part_child", "msg_child", "child", "working", 1_200);
+    db.close();
+
+    const agent = new ZCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const data = agent.getSessionData("parent");
+    expect(data.stats).toMatchObject({
+      message_count: 1,
+      total_input_tokens: 50,
+      total_output_tokens: 60,
+    });
+    expect(data.messages).toHaveLength(1);
+    expect(data.messages[0].id).toBe("msg_parent");
+  });
+
+  it("aggregates tokens across multiple children", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-zcode-subagent-"));
+    tempDirs.push(tempDir);
+    const dbPath = createZCodeDbWithSubagent(tempDir);
+    const db = new Database(dbPath);
+
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files, task_type, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "parent",
+      "",
+      1_000,
+      3_000,
+      "/tmp/project",
+      "/tmp/project",
+      "0.14.8",
+      1,
+      "interactive",
+      null,
+    );
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files, task_type, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "child_a",
+      "",
+      1_100,
+      1_500,
+      "/tmp/project",
+      "/tmp/project",
+      "0.14.8",
+      0,
+      "subagent_child",
+      "parent",
+    );
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files, task_type, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "child_b",
+      "",
+      2_000,
+      2_500,
+      "/tmp/project",
+      "/tmp/project",
+      "0.14.8",
+      0,
+      "subagent_child",
+      "parent",
+    );
+
+    insertMessage(
+      db,
+      "msg_parent",
+      "parent",
+      { role: "user", tokens: { input: 5, output: 5 } },
+      1_000,
+    );
+    insertTextPart(db, "part_parent", "msg_parent", "parent", "hi", 1_000);
+    insertMessage(
+      db,
+      "msg_a",
+      "child_a",
+      { role: "assistant", tokens: { input: 30, output: 10 } },
+      1_200,
+    );
+    insertTextPart(db, "part_a", "msg_a", "child_a", "a", 1_200);
+    insertMessage(
+      db,
+      "msg_b",
+      "child_b",
+      { role: "assistant", tokens: { input: 20, output: 20 } },
+      2_100,
+    );
+    insertTextPart(db, "part_b", "msg_b", "child_b", "b", 2_100);
+    db.close();
+
+    const agent = new ZCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const [head] = agent.scan({ from: 0 });
+    expect(head.stats).toMatchObject({
+      message_count: 1,
+      total_input_tokens: 55,
+      total_output_tokens: 35,
+    });
+
+    const data = agent.getSessionData("parent");
+    expect(data.stats.total_input_tokens).toBe(55);
+    expect(data.stats.total_output_tokens).toBe(35);
+    expect(data.messages).toHaveLength(1);
+  });
+
+  it("does not fold when task_type/parent_id columns are absent (OpenCode baseline)", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-zcode-subagent-"));
+    tempDirs.push(tempDir);
+    const dbPath = createZCodeDb(tempDir);
+    const db = new Database(dbPath);
+
+    db.prepare(
+      "INSERT INTO session (id, title, time_created, time_updated, directory, path, version, summary_files) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run("only", "", 1_000, 2_000, "/tmp/project", "/tmp/project", "0.14.8", 1);
+    insertMessage(
+      db,
+      "msg_only",
+      "only",
+      { role: "user", tokens: { input: 10, output: 0 } },
+      1_000,
+    );
+    insertTextPart(db, "part_only", "msg_only", "only", "hi", 1_000);
+    db.close();
+
+    const agent = new ZCodeAgent() as any;
+    agent.dbPath = dbPath;
+
+    const [head] = agent.scan({ from: 0 });
+    expect(head.id).toBe("only");
+    expect(head.stats).toMatchObject({ total_input_tokens: 10, total_output_tokens: 0 });
+    expect(agent.getSessionData("only").stats.total_input_tokens).toBe(10);
   });
 });

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -9,7 +9,7 @@ import {
 import type { AgentScanOptions, ParseSessionResult, SessionWatchPlan } from "./base.js";
 import type { SessionHead, SessionDetail, Message, MessagePart } from "../types/index.js";
 import { normalizeMessageParts } from "../contract/message-part.js";
-import { openDbReadOnly, type SQLiteDatabase } from "../utils/sqlite.js";
+import { columnExists, openDbReadOnly, type SQLiteDatabase } from "../utils/sqlite.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { resolveSessionTitle } from "../utils/title-fallback.js";
 import { isInternalEventType } from "../utils/parse-cleanup.js";
@@ -25,6 +25,7 @@ interface OpenCodeMessageRow {
   session_id?: unknown;
   data?: string;
   time_created?: unknown;
+  parent_id?: unknown;
 }
 
 interface OpenCodePartRow {
@@ -46,6 +47,25 @@ interface OpenCodeSqliteAgentConfig {
 }
 
 const MESSAGE_ROLES = new Set<Message["role"]>(["user", "assistant", "tool"]);
+
+function accumulateTokenStats(
+  stats: SessionHead["stats"],
+  msgData: Record<string, unknown>,
+  agentName: string,
+): void {
+  const cost = Number(msgData.cost ?? 0);
+  const tokens = parseTokens(msgData.tokens, agentName);
+  const inputTokens = Number(tokens?.input ?? 0);
+  const outputTokens = Number(tokens?.output ?? 0);
+  const model = parseModel(msgData.modelID, agentName);
+  const estimatedCost =
+    cost > 0 ? null : estimateTokenCost(model, { input: inputTokens, output: outputTokens });
+
+  if (estimatedCost !== null) stats.cost_source = "estimated";
+  stats.total_cost += cost || estimatedCost || 0;
+  stats.total_input_tokens += inputTokens;
+  stats.total_output_tokens += outputTokens;
+}
 
 /** Parses a SQLite `data` JSON column; non-object payloads fall back to `{}` (reported as drift). */
 function parseJsonRecord(raw: unknown, agentName: string, field: string): Record<string, unknown> {
@@ -121,6 +141,12 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
           .get(),
       );
 
+      const hasTaskType = columnExists(db, "session", "task_type");
+      const hasParentId = columnExists(db, "session", "parent_id");
+      const childPredicate = hasTaskType
+        ? "AND (s.task_type IS NULL OR s.task_type != 'subagent_child')"
+        : "";
+
       let rows: Record<string, unknown>[];
       if (hasMessageTable) {
         rows = db
@@ -130,6 +156,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
             s.version, s.summary_files
           FROM session s
           WHERE COALESCE(s.time_updated, s.time_created) >= ?
+          ${childPredicate}
           ORDER BY s.time_created DESC
         `)
           .all(cutoffTime);
@@ -140,6 +167,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
             s.version, s.summary_files, 0 AS message_count, NULL AS model_message_data
           FROM session s
           WHERE COALESCE(s.time_updated, s.time_created) >= ?
+          ${childPredicate}
           ORDER BY s.time_created DESC
         `)
           .all(cutoffTime);
@@ -147,8 +175,9 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
 
       const headContexts = hasMessageTable
         ? this.buildHeadContexts(
-            this.readHeadMessageRows(db, cutoffTime),
+            this.readHeadMessageRows(db, cutoffTime, hasParentId),
             this.readHeadPartRows(db, cutoffTime),
+            hasParentId,
           )
         : new Map<string, OpenCodeHeadContext>();
       const heads: SessionHead[] = [];
@@ -213,11 +242,16 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
     });
   }
 
-  private readHeadMessageRows(db: SQLiteDatabase, cutoffTime: number): OpenCodeMessageRow[] {
+  private readHeadMessageRows(
+    db: SQLiteDatabase,
+    cutoffTime: number,
+    withParentId: boolean,
+  ): OpenCodeMessageRow[] {
+    const parentIdSelect = withParentId ? ", s.parent_id" : "";
     return db
       .prepare(
         `
-          SELECT m.id, m.session_id, m.data, m.time_created
+          SELECT m.id, m.session_id, m.data, m.time_created${parentIdSelect}
           FROM message m
           JOIN session s ON s.id = m.session_id
           WHERE COALESCE(s.time_updated, s.time_created) >= ?
@@ -293,18 +327,12 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
   private buildHeadContexts(
     messageRows: OpenCodeMessageRow[],
     partRows: OpenCodePartRow[],
+    withParentId: boolean,
   ): Map<string, OpenCodeHeadContext> {
     const partsByMessage = this.buildPartsByMessage(partRows);
     const contexts = new Map<string, OpenCodeHeadContext>();
 
-    for (const row of messageRows) {
-      const sessionId = String(row.session_id ?? "");
-      if (!sessionId) continue;
-      const msgData = parseJsonRecord(row.data, this.name, "message.data");
-      if (isInternalEventType(msgData.type)) continue;
-      const parts = partsByMessage.get(String(row.id ?? "")) ?? [];
-      if (parts.length === 0) continue;
-
+    const ensureContext = (sessionId: string): OpenCodeHeadContext => {
       let context = contexts.get(sessionId);
       if (!context) {
         context = {
@@ -318,19 +346,29 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
         };
         contexts.set(sessionId, context);
       }
+      return context;
+    };
 
-      const cost = Number(msgData.cost ?? 0);
-      const tokens = parseTokens(msgData.tokens, this.name);
-      const inputTokens = Number(tokens?.input ?? 0);
-      const outputTokens = Number(tokens?.output ?? 0);
-      const model = parseModel(msgData.modelID, this.name);
-      const estimatedCost =
-        cost > 0 ? null : estimateTokenCost(model, { input: inputTokens, output: outputTokens });
+    for (const row of messageRows) {
+      const sessionId = String(row.session_id ?? "");
+      if (!sessionId) continue;
+      const msgData = parseJsonRecord(row.data, this.name, "message.data");
+      if (isInternalEventType(msgData.type)) continue;
 
-      if (estimatedCost !== null) context.stats.cost_source = "estimated";
-      context.stats.total_cost += cost || estimatedCost || 0;
-      context.stats.total_input_tokens += inputTokens;
-      context.stats.total_output_tokens += outputTokens;
+      const parentId = withParentId ? String(row.parent_id ?? "") : "";
+      const isChild = parentId !== "";
+
+      if (isChild) {
+        const context = ensureContext(parentId);
+        accumulateTokenStats(context.stats, msgData, this.name);
+        continue;
+      }
+
+      const parts = partsByMessage.get(String(row.id ?? "")) ?? [];
+      if (parts.length === 0) continue;
+
+      const context = ensureContext(sessionId);
+      accumulateTokenStats(context.stats, msgData, this.name);
       context.stats.message_count += 1;
 
       if (!context.messageTitle && String(msgData.role ?? "") === "user") {
@@ -353,6 +391,36 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
     }
 
     return contexts;
+  }
+
+  private sumChildTokenStats(db: SQLiteDatabase, parentSessionId: string): SessionHead["stats"][] {
+    if (!columnExists(db, "session", "parent_id")) return [];
+
+    const childRows = db
+      .prepare("SELECT id FROM session WHERE parent_id = ?")
+      .all(parentSessionId) as Record<string, unknown>[];
+
+    const results: SessionHead["stats"][] = [];
+    for (const child of childRows) {
+      const childId = String(child.id ?? "");
+      if (!childId) continue;
+      const msgRows = db
+        .prepare("SELECT data FROM message WHERE session_id = ? ORDER BY time_created ASC, id ASC")
+        .all(childId) as OpenCodeMessageRow[];
+      const stats: SessionHead["stats"] = {
+        message_count: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 0,
+      };
+      for (const row of msgRows) {
+        const msgData = parseJsonRecord(row.data, this.name, "message.data");
+        if (isInternalEventType(msgData.type)) continue;
+        accumulateTokenStats(stats, msgData, this.name);
+      }
+      results.push(stats);
+    }
+    return results;
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -385,9 +453,6 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
       const timeUpdated = Number(sessionRow.time_updated ?? timeCreated);
 
       const messages: Message[] = [];
-      let totalCost = 0;
-      let totalInputTokens = 0;
-      let totalOutputTokens = 0;
       let hasEstimatedCost = false;
 
       // Get messages
@@ -433,11 +498,24 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
         firstUserMessageTitle(cleanedMessages),
         null,
       );
+      const stats: SessionHead["stats"] = {
+        message_count: cleanedMessages.length,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 0,
+      };
       for (const message of cleanedMessages) {
-        totalCost += message.cost ?? 0;
-        totalInputTokens += message.tokens?.input ?? 0;
-        totalOutputTokens += message.tokens?.output ?? 0;
+        stats.total_cost += message.cost ?? 0;
+        stats.total_input_tokens += message.tokens?.input ?? 0;
+        stats.total_output_tokens += message.tokens?.output ?? 0;
         if (message.cost_source === "estimated") hasEstimatedCost = true;
+      }
+
+      for (const childStats of this.sumChildTokenStats(db, sessionId)) {
+        stats.total_cost += childStats.total_cost;
+        stats.total_input_tokens += childStats.total_input_tokens;
+        stats.total_output_tokens += childStats.total_output_tokens;
+        if (childStats.cost_source === "estimated") hasEstimatedCost = true;
       }
 
       return {
@@ -451,11 +529,12 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
         time_updated: timeUpdated,
         summary_files: sessionRow.summary_files ?? undefined,
         stats: {
-          message_count: cleanedMessages.length,
-          total_input_tokens: totalInputTokens,
-          total_output_tokens: totalOutputTokens,
-          total_cost: totalCost,
-          cost_source: totalCost > 0 ? (hasEstimatedCost ? "estimated" : "recorded") : undefined,
+          message_count: stats.message_count,
+          total_input_tokens: stats.total_input_tokens,
+          total_output_tokens: stats.total_output_tokens,
+          total_cost: stats.total_cost,
+          cost_source:
+            stats.total_cost > 0 ? (hasEstimatedCost ? "estimated" : "recorded") : undefined,
         },
         messages: cleanedMessages,
       };

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -1057,6 +1057,30 @@ function migrateCodexExecDecode(db: SQLiteDatabase): void {
   ).run(CODEX_EXEC_DECODE_MIGRATION_KEY);
 }
 
+const OPENCODE_SUBAGENT_FOLD_KEY = "opencode_subagent_fold_v1";
+
+/**
+ * One-time: drop cached OpenCode-family (zcode/opencode) heads so the next scan
+ * re-parses them with subagent_child sessions filtered out and their tokens
+ * folded into the parent. `loadCachedSessions` returns null when agent_cache has
+ * no row for an agent, forcing a full rescan; the now-orphaned child session
+ * rows are removed by `saveCachedSessions` once the rescan publishes its set.
+ */
+function migrateOpenCodeSubagentFold(db: SQLiteDatabase): void {
+  if (!tableExists(db, "cache_meta")) return;
+  const done = db
+    .prepare("SELECT value FROM cache_meta WHERE key = ?")
+    .get(OPENCODE_SUBAGENT_FOLD_KEY);
+  if (done) return;
+
+  if (tableExists(db, "agent_cache")) {
+    db.prepare("DELETE FROM agent_cache WHERE agent_name IN ('zcode', 'opencode')").run();
+  }
+  db.prepare(
+    "INSERT INTO cache_meta(key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = '1'",
+  ).run(OPENCODE_SUBAGENT_FOLD_KEY);
+}
+
 function rebuildSearchIndex(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents_fts")) {
     return;
@@ -1199,6 +1223,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
     createLatestCacheSchema(db);
     setCacheSchemaVersion(db);
     migrateCodexExecDecode(db);
+    migrateOpenCodeSubagentFold(db);
     return;
   }
 
@@ -1273,4 +1298,5 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   }
 
   migrateCodexExecDecode(db);
+  migrateOpenCodeSubagentFold(db);
 }


### PR DESCRIPTION
## Problem

ZCode stores each subagent as an independent `session` row (`task_type='subagent_child'`, `parent_id` → parent). The OpenCode SQLite adapter ignored both columns, causing two issues:

1. **57 `subagent_child` sessions polluted the top-level list**, mixed with 24 interactive sessions — each subagent invocation showed up as a standalone session.
2. **Subagent tokens never reached the parent.** Both head-list and detail stats summed only the parent's own messages, so a session that spawned subagents severely understated its real cost.

The parent's `Agent` tool part already carries the full `input` (prompt/description/subagent_type) and `output` (final subagent text), and the ZCode tool strategy (`zcode.ts:242-259`) already renders them aligned with Claude Code — so no display-layer change is needed. The work is purely about **folding the child session row into its parent**: hide it from the list and merge its tokens.

## Approach

Guarded by `columnExists`, so behavior degrades gracefully when the columns are absent:

- **`scan()`** — when `session` has `task_type`, filter out `subagent_child` rows; when it has `parent_id`, fold each child's message tokens into the matching parent's head stats (token/cost only — never `message_count`).
- **`getSessionData()`** — fold child tokens into the detail stats the same way; child messages stay out of the `messages` array.
- **`sumChildTokenStats`** + module-level **`accumulateTokenStats`** — extracted so head and detail paths share one accumulation path.
- **One-time cache migration** (`migrateOpenCodeSubagentFold`) — drops cached zcode/opencode heads so the next scan republishes with folded tokens; orphaned child rows are cleared by `saveCachedSessions` on rescan.

Databases without `task_type`/`parent_id` (e.g. stock OpenCode, old fixtures) hit none of the new branches and behave exactly as before.

## Verification

- `pnpm --filter @codesesh/core exec vitest run` → 595 passed, 1 skipped
- `tsc --noEmit` clean; `oxlint` 0 warnings
- Against the real `~/.zcode/cli/db/db.sqlite`:
  - Top-level sessions **81 → 24** (all `interactive`; 57 children folded)
  - Session `sess_f8b53869…` with 4 children: input `7,639,625 → 9,077,618`, output `49,748 → 73,646`

## Test coverage

| Case | File |
|---|---|
| child filtered from top-level list + head token fold | `zcode.test.ts` |
| child tokens fold into detail stats, messages stay hidden | `zcode.test.ts` |
| multiple children aggregate correctly | `zcode.test.ts` |
| no `task_type`/`parent_id` columns → baseline unchanged | `zcode.test.ts`, `opencode-sqlite.test.ts` |