### PR TITLE
fix: preserve cache outside windowed scans

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -268,7 +268,12 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async (_agentName, payload) => {
-        payload.onCheckpoint?.({ stage: "scanned", sessions: [head], meta });
+        payload.onCheckpoint?.({
+          stage: "scanned",
+          sessions: [head],
+          meta,
+          completeness: "complete",
+        });
         payload.onCheckpoint?.({
           stage: "finalizing",
           changes: [{ session: tagged, sortIndex: 0 }],
@@ -282,7 +287,9 @@ describe("AgentSyncEngine", () => {
 
     await engine.refresh("codex");
 
-    expect(core.saveCachedSessions).toHaveBeenCalledWith("codex", [head], meta);
+    expect(core.saveCachedSessions).toHaveBeenCalledWith("codex", [head], meta, {
+      completeness: "complete",
+    });
     expect(core.markAgentCacheInitialized).toHaveBeenCalledWith("codex");
     expect(core.saveCachedSessionChanges).toHaveBeenCalledWith(
       "codex",
@@ -291,6 +298,60 @@ describe("AgentSyncEngine", () => {
       meta,
     );
     expect(engine.snapshot().sessions[0]?.smart_tags).toEqual(["feature-dev"]);
+  });
+
+  it("persists a windowed initialization without authorizing cached session deletion", async () => {
+    core.isAgentCacheInitialized.mockReturnValue(false);
+    const old = makeSession("old");
+    const recent = makeSession("recent", "updated");
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [old, recent],
+      meta: {},
+      timestamp: Date.now(),
+    });
+    const logInfo = vi.spyOn(appLogger, "info");
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async (_agentName, payload) => {
+        payload.onCheckpoint?.({
+          stage: "scanned",
+          sessions: [recent],
+          meta: {},
+          completeness: "partial",
+        });
+        return { sessions: [recent], meta: {} };
+      }),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const state: LiveSnapshot = {
+      agents: [makeAgent()],
+      byAgent: { codex: [recent] },
+      sessions: [recent],
+    };
+    const engine = new AgentSyncEngine({
+      workerRunner,
+      startupScanOptions: { from: 2 },
+    });
+    engine.initialize(state);
+
+    await engine.refresh("codex");
+
+    expect(logInfo).toHaveBeenCalledWith("scan.checkpoint.replacement_candidate", {
+      agent: "codex",
+      completeness: "partial",
+      cached_sessions: 2,
+      checkpoint_sessions: 1,
+      missing_cached_sessions: 1,
+      delete_candidates: 0,
+    });
+    expect(core.saveCachedSessions).toHaveBeenCalledWith(
+      "codex",
+      [recent],
+      {},
+      {
+        completeness: "partial",
+      },
+    );
   });
 
   it("keeps the last durable snapshot when a head checkpoint is rejected", async () => {
@@ -305,7 +366,12 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async (_agentName, payload) => {
-        payload.onCheckpoint?.({ stage: "scanned", sessions: [head], meta });
+        payload.onCheckpoint?.({
+          stage: "scanned",
+          sessions: [head],
+          meta,
+          completeness: "complete",
+        });
         return { sessions: [head], meta };
       }),
       shutdown: vi.fn(async () => undefined),
@@ -353,7 +419,12 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async (_agentName, payload) => {
-        payload.onCheckpoint?.({ stage: "scanned", sessions: [head], meta });
+        payload.onCheckpoint?.({
+          stage: "scanned",
+          sessions: [head],
+          meta,
+          completeness: "complete",
+        });
         return { sessions: [head], meta };
       }),
       shutdown: vi.fn(async () => undefined),

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -574,8 +574,33 @@ export class AgentSyncEngine {
     if (this.isShuttingDown) return;
 
     if (checkpoint.stage === "scanned") {
+      const cachedSessions = loadCachedSessions(agent.name)?.sessions ?? [];
+      const checkpointSessionIds = new Set(checkpoint.sessions.map((session) => session.id));
+      const missingCachedSessionCount = cachedSessions.reduce(
+        (count, session) => count + Number(!checkpointSessionIds.has(session.id)),
+        0,
+      );
+      const cachedSessionIds = new Set(cachedSessions.map((session) => session.id));
+      const addedSessionCount = checkpoint.sessions.reduce(
+        (count, session) => count + Number(!cachedSessionIds.has(session.id)),
+        0,
+      );
+      const deleteCandidateCount =
+        checkpoint.completeness === "complete" ? missingCachedSessionCount : 0;
+      appLogger.info("scan.checkpoint.replacement_candidate", {
+        agent: agent.name,
+        completeness: checkpoint.completeness,
+        cached_sessions: cachedSessions.length,
+        checkpoint_sessions: checkpoint.sessions.length,
+        missing_cached_sessions: missingCachedSessionCount,
+        delete_candidates: deleteCandidateCount,
+      });
       try {
-        if (!saveCachedSessions(agent.name, checkpoint.sessions, checkpoint.meta)) {
+        if (
+          !saveCachedSessions(agent.name, checkpoint.sessions, checkpoint.meta, {
+            completeness: checkpoint.completeness,
+          })
+        ) {
           throw new Error(`Failed to persist scanned checkpoint for ${agent.name}`);
         }
       } catch (error) {
@@ -599,7 +624,10 @@ export class AgentSyncEngine {
       appLogger.info("scan.checkpoint.persisted", {
         agent: agent.name,
         stage: checkpoint.stage,
+        completeness: checkpoint.completeness,
         sessions: checkpoint.sessions.length,
+        cached_sessions_before: cachedSessions.length,
+        cached_sessions_after: cachedSessions.length - deleteCandidateCount + addedSessionCount,
       });
       return;
     }

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1106,7 +1106,7 @@ describe("LiveScanStore", () => {
     worker.emitMessage({
       type: "checkpoint",
       requestId: worker.workerData.requestId,
-      checkpoint: { stage: "scanned", sessions: [], meta: {} },
+      checkpoint: { stage: "scanned", sessions: [], meta: {}, completeness: "complete" },
     });
 
     await expect(refresh).rejects.toThrow("checkpoint rejected");

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -191,11 +191,33 @@ describe("scan refresh worker entry", () => {
         checkpoint: expect.objectContaining({
           stage: "scanned",
           sessions: [session],
+          completeness: "complete",
         }),
       }),
     );
     expect(mocks.postMessage.mock.calls.at(-1)?.[0]).toEqual(
       expect.objectContaining({ type: "done" }),
+    );
+  });
+
+  it("marks a windowed head checkpoint as partial", async () => {
+    const agent = makeAgent({ scan: vi.fn(() => []) });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    setWorkerData({
+      checkpoint: true,
+      scanOptions: { fast: true, from: 1 },
+    });
+
+    await runWorker();
+
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "checkpoint",
+        checkpoint: expect.objectContaining({
+          stage: "scanned",
+          completeness: "partial",
+        }),
+      }),
     );
   });
 

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -17,6 +17,7 @@ import {
   type SessionCacheMeta,
   type SessionHead,
   type SessionHeadChange,
+  type SessionSnapshotCompleteness,
   type SessionTagTiming,
 } from "@codesesh/core";
 import { appLogger } from "./logging.js";
@@ -53,6 +54,7 @@ export type ScanRefreshWorkerCheckpoint =
       stage: "scanned";
       sessions: SessionHead[];
       meta: Record<string, SessionCacheMeta>;
+      completeness: SessionSnapshotCompleteness;
     }
   | {
       stage: "finalizing";
@@ -375,6 +377,8 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
         stage: "scanned",
         sessions: ordered,
         meta: buildAgentCacheMeta(agent, new Set(ordered.map((session) => session.id))),
+        completeness:
+          data.scanOptions.from == null && data.scanOptions.to == null ? "complete" : "partial",
       },
     } satisfies ScanRefreshWorkerMessage);
     sessions = ordered;

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -117,7 +117,9 @@ describe("search index worker", () => {
 
     await runWorker();
 
-    expect(mocks.saveCachedSessions).toHaveBeenCalledWith("codex", sessions, meta);
+    expect(mocks.saveCachedSessions).toHaveBeenCalledWith("codex", sessions, meta, {
+      completeness: "complete",
+    });
     expect(mocks.syncSessionSearchIndex).toHaveBeenCalledWith(
       "codex",
       sessions,

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -131,7 +131,10 @@ function runJob(job: SearchIndexWorkerJob, agent: WorkerAgent): SearchIndexPersi
     return null;
   }
 
-  if (job.saveCache && !saveCachedSessions(job.agentName, job.sessions, job.meta)) {
+  if (
+    job.saveCache &&
+    !saveCachedSessions(job.agentName, job.sessions, job.meta, { completeness: "complete" })
+  ) {
     return "cache";
   }
   const result = syncSessionSearchIndex(

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -2,7 +2,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { clearCache, loadCachedSessionData, saveCachedSessions } from "../cache/sessions.js";
+import {
+  clearCache,
+  loadCachedSessionData,
+  loadCachedSessions,
+  saveCachedSessions,
+} from "../cache/sessions.js";
 import { searchSessions, syncSessionSearchIndex } from "../cache/search.js";
 import { setSchemaEnsuredPath } from "../cache/db.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
@@ -66,5 +71,85 @@ describe("session cache integration", () => {
       id: "smoke",
       messages: [{ id: "message" }],
     });
+  });
+
+  it("merges a partial snapshot without deleting data outside its window", () => {
+    const old: SessionHead = {
+      id: "old",
+      slug: "codex/old",
+      title: "Old session",
+      directory: "/workspace/project",
+      time_created: 1,
+      time_updated: 1,
+      stats: {
+        message_count: 2,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 0,
+      },
+    };
+    const recent: SessionHead = {
+      ...old,
+      id: "recent",
+      slug: "codex/recent",
+      title: "Recent session",
+      time_created: 2,
+      time_updated: 2,
+    };
+    saveCachedSessions("codex", [recent, old], {
+      old: { id: "old", sourcePath: "/sessions/old.jsonl" },
+      recent: { id: "recent", sourcePath: "/sessions/recent.jsonl" },
+    });
+    syncSessionSearchIndex("codex", [recent, old], (sessionId) => {
+      const head = sessionId === "old" ? old : recent;
+      return {
+        ...head,
+        reference: { agentName: "codex", sessionId },
+        messages:
+          sessionId === "old"
+            ? [
+                {
+                  id: "old-user",
+                  role: "user",
+                  time_created: 1,
+                  parts: [{ type: "text", text: "historical-window-needle" }],
+                },
+                {
+                  id: "old-tool",
+                  role: "assistant",
+                  time_created: 2,
+                  parts: [
+                    {
+                      type: "tool",
+                      tool: "apply_patch",
+                      state: {
+                        status: "completed",
+                        input: { path: "src/legacy.ts" },
+                      },
+                    },
+                  ],
+                },
+              ]
+            : [],
+      } as SessionDetail;
+    });
+
+    const updatedRecent = { ...recent, title: "Updated recent", time_updated: 3 };
+    saveCachedSessions("codex", [updatedRecent], {}, { completeness: "partial" });
+
+    expect(loadCachedSessions("codex")).toMatchObject({
+      sessions: [{ id: "recent", title: "Updated recent" }, { id: "old" }],
+      meta: { old: { sourcePath: "/sessions/old.jsonl" } },
+    });
+    expect(loadCachedSessionData("codex", "old")).toMatchObject({
+      messages: [{ id: "old-user" }, { id: "old-tool" }],
+      file_activity: [{ path: "src/legacy.ts" }],
+    });
+    expect(searchSessions("historical-window-needle")[0]?.session.id).toBe("old");
+
+    saveCachedSessions("codex", [updatedRecent]);
+
+    expect(loadCachedSessionData("codex", "old")).toBeNull();
+    expect(searchSessions("historical-window-needle")).toEqual([]);
   });
 });

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -470,6 +470,27 @@ describe("scanSessions", () => {
     expect(result.sessions[0]!.id).toBe("new");
   });
 
