### PR TITLE
fix: retain sessions when source parsing fails

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FileSystemSessionSource } from "@codesesh/core";
-import type { BaseAgent, loadCachedSessions, LiveSnapshot, SessionHead } from "@codesesh/core";
+import type {
+  BaseAgent,
+  loadCachedSessions,
+  LiveSnapshot,
+  SessionHead,
+  SessionSourceFailure,
+} from "@codesesh/core";
 import type { ScanStatusEvent } from "@codesesh/core/contract";
 import type { WorkerRunner } from "./worker-runner.js";
 import { appLogger } from "./logging.js";
@@ -512,6 +518,66 @@ describe("AgentSyncEngine", () => {
         removedSessionIds: [],
       }),
     ]);
+  });
+
+  it("commits successful source updates while reporting retained parse failures", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const changed = makeSession("changed", "before");
+    const updated = makeSession("changed", "after");
+    const retained = makeSession("retained");
+    const failure: SessionSourceFailure = {
+      sessionId: retained.id,
+      sourcePath: "/retained",
+      stage: "parsing",
+      errorClass: "SyntaxError",
+      message: "Unexpected end of JSON input",
+    };
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [changed, retained],
+      meta: {
+        changed: { id: "changed", sourcePath: "/changed", sourceFingerprint: "old" },
+        retained: { id: "retained", sourcePath: "/retained", sourceFingerprint: "old" },
+      },
+      timestamp: 1,
+    });
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () => ({
+        sessions: [updated, retained],
+        meta: {
+          changed: { id: "changed", sourcePath: "/changed", sourceFingerprint: "new" },
+          retained: { id: "retained", sourcePath: "/retained", sourceFingerprint: "old" },
+        },
+        changedIds: [changed.id],
+        sourceFailures: [failure],
+      })),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(new FakeSyncAgent(), [changed, retained], workerRunner);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().sessions).toEqual([
+      expect.objectContaining({ id: updated.id, title: updated.title }),
+      expect.objectContaining({ id: retained.id, title: retained.title }),
+    ]);
+    expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.refresh", [
+      expect.objectContaining({
+        kind: "changes",
+        changes: [
+          expect.objectContaining({
+            session: expect.objectContaining({ id: updated.id, title: updated.title }),
+          }),
+        ],
+        removedSessionIds: [],
+      }),
+    ]);
+    expect(engine.status().agentStatuses.codex).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error: "1 session source failed; last-known-good data retained",
+      }),
+    );
   });
 
   it("keeps the previous snapshot when search indexing fails", async () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -20,6 +20,7 @@ import {
   type LiveSnapshot,
   type SessionHead,
   type SessionHeadChange,
+  type SessionSourceFailure,
 } from "@codesesh/core";
 import type {
   BackfillProgress,
@@ -84,6 +85,7 @@ interface RefreshStrategyResult {
   persistenceDiff: SessionPersistenceDiff | null;
   checkDuration: number;
   scanDuration: number;
+  sourceFailures: SessionSourceFailure[];
 }
 
 const REFRESH_DEBOUNCE_MS = 200;
@@ -104,6 +106,11 @@ function buildPersistenceDiff(
     sessionSignature,
   );
   return { changedSessions: changes, removedSessionIds };
+}
+
+function sourceFailureError(failures: SessionSourceFailure[]): Error {
+  const noun = failures.length === 1 ? "source" : "sources";
+  return new Error(`${failures.length} session ${noun} failed; last-known-good data retained`);
 }
 
 function restoreAgentCacheMeta(agent: BaseAgent, cached: CachedSessions): void {
@@ -387,22 +394,33 @@ export class AgentSyncEngine {
 
     const totalDurationMs = performance.now() - startedAt;
     this.scheduler.recordRefreshDuration(agentName, totalDurationMs);
-    appLogger.info("scan.refresh.done", {
-      agent: agentName,
-      duration_ms: Math.round(totalDurationMs),
-      sessions: nextSessions.length,
-      new_sessions: publication.event?.newSessions ?? 0,
-      updated_sessions: publication.event?.updatedSessions ?? 0,
-      removed_sessions: publication.event?.removedSessions ?? 0,
-      pending_paths: pendingPathCount,
-      availability_ms: Math.round(availabilityDuration),
-      check_ms: Math.round(strategyResult.checkDuration),
-      scan_ms: Math.round(strategyResult.scanDuration),
-      diff_ms: Math.round(publication.diffDuration),
-      persist_ms: Math.round(persistDuration),
-      search_index_ms: Math.round(persistDuration),
-      persistent_index_worker_job: persistentJob.kind,
-    });
+    appLogger.info(
+      strategyResult.sourceFailures.length > 0 ? "scan.refresh.partial" : "scan.refresh.done",
+      {
+        agent: agentName,
+        duration_ms: Math.round(totalDurationMs),
+        sessions: nextSessions.length,
+        new_sessions: publication.event?.newSessions ?? 0,
+        updated_sessions: publication.event?.updatedSessions ?? 0,
+        removed_sessions: publication.event?.removedSessions ?? 0,
+        pending_paths: pendingPathCount,
+        availability_ms: Math.round(availabilityDuration),
+        check_ms: Math.round(strategyResult.checkDuration),
+        scan_ms: Math.round(strategyResult.scanDuration),
+        diff_ms: Math.round(publication.diffDuration),
+        persist_ms: Math.round(persistDuration),
+        search_index_ms: Math.round(persistDuration),
+        persistent_index_worker_job: persistentJob.kind,
+        failed_sources: strategyResult.sourceFailures.length,
+      },
+    );
+    if (strategyResult.sourceFailures.length > 0) {
+      appLogger.warn("scan.refresh.source_failures", {
+        agent: agentName,
+        failures: strategyResult.sourceFailures,
+      });
+      throw sourceFailureError(strategyResult.sourceFailures);
+    }
     return "committed";
   }
 
@@ -440,6 +458,7 @@ export class AgentSyncEngine {
     return this.refreshStrategyResult(sessions, {
       fullScanSessions: sessions,
       scanDuration: performance.now() - scanStartedAt,
+      sourceFailures: result.sourceFailures ?? [],
     });
   }
 
@@ -460,7 +479,8 @@ export class AgentSyncEngine {
     this.lastRefreshAtByAgent.set(agent.name, Date.now());
     if (
       persistenceDiff.changedSessions.length === 0 &&
-      persistenceDiff.removedSessionIds.length === 0
+      persistenceDiff.removedSessionIds.length === 0 &&
+      (result.sourceFailures?.length ?? 0) === 0
     ) {
       this.logUnchangedRefresh(agent.name, refreshStartedAt);
       return this.refreshStrategyResult(sessions, {
@@ -472,6 +492,7 @@ export class AgentSyncEngine {
       preciseChangedIds,
       persistenceDiff,
       scanDuration: performance.now() - scanStartedAt,
+      sourceFailures: result.sourceFailures ?? [],
     });
   }
 
@@ -499,6 +520,7 @@ export class AgentSyncEngine {
         persistenceDiff: buildPersistenceDiff(baseline, sessions),
         checkDuration,
         scanDuration: performance.now() - scanStartedAt,
+        sourceFailures: result.sourceFailures ?? [],
       });
     }
     const sessions = attachMissingProjectIdentities(
@@ -509,6 +531,7 @@ export class AgentSyncEngine {
       persistenceDiff: buildPersistenceDiff(baseline, sessions, preciseChangedIds),
       checkDuration,
       scanDuration: performance.now() - scanStartedAt,
+      sourceFailures: checkResult.sourceFailures ?? [],
     });
   }
 
@@ -524,6 +547,7 @@ export class AgentSyncEngine {
     return this.refreshStrategyResult(sessions, {
       fullScanSessions: sessions,
       scanDuration: performance.now() - scanStartedAt,
+      sourceFailures: result.sourceFailures ?? [],
     });
   }
 
@@ -539,6 +563,7 @@ export class AgentSyncEngine {
       persistenceDiff: null,
       checkDuration: 0,
       scanDuration: 0,
+      sourceFailures: [],
       ...overrides,
     };
   }
