### PR TITLE
fix(core): keep session head stats local

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,9 +24,17 @@ _Avoid_: Session slug, global session ID
 在 CodeSesh 中唯一标识 Session 的复合身份，由 Agent 与该 Agent 内不透明的 Session ID 共同构成；Session ID 本身不全局唯一，也不应被拆解解释。
 _Avoid_: Session slug, session path
 
+**Session Hierarchy**:
+由 Session Reference 与 `parent_reference` 表达的 Session 亲子关系；无法抵达根节点的缺父或成环 Session 仍作为未挂载条目保留。
+_Avoid_: Session Tree, parent-child graph
+
 **Session Head**:
-用于列表、分组、搜索和统计的轻量 Session 摘要，不包含完整消息正文。
+用于列表、分组、搜索和统计的轻量 Session 摘要，不包含完整消息正文；其中的统计只归属于该 Session，不包含 descendant Session 的汇总。
 _Avoid_: Session metadata
+
+**Inclusive Session Stats**:
+从 Session Hierarchy 派生的统计汇总，包含目标 Session 与每个可挂载 descendant Session 恰好一次。
+_Avoid_: Session stats, parent stats
 
 **Session Detail**:
 包含完整归一化消息与工具活动、可用于回放 Session 的详细内容。

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CodexAgent } from "../codex.js";
 import type { Message, MessagePart, SessionHead, ToolPart } from "../../types/index.js";