+  it("persists a windowed scan as a partial snapshot", async () => {
+    const recent = makeSession("recent", { time_created: 500 });
+    mockedSaveCachedSessions.mockReturnValue(true);
+    mockedCreateRegisteredAgents.mockReturnValue([
+      createTestAgent({
+        name: "test",
+        available: true,
+        sessions: [recent],
+      }),
+    ]);
+
+    await scanSessions({ from: 200, includeSmartTags: false });
+
+    expect(mockedSaveCachedSessions).toHaveBeenCalledWith(
+      "test",
+      [expect.objectContaining({ id: "recent" })],
+      {},
+      { completeness: "partial" },
+    );
+  });
+
   it("uses cache when available", async () => {
     const cachedSessions = [makeSession("cached")];
     mockedLoadCachedSessions.mockReturnValue({

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -313,6 +313,16 @@ describe("saveCachedSessions", () => {
     expect(result?.sessions.map((session) => session.id)).toEqual(["new"]);
   });
 
+  it("preserves cached rows for an empty partial snapshot", () => {
+    saveCachedSessions("claudecode", [makeSession("existing")]);
+
+    saveCachedSessions("claudecode", [], {}, { completeness: "partial" });
+
+    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
+      "existing",
+    ]);
+  });
+
   it("preserves other agents", () => {
     saveCachedSessions("cursor", [makeSession("cursor-1")]);
     saveCachedSessions("claudecode", [makeSession("claude-1")]);

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -46,6 +46,12 @@ export interface CachedSessionRawEntry {
   pendingReindex: boolean;
 }
 
+export type SessionSnapshotCompleteness = "complete" | "partial";
+
+export interface SaveCachedSessionsOptions {
+  completeness?: SessionSnapshotCompleteness;
+}
+
 function parseCachedSessionMeta(value: string | null | undefined): SessionCacheMeta | null {
   if (!value) return null;
   try {
@@ -383,7 +389,9 @@ export function saveCachedSessions(
   agentName: string,
   sessions: SessionHead[],
   meta: Record<string, SessionCacheMeta> = {},
+  options: SaveCachedSessionsOptions = {},
 ): boolean {
+  const completeness = options.completeness ?? "complete";
   const persisted = withCacheDb((db) => {
     const deleteSession = db.prepare(
       "DELETE FROM sessions WHERE agent_name = ? AND session_id = ?",
@@ -406,6 +414,9 @@ export function saveCachedSessions(
       ON CONFLICT(agent_name) DO UPDATE SET timestamp = excluded.timestamp
     `);
     const upsertSession = prepareUpsertSession(db);
+    const updateSortIndex = db.prepare(
+      "UPDATE sessions SET sort_index = ? WHERE agent_name = ? AND session_id = ?",
+    );
 
     const write = db.transaction(() => {
       const timestamp = Date.now();
@@ -415,14 +426,16 @@ export function saveCachedSessions(
         .all(agentName) as SessionRow[];
       upsertAgent.run(agentName, timestamp);
 
-      for (const row of existingSessionIds) {
-        const sessionId = String(row.session_id);
-        if (!sessionIds.has(sessionId)) {
-          deleteSearchDocument.run(agentName, sessionId);
-          deleteMessageTools.run(agentName, sessionId);
-          deleteMessages.run(agentName, sessionId);
-          deleteFileActivity.run(agentName, sessionId);
-          deleteSession.run(agentName, sessionId);
+      if (completeness === "complete") {
+        for (const row of existingSessionIds) {
+          const sessionId = String(row.session_id);
+          if (!sessionIds.has(sessionId)) {
+            deleteSearchDocument.run(agentName, sessionId);
+            deleteMessageTools.run(agentName, sessionId);
+            deleteMessages.run(agentName, sessionId);
+            deleteFileActivity.run(agentName, sessionId);
+            deleteSession.run(agentName, sessionId);
+          }
         }
       }
 
@@ -438,6 +451,22 @@ export function saveCachedSessions(
           sourcePathFromMeta(sessionMeta),
         );
       });
+
+      if (completeness === "partial" && sessions.length > 0) {
+        const mergedRows = db
+          .prepare(
+            `
+              SELECT session_id
+              FROM sessions
+              WHERE agent_name = ?
+              ORDER BY activity_time DESC, sort_index, session_id
+            `,
+          )
+          .all(agentName) as SessionRow[];
+        mergedRows.forEach((row, index) => {
+          updateSortIndex.run(index, agentName, String(row.session_id));
+        });
+      }
     });
 
     write.immediate();

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -32,7 +32,11 @@ export {
   saveCachedSessionChanges,
   saveCachedSessions,
 } from "./cache/sessions.js";
-export type { CachedSessionDataEntry } from "./cache/sessions.js";
+export type {
+  CachedSessionDataEntry,
+  SaveCachedSessionsOptions,
+  SessionSnapshotCompleteness,
+} from "./cache/sessions.js";
 export { getCachePath } from "./cache/db.js";
 export type { SessionHeadChange } from "./cache/db.js";
 export { listCachedProjectGroups } from "./cache/project-groups.js";

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -514,13 +514,12 @@ async function scanAgentFull(
     const meta = buildAgentCacheMeta(agent);
 
     if (options.writeCache !== false) {
-      // 全量（无时间窗）扫描才落盘完整会话列表并记录一次全量同步，用于 backfill 节流判断
       const isFullWindow = options.from == null && options.to == null;
-      // 落盘失败时不得标记缓存已建立，否则后续刷新会基于不存在的缓存走增量路径
-      const persisted = isFullWindow ? saveCachedSessions(agent.name, tagged.sessions, meta) : true;
+      const persisted = saveCachedSessions(agent.name, tagged.sessions, meta, {
+        completeness: isFullWindow ? "complete" : "partial",
+      });
       if (persisted) {
         if (isFullWindow) markAgentFullSyncCompleted(agent.name);
-        // head 缓存是否建立与搜索索引是否完整是两回事，带时间窗的扫描同样应当标记
         markAgentCacheInitialized(agent.name);
       } else {
         getCoreDiagnostics()?.warn("cache.save_failed", {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,7 +65,9 @@ export {
 export type {
   FileActivityResult,
   LiveSnapshot,
+  SaveCachedSessionsOptions,
   ScanOptions,
+  SessionSnapshotCompleteness,
   SearchIndexSyncOptions,
   SearchIndexSyncFailure,
   SearchIndexSyncResult,


### PR DESCRIPTION
## Summary

- model scanned checkpoints as complete or partial snapshots
- merge partial snapshots without deleting sessions outside the active window
- preserve cached messages, search documents, FTS entries, file activity, and metadata until a complete scan confirms removal
- log cache counts and authorized deletion candidates for checkpoint persistence

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`
- `pnpm test:migration`
- `pnpm test:e2e`

Issue: CS-158