### PR TITLE
fix: eliminate SQLite busy failures and swap sidebar toggle icons

### DIFF
--- a/apps/web/src/components/ui/icons.tsx
+++ b/apps/web/src/components/ui/icons.tsx
@@ -89,8 +89,10 @@ export const Monitor = toIcon(ComputerIcon);
 export const Moon = toIcon(MoonIcon);
 export const MoreHorizontal = toIcon(MoreHorizontalIcon);
 export const NotebookPen = toIcon(NoteEditIcon);
-export const PanelLeftClose = toIcon(PanelLeftCloseIcon);
-export const PanelLeftOpen = toIcon(PanelLeftOpenIcon);
+// Hugeicons draws these arrows opposite to their names (Close points right,
+// Open points left), so the mapping is swapped to keep the visual direction correct.
+export const PanelLeftClose = toIcon(PanelLeftOpenIcon);
+export const PanelLeftOpen = toIcon(PanelLeftCloseIcon);
 export const PanelsTopLeft = toIcon(BrowserIcon);
 export const Pencil = toIcon(PencilIcon);
 export const Plug = toIcon(Plug01Icon);

--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -37,7 +37,12 @@ describe("withCacheDb diagnostics", () => {
     });
 
     expect(result).toBeNull();
-    expect(events).toEqual([{ event: "cache.write_failed", detail: { message: "disk full" } }]);
+    expect(events).toEqual([
+      {
+        event: "cache.write_failed",
+        detail: { message: "disk full", code: undefined, stack: expect.any(String) },
+      },
+    ]);
   });
 
   it("stays silent when no diagnostics sink is injected", () => {

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -123,26 +123,28 @@ export function runSearchIndexWrite<T>(
   rebuild: boolean,
   write: () => T,
 ): SearchIndexWriteResult<T> {
-  return db.transaction(() => {
-    if (rebuild) {
-      dropSearchTriggers(db);
-      dropMessageSearchTriggers(db);
-    }
+  return db
+    .transaction(() => {
+      if (rebuild) {
+        dropSearchTriggers(db);
+        dropMessageSearchTriggers(db);
+      }
 
-    const value = write();
-    let rebuildDurationMs: number | undefined;
+      const value = write();
+      let rebuildDurationMs: number | undefined;
 
-    if (rebuild) {
-      const rebuildStartedAt = performance.now();
-      rebuildSearchIndex(db);
-      rebuildMessageSearchIndex(db);
-      rebuildDurationMs = performance.now() - rebuildStartedAt;
-      createSearchTriggers(db);
-      createMessageSearchTriggers(db);
-    }
+      if (rebuild) {
+        const rebuildStartedAt = performance.now();
+        rebuildSearchIndex(db);
+        rebuildMessageSearchIndex(db);
+        rebuildDurationMs = performance.now() - rebuildStartedAt;
+        createSearchTriggers(db);
+        createMessageSearchTriggers(db);
+      }
 
-    return { value, rebuildDurationMs };
-  })();
+      return { value, rebuildDurationMs };
+    })
+    .immediate();
 }
 
 function createCacheTables(db: SQLiteDatabase): void {
@@ -1339,7 +1341,10 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
 
   createLatestCacheSchema(db);
 
-  if (getUserVersion(db) <= CACHE_SCHEMA_VERSION) {
+  // Only stamp when behind: every thread's first connection runs ensureSchema,
+  // and an unconditional PRAGMA user_version write would contend for the write
+  // lock against concurrent checkpoint/index writers on every startup.
+  if (getUserVersion(db) < CACHE_SCHEMA_VERSION) {
     setCacheSchemaVersion(db);
   }
 

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -83,6 +83,8 @@ export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
   } catch (error) {
     getCoreDiagnostics()?.warn("cache.write_failed", {
       message: error instanceof Error ? error.message : String(error),
+      code: (error as { code?: string })?.code,
+      stack: error instanceof Error ? error.stack : undefined,
     });
     return null;
   } finally {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -460,7 +460,7 @@ export function saveCachedSessions(
       });
     });
 
-    write();
+    write.immediate();
     deleteLegacyCacheFile();
     return true;
   });
@@ -523,7 +523,7 @@ export function saveCachedSessionChanges(
       }
     });
 
-    write();
+    write.immediate();
     deleteLegacyCacheFile();
     return true;
   });

--- a/packages/core/src/state/bookmarks.ts
+++ b/packages/core/src/state/bookmarks.ts
@@ -239,7 +239,7 @@ export function importBookmarks(
       }
     });
 
