### PR TITLE
feat(core): support Claude Code subagents

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -116,6 +116,51 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(windowed.map((ref: { sessionId: string }) => ref.sessionId)).toEqual(["new-session"]);
   });
 
+  it("keeps related child sources when a parent matches the scan window", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-related-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const parentId = "parent-session";
+    const childId = "child-session";
+    const childDir = join(projectDir, parentId, "subagents");
+    mkdirSync(childDir, { recursive: true });
+
+    const parentFile = join(projectDir, parentId + ".jsonl");
+    const childFile = join(childDir, "agent-" + childId + ".jsonl");
+    writeFileSync(parentFile, "parent");
+    writeFileSync(childFile, "child");
+    writeFileSync(
+      join(childDir, "agent-" + childId + ".meta.json"),
+      JSON.stringify({ parentAgentId: null }),
+    );
+
+    const parentTime = new Date(1_700_000_100_000);
+    const childTime = new Date(1_600_000_100_000);
+    utimesSync(parentFile, parentTime, parentTime);
+    utimesSync(childFile, childTime, childTime);
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    expect(
+      agent
+        .listSessionSources({
+          from: parentTime.getTime() - 1,
+          includeRelatedSessions: true,
+        })
+        .map((ref: { sessionId: string }) => ref.sessionId)
+        .sort(),
+    ).toEqual([parentId, childId].sort());
+    expect(
+      agent
+        .listSessionSources({
+          from: parentTime.getTime() - 1,
+          includeRelatedSessions: false,
+        })
+        .map((ref: { sessionId: string }) => ref.sessionId),
+    ).toEqual([parentId]);
+  });
+
   it("stats each session file once during a scan", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-stat-"));
     tempDirs.push(basePath);
@@ -175,7 +220,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
         sessionId: "session-1",
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "claudecode-head-v2",
+          "claudecode-head-v3",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           indexTime.getTime(),
@@ -333,6 +378,150 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(data.messages[3]).toMatchObject({
       role: "tool",
       parts: [{ type: "text", text: "detached output" }],
+    });
+  });
+
+  it("discovers Claude subagents and links Agent calls to child sessions", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-subagent-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const parentId = "parent-session";
+    const childId = "child-session";
+    const nestedChildId = "nested-child-session";
+    const childDir = join(projectDir, parentId, "subagents");
+    mkdirSync(childDir, { recursive: true });
+
+    writeFileSync(
+      join(projectDir, parentId + ".jsonl"),
+      [
+        JSON.stringify({
+          type: "user",
+          uuid: "user-1",
+          timestamp: "2026-04-20T10:00:00Z",
+          cwd: "/tmp/project",
+          message: { role: "user", content: "Delegate the repository check" },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          uuid: "assistant-1",
+          timestamp: "2026-04-20T10:00:01Z",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "tool-agent-1",
+                name: "Agent",
+                input: { prompt: "Inspect the repository" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          uuid: "user-2",
+          timestamp: "2026-04-20T10:00:02Z",
+          sourceToolAssistantUUID: "assistant-1",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tool-agent-1",
+                content: "Child completed",
+              },
+            ],
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(childDir, "agent-" + childId + ".meta.json"),
+      JSON.stringify({
+        name: "repository-check",
+        description: "Inspect the repository",
+        toolUseId: "tool-agent-1",
+      }),
+    );
+    writeFileSync(
+      join(childDir, "agent-" + childId + ".jsonl"),
+      [
+        JSON.stringify({
+          type: "user",
+          agentId: childId,
+          isSidechain: true,
+          timestamp: "2026-04-20T10:00:01Z",
+          cwd: "/tmp/project",
+          message: { role: "user", content: "Inspect the repository" },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          agentId: childId,
+          isSidechain: true,
+          timestamp: "2026-04-20T10:00:03Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Repository is clean" }],
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(childDir, "agent-" + nestedChildId + ".meta.json"),
+      JSON.stringify({
+        description: "Nested repository check",
+        parentAgentId: childId,
+      }),
+    );
+    writeFileSync(
+      join(childDir, "agent-" + nestedChildId + ".jsonl"),
+      [
+        JSON.stringify({
+          type: "user",
+          agentId: nestedChildId,
+          isSidechain: true,
+          timestamp: "2026-04-20T10:00:02Z",
+          cwd: "/tmp/project",
+          message: { role: "user", content: "Check the repository again" },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    const heads = agent.scan();
+    const parent = heads.find((head: SessionHead) => head.id === parentId);
+    const child = heads.find((head: SessionHead) => head.id === childId);
+
+    expect(heads.map((head: SessionHead) => head.id).sort()).toEqual(
+      [parentId, childId, nestedChildId].sort(),
+    );
+    expect(child).toMatchObject({
+      title: "repository-check",
+      parent_reference: { agentName: "claudecode", sessionId: parentId },
+    });
+    expect(heads.find((head: SessionHead) => head.id === nestedChildId)).toMatchObject({
+      title: "Nested repository check",
+      parent_reference: { agentName: "claudecode", sessionId: childId },
+    });
+    expect(parent?.parent_reference).toBeUndefined();
+
+    const parentData = agent.getSessionData(parentId);
+    const agentMessage = parentData.messages.find((message: Message) =>
+      message.parts.some((part: MessagePart) => part.type === "tool" && part.tool === "Agent"),
+    );
+    expect(agentMessage?.subagent_id).toBe(childId);
+    expect(agent.getSessionData(childId)).toMatchObject({
+      id: childId,
+      parent_reference: { agentName: "claudecode", sessionId: parentId },
+      messages: [
+        { role: "user" },
+        { role: "assistant", parts: [{ type: "text", text: "Repository is clean" }] },
+      ],
     });
   });
 

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, mkdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -10,7 +18,11 @@ import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostic
 // single-stat regression test can count per-file calls during a live scan.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
-  return { ...actual, statSync: vi.fn(actual.statSync) };
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+    statSync: vi.fn(actual.statSync),
+  };
 });
 
 let tempDirs: string[] = [];
@@ -161,6 +173,93 @@ describe("ClaudeCodeAgent cache refresh", () => {
     ).toEqual([parentId]);
   });
 
+  it("reuses child metadata between source refreshes", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-meta-cache-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const parentId = "parent-session";
+    const childIds = ["child-a", "child-b"];
+    const childDir = join(projectDir, parentId, "subagents");
+    mkdirSync(childDir, { recursive: true });
+    writeFileSync(join(projectDir, parentId + ".jsonl"), "parent");
+    const metaPaths: string[] = [];
+
+    for (const childId of childIds) {
+      writeFileSync(join(childDir, "agent-" + childId + ".jsonl"), "child");
+      const metaPath = join(childDir, "agent-" + childId + ".meta.json");
+      metaPaths.push(metaPath);
+      writeFileSync(metaPath, JSON.stringify({ name: childId }));
+    }
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+    const readSpy = vi.mocked(readFileSync);
+    const statSpy = vi.mocked(statSync);
+
+    readSpy.mockClear();
+    statSpy.mockClear();
+    agent.listSessionSources();
+    const firstMetaReads = readSpy.mock.calls.filter((call) =>
+      String(call[0]).endsWith(".meta.json"),
+    ).length;
+    const firstMetaStats = statSpy.mock.calls.filter((call) =>
+      String(call[0]).endsWith(".meta.json"),
+    ).length;
+
+    readSpy.mockClear();
+    statSpy.mockClear();
+    agent.listSessionSources();
+    const secondMetaReads = readSpy.mock.calls.filter((call) =>
+      String(call[0]).endsWith(".meta.json"),
+    ).length;
+    const secondMetaStats = statSpy.mock.calls.filter((call) =>
+      String(call[0]).endsWith(".meta.json"),
+    ).length;
+
+    expect(firstMetaReads).toBe(childIds.length);
+    expect(firstMetaStats).toBe(childIds.length);
+    expect(secondMetaReads).toBe(0);
+    expect(secondMetaStats).toBe(childIds.length);
+
+    const changedMetaTime = new Date(Date.now() + 2000);
+    utimesSync(metaPaths[0]!, changedMetaTime, changedMetaTime);
+    readSpy.mockClear();
+    agent.listSessionSources();
+    expect(
+      readSpy.mock.calls.filter((call) => String(call[0]).endsWith(".meta.json")),
+    ).toHaveLength(1);
+  });
+
+  it("drops a window-only child when its parent is outside the window", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-orphan-window-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const parentId = "parent-session";
+    const childId = "child-session";
+    const childDir = join(projectDir, parentId, "subagents");
+    mkdirSync(childDir, { recursive: true });
+
+    const parentFile = join(projectDir, parentId + ".jsonl");
+    const childFile = join(childDir, "agent-" + childId + ".jsonl");
+    writeFileSync(parentFile, "parent");
+    writeFileSync(childFile, "child");
+    writeFileSync(join(childDir, "agent-" + childId + ".meta.json"), "{}");
+
+    const parentTime = new Date(1_600_000_100_000);
+    const childTime = new Date(1_700_000_100_000);
+    utimesSync(parentFile, parentTime, parentTime);
+    utimesSync(childFile, childTime, childTime);
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    expect(
+      agent
+        .listSessionSources({ from: childTime.getTime() - 1 })
+        .map((ref: { sessionId: string }) => ref.sessionId),
+    ).toEqual([]);
+  });
+
   it("stats each session file once during a scan", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-stat-"));
     tempDirs.push(basePath);
@@ -220,7 +319,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
         sessionId: "session-1",
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "claudecode-head-v3",
+          "claudecode-head-v4",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           indexTime.getTime(),
@@ -814,6 +913,35 @@ describe("ClaudeCodeAgent head parsing", () => {
   it("skips an empty file", () => {
     expect(writeSession([]).agent.scan()).toEqual([]);
     expect(writeSession(["", "   ", ""]).agent.scan()).toEqual([]);
+  });
+
+  it("treats a child with missing metadata and parent as a root", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-orphan-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const childDir = join(projectDir, "missing-parent", "subagents");
+    const childId = "orphan-child";
+    mkdirSync(childDir, { recursive: true });
+    writeFileSync(
+      join(childDir, "agent-" + childId + ".jsonl"),
+      JSON.stringify({
+        type: "user",
+        timestamp: "2026-04-20T10:00:00Z",
+        cwd: "/tmp/project",
+        message: { role: "user", content: "Orphan child" },
+      }),
+    );
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    expect(agent.scan()).toMatchObject([
+      {
+        id: childId,
+        title: "Orphan child",
+        parent_reference: undefined,
+      },
+    ]);
   });
 
   it("skips a file whose first record is malformed", () => {

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -23,15 +23,17 @@ import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
-import type {
-  AgentScanOptions,
-  FileSessionMeta,
-  SessionSourceFile,
-  SessionSourceRef,
+import {
+  matchesScanWindow,
+  type AgentScanOptions,
+  type FileSessionMeta,
+  type SessionCacheMeta,
+  type SessionSourceFile,
+  type SessionSourceRef,
 } from "./base.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
-const HEAD_INDEX_VERSION = "claudecode-head-v2";
+const HEAD_INDEX_VERSION = "claudecode-head-v3";
 
 export function resolveClaudeCodeDataRoot(): string {
   return resolveHomePath("CLAUDE_CONFIG_DIR", ".claude");
@@ -50,6 +52,16 @@ interface SessionMeta extends FileSessionMeta {
   indexMtimeMs: number | null;
   headIndexVersion: string;
   model: string | null | undefined;
+  parentSessionId: string | null;
+}
+
+interface ClaudeChildContext {
+  sessionId: string;
+  projectDir: string;
+  parentSessionId: string | null;
+  explicitTitle: string | null;
+  metaMtimeMs: number | null;
+  toolUseId: string | null;
 }
 
 function parseTimestampMs(data: Record<string, unknown>): number {
@@ -115,6 +127,9 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private sessionsIndexCache: Record<string, any> = {};
   private sessionsIndexMtime: Record<string, number | null> = {};
+  private childContextsBySource = new Map<string, ClaudeChildContext>();
+  private childSessionIdByToolUseId = new Map<string, string>();
+  private childIndexReady = false;
 
   private findBasePath(): string | null {
     return firstExisting(join(resolveClaudeCodeDataRoot(), "projects"), "data/claudecode");
@@ -153,19 +168,80 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       indexMtimes.set(projectDir, this.readFileMtimeMs(indexPath));
     }
 
-    return this.walkFiles(projectDirs, (entry) => entry.name.endsWith(".jsonl"), {
-      recursive: false,
-      scanWindow: options,
-    }).map(({ file, stat }) => ({
-      sessionId: basename(file, ".jsonl"),
-      sourcePath: file,
-      fingerprint: this.sourceFingerprint(stat, indexMtimes.get(dirname(file)) ?? null),
-    }));
+    const projectDirSet = new Set(projectDirs);
+    const allSources = this.walkFiles(projectDirs, (entry) => entry.name.endsWith(".jsonl"), {
+      recursive: true,
+    });
+    this.indexChildContexts(allSources);
+    const indexedSources = allSources.flatMap((source) => {
+      const child = this.childContextsBySource.get(source.file);
+      if (!child && !projectDirSet.has(dirname(source.file))) return [];
+      return [
+        {
+          source,
+          sessionId: child?.sessionId ?? basename(source.file, ".jsonl"),
+          child,
+        },
+      ];
+    });
+    let selectedSources = indexedSources.filter(({ source }) =>
+      matchesScanWindow(source.stat.mtimeMs, options),
+    );
+
+    if (
+      options?.includeRelatedSessions !== false &&
+      (options?.from != null || options?.to != null)
+    ) {
+      type IndexedSource = (typeof indexedSources)[number];
+      const childrenByParent = new Map<string, IndexedSource[]>();
+      for (const indexed of indexedSources) {
+        const parentId = indexed.child?.parentSessionId;
+        if (!parentId) continue;
+        const children = childrenByParent.get(parentId);
+        if (children) children.push(indexed);
+        else childrenByParent.set(parentId, [indexed]);
+      }
+
+      const selectedById = new Map(selectedSources.map((indexed) => [indexed.sessionId, indexed]));
+      const pending = selectedSources
+        .filter(({ child }) => !child)
+        .map(({ sessionId }) => sessionId);
+      while (pending.length > 0) {
+        const parentId = pending.pop()!;
+        for (const child of childrenByParent.get(parentId) ?? []) {
+          if (selectedById.has(child.sessionId)) continue;
+          selectedById.set(child.sessionId, child);
+          pending.push(child.sessionId);
+        }
+      }
+      selectedSources = [...selectedById.values()];
+    }
+
+    return selectedSources.map(({ source: { file, stat }, sessionId, child }) => {
+      const projectDir = child?.projectDir ?? dirname(file);
+      return {
+        sessionId,
+        sourcePath: file,
+        fingerprint: this.sourceFingerprint(
+          stat,
+          indexMtimes.get(projectDir) ?? null,
+          child?.metaMtimeMs,
+        ),
+      };
+    });
+  }
+
+  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
+    super.setSessionMetaMap(meta);
+    this.childContextsBySource.clear();
+    this.childSessionIdByToolUseId.clear();
+    this.childIndexReady = false;
   }
 
   protected parseFileSessionHead(sourcePath: string): SessionHead | null {
-    const projectDir = dirname(sourcePath);
-    return getParsedSession(this.parseSessionHeadResult(sourcePath, projectDir));
+    const child = this.getChildContext(sourcePath);
+    const projectDir = child?.projectDir ?? dirname(sourcePath);
+    return getParsedSession(this.parseSessionHeadResult(sourcePath, projectDir, child));
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -177,12 +253,19 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       throw new Error(`Session file missing: ${meta.sourcePath}`);
     }
 
+    this.ensureChildIndex();
     const builder = new TranscriptBuilder();
     const assistantUuidToToolCalls = new Map<string, string[]>();
     const countedUsageKeys = new Set<string>();
     for (const record of readJsonlFile(meta.sourcePath)) {
       try {
-        this.convertRecord(record, builder, assistantUuidToToolCalls, countedUsageKeys);
+        this.convertRecord(
+          record,
+          builder,
+          assistantUuidToToolCalls,
+          countedUsageKeys,
+          this.childSessionIdByToolUseId,
+        );
       } catch {
         // skip malformed records
       }
@@ -196,6 +279,10 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       title: meta.title,
       slug: `claudecode/${meta.id}`,
       directory: meta.directory,
+      parent_reference:
+        meta.parentSessionId == null
+          ? undefined
+          : { agentName: this.name, sessionId: meta.parentSessionId },
       version: undefined,
       time_created: meta.createdAt,
       time_updated: meta.updatedAt,
@@ -217,19 +304,98 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     }
   }
 
+  private ensureChildIndex(): void {
+    if (this.childIndexReady) return;
+    this.basePath ??= this.findBasePath();
+    if (!this.basePath) {
+      this.childIndexReady = true;
+      return;
+    }
+
+    this.indexChildContexts(
+      this.walkFiles(this.listProjectDirs(), (entry) => entry.name.endsWith(".jsonl"), {
+        recursive: true,
+      }),
+    );
+  }
+
+  private indexChildContexts(sources: readonly SessionSourceFile[]): void {
+    this.childContextsBySource.clear();
+    this.childSessionIdByToolUseId.clear();
+
+    for (const source of sources) {
+      const child = this.readChildContext(source.file);
+      if (!child) continue;
+      this.childContextsBySource.set(source.file, child);
+      if (child.toolUseId) {
+        this.childSessionIdByToolUseId.set(child.toolUseId, child.sessionId);
+      }
+    }
+
+    this.childIndexReady = true;
+  }
+
+  private getChildContext(sourcePath: string): ClaudeChildContext | null {
+    const cached = this.childContextsBySource.get(sourcePath);
+    if (cached) return cached;
+
+    const child = this.readChildContext(sourcePath);
+    if (!child) return null;
+    this.childContextsBySource.set(sourcePath, child);
+    if (child.toolUseId) {
+      this.childSessionIdByToolUseId.set(child.toolUseId, child.sessionId);
+    }
+    return child;
+  }
+
+  private readChildContext(sourcePath: string): ClaudeChildContext | null {
+    const subagentsDir = dirname(sourcePath);
+    if (basename(subagentsDir) !== "subagents") return null;
+
+    const parentDir = dirname(subagentsDir);
+    const projectDir = dirname(parentDir);
+    const fileStem = basename(sourcePath, ".jsonl");
+    const metaPath = join(subagentsDir, fileStem + ".meta.json");
+    let metadata: Record<string, unknown> | null = null;
+    try {
+      metadata = asRecord(JSON.parse(readFileSync(metaPath, "utf-8"))) ?? null;
+    } catch {
+      // Child transcripts can outlive their metadata during an interrupted spawn.
+    }
+
+    const sessionId = asString(metadata?.["agentId"])?.trim() || fileStem.replace(/^agent-/, "");
+    if (!sessionId) return null;
+
+    const parentAgentId = asString(metadata?.["parentAgentId"])?.trim();
+    const parentSessionId = parentAgentId || basename(parentDir) || null;
+    const name = asString(metadata?.["name"])?.trim();
+    const description = asString(metadata?.["description"])?.trim();
+
+    return {
+      sessionId,
+      projectDir,
+      parentSessionId,
+      explicitTitle: name || description || null,
+      metaMtimeMs: this.readFileMtimeMs(metaPath),
+      toolUseId: asString(metadata?.["toolUseId"])?.trim() || null,
+    };
+  }
+
   protected createFileSessionMeta(head: SessionHead, source: SessionSourceFile): SessionMeta {
-    const projectDir = dirname(source.file);
+    const child = this.getChildContext(source.file);
+    const projectDir = child?.projectDir ?? dirname(source.file);
     const indexPath = this.getSessionsIndexPath(projectDir);
     const indexMtime = this.readFileMtimeMs(indexPath);
     return this.buildFileSessionMeta({
       head,
       source,
-      fingerprint: this.sourceFingerprint(source.stat, indexMtime),
+      fingerprint: this.sourceFingerprint(source.stat, indexMtime, child?.metaMtimeMs),
       extras: {
         indexPath: indexMtime === null ? null : indexPath,
         indexMtimeMs: indexMtime,
         headIndexVersion: HEAD_INDEX_VERSION,
         model: head.stats.total_tokens ? "unknown" : undefined,
+        parentSessionId: head.parent_reference?.sessionId ?? null,
       },
     });
   }
@@ -238,8 +404,11 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   private sourceFingerprint(
     stat: { mtimeMs: number; size: number },
     indexMtime: number | null,
+    metaMtime?: number | null,
   ): string {
-    return JSON.stringify([HEAD_INDEX_VERSION, stat.mtimeMs, stat.size, indexMtime]);
+    const fingerprint = [HEAD_INDEX_VERSION, stat.mtimeMs, stat.size, indexMtime];
+    if (metaMtime !== undefined) fingerprint.push(metaMtime);
+    return JSON.stringify(fingerprint);
   }
 
   private getSessionsIndexPath(projectDir: string): string {
@@ -282,13 +451,15 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   private parseSessionHeadResult(
     filePath: string,
     projectDir: string,
+    child?: ClaudeChildContext | null,
   ): ParseSessionResult<SessionHead> {
-    const sessionId = basename(filePath, ".jsonl");
+    const sessionId = child?.sessionId ?? basename(filePath, ".jsonl");
 
     // Try to get title from sessions-index.json
     const index = this.loadSessionsIndex(projectDir);
     const indexEntry = index.get(sessionId);
-    const explicitTitle = indexEntry?.summary ? String(indexEntry.summary) : null;
+    const explicitTitle =
+      child?.explicitTitle ?? (indexEntry?.summary ? String(indexEntry.summary) : null);
 
     // Extract lightweight metadata; cwd lives in user-type records, not the first line
     let createdAt = 0;
@@ -406,6 +577,10 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       slug: `claudecode/${sessionId}`,
       title,
       directory,
+      parent_reference:
+        child?.parentSessionId == null
+          ? undefined
+          : { agentName: this.name, sessionId: child.parentSessionId },
       time_created: createdAt,
       time_updated: updatedAt,
       stats: {
@@ -450,6 +625,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     builder: TranscriptBuilder,
     assistantUuidToToolCalls: Map<string, string[]>,
     countedUsageKeys: Set<string>,
+    childSessionIdByToolUseId: ReadonlyMap<string, string>,
   ): void {
     if (data["isMeta"] === true) return;
 
@@ -457,7 +633,13 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     if (isInternalEventType(msgType)) return;
 
     if (msgType === "assistant") {
-      this.convertAssistantRecord(data, builder, assistantUuidToToolCalls, countedUsageKeys);
+      this.convertAssistantRecord(
+        data,
+        builder,
+        assistantUuidToToolCalls,
+        countedUsageKeys,
+        childSessionIdByToolUseId,
+      );
     } else if (msgType === "user") {
       this.convertUserRecord(data, builder, assistantUuidToToolCalls);
     } else if (msgType === "tool_result") {
@@ -470,6 +652,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     builder: TranscriptBuilder,
     assistantUuidToToolCalls: Map<string, string[]>,
     countedUsageKeys: Set<string>,
+    childSessionIdByToolUseId: ReadonlyMap<string, string>,
   ): void {
     const msg = asRecord(data["message"]) ?? {};
     const timestampMs = parseTimestampMs(data);
@@ -515,13 +698,15 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       if (partType !== "tool_use") continue;
 
       const toolCallId = String(part["id"] ?? "").trim();
+      const subagentId = childSessionIdByToolUseId.get(toolCallId);
 
       const toolPart = this.buildToolPart(part, timestampMs);
       const message = builder.appendToolCall(
         toolPart,
-        { id: uuid, timestampMs, agent: "claude" },
+        { id: uuid, timestampMs, agent: "claude", subagentId },
         { modeOnCreate: "tool" },
       );
+      if (subagentId) message.subagent_id = subagentId;
       this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
       if (toolCallId) {
         toolCallIds.push(toolCallId);

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -33,7 +33,7 @@ import {
 } from "./base.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
-const HEAD_INDEX_VERSION = "claudecode-head-v3";
+const HEAD_INDEX_VERSION = "claudecode-head-v4";
 
 export function resolveClaudeCodeDataRoot(): string {
   return resolveHomePath("CLAUDE_CONFIG_DIR", ".claude");
@@ -62,6 +62,11 @@ interface ClaudeChildContext {
   explicitTitle: string | null;
   metaMtimeMs: number | null;
   toolUseId: string | null;
+}
+
+interface ClaudeChildContextCacheEntry {
+  metaMtimeMs: number | null;
+  context: ClaudeChildContext;
 }
 
 function parseTimestampMs(data: Record<string, unknown>): number {
@@ -128,6 +133,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   private sessionsIndexCache: Record<string, any> = {};
   private sessionsIndexMtime: Record<string, number | null> = {};
   private childContextsBySource = new Map<string, ClaudeChildContext>();
+  private childContextCache = new Map<string, ClaudeChildContextCacheEntry>();
   private childSessionIdByToolUseId = new Map<string, string>();
   private childIndexReady = false;
 
@@ -172,7 +178,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     const allSources = this.walkFiles(projectDirs, (entry) => entry.name.endsWith(".jsonl"), {
       recursive: true,
     });
-    this.indexChildContexts(allSources);
+    this.indexChildContexts(allSources, projectDirs);
     const indexedSources = allSources.flatMap((source) => {
       const child = this.childContextsBySource.get(source.file);
       if (!child && !projectDirSet.has(dirname(source.file))) return [];
@@ -188,10 +194,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       matchesScanWindow(source.stat.mtimeMs, options),
     );
 
-    if (
-      options?.includeRelatedSessions !== false &&
-      (options?.from != null || options?.to != null)
-    ) {
+    if (options?.from != null || options?.to != null) {
       type IndexedSource = (typeof indexedSources)[number];
       const childrenByParent = new Map<string, IndexedSource[]>();
       for (const indexed of indexedSources) {
@@ -202,19 +205,52 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
         else childrenByParent.set(parentId, [indexed]);
       }
 
-      const selectedById = new Map(selectedSources.map((indexed) => [indexed.sessionId, indexed]));
-      const pending = selectedSources
-        .filter(({ child }) => !child)
-        .map(({ sessionId }) => sessionId);
-      while (pending.length > 0) {
-        const parentId = pending.pop()!;
-        for (const child of childrenByParent.get(parentId) ?? []) {
-          if (selectedById.has(child.sessionId)) continue;
-          selectedById.set(child.sessionId, child);
-          pending.push(child.sessionId);
+      const windowSelectedById = new Map(
+        selectedSources.map((indexed) => [indexed.sessionId, indexed]),
+      );
+      const connectedSelected = new Map<string, IndexedSource>();
+      const acceptedIds = new Set<string>();
+      const visitingIds = new Set<string>();
+      const hasSelectedParent = (sessionId: string): boolean => {
+        if (acceptedIds.has(sessionId)) return true;
+        if (visitingIds.has(sessionId)) return false;
+
+        const indexed = windowSelectedById.get(sessionId);
+        if (!indexed) return false;
+        const parentId = indexed.child?.parentSessionId;
+        if (!parentId) {
+          acceptedIds.add(sessionId);
+          return true;
+        }
+
+        visitingIds.add(sessionId);
+        const connected = hasSelectedParent(parentId);
+        visitingIds.delete(sessionId);
+        if (connected) acceptedIds.add(sessionId);
+        return connected;
+      };
+
+      for (const indexed of selectedSources) {
+        if (hasSelectedParent(indexed.sessionId)) {
+          connectedSelected.set(indexed.sessionId, indexed);
         }
       }
-      selectedSources = [...selectedById.values()];
+
+      if (options?.includeRelatedSessions !== false) {
+        const pending = [...connectedSelected.values()]
+          .filter(({ child }) => !child?.parentSessionId)
+          .map(({ sessionId }) => sessionId);
+        while (pending.length > 0) {
+          const parentId = pending.pop()!;
+          for (const child of childrenByParent.get(parentId) ?? []) {
+            if (connectedSelected.has(child.sessionId)) continue;
+            connectedSelected.set(child.sessionId, child);
+            pending.push(child.sessionId);
+          }
+        }
+      }
+
+      selectedSources = [...connectedSelected.values()];
     }
 
     return selectedSources.map(({ source: { file, stat }, sessionId, child }) => {
@@ -312,23 +348,47 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       return;
     }
 
+    const projectDirs = this.listProjectDirs();
     this.indexChildContexts(
-      this.walkFiles(this.listProjectDirs(), (entry) => entry.name.endsWith(".jsonl"), {
+      this.walkFiles(projectDirs, (entry) => entry.name.endsWith(".jsonl"), {
         recursive: true,
       }),
+      projectDirs,
     );
   }
 
-  private indexChildContexts(sources: readonly SessionSourceFile[]): void {
+  private indexChildContexts(
+    sources: readonly SessionSourceFile[],
+    projectDirs: readonly string[],
+  ): void {
     this.childContextsBySource.clear();
     this.childSessionIdByToolUseId.clear();
+    const projectDirSet = new Set(projectDirs);
+    const contexts = new Map<string, ClaudeChildContext>();
+    const knownSessionIds = new Set<string>();
 
     for (const source of sources) {
       const child = this.readChildContext(source.file);
-      if (!child) continue;
-      this.childContextsBySource.set(source.file, child);
+      if (!child) {
+        if (projectDirSet.has(dirname(source.file))) {
+          knownSessionIds.add(basename(source.file, ".jsonl"));
+        }
+        continue;
+      }
+      contexts.set(source.file, child);
+      knownSessionIds.add(child.sessionId);
+    }
+
+    for (const [sourcePath, child] of contexts) {
+      const parentSessionId =
+        child.parentSessionId && knownSessionIds.has(child.parentSessionId)
+          ? child.parentSessionId
+          : null;
+      const normalized =
+        parentSessionId === child.parentSessionId ? child : { ...child, parentSessionId };
+      this.childContextsBySource.set(sourcePath, normalized);
       if (child.toolUseId) {
-        this.childSessionIdByToolUseId.set(child.toolUseId, child.sessionId);
+        this.childSessionIdByToolUseId.set(child.toolUseId, normalized.sessionId);
       }
     }
 
@@ -353,32 +413,54 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     if (basename(subagentsDir) !== "subagents") return null;
 
     const parentDir = dirname(subagentsDir);
+    // Claude stores nested transcripts flat here; parentAgentId carries the nesting relation.
     const projectDir = dirname(parentDir);
     const fileStem = basename(sourcePath, ".jsonl");
     const metaPath = join(subagentsDir, fileStem + ".meta.json");
+    const metaMtimeMs = this.readFileMtimeMs(metaPath);
+    const cached = this.childContextCache.get(sourcePath);
+    if (cached?.metaMtimeMs === metaMtimeMs) return cached.context;
+
     let metadata: Record<string, unknown> | null = null;
-    try {
-      metadata = asRecord(JSON.parse(readFileSync(metaPath, "utf-8"))) ?? null;
-    } catch {
-      // Child transcripts can outlive their metadata during an interrupted spawn.
+    if (metaMtimeMs !== null) {
+      try {
+        metadata = asRecord(JSON.parse(readFileSync(metaPath, "utf-8"))) ?? null;
+      } catch {
+        // Child transcripts can outlive their metadata during an interrupted spawn.
+      }
     }
 
     const sessionId = asString(metadata?.["agentId"])?.trim() || fileStem.replace(/^agent-/, "");
     if (!sessionId) return null;
 
     const parentAgentId = asString(metadata?.["parentAgentId"])?.trim();
-    const parentSessionId = parentAgentId || basename(parentDir) || null;
+    const candidateParentId = parentAgentId || basename(parentDir) || null;
+    const parentSessionId =
+      candidateParentId && this.hasChildParent(sourcePath, projectDir, candidateParentId)
+        ? candidateParentId
+        : null;
     const name = asString(metadata?.["name"])?.trim();
     const description = asString(metadata?.["description"])?.trim();
 
-    return {
+    const context = {
       sessionId,
       projectDir,
       parentSessionId,
       explicitTitle: name || description || null,
-      metaMtimeMs: this.readFileMtimeMs(metaPath),
+      metaMtimeMs,
       toolUseId: asString(metadata?.["toolUseId"])?.trim() || null,
     };
+    this.childContextCache.set(sourcePath, { metaMtimeMs, context });
+    return context;
+  }
+
+  private hasChildParent(sourcePath: string, projectDir: string, parentSessionId: string): boolean {
+    const subagentsDir = dirname(sourcePath);
+    return [
+      join(projectDir, parentSessionId + ".jsonl"),
+      join(subagentsDir, "agent-" + parentSessionId + ".jsonl"),
+      join(subagentsDir, parentSessionId + ".jsonl"),
+    ].some((path) => existsSync(path));
   }
 
   protected createFileSessionMeta(head: SessionHead, source: SessionSourceFile): SessionMeta {


### PR DESCRIPTION
## Summary

- Discover Claude Code child transcripts under `subagents/agent-*.jsonl`.
- Build nested `parent_reference` relationships from `.meta.json` metadata, including nested agents.
- Link parent `Agent` tool calls to child sessions through `toolUseId`.
- Preserve related child sources during windowed scans and fingerprint metadata changes for cache refreshes.
- Reuse the existing session-tree UI contract; no web-specific changes are required.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- Replayed the target Claude Code transcript: 18 first-level children and all 18 parent Agent links were resolved; nested child relationships were also detected.