### PR TITLE
refactor(bookmarks): store reference facts

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,7 +3,7 @@ declare const __APP_VERSION__: string;
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { PanelLeftOpen } from "./components/ui/icons";
 import { Link, useLocation, useMatches, useNavigate } from "react-router-dom";
-import type { BookmarkRecord, SessionHead } from "./lib/api";
+import type { BookmarkView, SessionHead } from "./lib/api";
 import { logClientEvent } from "./lib/api";
 import { getSessionRoutePath } from "./lib/session-indexes";
 import { ErrorBoundary } from "./components/ErrorBoundary";
@@ -140,7 +140,7 @@ export default function App() {
       ? location.state.searchQuery
       : "";
 
-  const bookmarks = useBookmarks(sessions);
+  const bookmarks = useBookmarks();
   const {
     bookmarkedSessions,
     isSessionBookmarked,
@@ -218,12 +218,18 @@ export default function App() {
     });
   }, []);
 
-  const handleRenameBookmarkedSession = useCallback((bookmark: BookmarkRecord) => {
+  const handleRenameBookmarkedSession = useCallback((bookmark: BookmarkView) => {
     setAliasTarget({
       agentKey: bookmark.reference.agentName,
       sessionId: bookmark.reference.sessionId,
-      title: bookmark.session.title,
-      displayTitle: bookmark.session.display_title,
+      title:
+        bookmark.availability === "available"
+          ? bookmark.session.title
+          : bookmark.reference.sessionId,
+      displayTitle:
+        bookmark.availability === "available"
+          ? bookmark.session.display_title
+          : bookmark.display_title,
     });
   }, []);
 

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import type { AgentInfo, ApiProjectGroup, ScanStatusEvent } from "../../lib/api";
+import type { AgentInfo, ApiProjectGroup, BookmarkView, ScanStatusEvent } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
 import { ScanStatusProvider } from "../../hooks/useScanStatus";
 import { AppSidebar, type AppSidebarActions, type AppSidebarViewModel } from "./AppSidebar";
@@ -116,5 +116,29 @@ describe("AppSidebar", () => {
     renderSidebar();
 
     expect(screen.queryByRole("heading", { name: /SESSIONS/ })).toBeNull();
+  });
+
+  it("renders unavailable bookmark facts without navigable stale session links", () => {
+    const bookmarkedSessions: BookmarkView[] = [
+      {
+        reference: { agentName: "codex", sessionId: "gone" },
+        bookmarkedAt: 2,
+        availability: "session-unavailable",
+        display_title: "Lost alias",
+      },
+      {
+        reference: { agentName: "removed-agent", sessionId: "orphan" },
+        bookmarkedAt: 1,
+        availability: "agent-unavailable",
+      },
+    ];
+
+    renderSidebar({ bookmarkedSessions });
+
+    expect(screen.getByText("Lost alias")).toBeTruthy();
+    expect(screen.getByText("Codex · gone · Session unavailable")).toBeTruthy();
+    expect(screen.getByText("removed-agent · Agent unavailable")).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /Lost alias/ })).toBeNull();
+    expect(screen.queryByRole("link", { name: /orphan/ })).toBeNull();
   });
 });

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import type { BookmarkRecord, ApiProjectGroup, SessionHead } from "../../lib/api";
+import type { BookmarkView, ApiProjectGroup, SessionHead } from "../../lib/api";
 import { useScanStatus } from "../../hooks/useScanStatus";
 import { findAgent, type AgentCatalog } from "../../lib/agents";
 import { getSessionBookmarkKey } from "../../lib/bookmarks";
