### PR TITLE
fix(sync): preserve partial scan history

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -12,7 +12,7 @@ import type {
   SessionSourceFailure,
 } from "@codesesh/core";
 import type { ScanStatusEvent } from "@codesesh/core/contract";
-import type { WorkerRunner } from "./worker-runner.js";
+import type { WorkerResult, WorkerRunner } from "./worker-runner.js";
 import { appLogger } from "./logging.js";
 
 const core = vi.hoisted(() => ({
@@ -124,13 +124,25 @@ class FakeSyncAgent extends FileSystemSessionSource {
   }
 }
 
+function workerResult(
+  result: Omit<WorkerResult, "completeness" | "explicitRemovedSessionIds">,
+  completeness: WorkerResult["completeness"] = "complete",
+): WorkerResult {
+  return { ...result, completeness, explicitRemovedSessionIds: [] };
+}
+
 function makeWorkerRunner(): WorkerRunner {
   return {
     activeCount: 0,
-    run: vi.fn(async (_agentName, payload) => ({
-      sessions: payload.derivedOnly ? payload.previousSessions : [],
-      meta: payload.meta,
-    })),
+    run: vi.fn(async (_agentName, payload) =>
+      workerResult(
+        {
+          sessions: payload.derivedOnly ? payload.previousSessions : [],
+          meta: payload.meta,
+        },
+        payload.scanOptions.from == null && payload.scanOptions.to == null ? "complete" : "partial",
+      ),
+    ),
     commit: vi.fn(),
     discard: vi.fn(),
     shutdown: vi.fn(async () => undefined),
@@ -211,7 +223,7 @@ describe("AgentSyncEngine", () => {
           payload.onProgress?.({ phase: "scanning", total: 10_000, processed });
         }
         payload.onProgress?.({ phase: "finalizing", total: 10_000, processed: 10_000 });
-        return { sessions: [], meta: {} };
+        return workerResult({ sessions: [], meta: {} });
       }),
       shutdown: vi.fn(async () => undefined),
     };
@@ -347,7 +359,7 @@ describe("AgentSyncEngine", () => {
           payload.onProgress?.({ phase: "scanning", total: 10_000, processed });
         }
         payload.onProgress?.({ phase: "finalizing", total: 10_000, processed: 10_000 });
-        return { sessions: [], meta: {} };
+        return workerResult({ sessions: [], meta: {} });
       }),
       shutdown: vi.fn(async () => undefined),
     };
@@ -394,7 +406,7 @@ describe("AgentSyncEngine", () => {
     };
     const workerRunner: WorkerRunner = {
       activeCount: 0,
-      run: vi.fn(async () => ({ sessions: [updated], meta: {} })),
+      run: vi.fn(async () => workerResult({ sessions: [updated], meta: {} })),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(
@@ -491,7 +503,7 @@ describe("AgentSyncEngine", () => {
           changes: [{ session: tagged, sortIndex: 0 }],
           meta,
         });
-        return { sessions: [tagged], meta };
+        return workerResult({ sessions: [tagged], meta });
       }),
       shutdown: vi.fn(async () => undefined),
     };
@@ -531,7 +543,7 @@ describe("AgentSyncEngine", () => {
           meta: {},
           completeness: "partial",
         });
-        return { sessions: [recent], meta: {} };
+        return workerResult({ sessions: [recent], meta: {} }, "partial");
       }),
       shutdown: vi.fn(async () => undefined),
     };
@@ -556,6 +568,15 @@ describe("AgentSyncEngine", () => {
       missing_cached_sessions: 1,
       delete_candidates: 0,
     });
+    expect(logInfo).toHaveBeenCalledWith("scan.refresh.persistence_candidate", {
+      agent: "codex",
+      scope_from: 2,
+      scope_to: undefined,
+      publication_completeness: "partial",
+      durable_baseline_sessions: 2,
+      payload_sessions: 1,
+      delete_candidates: 0,
+    });
     expect(core.saveCachedSessions).toHaveBeenCalledWith(
       "codex",
       [recent],
@@ -564,6 +585,9 @@ describe("AgentSyncEngine", () => {
         completeness: "partial",
       },
     );
+    expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.refresh", [
+      expect.objectContaining({ kind: "full", completeness: "partial" }),
+    ]);
   });
 
   it("keeps the last durable snapshot when a head checkpoint is rejected", async () => {
@@ -584,7 +608,7 @@ describe("AgentSyncEngine", () => {
           meta,
           completeness: "complete",
         });
-        return { sessions: [head], meta };
+        return workerResult({ sessions: [head], meta });
       }),
       shutdown: vi.fn(async () => undefined),
     };
@@ -637,7 +661,7 @@ describe("AgentSyncEngine", () => {
           meta,
           completeness: "complete",
         });
-        return { sessions: [head], meta };
+        return workerResult({ sessions: [head], meta });
       }),
       shutdown: vi.fn(async () => undefined),
     };