+import { buildSessionTree } from "../../contract/session-tree.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 // Spies while delegating to the real implementation so regression tests can
@@ -254,7 +255,7 @@ describe("CodexAgent cache refresh", () => {
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
           "codex-head-v1",
-          "codex-parser-v6",
+          "codex-parser-v7",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           "Indexed title",
@@ -1356,7 +1357,7 @@ describe("CodexAgent subagent folding", () => {
     tempDirs = [];
   });
 
-  it("returns subagent files and folds their tokens into the parent head", () => {
+  it("returns subagent files with node-local head stats", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
     tempDirs.push(tempDir);
 
@@ -1379,10 +1380,14 @@ describe("CodexAgent subagent folding", () => {
 
     const heads = agent.scan({ from: 0 });
     expect(heads.map((h: SessionHead) => h.id)).toEqual([PARENT_ID, CHILD_ID]);
-    expect(heads[0].stats.total_input_tokens).toBe(140);
-    expect(heads[0].stats.total_output_tokens).toBe(80);
+    expect(heads[0].stats.total_input_tokens).toBe(100);
+    expect(heads[0].stats.total_output_tokens).toBe(20);
     expect(heads[1].parent_reference).toEqual({ agentName: "codex", sessionId: PARENT_ID });
     expect(heads[1].stats.total_input_tokens).toBe(40);
+    expect(buildSessionTree(heads).roots[0]?.inclusiveStats).toMatchObject({
+      inputTokens: 140,
+      outputTokens: 80,
+    });
   });
 
   it("folds subagent tokens into getSessionData detail stats", () => {
@@ -1542,7 +1547,7 @@ describe("CodexAgent subagent folding", () => {
     expect(agent.expandChangedSessionIds([PARENT_ID], refs)).toEqual([PARENT_ID]);
   });
 
-  it("expands a removed child via cached metadata and re-aggregates the parent", () => {
+  it("expands a removed child via cached metadata to refresh the parent", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
     tempDirs.push(tempDir);
 
@@ -1560,7 +1565,7 @@ describe("CodexAgent subagent folding", () => {
     agent.basePath = tempDir;
     agent.sessionIndexCache = new Map();
     const [parentHead] = agent.scan({ from: 0 });
-    expect(parentHead.stats.total_input_tokens).toBe(140);
+    expect(parentHead.stats.total_input_tokens).toBe(100);
 
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
     rmSync(childFile);

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -156,6 +156,28 @@ describe("OpenCodeSqliteAgent", () => {
     });
   });
 
+  it("invalidates cached heads from an older parser revision", () => {
+    const dbPath = createDatabase();
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+      getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
+    });
+    agent.isAvailable();
+    const heads = agent.scan({ from: 0 });
+
+    expect(agent.getSessionMetaMap().get("s1")).toMatchObject({
+      headParserVersion: "opencode-sqlite-head-v1",
+    });
+    expect(agent.checkForChanges(Number.MAX_SAFE_INTEGER, heads).hasChanges).toBe(false);
+
+    agent.setSessionMetaMap(
+      new Map([["s1", { id: "s1", sourcePath: dbPath, headParserVersion: "legacy" }]]),
+    );
+    expect(agent.checkForChanges(Number.MAX_SAFE_INTEGER, heads).hasChanges).toBe(true);
+  });
+
   it("falls back to an empty message record and reports drift when message data isn't a JSON object", () => {
     const dbPath = createDatabaseWithMessageData("null");
     const calls: Array<{ event: string; detail?: Record<string, unknown> }> = [];

--- a/packages/core/src/agents/__tests__/zcode.test.ts
+++ b/packages/core/src/agents/__tests__/zcode.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { ZCodeAgent } from "../zcode.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
+import { buildSessionTree } from "../../contract/session-tree.js";
 
 let tempDirs: string[] = [];
 
@@ -322,12 +323,16 @@ describe("ZCodeAgent subagent folding", () => {
     const [head] = heads;
     expect(head.stats).toMatchObject({
       message_count: 1,
-      total_input_tokens: 50,
-      total_output_tokens: 60,
+      total_input_tokens: 10,
+      total_output_tokens: 0,
     });
     expect(head.parent_reference).toBeUndefined();
     expect(heads[1].parent_reference).toEqual({ agentName: "zcode", sessionId: "parent" });
     expect(heads[1].stats).toMatchObject({ message_count: 1, total_input_tokens: 40 });
+    expect(buildSessionTree(heads).roots[0]?.inclusiveStats).toMatchObject({
+      inputTokens: 50,
+      outputTokens: 60,
+    });
   });
 
   it("folds child tokens into getSessionData detail stats without surfacing child messages", () => {
@@ -481,8 +486,8 @@ describe("ZCodeAgent subagent folding", () => {
     const [head] = agent.scan({ from: 0 });
     expect(head.stats).toMatchObject({
       message_count: 1,
-      total_input_tokens: 55,
-      total_output_tokens: 35,
+      total_input_tokens: 5,
+      total_output_tokens: 5,
     });
 
     const data = agent.getSessionData("parent");

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -43,7 +43,7 @@ const PLAN_APPROVAL_PREFIX = "PLEASE IMPLEMENT THIS PLAN";
 const SUBAGENT_NOTIFICATION_PATTERN =
   /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
 const HEAD_INDEX_VERSION = "codex-head-v1";
-const PARSER_VERSION = "codex-parser-v6";
+const PARSER_VERSION = "codex-parser-v7";
 
 export function resolveCodexDataRoot(): string {
   return resolveHomePath("CODEX_HOME", ".codex");
@@ -956,9 +956,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
 
   protected parseFileSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {
     this.loadSessionIndex();
-    const head = this.parseSessionHead(filePath, options);
-    if (head) this.applyChildStats(head.stats, head.id);
-    return head;
+    return this.parseSessionHead(filePath, options);
   }
 
   private parseSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -6,7 +6,12 @@ import {
   parsedSession,
   skippedSession,
 } from "./base.js";
-import type { AgentScanOptions, ParseSessionResult, SessionWatchPlan } from "./base.js";
+import type {
+  AgentScanOptions,
+  ChangeCheckResult,
+  ParseSessionResult,
+  SessionWatchPlan,
+} from "./base.js";
 import type { SessionHead, SessionDetail, Message, MessagePart } from "../types/index.js";
 import { normalizeMessageParts } from "../contract/message-part.js";
 import { columnExists, openDbReadOnly, type SQLiteDatabase } from "../utils/sqlite.js";
@@ -25,7 +30,6 @@ interface OpenCodeMessageRow {
   session_id?: unknown;
   data?: string;
   time_created?: unknown;
-  parent_id?: unknown;
 }
 
 interface OpenCodePartRow {
@@ -48,6 +52,7 @@ interface OpenCodeSqliteAgentConfig {
 
 const MESSAGE_ROLES = new Set<Message["role"]>(["user", "assistant", "tool"]);
 const SESSION_ID_QUERY_CHUNK_SIZE = 500;
+const HEAD_PARSER_VERSION = "opencode-sqlite-head-v1";
 
 function compareSessionRowsByActivityDesc(
   left: Record<string, unknown>,
@@ -203,14 +208,8 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
 
       const headContexts = hasMessageTable
         ? this.buildHeadContexts(
-            this.readHeadMessageRows(
-              db,
-              cutoffTime,
-              hasParentId,
-              sessionIds.size > 0 ? sessionIds : undefined,
-            ),
+            this.readHeadMessageRows(db, cutoffTime, sessionIds.size > 0 ? sessionIds : undefined),
             this.readHeadPartRows(db, cutoffTime, sessionIds.size > 0 ? sessionIds : undefined),
-            hasParentId,
           )
         : new Map<string, OpenCodeHeadContext>();
       const heads: SessionHead[] = [];
@@ -228,6 +227,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
             this.sessionMetaMap.set(head.id, {
               id: head.id,
               sourcePath: this.dbPath,
+              headParserVersion: HEAD_PARSER_VERSION,
             });
           }
         }
@@ -282,16 +282,14 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
   private readHeadMessageRows(
     db: SQLiteDatabase,
     cutoffTime: number,
-    withParentId: boolean,
     sessionIds?: Set<string>,
   ): OpenCodeMessageRow[] {
-    const parentIdSelect = withParentId ? ", s.parent_id" : "";
     const ids = sessionIds ? [...sessionIds] : [];
     if (ids.length === 0) {
       return db
         .prepare(
           `
-            SELECT m.id, m.session_id, m.data, m.time_created${parentIdSelect}
+            SELECT m.id, m.session_id, m.data, m.time_created
             FROM message m
             JOIN session s ON s.id = m.session_id
             WHERE COALESCE(s.time_updated, s.time_created) >= ?
@@ -308,7 +306,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
         ...(db
           .prepare(
             `
-              SELECT m.id, m.session_id, m.data, m.time_created${parentIdSelect}
+              SELECT m.id, m.session_id, m.data, m.time_created
               FROM message m
               JOIN session s ON s.id = m.session_id
               WHERE s.id IN (${chunk.map(() => "?").join(",")})
@@ -454,7 +452,6 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
   private buildHeadContexts(
     messageRows: OpenCodeMessageRow[],
     partRows: OpenCodePartRow[],
-    withParentId: boolean,
   ): Map<string, OpenCodeHeadContext> {
     const partsByMessage = this.buildPartsByMessage(partRows);
     const contexts = new Map<string, OpenCodeHeadContext>();
@@ -481,32 +478,6 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
       if (!sessionId) continue;
       const msgData = parseJsonRecord(row.data, this.name, "message.data");
       if (isInternalEventType(msgData.type)) continue;
-
-      const parentId = withParentId ? String(row.parent_id ?? "") : "";
-      const isChild = parentId !== "";
-
-      if (isChild) {
-        const childContext = ensureContext(sessionId);
-        const parts = partsByMessage.get(String(row.id ?? "")) ?? [];
-        if (parts.length > 0) {
-          accumulateTokenStats(childContext.stats, msgData, this.name);
-          childContext.stats.message_count += 1;
-          if (!childContext.messageTitle && String(msgData.role ?? "") === "user") {
-            childContext.messageTitle = firstUserMessageTitle([
-              {
-                id: String(row.id ?? ""),
-                role: "user",
-                agent: null,
-                time_created: Number(row.time_created ?? 0),
-                parts,
-              },
-            ]);
-          }
-        }
-        const parentContext = ensureContext(parentId);
-        accumulateTokenStats(parentContext.stats, msgData, this.name);
-        continue;
-      }
 
       const parts = partsByMessage.get(String(row.id ?? "")) ?? [];
       if (parts.length === 0) continue;
@@ -535,6 +506,14 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
     }
 
     return contexts;
+  }
+
+  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
+    const hasStaleHead = cachedSessions.some(
+      (session) => this.sessionMetaMap.get(session.id)?.headParserVersion !== HEAD_PARSER_VERSION,
+    );
+    if (hasStaleHead) return { hasChanges: true, timestamp: Date.now() };
+    return super.checkForChanges(sinceTimestamp, cachedSessions);
   }
 
   private sumChildTokenStats(db: SQLiteDatabase, parentSessionId: string): SessionHead["stats"][] {


### PR DESCRIPTION
## Summary

- keep Codex, OpenCode, and ZCode session-head statistics node-local
- preserve explicit inclusive aggregation for session detail views
- invalidate stale cached heads when the head parser semantics change
- define session hierarchy and statistic ownership in the domain glossary

## Root cause

Agent adapters folded child-session tokens into parent session heads while the canonical hierarchy layer performed another roll-up. Parent totals therefore counted child activity twice.

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm perf:check`
- `pnpm test:migration`
- `pnpm test:e2e`

Tracks local issue CS-155.