### PR TITLE
fix(cli): require auth for loopback proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ backup of your history. Session content stays in each agent's own data directory
 | `-v` | — | — | Print version number |
 | `-h` / `--help` | — | — | Show help |
 
-Non-loopback binding is rejected unless `--remote-access` is also present. CodeSesh generates a
-new access token for every process and includes it in the printed startup URL. Treat that URL as a
+Non-loopback binding and `--trust-proxy` are rejected unless `--remote-access` is also present.
+This includes a loopback listener exposed by a same-machine reverse proxy. CodeSesh generates a new
+access token for every process and includes it in the printed startup URL. Treat that URL as a
 password: do not publish it or place it in shared shell history.
 
 A token proves who is asking; it does not hide the answer. Without TLS the token and the full
@@ -212,16 +213,16 @@ proxy access logs. Pick one of:
 # CodeSesh terminates TLS
 npx codesesh --host 0.0.0.0 --remote-access --tls-cert ./cert.pem --tls-key ./key.pem
 
-# A reverse proxy terminates TLS and forwards to CodeSesh
-npx codesesh --host 0.0.0.0 --remote-access --trust-proxy
+# A reverse proxy terminates TLS; CodeSesh stays bound to loopback
+npx codesesh --host 127.0.0.1 --remote-access --trust-proxy
 ```
 
 `--trust-proxy` requires every API request to arrive with `X-Forwarded-Proto: https`, and refuses
 it otherwise — so a request that bypassed the proxy is rejected before authentication. This assumes
 the deployment makes CodeSesh unreachable except through that proxy.
 
-Binding to a non-loopback address without either option still starts, and prints a warning that the
-transport is unencrypted.
+Using `--remote-access` without either TLS option still starts on a non-loopback address and prints
+a warning that the transport is unencrypted.
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -87,7 +87,10 @@ npx codesesh --trace
 | ----------- | ----- | ------- | ----------------------------------------------------------- |
 | `--port`    | `-p`  | `4521`  | HTTP server starting port; falls back to the next available port if busy |
 | `--host`    | —     | `127.0.0.1` | HTTP server bind address; non-loopback values require `--remote-access` |
-| `--remote-access` | — | `false` | Enable token-protected access on a non-loopback host                  |
+| `--remote-access` | — | `false` | Enable token-protected access for any remotely exposed transport     |
+| `--tls-cert` | — | — | Path to a TLS certificate; serves remote access over HTTPS            |
+| `--tls-key` | — | — | Path to the private key matching `--tls-cert`                          |
+| `--trust-proxy` | — | `false` | A reverse proxy in front of CodeSesh terminates TLS                    |
 | `--days`    | `-d`  | `7`     | Only include sessions active in the last N days (`0` = all time) |
 | `--cwd`     | —     | —       | Filter to sessions from a project directory                 |
 | `--agent`   | `-a`  | all     | Filter to specific agent(s), comma-separated                |
@@ -101,9 +104,25 @@ npx codesesh --trace
 | `--clear-cache` | — | `false` | Clear scan cache before starting                            |
 | `-v`        | —     | —       | Print version number                                        |
 
-When remote access is enabled, CodeSesh prints a startup URL containing a fresh access token.
-Anyone with that URL can read the indexed AI session history, so treat it as a password and do not
-share or persist it.
+Non-loopback binding and `--trust-proxy` both require `--remote-access`. This includes the common
+setup where CodeSesh listens on `127.0.0.1` and a same-machine reverse proxy exposes it publicly.
+CodeSesh prints a startup URL containing a fresh access token. Anyone with that URL can read the
+indexed AI session history, so treat it as a password and do not share or persist it.
+
+A token authenticates the requester but does not encrypt traffic. Without TLS, the token and full
+session content travel over the network in plaintext, and URL tokens may be recorded in proxy logs.
+Use one of these protected transports:
+
+```bash
+# CodeSesh terminates TLS
+npx codesesh --host 0.0.0.0 --remote-access --tls-cert ./cert.pem --tls-key ./key.pem
+
+# A reverse proxy terminates TLS; CodeSesh stays bound to loopback
+npx codesesh --host 127.0.0.1 --remote-access --trust-proxy
+```
+
+`--trust-proxy` requires `X-Forwarded-Proto: https` on every API request. The listener must remain
+unreachable except through that trusted proxy.
 
 ## Requirements
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@ import { VERSION } from "./version.js";
 import { appLogger } from "./logging.js";
 import { buildSessionIndexOutput } from "./session-index-output.js";
 import {
-  isLoopbackHostname,
+  resolveRemoteAccessPolicy,
   resolveRemoteTransport,
   type RemoteTransport,
 } from "./remote-access.js";
@@ -129,13 +129,6 @@ const main = defineCommand({
     const hostname = args.host as string;
     const remoteAccess = args["remote-access"] as boolean;
 
-    if (!isLoopbackHostname(hostname) && !remoteAccess) {
-      console.error(
-        `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
-      );
-      process.exit(1);
-    }
-
     let transport: RemoteTransport;
     try {
       transport = resolveRemoteTransport({
@@ -146,6 +139,13 @@ const main = defineCommand({
       });
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+
+    if (resolveRemoteAccessPolicy(hostname, transport).authenticationRequired && !remoteAccess) {
+      console.error(
+        `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
+      );
       process.exit(1);
     }
 

--- a/packages/cli/src/remote-access.test.ts
+++ b/packages/cli/src/remote-access.test.ts
@@ -7,6 +7,7 @@ import {
   isConfidentialTransport,
   isLoopbackHostname,
   RemoteTransportError,
+  resolveRemoteAccessPolicy,
   resolveRemoteTransport,
 } from "./remote-access.js";
 
@@ -31,6 +32,21 @@ describe("remote access", () => {
 
     expect(first).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(second).not.toBe(first);
+  });
+
+  it("resolves authentication from the complete exposure boundary", () => {
+    expect(resolveRemoteAccessPolicy("127.0.0.1", { kind: "loopback" })).toEqual({
+      bindCategory: "loopback",
+      authenticationRequired: false,
+    });
+    expect(resolveRemoteAccessPolicy("127.0.0.1", { kind: "trusted-proxy" })).toEqual({
+      bindCategory: "loopback",
+      authenticationRequired: true,
+    });
+    expect(resolveRemoteAccessPolicy("0.0.0.0", { kind: "plaintext" })).toEqual({
+      bindCategory: "network",
+      authenticationRequired: true,
+    });
   });
 });
 

--- a/packages/cli/src/remote-access.ts
+++ b/packages/cli/src/remote-access.ts
@@ -19,6 +19,11 @@ export type RemoteTransport =
   /** The operator accepted plaintext on an untrusted network. */
   | { kind: "plaintext" };
 
+export interface RemoteAccessPolicy {
+  bindCategory: "loopback" | "network";
+  authenticationRequired: boolean;
+}
+
 export interface RemoteTransportRequest {
   hostname: string;
   tlsCertPath?: string;
@@ -65,6 +70,17 @@ export function resolveRemoteTransport(request: RemoteTransportRequest): RemoteT
 /** Whether the transport keeps request and response bodies off the wire in the clear. */
 export function isConfidentialTransport(transport: RemoteTransport): boolean {
   return transport.kind !== "plaintext";
+}
+
+export function resolveRemoteAccessPolicy(
+  hostname: string,
+  transport: RemoteTransport,
+): RemoteAccessPolicy {
+  const bindCategory = isLoopbackHostname(hostname) ? "loopback" : "network";
+  return {
+    bindCategory,
+    authenticationRequired: bindCategory === "network" || transport.kind !== "loopback",
+  };
 }
 
 const FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
+import { appLogger } from "./logging.js";
 import { createServer } from "./server.js";
 import { resolveRemoteTransport } from "./remote-access.js";
 
@@ -462,6 +463,62 @@ describe("createServer", () => {
       await app.shutdown();
       warnSpy.mockRestore();
     }
+  });
+
+  it("CS-174: authenticates a loopback listener behind a trusted proxy", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const logSpy = vi.spyOn(appLogger, "info");
+    const app = await createServer(0, createStore(), {
+      hostname: "127.0.0.1",
+      remoteAccess: true,
+      remoteAccessToken: "proxy-token",
+      transport: { kind: "trusted-proxy" },
+    });
+    const origin = `http://127.0.0.1:${new URL(app.url).port}`;
+    const proxyHeaders = { "X-Forwarded-Proto": "https" };
+
+    try {
+      expect(logSpy).toHaveBeenCalledWith("server.access_policy", {
+        bind_category: "loopback",
+        transport: "trusted-proxy",
+        authentication: "token",
+      });
+      expect((await fetch(`${origin}/api/agents`, { headers: proxyHeaders })).status).toBe(401);
+      expect(
+        (
+          await fetch(`${origin}/api/agents`, {
+            headers: { ...proxyHeaders, Authorization: "Bearer proxy-token" },
+          })
+        ).status,
+      ).toBe(200);
+      const events = await fetch(`${origin}/api/events?access_token=proxy-token`, {
+        headers: proxyHeaders,
+      });
+      expect(events.headers.get("Content-Type")).toContain("text/event-stream");
+      await events.body?.cancel();
+      expect(
+        (
+          await fetch(`${origin}/api/logs?access_token=proxy-token`, {
+            method: "POST",
+            headers: { ...proxyHeaders, "Content-Type": "application/json" },
+            body: JSON.stringify({ event: "test" }),
+          })
+        ).status,
+      ).toBe(401);
+    } finally {
+      await app.shutdown();
+      warnSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
+  it("CS-174: refuses an unauthenticated loopback trusted proxy", async () => {
+    await expect(
+      createServer(0, createStore(), {
+        hostname: "127.0.0.1",
+        transport: { kind: "trusted-proxy" },
+      }),
+    ).rejects.toThrow("Add --remote-access");
   });
 
   it("fails on an occupied port when fallback is disabled", async () => {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -15,10 +15,11 @@ import { appLogger } from "./logging.js";
 import { validateLoopbackAuthority } from "./loopback-authority.js";
 import {
   createRemoteAccessToken,
-  isLoopbackHostname,
   REMOTE_ACCESS_QUERY_PARAM,
   remoteAccessAuth,
   requireProxyTls,
+  resolveRemoteAccessPolicy,
+  resolveRemoteTransport,
   type RemoteTransport,
 } from "./remote-access.js";
 import type { ScanEventSource } from "./scan-source.js";
@@ -104,21 +105,26 @@ export async function createServer(
 ): Promise<{ url: string; shutdown: () => Promise<void> }> {
   const app = new Hono<{ Bindings: HttpBindings }>();
   const hostname = options.hostname ?? "127.0.0.1";
-  const isLoopback = isLoopbackHostname(hostname);
-  const transport: RemoteTransport =
-    options.transport ?? (isLoopback ? { kind: "loopback" } : { kind: "plaintext" });
-  const remoteAccessToken = !isLoopback
+  const transport: RemoteTransport = options.transport ?? resolveRemoteTransport({ hostname });
+  const accessPolicy = resolveRemoteAccessPolicy(hostname, transport);
+  const remoteAccessToken = accessPolicy.authenticationRequired
     ? (options.remoteAccessToken ?? (options.remoteAccess ? createRemoteAccessToken() : null))
     : null;
   let actualPort: number | null = null;
 
-  if (!isLoopback && !remoteAccessToken) {
+  appLogger.info("server.access_policy", {
+    bind_category: accessPolicy.bindCategory,
+    transport: transport.kind,
+    authentication: remoteAccessToken ? "token" : "none",
+  });
+
+  if (accessPolicy.authenticationRequired && !remoteAccessToken) {
     throw new Error(
       `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
     );
   }
 
-  if (isLoopback) {
+  if (accessPolicy.bindCategory === "loopback") {
     app.use("*", async (c, next) => {
       const decision = validateLoopbackAuthority(c.env.incoming.rawHeaders, hostname, actualPort);
       if (!decision.allowed) {
@@ -235,9 +241,10 @@ export async function createServer(
   // A trusted proxy publishes its own https origin, so only direct TLS changes
   // the scheme CodeSesh prints for itself.
   const scheme = transport.kind === "tls" ? "https" : "http";
-  const baseUrl = isLoopback
-    ? `${scheme}://localhost:${actualPort}`
-    : `${scheme}://${hostname}:${actualPort}`;
+  const baseUrl =
+    accessPolicy.bindCategory === "loopback"
+      ? `${scheme}://localhost:${actualPort}`
+      : `${scheme}://${hostname}:${actualPort}`;
   const url = remoteAccessToken
     ? `${baseUrl}/?${REMOTE_ACCESS_QUERY_PARAM}=${encodeURIComponent(remoteAccessToken)}`
     : baseUrl;
@@ -249,7 +256,7 @@ export async function createServer(
     transport: transport.kind,
   });
 
-  if (!isLoopback) {
+  if (accessPolicy.authenticationRequired) {
     appLogger.warn("server.listen.remote_access", {
       hostname,
       port: actualPort,

--- a/scripts/package-artifact-checks.mjs
+++ b/scripts/package-artifact-checks.mjs
@@ -13,6 +13,7 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const sourceManifest = JSON.parse(
   readFileSync(resolve(scriptDir, "../packages/cli/package.json"), "utf8"),
 );
+const publishedReadme = readFileSync(resolve(scriptDir, "../packages/cli/README.md"), "utf8");
 const validFiles = [
   "README.md",
   "package.json",
@@ -57,4 +58,13 @@ test("rejects missing runtime entries and Web assets", () => {
 
 test("rejects source files outside the publish allowlist", () => {
   assert.throws(() => validatePackedFiles([...validFiles, "src/index.ts"]));
+});
+
+test("documents the remote access security contract in the published README", () => {
+  for (const flag of ["--remote-access", "--tls-cert", "--tls-key", "--trust-proxy"]) {
+    assert.ok(publishedReadme.includes("`" + flag + "`"), `README is missing ${flag}`);
+  }
+  assert.match(publishedReadme, /loopback listener exposed by|listens on `127\.0\.0\.1`/i);
+  assert.match(publishedReadme, /plaintext/i);
+  assert.match(publishedReadme, /X-Forwarded-Proto: https/);
 });


### PR DESCRIPTION
## Summary

- derive authentication requirements from both the listener bind category and the selected transport
- require token authentication for loopback listeners exposed through a trusted proxy
- log the resolved access policy without exposing credentials
- document TLS and trusted-proxy security requirements in the published CLI README

## Root cause

Authentication was derived only from whether the listener bound to a loopback address. A trusted proxy can expose that listener remotely, so the server installed the proxy TLS check but skipped token authentication.

## Impact

Loopback reverse-proxy deployments now fail closed unless `--remote-access` is enabled, and all `/api/*` routes require the generated token after the proxy TLS check.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm package:artifact:test`

Issue: CS-174