-    write();
+    write.immediate();
     const rows = db
       .prepare(
         `

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -24,6 +24,16 @@ interface SQLiteTransaction {
   (...params: unknown[]): unknown;
 }
 
+export interface SQLiteTransactionRunner<T extends SQLiteTransaction> {
+  (...params: Parameters<T>): ReturnType<T>;
+  /**
+   * BEGIN IMMEDIATE: takes the write lock up front so busy_timeout governs the
+   * wait. A deferred write transaction that reads first can die instantly with
+   * SQLITE_BUSY_SNAPSHOT when another connection commits in between.
+   */
+  immediate(...params: Parameters<T>): ReturnType<T>;
+}
+
 interface SQLitePragmaCapable {
   pragma(sql: string): unknown;
 }
@@ -66,7 +76,7 @@ export interface DatabaseRow {
 export interface SQLiteDatabase {
   prepare(sql: string): SQLiteStatement;
   exec(sql: string): void;
-  transaction<T extends SQLiteTransaction>(fn: T): T;
+  transaction<T extends SQLiteTransaction>(fn: T): SQLiteTransactionRunner<T>;
   close(): void;
 }
 
@@ -214,7 +224,7 @@ export function runSchemaMigrations(
         migration.migrate(db);
         setUserVersion(db, migration.version);
       });
-      apply();
+      apply.immediate();
       currentVersion = migration.version;
       getCoreDiagnostics()?.info?.("sqlite.migration.completed", {
         label: options.backupLabel,
@@ -277,10 +287,12 @@ export function openDb(dbPath: string): SQLiteDatabase | null {
     // The sidecars only exist once the connection is established.
     restrictPrivateDatabase(dbPath);
     try {
+      // busy_timeout first: if a later pragma throws, writes must still wait for
+      // concurrent writers instead of failing instantly with SQLITE_BUSY.
+      db.pragma("busy_timeout = 5000");
       db.pragma("journal_mode = WAL");
       db.pragma("synchronous = NORMAL");
       db.pragma("foreign_keys = ON");
-      db.pragma("busy_timeout = 5000");
     } catch {
       // The database remains usable when SQLite rejects connection-level tuning.
     }


### PR DESCRIPTION
## Summary

### Search index persistence failures (`database is locked`)

Startup logged `[agent] Session refresh failed: Search index worker failed to persist search_index` for several agents. Runtime logs pinned the cause to `cache.write_failed: database is locked` (SQLITE_BUSY) raced between the search-index worker threads and main-thread checkpoint writes.

Root causes fixed in `@codesesh/core`:

1. **Redundant schema stamp on every connection** — `ensureSchema` wrote `PRAGMA user_version` + `cache_meta` even when the schema was already at the target version (`<=` instead of `<`). Every worker thread's first connection joined the write-lock contention for no reason. Reproduced deterministically with a concurrent stress script; the failure stack pointed exactly at `setUserVersion`.
2. **Deferred write transactions** — `db.transaction(...)()` uses deferred `BEGIN`. A transaction that reads before writing (e.g. `saveCachedSessions` selects existing session ids first) fails instantly with `SQLITE_BUSY_SNAPSHOT` when another connection commits in between — bypassing `busy_timeout` entirely, which matches the observed sub-second failures. All cache write transactions now run with `BEGIN IMMEDIATE`.
3. **`busy_timeout` ordering** — it was the last pragma inside a shared `try/catch`; any earlier pragma failure would silently drop it, making every subsequent lock conflict fail immediately. It is now set first.

Also: `cache.write_failed` diagnostics now include the error code and stack, which is how this was diagnosed.

**Verification**: a stress script running concurrent checkpoint writes against `syncSessionSearchIndex` on a copy of the real cache failed 100% before the fix (`SQLITE_BUSY` at `setUserVersion`) and passes cleanly after.

### Sidebar toggle icons swapped

Hugeicons draws `PanelLeftCloseIcon` with a right-pointing arrow and `PanelLeftOpenIcon` with a left-pointing one — opposite to their names, so the collapse button looked like expand and vice versa. The mapping in `icons.tsx` is swapped with a comment; call sites keep their semantic names.

## Test plan

- [x] `pnpm turbo build test lint` passes
- [x] Concurrent write stress test passes after the fix (failed before)
- [x] Fresh-cache startup (`XDG_CACHE_HOME` sandbox) shows no `write_failed` / `persist_failed` events