### PR TITLE
Refactor backfill lifecycle into explicit attempts

### DIFF
--- a/packages/cli/src/agent-operation-scheduler.ts
+++ b/packages/cli/src/agent-operation-scheduler.ts
@@ -86,11 +86,11 @@ export class AgentOperationScheduler {
     }
   }
 
-  run(
+  run<Result extends AgentOperationResult>(
     agentName: string,
     kind: AgentOperationKind,
-    operation: () => Promise<AgentOperationResult>,
-  ): Promise<AgentOperationResult> {
+    operation: () => Promise<Result>,
+  ): Promise<Result | "skipped"> {
     const previous = this.operationTails.get(agentName) ?? Promise.resolve();
     const run = previous.then(async () => {
       if (this.isStopped) return "skipped";

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -150,6 +150,15 @@ function makeEngine(
   return { engine };
 }
 
+function expectValidBackfillStatus(status: ScanStatusEvent["backfill"]): void {
+  const terminalAgents = new Set([...status.completedAgents, ...status.failedAgents]);
+  expect(terminalAgents.size).toBe(status.completedAgents.length + status.failedAgents.length);
+  expect(status.progress == null || status.currentAgent != null).toBe(true);
+  expect(status.currentAgent == null || !status.pendingAgents.includes(status.currentAgent)).toBe(
+    true,
+  );
+}
+
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
@@ -166,6 +175,60 @@ afterEach(() => {
 });
 
 describe("AgentSyncEngine", () => {
+  it("publishes only the latest backfill attempt terminal", async () => {
+    const { engine } = makeEngine(makeAgent());
+    const internal = engine as unknown as {
+      enqueueBackfill(agentName: string): void;
+      runBackfill(attempt: { agentName: string; attemptId: number }): Promise<unknown>;
+    };
+    vi.spyOn(internal, "runBackfill")
+      .mockResolvedValueOnce("committed")
+      .mockResolvedValueOnce("failed");
+    const statuses: ScanStatusEvent[] = [];
+    engine.subscribeStatusChanged((status) => statuses.push(status));
+
+    internal.enqueueBackfill("codex");
+    await vi.waitFor(() => expect(statuses.at(-1)?.backfill.completedAgents).toEqual(["codex"]));
+    internal.enqueueBackfill("codex");
+    await vi.waitFor(() => expect(statuses.at(-1)?.backfill.failedAgents).toEqual(["codex"]));
+
+    for (const status of statuses) expectValidBackfillStatus(status.backfill);
+    expect(statuses.at(-1)?.backfill).toEqual({
+      active: false,
+      pendingAgents: [],
+      completedAgents: [],
+      failedAgents: ["codex"],
+    });
+  });
+
+  it("cancels backfill lifecycle before awaiting shutdown", async () => {
+    let resolveBackfill!: (result: "committed") => void;
+    const { engine } = makeEngine(makeAgent());
+    const internal = engine as unknown as {
+      backfills: { stateFor(agentName: string): { status: string } | undefined };
+      enqueueBackfill(agentName: string): void;
+      runBackfill(attempt: { agentName: string; attemptId: number }): Promise<unknown>;
+    };
+    const runBackfill = vi.spyOn(internal, "runBackfill").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveBackfill = resolve as (result: "committed") => void;
+        }),
+    );
+    const statuses: ScanStatusEvent[] = [];
+    engine.subscribeStatusChanged((status) => statuses.push(status));
+    internal.enqueueBackfill("codex");
+    await vi.waitFor(() => expect(statuses.at(-1)?.backfill.currentAgent).toBe("codex"));
+
+    await engine.shutdown();
+    const statusCountAtShutdown = statuses.length;
+    resolveBackfill("committed");
+    await Promise.resolve();
+
+    expect(internal.backfills.stateFor("codex")?.status).toBe("cancelled");
+    expect(runBackfill).toHaveBeenCalledOnce();
+    expect(statuses).toHaveLength(statusCountAtShutdown);
+  });
   it("keeps the earliest refresh deadline", async () => {
     vi.useFakeTimers();
     const checkForChanges = vi.fn(() => ({ hasChanges: false, timestamp: Date.now() }));

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -22,13 +22,13 @@ import {
   type SessionHeadChange,
   type SessionSourceFailure,
 } from "@codesesh/core";
-import type {
-  BackfillProgress,
-  BackfillStatus,
-  ScanStatusEvent,
-  SessionsUpdatedEvent,
-} from "@codesesh/core/contract";
+import type { ScanStatusEvent, SessionsUpdatedEvent } from "@codesesh/core/contract";
 import { AgentOperationScheduler, type AgentOperationResult } from "./agent-operation-scheduler.js";
+import {
+  BackfillLifecycle,
+  type BackfillAttemptRef,
+  type BackfillTerminalStatus,
+} from "./backfill-lifecycle.js";
 import { LiveSessionIndex, type LiveSessionIndexOptions } from "./live-session-index.js";
 import { appLogger, logSearchIndexSync } from "./logging.js";
 import { SearchIndexJobRunner } from "./search-index-job-runner.js";
@@ -121,12 +121,8 @@ export class AgentSyncEngine {
   private lastRefreshAtByAgent = new Map<string, number>();
   private readonly scheduler: AgentOperationScheduler;
   private readonly sessionIndex = new LiveSessionIndex();
-  private backfillQueue: string[] = [];
-  private currentBackfillAgent: string | undefined;
-  private currentBackfillProgress: BackfillProgress | undefined;
+  private readonly backfills = new BackfillLifecycle();
   private cacheIntegrityCheckedAgents = new Set<string>();
-  private completedBackfillAgents: string[] = [];
-  private failedBackfillAgents: string[] = [];
   private sessionsChangedListeners = new Set<SessionsChangedListener>();
   private statusChangedListeners = new Set<StatusChangedListener>();
   private scanStatus = new ScanStatusModel();
@@ -208,7 +204,7 @@ export class AgentSyncEngine {
     const activeOperations = {
       agent_operations: schedulerSnapshot.activeOperations,
       refreshes: schedulerSnapshot.activeRefreshes,
-      backfill_running: this.currentBackfillAgent != null || undefined,
+      backfill_running: this.backfills.runningAttempt()?.agentName || undefined,
       scan_workers: this.options.workerRunner.activeCount,
     };
     if (activeOperations.agent_operations > 0 || activeOperations.scan_workers > 0) {
@@ -219,9 +215,7 @@ export class AgentSyncEngine {
       clearTimeout(this.backgroundRefreshTimer);
       this.backgroundRefreshTimer = null;
     }
-    this.backfillQueue.length = 0;
-    this.currentBackfillAgent = undefined;
-    this.currentBackfillProgress = undefined;
+    this.backfills.cancelAll();
     this.cacheIntegrityCheckedAgents.clear();
     const searchIndexSnapshot = this.searchIndexJobs.snapshot();
     appLogger.info("search_index.shutdown.started", {
@@ -258,15 +252,22 @@ export class AgentSyncEngine {
     );
   }
 
-  private updateAgentScanProgress(agentName: string, progress: AgentScanProgress): void {
-    if (this.currentBackfillAgent === agentName) {
-      this.currentBackfillProgress = {
-        phase: progress.phase,
-        total: progress.total,
-        processed: progress.processed,
-        sessions: progress.sessions,
-      };
-      this.publishBackfillStatus();
+  private updateAgentScanProgress(
+    agentName: string,
+    progress: AgentScanProgress,
+    backfillAttempt?: BackfillAttemptRef,
+  ): void {
+    if (backfillAttempt) {
+      if (
+        this.backfills.updateProgress(backfillAttempt, {
+          phase: progress.phase,
+          total: progress.total,
+          processed: progress.processed,
+          sessions: progress.sessions,
+        })
+      ) {
+        this.publishBackfillStatus();
+      }
       return;
     }
     this.publishStatus(this.scanStatus.updateAgent(agentName, progress));
@@ -286,7 +287,7 @@ export class AgentSyncEngine {
   }
 
   private publishBackfillStatus(): void {
-    this.publishStatus(this.scanStatus.updateBackfill(this.backfillStatus()));
+    this.publishStatus(this.scanStatus.updateBackfill(this.backfills.status()));
   }
 
   private publishStatus(event: ScanStatusEvent | null): void {
@@ -597,6 +598,7 @@ export class AgentSyncEngine {
       sourceSync?: boolean;
       derivedOnly?: boolean;
       backfill?: boolean;
+      backfillAttempt?: BackfillAttemptRef;
       backfillCursor?: string | null;
       checkpoint?: boolean;
       meta?: CachedSessions["meta"];
@@ -612,7 +614,8 @@ export class AgentSyncEngine {
       backfillCursor: workerOptions.backfillCursor,
       checkpoint: workerOptions.checkpoint,
       meta: workerOptions.meta ?? buildAgentCacheMeta(agent),
-      onProgress: (progress) => this.updateAgentScanProgress(agent.name, progress),
+      onProgress: (progress) =>
+        this.updateAgentScanProgress(agent.name, progress, workerOptions.backfillAttempt),
       onCheckpoint: (checkpoint) => this.handleWorkerCheckpoint(agent, checkpoint),
     });
   }
@@ -729,50 +732,31 @@ export class AgentSyncEngine {
   }
 
   private enqueueBackfill(agentName: string): void {
-    if (
-      this.isShuttingDown ||
-      this.currentBackfillAgent === agentName ||
-      this.backfillQueue.includes(agentName)
-    ) {
-      return;
-    }
-    this.backfillQueue.push(agentName);
+    if (this.isShuttingDown || !this.backfills.enqueue(agentName)) return;
     this.publishBackfillStatus();
     this.pumpBackfillQueue();
   }
 
   private pumpBackfillQueue(): void {
-    if (this.isShuttingDown || this.currentBackfillAgent) return;
-    const agentName = this.backfillQueue.shift();
-    if (!agentName) return;
-    this.currentBackfillAgent = agentName;
-    this.currentBackfillProgress = undefined;
+    if (this.isShuttingDown) return;
+    const attempt = this.backfills.startNext();
+    if (!attempt) return;
     this.publishBackfillStatus();
-    void this.runBackfill(agentName).then((result) => {
+    void this.runBackfill(attempt).then((result) => {
       if (this.isShuttingDown) return;
-      this.currentBackfillAgent = undefined;
-      this.currentBackfillProgress = undefined;
-      if (result === "committed") {
-        if (!this.completedBackfillAgents.includes(agentName)) {
-          this.completedBackfillAgents.push(agentName);
-        }
-        this.failedBackfillAgents = this.failedBackfillAgents.filter(
-          (failedAgent) => failedAgent !== agentName,
-        );
-      } else if (!this.failedBackfillAgents.includes(agentName)) {
-        this.failedBackfillAgents.push(agentName);
-        this.cacheIntegrityCheckedAgents.delete(agentName);
-      }
+      if (!this.backfills.complete(attempt, result)) return;
+      if (result === "failed") this.cacheIntegrityCheckedAgents.delete(attempt.agentName);
       this.publishBackfillStatus();
       this.pumpBackfillQueue();
     });
   }
 
-  private runBackfill(agentName: string): Promise<AgentOperationResult> {
-    return this.scheduler.run(agentName, "backfill", () => this.performBackfill(agentName));
+  private runBackfill(attempt: BackfillAttemptRef): Promise<BackfillTerminalStatus> {
+    return this.scheduler.run(attempt.agentName, "backfill", () => this.performBackfill(attempt));
   }
 
-  private async performBackfill(agentName: string): Promise<AgentOperationResult> {
+  private async performBackfill(attempt: BackfillAttemptRef): Promise<BackfillTerminalStatus> {
+    const { agentName } = attempt;
     const startedAt = performance.now();
     const agent = this.findAgent(agentName);
     if (!agent || !agent.isAvailable()) return "skipped";
@@ -792,6 +776,7 @@ export class AgentSyncEngine {
         {
           sourceSync: agent instanceof FileSystemSessionSource,
           backfill: true,
+          backfillAttempt: attempt,
           backfillCursor,
           meta,
           checkpoint: true,
@@ -799,8 +784,14 @@ export class AgentSyncEngine {
       );
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const fullSessions = attachMissingProjectIdentities(result.sessions);
-      this.currentBackfillProgress = { phase: "indexing", sessions: fullSessions.length };
-      this.publishBackfillStatus();
+      if (
+        this.backfills.updateProgress(attempt, {
+          phase: "indexing",
+          sessions: fullSessions.length,
+        })
+      ) {
+        this.publishBackfillStatus();
+      }
       await this.commitSessionPublication({
         context: "scan.backfill",
         agentName,
@@ -829,17 +820,6 @@ export class AgentSyncEngine {
       console.error(`[${agentName}] Backfill failed:`, error);
       return "failed";
     }
-  }
-
-  private backfillStatus(): BackfillStatus {
-    return {
-      active: this.currentBackfillAgent != null || this.backfillQueue.length > 0,
-      pendingAgents: [...this.backfillQueue],
-      currentAgent: this.currentBackfillAgent,
-      progress: this.currentBackfillProgress,
-      completedAgents: [...this.completedBackfillAgents],
-      failedAgents: [...this.failedBackfillAgents],
-    };
   }
 
   private buildFullSearchIndexJobs(context: string): SearchIndexWorkerJob[] {

--- a/packages/cli/src/backfill-lifecycle.test.ts
+++ b/packages/cli/src/backfill-lifecycle.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { BackfillLifecycle, type BackfillTerminalStatus } from "./backfill-lifecycle.js";
+
+function expectValidStatus(lifecycle: BackfillLifecycle): void {
+  const status = lifecycle.status();
+  const terminal = new Set([...status.completedAgents, ...status.failedAgents]);
+  expect(terminal.size).toBe(status.completedAgents.length + status.failedAgents.length);
+  expect(status.progress == null || status.currentAgent != null).toBe(true);
+  expect(status.currentAgent == null || !status.pendingAgents.includes(status.currentAgent)).toBe(
+    true,
+  );
+  expect(status.active).toBe(status.currentAgent != null || status.pendingAgents.length > 0);
+}
+
+describe("BackfillLifecycle", () => {
+  it.each<BackfillTerminalStatus>(["committed", "failed", "skipped"])(
+    "transitions queued to running to %s",
+    (terminal) => {
+      const lifecycle = new BackfillLifecycle();
+      lifecycle.enqueue("codex");
+      expect(lifecycle.status()).toMatchObject({ active: true, pendingAgents: ["codex"] });
+
+      const attempt = lifecycle.startNext()!;
+      expect(lifecycle.status()).toMatchObject({ currentAgent: "codex", pendingAgents: [] });
+      expect(lifecycle.updateProgress(attempt, { phase: "scanning", processed: 2 })).toBe(true);
+      expect(lifecycle.complete(attempt, terminal)).toBe(true);
+
+      expect(lifecycle.stateFor("codex")?.status).toBe(terminal);
+      expectValidStatus(lifecycle);
+    },
+  );
+
+  it("replaces a committed attempt with a later failed attempt", () => {
+    const lifecycle = new BackfillLifecycle();
+    lifecycle.enqueue("codex");
+    lifecycle.complete(lifecycle.startNext()!, "committed");
+    lifecycle.enqueue("codex");
+    lifecycle.complete(lifecycle.startNext()!, "failed");
+
+    expect(lifecycle.status()).toMatchObject({ completedAgents: [], failedAgents: ["codex"] });
+    expectValidStatus(lifecycle);
+  });
+
+  it("replaces a failed attempt with a later committed attempt", () => {
+    const lifecycle = new BackfillLifecycle();
+    lifecycle.enqueue("codex");
+    lifecycle.complete(lifecycle.startNext()!, "failed");
+    lifecycle.enqueue("codex");
+    lifecycle.complete(lifecycle.startNext()!, "committed");
+
+    expect(lifecycle.status()).toMatchObject({ completedAgents: ["codex"], failedAgents: [] });
+    expectValidStatus(lifecycle);
+  });
+
+  it("ignores progress and results from an older attempt", () => {
+    const lifecycle = new BackfillLifecycle();
+    lifecycle.enqueue("codex");
+    const first = lifecycle.startNext()!;
+    lifecycle.complete(first, "failed");
+    lifecycle.enqueue("codex");
+    const retry = lifecycle.startNext()!;
+
+    expect(lifecycle.updateProgress(first, { phase: "indexing" })).toBe(false);
+    expect(lifecycle.complete(first, "committed")).toBe(false);
+    expect(lifecycle.stateFor("codex")).toMatchObject({
+      status: "running",
+      attemptId: retry.attemptId,
+    });
+    expectValidStatus(lifecycle);
+  });
+
+  it("cancels queued and running attempts without accepting late results", () => {
+    const lifecycle = new BackfillLifecycle();
+    lifecycle.enqueue("codex");
+    const running = lifecycle.startNext()!;
+    lifecycle.enqueue("claude");
+
+    lifecycle.cancelAll();
+
+    expect(lifecycle.stateFor("codex")?.status).toBe("cancelled");
+    expect(lifecycle.stateFor("claude")?.status).toBe("cancelled");
+    expect(lifecycle.complete(running, "committed")).toBe(false);
+    expect(lifecycle.status()).toEqual({
+      active: false,
+      pendingAgents: [],
+      completedAgents: [],
+      failedAgents: [],
+    });
+    expectValidStatus(lifecycle);
+  });
+});

--- a/packages/cli/src/backfill-lifecycle.ts
+++ b/packages/cli/src/backfill-lifecycle.ts
@@ -1,0 +1,110 @@
+import type { BackfillProgress, BackfillStatus } from "@codesesh/core/contract";
+
+export type BackfillTerminalStatus = "committed" | "failed" | "skipped";
+
+export interface BackfillAttemptRef {
+  agentName: string;
+  attemptId: number;
+}
+
+export type BackfillAttemptState =
+  | (BackfillAttemptRef & { status: "queued" })
+  | (BackfillAttemptRef & { status: "running"; progress?: BackfillProgress })
+  | (BackfillAttemptRef & { status: BackfillTerminalStatus | "cancelled" });
+
+export class BackfillLifecycle {
+  private readonly attempts = new Map<string, BackfillAttemptState>();
+  private nextAttemptId = 1;
+
+  enqueue(agentName: string): BackfillAttemptRef | null {
+    const current = this.attempts.get(agentName);
+    if (current?.status === "queued" || current?.status === "running") return null;
+
+    const attempt: BackfillAttemptState = {
+      agentName,
+      attemptId: this.nextAttemptId++,
+      status: "queued",
+    };
+    this.attempts.set(agentName, attempt);
+    return attempt;
+  }
+
+  startNext(): BackfillAttemptRef | null {
+    if ([...this.attempts.values()].some((attempt) => attempt.status === "running")) return null;
+
+    const queued = [...this.attempts.values()]
+      .filter((attempt) => attempt.status === "queued")
+      .sort((left, right) => left.attemptId - right.attemptId)[0];
+    if (!queued) return null;
+
+    const running: BackfillAttemptState = { ...queued, status: "running" };
+    this.attempts.set(running.agentName, running);
+    return running;
+  }
+
+  updateProgress(attempt: BackfillAttemptRef, progress: BackfillProgress): boolean {
+    const current = this.matchingRunningAttempt(attempt);
+    if (!current) return false;
+    this.attempts.set(attempt.agentName, { ...current, progress: { ...progress } });
+    return true;
+  }
+
+  complete(attempt: BackfillAttemptRef, status: BackfillTerminalStatus): boolean {
+    if (!this.matchingRunningAttempt(attempt)) return false;
+    this.attempts.set(attempt.agentName, { ...attempt, status });
+    return true;
+  }
+
+  cancelAll(): void {
+    for (const [agentName, attempt] of this.attempts) {
+      if (attempt.status === "queued" || attempt.status === "running") {
+        this.attempts.set(agentName, { ...attempt, status: "cancelled" });
+      }
+    }
+  }
+
+  runningAttempt(): BackfillAttemptRef | null {
+    const running = [...this.attempts.values()].find((attempt) => attempt.status === "running");
+    return running ?? null;
+  }
+
+  stateFor(agentName: string): BackfillAttemptState | undefined {
+    const state = this.attempts.get(agentName);
+    if (!state) return undefined;
+    return state.status === "running" && state.progress
+      ? { ...state, progress: { ...state.progress } }
+      : { ...state };
+  }
+
+  status(): BackfillStatus {
+    const states = [...this.attempts.values()];
+    const queued = states
+      .filter((attempt) => attempt.status === "queued")
+      .sort((left, right) => left.attemptId - right.attemptId);
+    const running = states.find((attempt) => attempt.status === "running");
+    const status: BackfillStatus = {
+      active: running != null || queued.length > 0,
+      pendingAgents: queued.map((attempt) => attempt.agentName),
+      completedAgents: states
+        .filter((attempt) => attempt.status === "committed")
+        .map((attempt) => attempt.agentName),
+      failedAgents: states
+        .filter((attempt) => attempt.status === "failed")
+        .map((attempt) => attempt.agentName),
+    };
+    if (running) {
+      status.currentAgent = running.agentName;
+      if (running.progress) status.progress = { ...running.progress };
+    }
+    return status;
+  }
+
+  private matchingRunningAttempt(
+    attempt: BackfillAttemptRef,
+  ): Extract<BackfillAttemptState, { status: "running" }> | null {
+    const current = this.attempts.get(attempt.agentName);
+    return current?.status === "running" && current.attemptId === attempt.attemptId
+      ? current
+      : null;
+  }
+}

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -355,9 +355,9 @@ function syncEngineOf(store: LiveScanStore): AgentSyncEngine {
 
 function runBackfill(store: LiveScanStore, agentName: string) {
   const engine = syncEngineOf(store) as unknown as {
-    runBackfill: (agentName: string) => Promise<unknown>;
+    runBackfill: (attempt: { agentName: string; attemptId: number }) => Promise<unknown>;
   };
-  return engine.runBackfill(agentName);
+  return engine.runBackfill({ agentName, attemptId: 0 });
 }
 
 function setRefreshDuration(store: LiveScanStore, agentName: string, durationMs: number): void {

--- a/packages/cli/src/scan-status-model.test.ts
+++ b/packages/cli/src/scan-status-model.test.ts
@@ -239,6 +239,8 @@ describe("ScanStatusModel", () => {
       active: true,
       currentAgent: "codex",
       pendingAgents: ["claude"],
+      completedAgents: [],
+      failedAgents: [],
     });
 
     expect(status.phase).toBe("idle");
@@ -257,7 +259,10 @@ describe("ScanStatusModel", () => {
     const status = model.updateBackfill({
       active: true,
       currentAgent: "codex",
+      pendingAgents: [],
       progress: { phase: "finalizing", total: 2107, processed: 68, sessions: 2108 },
+      completedAgents: [],
+      failedAgents: [],
     });
 
     expect(status.backfill.progress).toEqual({
@@ -267,5 +272,31 @@ describe("ScanStatusModel", () => {
       sessions: 2108,
     });
     expect(status.agentStatuses).toEqual({});
+  });
+
+  it("replaces the complete backfill snapshot and clears stale progress", () => {
+    const model = new ScanStatusModel();
+    model.updateBackfill({
+      active: true,
+      currentAgent: "codex",
+      pendingAgents: [],
+      progress: { phase: "indexing", sessions: 10 },
+      completedAgents: [],
+      failedAgents: [],
+    });
+
+    const status = model.updateBackfill({
+      active: false,
+      pendingAgents: [],
+      completedAgents: ["codex"],
+      failedAgents: [],
+    });
+
+    expect(status.backfill).toEqual({
+      active: false,
+      pendingAgents: [],
+      completedAgents: ["codex"],
+      failedAgents: [],
+    });
   });
 });

--- a/packages/cli/src/scan-status-model.ts
+++ b/packages/cli/src/scan-status-model.ts
@@ -268,10 +268,16 @@ export class ScanStatusModel {
     });
   }
 
-  updateBackfill(patch: Partial<BackfillStatus>): ScanStatusEvent {
+  updateBackfill(backfill: BackfillStatus): ScanStatusEvent {
     return this.set({
       ...this.status,
-      backfill: { ...this.status.backfill, ...patch },
+      backfill: {
+        ...backfill,
+        pendingAgents: [...backfill.pendingAgents],
+        completedAgents: [...backfill.completedAgents],
+        failedAgents: [...backfill.failedAgents],
+        progress: backfill.progress ? { ...backfill.progress } : undefined,
+      },
       updatedAt: Date.now(),
     });
   }


### PR DESCRIPTION
## Summary

- replace independently mutable backfill fields with an attempt-scoped lifecycle model
- reject stale progress and terminal callbacks while keeping the existing status wire format
- replace partial backfill status merges with complete snapshots
- cancel queued and running attempts explicitly during shutdown

## Testing

- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

Issue: CS-164