@@ -768,6 +793,7 @@ export class AgentSyncEngine {
           saveCache: true,
         },
       });
+      if (result.sourceFailures?.length) throw sourceFailureError(result.sourceFailures);
       markAgentFullSyncCompleted(agentName);
       appLogger.info("scan.backfill.done", {
         agent: agentName,

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -2,7 +2,39 @@ import type { BaseAgent, SessionCacheMeta, SessionHead, SessionSourceRef } from 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
-  class FileSystemSessionSource {}
+  class FileSystemSessionSource {
+    scanSessionSourceOutcome(source: SessionSourceRef) {
+      try {
+        const session = (
+          this as unknown as { scanSessionSource(path: string): SessionHead | null }
+        ).scanSessionSource(source.sourcePath);
+        if (session) return { status: "parsed" as const, source, session };
+        return {
+          status: "failed" as const,
+          source,
+          failure: {
+            sessionId: source.sessionId,
+            sourcePath: source.sourcePath,
+            stage: "parsing" as const,
+            errorClass: "Error",
+            message: "source produced no session",
+          },
+        };
+      } catch (error) {
+        return {
+          status: "failed" as const,
+          source,
+          failure: {
+            sessionId: source.sessionId,
+            sourcePath: source.sourcePath,
+            stage: "parsing" as const,
+            errorClass: error instanceof Error ? error.name : typeof error,
+            message: error instanceof Error ? error.message : String(error),
+          },
+        };
+      }
+    }
+  }
 
   return {
     workerData: {} as Record<string, unknown>,
@@ -20,6 +52,12 @@ const mocks = vi.hoisted(() => {
       },
     ),
     FileSystemSessionSource,
+    appLogger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
   };
 });
 
@@ -29,6 +67,8 @@ vi.mock("node:worker_threads", () => ({
     return mocks.workerData;
   },
 }));
+
+vi.mock("./logging.js", () => ({ appLogger: mocks.appLogger }));
 
 vi.mock("@codesesh/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core")>();
@@ -177,7 +217,10 @@ describe("scan refresh worker entry", () => {
   it("emits a durable head checkpoint before metadata finalization", async () => {
     const session = makeSession("fresh", { time_updated: 1 });
     const agent = makeAgent({
-      scan: vi.fn(() => [session]),
+      listSessionSources: vi.fn(() => [
+        { sessionId: "fresh", sourcePath: "/fresh", fingerprint: "fresh" },
+      ]),
+      scanSessionSource: vi.fn(() => session),
       getSessionMetaMap: vi.fn(() => new Map([["fresh", { sourcePath: "/fresh" }]])),
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
@@ -217,6 +260,43 @@ describe("scan refresh worker entry", () => {
           stage: "scanned",
           completeness: "partial",
         }),
+      }),
+    );
+  });
+
+  it("keeps a failed cached source in a partial full-scan checkpoint", async () => {
+    const cached = makeSession("cached");
+    const agent = makeAgent({
+      listSessionSources: vi.fn(() => [
+        { sessionId: "cached", sourcePath: "/cached", fingerprint: "new" },
+      ]),
+      scanSessionSource: vi.fn(() => null),
+    });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    setWorkerData({
+      checkpoint: true,
+      previousSessions: [cached],
+      meta: {
+        cached: { id: "cached", sourcePath: "/cached", sourceFingerprint: "old" },
+      },
+    });
+
+    await runWorker();
+
+    expect(mocks.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "checkpoint",
+        checkpoint: expect.objectContaining({
+          sessions: [cached],
+          completeness: "partial",
+        }),
+      }),
+    );
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "done",
+        removedSessionIds: [],
+        sourceFailures: [expect.objectContaining({ sessionId: "cached" })],
       }),
     );
   });
@@ -577,7 +657,7 @@ describe("scan refresh worker entry", () => {
     expect(mocks.ensureSessionTagsSync).not.toHaveBeenCalled();
   });
 