@@ -73,7 +73,7 @@ export interface AppSidebarViewModel {
   projects: ApiProjectGroup[];
   selectedProjectNavigationId: string | null;
   loading: boolean;
-  bookmarkedSessions: BookmarkRecord[];
+  bookmarkedSessions: BookmarkView[];
   sidebarSessions: SessionHead[];
   selectedSidebarSessionReference: string | null;
   bookmarkedSidebarSessionReferences: Set<string>;
@@ -82,11 +82,11 @@ export interface AppSidebarViewModel {
 export interface AppSidebarActions {
   onCollapse: () => void;
   onSelectProject: (identity: ReturnType<typeof getProjectGroupIdentity>) => void;
-  onToggleBookmark: (session: BookmarkRecord) => void;
+  onToggleBookmark: (session: BookmarkView) => void;
   onSelectFlatSidebarSession: (session: SessionHead) => void;
   onToggleSidebarSessionBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
-  onRenameBookmarkedSession: (session: BookmarkRecord) => void;
+  onRenameBookmarkedSession: (session: BookmarkView) => void;
 }
 
 export function AppSidebar({
@@ -172,12 +172,44 @@ export function AppSidebar({
           ) : (
             <ul className="space-y-1">
               {bookmarkedSessions.map((bookmark) => {
-                const { reference, session } = bookmark;
+                const { reference } = bookmark;
                 const isActive =
                   viewState.mode === "session" &&
                   viewState.activeAgentKey === reference.agentName &&
                   viewState.activeSessionId === reference.sessionId;
                 const agent = findAgent(agentCatalog, reference.agentName);
+                const available = bookmark.availability === "available";
+                const unavailableTitle = available ? undefined : bookmark.display_title;
+                const availabilityLabel =
+                  bookmark.availability === "agent-unavailable"
+                    ? "Agent unavailable"
+                    : "Session unavailable";
+                const title = available
+                  ? getSessionDisplayTitle(bookmark.session)
+                  : (unavailableTitle ?? reference.sessionId);
+                const unavailableDetail = unavailableTitle
+                  ? `${agent?.displayName ?? reference.agentName} · ${reference.sessionId} · ${availabilityLabel}`
+                  : `${agent?.displayName ?? reference.agentName} · ${availabilityLabel}`;
+                const label = (
+                  <>
+                    {agent?.icon ? (
+                      <AgentIcon
+                        icon={agent.icon}
+                        iconColored={agent.iconColored}
+                        alt={agent.displayName}
+                        className="mt-0.5 size-3.5 shrink-0 object-contain"
+                      />
+                    ) : null}
+                    <div className="min-w-0 flex-1">
+                      <span className="console-mono line-clamp-1 block text-xs">{title}</span>
+                      <span className="console-mono mt-0.5 line-clamp-1 block text-[10px] text-[var(--console-muted)]">
+                        {available
+                          ? (agent?.displayName ?? reference.agentName)
+                          : unavailableDetail}
+                      </span>
+                    </div>
+                  </>
+                );
                 return (
                   <li key={getSessionBookmarkKey(reference)}>
                     <div
@@ -188,27 +220,18 @@ export function AppSidebar({
                           : "text-[var(--console-muted)] hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)]"
                       }`}
                     >
-                      <Link
-                        to={getSessionRoutePath(session)}
-                        className="flex min-w-0 flex-1 items-start gap-2"
-                      >
-                        {agent?.icon ? (
-                          <AgentIcon
-                            icon={agent.icon}
-                            iconColored={agent.iconColored}
-                            alt={agent.displayName}
-                            className="mt-0.5 size-3.5 shrink-0 object-contain"
-                          />
-                        ) : null}
-                        <div className="min-w-0 flex-1">
-                          <span className="console-mono line-clamp-1 block text-xs">
-                            {getSessionDisplayTitle(session)}
-                          </span>
-                          <span className="console-mono mt-0.5 line-clamp-1 block text-[10px] text-[var(--console-muted)]">
-                            {agent?.displayName ?? reference.agentName}
-                          </span>
+                      {available ? (
+                        <Link
+                          to={getSessionRoutePath(bookmark.session)}
+                          className="flex min-w-0 flex-1 items-start gap-2"
+                        >
+                          {label}
+                        </Link>
+                      ) : (
+                        <div className="flex min-w-0 flex-1 items-start gap-2" aria-disabled="true">
+                          {label}
                         </div>
-                      </Link>
+                      )}
                       <SessionActionsMenu
                         bookmarked
                         onRename={() => onRenameBookmarkedSession(bookmark)}

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import type { BookmarkRecord, SessionHead } from "../lib/api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BookmarkRecord, BookmarkView, SessionHead } from "../lib/api";
 import * as api from "../lib/api";
 import * as bookmarkUtils from "../lib/bookmarks";
 import { createQueryWrapper } from "../test/query-wrapper";
@@ -18,15 +18,20 @@ vi.mock("../lib/bookmarks", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/bookmarks")>();
   return {
     ...actual,
-    mergeBookmarksWithSessions: vi.fn((prev) => prev),
     loadLegacyBookmarks: vi.fn(() => []),
     clearLegacyBookmarks: vi.fn(),
   };
 });
 
-const snap = (id: string, updated = 1): BookmarkRecord => ({
-  reference: { agentName: "cc", sessionId: id },
-  session: {
+function fact(id: string, bookmarkedAt = 1): BookmarkRecord {
+  return {
+    reference: { agentName: "cc", sessionId: id },
+    bookmarkedAt,
+  };
+}
+
+function session(id: string, updated = 1): SessionHead {
+  return {
     id,
     slug: `cc/${id}`,
     title: id,
@@ -34,28 +39,28 @@ const snap = (id: string, updated = 1): BookmarkRecord => ({
     time_created: 1,
     time_updated: updated,
     stats: {
-      message_count: 0,
+      message_count: 1,
       total_input_tokens: 0,
       total_output_tokens: 0,
       total_cost: 0,
     },
-  },
-  bookmarkedAt: 0,
-});
+  };
+}
 
-const session = (id: string): SessionHead => ({
-  id,
-  slug: `cc/${id}`,
-  title: id,
-  directory: "/d",
-  time_created: 1,
-  stats: {
-    message_count: 1,
-    total_input_tokens: 0,
-    total_output_tokens: 0,
-    total_cost: 0,
-  },
-});
+function available(id: string, updated = 1): BookmarkView {
+  return {
+    ...fact(id),
+    availability: "available",
+    session: session(id, updated),
+  };
+}
+
+function unavailable(id: string): BookmarkView {
+  return {
+    ...fact(id),
+    availability: "session-unavailable",
+  };
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -70,9 +75,8 @@ function deferred<T>() {
 beforeEach(() => {
   vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [] });
   vi.mocked(api.importBookmarks).mockResolvedValue({ bookmarks: [] });
-  vi.mocked(api.upsertBookmark).mockResolvedValue(undefined as never);
-  vi.mocked(api.deleteBookmark).mockResolvedValue(undefined as never);
-  vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((prev) => prev);
+  vi.mocked(api.upsertBookmark).mockResolvedValue({ bookmark: fact("saved") });
+  vi.mocked(api.deleteBookmark).mockResolvedValue(undefined);
   vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([]);
 });
 
@@ -81,208 +85,107 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-function renderBookmarks(sessions: SessionHead[] = []) {
+function renderBookmarks() {
   const { Wrapper } = createQueryWrapper();
-  return renderHook(({ currentSessions }) => useBookmarks(currentSessions), {
-    initialProps: { currentSessions: sessions },
-    wrapper: Wrapper,
-  });
+  return renderHook(() => useBookmarks(), { wrapper: Wrapper });
 }
 
 describe("useBookmarks", () => {
-  it("loads bookmarks on mount", async () => {
-    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
-    const { result } = renderBookmarks();
-
-    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s1")).toBe(true));
-  });
-
-  it("toggleBookmark adds optimistically and calls upsert", async () => {
-    const { result } = renderBookmarks();
-    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
-
-    act(() => result.current.toggleBookmark(snap("s2")));
-
-    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s2")).toBe(true));
-    await waitFor(() => expect(api.upsertBookmark).toHaveBeenCalledOnce());
-  });
-
-  it("toggleBookmark removes an existing bookmark and calls delete", async () => {
-    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s3")] });
-    const { result } = renderBookmarks();
-    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s3")).toBe(true));
-
-    act(() => result.current.toggleBookmark(snap("s3")));
-
-    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "s3")).toBe(false));
-    await waitFor(() =>
-      expect(api.deleteBookmark).toHaveBeenCalledWith({
-        agentName: "cc",
-        sessionId: "s3",
-      }),
-    );
-  });
-
-  it("bookmarkedSessions is sorted by most-recent activity", async () => {
+  it("loads server-materialized bookmark views", async () => {
     vi.mocked(api.fetchBookmarks).mockResolvedValue({
-      bookmarks: [snap("old", 10), snap("new", 20)],
+      bookmarks: [available("live"), unavailable("gone")],
     });
     const { result } = renderBookmarks();
 
     await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(2));
-    expect(result.current.bookmarkedSessions[0]?.reference.sessionId).toBe("new");
+    expect(result.current.isSessionBookmarked("cc", "live")).toBe(true);
+    expect(result.current.isSessionBookmarked("cc", "gone")).toBe(true);
   });
 
-  it("falls back to creation time when sorting bookmarks without update times", async () => {
-    const old = {
-      ...snap("old"),
-      session: { ...snap("old").session, time_created: 10, time_updated: undefined },
-    };
-    const recent = {
-      ...snap("recent"),
-      session: { ...snap("recent").session, time_created: 20, time_updated: undefined },
-    };
-    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [old] });
+  it("adds optimistically while persisting only the session reference", async () => {
+    const request = deferred<{ bookmark: BookmarkRecord }>();
+    vi.mocked(api.upsertBookmark).mockReturnValueOnce(request.promise);
     const { result } = renderBookmarks();
-    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalledOnce());
 
-    act(() => result.current.toggleBookmark(recent));
+    act(() => result.current.toggleBookmark(available("new")));
 
-    await waitFor(() =>
-      expect(
-        result.current.bookmarkedSessions.map((bookmark) => bookmark.reference.sessionId),
-      ).toEqual(["recent", "old"]),
-    );
-  });
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "new")).toBe(true));
+    expect(api.upsertBookmark).toHaveBeenCalledWith({ agentName: "cc", sessionId: "new" });
+    expect(api.logClientEvent).toHaveBeenCalledWith("bookmark.add", {
+      agent: "cc",
+      session: "new",
+    });
 
-  it("refreshes bookmarks and reports load failures", async () => {
-    const error = new Error("offline");
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
-    const { result } = renderBookmarks();
-    await waitFor(() =>
-      expect(consoleError).toHaveBeenCalledWith("Failed to load bookmarks:", error),
-    );
-
-    vi.mocked(api.fetchBookmarks).mockResolvedValueOnce({ bookmarks: [snap("refreshed")] });
-    await act(() => result.current.refresh());
-    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "refreshed")).toBe(true));
-
-    vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
-    await act(() => result.current.refresh());
-    expect(consoleError).toHaveBeenLastCalledWith("Failed to load bookmarks:", error);
-  });
-
-  it("does not apply the initial response after unmount", async () => {
-    const request = deferred<{ bookmarks: BookmarkRecord[] }>();
-    vi.mocked(api.fetchBookmarks).mockReturnValueOnce(request.promise);
-    const { unmount } = renderBookmarks();
-
-    unmount();
-    request.resolve({ bookmarks: [snap("late")] });
+    request.resolve({ bookmark: fact("new") });
     await request.promise;
-
-    expect(api.fetchBookmarks).toHaveBeenCalledOnce();
   });
 
-  it("synchronizes changed bookmark snapshots with the server", async () => {
-    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1", 1)] });
-    const updated = snap("s1", 2);
-    let didMerge = false;
-    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) => {
-      if (didMerge || previous.length === 0 || sessions.length === 0) return previous;
-      didMerge = true;
-      return [updated];
+  it("removes unavailable bookmark views by identity", async () => {
+    const request = deferred<void>();
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [unavailable("gone")] });
+    vi.mocked(api.deleteBookmark).mockReturnValueOnce(request.promise);
+    const { result } = renderBookmarks();
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "gone")).toBe(true));
+
+    act(() => result.current.toggleBookmark(unavailable("gone")));
+
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "gone")).toBe(false));
+    expect(api.deleteBookmark).toHaveBeenCalledWith({ agentName: "cc", sessionId: "gone" });
+
+    request.resolve();
+    await request.promise;
+  });
+
+  it("preserves the server projection order", async () => {
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({
+      bookmarks: [available("server-first", 1), available("server-second", 100)],
     });
-    const { result, rerender } = renderBookmarks();
-    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
+    const { result } = renderBookmarks();
 
-    rerender({ currentSessions: [session("s1")] });
-    await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
-
-    expect(api.importBookmarks).toHaveBeenCalledWith([
-      expect.not.objectContaining({ bookmarkedAt: expect.anything() }),
+    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(2));
+    expect(result.current.bookmarkedSessions.map(({ reference }) => reference.sessionId)).toEqual([
+      "server-first",
+      "server-second",
     ]);
-    expect(result.current.bookmarkedSessions[0]?.session.time_updated).toBe(2);
   });
 
-  it("reports snapshot sync failures while mounted", async () => {
-    const error = new Error("sync failed");
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
-    vi.mocked(api.importBookmarks).mockRejectedValueOnce(error);
-    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) =>
-      previous.length > 0 && sessions.length > 0 ? [snap("s1", 2)] : previous,
+  it("does not synchronize session snapshots during rerenders", async () => {
+    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [available("s1")] });
+    const { Wrapper } = createQueryWrapper();
+    const { result, rerender } = renderHook(
+      ({ sessionVersion }) => {
+        void sessionVersion;
+        return useBookmarks();
+      },
+      {
+        initialProps: { sessionVersion: 1 },
+        wrapper: Wrapper,
+      },
     );
-    const { result, rerender } = renderBookmarks();
     await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
 
-    rerender({ currentSessions: [session("s1")] });
+    rerender({ sessionVersion: 2 });
 
-    await waitFor(() =>
-      expect(consoleError).toHaveBeenCalledWith("Failed to sync bookmark snapshots:", error),
-    );
+    expect(api.importBookmarks).not.toHaveBeenCalled();
+    expect(api.upsertBookmark).not.toHaveBeenCalled();
   });
 
-  it("does not report snapshot sync failures after unmount", async () => {
-    const request = deferred<{ bookmarks: BookmarkRecord[] }>();
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(api.fetchBookmarks).mockResolvedValue({ bookmarks: [snap("s1")] });
-    vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
-    const updated = snap("s1", 2);
-    let didMerge = false;
-    vi.mocked(bookmarkUtils.mergeBookmarksWithSessions).mockImplementation((previous, sessions) => {
-      if (didMerge || previous.length === 0 || sessions.length === 0) return previous;
-      didMerge = true;
-      return [updated];
-    });
-    const { result, rerender, unmount } = renderBookmarks();
-    await waitFor(() => expect(result.current.bookmarkedSessions).toHaveLength(1));
-    rerender({ currentSessions: [session("s1")] });
-    await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
-
-    unmount();
-    request.reject(new Error("late failure"));
-    await request.promise.catch(() => undefined);
-
-    expect(consoleError).not.toHaveBeenCalledWith(
-      "Failed to sync bookmark snapshots:",
-      expect.anything(),
-    );
-  });
-
-  it("migrates legacy bookmarks once", async () => {
-    const legacy = snap("legacy");
+  it("migrates legacy bookmark facts once without snapshot fields", async () => {
+    const legacy = fact("legacy", 42);
     vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([legacy]);
-    vi.mocked(api.importBookmarks).mockResolvedValueOnce({ bookmarks: [legacy] });
+    vi.mocked(api.importBookmarks).mockResolvedValueOnce({ bookmarks: [available("legacy")] });
     const { result } = renderBookmarks();
 
     await waitFor(() => expect(result.current.isSessionBookmarked("cc", "legacy")).toBe(true));
-    expect(api.importBookmarks).toHaveBeenCalledWith([
-      expect.not.objectContaining({ bookmarkedAt: expect.anything() }),
-    ]);
+    expect(vi.mocked(api.importBookmarks).mock.calls[0]?.[0]).toEqual([legacy]);
     expect(bookmarkUtils.clearLegacyBookmarks).toHaveBeenCalledOnce();
   });
 
-  it("does not apply a completed legacy migration after unmount", async () => {
-    const legacy = snap("legacy");
-    const request = deferred<{ bookmarks: BookmarkRecord[] }>();
-    vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([legacy]);
-    vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
-    const { unmount } = renderBookmarks();
-    await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
-
-    unmount();
-    request.resolve({ bookmarks: [legacy] });
-    await request.promise;
-
-    expect(bookmarkUtils.clearLegacyBookmarks).not.toHaveBeenCalled();
-  });
-
-  it("reports legacy migration failures", async () => {
+  it("keeps legacy storage when migration fails", async () => {
     const error = new Error("migration failed");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([snap("legacy")]);
+    vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([fact("legacy")]);
     vi.mocked(api.importBookmarks).mockRejectedValueOnce(error);
 
     renderBookmarks();
@@ -293,60 +196,55 @@ describe("useBookmarks", () => {
     expect(bookmarkUtils.clearLegacyBookmarks).not.toHaveBeenCalled();
   });
 
-  it("does not report legacy migration failures after unmount", async () => {
-    const request = deferred<{ bookmarks: BookmarkRecord[] }>();
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(bookmarkUtils.loadLegacyBookmarks).mockReturnValue([snap("legacy")]);
-    vi.mocked(api.importBookmarks).mockReturnValueOnce(request.promise);
-    const { unmount } = renderBookmarks();
-    await waitFor(() => expect(api.importBookmarks).toHaveBeenCalledOnce());
-
-    unmount();
-    request.reject(new Error("late migration failure"));
-    await request.promise.catch(() => undefined);
-
-    expect(consoleError).not.toHaveBeenCalledWith(
-      "Failed to migrate legacy bookmarks:",
-      expect.anything(),
-    );
-  });
-
   it("rolls back an optimistic toggle when persistence fails", async () => {
     const error = new Error("write failed");
-    let rejectWrite!: (reason?: unknown) => void;
-    const write = new Promise<never>((_resolve, reject) => {
-      rejectWrite = reject;
-    });
+    const request = deferred<{ bookmark: BookmarkRecord }>();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(api.upsertBookmark).mockReturnValueOnce(write);
+    vi.mocked(api.upsertBookmark).mockReturnValueOnce(request.promise);
     const { result } = renderBookmarks();
-    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalledOnce());
 
-    act(() => result.current.toggleBookmark(snap("failed")));
+    act(() => result.current.toggleBookmark(available("failed")));
     await waitFor(() => expect(result.current.isSessionBookmarked("cc", "failed")).toBe(true));
 
-    rejectWrite(error);
+    request.reject(error);
+    await request.promise.catch(() => undefined);
     await waitFor(() => expect(result.current.isSessionBookmarked("cc", "failed")).toBe(false));
     expect(consoleError).toHaveBeenCalledWith("Failed to toggle bookmark:", error);
-    expect(api.logClientEvent).toHaveBeenCalledWith("bookmark.add", {
-      agent: "cc",
-      session: "failed",
-    });
   });
 
-  it("converts live sessions before toggling bookmarks", async () => {
+  it("converts live sessions into optimistic views but writes only their reference", async () => {
+    const request = deferred<{ bookmark: BookmarkRecord }>();
+    vi.mocked(api.upsertBookmark).mockReturnValueOnce(request.promise);
     const { result } = renderBookmarks();
-    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalled());
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalledOnce());
 
     act(() => result.current.toggleSessionBookmark(session("live"), "cc"));
 
     await waitFor(() =>
-      expect(api.upsertBookmark).toHaveBeenCalledWith(
-        expect.objectContaining({
-          reference: { agentName: "cc", sessionId: "live" },
-          session: expect.objectContaining({ id: "live", slug: "cc/live" }),
-        }),
-      ),
+      expect(api.upsertBookmark).toHaveBeenCalledWith({ agentName: "cc", sessionId: "live" }),
     );
+    expect(result.current.bookmarkedSessions[0]).toMatchObject({
+      availability: "available",
+      reference: { agentName: "cc", sessionId: "live" },
+      session: { id: "live", slug: "cc/live" },
+    });
+
+    request.resolve({ bookmark: fact("live") });
+    await request.promise;
+  });
+
+  it("reports load and explicit refresh failures", async () => {
+    const error = new Error("offline");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
+    const { result } = renderBookmarks();
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith("Failed to load bookmarks:", error),
+    );
+
+    vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
+    await act(() => result.current.refresh());
+    expect(consoleError).toHaveBeenLastCalledWith("Failed to load bookmarks:", error);
   });
 });

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import {
-  type BookmarkRecord,
+  type BookmarkView,
   type SessionHead,
   deleteBookmark,
   fetchBookmarks,
@@ -13,43 +13,30 @@ import {
   clearLegacyBookmarks,
   getSessionBookmarkKey,
   loadLegacyBookmarks,
-  mergeBookmarksWithSessions,
-  toBookmarkRecord,
+  toBookmarkView,
 } from "../lib/bookmarks";
 import { queryKeys } from "../lib/query-keys";
 
 interface ToggleBookmarkVariables {
-  snapshot: BookmarkRecord;
+  bookmark: BookmarkView;
   isBookmarked: boolean;
 }
 
-const EMPTY_BOOKMARKS: BookmarkRecord[] = [];
-
-function withoutBookmarkTimestamp(bookmarks: BookmarkRecord[]) {
-  return bookmarks.map(({ bookmarkedAt: _bookmarkedAt, ...bookmark }) => bookmark);
-}
+const EMPTY_BOOKMARKS: BookmarkView[] = [];
 
 function toggledBookmarks(
-  bookmarks: BookmarkRecord[],
-  snapshot: BookmarkRecord,
+  bookmarks: BookmarkView[],
+  bookmark: BookmarkView,
   isBookmarked: boolean,
-): BookmarkRecord[] {
-  const key = getSessionBookmarkKey(snapshot.reference);
+): BookmarkView[] {
+  const key = getSessionBookmarkKey(bookmark.reference);
   if (isBookmarked) {
-    return bookmarks.filter((bookmark) => getSessionBookmarkKey(bookmark.reference) !== key);
+    return bookmarks.filter((item) => getSessionBookmarkKey(item.reference) !== key);
   }
-  return [...bookmarks, snapshot].toSorted((a, b) => {
-    const aTime = a.session.time_updated ?? a.session.time_created;
-    const bTime = b.session.time_updated ?? b.session.time_created;
-    return bTime - aTime;
-  });
+  return [bookmark, ...bookmarks];
 }
 
-function sameBookmarks(left: BookmarkRecord[], right: BookmarkRecord[]): boolean {
-  return left.length === right.length && left.every((bookmark, index) => bookmark === right[index]);
-}
-
-export function useBookmarks(sessions: SessionHead[]) {
+export function useBookmarks() {
   const queryClient = useQueryClient();
   const bookmarksQuery = useQuery({
     queryKey: queryKeys.bookmarks,
@@ -65,30 +52,27 @@ export function useBookmarks(sessions: SessionHead[]) {
   const bookmarks = bookmarksQuery.data?.bookmarks ?? EMPTY_BOOKMARKS;
 
   const setBookmarks = useCallback(
-    (next: BookmarkRecord[]) => {
+    (next: BookmarkView[]) => {
       queryClient.setQueryData(queryKeys.bookmarks, { bookmarks: next });
     },
     [queryClient],
   );
 
   const { mutate: mutateBookmark } = useMutation({
-    mutationFn: async ({ snapshot, isBookmarked }: ToggleBookmarkVariables) => {
+    mutationFn: async ({ bookmark, isBookmarked }: ToggleBookmarkVariables) => {
       if (isBookmarked) {
-        await deleteBookmark(snapshot.reference);
+        await deleteBookmark(bookmark.reference);
         return;
       }
-      const { bookmarkedAt: _bookmarkedAt, ...bookmark } = snapshot;
-      await upsertBookmark(bookmark);
+      await upsertBookmark(bookmark.reference);
     },
-    onMutate: async ({ snapshot, isBookmarked }) => {
+    onMutate: async ({ bookmark, isBookmarked }) => {
       const cancellation = queryClient.cancelQueries({ queryKey: queryKeys.bookmarks });
-      const previous = queryClient.getQueryData<{ bookmarks: BookmarkRecord[] }>(
-        queryKeys.bookmarks,
-      );
-      setBookmarks(toggledBookmarks(previous?.bookmarks ?? [], snapshot, isBookmarked));
+      const previous = queryClient.getQueryData<{ bookmarks: BookmarkView[] }>(queryKeys.bookmarks);
+      setBookmarks(toggledBookmarks(previous?.bookmarks ?? [], bookmark, isBookmarked));
       logClientEvent(isBookmarked ? "bookmark.delete" : "bookmark.add", {
-        agent: snapshot.reference.agentName,
-        session: snapshot.reference.sessionId,
+        agent: bookmark.reference.agentName,
+        session: bookmark.reference.sessionId,
       });
       await cancellation;
       return previous;
@@ -97,29 +81,18 @@ export function useBookmarks(sessions: SessionHead[]) {
       if (previous) queryClient.setQueryData(queryKeys.bookmarks, previous);
       console.error("Failed to toggle bookmark:", error);
     },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.bookmarks }),
   });
 
-  const { mutate: syncBookmarks } = useMutation({
-    mutationFn: (bookmarks: Omit<BookmarkRecord, "bookmarkedAt">[]) => importBookmarks(bookmarks),
-  });
   const { mutate: migrateBookmarks } = useMutation({
-    mutationFn: (bookmarks: Omit<BookmarkRecord, "bookmarkedAt">[]) => importBookmarks(bookmarks),
+    mutationFn: importBookmarks,
   });
-
-  useEffect(() => {
-    const next = mergeBookmarksWithSessions(bookmarks, sessions);
-    if (next === bookmarks || sameBookmarks(next, bookmarks)) return;
-    setBookmarks(next);
-    syncBookmarks(withoutBookmarkTimestamp(next), {
-      onError: (error) => console.error("Failed to sync bookmark snapshots:", error),
-    });
-  }, [bookmarks, sessions, setBookmarks, syncBookmarks]);
 
   useEffect(() => {
     const legacy = loadLegacyBookmarks();
     if (legacy.length === 0) return;
     void queryClient.cancelQueries({ queryKey: queryKeys.bookmarks });
-    migrateBookmarks(withoutBookmarkTimestamp(legacy), {
+    migrateBookmarks(legacy, {
       onSuccess: (data) => {
         setBookmarks(data.bookmarks);
         clearLegacyBookmarks();
@@ -140,28 +113,18 @@ export function useBookmarks(sessions: SessionHead[]) {
   );
 
   const toggleBookmark = useCallback(
-    (snapshot: BookmarkRecord) => {
-      const key = getSessionBookmarkKey(snapshot.reference);
-      mutateBookmark({ snapshot, isBookmarked: bookmarkKeySet.has(key) });
+    (bookmark: BookmarkView) => {
+      const key = getSessionBookmarkKey(bookmark.reference);
+      mutateBookmark({ bookmark, isBookmarked: bookmarkKeySet.has(key) });
     },
     [bookmarkKeySet, mutateBookmark],
   );
 
   const toggleSessionBookmark = useCallback(
     (session: SessionHead, agentKey: string) => {
-      toggleBookmark(toBookmarkRecord(session, agentKey));
+      toggleBookmark(toBookmarkView(session, agentKey));
     },
     [toggleBookmark],
-  );
-
-  const bookmarkedSessions = useMemo(
-    () =>
-      bookmarks.toSorted(
-        (a, b) =>
-          (b.session.time_updated ?? b.session.time_created) -
-          (a.session.time_updated ?? a.session.time_created),
-      ),
-    [bookmarks],
   );
 
   const refreshBookmarks = bookmarksQuery.refetch;
@@ -170,7 +133,7 @@ export function useBookmarks(sessions: SessionHead[]) {
   }, [refreshBookmarks]);
 
   return {
-    bookmarkedSessions,
+    bookmarkedSessions: bookmarks,
     isSessionBookmarked,
     toggleBookmark,
     toggleSessionBookmark,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -40,6 +40,7 @@ export type {
   ApiProjectGroup,
   ApiProjectAgentStat,
   BookmarkRecord,
+  BookmarkView,
 } from "@codesesh/core/contract";
 
 import { sessionRoutePath } from "@codesesh/core/contract";
@@ -48,6 +49,7 @@ import type {
   ApiProjectGroup,
   AppConfig,
   BookmarkRecord,
+  BookmarkView,
   DashboardData,
   FileActivityKind,
   ProjectIdentityKind,
@@ -235,23 +237,23 @@ export async function fetchSearchResults(
 
 export async function fetchBookmarks(
   options?: FetchOptions,
-): Promise<{ bookmarks: BookmarkRecord[] }> {
+): Promise<{ bookmarks: BookmarkView[] }> {
   return fetchJson("/api/bookmarks", options);
 }
 
 export async function upsertBookmark(
-  bookmark: Omit<BookmarkRecord, "bookmarkedAt">,
+  reference: SessionReference,
 ): Promise<{ bookmark: BookmarkRecord }> {
   return fetchJson("/api/bookmarks", {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(bookmark),
+    body: JSON.stringify({ reference }),
   });
 }
 
 export async function importBookmarks(
-  bookmarks: Omit<BookmarkRecord, "bookmarkedAt">[],
-): Promise<{ bookmarks: BookmarkRecord[] }> {
+  bookmarks: BookmarkRecord[],
+): Promise<{ bookmarks: BookmarkView[] }> {
   return fetchJson("/api/bookmarks/import", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/apps/web/src/lib/bookmarks.test.ts
+++ b/apps/web/src/lib/bookmarks.test.ts
@@ -4,142 +4,106 @@ import {
   clearLegacyBookmarks,
   getSessionBookmarkKey,
   loadLegacyBookmarks,
-  mergeBookmarksWithSessions,
-  sortBookmarks,
-  toBookmarkRecord,
+  toBookmarkView,
 } from "./bookmarks";
 
-function createSession(
-  overrides: Partial<SessionHead> & Pick<SessionHead, "id" | "slug" | "title">,
-): SessionHead {
+function createSession(overrides: Partial<SessionHead> = {}): SessionHead {
   return {
-    id: overrides.id,
-    slug: overrides.slug,
-    title: overrides.title,
-    directory: overrides.directory ?? "/tmp/project",
-    time_created: overrides.time_created ?? 100,
-    time_updated: overrides.time_updated,
-    stats: overrides.stats ?? {
+    id: "s1",
+    slug: "stale/route",
+    title: "Bookmark me",
+    directory: "/tmp/project",
+    time_created: 100,
+    time_updated: 200,
+    stats: {
       message_count: 1,
       total_input_tokens: 2,
       total_output_tokens: 3,
       total_cost: 0,
     },
+    ...overrides,
   };
 }
 
 describe("bookmarks", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
-  it("uses agent + session id as bookmark key", () => {
-    expect(getSessionBookmarkKey({ agentName: "codex", sessionId: "abc" })).toBe('["codex","abc"]');
+  it("uses normalized agent + opaque session id as bookmark key", () => {
+    expect(getSessionBookmarkKey({ agentName: " CoDeX ", sessionId: "a/b" })).toBe(
+      '["codex","a/b"]',
+    );
   });
 
-  it("builds a snapshot from session head", () => {
-    const session = createSession({
-      id: "s1",
-      slug: "codex/s1",
-      title: "Bookmark me",
-      time_updated: 200,
-    });
+  it("builds an optimistic available view from a live session", () => {
+    vi.spyOn(Date, "now").mockReturnValue(300);
+    const session = createSession();
 
-    expect(toBookmarkRecord(session, "codex")).toEqual({
+    expect(toBookmarkView(session, " CoDeX ")).toEqual({
       reference: { agentName: "codex", sessionId: "s1" },
-      session,
-      bookmarkedAt: expect.any(Number),
+      session: { ...session, id: "s1", slug: "codex/s1" },
+      availability: "available",
+      bookmarkedAt: 300,
     });
   });
 
-  it("refreshes stored snapshots when live sessions change", () => {
-    const bookmark = toBookmarkRecord(
-      createSession({
-        id: "s1",
-        slug: "codex/s1",
-        title: "Old title",
-        time_updated: 100,
-      }),
-      "codex",
-    );
-
-    const merged = mergeBookmarksWithSessions(
-      [bookmark],
-      [
-        createSession({
-          id: "s1",
-          slug: "codex/s1",
-          title: "New title",
-          time_updated: 300,
-          stats: {
-            message_count: 5,
-            total_input_tokens: 8,
-            total_output_tokens: 13,
-            total_cost: 0,
-            total_tokens: 21,
-          },
-        }),
-      ],
-    );
-
-    expect(merged[0]?.session.title).toBe("New title");
-    expect(merged[0]?.session.time_updated).toBe(300);
-    expect(merged[0]?.session.stats.total_tokens).toBe(21);
-  });
-
-  it("loads valid legacy bookmarks and drops invalid entries", () => {
-    const older = toBookmarkRecord(
-      createSession({ id: "old", slug: "codex/old", title: "Old", time_updated: 100 }),
-      "codex",
-    );
-    const newer = toBookmarkRecord(
-      createSession({ id: "new", slug: "codex/new", title: "New", time_updated: 300 }),
-      "codex",
-    );
-    const toLegacy = (bookmark: typeof older) => ({
-      agentKey: bookmark.reference.agentName,
-      sessionId: bookmark.reference.sessionId,
-      fullPath: bookmark.session.slug,
-      title: bookmark.session.title,
-      directory: bookmark.session.directory,
-      time_created: bookmark.session.time_created,
-      time_updated: bookmark.session.time_updated,
-      stats: bookmark.session.stats,
-      bookmarked_at: bookmark.bookmarkedAt,
-    });
+  it("migrates only durable facts from legacy and current payload shapes", () => {
+    vi.spyOn(Date, "now").mockReturnValue(500);
     const removeItem = vi.fn();
     vi.stubGlobal("window", {
       localStorage: {
         getItem: vi.fn(() =>
           JSON.stringify([
-            toLegacy(older),
-            { ...toLegacy(newer), bookmarked_at: "bad" },
-            toLegacy(newer),
-            { ...toLegacy(newer), agentKey: " " },
-            { ...toLegacy(newer), sessionId: "" },
-            { sessionId: "bad", stats: { message_count: "bad" } },
+            {
+              agentKey: "codex",
+              sessionId: "old",
+              bookmarked_at: 100,
+              title: "Stale title",
+              stats: { message_count: "malformed snapshot is ignored" },
+            },
+            {
+              reference: { agentName: " CuRsOr ", sessionId: "new" },
+              bookmarkedAt: 300,
+              session: { title: "Another stale snapshot" },
+            },
+            { agentKey: "codex", sessionId: "default-time" },
+            { agentKey: " ", sessionId: "missing-agent", bookmarked_at: 400 },
+            { agentKey: "codex", sessionId: "", bookmarked_at: 400 },
+            { agentKey: "codex", sessionId: "bad-time", bookmarked_at: "400" },
           ]),
         ),
         removeItem,
       },
     });
 
-    expect(loadLegacyBookmarks().map((bookmark) => bookmark.reference.sessionId)).toEqual([
-      "new",
-      "old",
+    expect(loadLegacyBookmarks()).toEqual([
+      {
+        reference: { agentName: "codex", sessionId: "default-time" },
+        bookmarkedAt: 500,
+      },
+      {
+        reference: { agentName: "cursor", sessionId: "new" },
+        bookmarkedAt: 300,
+      },
+      {
+        reference: { agentName: "codex", sessionId: "old" },
+        bookmarkedAt: 100,
+      },
     ]);
+
     clearLegacyBookmarks();
     expect(removeItem).toHaveBeenCalledWith("codesesh:bookmarks:v1");
   });
 
-  it("returns empty legacy bookmarks for missing or malformed storage", () => {
+  it("returns empty legacy facts for missing, malformed, and server-side storage", () => {
     vi.stubGlobal("window", {
       localStorage: {
         getItem: vi.fn(() => "{bad json"),
         removeItem: vi.fn(),
       },
     });
-
     expect(loadLegacyBookmarks()).toEqual([]);
 
     vi.stubGlobal("window", {
@@ -148,43 +112,10 @@ describe("bookmarks", () => {
         removeItem: vi.fn(),
       },
     });
-
     expect(loadLegacyBookmarks()).toEqual([]);
-  });
 
-  it("keeps bookmark arrays unchanged when live sessions add no new data", () => {
-    const bookmark = toBookmarkRecord(
-      createSession({ id: "s1", slug: "codex/s1", title: "Same", time_updated: 100 }),
-      "codex",
-    );
-    const bookmarks = [bookmark];
-
-    expect(
-      mergeBookmarksWithSessions(
-        [],
-        [createSession({ id: "s1", slug: "codex/s1", title: "Same" })],
-      ),
-    ).toEqual([]);
-    expect(mergeBookmarksWithSessions(bookmarks, [])).toBe(bookmarks);
-    expect(
-      mergeBookmarksWithSessions(bookmarks, [
-        createSession({ id: "s1", slug: "codex/s1", title: "Same", time_updated: 100 }),
-      ]),
-    ).toBe(bookmarks);
-  });
-
-  it("sorts bookmarks by updated time with created time fallback", () => {
-    const createdOnly = toBookmarkRecord(
-      createSession({ id: "created", slug: "codex/created", title: "Created", time_created: 200 }),
-      "codex",
-    );
-    const updated = toBookmarkRecord(
-      createSession({ id: "updated", slug: "codex/updated", title: "Updated", time_updated: 300 }),
-      "codex",
-    );
-
-    expect(
-      [createdOnly, updated].toSorted(sortBookmarks).map((item) => item.reference.sessionId),
-    ).toEqual(["updated", "created"]);
+    vi.stubGlobal("window", undefined);
+    expect(loadLegacyBookmarks()).toEqual([]);
+    expect(() => clearLegacyBookmarks()).not.toThrow();
   });
 });

--- a/apps/web/src/lib/bookmarks.ts
+++ b/apps/web/src/lib/bookmarks.ts
@@ -1,7 +1,6 @@
-import type { BookmarkRecord, SessionHead } from "./api";
+import type { BookmarkRecord, BookmarkView, SessionHead } from "./api";
 import {
   formatSessionReference,
-  getSessionAgentKey,
   normalizeSessionReference,
   type SessionReference,
 } from "@codesesh/core/contract";
@@ -12,52 +11,47 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isStats(value: unknown): value is SessionHead["stats"] {
-  if (!isRecord(value)) return false;
-  return (
-    typeof value.message_count === "number" &&
-    typeof value.total_input_tokens === "number" &&
-    typeof value.total_output_tokens === "number" &&
-    typeof value.total_cost === "number" &&
-    (value.total_tokens == null || typeof value.total_tokens === "number")
-  );
+function parseReference(value: Record<string, unknown>): SessionReference | null {
+  if (
+    isRecord(value.reference) &&
+    typeof value.reference.agentName === "string" &&
+    typeof value.reference.sessionId === "string" &&
+    value.reference.agentName.trim() &&
+    value.reference.sessionId
+  ) {
+    return normalizeSessionReference({
+      agentName: value.reference.agentName,
+      sessionId: value.reference.sessionId,
+    });
+  }
+
+  if (
+    typeof value.agentKey !== "string" ||
+    typeof value.sessionId !== "string" ||
+    !value.agentKey.trim() ||
+    !value.sessionId
+  ) {
+    return null;
+  }
+  return normalizeSessionReference({
+    agentName: value.agentKey,
+    sessionId: value.sessionId,
+  });
 }
 
 function parseLegacyBookmark(value: unknown): BookmarkRecord | null {
   if (!isRecord(value)) return null;
-  if (
-    typeof value.sessionId === "string" &&
-    typeof value.agentKey === "string" &&
-    typeof value.fullPath === "string" &&
-    Boolean(value.sessionId) &&
-    Boolean(value.agentKey.trim()) &&
-    typeof value.title === "string" &&
-    typeof value.directory === "string" &&
-    typeof value.time_created === "number" &&
-    (value.time_updated == null || typeof value.time_updated === "number") &&
-    (value.bookmarked_at == null || typeof value.bookmarked_at === "number") &&
-    isStats(value.stats)
-  ) {
-    const reference = normalizeSessionReference({
-      agentName: value.agentKey,
-      sessionId: value.sessionId,
-    });
-    return {
-      reference,
-      session: {
-        id: reference.sessionId,
-        slug: formatSessionReference(reference),
-        title: value.title,
-        display_title: typeof value.display_title === "string" ? value.display_title : undefined,
-        directory: value.directory,
-        time_created: value.time_created,
-        time_updated: typeof value.time_updated === "number" ? value.time_updated : undefined,
-        stats: value.stats,
-      },
-      bookmarkedAt: typeof value.bookmarked_at === "number" ? value.bookmarked_at : Date.now(),
-    };
+  const reference = parseReference(value);
+  if (!reference) return null;
+
+  const timestamp = value.bookmarkedAt ?? value.bookmarked_at;
+  if (timestamp != null && (typeof timestamp !== "number" || !Number.isFinite(timestamp))) {
+    return null;
   }
-  return null;
+  return {
+    reference,
+    bookmarkedAt: typeof timestamp === "number" ? timestamp : Date.now(),
+  };
 }
 
 export function getSessionBookmarkKey(reference: SessionReference): string {
@@ -65,7 +59,7 @@ export function getSessionBookmarkKey(reference: SessionReference): string {
   return JSON.stringify([normalized.agentName, normalized.sessionId]);
 }
 
-export function toBookmarkRecord(session: SessionHead, agentKey: string): BookmarkRecord {
+export function toBookmarkView(session: SessionHead, agentKey: string): BookmarkView {
   const reference = normalizeSessionReference({
     agentName: agentKey,
     sessionId: session.id,
@@ -77,6 +71,7 @@ export function toBookmarkRecord(session: SessionHead, agentKey: string): Bookma
       id: reference.sessionId,
       slug: formatSessionReference(reference),
     },
+    availability: "available",
     bookmarkedAt: Date.now(),
   };
 }
@@ -92,7 +87,7 @@ export function loadLegacyBookmarks(): BookmarkRecord[] {
     return parsed
       .map(parseLegacyBookmark)
       .filter((bookmark): bookmark is BookmarkRecord => bookmark !== null)
-      .toSorted(sortBookmarks);
+      .toSorted((left, right) => right.bookmarkedAt - left.bookmarkedAt);
   } catch {
     return [];
   }
@@ -101,50 +96,4 @@ export function loadLegacyBookmarks(): BookmarkRecord[] {
 export function clearLegacyBookmarks(): void {
   if (typeof window === "undefined") return;
   window.localStorage.removeItem(LEGACY_BOOKMARK_STORAGE_KEY);
-}
-
-export function sortBookmarks(a: BookmarkRecord, b: BookmarkRecord): number {
-  const aTime = a.session.time_updated ?? a.session.time_created;
-  const bTime = b.session.time_updated ?? b.session.time_created;
-  return bTime - aTime;
-}
-
-export function mergeBookmarksWithSessions(
-  bookmarks: BookmarkRecord[],
-  sessions: SessionHead[],
-): BookmarkRecord[] {
-  if (bookmarks.length === 0 || sessions.length === 0) return bookmarks;
-
-  const liveSnapshots = new Map(
-    sessions.map((session) => {
-      const agentKey = getSessionAgentKey(session);
-      const snapshot = toBookmarkRecord(session, agentKey);
-      return [getSessionBookmarkKey(snapshot.reference), snapshot] as const;
-    }),
-  );
-
-  let changed = false;
-  const next = bookmarks.map((bookmark) => {
-    const live = liveSnapshots.get(getSessionBookmarkKey(bookmark.reference));
-    if (!live) return bookmark;
-    const same =
-      live.session.slug === bookmark.session.slug &&
-      live.session.title === bookmark.session.title &&
-      live.session.directory === bookmark.session.directory &&
-      live.session.time_created === bookmark.session.time_created &&
-      live.session.time_updated === bookmark.session.time_updated &&
-      live.session.stats.message_count === bookmark.session.stats.message_count &&
-      live.session.stats.total_input_tokens === bookmark.session.stats.total_input_tokens &&
-      live.session.stats.total_output_tokens === bookmark.session.stats.total_output_tokens &&
-      live.session.stats.total_cost === bookmark.session.stats.total_cost &&
-      live.session.stats.total_tokens === bookmark.session.stats.total_tokens;
-    if (same) return bookmark;
-    changed = true;
-    return {
-      ...live,
-      bookmarkedAt: bookmark.bookmarkedAt,
-    };
-  });
-
-  return changed ? next.toSorted(sortBookmarks) : bookmarks;
 }

--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -42,7 +42,9 @@ import {
   SessionAliasValidationError,
   StateStorageUnavailableError,
   type BookmarkRecord,
+  type BookmarkView,
   type LiveSnapshot,
+  type SessionHead,
 } from "@codesesh/core";
 import {
   handleDeleteBookmark,
@@ -88,29 +90,11 @@ function getResponsePayload<T>(context: ReturnType<typeof makeContext>): T {
   return context.json.mock.calls[0]![0] as T;
 }
 
-const validBookmark: Omit<BookmarkRecord, "bookmarkedAt"> = {
-  reference: { agentName: "codex", sessionId: "s1" },
-  session: {
-    id: "s1",
-    slug: "codex/s1",
-    title: "Session one",
-    directory: "/workspace",
-    time_created: 1,
-    time_updated: 2,
-    stats: {
-      message_count: 1,
-      total_input_tokens: 2,
-      total_output_tokens: 3,
-      total_cost: 0.1,
-      total_tokens: 5,
-    },
-  },
-};
+const validReference = { agentName: "codex", sessionId: "s1" };
 
-const legacyBookmark = {
-  agentKey: "codex",
-  sessionId: "s1",
-  fullPath: "stale/legacy-route",
+const sessionHead: SessionHead = {
+  id: "s1",
+  slug: "codex/s1",
   title: "Session one",
   directory: "/workspace",
   time_created: 1,
@@ -124,9 +108,33 @@ const legacyBookmark = {
   },
 };
 
+const legacyBookmark = {
+  agentKey: "codex",
+  sessionId: "s1",
+  fullPath: "stale/legacy-route",
+  title: "Session one",
+  directory: "/workspace",
+  time_created: 1,
+  time_updated: 2,
+  bookmarked_at: 3,
+  stats: {
+    message_count: 1,
+    total_input_tokens: 2,
+    total_output_tokens: 3,
+    total_cost: 0.1,
+    total_tokens: 5,
+  },
+};
+
 const storedBookmark: BookmarkRecord = {
-  ...validBookmark,
+  reference: validReference,
   bookmarkedAt: 3,
+};
+
+const availableBookmark: BookmarkView = {
+  ...storedBookmark,
+  availability: "available",
+  session: sessionHead,
 };
 
 const scanSource: ScanResultSource = {
@@ -134,6 +142,15 @@ const scanSource: ScanResultSource = {
     ({
       sessions: [],
       byAgent: { codex: [] },
+      agents: [],
+    }) as LiveSnapshot,
+};
+
+const bookmarkScanSource: ScanResultSource = {
+  getSnapshot: () =>
+    ({
+      sessions: [sessionHead],
+      byAgent: { codex: [sessionHead] },
       agents: [],
     }) as LiveSnapshot,
 };
@@ -208,45 +225,41 @@ describe("client logging handler", () => {
 });
 
 describe("bookmark handlers", () => {
-  it("projects aliases onto stored bookmark snapshots", () => {
+  it("materializes current session data and decorates it with aliases", () => {
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
     coreMocks.listSessionAliases.mockReturnValue([
-      {
-        reference: { agentName: "codex", sessionId: "s1" },
-        alias: "Renamed",
-        updatedAt: 1,
-      },
+      { reference: validReference, alias: "Renamed", updatedAt: 1 },
     ]);
     const c = makeContext();
 
-    handleGetBookmarks(c as never);
+    handleGetBookmarks(c as never, bookmarkScanSource);
 
     expect(c.json).toHaveBeenCalledWith({
       bookmarks: [
         {
-          ...storedBookmark,
-          session: { ...storedBookmark.session, display_title: "Renamed" },
+          ...availableBookmark,
+          session: { ...sessionHead, display_title: "Renamed" },
         },
       ],
       storageAvailable: true,
     });
+    expect(coreMocks.upsertBookmark).not.toHaveBeenCalled();
+    expect(coreMocks.importBookmarks).not.toHaveBeenCalled();
   });
 
   it("tolerates unavailable alias storage and logs unexpected alias failures", () => {
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
-    // Each failure mode is a separate load: the alias read model caches its
-    // result, so the view has to be invalidated between scenarios.
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw new StateStorageUnavailableError();
     });
-    handleGetBookmarks(makeContext() as never);
+    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
     expect(loggerMocks.warn).not.toHaveBeenCalled();
 
     invalidateAliasView();
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw new Error("corrupt aliases");
     });
-    handleGetBookmarks(makeContext() as never);
+    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
     expect(loggerMocks.warn).toHaveBeenLastCalledWith("api.session_aliases.load_failed", {
       error: "corrupt aliases",
     });
@@ -255,7 +268,7 @@ describe("bookmark handlers", () => {
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw "invalid aliases";
     });
-    handleGetBookmarks(makeContext() as never);
+    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
     expect(loggerMocks.warn).toHaveBeenLastCalledWith("api.session_aliases.load_failed", {
       error: "invalid aliases",
     });
@@ -266,63 +279,26 @@ describe("bookmark handlers", () => {
       throw new BookmarkStorageUnavailableError();
     });
     const unavailable = makeContext();
-    handleGetBookmarks(unavailable as never);
+    handleGetBookmarks(unavailable as never, bookmarkScanSource);
     expect(unavailable.json).toHaveBeenCalledWith({ bookmarks: [], storageAvailable: false });
 
     coreMocks.listBookmarks.mockImplementationOnce(() => {
       throw new Error("unexpected");
     });
-    expect(() => handleGetBookmarks(makeContext() as never)).toThrow("unexpected");
+    expect(() => handleGetBookmarks(makeContext() as never, bookmarkScanSource)).toThrow(
+      "unexpected",
+    );
   });
 
   it.each([
     null,
     {},
-    { ...validBookmark, reference: { ...validBookmark.reference, agentName: 1 } },
-    { ...validBookmark, reference: { ...validBookmark.reference, sessionId: 1 } },
-    { ...validBookmark, session: { ...validBookmark.session, id: "other" } },
-    { ...validBookmark, session: { ...validBookmark.session, slug: 1 } },
-    { ...validBookmark, session: { ...validBookmark.session, title: 1 } },
-    { ...validBookmark, session: { ...validBookmark.session, directory: 1 } },
-    { ...validBookmark, session: { ...validBookmark.session, time_created: "1" } },
-    { ...validBookmark, session: { ...validBookmark.session, time_updated: "2" } },
-    { ...validBookmark, session: { ...validBookmark.session, stats: null } },
-    {
-      ...validBookmark,
-      session: {
-        ...validBookmark.session,
-        stats: { ...validBookmark.session.stats, message_count: "1" },
-      },
-    },
-    {
-      ...validBookmark,
-      session: {
-        ...validBookmark.session,
-        stats: { ...validBookmark.session.stats, total_input_tokens: "2" },
-      },
-    },
-    {
-      ...validBookmark,
-      session: {
-        ...validBookmark.session,
-        stats: { ...validBookmark.session.stats, total_output_tokens: "3" },
-      },
-    },
-    {
-      ...validBookmark,
-      session: {
-        ...validBookmark.session,
-        stats: { ...validBookmark.session.stats, total_cost: "0.1" },
-      },
-    },
-    {
-      ...validBookmark,
-      session: {
-        ...validBookmark.session,
-        stats: { ...validBookmark.session.stats, total_tokens: "5" },
-      },
-    },
-  ])("rejects invalid bookmark payload %#", async (body) => {
+    { reference: { agentName: 1, sessionId: "s1" } },
+    { reference: { agentName: "codex", sessionId: 1 } },
+    { reference: { agentName: " ", sessionId: "s1" } },
+    { reference: { agentName: "codex", sessionId: "" } },
+    { agentKey: 1, sessionId: "s1" },
+  ])("rejects invalid bookmark identity payload %#", async (body) => {
     const c = makeContext({ body });
 
     await handlePutBookmark(c as never);
@@ -331,20 +307,28 @@ describe("bookmark handlers", () => {
     expect(coreMocks.upsertBookmark).not.toHaveBeenCalled();
   });
 
-  it("stores valid bookmarks without transport-only fields", async () => {
-    const c = makeContext({ body: { ...validBookmark, bookmarkedAt: 99 } });
+  it("stores only identity from current and legacy snapshot payloads", async () => {
+    const current = makeContext({
+      body: { reference: validReference, session: { stale: true }, bookmarkedAt: 99 },
+    });
+    await handlePutBookmark(current as never);
 
-    await handlePutBookmark(c as never);
+    const legacy = makeContext({ body: legacyBookmark });
+    await handlePutBookmark(legacy as never);
 
-    expect(coreMocks.upsertBookmark).toHaveBeenCalledWith(validBookmark);
-    expect(c.json).toHaveBeenCalledWith({ bookmark: storedBookmark, storageAvailable: true });
+    expect(coreMocks.upsertBookmark).toHaveBeenNthCalledWith(1, validReference);
+    expect(coreMocks.upsertBookmark).toHaveBeenNthCalledWith(2, validReference);
+    expect(current.json).toHaveBeenCalledWith({
+      bookmark: storedBookmark,
+      storageAvailable: true,
+    });
   });
 
   it("maps bookmark write availability errors and rethrows unexpected failures", async () => {
     coreMocks.upsertBookmark.mockImplementationOnce(() => {
       throw new BookmarkStorageUnavailableError();
     });
-    const unavailable = makeContext({ body: validBookmark });
+    const unavailable = makeContext({ body: { reference: validReference } });
     await handlePutBookmark(unavailable as never);
     expect(unavailable.json).toHaveBeenCalledWith(
       { error: "Bookmark storage is unavailable" },
@@ -354,39 +338,50 @@ describe("bookmark handlers", () => {
     coreMocks.upsertBookmark.mockImplementationOnce(() => {
       throw new Error("unexpected");
     });
-    await expect(handlePutBookmark(makeContext({ body: validBookmark }) as never)).rejects.toThrow(
-      "unexpected",
-    );
+    await expect(
+      handlePutBookmark(makeContext({ body: { reference: validReference } }) as never),
+    ).rejects.toThrow("unexpected");
   });
 
-  it("validates and imports bookmark batches", async () => {
-    const nonArray = makeContext({ body: validBookmark });
-    await handleImportBookmarks(nonArray as never);
+  it("validates, imports, and materializes bookmark fact batches", async () => {
+    const nonArray = makeContext({ body: storedBookmark });
+    await handleImportBookmarks(nonArray as never, bookmarkScanSource);
     expect(nonArray.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
 
-    const mixed = makeContext({ body: [validBookmark, { invalid: true }] });
-    await handleImportBookmarks(mixed as never);
+    const mixed = makeContext({ body: [storedBookmark, { invalid: true }] });
+    await handleImportBookmarks(mixed as never, bookmarkScanSource);
     expect(mixed.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
 
-    const valid = makeContext({ body: [validBookmark] });
-    await handleImportBookmarks(valid as never);
-    expect(coreMocks.importBookmarks).toHaveBeenCalledWith([validBookmark]);
+    const valid = makeContext({ body: [storedBookmark] });
+    await handleImportBookmarks(valid as never, bookmarkScanSource);
+    expect(coreMocks.importBookmarks).toHaveBeenCalledWith([storedBookmark]);
     expect(valid.json).toHaveBeenCalledWith({
-      bookmarks: [storedBookmark],
+      bookmarks: [availableBookmark],
       storageAvailable: true,
     });
 
     const legacy = makeContext({ body: [legacyBookmark] });
-    await handleImportBookmarks(legacy as never);
-    expect(coreMocks.importBookmarks).toHaveBeenLastCalledWith([validBookmark]);
+    await handleImportBookmarks(legacy as never, bookmarkScanSource);
+    expect(coreMocks.importBookmarks).toHaveBeenLastCalledWith([storedBookmark]);
+  });
+
+  it("rejects invalid import timestamps", async () => {
+    const context = makeContext({
+      body: [{ reference: validReference, bookmarkedAt: "3" }],
+    });
+
+    await handleImportBookmarks(context as never, bookmarkScanSource);
+
+    expect(context.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
+    expect(coreMocks.importBookmarks).not.toHaveBeenCalled();
   });
 
   it("maps bookmark import availability errors and rethrows unexpected failures", async () => {
     coreMocks.importBookmarks.mockImplementationOnce(() => {
       throw new BookmarkStorageUnavailableError();
     });
-    const unavailable = makeContext({ body: [validBookmark] });
-    await handleImportBookmarks(unavailable as never);
+    const unavailable = makeContext({ body: [storedBookmark] });
+    await handleImportBookmarks(unavailable as never, bookmarkScanSource);
     expect(unavailable.json).toHaveBeenCalledWith(
       { error: "Bookmark storage is unavailable" },
       503,
@@ -396,7 +391,7 @@ describe("bookmark handlers", () => {
       throw new Error("unexpected");
     });
     await expect(
-      handleImportBookmarks(makeContext({ body: [validBookmark] }) as never),
+      handleImportBookmarks(makeContext({ body: [storedBookmark] }) as never, bookmarkScanSource),
     ).rejects.toThrow("unexpected");
   });
 
@@ -731,7 +726,7 @@ describe("session alias caching", () => {
 
     handleGetSessions(makeContext() as never, scanSource);
     handleGetSessions(makeContext() as never, scanSource);
-    handleGetBookmarks(makeContext() as never);
+    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
 
     expect(coreMocks.listSessionAliases).toHaveBeenCalledTimes(1);
   });
@@ -748,9 +743,9 @@ describe("session alias caching", () => {
 
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
     const after = makeContext();
-    handleGetBookmarks(after as never);
+    handleGetBookmarks(after as never, bookmarkScanSource);
 
-    expect(getResponsePayload<{ bookmarks: BookmarkRecord[] }>(after).bookmarks[0]).toMatchObject({
+    expect(getResponsePayload<{ bookmarks: BookmarkView[] }>(after).bookmarks[0]).toMatchObject({
       session: { display_title: "Renamed" },
     });
   });
@@ -758,18 +753,19 @@ describe("session alias caching", () => {
   it("drops a removed alias on the next read", () => {
     coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
-    handleGetBookmarks(makeContext() as never);
+    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
 
     coreMocks.listSessionAliases.mockReturnValue([]);
     handleDeleteSessionAlias(makeContext({ param: { agent: "codex", id: "s1" } }) as never);
 
     const after = makeContext();
-    handleGetBookmarks(after as never);
+    handleGetBookmarks(after as never, bookmarkScanSource);
 
+    const bookmark = getResponsePayload<{ bookmarks: BookmarkView[] }>(after).bookmarks[0];
+    expect(bookmark).toMatchObject({ availability: "available" });
     expect(
-      getResponsePayload<{ bookmarks: BookmarkRecord[] }>(after).bookmarks[0]?.session
-        .display_title,
-    ).toBeUndefined();
+      bookmark?.availability === "available" ? bookmark.session : undefined,
+    ).not.toHaveProperty("display_title");
   });
 
   it("caches an unavailable store but retries it after invalidation", () => {
@@ -785,10 +781,10 @@ describe("session alias caching", () => {
     coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
     const recovered = makeContext();
-    handleGetBookmarks(recovered as never);
+    handleGetBookmarks(recovered as never, bookmarkScanSource);
 
-    expect(
-      getResponsePayload<{ bookmarks: BookmarkRecord[] }>(recovered).bookmarks[0],
-    ).toMatchObject({ session: { display_title: "Renamed" } });
+    expect(getResponsePayload<{ bookmarks: BookmarkView[] }>(recovered).bookmarks[0]).toMatchObject(
+      { session: { display_title: "Renamed" } },
+    );
   });
 });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -1,6 +1,7 @@
 import type { Context } from "hono";
 import type {
   BookmarkRecord,
+  BookmarkView,
   LiveSnapshot,
   SessionDetail,
   SessionHead,
@@ -9,6 +10,7 @@ import type {
 import {
   addCalendarDays,
   countCalendarDays,
+  createSessionIndex,
   formatSessionReference,
   getSessionAgentKey,
   getSessionRouteKey,
@@ -30,10 +32,12 @@ import {
   importBookmarks,
   listFileActivity,
   listCachedProjectGroups,
+  loadCachedSessionHeads,
   listBookmarks,
   listModelCostDistribution,
   deleteSessionAlias,
   materializeSessionDetailResponse,
+  materializeBookmarkViews,
   upsertSessionAlias,
   upsertBookmark,
   matchesProjectScope as sessionMatchesProjectScope,
@@ -77,6 +81,7 @@ export interface ScanStatusSource {
 }
 
 const KNOWN_AGENT_NAMES = getAgentInfoMap({}).map((agent) => agent.name);
+const KNOWN_AGENT_NAME_SET = new Set(KNOWN_AGENT_NAMES);
 
 function reportInvalidQueryParameter(
   endpoint: string,
@@ -153,47 +158,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isSessionStats(value: unknown): value is SessionHead["stats"] {
-  if (!isRecord(value)) return false;
-  return (
-    typeof value.message_count === "number" &&
-    typeof value.total_input_tokens === "number" &&
-    typeof value.total_output_tokens === "number" &&
-    typeof value.total_cost === "number" &&
-    (value.total_tokens == null || typeof value.total_tokens === "number")
-  );
-}
-
-type BookmarkInput = Omit<BookmarkRecord, "bookmarkedAt">;
-
-function parseBookmarkSession(
-  value: unknown,
-  reference: SessionReference,
-): BookmarkInput["session"] | null {
-  if (!isRecord(value)) return null;
-  if (
-    value.id !== reference.sessionId ||
-    typeof value.slug !== "string" ||
-    typeof value.title !== "string" ||
-    typeof value.directory !== "string" ||
-    typeof value.time_created !== "number" ||
-    (value.time_updated != null && typeof value.time_updated !== "number") ||
-    !isSessionStats(value.stats)
-  ) {
-    return null;
-  }
-
-  return {
-    id: reference.sessionId,
-    slug: formatSessionReference(reference),
-    title: value.title,
-    directory: value.directory,
-    time_created: value.time_created,
-    time_updated: value.time_updated ?? undefined,
-    stats: value.stats,
-  };
-}
-
 function parseSessionReferencePayload(value: unknown): SessionReference | null {
   if (
     !isRecord(value) ||
@@ -210,37 +174,39 @@ function parseSessionReferencePayload(value: unknown): SessionReference | null {
   });
 }
 
-function parseBookmarkPayload(value: unknown): BookmarkInput | null {
+function parseBookmarkReference(value: unknown): SessionReference | null {
   if (!isRecord(value)) return null;
 
   const reference = parseSessionReferencePayload(value.reference);
-  if (reference) {
-    const session = parseBookmarkSession(value.session, reference);
-    return session ? { reference, session } : null;
-  }
+  if (reference) return reference;
 
   if (
     typeof value.agentKey !== "string" ||
     typeof value.sessionId !== "string" ||
-    typeof value.fullPath !== "string" ||
     !value.agentKey.trim() ||
     !value.sessionId
   ) {
     return null;
   }
-  const legacyReference = normalizeSessionReference({
+  return normalizeSessionReference({
     agentName: value.agentKey.trim().toLowerCase(),
     sessionId: value.sessionId,
   });
-  const session = parseBookmarkSession(
-    {
-      ...value,
-      id: value.sessionId,
-      slug: value.fullPath,
-    },
-    legacyReference,
-  );
-  return session ? { reference: legacyReference, session } : null;
+}
+
+function parseBookmarkImport(value: unknown): BookmarkRecord | null {
+  if (!isRecord(value)) return null;
+  const reference = parseBookmarkReference(value);
+  if (!reference) return null;
+
+  const timestamp = value.bookmarkedAt ?? value.bookmarked_at;
+  if (timestamp != null && (typeof timestamp !== "number" || !Number.isFinite(timestamp))) {
+    return null;
+  }
+  return {
+    reference,
+    bookmarkedAt: typeof timestamp === "number" ? timestamp : Date.now(),
+  };
 }
 
 function sanitizeClientLogData(value: unknown): Record<string, unknown> {
@@ -634,12 +600,32 @@ export async function handlePostClientLog(c: Context) {
   return c.json({ ok: true });
 }
 
-export function handleGetBookmarks(c: Context) {
+function materializeStoredBookmarks(
+  scanSource: ScanResultSource,
+  bookmarks: readonly BookmarkRecord[],
+  aliases: AliasView,
+): BookmarkView[] {
+  const snapshot = scanSource.getSnapshot();
+  const sessionIndex = getSnapshotAggregation(
+    scanSource,
+    snapshot.sessions,
+    ["bookmark-session-index"],
+    () => createSessionIndex(snapshot.sessions),
+  );
+  return materializeBookmarkViews(bookmarks, {
+    liveSessionsByReference: sessionIndex.byRouteKey,
+    knownAgentNames: KNOWN_AGENT_NAME_SET,
+    resolveCachedSessions: loadCachedSessionHeads,
+  }).map((bookmark) => decorateBookmark(bookmark, aliases));
+}
+
+export function handleGetBookmarks(c: Context, scanSource: ScanResultSource) {
   return withStorageErrors(
     () => {
       const aliases = loadAliasView();
+      const bookmarks = materializeStoredBookmarks(scanSource, listBookmarks(), aliases);
       return c.json({
-        bookmarks: listBookmarks().map((bookmark) => decorateBookmark(bookmark, aliases)),
+        bookmarks,
         storageAvailable: true,
       });
     },
@@ -648,7 +634,7 @@ export function handleGetBookmarks(c: Context) {
 }
 
 export async function handlePutBookmark(c: Context) {
-  const payload = parseBookmarkPayload(await c.req.json().catch(() => null));
+  const payload = parseBookmarkReference(await c.req.json().catch(() => null));
   if (!payload) {
     return c.json({ error: "Invalid bookmark payload" }, 400);
   }
@@ -659,14 +645,14 @@ export async function handlePutBookmark(c: Context) {
   );
 }
 
-export async function handleImportBookmarks(c: Context) {
+export async function handleImportBookmarks(c: Context, scanSource: ScanResultSource) {
   const payload = await c.req.json().catch(() => null);
   if (!Array.isArray(payload)) {
     return c.json({ error: "Invalid bookmark payload" }, 400);
   }
 
   const bookmarks = payload
-    .map((entry) => parseBookmarkPayload(entry))
+    .map((entry) => parseBookmarkImport(entry))
     .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 
   if (bookmarks.length !== payload.length) {
@@ -674,7 +660,11 @@ export async function handleImportBookmarks(c: Context) {
   }
 
   return withStorageErrors(
-    () => c.json({ bookmarks: importBookmarks(bookmarks), storageAvailable: true }),
+    () => {
+      const imported = importBookmarks(bookmarks);
+      const views = materializeStoredBookmarks(scanSource, imported, loadAliasView());
+      return c.json({ bookmarks: views, storageAvailable: true });
+    },
     () => c.json({ error: "Bookmark storage is unavailable" }, 503),
   );
 }

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -118,9 +118,9 @@ export function createApiRoutes(
   api.get("/file-activity", (c) => handleGetFileActivity(c, listDefaults));
   api.get("/sessions/:agent/:id", (c) => handleGetSessionData(c, scanSource));
   api.get("/dashboard", (c) => handleGetDashboard(c, scanSource, listDefaults));
-  api.get("/bookmarks", (c) => handleGetBookmarks(c));
+  api.get("/bookmarks", (c) => handleGetBookmarks(c, scanSource));
   api.put("/bookmarks", (c) => handlePutBookmark(c));
-  api.post("/bookmarks/import", (c) => handleImportBookmarks(c));
+  api.post("/bookmarks/import", (c) => handleImportBookmarks(c, scanSource));
   api.delete("/bookmarks/:agent/:id", (c) => handleDeleteBookmark(c));
   api.put("/session-aliases/:agent/:id", (c) => handlePutSessionAlias(c));
   api.delete("/session-aliases/:agent/:id", (c) => handleDeleteSessionAlias(c));

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -2,7 +2,7 @@
  * Session aliases as a read model for the HTTP layer: load the user's local
  * renames once, then decorate outgoing records with `display_title`.
  */
-import type { BookmarkRecord, SessionAlias, SessionHead } from "@codesesh/core";
+import type { BookmarkView, SessionAlias, SessionHead } from "@codesesh/core";
 import type { SearchResult, SessionReference } from "@codesesh/core/contract";
 import {
   filterSessionSearchCandidates,
@@ -74,11 +74,16 @@ export function invalidateAliasView(): void {
   cachedView = null;
 }
 
-export function decorateBookmark(bookmark: BookmarkRecord, aliases: AliasView): BookmarkRecord {
-  return {
-    ...bookmark,
-    session: aliases.decorate(bookmark.session, bookmark.reference),
-  };
+export function decorateBookmark(bookmark: BookmarkView, aliases: AliasView): BookmarkView {
+  if (bookmark.availability === "available") {
+    return {
+      ...bookmark,
+      session: aliases.decorate(bookmark.session, bookmark.reference),
+    };
+  }
+
+  const displayTitle = aliases.get(bookmark.reference);
+  return displayTitle ? { ...bookmark, display_title: displayTitle } : bookmark;
 }
 
 export function decorateFileActivity(

--- a/packages/core/src/bookmarks/index.ts
+++ b/packages/core/src/bookmarks/index.ts
@@ -1,0 +1,5 @@
+export {
+  compareBookmarkViews,
+  materializeBookmarkViews,
+  type BookmarkMaterializationOptions,
+} from "./materialize.js";

--- a/packages/core/src/bookmarks/materialize.test.ts
+++ b/packages/core/src/bookmarks/materialize.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BookmarkRecord, ReferencedSessionHead, SessionHead } from "../contract/index.js";
+import { materializeBookmarkViews } from "./materialize.js";
+
+function makeBookmark(sessionId: string, agentName = "codex", bookmarkedAt = 1): BookmarkRecord {
+  return { reference: { agentName, sessionId }, bookmarkedAt };
+}
+
+function makeSession(sessionId: string, agentName = "codex", timeUpdated = 1): SessionHead {
+  return {
+    id: sessionId,
+    slug: `${agentName}/${sessionId}`,
+    title: `${sessionId} title`,
+    directory: "/workspace",
+    time_created: 1,
+    time_updated: timeUpdated,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 2,
+      total_output_tokens: 3,
+      total_cost: 0,
+    },
+  };
+}
+
+describe("materializeBookmarkViews", () => {
+  it("projects live session heads from bookmark facts", () => {
+    const session = { ...makeSession("s1", "codex", 20), title: "Current title" };
+
+    const views = materializeBookmarkViews([makeBookmark("s1", " CoDeX ", 5)], {
+      liveSessionsByReference: new Map([["codex/s1", session]]),
+      knownAgentNames: new Set(["codex"]),
+    });
+
+    expect(views).toEqual([
+      {
+        reference: { agentName: "codex", sessionId: "s1" },
+        bookmarkedAt: 5,
+        availability: "available",
+        session,
+      },
+    ]);
+  });
+
+  it("resolves sessions outside the live window in one targeted cache batch", () => {
+    const cached: ReferencedSessionHead = {
+      reference: { agentName: "codex", sessionId: "old" },
+      session: { ...makeSession("wrong", "stale", 8), title: "Cached title" },
+    };
+    const resolveCachedSessions = vi.fn(() => [cached]);
+
+    const views = materializeBookmarkViews(
+      [makeBookmark("old"), makeBookmark("missing", "codex", 2)],
+      {
+        liveSessionsByReference: new Map(),
+        knownAgentNames: new Set(["codex"]),
+        resolveCachedSessions,
+      },
+    );
+
+    expect(resolveCachedSessions).toHaveBeenCalledOnce();
+    expect(resolveCachedSessions).toHaveBeenCalledWith([
+      { agentName: "codex", sessionId: "old" },
+      { agentName: "codex", sessionId: "missing" },
+    ]);
+    expect(views[0]).toMatchObject({
+      availability: "available",
+      reference: { agentName: "codex", sessionId: "old" },
+      session: { id: "old", slug: "codex/old", title: "Cached title" },
+    });
+  });
+
+  it("distinguishes unavailable sessions from unavailable agents", () => {
+    const views = materializeBookmarkViews(
+      [makeBookmark("gone", "codex", 3), makeBookmark("gone", "removed-agent", 2)],
+      {
+        liveSessionsByReference: new Map(),
+        knownAgentNames: new Set(["codex"]),
+      },
+    );
+
+    expect(views).toEqual([
+      {
+        ...makeBookmark("gone", "codex", 3),
+        availability: "session-unavailable",
+      },
+      {
+        ...makeBookmark("gone", "removed-agent", 2),
+        availability: "agent-unavailable",
+      },
+    ]);
+  });
+
+  it("looks up only bookmark identities regardless of live collection size", () => {
+    const live = new Map(
+      Array.from({ length: 10_000 }, (_, index) => {
+        const session = makeSession(`unrelated-${index}`);
+        return [session.slug, session] as const;
+      }),
+    );
+    live.set("codex/first", makeSession("first"));
+    live.set("codex/second", makeSession("second"));
+    const get = vi.spyOn(live, "get");
+
+    materializeBookmarkViews([makeBookmark("first"), makeBookmark("second")], {
+      liveSessionsByReference: live,
+      knownAgentNames: new Set(["codex"]),
+    });
+
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it("orders available views by activity and unavailable views by bookmarkedAt", () => {
+    const live = new Map([
+      ["codex/older", makeSession("older", "codex", 10)],
+      ["codex/newer", makeSession("newer", "codex", 20)],
+    ]);
+
+    const views = materializeBookmarkViews(
+      [
+        makeBookmark("missing-old", "codex", 2),
+        makeBookmark("older", "codex", 100),
+        makeBookmark("missing-new", "codex", 4),
+        makeBookmark("newer", "codex", 1),
+      ],
+      { liveSessionsByReference: live, knownAgentNames: new Set(["codex"]) },
+    );
+
+    expect(views.map(({ reference }) => reference.sessionId)).toEqual([
+      "newer",
+      "older",
+      "missing-new",
+      "missing-old",
+    ]);
+  });
+});

--- a/packages/core/src/bookmarks/materialize.ts
+++ b/packages/core/src/bookmarks/materialize.ts
@@ -1,0 +1,94 @@
+import type {
+  BookmarkRecord,
+  BookmarkView,
+  ReferencedSessionHead,
+  SessionHead,
+  SessionReference,
+} from "../contract/index.js";
+import { formatSessionReference, normalizeSessionReference } from "../contract/index.js";
+
+export interface BookmarkMaterializationOptions {
+  liveSessionsByReference: ReadonlyMap<string, SessionHead>;
+  knownAgentNames: ReadonlySet<string>;
+  resolveCachedSessions?: (
+    references: readonly SessionReference[],
+  ) => readonly ReferencedSessionHead[];
+}
+
+function referenceKey(reference: SessionReference): string {
+  return formatSessionReference(normalizeSessionReference(reference));
+}
+
+function canonicalSession(reference: SessionReference, session: SessionHead): SessionHead {
+  return {
+    ...session,
+    id: reference.sessionId,
+    slug: formatSessionReference(reference),
+  };
+}
+
+function compareDescending(left: number, right: number): number {
+  if (left === right) return 0;
+  return left > right ? -1 : 1;
+}
+
+function getBookmarkViewTime(bookmark: BookmarkView): number {
+  return bookmark.availability === "available"
+    ? (bookmark.session.time_updated ?? bookmark.session.time_created)
+    : bookmark.bookmarkedAt;
+}
+
+export function compareBookmarkViews(left: BookmarkView, right: BookmarkView): number {
+  return (
+    compareDescending(getBookmarkViewTime(left), getBookmarkViewTime(right)) ||
+    compareDescending(left.bookmarkedAt, right.bookmarkedAt) ||
+    referenceKey(left.reference).localeCompare(referenceKey(right.reference))
+  );
+}
+
+export function materializeBookmarkViews(
+  bookmarks: readonly BookmarkRecord[],
+  options: BookmarkMaterializationOptions,
+): BookmarkView[] {
+  const liveByKey = new Map<string, SessionHead>();
+  const missingByKey = new Map<string, SessionReference>();
+  const normalizedBookmarks = bookmarks.map((bookmark) => {
+    const reference = normalizeSessionReference(bookmark.reference);
+    return {
+      bookmark: { reference, bookmarkedAt: bookmark.bookmarkedAt },
+      key: referenceKey(reference),
+    };
+  });
+
+  for (const { bookmark, key } of normalizedBookmarks) {
+    const { reference } = bookmark;
+    const live = options.liveSessionsByReference.get(key);
+    if (live) liveByKey.set(key, canonicalSession(reference, live));
+    else if (!missingByKey.has(key)) missingByKey.set(key, reference);
+  }
+
+  const cachedByKey = new Map<string, SessionHead>();
+  if (missingByKey.size > 0 && options.resolveCachedSessions) {
+    for (const cached of options.resolveCachedSessions([...missingByKey.values()])) {
+      const reference = normalizeSessionReference(cached.reference);
+      const key = referenceKey(reference);
+      if (missingByKey.has(key) && !cachedByKey.has(key)) {
+        cachedByKey.set(key, canonicalSession(reference, cached.session));
+      }
+    }
+  }
+
+  const views = normalizedBookmarks.map(({ bookmark, key }): BookmarkView => {
+    const session = liveByKey.get(key) ?? cachedByKey.get(key);
+    if (session) return { ...bookmark, availability: "available", session };
+
+    return {
+      ...bookmark,
+      availability: options.knownAgentNames.has(bookmark.reference.agentName)
+        ? "session-unavailable"
+        : "agent-unavailable",
+    };
+  });
+
+  return views.sort(compareBookmarkViews);
+}

--- a/packages/core/src/contract/bookmarks.ts
+++ b/packages/core/src/contract/bookmarks.ts
@@ -1,5 +1,19 @@
-import type { ReferencedSessionHead } from "./session.js";
+import type { SessionHead } from "./session.js";
+import type { SessionReference } from "./session-reference.js";
 
-export interface BookmarkRecord extends ReferencedSessionHead {
+export interface BookmarkRecord {
+  reference: SessionReference;
   bookmarkedAt: number;
 }
+
+export interface AvailableBookmarkView extends BookmarkRecord {
+  availability: "available";
+  session: SessionHead;
+}
+
+export interface UnavailableBookmarkView extends BookmarkRecord {
+  availability: "session-unavailable" | "agent-unavailable";
+  display_title?: string;
+}
+
+export type BookmarkView = AvailableBookmarkView | UnavailableBookmarkView;

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listBookmarks, type BookmarkRecord } from "../../state/bookmarks.js";
+import { setStateSchemaEnsuredPath } from "../../state/database.js";
 import type { SessionHead } from "../../types/index.js";
 import { setSchemaEnsuredPath } from "../cache/db.js";
 import { searchFileActivitySessions } from "../cache/file-activity.js";
@@ -105,15 +106,13 @@ function createCacheFixture(fixture: ReleaseCacheFixture, populated = true): voi
   }
 }
 
-function createLegacyStateFixture(): void {
+function createLegacyStateFixture(version: 1 | 2): void {
   mkdirSync(getStateDir(), { recursive: true });
   const db = new Database(getStatePath());
   const session = makeSession();
 
   try {
     db.exec(`
-      PRAGMA user_version = 0;
-
       CREATE TABLE state_meta (
         key TEXT PRIMARY KEY,
         value TEXT NOT NULL
@@ -132,7 +131,19 @@ function createLegacyStateFixture(): void {
         PRIMARY KEY (agent_name, session_id)
       );
     `);
-    db.prepare("INSERT INTO state_meta(key, value) VALUES ('version', '1')").run();
+    if (version === 2) {
+      db.exec(`
+        CREATE TABLE session_aliases (
+          agent_name TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          alias TEXT NOT NULL,
+          updated_at INTEGER NOT NULL,
+          PRIMARY KEY (agent_name, session_id)
+        );
+      `);
+    }
+    db.pragma(`user_version = ${version === 2 ? 2 : 0}`);
+    db.prepare("INSERT INTO state_meta(key, value) VALUES ('version', ?)").run(String(version));
     db.prepare(
       `
         INSERT INTO bookmarks(
@@ -170,6 +181,27 @@ function getMigrationBackups(): string[] {
   return readdirSync(getCacheDir())
     .filter((name) => name.startsWith("codesesh.db.") && name.endsWith(".bak"))
     .sort();
+}
+
+function getStateMigrationBackups(): string[] {
+  if (!existsSync(getStateDir())) return [];
+  return readdirSync(getStateDir())
+    .filter(
+      (name) =>
+        name.startsWith("state.db.") && name.includes(".state-migration") && name.endsWith(".bak"),
+    )
+    .sort();
+}
+
+function getBookmarkColumns(): string[] {
+  const db = new Database(getStatePath(), { readonly: true });
+  try {
+    return (db.prepare("PRAGMA table_info(bookmarks)").all() as Array<{ name: string }>).map(
+      ({ name }) => name,
+    );
+  } finally {
+    db.close();
+  }
 }
 
 function readMigratedFacts(): Record<string, unknown> {
@@ -259,12 +291,14 @@ beforeEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   rmSync(getStateDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  setStateSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   rmSync(getStateDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  setStateSchemaEnsuredPath(null);
 });
 
 afterAll(() => {
@@ -368,32 +402,19 @@ describe("sqlite migration release gate", () => {
     expect(getUserVersion(getCachePath())).toBe(EXPECTED_CACHE_SCHEMA_VERSION);
   });
 
-  it("migrates the released state v1 bookmark schema", () => {
-    createLegacyStateFixture();
+  it.each([1, 2] as const)("migrates the released state v%s bookmark schema", (version) => {
+    createLegacyStateFixture(version);
 
     const bookmarks: BookmarkRecord[] = listBookmarks();
 
     expect(bookmarks).toEqual([
       {
         reference: { agentName: "claudecode", sessionId: "legacy-smoke" },
-        session: {
-          id: "legacy-smoke",
-          slug: "claudecode/legacy-smoke",
-          title: "Legacy smoke session",
-          directory: FIXTURE_DIR,
-          time_created: now - 1_000,
-          time_updated: now,
-          stats: {
-            message_count: 1,
-            total_input_tokens: 10,
-            total_output_tokens: 5,
-            total_cost: 0,
-            total_tokens: 15,
-          },
-        },
         bookmarkedAt: now - 500,
       },
     ]);
-    expect(getUserVersion(getStatePath())).toBe(2);
+    expect(getBookmarkColumns()).toEqual(["agent_name", "session_id", "bookmarked_at"]);
+    expect(getStateMigrationBackups()).toHaveLength(1);
+    expect(getUserVersion(getStatePath())).toBe(3);
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -88,15 +88,19 @@ describe("cached sessions", () => {
   });
 
   it("chunks large targeted session-head lookups", () => {
-    const sessions = Array.from({ length: 401 }, (_, index) => makeSessionHead(`session-${index}`));
-    saveCachedSessions("codex", sessions);
+    saveCachedSessions("codex", [makeSessionHead("session-400")]);
+    const references = Array.from({ length: 401 }, (_, index) => ({
+      agentName: "codex",
+      sessionId: `session-${index}`,
+    }));
 
-    const resolved = loadCachedSessionHeads(
-      sessions.map(({ id }) => ({ agentName: "codex", sessionId: id })),
-    );
+    const resolved = loadCachedSessionHeads(references);
 
-    expect(resolved).toHaveLength(401);
-    expect(new Set(resolved.map(({ reference }) => reference.sessionId)).size).toBe(401);
+    expect(resolved).toEqual([
+      expect.objectContaining({
+        reference: { agentName: "codex", sessionId: "session-400" },
+      }),
+    ]);
   });
 
   it("CS-137: reports whether the write reached disk", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearCache,
   getCacheInfo,
+  loadCachedSessionHeads,
   loadCachedSessions,
   saveCachedSessionChanges,
   saveCachedSessions,
@@ -59,6 +60,43 @@ describe("cached sessions", () => {
       agentName: "codex",
       sessionId: "parent",
     });
+  });
+
+  it("loads only requested session heads by compound identity", () => {
+    saveCachedSessions("codex", [makeSessionHead("shared"), makeSessionHead("other")]);
+    saveCachedSessions("cursor", [
+      makeSessionHead("shared", { slug: "cursor/shared", title: "Cursor shared" }),
+    ]);
+
+    const sessions = loadCachedSessionHeads([
+      { agentName: " CoDeX ", sessionId: "shared" },
+      { agentName: "cursor", sessionId: "shared" },
+      { agentName: "codex", sessionId: "shared" },
+      { agentName: "codex", sessionId: "missing" },
+    ]);
+
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        reference: { agentName: "codex", sessionId: "shared" },
+        session: expect.objectContaining({ title: "Session shared" }),
+      }),
+      expect.objectContaining({
+        reference: { agentName: "cursor", sessionId: "shared" },
+        session: expect.objectContaining({ title: "Cursor shared" }),
+      }),
+    ]);
+  });
+
+  it("chunks large targeted session-head lookups", () => {
+    const sessions = Array.from({ length: 401 }, (_, index) => makeSessionHead(`session-${index}`));
+    saveCachedSessions("codex", sessions);
+
+    const resolved = loadCachedSessionHeads(
+      sessions.map(({ id }) => ({ agentName: "codex", sessionId: id })),
+    );
+
+    expect(resolved).toHaveLength(401);
+    expect(new Set(resolved.map(({ reference }) => reference.sessionId)).size).toBe(401);
   });
 
   it("CS-137: reports whether the write reached disk", () => {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -3,6 +3,8 @@
  */
 import { existsSync, rmSync, unlinkSync } from "node:fs";
 import type { SessionCacheMeta } from "../../agents/base.js";
+import type { ReferencedSessionHead, SessionReference } from "../../contract/index.js";
+import { formatSessionReference, normalizeSessionReference } from "../../contract/index.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { tableExists, type SQLiteDatabase } from "../../utils/sqlite.js";
 import {
@@ -27,6 +29,38 @@ import { fileActivityFromRow, type FileActivityRow } from "./file-activity.js";
 
 export const CACHE_INITIALIZATION_VERSION = "session-cache-v2";
 const FULL_SYNC_CURSOR_PREFIX = "full_sync_cursor:";
+const SESSION_REFERENCE_QUERY_CHUNK_SIZE = 400;
+const SESSION_HEAD_SELECT_COLUMNS = `
+  s.agent_name,
+  s.session_id,
+  s.sort_index,
+  s.slug,
+  s.title,
+  s.source_path,
+  s.directory,
+  s.parent_agent_name,
+  s.parent_session_id,
+  s.project_identity_kind,
+  s.project_identity_key,
+  s.project_display_name,
+  s.project_identity_resolver_revision,
+  s.project_identity_input_signature,
+  s.time_created,
+  s.time_updated,
+  s.message_count,
+  s.total_input_tokens,
+  s.total_output_tokens,
+  s.total_cache_read_tokens,
+  s.total_cache_create_tokens,
+  s.total_cost,
+  s.cost_source,
+  s.total_tokens,
+  s.model_usage_json,
+  s.smart_tags_json,
+  s.smart_tags_source_updated_at,
+  s.smart_tags_classifier_revision,
+  s.meta_json
+`;
 export interface CachedResult {
   sessions: SessionHead[];
   meta: Record<string, SessionCacheMeta>;
@@ -93,38 +127,10 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
     const rows = db
       .prepare(
         `
-          SELECT
-            session_id,
-            sort_index,
-            slug,
-            title,
-            source_path,
-            directory,
-            parent_agent_name,
-            parent_session_id,
-            project_identity_kind,
-            project_identity_key,
-            project_display_name,
-            project_identity_resolver_revision,
-            project_identity_input_signature,
-            time_created,
-            time_updated,
-            message_count,
-            total_input_tokens,
-            total_output_tokens,
-            total_cache_read_tokens,
-            total_cache_create_tokens,
-            total_cost,
-            cost_source,
-            total_tokens,
-            model_usage_json,
-            smart_tags_json,
-            smart_tags_source_updated_at,
-            smart_tags_classifier_revision,
-            meta_json
-          FROM sessions
-          WHERE agent_name = ?
-          ORDER BY sort_index, activity_time DESC
+          SELECT ${SESSION_HEAD_SELECT_COLUMNS}
+          FROM sessions s
+          WHERE s.agent_name = ?
+          ORDER BY s.sort_index, s.activity_time DESC
         `,
       )
       .all(agentName) as SessionRow[];
@@ -143,6 +149,60 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
 
     return { sessions, meta, timestamp };
   });
+}
+
+export function loadCachedSessionHeads(
+  references: readonly SessionReference[],
+): ReferencedSessionHead[] {
+  if (references.length === 0 || !hasCacheStorage()) return [];
+
+  const unique = new Map<string, SessionReference>();
+  for (const reference of references) {
+    const normalized = normalizeSessionReference(reference);
+    const key = formatSessionReference(normalized);
+    if (!unique.has(key)) unique.set(key, normalized);
+  }
+
+  return (
+    withCacheDbReadOnly((db) => {
+      const resolved: ReferencedSessionHead[] = [];
+      const normalized = [...unique.values()];
+      for (
+        let offset = 0;
+        offset < normalized.length;
+        offset += SESSION_REFERENCE_QUERY_CHUNK_SIZE
+      ) {
+        const chunk = normalized.slice(offset, offset + SESSION_REFERENCE_QUERY_CHUNK_SIZE);
+        const values = chunk.map(() => "(?, ?)").join(", ");
+        const params = chunk.flatMap((reference) => [reference.agentName, reference.sessionId]);
+        const rows = db
+          .prepare(
+            `
+              WITH requested(agent_name, session_id) AS (
+                VALUES ${values}
+              )
+              SELECT ${SESSION_HEAD_SELECT_COLUMNS}
+              FROM requested r
+              JOIN sessions s
+                ON s.agent_name = r.agent_name
+                AND s.session_id = r.session_id
+            `,
+          )
+          .all(...params) as SessionRow[];
+
+        for (const row of rows) {
+          resolved.push({
+            reference: normalizeSessionReference({
+              agentName: String(row.agent_name ?? ""),
+              sessionId: String(row.session_id ?? ""),
+            }),
+            session: sessionFromRow(row),
+          });
+        }
+      }
+      return resolved;
+    }) ?? []
+  );
 }
 
 export function isAgentCacheInitialized(

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -24,6 +24,7 @@ export {
   isAgentCacheInitialized,
   loadCachedSessionData,
   loadCachedSessionDataEntry,
+  loadCachedSessionHeads,
   loadCachedSessions,
   markAgentCacheInitialized,
   markAgentFullSyncProgress,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export {
   listFileActivity,
   listModelCostDistribution,
   loadCachedSessions,
+  loadCachedSessionHeads,
   markAgentCacheInitialized,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
@@ -105,6 +106,16 @@ export {
   upsertSessionAlias,
 } from "./state/index.js";
 export type { BookmarkRecord, SessionAlias } from "./state/index.js";
+export type {
+  AvailableBookmarkView,
+  BookmarkView,
+  UnavailableBookmarkView,
+} from "./contract/index.js";
+export {
+  compareBookmarkViews,
+  materializeBookmarkViews,
+  type BookmarkMaterializationOptions,
+} from "./bookmarks/index.js";
 export {
   classifySessionTags,
   ensurePrivateDirectory,

--- a/packages/core/src/state/__tests__/bookmarks.test.ts
+++ b/packages/core/src/state/__tests__/bookmarks.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -26,16 +26,6 @@ vi.mock("node:os", async (importOriginal) => {
 const now = 1_700_000_000_000;
 const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
 
-interface BookmarkOverrides {
-  agentName?: string;
-  sessionId?: string;
-  title?: string;
-  directory?: string;
-  timeCreated?: number;
-  timeUpdated?: number;
-  stats?: BookmarkRecord["session"]["stats"];
-}
-
 function getStateDir(): string {
   return join(testHomeDir, ".local", "share", "codesesh");
 }
@@ -53,27 +43,10 @@ function getUserVersion(dbPath: string): number {
   }
 }
 
-function makeBookmark(overrides: BookmarkOverrides = {}): Omit<BookmarkRecord, "bookmarkedAt"> {
-  const reference = {
-    agentName: overrides.agentName ?? "codex",
-    sessionId: overrides.sessionId ?? "s1",
-  };
+function makeBookmark(sessionId = "s1", agentName = "codex", bookmarkedAt = now): BookmarkRecord {
   return {
-    reference,
-    session: {
-      id: reference.sessionId,
-      slug: `${reference.agentName}/${reference.sessionId}`,
-      title: overrides.title ?? "Session 1",
-      directory: overrides.directory ?? "/tmp/project",
-      time_created: overrides.timeCreated ?? now - 1000,
-      time_updated: overrides.timeUpdated ?? now,
-      stats: overrides.stats ?? {
-        message_count: 1,
-        total_input_tokens: 2,
-        total_output_tokens: 3,
-        total_cost: 0,
-      },
-    },
+    reference: { agentName, sessionId },
+    bookmarkedAt,
   };
 }
 
@@ -91,68 +64,55 @@ afterEach(() => {
 });
 
 describe("bookmarks state storage", () => {
-  it("persists and lists bookmarks", () => {
-    upsertBookmark(makeBookmark());
+  it("persists only bookmark identity and timestamp facts", () => {
+    upsertBookmark(makeBookmark().reference);
 
-    expect(listBookmarks()).toEqual([
-      {
-        ...makeBookmark(),
-        bookmarkedAt: now,
-      },
-    ]);
-    expect(getUserVersion(getStatePath())).toBe(2);
-  });
+    expect(listBookmarks()).toEqual([makeBookmark()]);
+    expect(getUserVersion(getStatePath())).toBe(3);
 
-  it("derives canonical identity fields instead of trusting the legacy slug column", () => {
-    const bookmark = makeBookmark({ agentName: " CoDeX " });
-    bookmark.session.slug = "stale/route";
-    upsertBookmark(bookmark);
-
-    const db = new Database(getStatePath());
+    const db = new Database(getStatePath(), { readonly: true });
     try {
-      db.prepare("UPDATE bookmarks SET slug = 'another/stale-route'").run();
+      const columns = db.prepare("PRAGMA table_info(bookmarks)").all() as Array<{ name: string }>;
+      expect(columns.map(({ name }) => name)).toEqual([
+        "agent_name",
+        "session_id",
+        "bookmarked_at",
+      ]);
     } finally {
       db.close();
     }
-
-    expect(listBookmarks()[0]).toMatchObject({
-      reference: { agentName: "codex", sessionId: "s1" },
-      session: { id: "s1", slug: "codex/s1" },
-    });
   });
 
-  it("preserves bookmarkedAt when refreshing a snapshot", () => {
-    upsertBookmark(makeBookmark({ title: "Old title" }));
-    dateNowSpy.mockReturnValue(now + 5000);
+  it("normalizes identity without storing derived session fields", () => {
+    upsertBookmark({ agentName: " CoDeX ", sessionId: "s1" });
 
-    const updated = upsertBookmark(makeBookmark({ title: "New title" }));
-
-    expect(updated.bookmarkedAt).toBe(now);
-    expect(listBookmarks()[0]?.session.title).toBe("New title");
-    expect(listBookmarks()[0]?.bookmarkedAt).toBe(now);
+    expect(listBookmarks()).toEqual([makeBookmark()]);
   });
 
-  it("imports multiple bookmarks without duplicating existing rows", () => {
-    upsertBookmark(makeBookmark({ sessionId: "s1", title: "Before import" }));
+  it("preserves the original bookmarkedAt when upserting again", () => {
+    upsertBookmark(makeBookmark().reference);
+    dateNowSpy.mockReturnValue(now + 5_000);
+
+    const existing = upsertBookmark(makeBookmark().reference);
+
+    expect(existing.bookmarkedAt).toBe(now);
+    expect(listBookmarks()).toEqual([makeBookmark()]);
+  });
+
+  it("imports facts idempotently and preserves existing timestamps", () => {
+    upsertBookmark(makeBookmark("s1").reference);
 
     const imported = importBookmarks([
-      makeBookmark({ sessionId: "s1", title: "After import" }),
-      makeBookmark({
-        agentName: "cursor",
-        sessionId: "s2",
-        title: "Cursor session",
-      }),
+      makeBookmark("s1", "codex", now + 5_000),
+      makeBookmark("s2", "cursor", now - 500),
+      makeBookmark("s2", "cursor", now + 10_000),
     ]);
 
-    expect(imported).toHaveLength(2);
-    expect(imported.map((bookmark) => bookmark.session.title)).toEqual([
-      "After import",
-      "Cursor session",
-    ]);
+    expect(imported).toEqual([makeBookmark("s1"), makeBookmark("s2", "cursor", now - 500)]);
   });
 
   it("deletes a bookmark by normalized session reference", () => {
-    upsertBookmark(makeBookmark());
+    upsertBookmark(makeBookmark().reference);
     deleteBookmark({ agentName: " CoDeX ", sessionId: "s1" });
     expect(listBookmarks()).toEqual([]);
   });
@@ -161,24 +121,24 @@ describe("bookmarks state storage", () => {
     const stateDir = join(testHomeDir, "custom-state");
     vi.stubEnv("CODESESH_STATE_DIR", stateDir);
 
-    upsertBookmark(makeBookmark());
+    upsertBookmark(makeBookmark().reference);
 
-    expect(getUserVersion(join(stateDir, "state.db"))).toBe(2);
+    expect(getUserVersion(join(stateDir, "state.db"))).toBe(3);
   });
 
   it("uses memory state storage when configured", () => {
     vi.stubEnv("CODESESH_STATE_STORE", "memory");
 
-    expect(upsertBookmark(makeBookmark()).bookmarkedAt).toBe(now);
-    expect(listBookmarks()).toEqual([{ ...makeBookmark(), bookmarkedAt: now }]);
+    expect(upsertBookmark(makeBookmark().reference)).toEqual(makeBookmark());
+    expect(listBookmarks()).toEqual([makeBookmark()]);
     expect(existsSync(getStatePath())).toBe(false);
 
-    deleteBookmark({ agentName: "codex", sessionId: "s1" });
+    deleteBookmark(makeBookmark().reference);
     expect(listBookmarks()).toEqual([]);
   });
 
   it("migrates legacy state metadata to user_version", () => {
-    upsertBookmark(makeBookmark());
+    upsertBookmark(makeBookmark().reference);
     const db = new Database(getStatePath());
     try {
       db.exec("PRAGMA user_version = 0");
@@ -193,24 +153,22 @@ describe("bookmarks state storage", () => {
       db.close();
     }
 
-    // Force ensureSchema to re-run against the externally rewritten file,
-    // as a fresh process would on its first open.
     setStateSchemaEnsuredPath(null);
-    expect(listBookmarks()[0]?.reference.sessionId).toBe("s1");
-    expect(getUserVersion(getStatePath())).toBe(2);
+    expect(listBookmarks()).toEqual([makeBookmark()]);
+    expect(getUserVersion(getStatePath())).toBe(3);
   });
 
   it("does not downgrade a state database created by a newer version", () => {
-    upsertBookmark(makeBookmark());
+    upsertBookmark(makeBookmark().reference);
     const db = new Database(getStatePath());
     try {
-      db.exec("PRAGMA user_version = 3");
+      db.exec("PRAGMA user_version = 4");
     } finally {
       db.close();
     }
 
     setStateSchemaEnsuredPath(null);
-    expect(listBookmarks()[0]?.reference.sessionId).toBe("s1");
-    expect(getUserVersion(getStatePath())).toBe(3);
+    expect(listBookmarks()).toEqual([makeBookmark()]);
+    expect(getUserVersion(getStatePath())).toBe(4);
   });
 });

--- a/packages/core/src/state/__tests__/database.test.ts
+++ b/packages/core/src/state/__tests__/database.test.ts
@@ -61,10 +61,10 @@ describe("state database", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withStateDb(() => undefined);
     expect(getStateSchemaEnsuredPath()).toBe(getStatePath());
-    expect(getUserVersion(getStatePath())).toBe(2);
+    expect(getUserVersion(getStatePath())).toBe(3);
 
     // Downgrade the on-disk version to prove the next open leaves it alone:
-    // if ensureSchema ran, it would migrate this back up to 2.
+    // if ensureSchema ran, it would migrate this back up to 3.
     const db = new Database(getStatePath());
     db.pragma("user_version = 1");
     db.close();
@@ -74,6 +74,6 @@ describe("state database", () => {
 
     setStateSchemaEnsuredPath(null);
     withStateDb(() => undefined);
-    expect(getUserVersion(getStatePath())).toBe(2);
+    expect(getUserVersion(getStatePath())).toBe(3);
   });
 });

--- a/packages/core/src/state/bookmarks.ts
+++ b/packages/core/src/state/bookmarks.ts
@@ -1,12 +1,10 @@
-import type { SessionStats } from "../types/index.js";
 import {
-  formatSessionReference,
   normalizeSessionReference,
   type BookmarkRecord,
   type SessionReference,
 } from "../contract/index.js";
 import { StateStorageUnavailableError, useMemoryStateStore, withStateDb } from "./database.js";
-import type { DatabaseRow } from "../utils/sqlite.js";
+import type { DatabaseRow, SQLiteDatabase } from "../utils/sqlite.js";
 
 const memoryBookmarks = new Map<string, BookmarkRecord>();
 
@@ -17,11 +15,6 @@ export type { BookmarkRecord };
 interface BookmarkRow extends DatabaseRow {
   agent_name?: string;
   session_id?: string;
-  title?: string;
-  directory?: string;
-  time_created?: number;
-  time_updated?: number | null;
-  stats_json?: string;
   bookmarked_at?: number;
 }
 
@@ -30,234 +23,119 @@ function getBookmarkKey(reference: SessionReference): string {
   return JSON.stringify([normalized.agentName, normalized.sessionId]);
 }
 
-function getActivityTime(bookmark: BookmarkRecord): number {
-  return bookmark.session.time_updated ?? bookmark.session.time_created;
+function compareBookmarks(left: BookmarkRecord, right: BookmarkRecord): number {
+  if (left.bookmarkedAt !== right.bookmarkedAt) {
+    return left.bookmarkedAt > right.bookmarkedAt ? -1 : 1;
+  }
+  return getBookmarkKey(left.reference).localeCompare(getBookmarkKey(right.reference));
 }
 
-function sortBookmarks(bookmarks: BookmarkRecord[]): BookmarkRecord[] {
-  return bookmarks.sort((a, b) => {
-    const activityDelta = getActivityTime(b) - getActivityTime(a);
-    return activityDelta || b.bookmarkedAt - a.bookmarkedAt;
-  });
-}
-
-function listMemoryBookmarks(): BookmarkRecord[] {
-  return sortBookmarks(Array.from(memoryBookmarks.values()));
-}
-
-function normalizeBookmark(
-  bookmark: Omit<BookmarkRecord, "bookmarkedAt">,
-): Omit<BookmarkRecord, "bookmarkedAt"> {
-  const reference = normalizeSessionReference(bookmark.reference);
+function normalizeBookmark(bookmark: BookmarkRecord): BookmarkRecord {
   return {
-    reference,
-    session: {
-      ...bookmark.session,
-      id: reference.sessionId,
-      slug: formatSessionReference(reference),
-    },
+    reference: normalizeSessionReference(bookmark.reference),
+    bookmarkedAt: bookmark.bookmarkedAt,
   };
-}
-
-function upsertMemoryBookmark(bookmark: Omit<BookmarkRecord, "bookmarkedAt">): BookmarkRecord {
-  const key = getBookmarkKey(bookmark.reference);
-  const saved = {
-    ...bookmark,
-    bookmarkedAt: memoryBookmarks.get(key)?.bookmarkedAt ?? Date.now(),
-  };
-  memoryBookmarks.set(key, saved);
-  return saved;
 }
 
 function toBookmarkRecord(row: BookmarkRow): BookmarkRecord {
-  const reference = normalizeSessionReference({
-    agentName: String(row.agent_name ?? ""),
-    sessionId: String(row.session_id ?? ""),
-  });
   return {
-    reference,
-    session: {
-      id: reference.sessionId,
-      slug: formatSessionReference(reference),
-      title: String(row.title ?? ""),
-      directory: String(row.directory ?? ""),
-      time_created: Number(row.time_created ?? 0),
-      time_updated: row.time_updated == null ? undefined : Number(row.time_updated),
-      stats: JSON.parse(String(row.stats_json ?? "{}")) as SessionStats,
-    },
+    reference: normalizeSessionReference({
+      agentName: String(row.agent_name ?? ""),
+      sessionId: String(row.session_id ?? ""),
+    }),
     bookmarkedAt: Number(row.bookmarked_at ?? 0),
   };
 }
 
-export function listBookmarks(): BookmarkRecord[] {
-  if (useMemoryStateStore()) {
-    return listMemoryBookmarks();
-  }
-
-  return withStateDb((db) => {
-    const rows = db
-      .prepare(
-        `
-          SELECT
-            agent_name,
-            session_id,
-            title,
-            directory,
-            time_created,
-            time_updated,
-            stats_json,
-            bookmarked_at
-          FROM bookmarks
-          ORDER BY COALESCE(time_updated, time_created) DESC, bookmarked_at DESC
-        `,
-      )
-      .all() as BookmarkRow[];
-
-    return rows.map(toBookmarkRecord);
-  });
+function readBookmarks(db: SQLiteDatabase): BookmarkRecord[] {
+  const rows = db
+    .prepare(
+      `
+        SELECT agent_name, session_id, bookmarked_at
+        FROM bookmarks
+        ORDER BY bookmarked_at DESC, agent_name ASC, session_id ASC
+      `,
+    )
+    .all() as BookmarkRow[];
+  return rows.map(toBookmarkRecord);
 }
 
-export function upsertBookmark(bookmark: Omit<BookmarkRecord, "bookmarkedAt">): BookmarkRecord {
-  const normalized = normalizeBookmark(bookmark);
+function listMemoryBookmarks(): BookmarkRecord[] {
+  return [...memoryBookmarks.values()].sort(compareBookmarks);
+}
+
+export function listBookmarks(): BookmarkRecord[] {
+  if (useMemoryStateStore()) return listMemoryBookmarks();
+  return withStateDb(readBookmarks);
+}
+
+export function upsertBookmark(reference: SessionReference): BookmarkRecord {
+  const normalized = normalizeSessionReference(reference);
+  const key = getBookmarkKey(normalized);
   if (useMemoryStateStore()) {
-    return upsertMemoryBookmark(normalized);
+    const bookmark = memoryBookmarks.get(key) ?? {
+      reference: normalized,
+      bookmarkedAt: Date.now(),
+    };
+    memoryBookmarks.set(key, bookmark);
+    return bookmark;
   }
 
   return withStateDb((db) => {
-    const existing = db
+    db.prepare(
+      `
+        INSERT INTO bookmarks(agent_name, session_id, bookmarked_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(agent_name, session_id) DO NOTHING
+      `,
+    ).run(normalized.agentName, normalized.sessionId, Date.now());
+    const row = db
       .prepare(
         `
-          SELECT bookmarked_at
+          SELECT agent_name, session_id, bookmarked_at
           FROM bookmarks
           WHERE agent_name = ? AND session_id = ?
         `,
       )
-      .get(normalized.reference.agentName, normalized.reference.sessionId) as
-      | DatabaseRow
-      | undefined;
-    const bookmarkedAt = Number(existing?.bookmarked_at ?? Date.now());
-
-    db.prepare(
-      `
-        INSERT INTO bookmarks(
-          agent_name,
-          session_id,
-          slug,
-          title,
-          directory,
-          time_created,
-          time_updated,
-          stats_json,
-          bookmarked_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(agent_name, session_id) DO UPDATE SET
-          slug = excluded.slug,
-          title = excluded.title,
-          directory = excluded.directory,
-          time_created = excluded.time_created,
-          time_updated = excluded.time_updated,
-          stats_json = excluded.stats_json
-      `,
-    ).run(
-      normalized.reference.agentName,
-      normalized.reference.sessionId,
-      formatSessionReference(normalized.reference),
-      normalized.session.title,
-      normalized.session.directory,
-      normalized.session.time_created,
-      normalized.session.time_updated ?? null,
-      JSON.stringify(normalized.session.stats),
-      bookmarkedAt,
-    );
-
-    return { ...normalized, bookmarkedAt };
+      .get(normalized.agentName, normalized.sessionId) as BookmarkRow;
+    return toBookmarkRecord(row);
   });
 }
 
-export function importBookmarks(
-  bookmarks: Omit<BookmarkRecord, "bookmarkedAt">[],
-): BookmarkRecord[] {
-  const normalizedBookmarks = bookmarks.map(normalizeBookmark);
+export function importBookmarks(bookmarks: readonly BookmarkRecord[]): BookmarkRecord[] {
+  const unique = new Map<string, BookmarkRecord>();
+  for (const bookmark of bookmarks) {
+    const normalized = normalizeBookmark(bookmark);
+    const key = getBookmarkKey(normalized.reference);
+    if (!unique.has(key)) unique.set(key, normalized);
+  }
+
   if (useMemoryStateStore()) {
-    for (const bookmark of normalizedBookmarks) {
-      upsertMemoryBookmark(bookmark);
+    for (const [key, bookmark] of unique) {
+      if (!memoryBookmarks.has(key)) memoryBookmarks.set(key, bookmark);
     }
     return listMemoryBookmarks();
   }
 
   return withStateDb((db) => {
-    const existingRows = db
-      .prepare("SELECT agent_name, session_id, bookmarked_at FROM bookmarks")
-      .all() as DatabaseRow[];
-    const existingTimes = new Map(
-      existingRows.map((row) => [
-        getBookmarkKey({
-          agentName: String(row.agent_name ?? ""),
-          sessionId: String(row.session_id ?? ""),
-        }),
-        Number(row.bookmarked_at ?? 0),
-      ]),
-    );
-
-    const upsert = db.prepare(
+    const insert = db.prepare(
       `
-        INSERT INTO bookmarks(
-          agent_name,
-          session_id,
-          slug,
-          title,
-          directory,
-          time_created,
-          time_updated,
-          stats_json,
-          bookmarked_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(agent_name, session_id) DO UPDATE SET
-          slug = excluded.slug,
-          title = excluded.title,
-          directory = excluded.directory,
-          time_created = excluded.time_created,
-          time_updated = excluded.time_updated,
-          stats_json = excluded.stats_json
+        INSERT INTO bookmarks(agent_name, session_id, bookmarked_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(agent_name, session_id) DO NOTHING
       `,
     );
-
     const write = db.transaction(() => {
-      for (const bookmark of normalizedBookmarks) {
-        const key = getBookmarkKey(bookmark.reference);
-        upsert.run(
+      for (const bookmark of unique.values()) {
+        insert.run(
           bookmark.reference.agentName,
           bookmark.reference.sessionId,
-          formatSessionReference(bookmark.reference),
-          bookmark.session.title,
-          bookmark.session.directory,
-          bookmark.session.time_created,
-          bookmark.session.time_updated ?? null,
-          JSON.stringify(bookmark.session.stats),
-          existingTimes.get(key) ?? Date.now(),
+          bookmark.bookmarkedAt,
         );
       }
     });
-
     write.immediate();
-    const rows = db
-      .prepare(
-        `
-          SELECT
-            agent_name,
-            session_id,
-            title,
-            directory,
-            time_created,
-            time_updated,
-            stats_json,
-            bookmarked_at
-          FROM bookmarks
-          ORDER BY COALESCE(time_updated, time_created) DESC, bookmarked_at DESC
-        `,
-      )
-      .all() as BookmarkRow[];
-    return rows.map(toBookmarkRecord);
+    return readBookmarks(db);
   });
 }
 

--- a/packages/core/src/state/database.ts
+++ b/packages/core/src/state/database.ts
@@ -12,7 +12,7 @@ import {
 } from "../utils/sqlite.js";
 
 const STATE_DB_FILENAME = "state.db";
-const STATE_SCHEMA_VERSION = 2;
+const STATE_SCHEMA_VERSION = 3;
 const MEMORY_STATE_STORE = "memory";
 
 // One-shot per-process ensureSchema guard, mirroring the cache side's
@@ -62,15 +62,21 @@ function createBookmarksTable(db: SQLiteDatabase): void {
     CREATE TABLE IF NOT EXISTS bookmarks (
       agent_name TEXT NOT NULL,
       session_id TEXT NOT NULL,
-      slug TEXT NOT NULL,
-      title TEXT NOT NULL,
-      directory TEXT NOT NULL,
-      time_created INTEGER NOT NULL,
-      time_updated INTEGER,
-      stats_json TEXT NOT NULL,
       bookmarked_at INTEGER NOT NULL,
       PRIMARY KEY (agent_name, session_id)
     );
+  `);
+}
+
+function migrateBookmarkFacts(db: SQLiteDatabase): void {
+  db.exec("ALTER TABLE bookmarks RENAME TO bookmarks_with_snapshots");
+  createBookmarksTable(db);
+  db.exec(`
+    INSERT INTO bookmarks(agent_name, session_id, bookmarked_at)
+    SELECT agent_name, session_id, bookmarked_at
+    FROM bookmarks_with_snapshots;
+
+    DROP TABLE bookmarks_with_snapshots;
   `);
 }
 
@@ -154,6 +160,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
     migrations: [
       { version: 1, migrate: createBookmarksTable },
       { version: 2, migrate: createSessionAliasesTable },
+      { version: 3, destructive: true, migrate: migrateBookmarkFacts },
     ],
   });
 


### PR DESCRIPTION
## Summary

- store bookmarks as durable session references plus `bookmarkedAt` instead of copied session heads
- materialize current bookmark views from the live reference index with targeted cache fallback and explicit unavailable states
- migrate state schema v1/v2 to v3 and remove client-side snapshot synchronization

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`
- `pnpm exec playwright test tests/e2e/browsing.spec.ts --project web-chromium --grep "bookmarks a recent session"`

Issue: CS-181