### PR TITLE
docs: enforce repository fact consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
 
       - run: pnpm build
 
+      - name: Verify documented repository facts
+        run: node scripts/check-docs-facts.mjs
+
       - name: Smoke test CLI on minimum Node version
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == 22
         run: node packages/cli/dist/index.js --version

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **One place to see every AI coding session you've ever had.**
 
-You've been coding with AI agents — Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode — and the conversations are scattered everywhere on your filesystem. Context is lost. Cost is invisible. History is buried.
+You've been coding with AI agents — Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode — and the conversations are scattered everywhere on your filesystem. Context is lost. Cost is invisible. History is buried.
 
 **CodeSesh** fixes that. It scans your local machine, finds every AI agent session, and surfaces them in a unified, beautiful Web UI. Think of it as a time machine for your AI-assisted development workflow.
 
@@ -46,17 +46,21 @@ CodeSesh believes your session history belongs to **you** — and you deserve to
 
 ## Supported Agents
 
-| Agent | Status |
-|-------|--------|
+<!-- repo-fact:agents:start -->
+
+| Agent       | Status    |
+| ----------- | --------- |
 | Claude Code | Supported |
-| Cursor | Supported |
-| Kimi | Supported |
-| Kimi-Code | Supported |
-| Codex | Supported |
-| Grok | Supported |
-| Pi | Supported |
-| OpenCode | Supported |
-| ZCode | Supported |
+| Cursor      | Supported |
+| Kimi-Cli    | Supported |
+| Kimi-Code   | Supported |
+| Codex       | Supported |
+| Grok        | Supported |
+| Pi          | Supported |
+| OpenCode    | Supported |
+| ZCode       | Supported |
+
+<!-- repo-fact:agents:end -->
 
 More agents coming soon. See the [extension checklist](#extending).
 
@@ -66,8 +70,12 @@ More agents coming soon. See the [extension checklist](#extending).
 
 ### Prerequisites
 
+<!-- repo-fact:pnpm-version:start -->
+
 - Node.js 22+ for the published CLI
-- Node.js 24 and pnpm 11.11.0 for building from source
+- Node.js 24 and pnpm 11.20.0 for building from source
+
+<!-- repo-fact:pnpm-version:end -->
 
 ### Install & Run
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 
 > **一个地方，看遍你所有的 AI 编程会话。**
 
-你一直在用 AI Agent 写代码 —— Claude Code、Cursor、Kimi、Kimi-Code、Codex、Grok、Pi、OpenCode、ZCode —— 但这些对话分散在文件系统的各个角落。上下文丢失，成本不可见，历史深埋。
+你一直在用 AI Agent 写代码 —— Claude Code、Cursor、Kimi-Cli、Kimi-Code、Codex、Grok、Pi、OpenCode、ZCode —— 但这些对话分散在文件系统的各个角落。上下文丢失，成本不可见，历史深埋。
 
 **CodeSesh** 解决这个问题。它扫描你的本地机器，找到所有 AI Agent 会话，并在统一的 Web UI 中呈现。把它理解为你 AI 辅助开发历程的时光机。
 
@@ -46,17 +46,21 @@ CodeSesh 认为，你的会话历史属于**你** —— 你应该在一个地�
 
 ## 支持的 Agent
 
-| Agent | 状态 |
-|-------|------|
+<!-- repo-fact:agents:start -->
+
+| Agent       | 状态   |
+| ----------- | ------ |
 | Claude Code | 已支持 |
-| Cursor | 已支持 |
-| Kimi | 已支持 |
-| Kimi-Code | 已支持 |
-| Codex | 已支持 |
-| Grok | 已支持 |
-| Pi | 已支持 |
-| OpenCode | 已支持 |
-| ZCode | 已支持 |
+| Cursor      | 已支持 |
+| Kimi-Cli    | 已支持 |
+| Kimi-Code   | 已支持 |
+| Codex       | 已支持 |
+| Grok        | 已支持 |
+| Pi          | 已支持 |
+| OpenCode    | 已支持 |
+| ZCode       | 已支持 |
+
+<!-- repo-fact:agents:end -->
 
 更多 Agent 持续接入中。参见[扩展清单](#扩展新-agent)。
 
@@ -66,8 +70,12 @@ CodeSesh 认为，你的会话历史属于**你** —— 你应该在一个地�
 
 ### 环境要求
 
+<!-- repo-fact:pnpm-version:start -->
+
 - 发布后的 CLI 需要 Node.js 22+
-- 源码构建需要 Node.js 24 和 pnpm 11.11.0
+- 源码构建需要 Node.js 24 和 pnpm 11.20.0
+
+<!-- repo-fact:pnpm-version:end -->
 
 ### 安装与运行
 

--- a/apps/www/public/llms-full.txt
+++ b/apps/www/public/llms-full.txt
@@ -1,6 +1,6 @@
 # CodeSesh: AI-Readable Product Knowledge
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It works with local sessions created by Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode, then presents them in one unified Web UI.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It works with local sessions created by Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode, then presents them in one unified Web UI.
 
 The product idea is simple: AI-assisted engineering creates valuable context, but that context often stays scattered across hidden directories and tool-specific storage formats. CodeSesh turns those local records into reusable engineering memory.
 
@@ -14,7 +14,7 @@ CodeSesh runs on the developer's machine. It does not require an account, cloud 
 
 ## One-Line Description
 
-CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode into project-aware, structurally searchable, replayable engineering memory.
+CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode into project-aware, structurally searchable, replayable engineering memory.
 
 ## Primary Audience
 
@@ -31,7 +31,7 @@ Typical users have one or more of these needs:
 
 ## Core Problem
 
-Modern AI coding tools save session history in different local formats and directories. A developer may have useful context inside Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode at the same time. Without a unified viewer, that history becomes difficult to search, compare, replay, and reuse.
+Modern AI coding tools save session history in different local formats and directories. A developer may have useful context inside Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode at the same time. Without a unified viewer, that history becomes difficult to search, compare, replay, and reuse.
 
 This matters because AI coding sessions often contain:
 
@@ -69,15 +69,17 @@ The Web UI includes:
 
 CodeSesh currently supports these AI coding agents:
 
+<!-- repo-fact:agents:start -->
 - Claude Code
 - Cursor
-- Kimi
+- Kimi-Cli
 - Kimi-Code
 - Codex
 - Grok
 - Pi
 - OpenCode
 - ZCode
+<!-- repo-fact:agents:end -->
 
 Each supported agent has an adapter in the core package. Adding support for another agent follows the same adapter pattern.
 
@@ -101,18 +103,20 @@ Published CLI requirement:
 
 Source build requirement:
 
+<!-- repo-fact:pnpm-version:start -->
 - Node.js 24
-- pnpm 11.11.0
+- pnpm 11.20.0
+<!-- repo-fact:pnpm-version:end -->
 
 ## Key Questions
 
 ### What is CodeSesh?
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
 
 ### Which AI coding tools does CodeSesh support?
 
-CodeSesh currently supports Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
+CodeSesh currently supports Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, and ZCode. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
 
 ### Does CodeSesh upload local AI session data?
 
@@ -120,7 +124,9 @@ CodeSesh runs on the user's machine and uses a local SQLite index with a local W
 
 ### How do you install and start CodeSesh?
 
-The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 22+; source development uses Node.js 24 and pnpm 11.11.0.
+<!-- repo-fact:pnpm-version:start -->
+The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 22+; source development uses Node.js 24 and pnpm 11.20.0.
+<!-- repo-fact:pnpm-version:end -->
 
 ## Common CLI Usage
 
@@ -228,7 +234,7 @@ CodeSesh uses a local SQLite-backed cache and search index to restore session li
 
 ### Agent Resume Commands
 
-When an agent declares a resume capability, session details can copy a worktree-aware command for returning to that local context. CodeSesh currently declares resume commands for Claude Code, OpenCode, Kimi, Kimi-Code, Codex, Grok, and Pi. Cursor and ZCode explicitly declare no resume command.
+When an agent declares a resume capability, session details can copy a worktree-aware command for returning to that local context. CodeSesh currently declares resume commands for Claude Code, OpenCode, Kimi-Cli, Kimi-Code, Codex, Grok, and Pi. Cursor and ZCode explicitly declare no resume command.
 
 ### Local Session Ownership
 
@@ -334,7 +340,7 @@ CodeSesh is relevant for queries like:
 
 ## Chinese Summary
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码 Agent 的历史会话。它支持 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Grok、Pi、OpenCode、ZCode，把分散在本地文件系统里的会话沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码 Agent 的历史会话。它支持 Claude Code、Cursor、Kimi-Cli、Kimi-Code、Codex、Grok、Pi、OpenCode、ZCode，把分散在本地文件系统里的会话沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
 
 核心价值包括：跨 Agent 统一时间线、结构化全局搜索、项目浏览模式、项目化会话树、智能标签、会话收藏、完整回放、文件活动索引、Token 与成本可见、SQLite 迁移与本地索引、零配置启动、本地私有、实时刷新。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,6 @@
 # CodeSesh 扫描架构
 
+<!-- repo-fact:agent-source-kinds:start -->
 ```
 ┌────────────────────────────────────────────────────────────────┐
 │                         CLI Entry                              │
@@ -39,7 +40,7 @@
 │                        Agent Registry                          │
 │              packages/core/src/agents/register.ts              │
 │                                                                │
-│  文件系统: Claude Code · Codex · Grok · Kimi-Cli · Pi          │
+│  文件系统: Claude Code · Codex · Grok · Kimi-Cli · Kimi-Code · Pi │
 │  SQLite:  OpenCode · Cursor · ZCode                            │
 │  扩展方式: 实现适配器 + 在 register.ts 声明完整能力             │
 └────────────────────────────────────────────────────────────────┘
@@ -54,6 +55,7 @@
 
 详细表结构和数据流见 [sqlite-storage.md](./sqlite-storage.md)。
 ```
+<!-- repo-fact:agent-source-kinds:end -->
 
 ## 性能说明
 

--- a/docs/scanning-and-caching.md
+++ b/docs/scanning-and-caching.md
@@ -41,8 +41,10 @@ CLI
 
 当前数据源类型：
 
-- 文件型：Claude Code、Codex、Grok、Kimi、Pi
+<!-- repo-fact:agent-source-kinds:start -->
+- 文件型：Claude Code、Codex、Grok、Kimi-Cli、Kimi-Code、Pi
 - 单 SQLite 数据库型：OpenCode、Cursor、ZCode
+<!-- repo-fact:agent-source-kinds:end -->
 
 不同 Agent 可以并行刷新；同一个 Agent 的 refresh 与 backfill 由 `AgentSyncEngine`
 串行化，并为每次 operation 记录 generation。SQLite 搜索写入另由单一 job runner

--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -5,7 +5,9 @@
 CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存储在同一个 SQLite 数据库：
 
 - 路径：`~/.cache/codesesh/codesesh.db`
-- 当前 schema：`CACHE_SCHEMA_VERSION = 16`
+<!-- repo-fact:cache-schema-version:start -->
+- 当前 schema：`CACHE_SCHEMA_VERSION = 20`
+<!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,11 @@
       "types": "./dist/contract/index.d.ts",
       "import": "./dist/contract/index.mjs",
       "require": "./dist/contract/index.js"
+    },
+    "./repository-facts": {
+      "types": "./dist/repository-facts.d.ts",
+      "import": "./dist/repository-facts.mjs",
+      "require": "./dist/repository-facts.js"
     }
   },
   "scripts": {

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -30,8 +30,8 @@ import {
   type MessageBackfillRow,
   type SessionRow,
 } from "./messages.js";
+import { CACHE_SCHEMA_VERSION } from "./version.js";
 
-const CACHE_SCHEMA_VERSION = 20;
 interface MessageToolBackfillRow extends DatabaseRow {
   agent_name?: string;
   session_id?: string;

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,0 +1,1 @@
+export const CACHE_SCHEMA_VERSION = 20;

--- a/packages/core/src/repository-facts.test.ts
+++ b/packages/core/src/repository-facts.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getCoreRepositoryFacts } from "./repository-facts.js";
+
+describe("repository facts", () => {
+  it("derives a complete, unambiguous agent snapshot from the runtime registry", () => {
+    const facts = getCoreRepositoryFacts();
+    const names = facts.agents.map(({ name }) => name);
+    const displayNames = facts.agents.map(({ displayName }) => displayName);
+
+    expect(facts.cacheSchemaVersion).toBeGreaterThan(0);
+    expect(facts.agents.length).toBeGreaterThan(0);
+    expect(new Set(names).size).toBe(names.length);
+    expect(new Set(displayNames).size).toBe(displayNames.length);
+    expect(new Set(facts.agents.map(({ sourceKind }) => sourceKind))).toEqual(
+      new Set(["filesystem", "sqlite"]),
+    );
+  });
+});

--- a/packages/core/src/repository-facts.ts
+++ b/packages/core/src/repository-facts.ts
@@ -1,0 +1,34 @@
+import "./agents/register.js";
+import { DatabaseSessionSource, FileSystemSessionSource, type BaseAgent } from "./agents/base.js";
+import { createRegisteredAgents } from "./agents/registry.js";
+import { CACHE_SCHEMA_VERSION } from "./discovery/cache/version.js";
+
+export type AgentSourceKind = "filesystem" | "sqlite";
+
+export interface RepositoryAgentFact {
+  name: string;
+  displayName: string;
+  sourceKind: AgentSourceKind;
+}
+
+export interface CoreRepositoryFacts {
+  cacheSchemaVersion: number;
+  agents: RepositoryAgentFact[];
+}
+
+function getAgentSourceKind(agent: BaseAgent): AgentSourceKind {
+  if (agent instanceof DatabaseSessionSource) return "sqlite";
+  if (agent instanceof FileSystemSessionSource) return "filesystem";
+  throw new Error(`Registered agent ${agent.name} has no documented source kind`);
+}
+
+export function getCoreRepositoryFacts(): CoreRepositoryFacts {
+  return {
+    cacheSchemaVersion: CACHE_SCHEMA_VERSION,
+    agents: createRegisteredAgents().map((agent) => ({
+      name: agent.name,
+      displayName: agent.displayName,
+      sourceKind: getAgentSourceKind(agent),
+    })),
+  };
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "tsup";
 const isWatch = process.argv.includes("--watch");
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/contract/index.ts"],
+  entry: ["src/index.ts", "src/contract/index.ts", "src/repository-facts.ts"],
   format: ["esm", "cjs"],
   dts: false,
   clean: !isWatch,

--- a/scripts/check-docs-facts.mjs
+++ b/scripts/check-docs-facts.mjs
@@ -1,0 +1,197 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const FACT_SPECS = [
+  { document: "README.md", fact: "agents" },
+  { document: "README_CN.md", fact: "agents" },
+  { document: "apps/www/public/llms-full.txt", fact: "agents" },
+  { document: "docs/scanning-and-caching.md", fact: "agent-source-kinds" },
+  { document: "docs/architecture.md", fact: "agent-source-kinds" },
+  { document: "docs/sqlite-storage.md", fact: "cache-schema-version" },
+  { document: "README.md", fact: "pnpm-version" },
+  { document: "README_CN.md", fact: "pnpm-version" },
+  { document: "apps/www/public/llms-full.txt", fact: "pnpm-version" },
+];
+
+export const CHECKED_FACT_DOCUMENTS = [...new Set(FACT_SPECS.map(({ document }) => document))];
+
+export function extractMarkedFactRegions(contents, fact) {
+  const pattern = new RegExp(
+    `<!--\\s*repo-fact:${fact}:start\\s*-->([\\s\\S]*?)<!--\\s*repo-fact:${fact}:end\\s*-->`,
+    "g",
+  );
+  return [...contents.matchAll(pattern)].map((match) => match[1]);
+}
+
+export function readPnpmVersion(repoRoot) {
+  const manifest = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+  const match = /^pnpm@(\d+\.\d+\.\d+)$/.exec(manifest.packageManager ?? "");
+  if (!match) throw new Error("package.json packageManager must be an exact pnpm version");
+  return match[1];
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function sorted(values) {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+function compareNames(expected, actual) {
+  const expectedNames = sorted(unique(expected));
+  const actualNames = sorted(unique(actual));
+  const missing = expectedNames.filter((name) => !actualNames.includes(name));
+  const unexpected = actualNames.filter((name) => !expectedNames.includes(name));
+  const duplicates = unique(actual.filter((name, index) => actual.indexOf(name) !== index));
+  if (missing.length === 0 && unexpected.length === 0 && duplicates.length === 0) return null;
+
+  return [
+    missing.length > 0 ? `missing ${JSON.stringify(missing)}` : null,
+    unexpected.length > 0 ? `unexpected ${JSON.stringify(unexpected)}` : null,
+    duplicates.length > 0 ? `duplicated ${JSON.stringify(sorted(duplicates))}` : null,
+    `expected ${JSON.stringify(expectedNames)}`,
+    `documented ${JSON.stringify(actualNames)}`,
+  ]
+    .filter(Boolean)
+    .join("; ");
+}
+
+function parseAgentNames(region) {
+  const tableNames = [...region.matchAll(/^\|\s*([^|\n]+?)\s*\|.*$/gm)]
+    .map((match) => match[1].trim())
+    .filter((name) => name !== "Agent" && !/^-+$/.test(name));
+  if (tableNames.length > 0) return tableNames;
+  return [...region.matchAll(/^\s*-\s+(.+?)\s*$/gm)].map((match) => match[1].trim());
+}
+
+function parseSourceKindNames(region) {
+  const filesystem = /文件(?:系统|型)\s*[:：]\s*([^\n│]+)/u.exec(region)?.[1];
+  const sqlite = /SQLite(?:\s+数据库型)?\s*[:：]\s*([^\n│]+)/u.exec(region)?.[1];
+  if (!filesystem || !sqlite) return null;
+
+  const splitNames = (value) => value.split(/\s*(?:、|·)\s*/u).filter(Boolean);
+  return { filesystem: splitNames(filesystem.trim()), sqlite: splitNames(sqlite.trim()) };
+}
+
+function validateRegion(fact, region, repositoryFacts) {
+  if (fact === "pnpm-version") {
+    const versions = [...region.matchAll(/\bpnpm\s+(\d+\.\d+\.\d+)\b/g)].map((match) => match[1]);
+    if (versions.length === 0) return "marker contains no `pnpm x.y.z` declaration";
+    const stale = unique(versions.filter((version) => version !== repositoryFacts.pnpmVersion));
+    return stale.length > 0
+      ? `expected pnpm ${repositoryFacts.pnpmVersion}; documented ${stale.join(", ")}`
+      : null;
+  }
+
+  if (fact === "cache-schema-version") {
+    const versions = [...region.matchAll(/CACHE_SCHEMA_VERSION\s*=\s*(\d+)/g)].map((match) =>
+      Number(match[1]),
+    );
+    if (versions.length === 0) return "marker contains no `CACHE_SCHEMA_VERSION = n` declaration";
+    const stale = unique(
+      versions.filter((version) => version !== repositoryFacts.cacheSchemaVersion),
+    );
+    return stale.length > 0
+      ? `expected CACHE_SCHEMA_VERSION = ${repositoryFacts.cacheSchemaVersion}; documented ${stale.join(", ")}`
+      : null;
+  }
+
+  if (fact === "agents") {
+    return compareNames(
+      repositoryFacts.agents.map(({ displayName }) => displayName),
+      parseAgentNames(region),
+    );
+  }
+
+  const documented = parseSourceKindNames(region);
+  if (!documented) return "marker must declare both filesystem and SQLite agent lists";
+  const filesystemMismatch = compareNames(
+    repositoryFacts.agents
+      .filter(({ sourceKind }) => sourceKind === "filesystem")
+      .map(({ displayName }) => displayName),
+    documented.filesystem,
+  );
+  const sqliteMismatch = compareNames(
+    repositoryFacts.agents
+      .filter(({ sourceKind }) => sourceKind === "sqlite")
+      .map(({ displayName }) => displayName),
+    documented.sqlite,
+  );
+  return [
+    filesystemMismatch ? `filesystem: ${filesystemMismatch}` : null,
+    sqliteMismatch ? `sqlite: ${sqliteMismatch}` : null,
+  ]
+    .filter(Boolean)
+    .join("; ");
+}
+
+export function findDocumentationFactMismatches(repoRoot, coreFacts) {
+  const repositoryFacts = { ...coreFacts, pnpmVersion: readPnpmVersion(repoRoot) };
+  const mismatches = [];
+
+  for (const { document, fact } of FACT_SPECS) {
+    const fullPath = join(repoRoot, document);
+    if (!existsSync(fullPath)) {
+      mismatches.push({ document, fact, message: "document not found" });
+      continue;
+    }
+
+    const regions = extractMarkedFactRegions(readFileSync(fullPath, "utf8"), fact);
+    if (regions.length === 0) {
+      mismatches.push({ document, fact, message: `missing repo-fact:${fact} marker` });
+      continue;
+    }
+
+    regions.forEach((region, index) => {
+      const message = validateRegion(fact, region, repositoryFacts);
+      if (message) {
+        mismatches.push({
+          document,
+          fact,
+          message: regions.length > 1 ? `region ${index + 1}: ${message}` : message,
+        });
+      }
+    });
+  }
+
+  return mismatches;
+}
+
+async function loadCoreRepositoryFacts(repoRoot) {
+  const modulePath = join(repoRoot, "packages/core/dist/repository-facts.mjs");
+  if (!existsSync(modulePath)) {
+    throw new Error(
+      "Core repository facts are not built; run `pnpm --filter @codesesh/core build`",
+    );
+  }
+  const module = await import(pathToFileURL(modulePath).href);
+  return module.getCoreRepositoryFacts();
+}
+
+async function main() {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const mismatches = findDocumentationFactMismatches(
+    repoRoot,
+    await loadCoreRepositoryFacts(repoRoot),
+  );
+
+  if (mismatches.length > 0) {
+    console.error("Documentation repository facts are out of date:");
+    for (const { document, fact, message } of mismatches) {
+      console.error(`  - ${document} [${fact}]: ${message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Documentation facts agree in ${CHECKED_FACT_DOCUMENTS.length} files`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-docs-facts.test.mjs
+++ b/scripts/check-docs-facts.test.mjs
@@ -1,0 +1,131 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CHECKED_FACT_DOCUMENTS,
+  extractMarkedFactRegions,
+  findDocumentationFactMismatches,
+} from "./check-docs-facts.mjs";
+
+const tempDirs = [];
+const coreFacts = {
+  cacheSchemaVersion: 20,
+  agents: [
+    { name: "claudecode", displayName: "Claude Code", sourceKind: "filesystem" },
+    { name: "cursor", displayName: "Cursor", sourceKind: "sqlite" },
+  ],
+};
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function marked(fact, contents) {
+  return `<!-- repo-fact:${fact}:start -->\n${contents}\n<!-- repo-fact:${fact}:end -->`;
+}
+
+function fixtureRepo(packageManager = "pnpm@11.20.0") {
+  const dir = mkdtempSync(join(tmpdir(), "codesesh-docs-facts-"));
+  tempDirs.push(dir);
+  const agentsTable = marked(
+    "agents",
+    "| Agent | Status |\n|---|---|\n| Claude Code | Supported |\n| Cursor | Supported |",
+  );
+  const agentsList = marked("agents", "- Claude Code\n- Cursor");
+  const pnpm = marked("pnpm-version", "- Node.js 24 and pnpm 11.20.0");
+  const sourceKinds = marked(
+    "agent-source-kinds",
+    "- 文件型：Claude Code\n- 单 SQLite 数据库型：Cursor",
+  );
+  const files = {
+    "package.json": JSON.stringify({ packageManager }),
+    "README.md": `${agentsTable}\n${pnpm}`,
+    "README_CN.md": `${agentsTable}\n${pnpm}`,
+    "apps/www/public/llms-full.txt": `${agentsList}\n${pnpm}\n${pnpm}`,
+    "docs/scanning-and-caching.md": sourceKinds,
+    "docs/architecture.md": sourceKinds,
+    "docs/sqlite-storage.md": marked(
+      "cache-schema-version",
+      "- 当前 schema：`CACHE_SCHEMA_VERSION = 20`",
+    ),
+  };
+
+  for (const [path, contents] of Object.entries(files)) {
+    const fullPath = join(dir, path);
+    mkdirSync(join(fullPath, ".."), { recursive: true });
+    writeFileSync(fullPath, contents);
+  }
+  return dir;
+}
+
+describe("CS-172: semantic documentation facts", () => {
+  it("extracts every region for a repeated fact", () => {
+    expect(
+      extractMarkedFactRegions(
+        `${marked("pnpm-version", "pnpm 11.20.0")}\n${marked("pnpm-version", "pnpm 11.20.0")}`,
+        "pnpm-version",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("accepts documents that match executable facts", () => {
+    expect(findDocumentationFactMismatches(fixtureRepo(), coreFacts)).toEqual([]);
+  });
+
+  it("reports a schema bump that was not copied to documentation", () => {
+    const mismatches = findDocumentationFactMismatches(fixtureRepo(), {
+      ...coreFacts,
+      cacheSchemaVersion: 21,
+    });
+
+    expect(mismatches).toContainEqual({
+      document: "docs/sqlite-storage.md",
+      fact: "cache-schema-version",
+      message: "expected CACHE_SCHEMA_VERSION = 21; documented 20",
+    });
+  });
+
+  it("reports a newly registered agent in both support and source-kind declarations", () => {
+    const mismatches = findDocumentationFactMismatches(fixtureRepo(), {
+      ...coreFacts,
+      agents: [
+        ...coreFacts.agents,
+        { name: "fixture", displayName: "Fixture", sourceKind: "filesystem" },
+      ],
+    });
+
+    expect(mismatches).toHaveLength(5);
+    expect(mismatches.every(({ message }) => message.includes('missing ["Fixture"]'))).toBe(true);
+  });
+
+  it("reports every marked pnpm copy after packageManager changes", () => {
+    const mismatches = findDocumentationFactMismatches(fixtureRepo("pnpm@11.21.0"), coreFacts);
+    const pnpmMismatches = mismatches.filter(({ fact }) => fact === "pnpm-version");
+
+    expect(pnpmMismatches).toHaveLength(4);
+    expect(pnpmMismatches[0].message).toContain("expected pnpm 11.21.0");
+  });
+
+  it("requires an explicit marker in every checked document", () => {
+    const dir = fixtureRepo();
+    writeFileSync(join(dir, "README.md"), marked("agents", "- Claude Code\n- Cursor"));
+
+    expect(findDocumentationFactMismatches(dir, coreFacts)).toContainEqual({
+      document: "README.md",
+      fact: "pnpm-version",
+      message: "missing repo-fact:pnpm-version marker",
+    });
+  });
+
+  it("covers user, architecture, and AI knowledge documents", () => {
+    expect(CHECKED_FACT_DOCUMENTS).toEqual(
+      expect.arrayContaining([
+        "README.md",
+        "README_CN.md",
+        "docs/architecture.md",
+        "apps/www/public/llms-full.txt",
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- expose a build-time core repository facts entry derived from the live agent registry and cache schema owner
- correct documented schema, agent source kinds, display names, and pnpm version across user and AI-facing docs
- add marked semantic fact checks with schema, agent, and package-manager drift tests to CI

## Testing

- pnpm lint
- pnpm format:check
- pnpm test
- pnpm package:artifact:test
- pnpm package:artifact
- node scripts/check-docs-paths.mjs
- node scripts/check-docs-facts.mjs
- pnpm exec vitest run --project scripts scripts/check-docs-facts.test.mjs