### PR TITLE
feat(core): fold Codex subagent sessions into parent

### DIFF
--- a/apps/web/src/components/session-detail/tool-strategy/codex.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/codex.ts
@@ -77,27 +77,6 @@ export function extractCodexNodeReplTextOutput(outputText: string) {
   return text || outputText;
 }
 
-function getSubagentToolTitle(part: ToolPart) {
-  const input = toRecord(part.state.input);
-  const agentType = compactText(input.agent_type);
-  const model = compactText(input.model);
-  const reasoningEffort = compactText(input.reasoning_effort);
-  const modelSuffix = [model, reasoningEffort].filter(Boolean).join("-");
-  return [agentType, modelSuffix].filter(Boolean).join(" ");
-}
-
-function getSubagentPrompt(part: ToolPart) {
-  const metadata = toRecord(part.state.metadata);
-  const prompt = compactText(metadata.prompt);
-  if (prompt) return prompt;
-
-  const input = toRecord(part.state.input);
-  const message = compactText(input.message);
-  if (message) return message;
-
-  return "";
-}
-
 export function buildCodexToolStrategy(
   tool: ToolPart,
   state: NormalizedToolState,
@@ -269,18 +248,24 @@ export function buildCodexToolStrategy(
   }
 
   if (toolKey === "subagent") {
-    const prompt = getSubagentPrompt(tool);
+    const input = toRecord(state.inputValue);
+    const taskName = compactText(input.task_name);
+    const model = compactText(input.model);
+    const reasoningEffort = compactText(input.reasoning_effort);
     const fallbackText = getOutputOrErrorText(state);
     return {
       ...defaultStrategy,
       Icon: Bot,
-      title: getSubagentToolTitle(tool) || getToolTitle(tool, "subagent"),
+      title: taskName || getToolTitle(tool, "subagent"),
       secondaryText: undefined,
-      details: [],
+      details: [
+        model ? { label: "Model", value: model } : null,
+        reasoningEffort ? { label: "Effort", value: reasoningEffort } : null,
+      ].filter((d): d is NonNullable<typeof d> => d !== null),
       showInputPreview: false,
       outputContent: {
         kind: "plain",
-        text: prompt || fallbackText,
+        text: fallbackText,
         language: "markdown",
         isCode: false,
       },

--- a/apps/web/src/components/session-detail/tool-strategy/codex.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/codex.ts
@@ -252,6 +252,8 @@ export function buildCodexToolStrategy(
     const taskName = compactText(input.task_name);
     const model = compactText(input.model);
     const reasoningEffort = compactText(input.reasoning_effort);
+    const forkTurns = compactText(input.fork_turns);
+    const isPriority = compactText(input.service_tier) === "priority";
     const fallbackText = getOutputOrErrorText(state);
     return {
       ...defaultStrategy,
@@ -259,8 +261,9 @@ export function buildCodexToolStrategy(
       title: taskName || getToolTitle(tool, "subagent"),
       secondaryText: undefined,
       details: [
-        model ? { label: "Model", value: model } : null,
+        model ? { label: "Model", value: isPriority ? `${model} · Fast` : model } : null,
         reasoningEffort ? { label: "Effort", value: reasoningEffort } : null,
+        forkTurns ? { label: "Fork", value: forkTurns } : null,
       ].filter((d): d is NonNullable<typeof d> => d !== null),
       showInputPreview: false,
       outputContent: {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -254,7 +254,7 @@ describe("CodexAgent cache refresh", () => {
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
           "codex-head-v1",
-          "codex-parser-v4",
+          "codex-parser-v5",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           "Indexed title",
@@ -1313,5 +1313,117 @@ describe("CodexAgent field shape mismatches", () => {
       event: "agent.field_shape_mismatch",
       detail: { agentName: "codex", field: "payload" },
     });
+  });
+});
+
+describe("CodexAgent subagent folding", () => {
+  const PARENT_ID = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+  const CHILD_ID = "019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb";
+
+  function writeSession(
+    dir: string,
+    id: string,
+    lines: { threadSource: string; parentThreadId?: string | null; extra?: string[] },
+  ) {
+    const meta = {
+      session_id: lines.parentThreadId ?? id,
+      id,
+      thread_source: lines.threadSource,
+      ...(lines.parentThreadId ? { parent_thread_id: lines.parentThreadId } : {}),
+    };
+    const content = [
+      `{"timestamp":"2026-04-20T10:00:00Z","type":"session_meta","payload":${JSON.stringify({ cwd: "/tmp/project", ...meta })}}`,
+      ...(lines.extra ?? []),
+      "",
+    ].join("\n");
+    writeFileSync(join(dir, `rollout-2026-04-20T10-00-00-${id}.jsonl`), content);
+  }
+
+  function tokenCountLine(input: number, output: number, total: number) {
+    return `{"timestamp":"2026-04-20T10:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":${input},"output_tokens":${output}},"total_token_usage":{"total_tokens":${total}}}}}`;
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  it("filters subagent files out of scan and folds their tokens into the parent head", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
+    tempDirs.push(tempDir);
+
+    writeSession(tempDir, PARENT_ID, {
+      threadSource: "user",
+      extra: [
+        tokenCountLine(100, 20, 120),
+        '{"timestamp":"2026-04-20T10:02:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}',
+      ],
+    });
+    writeSession(tempDir, CHILD_ID, {
+      threadSource: "subagent",
+      parentThreadId: PARENT_ID,
+      extra: [tokenCountLine(40, 60, 100)],
+    });
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+
+    const heads = agent.scan({ from: 0 });
+    expect(heads.map((h: SessionHead) => h.id)).toEqual([PARENT_ID]);
+    expect(heads[0].stats.total_input_tokens).toBe(140);
+    expect(heads[0].stats.total_output_tokens).toBe(80);
+  });
+
+  it("folds subagent tokens into getSessionData detail stats", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
+    tempDirs.push(tempDir);
+
+    writeSession(tempDir, PARENT_ID, {
+      threadSource: "user",
+      extra: [
+        tokenCountLine(100, 20, 120),
+        '{"timestamp":"2026-04-20T10:02:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}',
+      ],
+    });
+    writeSession(tempDir, CHILD_ID, {
+      threadSource: "subagent",
+      parentThreadId: PARENT_ID,
+      extra: [tokenCountLine(40, 60, 100)],
+    });
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+    agent.scan({ from: 0 });
+
+    const data = agent.getSessionData(PARENT_ID);
+    expect(data.stats.total_input_tokens).toBe(140);
+    expect(data.stats.total_output_tokens).toBe(80);
+    expect(data.messages.every((m: Message) => m.parts.length >= 0)).toBe(true);
+  });
+
+  it("leaves a session without children unchanged", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
+    tempDirs.push(tempDir);
+
+    writeSession(tempDir, PARENT_ID, {
+      threadSource: "user",
+      extra: [
+        tokenCountLine(100, 20, 120),
+        '{"timestamp":"2026-04-20T10:02:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}',
+      ],
+    });
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+
+    const [head] = agent.scan({ from: 0 });
+    expect(head.id).toBe(PARENT_ID);
+    expect(head.stats.total_input_tokens).toBe(100);
+    expect(head.stats.total_output_tokens).toBe(20);
   });
 });

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1426,4 +1426,22 @@ describe("CodexAgent subagent folding", () => {
     expect(head.stats.total_input_tokens).toBe(100);
     expect(head.stats.total_output_tokens).toBe(20);
   });
+
+  it("filters subagent files via scanSessionSource (incrementalScan path)", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
+    tempDirs.push(tempDir);
+
+    writeSession(tempDir, CHILD_ID, {
+      threadSource: "subagent",
+      parentThreadId: PARENT_ID,
+      extra: [tokenCountLine(40, 60, 100)],
+    });
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+
+    const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
+    expect(agent.scanSessionSource(childFile)).toBeNull();
+  });
 });

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -34,7 +34,7 @@ const PLAN_APPROVAL_PREFIX = "PLEASE IMPLEMENT THIS PLAN";
 const SUBAGENT_NOTIFICATION_PATTERN =
   /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
 const HEAD_INDEX_VERSION = "codex-head-v1";
