### PR TITLE
feat(web): improve long session title behavior

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -260,18 +260,64 @@ describe("SessionTreeSidebar session options menu", () => {
       expect(element).not.toBeNull();
       return element!;
     });
+    const track = content.querySelector<HTMLElement>('[data-truncate-group-container="middle"]');
+    expect(track).not.toBeNull();
+    Object.defineProperty(track!, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({ width: 320 }) as DOMRect,
+    });
     Object.defineProperties(content, {
       clientWidth: { configurable: true, value: 100 },
-      scrollWidth: { configurable: true, value: 320 },
+      scrollWidth: { configurable: true, value: 640 },
     });
 
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    dispatch(content, "pointerover");
-    await waitFor(() => expect(content.dataset.sessionTitleScroll).toBe("running"));
+    const frames = new Map<number, FrameRequestCallback>();
+    let nextFrame = 1;
+    const requestFrame = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        const frame = nextFrame++;
+        frames.set(frame, callback);
+        return frame;
+      });
+    const cancelFrame = vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation((frame) => {
+      frames.delete(frame);
+    });
+    const performanceNow = vi.spyOn(performance, "now").mockReturnValue(0);
 
-    dispatch(content, "pointerout");
-    expect(content.scrollLeft).toBe(0);
-    expect(content.dataset.sessionTitleScroll).toBeUndefined();
+    const runFrame = (timestamp: number) => {
+      const callbacks = [...frames.values()];
+      frames.clear();
+      for (const callback of callbacks) callback(timestamp);
+    };
+
+    try {
+      dispatch(content, "pointerover");
+      expect(content.dataset.sessionTitleScroll).toBe("running");
+      expect(content.querySelector("[data-session-title-scroll-copy]")).not.toBeNull();
+
+      runFrame(0);
+      expect(content.scrollLeft).toBe(0);
+      runFrame(1_500);
+      expect(content.scrollLeft).toBeGreaterThan(0);
+      runFrame(2_850);
+      expect(content.scrollLeft).toBeLessThan(320);
+      expect(content.scrollLeft).toBeGreaterThan(240);
+      runFrame(3_000);
+      expect(content.scrollLeft).toBe(320);
+      expect(content.dataset.sessionTitleScrollComplete).toBe("true");
+
+      dispatch(content, "pointerout");
+      expect(content.scrollLeft).toBe(0);
+      expect(content.dataset.sessionTitleScroll).toBeUndefined();
+      expect(content.dataset.sessionTitleScrollComplete).toBeUndefined();
+      expect(content.querySelector("[data-session-title-scroll-copy]")).toBeNull();
+    } finally {
+      requestFrame.mockRestore();
+      cancelFrame.mockRestore();
+      performanceNow.mockRestore();
+    }
   });
 
   it("shows and opens the parent row options when it has a child session", async () => {

--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -219,7 +219,12 @@ function renderSessionTreeSidebar(sessions = [makeSession({ id: "s1" })]) {
 }
 
 function dispatch(target: HTMLElement, type: string, init: EventInit & { key?: string } = {}) {
-  const Ctor = type === "keydown" ? KeyboardEvent : MouseEvent;
+  const Ctor =
+    type === "keydown"
+      ? KeyboardEvent
+      : type.startsWith("pointer") && typeof PointerEvent !== "undefined"
+        ? PointerEvent
+        : MouseEvent;
   target.dispatchEvent(
     new Ctor(type, { bubbles: true, cancelable: true, composed: true, ...init }),
   );
@@ -248,20 +253,53 @@ describe("SessionTreeSidebar session options menu", () => {
   it("scrolls an overflowing title once while hovered", async () => {
     const title = "A deliberately long session title that needs a marquee";
     const { shadowRoot } = renderSessionTreeSidebar([makeSession({ id: "long", title })]);
-    const content = shadowRoot.querySelector<HTMLElement>(
-      '[data-item-type="file"] [data-item-section="content"]',
-    )!;
+    const content = await waitFor(() => {
+      const element = shadowRoot.querySelector<HTMLElement>(
+        '[data-item-type="file"] [data-item-section="content"]',
+      );
+      expect(element).not.toBeNull();
+      return element!;
+    });
     Object.defineProperties(content, {
       clientWidth: { configurable: true, value: 100 },
       scrollWidth: { configurable: true, value: 320 },
     });
 
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     dispatch(content, "pointerover");
     await waitFor(() => expect(content.dataset.sessionTitleScroll).toBe("running"));
 
     dispatch(content, "pointerout");
     expect(content.scrollLeft).toBe(0);
     expect(content.dataset.sessionTitleScroll).toBeUndefined();
+  });
+
+  it("shows and opens the parent row options when it has a child session", async () => {
+    const parent = makeSession({ id: "parent", title: "Main parent session with child" });
+    const child = makeSession({
+      id: "child",
+      title: "Worker",
+      parent_reference: { agentName: "codex", sessionId: "parent" },
+    });
+
+    const { onToggleBookmark, shadowRoot } = renderSessionTreeSidebar([parent, child]);
+
+    const parentItem = await waitFor(() => {
+      const parentItem = shadowRoot.querySelector<HTMLElement>(
+        '[data-item-type="folder"][aria-label="Main parent session with child"]',
+      );
+      expect(parentItem).not.toBeNull();
+      return parentItem!;
+    });
+    const decoration = parentItem.querySelector<HTMLElement>(
+      '[data-item-section="decoration"] > span',
+    );
+    expect(decoration).not.toBeNull();
+    dispatch(decoration!, "click");
+
+    await waitFor(() => expect(screen.queryByRole("menu")).not.toBeNull());
+    dispatch(await screen.findByRole("menuitem", { name: "Add bookmark" }), "click");
+    expect(onToggleBookmark).toHaveBeenCalledWith(parent);
   });
 
   it("opens via keyboard (ContextMenu key) with the first item focused, navigates, and executes", async () => {

--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -295,17 +295,21 @@ describe("SessionTreeSidebar session options menu", () => {
     try {
       dispatch(content, "pointerover");
       expect(content.dataset.sessionTitleScroll).toBe("running");
-      expect(content.querySelector("[data-session-title-scroll-copy]")).not.toBeNull();
+      const copy = content.querySelector<HTMLElement>("[data-session-title-scroll-copy]");
+      expect(copy).not.toBeNull();
+      const gap = Number.parseFloat(copy!.style.marginInlineStart);
+      expect(gap).toBeGreaterThan(0);
+      const scrollDistance = 320 + gap;
 
       runFrame(0);
       expect(content.scrollLeft).toBe(0);
       runFrame(1_500);
       expect(content.scrollLeft).toBeGreaterThan(0);
       runFrame(2_850);
-      expect(content.scrollLeft).toBeLessThan(320);
+      expect(content.scrollLeft).toBeLessThan(scrollDistance);
       expect(content.scrollLeft).toBeGreaterThan(240);
       runFrame(3_000);
-      expect(content.scrollLeft).toBe(320);
+      expect(content.scrollLeft).toBe(scrollDistance);
       expect(content.dataset.sessionTitleScrollComplete).toBe("true");
 
       dispatch(content, "pointerout");

--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -197,13 +197,13 @@ function patchShadowEventRetargeting() {
   document.addEventListener("keydown", retarget, true);
 }
 
-function renderSessionTreeSidebar() {
-  const session = makeSession({ id: "s1" });
+function renderSessionTreeSidebar(sessions = [makeSession({ id: "s1" })]) {
+  const session = sessions[0]!;
   const onToggleBookmark = vi.fn();
   const onRenameSession = vi.fn();
   render(
     <SessionTreeSidebar
-      sessions={[session]}
+      sessions={sessions}
       activeSessionReference={getSessionReferenceKey(session)}
       selectedSessionReference={getSessionReferenceKey(session)}
       onSelectSession={() => {}}
@@ -243,6 +243,25 @@ describe("SessionTreeSidebar session options menu", () => {
     expect(onToggleBookmark).toHaveBeenCalledWith(session);
     await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
     await waitFor(() => expect((item.getRootNode() as ShadowRoot).activeElement).toBe(item));
+  });
+
+  it("scrolls an overflowing title once while hovered", async () => {
+    const title = "A deliberately long session title that needs a marquee";
+    const { shadowRoot } = renderSessionTreeSidebar([makeSession({ id: "long", title })]);
+    const content = shadowRoot.querySelector<HTMLElement>(
+      '[data-item-type="file"] [data-item-section="content"]',
+    )!;
+    Object.defineProperties(content, {
+      clientWidth: { configurable: true, value: 100 },
+      scrollWidth: { configurable: true, value: 320 },
+    });
+
+    dispatch(content, "pointerover");
+    await waitFor(() => expect(content.dataset.sessionTitleScroll).toBe("running"));
+
+    dispatch(content, "pointerout");
+    expect(content.scrollLeft).toBe(0);
+    expect(content.dataset.sessionTitleScroll).toBeUndefined();
   });
 
   it("opens via keyboard (ContextMenu key) with the first item focused, navigates, and executes", async () => {

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -78,7 +78,7 @@ const SESSION_TREE_CSS = `
     height: 8px;
   }
 
-  [data-type='item'][data-item-type='file'] > [data-item-section='content'] {
+  [data-type='item'] > [data-item-section='content'] {
     flex: 1 1 auto;
   }
 
@@ -91,13 +91,12 @@ const SESSION_TREE_CSS = `
     direction: ltr;
   }
 
-  [data-type='item'][data-item-type='file'] > [data-item-section='decoration'] {
-    flex: 1 1 0;
-    padding: 0;
+  [data-type='item'] > [data-item-section='decoration'] {
+    flex: 0 0 auto;
+    padding-inline: 6px 2px;
   }
 
-  [data-type='item'][data-item-type='file'] > [data-item-section='decoration'] > span,
-  [data-type='item'][data-item-type='folder'] > [data-item-section='decoration'] > span {
+  [data-type='item'] > [data-item-section='decoration'] > span {
     cursor: pointer;
     font-size: 12px;
     line-height: 24px;
@@ -531,9 +530,23 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   }, [onRenameSession]);
 
   useEffect(() => {
-    const host = model.getFileTreeContainer();
-    if (!host) return;
-    return installSessionTitleScrolling(host);
+    let cleanup: (() => void) | undefined;
+    let frame = 0;
+
+    const install = () => {
+      const host = model.getFileTreeContainer();
+      if (!host) {
+        frame = requestAnimationFrame(install);
+        return;
+      }
+      cleanup = installSessionTitleScrolling(host);
+    };
+
+    install();
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      cleanup?.();
+    };
   }, [model]);
 
   function openSessionMenu(session: SessionHead, anchor: HTMLElement, trigger: HTMLElement) {

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -142,7 +142,8 @@ const SESSION_TREE_CSS = `
     display: none;
   }
 
-  [data-type='item'] [data-session-title-scroll='running'] {
+  [data-type='item'] [data-session-title-scroll='running'],
+  [data-type='item'] [data-session-title-scroll-complete] {
     text-overflow: clip;
   }
 `;
@@ -341,7 +342,7 @@ function measureSessionTreeWork<T>(id: string, compute: () => T): T {
 const SESSION_TITLE_SCROLL_SPEED_PX_PER_MS = 0.08;
 const SESSION_TITLE_SCROLL_MIN_DURATION_MS = 700;
 const SESSION_TITLE_SCROLL_MAX_DURATION_MS = 3_000;
-const SESSION_TITLE_RETURN_DURATION_RATIO = 0.75;
+const SESSION_TITLE_SCROLL_SLOWDOWN_START = 0.75;
 
 function getSessionTitleContent(target: EventTarget | null): HTMLElement | null {
   if (!(target instanceof Element)) return null;
@@ -354,20 +355,37 @@ function isReducedMotionPreferred() {
   return globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
 }
 
+function easeSessionTitleScrollToStop(progress: number) {
+  if (progress <= SESSION_TITLE_SCROLL_SLOWDOWN_START) return progress;
+
+  const slowdownProgress =
+    (progress - SESSION_TITLE_SCROLL_SLOWDOWN_START) / (1 - SESSION_TITLE_SCROLL_SLOWDOWN_START);
+  const easedProgress = slowdownProgress + slowdownProgress ** 2 - slowdownProgress ** 3;
+  return (
+    SESSION_TITLE_SCROLL_SLOWDOWN_START + (1 - SESSION_TITLE_SCROLL_SLOWDOWN_START) * easedProgress
+  );
+}
+
 function installSessionTitleScrolling(host: HTMLElement) {
   const root = host.shadowRoot;
   if (!root) return () => {};
 
   const activeElements = new Set<HTMLElement>();
+  const preparedElements = new Set<HTMLElement>();
   const frameByElement = new WeakMap<HTMLElement, number>();
+  const copyByElement = new WeakMap<HTMLElement, HTMLElement>();
 
   function reset(element: HTMLElement) {
     const frame = frameByElement.get(element);
     if (frame !== undefined) cancelAnimationFrame(frame);
+    copyByElement.get(element)?.remove();
+    copyByElement.delete(element);
+    preparedElements.delete(element);
     frameByElement.delete(element);
     activeElements.delete(element);
     element.scrollLeft = 0;
     element.removeAttribute("data-session-title-scroll");
+    element.removeAttribute("data-session-title-scroll-complete");
   }
 
   function start(element: HTMLElement) {
@@ -376,36 +394,35 @@ function installSessionTitleScrolling(host: HTMLElement) {
     }
 
     reset(element);
-    const maxScroll = element.scrollWidth - element.clientWidth;
-    if (maxScroll <= 1) return;
+    const track = element.querySelector<HTMLElement>('[data-truncate-group-container="middle"]');
+    const trackWidth = track?.getBoundingClientRect().width ?? 0;
+    if (!track || trackWidth <= element.clientWidth + 1) return;
+
+    const copy = track.cloneNode(true) as HTMLElement;
+    copy.dataset.sessionTitleScrollCopy = "true";
+    copy.setAttribute("aria-hidden", "true");
+    element.append(copy);
+    copyByElement.set(element, copy);
+    preparedElements.add(element);
+    element.setAttribute("data-session-title-scroll", "running");
 
     const forwardDuration = Math.min(
       SESSION_TITLE_SCROLL_MAX_DURATION_MS,
       Math.max(
         SESSION_TITLE_SCROLL_MIN_DURATION_MS,
-        maxScroll / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS,
+        trackWidth / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS,
       ),
     );
-    const returnDuration = forwardDuration * SESSION_TITLE_RETURN_DURATION_RATIO;
     const startedAt = performance.now();
-    const returnStartedAt = startedAt + forwardDuration;
     activeElements.add(element);
-    element.setAttribute("data-session-title-scroll", "running");
 
     const step = (now: number) => {
       if (!activeElements.has(element)) return;
 
-      if (now < returnStartedAt) {
-        const progress = Math.min(1, (now - startedAt) / forwardDuration);
-        element.scrollLeft = maxScroll * progress;
-      } else {
-        const progress = Math.min(1, (now - returnStartedAt) / returnDuration);
-        const easedProgress = 1 - (1 - progress) ** 3;
-        element.scrollLeft = maxScroll * (1 - easedProgress);
-      }
+      const progress = Math.min(1, Math.max(0, (now - startedAt) / forwardDuration));
+      element.scrollLeft = trackWidth * easeSessionTitleScrollToStop(progress);
 
-      if (now >= returnStartedAt + returnDuration) {
-        element.scrollLeft = 0;
+      if (progress >= 1) {
         activeElements.delete(element);
         frameByElement.delete(element);
         element.removeAttribute("data-session-title-scroll");
@@ -431,7 +448,6 @@ function installSessionTitleScrolling(host: HTMLElement) {
     const relatedTarget = (event as PointerEvent).relatedTarget;
     if (!element || (relatedTarget instanceof Node && element.contains(relatedTarget))) return;
     reset(element);
-    element.removeAttribute("data-session-title-scroll-complete");
   }
 
   root.addEventListener("pointerover", handlePointerOver);
@@ -440,7 +456,7 @@ function installSessionTitleScrolling(host: HTMLElement) {
   return () => {
     root.removeEventListener("pointerover", handlePointerOver);
     root.removeEventListener("pointerout", handlePointerOut);
-    for (const element of activeElements) reset(element);
+    for (const element of preparedElements) reset(element);
   };
 }
 

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -82,56 +82,69 @@ const SESSION_TREE_CSS = `
     flex: 1 1 auto;
   }
 
+  [data-type='item'] > [data-item-section='content'] {
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: ltr;
+  }
+
   [data-type='item'][data-item-type='file'] > [data-item-section='decoration'] {
     flex: 1 1 0;
     padding: 0;
   }
 
-  [data-type='item'][data-item-type='file'] > [data-item-section='decoration'] > span {
+  [data-type='item'][data-item-type='file'] > [data-item-section='decoration'] > span,
+  [data-type='item'][data-item-type='folder'] > [data-item-section='decoration'] > span {
     cursor: pointer;
     font-size: 12px;
     line-height: 24px;
   }
 
-  [data-type='item'][data-item-type='file'] [data-truncate-group-container='middle'] {
-    width: 100%;
+  [data-type='item'] [data-truncate-group-container='middle'] {
+    display: inline;
+    min-width: 0;
+    white-space: nowrap;
   }
 
-  [data-type='item'][data-item-type='file']
-    [data-truncate-group-container='middle']
-    > div[data-truncate-segment-priority='2'] {
-    flex: 0 1 auto;
+  [data-type='item'] [data-truncate-group-container='middle'] > div {
+    display: inline;
+    min-width: 0;
   }
 
-  [data-type='item'][data-item-type='file']
-    [data-truncate-group-container='middle']
-    > div[data-truncate-segment-priority='1'] {
-    flex: 1 999999 auto;
+  [data-type='item'] [data-truncate-container] {
+    display: inline;
+    height: auto;
+    margin: 0;
+    overflow: visible;
   }
 
-  [data-type='item'][data-item-type='file']
-    [data-truncate-group-container='middle']
-    [data-truncate-container='fruncate']
-    [data-truncate-grid] {
-    grid-template-columns: minmax(0, max-content) 0;
+  [data-type='item'] [data-truncate-grid] {
+    display: inline;
+    position: static;
   }
 
-  [data-type='item'][data-item-type='file']
-    [data-truncate-group-container='middle']
-    [data-truncate-container='fruncate']
-    [data-truncate-content] {
+  [data-type='item'] [data-truncate-grid] > div:not([data-truncate-marker-cell]) {
+    display: inline;
+  }
+
+  [data-type='item'] [data-truncate-content='visible'] {
+    display: inline;
+    white-space: nowrap;
     direction: ltr;
   }
 
-  [data-type='item'][data-item-type='file']
-    [data-truncate-group-container='middle']
-    [data-truncate-container='fruncate']
-    [data-truncate-marker] {
-    right: 0;
+  [data-type='item'] [data-truncate-content='overflow'],
+  [data-type='item'] [data-truncate-fill],
+  [data-type='item'] [data-truncate-marker-cell],
+  [data-type='item'] [data-truncate-marker] {
+    display: none;
   }
 
-  [data-type='item'][data-item-type='file'] [data-truncate-marker] {
-    display: none;
+  [data-type='item'] [data-session-title-scroll='running'] {
+    text-overflow: clip;
   }
 `;
 
@@ -326,6 +339,112 @@ function measureSessionTreeWork<T>(id: string, compute: () => T): T {
   return value;
 }
 
+const SESSION_TITLE_SCROLL_SPEED_PX_PER_MS = 0.08;
+const SESSION_TITLE_SCROLL_MIN_DURATION_MS = 700;
+const SESSION_TITLE_SCROLL_MAX_DURATION_MS = 3_000;
+const SESSION_TITLE_RETURN_DURATION_RATIO = 0.75;
+
+function getSessionTitleContent(target: EventTarget | null): HTMLElement | null {
+  if (!(target instanceof Element)) return null;
+  const content = target.closest<HTMLElement>('[data-item-section="content"]');
+  if (!content || content.parentElement?.getAttribute("data-type") !== "item") return null;
+  return content;
+}
+
+function isReducedMotionPreferred() {
+  return globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+}
+
+function installSessionTitleScrolling(host: HTMLElement) {
+  const root = host.shadowRoot;
+  if (!root) return () => {};
+
+  const activeElements = new Set<HTMLElement>();
+  const frameByElement = new WeakMap<HTMLElement, number>();
+
+  function reset(element: HTMLElement) {
+    const frame = frameByElement.get(element);
+    if (frame !== undefined) cancelAnimationFrame(frame);
+    frameByElement.delete(element);
+    activeElements.delete(element);
+    element.scrollLeft = 0;
+    element.removeAttribute("data-session-title-scroll");
+  }
+
+  function start(element: HTMLElement) {
+    if (isReducedMotionPreferred() || element.hasAttribute("data-session-title-scroll-complete")) {
+      return;
+    }
+
+    reset(element);
+    const maxScroll = element.scrollWidth - element.clientWidth;
+    if (maxScroll <= 1) return;
+
+    const forwardDuration = Math.min(
+      SESSION_TITLE_SCROLL_MAX_DURATION_MS,
+      Math.max(
+        SESSION_TITLE_SCROLL_MIN_DURATION_MS,
+        maxScroll / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS,
+      ),
+    );
+    const returnDuration = forwardDuration * SESSION_TITLE_RETURN_DURATION_RATIO;
+    const startedAt = performance.now();
+    const returnStartedAt = startedAt + forwardDuration;
+    activeElements.add(element);
+    element.setAttribute("data-session-title-scroll", "running");
+
+    const step = (now: number) => {
+      if (!activeElements.has(element)) return;
+
+      if (now < returnStartedAt) {
+        const progress = Math.min(1, (now - startedAt) / forwardDuration);
+        element.scrollLeft = maxScroll * progress;
+      } else {
+        const progress = Math.min(1, (now - returnStartedAt) / returnDuration);
+        const easedProgress = 1 - (1 - progress) ** 3;
+        element.scrollLeft = maxScroll * (1 - easedProgress);
+      }
+
+      if (now >= returnStartedAt + returnDuration) {
+        element.scrollLeft = 0;
+        activeElements.delete(element);
+        frameByElement.delete(element);
+        element.removeAttribute("data-session-title-scroll");
+        element.setAttribute("data-session-title-scroll-complete", "true");
+        return;
+      }
+
+      frameByElement.set(element, requestAnimationFrame(step));
+    };
+
+    frameByElement.set(element, requestAnimationFrame(step));
+  }
+
+  function handlePointerOver(event: Event) {
+    const element = getSessionTitleContent(event.target);
+    const relatedTarget = (event as PointerEvent).relatedTarget;
+    if (!element || (relatedTarget instanceof Node && element.contains(relatedTarget))) return;
+    start(element);
+  }
+
+  function handlePointerOut(event: Event) {
+    const element = getSessionTitleContent(event.target);
+    const relatedTarget = (event as PointerEvent).relatedTarget;
+    if (!element || (relatedTarget instanceof Node && element.contains(relatedTarget))) return;
+    reset(element);
+    element.removeAttribute("data-session-title-scroll-complete");
+  }
+
+  root.addEventListener("pointerover", handlePointerOver);
+  root.addEventListener("pointerout", handlePointerOut);
+
+  return () => {
+    root.removeEventListener("pointerover", handlePointerOver);
+    root.removeEventListener("pointerout", handlePointerOut);
+    for (const element of activeElements) reset(element);
+  };
+}
+
 export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   sessions,
   activeSessionReference,
@@ -410,6 +529,12 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   useEffect(() => {
     onRenameSessionRef.current = onRenameSession;
   }, [onRenameSession]);
+
+  useEffect(() => {
+    const host = model.getFileTreeContainer();
+    if (!host) return;
+    return installSessionTitleScrolling(host);
+  }, [model]);
 
   function openSessionMenu(session: SessionHead, anchor: HTMLElement, trigger: HTMLElement) {
     menuAnchorRef.current = anchor;

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -340,6 +340,7 @@ function measureSessionTreeWork<T>(id: string, compute: () => T): T {
 }
 
 const SESSION_TITLE_SCROLL_SPEED_PX_PER_MS = 0.08;
+const SESSION_TITLE_SCROLL_GAP_PX = 16;
 const SESSION_TITLE_SCROLL_MIN_DURATION_MS = 700;
 const SESSION_TITLE_SCROLL_MAX_DURATION_MS = 3_000;
 const SESSION_TITLE_SCROLL_SLOWDOWN_START = 0.75;
@@ -401,16 +402,18 @@ function installSessionTitleScrolling(host: HTMLElement) {
     const copy = track.cloneNode(true) as HTMLElement;
     copy.dataset.sessionTitleScrollCopy = "true";
     copy.setAttribute("aria-hidden", "true");
+    copy.style.marginInlineStart = `${SESSION_TITLE_SCROLL_GAP_PX}px`;
     element.append(copy);
     copyByElement.set(element, copy);
     preparedElements.add(element);
     element.setAttribute("data-session-title-scroll", "running");
 
+    const scrollDistance = trackWidth + SESSION_TITLE_SCROLL_GAP_PX;
     const forwardDuration = Math.min(
       SESSION_TITLE_SCROLL_MAX_DURATION_MS,
       Math.max(
         SESSION_TITLE_SCROLL_MIN_DURATION_MS,
-        trackWidth / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS,
+        scrollDistance / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS,
       ),
     );
     const startedAt = performance.now();
@@ -420,7 +423,7 @@ function installSessionTitleScrolling(host: HTMLElement) {
       if (!activeElements.has(element)) return;
 
       const progress = Math.min(1, Math.max(0, (now - startedAt) / forwardDuration));
-      element.scrollLeft = trackWidth * easeSessionTitleScrollToStop(progress);
+      element.scrollLeft = scrollDistance * easeSessionTitleScrollToStop(progress);
 
       if (progress >= 1) {
         activeElements.delete(element);


### PR DESCRIPTION
## Summary
- Replace middle truncation in the session tree with tail ellipsis.
- Add a single hover marquee that traverses the full title, eases back to the start, and respects reduced-motion preferences.
- Keep the options affordance visible for parent sessions that contain child sessions.

## Root cause
- The tree component renders middle-truncation wrappers that prevent native tail ellipsis from working consistently, so the session rows now normalize those wrappers into one overflow surface.
- Parent rows use the folder layout, whose flexible decoration lane could collapse the options affordance; the row layout now reserves that lane for every session item.

## Validation
- `pnpm lint`
- `pnpm format:check`
- `node scripts/release-preflight.mjs`
- `node scripts/check-docs-paths.mjs`
- `pnpm build`
- `pnpm test`
- Chromium smoke check with mocked local API data