### PR TITLE
fix: enforce loopback request authority

### DIFF
--- a/packages/cli/src/loopback-authority.test.ts
+++ b/packages/cli/src/loopback-authority.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { validateLoopbackAuthority } from "./loopback-authority.js";
+
+function host(value: string): string[] {
+  return ["Host", value];
+}
+
+describe("validateLoopbackAuthority", () => {
+  it.each(["localhost:4521", "LOCALHOST:4521", "127.0.0.1:4521", "[::1]:4521"])(
+    "accepts the canonical loopback authority %s",
+    (authority) => {
+      expect(validateLoopbackAuthority(host(authority), "127.0.0.1", 4521)).toMatchObject({
+        allowed: true,
+      });
+    },
+  );
+
+  it("accepts an explicitly configured loopback listener hostname", () => {
+    expect(validateLoopbackAuthority(host("127.20.30.40:4521"), "127.20.30.40", 4521)).toEqual({
+      allowed: true,
+      authority: "127.20.30.40:4521",
+    });
+  });
+
+  it.each([
+    ["not ready", host("localhost:4521"), null, "listener-not-ready"],
+    ["missing", [], 4521, "missing-host"],
+    ["duplicate", ["Host", "localhost:4521", "host", "127.0.0.1:4521"], 4521, "multiple-hosts"],
+    ["userinfo", host("attacker@localhost:4521"), 4521, "invalid-host"],
+    ["unbracketed IPv6", host("::1:4521"), 4521, "invalid-host"],
+    ["missing port", host("localhost"), 4521, "invalid-host"],
+    ["wrong port", host("localhost:4522"), 4521, "port-mismatch"],
+    ["attacker domain", host("attacker.example:4521"), 4521, "hostname-not-allowed"],
+    ["different loopback IP", host("127.0.0.2:4521"), 4521, "hostname-not-allowed"],
+  ])("rejects a %s authority", (_name, rawHeaders, port, reason) => {
+    expect(
+      validateLoopbackAuthority(rawHeaders as string[], "127.0.0.1", port as number | null),
+    ).toMatchObject({
+      allowed: false,
+      reason,
+    });
+  });
+});

