### PR TITLE
fix: unify session hierarchy consumers

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -30,6 +30,26 @@ function groupOrderOf(paths: string[]) {
 }
 
 describe("buildSessionTreeModel group sorting", () => {
+  it("renders every cycle member once under the Unmounted group", () => {
+    const a = makeSession({
+      id: "a",
+      parent_reference: { agentName: "codex", sessionId: "b" },
+    });
+    const b = makeSession({
+      id: "b",
+      parent_reference: { agentName: "codex", sessionId: "a" },
+    });
+
+    const model = buildSessionTreeModel([a, b]);
+    const references = [a, b].map((session) => getSessionReferenceKey(session));
+
+    expect(model.paths).toHaveLength(2);
+    expect(new Set(model.paths).size).toBe(2);
+    for (const reference of references) {
+      expect(model.pathBySessionReference.get(reference)).toMatch(/^Unmounted\//);
+    }
+  });
+
   it("orders groups by most recent session time, descending", () => {
     const sessions = [
       makeSession({

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -1,4 +1,5 @@
 import { Menu } from "@base-ui/react/menu";
+import { buildSessionTree, type SessionTreeNode } from "@codesesh/core/contract";
 import type { FileTreeSortEntry } from "@pierre/trees";
 import { FileTree, useFileTree } from "@pierre/trees/react";
 import {
@@ -13,7 +14,7 @@ import {
 } from "react";
 import type { SessionHead } from "../lib/api";
 import { getProjectIdentityKey } from "../lib/projects";
-import { getSessionReferenceKey, getSessionRouteKey } from "../lib/session-indexes";
+import { getSessionReferenceKey } from "../lib/session-indexes";
 import { getSessionDisplayTitle } from "../lib/session-title";
 import { isRenderProfilerEnabled, recordRenderProfileEntry } from "./RenderProfiler";
 import { SessionActionMenuItems } from "./SessionActionsMenu";
@@ -244,8 +245,7 @@ function createPathAllocator() {
   };
 }
 
-/** Sub-sessions whose parent is missing from the current listing still have to
- *  reach the user, so they hang off a dedicated top-level group. */
+/** Sessions the canonical hierarchy cannot mount still need a visible axis. */
 const UNMOUNTED_GROUP_LABEL = "Unmounted";
 
 /**
@@ -264,49 +264,31 @@ export function buildSessionTreeModel(
   const sessionByPath = new Map<string, SessionHead>();
   const allocateSessionPath = createPathAllocator();
   const paths: string[] = [];
-  const childrenByParent = new Map<string, SessionHead[]>();
-  const roots: SessionHead[] = [];
-  const orphans: SessionHead[] = [];
-  const presentReferences = new Set(sessions.map((session) => getSessionReferenceKey(session)));
-  for (const session of sessions) {
-    const parentReference = session.parent_reference;
-    if (!parentReference) {
-      roots.push(session);
-      continue;
-    }
-    const parentKey = getSessionRouteKey(parentReference.agentName, parentReference.sessionId);
-    if (!presentReferences.has(parentKey)) {
-      orphans.push(session);
-      continue;
-    }
-    const children = childrenByParent.get(parentKey);
-    if (children) children.push(session);
-    else childrenByParent.set(parentKey, [session]);
-  }
+  const tree = buildSessionTree(sessions);
+  const groups = new Map<string, { label: string; nodes: SessionTreeNode[]; maxTime: number }>();
 
-  const groups = new Map<string, { label: string; sessions: SessionHead[]; maxTime: number }>();
-
-  for (const session of roots) {
+  for (const node of tree.roots) {
+    const session = node.session;
     const { key, label } = getProjectGroup(session);
     const time = getSessionTime(session);
     const group = groups.get(key);
     if (group) {
-      group.sessions.push(session);
+      group.nodes.push(node);
       if (time > group.maxTime) group.maxTime = time;
     } else {
-      groups.set(key, { label, sessions: [session], maxTime: time });
+      groups.set(key, { label, nodes: [node], maxTime: time });
     }
   }
 
-  const orderedGroups: Array<{ label: string | null; sessions: SessionHead[] }> = groupByProject
+  const orderedGroups: Array<{ label: string | null; nodes: SessionTreeNode[] }> = groupByProject
     ? [...groups.values()].sort((a, b) => {
         if (a.label === "(unknown)") return 1;
         if (b.label === "(unknown)") return -1;
         return b.maxTime - a.maxTime;
       })
-    : [{ label: null, sessions: roots }];
-  if (orphans.length > 0) {
-    orderedGroups.push({ label: UNMOUNTED_GROUP_LABEL, sessions: orphans });
+    : [{ label: null, nodes: tree.roots }];
+  if (tree.orphans.length > 0) {
+    orderedGroups.push({ label: UNMOUNTED_GROUP_LABEL, nodes: tree.orphans });
   }
 
   let order = 0;
@@ -319,15 +301,16 @@ export function buildSessionTreeModel(
       sortOrderByPath.set(groupPath, order);
       sortOrderByPath.set(bareGroupPath, order);
       order += 1;
-      groupCountByPath.set(groupPath, `${group.sessions.length}`);
-      groupCountByPath.set(bareGroupPath, `${group.sessions.length}`);
+      groupCountByPath.set(groupPath, `${group.nodes.length}`);
+      groupCountByPath.set(bareGroupPath, `${group.nodes.length}`);
     }
 
     const appendSession = (
-      session: SessionHead,
+      node: SessionTreeNode,
       parentPath: string,
       siblingTitleCounts: Map<string, number>,
     ): void => {
+      const session = node.session;
       const title = getSessionDisplayTitle(session);
       siblingTitleCounts.set(title, (siblingTitleCounts.get(title) ?? 0) + 1);
       const siblingCount = siblingTitleCounts.get(title) ?? 1;
@@ -337,8 +320,7 @@ export function buildSessionTreeModel(
           : sanitizeSegment(title);
       const basePath = allocateSessionPath(`${parentPath}${leaf}`);
       const reference = getSessionReferenceKey(session);
-      const childSessions = childrenByParent.get(reference) ?? [];
-      const isDirectory = childSessions.length > 0;
+      const isDirectory = node.children.length > 0;
       const sessionPath = isDirectory ? `${basePath}/` : basePath;
 
       if (isDirectory) {
@@ -356,14 +338,14 @@ export function buildSessionTreeModel(
       groupPathBySessionReference.set(reference, groupPath);
 
       const childTitleCounts = new Map<string, number>();
-      for (const child of childSessions) {
+      for (const child of node.children) {
         appendSession(child, sessionPath, childTitleCounts);
       }
     };
 
     const rootTitleCounts = new Map<string, number>();
-    for (const session of group.sessions) {
-      appendSession(session, groupPath, rootTitleCounts);
+    for (const node of group.nodes) {
+      appendSession(node, groupPath, rootTitleCounts);
     }
   }
 

--- a/apps/web/src/lib/session-timeline.test.ts
+++ b/apps/web/src/lib/session-timeline.test.ts
@@ -111,6 +111,38 @@ describe("buildProjectTimeline", () => {
     expect(timeline.orphanCount).toBe(1);
   });
 
+  it("keeps every cycle member once on the unmounted axis", () => {
+    const timeline = buildProjectTimeline(
+      [
+        createSession({
+          id: "a",
+          time_updated: at(6, 9),
+          parent_reference: { agentName: "codex", sessionId: "b" },
+        }),
+        createSession({
+          id: "b",
+          time_updated: at(6, 10),
+          parent_reference: { agentName: "codex", sessionId: "a" },
+        }),
+        createSession({
+          id: "below",
+          time_updated: at(6, 11),
+          parent_reference: { agentName: "codex", sessionId: "a" },
+        }),
+      ],
+      { now: NOW },
+    );
+
+    const rows = timeline.days.flatMap((day) => day.rows);
+    expect(rows.map((row) => row.routeKey).toSorted()).toEqual([
+      "codex/a",
+      "codex/b",
+      "codex/below",
+    ]);
+    expect(rows.every((row) => row.isOrphan)).toBe(true);
+    expect(timeline.orphanCount).toBe(3);
+  });
+
   it("reports main and sub counts per day and across the timeline", () => {
     const timeline = buildProjectTimeline(
       [

--- a/packages/core/src/contract/__tests__/session-tree.test.ts
+++ b/packages/core/src/contract/__tests__/session-tree.test.ts
@@ -44,6 +44,49 @@ function ids(nodes: { session: SessionHead }[]): string[] {
 }
 
 describe("buildSessionTree", () => {
+  it.each([
+    {
+      name: "root tree",
+      sessions: [makeSession("root", 1), makeSession("child", 2, { parent: "root" })],
+    },
+    {
+      name: "missing parent",
+      sessions: [
+        makeSession("orphan", 1, { parent: "missing" }),
+        makeSession("below", 2, { parent: "orphan" }),
+      ],
+    },
+    {
+      name: "self-cycle",
+      sessions: [makeSession("self", 1, { parent: "self" })],
+    },
+    {
+      name: "two-node cycle",
+      sessions: [makeSession("a", 1, { parent: "b" }), makeSession("b", 2, { parent: "a" })],
+    },
+    {
+      name: "cycle with an outgoing child",
+      sessions: [
+        makeSession("a", 1, { parent: "b" }),
+        makeSession("b", 2, { parent: "a" }),
+        makeSession("below", 3, { parent: "a" }),
+      ],
+    },
+  ])("keeps every session exactly once for a $name", ({ sessions }) => {
+    const tree = buildSessionTree(sessions);
+    const pending = [...tree.entries];
+    const visible: string[] = [];
+
+    while (pending.length > 0) {
+      const node = pending.pop()!;
+      visible.push(node.session.id);
+      pending.push(...node.children);
+    }
+
+    expect([...visible].sort()).toEqual(sessions.map((session) => session.id).sort());
+    expect(new Set(visible).size).toBe(sessions.length);
+  });
+
   it("splits a mixed array into roots, children and orphans", () => {
     const sessions = [
       makeSession("child", 2, { parent: "root" }),
@@ -171,6 +214,14 @@ describe("groupSessionsByCalendarDay", () => {
 });
 
 describe("session tree window filtering", () => {
+  it("keeps an in-window cycle member as an unmounted entry", () => {
+    const sessions = [makeSession("a", 100, { parent: "b" }), makeSession("b", 1, { parent: "a" })];
+
+    expect(
+      filterSessionTreeByActivityWindow(sessions, 90, 110).map((session) => session.id),
+    ).toEqual(["a"]);
+  });
+
   it("filters roots by activity and includes descendants regardless of their activity", () => {
     const sessions = [
       makeSession("parent", 100),
@@ -205,5 +256,17 @@ describe("session tree window filtering", () => {
     expect(
       filterSessionTreeByActivityWindow(sessions, 90, 110).map((session) => session.id),
     ).toEqual(["orphan"]);
+  });
+
+  it("keeps mounted descendants below an in-window orphan", () => {
+    const sessions = [
+      makeSession("orphan", 100, { parent: "missing" }),
+      makeSession("child", 1, { parent: "orphan" }),
+      makeSession("grandchild", 1, { parent: "child" }),
+    ];
+
+    expect(
+      filterSessionTreeByActivityWindow(sessions, 90, 110).map((session) => session.id),
+    ).toEqual(["orphan", "child", "grandchild"]);
   });
 });

--- a/packages/core/src/contract/session-tree.ts
+++ b/packages/core/src/contract/session-tree.ts
@@ -248,8 +248,8 @@ export function groupSessionsByCalendarDay(nodes: SessionTreeNode[]): SessionDay
 }
 
 /**
- * Filters unmounted sessions (roots and orphans alike) by activity and keeps
- * every descendant of a match. The input order is preserved so callers keep
+ * Filters main-axis sessions (roots and orphans) by activity and keeps every
+ * mounted descendant of a match. The input order is preserved so callers keep
  * their existing sort behavior.
  */
 export function filterSessionTreeByActivityWindow(
@@ -259,27 +259,16 @@ export function filterSessionTreeByActivityWindow(
 ): SessionHead[] {
   if (from == null && to == null) return sessions;
 
-  const available = new Set(sessions.map(sessionKey));
-  const childrenByParent = new Map<string, string[]>();
-  const pending: string[] = [];
-
-  for (const session of sessions) {
-    const parent = parentKey(session);
-    if (parent != null && available.has(parent)) {
-      const children = childrenByParent.get(parent);
-      if (children) children.push(sessionKey(session));
-      else childrenByParent.set(parent, [sessionKey(session)]);
-      continue;
-    }
-    if (hasActivityInWindow(session, from, to)) pending.push(sessionKey(session));
-  }
+  const tree = buildSessionTree(sessions);
+  const pending = tree.entries.filter((node) => hasActivityInWindow(node.session, from, to));
 
   const visible = new Set<string>();
   while (pending.length > 0) {
-    const key = pending.pop()!;
+    const node = pending.pop()!;
+    const key = sessionKey(node.session);
     if (visible.has(key)) continue;
     visible.add(key);
-    for (const childKey of childrenByParent.get(key) ?? []) pending.push(childKey);
+    for (const child of node.children) pending.push(child);
   }
 
   return sessions.filter((session) => visible.has(sessionKey(session)));


### PR DESCRIPTION
## Summary

- filter activity windows through the canonical Core session tree
- render sidebar roots, unmounted entries, and children from the same mount policy
- keep self-cycles, multi-node cycles, and outgoing cycle nodes visible exactly once
- preserve project grouping, title disambiguation, path allocation, and timeline semantics

## Tests

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`
- `pnpm test:migration`
- `pnpm test:e2e`

Issue: CS-161