### PR TITLE
fix: preserve failed scan outcomes

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -623,6 +623,38 @@ describe("AgentSyncEngine", () => {
     expect(completed).toBe(true);
   });
 
+  it("publishes an initial scan failure without indexing a false empty baseline", async () => {
+    const agent = makeAgent();
+    const engine = new AgentSyncEngine({ workerRunner: makeWorkerRunner() });
+    engine.initialize({
+      agents: [agent],
+      byAgent: {},
+      sessions: [],
+      scanFailures: {
+        codex: {
+          agentName: "codex",
+          stage: "enumerating session sources",
+          sourcePath: "/sessions",
+          errorClass: "EACCES",
+          message: "permission denied",
+        },
+      },
+    });
+
+    expect(engine.status().agentStatuses.codex).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        sessions: 0,
+        error: "enumerating session sources: permission denied",
+      }),
+    );
+
+    await engine.syncInitialIndex();
+
+    expect(core.loadCachedSessions).not.toHaveBeenCalled();
+    expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.initial", []);
+  });
+
   it("rescans imprecise changes in a worker and persists only the signature diff", async () => {
     const steady = makeSession("steady");
     const previous = makeSession("changed", "before");

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -146,6 +146,13 @@ export class AgentSyncEngine {
         options.cacheTimestamps?.[agent.name] ?? Date.now(),
       );
     }
+    for (const [agentName, failure] of Object.entries(snapshot.scanFailures ?? {})) {
+      this.scanStatus.failAgent(
+        agentName,
+        `${failure.stage}: ${failure.message}`,
+        snapshot.byAgent[agentName]?.length ?? 0,
+      );
+    }
   }
 
   snapshot(): LiveSnapshot {
@@ -885,27 +892,30 @@ export class AgentSyncEngine {
 
   private buildFullSearchIndexJobs(context: string): SearchIndexWorkerJob[] {
     const snapshot = this.sessionIndex.snapshot();
-    return snapshot.agents.map((agent) => {
+    return snapshot.agents.flatMap((agent) => {
+      if (!(agent.name in snapshot.byAgent)) return [];
       const cached = loadCachedSessions(agent.name);
-      return cached
-        ? {
-            kind: "full",
-            context,
-            agentName: agent.name,
-            sessions: cached.sessions,
-            meta: cached.meta,
-            completeness: "partial",
-            removedSessionIds: [],
-          }
-        : {
-            kind: "full",
-            context,
-            agentName: agent.name,
-            sessions: snapshot.byAgent[agent.name] ?? [],
-            meta: buildAgentCacheMeta(agent),
-            completeness: "partial",
-            removedSessionIds: [],
-          };
+      return [
+        cached
+          ? {
+              kind: "full",
+              context,
+              agentName: agent.name,
+              sessions: cached.sessions,
+              meta: cached.meta,
+              completeness: "partial",
+              removedSessionIds: [],
+            }
+          : {
+              kind: "full",
+              context,
+              agentName: agent.name,
+              sessions: snapshot.byAgent[agent.name] ?? [],
+              meta: buildAgentCacheMeta(agent),
+              completeness: "partial",
+              removedSessionIds: [],
+            },
+      ];
     });
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@ import { LiveScanStore } from "./live-scan.js";
 import { printScanResults } from "./output.js";
 import { VERSION } from "./version.js";
 import { appLogger } from "./logging.js";
-import { buildSessionIndexOutput } from "./session-index-output.js";
+import { buildSessionIndexOutput, formatScanFailureDiagnostics } from "./session-index-output.js";
 import {
   resolveRemoteAccessPolicy,
   resolveRemoteTransport,
@@ -224,6 +224,13 @@ const main = defineCommand({
     if (jsonOnly) {
       // Nothing will consume a later generation, so stop waiting for it.
       await pricingRefresh.cancel();
+      const scanFailureDiagnostics = formatScanFailureDiagnostics(result);
+      if (scanFailureDiagnostics.length > 0) {
+        await store.shutdown();
+        for (const diagnostic of scanFailureDiagnostics) console.error(diagnostic);
+        process.exitCode = 1;
+        return;
+      }
       const output = buildSessionIndexOutput(result, { from: listDefaultFrom, to: listDefaultTo });
       appLogger.info("cli.json_output", {
         sessions: output.sessions.length,

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -31,6 +31,33 @@ function snapshot(agents: BaseAgent[], byAgent: Record<string, SessionHead[]>): 
 }
 
 describe("LiveSessionIndex", () => {
+  it("keeps a failed agent out of the empty-success projection until recovery", () => {
+    const codex = makeAgent("codex");
+    const recovered = makeSession("recovered", 1);
+    const index = new LiveSessionIndex();
+    index.initialize({
+      agents: [codex],
+      byAgent: {},
+      sessions: [],
+      scanFailures: {
+        codex: {
+          agentName: "codex",
+          stage: "opening the database",
+          errorClass: "SessionScanError",
+          message: "database unavailable",
+        },
+      },
+    });
+
+    expect(index.snapshot().byAgent.codex).toBeUndefined();
+    expect(index.snapshot().scanFailures?.codex).toBeDefined();
+
+    index.commitAgentSessions("codex", [recovered]);
+
+    expect(index.snapshot().byAgent.codex).toEqual([recovered]);
+    expect(index.snapshot().scanFailures).toBeUndefined();
+  });
+
   it("initializes sorted views for the allowed agent catalog", () => {
     const codex = makeAgent("codex");
     const kimi = makeAgent("kimi");

--- a/packages/cli/src/live-session-index.ts
+++ b/packages/cli/src/live-session-index.ts
@@ -3,6 +3,7 @@ import {
   mergeSortedSessions,
   sessionSignature,
   sortSessions,
+  type AgentScanFailure,
   type BaseAgent,
   type LiveSnapshot,
   type SessionHead,
@@ -19,6 +20,7 @@ export class LiveSessionIndex {
   private agentsByName = new Map<string, BaseAgent>();
   private byAgent: Record<string, SessionHead[]> = {};
   private sessions: SessionHead[] = [];
+  private scanFailures: Record<string, AgentScanFailure> = {};
   private signatureCaches = new Map<string, Map<string, string>>();
 
   initialize(snapshot: LiveSnapshot, options: LiveSessionIndexOptions = {}): void {
@@ -32,8 +34,12 @@ export class LiveSessionIndex {
       (agent) => !options.allowedAgents || options.allowedAgents.has(agent.name.toLowerCase()),
     );
     this.agentsByName = new Map(this.agents.map((agent) => [agent.name, agent]));
+    this.scanFailures = { ...snapshot.scanFailures };
     this.byAgent = Object.fromEntries(
-      this.agents.map((agent) => [agent.name, sortSessions(snapshot.byAgent[agent.name] ?? [])]),
+      this.agents.flatMap((agent) => {
+        if (this.scanFailures[agent.name] && !(agent.name in snapshot.byAgent)) return [];
+        return [[agent.name, sortSessions(snapshot.byAgent[agent.name] ?? [])]];
+      }),
     );
     this.sessions = mergeSortedSessions(Object.values(this.byAgent));
     this.signatureCaches.clear();
@@ -44,6 +50,7 @@ export class LiveSessionIndex {
       agents: this.agents,
       byAgent: this.byAgent,
       sessions: this.sessions,
+      ...(Object.keys(this.scanFailures).length > 0 ? { scanFailures: this.scanFailures } : {}),
     };
   }
 
@@ -56,6 +63,7 @@ export class LiveSessionIndex {
     nextSessions: SessionHead[],
     candidateChangedIds: string[] = [],
   ): SessionsUpdatedEvent | null {
+    delete this.scanFailures[agentName];
     const previousSessions = this.byAgent[agentName] ?? [];
     const signatureCache = this.signatureCache(agentName);
     const { changes, removedSessionIds, counts } = computeSessionDiff(

--- a/packages/cli/src/scan-status-model.ts
+++ b/packages/cli/src/scan-status-model.ts
@@ -207,7 +207,7 @@ export class ScanStatusModel {
     });
   }
 
-  failAgent(agentName: string, error: string): ScanStatusEvent {
+  failAgent(agentName: string, error: string, sessionCount?: number): ScanStatusEvent {
     const pendingAgents = this.status.pendingAgents.filter((agent) => agent !== agentName);
     const scanningAgents = this.status.scanningAgents.filter((agent) => agent !== agentName);
     const completedAgents = this.status.completedAgents.filter((agent) => agent !== agentName);
@@ -231,7 +231,7 @@ export class ScanStatusModel {
           error,
           total: previousStatus?.total,
           processed: previousStatus?.processed,
-          sessions: previousStatus?.sessions ?? 0,
+          sessions: sessionCount ?? previousStatus?.sessions ?? 0,
           startedAt: previousStatus?.startedAt,
           updatedAt: now,
           completedAt: now,

--- a/packages/cli/src/session-index-output.test.ts
+++ b/packages/cli/src/session-index-output.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { LiveSnapshot, SessionHead } from "@codesesh/core";
-import { buildSessionIndexOutput } from "./session-index-output.js";
+import { buildSessionIndexOutput, formatScanFailureDiagnostics } from "./session-index-output.js";
 
 function makeSession(id: string, activity: number): SessionHead {
   return {
@@ -81,5 +81,25 @@ describe("CS-150: --json is a session index", () => {
       count: 0,
       available: false,
     });
+  });
+});
+
+describe("scan failure diagnostics", () => {
+  it("formats agent-level failures without inventing a session", () => {
+    expect(
+      formatScanFailureDiagnostics({
+        scanFailures: {
+          codex: {
+            agentName: "codex",
+            stage: "enumerating session sources",
+            sourcePath: "/sessions",
+            errorClass: "EACCES",
+            message: "permission denied",
+          },
+        },
+      }),
+    ).toEqual([
+      "[codex] Scan failed during enumerating session sources at /sessions (EACCES): permission denied",
+    ]);
   });
 });

--- a/packages/cli/src/session-index-output.ts
+++ b/packages/cli/src/session-index-output.ts
@@ -29,6 +29,15 @@ export interface SessionIndexWindow {
   to?: number;
 }
 
+export function formatScanFailureDiagnostics(
+  snapshot: Pick<LiveSnapshot, "scanFailures">,
+): string[] {
+  return Object.values(snapshot.scanFailures ?? {}).map((failure) => {
+    const source = failure.sourcePath ? ` at ${failure.sourcePath}` : "";
+    return `[${failure.agentName}] Scan failed during ${failure.stage}${source} (${failure.errorClass}): ${failure.message}`;
+  });
+}
+
 export function buildSessionIndexOutput(
   snapshot: Pick<LiveSnapshot, "sessions" | "byAgent">,
   window: SessionIndexWindow = {},

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -40,6 +40,10 @@ class FakeFileSystemSource extends FileSystemSessionSource {
     this.sources = sources;
   }
 
+  walk(root: string) {
+    return this.walkFiles(root, () => true);
+  }
+
   isAvailable(): boolean {
     return true;
   }
@@ -116,6 +120,21 @@ describe("BaseAgent", () => {
 });
 
 describe("FileSystemSessionSource.scan", () => {
+  it("raises a root-level failure when source enumeration cannot complete", () => {
+    const agent = new FakeFileSystemSource();
+    try {
+      agent.walk("invalid\0root");
+      expect.unreachable("source enumeration should fail");
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: "SessionScanError",
+        agentName: "fake",
+        stage: "enumerating session sources",
+        sourcePath: "invalid\0root",
+      });
+    }
+  });
+
   it("scans listed sources and reports progress while skipping invalid entries", () => {
     const agent = new FakeFileSystemSource([
       source("a"),

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 import { CursorAgent } from "../cursor.js";
+import { SessionScanError } from "../base.js";
 import type { MessagePart } from "../../types/index.js";
 import {
   getCoreDiagnostics,
@@ -187,5 +188,38 @@ describe("CursorAgent parsing", () => {
       setCoreDiagnostics(null);
       expect(getCoreDiagnostics()).toBeNull();
     }
+  });
+});
+
+describe("CursorAgent scan outcomes", () => {
+  function makeScanningAgent(dbPath: string): CursorAgent {
+    const agent = new CursorAgent();
+    Object.assign(agent, { dbPath });
+    return agent;
+  }
+
+  it("reports a corrupt database as a failure", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "state.vscdb");
+    writeFileSync(dbPath, "this is not a sqlite file");
+
+    expect(() => makeScanningAgent(dbPath).scan()).toThrow(SessionScanError);
+  });
+
+  it("reports a missing composer table as a failure", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "state.vscdb");
+    new Database(dbPath).close();
+
+    expect(() => makeScanningAgent(dbPath).scan()).toThrow(SessionScanError);
+  });
+
+  it("returns an empty result for a readable empty database", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+
+    expect(makeScanningAgent(createCursorDb(tempDir)).scan()).toEqual([]);
   });
 });

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -80,6 +80,14 @@ export interface SessionSourceFailure {
   message: string;
 }
 
+export interface AgentScanFailure {
+  agentName: string;
+  stage: string;
+  sourcePath?: string;
+  errorClass: string;
+  message: string;
+}
+
 export type SessionSourceOutcome =
   | { status: "parsed"; session: SessionHead; source: SessionSourceRef }
   | { status: "filtered"; reason: string; source: SessionSourceRef }
@@ -279,6 +287,36 @@ function failureClass(error: unknown): string {
 function failureMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return message.slice(0, 500);
+}
+
+export function createAgentScanFailure(
+  agentName: string,
+  stage: string,
+  error: unknown,
+  sourcePath?: string,
+): AgentScanFailure {
+  const scanError = error instanceof SessionScanError ? error : null;
+  const cause = scanError?.cause ?? error;
+  return {
+    agentName: scanError?.agentName ?? agentName,
+    stage: scanError?.stage ?? stage,
+    ...((scanError?.sourcePath ?? sourcePath)
+      ? { sourcePath: scanError?.sourcePath ?? sourcePath }
+      : {}),
+    errorClass: failureClass(cause),
+    message: failureMessage(cause),
+  };
+}
+
+export function reportAgentScanFailure(failure: AgentScanFailure, baselineRetained: boolean): void {
+  getCoreDiagnostics()?.warn("agent.scan_failed", {
+    agent: failure.agentName,
+    stage: failure.stage,
+    source_path: failure.sourcePath,
+    error_class: failure.errorClass,
+    message: failure.message,
+    baseline_retained: baselineRetained,
+  });
 }
 
 export function createSessionSourceFailure(
@@ -497,12 +535,7 @@ export abstract class FileSystemSessionSource<
     this.sourceFileStats.clear();
 
     const walk = (directory: string): void => {
-      let entries: Dirent[];
-      try {
-        entries = readdirSync(directory, { withFileTypes: true });
-      } catch {
-        return;
-      }
+      const entries = this.readSessionSourceDirectory(directory);
 
       for (const entry of entries) {
         const filePath = join(directory, entry.name);
@@ -515,8 +548,12 @@ export abstract class FileSystemSessionSource<
         let stat: Stats;
         try {
           stat = statSync(filePath);
-        } catch {
-          continue;
+        } catch (error) {
+          if (isMissingSourceError(error)) continue;
+          throw new SessionScanError(this.name, "reading session source metadata", {
+            cause: error,
+            sourcePath: filePath,
+          });
         }
         if (!matchesScanWindow(stat.mtimeMs, options.scanWindow)) continue;
 
@@ -527,6 +564,17 @@ export abstract class FileSystemSessionSource<
 
     for (const root of typeof roots === "string" ? [roots] : roots) walk(root);
     return files;
+  }
+
+  protected readSessionSourceDirectory(directory: string): Dirent[] {
+    try {
+      return readdirSync(directory, { withFileTypes: true });
+    } catch (error) {
+      throw new SessionScanError(this.name, "enumerating session sources", {
+        cause: error,
+        sourcePath: directory,
+      });
+    }
   }
 
   protected sessionSourceFile(sourcePath: string): SessionSourceFile {
@@ -704,11 +752,14 @@ export class SessionScanError extends Error {
   constructor(
     readonly agentName: string,
     readonly stage: string,
-    options?: { cause?: unknown },
+    options?: { cause?: unknown; sourcePath?: string },
   ) {
     super(`${agentName} session scan failed while ${stage}`, options);
     this.name = "SessionScanError";
+    this.sourcePath = options?.sourcePath;
   }
+
+  readonly sourcePath?: string;
 }
 
 /**

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import {
   SingleFileSessionSource,
@@ -152,15 +152,16 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   isAvailable(): boolean {
     this.basePath = this.findBasePath();
     if (!this.basePath) return false;
-    try {
-      for (const entry of readdirSync(this.basePath)) {
-        const dir = join(this.basePath, entry);
-        if (existsSync(dir) && readdirSync(dir).some((f) => f.endsWith(".jsonl"))) {
-          return true;
-        }
+    for (const entry of this.readSessionSourceDirectory(this.basePath)) {
+      if (!entry.isDirectory()) continue;
+      const directory = join(this.basePath, entry.name);
+      if (
+        this.readSessionSourceDirectory(directory).some(
+          (child) => child.isFile() && child.name.endsWith(".jsonl"),
+        )
+      ) {
+        return true;
       }
-    } catch {
-      // ignore
     }
     return false;
   }
@@ -337,13 +338,9 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
 
   private listProjectDirs(): string[] {
     if (!this.basePath) return [];
-    try {
-      return readdirSync(this.basePath)
-        .map((e) => join(this.basePath!, e))
-        .filter((p) => existsSync(p));
-    } catch {
-      return [];
-    }
+    return this.readSessionSourceDirectory(this.basePath)
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(this.basePath!, entry.name));
   }
 
   private ensureChildIndex(): void {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1,13 +1,4 @@
-import {
-  closeSync,
-  existsSync,
-  openSync,
-  readdirSync,
-  readFileSync,
-  readSync,
-  statSync,
-  type Dirent,
-} from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import {
   SingleFileSessionSource,
@@ -821,12 +812,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     if (!this.basePath) return [];
     const paths: string[] = [];
     const walk = (directory: string): void => {
-      let entries: Dirent[];
-      try {
-        entries = readdirSync(directory, { withFileTypes: true });
-      } catch {
-        return;
-      }
+      const entries = this.readSessionSourceDirectory(directory);
       for (const entry of entries) {
         const filePath = join(directory, entry.name);
         if (entry.isDirectory()) walk(filePath);

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -6,16 +6,19 @@ export {
   SingleFileSessionSource,
 } from "./base.js";
 export {
+  createAgentScanFailure,
   createSessionSourceFailure,
   diffSessionSources,
   filteredSession,
   getParsedSession,
   matchesScanWindow,
   parsedSession,
+  reportAgentScanFailure,
   reportSessionSourceOutcome,
   skippedSession,
 } from "./base.js";
 export type {
+  AgentScanFailure,
   AgentScanOptions,
   AgentScanProgress,
   CachedMetaLookup,

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import {
   FileSystemSessionSource,
@@ -374,11 +374,7 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
   isAvailable(): boolean {
     this.basePath = this.findBasePath();
     if (!this.basePath) return false;
-    try {
-      return this.listSessionDirs().length > 0;
-    } catch {
-      return false;
-    }
+    return this.listSessionDirs().length > 0;
   }
 
   private loadSessionIndex(): void {
@@ -399,23 +395,19 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     if (!this.basePath) return [];
     const dirs: string[] = [];
 
-    try {
-      for (const bucket of readdirSync(this.basePath, { withFileTypes: true })) {
-        if (!bucket.isDirectory()) continue;
-        const bucketPath = join(this.basePath, bucket.name);
-        for (const session of readdirSync(bucketPath, { withFileTypes: true })) {
-          if (!session.isDirectory()) continue;
-          const sessionPath = join(bucketPath, session.name);
-          if (
-            existsSync(join(sessionPath, "state.json")) &&
-            existsSync(join(sessionPath, "agents", "main", "wire.jsonl"))
-          ) {
-            dirs.push(sessionPath);
-          }
+    for (const bucket of this.readSessionSourceDirectory(this.basePath)) {
+      if (!bucket.isDirectory()) continue;
+      const bucketPath = join(this.basePath, bucket.name);
+      for (const session of this.readSessionSourceDirectory(bucketPath)) {
+        if (!session.isDirectory()) continue;
+        const sessionPath = join(bucketPath, session.name);
+        if (
+          existsSync(join(sessionPath, "state.json")) &&
+          existsSync(join(sessionPath, "agents", "main", "wire.jsonl"))
+        ) {
+          dirs.push(sessionPath);
         }
       }
-    } catch {
-      return dirs;
     }
 
     return dirs;

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import {
   FileSystemSessionSource,
@@ -227,39 +227,26 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     this.basePath = this.findBasePath();
     if (!this.basePath) return false;
     this.loadKimiConfig();
-    try {
-      return this.listSessionDirs().length > 0;
-    } catch {
-      // ignore
-    }
-    return false;
+    return this.listSessionDirs().length > 0;
   }
 
   /** Walk sessions/{project_hash}/{session_id}/ and find valid session dirs */
   private listSessionDirs(): string[] {
     if (!this.basePath) return [];
     const dirs: string[] = [];
-    try {
-      for (const hashEntry of readdirSync(this.basePath, { withFileTypes: true })) {
-        if (!hashEntry.isDirectory()) continue;
-        const hashPath = join(this.basePath, hashEntry.name);
-        try {
-          for (const sessionEntry of readdirSync(hashPath, { withFileTypes: true })) {
-            if (!sessionEntry.isDirectory()) continue;
-            const sessionPath = join(hashPath, sessionEntry.name);
-            if (
-              existsSync(join(sessionPath, "metadata.json")) ||
-              existsSync(join(sessionPath, "state.json"))
-            ) {
-              dirs.push(sessionPath);
-            }
-          }
-        } catch {
-          // skip unreadable hash dirs
+    for (const hashEntry of this.readSessionSourceDirectory(this.basePath)) {
+      if (!hashEntry.isDirectory()) continue;
+      const hashPath = join(this.basePath, hashEntry.name);
+      for (const sessionEntry of this.readSessionSourceDirectory(hashPath)) {
+        if (!sessionEntry.isDirectory()) continue;
+        const sessionPath = join(hashPath, sessionEntry.name);
+        if (
+          existsSync(join(sessionPath, "metadata.json")) ||
+          existsSync(join(sessionPath, "state.json"))
+        ) {
+          dirs.push(sessionPath);
         }
       }
-    } catch {
-      // skip unreadable base
     }
     return dirs;
   }

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -3,12 +3,14 @@ import type { SessionHead, SessionDetail } from "../../types/index.js";
 import {
   BaseAgent,
   FileSystemSessionSource,
+  SessionScanError,
   type ChangeCheckResult,
   type SessionCacheMeta,
   type SessionSourceRef,
 } from "../../agents/base.js";
 import { filterSessions } from "../scanner.js";
 import { computeIdentityProjection, realFs } from "../../projects/index.js";
+import { setCoreDiagnostics } from "../../utils/diagnostics.js";
 
 // --- filterSessions tests (pure function) ---
 
@@ -235,6 +237,7 @@ const mockedSaveCachedSessions = vi.mocked(saveCachedSessions);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockedLoadCachedSessions.mockReturnValue(null);
 });
 
 function createTestAgent(overrides: {
@@ -340,6 +343,7 @@ describe("finalizeAgentScan", () => {
       options: { from: 200, includeSmartTags: true },
       timing: { total: 0 },
       agentStart: performance.now(),
+      completeness: "partial",
       onProgress,
     });
 
@@ -370,6 +374,7 @@ describe("finalizeAgentScan", () => {
       options: { includeSmartTags: false },
       timing: { total: 0 },
       agentStart: performance.now(),
+      completeness: "complete",
     });
 
     expect(result.refreshed).toBe(true);
@@ -399,6 +404,7 @@ describe("finalizeAgentScan", () => {
       options: { includeSmartTags: false },
       timing: { total: 0 },
       agentStart: performance.now(),
+      completeness: "complete",
     });
 
     expect(result.refreshed).toBeUndefined();
@@ -418,6 +424,7 @@ describe("finalizeAgentScan", () => {
       options: { includeSmartTags: false },
       timing: { total: 0 },
       agentStart: performance.now(),
+      completeness: "complete",
     });
 
     expect(mockedSaveCachedSessionChanges).toHaveBeenCalledWith(
@@ -449,6 +456,7 @@ describe("finalizeAgentScan", () => {
       options: {},
       timing: { total: 0 },
       agentStart: performance.now(),
+      completeness: "complete",
     });
 
     expect(result.heads[0]).toMatchObject({
@@ -502,6 +510,8 @@ describe("scanSessions", () => {
   });
 
   it("handles scan errors gracefully", async () => {
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    setCoreDiagnostics({ warn: (event, detail) => events.push({ event, detail }) });
     mockedCreateRegisteredAgents.mockReturnValue([
       createTestAgent({
         name: "error",
@@ -510,9 +520,121 @@ describe("scanSessions", () => {
         shouldThrow: true,
       }),
     ]);
+    try {
+      const result = await scanSessions({});
+      expect(result.agents).toHaveLength(1);
+      expect(result.byAgent.error).toBeUndefined();
+      expect(result.scanFailures?.error).toEqual({
+        agentName: "error",
+        stage: "scanning sessions",
+        errorClass: "Error",
+        message: "scan failed",
+      });
+      expect(events).toContainEqual({
+        event: "agent.scan_failed",
+        detail: expect.objectContaining({
+          agent: "error",
+          stage: "scanning sessions",
+          error_class: "Error",
+          message: "scan failed",
+          baseline_retained: false,
+        }),
+      });
+    } finally {
+      setCoreDiagnostics(null);
+    }
+  });
+
+  it("keeps successful agents when another agent fails", async () => {
+    mockedCreateRegisteredAgents.mockReturnValue([
+      createTestAgent({ name: "failed", available: true, sessions: [], shouldThrow: true }),
+      createTestAgent({ name: "healthy", available: true, sessions: [makeSession("ok")] }),
+    ]);
+
     const result = await scanSessions({});
-    expect(result.agents).toHaveLength(1);
-    expect(result.byAgent.error).toEqual([]);
+
+    expect(result.sessions.map((session) => session.id)).toEqual(["ok"]);
+    expect(result.byAgent.healthy).toHaveLength(1);
+    expect(result.byAgent.failed).toBeUndefined();
+    expect(result.scanFailures?.failed).toBeDefined();
+  });
+
+  it("retains a cached baseline when source enumeration fails", async () => {
+    const cached = makeSession("cached");
+    mockedLoadCachedSessions.mockReturnValue({
+      sessions: [cached],
+      meta: { cached: { id: "cached", sourcePath: "/sessions/cached" } },
+      timestamp: 123,
+    });
+    const agent = createTestAgent({ name: "test", available: true, sessions: [] });
+    agent.checkForChanges = () => {
+      throw new SessionScanError("test", "enumerating session sources", {
+        cause: Object.assign(new Error("permission denied"), { code: "EACCES" }),
+        sourcePath: "/sessions",
+      });
+    };
+    mockedCreateRegisteredAgents.mockReturnValue([agent]);
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    setCoreDiagnostics({ warn: (event, detail) => events.push({ event, detail }) });
+
+    try {
+      const result = await scanSessions({ useCache: true });
+
+      expect(result.sessions.map((session) => session.id)).toEqual(["cached"]);
+      expect(result.byAgent.test?.map((session) => session.id)).toEqual(["cached"]);
+      expect(result.scanFailures?.test).toEqual({
+        agentName: "test",
+        stage: "enumerating session sources",
+        sourcePath: "/sessions",
+        errorClass: "EACCES",
+        message: "permission denied",
+      });
+      expect(events).toContainEqual({
+        event: "agent.scan_failed",
+        detail: expect.objectContaining({
+          agent: "test",
+          source_path: "/sessions",
+          error_class: "EACCES",
+          baseline_retained: true,
+        }),
+      });
+    } finally {
+      setCoreDiagnostics(null);
+    }
+  });
+
+  it("does not publish a false empty baseline when a forced scan fails", async () => {
+    const cached = makeSession("cached");
+    mockedLoadCachedSessions.mockReturnValue({ sessions: [cached], meta: {}, timestamp: 123 });
+    mockedCreateRegisteredAgents.mockReturnValue([
+      createTestAgent({ name: "test", available: true, sessions: [], shouldThrow: true }),
+    ]);
+
+    const result = await scanSessions({ useCache: false });
+
+    expect(result.byAgent.test).toBeUndefined();
+    expect(result.scanFailures?.test).toEqual(
+      expect.objectContaining({ stage: "scanning sessions", message: "scan failed" }),
+    );
+  });
+
+  it("recovers from an agent-level failure in the same process", async () => {
+    const agent = createTestAgent({ name: "test", available: true, sessions: [] });
+    agent.scan = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new SessionScanError("test", "opening the database");
+      })
+      .mockReturnValue([makeSession("recovered")]);
+    mockedCreateRegisteredAgents.mockReturnValue([agent]);
+
+    const failed = await scanSessions({ useCache: false });
+    const recovered = await scanSessions({ useCache: false });
+
+    expect(failed.scanFailures?.test?.stage).toBe("opening the database");
+    expect(failed.byAgent.test).toBeUndefined();
+    expect(recovered.scanFailures).toBeUndefined();
+    expect(recovered.byAgent.test?.map((session) => session.id)).toEqual(["recovered"]);
   });
 
   it("calls onProgress for complete phase", async () => {

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -3,16 +3,20 @@ import { Worker } from "node:worker_threads";
 import type { SessionDetail, SessionHead, SmartTag } from "../types/index.js";
 import { filterSessionTreeByActivityWindow } from "../contract/session-tree.js";
 import type {
+  AgentScanFailure,
   AgentScanOptions,
   BaseAgent,
   SessionCacheMeta,
   SessionSourceFailure,
 } from "../agents/index.js";
 import {
+  createAgentScanFailure,
   createRegisteredAgents,
   diffSessionSources,
   FileSystemSessionSource,
+  reportAgentScanFailure,
   reportSessionSourceOutcome,
+  SessionScanError,
 } from "../agents/index.js";
 import { filterSessionsByProjectScope } from "../projects/index.js";
 import {
@@ -68,6 +72,7 @@ export interface LiveSnapshot {
   agents: BaseAgent[];
   timings?: Record<string, AgentScanTiming>;
   cacheTimestamps?: Record<string, number>;
+  scanFailures?: Record<string, AgentScanFailure>;
 }
 
 /** 扫描状态更新回调 */
@@ -109,7 +114,8 @@ export interface SessionTagTiming {
   classifySessionTagsMs: number;
 }
 
-interface AgentScanResult {
+interface SuccessfulAgentScanResult {
+  status: "complete" | "partial";
   agent: BaseAgent;
   heads: SessionHead[];
   fromCache?: boolean;
@@ -117,6 +123,17 @@ interface AgentScanResult {
   timing?: AgentScanTiming;
   cacheTimestamp?: number;
 }
+
+interface FailedAgentScanResult {
+  status: "failed";
+  agent: BaseAgent;
+  failure: AgentScanFailure;
+  retainedHeads?: SessionHead[];
+  cacheTimestamp?: number;
+  timing: AgentScanTiming;
+}
+
+type AgentScanResult = SuccessfulAgentScanResult | FailedAgentScanResult;
 
 type AgentScanFinalization =
   | { kind: "cache-only"; cached: CachedResult }
@@ -133,6 +150,7 @@ interface FinalizeAgentScanContext {
   options: ScanOptions;
   timing: AgentScanTiming;
   agentStart: number;
+  completeness: "complete" | "partial";
   onProgress?: (progress: ScanProgress) => void;
 }
 
@@ -141,6 +159,10 @@ interface SmartTagWorkerResult {
   tags?: SmartTag[];
   sourceUpdatedAt?: number;
   error?: string;
+}
+
+function restoreAgentCacheMeta(agent: BaseAgent, cached: CachedResult): void {
+  agent.setSessionMetaMap(new Map(Object.entries(cached.meta)));
 }
 
 function saveCachedSessionDiff(
@@ -324,7 +346,7 @@ export async function finalizeAgentScan(
   agent: BaseAgent,
   sessions: SessionHead[],
   context: FinalizeAgentScanContext,
-): Promise<AgentScanResult> {
+): Promise<SuccessfulAgentScanResult> {
   const { finalization, options, timing, agentStart, onProgress } = context;
   const isIncremental = finalization.kind === "incremental";
 
@@ -370,6 +392,7 @@ export async function finalizeAgentScan(
   const heads = filterSessions(tagged.sessions, options);
   timing.total = performance.now() - agentStart;
   return {
+    status: context.completeness,
     agent,
     heads,
     fromCache: true,
@@ -402,11 +425,7 @@ async function scanAgentSmart(
 
     if (cached !== null) {
       // 恢复元数据
-      const metaMap = new Map<string, SessionCacheMeta>();
-      for (const [id, meta] of Object.entries(cached.meta)) {
-        metaMap.set(id, meta);
-      }
-      agent.setSessionMetaMap(metaMap);
+      restoreAgentCacheMeta(agent, cached);
 
       if (options.cacheOnly) {
         const visibleSessions = agent.filterCachedSessions(cached.sessions);
@@ -420,6 +439,7 @@ async function scanAgentSmart(
           options,
           timing,
           agentStart,
+          completeness: "partial",
           onProgress,
         });
       }
@@ -467,6 +487,7 @@ async function scanAgentSmart(
           options,
           timing,
           agentStart,
+          completeness: (checkResult.sourceFailures?.length ?? 0) > 0 ? "partial" : "complete",
           onProgress,
         });
       }
@@ -476,6 +497,7 @@ async function scanAgentSmart(
         options,
         timing,
         agentStart,
+        completeness: "complete",
         onProgress,
       });
     }
@@ -531,7 +553,7 @@ async function scanAgentFull(
     if (agent instanceof FileSystemSessionSource) {
       const cached = loadCachedSessions(agent.name);
       if (cached) {
-        agent.setSessionMetaMap(new Map(Object.entries(cached.meta)));
+        restoreAgentCacheMeta(agent, cached);
       }
       const batch = agent.scanSessionSources(agentScanOptions);
       const sessionMap = new Map(cached?.sessions.map((session) => [session.id, session]) ?? []);
@@ -604,10 +626,46 @@ async function scanAgentFull(
 
     const filtered = filterSessions(tagged.sessions, options);
     timing.total = performance.now() - agentStart;
-    return { agent, heads: filtered, fromCache: false, timing };
+    return {
+      status:
+        options.from == null && options.to == null && sourceFailures.length === 0
+          ? "complete"
+          : "partial",
+      agent,
+      heads: filtered,
+      fromCache: false,
+      timing,
+    };
   } catch (err) {
-    console.error(`Error scanning ${agent.name}:`, err);
-    return { agent, heads: [], fromCache: false };
+    if (err instanceof SessionScanError) throw err;
+    throw new SessionScanError(agent.name, "scanning sessions", { cause: err });
+  }
+}
+
+async function scanAgentOutcome(
+  agent: BaseAgent,
+  options: ScanOptions,
+  onProgress?: (progress: ScanProgress) => void,
+): Promise<AgentScanResult | null> {
+  const startedAt = performance.now();
+  try {
+    return await scanAgentSmart(agent, options, onProgress);
+  } catch (error) {
+    const cached = (options.useCache ?? true) ? loadCachedSessions(agent.name) : null;
+    if (cached) restoreAgentCacheMeta(agent, cached);
+    const retainedHeads = cached
+      ? filterSessions(agent.filterCachedSessions(cached.sessions), options)
+      : undefined;
+    const failure = createAgentScanFailure(agent.name, "scanning sessions", error);
+    reportAgentScanFailure(failure, retainedHeads !== undefined);
+    return {
+      status: "failed",
+      agent,
+      failure,
+      ...(retainedHeads !== undefined ? { retainedHeads } : {}),
+      ...(cached ? { cacheTimestamp: cached.timestamp } : {}),
+      timing: { total: performance.now() - startedAt },
+    };
   }
 }
 
@@ -624,6 +682,7 @@ export async function scanSessions(
   const allSessions: SessionHead[] = [];
   const availableAgents: BaseAgent[] = [];
   const cacheTimestamps: Record<string, number> = {};
+  const scanFailures: Record<string, AgentScanFailure> = {};
 
   const agentFilter = options.agents?.length
     ? new Set(options.agents.map((a) => a.toLowerCase()))
@@ -638,7 +697,7 @@ export async function scanSessions(
   });
 
   // 并行扫描所有 Agent
-  const scanPromises = agentsToScan.map((agent) => scanAgentSmart(agent, options, onProgress));
+  const scanPromises = agentsToScan.map((agent) => scanAgentOutcome(agent, options, onProgress));
 
   const results = await Promise.all(scanPromises);
 
@@ -647,8 +706,16 @@ export async function scanSessions(
   for (const result of results) {
     if (result) {
       availableAgents.push(result.agent);
-      byAgent[result.agent.name] = result.heads;
-      allSessions.push(...result.heads);
+      if (result.status === "failed") {
+        scanFailures[result.agent.name] = result.failure;
+        if (result.retainedHeads !== undefined) {
+          byAgent[result.agent.name] = result.retainedHeads;
+          allSessions.push(...result.retainedHeads);
+        }
+      } else {
+        byAgent[result.agent.name] = result.heads;
+        allSessions.push(...result.heads);
+      }
       if (result.timing) {
         timings[result.agent.name] = result.timing;
       }
@@ -665,5 +732,6 @@ export async function scanSessions(
     agents: availableAgents,
     timings,
     cacheTimestamps: Object.keys(cacheTimestamps).length > 0 ? cacheTimestamps : undefined,
+    scanFailures: Object.keys(scanFailures).length > 0 ? scanFailures : undefined,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export {
   reportSessionSourceOutcome,
 } from "./agents/index.js";
 export type {
+  AgentScanFailure,
   AgentRoots,
   AgentScanOptions,
   AgentScanProgress,


### PR DESCRIPTION
## Summary

- model agent scans as explicit complete, partial, or failed outcomes
- propagate root enumeration and database failures without publishing false empty agents
- retain last-known-good sessions when cache use is enabled
- expose initial failures through server scan status and make `--json` fail without emitting misleading JSON
- skip initial search indexing when a failed agent has no publishable baseline

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm test:migration`
- `pnpm test:e2e`
- `pnpm perf:check`
- `pnpm package:artifact:test`
- `pnpm package:artifact`
- package artifact smoke test
- real `--json --agent codex --no-cache` EACCES smoke: empty stdout, diagnostic stderr, exit code 1

Issue: CS-177