-const PARSER_VERSION = "codex-parser-v4";
+const PARSER_VERSION = "codex-parser-v5";
 
 export function resolveCodexDataRoot(): string {
   return resolveHomePath("CODEX_HOME", ".codex");
@@ -108,6 +108,19 @@ function narrowRecordField(value: unknown, field: string): Record<string, unknow
 
 function extractPayload(data: Record<string, unknown>): Record<string, unknown> {
   return narrowRecordField(data["payload"], "payload") ?? {};
+}
+
+interface ThreadMeta {
+  threadSource: string;
+  parentThreadId: string | null;
+}
+
+function extractThreadMeta(firstRecord: Record<string, unknown>): ThreadMeta | null {
+  if (firstRecord["type"] !== "session_meta") return null;
+  const payload = extractPayload(firstRecord);
+  const threadSource = asString(payload["thread_source"]) ?? "";
+  const parentThreadId = asString(payload["parent_thread_id"]) ?? null;
+  return { threadSource, parentThreadId };
 }
 
 function extractTokenUsage(payload: Record<string, unknown>): {
@@ -331,6 +344,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   private sessionIndexCache = new Map<string, string>();
   private sessionIndexMtime: number | null | undefined;
   private sessionIndexPath: string | undefined;
+  private subagentStatsByParent = new Map<string, SessionHead["stats"][]>();
 
   // ---- BaseAgent implementation ----
 
@@ -363,6 +377,74 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       sourcePath: file,
       fingerprint: this.sourceFingerprint(file, stat),
     }));
