### PR TITLE
refactor(cli): retain scan worker baselines

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -131,6 +131,8 @@ function makeWorkerRunner(): WorkerRunner {
       sessions: payload.derivedOnly ? payload.previousSessions : [],
       meta: payload.meta,
     })),
+    commit: vi.fn(),
+    discard: vi.fn(),
     shutdown: vi.fn(async () => undefined),
   };
 }
@@ -311,11 +313,12 @@ describe("AgentSyncEngine", () => {
   it("publishes session and status changes through its interface", async () => {
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
+    const workerRunner = makeWorkerRunner();
     const agent = makeAgent({
       checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
       incrementalScan: () => [updated],
     });
-    const { engine } = makeEngine(agent, [previous]);
+    const { engine } = makeEngine(agent, [previous], workerRunner);
     const sessionChanges = vi.fn();
     const statusChanges = vi.fn();
     engine.subscribeSessionsChanged(sessionChanges);
@@ -333,6 +336,7 @@ describe("AgentSyncEngine", () => {
     expect(statusChanges).toHaveBeenCalledWith(
       expect.objectContaining({ type: "scan-status", active: false }),
     );
+    expect(workerRunner.discard).toHaveBeenCalledWith("codex");
   });
 
   it("bounds progress broadcasts while preserving phase and completion", async () => {
@@ -990,6 +994,8 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async () => ({ sessions: [newSession], meta: {}, changedIds: [] })),
+      commit: vi.fn(),
+      discard: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const engine = new AgentSyncEngine({ workerRunner });
@@ -1010,6 +1016,8 @@ describe("AgentSyncEngine", () => {
 
     expect(engine.snapshot().sessions).toEqual([oldSession]);
     expect(sessionChanges).not.toHaveBeenCalled();
+    expect(workerRunner.commit).not.toHaveBeenCalled();
+    expect(workerRunner.discard).toHaveBeenCalledTimes(1);
 
     await engine.refresh("codex");
 
@@ -1024,6 +1032,7 @@ describe("AgentSyncEngine", () => {
         event: expect.objectContaining({ updatedSessions: 1 }),
       }),
     );
+    expect(workerRunner.commit).toHaveBeenCalledTimes(1);
   });
 
   it("CS-73 regression: a windowed startup scan with one unindexed session still switches to the incremental refresh path", async () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -369,6 +369,7 @@ export class AgentSyncEngine {
     try {
       return await this.runRefresh(agentName);
     } catch (error) {
+      this.options.workerRunner.discard?.(agentName);
       failed = true;
       const failure = toError(error);
       appLogger.error("scan.refresh.error", { agent: agentName, error });
@@ -417,7 +418,10 @@ export class AgentSyncEngine {
     } else {
       strategyResult = await this.scanAgentFully(agent, previousSessions);
     }
-    if (strategyResult.status === "unchanged") return "unchanged";
+    if (strategyResult.status === "unchanged") {
+      this.options.workerRunner.commit?.(agentName);
+      return "unchanged";
+    }
 
     const nextSessions = attachMissingProjectIdentities(strategyResult.nextSessions);
     const searchIndexOptions =
@@ -454,6 +458,7 @@ export class AgentSyncEngine {
       candidateChangedIds: strategyResult.preciseChangedIds ?? [],
       indexJob: persistentJob,
     });
+    this.options.workerRunner.commit?.(agentName);
     const persistDuration = performance.now() - persistStartedAt;
     logSearchIndexSync("scan.refresh", null, { pending_paths: pendingPathCount });
 
@@ -608,6 +613,7 @@ export class AgentSyncEngine {
         sourceFailures: result.sourceFailures ?? [],
       });
     }
+    this.options.workerRunner.discard?.(agent.name);
     const sessions = attachMissingProjectIdentities(
       await Promise.resolve(agent.incrementalScan(baseline, preciseChangedIds, checkResult.refs)),
     );
@@ -878,6 +884,7 @@ export class AgentSyncEngine {
           saveCache: true,
         },
       });
+      this.options.workerRunner.commit?.(agentName);
       if (result.sourceFailures?.length) throw sourceFailureError(result.sourceFailures);
       markAgentFullSyncCompleted(agentName);
       appLogger.info("scan.backfill.done", {
@@ -888,6 +895,7 @@ export class AgentSyncEngine {
       });
       return "committed";
     } catch (error) {
+      this.options.workerRunner.discard?.(agentName);
       appLogger.error("scan.backfill.error", { agent: agentName, error });
       console.error(`[${agentName}] Backfill failed:`, error);
       return "failed";

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -85,6 +85,20 @@ const workerThreads = vi.hoisted(() => ({
     const messageHandlers: Array<(message: unknown) => void> = [];
     const exitHandlers: Array<(code: number) => void> = [];
     const errorHandlers: Array<(error: Error) => void> = [];
+    let scanBaseline = isScanWorker
+      ? {
+          sessions: workerData.previousSessions ?? [],
+          meta: workerData.meta ?? {},
+          generation: workerData.generation ?? 0,
+        }
+      : null;
+    let stagedScanBaseline: {
+      requestId: number;
+      sessions: SessionHead[];
+      meta: Record<string, SessionCacheMeta>;
+      generation: number;
+    } | null = null;
+    let scanAgent: any;
     const runSourceSync = (data: any, agent: any) => {
       const parseSourceFingerprint = (fingerprint: string) => {
         try {
@@ -179,39 +193,77 @@ const workerThreads = vi.hoisted(() => ({
     };
     const dispatch = (data: any) => {
       queueMicrotask(() => {
+        if (data?.type === "commit") {
+          const staged = stagedScanBaseline;
+          if (
+            scanBaseline &&
+            staged &&
+            staged.requestId === data.requestId &&
+            staged.generation === data.generation &&
+            scanBaseline.generation === data.generation
+          ) {
+            scanBaseline = {
+              sessions: staged.sessions,
+              meta: staged.meta,
+              generation: data.generation + 1,
+            };
+            stagedScanBaseline = null;
+          }
+          return;
+        }
         for (const handler of messageHandlers) {
           try {
             if (data?.agentName) {
-              const agent = core
+              if (!scanBaseline || scanBaseline.generation !== (data.generation ?? 0)) {
+                throw new Error("worker generation mismatch");
+              }
+              if (stagedScanBaseline) throw new Error("worker result is awaiting commit");
+              const runData = {
+                ...data,
+                previousSessions: data.previousSessions ?? scanBaseline.sessions,
+                meta: data.meta ?? scanBaseline.meta,
+              };
+              const agent = (scanAgent ??= core
                 .createRegisteredAgents()
-                .find((item: any) => item.name === data.agentName);
-              agent?.setSessionMetaMap?.(new Map(Object.entries(data.meta ?? {})));
+                .find((item: any) => item.name === runData.agentName));
+              agent?.setSessionMetaMap?.(new Map(Object.entries(runData.meta)));
               let sessions: SessionHead[] = [];
               let changedIds: string[] | undefined;
               if (agent?.isAvailable?.() !== false) {
-                if (data.derivedOnly) {
-                  sessions = data.previousSessions;
+                if (runData.derivedOnly) {
+                  sessions = runData.previousSessions;
                 } else if (
-                  data.sourceSync &&
+                  runData.sourceSync &&
                   agent?.listSessionSources &&
                   agent?.scanSessionSource
                 ) {
-                  const result = runSourceSync(data, agent);
+                  const result = runSourceSync(runData, agent);
                   sessions = result.sessions as SessionHead[];
                   changedIds = result.changedIds;
-                } else if (data.changedIds && agent?.incrementalScan) {
-                  sessions = agent.incrementalScan(data.previousSessions, data.changedIds);
+                } else if (runData.changedIds && agent?.incrementalScan) {
+                  sessions = agent.incrementalScan(runData.previousSessions, runData.changedIds);
                 } else {
                   sessions = agent?.scan?.({
-                    ...data.scanOptions,
+                    ...runData.scanOptions,
                     onProgress: () => undefined,
                   });
                 }
               }
-              const delta = computeDelta(data, sessions, changedIds, serializeMeta(agent));
+              const serializedMeta = serializeMeta(agent);
+              const delta = computeDelta(runData, sessions, changedIds, serializedMeta);
+              const sessionIds = new Set(sessions.map((session) => session.id));
+              stagedScanBaseline = {
+                requestId: runData.requestId,
+                sessions,
+                meta: Object.fromEntries(
+                  Object.entries(serializedMeta).filter(([sessionId]) => sessionIds.has(sessionId)),
+                ),
+                generation: runData.generation ?? 0,
+              };
               handler({
                 type: "done",
-                requestId: data.requestId,
+                requestId: runData.requestId,
+                generation: runData.generation ?? 0,
                 ...delta,
                 durationMs: 0,
               });
@@ -221,6 +273,7 @@ const workerThreads = vi.hoisted(() => ({
             handler({
               type: "error",
               requestId: data.requestId,
+              generation: data.generation ?? 0,
               error: error instanceof Error ? error.message : String(error),
               durationMs: 0,
             });
@@ -263,8 +316,7 @@ const workerThreads = vi.hoisted(() => ({
         return worker;
       }),
       postMessage: vi.fn((data: unknown) => {
-        Object.assign(workerData, data);
-        if (!workerThreads.deferScanRefreshWorkers) dispatch(workerData);
+        if (!workerThreads.deferScanRefreshWorkers) dispatch(data);
       }),
       unref: vi.fn(),
       terminate: vi.fn(async () => {
@@ -345,6 +397,8 @@ function makeWorkerRunner() {
   return {
     activeCount: 0,
     run: vi.fn<WorkerRunner["run"]>(),
+    commit: vi.fn<NonNullable<WorkerRunner["commit"]>>(),
+    discard: vi.fn<NonNullable<WorkerRunner["discard"]>>(),
     shutdown: vi.fn<WorkerRunner["shutdown"]>(async () => undefined),
   } satisfies WorkerRunner;
 }
@@ -824,7 +878,13 @@ describe("LiveScanStore", () => {
       (worker) => worker.workerData.agentName === "codex",
     );
     expect(scanWorkers).toHaveLength(1);
-    expect(scanWorkers[0]?.postMessage).toHaveBeenCalledTimes(1);
+    const reusedRunRequests = scanWorkers[0]!.postMessage.mock.calls
+      .map(([request]) => request)
+      .filter((request) => request.type === "run");
+    expect(reusedRunRequests).toHaveLength(1);
+    expect(reusedRunRequests[0]).not.toHaveProperty("previousSessions");
+    expect(reusedRunRequests[0]).not.toHaveProperty("meta");
+    expect(JSON.stringify(reusedRunRequests[0]).length).toBeLessThan(512);
     expect(core.markAgentFullSyncStarted).toHaveBeenCalledWith("codex");
   });
 
@@ -1118,6 +1178,7 @@ describe("LiveScanStore", () => {
     worker.emitMessage({
       type: "checkpoint",
       requestId: worker.workerData.requestId,
+      generation: worker.workerData.generation,
       checkpoint: { stage: "scanned", sessions: [], meta: {}, completeness: "complete" },
     });
 
@@ -1166,7 +1227,139 @@ describe("LiveScanStore", () => {
       },
       changedIds: undefined,
     });
+    expect(runner.activeCount).toBe(1);
+    runner.commit("codex");
     expect(runner.activeCount).toBe(0);
+    await runner.shutdown();
+  });
+
+  it("sends only operation fields after committing an Agent baseline", async () => {
+    const session = makeSession("stateful");
+    const agent = makeAgent("codex", { scan: vi.fn(() => [session]) });
+    core.createRegisteredAgents.mockReturnValue([agent]);
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+
+    const first = await runner.run("codex", {
+      previousSessions: [],
+      changedIds: null,
+      scanOptions: {},
+      meta: {},
+    });
+    await expect(
+      runner.run("codex", {
+        previousSessions: first.sessions,
+        changedIds: [],
+        derivedOnly: true,
+        scanOptions: {},
+        meta: first.meta,
+      }),
+    ).rejects.toThrow("Scan refresh worker for codex is busy");
+    runner.commit("codex");
+    const worker = workerThreads.workers.at(-1)!;
+
+    const second = await runner.run("codex", {
+      previousSessions: first.sessions,
+      changedIds: [],
+      derivedOnly: true,
+      scanOptions: {},
+      meta: first.meta,
+    });
+    const runRequest = worker.postMessage.mock.calls
+      .map(([request]) => request)
+      .find((request) => request.type === "run");
+
+    expect(runRequest).toMatchObject({ type: "run", generation: 1, changedIds: [] });
+    expect(runRequest).not.toHaveProperty("previousSessions");
+    expect(runRequest).not.toHaveProperty("meta");
+    expect(second.sessions).toEqual([session]);
+    expect(core.createRegisteredAgents).toHaveBeenCalledTimes(1);
+
+    runner.commit("codex");
+    worker.emitExit(1);
+    await runner.run("codex", {
+      previousSessions: second.sessions,
+      changedIds: null,
+      scanOptions: {},
+      meta: second.meta,
+    });
+    const replacementWorker = workerThreads.workers.at(-1)!;
+    expect(replacementWorker).not.toBe(worker);
+    expect(replacementWorker.workerData.previousSessions).toEqual(second.sessions);
+    runner.commit("codex");
+    await runner.shutdown();
+  });
+
+  it("discards an uncommitted result and restores from the next main-thread baseline", async () => {
+    const lastKnownGood = makeSession("last-known-good");
+    const candidate = makeSession("candidate");
+    const agent = makeAgent("codex", { scan: vi.fn(() => [candidate]) });
+    core.createRegisteredAgents.mockReturnValue([agent]);
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+
+    await runner.run("codex", {
+      previousSessions: [lastKnownGood],
+      changedIds: null,
+      scanOptions: {},
+      meta: {},
+    });
+    const discardedWorker = workerThreads.workers.at(-1)!;
+    runner.discard("codex");
+
+    expect(discardedWorker.terminate).toHaveBeenCalledTimes(1);
+    await runner.run("codex", {
+      previousSessions: [lastKnownGood],
+      changedIds: null,
+      scanOptions: {},
+      meta: {},
+    });
+    const replacementWorker = workerThreads.workers.at(-1)!;
+    expect(replacementWorker).not.toBe(discardedWorker);
+    expect(replacementWorker.workerData.previousSessions).toEqual([lastKnownGood]);
+    expect(replacementWorker.workerData.generation).toBe(0);
+
+    runner.commit("codex");
+    await runner.shutdown();
+  });
+
+  it("rejects a stale generation result and recreates the worker", async () => {
+    workerThreads.deferScanRefreshWorkers = true;
+    const agent = makeAgent("codex", { scan: vi.fn(() => []) });
+    core.createRegisteredAgents.mockReturnValue([agent]);
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+
+    const refresh = runner.run("codex", {
+      previousSessions: [],
+      changedIds: null,
+      scanOptions: {},
+      meta: {},
+    });
+    const staleWorker = workerThreads.workers.at(-1)!;
+    staleWorker.emitMessage({
+      type: "done",
+      requestId: staleWorker.workerData.requestId,
+      generation: 1,
+      changes: [],
+      removedSessionIds: [],
+      meta: {},
+      removedMetaIds: [],
+      sourceFailures: [],
+      durationMs: 0,
+    });
+
+    await expect(refresh).rejects.toThrow(
+      "Scan refresh generation mismatch: expected 0, received 1",
+    );
+    expect(staleWorker.terminate).toHaveBeenCalledTimes(1);
+
+    workerThreads.deferScanRefreshWorkers = false;
+    await runner.run("codex", {
+      previousSessions: [],
+      changedIds: null,
+      scanOptions: {},
+      meta: {},
+    });
+    expect(workerThreads.workers.at(-1)).not.toBe(staleWorker);
+    runner.commit("codex");
     await runner.shutdown();
   });
 

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => {
 
   return {
     workerData: {} as Record<string, unknown>,
+    workerMessageHandler: undefined as ((message: unknown) => void) | undefined,
     postMessage: vi.fn(),
     attachMissingProjectIdentities: vi.fn((sessions: SessionHead[]) => sessions),
     createRegisteredAgents: vi.fn(),
@@ -62,7 +63,12 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock("node:worker_threads", () => ({
-  parentPort: { postMessage: mocks.postMessage, on: vi.fn() },
+  parentPort: {
+    postMessage: mocks.postMessage,
+    on: vi.fn((event: string, handler: (message: unknown) => void) => {
+      if (event === "message") mocks.workerMessageHandler = handler;
+    }),
+  },
   get workerData() {
     return mocks.workerData;
   },
@@ -146,6 +152,7 @@ async function runWorker() {
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
+  mocks.workerMessageHandler = undefined;
   mocks.attachMissingProjectIdentities.mockImplementation((sessions) => sessions);
   mocks.ensureSessionTagsSync.mockImplementation((_agent, sessions, onProgress) => {
     onProgress?.(sessions.length, sessions.length);
@@ -202,6 +209,7 @@ describe("scan refresh worker entry", () => {
     expect(mocks.postMessage).toHaveBeenNthCalledWith(1, {
       type: "progress",
       requestId: 1,
+      generation: 0,
       progress: { agent: "codex", current: 1 },
     });
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
@@ -240,6 +248,78 @@ describe("scan refresh worker entry", () => {
     ]);
     expect(mocks.postMessage.mock.calls.at(-1)?.[0]).toEqual(
       expect.objectContaining({ type: "done" }),
+    );
+  });
+
+  it("reuses a committed baseline without receiving the full history again", async () => {
+    const session = makeSession("stateful");
+    const scan = vi.fn(() => [session]);
+    mocks.createRegisteredAgents.mockReturnValue([makeAgent({ scan })]);
+    setWorkerData({ generation: 4 });
+
+    await runWorker();
+    await vi.waitFor(() =>
+      expect(mocks.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "done", requestId: 1, generation: 4 }),
+      ),
+    );
+
+    mocks.workerMessageHandler?.({ type: "commit", requestId: 1, generation: 4 });
+    mocks.workerMessageHandler?.({
+      type: "run",
+      requestId: 2,
+      agentName: "codex",
+      generation: 5,
+      changedIds: [],
+      derivedOnly: true,
+      scanOptions: {},
+    });
+
+    await vi.waitFor(() =>
+      expect(mocks.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "done",
+          requestId: 2,
+          generation: 5,
+          changes: [],
+          removedSessionIds: [],
+        }),
+      ),
+    );
+    expect(scan).toHaveBeenCalledTimes(1);
+    expect(mocks.createRegisteredAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when an operation skips the committed generation", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([makeAgent({ scan: vi.fn(() => []) })]);
+    setWorkerData({ generation: 2 });
+
+    await runWorker();
+    await vi.waitFor(() =>
+      expect(mocks.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "done", requestId: 1, generation: 2 }),
+      ),
+    );
+    mocks.workerMessageHandler?.({ type: "commit", requestId: 1, generation: 2 });
+    mocks.workerMessageHandler?.({
+      type: "run",
+      requestId: 2,
+      agentName: "codex",
+      generation: 4,
+      changedIds: [],
+      derivedOnly: true,
+      scanOptions: {},
+    });
+
+    await vi.waitFor(() =>
+      expect(mocks.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          requestId: 2,
+          generation: 4,
+          error: "Worker generation mismatch: expected 3, received 4",
+        }),
+      ),
     );
   });
 

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -30,16 +30,19 @@ export type ScanRefreshWorkerMessage =
   | {
       type: "progress";
       requestId: number;
+      generation: number;
       progress: AgentScanProgress;
     }
   | {
       type: "checkpoint";
       requestId: number;
+      generation: number;
       checkpoint: ScanRefreshWorkerCheckpoint;
     }
   | {
       type: "done";
       requestId: number;
+      generation: number;
       changes: SessionHeadChange[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
@@ -50,6 +53,7 @@ export type ScanRefreshWorkerMessage =
   | {
       type: "error";
       requestId: number;
+      generation: number;
       error: string;
       durationMs: number;
     };
@@ -68,11 +72,12 @@ export type ScanRefreshWorkerCheckpoint =
       backfillCursor?: string;
     };
 
-export interface ScanRefreshWorkerRequest {
+export interface ScanRefreshWorkerRunRequest {
   type: "run";
   requestId: number;
   agentName: string;
-  previousSessions: SessionHead[];
+  generation: number;
+  previousSessions?: SessionHead[];
   changedIds: string[] | null;
   sourceSync?: boolean;
   derivedOnly?: boolean;
@@ -80,7 +85,31 @@ export interface ScanRefreshWorkerRequest {
   backfillCursor?: string | null;
   checkpoint?: boolean;
   scanOptions: Pick<ScanOptions, "from" | "to" | "fast">;
+  meta?: Record<string, SessionCacheMeta>;
+}
+
+export interface ScanRefreshWorkerCommitRequest {
+  type: "commit";
+  requestId: number;
+  generation: number;
+}
+
+export type ScanRefreshWorkerRequest = ScanRefreshWorkerRunRequest | ScanRefreshWorkerCommitRequest;
+
+interface StagedWorkerBaseline {
+  requestId: number;
+  generation: number;
+  sessions: SessionHead[];
   meta: Record<string, SessionCacheMeta>;
+}
+
+interface WorkerBaseline {
+  agentName: string;
+  agent: BaseAgent;
+  generation: number;
+  sessions: SessionHead[];
+  meta: Record<string, SessionCacheMeta>;
+  staged: StagedWorkerBaseline | null;
 }
 
 interface CacheMetaDiff {
@@ -362,15 +391,55 @@ export function finalizeSessions(
   return ordered.map((session) => taggedById.get(session.id) ?? session);
 }
 
+let workerBaseline: WorkerBaseline | null = null;
+
+function baselineFor(data: ScanRefreshWorkerRunRequest): WorkerBaseline {
+  const generation = data.generation ?? 0;
+  const hasSessions = Array.isArray(data.previousSessions);
+  const hasMeta = data.meta != null;
+  if (hasSessions !== hasMeta)
+    throw new Error("Worker baseline requires sessions and meta together");
+
+  if (hasSessions && hasMeta) {
+    if (workerBaseline) throw new Error("Scan refresh worker baseline is already initialized");
+    const agent = createRegisteredAgents().find((item) => item.name === data.agentName);
+    if (!agent) throw new Error(`Unknown agent: ${data.agentName}`);
+    workerBaseline = {
+      agentName: data.agentName,
+      agent,
+      generation,
+      sessions: data.previousSessions!,
+      meta: data.meta!,
+      staged: null,
+    };
+  }
+
+  if (!workerBaseline) throw new Error("Scan refresh worker baseline is not initialized");
+  if (workerBaseline.agentName !== data.agentName) {
+    throw new Error(`Worker Agent mismatch: expected ${workerBaseline.agentName}`);
+  }
+  if (workerBaseline.generation !== generation) {
+    throw new Error(
+      `Worker generation mismatch: expected ${workerBaseline.generation}, received ${generation}`,
+    );
+  }
+  if (workerBaseline.staged) {
+    throw new Error(`Worker result ${workerBaseline.staged.requestId} is awaiting commit`);
+  }
+
+  workerBaseline.agent.setSessionMetaMap(new Map(Object.entries(workerBaseline.meta)));
+  return workerBaseline;
+}
+
 async function run(
-  data: ScanRefreshWorkerRequest,
+  data: ScanRefreshWorkerRunRequest,
   progressEmitter: MonotonicValueSampler<AgentScanProgress>,
 ): Promise<void> {
   const startedAt = performance.now();
-  const agent = createRegisteredAgents().find((item) => item.name === data.agentName);
-  if (!agent) {
-    throw new Error(`Unknown agent: ${data.agentName}`);
-  }
+  const baseline = baselineFor(data);
+  const { agent } = baseline;
+  const previousSessions = baseline.sessions;
+  const previousMeta = baseline.meta;
 
   appLogger.debug("scan.refresh_worker.started", {
     agent: data.agentName,
@@ -378,14 +447,12 @@ async function run(
     backfill: data.backfill ?? false,
     backfill_cursor: data.backfillCursor ?? undefined,
     changed_ids: data.changedIds?.length ?? 0,
-    previous_sessions: data.previousSessions.length,
+    previous_sessions: previousSessions.length,
   });
 
   const reportProgress = (progress: AgentScanProgress): void => {
     progressEmitter.push(progress, progress.phase ?? "scanning");
   };
-
-  agent.setSessionMetaMap(new Map(Object.entries(data.meta)));
 
   const isAvailable = agent.isAvailable();
   let sessions: SessionHead[];
@@ -404,15 +471,15 @@ async function run(
   if (!isAvailable) {
     sessions = [];
   } else if (data.derivedOnly) {
-    sessions = data.previousSessions;
+    sessions = previousSessions;
   } else if (
     agent instanceof FileSystemSessionSource &&
     (data.sourceSync === true || data.checkpoint === true)
   ) {
     const result = syncAgentSources(
       agent,
-      data.previousSessions,
-      data.meta,
+      previousSessions,
+      previousMeta,
       data.scanOptions,
       reportProgress,
     );
@@ -422,7 +489,7 @@ async function run(
     sourceSyncDetails = result;
     sourceFailures = result.sourceFailures;
   } else if (data.changedIds) {
-    sessions = await Promise.resolve(agent.incrementalScan(data.previousSessions, data.changedIds));
+    sessions = await Promise.resolve(agent.incrementalScan(previousSessions, data.changedIds));
   } else {
     sessions = await Promise.resolve(
       agent.scan({
@@ -438,6 +505,7 @@ async function run(
     parentPort?.postMessage({
       type: "checkpoint",
       requestId: data.requestId,
+      generation: baseline.generation,
       checkpoint: {
         stage: "scanned",
         sessions: ordered,
@@ -503,6 +571,7 @@ async function run(
       parentPort?.postMessage({
         type: "checkpoint",
         requestId: data.requestId,
+        generation: baseline.generation,
         checkpoint: nextCheckpoint,
       } satisfies ScanRefreshWorkerMessage);
     },
@@ -560,18 +629,25 @@ async function run(
     total_duration_ms: Math.round(performance.now() - startedAt),
   });
   const nextMeta = buildAgentCacheMeta(agent, new Set(sessions.map((session) => session.id)));
-  const metaDiff = computeCacheMetaDiff(data.meta, nextMeta);
+  const metaDiff = computeCacheMetaDiff(previousMeta, nextMeta);
   const diff = computeSessionDiff(
-    data.previousSessions,
+    previousSessions,
     sessions,
     [...(changedIds ?? []), ...Object.keys(metaDiff.changes), ...metaDiff.removedIds],
     sessionSignature,
   );
 
+  baseline.staged = {
+    requestId: data.requestId,
+    generation: baseline.generation,
+    sessions,
+    meta: nextMeta,
+  };
   progressEmitter.flush();
   parentPort?.postMessage({
     type: "done",
     requestId: data.requestId,
+    generation: baseline.generation,
     changes: diff.changes,
     removedSessionIds: diff.removedSessionIds,
     meta: metaDiff.changes,
@@ -581,7 +657,7 @@ async function run(
   } satisfies ScanRefreshWorkerMessage);
 }
 
-async function handleRequest(data: ScanRefreshWorkerRequest): Promise<void> {
+async function handleRequest(data: ScanRefreshWorkerRunRequest): Promise<void> {
   const startedAt = performance.now();
   const progressEmitter = new MonotonicValueSampler<AgentScanProgress>(
     PROGRESS_INTERVAL_MS,
@@ -589,6 +665,7 @@ async function handleRequest(data: ScanRefreshWorkerRequest): Promise<void> {
       parentPort?.postMessage({
         type: "progress",
         requestId: data.requestId,
+        generation: data.generation ?? 0,
         progress,
       } satisfies ScanRefreshWorkerMessage);
     },
@@ -600,6 +677,7 @@ async function handleRequest(data: ScanRefreshWorkerRequest): Promise<void> {
     parentPort?.postMessage({
       type: "error",
       requestId: data.requestId,
+      generation: data.generation ?? 0,
       error: error instanceof Error ? error.message : String(error),
       durationMs: performance.now() - startedAt,
     } satisfies ScanRefreshWorkerMessage);
@@ -610,8 +688,27 @@ async function handleRequest(data: ScanRefreshWorkerRequest): Promise<void> {
 
 let requestTail = Promise.resolve();
 
+function commitBaseline(data: ScanRefreshWorkerCommitRequest): void {
+  if (!workerBaseline) throw new Error("Cannot commit an uninitialized worker baseline");
+  const staged = workerBaseline.staged;
+  if (!staged || staged.requestId !== data.requestId) {
+    throw new Error(`Worker result ${data.requestId} is not awaiting commit`);
+  }
+  if (workerBaseline.generation !== data.generation || staged.generation !== data.generation) {
+    throw new Error(
+      `Worker commit generation mismatch: expected ${workerBaseline.generation}, received ${data.generation}`,
+    );
+  }
+  workerBaseline.sessions = staged.sessions;
+  workerBaseline.meta = staged.meta;
+  workerBaseline.generation += 1;
+  workerBaseline.staged = null;
+}
+
 function enqueueRequest(data: ScanRefreshWorkerRequest): void {
-  requestTail = requestTail.then(() => handleRequest(data));
+  requestTail = requestTail.then(() =>
+    data.type === "commit" ? commitBaseline(data) : handleRequest(data),
+  );
 }
 
 const initialRequest = workerData as Partial<ScanRefreshWorkerRequest> | undefined;
@@ -619,11 +716,12 @@ if (
   initialRequest?.type === "run" &&
   typeof initialRequest.requestId === "number" &&
   typeof initialRequest.agentName === "string" &&
-  Array.isArray(initialRequest.previousSessions)
+  Array.isArray(initialRequest.previousSessions) &&
+  initialRequest.meta != null
 ) {
-  enqueueRequest(initialRequest as ScanRefreshWorkerRequest);
+  enqueueRequest(initialRequest as ScanRefreshWorkerRunRequest);
 }
 
 parentPort?.on("message", (message: ScanRefreshWorkerRequest) => {
-  if (message.type === "run") enqueueRequest(message);
+  enqueueRequest(message);
 });

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -9,9 +9,10 @@ import type {
 } from "@codesesh/core";
 import { appLogger } from "./logging.js";
 import type {
+  ScanRefreshWorkerCommitRequest,
   ScanRefreshWorkerCheckpoint,
   ScanRefreshWorkerMessage,
-  ScanRefreshWorkerRequest,
+  ScanRefreshWorkerRunRequest,
 } from "./scan-refresh-worker.js";
 import { toError } from "./errors.js";
 
@@ -39,6 +40,8 @@ export interface WorkerResult {
 export interface WorkerRunner {
   readonly activeCount: number;
   run(agentName: string, payload: WorkerPayload): Promise<WorkerResult>;
+  commit?(agentName: string): void;
+  discard?(agentName: string): void;
   shutdown(): Promise<void>;
 }
 
@@ -46,13 +49,17 @@ interface PendingRequest {
   resolve: (result: WorkerResult) => void;
   reject: (error: Error) => void;
   payload: WorkerPayload;
+  generation: number;
   onProgress?: (progress: AgentScanProgress) => void;
   onCheckpoint?: (checkpoint: ScanRefreshWorkerCheckpoint) => void;
 }
 
 interface WorkerSlot {
+  agentName: string;
   worker: Worker;
   pending: Map<number, PendingRequest>;
+  generation: number;
+  awaitingCommit: { requestId: number; generation: number } | null;
   closed: boolean;
 }
 
@@ -63,6 +70,7 @@ function applySessionChanges(
   changes: SessionHeadChange[],
   removedSessionIds: string[],
 ): SessionHead[] {
+  if (changes.length === 0 && removedSessionIds.length === 0) return previousSessions;
   const replacedIds = new Set(removedSessionIds);
   for (const { session } of changes) replacedIds.add(session.id);
   const retained = previousSessions.filter((session) => !replacedIds.has(session.id));
@@ -92,8 +100,10 @@ function applyMetaChanges(
   changed: Record<string, SessionCacheMeta>,
   replacedSessionIds: Iterable<string>,
 ): Record<string, SessionCacheMeta> {
+  const replacedIds = [...replacedSessionIds];
+  if (Object.keys(changed).length === 0 && replacedIds.length === 0) return previous;
   const next = { ...previous };
-  for (const id of replacedSessionIds) delete next[id];
+  for (const id of replacedIds) delete next[id];
   return Object.assign(next, changed);
 }
 
@@ -106,18 +116,25 @@ export class ThreadWorkerRunner implements WorkerRunner {
 
   get activeCount(): number {
     let count = 0;
-    for (const slot of this.workers.values()) count += slot.pending.size;
+    for (const slot of this.workers.values()) {
+      count += slot.pending.size + Number(slot.awaitingCommit != null);
+    }
     return count;
   }
 
   run(agentName: string, payload: WorkerPayload): Promise<WorkerResult> {
     if (this.isShuttingDown) return Promise.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
 
-    const request: ScanRefreshWorkerRequest = {
+    const existingSlot = this.workers.get(agentName);
+    if (existingSlot && (existingSlot.pending.size > 0 || existingSlot.awaitingCommit)) {
+      return Promise.reject(new Error(`Scan refresh worker for ${agentName} is busy`));
+    }
+    const generation = existingSlot?.generation ?? 0;
+    const request: ScanRefreshWorkerRunRequest = {
       type: "run",
       requestId: this.nextRequestId++,
       agentName,
-      previousSessions: payload.previousSessions,
+      generation,
       changedIds: payload.changedIds,
       sourceSync: payload.sourceSync,
       derivedOnly: payload.derivedOnly,
@@ -125,7 +142,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       backfillCursor: payload.backfillCursor,
       checkpoint: payload.checkpoint,
       scanOptions: payload.scanOptions,
-      meta: payload.meta,
+      ...(existingSlot ? {} : { previousSessions: payload.previousSessions, meta: payload.meta }),
     };
 
     return new Promise((resolve, reject) => {
@@ -144,6 +161,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
         resolve,
         reject,
         payload,
+        generation,
         onProgress: payload.onProgress,
         onCheckpoint: payload.onCheckpoint,
       });
@@ -154,9 +172,33 @@ export class ThreadWorkerRunner implements WorkerRunner {
         } catch (error) {
           slot.pending.delete(request.requestId);
           reject(toError(error));
+          this.invalidateWorker(agentName, slot);
         }
       }
     });
+  }
+
+  commit(agentName: string): void {
+    const slot = this.workers.get(agentName);
+    const awaiting = slot?.awaitingCommit;
+    if (!slot || !awaiting) return;
+    const request: ScanRefreshWorkerCommitRequest = {
+      type: "commit",
+      requestId: awaiting.requestId,
+      generation: awaiting.generation,
+    };
+    try {
+      slot.worker.postMessage(request);
+      slot.awaitingCommit = null;
+      slot.generation += 1;
+    } catch {
+      this.invalidateWorker(agentName, slot);
+    }
+  }
+
+  discard(agentName: string): void {
+    const slot = this.workers.get(agentName);
+    if (slot) this.invalidateWorker(agentName, slot);
   }
 
   async shutdown(): Promise<void> {
@@ -172,9 +214,16 @@ export class ThreadWorkerRunner implements WorkerRunner {
     await Promise.allSettled(slots.map((slot) => slot.worker.terminate()));
   }
 
-  private createWorker(agentName: string, request: ScanRefreshWorkerRequest): WorkerSlot {
+  private createWorker(agentName: string, request: ScanRefreshWorkerRunRequest): WorkerSlot {
     const worker = new Worker(this.workerUrl, { workerData: request });
-    const slot: WorkerSlot = { worker, pending: new Map(), closed: false };
+    const slot: WorkerSlot = {
+      agentName,
+      worker,
+      pending: new Map(),
+      generation: request.generation,
+      awaitingCommit: null,
+      closed: false,
+    };
     worker.unref();
     this.workers.set(agentName, slot);
     worker.on("message", (message: ScanRefreshWorkerMessage) => {
@@ -197,6 +246,15 @@ export class ThreadWorkerRunner implements WorkerRunner {
   private handleMessage(slot: WorkerSlot, message: ScanRefreshWorkerMessage): void {
     const pending = slot.pending.get(message.requestId);
     if (!pending) return;
+    if (message.generation !== pending.generation) {
+      const error = new Error(
+        `Scan refresh generation mismatch: expected ${pending.generation}, received ${message.generation}`,
+      );
+      slot.pending.delete(message.requestId);
+      pending.reject(error);
+      this.invalidateWorker(slot.agentName, slot);
+      return;
+    }
     if (message.type === "progress") {
       pending.onProgress?.(message.progress);
       return;
@@ -207,6 +265,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       } catch (error) {
         slot.pending.delete(message.requestId);
         pending.reject(toError(error));
+        this.invalidateWorker(slot.agentName, slot);
       }
       return;
     }
@@ -214,13 +273,14 @@ export class ThreadWorkerRunner implements WorkerRunner {
     slot.pending.delete(message.requestId);
     if (message.type === "error") {
       pending.reject(new Error(message.error));
+      this.invalidateWorker(slot.agentName, slot);
       return;
     }
     const changedIds = message.changes.map(({ session }) => session.id);
     const replacedSessionIds = [...changedIds, ...message.removedSessionIds];
     const removedMetaIds = [...message.removedSessionIds, ...message.removedMetaIds];
     try {
-      pending.resolve({
+      const result = {
         sessions: applySessionChanges(
           pending.payload.previousSessions,
           message.changes,
@@ -229,9 +289,15 @@ export class ThreadWorkerRunner implements WorkerRunner {
         meta: applyMetaChanges(pending.payload.meta, message.meta, removedMetaIds),
         changedIds: pending.payload.sourceSync ? replacedSessionIds : undefined,
         sourceFailures: message.sourceFailures,
-      });
+      };
+      slot.awaitingCommit = {
+        requestId: message.requestId,
+        generation: message.generation,
+      };
+      pending.resolve(result);
     } catch (error) {
       pending.reject(toError(error));
+      this.invalidateWorker(slot.agentName, slot);
     }
   }
 
@@ -241,5 +307,15 @@ export class ThreadWorkerRunner implements WorkerRunner {
     if (this.workers.get(agentName) === slot) this.workers.delete(agentName);
     for (const pending of slot.pending.values()) pending.reject(error);
     slot.pending.clear();
+    slot.awaitingCommit = null;
+  }
+
+  private invalidateWorker(agentName: string, slot: WorkerSlot): void {
+    this.closeWorker(
+      agentName,
+      slot,
+      new Error(`Scan refresh worker state discarded for ${agentName}`),
+    );
+    void slot.worker.terminate().catch(() => undefined);
   }
 }


### PR DESCRIPTION
## Summary

- initialize each per-agent scan worker with the full session/meta baseline only once
- send operation-only refresh requests after initialization and advance baselines through an explicit generation commit
- discard worker state on publication failures, protocol mismatches, and main-thread incremental scans so restart always uses the last-known-good snapshot
- cover commit ordering, crash recovery, stale generations, and bounded steady-state request size

## Why

A 100k-session refresh cloned an estimated 39 MB payload and added roughly 81 MB of heap pressure even for a single changed source. The steady-state request is now independent of total history size.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm perf:check`

Tracks local issue CS-168.