### PR TITLE
test(coverage): validate critical owners

### DIFF
--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ApiProjectGroup, SessionDetail } from "../../lib/api";
+import type { AgentInfo, ApiProjectGroup, SessionDetail } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
 import { createQueryWrapper } from "../../test/query-wrapper";
+import type { LandingSession } from "../DetailLanding";
 import { AppRouteContent } from "./AppRouteContent";
 
 vi.mock("../SessionDetail", () => ({
@@ -26,6 +27,21 @@ const project = {
   cost: 0,
   agentStats: [],
 } satisfies ApiProjectGroup;
+
+const routeAgents = [
+  {
+    name: "claudecode",
+    displayName: "Claude Code",
+    count: 2,
+    resumeCommandPrefix: "claude --resume",
+  },
+  {
+    name: "codex",
+    displayName: "Codex",
+    count: 1,
+    resumeCommandPrefix: "codex resume",
+  },
+] satisfies AgentInfo[];
 
 function makeProps(): Parameters<typeof AppRouteContent>[0] {
   return {
@@ -90,6 +106,32 @@ function makeSession(id: string): SessionDetail {
     },
     messages: [],
   };
+}
+
+function makeLandingSession(agentKey: string, sessionId: string, title: string): LandingSession {
+  return {
+    id: sessionId,
+    sessionId,
+    agentKey,
+    reference: `${agentKey}/${sessionId}`,
+    slug: `${agentKey}/${sessionId}`,
+    title,
+    directory: "/repo",
+    time_created: 1,
+    time_updated: 2,
+    stats: {
+      message_count: 3,
+      total_input_tokens: 5,
+      total_output_tokens: 8,
+      total_cost: 0.1,
+    },
+  };
+}
+
+function addRouteAgents(props: ReturnType<typeof makeProps>): void {
+  props.agents = routeAgents;
+  props.agentCatalog = createAgentCatalog(routeAgents);
+  props.agentNameMap = props.agentCatalog.displayNameByKey;
 }
 
 afterEach(cleanup);
@@ -187,5 +229,90 @@ describe("AppRouteContent", () => {
     );
 
     expect(await screen.findByTestId("session-detail")).not.toBe(firstDetail);
+  });
+
+  it("renders an agent landing with encoded session links and full-reference bookmark actions", () => {
+    const props = makeProps();
+    addRouteAgents(props);
+    const sessionId = "shared/id?x#y%";
+    const claudeSession = makeLandingSession("claudecode", sessionId, "Claude opaque session");
+    const codexSession = makeLandingSession("codex", sessionId, "Codex twin session");
+    props.viewState = {
+      mode: "agent",
+      activeAgentKey: "claudecode",
+      activeSessionId: null,
+    };
+    props.sessionsByAgent = new Map([
+      ["claudecode", [claudeSession]],
+      ["codex", [codexSession]],
+    ]);
+
+    renderContent(props);
+
+    expect(screen.getByRole("heading", { name: "Claude Code" })).toBeTruthy();
+    const sessionLink = screen.getByRole("link", { name: /Claude opaque session/ });
+    expect(sessionLink.getAttribute("href")).toBe("/claudecode/shared%2Fid%3Fx%23y%25");
+    expect(screen.queryByText("Codex twin session")).toBeNull();
+    expect(props.bookmarks.isBookmarked).toHaveBeenCalledWith("claudecode", sessionId);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add bookmark" }));
+    expect(props.bookmarks.toggleSessionBookmark).toHaveBeenCalledWith(claudeSession, "claudecode");
+  });
+
+  it("renders a missing session with agent-scoped recovery links", () => {
+    const props = makeProps();
+    addRouteAgents(props);
+    const attemptedSessionId = "missing/id?#%";
+    const recoverySessionId = "recovery/id?#%";
+    const claudeSession = makeLandingSession(
+      "claudecode",
+      recoverySessionId,
+      "Claude recovery session",
+    );
+    const codexSession = makeLandingSession("codex", recoverySessionId, "Codex recovery session");
+    props.viewState = {
+      mode: "session",
+      activeAgentKey: "claudecode",
+      activeSessionId: attemptedSessionId,
+    };
+    props.sessionDetail = { session: null, loading: false, error: "not found" };
+    props.sessionsByAgent = new Map([
+      ["claudecode", [claudeSession]],
+      ["codex", [codexSession]],
+    ]);
+
+    renderContent(props);
+
+    expect(screen.getByRole("heading", { name: "This session isn't in the index." })).toBeTruthy();
+    expect(screen.getByText(attemptedSessionId)).toBeTruthy();
+    const recoveryLink = screen.getByRole("link", { name: /Claude recovery session/ });
+    expect(recoveryLink.getAttribute("href")).toBe("/claudecode/recovery%2Fid%3F%23%25");
+    expect(screen.queryByText("Codex recovery session")).toBeNull();
+    expect(props.bookmarks.isBookmarked).toHaveBeenCalledWith("claudecode", recoverySessionId);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add bookmark" }));
+    expect(props.bookmarks.toggleSessionBookmark).toHaveBeenCalledWith(claudeSession, "claudecode");
+  });
+
+  it("renders a missing agent with diagnostics and canonical recovery links", () => {
+    const props = makeProps();
+    addRouteAgents(props);
+    props.viewState = {
+      mode: "missingAgent",
+      activeAgentKey: null,
+      activeSessionId: null,
+      attemptedKey: "ghost-agent",
+    };
+
+    renderContent(props);
+
+    expect(screen.getByRole("heading", { name: "This agent isn't on the roster." })).toBeTruthy();
+    expect(screen.getByText("ghost-agent")).toBeTruthy();
+    expect(screen.getByText("/ghost-agent")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Claude Code/ }).getAttribute("href")).toBe(
+      "/claudecode",
+    );
+    expect(screen.getByRole("link", { name: /Codex/ }).getAttribute("href")).toBe("/codex");
+    expect(screen.queryByRole("button", { name: /bookmark/i })).toBeNull();
   });
 });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "bench:perf": "node scripts/benchmark-performance.mjs",
     "perf:check": "node scripts/perf-scale.mjs",
     "bench:session-index": "pnpm --filter @codesesh/core build && node scripts/benchmark-session-index.mjs",