+  }
+
+  scan(options?: AgentScanOptions): SessionHead[] {
+    this.loadSessionIndex();
+    const sources = this.listRolloutFiles(options);
+
+    const childStatsByParent = new Map<string, SessionHead["stats"][]>();
+    this.subagentStatsByParent = childStatsByParent;
+
+    const heads: SessionHead[] = [];
+    options?.onProgress?.({ total: sources.length, processed: 0, sessions: 0 });
+
+    for (const [index, { file }] of sources.entries()) {
+      try {
+        const threadMeta = this.readThreadMeta(file);
+
+        if (threadMeta?.threadSource === "subagent") {
+          const parentId = threadMeta.parentThreadId;
+          if (parentId) {
+            const childHead = getParsedSession(this.parseSessionHeadResult(file, options));
+            if (childHead) {
+              const list = childStatsByParent.get(parentId);
+              if (list) list.push(childHead.stats);
+              else childStatsByParent.set(parentId, [childHead.stats]);
+            }
+          }
+        } else {
+          const head = this.scanSessionSource(file, options);
+          if (head) heads.push(head);
+        }
+      } catch {
+        // skip unreadable files
+      } finally {
+        options?.onProgress?.({
+          total: sources.length,
+          processed: index + 1,
+          sessions: heads.length,
+        });
+      }
+    }
+
+    for (const head of heads) {
+      const childStats = childStatsByParent.get(head.id);
+      if (!childStats) continue;
+      for (const stats of childStats) {
+        head.stats.total_input_tokens += stats.total_input_tokens ?? 0;
+        head.stats.total_output_tokens += stats.total_output_tokens ?? 0;
+        head.stats.total_cost += stats.total_cost ?? 0;
+        if (stats.total_cache_read_tokens) {
+          head.stats.total_cache_read_tokens =
+            (head.stats.total_cache_read_tokens ?? 0) + stats.total_cache_read_tokens;
+        }
+      }
+    }
+
+    return heads;
+  }
+
+  private readThreadMeta(filePath: string): ThreadMeta | null {
+    try {
+      const firstLine = this.readFilePrefix(filePath)
+        .split("\n")
+        .filter((l) => l.trim())[0];
+      if (!firstLine) return null;
+      return extractThreadMeta(JSON.parse(firstLine));
+    } catch {
+      return null;
+    }
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -471,6 +553,17 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       cost_source: totalCost > 0 ? "estimated" : undefined,
     });
 
+    const childStats = this.collectChildStats(meta.id);
+    for (const stats of childStats) {
+      result.stats.total_input_tokens += stats.total_input_tokens ?? 0;
+      result.stats.total_output_tokens += stats.total_output_tokens ?? 0;
+      result.stats.total_cost += stats.total_cost ?? 0;
+      if (stats.total_cache_read_tokens) {
+        result.stats.total_cache_read_tokens =
+          (result.stats.total_cache_read_tokens ?? 0) + stats.total_cache_read_tokens;
+      }
+    }
+
     return {
       reference: { agentName: this.name, sessionId: meta.id },
       id: meta.id,
@@ -482,6 +575,23 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       stats: result.stats,
       messages: result.messages,
     };
