### PR TITLE
Add Kimi-Code session support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # CodeSesh
 
-**用途**：发现、聚合、可视化本地 AI 编码 Agent（Claude Code、Cursor、Kimi、Codex、Pi、OpenCode、ZCode）的历史会话，通过 Web UI 统一浏览。
+**用途**：发现、聚合、可视化本地 AI 编码 Agent（Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode、ZCode）的历史会话，通过 Web UI 统一浏览。
 
 ## 技术栈
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **One place to see every AI coding session you've ever had.**
 
-You've been coding with AI agents — Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, ZCode — and the conversations are scattered everywhere on your filesystem. Context is lost. Cost is invisible. History is buried.
+You've been coding with AI agents — Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, ZCode — and the conversations are scattered everywhere on your filesystem. Context is lost. Cost is invisible. History is buried.
 
 **CodeSesh** fixes that. It scans your local machine, finds every AI agent session, and surfaces them in a unified, beautiful Web UI. Think of it as a time machine for your AI-assisted development workflow.
 
@@ -50,6 +50,7 @@ CodeSesh believes your session history belongs to **you** — and you deserve to
 | Claude Code | Supported |
 | Cursor | Supported |
 | Kimi | Supported |
+| Kimi-Code | Supported |
 | Codex | Supported |
 | Pi | Supported |
 | OpenCode | Supported |

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 
 > **一个地方，看遍你所有的 AI 编程会话。**
 
-你一直在用 AI Agent 写代码 —— Claude Code、Cursor、Kimi、Codex、Pi、OpenCode、ZCode —— 但这些对话分散在文件系统的各个角落。上下文丢失，成本不可见，历史深埋。
+你一直在用 AI Agent 写代码 —— Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode、ZCode —— 但这些对话分散在文件系统的各个角落。上下文丢失，成本不可见，历史深埋。
 
 **CodeSesh** 解决这个问题。它扫描你的本地机器，找到所有 AI Agent 会话，并在统一的 Web UI 中呈现。把它理解为你 AI 辅助开发历程的时光机。
 
@@ -50,6 +50,7 @@ CodeSesh 认为，你的会话历史属于**你** —— 你应该在一个地�
 | Claude Code | 已支持 |
 | Cursor | 已支持 |
 | Kimi | 已支持 |
