### PR TITLE
fix(core): version persisted derived projections

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { FileSystemSessionSource } from "@codesesh/core";
+import {
+  attachMissingProjectIdentities,
+  FileSystemSessionSource,
+  SMART_TAG_CLASSIFIER_REVISION,
+} from "@codesesh/core";
 import type {
   BaseAgent,
   loadCachedSessions,
@@ -48,6 +52,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     saveCachedSessionChanges: core.saveCachedSessionChanges,
     saveCachedSessions: core.saveCachedSessions,
     sessionSignature: core.sessionSignature,
+    SMART_TAG_CLASSIFIER_REVISION: "smart-tags-v1",
   };
 });
 
@@ -62,7 +67,7 @@ vi.mock("./search-index-job-runner.js", () => ({
 import { AgentSyncEngine } from "./agent-sync-engine.js";
 
 function makeSession(id: string, title = id): SessionHead {
-  return {
+  const session: SessionHead = {
     id,
     slug: `codex/${id}`,
     title,
@@ -76,6 +81,7 @@ function makeSession(id: string, title = id): SessionHead {
       total_cost: 0,
     },
   };
+  return attachMissingProjectIdentities([session])[0]!;
 }
 
 function makeAgent(overrides: Partial<BaseAgent> = {}): BaseAgent {
@@ -121,7 +127,10 @@ class FakeSyncAgent extends FileSystemSessionSource {
 function makeWorkerRunner(): WorkerRunner {
   return {
     activeCount: 0,
-    run: vi.fn(async () => ({ sessions: [], meta: {} })),
+    run: vi.fn(async (_agentName, payload) => ({
+      sessions: payload.derivedOnly ? payload.previousSessions : [],
+      meta: payload.meta,
+    })),
     shutdown: vi.fn(async () => undefined),
   };
 }
@@ -221,6 +230,57 @@ describe("AgentSyncEngine", () => {
     );
     expect(statusChanges).toHaveBeenCalledWith(
       expect.objectContaining({ type: "scan-status", active: false }),
+    );
+  });
+
+  it("publishes a classifier revision refresh when the source is unchanged", async () => {
+    const resolved = attachMissingProjectIdentities([makeSession("session")])[0]!;
+    const previous = {
+      ...resolved,
+      smart_tags: ["bugfix" as const],
+      smart_tags_source_updated_at: resolved.time_updated,
+      smart_tags_classifier_revision: "smart-tags-v0",
+    };
+    const updated = {
+      ...previous,
+      smart_tags: ["docs" as const],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    };
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () => ({ sessions: [updated], meta: {} })),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(
+      makeAgent({ checkForChanges: () => ({ hasChanges: false, timestamp: 2 }) }),
+      [previous],
+      workerRunner,
+    );
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(workerRunner.run).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ derivedOnly: true, changedIds: [] }),
+    );
+    expect(engine.snapshot().sessions[0]).toMatchObject({
+      smart_tags: ["docs"],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    });
+    expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.refresh", [
+      expect.objectContaining({
+        kind: "changes",
+        changes: [
+          expect.objectContaining({
+            session: expect.objectContaining({ smart_tags: ["docs"] }),
+          }),
+        ],
+      }),
+    ]);
+    expect(sessionChanges).toHaveBeenCalledWith(
+      expect.objectContaining({ event: expect.objectContaining({ updatedSessions: 1 }) }),
     );
   });
 
