### PR TITLE
fix(cache): preserve migration invariants

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "turbo run test",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "test:migration": "vitest run packages/core/src/discovery/__tests__/migration-smoke.test.ts",
+    "test:migration": "vitest run --reporter=verbose packages/core/src/discovery/__tests__/migration-smoke.test.ts",
     "package:artifact": "node scripts/package-artifact.mjs",
     "package:artifact:test": "node --test scripts/package-artifact-checks.mjs",
     "package:smoke": "node scripts/smoke-package-artifact.mjs",

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,0 +1,731 @@
+import type Database from "better-sqlite3";
+import type { SessionHead } from "../../types/index.js";
+
+export const EXPECTED_CACHE_SCHEMA_VERSION = 20;
+
+export const RELEASE_CACHE_FIXTURES = [
+  { version: 3, sourceTag: "v0.3.0" },
+  { version: 4, sourceTag: "v0.4.0" },
+  { version: 6, sourceTag: "v0.5.0" },
+  { version: 8, sourceTag: "v0.6.0" },
+  { version: 13, sourceTag: "v0.7.0" },
+  { version: 14, sourceTag: "v0.14.0" },
+  { version: 17, sourceTag: "v0.17.0" },
+  { version: 18, sourceTag: "v1.0.0" },
+] as const;
+
+export type ReleaseCacheFixture = (typeof RELEASE_CACHE_FIXTURES)[number];
+
+export interface MigrationFixtureSeed {
+  agentName: string;
+  session: SessionHead;
+  sourcePath: string;
+  searchContent: string;
+  messageText: string;
+  filePath: string;
+  now: number;
+}
+
+export function hasStructuredMessages(fixture: ReleaseCacheFixture): boolean {
+  return fixture.version >= 8;
+}
+
+export function expectedBackupCount(fixture: ReleaseCacheFixture): number {
+  return [6, 15].filter((version) => version > fixture.version).length;
+}
+
+export function createReleaseCacheFixture(
+  db: Database.Database,
+  fixture: ReleaseCacheFixture,
+  seed?: MigrationFixtureSeed,
+): void {
+  db.pragma("foreign_keys = ON");
+  if (fixture.version <= 6) {
+    createLegacySchema(db, fixture.version);
+  } else {
+    createNormalizedSchema(db, fixture.version);
+  }
+  stampVersion(db, fixture.version);
+  if (!seed) return;
+
+  seedSharedRows(db, fixture.version, seed);
+  if (fixture.version <= 6) {
+    seedLegacyRows(db, fixture.version, seed);
+  } else {
+    seedNormalizedRows(db, fixture.version, seed);
+  }
+}
+
+function createLegacySchema(db: Database.Database, version: number): void {
+  const projectColumns =
+    version >= 6
+      ? `
+        project_identity_kind TEXT NOT NULL DEFAULT 'path',
+        project_identity_key TEXT NOT NULL DEFAULT '',
+        project_display_name TEXT NOT NULL DEFAULT '',`
+      : "";
+
+  db.exec(`
+    CREATE TABLE cache_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    CREATE TABLE agent_cache (
+      agent_name TEXT PRIMARY KEY,
+      timestamp INTEGER NOT NULL
+    );
+
+    CREATE TABLE cached_sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      session_json TEXT NOT NULL,
+      meta_json TEXT,
+      PRIMARY KEY (agent_name, session_id)
+    );
+
+    CREATE TABLE session_documents (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      slug TEXT NOT NULL,
+      title TEXT NOT NULL,
+      directory TEXT NOT NULL,${projectColumns}
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER,
+      activity_time INTEGER NOT NULL,
+      content_text TEXT NOT NULL,
+      content_hash TEXT NOT NULL,
+      indexed_at INTEGER NOT NULL,
+      UNIQUE(agent_name, session_id)
+    );
+
+    CREATE VIRTUAL TABLE session_documents_fts USING fts5(
+      title,
+      content_text,
+      content='session_documents',
+      content_rowid='id'
+    );
+
+    CREATE TRIGGER session_documents_ai AFTER INSERT ON session_documents BEGIN
+      INSERT INTO session_documents_fts(rowid, title, content_text)
+      VALUES (new.id, new.title, new.content_text);
+    END;
+
+    CREATE TRIGGER session_documents_ad AFTER DELETE ON session_documents BEGIN
+      INSERT INTO session_documents_fts(session_documents_fts, rowid, title, content_text)
+      VALUES ('delete', old.id, old.title, old.content_text);
+    END;
+
+    CREATE TRIGGER session_documents_au AFTER UPDATE ON session_documents BEGIN
+      INSERT INTO session_documents_fts(session_documents_fts, rowid, title, content_text)
+      VALUES ('delete', old.id, old.title, old.content_text);
+      INSERT INTO session_documents_fts(rowid, title, content_text)
+      VALUES (new.id, new.title, new.content_text);
+    END;
+  `);
+
+  if (version < 6) return;
+  db.exec(`
+    CREATE TABLE project_sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      identity_kind TEXT NOT NULL,
+      identity_key TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      activity_time INTEGER NOT NULL,
+      PRIMARY KEY (agent_name, session_id)
+    );
+
+    CREATE INDEX idx_project_sessions_identity
+      ON project_sessions(identity_kind, identity_key);
+
+    CREATE VIEW project_groups_v AS
+      SELECT
+        identity_kind,
+        identity_key,
+        MIN(display_name) AS display_name,
+        GROUP_CONCAT(DISTINCT agent_name) AS sources_csv,
+        COUNT(*) AS session_count,
+        MAX(activity_time) AS last_activity
+      FROM project_sessions
+      GROUP BY identity_kind, identity_key;
+  `);
+}
+
+function createNormalizedSchema(db: Database.Database, version: number): void {
+  createNormalizedCacheTables(db, version);
+  createNormalizedSessionTables(db, version);
+  createNormalizedFileActivityTables(db, version);
+  createNormalizedSearchTables(db, version);
+  createNormalizedProjectTables(db, version);
+}
+
+function createNormalizedCacheTables(db: Database.Database, version: number): void {
+  db.exec(`
+    CREATE TABLE cache_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+
+    CREATE TABLE agent_cache (
+      agent_name TEXT PRIMARY KEY,
+      timestamp INTEGER NOT NULL
+    );
+
+    CREATE TABLE cached_sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      session_json TEXT NOT NULL,
+      meta_json TEXT,
+      PRIMARY KEY (agent_name, session_id)
+    );
+  `);
+
+  if (version >= 13) {
+    db.exec(`
+      CREATE TABLE cache_initialization (
+        agent_name TEXT PRIMARY KEY,
+        initialized_at INTEGER NOT NULL,
+        index_version TEXT NOT NULL,
+        last_sync_at INTEGER NOT NULL
+      );
+    `);
+  }
+  if (version >= 17) {
+    db.exec(`
+      CREATE TABLE pending_reindex (
+        agent_name TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        PRIMARY KEY (agent_name, session_id)
+      );
+    `);
+  }
+}
+
+function createNormalizedSessionTables(db: Database.Database, version: number): void {
+  const parentColumns =
+    version >= 18
+      ? `
+        parent_agent_name TEXT,
+        parent_session_id TEXT,`
+      : "";
+  const partsFormatColumn = version >= 17 ? "parts_format_version INTEGER NOT NULL DEFAULT 0," : "";
+
+  db.exec(`
+    CREATE TABLE sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      sort_index INTEGER NOT NULL DEFAULT 0,
+      slug TEXT NOT NULL,
+      title TEXT NOT NULL,
+      source_path TEXT,
+      directory TEXT NOT NULL,${parentColumns}
+      project_identity_kind TEXT NOT NULL,
+      project_identity_key TEXT NOT NULL,
+      project_display_name TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER,
+      activity_time INTEGER NOT NULL,
+      message_count INTEGER NOT NULL,
+      total_input_tokens INTEGER NOT NULL,
+      total_output_tokens INTEGER NOT NULL,
+      total_cache_read_tokens INTEGER,
+      total_cache_create_tokens INTEGER,
+      total_cost REAL NOT NULL,
+      cost_source TEXT,
+      total_tokens INTEGER,
+      model_usage_json TEXT,
+      smart_tags_json TEXT,
+      smart_tags_source_updated_at INTEGER,
+      meta_json TEXT,
+      PRIMARY KEY (agent_name, session_id)
+    );
+
+    CREATE INDEX idx_sessions_agent_activity
+      ON sessions(agent_name, activity_time);
+
+    CREATE INDEX idx_sessions_project
+      ON sessions(project_identity_kind, project_identity_key, activity_time);
+
+    CREATE TABLE messages (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      message_index INTEGER NOT NULL,
+      message_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_completed INTEGER,
+      agent TEXT,
+      mode TEXT,
+      model TEXT,
+      provider TEXT,
+      tokens_json TEXT,
+      cost REAL,
+      cost_source TEXT,
+      parts_json TEXT NOT NULL,
+      ${partsFormatColumn}
+      subagent_id TEXT,
+      nickname TEXT,
+      content_text TEXT NOT NULL,
+      tool_metadata_json TEXT,
+      PRIMARY KEY (agent_name, session_id, message_index),
+      FOREIGN KEY (agent_name, session_id)
+        REFERENCES sessions(agent_name, session_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX idx_messages_session
+      ON messages(agent_name, session_id, message_index);
+  `);
+
+  if (version >= 18) {
+    db.exec("CREATE INDEX idx_sessions_parent ON sessions(parent_agent_name, parent_session_id)");
+  }
+  if (version < 13) return;
+
+  db.exec(`
+    CREATE TABLE message_tools (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      message_index INTEGER NOT NULL,
+      tool_name TEXT NOT NULL,
+      PRIMARY KEY (agent_name, session_id, message_index, tool_name),
+      FOREIGN KEY (agent_name, session_id, message_index)
+        REFERENCES messages(agent_name, session_id, message_index)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX idx_message_tools_filter
+      ON message_tools(tool_name, agent_name, session_id);
+
+    CREATE VIRTUAL TABLE messages_fts USING fts5(
+      content_text,
+      content='messages',
+      content_rowid='rowid'
+    );
+
+    CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+      INSERT INTO messages_fts(rowid, content_text)
+      VALUES (new.rowid, new.content_text);
+    END;
+
+    CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content_text)
+      VALUES ('delete', old.rowid, old.content_text);
+    END;
+
+    CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content_text)
+      VALUES ('delete', old.rowid, old.content_text);
+      INSERT INTO messages_fts(rowid, content_text)
+      VALUES (new.rowid, new.content_text);
+    END;
+  `);
+}
+
+function createNormalizedFileActivityTables(db: Database.Database, version: number): void {
+  db.exec(`
+    CREATE TABLE session_file_activity (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      project_identity_key TEXT NOT NULL,
+      path TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      count INTEGER NOT NULL,
+      latest_time INTEGER NOT NULL,
+      PRIMARY KEY (agent_name, session_id, project_identity_key, path, kind),
+      FOREIGN KEY (agent_name, session_id)
+        REFERENCES sessions(agent_name, session_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX idx_file_activity_project_latest
+      ON session_file_activity(project_identity_key, latest_time);
+
+    CREATE INDEX idx_file_activity_path ON session_file_activity(path);
+    CREATE INDEX idx_file_activity_kind ON session_file_activity(kind);
+  `);
+
+  if (version < 13) return;
+  db.exec(`
+    CREATE INDEX idx_file_activity_latest
+      ON session_file_activity(latest_time DESC, count DESC, path);
+    CREATE INDEX idx_file_activity_agent_latest
+      ON session_file_activity(agent_name, latest_time DESC, count DESC, path);
+    CREATE INDEX idx_file_activity_project_latest_ordered
+      ON session_file_activity(project_identity_key, latest_time DESC, count DESC, path);
+
+    CREATE VIRTUAL TABLE session_file_activity_path_fts USING fts5(
+      path,
+      content='session_file_activity',
+      content_rowid='rowid',
+      tokenize='trigram'
+    );
+
+    CREATE TRIGGER session_file_activity_path_ai
+    AFTER INSERT ON session_file_activity BEGIN
+      INSERT INTO session_file_activity_path_fts(rowid, path)
+      VALUES (new.rowid, new.path);
+    END;
+
+    CREATE TRIGGER session_file_activity_path_ad
+    AFTER DELETE ON session_file_activity BEGIN
+      INSERT INTO session_file_activity_path_fts(session_file_activity_path_fts, rowid, path)
+      VALUES ('delete', old.rowid, old.path);
+    END;
+
+    CREATE TRIGGER session_file_activity_path_au
+    AFTER UPDATE ON session_file_activity BEGIN
+      INSERT INTO session_file_activity_path_fts(session_file_activity_path_fts, rowid, path)
+      VALUES ('delete', old.rowid, old.path);
+      INSERT INTO session_file_activity_path_fts(rowid, path)
+      VALUES (new.rowid, new.path);
+    END;
+  `);
+}
+
+function createNormalizedSearchTables(db: Database.Database, version: number): void {
+  if (version >= 17) {
+    db.exec(`
+      CREATE TABLE session_documents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agent_name TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        content_text TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        indexed_message_count INTEGER NOT NULL,
+        indexed_at INTEGER NOT NULL,
+        UNIQUE(agent_name, session_id)
+      );
+    `);
+  } else {
+    const indexedMessageCount = version >= 14 ? "indexed_message_count INTEGER NOT NULL," : "";
+    db.exec(`
+      CREATE TABLE session_documents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        agent_name TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        slug TEXT NOT NULL,
+        title TEXT NOT NULL,
+        directory TEXT NOT NULL,
+        time_created INTEGER NOT NULL,
+        time_updated INTEGER,
+        activity_time INTEGER NOT NULL,
+        content_text TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        ${indexedMessageCount}
+        indexed_at INTEGER NOT NULL,
+        UNIQUE(agent_name, session_id)
+      );
+    `);
+    db.exec(`
+      ALTER TABLE session_documents
+      ADD COLUMN project_identity_kind TEXT NOT NULL DEFAULT 'path';
+      ALTER TABLE session_documents
+      ADD COLUMN project_identity_key TEXT NOT NULL DEFAULT '';
+      ALTER TABLE session_documents
+      ADD COLUMN project_display_name TEXT NOT NULL DEFAULT '';
+    `);
+  }
+
+  db.exec(`
+    CREATE VIRTUAL TABLE session_documents_fts USING fts5(
+      title,
+      content_text,
+      content='session_documents',
+      content_rowid='id'
+    );
+
+    CREATE TRIGGER session_documents_ai AFTER INSERT ON session_documents BEGIN
+      INSERT INTO session_documents_fts(rowid, title, content_text)
+      VALUES (new.id, new.title, new.content_text);
+    END;
+
+    CREATE TRIGGER session_documents_ad AFTER DELETE ON session_documents BEGIN
+      INSERT INTO session_documents_fts(session_documents_fts, rowid, title, content_text)
+      VALUES ('delete', old.id, old.title, old.content_text);
+    END;
+
+    CREATE TRIGGER session_documents_au AFTER UPDATE ON session_documents BEGIN
+      INSERT INTO session_documents_fts(session_documents_fts, rowid, title, content_text)
+      VALUES ('delete', old.id, old.title, old.content_text);
+      INSERT INTO session_documents_fts(rowid, title, content_text)
+      VALUES (new.id, new.title, new.content_text);
+    END;
+  `);
+}
+
+function createNormalizedProjectTables(db: Database.Database, version: number): void {
+  const parentFilter =
+    version >= 18 ? "WHERE parent_agent_name IS NULL OR parent_session_id IS NULL" : "";
+  db.exec(`
+    CREATE TABLE project_sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      identity_kind TEXT NOT NULL,
+      identity_key TEXT NOT NULL,
+      display_name TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      activity_time INTEGER NOT NULL,
+      PRIMARY KEY (agent_name, session_id)
+    );
+
+    CREATE INDEX idx_project_sessions_identity
+      ON project_sessions(identity_kind, identity_key);
+
+    CREATE VIEW project_groups_v AS
+      SELECT
+        project_identity_kind AS identity_kind,
+        project_identity_key AS identity_key,
+        MIN(project_display_name) AS display_name,
+        GROUP_CONCAT(DISTINCT agent_name) AS sources_csv,
+        COUNT(*) AS session_count,
+        MAX(activity_time) AS last_activity
+      FROM sessions
+      ${parentFilter}
+      GROUP BY project_identity_kind, project_identity_key;
+  `);
+}
+
+function stampVersion(db: Database.Database, version: number): void {
+  db.prepare("INSERT INTO cache_meta(key, value) VALUES ('version', ?)").run(String(version));
+  if (version >= 8) {
+    db.pragma(`user_version = ${version}`);
+  }
+}
+
+function seedSharedRows(db: Database.Database, version: number, seed: MigrationFixtureSeed): void {
+  const sessionJson = JSON.stringify(seed.session);
+  const metaJson = JSON.stringify({ id: seed.session.id, sourcePath: seed.sourcePath });
+  db.prepare("INSERT INTO agent_cache(agent_name, timestamp) VALUES (?, ?)").run(
+    seed.agentName,
+    seed.now,
+  );
+  db.prepare(
+    "INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json) VALUES (?, ?, ?, ?)",
+  ).run(seed.agentName, seed.session.id, sessionJson, metaJson);
+
+  if (version >= 13) {
+    db.prepare(
+      `
+        INSERT INTO cache_initialization(agent_name, initialized_at, index_version, last_sync_at)
+        VALUES (?, ?, 'session-cache-v1', ?)
+      `,
+    ).run(seed.agentName, seed.now - 100, seed.now - 50);
+  }
+}
+
+function seedLegacyRows(db: Database.Database, version: number, seed: MigrationFixtureSeed): void {
+  const session = seed.session;
+  if (version >= 6) {
+    db.prepare(
+      `
+        INSERT INTO session_documents(
+          agent_name, session_id, slug, title, directory,
+          project_identity_kind, project_identity_key, project_display_name,
+          time_created, time_updated, activity_time, content_text, content_hash, indexed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      seed.agentName,
+      session.id,
+      session.slug,
+      session.title,
+      session.directory,
+      session.project_identity?.kind ?? "path",
+      session.project_identity?.key ?? session.directory,
+      session.project_identity?.displayName ?? session.directory,
+      session.time_created,
+      session.time_updated ?? null,
+      session.time_updated ?? session.time_created,
+      seed.searchContent,
+      "legacy-content-hash",
+      seed.now,
+    );
+    seedProjectSession(db, seed);
+    return;
+  }
+
+  db.prepare(
+    `
+      INSERT INTO session_documents(
+        agent_name, session_id, slug, title, directory, time_created, time_updated,
+        activity_time, content_text, content_hash, indexed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+  ).run(
+    seed.agentName,
+    session.id,
+    session.slug,
+    session.title,
+    session.directory,
+    session.time_created,
+    session.time_updated ?? null,
+    session.time_updated ?? session.time_created,
+    seed.searchContent,
+    "legacy-content-hash",
+    seed.now,
+  );
+}
+
+function seedNormalizedRows(
+  db: Database.Database,
+  version: number,
+  seed: MigrationFixtureSeed,
+): void {
+  const session = seed.session;
+  const parentColumns = version >= 18 ? "parent_agent_name, parent_session_id," : "";
+  const parentValues = version >= 18 ? "NULL, NULL," : "";
+  db.prepare(
+    `
+      INSERT INTO sessions(
+        agent_name, session_id, sort_index, slug, title, source_path, directory,
+        ${parentColumns}
+        project_identity_kind, project_identity_key, project_display_name,
+        time_created, time_updated, activity_time, message_count,
+        total_input_tokens, total_output_tokens, total_cache_read_tokens,
+        total_cache_create_tokens, total_cost, cost_source, total_tokens,
+        model_usage_json, smart_tags_json, smart_tags_source_updated_at, meta_json
+      ) VALUES (
+        @agentName, @sessionId, 0, @slug, @title, @sourcePath, @directory,
+        ${parentValues}
+        @projectKind, @projectKey, @projectDisplayName,
+        @timeCreated, @timeUpdated, @activityTime, @messageCount,
+        @inputTokens, @outputTokens, NULL, NULL, @totalCost, NULL, @totalTokens,
+        NULL, NULL, NULL, @metaJson
+      )
+    `,
+  ).run({
+    agentName: seed.agentName,
+    sessionId: session.id,
+    slug: session.slug,
+    title: session.title,
+    sourcePath: seed.sourcePath,
+    directory: session.directory,
+    projectKind: session.project_identity?.kind ?? "path",
+    projectKey: session.project_identity?.key ?? session.directory,
+    projectDisplayName: session.project_identity?.displayName ?? session.directory,
+    timeCreated: session.time_created,
+    timeUpdated: session.time_updated ?? null,
+    activityTime: session.time_updated ?? session.time_created,
+    messageCount: session.stats.message_count,
+    inputTokens: session.stats.total_input_tokens,
+    outputTokens: session.stats.total_output_tokens,
+    totalCost: session.stats.total_cost,
+    totalTokens: session.stats.total_tokens ?? null,
+    metaJson: JSON.stringify({ id: session.id, sourcePath: seed.sourcePath }),
+  });
+
+  const partsFormatColumn = version >= 17 ? "parts_format_version," : "";
+  const partsFormatValue = version >= 17 ? "0," : "";
+  db.prepare(
+    `
+      INSERT INTO messages(
+        agent_name, session_id, message_index, message_id, role, time_created,
+        parts_json, ${partsFormatColumn} content_text, tool_metadata_json
+      ) VALUES (?, ?, 0, ?, 'assistant', ?, ?, ${partsFormatValue} ?, ?)
+    `,
+  ).run(
+    seed.agentName,
+    session.id,
+    `${session.id}-message`,
+    session.time_created,
+    JSON.stringify([{ type: "text", text: seed.messageText }]),
+    seed.messageText,
+    JSON.stringify([{ tool: "Read" }]),
+  );
+
+  if (version >= 13) {
+    db.prepare(
+      `
+        INSERT INTO message_tools(agent_name, session_id, message_index, tool_name)
+        VALUES (?, ?, 0, 'read')
+      `,
+    ).run(seed.agentName, session.id);
+  }
+
+  db.prepare(
+    `
+      INSERT INTO session_file_activity(
+        agent_name, session_id, project_identity_key, path, kind, count, latest_time
+      ) VALUES (?, ?, ?, ?, 'read', 2, ?)
+    `,
+  ).run(
+    seed.agentName,
+    session.id,
+    session.project_identity?.key ?? session.directory,
+    seed.filePath,
+    seed.now,
+  );
+
+  seedNormalizedSearchDocument(db, version, seed);
+  seedProjectSession(db, seed);
+}
+
+function seedNormalizedSearchDocument(
+  db: Database.Database,
+  version: number,
+  seed: MigrationFixtureSeed,
+): void {
+  const session = seed.session;
+  if (version >= 17) {
+    db.prepare(
+      `
+        INSERT INTO session_documents(
+          agent_name, session_id, title, content_text, content_hash,
+          indexed_message_count, indexed_at
+        ) VALUES (?, ?, ?, ?, 'normalized-content-hash', 1, ?)
+      `,
+    ).run(seed.agentName, session.id, session.title, seed.searchContent, seed.now);
+    return;
+  }
+
+  const indexedMessageColumn = version >= 14 ? "indexed_message_count," : "";
+  const indexedMessageValue = version >= 14 ? "1," : "";
+  db.prepare(
+    `
+      INSERT INTO session_documents(
+        agent_name, session_id, slug, title, directory, time_created, time_updated,
+        activity_time, content_text, content_hash, ${indexedMessageColumn} indexed_at,
+        project_identity_kind, project_identity_key, project_display_name
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'normalized-content-hash', ${indexedMessageValue} ?, ?, ?, ?)
+    `,
+  ).run(
+    seed.agentName,
+    session.id,
+    session.slug,
+    session.title,
+    session.directory,
+    session.time_created,
+    session.time_updated ?? null,
+    session.time_updated ?? session.time_created,
+    seed.searchContent,
+    seed.now,
+    session.project_identity?.kind ?? "path",
+    session.project_identity?.key ?? session.directory,
+    session.project_identity?.displayName ?? session.directory,
+  );
+}
+
+function seedProjectSession(db: Database.Database, seed: MigrationFixtureSeed): void {
+  const session = seed.session;
+  db.prepare(
+    `
+      INSERT INTO project_sessions(
+        agent_name, session_id, identity_kind, identity_key,
+        display_name, directory, activity_time
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `,
+  ).run(
+    seed.agentName,
+    session.id,
+    session.project_identity?.kind ?? "path",
+    session.project_identity?.key ?? session.directory,
+    session.project_identity?.displayName ?? session.directory,
+    session.directory,
+    session.time_updated ?? session.time_created,
+  );
+}

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -1,21 +1,35 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listBookmarks, type BookmarkRecord } from "../../state/bookmarks.js";
-import { listCachedProjectGroups } from "../cache/project-groups.js";
-import { loadCachedSessions } from "../cache/sessions.js";
-import { searchSessions } from "../cache/search.js";
 import type { SessionHead } from "../../types/index.js";
+import { setSchemaEnsuredPath } from "../cache/db.js";
+import { searchFileActivitySessions } from "../cache/file-activity.js";
+import { listCachedProjectGroups } from "../cache/project-groups.js";
+import {
+  loadCachedSessionData,
+  loadCachedSessionRawEntry,
+  loadCachedSessions,
+  saveCachedSessions,
+} from "../cache/sessions.js";
+import { searchSessions } from "../cache/search.js";
+import {
+  createReleaseCacheFixture,
+  EXPECTED_CACHE_SCHEMA_VERSION,
+  expectedBackupCount,
+  hasStructuredMessages,
+  RELEASE_CACHE_FIXTURES,
+  type MigrationFixtureSeed,
+  type ReleaseCacheFixture,
+} from "./migration-fixtures.js";
 
-// Isolated temp directory so computeIdentity resolves to a deterministic
-// "path" identity regardless of manifests in /tmp.
 const FIXTURE_DIR = mkdtempSync(join(tmpdir(), "codesesh-smoke-"));
 const FIXTURE_DIR_NAME = FIXTURE_DIR.split(/[\\/]/).pop()!;
-
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-migration-smoke-"));
 const now = 1_700_000_000_000;
+const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
 
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
@@ -26,14 +40,16 @@ vi.mock("node:os", async (importOriginal) => {
   };
 });
 