+| Kimi-Code | 已支持 |
 | Codex | 已支持 |
 | Pi | 已支持 |
 | OpenCode | 已支持 |

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -153,7 +153,9 @@ export const MessageItem = memo(function MessageItem({
             <span className="console-mono text-sm font-bold tracking-wide text-[var(--console-text)]">
               {roleLabel}
             </span>
-            <time className="console-mono text-xs text-[var(--console-muted)]">{time}</time>
+            {time ? (
+              <time className="console-mono text-xs text-[var(--console-muted)]">{time}</time>
+            ) : null}
             {modeLabel && (
               <span className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-1.5 py-0.5 text-[10px] text-[var(--console-muted)]">
                 {modeLabel}

--- a/apps/web/src/components/session-detail/tool-strategy.test.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.test.ts
@@ -33,6 +33,12 @@ const FILE_TOOL_CASES = [
   ["kimi", "ReadFile", "read"],
   ["kimi", "StrReplaceFile", "edit"],
   ["kimi", "WriteFile", "write"],
+  ["kimi-code", "ReadFile", "read"],
+  ["kimi-code", "StrReplaceFile", "edit"],
+  ["kimi-code", "WriteFile", "write"],
+  ["kimi-code", "Read", "read"],
+  ["kimi-code", "Edit", "edit"],
+  ["kimi-code", "Write", "write"],
   ["cursor", "read_file_v2", "read"],
   ["cursor", "edit_file_v2", "edit"],
 ] as const;
@@ -239,6 +245,71 @@ describe("getToolDisplayStrategy", () => {
     expect(strategy.outputContent).toMatchObject({
       kind: "plain",
       text: "No output captured.",
+    });
+  });
+
+  it("renders Kimi-Code question answers from JSON output", () => {
+    const tool = part({
+      tool: "AskUserQuestion",
+      title: "ask",
+      state: {
+        status: "completed",
+        input: {
+          questions: [
+            {
+              header: "响应式",
+              question: "响应式回退方案怎么定？",
+              options: [{ label: "浮层", description: "不挤压详情" }],
+            },
+          ],
+        },
+        output: JSON.stringify({ answers: { "响应式回退方案怎么定？": "浮层" } }),
+      },
+    });
+
+    const strategy = getToolDisplayStrategy("kimi-code", tool, normalizeToolState(tool));
+
+    expect(strategy).toMatchObject({ title: "ask", showInputPreview: false });
+    expect(strategy.outputContent).toEqual({
+      kind: "question-list",
+      questions: [
+        {
+          header: "响应式",
+          question: "响应式回退方案怎么定？",
+          options: [{ label: "浮层", description: "不挤压详情" }],
+          answers: ["浮层"],
+        },
+      ],
+    });
+  });
+
+  it("renders Kimi-Code TodoList items instead of raw JSON", () => {
+    const tool = part({
+      tool: "TodoList",
+      title: "todo",
+      state: {
+        status: "completed",
+        input: {
+          todos: [
+            { title: "Inspect", status: "completed" },
+            { title: "Patch", status: "pending" },
+          ],
+        },
+        output: "Todo list updated.",
+      },
+    });
+
+    const strategy = getToolDisplayStrategy("kimi-code", tool, normalizeToolState(tool));
+
+    expect(strategy).toMatchObject({
+      title: "todo",
+      secondaryText: "1 completed · 1 pending",
+      showInputPreview: false,
+      outputContent: {
+        kind: "plain",
+        text: "- [x] Inspect\n- [ ] Patch",
+        language: "markdown",
+      },
     });
   });
 

--- a/apps/web/src/components/session-detail/tool-strategy/index.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/index.ts
@@ -16,10 +16,11 @@ import type { NormalizedToolState, ToolDisplayStrategy } from "../tool-normalize
 import { buildClaudeToolStrategy } from "./claudecode";
 import { buildOpencodeToolStrategy } from "./opencode";
 import { buildKimiToolStrategy } from "./kimi";
+import { buildKimiCodeToolStrategy } from "./kimi-code";
+import { buildZCodeToolStrategy } from "./zcode";
 import { buildCodexToolStrategy } from "./codex";
 import { buildCursorToolStrategy } from "./cursor";
 import { buildPiToolStrategy } from "./pi";
-import { buildZCodeToolStrategy } from "./zcode";
 import { buildDefaultToolStrategy } from "./shared";
 
 export type { NormalizedToolState, ToolDisplayStrategy, ToolStatus } from "../tool-normalize";
@@ -48,6 +49,7 @@ const TOOL_STRATEGY_BUILDERS: Record<string, ToolStrategyBuilder> = {
   claudecode: buildClaudeToolStrategy,
   opencode: buildOpencodeToolStrategy,
   kimi: buildKimiToolStrategy,
+  "kimi-code": buildKimiCodeToolStrategy,
   codex: buildCodexToolStrategy,
   cursor: buildCursorToolStrategy,
   pi: buildPiToolStrategy,

--- a/apps/web/src/components/session-detail/tool-strategy/kimi-code.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/kimi-code.ts
@@ -1,0 +1,18 @@
+/**
+ * Kimi-Code tool display strategy.
+ *
+ * Kimi-Code uses the same native workflow tool vocabulary as ZCode, while its
+ * agent adapter and transcript format remain independent. Normalize from the
+ * raw tool name so persisted display titles cannot hide the tool semantics.
+ */
+import type { ToolPart } from "../../../lib/api";
+import type { NormalizedToolState, ToolDisplayStrategy } from "../tool-normalize";
+import { buildZCodeToolStrategy } from "./zcode";
+
+export function buildKimiCodeToolStrategy(
+  tool: ToolPart,
+  state: NormalizedToolState,
+  baseDirectory?: string,
+): ToolDisplayStrategy {
+  return buildZCodeToolStrategy({ ...tool, title: "" }, state, baseDirectory);
+}

--- a/apps/web/src/components/session-detail/tool-strategy/zcode.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/zcode.ts
@@ -46,7 +46,7 @@ function buildZCodeTodoOutput(todos: unknown[]) {
     const item = toRecord(todo);
     const status = toPlainText(item.status) || "pending";
     const priority = toPlainText(item.priority);
-    const content = toPlainText(item.content);
+    const content = toPlainText(item.content) || toPlainText(item.title);
     counts.set(status, (counts.get(status) ?? 0) + 1);
     const marker = status === "completed" ? "x" : status === "in_progress" ? "~" : " ";
     const suffix = priority ? ` _${priority}_` : "";
@@ -65,6 +65,19 @@ function buildZCodeTodoOutput(todos: unknown[]) {
 
 function parseZCodeQuestionAnswers(outputText: string) {
   const answers = new Map<string, string[]>();
+  try {
+    const parsed = JSON.parse(outputText) as unknown;
+    const answerRecord = toRecord(toRecord(parsed).answers);
+    if (answerRecord) {
+      for (const [question, answer] of Object.entries(answerRecord)) {
+        const value = toPlainText(answer);
+        if (question.trim() && value) answers.set(question.trim(), [stripRecommendedMarker(value)]);
+      }
+    }
+  } catch {
+    // Tool output may be a human-readable sentence instead of JSON.
+  }
+
   const pattern = /"([^"]+)"="([^"]+)"/g;
   for (const match of outputText.matchAll(pattern)) {
     const question = match[1]?.trim();
@@ -135,7 +148,7 @@ export function buildZCodeToolStrategy(
   const displayPath = getDisplayPath(filePath, baseDirectory);
   const outputText = getOutputOrErrorText(state);
 
-  if (toolKey === "bash") {
+  if (toolKey === "bash" || toolKey === "shell") {
     const description = toPlainText(input.description);
     const command = toPlainText(input.command);
     const displayCommand = getDisplayTextWithRelativePaths(command, baseDirectory);
@@ -161,11 +174,11 @@ export function buildZCodeToolStrategy(
     };
   }
 
-  if (toolKey === "read") {
+  if (toolKey === "read" || toolKey === "readfile") {
     return buildFileReadStrategy({ defaultStrategy, state, filePath, displayPath });
   }
 
-  if (toolKey === "edit") {
+  if (toolKey === "edit" || toolKey === "strreplacefile") {
     const diffBlocks = buildZCodeEditDiffBlocks(state, displayPath || filePath);
     const oldValue = toStringValue(input.old_string);
     const newValue = toStringValue(input.new_string);
@@ -194,7 +207,7 @@ export function buildZCodeToolStrategy(
     });
   }
 
-  if (toolKey === "write") {
+  if (toolKey === "write" || toolKey === "writefile") {
     return buildFileWriteStrategy({
       defaultStrategy,
       state,
@@ -220,7 +233,7 @@ export function buildZCodeToolStrategy(
     };
   }
 
-  if (toolKey === "todowrite") {
+  if (toolKey === "todowrite" || toolKey === "todolist") {
     const todos = Array.isArray(input.todos) ? input.todos : [];
     const todoOutput = buildZCodeTodoOutput(todos);
     return {

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -132,7 +132,15 @@ describe("formatTokens", () => {
 describe("formatMessageTime", () => {
   it("formats a millisecond timestamp", () => {
     const result = formatMessageTime(Date.now());
-    expect(typeof result).toBe("string");
+    expect(result).toBeTypeOf("string");
+    if (result === null) throw new Error("expected a formatted message time");
     expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("omits missing or invalid timestamps", () => {
+    expect(formatMessageTime(0)).toBeNull();
+    expect(formatMessageTime(undefined)).toBeNull();
+    expect(formatMessageTime("0")).toBeNull();
+    expect(formatMessageTime("not-a-time")).toBeNull();
   });
 });

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -37,8 +37,9 @@ export function formatTokens(n: number) {
   return n.toString();
 }
 
-export function formatMessageTime(rawTime: number | string) {
-  if (typeof rawTime === "number" && rawTime <= 0) return "Unknown time";
+export function formatMessageTime(rawTime: number | string | null | undefined): string | null {
+  if (rawTime == null) return null;
+  if (typeof rawTime === "number" && (!Number.isFinite(rawTime) || rawTime <= 0)) return null;
 
   let date: Date | null = null;
   if (typeof rawTime === "number") {
@@ -47,15 +48,15 @@ export function formatMessageTime(rawTime: number | string) {
   } else if (typeof rawTime === "string") {
     if (rawTime.trim()) {
       const timestamp = Number(rawTime);
-      if (!Number.isNaN(timestamp) && timestamp > 0) {
+      if (Number.isFinite(timestamp) && timestamp > 0) {
         date = new Date(timestamp < 10 ** 12 ? timestamp * 1000 : timestamp);
       } else {
-        date = new Date(rawTime);
+        date = Number.isFinite(timestamp) ? null : new Date(rawTime);
       }
     }
   }
 
-  if (!date || Number.isNaN(date.getTime())) return "Unknown time";
+  if (!date || Number.isNaN(date.getTime())) return null;
 
   return date.toLocaleTimeString("en-US", {
     hour: "2-digit",

--- a/apps/web/tests/agent-registration-completeness.test.ts
+++ b/apps/web/tests/agent-registration-completeness.test.ts
@@ -34,13 +34,15 @@ describe("agent registration completeness", () => {
   });
 
   it("keeps the agent icon directory aligned with registered icons", () => {
-    const registeredIcons = getRegisteredAgents()
-      .map((registration) => {
-        const iconPath = resolve(PUBLIC_ROOT, registration.icon.replace(/^\/+/, ""));
-        expect(existsSync(iconPath), `${registrationName(registration)} icon`).toBe(true);
-        return basename(iconPath);
-      })
-      .toSorted();
+    const registeredIcons = [
+      ...new Set(
+        getRegisteredAgents().map((registration) => {
+          const iconPath = resolve(PUBLIC_ROOT, registration.icon.replace(/^\/+/, ""));
+          expect(existsSync(iconPath), `${registrationName(registration)} icon`).toBe(true);
+          return basename(iconPath);
+        }),
+      ),
+    ].toSorted();
     const iconFiles = readdirSync(AGENT_ICON_ROOT)
       .filter((file) => file.endsWith(".svg"))
       .toSorted();

--- a/apps/www/public/index.md
+++ b/apps/www/public/index.md
@@ -2,7 +2,7 @@
 
 CodeSesh turns local AI coding history into reusable engineering memory.
 
-It discovers local sessions from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode, then preserves problems, reasoning, attempts, file activity, and outcomes in one project-aware searchable memory layer.
+It discovers local sessions from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode, then preserves problems, reasoning, attempts, file activity, and outcomes in one project-aware searchable memory layer.
 
 ## Start
 
@@ -38,7 +38,7 @@ CodeSesh brings local sessions from different agents into one index.
 
 - Zero Configuration: run one command and scan supported agent sessions on your filesystem.
 - Live Refresh: local session changes appear automatically as new collaboration records are written.
-- Unified Timeline: browse Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode sessions in one interface.
+- Unified Timeline: browse Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode sessions in one interface.
 
 ### Organize
 
@@ -73,6 +73,7 @@ CodeSesh reconstructs the full path from problem to result.
 - Claude Code
 - Cursor
 - Kimi
+- Kimi-Code
 - Codex
 - Pi
 - OpenCode
@@ -82,11 +83,11 @@ CodeSesh reconstructs the full path from problem to result.
 
 ### What is CodeSesh?
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
 
 ### Which AI coding tools does CodeSesh support?
 
-CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
+CodeSesh currently supports Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
 
 ### Does CodeSesh upload local AI session data?
 
@@ -106,4 +107,4 @@ The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeS
 
 ## 中文说明
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode、ZCode 的本地 AI 编码历史，把分散的协作记录沉淀成可复用的工程记忆。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode、ZCode 的本地 AI 编码历史，把分散的协作记录沉淀成可复用的工程记忆。

--- a/apps/www/public/llms-full.txt
+++ b/apps/www/public/llms-full.txt
@@ -1,6 +1,6 @@
 # CodeSesh: AI-Readable Product Knowledge
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It works with local sessions created by Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode, then presents them in one unified Web UI.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It works with local sessions created by Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode, then presents them in one unified Web UI.
 
 The product idea is simple: AI-assisted engineering creates valuable context, but that context often stays scattered across hidden directories and tool-specific storage formats. CodeSesh turns those local records into reusable engineering memory.
 
@@ -14,7 +14,7 @@ CodeSesh runs on the developer's machine. It does not require an account, cloud 
 
 ## One-Line Description
 
-CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode into project-aware, structurally searchable, replayable engineering memory.
+CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode into project-aware, structurally searchable, replayable engineering memory.
 
 ## Primary Audience
 
@@ -31,7 +31,7 @@ Typical users have one or more of these needs:
 
 ## Core Problem
 
-Modern AI coding tools save session history in different local formats and directories. A developer may have useful context inside Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode at the same time. Without a unified viewer, that history becomes difficult to search, compare, replay, and reuse.
+Modern AI coding tools save session history in different local formats and directories. A developer may have useful context inside Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode at the same time. Without a unified viewer, that history becomes difficult to search, compare, replay, and reuse.
 
 This matters because AI coding sessions often contain:
 
@@ -72,6 +72,7 @@ CodeSesh currently supports these AI coding agents:
 - Claude Code
 - Cursor
 - Kimi
+- Kimi-Code
 - Codex
 - Pi
 - OpenCode
@@ -106,11 +107,11 @@ Source build requirement:
 
 ### What is CodeSesh?
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
 
 ### Which AI coding tools does CodeSesh support?
 
-CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
+CodeSesh currently supports Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
 
 ### Does CodeSesh upload local AI session data?
 
@@ -330,7 +331,7 @@ CodeSesh is relevant for queries like:
 
 ## Chinese Summary
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码 Agent 的历史会话。它支持 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode、ZCode，把分散在本地文件系统里的会话沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码 Agent 的历史会话。它支持 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode、ZCode，把分散在本地文件系统里的会话沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
 
 核心价值包括：跨 Agent 统一时间线、结构化全局搜索、项目浏览模式、项目化会话树、智能标签、会话收藏、完整回放、文件活动索引、Token 与成本可见、SQLite 迁移与本地索引、零配置启动、本地私有、实时刷新。
 

--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -1,6 +1,6 @@
 # CodeSesh
 
-> CodeSesh is a local developer tool that turns AI coding session history from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode into project-aware, structurally searchable, replayable engineering memory.
+> CodeSesh is a local developer tool that turns AI coding session history from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode into project-aware, structurally searchable, replayable engineering memory.
 
 ## Links
 
@@ -21,6 +21,7 @@ CodeSesh scans local AI coding agent session files and presents them in one Web 
 - Claude Code
 - Cursor
 - Kimi
+- Kimi-Code
 - Codex
 - Pi
 - OpenCode
@@ -39,11 +40,11 @@ CodeSesh scans local AI coding agent session files and presents them in one Web 
 
 ### What is CodeSesh?
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
 
 ### Which AI coding tools does CodeSesh support?
 
-CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
+CodeSesh currently supports Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
 
 ### Does CodeSesh upload local AI session data?
 
@@ -63,4 +64,4 @@ CodeSesh opens a local Web UI at `http://localhost:4521`.
 
 ## Chinese Summary
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode、ZCode 等 AI 编码工具的本地历史会话，把分散的 AI 协作过程沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode、ZCode 等 AI 编码工具的本地历史会话，把分散的 AI 协作过程沉淀成按项目组织、可结构化检索、可复盘的工程记忆。

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -105,6 +105,7 @@ export const agents = [
   { name: "Claude Code", icon: "/icon/agent/claudecode.svg", iconColored: true },
   { name: "Cursor", icon: "/icon/agent/cursor.svg" },
   { name: "Kimi", icon: "/icon/agent/kimi.svg" },
+  { name: "Kimi-Code", icon: "/icon/agent/kimi.svg" },
   { name: "Codex", icon: "/icon/agent/codex.svg" },
   { name: "Pi", icon: "/icon/agent/pi.svg" },
   { name: "OpenCode", icon: "/icon/agent/opencode.svg" },
@@ -116,7 +117,7 @@ export const copy = {
     meta: {
       title: "CodeSesh：可复用的 AI 编码工程记忆",
       description:
-        "CodeSesh 把 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode 和 ZCode 的本地 AI 编码历史，沉淀成按项目组织、可结构化检索、可复盘的工程记忆。",
+        "CodeSesh 把 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode 和 ZCode 的本地 AI 编码历史，沉淀成按项目组织、可结构化检索、可复盘的工程记忆。",
     },
     header: {
       github: "GitHub",
@@ -130,7 +131,7 @@ export const copy = {
     hero: {
       title: ["把 AI 编码历史，", "变成可复用的工程记忆。"],
       latest: "最新版",
-      body: "CodeSesh 自动发现 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode 和 ZCode 的本地会话，把问题、推理、尝试、文件活动和结果沉淀成按项目组织、可结构化检索、可复盘的工程记忆。",
+      body: "CodeSesh 自动发现 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode 和 ZCode 的本地会话，把问题、推理、尝试、文件活动和结果沉淀成按项目组织、可结构化检索、可复盘的工程记忆。",
       commandTitle: "从本地开始积累",
       command: "npx codesesh",
       copied: "已复制",
@@ -194,7 +195,7 @@ export const copy = {
               icon: "eye",
               title: "统一时间线",
               description:
-                "在一个界面里浏览 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode 和 ZCode 的历史会话。",
+                "在一个界面里浏览 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode 和 ZCode 的历史会话。",
             },
           ],
         },
@@ -289,12 +290,12 @@ export const copy = {
         {
           question: "CodeSesh 是什么？",
           answer:
-            "CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码会话历史。它把 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode 和 ZCode 的本地记录整理成一个按项目组织的工程记忆层，帮助开发者找回历史决策、文件活动和完整协作过程。",
+            "CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码会话历史。它把 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode 和 ZCode 的本地记录整理成一个按项目组织的工程记忆层，帮助开发者找回历史决策、文件活动和完整协作过程。",
         },
         {
           question: "CodeSesh 支持哪些 AI 编码工具？",
           answer:
-            "CodeSesh 当前支持 Claude Code、Cursor、Kimi、Codex、Pi、OpenCode 和 ZCode。每个工具通过 core 包里的 Agent 适配器接入，扫描本地会话存储后统一生成会话列表、项目浏览、结构化搜索索引、文件活动、标签、Token 统计和会话详情。",
+            "CodeSesh 当前支持 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Pi、OpenCode 和 ZCode。每个工具通过 core 包里的 Agent 适配器接入，扫描本地会话存储后统一生成会话列表、项目浏览、结构化搜索索引、文件活动、标签、Token 统计和会话详情。",
         },
         {
           question: "CodeSesh 会上传本地 AI 会话数据吗？",
@@ -313,7 +314,7 @@ export const copy = {
     meta: {
       title: "CodeSesh: Reusable Engineering Memory for AI Coding",
       description:
-        "CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode into project-aware, structurally searchable, replayable engineering memory.",
+        "CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode into project-aware, structurally searchable, replayable engineering memory.",
     },
     header: {
       github: "GitHub",
@@ -327,7 +328,7 @@ export const copy = {
     hero: {
       title: ["Turn AI coding history", "into reusable engineering memory."],
       latest: "Latest",
-      body: "CodeSesh discovers local sessions from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode, then preserves problems, reasoning, attempts, file activity, and outcomes in one project-aware searchable memory layer.",
+      body: "CodeSesh discovers local sessions from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode, then preserves problems, reasoning, attempts, file activity, and outcomes in one project-aware searchable memory layer.",
       commandTitle: "Start from your machine",
       command: "npx codesesh",
       copied: "Copied",
@@ -395,7 +396,7 @@ export const copy = {
               icon: "eye",
               title: "Unified Timeline",
               description:
-                "Browse Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode sessions in one interface.",
+                "Browse Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode sessions in one interface.",
             },
           ],
         },
@@ -497,12 +498,12 @@ export const copy = {
         {
           question: "What is CodeSesh?",
           answer:
-            "CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.",
+            "CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.",
         },
         {
           question: "Which AI coding tools does CodeSesh support?",
           answer:
-            "CodeSesh currently supports Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.",
+            "CodeSesh currently supports Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.",
         },
         {
           question: "Does CodeSesh upload local AI session data?",

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -187,7 +187,7 @@ const jsonLd = {
     <meta name="description" content={t.meta.description} />
     <meta
       name="keywords"
-      content="AI coding, Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, ZCode, engineering memory, session history, developer tools, AI pair programming"
+      content="AI coding, Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, ZCode, engineering memory, session history, developer tools, AI pair programming"
     />
     <meta name="author" content="XingKaiXin" />
     <meta name="robots" content="index, follow" />

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><strong>One place to see every AI coding session you've ever had.</strong></p>
 
-CodeSesh scans your local machine, finds every AI agent session (Claude Code, Cursor, Kimi, Codex, Pi, OpenCode, ZCode), and surfaces them in a unified, beautiful Web UI.
+CodeSesh scans your local machine, finds every AI agent session (Claude Code, Cursor, Kimi, Kimi-Code, Codex, Pi, OpenCode, ZCode), and surfaces them in a unified, beautiful Web UI.
 
 ## Quick Start
 
@@ -45,6 +45,7 @@ Your browser will open at `http://localhost:4521` with all your sessions ready t
 | Claude Code | ✅ Supported |
 | Cursor      | ✅ Supported |
 | Kimi        | ✅ Supported |
+| Kimi-Code   | ✅ Supported |
 | Codex       | ✅ Supported |
 | Pi          | ✅ Supported |
 | OpenCode    | ✅ Supported |

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -253,6 +253,7 @@ describe("handleGetAgents", () => {
       "opencode",
       "zcode",
       "kimi",
+      "kimi-code",
       "codex",
       "pi",
       "cursor",

--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -1,0 +1,341 @@
+import { appendFileSync, mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { KimiCodeAgent } from "../kimi-code.js";
+
+const SESSION_ID = "ses_test-kimi-code";
+const WORK_DIR = "/tmp/kimi-code-project";
+
+let tempDirs: string[] = [];
+
+function createAgent(dataRoot: string): KimiCodeAgent {
+  const agent = new KimiCodeAgent() as never as { basePath: string };
+  agent.basePath = join(dataRoot, "sessions");
+  return agent as never as KimiCodeAgent;
+}
+
+function createSession(
+  dataRoot: string,
+  wire: Record<string, unknown>[],
+  sessionId = SESSION_ID,
+): string {
+  const sessionDir = join(dataRoot, "sessions", "wd_project_hash", sessionId);
+  mkdirSync(join(sessionDir, "agents", "main"), { recursive: true });
+  writeFileSync(
+    join(sessionDir, "state.json"),
+    JSON.stringify({
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:01:00.000Z",
+      title: "",
+      agents: { main: { homedir: join(sessionDir, "agents", "main") } },
+    }),
+  );
+  const wireFile = join(sessionDir, "agents", "main", "wire.jsonl");
+  writeFileSync(wireFile, wire.map((record) => JSON.stringify(record)).join("\n") + "\n");
+  utimesSync(wireFile, 1767225607, 1767225607);
+  writeFileSync(
+    join(dataRoot, "session_index.jsonl"),
+    `${JSON.stringify({ sessionId, sessionDir, workDir: WORK_DIR })}\n`,
+  );
+  return sessionDir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs = [];
+});
+
+describe("KimiCodeAgent", () => {
+  it("discovers workdir-keyed sessions and rebuilds loop events", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    const sessionDir = createSession(dataRoot, [
+      { type: "metadata", protocol_version: "1.4", created_at: 1767225600000 },
+      {
+        type: "context.append_message",
+        time: 1767225601000,
+        message: { role: "user", content: [{ type: "text", text: "Read package.json" }] },
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225602000,
+        event: { type: "step.begin", uuid: "step-1", turnId: "0", step: 1 },
+      },
+      {
+        type: "llm.request",
+        time: 1767225602001,
+        provider: "kimi",
+        model: "moonshot-cn/kimi-k2.7-code",
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225603000,
+        event: {
+          type: "content.part",
+          stepUuid: "step-1",
+          part: { type: "think", think: "Inspect the package manifest" },
+        },
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225604000,
+        event: {
+          type: "tool.call",
+          stepUuid: "step-1",
+          toolCallId: "call-1",
+          name: "ReadFile",
+          args: { path: "package.json" },
+        },
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225605000,
+        event: {
+          type: "tool.result",
+          stepUuid: "step-1",
+          toolCallId: "call-1",
+          result: { output: '{"name":"codesesh"}', isError: false },
+        },
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225606000,
+        event: {
+          type: "content.part",
+          stepUuid: "step-1",
+          part: { type: "text", text: "I found the package manifest." },
+        },
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225607000,
+        event: { type: "step.end", uuid: "step-1" },
+      },
+      {
+        type: "usage.record",
+        time: 1767225608000,
+        model: "moonshot-cn/kimi-k2.7-code",
+        usage: { inputOther: 10, inputCacheRead: 2, inputCacheCreation: 1, output: 4 },
+        usageScope: "turn",
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225609000,
+        event: { type: "step.begin", uuid: "step-2", turnId: "0", step: 2 },
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225610000,
+        event: {
+          type: "content.part",
+          stepUuid: "step-2",
+          part: { type: "text", text: "The next step is separate." },
+        },
+      },
+      {
+        type: "context.append_loop_event",
+        time: 1767225611000,
+        event: { type: "step.end", uuid: "step-2" },
+      },
+    ]);
+
+    const agent = createAgent(dataRoot);
+    const refs = agent.listSessionSources();
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.sourcePath).toBe(sessionDir);
+
+    writeFileSync(
+      join(dataRoot, "session_index.jsonl"),
+      `${JSON.stringify({ sessionId: SESSION_ID, sessionDir, workDir: "/tmp/renamed-project" })}\n`,
+    );
+    expect(agent.listSessionSources()[0]?.fingerprint).not.toBe(refs[0]?.fingerprint);
+
+    const [head] = agent.scan();
+    expect(head).toMatchObject({
+      id: SESSION_ID,
+      slug: `kimi-code/${SESSION_ID}`,
+      title: "Read package.json",
+      directory: "/tmp/renamed-project",
+      time_created: 1767225600000,
+      time_updated: 1767225660000,
+      stats: {
+        message_count: 3,
+        total_input_tokens: 13,
+        total_output_tokens: 4,
+        total_tokens: 17,
+        total_cache_read_tokens: 2,
+        total_cache_create_tokens: 1,
+      },
+      model_usage: { "moonshot-cn/kimi-k2.7-code": 17 },
+    });
+
+    const detail = agent.getSessionData(SESSION_ID);
+    expect(detail.reference).toEqual({ agentName: "kimi-code", sessionId: SESSION_ID });
+    expect(detail.messages).toHaveLength(3);
+    expect(detail.messages[0]).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", text: "Read package.json" }],
+    });
+    expect(detail.messages[1]).toMatchObject({
+      role: "assistant",
+      time_created: 1767225603000,
+      parts: [
+        { type: "reasoning", text: "Inspect the package manifest" },
+        {
+          type: "tool",
+          tool: "ReadFile",
+          title: "read",
+          callID: "call-1",
+          state: {
+            status: "completed",
+            input: { path: "package.json" },
+            output: [{ type: "text", text: '{"name":"codesesh"}' }],
+          },
+        },
+        { type: "text", text: "I found the package manifest." },
+      ],
+      tokens: { input: 13, output: 4, cache_read: 2, cache_create: 1 },
+    });
+    expect(detail.messages[2]).toMatchObject({
+      role: "assistant",
+      parts: [{ type: "text", text: "The next step is separate." }],
+    });
+  });
+
+  it("supports context messages written by migrated sessions", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    createSession(dataRoot, [
+      { type: "metadata", protocol_version: "1.0", created_at: 1767225600000 },
+      {
+        type: "context.append_message",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "Inspect the file" },
+            { type: "image_url", imageUrl: { url: "data:image/png;base64,abc" } },
+          ],
+        },
+      },
+      {
+        type: "context.append_message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Reading it." }],
+          toolCalls: [
+            {
+              type: "function",
+              id: "call-2",
+              function: { name: "ReadFile", arguments: '{"path":"src/index.ts"}' },
+            },
+          ],
+        },
+      },
+      {
+        type: "context.append_message",
+        message: {
+          role: "tool",
+          toolCallId: "call-2",
+          content: [{ type: "text", text: "export const answer = 42;" }],
+        },
+      },
+    ]);
+
+    const agent = createAgent(dataRoot);
+    agent.scan();
+    const detail = agent.getSessionData(SESSION_ID);
+    expect(detail.messages).toHaveLength(2);
+    expect(detail.messages[1]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: "Reading it." }),
+      expect.objectContaining({
+        type: "tool",
+        tool: "ReadFile",
+        state: expect.objectContaining({
+          status: "completed",
+          input: { path: "src/index.ts" },
+          output: [expect.objectContaining({ type: "text", text: "export const answer = 42;" })],
+        }),
+      }),
+    ]);
+    expect(detail.messages[0]?.parts).toEqual([
+      { type: "text", text: "Inspect the file", time_created: expect.any(Number) },
+      {
+        type: "image",
+        url: "data:image/png;base64,abc",
+        time_created: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("does not expose empty sessions until their wire gains content", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    const emptyId = "ses_empty-kimi-code";
+    const sessionDir = createSession(
+      dataRoot,
+      [{ type: "metadata", protocol_version: "1.4", created_at: 1767225600000 }],
+      emptyId,
+    );
+    const agent = createAgent(dataRoot);
+
+    expect(agent.scan()).toEqual([]);
+    expect(agent.getSessionMetaMap().has(emptyId)).toBe(false);
+
+    appendFileSync(
+      join(sessionDir, "agents", "main", "wire.jsonl"),
+      `${JSON.stringify({
+        type: "context.append_message",
+        time: 1767225601000,
+        message: { role: "user", content: [{ type: "text", text: "Continue" }] },
+      })}\n`,
+    );
+
+    const refs = agent.listSessionSources();
+    expect(agent.incrementalScan([], [emptyId], refs)).toMatchObject([
+      { id: emptyId, stats: { message_count: 1 } },
+    ]);
+  });
+
+  it("drops empty sessions restored from an older cache", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    createSession(dataRoot, [
+      { type: "metadata", protocol_version: "1.4", created_at: 1767225600000 },
+    ]);
+
+    const agent = createAgent(dataRoot);
+    const stale = {
+      id: SESSION_ID,
+      slug: `kimi-code/${SESSION_ID}`,
+      title: "New Session",
+      directory: WORK_DIR,
+      time_created: 1767225600000,
+      stats: { message_count: 0, total_input_tokens: 0, total_output_tokens: 0, total_cost: 0 },
+    };
+    agent.setSessionMetaMap(
+      new Map([[SESSION_ID, { id: SESSION_ID, sourcePath: join(dataRoot, "sessions") }]]),
+    );
+
+    expect(agent.filterCachedSessions([stale])).toEqual([]);
+    expect(agent.getSessionMetaMap().has(SESSION_ID)).toBe(false);
+
+    const changes = agent.checkForChanges(0, [stale]);
+    expect(changes.hasChanges).toBe(true);
+    expect(changes.changedIds).toContain(SESSION_ID);
+    expect(agent.incrementalScan([stale], changes.changedIds ?? [], changes.refs)).toEqual([]);
+  });
+
+  it("keeps a missing record timestamp unavailable", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    createSession(dataRoot, [
+      { type: "metadata", protocol_version: "1.4", created_at: 1767225600000 },
+      { type: "context.append_message", message: { role: "user", content: "No time" } },
+    ]);
+
+    const agent = createAgent(dataRoot);
+    agent.scan();
+    expect(agent.getSessionData(SESSION_ID).messages[0]?.time_created).toBe(0);
+  });
+});

--- a/packages/core/src/agents/__tests__/registry.test.ts
+++ b/packages/core/src/agents/__tests__/registry.test.ts
@@ -35,6 +35,13 @@ describe("agent registry", () => {
         count: 0,
       },
       {
+        name: "kimi-code",
+        displayName: "Kimi-Code",
+        icon: "/icon/agent/kimi.svg",
+        resumeCommandPrefix: "kimi -r",
+        count: 0,
+      },
+      {
         name: "codex",
         displayName: "Codex",
         icon: "/icon/agent/codex.svg",

--- a/packages/core/src/agents/__tests__/watch-plan.test.ts
+++ b/packages/core/src/agents/__tests__/watch-plan.test.ts
@@ -16,6 +16,7 @@ describe("registered agent session watch plans", () => {
       "codex",
       "cursor",
       "kimi",
+      "kimi-code",
       "opencode",
       "pi",
       "zcode",
@@ -32,6 +33,7 @@ describe("registered agent session watch plans", () => {
     vi.stubEnv("CODEX_HOME", "/tmp/codex-home");
     vi.stubEnv("PI_HOME", "/tmp/pi-home");
     vi.stubEnv("KIMI_SHARE_DIR", "/tmp/kimi-home");
+    vi.stubEnv("KIMI_CODE_HOME", "/tmp/kimi-code-home");
     vi.stubEnv("CURSOR_DATA_PATH", "/tmp/cursor-home");
     vi.stubEnv("XDG_DATA_HOME", "/tmp/data-home");
     const agents = new Map(createRegisteredAgents().map((agent) => [agent.name, agent]));
@@ -61,6 +63,13 @@ describe("registered agent session watch plans", () => {
     expect(agents.get("kimi")?.getSessionWatchPlan()).toEqual({
       status: "supported",
       targets: [{ root: roots.kimi, path: join(roots.kimi!, "sessions") }, { path: "data/kimi" }],
+    });
+    expect(agents.get("kimi-code")?.getSessionWatchPlan()).toEqual({
+      status: "supported",
+      targets: [
+        { root: roots["kimi-code"], path: join(roots["kimi-code"]!, "sessions") },
+        { root: roots["kimi-code"], path: join(roots["kimi-code"]!, "session_index.jsonl") },
+      ],
     });
     expect(agents.get("cursor")?.getSessionWatchPlan()).toEqual({
       status: "supported",

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -228,6 +228,10 @@ export abstract class BaseAgent {
     refs?: SessionSourceRef[],
   ): Promise<SessionHead[]> | SessionHead[];
 
+  filterCachedSessions(sessions: SessionHead[]): SessionHead[] {
+    return sessions;
+  }
+
   /** Get session metadata for caching. */
   abstract getSessionMetaMap(): Map<string, SessionCacheMeta>;
 

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -1,0 +1,749 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+  FileSystemSessionSource,
+  getParsedSession,
+  matchesScanWindow,
+  parsedSession,
+  skippedSession,
+} from "./base.js";
+import type {
+  AgentScanOptions,
+  ParseSessionResult,
+  SessionCacheMeta,
+  SessionSourceRef,
+} from "./base.js";
+import type {
+  MessagePart,
+  SessionDetail,
+  SessionHead,
+  SessionStats,
+  ToolPart,
+} from "../types/index.js";
+import { resolveHomePath } from "../discovery/paths.js";
+import { readJsonlFile } from "../utils/jsonl.js";
+import { asArray, asNumber, asRecord, asString } from "../utils/narrow.js";
+import { cleanInternalText } from "../utils/session-normalization.js";
+import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
+import { estimateTokenCost } from "../utils/cost.js";
+import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
+
+const KIMI_CODE_TOOL_TITLE_MAP: Record<string, string> = {
+  Read: "read",
+  Write: "write",
+  Edit: "edit",
+  Bash: "bash",
+  TodoList: "todo",
+  AskUserQuestion: "ask",
+  EnterPlanMode: "plan mode",
+  ExitPlanMode: "plan approved",
+  ReadFile: "read",
+  Glob: "glob",
+  StrReplaceFile: "edit",
+  Grep: "grep",
+  WriteFile: "write",
+  Shell: "bash",
+};
+
+const KIMI_CODE_IGNORED_TOOLS = new Set(["SetTodoList"]);
+
+export function resolveKimiCodeDataRoot(): string {
+  return resolveHomePath("KIMI_CODE_HOME", ".kimi-code");
+}
+
+interface SessionSource {
+  id: string;
+  sourcePath: string;
+  stateFile: string;
+  wireFile: string;
+  workDir: string;
+  createdAt: number;
+  updatedAt: number;
+  explicitTitle: string;
+}
+
+interface SessionMeta extends SessionCacheMeta, SessionSource {
+  title: string;
+  sourceMtimeMs: number;
+}
+
+interface UsageTotals {
+  totalCost: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  totalCacheCreateTokens: number;
+  modelUsage: Record<string, number>;
+}
+
+interface ParsedWire {
+  builder: TranscriptBuilder;
+  stats: SessionStats;
+  firstUserTitle: string | null;
+  modelUsage: Record<string, number>;
+}
+
+function mapToolTitle(toolName: string): string {
+  return KIMI_CODE_TOOL_TITLE_MAP[toolName] ?? toolName;
+}
+
+function normalizeToolArguments(raw: unknown): unknown {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function parseTimestamp(raw: unknown): number | null {
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric)) return numeric;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function timestampFromRecord(record: Record<string, unknown>): number {
+  return parseTimestamp(record.time) ?? 0;
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) {
+    const record = asRecord(content);
+    return record ? String(record.text ?? "") : "";
+  }
+
+  return content
+    .map((item) => {
+      if (typeof item === "string") return item;
+      const record = asRecord(item);
+      return record ? String(record.text ?? "") : "";
+    })
+    .join(" ");
+}
+
+function contentParts(content: unknown, timestampMs: number): MessagePart[] {
+  const values = Array.isArray(content) ? content : [content];
+  const parts: MessagePart[] = [];
+
+  for (const value of values) {
+    if (typeof value === "string") {
+      const text = cleanInternalText(value);
+      if (text) parts.push({ type: "text", text, time_created: timestampMs });
+      continue;
+    }
+
+    const record = asRecord(value);
+    if (!record) continue;
+    const type = asString(record.type) ?? "";
+    if (type === "text") {
+      const text = cleanInternalText(asString(record.text) ?? "");
+      if (text) parts.push({ type: "text", text, time_created: timestampMs });
+      continue;
+    }
+    if (type === "think") {
+      const text = cleanInternalText(asString(record.think) ?? "");
+      if (text) parts.push({ type: "reasoning", text, time_created: timestampMs });
+      continue;
+    }
+    if (type === "plan") {
+      const text = cleanInternalText(asString(record.text) ?? "");
+      if (text) {
+        parts.push({
+          type: "plan",
+          text,
+          approval_status: record.approved === false ? "fail" : "success",
+          time_created: timestampMs,
+        });
+      }
+      continue;
+    }
+    if (type === "image") {
+      const source = asRecord(record.source);
+      const imageUrl = asRecord(record.imageUrl);
+      const url =
+        asString(record.url) ??
+        asString(imageUrl?.url) ??
+        (source?.kind === "url" ? asString(source.url) : undefined);
+      const data =
+        asString(record.data) ?? (source?.kind === "base64" ? asString(source.data) : undefined);
+      const mimeType =
+        asString(record.mime_type) ??
+        asString(record.media_type) ??
+        (source?.kind === "base64" ? asString(source.media_type) : undefined) ??
+        "application/octet-stream";
+      if (url) parts.push({ type: "image", url, mime_type: mimeType, time_created: timestampMs });
+      else if (data) {
+        parts.push({
+          type: "image",
+          data,
+          mime_type: mimeType,
+          time_created: timestampMs,
+        });
+      }
+      continue;
+    }
+    if (type === "image_url") {
+      const imageUrl = asRecord(record.imageUrl);
+      const url = asString(imageUrl?.url) ?? asString(record.url);
+      if (url) parts.push({ type: "image", url, time_created: timestampMs });
+    }
+  }
+
+  return parts;
+}
+
+function toolOutputParts(output: unknown, timestampMs: number): MessagePart[] {
+  if (typeof output === "string") {
+    const text = cleanInternalText(output);
+    return text ? [{ type: "text", text, time_created: timestampMs }] : [];
+  }
+  if (Array.isArray(output)) return contentParts(output, timestampMs);
+  if (output == null) return [];
+
+  const record = asRecord(output);
+  if (record?.type === "text") return contentParts([record], timestampMs);
+
+  const text = cleanInternalText(JSON.stringify(output, null, 2));
+  return text ? [{ type: "text", text, time_created: timestampMs }] : [];
+}
+
+function toolPart(toolName: string, callId: string, input: unknown, timestampMs: number): ToolPart {
+  return {
+    type: "tool",
+    tool: toolName,
+    callID: callId,
+    title: mapToolTitle(toolName),
+    state: {
+      status: "running",
+      ...(input === undefined ? {} : { input }),
+      output: null,
+    },
+    time_created: timestampMs,
+  };
+}
+
+function toolCallParts(
+  message: Record<string, unknown>,
+  timestampMs: number,
+  ignoredToolCallIds: Set<string>,
+): MessagePart[] {
+  const calls = asArray(message.toolCalls) ?? [];
+  const parts: MessagePart[] = [];
+
+  for (const call of calls) {
+    const callRecord = asRecord(call);
+    const functionRecord = asRecord(callRecord?.function) ?? callRecord;
+    const toolName = asString(functionRecord?.name)?.trim() ?? "";
+    const callId = asString(callRecord?.id)?.trim() ?? "";
+    if (!toolName || !callId) continue;
+    if (KIMI_CODE_IGNORED_TOOLS.has(toolName)) {
+      ignoredToolCallIds.add(callId);
+      continue;
+    }
+
+    const rawArguments = functionRecord?.arguments ?? callRecord?.arguments;
+    parts.push(toolPart(toolName, callId, normalizeToolArguments(rawArguments), timestampMs));
+  }
+
+  return parts;
+}
+
+function addToolResolution(
+  builder: TranscriptBuilder,
+  callId: string,
+  output: unknown,
+  timestampMs: number,
+  isError = false,
+  note?: string,
+): boolean {
+  const outputParts = toolOutputParts(output, timestampMs);
+  return builder.resolveToolCall(callId, {
+    output: outputParts,
+    status: isError ? "error" : "completed",
+    ...(note ? { metadata: { note: cleanInternalText(note) } } : {}),
+  });
+}
+
+function usageNumber(usage: Record<string, unknown>, field: string): number {
+  return asNumber(usage[field]) ?? 0;
+}
+
+function emptyStats(): SessionStats {
+  return {
+    message_count: 0,
+    total_input_tokens: 0,
+    total_output_tokens: 0,
+    total_cost: 0,
+  };
+}
+
+function buildUsageTotals(): UsageTotals {
+  return {
+    totalCost: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheCreateTokens: 0,
+    modelUsage: {},
+  };
+}
+
+function applyUsage(
+  builder: TranscriptBuilder,
+  record: Record<string, unknown>,
+  activeModel: string | null,
+  totals: UsageTotals,
+): void {
+  const usage = asRecord(record.usage);
+  if (!usage) return;
+
+  const cacheRead = usageNumber(usage, "inputCacheRead");
+  const cacheCreate = usageNumber(usage, "inputCacheCreation");
+  const inputOther = usageNumber(usage, "inputOther");
+  const output = usageNumber(usage, "output");
+  const input = inputOther + cacheRead + cacheCreate;
+  const model = asString(record.model) ?? activeModel;
+  const tokens = {
+    input,
+    output,
+    cache_read: cacheRead,
+    cache_create: cacheCreate,
+  };
+  const cost = estimateTokenCost(model, tokens);
+
+  totals.totalInputTokens += input;
+  totals.totalOutputTokens += output;
+  totals.totalCacheReadTokens += cacheRead;
+  totals.totalCacheCreateTokens += cacheCreate;
+  if (model) totals.modelUsage[model] = (totals.modelUsage[model] ?? 0) + input + output;
+  if (cost !== null) totals.totalCost += cost;
+
+  builder.attachUsageToLatestAssistant(tokens, {
+    model,
+    cost: cost ?? undefined,
+    costSource: cost === null ? undefined : "estimated",
+  });
+}
+
+function readState(stateFile: string): Record<string, unknown> | null {
+  try {
+    return asRecord(JSON.parse(readFileSync(stateFile, "utf-8"))) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
+  readonly name = "kimi-code";
+  readonly displayName = "Kimi-Code";
+
+  private basePath: string | null = null;
+  private workDirBySessionPath = new Map<string, string>();
+
+  private findBasePath(): string | null {
+    const sessionsPath = join(resolveKimiCodeDataRoot(), "sessions");
+    return existsSync(sessionsPath) ? sessionsPath : null;
+  }
+
+  getSessionWatchPlan() {
+    const dataRoot = resolveKimiCodeDataRoot();
+    return {
+      status: "supported" as const,
+      targets: [
+        { root: dataRoot, path: join(dataRoot, "sessions") },
+        { root: dataRoot, path: join(dataRoot, "session_index.jsonl") },
+      ],
+    };
+  }
+
+  isAvailable(): boolean {
+    this.basePath = this.findBasePath();
+    if (!this.basePath) return false;
+    try {
+      return this.listSessionDirs().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  private loadSessionIndex(): void {
+    this.workDirBySessionPath.clear();
+    if (!this.basePath) return;
+
+    const indexPath = join(dirname(this.basePath), "session_index.jsonl");
+    if (!existsSync(indexPath)) return;
+    for (const record of readJsonlFile(indexPath)) {
+      const sessionPath = asString(record.sessionDir);
+      const workDir = asString(record.workDir);
+      if (!sessionPath || !workDir) continue;
+      this.workDirBySessionPath.set(resolve(sessionPath), workDir);
+    }
+  }
+
+  private listSessionDirs(): string[] {
+    if (!this.basePath) return [];
+    const dirs: string[] = [];
+
+    try {
+      for (const bucket of readdirSync(this.basePath, { withFileTypes: true })) {
+        if (!bucket.isDirectory()) continue;
+        const bucketPath = join(this.basePath, bucket.name);
+        for (const session of readdirSync(bucketPath, { withFileTypes: true })) {
+          if (!session.isDirectory()) continue;
+          const sessionPath = join(bucketPath, session.name);
+          if (
+            existsSync(join(sessionPath, "state.json")) &&
+            existsSync(join(sessionPath, "agents", "main", "wire.jsonl"))
+          ) {
+            dirs.push(sessionPath);
+          }
+        }
+      }
+    } catch {
+      return dirs;
+    }
+
+    return dirs;
+  }
+
+  private resolveSessionSourceResult(sessionDir: string): ParseSessionResult<SessionSource> {
+    try {
+      const stateFile = join(sessionDir, "state.json");
+      const wireFile = join(sessionDir, "agents", "main", "wire.jsonl");
+      if (!existsSync(stateFile) || !existsSync(wireFile)) return skippedSession("missing wire");
+
+      const state = readState(stateFile);
+      if (!state) return skippedSession("malformed state");
+
+      const stateMtime = statSync(stateFile).mtimeMs;
+      const wireMtime = statSync(wireFile).mtimeMs;
+      const createdAt =
+        parseTimestamp(state.createdAt) ?? parseTimestamp(state.created_at) ?? stateMtime;
+      const updatedAt = Math.max(
+        parseTimestamp(state.updatedAt) ?? parseTimestamp(state.updated_at) ?? createdAt,
+        wireMtime,
+      );
+      const custom = asRecord(state.custom);
+      const workDir =
+        asString(state.workDir) ??
+        asString(custom?.cwd) ??
+        this.workDirBySessionPath.get(resolve(sessionDir)) ??
+        "";
+      const explicitTitle = asString(state.title) ?? asString(state.customTitle) ?? "";
+
+      return parsedSession({
+        id: basename(sessionDir),
+        sourcePath: sessionDir,
+        stateFile,
+        wireFile,
+        workDir,
+        createdAt,
+        updatedAt,
+        explicitTitle,
+      });
+    } catch {
+      return skippedSession("malformed session");
+    }
+  }
+
+  private sourceFingerprint(
+    source: Pick<SessionSource, "stateFile" | "wireFile" | "workDir">,
+  ): string {
+    return JSON.stringify([
+      this.readFileMtimeMs(source.stateFile),
+      this.readFileMtimeMs(source.wireFile),
+      source.workDir,
+    ]);
+  }
+
+  listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
+    if (!this.basePath) return [];
+    this.loadSessionIndex();
+    const refs: SessionSourceRef[] = [];
+
+    for (const sessionDir of this.listSessionDirs()) {
+      const source = getParsedSession(this.resolveSessionSourceResult(sessionDir));
+      if (!source || !matchesScanWindow(source.createdAt, options)) continue;
+      refs.push({
+        sessionId: source.id,
+        sourcePath: source.sourcePath,
+        fingerprint: this.sourceFingerprint(source),
+      });
+    }
+
+    return refs;
+  }
+
+  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]) {
+    const result = super.checkForChanges(sinceTimestamp, cachedSessions);
+    const emptySessionIds = cachedSessions
+      .filter((session) => !this.hasMessages(session))
+      .map((session) => session.id);
+    if (emptySessionIds.length === 0) return result;
+
+    return {
+      ...result,
+      hasChanges: true,
+      changedIds: [...new Set([...(result.changedIds ?? []), ...emptySessionIds])],
+    };
+  }
+
+  filterCachedSessions(sessions: SessionHead[]): SessionHead[] {
+    return this.removeEmptyCachedSessions(sessions);
+  }
+
+  incrementalScan(
+    cachedSessions: SessionHead[],
+    changedIds: string[],
+    refs?: SessionSourceRef[],
+  ): SessionHead[] {
+    const visibleSessions = this.removeEmptyCachedSessions(cachedSessions);
+    return super.incrementalScan(visibleSessions, changedIds, refs);
+  }
+
+  private hasMessages(session: SessionHead): boolean {
+    return session.stats.message_count > 0;
+  }
+
+  private removeEmptyCachedSessions(sessions: SessionHead[]): SessionHead[] {
+    return sessions.filter((session) => {
+      if (this.hasMessages(session)) return true;
+      this.sessionMetaMap.delete(session.id);
+      return false;
+    });
+  }
+
+  scanSessionSource(sourcePath: string): SessionHead | null {
+    this.loadSessionIndex();
+    const source = getParsedSession(this.resolveSessionSourceResult(sourcePath));
+    if (!source) return null;
+
+    const parsed = this.parseWire(source);
+    const transcript = parsed.builder.finish(parsed.stats);
+    if (transcript.messages.length === 0) {
+      this.sessionMetaMap.delete(source.id);
+      return null;
+    }
+
+    const title = resolveSessionTitle(source.explicitTitle, parsed.firstUserTitle, null);
+    const meta: SessionMeta = {
+      ...source,
+      title,
+      sourceMtimeMs: source.createdAt,
+      sourceFingerprint: this.sourceFingerprint(source),
+    };
+    this.sessionMetaMap.set(meta.id, meta);
+    return {
+      id: meta.id,
+      slug: `${this.name}/${meta.id}`,
+      title: meta.title,
+      directory: meta.workDir,
+      time_created: meta.createdAt,
+      time_updated: meta.updatedAt,
+      stats: transcript.stats,
+      ...(Object.keys(parsed.modelUsage).length > 0 ? { model_usage: parsed.modelUsage } : {}),
+    };
+  }
+
+  getSessionData(sessionId: string): SessionDetail {
+    const meta = this.sessionMetaMap.get(sessionId);
+    if (!meta) throw new Error(`Session not found: ${sessionId}`);
+
+    const parsed = this.parseWire(meta);
+    const transcript = parsed.builder.finish(parsed.stats);
+    return {
+      reference: { agentName: this.name, sessionId: meta.id },
+      id: meta.id,
+      title: meta.title,
+      slug: `${this.name}/${meta.id}`,
+      directory: meta.workDir,
+      time_created: meta.createdAt,
+      time_updated: meta.updatedAt,
+      stats: transcript.stats,
+      messages: transcript.messages,
+    };
+  }
+
+  private parseWire(source: SessionSource): ParsedWire {
+    const builder = new TranscriptBuilder();
+    const totals = buildUsageTotals();
+    const ignoredToolCallIds = new Set<string>();
+    let activeModel: string | null = null;
+    let activeProvider: string | null = null;
+    let firstUserTitle: string | null = null;
+    let sequence = 0;
+
+    for (const record of readJsonlFile(source.wireFile)) {
+      sequence += 1;
+      try {
+        const timestampMs = timestampFromRecord(record);
+        const recordType = asString(record.type) ?? "";
+
+        if (recordType === "llm.request") {
+          activeModel = asString(record.model) ?? activeModel;
+          activeProvider = asString(record.provider) ?? activeProvider;
+          continue;
+        }
+        if (recordType === "config.update") {
+          activeModel = asString(record.modelAlias) ?? activeModel;
+          continue;
+        }
+        if (recordType === "usage.record") {
+          applyUsage(builder, record, activeModel, totals);
+          continue;
+        }
+        if (recordType === "context.append_message") {
+          const message = asRecord(record.message);
+          if (!message) continue;
+          const role = asString(message.role) ?? "";
+          const messageTimestamp = timestampMs;
+
+          if (role === "user") {
+            const text = normalizeTitleText(contentText(message.content));
+            if (!firstUserTitle && text) firstUserTitle = text;
+          }
+
+          if (role === "tool") {
+            const callId = asString(message.toolCallId)?.trim() ?? "";
+            const output = message.content;
+            if (callId && ignoredToolCallIds.has(callId)) continue;
+            if (callId && addToolResolution(builder, callId, output, messageTimestamp)) continue;
+            const outputParts = toolOutputParts(output, messageTimestamp);
+            if (outputParts.length > 0) {
+              builder.appendMessage({
+                id: `wire-${sequence}`,
+                role: "tool",
+                timestampMs: messageTimestamp,
+                parts: outputParts,
+              });
+            }
+            continue;
+          }
+
+          if (role !== "user" && role !== "assistant") continue;
+          const parts = [
+            ...contentParts(message.content, messageTimestamp),
+            ...(role === "assistant"
+              ? toolCallParts(message, messageTimestamp, ignoredToolCallIds)
+              : []),
+          ];
+          if (parts.length === 0) continue;
+          const allTools = parts.every((part) => part.type === "tool");
+          const input: TranscriptMessageInput = {
+            id: `wire-${sequence}`,
+            role,
+            timestampMs: messageTimestamp,
+            parts,
+            ...(role === "assistant"
+              ? {
+                  agent: this.name,
+                  mode: allTools ? "tool" : undefined,
+                  model: activeModel,
+                  provider: activeProvider,
+                }
+              : {}),
+          };
+          builder.appendMessage(input);
+          continue;
+        }
+        if (recordType === "context.append_loop_event") {
+          const event = asRecord(record.event);
+          if (!event) continue;
+          const eventType = asString(event.type) ?? "";
+          const metadata = {
+            id: `wire-${sequence}`,
+            timestampMs,
+            agent: this.name,
+            model: activeModel,
+            provider: activeProvider,
+          };
+
+          if (eventType === "step.begin") {
+            builder.beginTurn();
+            continue;
+          }
+          if (eventType === "content.part") {
+            const part = asRecord(event.part);
+            if (!part) continue;
+            const parts = contentParts([part], timestampMs);
+            for (const contentPart of parts) {
+              if (contentPart.type === "tool") continue;
+              if (contentPart.type === "image" && builder.appendToCurrentAssistant(contentPart)) {
+                continue;
+              }
+              builder.appendAssistantPart(contentPart, metadata, { grouping: "current" });
+            }
+            continue;
+          }
+          if (eventType === "tool.call") {
+            const toolName = asString(event.name)?.trim() ?? "";
+            const callId = asString(event.toolCallId)?.trim() ?? "";
+            if (!toolName || !callId) continue;
+            if (KIMI_CODE_IGNORED_TOOLS.has(toolName)) {
+              ignoredToolCallIds.add(callId);
+              continue;
+            }
+            builder.appendToolCall(toolPart(toolName, callId, event.args, timestampMs), metadata, {
+              markModeAsTool: true,
+              target: "current",
+            });
+            continue;
+          }
+          if (eventType === "tool.result") {
+            const callId = asString(event.toolCallId)?.trim() ?? "";
+            const result = asRecord(event.result);
+            if (!callId || ignoredToolCallIds.has(callId)) continue;
+            const output = result?.output;
+            const isError = result?.isError === true;
+            const note = asString(result?.note);
+            if (addToolResolution(builder, callId, output, timestampMs, isError, note)) continue;
+            const outputParts = toolOutputParts(output, timestampMs);
+            if (outputParts.length > 0) {
+              builder.appendMessage({
+                id: `wire-${sequence}`,
+                role: "tool",
+                timestampMs,
+                parts: outputParts,
+              });
+            }
+          }
+          continue;
+        }
+        if (recordType === "context.apply_compaction") {
+          const summary = cleanInternalText(asString(record.summary) ?? "");
+          if (summary) {
+            builder.appendMessage({
+              id: `wire-${sequence}`,
+              role: "user",
+              timestampMs,
+              parts: [{ type: "text", text: summary, time_created: timestampMs }],
+            });
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    const stats: SessionStats = {
+      ...emptyStats(),
+      total_input_tokens: totals.totalInputTokens,
+      total_output_tokens: totals.totalOutputTokens,
+      total_cost: Number(totals.totalCost.toFixed(8)),
+      total_tokens: totals.totalInputTokens + totals.totalOutputTokens,
+      ...(totals.totalCacheReadTokens > 0
+        ? { total_cache_read_tokens: totals.totalCacheReadTokens }
+        : {}),
+      ...(totals.totalCacheCreateTokens > 0
+        ? { total_cache_create_tokens: totals.totalCacheCreateTokens }
+        : {}),
+      ...(totals.totalCost > 0 ? { cost_source: "estimated" as const } : {}),
+    };
+    return { builder, stats, firstUserTitle, modelUsage: totals.modelUsage };
+  }
+}

--- a/packages/core/src/agents/register.ts
+++ b/packages/core/src/agents/register.ts
@@ -2,6 +2,7 @@ import { registerAgent } from "./registry.js";
 import { ClaudeCodeAgent, resolveClaudeCodeDataRoot } from "./claudecode.js";
 import { OpenCodeAgent, resolveOpenCodeDataRoot } from "./opencode.js";
 import { KimiAgent, resolveKimiDataRoot } from "./kimi.js";
+import { KimiCodeAgent, resolveKimiCodeDataRoot } from "./kimi-code.js";
 import { CodexAgent, resolveCodexDataRoot } from "./codex.js";
 import { CursorAgent, resolveCursorDataRoot } from "./cursor.js";
 import { PiAgent, resolvePiDataRoot } from "./pi.js";
@@ -38,6 +39,14 @@ registerAgent({
   resumeCommandPrefix: "kimi -r",
   toolStrategy: "custom",
   create: () => new KimiAgent(),
+});
+
+registerAgent({
+  icon: "/icon/agent/kimi.svg",
+  resolveDataRoot: resolveKimiCodeDataRoot,
+  resumeCommandPrefix: "kimi -r",
+  toolStrategy: "custom",
+  create: () => new KimiCodeAgent(),
 });
 
 registerAgent({

--- a/packages/core/src/discovery/__tests__/paths.test.ts
+++ b/packages/core/src/discovery/__tests__/paths.test.ts
@@ -34,6 +34,7 @@ beforeEach(() => {
   vi.stubEnv("CODEX_HOME", undefined);
   vi.stubEnv("CLAUDE_CONFIG_DIR", undefined);
   vi.stubEnv("KIMI_SHARE_DIR", undefined);
+  vi.stubEnv("KIMI_CODE_HOME", undefined);
   vi.stubEnv("PI_HOME", undefined);
   vi.stubEnv("CURSOR_DATA_PATH", undefined);
   vi.stubEnv("XDG_DATA_HOME", undefined);
@@ -52,6 +53,7 @@ describe("resolveAgentRoots", () => {
     expectPath(roots.codex!).toBe("/home/user/.codex");
     expectPath(roots.claudecode!).toBe("/home/user/.claude");
     expectPath(roots.kimi!).toBe("/home/user/.kimi");
+    expectPath(roots["kimi-code"]!).toBe("/home/user/.kimi-code");
     expectPath(roots.pi!).toBe("/home/user/.pi");
     expectPath(roots.zcode!).toBe("/home/user/.zcode");
   });
@@ -75,6 +77,13 @@ describe("resolveAgentRoots", () => {
     mockedHomedir.mockReturnValue("/home/user");
     const roots = resolveAgentRoots();
     expectPath(roots.kimi!).toBe("/custom/kimi");
+  });
+
+  it("respects KIMI_CODE_HOME override", () => {
+    vi.stubEnv("KIMI_CODE_HOME", "/custom/kimi-code");
+    mockedHomedir.mockReturnValue("/home/user");
+    const roots = resolveAgentRoots();
+    expectPath(roots["kimi-code"]!).toBe("/custom/kimi-code");
   });
 
   it("respects PI_HOME override", () => {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -500,6 +500,34 @@ describe("scanSessions", () => {
     expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
   });
 
+  it("filters agent-specific stale sessions from cache-only results", async () => {
+    const empty = makeSession("empty", {
+      stats: { message_count: 0, total_input_tokens: 0, total_output_tokens: 0, total_cost: 0 },
+    });
+    const visible = makeSession("visible");
+    const cachedSessions = [empty, visible];
+    mockedLoadCachedSessions.mockReturnValue({
+      sessions: cachedSessions,
+      meta: {},
+      timestamp: Date.now(),
+    });
+    const filterCachedSessions = vi.fn(() => [visible]);
+    const agent = createTestAgent({
+      name: "test",
+      available: false,
+      sessions: [],
+    });
+    agent.filterCachedSessions = filterCachedSessions;
+    mockedCreateRegisteredAgents.mockReturnValue([agent]);
+
+    const result = await scanSessions({ useCache: true, cacheOnly: true });
+
+    expect(filterCachedSessions).toHaveBeenCalledWith(cachedSessions);
+    expect(result.sessions.map((session) => session.id)).toEqual(["visible"]);
+    expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
+    expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
+  });
+
   it("uses cached sessions even when last refresh is old", async () => {
     mockedLoadCachedSessions.mockReturnValue({
       sessions: [makeSession("cached")],

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -452,6 +452,15 @@ describe("saveCachedSessions", () => {
 });
 
 describe("saveCachedSessionChanges", () => {
+  it("advances the cache timestamp for a successful no-op refresh", () => {
+    saveCachedSessions("claudecode", [makeSession("unchanged")]);
+    expect(loadCachedSessions("claudecode")?.timestamp).toBe(now);
+
+    dateNowSpy.mockReturnValue(now + 1_000);
+    expect(saveCachedSessionChanges("claudecode", [], [])).toBe(true);
+    expect(loadCachedSessions("claudecode")?.timestamp).toBe(now + 1_000);
+  });
+
   it("updates changed sessions and removes deleted sessions", () => {
     const unchanged = makeSession("unchanged");
     const changed = makeSession("changed");

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -418,10 +418,6 @@ export function saveCachedSessionChanges(
   removedSessionIds: string[],
   meta: Record<string, SessionCacheMeta> = {},
 ): boolean {
-  if (changes.length === 0 && removedSessionIds.length === 0) {
-    return true;
-  }
-
   const persisted = withCacheDb((db) => {
     const deleteSession = db.prepare(
       "DELETE FROM sessions WHERE agent_name = ? AND session_id = ?",

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -338,12 +338,13 @@ async function scanAgentSmart(
       agent.setSessionMetaMap(metaMap);
 
       if (options.cacheOnly) {
+        const visibleSessions = agent.filterCachedSessions(cached.sessions);
         onProgress?.({
           agent: agent.name,
           phase: "cache",
-          cachedCount: cached.sessions.length,
+          cachedCount: visibleSessions.length,
         });
-        return finalizeAgentScan(agent, cached.sessions, {
+        return finalizeAgentScan(agent, visibleSessions, {
           finalization: { kind: "cache-only", cached },
           options,
           timing,


### PR DESCRIPTION
## Summary

- Add Kimi-Code as a separate agent backed by `~/.kimi-code` sessions.
- Parse native Kimi-Code transcripts, model usage, timestamps, images, and tool calls with dedicated UI rendering.
- Hide empty sessions and unavailable timestamps while preserving sessions that later receive content.
- Persist cache timestamps for successful no-op refreshes to prevent ZCode from rescanning on every startup.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm format:check`