### PR TITLE
fix(web): prevent duplicate session selection

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -252,6 +252,52 @@ function dispatch(target: HTMLElement, type: string, init: EventInit & { key?: s
   );
 }
 
+describe("SessionTreeSidebar selection state", () => {
+  afterEach(cleanup);
+
+  it("keeps one active row and hides its fill while keyboard focus is elsewhere", async () => {
+    const first = makeSession({ id: "first", title: "First session" });
+    const second = makeSession({ id: "second", title: "Second session" });
+    const sessions = [first, second];
+    const firstReference = getSessionReferenceKey(first);
+    const secondReference = getSessionReferenceKey(second);
+    const onSelectSession = vi.fn();
+    const renderTree = (activeSessionReference: string, selectedSessionReference: string) => (
+      <SessionTreeSidebar
+        sessions={sessions}
+        activeSessionReference={activeSessionReference}
+        selectedSessionReference={selectedSessionReference}
+        onSelectSession={onSelectSession}
+        bookmarkedSessionReferences={new Set()}
+        onToggleBookmark={() => {}}
+        onRenameSession={() => {}}
+        groupByProject={false}
+      />
+    );
+    const { rerender } = render(renderTree(firstReference, secondReference));
+    const tree = document.querySelector<HTMLElement>(".session-tree")!;
+    const shadowRoot = document.querySelector("file-tree-container")!.shadowRoot!;
+
+    await waitFor(() => {
+      const activeRows = shadowRoot.querySelectorAll('[aria-selected="true"]');
+      expect(activeRows).toHaveLength(1);
+      expect(activeRows[0]?.getAttribute("aria-label")).toBe("First session");
+    });
+    expect(tree.style.getPropertyValue("--trees-selected-bg-override")).toBe("transparent");
+    expect(onSelectSession).not.toHaveBeenCalled();
+
+    rerender(renderTree(secondReference, secondReference));
+
+    await waitFor(() => {
+      const activeRows = shadowRoot.querySelectorAll('[aria-selected="true"]');
+      expect(activeRows).toHaveLength(1);
+      expect(activeRows[0]?.getAttribute("aria-label")).toBe("Second session");
+    });
+    expect(tree.style.getPropertyValue("--trees-selected-bg-override")).toBe("var(--brand-soft)");
+    expect(onSelectSession).not.toHaveBeenCalled();
+  });
+});
+
 describe("SessionTreeSidebar session options menu", () => {
   beforeEach(() => {
     patchShadowEventRetargeting();

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -554,6 +554,9 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   const onSelectSessionRef = useRef(onSelectSession);
   const onToggleBookmarkRef = useRef(onToggleBookmark);
   const onRenameSessionRef = useRef(onRenameSession);
+  const syncingActiveSelectionRef = useRef(false);
+  const hasPendingSessionSelection =
+    selectedSessionReference !== null && selectedSessionReference !== activeSessionReference;
   const treeHostStyle: TreeHostStyle = {
     "--trees-bg-override": "transparent",
     "--trees-border-color-override": "var(--console-border)",
@@ -564,7 +567,9 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     "--trees-item-margin-x-override": "0px",
     "--trees-item-padding-x-override": "4px",
     "--trees-padding-inline-override": "4px",
-    "--trees-selected-bg-override": "var(--brand-soft)",
+    "--trees-selected-bg-override": hasPendingSessionSelection
+      ? "transparent"
+      : "var(--brand-soft)",
   };
   const { model } = useFileTree({
     flattenEmptyDirectories: false,
@@ -574,6 +579,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     density: "compact",
     unsafeCSS: SESSION_TREE_CSS,
     onSelectionChange(paths) {
+      if (syncingActiveSelectionRef.current) return;
       const session = sessionByPathRef.current.get(paths[0] ?? "");
       if (session) onSelectSessionRef.current(session);
     },
@@ -692,7 +698,17 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
     const focusedSessionReference = selectedSessionReference ?? activeSessionReference ?? "";
     const focusedGroupPath = modelData.groupPathBySessionReference.get(focusedSessionReference);
 
-    if (activePath) model.getItem(activePath)?.select();
+    syncingActiveSelectionRef.current = true;
+    try {
+      for (const path of model.getSelectedPaths()) {
+        if (path !== activePath) model.getItem(path)?.deselect();
+      }
+      if (activePath && !model.getSelectedPaths().includes(activePath)) {
+        model.getItem(activePath)?.select();
+      }
+    } finally {
+      syncingActiveSelectionRef.current = false;
+    }
     if (focusedPath && activeSessionReference) {
       const segments = focusedPath.split("/").filter(Boolean);
       for (let index = 1; index <= segments.length; index += 1) {


### PR DESCRIPTION
## Summary

- keep the session tree synchronized to exactly one active row
- suppress navigation callbacks during route-driven selection updates
- hide the active-row fill while keyboard focus previews another session
- add regression coverage for focus divergence and active-session changes

## Root cause

The tree item `select()` API appends to the existing selection. Route synchronization used it as if it were an exclusive selection operation, so previous rows could remain selected and their callbacks could navigate back to an older session. Separately, the active-row fill remained visible when keyboard focus moved to a different row, making two rows look selected.

## User impact

Keyboard navigation now presents a single clear focus target. Pressing Enter opens the focused session without retaining stale selected rows or bouncing back to the previously active session.

## Validation

- `pnpm --filter @codesesh/web test` — 73 files, 635 tests passed
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web build`
- browser verification of `j` / `k` navigation and Enter activation