-vi.spyOn(Date, "now").mockReturnValue(now);
-
 function getCacheDir(): string {
   return join(testHomeDir, ".cache", "codesesh");
 }
 
 function getCachePath(): string {
   return join(getCacheDir(), "codesesh.db");
+}
+
+function getLegacyCachePath(): string {
+  return join(getCacheDir(), "scan-cache.json");
 }
 
 function getStateDir(): string {
@@ -58,7 +74,7 @@ function makeSession(): SessionHead {
     time_created: now - 1_000,
     time_updated: now,
     stats: {
-      message_count: 2,
+      message_count: 1,
       total_input_tokens: 10,
       total_output_tokens: 5,
       total_cost: 0,
@@ -67,97 +83,23 @@ function makeSession(): SessionHead {
   };
 }
 
-function createLegacyCacheFixture(): void {
+function makeSeed(): MigrationFixtureSeed {
+  return {
+    agentName: "claudecode",
+    session: makeSession(),
+    sourcePath: join(FIXTURE_DIR, "session.jsonl"),
+    searchContent: "legacy migration smoke needle content",
+    messageText: "structured detail survived migration",
+    filePath: join(FIXTURE_DIR, "src", "legacy.ts"),
+    now,
+  };
+}
+
+function createCacheFixture(fixture: ReleaseCacheFixture, populated = true): void {
   mkdirSync(getCacheDir(), { recursive: true });
   const db = new Database(getCachePath());
-  const session = makeSession();
-
   try {
-    db.exec(`
-      PRAGMA user_version = 0;
-
-      CREATE TABLE cache_meta (
-        key TEXT PRIMARY KEY,
-        value TEXT NOT NULL
-      );
-
-      CREATE TABLE agent_cache (
-        agent_name TEXT PRIMARY KEY,
-        timestamp INTEGER NOT NULL
-      );
-
-      CREATE TABLE cached_sessions (
-        agent_name TEXT NOT NULL,
-        session_id TEXT NOT NULL,
-        session_json TEXT NOT NULL,
-        meta_json TEXT,
-        PRIMARY KEY (agent_name, session_id)
-      );
-
-      CREATE TABLE session_documents (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        agent_name TEXT NOT NULL,
-        session_id TEXT NOT NULL,
-        slug TEXT NOT NULL,
-        title TEXT NOT NULL,
-        directory TEXT NOT NULL,
-        time_created INTEGER NOT NULL,
-        time_updated INTEGER,
-        activity_time INTEGER NOT NULL,
-        content_text TEXT NOT NULL,
-        content_hash TEXT NOT NULL,
-        indexed_at INTEGER NOT NULL,
-        UNIQUE(agent_name, session_id)
-      );
-
-      CREATE VIRTUAL TABLE session_documents_fts USING fts5(
-        title,
-        content_text,
-        content='session_documents',
-        content_rowid='id'
-      );
-    `);
-
-    db.prepare("INSERT INTO cache_meta(key, value) VALUES ('version', '4')").run();
-    db.prepare("INSERT INTO agent_cache(agent_name, timestamp) VALUES (?, ?)").run(
-      "claudecode",
-      now,
-    );
-    db.prepare(
-      `
-        INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json)
-        VALUES (?, ?, ?, ?)
-      `,
-    ).run("claudecode", session.id, JSON.stringify(session), null);
-    db.prepare(
-      `
-        INSERT INTO session_documents(
-          agent_name,
-          session_id,
-          slug,
-          title,
-          directory,
-          time_created,
-          time_updated,
-          activity_time,
-          content_text,
-          content_hash,
-          indexed_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `,
-    ).run(
-      "claudecode",
-      session.id,
-      session.slug,
-      session.title,
-      session.directory,
-      session.time_created,
-      session.time_updated,
-      session.time_updated,
-      "legacy migration smoke needle content",
-      "old-hash",
-      now,
-    );
+    createReleaseCacheFixture(db, fixture, populated ? makeSeed() : undefined);
   } finally {
     db.close();
   }
@@ -190,20 +132,12 @@ function createLegacyStateFixture(): void {
         PRIMARY KEY (agent_name, session_id)
       );
     `);
-
     db.prepare("INSERT INTO state_meta(key, value) VALUES ('version', '1')").run();
     db.prepare(
       `
         INSERT INTO bookmarks(
-          agent_name,
-          session_id,
-          slug,
-          title,
-          directory,
-          time_created,
-          time_updated,
-          stats_json,
-          bookmarked_at
+          agent_name, session_id, slug, title, directory, time_created,
+          time_updated, stats_json, bookmarked_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
     ).run(
@@ -231,41 +165,214 @@ function getUserVersion(dbPath: string): number {
   }
 }
 
+function getMigrationBackups(): string[] {
+  if (!existsSync(getCacheDir())) return [];
+  return readdirSync(getCacheDir())
+    .filter((name) => name.startsWith("codesesh.db.") && name.endsWith(".bak"))
+    .sort();
+}
+
+function readMigratedFacts(): Record<string, unknown> {
+  const db = new Database(getCachePath(), { readonly: true });
+  try {
+    const scalar = (sql: string): number => {
+      const row = db.prepare(sql).get() as { value?: number } | undefined;
+      return Number(row?.value ?? 0);
+    };
+    return {
+      userVersion: Number(db.pragma("user_version", { simple: true })),
+      cacheVersion: (
+        db.prepare("SELECT value FROM cache_meta WHERE key = 'version'").get() as {
+          value?: string;
+        }
+      ).value,
+      integrity: (
+        db.prepare("PRAGMA integrity_check").get() as { integrity_check?: string } | undefined
+      )?.integrity_check,
+      foreignKeyViolations: db.prepare("PRAGMA foreign_key_check").all(),
+      cachedSessions: scalar("SELECT COUNT(*) AS value FROM cached_sessions"),
+      sessions: scalar("SELECT COUNT(*) AS value FROM sessions"),
+      messages: scalar("SELECT COUNT(*) AS value FROM messages"),
+      messageTools: scalar("SELECT COUNT(*) AS value FROM message_tools"),
+      fileActivity: scalar("SELECT COUNT(*) AS value FROM session_file_activity"),
+      searchDocuments: scalar("SELECT COUNT(*) AS value FROM session_documents"),
+      projects: scalar("SELECT COUNT(*) AS value FROM project_sessions"),
+      pendingReindex: scalar("SELECT COUNT(*) AS value FROM pending_reindex"),
+      documentColumns: (
+        db.prepare("PRAGMA table_info(session_documents)").all() as Array<{ name: string }>
+      )
+        .map((row) => row.name)
+        .sort(),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function expectMigratedBehavior(structured: boolean): void {
+  const cached = loadCachedSessions("claudecode");
+  const detail = loadCachedSessionData("claudecode", "legacy-smoke");
+  const rawDetail = loadCachedSessionRawEntry("claudecode", "legacy-smoke");
+  const projects = listCachedProjectGroups();
+  const results = searchSessions("needle");
+
+  expect(cached?.sessions.map((session) => session.id)).toEqual(["legacy-smoke"]);
+  expect(cached?.sessions[0]?.stats).toMatchObject({
+    message_count: 1,
+    total_input_tokens: 10,
+    total_output_tokens: 5,
+    total_tokens: 15,
+  });
+  expect(detail?.id).toBe("legacy-smoke");
+  expect(detail?.messages).toEqual([]);
+  expect(rawDetail?.pendingReindex).toBe(true);
+  expect(rawDetail?.messageRows).toHaveLength(structured ? 1 : 0);
+  if (structured) {
+    expect(JSON.parse(String(rawDetail?.messageRows[0]?.parts_json))).toEqual([
+      { type: "text", text: "structured detail survived migration" },
+    ]);
+  }
+  expect(projects).toEqual([
+    {
+      identityKind: "path",
+      identityKey: FIXTURE_DIR,
+      displayName: FIXTURE_DIR_NAME,
+      sources: ["claudecode"],
+      sessionCount: 1,
+      lastActivity: now,
+    },
+  ]);
+  expect(results).toHaveLength(1);
+  expect(results[0]?.session.id).toBe("legacy-smoke");
+  expect(results[0]?.snippet).toContain("<mark>needle</mark>");
+
+  if (structured) {
+    const toolResults = searchSessions("tool:read");
+    const fileResults = searchFileActivitySessions("legacy.ts");
+    expect(toolResults.map((result) => result.session.id)).toEqual(["legacy-smoke"]);
+    expect(fileResults.map((result) => result.session.id)).toEqual(["legacy-smoke"]);
+    expect(fileResults[0]?.snippet).toContain("<mark>legacy.ts</mark>");
+  }
+}
+
 beforeEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   rmSync(getStateDir(), { recursive: true, force: true });
+  setSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   rmSync(getStateDir(), { recursive: true, force: true });
+  setSchemaEnsuredPath(null);
 });
 
-describe("sqlite migration smoke", () => {
-  it("migrates old cache and state fixtures for browsing data", () => {
-    createLegacyCacheFixture();
+afterAll(() => {
+  dateNowSpy.mockRestore();
+  rmSync(FIXTURE_DIR, { recursive: true, force: true });
+  rmSync(testHomeDir, { recursive: true, force: true });
+});
+
+describe("sqlite migration release gate", () => {
+  it("registers every released SQLite schema epoch", () => {
+    expect(RELEASE_CACHE_FIXTURES).toEqual([
+      { version: 3, sourceTag: "v0.3.0" },
+      { version: 4, sourceTag: "v0.4.0" },
+      { version: 6, sourceTag: "v0.5.0" },
+      { version: 8, sourceTag: "v0.6.0" },
+      { version: 13, sourceTag: "v0.7.0" },
+      { version: 14, sourceTag: "v0.14.0" },
+      { version: 17, sourceTag: "v0.17.0" },
+      { version: 18, sourceTag: "v1.0.0" },
+    ]);
+  });
+
+  it.each(RELEASE_CACHE_FIXTURES)(
+    "migrates schema v$version from $sourceTag through public storage APIs",
+    (fixture) => {
+      createCacheFixture(fixture);
+      const structured = hasStructuredMessages(fixture);
+
+      expectMigratedBehavior(structured);
+      const migratedFacts = readMigratedFacts();
+      expect(migratedFacts).toEqual({
+        userVersion: EXPECTED_CACHE_SCHEMA_VERSION,
+        cacheVersion: String(EXPECTED_CACHE_SCHEMA_VERSION),
+        integrity: "ok",
+        foreignKeyViolations: [],
+        cachedSessions: 1,
+        sessions: 1,
+        messages: structured ? 1 : 0,
+        messageTools: structured ? 1 : 0,
+        fileActivity: structured ? 1 : 0,
+        searchDocuments: 1,
+        projects: 1,
+        pendingReindex: 1,
+        documentColumns: [
+          "agent_name",
+          "content_hash",
+          "content_text",
+          "detail_version",
+          "id",
+          "indexed_at",
+          "indexed_message_count",
+          "session_id",
+          "title",
+        ],
+      });
+      const backups = getMigrationBackups();
+      expect(backups).toHaveLength(expectedBackupCount(fixture));
+
+      setSchemaEnsuredPath(null);
+      expectMigratedBehavior(structured);
+      expect(readMigratedFacts()).toEqual(migratedFacts);
+      expect(getMigrationBackups()).toEqual(backups);
+    },
+    30_000,
+  );
+
+  it("upgrades an empty pre-compaction cache without a meaningless backup", () => {
+    const fixture = RELEASE_CACHE_FIXTURES.find(({ version }) => version === 14)!;
+    createCacheFixture(fixture, false);
+
+    expect(loadCachedSessions("claudecode")).toBeNull();
+    expect(getUserVersion(getCachePath())).toBe(EXPECTED_CACHE_SCHEMA_VERSION);
+    expect(getMigrationBackups()).toEqual([]);
+  });
+
+  it("replaces the released v2 JSON cache on the first SQLite write", () => {
+    const session = makeSession();
+    mkdirSync(getCacheDir(), { recursive: true });
+    writeFileSync(
+      getLegacyCachePath(),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          claudecode: {
+            sessions: [session],
+            meta: { [session.id]: { id: session.id, sourcePath: "legacy.jsonl" } },
+            timestamp: now,
+            version: 2,
+          },
+        },
+        lastScanTime: now,
+      }),
+    );
+
+    expect(loadCachedSessions("claudecode")).toBeNull();
+    expect(saveCachedSessions("claudecode", [session])).toBe(true);
+    expect(existsSync(getLegacyCachePath())).toBe(false);
+    expect(loadCachedSessions("claudecode")?.sessions.map(({ id }) => id)).toEqual([
+      "legacy-smoke",
+    ]);
+    expect(getUserVersion(getCachePath())).toBe(EXPECTED_CACHE_SCHEMA_VERSION);
+  });
+
+  it("migrates the released state v1 bookmark schema", () => {
     createLegacyStateFixture();
 
-    const cached = loadCachedSessions("claudecode");
-    const projects = listCachedProjectGroups();
-    const results = searchSessions("needle");
     const bookmarks: BookmarkRecord[] = listBookmarks();
 
-    expect(cached?.sessions.map((session) => session.id)).toEqual(["legacy-smoke"]);
-    expect(cached?.sessions[0]?.stats.total_tokens).toBe(15);
-    expect(projects).toEqual([
-      {
-        identityKind: "path",
-        identityKey: FIXTURE_DIR,
-        displayName: FIXTURE_DIR_NAME,
-        sources: ["claudecode"],
-        sessionCount: 1,
-        lastActivity: now,
-      },
-    ]);
-    expect(results).toHaveLength(1);
-    expect(results[0]?.session.id).toBe("legacy-smoke");
-    expect(results[0]?.snippet).toContain("<mark>needle</mark>");
     expect(bookmarks).toEqual([
       {
         reference: { agentName: "claudecode", sessionId: "legacy-smoke" },
@@ -277,7 +384,7 @@ describe("sqlite migration smoke", () => {
           time_created: now - 1_000,
           time_updated: now,
           stats: {
-            message_count: 2,
+            message_count: 1,
             total_input_tokens: 10,
             total_output_tokens: 5,
             total_cost: 0,
@@ -287,23 +394,6 @@ describe("sqlite migration smoke", () => {
         bookmarkedAt: now - 500,
       },
     ]);
-    const migratedCache = new Database(getCachePath(), { readonly: true });
-    const documentColumns = (
-      migratedCache.prepare("PRAGMA table_info(session_documents)").all() as Array<{ name: string }>
-    ).map((row) => row.name);
-    migratedCache.close();
-    expect(documentColumns).toEqual([
-      "id",
-      "agent_name",
-      "session_id",
-      "title",
-      "content_text",
-      "content_hash",
-      "indexed_message_count",
-      "detail_version",
-      "indexed_at",
-    ]);
-    expect(getUserVersion(getCachePath())).toBe(20);
     expect(getUserVersion(getStatePath())).toBe(2);
-  }, 30_000);
+  });
 });

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -478,6 +478,7 @@ function addIndexedMessageCount(db: SQLiteDatabase): void {
 
 function addDetailVersion(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents")) return;
+  createCacheTables(db);
   if (!columnExists(db, "session_documents", "detail_version")) {
     db.exec("ALTER TABLE session_documents ADD COLUMN detail_version TEXT NOT NULL DEFAULT ''");
   }
@@ -1275,9 +1276,8 @@ function runWithFtsRecovery<T>(db: SQLiteDatabase, fn: (db: SQLiteDatabase) => T
   }
 }
 
-function setCacheSchemaVersion(db: SQLiteDatabase): void {
+function setCacheMetaVersion(db: SQLiteDatabase): void {
   createCacheTables(db);
-  setUserVersion(db, CACHE_SCHEMA_VERSION);
   db.prepare(
     `
       INSERT INTO cache_meta(key, value)
@@ -1285,6 +1285,11 @@ function setCacheSchemaVersion(db: SQLiteDatabase): void {
       ON CONFLICT(key) DO UPDATE SET value = excluded.value
     `,
   ).run(String(CACHE_SCHEMA_VERSION));
+}
+
+function setCacheSchemaVersion(db: SQLiteDatabase): void {
+  setUserVersion(db, CACHE_SCHEMA_VERSION);
+  setCacheMetaVersion(db);
 }
 
 function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
@@ -1376,8 +1381,14 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   // Only stamp when behind: every thread's first connection runs ensureSchema,
   // and an unconditional PRAGMA user_version write would contend for the write
   // lock against concurrent checkpoint/index writers on every startup.
-  if (getUserVersion(db) < CACHE_SCHEMA_VERSION) {
+  const userVersion = getUserVersion(db);
+  if (userVersion < CACHE_SCHEMA_VERSION) {
     setCacheSchemaVersion(db);
+  } else if (
+    userVersion === CACHE_SCHEMA_VERSION &&
+    readLegacyCacheVersion(db) !== CACHE_SCHEMA_VERSION
+  ) {
+    setCacheMetaVersion(db);
   }
 
   migrateCodexExecDecode(db);

--- a/packages/core/src/utils/__tests__/sqlite.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite.test.ts
@@ -1,10 +1,11 @@
 import Database from "better-sqlite3";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   backupDatabaseIfPopulated,
+  getUserVersion,
   openDb,
   openDbReadOnly,
   runSchemaMigrations,
@@ -128,6 +129,80 @@ describe("sqlite migration helpers", () => {
       );
     } finally {
       db.close();
+    }
+  });
+
+  it("keeps the source and backup recoverable when a destructive migration fails", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-migration-recovery-"));
+    const dbPath = join(dir, "cache.db");
+    const db = new Database(dbPath) as unknown as SQLiteDatabase;
+    try {
+      db.exec("CREATE TABLE rows(id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
+      db.prepare("INSERT INTO rows(id, value) VALUES (1, 'before')").run();
+
+      expect(() =>
+        runSchemaMigrations(db, {
+          dbPath,
+          currentVersion: 0,
+          targetVersion: 1,
+          migrations: [
+            {
+              version: 1,
+              destructive: true,
+              migrate(database) {
+                database.exec("ALTER TABLE rows ADD COLUMN migrated INTEGER NOT NULL DEFAULT 1");
+                database.exec("UPDATE rows SET value = 'during'");
+                throw new Error("migration interrupted");
+              },
+            },
+          ],
+          backupTables: ["rows"],
+          backupLabel: "recovery",
+        }),
+      ).toThrow("migration interrupted");
+
+      expect(getUserVersion(db)).toBe(0);
+      expect(db.prepare("SELECT * FROM rows").all()).toEqual([{ id: 1, value: "before" }]);
+      expect(
+        db
+          .prepare("PRAGMA table_info(rows)")
+          .all()
+          .map((row) => row.name),
+      ).toEqual(["id", "value"]);
+
+      const backupName = readdirSync(dir).find((name) => name.endsWith(".recovery.bak"));
+      expect(backupName).toBeDefined();
+      const backup = new Database(join(dir, backupName!), { readonly: true });
+      try {
+        expect(backup.prepare("SELECT * FROM rows").all()).toEqual([{ id: 1, value: "before" }]);
+      } finally {
+        backup.close();
+      }
+
+      runSchemaMigrations(db, {
+        dbPath,
+        currentVersion: 0,
+        targetVersion: 1,
+        migrations: [
+          {
+            version: 1,
+            destructive: true,
+            migrate(database) {
+              database.exec("ALTER TABLE rows ADD COLUMN migrated INTEGER NOT NULL DEFAULT 1");
+            },
+          },
+        ],
+        backupTables: ["rows"],
+        backupLabel: "recovery",
+      });
+
+      expect(getUserVersion(db)).toBe(1);
+      expect(db.prepare("SELECT * FROM rows").all()).toEqual([
+        { id: 1, value: "before", migrated: 1 },
+      ]);
+    } finally {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

- add release-derived fixtures for JSON v2 and SQLite schema epochs 3, 4, 6, 8, 13, 14, 17, and 18
- exercise each populated SQLite fixture through the public cache boundary and verify browse, search, project, detail, tool, file activity, backup, integrity, and idempotent reopen behavior
- keep `cache_meta.version` synchronized after real sequential upgrades without restoring an unconditional startup write
- ensure the detail-version migration creates its required pending-reindex table before invalidating legacy details
- verify destructive migration rollback, readable backups, and successful retry after an injected failure
- make `test:migration` print every covered release epoch in CI

## Why

The previous release gate used one synthetic v4-style database. It could not detect failures that only occur when real released schemas traverse multiple migrations. The new matrix immediately exposed two inconsistencies: migrated databases retained stale cache metadata, and authentic v13/v14 databases skipped detail invalidation because they did not yet contain `pending_reindex`.

## Testing

- `pnpm test:migration` (12 passed)
- `pnpm test` (Core 706 passed / 1 skipped, CLI 377 passed, Web 640 passed)
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm perf:check`
- `pnpm --filter @codesesh/core typecheck`
- `pnpm package:artifact`
- `pnpm package:smoke -- artifacts/npm/codesesh-1.0.0.tgz`