+  }
+
+  private collectChildStats(parentSessionId: string): SessionHead["stats"][] {
+    const cached = this.subagentStatsByParent.get(parentSessionId);
+    if (cached) return cached;
+
+    const stats: SessionHead["stats"][] = [];
+    for (const { file } of this.listRolloutFiles()) {
+      const threadMeta = this.readThreadMeta(file);
+      if (threadMeta?.threadSource !== "subagent") continue;
+      if (threadMeta.parentThreadId !== parentSessionId) continue;
+      const childHead = getParsedSession(this.parseSessionHeadResult(file));
+      if (childHead) stats.push(childHead.stats);
+    }
+
+    if (stats.length > 0) this.subagentStatsByParent.set(parentSessionId, stats);
+    return stats;
   }
 
   // ---- File listing ----

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -396,12 +396,10 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
         if (threadMeta?.threadSource === "subagent") {
           const parentId = threadMeta.parentThreadId;
           if (parentId) {
-            const childHead = getParsedSession(this.parseSessionHeadResult(file, options));
-            if (childHead) {
-              const list = childStatsByParent.get(parentId);
-              if (list) list.push(childHead.stats);
-              else childStatsByParent.set(parentId, [childHead.stats]);
-            }
+            const stats = this.parseTokenStats(file);
+            const list = childStatsByParent.get(parentId);
+            if (list) list.push(stats);
+            else childStatsByParent.set(parentId, [stats]);
           }
         } else {
           const head = this.scanSessionSource(file, options);
@@ -445,6 +443,86 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     } catch {
       return null;
     }
+  }
+
+  private parseTokenStats(filePath: string): SessionHead["stats"] {
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalCacheReadTokens = 0;
+    let totalCost = 0;
+    let activeModel: string | null = null;
+
+    let prevCumulativeTotal = 0;
+    let prevInput = 0;
+    let prevOutput = 0;
+    let prevReasoning = 0;
+    let prevCachedInput = 0;
+
+    for (const line of readJsonlFileLines(filePath)) {
+      try {
+        const data = JSON.parse(line);
+        const recordType = String(data["type"] ?? "");
+        const payload = extractPayload(data);
+
+        if (recordType === "session_meta" || recordType === "turn_context") {
+          const nextModel = extractModelName(payload["model"]);
+          if (nextModel) activeModel = nextModel;
+          continue;
+        }
+
+        if (recordType === "event_msg" && String(payload["type"] ?? "") === "token_count") {
+          const { totalUsage, lastUsage } = extractTokenUsage(payload);
+          const cumulativeTotal = Number(totalUsage?.["total_tokens"] ?? 0);
+          if (cumulativeTotal <= 0 || cumulativeTotal === prevCumulativeTotal) continue;
+          prevCumulativeTotal = cumulativeTotal;
+
+          let inputTokens = 0;
+          let outputTokens = 0;
+          let reasoningTokens = 0;
+          let cacheReadTokens = 0;
+
+          if (lastUsage) {
+            inputTokens = Number(lastUsage["input_tokens"] ?? 0);
+            outputTokens = Number(lastUsage["output_tokens"] ?? 0);
+            reasoningTokens = Number(lastUsage["reasoning_output_tokens"] ?? 0);
+            cacheReadTokens = extractCachedInputTokens(lastUsage);
+          } else if (totalUsage) {
+            inputTokens = Number(totalUsage["input_tokens"] ?? 0) - prevInput;
+            outputTokens = Number(totalUsage["output_tokens"] ?? 0) - prevOutput;
+            reasoningTokens = Number(totalUsage["reasoning_output_tokens"] ?? 0) - prevReasoning;
+            cacheReadTokens = extractCachedInputTokens(totalUsage) - prevCachedInput;
+            prevInput = Number(totalUsage["input_tokens"] ?? 0);
+            prevOutput = Number(totalUsage["output_tokens"] ?? 0);
+            prevReasoning = Number(totalUsage["reasoning_output_tokens"] ?? 0);
+            prevCachedInput = extractCachedInputTokens(totalUsage);
+          }
+
+          const totalInput = Math.max(0, inputTokens);
+          const totalCacheRead = Math.max(0, cacheReadTokens);
+          totalInputTokens += totalInput;
+          totalOutputTokens += outputTokens + reasoningTokens;
+          totalCacheReadTokens += totalCacheRead;
+          totalCost +=
+            estimateTokenCost(activeModel, {
+              input: totalInput,
+              output: outputTokens,
+              reasoning: reasoningTokens || undefined,
+              cache_read: totalCacheRead || undefined,
+            }) ?? 0;
+        }
+      } catch {
+        // skip malformed records
+      }
+    }
+
+    return {
+      message_count: 0,
+      total_input_tokens: totalInputTokens,
+      total_output_tokens: totalOutputTokens,
+      total_cache_read_tokens: totalCacheReadTokens || undefined,
+      total_cost: totalCost,
+      cost_source: totalCost > 0 ? "estimated" : undefined,
+    };
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -586,8 +664,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       const threadMeta = this.readThreadMeta(file);
       if (threadMeta?.threadSource !== "subagent") continue;
       if (threadMeta.parentThreadId !== parentSessionId) continue;
-      const childHead = getParsedSession(this.parseSessionHeadResult(file));
-      if (childHead) stats.push(childHead.stats);
+      stats.push(this.parseTokenStats(file));
     }
 
     if (stats.length > 0) this.subagentStatsByParent.set(parentSessionId, stats);
