### PR TITLE
build(types): enforce Node 22 runtime surface

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,8 +37,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --noEmit && tsup && node scripts/copy-web-dist.js",
-    "release": "tsc --noEmit && tsup && node scripts/copy-web-dist.js",
+    "build": "pnpm run typecheck && tsup && node scripts/copy-web-dist.js",
+    "release": "pnpm run typecheck && tsup && node scripts/copy-web-dist.js",
     "dev": "tsup --watch",
     "clean": "node ../../scripts/clean.mjs",
     "start": "node dist/index.js",
@@ -46,7 +46,8 @@
     "lint:fix": "oxlint src/ --fix",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.node22.json"
   },
   "dependencies": {
     "@codesesh/core": "workspace:*",
@@ -59,7 +60,7 @@
   },
   "devDependencies": {
     "@codesesh/web": "workspace:*",
-    "@types/node": "^26.1.2",
+    "@types/node": "22.20.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "tsup": "^8.5.1",
     "typescript": "npm:@typescript/typescript6@^6.0.2"

--- a/packages/cli/tsconfig.node22.json
+++ b/packages/cli/tsconfig.node22.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "type-tests"]
+}

--- a/packages/cli/type-tests/node22-runtime.ts
+++ b/packages/cli/type-tests/node22-runtime.ts
@@ -1,0 +1,4 @@
+// @ts-expect-error Node 22 does not include disposable temp directories, added in Node 24.4.
+import { mkdtempDisposableSync } from "node:fs";
+
+void mkdtempDisposableSync;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,18 +21,19 @@
     }
   },
   "scripts": {
-    "build": "tsup && tsc6 --emitDeclarationOnly",
+    "build": "pnpm run typecheck && tsup && tsc6 --emitDeclarationOnly",
     "dev": "tsup --watch",
     "clean": "node ../../scripts/clean.mjs",
     "lint": "oxlint src/",
     "lint:fix": "oxlint src/ --fix",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.node22.json"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^9.6.0",
-    "@types/node": "^26.1.2",
+    "@types/node": "22.20.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "node-gyp": "^13.0.1",
     "tsup": "^8.5.1",

--- a/packages/core/tsconfig.node22.json
+++ b/packages/core/tsconfig.node22.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "type-tests"]
+}

--- a/packages/core/type-tests/node22-runtime.ts
+++ b/packages/core/type-tests/node22-runtime.ts
@@ -1,0 +1,4 @@
+// @ts-expect-error Node 22 does not include disposable temp directories, added in Node 24.4.
+import { mkdtempDisposableSync } from "node:fs";
+
+void mkdtempDisposableSync;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,8 +207,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/web
       '@types/node':
-        specifier: ^26.1.2
-        version: 26.1.2
+        specifier: 22.20.1
+        version: 22.20.1
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
@@ -229,8 +229,8 @@ importers:
         specifier: ^9.6.0
         version: 9.6.0
       '@types/node':
-        specifier: ^26.1.2
-        version: 26.1.2
+        specifier: 22.20.1
+        version: 22.20.1
       '@typescript/native':
         specifier: npm:typescript@^7.0.2
         version: typescript@7.0.2
@@ -1836,6 +1836,9 @@ packages:
 
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
@@ -3600,6 +3603,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -5103,6 +5109,10 @@ snapshots:
   '@types/nlcst@2.0.3':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@26.1.2':
     dependencies:
@@ -7081,6 +7091,8 @@ snapshots:
   ultrahtml@1.7.0: {}
 
   uncrypto@0.1.3: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@8.3.0: {}
 


### PR DESCRIPTION
## Summary

- pin Core and CLI to the maintained Node 22 type surface
- add package-specific minimum-runtime typecheck configs and drift guards
- run the Node 22 typecheck before Core builds and CLI builds/releases
- keep frontend tooling on its existing Node 26 types

## Why

The published CLI declares Node.js 22 as its runtime floor, but Core and CLI were compiled against Node 26 types. That allowed runtime code to reference APIs unavailable on the supported minimum version. The artifact smoke coverage added in CS-169 already exercises the bundled tarball on Node 22 and Node 24; this change aligns the compile-time contract with that runtime gate.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm perf:check`
- `pnpm build`
- `pnpm --filter @codesesh/core build`
- `pnpm package:artifact && pnpm package:smoke -- artifacts/npm/codesesh-1.0.0.tgz`