@@ -866,6 +926,10 @@ describe("AgentSyncEngine", () => {
     // The second refresh takes the incremental path (checkForChanges), not
     // another windowed initializeAgent full scan.
     expect(checkForChanges).toHaveBeenCalledTimes(1);
-    expect(workerRunner.run).toHaveBeenCalledTimes(1);
+    expect(workerRunner.run).toHaveBeenCalledTimes(2);
+    expect(workerRunner.run).toHaveBeenLastCalledWith(
+      "codex",
+      expect.objectContaining({ derivedOnly: true, changedIds: [] }),
+    );
   });
 });

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -507,8 +507,28 @@ export class AgentSyncEngine {
     const checkDuration = performance.now() - checkStartedAt;
     this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
     if (!checkResult.hasChanges) {
-      this.logUnchangedRefresh(agent.name, refreshStartedAt);
-      return this.refreshStrategyResult(baseline, { status: "unchanged", checkDuration });
+      const scanStartedAt = performance.now();
+      const result = await this.runWorker(agent, baseline, [], {}, { derivedOnly: true });
+      agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
+      const sessions = attachMissingProjectIdentities(result.sessions);
+      const persistenceDiff = buildPersistenceDiff(baseline, sessions);
+      if (
+        persistenceDiff.changedSessions.length === 0 &&
+        persistenceDiff.removedSessionIds.length === 0
+      ) {
+        this.logUnchangedRefresh(agent.name, refreshStartedAt);
+        return this.refreshStrategyResult(sessions, {
+          status: "unchanged",
+          checkDuration,
+          scanDuration: performance.now() - scanStartedAt,
+        });
+      }
+      return this.refreshStrategyResult(sessions, {
+        persistenceDiff,
+        checkDuration,
+        scanDuration: performance.now() - scanStartedAt,
+        sourceFailures: result.sourceFailures ?? [],
+      });
     }
     const preciseChangedIds = checkResult.changedIds ?? null;
     const scanStartedAt = performance.now();
@@ -575,6 +595,7 @@ export class AgentSyncEngine {
     scanOptions: Pick<ScanOptions, "from" | "to" | "fast">,
     workerOptions: {
       sourceSync?: boolean;
+      derivedOnly?: boolean;
       backfill?: boolean;
       backfillCursor?: string | null;
       checkpoint?: boolean;
@@ -586,6 +607,7 @@ export class AgentSyncEngine {
       changedIds,
       scanOptions,
       sourceSync: workerOptions.sourceSync,
+      derivedOnly: workerOptions.derivedOnly,
       backfill: workerOptions.backfill,
       backfillCursor: workerOptions.backfillCursor,
       checkpoint: workerOptions.checkpoint,

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  attachMissingProjectIdentities,
   FileSystemSessionSource,
   type AgentScanOptions,
   type ChangeCheckResult,
@@ -188,7 +189,13 @@ const workerThreads = vi.hoisted(() => ({
               let sessions: SessionHead[] = [];
               let changedIds: string[] | undefined;
               if (agent?.isAvailable?.() !== false) {
-                if (data.sourceSync && agent?.listSessionSources && agent?.scanSessionSource) {
+                if (data.derivedOnly) {
+                  sessions = data.previousSessions;
+                } else if (
+                  data.sourceSync &&
+                  agent?.listSessionSources &&
+                  agent?.scanSessionSource
+                ) {
                   const result = runSourceSync(data, agent);
                   sessions = result.sessions as SessionHead[];
                   changedIds = result.changedIds;
@@ -402,7 +409,7 @@ function registerMockWatcher(
 }
 
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
-  return {
+  const session: SessionHead = {
     id,
     slug: `codex/${id}`,
     title: id,
@@ -417,6 +424,7 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
     },
     ...overrides,
   };
+  return attachMissingProjectIdentities([session])[0]!;
 }
 
 const projectIdentity = {
@@ -738,7 +746,11 @@ describe("LiveScanStore", () => {
     expect(codex.scan).not.toHaveBeenCalled();
     expect(codex.incrementalScan).not.toHaveBeenCalled();
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
-    expect(workerThreads.workers).toHaveLength(0);
+    expect(workerThreads.workers).toHaveLength(1);
+    expect(workerThreads.workers[0]?.workerData).toMatchObject({
+      derivedOnly: true,
+      changedIds: [],
+    });
   });
 
   it("publishes the startup window before backfilling a database agent", async () => {

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -80,6 +80,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     buildAgentCacheMeta: actual.buildAgentCacheMeta,
     computeSessionDiff: actual.computeSessionDiff,
     sessionSignature: actual.sessionSignature,
+    SMART_TAG_CLASSIFIER_REVISION: "smart-tags-v1",
     sortSessions: actual.sortSessions,
     // The change decision is shared with FileSystemSessionSource.checkForChanges;
     // stubbing it would stop this suite from covering the wiring it exists to test.
@@ -430,12 +431,14 @@ describe("scan refresh worker entry", () => {
       time_updated: 3_000,
       smart_tags: [],
       smart_tags_source_updated_at: 3_000,
+      smart_tags_classifier_revision: "smart-tags-v1",
     });
     const cursor = makeSession("cursor", {
       time_created: 2_000,
       time_updated: 2_000,
       smart_tags: [],
       smart_tags_source_updated_at: 2_000,
+      smart_tags_classifier_revision: "smart-tags-v1",
     });
     const next = makeSession("next", { time_created: 1_000, time_updated: 1_000 });
     const agent = makeAgent({

--- a/packages/cli/src/scan-refresh-worker.test.ts
+++ b/packages/cli/src/scan-refresh-worker.test.ts
@@ -139,6 +139,7 @@ describe("finalizeSessions", () => {
     const session = makeSession("s1", {
       smart_tags: ["bugfix"],
       smart_tags_source_updated_at: 1000,
+      smart_tags_classifier_revision: "smart-tags-v1",
     });
 
     const [result] = finalizeSessions(agent, [session]);

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -10,6 +10,7 @@ import {
   ensureSessionTagsSync,
   FileSystemSessionSource,
   sessionSignature,
+  SMART_TAG_CLASSIFIER_REVISION,
   sortSessions,
   type AgentScanProgress,
   type BaseAgent,
@@ -73,6 +74,7 @@ export interface ScanRefreshWorkerRequest {
   previousSessions: SessionHead[];
   changedIds: string[] | null;
   sourceSync?: boolean;
+  derivedOnly?: boolean;
   backfill?: boolean;
   backfillCursor?: string | null;
   checkpoint?: boolean;
@@ -103,7 +105,9 @@ function computeCacheMetaDiff(
 function hasStaleSmartTags(session: SessionHead): boolean {
   const sourceUpdatedAt = session.time_updated ?? session.time_created;
   return (
-    !Array.isArray(session.smart_tags) || session.smart_tags_source_updated_at !== sourceUpdatedAt
+    !Array.isArray(session.smart_tags) ||
+    session.smart_tags_source_updated_at !== sourceUpdatedAt ||
+    session.smart_tags_classifier_revision !== SMART_TAG_CLASSIFIER_REVISION
   );
 }
 
@@ -398,6 +402,8 @@ async function run(data: ScanRefreshWorkerRequest): Promise<void> {
 
   if (!isAvailable) {
     sessions = [];
+  } else if (data.derivedOnly) {
+    sessions = data.previousSessions;
   } else if (
     agent instanceof FileSystemSessionSource &&
     (data.sourceSync === true || data.checkpoint === true)

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -19,6 +19,7 @@ export interface WorkerPayload {
   previousSessions: SessionHead[];
   changedIds: string[] | null;
   sourceSync?: boolean;
+  derivedOnly?: boolean;
   backfill?: boolean;
   backfillCursor?: string | null;
   checkpoint?: boolean;
@@ -119,6 +120,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       previousSessions: payload.previousSessions,
       changedIds: payload.changedIds,
       sourceSync: payload.sourceSync,
+      derivedOnly: payload.derivedOnly,
       backfill: payload.backfill,
       backfillCursor: payload.backfillCursor,
       checkpoint: payload.checkpoint,

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -154,12 +154,15 @@ export interface SessionHead {
   directory: string;
   parent_reference?: SessionReference;
   project_identity?: ProjectIdentity;
+  project_identity_resolver_revision?: string;
+  project_identity_input_signature?: string;
   time_created: number;
   time_updated?: number;
   stats: SessionStats;
   model_usage?: Record<string, number>;
   smart_tags?: SmartTag[];
   smart_tags_source_updated_at?: number;
+  smart_tags_classifier_revision?: string;
 }
 
 export interface ReferencedSessionHead {
@@ -177,6 +180,8 @@ export interface SessionDetail {
   directory: string;
   parent_reference?: SessionReference;
   project_identity?: ProjectIdentity;
+  project_identity_resolver_revision?: string;
+  project_identity_input_signature?: string;
   version?: string | null;
   detail_freshness?: "fresh" | "stale";
   time_created: number;
@@ -186,5 +191,6 @@ export interface SessionDetail {
   messages: Message[];
   smart_tags?: SmartTag[];
   smart_tags_source_updated_at?: number;
+  smart_tags_classifier_revision?: string;
   file_activity?: SessionFileActivity[];
 }

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -303,7 +303,7 @@ describe("sqlite migration smoke", () => {
       "detail_version",
       "indexed_at",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(19);
+    expect(getUserVersion(getCachePath())).toBe(20);
     expect(getUserVersion(getStatePath())).toBe(2);
   }, 30_000);
 });

--- a/packages/core/src/discovery/__tests__/orchestrate.test.ts
+++ b/packages/core/src/discovery/__tests__/orchestrate.test.ts
@@ -117,6 +117,32 @@ describe("sessionSignature", () => {
     expect(sessionSignature(base)).not.toBe(sessionSignature(retagged));
   });
 
+  it("changes when the project identity changes", () => {
+    const base = makeSession("a", {
+      project_identity: { kind: "path", key: "/old", displayName: "old" },
+    });
+    const resolved = {
+      ...base,
+      project_identity: { kind: "git" as const, key: "github.com/acme/new", displayName: "new" },
+    };
+    expect(sessionSignature(base)).not.toBe(sessionSignature(resolved));
+  });
+
+  it("changes when smart tags change without a source timestamp change", () => {
+    const base = makeSession("a", {
+      smart_tags: ["debugging"],
+      smart_tags_source_updated_at: 9999,
+    });
+    const retagged = { ...base, smart_tags: ["implementation" as const] };
+    expect(sessionSignature(base)).not.toBe(sessionSignature(retagged));
+  });
+
+  it("ignores smart tag ordering", () => {
+    const base = makeSession("a", { smart_tags: ["debugging", "implementation"] });
+    const reordered = { ...base, smart_tags: ["implementation" as const, "debugging" as const] };
+    expect(sessionSignature(base)).toBe(sessionSignature(reordered));
+  });
+
   it("changes when a stat field changes", () => {
     const base = makeSession("a");
     const grown = {

--- a/packages/core/src/discovery/__tests__/orchestrate.test.ts
+++ b/packages/core/src/discovery/__tests__/orchestrate.test.ts
@@ -38,11 +38,20 @@ function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead 
 }
 
 describe("attachMissingProjectIdentities", () => {
-  it("leaves sessions that already have an identity untouched", () => {
+  it("leaves a session untouched when its identity provenance is current", () => {
     const existing = { kind: "path" as const, displayName: "proj", key: "/p" };
-    const sessions = [makeSession("a", { project_identity: existing })];
-    const result = attachMissingProjectIdentities(sessions);
-    expect(result[0]!.project_identity).toBe(existing);
+    const projection = {
+      identity: existing,
+      resolverRevision: "resolver-v1",
+      inputSignature: "input-v1",
+    };
+    const session = makeSession("a", {
+      project_identity: existing,
+      project_identity_resolver_revision: projection.resolverRevision,
+      project_identity_input_signature: projection.inputSignature,
+    });
+    const result = attachMissingProjectIdentities([session], () => projection);
+    expect(result[0]).toBe(session);
   });
 
   it("computes an identity for sessions missing one", () => {
@@ -50,15 +59,68 @@ describe("attachMissingProjectIdentities", () => {
     const result = attachMissingProjectIdentities(sessions);
     expect(result[0]!.project_identity).toBeDefined();
     expect(result[0]!.project_identity?.displayName).toBeTruthy();
+    expect(result[0]!.project_identity_resolver_revision).toBeTruthy();
+    expect(result[0]!.project_identity_input_signature).toBeTruthy();
   });
 
-  it("dedupes identity computation by directory", () => {
+  it("dedupes identity resolution by normalized directory", () => {
     const sessions = [
-      makeSession("a", { directory: "/tmp/shared" }),
-      makeSession("b", { directory: "/tmp/shared" }),
+      makeSession("a", { directory: "/workspace/shared" }),
+      makeSession("b", { directory: "/workspace/shared/." }),
     ];
-    const result = attachMissingProjectIdentities(sessions);
+    const resolve = vi.fn(() => ({
+      identity: { kind: "path" as const, key: "/workspace/shared", displayName: "shared" },
+      resolverRevision: "resolver-v1",
+      inputSignature: "input-v1",
+    }));
+    const result = attachMissingProjectIdentities(sessions, resolve);
     expect(result[0]!.project_identity).toEqual(result[1]!.project_identity);
+    expect(resolve).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes all sessions when a directory's identity input changes", () => {
+    const oldIdentity = { kind: "git_remote" as const, key: "github.com/acme/a", displayName: "a" };
+    const sessions = ["a", "b"].map((id) =>
+      makeSession(id, {
+        project_identity: oldIdentity,
+        project_identity_resolver_revision: "resolver-v1",
+        project_identity_input_signature: "remote-a",
+      }),
+    );
+    const resolve = vi.fn(() => ({
+      identity: { kind: "git_remote" as const, key: "github.com/acme/b", displayName: "b" },
+      resolverRevision: "resolver-v1",
+      inputSignature: "remote-b",
+    }));
+
+    const result = attachMissingProjectIdentities(sessions, resolve);
+
+    expect(result.map((session) => session.project_identity?.key)).toEqual([
+      "github.com/acme/b",
+      "github.com/acme/b",
+    ]);
+    expect(resolve).toHaveBeenCalledOnce();
+  });
+
+  it("revalidates legacy and older-revision identities", () => {
+    const identity = { kind: "path" as const, key: "/workspace/app", displayName: "app" };
+    const projection = {
+      identity,
+      resolverRevision: "resolver-v2",
+      inputSignature: "same-input",
+    };
+    const legacy = makeSession("legacy", { project_identity: identity });
+    const oldRevision = makeSession("old", {
+      project_identity: identity,
+      project_identity_resolver_revision: "resolver-v1",
+      project_identity_input_signature: "same-input",
+    });
+
+    const result = attachMissingProjectIdentities([legacy, oldRevision], () => projection);
+
+    expect(
+      result.every((session) => session.project_identity_resolver_revision === "resolver-v2"),
+    ).toBe(true);
   });
 });
 
@@ -123,23 +185,51 @@ describe("sessionSignature", () => {
     });
     const resolved = {
       ...base,
-      project_identity: { kind: "git" as const, key: "github.com/acme/new", displayName: "new" },
+      project_identity: {
+        kind: "git_remote" as const,
+        key: "github.com/acme/new",
+        displayName: "new",
+      },
     };
     expect(sessionSignature(base)).not.toBe(sessionSignature(resolved));
   });
 
+  it("changes when project identity provenance changes", () => {
+    const identity = { kind: "path" as const, key: "/app", displayName: "app" };
+    const base = makeSession("a", {
+      project_identity: identity,
+      project_identity_resolver_revision: "resolver-v1",
+      project_identity_input_signature: "input-v1",
+    });
+    const revised = { ...base, project_identity_resolver_revision: "resolver-v2" };
+    const changedInput = { ...base, project_identity_input_signature: "input-v2" };
+
+    expect(sessionSignature(base)).not.toBe(sessionSignature(revised));
+    expect(sessionSignature(base)).not.toBe(sessionSignature(changedInput));
+  });
+
   it("changes when smart tags change without a source timestamp change", () => {
     const base = makeSession("a", {
-      smart_tags: ["debugging"],
+      smart_tags: ["bugfix"],
       smart_tags_source_updated_at: 9999,
     });
-    const retagged = { ...base, smart_tags: ["implementation" as const] };
+    const retagged = { ...base, smart_tags: ["feature-dev" as const] };
     expect(sessionSignature(base)).not.toBe(sessionSignature(retagged));
   });
 
+  it("changes when the smart tag classifier revision changes", () => {
+    const base = makeSession("a", {
+      smart_tags: ["bugfix"],
+      smart_tags_source_updated_at: 9999,
+      smart_tags_classifier_revision: "smart-tags-v1",
+    });
+    const revised = { ...base, smart_tags_classifier_revision: "smart-tags-v2" };
+    expect(sessionSignature(base)).not.toBe(sessionSignature(revised));
+  });
+
   it("ignores smart tag ordering", () => {
-    const base = makeSession("a", { smart_tags: ["debugging", "implementation"] });
-    const reordered = { ...base, smart_tags: ["implementation" as const, "debugging" as const] };
+    const base = makeSession("a", { smart_tags: ["bugfix", "feature-dev"] });
+    const reordered = { ...base, smart_tags: ["feature-dev" as const, "bugfix" as const] };
     expect(sessionSignature(base)).toBe(sessionSignature(reordered));
   });
 

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -8,6 +8,7 @@ import {
   type SessionSourceRef,
 } from "../../agents/base.js";
 import { filterSessions } from "../scanner.js";
+import { computeIdentityProjection, realFs } from "../../projects/index.js";
 
 // --- filterSessions tests (pure function) ---
 
@@ -27,6 +28,16 @@ function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead 
       total_cost: 0,
     },
     ...overrides,
+  };
+}
+
+function withCurrentIdentity(session: SessionHead): SessionHead {
+  const projection = computeIdentityProjection(session.directory, realFs);
+  return {
+    ...session,
+    project_identity: projection.identity,
+    project_identity_resolver_revision: projection.resolverRevision,
+    project_identity_input_signature: projection.inputSignature,
   };
 }
 
@@ -196,6 +207,7 @@ vi.mock("../cache/sessions.js", () => ({
 vi.mock("../../utils/index.js", () => ({
   classifySessionTags: vi.fn(() => []),
   getSmartTagSourceTimestamp: vi.fn(() => 1000),
+  SMART_TAG_CLASSIFIER_REVISION: "smart-tags-v1",
   perf: {
     start: vi.fn(() => ({ name: "test", startTime: 0, children: [] })),
     end: vi.fn(),
@@ -271,6 +283,7 @@ describe("ensureSessionTagsSync", () => {
     const cached = makeSession("cached", {
       smart_tags: [],
       smart_tags_source_updated_at: 1000,
+      smart_tags_classifier_revision: "smart-tags-v1",
     });
     const stale = makeSession("stale", { time_updated: 2000 });
     const agent = createTestAgent({ name: "test", available: true, sessions: [cached, stale] });
@@ -288,13 +301,32 @@ describe("ensureSessionTagsSync", () => {
     expect(result.timing.getSessionDataMs).toBeGreaterThanOrEqual(0);
     expect(result.timing.classifySessionTagsMs).toBeGreaterThanOrEqual(0);
   });
+
+  it("reclassifies unchanged sources produced by an older classifier", () => {
+    const cached = makeSession("cached", {
+      smart_tags: ["bugfix"],
+      smart_tags_source_updated_at: 1000,
+      smart_tags_classifier_revision: "smart-tags-v0",
+    });
+    const agent = createTestAgent({ name: "test", available: true, sessions: [cached] });
+
+    const result = ensureSessionTagsSync(agent, [cached]);
+
+    expect(result.changed).toBe(true);
+    expect(result.timing).toMatchObject({ cacheHits: 0, staleSessions: 1 });
+    expect(result.sessions[0]).toMatchObject({
+      smart_tags: [],
+      smart_tags_source_updated_at: 1000,
+      smart_tags_classifier_revision: "smart-tags-v1",
+    });
+  });
 });
 
 describe("finalizeAgentScan", () => {
   it("finalizes cache-only sessions without classifying or writing", async () => {
     const sessions = [
-      makeSession("old", { time_created: 100 }),
-      makeSession("current", { time_created: 300 }),
+      withCurrentIdentity(makeSession("old", { time_created: 100 })),
+      withCurrentIdentity(makeSession("current", { time_created: 300 })),
     ];
     const agent = createTestAgent({ name: "test", available: true, sessions });
     agent.getSessionData = vi.fn();
@@ -356,7 +388,7 @@ describe("finalizeAgentScan", () => {
   });
 
   it("does not rewrite an unchanged cache when tag maintenance is disabled", async () => {
-    const sessions = [makeSession("cached")];
+    const sessions = [withCurrentIdentity(makeSession("cached"))];
     const agent = createTestAgent({ name: "test", available: true, sessions });
 
     const result = await finalizeAgentScan(agent, sessions, {
@@ -372,6 +404,37 @@ describe("finalizeAgentScan", () => {
     expect(result.refreshed).toBeUndefined();
     expect(result.cacheTimestamp).toBe(123);
     expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
+  });
+
+  it("persists refreshed identity provenance for an otherwise unchanged cache", async () => {
+    const sessions = [makeSession("cached")];
+    const agent = createTestAgent({ name: "test", available: true, sessions });
+
+    await finalizeAgentScan(agent, sessions, {
+      finalization: {
+        kind: "unchanged",
+        cached: { sessions, meta: {}, timestamp: 123 },
+      },
+      options: { includeSmartTags: false },
+      timing: { total: 0 },
+      agentStart: performance.now(),
+    });
+
+    expect(mockedSaveCachedSessionChanges).toHaveBeenCalledWith(
+      "test",
+      [
+        {
+          session: expect.objectContaining({
+            id: "cached",
+            project_identity_resolver_revision: expect.any(String),
+            project_identity_input_signature: expect.any(String),
+          }),
+          sortIndex: 0,
+        },
+      ],
+      [],
+      {},
+    );
   });
 
   it("persists tag maintenance for an otherwise unchanged cache", async () => {
@@ -551,7 +614,7 @@ describe("scanSessions", () => {
   });
 
   it("uses cache when available", async () => {
-    const cachedSessions = [makeSession("cached")];
+    const cachedSessions = [withCurrentIdentity(makeSession("cached"))];
     mockedLoadCachedSessions.mockReturnValue({
       sessions: cachedSessions,
       meta: {},
@@ -571,7 +634,7 @@ describe("scanSessions", () => {
   });
 
   it("can return cached sessions without validating agent availability", async () => {
-    const cachedSessions = [makeSession("cached")];
+    const cachedSessions = [withCurrentIdentity(makeSession("cached"))];
     mockedLoadCachedSessions.mockReturnValue({
       sessions: cachedSessions,
       meta: {},
@@ -705,7 +768,7 @@ describe("scanSessions", () => {
       key: "/home/user/project",
       displayName: "project",
     };
-    const keep = makeSession("keep", { project_identity: projectIdentity });
+    const keep = withCurrentIdentity(makeSession("keep", { project_identity: projectIdentity }));
     const changed = makeSession("changed");
     const removed = makeSession("removed");
     const updatedChanged = makeSession("changed", { title: "Updated changed" });

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -9,6 +9,7 @@ import { materializeSessionDetail, materializeSessionDetailResponse } from "../s
 import type { LiveSnapshot } from "../scanner.js";
 import { setSchemaEnsuredPath } from "../cache/db.js";
 import { setCoreDiagnostics } from "../../utils/diagnostics.js";
+import { SMART_TAG_CLASSIFIER_REVISION } from "../../utils/smart-tags.js";
 
 const { testHomeDir } = vi.hoisted(() => ({
   testHomeDir: `/tmp/codesesh-session-detail-test-${process.pid}`,
@@ -285,8 +286,15 @@ describe("materializeSessionDetail", () => {
   });
 
   it("returns cached messages as lazy JSON without reading the source", () => {
-    const head = makeHead({ smart_tags: [] });
-    const detail = { ...makeDetail("Cached Session"), smart_tags: [] };
+    const head = makeHead({
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    });
+    const detail = {
+      ...makeDetail("Cached Session"),
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    };
     persistDetail(head, detail, "same");
     const agent = new TestAgent(makeDetail(), new Map([["s1", makeMeta("same")]]));
     const scanResult = makeScanResult(agent, head);

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -40,6 +40,9 @@ describe("cache schema boundary", () => {
         messageColumns: (
           db.prepare("PRAGMA table_info(messages)").all() as Array<{ name: string }>
         ).map((row) => row.name),
+        sessionColumns: (
+          db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>
+        ).map((row) => row.name),
         version: Number(
           (db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined)
             ?.user_version ?? 0,
@@ -68,7 +71,14 @@ describe("cache schema boundary", () => {
       "indexed_at",
     ]);
     expect(state?.messageColumns).toContain("parts_format_version");
-    expect(state?.version).toBe(19);
+    expect(state?.sessionColumns).toEqual(
+      expect.arrayContaining([
+        "project_identity_resolver_revision",
+        "project_identity_input_signature",
+        "smart_tags_classifier_revision",
+      ]),
+    );
+    expect(state?.version).toBe(20);
   });
 
   it("exposes capabilities instead of migration steps", () => {
@@ -112,7 +122,50 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 19, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 20, detailVersion: "", pending: true });
+  });
+
+  it("marks legacy project identities stale by leaving added provenance empty", () => {
+    const session = makeSessionHead("legacy-identity");
+    saveCachedSessions("codex", [session], {});
+
+    const legacyDb = new Database(getCachePath());
+    legacyDb.exec("ALTER TABLE sessions DROP COLUMN project_identity_resolver_revision");
+    legacyDb.exec("ALTER TABLE sessions DROP COLUMN project_identity_input_signature");
+    legacyDb.exec("ALTER TABLE sessions DROP COLUMN smart_tags_classifier_revision");
+    legacyDb.pragma("user_version = 19");
+    legacyDb.prepare("UPDATE cache_meta SET value = '19' WHERE key = 'version'").run();
+    legacyDb.close();
+    setSchemaEnsuredPath(null);
+
+    const migrated = schema.withCacheDb((db) => {
+      const row = db
+        .prepare(
+          `SELECT project_identity_resolver_revision, project_identity_input_signature,
+                  smart_tags_classifier_revision
+           FROM sessions WHERE session_id = ?`,
+        )
+        .get(session.id) as {
+        project_identity_resolver_revision?: string | null;
+        project_identity_input_signature?: string | null;
+        smart_tags_classifier_revision?: string | null;
+      };
+      return {
+        version: Number(
+          (db.prepare("PRAGMA user_version").get() as { user_version?: number }).user_version,
+        ),
+        resolverRevision: row.project_identity_resolver_revision,
+        inputSignature: row.project_identity_input_signature,
+        classifierRevision: row.smart_tags_classifier_revision,
+      };
+    });
+
+    expect(migrated).toEqual({
+      version: 20,
+      resolverRevision: null,
+      inputSignature: null,
+      classifierRevision: null,
+    });
   });
 
   it.each([15, 16])(
@@ -178,7 +231,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 19,
+        version: 20,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -680,7 +680,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(19);
+    expect(getUserVersion(getCachePath())).toBe(20);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -1468,7 +1468,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(19);
+    expect(getUserVersion(getCachePath())).toBe(20);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -196,7 +196,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(19);
+    expect(getUserVersion(getCachePath())).toBe(20);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -207,7 +207,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(19);
+    expect(getUserVersion(getCachePath())).toBe(20);
   });
 });
 
@@ -215,7 +215,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(19);
+    expect(getUserVersion(getCachePath())).toBe(20);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -230,8 +230,11 @@ describe("saveCachedSessions", () => {
         total_cache_read_tokens: 2,
       },
       model_usage: { "claude-sonnet": 20 },
+      project_identity_resolver_revision: "resolver-v1",
+      project_identity_input_signature: "identity-input-v1",
       smart_tags: ["feature-dev" as const],
       smart_tags_source_updated_at: now,
+      smart_tags_classifier_revision: "smart-tags-v1",
     };
 
     saveCachedSessions("claudecode", [session], {
@@ -247,6 +250,9 @@ describe("saveCachedSessions", () => {
         total_tokens?: number;
         model_usage_json?: string;
         smart_tags_json?: string;
+        smart_tags_classifier_revision?: string;
+        project_identity_resolver_revision?: string;
+        project_identity_input_signature?: string;
       };
 
       expect(row.session_id).toBe("s1");
@@ -255,6 +261,14 @@ describe("saveCachedSessions", () => {
       expect(row.total_tokens).toBe(20);
       expect(JSON.parse(row.model_usage_json ?? "{}")).toEqual({ "claude-sonnet": 20 });
       expect(JSON.parse(row.smart_tags_json ?? "[]")).toEqual(["feature-dev"]);
+      expect(row.smart_tags_classifier_revision).toBe("smart-tags-v1");
+      expect(row.project_identity_resolver_revision).toBe("resolver-v1");
+      expect(row.project_identity_input_signature).toBe("identity-input-v1");
+      expect(loadCachedSessions("claudecode")?.sessions[0]).toMatchObject({
+        project_identity_resolver_revision: "resolver-v1",
+        project_identity_input_signature: "identity-input-v1",
+        smart_tags_classifier_revision: "smart-tags-v1",
+      });
     } finally {
       db.close();
     }
@@ -413,7 +427,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(19);
+    expect(getUserVersion(getCachePath())).toBe(20);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -32,6 +32,8 @@ export interface SessionRow extends DatabaseRow {
   project_identity_kind?: ProjectIdentityKind;
   project_identity_key?: string;
   project_display_name?: string;
+  project_identity_resolver_revision?: string | null;
+  project_identity_input_signature?: string | null;
   time_created?: number;
   time_updated?: number | null;
   activity_time?: number;
@@ -46,6 +48,7 @@ export interface SessionRow extends DatabaseRow {
   model_usage_json?: string | null;
   smart_tags_json?: string | null;
   smart_tags_source_updated_at?: number | null;
+  smart_tags_classifier_revision?: string | null;
   meta_json?: string | null;
 }
 
@@ -124,6 +127,8 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
       project_identity_kind,
       project_identity_key,
       project_display_name,
+      project_identity_resolver_revision,
+      project_identity_input_signature,
       time_created,
       time_updated,
       activity_time,
@@ -138,8 +143,9 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
       model_usage_json,
       smart_tags_json,
       smart_tags_source_updated_at,
+      smart_tags_classifier_revision,
       meta_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id) DO UPDATE SET
       sort_index = excluded.sort_index,
       slug = excluded.slug,
@@ -151,6 +157,8 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
       project_identity_kind = excluded.project_identity_kind,
       project_identity_key = excluded.project_identity_key,
       project_display_name = excluded.project_display_name,
+      project_identity_resolver_revision = excluded.project_identity_resolver_revision,
+      project_identity_input_signature = excluded.project_identity_input_signature,
       time_created = excluded.time_created,
       time_updated = excluded.time_updated,
       activity_time = excluded.activity_time,
@@ -165,6 +173,7 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
       model_usage_json = excluded.model_usage_json,
       smart_tags_json = excluded.smart_tags_json,
       smart_tags_source_updated_at = excluded.smart_tags_source_updated_at,
+      smart_tags_classifier_revision = excluded.smart_tags_classifier_revision,
       meta_json = excluded.meta_json
   `);
 }
@@ -184,6 +193,8 @@ export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement
       project_identity_kind,
       project_identity_key,
       project_display_name,
+      project_identity_resolver_revision,
+      project_identity_input_signature,
       time_created,
       time_updated,
       activity_time,
@@ -198,8 +209,9 @@ export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement
       model_usage_json,
       smart_tags_json,
       smart_tags_source_updated_at,
+      smart_tags_classifier_revision,
       meta_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id) DO UPDATE SET
       slug = excluded.slug,
       title = excluded.title,
@@ -209,6 +221,8 @@ export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement
       project_identity_kind = excluded.project_identity_kind,
       project_identity_key = excluded.project_identity_key,
       project_display_name = excluded.project_display_name,
+      project_identity_resolver_revision = excluded.project_identity_resolver_revision,
+      project_identity_input_signature = excluded.project_identity_input_signature,
       time_created = excluded.time_created,
       time_updated = excluded.time_updated,
       activity_time = excluded.activity_time,
@@ -222,7 +236,8 @@ export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement
       total_tokens = excluded.total_tokens,
       model_usage_json = excluded.model_usage_json,
       smart_tags_json = excluded.smart_tags_json,
-      smart_tags_source_updated_at = excluded.smart_tags_source_updated_at
+      smart_tags_source_updated_at = excluded.smart_tags_source_updated_at,
+      smart_tags_classifier_revision = excluded.smart_tags_classifier_revision
   `);
 }
 
@@ -249,6 +264,8 @@ export function upsertSessionRow(
     identity.kind,
     identity.key,
     identity.displayName,
+    session.project_identity_resolver_revision ?? null,
+    session.project_identity_input_signature ?? null,
     session.time_created,
     session.time_updated ?? null,
     activityTime,
@@ -263,6 +280,7 @@ export function upsertSessionRow(
     stringifyOptionalJson(session.model_usage),
     stringifyOptionalJson(session.smart_tags),
     session.smart_tags_source_updated_at ?? null,
+    session.smart_tags_classifier_revision ?? null,
     metaJson,
   );
 }
@@ -331,6 +349,12 @@ export function sessionFromRow(row: SessionRow): SessionHead {
       displayName: String(row.project_display_name ?? ""),
     };
   }
+  if (row.project_identity_resolver_revision) {
+    session.project_identity_resolver_revision = String(row.project_identity_resolver_revision);
+  }
+  if (row.project_identity_input_signature) {
+    session.project_identity_input_signature = String(row.project_identity_input_signature);
+  }
   if (row.parent_agent_name && row.parent_session_id) {
     session.parent_reference = {
       agentName: String(row.parent_agent_name),
@@ -364,6 +388,9 @@ export function sessionFromRow(row: SessionRow): SessionHead {
   }
   if (row.smart_tags_source_updated_at != null) {
     session.smart_tags_source_updated_at = Number(row.smart_tags_source_updated_at);
+  }
+  if (row.smart_tags_classifier_revision) {
+    session.smart_tags_classifier_revision = String(row.smart_tags_classifier_revision);
   }
 
   return session;

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -31,7 +31,7 @@ import {
   type SessionRow,
 } from "./messages.js";
 
-const CACHE_SCHEMA_VERSION = 19;
+const CACHE_SCHEMA_VERSION = 20;
 interface MessageToolBackfillRow extends DatabaseRow {
   agent_name?: string;
   session_id?: string;
@@ -197,6 +197,8 @@ function createSessionTables(db: SQLiteDatabase): void {
       project_identity_kind TEXT NOT NULL,
       project_identity_key TEXT NOT NULL,
       project_display_name TEXT NOT NULL,
+      project_identity_resolver_revision TEXT,
+      project_identity_input_signature TEXT,
       time_created INTEGER NOT NULL,
       time_updated INTEGER,
       activity_time INTEGER NOT NULL,
@@ -211,6 +213,7 @@ function createSessionTables(db: SQLiteDatabase): void {
       model_usage_json TEXT,
       smart_tags_json TEXT,
       smart_tags_source_updated_at INTEGER,
+      smart_tags_classifier_revision TEXT,
       meta_json TEXT,
       PRIMARY KEY (agent_name, session_id)
     );
@@ -483,6 +486,19 @@ function addDetailVersion(db: SQLiteDatabase): void {
       INSERT OR IGNORE INTO pending_reindex(agent_name, session_id)
       SELECT agent_name, session_id FROM sessions
     `);
+  }
+}
+
+function addProjectIdentityProvenance(db: SQLiteDatabase): void {
+  if (!tableExists(db, "sessions")) return;
+  if (!columnExists(db, "sessions", "project_identity_resolver_revision")) {
+    db.exec("ALTER TABLE sessions ADD COLUMN project_identity_resolver_revision TEXT");
+  }
+  if (!columnExists(db, "sessions", "project_identity_input_signature")) {
+    db.exec("ALTER TABLE sessions ADD COLUMN project_identity_input_signature TEXT");
+  }
+  if (!columnExists(db, "sessions", "smart_tags_classifier_revision")) {
+    db.exec("ALTER TABLE sessions ADD COLUMN smart_tags_classifier_revision TEXT");
   }
 }
 
@@ -1351,6 +1367,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 17, migrate: addMessagePartsFormatVersion },
       { version: 18, migrate: addSessionParentReference },
       { version: 19, migrate: addDetailVersion },
+      { version: 20, migrate: addProjectIdentityProvenance },
     ],
   });
 

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -104,6 +104,8 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
             project_identity_kind,
             project_identity_key,
             project_display_name,
+            project_identity_resolver_revision,
+            project_identity_input_signature,
             time_created,
             time_updated,
             message_count,
@@ -117,6 +119,7 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
             model_usage_json,
             smart_tags_json,
             smart_tags_source_updated_at,
+            smart_tags_classifier_revision,
             meta_json
           FROM sessions
           WHERE agent_name = ?

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -11,13 +11,47 @@ import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import { sortSessionsByActivity } from "../contract/session-index.js";
 import type { SessionHead } from "../types/index.js";
 import type { SessionHeadChange } from "./cache/db.js";
-import { computeIdentity, realFs } from "../projects/index.js";
+import {
+  computeIdentityProjection,
+  normalizeProjectDirectory,
+  realFs,
+  type ProjectIdentityProjection,
+} from "../projects/index.js";
 
-/** Attach a project identity to sessions that don't already have one. */
-export function attachMissingProjectIdentities(sessions: SessionHead[]): SessionHead[] {
+type ProjectIdentityResolver = (directory: string) => ProjectIdentityProjection;
+
+/** Attach or refresh project identities once per normalized directory. */
+export function attachMissingProjectIdentities(
+  sessions: SessionHead[],
+  resolve: ProjectIdentityResolver = (directory) => computeIdentityProjection(directory, realFs),
+): SessionHead[] {
+  const projections = new Map<string, ProjectIdentityProjection>();
+
   return sessions.map((session) => {
-    if (session.project_identity) return session;
-    return { ...session, project_identity: computeIdentity(session.directory, realFs) };
+    const directory = normalizeProjectDirectory(session.directory);
+    let projection = projections.get(directory);
+    if (!projection) {
+      projection = resolve(directory);
+      projections.set(directory, projection);
+    }
+
+    const identity = session.project_identity;
+    if (
+      identity?.kind === projection.identity.kind &&
+      identity.key === projection.identity.key &&
+      identity.displayName === projection.identity.displayName &&
+      session.project_identity_resolver_revision === projection.resolverRevision &&
+      session.project_identity_input_signature === projection.inputSignature
+    ) {
+      return session;
+    }
+
+    return {
+      ...session,
+      project_identity: projection.identity,
+      project_identity_resolver_revision: projection.resolverRevision,
+      project_identity_input_signature: projection.inputSignature,
+    };
   });
 }
 
@@ -60,8 +94,11 @@ export function sessionSignature(session: SessionHead): string {
     session.project_identity?.kind ?? null,
     session.project_identity?.key ?? null,
     session.project_identity?.displayName ?? null,
+    session.project_identity_resolver_revision ?? null,
+    session.project_identity_input_signature ?? null,
     session.smart_tags ? [...session.smart_tags].sort() : null,
     session.smart_tags_source_updated_at ?? null,
+    session.smart_tags_classifier_revision ?? null,
   ]);
 }
 

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -41,8 +41,8 @@ export function buildAgentCacheMeta(
 /**
  * Stable signature for the user-visible fields that define a session's identity.
  * Used by both orchestrators to decide whether a session "changed". Includes
- * smart_tags_source_updated_at so that smart-tag reclassification propagates to
- * the persistence diff even when the underlying message stats are unchanged.
+ * Derived values are part of the projection: changing an identity or tag must
+ * propagate even when the underlying source timestamp and statistics do not.
  */
 export function sessionSignature(session: SessionHead): string {
   return JSON.stringify([
@@ -57,6 +57,10 @@ export function sessionSignature(session: SessionHead): string {
     session.stats.total_output_tokens,
     session.stats.total_cost,
     session.stats.total_tokens ?? 0,
+    session.project_identity?.kind ?? null,
+    session.project_identity?.key ?? null,
+    session.project_identity?.displayName ?? null,
+    session.smart_tags ? [...session.smart_tags].sort() : null,
     session.smart_tags_source_updated_at ?? null,
   ]);
 }

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -15,7 +15,12 @@ import {
   reportSessionSourceOutcome,
 } from "../agents/index.js";
 import { filterSessionsByProjectScope } from "../projects/index.js";
-import { classifySessionTags, getSmartTagSourceTimestamp, perf } from "../utils/index.js";
+import {
+  classifySessionTags,
+  getSmartTagSourceTimestamp,
+  perf,
+  SMART_TAG_CLASSIFIER_REVISION,
+} from "../utils/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import {
   loadCachedSessions,
@@ -170,6 +175,7 @@ export function ensureSessionTagsSync(
   agent: BaseAgent,
   sessions: SessionHead[],
   onProgress?: (processed: number, total: number) => void,
+  classifierRevision = SMART_TAG_CLASSIFIER_REVISION,
 ): { sessions: SessionHead[]; changed: boolean; timing: SessionTagTiming } {
   let changed = false;
   let processed = 0;
@@ -188,7 +194,11 @@ export function ensureSessionTagsSync(
   const tagged = sessions.map((session) => {
     const sourceUpdatedAt = session.time_updated ?? session.time_created;
     const currentTags = Array.isArray(session.smart_tags) ? session.smart_tags : null;
-    if (currentTags && session.smart_tags_source_updated_at === sourceUpdatedAt) {
+    if (
+      currentTags &&
+      session.smart_tags_source_updated_at === sourceUpdatedAt &&
+      session.smart_tags_classifier_revision === classifierRevision
+    ) {
       timing.cacheHits += 1;
       processed += 1;
       onProgress?.(processed, total);
@@ -220,6 +230,7 @@ export function ensureSessionTagsSync(
         ...session,
         smart_tags: tags,
         smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
+        smart_tags_classifier_revision: classifierRevision,
       };
     } catch {
       timing.failedSessions += 1;
@@ -261,7 +272,11 @@ async function ensureSessionTags(
   const staleSessions = sessions.filter((session) => {
     const sourceUpdatedAt = session.time_updated ?? session.time_created;
     const currentTags = Array.isArray(session.smart_tags) ? session.smart_tags : null;
-    return !currentTags || session.smart_tags_source_updated_at !== sourceUpdatedAt;
+    return (
+      !currentTags ||
+      session.smart_tags_source_updated_at !== sourceUpdatedAt ||
+      session.smart_tags_classifier_revision !== SMART_TAG_CLASSIFIER_REVISION
+    );
   });
 
   if (staleSessions.length === 0) {
@@ -296,6 +311,7 @@ async function ensureSessionTags(
           ...session,
           smart_tags: result.tags,
           smart_tags_source_updated_at: result.sourceUpdatedAt,
+          smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
         };
       }),
     };
@@ -317,7 +333,11 @@ export async function finalizeAgentScan(
   }
 
   const identityStart = performance.now();
-  const sessionsWithIdentity = attachMissingProjectIdentities(sessions);
+  const sessionsWithIdentity =
+    finalization.kind === "cache-only" ? sessions : attachMissingProjectIdentities(sessions);
+  const identityChanged = sessionsWithIdentity.some(
+    (session, index) => session !== sessions[index],
+  );
   timing.identity = performance.now() - identityStart;
 
   let tagged = { sessions: sessionsWithIdentity, changed: false };
@@ -338,7 +358,7 @@ export async function finalizeAgentScan(
         tagged.sessions,
         finalization.changedIds,
       );
-    } else if (finalization.kind === "unchanged" && tagged.changed) {
+    } else if (finalization.kind === "unchanged" && (identityChanged || tagged.changed)) {
       saveCachedSessionDiff(agent, finalization.cached.sessions, tagged.sessions);
     }
   }

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -6,6 +6,7 @@ import {
   classifySessionTags,
   extractSessionFileActivity,
   getSmartTagSourceTimestamp,
+  SMART_TAG_CLASSIFIER_REVISION,
 } from "../utils/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import { listSessionFileActivity } from "./cache/file-activity.js";
@@ -106,7 +107,17 @@ function getProjectIdentity(
   data: Pick<SessionDetail, "directory" | "project_identity">,
   head: SessionHead | undefined,
 ) {
-  return data.project_identity ?? head?.project_identity ?? computeIdentity(data.directory, realFs);
+  return head?.project_identity ?? data.project_identity ?? computeIdentity(data.directory, realFs);
+}
+
+function getSmartTags(data: SessionDetail) {
+  if (
+    Array.isArray(data.smart_tags) &&
+    data.smart_tags_classifier_revision === SMART_TAG_CLASSIFIER_REVISION
+  ) {
+    return data.smart_tags;
+  }
+  return classifySessionTags(data);
 }
 
 function materializeStructuredSessionDetail(
@@ -174,8 +185,13 @@ function materializeStructuredSessionDetail(
       reference,
       detail_freshness: freshness,
       project_identity: projectIdentity,
-      smart_tags: data.smart_tags ?? classifySessionTags(data),
+      project_identity_resolver_revision:
+        head?.project_identity_resolver_revision ?? data.project_identity_resolver_revision,
+      project_identity_input_signature:
+        head?.project_identity_input_signature ?? data.project_identity_input_signature,
+      smart_tags: getSmartTags(data),
       smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
       file_activity: fileActivity,
     },
   };
@@ -208,7 +224,12 @@ export function materializeSessionDetailResponse(
     ? context.agent.getSessionMetaMap().get(reference.sessionId)
     : undefined;
   const cacheState = cachedDetailState(cachedEntry, currentMeta);
-  if (!cachedEntry || cacheState !== "fresh" || cachedEntry.data.smart_tags == null) {
+  if (
+    !cachedEntry ||
+    cacheState !== "fresh" ||
+    cachedEntry.data.smart_tags == null ||
+    cachedEntry.data.smart_tags_classifier_revision !== SMART_TAG_CLASSIFIER_REVISION
+  ) {
     return materializeStructuredSessionDetail(context, reference, cachedEntry);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -104,6 +104,7 @@ export {
   classifySessionTags,
   ensurePrivateDirectory,
   getSmartTagSourceTimestamp,
+  SMART_TAG_CLASSIFIER_REVISION,
   perf,
   restrictExistingPrivateFiles,
   restrictPrivateFile,

--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearIdentityCache,
   computeIdentity,
+  computeIdentityProjection,
   getProjectIdentityKey,
   matchesProjectIdentity,
   normalizeGitRemote,
@@ -87,6 +88,29 @@ describe("computeIdentity", () => {
       key: "github.com/xingkaixin/codesesh",
       displayName: "codesesh",
     });
+  });
+
+  it("versions a projection independently from its input signature", () => {
+    const fs = createFs({ "/repo/.git": true }, { "/repo": "git@github.com:acme/app.git" });
+
+    const first = computeIdentityProjection("/repo/src", fs, "resolver-v1");
+    const revised = computeIdentityProjection("/repo/src", fs, "resolver-v2");
+
+    expect(revised.identity).toEqual(first.identity);
+    expect(revised.inputSignature).toBe(first.inputSignature);
+    expect(revised.resolverRevision).not.toBe(first.resolverRevision);
+  });
+
+  it("changes the input signature when the git remote changes", () => {
+    const paths: Record<string, string | true> = { "/repo/.git": true };
+    const remoteA = createFs(paths, { "/repo": "git@github.com:acme/a.git" });
+    const remoteB = createFs(paths, { "/repo": "git@github.com:acme/b.git" });
+
+    const first = computeIdentityProjection("/repo/src", remoteA);
+    const changed = computeIdentityProjection("/repo/src", remoteB);
+
+    expect(changed.identity.key).toBe("github.com/acme/b");
+    expect(changed.inputSignature).not.toBe(first.inputSignature);
   });
 
   it("uses manifest path when git metadata is absent", () => {

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -1,5 +1,6 @@
 import * as os from "node:os";
 import * as path from "node:path";
+import { createHash } from "node:crypto";
 import type { ProjectIdentity, ProjectIdentityKind } from "../types/index.js";
 import { fallbackDisplayName } from "./display-name.js";
 import { realFs } from "./fs.js";
@@ -8,6 +9,14 @@ export interface IdentityFs {
   exists(path: string): boolean;
   readText(path: string): string | null;
   spawn(cmd: string, args: string[], opts: { cwd: string }): { stdout: string; exitCode: number };
+}
+
+export const PROJECT_IDENTITY_RESOLVER_REVISION = "project-identity-v1";
+
+export interface ProjectIdentityProjection {
+  identity: ProjectIdentity;
+  resolverRevision: string;
+  inputSignature: string;
 }
 
 const MANIFESTS = [
@@ -54,7 +63,7 @@ export function normalizeGitRemote(url: string): string | null {
 const IDENTITY_CACHE_TTL_MS = 10 * 60 * 1000;
 
 interface IdentityCacheEntry {
-  identity: ProjectIdentity;
+  projection: ProjectIdentityProjection;
   resolvedAt: number;
 }
 
@@ -66,32 +75,55 @@ export function clearIdentityCache(): void {
 }
 
 export function computeIdentity(cwd: string | null | undefined, fs: IdentityFs): ProjectIdentity {
-  if (fs !== realFs) return resolveIdentity(cwd, fs);
-
-  const key = cwd ?? "";
-  const cached = identityCache.get(key);
-  if (cached && Date.now() - cached.resolvedAt < IDENTITY_CACHE_TTL_MS) {
-    return cached.identity;
-  }
-  const identity = resolveIdentity(cwd, fs);
-  identityCache.set(key, { identity, resolvedAt: Date.now() });
-  return identity;
+  return computeIdentityProjection(cwd, fs).identity;
 }
 
-function resolveIdentity(cwd: string | null | undefined, fs: IdentityFs): ProjectIdentity {
-  if (!cwd) return loose();
+export function normalizeProjectDirectory(cwd: string | null | undefined): string {
+  if (!cwd) return "";
+  return getPathOps(cwd).resolve(cwd);
+}
+
+export function computeIdentityProjection(
+  cwd: string | null | undefined,
+  fs: IdentityFs,
+  resolverRevision = PROJECT_IDENTITY_RESOLVER_REVISION,
+): ProjectIdentityProjection {
+  if (fs !== realFs) return resolveIdentityProjection(cwd, fs, resolverRevision);
+
+  const key = normalizeProjectDirectory(cwd);
+  const cached = identityCache.get(key);
+  if (
+    cached &&
+    cached.projection.resolverRevision === resolverRevision &&
+    Date.now() - cached.resolvedAt < IDENTITY_CACHE_TTL_MS
+  ) {
+    return cached.projection;
+  }
+  const projection = resolveIdentityProjection(cwd, fs, resolverRevision);
+  identityCache.set(key, { projection, resolvedAt: Date.now() });
+  return projection;
+}
+
+function resolveIdentityProjection(
+  cwd: string | null | undefined,
+  fs: IdentityFs,
+  resolverRevision: string,
+): ProjectIdentityProjection {
+  if (!cwd) return projectIdentityProjection(loose(), resolverRevision, ["loose", "missing"]);
 
   const pathOps = getPathOps(cwd);
   const absoluteCwd = pathOps.resolve(cwd);
   const homeDir = os.homedir();
   const homePathOps = getPathOps(homeDir);
   const home = homePathOps === pathOps ? pathOps.resolve(homeDir) : homeDir;
-  if (absoluteCwd === home || LOOSE_DIRS.has(absoluteCwd)) return loose();
+  if (absoluteCwd === home || LOOSE_DIRS.has(absoluteCwd)) {
+    return projectIdentityProjection(loose(), resolverRevision, ["loose", absoluteCwd]);
+  }
   if (
     homePathOps === pathOps &&
     LOOSE_HOME_DIRS.some((dir) => absoluteCwd === pathOps.join(home, dir))
   ) {
-    return loose();
+    return projectIdentityProjection(loose(), resolverRevision, ["loose", absoluteCwd]);
   }
 
   const gitRoot = findGitRoot(absoluteCwd, fs, pathOps);
@@ -100,11 +132,17 @@ function resolveIdentity(cwd: string | null | undefined, fs: IdentityFs): Projec
     if (remote.exitCode === 0) {
       const normalized = normalizeGitRemote(remote.stdout.trim());
       if (normalized) {
-        return {
+        const identity: ProjectIdentity = {
           kind: "git_remote",
           key: normalized,
           displayName: deriveDisplayName({ kind: "git_remote", key: normalized, gitRoot, fs }),
         };
+        return projectIdentityProjection(identity, resolverRevision, [
+          "git_remote",
+          gitRoot,
+          normalized,
+          identity.displayName,
+        ]);
       }
     }
 
@@ -113,33 +151,59 @@ function resolveIdentity(cwd: string | null | undefined, fs: IdentityFs): Projec
       const raw = common.stdout.trim();
       if (raw) {
         const key = pathOps.isAbsolute(raw) ? raw : pathOps.resolve(gitRoot, raw);
-        return {
+        const identity: ProjectIdentity = {
           kind: "git_common_dir",
           key,
           displayName: deriveDisplayName({ kind: "git_common_dir", key, gitRoot, fs }),
         };
+        return projectIdentityProjection(identity, resolverRevision, [
+          "git_common_dir",
+          gitRoot,
+          key,
+          identity.displayName,
+        ]);
       }
     }
   }
 
   const manifestDir = findManifestDir(absoluteCwd, fs, pathOps);
   if (manifestDir) {
-    return {
+    const identity: ProjectIdentity = {
       kind: "manifest_path",
       key: manifestDir,
       displayName: deriveDisplayName({ kind: "manifest_path", key: manifestDir, fs }),
     };
+    return projectIdentityProjection(identity, resolverRevision, [
+      "manifest_path",
+      manifestDir,
+      identity.displayName,
+    ]);
   }
 
   if (homePathOps === pathOps) {
     const synthetic = synthesizeCodexScratchIdentity(absoluteCwd, home, pathOps);
-    if (synthetic) return synthetic;
+    if (synthetic) {
+      return projectIdentityProjection(synthetic, resolverRevision, ["synthetic", synthetic.key]);
+    }
   }
 
-  return {
+  const identity: ProjectIdentity = {
     kind: "path",
     key: absoluteCwd,
     displayName: fallbackDisplayName(absoluteCwd),
+  };
+  return projectIdentityProjection(identity, resolverRevision, ["path", absoluteCwd]);
+}
+
+function projectIdentityProjection(
+  identity: ProjectIdentity,
+  resolverRevision: string,
+  inputs: readonly string[],
+): ProjectIdentityProjection {
+  return {
+    identity,
+    resolverRevision,
+    inputSignature: createHash("sha256").update(JSON.stringify(inputs)).digest("hex"),
   };
 }
 

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -13,7 +13,11 @@ export { basenameTitle, resolveSessionTitle, normalizeTitleText } from "./title-
 export { cleanDisplayText, firstVisibleLine } from "./parse-cleanup.js";
 export { openDb, openDbReadOnly, isSqliteAvailable } from "./sqlite.js";
 export { perf, type PerfMarker } from "./perf.js";
-export { classifySessionTags, getSmartTagSourceTimestamp } from "./smart-tags.js";
+export {
+  classifySessionTags,
+  getSmartTagSourceTimestamp,
+  SMART_TAG_CLASSIFIER_REVISION,
+} from "./smart-tags.js";
 export { estimateTokenCost } from "./cost.js";
 export {
   extractFileActivityOccurrences,

--- a/packages/core/src/utils/smart-tags.ts
+++ b/packages/core/src/utils/smart-tags.ts
@@ -1,5 +1,7 @@
 import type { MessagePart, SessionDetail, SmartTag, ToolPart } from "../types/index.js";
 
+export const SMART_TAG_CLASSIFIER_REVISION = "smart-tags-v1";
+
 const TAG_ORDER: SmartTag[] = [
   "bugfix",
   "refactoring",


### PR DESCRIPTION
## Summary

- include project identity and smart-tag values and provenance in session diff signatures
- refresh project identities once per normalized directory using resolver revisions and input signatures
- version smart-tag classifications per session and revalidate derived fields even when session sources are unchanged
- migrate legacy caches to nullable provenance columns so existing projections are revalidated safely

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`