### PR TITLE
fix: align Kimi-Code source activity

### DIFF
--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -1,4 +1,12 @@
-import { appendFileSync, mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -47,6 +55,97 @@ afterEach(() => {
 });
 
 describe("KimiCodeAgent", () => {
+  it("enumerates an old session by recent wire activity", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    const sessionDir = createSession(dataRoot, [
+      { type: "context.append_message", message: { role: "user", content: "Continue" } },
+    ]);
+    const recentActivity = Date.parse("2026-02-01T00:00:00.000Z");
+    const wireFile = join(sessionDir, "agents", "main", "wire.jsonl");
+    utimesSync(wireFile, recentActivity / 1000, recentActivity / 1000);
+    const agent = createAgent(dataRoot);
+    const from = Date.parse("2026-01-25T00:00:00.000Z");
+
+    const refs = agent.listSessionSources({ from });
+    const [head] = agent.scan({ from });
+    const meta = agent.getSessionMetaMap().get(SESSION_ID);
+
+    expect(refs).toHaveLength(1);
+    expect(head).toMatchObject({
+      time_created: Date.parse("2026-01-01T00:00:00.000Z"),
+      time_updated: recentActivity,
+    });
+    expect(meta?.sourceMtimeMs).toBe(recentActivity);
+    expect(meta?.sourceMtimeMs).toBe(head?.time_updated);
+    expect(meta?.sourceFingerprint).toBe(refs[0]?.fingerprint);
+  });
+
+  it("changes the source fingerprint when the wire grows with a preserved mtime", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    const sessionDir = createSession(dataRoot, [
+      { type: "context.append_message", message: { role: "user", content: "First" } },
+    ]);
+    const wireFile = join(sessionDir, "agents", "main", "wire.jsonl");
+    const pinnedMtime = statSync(wireFile).mtimeMs;
+    const agent = createAgent(dataRoot);
+    const before = agent.listSessionSources()[0]?.fingerprint;
+
+    appendFileSync(
+      wireFile,
+      `${JSON.stringify({
+        type: "context.append_message",
+        message: { role: "assistant", content: "Second" },
+      })}\n`,
+    );
+    utimesSync(wireFile, pinnedMtime / 1000, pinnedMtime / 1000);
+
+    expect(statSync(wireFile).mtimeMs).toBe(pinnedMtime);
+    expect(agent.listSessionSources()[0]?.fingerprint).not.toBe(before);
+  });
+
+  it("invalidates a cached head from an older parser revision", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    const sessionDir = createSession(dataRoot, [
+      { type: "context.append_message", message: { role: "user", content: "Refresh me" } },
+    ]);
+    const agent = createAgent(dataRoot);
+    const heads = agent.scan();
+    const currentMeta = agent.getSessionMetaMap().get(SESSION_ID)!;
+    if (typeof currentMeta.sourceFingerprint !== "string") {
+      throw new TypeError("Expected Kimi-Code source fingerprint");
+    }
+    const fingerprint = JSON.parse(currentMeta.sourceFingerprint) as unknown[];
+    expect(fingerprint[0]).toBe("kimi-code-parser-v1");
+    expect(fingerprint[2]).toBe(statSync(join(sessionDir, "state.json")).size);
+    expect(fingerprint[4]).toBe(statSync(join(sessionDir, "agents", "main", "wire.jsonl")).size);
+    agent.setSessionMetaMap(
+      new Map([
+        [
+          SESSION_ID,
+          {
+            ...currentMeta,
+            sourceFingerprint: JSON.stringify(["kimi-code-parser-v0", ...fingerprint.slice(1)]),
+          },
+        ],
+      ]),
+    );
+
+    const changes = agent.checkForChanges(0, heads);
+    expect(changes.changedIds).toContain(SESSION_ID);
+    const refreshed = agent.incrementalScan(heads, changes.changedIds ?? [], changes.refs);
+    expect(refreshed).toMatchObject([{ id: SESSION_ID, title: "Refresh me" }]);
+    expect(agent.getSessionMetaMap().get(SESSION_ID)?.sourceFingerprint).toBe(
+      changes.refs?.[0]?.fingerprint,
+    );
+    expect(agent.getSessionData(SESSION_ID).messages[0]).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", text: "Refresh me" }],
+    });
+  });
+
   it("discovers workdir-keyed sessions and rebuilds loop events", () => {
     const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
     tempDirs.push(dataRoot);
@@ -144,6 +243,7 @@ describe("KimiCodeAgent", () => {
     const refs = agent.listSessionSources();
     expect(refs).toHaveLength(1);
     expect(refs[0]?.sourcePath).toBe(sessionDir);
+    expect(agent.listSessionSources({ from: 1767225599000, to: 1767225661000 })).toHaveLength(1);
 
     writeFileSync(
       join(dataRoot, "session_index.jsonl"),

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -47,6 +47,7 @@ const KIMI_CODE_TOOL_TITLE_MAP: Record<string, string> = {
 };
 
 const KIMI_CODE_IGNORED_TOOLS = new Set(["SetTodoList"]);
+const KIMI_CODE_PARSER_REVISION = "kimi-code-parser-v1";
 
 export function resolveKimiCodeDataRoot(): string {
   return resolveHomePath("KIMI_CODE_HOME", ".kimi-code");
@@ -59,11 +60,19 @@ interface SessionSource {
   wireFile: string;
   workDir: string;
   createdAt: number;
-  updatedAt: number;
+  activityAt: number;
+  stateMtimeMs: number;
+  stateSize: number;
+  wireMtimeMs: number;
+  wireSize: number;
   explicitTitle: string;
 }
 
-interface SessionMeta extends SessionCacheMeta, SessionSource {
+interface SessionMeta extends SessionCacheMeta {
+  wireFile: string;
+  workDir: string;
+  createdAt: number;
+  activityAt: number;
   title: string;
   sourceMtimeMs: number;
 }
@@ -421,13 +430,13 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
       const state = readState(stateFile);
       if (!state) return skippedSession("malformed state");
 
-      const stateMtime = statSync(stateFile).mtimeMs;
-      const wireMtime = statSync(wireFile).mtimeMs;
+      const stateStat = statSync(stateFile);
+      const wireStat = statSync(wireFile);
       const createdAt =
-        parseTimestamp(state.createdAt) ?? parseTimestamp(state.created_at) ?? stateMtime;
-      const updatedAt = Math.max(
+        parseTimestamp(state.createdAt) ?? parseTimestamp(state.created_at) ?? stateStat.mtimeMs;
+      const activityAt = Math.max(
         parseTimestamp(state.updatedAt) ?? parseTimestamp(state.updated_at) ?? createdAt,
-        wireMtime,
+        wireStat.mtimeMs,
       );
       const custom = asRecord(state.custom);
       const workDir =
@@ -444,7 +453,11 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
         wireFile,
         workDir,
         createdAt,
-        updatedAt,
+        activityAt,
+        stateMtimeMs: stateStat.mtimeMs,
+        stateSize: stateStat.size,
+        wireMtimeMs: wireStat.mtimeMs,
+        wireSize: wireStat.size,
         explicitTitle,
       });
     } catch {
@@ -452,13 +465,17 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     }
   }
 
-  private sourceFingerprint(
-    source: Pick<SessionSource, "stateFile" | "wireFile" | "workDir">,
-  ): string {
+  private sourceFingerprint(source: SessionSource): string {
     return JSON.stringify([
-      this.readFileMtimeMs(source.stateFile),
-      this.readFileMtimeMs(source.wireFile),
+      KIMI_CODE_PARSER_REVISION,
+      source.stateMtimeMs,
+      source.stateSize,
+      source.wireMtimeMs,
+      source.wireSize,
+      source.createdAt,
+      source.activityAt,
       source.workDir,
+      source.explicitTitle,
     ]);
   }
 
@@ -469,7 +486,7 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
     for (const sessionDir of this.listSessionDirs()) {
       const source = getParsedSession(this.resolveSessionSourceResult(sessionDir));
-      if (!source || !matchesScanWindow(source.createdAt, options)) continue;
+      if (!source || !matchesScanWindow(source.activityAt, options)) continue;
       refs.push({
         sessionId: source.id,
         sourcePath: source.sourcePath,
@@ -544,9 +561,14 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
 
     const title = resolveSessionTitle(source.explicitTitle, parsed.firstUserTitle, null);
     const meta: SessionMeta = {
-      ...source,
+      id: source.id,
+      sourcePath: source.sourcePath,
+      wireFile: source.wireFile,
+      workDir: source.workDir,
+      createdAt: source.createdAt,
+      activityAt: source.activityAt,
       title,
-      sourceMtimeMs: source.createdAt,
+      sourceMtimeMs: source.activityAt,
       sourceFingerprint: this.sourceFingerprint(source),
     };
     this.sessionMetaMap.set(meta.id, meta);
@@ -556,7 +578,7 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
       title: meta.title,
       directory: meta.workDir,
       time_created: meta.createdAt,
-      time_updated: meta.updatedAt,
+      time_updated: meta.activityAt,
       stats: transcript.stats,
       ...(Object.keys(parsed.modelUsage).length > 0 ? { model_usage: parsed.modelUsage } : {}),
     });
@@ -575,13 +597,13 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
       slug: `${this.name}/${meta.id}`,
       directory: meta.workDir,
       time_created: meta.createdAt,
-      time_updated: meta.updatedAt,
+      time_updated: meta.activityAt,
       stats: transcript.stats,
       messages: transcript.messages,
     };
   }
 
-  private parseWire(source: SessionSource): ParsedWire {
+  private parseWire(source: Pick<SessionSource, "wireFile">): ParsedWire {
     const builder = new TranscriptBuilder();
     const totals = buildUsageTotals();
     const ignoredToolCallIds = new Set<string>();


### PR DESCRIPTION
## Summary

- derive one Kimi-Code `activityAt` fact from state updates and wire mtime
- use that fact for scan windows, cached freshness, SessionHead, and SessionDetail
- version source fingerprints and include state/wire mtime and size plus parsed source facts
- keep cached metadata minimal while forcing legacy parser fingerprints to refresh

## Tests

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`
- `pnpm test:migration`
- `pnpm test:e2e`

Issue: CS-162