@@ -681,13 +705,15 @@ describe("AgentSyncEngine", () => {
     const previous = makeSession("changed", "before");
     const updated = makeSession("changed", "after");
     const incrementalScan = vi.fn(() => [updated]);
-    const runWorker = vi.fn(async () => ({
-      sessions: [steady, updated],
-      meta: {
-        steady: { id: "steady", sourcePath: "/database" },
-        changed: { id: "changed", sourcePath: "/database" },
-      },
-    }));
+    const runWorker = vi.fn(async () =>
+      workerResult({
+        sessions: [steady, updated],
+        meta: {
+          steady: { id: "steady", sourcePath: "/database" },
+          changed: { id: "changed", sourcePath: "/database" },
+        },
+      }),
+    );
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: runWorker,
@@ -748,15 +774,20 @@ describe("AgentSyncEngine", () => {
     });
     const workerRunner: WorkerRunner = {
       activeCount: 0,
-      run: vi.fn(async () => ({
-        sessions: [updated, retained],
-        meta: {
-          changed: { id: "changed", sourcePath: "/changed", sourceFingerprint: "new" },
-          retained: { id: "retained", sourcePath: "/retained", sourceFingerprint: "old" },
-        },
-        changedIds: [changed.id],
-        sourceFailures: [failure],
-      })),
+      run: vi.fn(async () =>
+        workerResult(
+          {
+            sessions: [updated, retained],
+            meta: {
+              changed: { id: "changed", sourcePath: "/changed", sourceFingerprint: "new" },
+              retained: { id: "retained", sourcePath: "/retained", sourceFingerprint: "old" },
+            },
+            changedIds: [changed.id],
+            sourceFailures: [failure],
+          },
+          "partial",
+        ),
+      ),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(new FakeSyncAgent(), [changed, retained], workerRunner);
@@ -919,7 +950,7 @@ describe("AgentSyncEngine", () => {
     const agent = new FakeSyncAgent();
     const workerRunner: WorkerRunner = {
       activeCount: 0,
-      run: vi.fn(async () => ({ sessions: [session], meta: {}, changedIds: [] })),
+      run: vi.fn(async () => workerResult({ sessions: [session], meta: {}, changedIds: [] })),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(agent, [session], workerRunner);
@@ -955,7 +986,7 @@ describe("AgentSyncEngine", () => {
       // The sync worker reports no changedIds even though the session content
       // changed — mirrors an out-of-band reclassification the file-fingerprint
       // check can't see.
-      run: vi.fn(async () => ({ sessions: [newSession], meta: {}, changedIds: [] })),
+      run: vi.fn(async () => workerResult({ sessions: [newSession], meta: {}, changedIds: [] })),
       shutdown: vi.fn(async () => undefined),
     };
     const state: LiveSnapshot = {
@@ -993,7 +1024,7 @@ describe("AgentSyncEngine", () => {
     const agent = new FakeSyncAgent();
     const workerRunner: WorkerRunner = {
       activeCount: 0,
-      run: vi.fn(async () => ({ sessions: [newSession], meta: {}, changedIds: [] })),
+      run: vi.fn(async () => workerResult({ sessions: [newSession], meta: {}, changedIds: [] })),
       commit: vi.fn(),
       discard: vi.fn(),
       shutdown: vi.fn(async () => undefined),
@@ -1058,7 +1089,7 @@ describe("AgentSyncEngine", () => {
     const scanResult = [makeSession("broken")];
     const workerRunner: WorkerRunner = {
       activeCount: 0,
-      run: vi.fn(async () => ({ sessions: scanResult, meta: {} })),
+      run: vi.fn(async () => workerResult({ sessions: scanResult, meta: {} }, "partial")),
       shutdown: vi.fn(async () => undefined),
     };
     const state: LiveSnapshot = { agents: [agent], byAgent: { codex: [] }, sessions: [] };

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -21,6 +21,7 @@ import {
   type SessionHead,
   type SessionHeadChange,
   type SessionSourceFailure,
+  type SessionSnapshotCompleteness,
 } from "@codesesh/core";
 import type { ScanStatusEvent, SessionsUpdatedEvent } from "@codesesh/core/contract";
 import { AgentOperationScheduler, type AgentOperationResult } from "./agent-operation-scheduler.js";
@@ -87,6 +88,9 @@ interface RefreshStrategyResult {
   checkDuration: number;
   scanDuration: number;
   sourceFailures: SessionSourceFailure[];
+  completeness: SessionSnapshotCompleteness;
+  scope: Pick<ScanOptions, "from" | "to">;
+  explicitRemovedSessionIds: string[];
 }
 
 const REFRESH_DEBOUNCE_MS = 200;
@@ -427,6 +431,26 @@ export class AgentSyncEngine {
     const searchIndexOptions =
       pendingPathCount >= SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD ? { isBulk: true } : undefined;
     const persistenceDiff = strategyResult.persistenceDiff;
+    const publicationSessions = strategyResult.fullScanSessions ?? nextSessions;
+    const publicationSessionIds = new Set(publicationSessions.map((session) => session.id));
+    const missingBaselineSessions = refreshBaseline.reduce(
+      (count, session) => count + Number(!publicationSessionIds.has(session.id)),
+      0,
+    );
+    const replacementDeleteCandidates = persistenceDiff
+      ? persistenceDiff.removedSessionIds.length
+      : strategyResult.completeness === "complete"
+        ? missingBaselineSessions
+        : strategyResult.explicitRemovedSessionIds.length;
+    appLogger.info("scan.refresh.persistence_candidate", {
+      agent: agentName,
+      scope_from: strategyResult.scope.from,
+      scope_to: strategyResult.scope.to,
+      publication_completeness: strategyResult.completeness,
+      durable_baseline_sessions: refreshBaseline.length,
+      payload_sessions: publicationSessions.length,
+      delete_candidates: replacementDeleteCandidates,
+    });
     const changedSessionIds = persistenceDiff
       ? new Set(persistenceDiff.changedSessions.map(({ session }) => session.id))
       : undefined;
@@ -445,8 +469,10 @@ export class AgentSyncEngine {
           kind: "full",
           context: "scan.refresh",
           agentName,
-          sessions: strategyResult.fullScanSessions ?? nextSessions,
+          sessions: publicationSessions,
           meta: buildAgentCacheMeta(agent),
+          completeness: strategyResult.completeness,
+          removedSessionIds: strategyResult.explicitRemovedSessionIds,
           saveCache: true,
           ...(searchIndexOptions ? { searchIndexOptions } : {}),
         };
@@ -508,9 +534,9 @@ export class AgentSyncEngine {
         agent: agentName,
         retained_sessions: previousSessions.length,
       });
-      return this.refreshStrategyResult(previousSessions, { status: "unchanged" });
+      return this.refreshStrategyResult(previousSessions, "partial", {}, { status: "unchanged" });
     }
-    return this.refreshStrategyResult([]);
+    return this.refreshStrategyResult([], "partial", {});
   }
 
   private async initializeAgent(
@@ -519,14 +545,16 @@ export class AgentSyncEngine {
   ): Promise<RefreshStrategyResult> {
     this.setScanPhase("initializing");
     const scanStartedAt = performance.now();
-    const result = await this.runWorker(agent, previousSessions, null, this.startupScanOptions(), {
+    const scope = this.startupScanOptions();
+    const result = await this.runWorker(agent, previousSessions, null, scope, {
       checkpoint: true,
     });
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
     const sessions = attachMissingProjectIdentities(result.sessions);
     this.lastRefreshAtByAgent.set(agent.name, Date.now());
-    return this.refreshStrategyResult(sessions, {
+    return this.refreshStrategyResult(sessions, result.completeness, scope, {
       fullScanSessions: sessions,
+      explicitRemovedSessionIds: result.explicitRemovedSessionIds,
       scanDuration: performance.now() - scanStartedAt,
       sourceFailures: result.sourceFailures ?? [],
     });
@@ -538,7 +566,8 @@ export class AgentSyncEngine {
     refreshStartedAt: number,
   ): Promise<RefreshStrategyResult> {
     const scanStartedAt = performance.now();
-    const result = await this.runWorker(agent, cached.sessions, null, this.startupScanOptions(), {
+    const scope = this.startupScanOptions();
+    const result = await this.runWorker(agent, cached.sessions, null, scope, {
       sourceSync: true,
       meta: cached.meta,
     });
@@ -553,12 +582,12 @@ export class AgentSyncEngine {
       (result.sourceFailures?.length ?? 0) === 0
     ) {
       this.logUnchangedRefresh(agent.name, refreshStartedAt);
-      return this.refreshStrategyResult(sessions, {
+      return this.refreshStrategyResult(sessions, result.completeness, scope, {
         status: "unchanged",
         scanDuration: performance.now() - scanStartedAt,
       });
     }
-    return this.refreshStrategyResult(sessions, {
+    return this.refreshStrategyResult(sessions, result.completeness, scope, {
       preciseChangedIds,
       persistenceDiff,
       scanDuration: performance.now() - scanStartedAt,
@@ -587,18 +616,28 @@ export class AgentSyncEngine {
         persistenceDiff.removedSessionIds.length === 0
       ) {
         this.logUnchangedRefresh(agent.name, refreshStartedAt);
-        return this.refreshStrategyResult(sessions, {
-          status: "unchanged",
+        return this.refreshStrategyResult(
+          sessions,
+          result.completeness,
+          {},
+          {
+            status: "unchanged",
+            checkDuration,
+            scanDuration: performance.now() - scanStartedAt,
+          },
+        );
+      }
+      return this.refreshStrategyResult(
+        sessions,
+        result.completeness,
+        {},
+        {
+          persistenceDiff,
           checkDuration,
           scanDuration: performance.now() - scanStartedAt,
-        });
-      }
-      return this.refreshStrategyResult(sessions, {
-        persistenceDiff,
-        checkDuration,
-        scanDuration: performance.now() - scanStartedAt,
-        sourceFailures: result.sourceFailures ?? [],
-      });
+          sourceFailures: result.sourceFailures ?? [],
+        },
+      );
     }
     const preciseChangedIds = checkResult.changedIds ?? null;
     const scanStartedAt = performance.now();
@@ -606,24 +645,35 @@ export class AgentSyncEngine {
       const result = await this.runWorker(agent, baseline, null, {}, { checkpoint: true });
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
-      return this.refreshStrategyResult(sessions, {
-        persistenceDiff: buildPersistenceDiff(baseline, sessions),
-        checkDuration,
-        scanDuration: performance.now() - scanStartedAt,
-        sourceFailures: result.sourceFailures ?? [],
-      });
+      return this.refreshStrategyResult(
+        sessions,
+        result.completeness,
+        {},
+        {
+          persistenceDiff: buildPersistenceDiff(baseline, sessions),
+          checkDuration,
+          scanDuration: performance.now() - scanStartedAt,
+          sourceFailures: result.sourceFailures ?? [],
+        },
+      );
     }
     this.options.workerRunner.discard?.(agent.name);
     const sessions = attachMissingProjectIdentities(
       await Promise.resolve(agent.incrementalScan(baseline, preciseChangedIds, checkResult.refs)),
     );
-    return this.refreshStrategyResult(sessions, {
-      preciseChangedIds,
-      persistenceDiff: buildPersistenceDiff(baseline, sessions, preciseChangedIds),
-      checkDuration,
-      scanDuration: performance.now() - scanStartedAt,
-      sourceFailures: checkResult.sourceFailures ?? [],
-    });
+    const sourceFailures = checkResult.sourceFailures ?? [];
+    return this.refreshStrategyResult(
+      sessions,
+      sourceFailures.length > 0 ? "partial" : "complete",
+      {},
+      {
+        preciseChangedIds,
+        persistenceDiff: buildPersistenceDiff(baseline, sessions, preciseChangedIds),
+        checkDuration,
+        scanDuration: performance.now() - scanStartedAt,
+        sourceFailures,
+      },
+    );
   }
 
   private async scanAgentFully(
@@ -635,16 +685,24 @@ export class AgentSyncEngine {
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
     const sessions = attachMissingProjectIdentities(result.sessions);
     this.lastRefreshAtByAgent.set(agent.name, Date.now());
-    return this.refreshStrategyResult(sessions, {
-      fullScanSessions: sessions,
-      scanDuration: performance.now() - scanStartedAt,
-      sourceFailures: result.sourceFailures ?? [],
-    });
+    return this.refreshStrategyResult(
+      sessions,
+      result.completeness,
+      {},
+      {
+        fullScanSessions: sessions,
+        explicitRemovedSessionIds: result.explicitRemovedSessionIds,
+        scanDuration: performance.now() - scanStartedAt,
+        sourceFailures: result.sourceFailures ?? [],
+      },
+    );
   }
 
   private refreshStrategyResult(
     nextSessions: SessionHead[],
-    overrides: Partial<Omit<RefreshStrategyResult, "nextSessions">> = {},
+    completeness: SessionSnapshotCompleteness,
+    scope: Pick<ScanOptions, "from" | "to">,
+    overrides: Partial<Omit<RefreshStrategyResult, "nextSessions" | "completeness" | "scope">> = {},
   ): RefreshStrategyResult {
     return {
       status: "continue",
@@ -655,6 +713,9 @@ export class AgentSyncEngine {
       checkDuration: 0,
       scanDuration: 0,
       sourceFailures: [],
+      completeness,
+      scope,
+      explicitRemovedSessionIds: [],
       ...overrides,
     };
   }
@@ -881,6 +942,8 @@ export class AgentSyncEngine {
           agentName,
           sessions: fullSessions,
           meta: buildAgentCacheMeta(agent),
+          completeness: result.completeness,
+          removedSessionIds: result.explicitRemovedSessionIds,
           saveCache: true,
         },
       });
@@ -913,6 +976,8 @@ export class AgentSyncEngine {
             agentName: agent.name,
             sessions: cached.sessions,
             meta: cached.meta,
+            completeness: "partial",
+            removedSessionIds: [],
           }
         : {
             kind: "full",
@@ -920,6 +985,8 @@ export class AgentSyncEngine {
             agentName: agent.name,
             sessions: snapshot.byAgent[agent.name] ?? [],
             meta: buildAgentCacheMeta(agent),
+            completeness: "partial",
+            removedSessionIds: [],
           };
     });
   }

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -265,6 +265,12 @@ const workerThreads = vi.hoisted(() => ({
                 requestId: runData.requestId,
                 generation: runData.generation ?? 0,
                 ...delta,
+                sourceFailures: [],
+                completeness:
+                  runData.scanOptions?.from == null && runData.scanOptions?.to == null
+                    ? "complete"
+                    : "partial",
+                explicitRemovedSessionIds: runData.sourceSync ? delta.removedSessionIds : [],
                 durationMs: 0,
               });
               continue;
@@ -401,6 +407,12 @@ function makeWorkerRunner() {
     discard: vi.fn<NonNullable<WorkerRunner["discard"]>>(),
     shutdown: vi.fn<WorkerRunner["shutdown"]>(async () => undefined),
   } satisfies WorkerRunner;
+}
+
+function completeWorkerResult(
+  result: Omit<WorkerResult, "completeness" | "explicitRemovedSessionIds">,
+): WorkerResult {
+  return { ...result, completeness: "complete", explicitRemovedSessionIds: [] };
 }
 
 function syncEngineOf(store: LiveScanStore): AgentSyncEngine {
@@ -955,7 +967,9 @@ describe("LiveScanStore", () => {
             releaseBackfill = resolve;
           }),
       )
-      .mockResolvedValueOnce({ sessions: [fresh], meta: {}, changedIds: [fresh.id] });
+      .mockResolvedValueOnce(
+        completeWorkerResult({ sessions: [fresh], meta: {}, changedIds: [fresh.id] }),
+      );
     const store = new LiveScanStore({ watchEnabled: false, workerRunner });
     await store.initialize();
     const logInfo = vi.spyOn(appLogger, "info").mockImplementation(() => undefined);
@@ -967,7 +981,7 @@ describe("LiveScanStore", () => {
     await Promise.resolve();
     expect(workerRunner.run).toHaveBeenCalledTimes(1);
 
-    releaseBackfill!({ sessions: [stale], meta: {}, changedIds: [stale.id] });
+    releaseBackfill!(completeWorkerResult({ sessions: [stale], meta: {}, changedIds: [stale.id] }));
     await backfill;
     await refresh;
 
@@ -1006,7 +1020,9 @@ describe("LiveScanStore", () => {
     const workerRunner = makeWorkerRunner();
     workerRunner.run
       .mockRejectedValueOnce(new Error("backfill failed"))
-      .mockResolvedValueOnce({ sessions: [fresh], meta: {}, changedIds: [fresh.id] });
+      .mockResolvedValueOnce(
+        completeWorkerResult({ sessions: [fresh], meta: {}, changedIds: [fresh.id] }),
+      );
     const store = new LiveScanStore({ watchEnabled: false, workerRunner });
     await store.initialize();
 
@@ -1064,7 +1080,7 @@ describe("LiveScanStore", () => {
     await syncEngineOf(store).refresh("kimi");
     expect(store.getSnapshot().byAgent.kimi![0]?.title).toBe("kimi fresh");
 
-    releaseBackfill!({ sessions: [codexInitial], meta: {}, changedIds: [] });
+    releaseBackfill!(completeWorkerResult({ sessions: [codexInitial], meta: {}, changedIds: [] }));
     await backfill;
   });
 
@@ -1098,8 +1114,12 @@ describe("LiveScanStore", () => {
             releaseBackfill = resolve;
           }),
       )
-      .mockResolvedValueOnce({ sessions: [refreshed], meta: {}, changedIds: [refreshed.id] })
-      .mockResolvedValueOnce({ sessions: [rerun], meta: {}, changedIds: [rerun.id] });
+      .mockResolvedValueOnce(
+        completeWorkerResult({ sessions: [refreshed], meta: {}, changedIds: [refreshed.id] }),
+      )
+      .mockResolvedValueOnce(
+        completeWorkerResult({ sessions: [rerun], meta: {}, changedIds: [rerun.id] }),
+      );
     const store = new LiveScanStore({ watchEnabled: false, workerRunner });
     await store.initialize();
 
@@ -1112,7 +1132,9 @@ describe("LiveScanStore", () => {
     await syncEngineOf(store).refresh("codex");
 
     expect(workerRunner.run).toHaveBeenCalledTimes(1);
-    releaseBackfill!({ sessions: [backfilled], meta: {}, changedIds: [backfilled.id] });
+    releaseBackfill!(
+      completeWorkerResult({ sessions: [backfilled], meta: {}, changedIds: [backfilled.id] }),
+    );
     await backfill;
     await refresh;
     await vi.waitFor(() => expect(workerRunner.run).toHaveBeenCalledTimes(2));
@@ -1156,6 +1178,9 @@ describe("LiveScanStore", () => {
       sessions: [],
       meta: {},
       changedIds: undefined,
+      sourceFailures: [],
+      completeness: "complete",
+      explicitRemovedSessionIds: [],
     });
   });
 
@@ -1226,6 +1251,9 @@ describe("LiveScanStore", () => {
         retained: { id: "retained", sourcePath: "/retained" },
       },
       changedIds: undefined,
+      sourceFailures: [],
+      completeness: "complete",
+      explicitRemovedSessionIds: [],
     });
     expect(runner.activeCount).toBe(1);
     runner.commit("codex");
@@ -2393,6 +2421,8 @@ describe("LiveScanStore", () => {
         agentName: "codex",
         sessions: [],
         meta: {},
+        completeness: "complete",
+        removedSessionIds: [],
       },
     ]);
     const pending = [1, 2, 3].map((version) =>
@@ -2448,6 +2478,8 @@ describe("LiveScanStore", () => {
       agentName: "codex",
       sessions: [],
       meta: {},
+      completeness: "complete" as const,
+      removedSessionIds: [],
     };
     const batch = runner.enqueue("scan.refresh", [job]);
     const outcome = batch.catch((error: Error) => error);
@@ -2471,6 +2503,8 @@ describe("LiveScanStore", () => {
       agentName: "codex",
       sessions: [],
       meta: {},
+      completeness: "complete" as const,
+      removedSessionIds: [],
     };
     const batch = runner.enqueue("scan.refresh", [job]);
     const outcome = Promise.allSettled([batch]);

--- a/packages/cli/src/pending-search-index-jobs.test.ts
+++ b/packages/cli/src/pending-search-index-jobs.test.ts
@@ -49,6 +49,8 @@ function fullJob(agentName: string, version: number): SearchIndexWorkerJob {
     agentName,
     sessions: [session],
     meta: { [session.id]: makeMeta(session.id, version) },
+    completeness: "complete",
+    removedSessionIds: [],
     saveCache: true,
   };
 }

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -348,7 +348,11 @@ describe("scan refresh worker entry", () => {
       }),
     );
     expect(mocks.postMessage.mock.calls.at(-1)?.[0]).toEqual(
-      expect.objectContaining({ type: "done" }),
+      expect.objectContaining({
+        type: "done",
+        completeness: "complete",
+        explicitRemovedSessionIds: [],
+      }),
     );
   });
 
@@ -370,6 +374,9 @@ describe("scan refresh worker entry", () => {
           completeness: "partial",
         }),
       }),
+    );
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", completeness: "partial" }),
     );
   });
 
@@ -833,6 +840,8 @@ describe("scan refresh worker entry", () => {
         changes: [{ session: updated, sortIndex: 1 }],
         removedSessionIds: ["removed"],
         removedMetaIds: ["removed"],
+        completeness: "partial",
+        explicitRemovedSessionIds: ["removed"],
         sourceFailures: [
           expect.objectContaining({ sessionId: "moved", stage: "parsing" }),
           expect.objectContaining({ sessionId: "missing", stage: "parsing" }),

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -48,6 +48,8 @@ export type ScanRefreshWorkerMessage =
       meta: Record<string, SessionCacheMeta>;
       removedMetaIds: string[];
       sourceFailures: SessionSourceFailure[];
+      completeness: SessionSnapshotCompleteness;
+      explicitRemovedSessionIds: string[];
       durationMs: number;
     }
   | {
@@ -192,6 +194,7 @@ function syncAgentSources(
   finalizeSessionIds: string[];
   sourceCount: number;
   removedCount: number;
+  explicitRemovedSessionIds: string[];
   sourceFailures: SessionSourceFailure[];
 } {
   const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
@@ -216,6 +219,7 @@ function syncAgentSources(
   );
   for (const outcome of sourceOutcomes) logAbsentSourceOutcome(agent.name, outcome);
   const appliedIds = new Set(removedIds);
+  const explicitRemovedSessionIds = new Set(removedIds);
 
   rescanIds.forEach((sessionId, index) => {
     const source = sourceById.get(sessionId);
@@ -228,6 +232,7 @@ function syncAgentSources(
       sessionMap.delete(sessionId);
       agent.getSessionMetaMap().delete(sessionId);
       appliedIds.add(sessionId);
+      explicitRemovedSessionIds.add(sessionId);
       appLogger.info("agent.session_source_outcome", {
         agent: agent.name,
         session_id: sessionId,
@@ -262,6 +267,7 @@ function syncAgentSources(
     finalizeSessionIds,
     sourceCount: sourceRefs.length,
     removedCount: removedIds.length,
+    explicitRemovedSessionIds: [...explicitRemovedSessionIds],
     sourceFailures,
   };
 }
@@ -458,6 +464,7 @@ async function run(
   let sessions: SessionHead[];
   let changedIds: string[] | undefined;
   let sourceFailures: SessionSourceFailure[] = [];
+  let explicitRemovedSessionIds: string[] = [];
   let finalizeSessionIds: ReadonlySet<string> | undefined;
   let backfillOrder: SessionHead[] | undefined;
   let backfillCursorIndex = -1;
@@ -488,6 +495,7 @@ async function run(
     finalizeSessionIds = new Set(result.finalizeSessionIds);
     sourceSyncDetails = result;
     sourceFailures = result.sourceFailures;
+    explicitRemovedSessionIds = result.explicitRemovedSessionIds;
   } else if (data.changedIds) {
     sessions = await Promise.resolve(agent.incrementalScan(previousSessions, data.changedIds));
   } else {
@@ -500,6 +508,10 @@ async function run(
   }
 
   sessions = attachMissingProjectIdentities(sessions);
+  const completeness: SessionSnapshotCompleteness =
+    data.scanOptions.from == null && data.scanOptions.to == null && sourceFailures.length === 0
+      ? "complete"
+      : "partial";
   if (data.checkpoint) {
     const ordered = sortSessions(sessions);
     parentPort?.postMessage({
@@ -510,12 +522,7 @@ async function run(
         stage: "scanned",
         sessions: ordered,
         meta: buildAgentCacheMeta(agent, new Set(ordered.map((session) => session.id))),
-        completeness:
-          data.scanOptions.from == null &&
-          data.scanOptions.to == null &&
-          sourceFailures.length === 0
-            ? "complete"
-            : "partial",
+        completeness,
       },
     } satisfies ScanRefreshWorkerMessage);
     sessions = ordered;
@@ -653,6 +660,8 @@ async function run(
     meta: metaDiff.changes,
     removedMetaIds: metaDiff.removedIds,
     sourceFailures,
+    completeness,
+    explicitRemovedSessionIds,
     durationMs: performance.now() - startedAt,
   } satisfies ScanRefreshWorkerMessage);
 }

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -109,6 +109,8 @@ describe("search index worker", () => {
           agentName: "codex",
           sessions,
           meta,
+          completeness: "complete",
+          removedSessionIds: [],
           saveCache: true,
           searchIndexOptions: { force: true },
         },
@@ -119,15 +121,67 @@ describe("search index worker", () => {
 
     expect(mocks.saveCachedSessions).toHaveBeenCalledWith("codex", sessions, meta, {
       completeness: "complete",
+      removedSessionIds: [],
     });
     expect(mocks.syncSessionSearchIndex).toHaveBeenCalledWith(
       "codex",
       sessions,
       expect.any(Function),
-      { force: true, detailVersions: { s1: "detail:s1" } },
+      {
+        force: true,
+        completeness: "complete",
+        removedSessionIds: [],
+        detailVersions: { s1: "detail:s1" },
+      },
     );
     expect(mocks.markAgentCacheInitialized).toHaveBeenCalledWith("codex");
     expect(mocks.appLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it("passes partial scope and explicit removals to both durable indexes", async () => {
+    const agent = makeAgent();
+    const sessions = [{ id: "recent" }];
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.syncSessionSearchIndex.mockReturnValue({ indexed: 1, skipped: 0 });
+    mocks.workerData = {
+      context: "refresh",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [
+        {
+          kind: "full",
+          context: "codex-partial",
+          agentName: "codex",
+          sessions,
+          meta: {},
+          completeness: "partial",
+          removedSessionIds: ["removed"],
+          saveCache: true,
+        },
+      ],
+    };
+
+    await runWorker();
+
+    expect(mocks.saveCachedSessions).toHaveBeenCalledWith(
+      "codex",
+      sessions,
+      {},
+      {
+        completeness: "partial",
+        removedSessionIds: ["removed"],
+      },
+    );
+    expect(mocks.syncSessionSearchIndex).toHaveBeenCalledWith(
+      "codex",
+      sessions,
+      expect.any(Function),
+      expect.objectContaining({
+        completeness: "partial",
+        removedSessionIds: ["removed"],
+      }),
+    );
   });
 
   it("CS-73 regression: still marks the agent initialized when a session couldn't be indexed, but warns", async () => {
@@ -149,6 +203,8 @@ describe("search index worker", () => {
           agentName: "codex",
           sessions,
           meta,
+          completeness: "complete",
+          removedSessionIds: [],
           saveCache: true,
         },
       ],
@@ -268,6 +324,8 @@ describe("search index worker", () => {
           agentName: "codex",
           sessions: [{ id: "s1" }, { id: "s2" }],
           meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
           saveCache: true,
         },
         {
@@ -276,6 +334,8 @@ describe("search index worker", () => {
           agentName: "codex",
           sessions: [{ id: "s3" }],
           meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
           saveCache: true,
         },
       ],

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -13,6 +13,7 @@ import {
   type SessionCacheMeta,
   type SessionHeadChange,
   type SessionHead,
+  type SessionSnapshotCompleteness,
 } from "@codesesh/core";
 import { appLogger } from "./logging.js";
 
@@ -45,6 +46,8 @@ export type SearchIndexWorkerJob =
       agentName: string;
       sessions: SessionHead[];
       meta: Record<string, SessionCacheMeta>;
+      completeness: SessionSnapshotCompleteness;
+      removedSessionIds: string[];
       saveCache?: boolean;
       searchIndexOptions?: SearchIndexSyncOptions;
     }
@@ -79,6 +82,8 @@ const jobs =
     agentName,
     sessions: data.sessionsByAgent[agentName] ?? [],
     meta: data.metaByAgent[agentName] ?? {},
+    completeness: "complete",
+    removedSessionIds: [],
   }));
 
 function jobSessionCount(job: SearchIndexWorkerJob): number {
@@ -88,6 +93,9 @@ function jobSessionCount(job: SearchIndexWorkerJob): number {
 function searchIndexOptions(job: SearchIndexWorkerJob): SearchIndexSyncOptions {
   return {
     ...job.searchIndexOptions,
+    ...(job.kind === "full"
+      ? { completeness: job.completeness, removedSessionIds: job.removedSessionIds }
+      : {}),
     detailVersions: Object.fromEntries(
       Object.entries(job.meta).map(([sessionId, meta]) => [sessionId, sessionDetailVersion(meta)]),
     ),
@@ -133,7 +141,10 @@ function runJob(job: SearchIndexWorkerJob, agent: WorkerAgent): SearchIndexPersi
 
   if (
     job.saveCache &&
-    !saveCachedSessions(job.agentName, job.sessions, job.meta, { completeness: "complete" })
+    !saveCachedSessions(job.agentName, job.sessions, job.meta, {
+      completeness: job.completeness,
+      removedSessionIds: job.removedSessionIds,
+    })
   ) {
     return "cache";
   }

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -6,6 +6,7 @@ import type {
   SessionHead,
   SessionHeadChange,
   SessionSourceFailure,
+  SessionSnapshotCompleteness,
 } from "@codesesh/core";
 import { appLogger } from "./logging.js";
 import type {
@@ -35,6 +36,8 @@ export interface WorkerResult {
   meta: Record<string, SessionCacheMeta>;
   changedIds?: string[];
   sourceFailures?: SessionSourceFailure[];
+  completeness: SessionSnapshotCompleteness;
+  explicitRemovedSessionIds: string[];
 }
 
 export interface WorkerRunner {
@@ -289,6 +292,8 @@ export class ThreadWorkerRunner implements WorkerRunner {
         meta: applyMetaChanges(pending.payload.meta, message.meta, removedMetaIds),
         changedIds: pending.payload.sourceSync ? replacedSessionIds : undefined,
         sourceFailures: message.sourceFailures,
+        completeness: message.completeness,
+        explicitRemovedSessionIds: message.explicitRemovedSessionIds,
       };
       slot.awaitingCommit = {
         requestId: message.requestId,

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -1657,6 +1657,80 @@ describe("searchSessions", () => {
     expect(results[0]?.matchType).toBe("recent");
   });
 
+  it("preserves omitted durable facts in a partial publication", () => {
+    const old = makeSession("old");
+    const recent = makeSession("recent");
+    const removed = makeSession("removed");
+    const sessions = [old, recent, removed];
+    const meta = Object.fromEntries(
+      sessions.map((session) => [
+        session.id,
+        { id: session.id, sourcePath: `/${session.id}.jsonl` },
+      ]),
+    );
+    saveCachedSessions("codex", sessions, meta);
+    syncSessionSearchIndex("codex", sessions, (sessionId) => {
+      const session = sessions.find(({ id }) => id === sessionId)!;
+      const text =
+        sessionId === "old"
+          ? "historicalscope"
+          : sessionId === "removed"
+            ? "deletedscope"
+            : "recentscope";
+      return {
+        ...session,
+        messages: [
+          {
+            id: `${sessionId}-message`,
+            role: "user",
+            time_created: now,
+            parts: [
+              { type: "text", text },
+              ...(sessionId === "old"
+                ? [
+                    {
+                      type: "tool" as const,
+                      tool: "Read",
+                      state: {
+                        status: "completed" as const,
+                        input: { file_path: "src/historical.ts" },
+                      },
+                    },
+                  ]
+                : []),
+            ],
+          },
+        ],
+      };
+    });
+
+    const updatedRecent = { ...recent, title: "Recent updated" };
+    saveCachedSessions(
+      "codex",
+      [updatedRecent],
+      { recent: meta.recent! },
+      { completeness: "partial", removedSessionIds: [removed.id] },
+    );
+    syncSessionSearchIndex(
+      "codex",
+      [updatedRecent],
+      () => makeSessionData("recent", "recentscope updated"),
+      { completeness: "partial", removedSessionIds: [removed.id] },
+    );
+
+    expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).toEqual(
+      expect.arrayContaining(["old", "recent"]),
+    );
+    expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).not.toContain("removed");
+    expect(loadCachedSessions("codex")?.meta.old).toEqual(meta.old);
+    expect(loadCachedSessionData("codex", "old")?.messages).toHaveLength(1);
+    expect(searchSessions("historicalscope").map(({ session }) => session.id)).toEqual(["old"]);
+    expect(searchSessions("deletedscope")).toEqual([]);
+    expect(
+      listFileActivity({ agent: "codex", sessionId: "old", limit: 10 }).map(({ path }) => path),
+    ).toContain("src/historical.ts");
+  });
+
   it("upserts parent session rows before indexed messages", () => {
     const session = {
       ...makeSession("windowed"),

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -18,11 +18,14 @@ import {
 } from "./messages.js";
 import { runSearchIndexWrite, withSearchIndexDb } from "./schema.js";
 import { sessionDetailVersion } from "./detail-version.js";
+import type { SessionSnapshotCompleteness } from "./sessions.js";
 
 export interface SearchIndexSyncOptions {
   isBulk?: boolean;
   bulkThreshold?: number;
   detailVersions?: Readonly<Record<string, string>>;
+  completeness?: SessionSnapshotCompleteness;
+  removedSessionIds?: readonly string[];
 }
 
 export interface SearchIndexSyncFailure {
@@ -456,9 +459,15 @@ export function syncSessionSearchIndex(
     );
     const sessionMap = new Map(sessions.map((session) => [session.id, session]));
 
+    const explicitRemovedSessionIds = new Set(options.removedSessionIds ?? []);
+    const completeness = options.completeness ?? "complete";
     const toDelete = existingRows
       .map((row) => String(row.session_id))
-      .filter((sessionId) => !sessionMap.has(sessionId));
+      .filter(
+        (sessionId) =>
+          explicitRemovedSessionIds.has(sessionId) ||
+          (completeness === "complete" && !sessionMap.has(sessionId)),
+      );
     const toUpsert = sessions.filter((session) =>
       searchIndexEntryNeedsUpdate(searchIndexState, session, options),
     );

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -50,6 +50,7 @@ export type SessionSnapshotCompleteness = "complete" | "partial";
 
 export interface SaveCachedSessionsOptions {
   completeness?: SessionSnapshotCompleteness;
+  removedSessionIds?: readonly string[];
 }
 
 function parseCachedSessionMeta(value: string | null | undefined): SessionCacheMeta | null {
@@ -429,17 +430,19 @@ export function saveCachedSessions(
         .all(agentName) as SessionRow[];
       upsertAgent.run(agentName, timestamp);
 
+      const sessionIdsToDelete = new Set(options.removedSessionIds ?? []);
       if (completeness === "complete") {
         for (const row of existingSessionIds) {
           const sessionId = String(row.session_id);
-          if (!sessionIds.has(sessionId)) {
-            deleteSearchDocument.run(agentName, sessionId);
-            deleteMessageTools.run(agentName, sessionId);
-            deleteMessages.run(agentName, sessionId);
-            deleteFileActivity.run(agentName, sessionId);
-            deleteSession.run(agentName, sessionId);
-          }
+          if (!sessionIds.has(sessionId)) sessionIdsToDelete.add(sessionId);
         }
+      }
+      for (const sessionId of sessionIdsToDelete) {
+        deleteSearchDocument.run(agentName, sessionId);
+        deleteMessageTools.run(agentName, sessionId);
+        deleteMessages.run(agentName, sessionId);
+        deleteFileActivity.run(agentName, sessionId);
+        deleteSession.run(agentName, sessionId);
       }
 
       sessions.forEach((session, index) => {


### PR DESCRIPTION
## Summary

- propagate snapshot completeness and explicit removals from scan workers to persistence
- preserve durable session facts when a windowed or degraded scan publishes a partial snapshot
- keep confirmed source deletions effective without treating omitted history as deleted

## Root cause

The refresh pipeline discarded the scan scope/completeness before it reached cache and search-index persistence. A partial publication was therefore interpreted as a complete replacement, which could delete sessions, messages, file activity, and indexed content outside the scan window.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:e2e`

Closes CS-175.