-    "test:coverage": "vitest run --coverage",
+    "check:coverage-scopes": "node scripts/critical-coverage.mjs",
+    "test:coverage": "pnpm check:coverage-scopes && vitest run --coverage",
     "deploy:www": "pnpm --filter @codesesh/www deploy:cf"
   },
   "devDependencies": {

--- a/scripts/critical-coverage.mjs
+++ b/scripts/critical-coverage.mjs
@@ -1,0 +1,164 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CRITICAL_COVERAGE_SCOPES = [
+  {
+    id: "core-boundaries",
+    owners: [
+      { path: "packages/core/src/utils", kind: "directory" },
+      { path: "packages/core/src/discovery", kind: "directory" },
+      { path: "packages/core/src/agents/base.ts", kind: "file" },
+      { path: "packages/cli/src/api", kind: "directory" },
+    ],
+    thresholds: { lines: 90 },
+  },
+  {
+    id: "cli-runtime",
+    owners: [
+      { path: "packages/cli/src/agent-operation-scheduler.ts", kind: "file" },
+      { path: "packages/cli/src/agent-sync-engine.ts", kind: "file" },
+      { path: "packages/cli/src/backfill-lifecycle.ts", kind: "file" },
+      { path: "packages/cli/src/live-scan.ts", kind: "file" },
+      { path: "packages/cli/src/live-session-index.ts", kind: "file" },
+      { path: "packages/cli/src/pending-search-index-jobs.ts", kind: "file" },
+      { path: "packages/cli/src/scan-refresh-worker.ts", kind: "file" },
+      { path: "packages/cli/src/scan-status-model.ts", kind: "file" },
+      { path: "packages/cli/src/search-index-job-runner.ts", kind: "file" },
+      { path: "packages/cli/src/search-index-worker.ts", kind: "file" },
+      { path: "packages/cli/src/session-watcher.ts", kind: "file" },
+      { path: "packages/cli/src/smart-tag-worker.ts", kind: "file" },
+      { path: "packages/cli/src/worker-runner.ts", kind: "file" },
+    ],
+    thresholds: { lines: 91 },
+  },
+  {
+    id: "cli-runtime-plan",
+    owners: [{ path: "packages/cli/src/runtime-plan.ts", kind: "file" }],
+    thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 },
+  },
+  {
+    id: "web-hooks",
+    owners: [{ path: "apps/web/src/hooks", kind: "directory" }],
+    thresholds: { lines: 95 },
+  },
+  {
+    id: "web-interactions",
+    owners: [
+      { path: "apps/web/src/components/overview/OverviewScreen.tsx", kind: "file" },
+      { path: "apps/web/src/components/app/SearchResultsPanel.tsx", kind: "file" },
+      { path: "apps/web/src/components/session-detail/message-list.tsx", kind: "file" },
+      {
+        path: "apps/web/src/components/session-detail/session-message-timeline.tsx",
+        kind: "file",
+      },
+    ],
+    thresholds: { lines: 87 },
+  },
+  {
+    id: "web-route-recovery",
+    owners: [
+      { path: "apps/web/src/components/app/AppRouteContent.tsx", kind: "file" },
+      { path: "apps/web/src/components/DetailLanding.tsx", kind: "file" },
+    ],
+    thresholds: { lines: 85 },
+  },
+];
+
+function ownerPattern(owner) {
+  return owner.kind === "directory" ? `${owner.path}/**` : owner.path;
+}
+
+export function getCoverageScopePattern(scope) {
+  const patterns = scope.owners.map(ownerPattern);
+  return patterns.length === 1 ? patterns[0] : `{${patterns.join(",")}}`;
+}
+
+export function getCriticalCoverageThresholds(scopes = CRITICAL_COVERAGE_SCOPES) {
+  return Object.fromEntries(
+    scopes.map((scope) => [getCoverageScopePattern(scope), scope.thresholds]),
+  );
+}
+
+function isProductionSource(path) {
+  const normalized = path.split(sep).join("/");
+  return (
+    /\.(?:ts|tsx)$/.test(normalized) &&
+    !/\.test\.(?:ts|tsx)$/.test(normalized) &&
+    !normalized.includes("/__tests__/") &&
+    !normalized.endsWith(".d.ts")
+  );
+}
+
+function listProductionSources(root, path) {
+  const files = [];
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) files.push(...listProductionSources(root, child));
+    else if (entry.isFile() && isProductionSource(child)) {
+      files.push(relative(root, child).split(sep).join("/"));
+    }
+  }
+  return files;
+}
+
+export function inspectCriticalCoverageOwners(repoRoot, scopes = CRITICAL_COVERAGE_SCOPES) {
+  const gaps = [];
+  const matches = new Map();
+
+  for (const scope of scopes) {
+    const scopeMatches = [];
+    for (const owner of scope.owners) {
+      const absolutePath = join(repoRoot, owner.path);
+      if (!existsSync(absolutePath)) {
+        gaps.push(`${scope.id}: owner does not exist: ${owner.path}`);
+        continue;
+      }
+
+      const stat = statSync(absolutePath);
+      if (owner.kind === "file") {
+        if (!stat.isFile()) gaps.push(`${scope.id}: expected file owner: ${owner.path}`);
+        else if (!isProductionSource(owner.path)) {
+          gaps.push(`${scope.id}: owner is not a production TypeScript file: ${owner.path}`);
+        } else scopeMatches.push(owner.path);
+        continue;
+      }
+
+      if (!stat.isDirectory()) {
+        gaps.push(`${scope.id}: expected directory owner: ${owner.path}`);
+        continue;
+      }
+
+      const directoryMatches = listProductionSources(repoRoot, absolutePath);
+      if (directoryMatches.length === 0) {
+        gaps.push(`${scope.id}: directory owner matches no production files: ${owner.path}`);
+      }
+      scopeMatches.push(...directoryMatches);
+    }
+
+    const uniqueMatches = [...new Set(scopeMatches)].sort();
+    if (uniqueMatches.length === 0) gaps.push(`${scope.id}: scope matches no production files`);
+    matches.set(scope.id, uniqueMatches);
+  }
+
+  return { gaps, matches };
+}
+
+function main() {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const result = inspectCriticalCoverageOwners(repoRoot);
+  if (result.gaps.length > 0) {
+    console.error("Critical coverage owner validation failed:");
+    for (const gap of result.gaps) console.error(`  - ${gap}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("Critical coverage owners:");
+  for (const [scope, files] of result.matches) {
+    console.log(`  ${scope} (${files.length})`);
+    for (const file of files) console.log(`    - ${file}`);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/scripts/critical-coverage.test.mjs
+++ b/scripts/critical-coverage.test.mjs
@@ -1,0 +1,52 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  CRITICAL_COVERAGE_SCOPES,
+  getCoverageScopePattern,
+  getCriticalCoverageThresholds,
+  inspectCriticalCoverageOwners,
+} from "./critical-coverage.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("critical coverage owners", () => {
+  it("resolves every declared owner to production files", () => {
+    const result = inspectCriticalCoverageOwners(repoRoot);
+
+    expect(result.gaps).toEqual([]);
+    for (const scope of CRITICAL_COVERAGE_SCOPES) {
+      expect(result.matches.get(scope.id)?.length).toBeGreaterThan(0);
+    }
+    expect([...result.matches.values()].flat().some((path) => path.includes("/__tests__/"))).toBe(
+      false,
+    );
+  });
+
+  it("fails with the scope and path when an owner drifts", () => {
+    const result = inspectCriticalCoverageOwners(repoRoot, [
+      {
+        id: "drifted-runtime",
+        owners: [{ path: "packages/cli/src/removed-coordinator.ts", kind: "file" }],
+        thresholds: { lines: 91 },
+      },
+    ]);
+
+    expect(result.gaps).toEqual([
+      "drifted-runtime: owner does not exist: packages/cli/src/removed-coordinator.ts",
+      "drifted-runtime: scope matches no production files",
+    ]);
+  });
+
+  it("generates threshold keys from the same owner manifest", () => {
+    const runtime = CRITICAL_COVERAGE_SCOPES.find(({ id }) => id === "cli-runtime");
+    if (!runtime) throw new Error("cli-runtime coverage scope is missing");
+    expect(runtime.owners.map(({ path }) => path)).toContain(
+      "packages/cli/src/agent-sync-engine.ts",
+    );
+    expect(getCoverageScopePattern(runtime)).not.toContain("coordinator");
+    expect(getCriticalCoverageThresholds()).toHaveProperty(getCoverageScopePattern(runtime), {
+      lines: 91,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,17 +1,9 @@
 import { defineConfig } from "vitest/config";
+import { getCriticalCoverageThresholds } from "./scripts/critical-coverage.mjs";
 
 const CORE_SOURCE_SCOPE = "packages/core/src/**/*.ts";
 const CLI_SOURCE_SCOPE = "packages/cli/src/**/*.ts";
 const WEB_SOURCE_SCOPE = "apps/web/src/**/*.{ts,tsx}";
-const CORE_CRITICAL_SCOPE =
-  "{packages/core/src/utils/**,packages/core/src/discovery/**,packages/core/src/agents/base.ts,packages/cli/src/api/**}";
-const CLI_RUNTIME_SCOPE =
-  "{packages/cli/src/live-scan.ts,packages/cli/src/session-watcher.ts,packages/cli/src/*-coordinator.ts,packages/cli/src/*-worker.ts,packages/cli/src/pending-search-index-jobs.ts,packages/cli/src/scan-status-model.ts}";
-const CLI_RUNTIME_PLAN_SCOPE = "packages/cli/src/runtime-plan.ts";
-const WEB_HOOKS_SCOPE = "apps/web/src/hooks/**";
-const WEB_INTERACTIONS_SCOPE =
-  "{apps/web/src/components/overview/OverviewScreen.tsx,apps/web/src/components/app/SearchResultsPanel.tsx,apps/web/src/components/session-detail/message-list.tsx,apps/web/src/components/session-detail/session-message-timeline.tsx}";
-
 export default defineConfig({
   test: {
     projects: [
@@ -54,24 +46,7 @@ export default defineConfig({
           functions: 58,
           lines: 56,
         },
-        [CORE_CRITICAL_SCOPE]: {
-          lines: 90,
-        },
-        [CLI_RUNTIME_SCOPE]: {
-          lines: 91,
-        },
-        [CLI_RUNTIME_PLAN_SCOPE]: {
-          statements: 100,
-          branches: 100,
-          functions: 100,
-          lines: 100,
-        },
-        [WEB_HOOKS_SCOPE]: {
-          lines: 95,
-        },
-        [WEB_INTERACTIONS_SCOPE]: {
-          lines: 87,
-        },
+        ...getCriticalCoverageThresholds(),
       },
     },
   },


### PR DESCRIPTION
## Summary

- define a single owner manifest for critical coverage thresholds and fail clearly when a file or directory drifts
- align the CLI runtime coverage scope with the modules that currently own orchestration behavior
- cover agent landing, missing-session, and missing-agent recovery behavior with opaque identifiers and full-reference bookmark assertions

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`
- `pnpm test:coverage`
- `pnpm test:e2e`