-  it("synchronizes changed, removed, and out-of-window sources", async () => {
+  it("synchronizes parsed, failed, removed, and out-of-window sources", async () => {
     const unchanged = makeSession("unchanged");
     const changed = makeSession("changed", { title: "old" });
     const removed = makeSession("removed");
@@ -640,8 +720,20 @@ describe("scan refresh worker entry", () => {
       expect.objectContaining({
         type: "done",
         changes: [{ session: updated, sortIndex: 1 }],
-        removedSessionIds: ["removed", "moved"],
-        removedMetaIds: ["removed", "moved"],
+        removedSessionIds: ["removed"],
+        removedMetaIds: ["removed"],
+        sourceFailures: [
+          expect.objectContaining({ sessionId: "moved", stage: "parsing" }),
+          expect.objectContaining({ sessionId: "missing", stage: "parsing" }),
+        ],
+      }),
+    );
+    expect(mocks.appLogger.warn).toHaveBeenCalledWith(
+      "agent.session_source_outcome",
+      expect.objectContaining({
+        session_id: "moved",
+        outcome: "failed",
+        error_class: "Error",
       }),
     );
   });

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -17,6 +17,8 @@ import {
   type SessionCacheMeta,
   type SessionHead,
   type SessionHeadChange,
+  type SessionSourceAbsenceOutcome,
+  type SessionSourceFailure,
   type SessionSnapshotCompleteness,
   type SessionTagTiming,
 } from "@codesesh/core";
@@ -40,6 +42,7 @@ export type ScanRefreshWorkerMessage =
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       removedMetaIds: string[];
+      sourceFailures: SessionSourceFailure[];
       durationMs: number;
     }
   | {
@@ -155,11 +158,12 @@ function syncAgentSources(
   finalizeSessionIds: string[];
   sourceCount: number;
   removedCount: number;
+  sourceFailures: SessionSourceFailure[];
 } {
   const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
   const sourceRefs = agent.listSessionSources(windowOptions);
   const sourceById = new Map(sourceRefs.map((source) => [source.sessionId, source]));
-  const { changedIds, removedIds } = diffSessionSources(
+  const { changedIds, removedIds, sourceOutcomes } = diffSessionSources(
     sourceRefs,
     cachedSessions,
     cachedMeta,
@@ -173,31 +177,80 @@ function syncAgentSources(
     sourceRefs,
   ) ?? [...new Set([...changedIds, ...removedIds])];
   const isWindowed = windowOptions?.from != null || windowOptions?.to != null;
-  const finalizeSessionIds = isWindowed
-    ? [...rescanIds]
-    : sourceRefs.map((source) => source.sessionId);
+  const sourceFailures = sourceOutcomes.flatMap((outcome) =>
+    outcome.status === "failed" ? [outcome.failure] : [],
+  );
+  for (const outcome of sourceOutcomes) logAbsentSourceOutcome(agent.name, outcome);
+  const appliedIds = new Set(removedIds);
 
   rescanIds.forEach((sessionId, index) => {
     const source = sourceById.get(sessionId);
     if (!source) return;
-    const next = agent.scanSessionSource(source.sourcePath);
-    if (next) {
-      sessionMap.set(next.id, next);
-    } else {
+    const outcome = agent.scanSessionSourceOutcome(source);
+    if (outcome.status === "parsed") {
+      sessionMap.set(outcome.session.id, outcome.session);
+      appliedIds.add(sessionId);
+    } else if (outcome.status === "filtered" || outcome.status === "missing") {
       sessionMap.delete(sessionId);
+      agent.getSessionMetaMap().delete(sessionId);
+      appliedIds.add(sessionId);
+      appLogger.info("agent.session_source_outcome", {
+        agent: agent.name,
+        session_id: sessionId,
+        source_path: source.sourcePath,
+        outcome: outcome.status,
+        ...(outcome.status === "filtered" ? { reason: outcome.reason } : {}),
+      });
+    } else {
+      sourceFailures.push(outcome.failure);
+      appLogger.warn("agent.session_source_outcome", {
+        agent: agent.name,
+        session_id: outcome.failure.sessionId,
+        source_path: outcome.failure.sourcePath,
+        outcome: outcome.status,
+        stage: outcome.failure.stage,
+        error_class: outcome.failure.errorClass,
+        message: outcome.failure.message,
+      });
     }
     onProgress?.({ total: rescanIds.length, processed: index + 1, sessions: sessionMap.size });
   });
 
   for (const sessionId of removedIds) sessionMap.delete(sessionId);
+  const failedIdSet = new Set(sourceFailures.map((failure) => failure.sessionId));
+  const finalizeSessionIds = (
+    isWindowed ? [...appliedIds] : sourceRefs.map((source) => source.sessionId)
+  ).filter((sessionId) => !failedIdSet.has(sessionId));
 
   return {
     sessions: [...sessionMap.values()],
-    changedIds: rescanIds,
+    changedIds: [...appliedIds],
     finalizeSessionIds,
     sourceCount: sourceRefs.length,
     removedCount: removedIds.length,
+    sourceFailures,
   };
+}
+
+function logAbsentSourceOutcome(agentName: string, outcome: SessionSourceAbsenceOutcome): void {
+  if (outcome.status === "missing") {
+    appLogger.info("agent.session_source_outcome", {
+      agent: agentName,
+      session_id: outcome.source.sessionId,
+      source_path: outcome.source.sourcePath,
+      outcome: outcome.status,
+    });
+    return;
+  }
+  appLogger.warn("agent.session_source_outcome", {
+    agent: agentName,
+    session_id: outcome.failure.sessionId,
+    source_path: outcome.failure.sourcePath,
+    outcome: outcome.status,
+    stage: outcome.failure.stage,
+    error_class: outcome.failure.errorClass,
+    message: outcome.failure.message,
+  });
 }
 
 /**
@@ -332,6 +385,7 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
   const isAvailable = agent.isAvailable();
   let sessions: SessionHead[];
   let changedIds: string[] | undefined;
+  let sourceFailures: SessionSourceFailure[] = [];
   let finalizeSessionIds: ReadonlySet<string> | undefined;
   let backfillOrder: SessionHead[] | undefined;
   let backfillCursorIndex = -1;
@@ -344,7 +398,10 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
 
   if (!isAvailable) {
     sessions = [];
-  } else if (data.sourceSync && agent instanceof FileSystemSessionSource) {
+  } else if (
+    agent instanceof FileSystemSessionSource &&
+    (data.sourceSync === true || data.checkpoint === true)
+  ) {
     const result = syncAgentSources(
       agent,
       data.previousSessions,
@@ -356,6 +413,7 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
     changedIds = result.changedIds;
     finalizeSessionIds = new Set(result.finalizeSessionIds);
     sourceSyncDetails = result;
+    sourceFailures = result.sourceFailures;
   } else if (data.changedIds) {
     sessions = await Promise.resolve(agent.incrementalScan(data.previousSessions, data.changedIds));
   } else {
@@ -378,7 +436,11 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
         sessions: ordered,
         meta: buildAgentCacheMeta(agent, new Set(ordered.map((session) => session.id))),
         completeness:
-          data.scanOptions.from == null && data.scanOptions.to == null ? "complete" : "partial",
+          data.scanOptions.from == null &&
+          data.scanOptions.to == null &&
+          sourceFailures.length === 0
+            ? "complete"
+            : "partial",
       },
     } satisfies ScanRefreshWorkerMessage);
     sessions = ordered;
@@ -402,6 +464,7 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
     changed_ids: changedIds?.length ?? 0,
     source_count: sourceSyncDetails?.sourceCount,
     removed_count: sourceSyncDetails?.removedCount,
+    failed_sources: sourceFailures.length,
     duration_ms: Math.round(scanDuration),
   });
 
@@ -505,6 +568,7 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
     removedSessionIds: diff.removedSessionIds,
     meta: metaDiff.changes,
     removedMetaIds: metaDiff.removedIds,
+    sourceFailures,
     durationMs: performance.now() - startedAt,
   } satisfies ScanRefreshWorkerMessage);
 }

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -5,6 +5,7 @@ import type {
   SessionCacheMeta,
   SessionHead,
   SessionHeadChange,
+  SessionSourceFailure,
 } from "@codesesh/core";
 import { appLogger } from "./logging.js";
 import type {
@@ -31,6 +32,7 @@ export interface WorkerResult {
   sessions: SessionHead[];
   meta: Record<string, SessionCacheMeta>;
   changedIds?: string[];
+  sourceFailures?: SessionSourceFailure[];
 }
 
 export interface WorkerRunner {
@@ -224,6 +226,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
         ),
         meta: applyMetaChanges(pending.payload.meta, message.meta, removedMetaIds),
         changedIds: pending.payload.sourceSync ? replacedSessionIds : undefined,
+        sourceFailures: message.sourceFailures,
       });
     } catch (error) {
       pending.reject(toError(error));

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import Database from "better-sqlite3";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -282,26 +282,18 @@ describe("diffSessionSources", () => {
     }
   });
 
-  it("treats an inaccessible cached path as failed, not missing", () => {
-    const directory = mkdtempSync(join(tmpdir(), "codesesh-source-permission-"));
-    const sourcePath = join(directory, "session.jsonl");
-    writeFileSync(sourcePath, "{}\n");
-    chmodSync(directory, 0o000);
-    try {
-      const diff = diffSessionSources([], [makeSession("cached")], {
-        cached: meta("cached", { sourcePath }),
-      });
+  it("treats a cached path stat error as failed, not missing", () => {
+    const sourcePath = "invalid\0path";
+    const diff = diffSessionSources([], [makeSession("cached")], {
+      cached: meta("cached", { sourcePath }),
+    });
 
-      expect(diff.removedIds).toEqual([]);
-      expect(diff.failedIds).toEqual(["cached"]);
-      expect(diff.sourceOutcomes[0]).toMatchObject({
-        status: "failed",
-        failure: { errorClass: "EACCES" },
-      });
-    } finally {
-      chmodSync(directory, 0o700);
-      rmSync(directory, { recursive: true, force: true });
-    }
+    expect(diff.removedIds).toEqual([]);
+    expect(diff.failedIds).toEqual(["cached"]);
+    expect(diff.sourceOutcomes[0]).toMatchObject({
+      status: "failed",
+      failure: { errorClass: "ERR_INVALID_ARG_VALUE" },
+    });
   });
 
   it("keeps sessions whose mtime falls outside the scan window", () => {

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -1,9 +1,14 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import Database from "better-sqlite3";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DatabaseSessionSource, diffSessionSources, FileSystemSessionSource } from "../base.js";
+import {
+  DatabaseSessionSource,
+  diffSessionSources,
+  FileSystemSessionSource,
+  filteredSession,
+} from "../base.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
@@ -14,6 +19,8 @@ interface FakeSource {
   fingerprint: string;
   head: SessionHead | null;
   throws?: boolean;
+  error?: Error;
+  filtered?: boolean;
 }
 
 /**
@@ -56,6 +63,7 @@ class FakeFileSystemSource extends FileSystemSessionSource {
   scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
     this.lastScanOptions = options;
     const found = this.sources.find((s) => s.sourcePath === sourcePath);
+    if (found?.error) throw found.error;
     if (found?.throws) throw new Error("parse failed");
     if (!found || !found.head) return null;
     this.sessionMetaMap.set(found.sessionId, {
@@ -64,6 +72,12 @@ class FakeFileSystemSource extends FileSystemSessionSource {
       sourceFingerprint: found.fingerprint,
     });
     return found.head;
+  }
+
+  protected override scanSessionSourceResult(ref: SessionSourceRef, options?: AgentScanOptions) {
+    const found = this.sources.find((item) => item.sourcePath === ref.sourcePath);
+    if (found?.filtered) return filteredSession<SessionHead>("no visible messages");
+    return super.scanSessionSourceResult(ref, options);
   }
 }
 
@@ -126,7 +140,7 @@ describe("FileSystemSessionSource.scan", () => {
     ]);
   });
 
-  it("reports agent.session_parse_failed via diagnostics when a source throws", () => {
+  it("reports a failed source outcome via diagnostics when parsing throws", () => {
     const agent = new FakeFileSystemSource([
       source("a"),
       source("broken", "fp-1", { throws: true }),
@@ -142,8 +156,16 @@ describe("FileSystemSessionSource.scan", () => {
       expect(sessions.map((session) => session.id)).toEqual(["a"]);
       expect(events).toEqual([
         {
-          event: "agent.session_parse_failed",
-          detail: { agentName: "fake", sourcePath: "/tmp/broken.jsonl", message: "parse failed" },
+          event: "agent.session_source_outcome",
+          detail: {
+            agent: "fake",
+            session_id: "broken",
+            source_path: "/tmp/broken.jsonl",
+            outcome: "failed",
+            stage: "parsing",
+            error_class: "Error",
+            message: "parse failed",
+          },
         },
       ]);
     } finally {
@@ -173,7 +195,12 @@ describe("diffSessionSources", () => {
     const fromObject = diffSessionSources(refs, cached, entries);
     const fromMap = diffSessionSources(refs, cached, new Map(Object.entries(entries)));
 
-    expect(fromObject).toEqual({ changedIds: ["b"], removedIds: [] });
+    expect(fromObject).toEqual({
+      changedIds: ["b"],
+      removedIds: [],
+      failedIds: [],
+      sourceOutcomes: [],
+    });
     expect(fromMap).toEqual(fromObject);
   });
 
@@ -188,12 +215,22 @@ describe("diffSessionSources", () => {
       },
     );
 
-    expect(diff).toEqual({ changedIds: ["a"], removedIds: [] });
+    expect(diff).toEqual({
+      changedIds: ["a"],
+      removedIds: [],
+      failedIds: [],
+      sourceOutcomes: [],
+    });
   });
 
   it("treats a ref with no cached session as changed even when its meta matches", () => {
     const diff = diffSessionSources([ref("a")], [], { a: meta("a") });
-    expect(diff).toEqual({ changedIds: ["a"], removedIds: [] });
+    expect(diff).toEqual({
+      changedIds: ["a"],
+      removedIds: [],
+      failedIds: [],
+      sourceOutcomes: [],
+    });
   });
 
   it("separates removed sessions from changed ones", () => {
@@ -202,7 +239,69 @@ describe("diffSessionSources", () => {
       gone: meta("gone"),
     });
 
-    expect(diff).toEqual({ changedIds: [], removedIds: ["gone"] });
+    expect(diff).toEqual({
+      changedIds: [],
+      removedIds: ["gone"],
+      failedIds: [],
+      sourceOutcomes: [
+        {
+          status: "missing",
+          source: ref("gone"),
+        },
+      ],
+    });
+  });
+
+  it("treats an existing cached path omitted by enumeration as failed, not removed", () => {
+    const directory = mkdtempSync(join(tmpdir(), "codesesh-source-outcome-"));
+    const sourcePath = join(directory, "half-written.jsonl");
+    writeFileSync(sourcePath, "{");
+    try {
+      const diff = diffSessionSources([], [makeSession("cached")], {
+        cached: meta("cached", { sourcePath }),
+      });
+
+      expect(diff).toMatchObject({
+        changedIds: [],
+        removedIds: [],
+        failedIds: ["cached"],
+        sourceOutcomes: [
+          {
+            status: "failed",
+            failure: {
+              sessionId: "cached",
+              sourcePath,
+              stage: "enumeration",
+              errorClass: "Error",
+            },
+          },
+        ],
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("treats an inaccessible cached path as failed, not missing", () => {
+    const directory = mkdtempSync(join(tmpdir(), "codesesh-source-permission-"));
+    const sourcePath = join(directory, "session.jsonl");
+    writeFileSync(sourcePath, "{}\n");
+    chmodSync(directory, 0o000);
+    try {
+      const diff = diffSessionSources([], [makeSession("cached")], {
+        cached: meta("cached", { sourcePath }),
+      });
+
+      expect(diff.removedIds).toEqual([]);
+      expect(diff.failedIds).toEqual(["cached"]);
+      expect(diff.sourceOutcomes[0]).toMatchObject({
+        status: "failed",
+        failure: { errorClass: "EACCES" },
+      });
+    } finally {
+      chmodSync(directory, 0o700);
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it("keeps sessions whose mtime falls outside the scan window", () => {
@@ -249,6 +348,10 @@ describe("FileSystemSessionSource.checkForChanges", () => {
   it("detects removed sources", () => {
     const agent = new FakeFileSystemSource([source("a")]);
     agent.scanSessionSource("/tmp/a.jsonl");
+    agent.getSessionMetaMap().set("ghost", {
+      id: "ghost",
+      sourcePath: "/tmp/ghost-does-not-exist.jsonl",
+    });
 
     const result = agent.checkForChanges(Date.now(), [makeSession("a"), makeSession("ghost")]);
     expect(result.hasChanges).toBe(true);
@@ -319,11 +422,58 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     expect(updated.map((s) => s.id).sort()).toEqual(["a", "b"]);
   });
 
-  it("drops sources that no longer parse", () => {
+  it("retains the last-known-good session when a source no longer parses", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b", "fp-1", { head: null })]);
     const updated = agent.incrementalScan([makeSession("a"), makeSession("b")], ["b"]);
-    expect(updated.map((s) => s.id)).toEqual(["a"]);
+    expect(updated.map((s) => s.id)).toEqual(["a", "b"]);
     expect(agent.getSessionMetaMap().has("b")).toBe(false);
+  });
+
+  it.each([
+    ["EACCES", Object.assign(new Error("permission denied"), { code: "EACCES" })],
+    ["truncated JSON", undefined],
+  ])("retains meta after %s and updates after the source recovers", (_label, error) => {
+    const before = makeSession("a");
+    const agent = new FakeFileSystemSource([source("a", "fp-old", { head: before })]);
+    agent.scanSessionSource("/tmp/a.jsonl");
+    agent.setSources([source("a", "fp-new", { head: null, error })]);
+
+    const retained = agent.incrementalScan([before], ["a"]);
+
+    expect(retained).toEqual([before]);
+    expect(agent.getSessionMetaMap().get("a")?.sourceFingerprint).toBe("fp-old");
+
+    const recovered = makeSession("a");
+    recovered.title = "recovered";
+    agent.setSources([source("a", "fp-new", { head: recovered })]);
+
+    expect(agent.incrementalScan(retained, ["a"])[0]?.title).toBe("recovered");
+    expect(agent.getSessionMetaMap().get("a")?.sourceFingerprint).toBe("fp-new");
+  });
+
+  it("removes a cached session only when the adapter explicitly filters it", () => {
+    const before = makeSession("a");
+    const agent = new FakeFileSystemSource([source("a", "fp-old", { head: before })]);
+    agent.scanSessionSource("/tmp/a.jsonl");
+    agent.setSources([source("a", "fp-new", { head: null, filtered: true })]);
+
+    const updated = agent.incrementalScan([before], ["a"]);
+
+    expect(updated).toEqual([]);
+    expect(agent.getSessionMetaMap().has("a")).toBe(false);
+  });
+
+  it("removes a cached session when its source disappears between enumeration and parsing", () => {
+    const before = makeSession("a");
+    const agent = new FakeFileSystemSource([source("a", "fp-old", { head: before })]);
+    agent.scanSessionSource("/tmp/a.jsonl");
+    const missingError = Object.assign(new Error("source disappeared"), { code: "ENOENT" });
+    agent.setSources([source("a", "fp-new", { head: null, error: missingError })]);
+
+    const updated = agent.incrementalScan([before], ["a"]);
+
+    expect(updated).toEqual([]);
+    expect(agent.getSessionMetaMap().has("a")).toBe(false);
   });
 
   it("skips listSessionSources when refs are passed explicitly, matching the fallback result", () => {

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -63,12 +63,38 @@ export interface ChangeCheckResult {
   timestamp: number;
   /** 检测过程中已枚举的会话源（可选），供 incrementalScan 复用以避免二次枚举 */
   refs?: SessionSourceRef[];
+  sourceFailures?: SessionSourceFailure[];
 }
 
 export interface SessionSourceRef {
   sessionId: string;
   sourcePath: string;
   fingerprint: string;
+}
+
+export interface SessionSourceFailure {
+  sessionId: string;
+  sourcePath: string;
+  stage: "enumeration" | "parsing";
+  errorClass: string;
+  message: string;
+}
+
+export type SessionSourceOutcome =
+  | { status: "parsed"; session: SessionHead; source: SessionSourceRef }
+  | { status: "filtered"; reason: string; source: SessionSourceRef }
+  | { status: "missing"; source: SessionSourceRef }
+  | { status: "failed"; failure: SessionSourceFailure };
+
+export type SessionSourceAbsenceOutcome = Extract<
+  SessionSourceOutcome,
+  { status: "missing" | "failed" }
+>;
+
+export interface SessionSourceScanBatch {
+  sources: SessionSourceRef[];
+  outcomes: SessionSourceOutcome[];
+  sessions: SessionHead[];
 }
 
 export interface SessionSourceFile {
@@ -105,6 +131,8 @@ export type SessionWatchPlan =
 export interface SessionSourceDiff {
   changedIds: string[];
   removedIds: string[];
+  failedIds: string[];
+  sourceOutcomes: SessionSourceAbsenceOutcome[];
 }
 
 /**
@@ -182,13 +210,121 @@ export function diffSessionSources(
   }
 
   const removedIds: string[] = [];
+  const failedIds: string[] = [];
+  const sourceOutcomes: SessionSourceAbsenceOutcome[] = [];
   for (const session of cachedSessions) {
     if (enumeratedIds.has(session.id)) continue;
-    if (!wasEnumeratedThisPass(readCachedMeta(cachedMeta, session.id), options)) continue;
-    removedIds.push(session.id);
+    const meta = readCachedMeta(cachedMeta, session.id);
+    if (!wasEnumeratedThisPass(meta, options)) continue;
+    const source = {
+      sessionId: session.id,
+      sourcePath: typeof meta?.sourcePath === "string" ? meta.sourcePath : "",
+      fingerprint: typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : "",
+    };
+    if (!source.sourcePath) {
+      failedIds.push(session.id);
+      sourceOutcomes.push({
+        status: "failed",
+        failure: createSessionSourceFailure(
+          source,
+          "enumeration",
+          new Error("cached source path is missing"),
+        ),
+      });
+      continue;
+    }
+    try {
+      statSync(source.sourcePath);
+      failedIds.push(session.id);
+      sourceOutcomes.push({
+        status: "failed",
+        failure: createSessionSourceFailure(
+          source,
+          "enumeration",
+          new Error("cached source was not enumerated"),
+        ),
+      });
+    } catch (error) {
+      if (!isMissingSourceError(error)) {
+        failedIds.push(session.id);
+        sourceOutcomes.push({
+          status: "failed",
+          failure: createSessionSourceFailure(source, "enumeration", error),
+        });
+        continue;
+      }
+      removedIds.push(session.id);
+      sourceOutcomes.push({ status: "missing", source });
+    }
   }
 
-  return { changedIds, removedIds };
+  return { changedIds, removedIds, failedIds, sourceOutcomes };
+}
+
+function isMissingSourceError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function failureClass(error: unknown): string {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string" && code) return code;
+  }
+  if (error instanceof Error && error.name) return error.name;
+  return typeof error;
+}
+
+function failureMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, 500);
+}
+
+export function createSessionSourceFailure(
+  source: Pick<SessionSourceRef, "sessionId" | "sourcePath">,
+  stage: SessionSourceFailure["stage"],
+  error: unknown,
+): SessionSourceFailure {
+  return {
+    sessionId: source.sessionId,
+    sourcePath: source.sourcePath,
+    stage,
+    errorClass: failureClass(error),
+    message: failureMessage(error),
+  };
+}
+
+export function reportSessionSourceOutcome(agentName: string, outcome: SessionSourceOutcome): void {
+  if (outcome.status === "parsed") return;
+  if (outcome.status === "filtered") {
+    getCoreDiagnostics()?.info?.("agent.session_source_outcome", {
+      agent: agentName,
+      session_id: outcome.source.sessionId,
+      source_path: outcome.source.sourcePath,
+      outcome: outcome.status,
+      reason: outcome.reason,
+    });
+    return;
+  }
+  if (outcome.status === "missing") {
+    getCoreDiagnostics()?.info?.("agent.session_source_outcome", {
+      agent: agentName,
+      session_id: outcome.source.sessionId,
+      source_path: outcome.source.sourcePath,
+      outcome: outcome.status,
+    });
+    return;
+  }
+  getCoreDiagnostics()?.warn("agent.session_source_outcome", {
+    agent: agentName,
+    session_id: outcome.failure.sessionId,
+    source_path: outcome.failure.sourcePath,
+    outcome: outcome.status,
+    stage: outcome.failure.stage,
+    error_class: outcome.failure.errorClass,
+    message: outcome.failure.message,
+  });
 }
 
 export abstract class BaseAgent {
@@ -269,6 +405,47 @@ export abstract class FileSystemSessionSource<
   /** 解析单个源并写入 metaMap，返回会话 head（解析失败/不可见返回 null）。 */
   abstract scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null;
 
+  protected scanSessionSourceResult(
+    source: SessionSourceRef,
+    options?: AgentScanOptions,
+  ): ParseSessionResult<SessionHead> {
+    const session = this.scanSessionSource(source.sourcePath, options);
+    return session ? parsedSession(session) : skippedSession("source produced no session");
+  }
+
+  scanSessionSourceOutcome(
+    source: SessionSourceRef,
+    options?: AgentScanOptions,
+  ): SessionSourceOutcome {
+    const previousMeta = this.sessionMetaMap.get(source.sessionId);
+    let result: ParseSessionResult<SessionHead>;
+    try {
+      result = this.scanSessionSourceResult(source, options);
+    } catch (error) {
+      if (previousMeta) this.sessionMetaMap.set(source.sessionId, previousMeta);
+      else this.sessionMetaMap.delete(source.sessionId);
+      if (isMissingSourceError(error)) return { status: "missing", source };
+      return {
+        status: "failed",
+        failure: createSessionSourceFailure(source, "parsing", error),
+      };
+    }
+    if (result.status === "parsed") return { status: "parsed", source, session: result.data };
+    if (result.status === "filtered") {
+      return { status: "filtered", source, reason: result.reason ?? "filtered by agent" };
+    }
+    if (previousMeta) this.sessionMetaMap.set(source.sessionId, previousMeta);
+    else this.sessionMetaMap.delete(source.sessionId);
+    return {
+      status: "failed",
+      failure: createSessionSourceFailure(
+        source,
+        "parsing",
+        new Error(result.reason ?? "source parse skipped"),
+      ),
+    };
+  }
+
   /**
    * 变更集合扩展：当某些会话变更会影响其他会话的派生数据时
    * （如 subagent 文件变更需要父会话重新聚合 token 统计），
@@ -279,31 +456,28 @@ export abstract class FileSystemSessionSource<
   }
 
   scan(options?: AgentScanOptions): SessionHead[] {
+    return this.scanSessionSources(options).sessions;
+  }
+
+  scanSessionSources(options?: AgentScanOptions): SessionSourceScanBatch {
     const sources = this.listSessionSources(options);
     const sessions: SessionHead[] = [];
+    const outcomes: SessionSourceOutcome[] = [];
     options?.onProgress?.({ total: sources.length, processed: 0, sessions: 0 });
 
     for (const [index, source] of sources.entries()) {
-      try {
-        const session = this.scanSessionSource(source.sourcePath, options);
-        if (session) sessions.push(session);
-      } catch (error) {
-        getCoreDiagnostics()?.warn("agent.session_parse_failed", {
-          agentName: this.name,
-          sourcePath: source.sourcePath,
-          message: error instanceof Error ? error.message : String(error),
-        });
-        continue;
-      } finally {
-        options?.onProgress?.({
-          total: sources.length,
-          processed: index + 1,
-          sessions: sessions.length,
-        });
-      }
+      const outcome = this.scanSessionSourceOutcome(source, options);
+      outcomes.push(outcome);
+      if (outcome.status === "parsed") sessions.push(outcome.session);
+      else reportSessionSourceOutcome(this.name, outcome);
+      options?.onProgress?.({
+        total: sources.length,
+        processed: index + 1,
+        sessions: sessions.length,
+      });
     }
 
-    return sessions;
+    return { sources, outcomes, sessions };
   }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
@@ -379,12 +553,17 @@ export abstract class FileSystemSessionSource<
     const currentRefs = this.listSessionSources();
     const diff = diffSessionSources(currentRefs, cachedSessions, this.sessionMetaMap);
     const changedIds = [...new Set([...diff.changedIds, ...diff.removedIds])];
+    const sourceFailures = diff.sourceOutcomes.flatMap((outcome) =>
+      outcome.status === "failed" ? [outcome.failure] : [],
+    );
+    for (const outcome of diff.sourceOutcomes) reportSessionSourceOutcome(this.name, outcome);
 
     return {
-      hasChanges: changedIds.length > 0,
+      hasChanges: changedIds.length > 0 || sourceFailures.length > 0,
       changedIds,
       timestamp: Date.now(),
       refs: currentRefs,
+      sourceFailures,
     };
   }
 
@@ -406,12 +585,14 @@ export abstract class FileSystemSessionSource<
     for (const ref of sources) {
       currentIds.add(ref.sessionId);
       if (!changedSet.has(ref.sessionId)) continue;
-      const head = this.scanSessionSource(ref.sourcePath);
-      if (head) {
-        sessionMap.set(head.id, head);
-      } else {
+      const outcome = this.scanSessionSourceOutcome(ref);
+      if (outcome.status === "parsed") {
+        sessionMap.set(outcome.session.id, outcome.session);
+      } else if (outcome.status === "filtered" || outcome.status === "missing") {
         sessionMap.delete(ref.sessionId);
         this.sessionMetaMap.delete(ref.sessionId);
+      } else {
+        reportSessionSourceOutcome(this.name, outcome);
       }
     }
 
@@ -431,22 +612,53 @@ export abstract class FileSystemSessionSource<
 export abstract class SingleFileSessionSource<
   TMeta extends FileSessionMeta = FileSessionMeta,
 > extends FileSystemSessionSource<TMeta> {
+  private readonly pendingParseResults = new Map<
+    string,
+    ParseSessionResult<SessionHead> | undefined
+  >();
+
   protected abstract parseFileSessionHead(
     sourcePath: string,
     options?: AgentScanOptions,
   ): SessionHead | null;
 
+  protected parseFileSessionHeadResult(
+    sourcePath: string,
+    options?: AgentScanOptions,
+  ): ParseSessionResult<SessionHead> {
+    const head = this.parseFileSessionHead(sourcePath, options);
+    return head ? parsedSession(head) : skippedSession("source produced no session");
+  }
+
   protected abstract createFileSessionMeta(head: SessionHead, source: SessionSourceFile): TMeta;
 
   scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
-    const head = this.parseFileSessionHead(sourcePath, options);
-    if (head) {
+    const result = this.parseFileSessionHeadResult(sourcePath, options);
+    if (this.pendingParseResults.has(sourcePath)) {
+      this.pendingParseResults.set(sourcePath, result);
+    }
+    if (result.status === "parsed") {
       this.sessionMetaMap.set(
-        head.id,
-        this.createFileSessionMeta(head, this.sessionSourceFile(sourcePath)),
+        result.data.id,
+        this.createFileSessionMeta(result.data, this.sessionSourceFile(sourcePath)),
       );
     }
-    return head;
+    return getParsedSession(result);
+  }
+
+  protected override scanSessionSourceResult(
+    source: SessionSourceRef,
+    options?: AgentScanOptions,
+  ): ParseSessionResult<SessionHead> {
+    this.pendingParseResults.set(source.sourcePath, undefined);
+    try {
+      const head = this.scanSessionSource(source.sourcePath, options);
+      const result = this.pendingParseResults.get(source.sourcePath);
+      if (head) return result?.status === "parsed" ? result : parsedSession(head);
+      return result ?? skippedSession("source produced no session");
+    } finally {
+      this.pendingParseResults.delete(source.sourcePath);
+    }
   }
 
   protected buildFileSessionMeta<TExtra extends object>({

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -275,9 +275,15 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   }
 
   protected parseFileSessionHead(sourcePath: string): SessionHead | null {
+    return getParsedSession(this.parseFileSessionHeadResult(sourcePath));
+  }
+
+  protected override parseFileSessionHeadResult(
+    sourcePath: string,
+  ): ParseSessionResult<SessionHead> {
     const child = this.getChildContext(sourcePath);
     const projectDir = child?.projectDir ?? dirname(sourcePath);
-    return getParsedSession(this.parseSessionHeadResult(sourcePath, projectDir, child));
+    return this.parseSessionHeadResult(sourcePath, projectDir, child);
   }
 
   getSessionData(sessionId: string): SessionDetail {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -955,18 +955,18 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   }
 
   protected parseFileSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {
-    this.loadSessionIndex();
     return this.parseSessionHead(filePath, options);
   }
 
   private parseSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {
-    return getParsedSession(this.parseSessionHeadResult(filePath, options));
+    return getParsedSession(this.parseFileSessionHeadResult(filePath, options));
   }
 
-  private parseSessionHeadResult(
+  protected override parseFileSessionHeadResult(
     filePath: string,
     options?: AgentScanOptions,
   ): ParseSessionResult<SessionHead> {
+    this.loadSessionIndex();
     if (options?.fast) {
       return this.parseFastSessionHeadResult(filePath);
     }

--- a/packages/core/src/agents/grok.ts
+++ b/packages/core/src/agents/grok.ts
@@ -2,9 +2,14 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
   FileSystemSessionSource,
+  filteredSession,
+  getParsedSession,
   matchesScanWindow,
+  parsedSession,
+  skippedSession,
   type AgentScanOptions,
   type FileSessionMeta,
+  type ParseSessionResult,
   type SessionSourceFile,
   type SessionSourceRef,
 } from "./base.js";
@@ -856,16 +861,26 @@ export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
   }
 
   scanSessionSource(sourcePath: string): SessionHead | null {
+    return getParsedSession(this.parseSessionHeadResult(sourcePath));
+  }
+
+  protected override scanSessionSourceResult(
+    source: SessionSourceRef,
+  ): ParseSessionResult<SessionHead> {
+    return this.parseSessionHeadResult(source.sourcePath);
+  }
+
+  private parseSessionHeadResult(sourcePath: string): ParseSessionResult<SessionHead> {
     const source = this.sessionSourceFile(sourcePath);
     const summary = parseSummary(source);
-    if (!summary) return null;
+    if (!summary) return skippedSession("malformed summary");
 
     const sessionDir = dirname(source.file);
     const updatesPath = join(sessionDir, UPDATES_FILE);
     const existingUpdatesPath = existsSync(updatesPath) ? updatesPath : null;
     const headData = scanHeadData(existingUpdatesPath, summary.createdAt);
     const messageCount = headData.visibleMessageCount || summary.messageCount;
-    if (messageCount === 0) return null;
+    if (messageCount === 0) return filteredSession("no visible messages");
 
     const title = resolveSessionTitle(
       summary.title,
@@ -903,7 +918,7 @@ export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
       updatesPath: existingUpdatesPath,
       stats,
     });
-    return head;
+    return parsedSession(head);
   }
 
   getSessionData(sessionId: string): SessionDetail {

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -6,11 +6,13 @@ export {
   SingleFileSessionSource,
 } from "./base.js";
 export {
+  createSessionSourceFailure,
   diffSessionSources,
   filteredSession,
   getParsedSession,
   matchesScanWindow,
   parsedSession,
+  reportSessionSourceOutcome,
   skippedSession,
 } from "./base.js";
 export type {
@@ -22,7 +24,11 @@ export type {
   FileWalkOptions,
   SessionCacheMeta,
   SessionSourceFile,
+  SessionSourceFailure,
+  SessionSourceAbsenceOutcome,
   SessionSourceDiff,
+  SessionSourceOutcome,
+  SessionSourceScanBatch,
   SessionSourceRef,
   SessionWatchPlan,
   SessionWatchTarget,

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import {
   FileSystemSessionSource,
+  filteredSession,
   getParsedSession,
   matchesScanWindow,
   parsedSession,
@@ -519,15 +520,26 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   scanSessionSource(sourcePath: string): SessionHead | null {
+    return getParsedSession(this.parseSessionHeadResult(sourcePath));
+  }
+
+  protected override scanSessionSourceResult(
+    source: SessionSourceRef,
+  ): ParseSessionResult<SessionHead> {
+    return this.parseSessionHeadResult(source.sourcePath);
+  }
+
+  private parseSessionHeadResult(sourcePath: string): ParseSessionResult<SessionHead> {
     this.loadSessionIndex();
-    const source = getParsedSession(this.resolveSessionSourceResult(sourcePath));
-    if (!source) return null;
+    const result = this.resolveSessionSourceResult(sourcePath);
+    if (result.status !== "parsed") return result;
+    const source = result.data;
 
     const parsed = this.parseWire(source);
     const transcript = parsed.builder.finish(parsed.stats);
     if (transcript.messages.length === 0) {
       this.sessionMetaMap.delete(source.id);
-      return null;
+      return filteredSession("no visible messages");
     }
 
     const title = resolveSessionTitle(source.explicitTitle, parsed.firstUserTitle, null);
@@ -538,7 +550,7 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
       sourceFingerprint: this.sourceFingerprint(source),
     };
     this.sessionMetaMap.set(meta.id, meta);
-    return {
+    return parsedSession({
       id: meta.id,
       slug: `${this.name}/${meta.id}`,
       title: meta.title,
@@ -547,7 +559,7 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
       time_updated: meta.updatedAt,
       stats: transcript.stats,
       ...(Object.keys(parsed.modelUsage).length > 0 ? { model_usage: parsed.modelUsage } : {}),
-    };
+    });
   }
 
   getSessionData(sessionId: string): SessionDetail {

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -354,12 +354,23 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   scanSessionSource(sourcePath: string): SessionHead | null {
-    const meta = getParsedSession(this.parseSessionDirResult(sourcePath));
-    if (!meta) return null;
+    return getParsedSession(this.parseSessionHeadResult(sourcePath));
+  }
+
+  protected override scanSessionSourceResult(
+    source: SessionSourceRef,
+  ): ParseSessionResult<SessionHead> {
+    return this.parseSessionHeadResult(source.sourcePath);
+  }
+
+  private parseSessionHeadResult(sourcePath: string): ParseSessionResult<SessionHead> {
+    const result = this.parseSessionDirResult(sourcePath);
+    if (result.status !== "parsed") return result;
+    const meta = result.data;
     meta.sourceFingerprint = this.sourceFingerprint(meta);
     this.sessionMetaMap.set(meta.id, meta);
     const stats = this.extractStats(meta.sourcePath);
-    return {
+    return parsedSession({
       id: meta.id,
       slug: `kimi/${meta.id}`,
       title: meta.title,
@@ -367,7 +378,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       time_created: meta.createdAt,
       time_updated: meta.createdAt,
       stats,
-    };
+    });
   }
 
   getSessionData(sessionId: string): SessionDetail {

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -228,10 +228,10 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
   }
 
   protected parseFileSessionHead(filePath: string): SessionHead | null {
-    return getParsedSession(this.parseSessionHeadResult(filePath));
+    return getParsedSession(this.parseFileSessionHeadResult(filePath));
   }
 
-  private parseSessionHeadResult(filePath: string): ParseSessionResult<SessionHead> {
+  protected override parseFileSessionHeadResult(filePath: string): ParseSessionResult<SessionHead> {
     const parsed = this.parsePiFile(filePath);
     const state = this.convertEntries(parsed.pathEntries);
     const messageCount = state.messages.length;

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { SessionHead, SessionDetail } from "../../types/index.js";
-import { BaseAgent, type SessionCacheMeta, type ChangeCheckResult } from "../../agents/base.js";
+import {
+  BaseAgent,
+  FileSystemSessionSource,
+  type ChangeCheckResult,
+  type SessionCacheMeta,
+  type SessionSourceRef,
+} from "../../agents/base.js";
 import { filterSessions } from "../scanner.js";
 
 // --- filterSessions tests (pure function) ---
@@ -58,6 +64,31 @@ class TestAgent extends BaseAgent {
 
   setSessionMetaMap(): void {
     // no-op
+  }
+}
+
+class FailingFileAgent extends FileSystemSessionSource {
+  readonly name = "files";
+  readonly displayName = "Files";
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  listSessionSources(): SessionSourceRef[] {
+    return [{ sessionId: "cached", sourcePath: "/cached.jsonl", fingerprint: "new" }];
+  }
+
+  scanSessionSource(): SessionHead | null {
+    throw new SyntaxError("Unexpected end of JSON input");
+  }
+
+  getSessionData(): SessionDetail {
+    return {} as SessionDetail;
+  }
+
+  getSessionWatchPlan() {
+    return { status: "not-needed" as const, reason: "scanner test adapter" };
   }
 }
 
@@ -172,10 +203,10 @@ vi.mock("../../utils/index.js", () => ({
 }));
 
 // Mock createRegisteredAgents to return controlled agents
-vi.mock("../../agents/index.js", () => ({
-  createRegisteredAgents: vi.fn(() => []),
-  BaseAgent: class {},
-}));
+vi.mock("../../agents/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/index.js")>();
+  return { ...actual, createRegisteredAgents: vi.fn(() => []) };
+});
 
 import { ensureSessionTagsSync, finalizeAgentScan, scanSessions } from "../scanner.js";
 import { createRegisteredAgents } from "../../agents/index.js";
@@ -487,6 +518,34 @@ describe("scanSessions", () => {
       "test",
       [expect.objectContaining({ id: "recent" })],
       {},
+      { completeness: "partial" },
+    );
+  });
+
+  it("retains a cached head and writes a partial snapshot when full parsing fails", async () => {
+    const cached = makeSession("cached");
+    const meta = {
+      cached: {
+        id: "cached",
+        sourcePath: "/cached.jsonl",
+        sourceFingerprint: "old",
+      },
+    };
+    mockedLoadCachedSessions.mockReturnValue({
+      sessions: [cached],
+      meta,
+      timestamp: Date.now(),
+    });
+    mockedSaveCachedSessions.mockReturnValue(true);
+    mockedCreateRegisteredAgents.mockReturnValue([new FailingFileAgent()]);
+
+    const result = await scanSessions({ useCache: false, includeSmartTags: false });
+
+    expect(result.sessions).toEqual([expect.objectContaining({ id: "cached" })]);
+    expect(mockedSaveCachedSessions).toHaveBeenCalledWith(
+      "files",
+      [expect.objectContaining({ id: "cached" })],
+      meta,
       { completeness: "partial" },
     );
   });

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -2,8 +2,18 @@ import { availableParallelism } from "node:os";
 import { Worker } from "node:worker_threads";
 import type { SessionDetail, SessionHead, SmartTag } from "../types/index.js";
 import { filterSessionTreeByActivityWindow } from "../contract/session-tree.js";
-import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
-import { createRegisteredAgents } from "../agents/index.js";
+import type {
+  AgentScanOptions,
+  BaseAgent,
+  SessionCacheMeta,
+  SessionSourceFailure,
+} from "../agents/index.js";
+import {
+  createRegisteredAgents,
+  diffSessionSources,
+  FileSystemSessionSource,
+  reportSessionSourceOutcome,
+} from "../agents/index.js";
 import { filterSessionsByProjectScope } from "../projects/index.js";
 import { classifySessionTags, getSmartTagSourceTimestamp, perf } from "../utils/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
@@ -481,7 +491,7 @@ async function scanAgentFull(
   try {
     const scanMarker = perf.start(`agent:${agent.name}:scan`);
     const t0 = performance.now();
-    const heads = agent.scan({
+    const agentScanOptions: AgentScanOptions = {
       from: options.from,
       to: options.to,
       fast: options.fast,
@@ -495,7 +505,48 @@ async function scanAgentFull(
           changedCount: progress.processed,
         });
       },
-    });
+    };
+    let heads: SessionHead[];
+    let sourceFailures: SessionSourceFailure[] = [];
+    if (agent instanceof FileSystemSessionSource) {
+      const cached = loadCachedSessions(agent.name);
+      if (cached) {
+        agent.setSessionMetaMap(new Map(Object.entries(cached.meta)));
+      }
+      const batch = agent.scanSessionSources(agentScanOptions);
+      const sessionMap = new Map(cached?.sessions.map((session) => [session.id, session]) ?? []);
+      for (const outcome of batch.outcomes) {
+        if (outcome.status === "parsed") {
+          sessionMap.delete(outcome.source.sessionId);
+          sessionMap.set(outcome.session.id, outcome.session);
+        } else if (outcome.status === "filtered" || outcome.status === "missing") {
+          sessionMap.delete(outcome.source.sessionId);
+          agent.getSessionMetaMap().delete(outcome.source.sessionId);
+        } else {
+          sourceFailures.push(outcome.failure);
+        }
+      }
+      if (cached) {
+        const diff = diffSessionSources(
+          batch.sources,
+          cached.sessions,
+          cached.meta,
+          agentScanOptions,
+        );
+        for (const outcome of diff.sourceOutcomes) {
+          reportSessionSourceOutcome(agent.name, outcome);
+          if (outcome.status === "missing") {
+            sessionMap.delete(outcome.source.sessionId);
+            agent.getSessionMetaMap().delete(outcome.source.sessionId);
+          } else {
+            sourceFailures.push(outcome.failure);
+          }
+        }
+      }
+      heads = [...sessionMap.values()];
+    } else {
+      heads = agent.scan(agentScanOptions);
+    }
     perf.end(scanMarker);
     timing.scan = performance.now() - t0;
 
@@ -516,10 +567,10 @@ async function scanAgentFull(
     if (options.writeCache !== false) {
       const isFullWindow = options.from == null && options.to == null;
       const persisted = saveCachedSessions(agent.name, tagged.sessions, meta, {
-        completeness: isFullWindow ? "complete" : "partial",
+        completeness: isFullWindow && sourceFailures.length === 0 ? "complete" : "partial",
       });
       if (persisted) {
-        if (isFullWindow) markAgentFullSyncCompleted(agent.name);
+        if (isFullWindow && sourceFailures.length === 0) markAgentFullSyncCompleted(agent.name);
         markAgentCacheInitialized(agent.name);
       } else {
         getCoreDiagnostics()?.warn("cache.save_failed", {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,11 +12,13 @@ export type {
 export {
   BaseAgent,
   createRegisteredAgents,
+  createSessionSourceFailure,
   diffSessionSources,
   FileSystemSessionSource,
   getAgentInfoMap,
   getRegisteredAgents,
   registerAgent,
+  reportSessionSourceOutcome,
 } from "./agents/index.js";
 export type {
   AgentRoots,
@@ -24,6 +26,10 @@ export type {
   AgentScanProgress,
   ChangeCheckResult,
   SessionCacheMeta,
+  SessionSourceFailure,
+  SessionSourceAbsenceOutcome,
+  SessionSourceOutcome,
+  SessionSourceScanBatch,
   SessionSourceRef,
   SessionWatchPlan,
 } from "./agents/index.js";


### PR DESCRIPTION
## Summary

- model parsed, filtered, confirmed-missing, and failed source outcomes explicitly
- preserve last-known-good sessions and metadata when enumeration or parsing fails
- commit successful sources from mixed batches while surfacing partial refreshes through diagnostics and scan status
- only authorize deletion for explicit filtering or confirmed `ENOENT`/`ENOTDIR`

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`
- `pnpm test:migration`
- `pnpm test:e2e` (26 passed)

Issue: CS-159