### PR TITLE
fix(web): keep session title scrolling readable

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -305,12 +305,19 @@ describe("SessionTreeSidebar session options menu", () => {
       expect(content.scrollLeft).toBe(0);
       runFrame(1_500);
       expect(content.scrollLeft).toBeGreaterThan(0);
-      runFrame(3_000);
-      expect(content.scrollLeft).toBeLessThan(scrollDistance);
-      expect(content.scrollLeft).toBeGreaterThan(200);
-      expect(content.dataset.sessionTitleScrollComplete).toBeUndefined();
+      runFrame(2_800);
+      expect(content.scrollLeft).toBeCloseTo((scrollDistance * 2) / 3, 5);
+      const slowdownStartOffset = content.scrollLeft;
       runFrame(4_200);
+      expect(content.scrollLeft).toBeGreaterThan(slowdownStartOffset);
+      expect(content.scrollLeft).toBeLessThan(scrollDistance);
+      expect(content.dataset.sessionTitleScrollComplete).toBeUndefined();
+      const slowdownMidpointOffset = content.scrollLeft;
+      runFrame(5_600);
       expect(content.scrollLeft).toBe(scrollDistance);
+      expect(slowdownMidpointOffset - slowdownStartOffset).toBeGreaterThan(
+        scrollDistance - slowdownMidpointOffset,
+      );
       expect(content.dataset.sessionTitleScrollComplete).toBe("true");
 
       dispatch(content, "pointerout");

--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -305,10 +305,11 @@ describe("SessionTreeSidebar session options menu", () => {
       expect(content.scrollLeft).toBe(0);
       runFrame(1_500);
       expect(content.scrollLeft).toBeGreaterThan(0);
-      runFrame(2_850);
-      expect(content.scrollLeft).toBeLessThan(scrollDistance);
-      expect(content.scrollLeft).toBeGreaterThan(240);
       runFrame(3_000);
+      expect(content.scrollLeft).toBeLessThan(scrollDistance);
+      expect(content.scrollLeft).toBeGreaterThan(200);
+      expect(content.dataset.sessionTitleScrollComplete).toBeUndefined();
+      runFrame(4_200);
       expect(content.scrollLeft).toBe(scrollDistance);
       expect(content.dataset.sessionTitleScrollComplete).toBe("true");
 

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -342,7 +342,10 @@ function measureSessionTreeWork<T>(id: string, compute: () => T): T {
 const SESSION_TITLE_SCROLL_SPEED_PX_PER_MS = 0.08;
 const SESSION_TITLE_SCROLL_GAP_PX = 16;
 const SESSION_TITLE_SCROLL_MIN_DURATION_MS = 700;
-const SESSION_TITLE_SCROLL_SLOWDOWN_START = 0.75;
+const SESSION_TITLE_SCROLL_SLOWDOWN_DISTANCE = 1 / 3;
+const SESSION_TITLE_SCROLL_DURATION_MULTIPLIER = 1 + SESSION_TITLE_SCROLL_SLOWDOWN_DISTANCE;
+const SESSION_TITLE_SCROLL_SLOWDOWN_START =
+  (1 - SESSION_TITLE_SCROLL_SLOWDOWN_DISTANCE) / SESSION_TITLE_SCROLL_DURATION_MULTIPLIER;
 
 function getSessionTitleContent(target: EventTarget | null): HTMLElement | null {
   if (!(target instanceof Element)) return null;
@@ -356,13 +359,20 @@ function isReducedMotionPreferred() {
 }
 
 function easeSessionTitleScrollToStop(progress: number) {
-  if (progress <= SESSION_TITLE_SCROLL_SLOWDOWN_START) return progress;
+  if (progress <= SESSION_TITLE_SCROLL_SLOWDOWN_START) {
+    return (
+      (progress / SESSION_TITLE_SCROLL_SLOWDOWN_START) *
+      (1 - SESSION_TITLE_SCROLL_SLOWDOWN_DISTANCE)
+    );
+  }
 
   const slowdownProgress =
     (progress - SESSION_TITLE_SCROLL_SLOWDOWN_START) / (1 - SESSION_TITLE_SCROLL_SLOWDOWN_START);
-  const easedProgress = slowdownProgress + slowdownProgress ** 2 - slowdownProgress ** 3;
+  const slowdownPosition = slowdownProgress * (2 - slowdownProgress);
   return (
-    SESSION_TITLE_SCROLL_SLOWDOWN_START + (1 - SESSION_TITLE_SCROLL_SLOWDOWN_START) * easedProgress
+    1 -
+    SESSION_TITLE_SCROLL_SLOWDOWN_DISTANCE +
+    SESSION_TITLE_SCROLL_SLOWDOWN_DISTANCE * slowdownPosition
   );
 }
 
@@ -410,7 +420,8 @@ function installSessionTitleScrolling(host: HTMLElement) {
     const scrollDistance = trackWidth + SESSION_TITLE_SCROLL_GAP_PX;
     const forwardDuration = Math.max(
       SESSION_TITLE_SCROLL_MIN_DURATION_MS,
-      scrollDistance / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS,
+      (scrollDistance / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS) *
+        SESSION_TITLE_SCROLL_DURATION_MULTIPLIER,
     );
     const startedAt = performance.now();
     activeElements.add(element);

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -342,7 +342,6 @@ function measureSessionTreeWork<T>(id: string, compute: () => T): T {
 const SESSION_TITLE_SCROLL_SPEED_PX_PER_MS = 0.08;
 const SESSION_TITLE_SCROLL_GAP_PX = 16;
 const SESSION_TITLE_SCROLL_MIN_DURATION_MS = 700;
-const SESSION_TITLE_SCROLL_MAX_DURATION_MS = 3_000;
 const SESSION_TITLE_SCROLL_SLOWDOWN_START = 0.75;
 
 function getSessionTitleContent(target: EventTarget | null): HTMLElement | null {
@@ -409,12 +408,9 @@ function installSessionTitleScrolling(host: HTMLElement) {
     element.setAttribute("data-session-title-scroll", "running");
 
     const scrollDistance = trackWidth + SESSION_TITLE_SCROLL_GAP_PX;
-    const forwardDuration = Math.min(
-      SESSION_TITLE_SCROLL_MAX_DURATION_MS,
-      Math.max(
-        SESSION_TITLE_SCROLL_MIN_DURATION_MS,
-        scrollDistance / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS,
-      ),
+    const forwardDuration = Math.max(
+      SESSION_TITLE_SCROLL_MIN_DURATION_MS,
+      scrollDistance / SESSION_TITLE_SCROLL_SPEED_PX_PER_MS,
     );
     const startedAt = performance.now();
     activeElements.add(element);


### PR DESCRIPTION
## Summary

- Keep long session title marquee duration proportional to its scroll distance instead of capping it at three seconds.
- Preserve a steady reading speed, then decelerate linearly across the final third of the travel.
- Extend the regression test to cover the uncapped duration and gradual slowdown.

## Root cause

The previous three-second maximum duration forced long titles to scroll faster than the configured 80px/s rate. The existing easing curve also started its final slowdown too late and did not model a linear deceleration.

## Validation

- pnpm --filter @codesesh/web test
- pnpm --filter @codesesh/web lint
- pnpm --filter @codesesh/web format:check
- pnpm --filter @codesesh/web build