### PR TITLE
fix: validate session query parameters

### DIFF
--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -133,7 +133,7 @@ const scanSource: ScanResultSource = {
   getSnapshot: () =>
     ({
       sessions: [],
-      byAgent: {},
+      byAgent: { codex: [] },
       agents: [],
     }) as LiveSnapshot,
 };
@@ -581,6 +581,26 @@ describe("session alias handlers", () => {
 });
 
 describe("query boundary handlers", () => {
+  it("reports rejected and empty-result parameter outcomes", () => {
+    const sessions = makeContext({ query: { agent: "nonexistent" } });
+    handleGetSessions(sessions as never, scanSource);
+    const files = makeContext({ query: { limit: "1.5" } });
+    handleGetFileActivity(files as never);
+
+    expect(loggerMocks.warn).toHaveBeenCalledWith("api.query_parameter.invalid", {
+      endpoint: "sessions",
+      parameter: "agent",
+      validation_outcome: "empty_result",
+    });
+    expect(loggerMocks.warn).toHaveBeenCalledWith("api.query_parameter.invalid", {
+      endpoint: "file-activity",
+      parameter: "limit",
+      validation_outcome: "rejected",
+    });
+    expect(files.json).toHaveBeenCalledWith({ error: "limit must be a positive integer" }, 400);
+    expect(coreMocks.listFileActivity).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid project identities consistently", () => {
     const sessions = makeContext({ query: { projectKind: "path" } });
     handleGetSessions(sessions as never, scanSource);
@@ -607,7 +627,7 @@ describe("query boundary handlers", () => {
   it("normalizes file activity filters and caps the result limit", () => {
     const c = makeContext({
       query: {
-        agent: " codex ",
+        agent: " CoDeX ",
         sessionId: " s1 ",
         projectKind: "path",
         projectKey: "/repo",
@@ -638,14 +658,25 @@ describe("query boundary handlers", () => {
     });
   });
 
-  it("uses safe defaults for invalid file activity filters", () => {
-    const c = makeContext({ query: { kind: "execute", limit: "invalid" } });
+  it.each(["1.5", "0", "-1", "", "Infinity", "invalid"])(
+    "rejects invalid file activity limit %j before storage",
+    (limit) => {
+      const c = makeContext({ query: { kind: "execute", limit } });
+
+      handleGetFileActivity(c as never);
+
+      expect(c.json).toHaveBeenCalledWith({ error: "limit must be a positive integer" }, 400);
+      expect(coreMocks.listFileActivity).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns an empty file activity result for an unknown agent without querying storage", () => {
+    const c = makeContext({ query: { agent: "nonexistent" } });
 
     handleGetFileActivity(c as never);
 
-    expect(coreMocks.listFileActivity).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: undefined, limit: 50 }),
-    );
+    expect(c.json).toHaveBeenCalledWith({ activity: [] });
+    expect(coreMocks.listFileActivity).not.toHaveBeenCalled();
   });
 
   // `days` is the number of calendar days covered, so it matches the bucket count.

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -351,12 +351,19 @@ describe("handleGetSessions", () => {
     expect(response.sessions).toHaveLength(2);
   });
 
-  it("falls back to all sessions when agent not found in byAgent", () => {
+  it("returns no sessions when the requested agent is unknown", () => {
     const c = makeMockContext({ query: { agent: "nonexistent" } });
     handleGetSessions(c, makeScanSource());
     const response = c.json.mock.calls[0]![0];
-    // Falls back to scanResult.sessions
-    expect(response.sessions).toHaveLength(2);
+    expect(response.sessions).toEqual([]);
+  });
+
+  it("normalizes the requested agent case", () => {
+    const c = makeMockContext({ query: { agent: "ClaudeCode" } });
+
+    handleGetSessions(c, makeScanSource());
+
+    expect(c.json.mock.calls[0]![0].sessions).toHaveLength(2);
   });
 
   it("filters by q (title search)", () => {
@@ -525,7 +532,7 @@ describe("handleSearchSessions", () => {
     const c = makeMockContext({
       query: {
         q: " needle ",
-        agent: "claudecode",
+        agent: "ClaudeCode",
         tag: "bugfix",
         limit: "5",
         projectKind: "git_remote",
@@ -557,6 +564,39 @@ describe("handleSearchSessions", () => {
       expect.objectContaining({ error: expect.any(String) }),
       400,
     );
+    expect(coreMocks.executeSessionSearch).not.toHaveBeenCalled();
+  });
+
+  it.each(["1.5", "0", "-1", "", "Infinity", "invalid"])(
+    "rejects invalid search limit %j before executing search",
+    (limit) => {
+      const c = makeMockContext({ query: { q: "needle", limit } });
+
+      handleSearchSessions(c, makeScanSource());
+
+      expect(c.json).toHaveBeenCalledWith({ error: "limit must be a positive integer" }, 400);
+      expect(coreMocks.executeSessionSearch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("caps an oversized integer search limit", () => {
+    const c = makeMockContext({ query: { q: "needle", limit: "999999999999999999999" } });
+
+    handleSearchSessions(c, makeScanSource());
+
+    expect(coreMocks.executeSessionSearch).toHaveBeenCalledWith(
+      "needle",
+      expect.objectContaining({ limit: 100 }),
+      expect.anything(),
+    );
+  });
+
+  it("returns no search results for an unknown agent without executing search", () => {
+    const c = makeMockContext({ query: { q: "needle", agent: "nonexistent" } });
+
+    handleSearchSessions(c, makeScanSource());
+
+    expect(c.json).toHaveBeenCalledWith({ results: [] });
     expect(coreMocks.executeSessionSearch).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/api/__tests__/query-params.test.ts
+++ b/packages/cli/src/api/__tests__/query-params.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseSessionQuery, SEARCH_LIMIT_POLICY } from "../query-params.js";
+
+describe("session query contract", () => {
+  it("distinguishes an absent agent from known and unknown values", () => {
+    expect(parseSessionQuery(new URLSearchParams(), ["claudecode"]).agent).toEqual({
+      kind: "all",
+    });
+    expect(
+      parseSessionQuery(new URLSearchParams("agent=ClaudeCode"), ["claudecode"]).agent,
+    ).toEqual({ kind: "known", agentName: "claudecode" });
+    expect(
+      parseSessionQuery(new URLSearchParams("agent=nonexistent"), ["claudecode"]).agent,
+    ).toEqual({ kind: "unknown" });
+    expect(parseSessionQuery(new URLSearchParams("agent="), ["claudecode"]).agent).toEqual({
+      kind: "unknown",
+    });
+  });
+
+  it.each([
+    [undefined, { kind: "default", value: 50 }],
+    ["1", { kind: "valid", value: 1 }],
+    ["100", { kind: "valid", value: 100 }],
+    ["999999999999999999999", { kind: "valid", value: 100 }],
+  ])("parses and bounds limit %j", (value, expected) => {
+    const params = new URLSearchParams();
+    if (value !== undefined) params.set("limit", value);
+
+    expect(parseSessionQuery(params, [], SEARCH_LIMIT_POLICY).limit).toEqual(expected);
+  });
+
+  it.each(["1.5", "0", "-1", "", "Infinity", "text"])("rejects invalid limit %j", (limit) => {
+    expect(
+      parseSessionQuery(new URLSearchParams({ limit }), [], SEARCH_LIMIT_POLICY).limit,
+    ).toEqual({ kind: "invalid", error: "limit must be a positive integer" });
+  });
+});

--- a/packages/cli/src/api/__tests__/search-transport.test.ts
+++ b/packages/cli/src/api/__tests__/search-transport.test.ts
@@ -5,8 +5,8 @@
  * filtering/ordering, FTS/file-activity dedupe, ...) are owned and fully
  * characterized by packages/core/src/search/__tests__/session-search.test.ts
  * via executeSessionSearch. This file only pins the HTTP-layer concerns that
- * live in handleSearchSessions itself: projectKind/projectKey pairing
- * validation, and a couple of smoke tests proving the route wires query
+ * live in handleSearchSessions itself: request validation, Agent
+ * canonicalization, and smoke tests proving the route wires validated query
  * params through to the search module and back into the response body.
  */
 import { mkdtempSync, rmSync } from "node:fs";
@@ -104,6 +104,27 @@ describe("search route: smoke wiring", () => {
     const { body } = await search(app, "?limit=2");
     expect(body.results!.map((r) => r.session.id)).toEqual(["recent-new", "recent-mid"]);
   });
+
+  it("normalizes a known agent and returns no results for an unknown agent", async () => {
+    const app = createApiRoutes(makeScanSource());
+
+    const known = await search(app, "?agent=ClaudeCode");
+    const unknown = await search(app, "?agent=nonexistent");
+
+    expect(known.body.results!.length).toBeGreaterThan(0);
+    expect(unknown.body.results).toEqual([]);
+  });
+
+  it.each(["1.5", "0", "-1", "", "Infinity", "invalid"])(
+    "400s for invalid limit %j",
+    async (limit) => {
+      const app = createApiRoutes(makeScanSource());
+      const { status, body } = await search(app, `?limit=${encodeURIComponent(limit)}`);
+
+      expect(status).toBe(400);
+      expect(body.error).toBe("limit must be a positive integer");
+    },
+  );
 
   it("routes a text q to the indexed FTS path and resolves matchType", async () => {
     const app = createApiRoutes(makeScanSource());

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -46,11 +46,15 @@ import { appLogger } from "../logging.js";
 import { resolveTimeWindow } from "../time-window-resolution.js";
 import {
   filterSessionsByActivityWindow,
+  FILE_ACTIVITY_LIMIT_POLICY,
   parseDateParam,
   parseFileActivityKind,
   parseProjectIdentityFilter,
+  parseSessionQuery,
   parseSearchOptions,
   optionalQueryValue,
+  searchParams,
+  SEARCH_LIMIT_POLICY,
   type SessionListDefaults,
 } from "./query-params.js";
 import {
@@ -70,6 +74,20 @@ export interface ScanResultSource {
 
 export interface ScanStatusSource {
   getScanStatus(): ScanStatusEvent;
+}
+
+const KNOWN_AGENT_NAMES = getAgentInfoMap({}).map((agent) => agent.name);
+
+function reportInvalidQueryParameter(
+  endpoint: string,
+  parameter: "agent" | "limit",
+  validationOutcome: "empty_result" | "rejected",
+): void {
+  appLogger.warn("api.query_parameter.invalid", {
+    endpoint,
+    parameter,
+    validation_outcome: validationOutcome,
+  });
 }
 
 interface SnapshotAggregationCache {
@@ -373,7 +391,7 @@ export function handleGetSessions(
   defaults: SessionListDefaults = {},
 ) {
   const scanResult = scanSource.getSnapshot();
-  const agent = c.req.query("agent");
+  const sessionQuery = parseSessionQuery(searchParams(c), KNOWN_AGENT_NAMES);
   const q = c.req.query("q")?.toLowerCase();
   const cwd = c.req.query("cwd");
   const projectIdentity = parseProjectIdentityFilter(
@@ -389,11 +407,12 @@ export function handleGetSessions(
 
   let sessions: SessionHead[] = [];
 
-  // If agent filter is specified, use byAgent directly
-  if (agent && scanResult.byAgent[agent]) {
-    sessions = [...scanResult.byAgent[agent]!];
-  } else {
+  if (sessionQuery.agent.kind === "all") {
     sessions = [...scanResult.sessions];
+  } else if (sessionQuery.agent.kind === "known") {
+    sessions = [...(scanResult.byAgent[sessionQuery.agent.agentName] ?? [])];
+  } else {
+    reportInvalidQueryParameter("sessions", "agent", "empty_result");
   }
 
   if (projectIdentity) {
@@ -459,6 +478,11 @@ export function handleSearchSessions(
 ) {
   const query = c.req.query("q")?.trim() ?? "";
   const scanResult = scanSource.getSnapshot();
+  const sessionQuery = parseSessionQuery(searchParams(c), KNOWN_AGENT_NAMES, SEARCH_LIMIT_POLICY);
+  if (sessionQuery.limit.kind === "invalid") {
+    reportInvalidQueryParameter("search", "limit", "rejected");
+    return c.json({ error: sessionQuery.limit.error }, 400);
+  }
   const projectIdentity = parseProjectIdentityFilter(
     c.req.query("projectKind"),
     c.req.query("projectKey"),
@@ -466,7 +490,19 @@ export function handleSearchSessions(
   if (projectIdentity === null) {
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
-  const searchOptions = parseSearchOptions(c, defaults, projectIdentity);
+  if (sessionQuery.agent.kind === "unknown") {
+    reportInvalidQueryParameter("search", "agent", "empty_result");
+    return c.json({ results: [] });
+  }
+  const searchOptions = parseSearchOptions(
+    c,
+    defaults,
+    {
+      agent: sessionQuery.agent.kind === "known" ? sessionQuery.agent.agentName : undefined,
+      limit: sessionQuery.limit.value,
+    },
+    projectIdentity,
+  );
   const aliases = loadAliasView();
   const results = executeSessionSearch(query, searchOptions, scanResult).map((result) => ({
     ...result,
@@ -487,8 +523,15 @@ export function handleSearchSessions(
 }
 
 export function handleGetFileActivity(c: Context, defaults: SessionListDefaults = {}) {
-  const limitValue = Number(c.req.query("limit"));
-  const limit = Number.isFinite(limitValue) && limitValue > 0 ? Math.min(limitValue, 200) : 50;
+  const sessionQuery = parseSessionQuery(
+    searchParams(c),
+    KNOWN_AGENT_NAMES,
+    FILE_ACTIVITY_LIMIT_POLICY,
+  );
+  if (sessionQuery.limit.kind === "invalid") {
+    reportInvalidQueryParameter("file-activity", "limit", "rejected");
+    return c.json({ error: sessionQuery.limit.error }, 400);
+  }
   const projectIdentity = parseProjectIdentityFilter(
     c.req.query("projectKind"),
     c.req.query("projectKey"),
@@ -496,11 +539,15 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
   if (projectIdentity === null) {
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
+  if (sessionQuery.agent.kind === "unknown") {
+    reportInvalidQueryParameter("file-activity", "agent", "empty_result");
+    return c.json({ activity: [] });
+  }
 
   const aliases = loadAliasView();
   return c.json({
     activity: listFileActivity({
-      agent: optionalQueryValue(c.req.query("agent")),
+      agent: sessionQuery.agent.kind === "known" ? sessionQuery.agent.agentName : undefined,
       sessionId: optionalQueryValue(c.req.query("sessionId")),
       projectKind: projectIdentity?.kind,
       projectKey: projectIdentity?.key,
@@ -510,7 +557,7 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
       kind: parseFileActivityKind(optionalQueryValue(c.req.query("kind"))),
       from: parseDateParam(c.req.query("from"), defaults.from),
       to: parseDateParam(c.req.query("to"), defaults.to),
-      limit,
+      limit: sessionQuery.limit.value,
     }).map((activity) => decorateFileActivity(activity, aliases)),
   });
 }

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -28,8 +28,31 @@ const SMART_TAGS: readonly string[] = [
   "planning",
 ];
 
-const SEARCH_LIMIT_MAX = 100;
-const SEARCH_LIMIT_DEFAULT = 50;
+export interface LimitPolicy {
+  defaultValue: number;
+  maxValue: number;
+}
+
+export const SEARCH_LIMIT_POLICY: LimitPolicy = { defaultValue: 50, maxValue: 100 };
+export const FILE_ACTIVITY_LIMIT_POLICY: LimitPolicy = { defaultValue: 50, maxValue: 200 };
+
+export type AgentFilterOutcome =
+  | { kind: "all" }
+  | { kind: "known"; agentName: string }
+  | { kind: "unknown" };
+
+export type LimitOutcome =
+  | { kind: "default"; value: number }
+  | { kind: "valid"; value: number }
+  | { kind: "invalid"; error: string };
+
+export interface SessionQuery {
+  agent: AgentFilterOutcome;
+}
+
+export interface LimitedSessionQuery extends SessionQuery {
+  limit: LimitOutcome;
+}
 
 export function searchParams(c: Context): URLSearchParams {
   return new URL(c.req.url ?? "http://localhost/", "http://localhost/").searchParams;
@@ -66,6 +89,53 @@ export function parseNumberParam(value: string | undefined): number | undefined 
   return Number.isFinite(number) ? number : undefined;
 }
 
+function parseAgentFilter(
+  value: string | null,
+  knownAgentNames: Iterable<string>,
+): AgentFilterOutcome {
+  if (value === null) return { kind: "all" };
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return { kind: "unknown" };
+
+  for (const agentName of knownAgentNames) {
+    if (agentName.toLowerCase() === normalized) return { kind: "known", agentName };
+  }
+  return { kind: "unknown" };
+}
+
+function parseLimit(value: string | null, policy: LimitPolicy): LimitOutcome {
+  if (value === null) return { kind: "default", value: policy.defaultValue };
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    return { kind: "invalid", error: "limit must be a positive integer" };
+  }
+
+  const digits = normalized.replace(/^0+/, "");
+  if (!digits) return { kind: "invalid", error: "limit must be a positive integer" };
+  const maxDigits = String(policy.maxValue);
+  const exceedsMaximum =
+    digits.length > maxDigits.length || (digits.length === maxDigits.length && digits > maxDigits);
+  return { kind: "valid", value: exceedsMaximum ? policy.maxValue : Number(digits) };
+}
+
+export function parseSessionQuery(
+  params: URLSearchParams,
+  knownAgentNames: Iterable<string>,
+): SessionQuery;
+export function parseSessionQuery(
+  params: URLSearchParams,
+  knownAgentNames: Iterable<string>,
+  limitPolicy: LimitPolicy,
+): LimitedSessionQuery;
+export function parseSessionQuery(
+  params: URLSearchParams,
+  knownAgentNames: Iterable<string>,
+  limitPolicy?: LimitPolicy,
+): SessionQuery | LimitedSessionQuery {
+  const agent = parseAgentFilter(params.get("agent"), knownAgentNames);
+  return limitPolicy ? { agent, limit: parseLimit(params.get("limit"), limitPolicy) } : { agent };
+}
+
 export function parseSmartTags(values: string[]): SmartTag[] | undefined {
   const tags = values
     .map((value) => value.toLowerCase())
@@ -99,12 +169,12 @@ export function parseProjectIdentityFilter(
 export function parseSearchOptions(
   c: Context,
   defaults: SessionListDefaults,
+  request: { agent?: string; limit: number },
   projectIdentity?: ProjectIdentityRef,
 ): SearchOptions {
   const params = searchParams(c);
-  const limitValue = parseNumberParam(params.get("limit") ?? undefined);
   return {
-    agent: optionalQueryValue(params.get("agent") ?? undefined),
+    agent: request.agent,
     project: optionalQueryValue(params.get("project") ?? undefined),
     projectKind: projectIdentity?.kind,
     projectKey: projectIdentity?.key,
@@ -119,8 +189,7 @@ export function parseSearchOptions(
     costMax: parseNumberParam(params.get("costMax") ?? undefined),
     from: parseDateParam(params.get("from") ?? undefined, defaults.from),
     to: parseDateParam(params.get("to") ?? undefined, defaults.to),
-    limit:
-      limitValue && limitValue > 0 ? Math.min(limitValue, SEARCH_LIMIT_MAX) : SEARCH_LIMIT_DEFAULT,
+    limit: request.limit,
   };
 }
 

--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../../utils/diagnostics.js";
-import { withCacheDb, withSearchIndexDb } from "../schema.js";
+import { withCacheDb, withCacheDbReadOnly, withSearchIndexDb } from "../schema.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-diag-test-"));
 
@@ -40,7 +40,33 @@ describe("withCacheDb diagnostics", () => {
     expect(events).toEqual([
       {
         event: "cache.write_failed",
-        detail: { message: "disk full", code: undefined, stack: expect.any(String) },
+        detail: {
+          message: "disk full",
+          code: undefined,
+          error_class: "Error",
+          stack: expect.any(String),
+        },
+      },
+    ]);
+  });
+
+  it("reports the error class for a read-only query failure", () => {
+    withCacheDb(() => undefined);
+    const events = collectDiagnostics();
+
+    const result = withCacheDbReadOnly(() => {
+      throw Object.assign(new Error("datatype mismatch"), { code: "SQLITE_MISMATCH" });
+    });
+
+    expect(result).toBeNull();
+    expect(events).toEqual([
+      {
+        event: "cache.read_failed",
+        detail: {
+          message: "datatype mismatch",
+          code: "SQLITE_MISMATCH",
+          error_class: "Error",
+        },
       },
     ]);
   });

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -84,6 +84,7 @@ export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
     getCoreDiagnostics()?.warn("cache.write_failed", {
       message: error instanceof Error ? error.message : String(error),
       code: (error as { code?: string })?.code,
+      error_class: error instanceof Error ? error.name : typeof error,
       stack: error instanceof Error ? error.stack : undefined,
     });
     return null;
@@ -98,7 +99,12 @@ export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): T | null 
 
   try {
     return fn(db);
-  } catch {
+  } catch (error) {
+    getCoreDiagnostics()?.warn("cache.read_failed", {
+      message: error instanceof Error ? error.message : String(error),
+      code: (error as { code?: string })?.code,
+      error_class: error instanceof Error ? error.name : typeof error,
+    });
     return null;
   } finally {
     db.close();


### PR DESCRIPTION
## Summary

- model session query parameters as explicit absent, valid, and invalid outcomes
- canonicalize known agent names and return empty results for unknown agents
- reject non-integer limits before storage while preserving endpoint defaults and caps
- report cache read/write error classes for actionable SQLite diagnostics

## Root cause

HTTP handlers passed raw optional primitives downstream and inferred meaning from truthiness, snapshot membership, or SQLite behavior. That made an unknown agent expand to all sessions in one endpoint and let fractional limits fail inside SQLite in others.

## Test plan

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm test:migration`
- `pnpm test:e2e`
- `pnpm perf:check`
- `pnpm package:artifact:test`
- `pnpm package:artifact`
- `node scripts/smoke-package-artifact.mjs artifacts/npm/codesesh-1.0.0.tgz`

Issue: CS-178