--- a/packages/cli/src/loopback-authority.ts
+++ b/packages/cli/src/loopback-authority.ts
@@ -1,0 +1,94 @@
+import { isIP } from "node:net";
+
+export type LoopbackAuthorityRejection =
+  | "listener-not-ready"
+  | "missing-host"
+  | "multiple-hosts"
+  | "invalid-host"
+  | "hostname-not-allowed"
+  | "port-mismatch";
+
+export type LoopbackAuthorityDecision =
+  | { allowed: true; authority: string }
+  | { allowed: false; reason: LoopbackAuthorityRejection; authority?: string };
+
+interface ParsedAuthority {
+  hostname: string;
+  port: number;
+  normalized: string;
+}
+
+const LOOPBACK_AUTHORITY_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function canonicalizeHostname(hostname: string): string | null {
+  const unwrapped = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  const authorityHost = isIP(unwrapped) === 6 ? `[${unwrapped}]` : unwrapped;
+  try {
+    return new URL(`http://${authorityHost}`).hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  } catch {
+    return null;
+  }
+}
+
+function parseAuthority(value: string): ParsedAuthority | null {
+  if (!value || value !== value.trim()) return null;
+  const bracketed = /^\[([^\]]+)\]:(\d{1,5})$/.exec(value);
+  const plain = /^([^:[\]]+):(\d{1,5})$/.exec(value);
+  const match = bracketed ?? plain;
+  if (!match) return null;
+
+  const port = Number(match[2]);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) return null;
+
+  const rawHostname = match[1]!;
+  const authorityHost = bracketed ? `[${rawHostname}]` : rawHostname;
+  try {
+    const parsed = new URL(`http://${authorityHost}:${port}`);
+    if (parsed.username || parsed.password) return null;
+    const hostname = parsed.hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+    return {
+      hostname,
+      port,
+      normalized: isIP(hostname) === 6 ? `[${hostname}]:${port}` : `${hostname}:${port}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function hostHeaders(rawHeaders: readonly string[]): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    if (rawHeaders[index]?.toLowerCase() === "host") values.push(rawHeaders[index + 1] ?? "");
+  }
+  return values;
+}
+
+export function validateLoopbackAuthority(
+  rawHeaders: readonly string[],
+  listenerHostname: string,
+  listenerPort: number | null,
+): LoopbackAuthorityDecision {
+  if (listenerPort === null) return { allowed: false, reason: "listener-not-ready" };
+
+  const hosts = hostHeaders(rawHeaders);
+  if (hosts.length === 0) return { allowed: false, reason: "missing-host" };
+  if (hosts.length !== 1) return { allowed: false, reason: "multiple-hosts" };
+
+  const authority = parseAuthority(hosts[0]!);
+  if (!authority) return { allowed: false, reason: "invalid-host" };
+  if (authority.port !== listenerPort) {
+    return { allowed: false, reason: "port-mismatch", authority: authority.normalized };
+  }
+
+  const listener = canonicalizeHostname(listenerHostname);
+  if (!LOOPBACK_AUTHORITY_HOSTS.has(authority.hostname) && authority.hostname !== listener) {
+    return {
+      allowed: false,
+      reason: "hostname-not-allowed",
+      authority: authority.normalized,
+    };
+  }
+
+  return { allowed: true, authority: authority.normalized };
+}

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { get as httpGet } from "node:http";
 import { get as httpsGet } from "node:https";
 import { createServer as createNodeServer, type Server as NodeServer } from "node:net";
 import { tmpdir } from "node:os";
@@ -12,6 +13,23 @@ import { resolveRemoteTransport } from "./remote-access.js";
 const serveOptionsLog = vi.hoisted(
   () => [] as { hostname?: string; port?: number; hasCreateServer: boolean }[],
 );
+
+function httpRequest(
+  url: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; contentType: string | undefined }> {
+  return new Promise((resolvePromise, reject) => {
+    const request = httpGet(url, { headers, agent: false }, (response) => {
+      resolvePromise({
+        status: response.statusCode ?? 0,
+        contentType: response.headers["content-type"],
+      });
+      response.destroy();
+      request.destroy();
+    });
+    request.on("error", reject);
+  });
+}
 
 vi.mock("@hono/node-server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@hono/node-server")>();
@@ -189,6 +207,41 @@ describe("createServer", () => {
     expect(app.url).toMatch(/^http:\/\/localhost:\d+$/);
 
     await app.shutdown();
+  });
+
+  it("CS-160: enforces loopback authority before API, SSE, and static routes", async () => {
+    const webDist = mkdtempSync(join(tmpdir(), "codesesh-authority-web-"));
+    writeFileSync(join(webDist, "index.html"), "<html>app shell</html>");
+    writeFileSync(join(webDist, "app.js"), "console.log('bundle')");
+    const app = await createServer(0, createStore(), { webDistPath: webDist });
+    const port = new URL(app.url).port;
+
+    try {
+      for (const authority of [`localhost:${port}`, `127.0.0.1:${port}`, `[::1]:${port}`]) {
+        expect((await httpRequest(`${app.url}/api/agents`, { Host: authority })).status).toBe(200);
+      }
+      expect(
+        (
+          await httpRequest(`${app.url}/api/agents`, {
+            Host: `localhost:${port}`,
+            Origin: "https://attacker.example",
+          })
+        ).status,
+      ).toBe(200);
+
+      for (const path of ["/api/agents", "/api/events", "/app.js"]) {
+        expect(
+          (
+            await httpRequest(`${app.url}${path}`, {
+              Host: `attacker.example:${port}`,
+            })
+          ).status,
+        ).toBe(403);
+      }
+    } finally {
+      await app.shutdown();
+      rmSync(webDist, { recursive: true, force: true });
+    }
   });
 
   it("refuses a non-loopback hostname without remote access", async () => {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { compress } from "hono/compress";
 import { serve } from "@hono/node-server";
-import type { ServerType } from "@hono/node-server";
+import type { HttpBindings, ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { existsSync } from "node:fs";
 import { createServer as createHttpsServer } from "node:https";
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import type { ScanResultSource } from "./api/handlers.js";
 import { createApiRoutes, type ApiRouteOptions } from "./api/routes.js";
 import { appLogger } from "./logging.js";
+import { validateLoopbackAuthority } from "./loopback-authority.js";
 import {
   createRemoteAccessToken,
   isLoopbackHostname,
@@ -101,7 +102,7 @@ export async function createServer(
   store: ScanResultSource & ScanEventSource & { shutdown(): Promise<void> },
   options: CreateServerOptions = {},
 ): Promise<{ url: string; shutdown: () => Promise<void> }> {
-  const app = new Hono();
+  const app = new Hono<{ Bindings: HttpBindings }>();
   const hostname = options.hostname ?? "127.0.0.1";
   const isLoopback = isLoopbackHostname(hostname);
   const transport: RemoteTransport =
@@ -109,11 +110,28 @@ export async function createServer(
   const remoteAccessToken = !isLoopback
     ? (options.remoteAccessToken ?? (options.remoteAccess ? createRemoteAccessToken() : null))
     : null;
+  let actualPort: number | null = null;
 
   if (!isLoopback && !remoteAccessToken) {
     throw new Error(
       `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
     );
+  }
+
+  if (isLoopback) {
+    app.use("*", async (c, next) => {
+      const decision = validateLoopbackAuthority(c.env.incoming.rawHeaders, hostname, actualPort);
+      if (!decision.allowed) {
+        appLogger.warn("http.loopback_authority.rejected", {
+          method: c.req.method,
+          path: new URL(c.req.url).pathname,
+          reason: decision.reason,
+          authority: decision.authority,
+        });
+        return c.json({ error: "Loopback request authority rejected" }, 403);
+      }
+      await next();
+    });
   }
 
   app.use("*", async (c, next) => {
@@ -175,7 +193,6 @@ export async function createServer(
 
   const attempts = Math.max(1, options.portFallbackAttempts ?? 1);
   let server: ServerType | null = null;
-  let actualPort = port;
 
   for (let offset = 0; offset < attempts; offset += 1) {
     const candidatePort = port + offset;


### PR DESCRIPTION
## Summary

- validate the raw `Host` header before every loopback API, SSE, and static route
- allow only canonical loopback authorities, the configured listener hostname, and the actual listening port
- preserve remote token mode and document why Origin remains diagnostic rather than an authorization boundary

## Tests

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`
- `pnpm test:migration`
- `pnpm test:e2e`

Issue: CS-160