@@ -746,6 +823,9 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
           return skippedSession("malformed first record");
         }
         firstPayload = extractPayload(firstRecord);
+        if (extractThreadMeta(firstRecord)?.threadSource === "subagent") {
+          return filteredSession("subagent child");
+        }
         createdAt =
           parseTimestampMs(firstRecord) ||
           parseTimestampMs(firstPayload) ||
@@ -891,6 +971,10 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       firstRecord = JSON.parse(lines[0]!);
     } catch {
       return skippedSession("malformed first record");
+    }
+
+    if (extractThreadMeta(firstRecord)?.threadSource === "subagent") {
+      return filteredSession("subagent child");
     }
 
     const payload = extractPayload(firstRecord);


### PR DESCRIPTION
## Problem

Codex stores every subagent as its own rollout jsonl file (thread_source=subagent, parent_thread_id -> parent session). The scanner treated each as a top-level session, so:

1. **365 subagent files polluted the top-level list**, mixed with 1723 real sessions.
2. **Subagent tokens never reached the parent.** A session that spawned 37 subagents showed only its own tokens — its real cost was massively understated.

The parent's spawn_agent tool part already carries model, reasoning_effort, and task_name in its arguments (the message/prompt field is an opaque encrypted blob, unreadable), but the subagent tool card showed an empty details list and a garbled title.

## Approach

**Override scan()** — read each file's first record once to classify it:
- thread_source=subagent -> parse its stats, route into a parent->children index, keep it out of the head list.
- thread_source=user (or absent) -> normal head, then fold its children's tokens into its head stats.

**getSessionData()** reuses that index (rebuilding on demand if a detail is opened before a scan) to fold child tokens into the detail stats without surfacing child messages.

**Subagent tool card** (codex.ts tool-strategy) — title is now the task_name, with Model and Effort details pulled from the spawn_agent arguments; the unreadable encrypted prompt is no longer shown as output.

**Cache invalidation** — bump PARSER_VERSION (v4 -> v5) so every cached Codex head re-parses; orphaned child session rows are cleared by saveCachedSessions on rescan.

## Verification

- vitest run -> 598 passed, 1 skipped
- tsc --noEmit clean (core + web); oxlint / oxfmt clean
- Against the real ~/.codex/sessions:
  - Top-level sessions 2088 -> 1722 (365 subagent files folded)
  - Session 019fb63e with 37 children: input 490487634, output 1922410, message_count 2115 (own messages only)
  - Zero subagent sessions in the top-level list

## Test coverage

| Case | File |
|---|---|
| subagent filtered + head token fold | codex.test.ts |
| subagent tokens fold into detail stats | codex.test.ts |
| childless session unchanged (regression) | codex.test.ts |
