### PR TITLE
fix(sync): reject non-durable checkpoints

### DIFF
--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -53,6 +53,21 @@ describe("formatScanStatusLabel", () => {
     ).toBe("Preparing local session index");
   });
 
+  it("surfaces an inactive refresh failure", () => {
+    const status = {
+      active: false,
+      backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
+      agentStatuses: {
+        codex: { agentName: "codex", status: "failed", error: "cache is read-only" },
+      },
+    } as unknown as ScanStatusEvent;
+
+    expect(formatScanStatusLabel(status)).toBe(
+      "Session refresh failed · codex · cache is read-only",
+    );
+    expect(formatAgentScanProgress(status, "codex")).toBe("Failed");
+  });
+
   it("shows full-history backfill progress after the main scan finishes", () => {
     expect(
       formatScanStatusLabel({

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -47,6 +47,12 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
   if (status.backfill?.failedAgents.length) {
     return `History indexing failed · ${status.backfill.failedAgents.join(", ")}`;
   }
+  const failedAgent = Object.values(status.agentStatuses ?? {}).find(
+    (agentStatus) => agentStatus.status === "failed",
+  );
+  if (failedAgent) {
+    return `Session refresh failed · ${failedAgent.agentName}${failedAgent.error ? ` · ${failedAgent.error}` : ""}`;
+  }
   if (!status.active) return null;
 
   const completed = status.completedAgents.length;
@@ -93,6 +99,7 @@ export function formatAgentScanProgress(
 ): string | null {
   const agentStatus = status?.agentStatuses[agentName];
   if (!agentStatus || agentStatus.status === "complete") return null;
+  if (agentStatus.status === "failed") return "Failed";
   if (agentStatus.status === "finalizing") {
     if (agentStatus.total && agentStatus.processed != null) {
       return `${agentStatus.processed}/${agentStatus.total}`;

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -3,6 +3,7 @@ import { FileSystemSessionSource } from "@codesesh/core";
 import type { BaseAgent, loadCachedSessions, LiveSnapshot, SessionHead } from "@codesesh/core";
 import type { ScanStatusEvent } from "@codesesh/core/contract";
 import type { WorkerRunner } from "./worker-runner.js";
+import { appLogger } from "./logging.js";
 
 const core = vi.hoisted(() => ({
   getAgentFullSyncCursor: vi.fn(() => null as string | null),
@@ -144,6 +145,8 @@ afterEach(() => {
   core.markAgentFullSyncStarted.mockClear();
   core.saveCachedSessionChanges.mockClear();
   core.saveCachedSessions.mockClear();
+  core.saveCachedSessionChanges.mockReturnValue(true);
+  core.saveCachedSessions.mockReturnValue(true);
   searchIndex.enqueue.mockImplementation(async () => undefined);
 });
 
@@ -288,6 +291,84 @@ describe("AgentSyncEngine", () => {
       meta,
     );
     expect(engine.snapshot().sessions[0]?.smart_tags).toEqual(["feature-dev"]);
+  });
+
+  it("keeps the last durable snapshot when a head checkpoint is rejected", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const logError = vi.spyOn(appLogger, "error").mockImplementation(() => undefined);
+    core.isAgentCacheInitialized.mockReturnValue(false);
+    core.saveCachedSessions.mockReturnValue(false);
+    const previous = makeSession("head", "before");
+    const head = makeSession("head", "after");
+    const meta = { head: { id: "head", sourcePath: "/head" } };
+    const setSessionMetaMap = vi.fn();
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async (_agentName, payload) => {
+        payload.onCheckpoint?.({ stage: "scanned", sessions: [head], meta });
+        return { sessions: [head], meta };
+      }),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(makeAgent({ setSessionMetaMap }), [previous], workerRunner);
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().sessions).toEqual([previous]);
+    expect(setSessionMetaMap).not.toHaveBeenCalled();
+    expect(sessionChanges).not.toHaveBeenCalled();
+    expect(searchIndex.enqueue).not.toHaveBeenCalled();
+    expect(engine.status().agentStatuses.codex).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error: "Failed to persist scanned checkpoint for codex",
+      }),
+    );
+    expect(logError).toHaveBeenCalledWith(
+      "scan.checkpoint.failed",
+      expect.objectContaining({ agent: "codex", stage: "scanned", sessions: 1 }),
+    );
+
+    core.saveCachedSessions.mockReturnValue(true);
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().sessions).toEqual([
+      expect.objectContaining({ id: head.id, title: head.title }),
+    ]);
+    expect(sessionChanges.mock.calls.filter(([change]) => change.event != null)).toHaveLength(1);
+    expect(core.markAgentCacheInitialized).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the last durable snapshot when head persistence throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    core.isAgentCacheInitialized.mockReturnValue(false);
+    core.saveCachedSessions.mockImplementation(() => {
+      throw new Error("database is read-only");
+    });
+    const previous = makeSession("head", "before");
+    const head = makeSession("head", "after");
+    const meta = { head: { id: "head", sourcePath: "/head" } };
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async (_agentName, payload) => {
+        payload.onCheckpoint?.({ stage: "scanned", sessions: [head], meta });
+        return { sessions: [head], meta };
+      }),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(makeAgent(), [previous], workerRunner);
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().sessions).toEqual([previous]);
+    expect(sessionChanges).not.toHaveBeenCalled();
+    expect(engine.status().agentStatuses.codex).toEqual(
+      expect.objectContaining({ status: "failed", error: "database is read-only" }),
+    );
   });
 
   it("waits for the initial search index commit", async () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -35,6 +35,7 @@ import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 import { ScanStatusModel } from "./scan-status-model.js";
 import type { ScanRefreshWorkerCheckpoint } from "./scan-refresh-worker.js";
 import type { WorkerRunner } from "./worker-runner.js";
+import { toError } from "./errors.js";
 
 export type { AgentOperationResult } from "./agent-operation-scheduler.js";
 
@@ -293,14 +294,18 @@ export class AgentSyncEngine {
 
   private async performRefresh(agentName: string): Promise<AgentOperationResult> {
     this.beginAgentScan(agentName);
+    let failed = false;
     try {
       return await this.runRefresh(agentName);
     } catch (error) {
+      failed = true;
+      const failure = toError(error);
       appLogger.error("scan.refresh.error", { agent: agentName, error });
       console.error(`[${agentName}] Session refresh failed:`, error);
+      this.publishStatus(this.scanStatus.failAgent(agentName, failure.message));
       return "failed";
     } finally {
-      this.finishAgentScan(agentName);
+      if (!failed) this.finishAgentScan(agentName);
       const agent = this.findAgent(agentName);
       if (agent && this.needsBackfill(agent)) this.enqueueBackfill(agentName);
     }
@@ -569,17 +574,20 @@ export class AgentSyncEngine {
     if (this.isShuttingDown) return;
 
     if (checkpoint.stage === "scanned") {
-      let persisted = false;
       try {
-        persisted = saveCachedSessions(agent.name, checkpoint.sessions, checkpoint.meta);
-        if (persisted) markAgentCacheInitialized(agent.name);
+        if (!saveCachedSessions(agent.name, checkpoint.sessions, checkpoint.meta)) {
+          throw new Error(`Failed to persist scanned checkpoint for ${agent.name}`);
+        }
       } catch (error) {
         appLogger.error("scan.checkpoint.failed", {
           agent: agent.name,
           stage: checkpoint.stage,
+          sessions: checkpoint.sessions.length,
           error,
         });
+        throw error;
       }
+      markAgentCacheInitialized(agent.name);
       agent.setSessionMetaMap(new Map(Object.entries(checkpoint.meta)));
 
       const event = this.sessionIndex.commitAgentSessions(agent.name, checkpoint.sessions);
@@ -592,14 +600,14 @@ export class AgentSyncEngine {
         agent: agent.name,
         stage: checkpoint.stage,
         sessions: checkpoint.sessions.length,
-        persisted,
       });
       return;
     }
 
-    let persisted = false;
     try {
-      persisted = saveCachedSessionChanges(agent.name, checkpoint.changes, [], checkpoint.meta);
+      if (!saveCachedSessionChanges(agent.name, checkpoint.changes, [], checkpoint.meta)) {
+        throw new Error(`Failed to persist finalizing checkpoint for ${agent.name}`);
+      }
     } catch (error) {
       appLogger.error("scan.checkpoint.failed", {
         agent: agent.name,
@@ -607,8 +615,9 @@ export class AgentSyncEngine {
         sessions: checkpoint.changes.length,
         error,
       });
+      throw error;
     }
-    if (persisted && checkpoint.backfillCursor) {
+    if (checkpoint.backfillCursor) {
       markAgentFullSyncProgress(agent.name, checkpoint.backfillCursor);
     }
     appLogger.debug("scan.checkpoint.persisted", {
@@ -616,7 +625,6 @@ export class AgentSyncEngine {
       stage: checkpoint.stage,
       sessions: checkpoint.changes.length,
       backfill_cursor: checkpoint.backfillCursor,
-      persisted,
     });
   }
 

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -69,6 +69,7 @@ const workerThreads = vi.hoisted(() => ({
     postMessage: ReturnType<typeof vi.fn>;
     unref: ReturnType<typeof vi.fn>;
     terminate: ReturnType<typeof vi.fn>;
+    emitMessage: (message: unknown) => void;
     emitDone: () => void;
     emitError: (error: Error) => void;
     emitExit: (code: number) => void;
@@ -262,6 +263,9 @@ const workerThreads = vi.hoisted(() => ({
       terminate: vi.fn(async () => {
         for (const handler of exitHandlers) handler(0);
       }),
+      emitMessage: (message: unknown) => {
+        for (const handler of messageHandlers) handler(message);
+      },
       emitDone: () => {
         for (const handler of messageHandlers) {
           handler({
@@ -1081,6 +1085,34 @@ describe("LiveScanStore", () => {
       meta: {},
       changedIds: undefined,
     });
+  });
+
+  it("rejects a scan worker request when its checkpoint cannot commit", async () => {
+    workerThreads.deferScanRefreshWorkers = true;
+    const agent = makeFileSystemAgent("codex");
+    core.createRegisteredAgents.mockReturnValue([agent]);
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+
+    const refresh = runner.run(agent.name, {
+      previousSessions: [],
+      changedIds: null,
+      scanOptions: {},
+      meta: {},
+      onCheckpoint: () => {
+        throw new Error("checkpoint rejected");
+      },
+    });
+    const worker = workerThreads.workers.at(-1)!;
+    worker.emitMessage({
+      type: "checkpoint",
+      requestId: worker.workerData.requestId,
+      checkpoint: { stage: "scanned", sessions: [], meta: {} },
+    });
+
+    await expect(refresh).rejects.toThrow("checkpoint rejected");
+    expect(runner.activeCount).toBe(0);
+    await runner.shutdown();
+    workerThreads.deferScanRefreshWorkers = false;
   });
 
   it("reconstructs an ordered snapshot from a scan worker delta", async () => {

--- a/packages/cli/src/scan-status-model.test.ts
+++ b/packages/cli/src/scan-status-model.test.ts
@@ -172,6 +172,26 @@ describe("ScanStatusModel", () => {
     );
   });
 
+  it("retains an actionable failure until the next scan starts", () => {
+    const model = new ScanStatusModel();
+    model.startBatch(["codex"], "scanning", { codex: 2 });
+    model.beginAgent("codex", 2);
+
+    const failed = model.failAgent("codex", "cache is read-only");
+
+    expect(failed).toEqual(
+      expect.objectContaining({ active: false, phase: "idle", completedAgents: [] }),
+    );
+    expect(failed.agentStatuses.codex).toEqual(
+      expect.objectContaining({ status: "failed", error: "cache is read-only" }),
+    );
+    expect(model.finishBatch().agentStatuses.codex?.status).toBe("failed");
+
+    const retry = model.beginAgent("codex", 2);
+    expect(retry.agentStatuses.codex).toEqual(expect.objectContaining({ status: "scanning" }));
+    expect(retry.agentStatuses.codex).not.toHaveProperty("error");
+  });
+
   it("models a complete multi-agent scan lifecycle", () => {
     const model = new ScanStatusModel();
 

--- a/packages/cli/src/scan-status-model.ts
+++ b/packages/cli/src/scan-status-model.ts
@@ -207,6 +207,41 @@ export class ScanStatusModel {
     });
   }
 
+  failAgent(agentName: string, error: string): ScanStatusEvent {
+    const pendingAgents = this.status.pendingAgents.filter((agent) => agent !== agentName);
+    const scanningAgents = this.status.scanningAgents.filter((agent) => agent !== agentName);
+    const completedAgents = this.status.completedAgents.filter((agent) => agent !== agentName);
+    const isActive = pendingAgents.length > 0 || scanningAgents.length > 0;
+    const now = Date.now();
+    const previousStatus = this.status.agentStatuses[agentName];
+    return this.set({
+      ...this.status,
+      active: isActive,
+      phase: isActive
+        ? this.activePhase(pendingAgents, scanningAgents, this.status.agentStatuses)
+        : "idle",
+      pendingAgents,
+      scanningAgents,
+      completedAgents,
+      agentStatuses: {
+        ...this.status.agentStatuses,
+        [agentName]: {
+          agentName,
+          status: "failed",
+          error,
+          total: previousStatus?.total,
+          processed: previousStatus?.processed,
+          sessions: previousStatus?.sessions ?? 0,
+          startedAt: previousStatus?.startedAt,
+          updatedAt: now,
+          completedAt: now,
+        },
+      },
+      updatedAt: now,
+      completedAt: isActive ? undefined : now,
+    });
+  }
+
   finishBatch(): ScanStatusEvent {
     const now = Date.now();
     return this.set({
@@ -218,7 +253,14 @@ export class ScanStatusModel {
       agentStatuses: Object.fromEntries(
         Object.entries(this.status.agentStatuses).map(([agentName, status]) => [
           agentName,
-          { ...status, status: "complete", completedAt: status.completedAt ?? now, updatedAt: now },
+          status.status === "failed"
+            ? { ...status, completedAt: status.completedAt ?? now, updatedAt: now }
+            : {
+                ...status,
+                status: "complete",
+                completedAt: status.completedAt ?? now,
+                updatedAt: now,
+              },
         ]),
       ),
       updatedAt: now,

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -198,7 +198,12 @@ export class ThreadWorkerRunner implements WorkerRunner {
       return;
     }
     if (message.type === "checkpoint") {
-      pending.onCheckpoint?.(message.checkpoint);
+      try {
+        pending.onCheckpoint?.(message.checkpoint);
+      } catch (error) {
+        slot.pending.delete(message.requestId);
+        pending.reject(toError(error));
+      }
       return;
     }
 

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -51,7 +51,8 @@ export function mergeSessionsUpdatedEvents(
 
 export interface AgentScanStatus {
   agentName: string;
-  status: "pending" | "scanning" | "finalizing" | "indexing" | "complete";
+  status: "pending" | "scanning" | "finalizing" | "indexing" | "complete" | "failed";
+  error?: string;
   total?: number;
   processed?: number;
   sessions?: number;


### PR DESCRIPTION
## Summary

- stop scan worker requests when a checkpoint cannot be persisted
- retain the last durable snapshot, metadata, and session event lineage
- expose actionable per-agent refresh failures through the scan-status contract and UI
- allow a later watcher refresh to retry from the durable baseline

## Root cause

The checkpoint callback treated cache persistence as best effort. It updated agent metadata and published the candidate snapshot even when the cache write returned `false` or threw, while callback failures had no path back to the worker request promise.

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`
- `pnpm perf:check`
- `pnpm test:migration`
- `pnpm test:e2e`

Tracks local issue CS-156.