### PR TITLE
Show only agent logos in project rankings

### DIFF
--- a/apps/web/src/components/overview/OverviewScreen.test.tsx
+++ b/apps/web/src/components/overview/OverviewScreen.test.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAgentCatalog } from "../../lib/agents";
@@ -130,6 +130,16 @@ describe("OverviewScreen", () => {
     expect(screen.getByText("1 projects · 2 agents in scope")).toBeTruthy();
     expect(screen.getAllByTestId("overview-project-row")).toHaveLength(1);
     expect(screen.getAllByTestId("overview-agent-row")).toHaveLength(1);
+  });
+
+  it("renders project agents as logos without visible names", async () => {
+    renderScreen();
+
+    await screen.findByRole("heading", { name: "Projects" });
+    const projectRow = within(screen.getByTestId("overview-project-row"));
+
+    expect(projectRow.getByRole("img", { name: "Codex" })).toBeTruthy();
+    expect(projectRow.queryByText("Codex")).toBeNull();
   });
 
   it("issues exactly one new request when the agent filter changes", async () => {

--- a/apps/web/src/components/overview/overview-project-rank.tsx
+++ b/apps/web/src/components/overview/overview-project-rank.tsx
@@ -6,21 +6,20 @@
 import type { DashboardProjectRollup } from "@codesesh/core/contract";
 import { Link } from "react-router-dom";
 
-import type { AgentCatalog } from "../../lib/agents";
+import { findAgent, type AgentCatalog } from "../../lib/agents";
 import { AgentIcon } from "../AgentIcon";
 import type { DashboardAgentStat, DashboardFilters, DashboardProjectStat } from "../../lib/api";
 import { formatCompact, formatInt, formatUsd } from "../../lib/format";
 import { Panel, PanelHeader } from "../ui/panel";
 import { ShareBar } from "../ui/share-bar";
 import { Sparkline } from "../ui/sparkline";
-import { agentDisplayName } from "./types";
 
 const RANK_LIMIT = 6;
 
 interface RankRow {
   key: string;
   name: string;
-  detail: string;
+  agentKeys?: string[];
   sessions: number;
   tokens: number;
   cost: number;
@@ -29,11 +28,11 @@ interface RankRow {
   iconColored?: boolean;
 }
 
-function toProjectRow(project: DashboardProjectStat, catalog: AgentCatalog): RankRow {
+function toProjectRow(project: DashboardProjectStat): RankRow {
   return {
     key: `${project.identityKind}:${project.identityKey}`,
     name: project.displayName,
-    detail: project.agents.map((agent) => agentDisplayName(catalog, agent)).join(" · "),
+    agentKeys: project.agents,
     sessions: project.sessions,
     tokens: project.tokens,
     cost: project.cost,
@@ -45,13 +44,39 @@ function toAgentRow(agent: DashboardAgentStat): RankRow {
   return {
     key: agent.name,
     name: agent.displayName,
-    detail: "",
     sessions: agent.sessions,
     tokens: agent.tokens,
     cost: agent.cost,
     icon: agent.icon,
     iconColored: agent.iconColored,
   };
+}
+
+function ProjectAgentLogos({
+  agentKeys,
+  agentCatalog,
+}: {
+  agentKeys: string[];
+  agentCatalog: AgentCatalog;
+}) {
+  return (
+    <span className="flex min-w-0 shrink-0 items-center gap-1">
+      {agentKeys.map((agentKey) => {
+        const agent = findAgent(agentCatalog, agentKey);
+        if (!agent?.icon) return null;
+
+        return (
+          <AgentIcon
+            key={agentKey}
+            icon={agent.icon}
+            iconColored={agent.iconColored}
+            alt={agent.displayName}
+            className="size-3 shrink-0 object-contain text-[var(--console-text)]"
+          />
+        );
+      })}
+    </span>
+  );
 }
 
 export function OverviewProjectRank({
@@ -70,9 +95,7 @@ export function OverviewProjectRank({
   agentCatalog: AgentCatalog;
 }) {
   const rankAgents = filters.project !== undefined;
-  const rows = rankAgents
-    ? perAgent.map(toAgentRow)
-    : projects.map((project) => toProjectRow(project, agentCatalog));
+  const rows = rankAgents ? perAgent.map(toAgentRow) : projects.map(toProjectRow);
   const visible = rows.slice(0, RANK_LIMIT);
   const topCost = visible.reduce((peak, row) => Math.max(peak, row.cost), 0);
   const showFooter = !rankAgents && rollup.projects > 0;
@@ -118,10 +141,8 @@ export function OverviewProjectRank({
                 </p>
                 <div className="mt-[5px] flex items-center gap-[6px]">
                   <ShareBar ratio={row.cost / topCost} className="h-1 max-w-[180px]" />
-                  {row.detail ? (
-                    <span className="console-mono truncate text-[9.5px] text-[var(--console-muted)]">
-                      {row.detail}
-                    </span>
+                  {row.agentKeys?.length ? (
+                    <ProjectAgentLogos agentKeys={row.agentKeys} agentCatalog={agentCatalog} />
                   ) : null}
                 </div>
               </div>

--- a/tests/e2e/aggregation.spec.ts
+++ b/tests/e2e/aggregation.spec.ts
@@ -22,7 +22,10 @@ test("aggregates Claude and Codex sessions under one project", async ({ page }) 
   const projectRow = dashboard.getByTestId("overview-project-row");
   await expect(projectRow).toHaveCount(1);
   await expect(projectRow).toContainText("codesesh-e2e");
-  await expect(projectRow).toContainText("Codex · Claude Code");
+  await expect(projectRow.getByRole("img", { name: "Codex", exact: true })).toBeVisible();
+  await expect(projectRow.getByRole("img", { name: "Claude Code", exact: true })).toBeVisible();
+  await expect(projectRow).not.toContainText("Codex");
+  await expect(projectRow).not.toContainText("Claude Code");
 
   await page.goto("/projects");
   const project = page.locator("main").getByRole("link", { name: /codesesh-e2e/ });


### PR DESCRIPTION
## Summary

- replace project ranking agent names with their registered logos
- preserve accessible agent labels without rendering visible names
- add unit and end-to-end regression coverage for logo-only project rows

## Why

Project ranking rows rendered agent names as plain text even though the shared agent catalog already provides the corresponding logos. This made the compact ranking unnecessarily verbose and inconsistent with the surrounding agent UI.

## Validation

- `pnpm --filter @codesesh/web test -- src/components/overview/OverviewScreen.test.tsx`
- `pnpm --filter @codesesh/web exec tsc --noEmit`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web build`
- `pnpm exec playwright test tests/e2e/aggregation.spec.ts --project=web-chromium`
- GitHub Actions: 7/7 checks passed