### PR TITLE
refactor: centralize session source synchronization

### DIFF
--- a/docs/scanning-and-caching.md
+++ b/docs/scanning-and-caching.md
@@ -17,7 +17,7 @@ CLI
        -> scanSessions() 恢复初始快照
        -> AgentSyncEngine 协调每个 Agent 的刷新与 backfill
        -> SessionWatcher 把文件系统事件归并为 Agent 刷新
-            -> scan-refresh worker 读取/解析数据源
+            -> scan-refresh worker 调用共享 Session Source synchronization module
             -> search-index worker 持久化会话、详情与索引
             -> LiveScanStore 发布内存快照和 SSE 更新
 ```
@@ -26,8 +26,9 @@ CLI
 
 | 模块 | 职责 |
 |------|------|
-| `packages/core/src/discovery/scanner.ts` | 通用扫描、缓存恢复和同步增量合并 |
-| `packages/core/src/agents/base.ts` | 文件型/数据库型 Agent 的变更检测模板 |
+| `packages/core/src/discovery/scanner.ts` | 通用扫描、缓存恢复和 one-shot 调用策略 |
+| `packages/core/src/agents/session-source-synchronization.ts` | 文件源枚举、diff、解析、last-known-good、完整性与删除事实 |
+| `packages/core/src/agents/base.ts` | 文件型/数据库型 Agent adapter 原语与兼容入口 |
 | `packages/cli/src/live-scan.ts` | 持有当前不可变快照，对外提供订阅 |
 | `packages/cli/src/agent-sync-engine.ts` | 串行化单个 Agent 的 refresh/backfill，并协调发布 |
 | `packages/cli/src/session-watcher.ts` | 跨平台文件监听、写入稳定性等待与事件归并 |
@@ -49,6 +50,11 @@ CLI
 不同 Agent 可以并行刷新；同一个 Agent 的 refresh 与 backfill 由 `AgentSyncEngine`
 串行化，并为每次 operation 记录 generation。SQLite 搜索写入另由单一 job runner
 排队。
+
+主线程与 scan-refresh worker 之间使用封闭 operation union：`full-scan`、
+`incremental-scan`、`source-refresh`、`recompute-derived`、`full-backfill` 和
+`source-backfill`。checkpoint 只能在支持它的 operation 上声明为 `durable`；协议不使用
+多个独立的同步、派生计算、回填与持久化布尔开关，以免表达非法组合。
 
 ## 启动流程
 
@@ -76,8 +82,9 @@ loadCachedSessions()
 
 ### 文件型 Agent：源枚举 + 指纹 diff
 
-`FileSystemSessionSource.checkForChanges()` 不用缓存时间戳判断单个文件是否变化。它先由
-适配器枚举当前 `SessionSourceRef[]`：
+文件型路径统一调用 `synchronizeSessionSources(adapter, baseline, request)`。adapter 只提供
+源枚举、单源解析、依赖扩展和 meta 访问原语；同步 module 先枚举当前
+`SessionSourceRef[]`：
 
 ```typescript
 interface SessionSourceRef {
@@ -87,7 +94,7 @@ interface SessionSourceRef {
 }
 ```
 
-`diffSessionSources()` 将当前引用与缓存的会话和 `SessionCacheMeta` 比较：
+同步 module 将当前引用与 baseline 中的会话和 `SessionCacheMeta` 比较：
 
 - 缓存中没有该会话：新增；
 - `sourcePath` 改变或 `sourceFingerprint` 不同：变更；
@@ -98,8 +105,15 @@ interface SessionSourceRef {
 mtime 或解析器版本。比较采用精确字符串相等；声明版本字段的适配器可通过提升版本主动
 失效旧缓存。
 
-`incrementalScan()` 复用本次枚举得到的 refs，只对变更/新增源调用
-`scanSessionSource()`，同时移除已消失的会话。
+request 是封闭状态：`inspect` 只报告 diff，`refresh` 只解析变化源，`reload` 解析所有
+枚举源，`known-changes` 应用调用方已知的变化。返回的 closed outcome 同时携带 sessions、
+meta、detected/applied ids、显式删除、source failures、finalization ids 和
+`complete | partial`，caller 不再从 payload 形状或布尔组合反推这些事实。
+
+解析失败保留 baseline 中的 Session Head 与 meta，并把 outcome 标为 `partial`；只有明确
+filtered、解析期间 missing，或完整枚举证明 source missing 时才产生显式删除。one-shot
+scanner 与 worker adapter 都跨这个 interface；`checkForChanges()` / `incrementalScan()` 仅作为
+现有 Agent interface 的兼容入口，同样委托给该 module。
 
 ### 数据库型 Agent：数据库 mtime + 全量重扫
 
@@ -200,6 +214,7 @@ pnpm bench:perf -- --iterations 3
 
 - 新快照只能在对应 SQLite 写入成功后发布。
 - 文件型会话是否变化由 source fingerprint 决定，不由全局 mtime 截断决定。
+- one-shot 与 worker 文件源路径必须消费同一 synchronization outcome，不能各自实现 diff/merge。
 - 数据库型 Agent 检测到数据库变化后必须全量重扫。
 - 未变化会话不重新解析、不重写结构化消息。
 - 缓存详情指纹过期时不得直接返回旧消息。

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -129,7 +129,7 @@ function makeWorkerRunner(): WorkerRunner {
     run: vi.fn(async (_agentName, payload) =>
       workerResult(
         {
-          sessions: payload.derivedOnly ? payload.previousSessions : [],
+          sessions: payload.operation.kind === "recompute-derived" ? payload.previousSessions : [],
           meta: payload.meta,
         },
         payload.scanOptions.from == null && payload.scanOptions.to == null ? "complete" : "partial",
@@ -408,7 +408,7 @@ describe("AgentSyncEngine", () => {
 
     expect(workerRunner.run).toHaveBeenCalledWith(
       "codex",
-      expect.objectContaining({ derivedOnly: true, changedIds: [] }),
+      expect.objectContaining({ operation: { kind: "recompute-derived" } }),
     );
     expect(engine.snapshot().sessions[0]).toMatchObject({
       smart_tags: ["docs"],
@@ -690,7 +690,7 @@ describe("AgentSyncEngine", () => {
       "codex",
       expect.objectContaining({
         previousSessions: [steady, previous],
-        changedIds: null,
+        operation: { kind: "full-scan" },
       }),
     );
     expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.refresh", [
@@ -1066,7 +1066,7 @@ describe("AgentSyncEngine", () => {
     expect(workerRunner.run).toHaveBeenCalledTimes(2);
     expect(workerRunner.run).toHaveBeenLastCalledWith(
       "codex",
-      expect.objectContaining({ derivedOnly: true, changedIds: [] }),
+      expect.objectContaining({ operation: { kind: "recompute-derived" } }),
     );
   });
 });

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -32,6 +32,7 @@ import { appLogger, logSearchIndexSync } from "./logging.js";
 import { SearchIndexJobRunner } from "./search-index-job-runner.js";
 import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 import { ScanStatusModel } from "./scan-status-model.js";
+import type { ScanRefreshOperation } from "./scan-refresh-operation.js";
 import type { WorkerRunner } from "./worker-runner.js";
 import { toError } from "./errors.js";
 
@@ -558,7 +559,7 @@ export class AgentSyncEngine {
     this.setScanPhase("initializing");
     const scanStartedAt = performance.now();
     const scope = this.startupScanOptions();
-    const result = await this.runWorker(agent, previousSessions, null, scope);
+    const result = await this.runWorker(agent, previousSessions, { kind: "full-scan" }, scope);
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
     const sessions = attachMissingProjectIdentities(result.sessions);
     this.lastRefreshAtByAgent.set(agent.name, Date.now());
@@ -577,8 +578,7 @@ export class AgentSyncEngine {
   ): Promise<RefreshStrategyResult> {
     const scanStartedAt = performance.now();
     const scope = this.startupScanOptions();
-    const result = await this.runWorker(agent, cached.sessions, null, scope, {
-      sourceSync: true,
+    const result = await this.runWorker(agent, cached.sessions, { kind: "source-refresh" }, scope, {
       meta: cached.meta,
     });
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
@@ -617,7 +617,7 @@ export class AgentSyncEngine {
     this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
     if (!checkResult.hasChanges) {
       const scanStartedAt = performance.now();
-      const result = await this.runWorker(agent, baseline, [], {}, { derivedOnly: true });
+      const result = await this.runWorker(agent, baseline, { kind: "recompute-derived" }, {});
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
       const persistenceDiff = buildPersistenceDiff(baseline, sessions);
@@ -652,7 +652,7 @@ export class AgentSyncEngine {
     const preciseChangedIds = checkResult.changedIds ?? null;
     const scanStartedAt = performance.now();
     if (preciseChangedIds === null) {
-      const result = await this.runWorker(agent, baseline, null, {});
+      const result = await this.runWorker(agent, baseline, { kind: "full-scan" }, {});
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
       return this.refreshStrategyResult(
@@ -691,7 +691,7 @@ export class AgentSyncEngine {
     previousSessions: SessionHead[],
   ): Promise<RefreshStrategyResult> {
     const scanStartedAt = performance.now();
-    const result = await this.runWorker(agent, previousSessions, null, {});
+    const result = await this.runWorker(agent, previousSessions, { kind: "full-scan" }, {});
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
     const sessions = attachMissingProjectIdentities(result.sessions);
     this.lastRefreshAtByAgent.set(agent.name, Date.now());
@@ -733,30 +733,20 @@ export class AgentSyncEngine {
   private runWorker(
     agent: BaseAgent,
     previousSessions: SessionHead[],
-    changedIds: string[] | null,
+    operation: ScanRefreshOperation,
     scanOptions: Pick<ScanOptions, "from" | "to" | "fast">,
-    workerOptions: {
-      sourceSync?: boolean;
-      derivedOnly?: boolean;
-      backfill?: boolean;
+    runOptions: {
       backfillAttempt?: BackfillAttemptRef;
-      backfillCursor?: string | null;
-      checkpoint?: boolean;
       meta?: CachedSessions["meta"];
     } = {},
   ) {
     return this.options.workerRunner.run(agent.name, {
       previousSessions,
-      changedIds,
+      operation,
       scanOptions,
-      sourceSync: workerOptions.sourceSync,
-      derivedOnly: workerOptions.derivedOnly,
-      backfill: workerOptions.backfill,
-      backfillCursor: workerOptions.backfillCursor,
-      checkpoint: workerOptions.checkpoint,
-      meta: workerOptions.meta ?? buildAgentCacheMeta(agent),
+      meta: runOptions.meta ?? buildAgentCacheMeta(agent),
       onProgress: (progress) =>
-        this.updateAgentScanProgress(agent.name, progress, workerOptions.backfillAttempt),
+        this.updateAgentScanProgress(agent.name, progress, runOptions.backfillAttempt),
     });
   }
 
@@ -826,16 +816,17 @@ export class AgentSyncEngine {
     let durableCommitted = false;
     try {
       markAgentFullSyncStarted(agentName);
+      const operation: ScanRefreshOperation =
+        agent instanceof FileSystemSessionSource
+          ? { kind: "source-backfill", cursor: backfillCursor }
+          : { kind: "full-backfill", cursor: backfillCursor };
       const result = await this.runWorker(
         agent,
         baseline,
-        null,
+        operation,
         {},
         {
-          sourceSync: agent instanceof FileSystemSessionSource,
-          backfill: true,
           backfillAttempt: attempt,
-          backfillCursor,
           meta,
         },
       );

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -230,18 +230,25 @@ const workerThreads = vi.hoisted(() => ({
               let sessions: SessionHead[] = [];
               let changedIds: string[] | undefined;
               if (agent?.isAvailable?.() !== false) {
-                if (runData.derivedOnly) {
+                if (runData.operation?.kind === "recompute-derived") {
                   sessions = runData.previousSessions;
                 } else if (
-                  runData.sourceSync &&
+                  (runData.operation?.kind === "source-refresh" ||
+                    runData.operation?.kind === "source-backfill") &&
                   agent?.listSessionSources &&
                   agent?.scanSessionSource
                 ) {
                   const result = runSourceSync(runData, agent);
                   sessions = result.sessions as SessionHead[];
                   changedIds = result.changedIds;
-                } else if (runData.changedIds && agent?.incrementalScan) {
-                  sessions = agent.incrementalScan(runData.previousSessions, runData.changedIds);
+                } else if (
+                  runData.operation?.kind === "incremental-scan" &&
+                  agent?.incrementalScan
+                ) {
+                  sessions = agent.incrementalScan(
+                    runData.previousSessions,
+                    runData.operation.changedIds,
+                  );
                 } else {
                   sessions = agent?.scan?.({
                     ...runData.scanOptions,
@@ -270,7 +277,11 @@ const workerThreads = vi.hoisted(() => ({
                   runData.scanOptions?.from == null && runData.scanOptions?.to == null
                     ? "complete"
                     : "partial",
-                explicitRemovedSessionIds: runData.sourceSync ? delta.removedSessionIds : [],
+                explicitRemovedSessionIds:
+                  runData.operation?.kind === "source-refresh" ||
+                  runData.operation?.kind === "source-backfill"
+                    ? delta.removedSessionIds
+                    : [],
                 durationMs: 0,
               });
               continue;
@@ -814,8 +825,7 @@ describe("LiveScanStore", () => {
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
     expect(workerThreads.workers).toHaveLength(1);
     expect(workerThreads.workers[0]?.workerData).toMatchObject({
-      derivedOnly: true,
-      changedIds: [],
+      operation: { kind: "recompute-derived" },
     });
   });
 
@@ -1153,7 +1163,7 @@ describe("LiveScanStore", () => {
 
     const refresh = runner.run(agent.name, {
       previousSessions: [],
-      changedIds: null,
+      operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {},
     });
@@ -1170,7 +1180,7 @@ describe("LiveScanStore", () => {
     await expect(
       runner.run(agent.name, {
         previousSessions: [],
-        changedIds: null,
+        operation: { kind: "full-scan" },
         scanOptions: {},
         meta: {},
       }),
@@ -1192,7 +1202,7 @@ describe("LiveScanStore", () => {
 
     const refresh = runner.run(agent.name, {
       previousSessions: [],
-      changedIds: null,
+      operation: { kind: "full-scan", checkpoint: "durable" },
       scanOptions: {},
       meta: {},
       onCheckpoint: () => {
@@ -1236,7 +1246,7 @@ describe("LiveScanStore", () => {
 
     const result = await runner.run("codex", {
       previousSessions: [removed, retained],
-      changedIds: null,
+      operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {
         removed: { id: "removed", sourcePath: "/removed" },
@@ -1269,15 +1279,14 @@ describe("LiveScanStore", () => {
 
     const first = await runner.run("codex", {
       previousSessions: [],
-      changedIds: null,
+      operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {},
     });
     await expect(
       runner.run("codex", {
         previousSessions: first.sessions,
-        changedIds: [],
-        derivedOnly: true,
+        operation: { kind: "recompute-derived" },
         scanOptions: {},
         meta: first.meta,
       }),
@@ -1287,8 +1296,7 @@ describe("LiveScanStore", () => {
 
     const second = await runner.run("codex", {
       previousSessions: first.sessions,
-      changedIds: [],
-      derivedOnly: true,
+      operation: { kind: "recompute-derived" },
       scanOptions: {},
       meta: first.meta,
     });
@@ -1296,7 +1304,11 @@ describe("LiveScanStore", () => {
       .map(([request]) => request)
       .find((request) => request.type === "run");
 
-    expect(runRequest).toMatchObject({ type: "run", generation: 1, changedIds: [] });
+    expect(runRequest).toMatchObject({
+      type: "run",
+      generation: 1,
+      operation: { kind: "recompute-derived" },
+    });
     expect(runRequest).not.toHaveProperty("previousSessions");
     expect(runRequest).not.toHaveProperty("meta");
     expect(second.sessions).toEqual([session]);
@@ -1306,7 +1318,7 @@ describe("LiveScanStore", () => {
     worker.emitExit(1);
     await runner.run("codex", {
       previousSessions: second.sessions,
-      changedIds: null,
+      operation: { kind: "full-scan" },
       scanOptions: {},
       meta: second.meta,
     });
@@ -1326,7 +1338,7 @@ describe("LiveScanStore", () => {
 
     await runner.run("codex", {
       previousSessions: [lastKnownGood],
-      changedIds: null,
+      operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {},
     });
@@ -1336,7 +1348,7 @@ describe("LiveScanStore", () => {
     expect(discardedWorker.terminate).toHaveBeenCalledTimes(1);
     await runner.run("codex", {
       previousSessions: [lastKnownGood],
-      changedIds: null,
+      operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {},
     });
@@ -1357,7 +1369,7 @@ describe("LiveScanStore", () => {
 
     const refresh = runner.run("codex", {
       previousSessions: [],
-      changedIds: null,
+      operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {},
     });
@@ -1382,7 +1394,7 @@ describe("LiveScanStore", () => {
     workerThreads.deferScanRefreshWorkers = false;
     await runner.run("codex", {
       previousSessions: [],
-      changedIds: null,
+      operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {},
     });

--- a/packages/cli/src/scan-refresh-operation.test.ts
+++ b/packages/cli/src/scan-refresh-operation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  isBackfillOperation,
+  synchronizesSessionSources,
+  usesDurableCheckpoints,
+  type ScanRefreshOperation,
+} from "./scan-refresh-operation.js";
+
+describe("ScanRefreshOperation", () => {
+  it.each<{
+    operation: ScanRefreshOperation;
+    sourceSynchronization: boolean;
+    backfill: boolean;
+    durableCheckpoints: boolean;
+  }>([
+    {
+      operation: { kind: "full-scan" },
+      sourceSynchronization: false,
+      backfill: false,
+      durableCheckpoints: false,
+    },
+    {
+      operation: { kind: "incremental-scan", changedIds: ["one"] },
+      sourceSynchronization: false,
+      backfill: false,
+      durableCheckpoints: false,
+    },
+    {
+      operation: { kind: "source-refresh", checkpoint: "durable" },
+      sourceSynchronization: true,
+      backfill: false,
+      durableCheckpoints: true,
+    },
+    {
+      operation: { kind: "recompute-derived" },
+      sourceSynchronization: false,
+      backfill: false,
+      durableCheckpoints: false,
+    },
+    {
+      operation: { kind: "full-backfill", cursor: "cursor" },
+      sourceSynchronization: false,
+      backfill: true,
+      durableCheckpoints: false,
+    },
+    {
+      operation: { kind: "source-backfill", cursor: "cursor", checkpoint: "durable" },
+      sourceSynchronization: true,
+      backfill: true,
+      durableCheckpoints: true,
+    },
+  ])(
+    "classifies $operation.kind without boolean mode inference",
+    ({ operation, sourceSynchronization, backfill, durableCheckpoints }) => {
+      expect(synchronizesSessionSources(operation)).toBe(sourceSynchronization);
+      expect(isBackfillOperation(operation)).toBe(backfill);
+      expect(usesDurableCheckpoints(operation)).toBe(durableCheckpoints);
+    },
+  );
+});

--- a/packages/cli/src/scan-refresh-operation.ts
+++ b/packages/cli/src/scan-refresh-operation.ts
@@ -1,0 +1,28 @@
+type DurableCheckpoint = { checkpoint?: "durable" };
+
+export type ScanRefreshOperation =
+  | ({ kind: "full-scan" } & DurableCheckpoint)
+  | { kind: "incremental-scan"; changedIds: string[] }
+  | ({ kind: "source-refresh" } & DurableCheckpoint)
+  | { kind: "recompute-derived" }
+  | ({ kind: "full-backfill"; cursor?: string | null } & DurableCheckpoint)
+  | ({ kind: "source-backfill"; cursor?: string | null } & DurableCheckpoint);
+
+export type BackfillScanRefreshOperation = Extract<
+  ScanRefreshOperation,
+  { kind: "full-backfill" | "source-backfill" }
+>;
+
+export function synchronizesSessionSources(operation: ScanRefreshOperation): boolean {
+  return operation.kind === "source-refresh" || operation.kind === "source-backfill";
+}
+
+export function isBackfillOperation(
+  operation: ScanRefreshOperation,
+): operation is BackfillScanRefreshOperation {
+  return operation.kind === "full-backfill" || operation.kind === "source-backfill";
+}
+
+export function usesDurableCheckpoints(operation: ScanRefreshOperation): boolean {
+  return "checkpoint" in operation && operation.checkpoint === "durable";
+}

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -88,11 +88,8 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     sessionSignature: actual.sessionSignature,
     SMART_TAG_CLASSIFIER_REVISION: "smart-tags-v1",
     sortSessions: actual.sortSessions,
-    // The change decision is shared with FileSystemSessionSource.checkForChanges;
-    // stubbing it would stop this suite from covering the wiring it exists to test.
-    diffSessionSources: actual.diffSessionSources,
-    // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
-    setCoreDiagnostics: vi.fn(),
+    synchronizeSessionSources: actual.synchronizeSessionSources,
+    setCoreDiagnostics: actual.setCoreDiagnostics,
   };
 });
 
@@ -123,6 +120,8 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
     incrementalScan: vi.fn(() => []),
     listSessionSources: vi.fn(() => []),
     scanSessionSource: vi.fn(() => null),
+    expandChangedSessionIds: vi.fn((changedIds: string[]) => changedIds),
+    filterCachedSessions: vi.fn((sessions: SessionHead[]) => sessions),
     getSessionData: vi.fn(),
     getSessionMetaMap: vi.fn(() => sessionMetaMap),
     setSessionMetaMap: vi.fn((next: Map<string, SessionCacheMeta>) => {
@@ -132,13 +131,17 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
   });
 }
 
+function makeGenericAgent(overrides: Record<string, unknown> = {}) {
+  return { ...makeAgent(overrides) };
+}
+
 function setWorkerData(overrides: Record<string, unknown> = {}) {
   mocks.workerData = {
     type: "run",
     requestId: 1,
     agentName: "codex",
     previousSessions: [],
-    changedIds: null,
+    operation: { kind: "full-scan" },
     scanOptions: { fast: true },
     meta: {},
     ...overrides,
@@ -198,7 +201,7 @@ describe("scan refresh worker entry", () => {
         return [session];
       },
     );
-    const agent = makeAgent({
+    const agent = makeGenericAgent({
       scan,
       getSessionMetaMap: vi.fn(() => new Map([["fresh", { sourcePath: "/fresh" }]])),
     });
@@ -231,7 +234,7 @@ describe("scan refresh worker entry", () => {
       }
       return [];
     });
-    mocks.createRegisteredAgents.mockReturnValue([makeAgent({ scan })]);
+    mocks.createRegisteredAgents.mockReturnValue([makeGenericAgent({ scan })]);
 
     try {
       await runWorker();
@@ -254,7 +257,7 @@ describe("scan refresh worker entry", () => {
   it("reuses a committed baseline without receiving the full history again", async () => {
     const session = makeSession("stateful");
     const scan = vi.fn(() => [session]);
-    mocks.createRegisteredAgents.mockReturnValue([makeAgent({ scan })]);
+    mocks.createRegisteredAgents.mockReturnValue([makeGenericAgent({ scan })]);
     setWorkerData({ generation: 4 });
 
     await runWorker();
@@ -270,8 +273,7 @@ describe("scan refresh worker entry", () => {
       requestId: 2,
       agentName: "codex",
       generation: 5,
-      changedIds: [],
-      derivedOnly: true,
+      operation: { kind: "recompute-derived" },
       scanOptions: {},
     });
 
@@ -306,8 +308,7 @@ describe("scan refresh worker entry", () => {
       requestId: 2,
       agentName: "codex",
       generation: 4,
-      changedIds: [],
-      derivedOnly: true,
+      operation: { kind: "recompute-derived" },
       scanOptions: {},
     });
 
@@ -333,7 +334,7 @@ describe("scan refresh worker entry", () => {
       getSessionMetaMap: vi.fn(() => new Map([["fresh", { sourcePath: "/fresh" }]])),
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
-    setWorkerData({ checkpoint: true });
+    setWorkerData({ operation: { kind: "full-scan", checkpoint: "durable" } });
 
     await runWorker();
 
@@ -360,7 +361,7 @@ describe("scan refresh worker entry", () => {
     const agent = makeAgent({ scan: vi.fn(() => []) });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      checkpoint: true,
+      operation: { kind: "full-scan", checkpoint: "durable" },
       scanOptions: { fast: true, from: 1 },
     });
 
@@ -390,7 +391,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      checkpoint: true,
+      operation: { kind: "full-scan", checkpoint: "durable" },
       previousSessions: [cached],
       meta: {
         cached: { id: "cached", sourcePath: "/cached", sourceFingerprint: "old" },
@@ -428,7 +429,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
+      operation: { kind: "source-refresh" },
       previousSessions: [makeSession("changed")],
       meta: {
         changed: {
@@ -469,8 +470,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
-      checkpoint: true,
+      operation: { kind: "source-refresh", checkpoint: "durable" },
       previousSessions: [unchanged, makeSession(changed.id, { time_created: 1, time_updated: 1 })],
       meta: {
         unchanged: {
@@ -522,7 +522,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
+      operation: { kind: "source-refresh" },
       previousSessions: [parent, makeSession("child")],
       meta: {
         parent: { id: "parent", sourcePath: "/parent", sourceFingerprint: "same" },
@@ -567,10 +567,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
-      backfill: true,
-      backfillCursor: cursor.id,
-      checkpoint: true,
+      operation: { kind: "source-backfill", cursor: cursor.id, checkpoint: "durable" },
       previousSessions: [newest, cursor, next],
       meta: Object.fromEntries(
         [newest, cursor, next].map((session) => [
@@ -610,7 +607,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
+      operation: { kind: "source-refresh" },
       previousSessions: [recent, old],
       scanOptions: { from: 5, fast: true },
       meta: {
@@ -646,7 +643,7 @@ describe("scan refresh worker entry", () => {
   it("returns a head when only its metadata changes", async () => {
     const session = makeSession("same");
     let meta = new Map<string, SessionCacheMeta>();
-    const agent = makeAgent({
+    const agent = makeGenericAgent({
       scan: vi.fn(() => {
         meta.set("same", {
           id: "same",
@@ -697,7 +694,10 @@ describe("scan refresh worker entry", () => {
     const incrementalScan = vi.fn(() => Promise.resolve([updated]));
     const agent = makeAgent({ incrementalScan });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
-    setWorkerData({ previousSessions: [previous], changedIds: ["previous"] });
+    setWorkerData({
+      previousSessions: [previous],
+      operation: { kind: "incremental-scan", changedIds: ["previous"] },
+    });
 
     await runWorker();
 
@@ -723,7 +723,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
+      operation: { kind: "source-refresh" },
       previousSessions: [session],
       meta: {
         unchanged: {
@@ -757,7 +757,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
+      operation: { kind: "source-refresh" },
       previousSessions: [recent],
       scanOptions: { from: 5, fast: true },
       meta: {
@@ -813,7 +813,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
+      operation: { kind: "source-refresh" },
       previousSessions: [unchanged, changed, removed, outsideWindow, moved],
       // from: 5 puts `outside` (mtime 0) before the window and `removed`
       // (mtime 10) inside it, so only the latter counts as deleted on disk.
@@ -870,7 +870,7 @@ describe("scan refresh worker entry", () => {
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      sourceSync: true,
+      operation: { kind: "source-refresh" },
       previousSessions: [cached],
       meta: {
         // Written by an older parser version: same file, but the head it produced

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -6,25 +6,30 @@ import {
   buildAgentCacheMeta,
   computeSessionDiff,
   createRegisteredAgents,
-  diffSessionSources,
   ensureSessionTagsSync,
   FileSystemSessionSource,
   sessionSignature,
   SMART_TAG_CLASSIFIER_REVISION,
   sortSessions,
+  synchronizeSessionSources,
   type AgentScanProgress,
   type BaseAgent,
   type ScanOptions,
   type SessionCacheMeta,
   type SessionHead,
   type SessionHeadChange,
-  type SessionSourceAbsenceOutcome,
   type SessionSourceFailure,
   type SessionSnapshotCompleteness,
   type SessionTagTiming,
 } from "@codesesh/core";
 import { appLogger } from "./logging.js";
 import { MonotonicValueSampler } from "./monotonic-value-sampler.js";
+import {
+  isBackfillOperation,
+  synchronizesSessionSources,
+  usesDurableCheckpoints,
+  type ScanRefreshOperation,
+} from "./scan-refresh-operation.js";
 
 export type ScanRefreshWorkerMessage =
   | {
@@ -80,12 +85,7 @@ export interface ScanRefreshWorkerRunRequest {
   agentName: string;
   generation: number;
   previousSessions?: SessionHead[];
-  changedIds: string[] | null;
-  sourceSync?: boolean;
-  derivedOnly?: boolean;
-  backfill?: boolean;
-  backfillCursor?: string | null;
-  checkpoint?: boolean;
+  operation: ScanRefreshOperation;
   scanOptions: Pick<ScanOptions, "from" | "to" | "fast">;
   meta?: Record<string, SessionCacheMeta>;
 }
@@ -173,124 +173,6 @@ function selectBackfillSessions(
   }
 
   return { orderedSessions, finalizeSessionIds, cursorIndex };
-}
-
-/**
- * Source-level incremental sync. The change decision itself lives in
- * diffSessionSources so this path and FileSystemSessionSource.checkForChanges
- * cannot drift; only the expansion, re-parse and merge are local, because the
- * worker holds cached meta received over workerData rather than the agent's
- * live metaMap.
- */
-function syncAgentSources(
-  agent: FileSystemSessionSource,
-  cachedSessions: SessionHead[],
-  cachedMeta: Record<string, SessionCacheMeta>,
-  windowOptions?: Pick<ScanOptions, "from" | "to">,
-  onProgress?: (progress: AgentScanProgress) => void,
-): {
-  sessions: SessionHead[];
-  changedIds: string[];
-  finalizeSessionIds: string[];
-  sourceCount: number;
-  removedCount: number;
-  explicitRemovedSessionIds: string[];
-  sourceFailures: SessionSourceFailure[];
-} {
-  const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
-  const sourceRefs = agent.listSessionSources(windowOptions);
-  const sourceById = new Map(sourceRefs.map((source) => [source.sessionId, source]));
-  const { changedIds, removedIds, sourceOutcomes } = diffSessionSources(
-    sourceRefs,
-    cachedSessions,
-    cachedMeta,
-    windowOptions,
-  );
-  // Expansion pulls in sessions whose derived data depends on the changed ones
-  // (e.g. parents of changed subagent files), so a targeted re-parse stays
-  // correct without rescanning the whole directory.
-  const rescanIds = agent.expandChangedSessionIds?.(
-    [...new Set([...changedIds, ...removedIds])],
-    sourceRefs,
-  ) ?? [...new Set([...changedIds, ...removedIds])];
-  const isWindowed = windowOptions?.from != null || windowOptions?.to != null;
-  const sourceFailures = sourceOutcomes.flatMap((outcome) =>
-    outcome.status === "failed" ? [outcome.failure] : [],
-  );
-  for (const outcome of sourceOutcomes) logAbsentSourceOutcome(agent.name, outcome);
-  const appliedIds = new Set(removedIds);
-  const explicitRemovedSessionIds = new Set(removedIds);
-
-  rescanIds.forEach((sessionId, index) => {
-    const source = sourceById.get(sessionId);
-    if (!source) return;
-    const outcome = agent.scanSessionSourceOutcome(source);
-    if (outcome.status === "parsed") {
-      sessionMap.set(outcome.session.id, outcome.session);
-      appliedIds.add(sessionId);
-    } else if (outcome.status === "filtered" || outcome.status === "missing") {
-      sessionMap.delete(sessionId);
-      agent.getSessionMetaMap().delete(sessionId);
-      appliedIds.add(sessionId);
-      explicitRemovedSessionIds.add(sessionId);
-      appLogger.info("agent.session_source_outcome", {
-        agent: agent.name,
-        session_id: sessionId,
-        source_path: source.sourcePath,
-        outcome: outcome.status,
-        ...(outcome.status === "filtered" ? { reason: outcome.reason } : {}),
-      });
-    } else {
-      sourceFailures.push(outcome.failure);
-      appLogger.warn("agent.session_source_outcome", {
-        agent: agent.name,
-        session_id: outcome.failure.sessionId,
-        source_path: outcome.failure.sourcePath,
-        outcome: outcome.status,
-        stage: outcome.failure.stage,
-        error_class: outcome.failure.errorClass,
-        message: outcome.failure.message,
-      });
-    }
-    onProgress?.({ total: rescanIds.length, processed: index + 1, sessions: sessionMap.size });
-  });
-
-  for (const sessionId of removedIds) sessionMap.delete(sessionId);
-  const failedIdSet = new Set(sourceFailures.map((failure) => failure.sessionId));
-  const finalizeSessionIds = (
-    isWindowed ? [...appliedIds] : sourceRefs.map((source) => source.sessionId)
-  ).filter((sessionId) => !failedIdSet.has(sessionId));
-
-  return {
-    sessions: [...sessionMap.values()],
-    changedIds: [...appliedIds],
-    finalizeSessionIds,
-    sourceCount: sourceRefs.length,
-    removedCount: removedIds.length,
-    explicitRemovedSessionIds: [...explicitRemovedSessionIds],
-    sourceFailures,
-  };
-}
-
-function logAbsentSourceOutcome(agentName: string, outcome: SessionSourceAbsenceOutcome): void {
-  if (outcome.status === "missing") {
-    appLogger.info("agent.session_source_outcome", {
-      agent: agentName,
-      session_id: outcome.source.sessionId,
-      source_path: outcome.source.sourcePath,
-      outcome: outcome.status,
-    });
-    return;
-  }
-  appLogger.warn("agent.session_source_outcome", {
-    agent: agentName,
-    session_id: outcome.failure.sessionId,
-    source_path: outcome.failure.sourcePath,
-    outcome: outcome.status,
-    stage: outcome.failure.stage,
-    error_class: outcome.failure.errorClass,
-    message: outcome.failure.message,
-  });
 }
 
 /**
@@ -446,13 +328,17 @@ async function run(
   const { agent } = baseline;
   const previousSessions = baseline.sessions;
   const previousMeta = baseline.meta;
+  const operation = data.operation;
+  const sourceSynchronization = synchronizesSessionSources(operation);
+  const backfill = isBackfillOperation(operation);
+  const durableCheckpoints = usesDurableCheckpoints(operation);
+  const backfillCursor = backfill ? operation.cursor : undefined;
 
   appLogger.debug("scan.refresh_worker.started", {
     agent: data.agentName,
-    source_sync: data.sourceSync ?? false,
-    backfill: data.backfill ?? false,
-    backfill_cursor: data.backfillCursor ?? undefined,
-    changed_ids: data.changedIds?.length ?? 0,
+    operation: operation.kind,
+    backfill_cursor: backfillCursor ?? undefined,
+    changed_ids: operation.kind === "incremental-scan" ? operation.changedIds.length : 0,
     previous_sessions: previousSessions.length,
   });
 
@@ -468,7 +354,7 @@ async function run(
   let finalizeSessionIds: ReadonlySet<string> | undefined;
   let backfillOrder: SessionHead[] | undefined;
   let backfillCursorIndex = -1;
-  let sourceSyncDetails:
+  let sourceSynchronizationDetails:
     | {
         sourceCount: number;
         removedCount: number;
@@ -477,27 +363,45 @@ async function run(
 
   if (!isAvailable) {
     sessions = [];
-  } else if (data.derivedOnly) {
+  } else if (operation.kind === "recompute-derived") {
     sessions = previousSessions;
-  } else if (
-    agent instanceof FileSystemSessionSource &&
-    (data.sourceSync === true || data.checkpoint === true)
-  ) {
-    const result = syncAgentSources(
+  } else if (sourceSynchronization) {
+    if (!(agent instanceof FileSystemSessionSource)) {
+      throw new Error(`Agent ${agent.name} does not support Session Source synchronization`);
+    }
+    const result = synchronizeSessionSources(
       agent,
-      previousSessions,
-      previousMeta,
-      data.scanOptions,
-      reportProgress,
+      { sessions: previousSessions, meta: previousMeta },
+      {
+        kind: "refresh",
+        scanOptions: { ...data.scanOptions, onProgress: reportProgress },
+      },
     );
     sessions = result.sessions;
-    changedIds = result.changedIds;
+    changedIds = result.changedSessionIds;
     finalizeSessionIds = new Set(result.finalizeSessionIds);
-    sourceSyncDetails = result;
+    sourceSynchronizationDetails = {
+      sourceCount: result.sourceCount,
+      removedCount: result.removedSourceCount,
+    };
     sourceFailures = result.sourceFailures;
     explicitRemovedSessionIds = result.explicitRemovedSessionIds;
-  } else if (data.changedIds) {
-    sessions = await Promise.resolve(agent.incrementalScan(previousSessions, data.changedIds));
+  } else if (operation.kind === "incremental-scan") {
+    changedIds = operation.changedIds;
+    sessions = await Promise.resolve(agent.incrementalScan(previousSessions, operation.changedIds));
+  } else if (agent instanceof FileSystemSessionSource) {
+    const result = synchronizeSessionSources(
+      agent,
+      { sessions: previousSessions, meta: previousMeta },
+      {
+        kind: "reload",
+        scanOptions: { ...data.scanOptions, onProgress: reportProgress },
+      },
+    );
+    sessions = result.sessions;
+    finalizeSessionIds = new Set(result.finalizeSessionIds);
+    sourceFailures = result.sourceFailures;
+    explicitRemovedSessionIds = result.explicitRemovedSessionIds;
   } else {
     sessions = await Promise.resolve(
       agent.scan({
@@ -512,7 +416,7 @@ async function run(
     data.scanOptions.from == null && data.scanOptions.to == null && sourceFailures.length === 0
       ? "complete"
       : "partial";
-  if (data.checkpoint) {
+  if (durableCheckpoints) {
     const ordered = sortSessions(sessions);
     parentPort?.postMessage({
       type: "checkpoint",
@@ -528,8 +432,8 @@ async function run(
     sessions = ordered;
   }
 
-  if (data.backfill) {
-    const selection = selectBackfillSessions(sessions, changedIds ?? [], data.backfillCursor);
+  if (backfill) {
+    const selection = selectBackfillSessions(sessions, changedIds ?? [], backfillCursor);
     sessions = selection.orderedSessions;
     finalizeSessionIds = selection.finalizeSessionIds;
     backfillOrder = selection.orderedSessions;
@@ -539,13 +443,12 @@ async function run(
   const scanDuration = performance.now() - startedAt;
   appLogger.debug("scan.refresh_worker.scanned", {
     agent: data.agentName,
-    source_sync: data.sourceSync ?? false,
-    backfill: data.backfill ?? false,
-    backfill_cursor: data.backfillCursor ?? undefined,
+    operation: operation.kind,
+    backfill_cursor: backfillCursor ?? undefined,
     sessions: sessions.length,
     changed_ids: changedIds?.length ?? 0,
-    source_count: sourceSyncDetails?.sourceCount,
-    removed_count: sourceSyncDetails?.removedCount,
+    source_count: sourceSynchronizationDetails?.sourceCount,
+    removed_count: sourceSynchronizationDetails?.removedCount,
     failed_sources: sourceFailures.length,
     duration_ms: Math.round(scanDuration),
   });
@@ -559,7 +462,7 @@ async function run(
     agent,
     sessions,
     reportProgress,
-    data.checkpoint
+    durableCheckpoints
       ? (checkpoint) => {
           let nextCheckpoint = checkpoint;
           if (checkpoint.stage === "finalizing" && backfillOrder && backfillPositionById) {
@@ -611,7 +514,7 @@ async function run(
   );
   appLogger.debug("scan.refresh_worker.finalized", {
     agent: data.agentName,
-    backfill: data.backfill ?? false,
+    operation: operation.kind,
     backfill_cursor: backfillOrder?.[backfillCursorIndex]?.id,
     sessions: sessions.length,
     finalized_sessions: finalizationTiming.sessions,
@@ -727,6 +630,7 @@ if (
   initialRequest?.type === "run" &&
   typeof initialRequest.requestId === "number" &&
   typeof initialRequest.agentName === "string" &&
+  initialRequest.operation != null &&
   Array.isArray(initialRequest.previousSessions) &&
   initialRequest.meta != null
 ) {

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -15,16 +15,12 @@ import type {
   ScanRefreshWorkerMessage,
   ScanRefreshWorkerRunRequest,
 } from "./scan-refresh-worker.js";
+import { synchronizesSessionSources, type ScanRefreshOperation } from "./scan-refresh-operation.js";
 import { toError } from "./errors.js";
 
 export interface WorkerPayload {
   previousSessions: SessionHead[];
-  changedIds: string[] | null;
-  sourceSync?: boolean;
-  derivedOnly?: boolean;
-  backfill?: boolean;
-  backfillCursor?: string | null;
-  checkpoint?: boolean;
+  operation: ScanRefreshOperation;
   scanOptions: Pick<ScanOptions, "from" | "to" | "fast">;
   meta: Record<string, SessionCacheMeta>;
   onProgress?: (progress: AgentScanProgress) => void;
@@ -138,12 +134,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       requestId: this.nextRequestId++,
       agentName,
       generation,
-      changedIds: payload.changedIds,
-      sourceSync: payload.sourceSync,
-      derivedOnly: payload.derivedOnly,
-      backfill: payload.backfill,
-      backfillCursor: payload.backfillCursor,
-      checkpoint: payload.checkpoint,
+      operation: payload.operation,
       scanOptions: payload.scanOptions,
       ...(existingSlot ? {} : { previousSessions: payload.previousSessions, meta: payload.meta }),
     };
@@ -290,7 +281,9 @@ export class ThreadWorkerRunner implements WorkerRunner {
           message.removedSessionIds,
         ),
         meta: applyMetaChanges(pending.payload.meta, message.meta, removedMetaIds),
-        changedIds: pending.payload.sourceSync ? replacedSessionIds : undefined,
+        changedIds: synchronizesSessionSources(pending.payload.operation)
+          ? replacedSessionIds
+          : undefined,
         sourceFailures: message.sourceFailures,
         completeness: message.completeness,
         explicitRemovedSessionIds: message.explicitRemovedSessionIds,

--- a/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
+++ b/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
@@ -1,0 +1,279 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { SessionHead } from "../../types/index.js";
+import {
+  createSessionSourceFailure,
+  synchronizeSessionSources,
+  type SessionCacheMeta,
+  type SessionSourceOutcome,
+  type SessionSourceRef,
+  type SessionSourceSynchronizationAdapter,
+} from "../base.js";
+
+function session(id: string, title = id): SessionHead {
+  return {
+    id,
+    slug: `test/${id}`,
+    title,
+    directory: "/workspace",
+    time_created: 1,
+    time_updated: 2,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+function source(sessionId: string, fingerprint = "current"): SessionSourceRef {
+  return { sessionId, sourcePath: `/${sessionId}`, fingerprint };
+}
+
+function meta(ref: SessionSourceRef, sourceMtimeMs = 2): SessionCacheMeta {
+  return {
+    id: ref.sessionId,
+    sourcePath: ref.sourcePath,
+    sourceFingerprint: ref.fingerprint,
+    sourceMtimeMs,
+  };
+}
+
+class MemorySourceAdapter implements SessionSourceSynchronizationAdapter {
+  readonly name = "memory";
+  listCalls = 0;
+  scannedIds: string[] = [];
+  listError: Error | null = null;
+  private meta = new Map<string, SessionCacheMeta>();
+
+  constructor(
+    private sources: SessionSourceRef[],
+    private outcomes: Map<string, SessionSourceOutcome>,
+    private readonly expandedIds: string[] | null = null,
+    private readonly visibleIds: Set<string> | null = null,
+  ) {}
+
+  setSources(sources: SessionSourceRef[]): void {
+    this.sources = sources;
+  }
+
+  setOutcomes(outcomes: Map<string, SessionSourceOutcome>): void {
+    this.outcomes = outcomes;
+  }
+
+  listSessionSources(): SessionSourceRef[] {
+    this.listCalls += 1;
+    if (this.listError) throw this.listError;
+    return this.sources;
+  }
+
+  scanSessionSourceOutcome(sourceRef: SessionSourceRef): SessionSourceOutcome {
+    this.scannedIds.push(sourceRef.sessionId);
+    const outcome = this.outcomes.get(sourceRef.sessionId);
+    if (!outcome) throw new Error(`Missing outcome for ${sourceRef.sessionId}`);
+    if (outcome.status === "parsed") this.meta.set(sourceRef.sessionId, meta(sourceRef));
+    return outcome;
+  }
+
+  expandChangedSessionIds(changedIds: string[]): string[] {
+    return this.expandedIds ?? changedIds;
+  }
+
+  filterCachedSessions(sessions: SessionHead[]): SessionHead[] {
+    return this.visibleIds
+      ? sessions.filter((session) => this.visibleIds!.has(session.id))
+      : sessions;
+  }
+
+  getSessionMetaMap(): Map<string, SessionCacheMeta> {
+    return this.meta;
+  }
+
+  setSessionMetaMap(metaMap: Map<string, SessionCacheMeta>): void {
+    this.meta = metaMap;
+  }
+}
+
+function parsed(ref: SessionSourceRef, head: SessionHead): SessionSourceOutcome {
+  return { status: "parsed", source: ref, session: head };
+}
+
+describe("synchronizeSessionSources", () => {
+  it("refreshes changed sources, expands dependencies, and removes proven absences", () => {
+    const unchangedRef = source("unchanged", "same");
+    const changedRef = source("changed", "new");
+    const parentRef = source("parent", "same");
+    const removedPath = join(tmpdir(), "codesesh-session-source-sync-removed");
+    const removedRef = { ...source("removed", "old"), sourcePath: removedPath };
+    const updated = session("changed", "updated");
+    const parent = session("parent", "recomputed");
+    const adapter = new MemorySourceAdapter(
+      [unchangedRef, changedRef, parentRef],
+      new Map([
+        ["changed", parsed(changedRef, updated)],
+        ["parent", parsed(parentRef, parent)],
+      ]),
+      ["changed", "removed", "parent"],
+    );
+
+    const outcome = synchronizeSessionSources(
+      adapter,
+      {
+        sessions: [
+          session("unchanged"),
+          session("changed", "old"),
+          session("parent", "old parent"),
+          session("removed"),
+        ],
+        meta: {
+          unchanged: meta(unchangedRef),
+          changed: meta(source("changed", "old")),
+          parent: meta(parentRef),
+          removed: meta(removedRef),
+        },
+      },
+      { kind: "refresh" },
+    );
+
+    expect(adapter.scannedIds).toEqual(["changed", "parent"]);
+    expect(adapter.listCalls).toBe(1);
+    expect(outcome.sessions.map(({ id }) => id)).toEqual(["unchanged", "changed", "parent"]);
+    expect(outcome.sessions.find(({ id }) => id === "changed")?.title).toBe("updated");
+    expect(outcome.detectedSessionIds).toEqual(["changed", "removed"]);
+    expect(outcome.changedSessionIds).toEqual(["removed", "changed", "parent"]);
+    expect(outcome.explicitRemovedSessionIds).toEqual(["removed"]);
+    expect(outcome.completeness).toBe("complete");
+  });
+
+  it("keeps sources outside a scoped enumeration and marks the outcome partial", () => {
+    const recentRef = source("recent", "new");
+    const recent = session("recent", "updated");
+    const adapter = new MemorySourceAdapter(
+      [recentRef],
+      new Map([["recent", parsed(recentRef, recent)]]),
+    );
+
+    const outcome = synchronizeSessionSources(
+      adapter,
+      {
+        sessions: [session("recent", "old"), session("outside")],
+        meta: {
+          recent: meta(source("recent", "old"), 200),
+          outside: meta(source("outside", "old"), 10),
+        },
+      },
+      { kind: "refresh", scanOptions: { from: 100 } },
+    );
+
+    expect(outcome.sessions.map(({ id }) => id)).toEqual(["recent", "outside"]);
+    expect(outcome.explicitRemovedSessionIds).toEqual([]);
+    expect(outcome.finalizeSessionIds).toEqual(["recent"]);
+    expect(outcome.completeness).toBe("partial");
+  });
+
+  it("retains last-known-good facts on failure and converges after retry", () => {
+    const ref = source("retry", "new");
+    const before = session("retry", "before");
+    const failure = createSessionSourceFailure(ref, "parsing", new Error("truncated JSON"));
+    const adapter = new MemorySourceAdapter(
+      [ref],
+      new Map([["retry", { status: "failed", failure }]]),
+    );
+    const baseline = {
+      sessions: [before],
+      meta: { retry: meta(source("retry", "old")) },
+    };
+
+    const failed = synchronizeSessionSources(adapter, baseline, { kind: "refresh" });
+
+    expect(failed.sessions).toEqual([before]);
+    expect(failed.meta.retry?.sourceFingerprint).toBe("old");
+    expect(failed.sourceFailures).toEqual([failure]);
+    expect(failed.completeness).toBe("partial");
+
+    const recovered = session("retry", "recovered");
+    adapter.setOutcomes(new Map([["retry", parsed(ref, recovered)]]));
+    const retried = synchronizeSessionSources(
+      adapter,
+      { sessions: failed.sessions, meta: failed.meta },
+      { kind: "refresh" },
+    );
+    const repeated = synchronizeSessionSources(
+      adapter,
+      { sessions: retried.sessions, meta: retried.meta },
+      { kind: "refresh" },
+    );
+
+    expect(retried.sessions).toEqual([recovered]);
+    expect(retried.completeness).toBe("complete");
+    expect(repeated.sessions).toEqual(retried.sessions);
+    expect(repeated.changedSessionIds).toEqual([]);
+    expect(adapter.scannedIds).toEqual(["retry", "retry"]);
+  });
+
+  it("reloads every enumerated source and removes explicitly filtered sessions", () => {
+    const visibleRef = source("visible");
+    const filteredRef = source("filtered");
+    const adapter = new MemorySourceAdapter(
+      [visibleRef, filteredRef],
+      new Map([
+        ["visible", parsed(visibleRef, session("visible", "reloaded"))],
+        ["filtered", { status: "filtered", source: filteredRef, reason: "no visible messages" }],
+      ]),
+    );
+
+    const outcome = synchronizeSessionSources(
+      adapter,
+      {
+        sessions: [session("visible", "cached"), session("filtered")],
+        meta: { visible: meta(visibleRef), filtered: meta(filteredRef) },
+      },
+      { kind: "reload" },
+    );
+
+    expect(adapter.scannedIds).toEqual(["visible", "filtered"]);
+    expect(outcome.sessions).toEqual([session("visible", "reloaded")]);
+    expect(outcome.explicitRemovedSessionIds).toEqual(["filtered"]);
+  });
+
+  it("surfaces cached sessions rejected by the adapter as explicit removals", () => {
+    const staleRef = source("stale", "old");
+    const adapter = new MemorySourceAdapter([], new Map(), null, new Set());
+
+    const outcome = synchronizeSessionSources(
+      adapter,
+      {
+        sessions: [session("stale")],
+        meta: { stale: meta(staleRef) },
+      },
+      { kind: "refresh" },
+    );
+
+    expect(outcome.sessions).toEqual([]);
+    expect(outcome.detectedSessionIds).toEqual(["stale"]);
+    expect(outcome.changedSessionIds).toEqual(["stale"]);
+    expect(outcome.explicitRemovedSessionIds).toEqual(["stale"]);
+    expect(outcome.sourceOutcomes).toContainEqual({
+      status: "filtered",
+      source: staleRef,
+      reason: "cached session rejected by adapter",
+    });
+  });
+
+  it("propagates root enumeration failures without interpreting them as empty data", () => {
+    const adapter = new MemorySourceAdapter([], new Map());
+    adapter.listError = new Error("root unavailable");
+
+    expect(() =>
+      synchronizeSessionSources(
+        adapter,
+        { sessions: [session("cached")], meta: {} },
+        {
+          kind: "refresh",
+        },
+      ),
+    ).toThrow("root unavailable");
+  });
+});

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -2,6 +2,31 @@ import { existsSync, readdirSync, statSync, type Dirent, type Stats } from "node
 import { join } from "node:path";
 import type { SessionHead, SessionDetail, ParseSessionResult } from "../types/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
+import {
+  createSessionSourceFailure,
+  isMissingSessionSourceError,
+  matchesScanWindow,
+  synchronizeSessionSources as runSessionSourceSynchronization,
+} from "./session-source-synchronization.js";
+import type {
+  SessionSourceSynchronizationBaseline,
+  SessionSourceSynchronizationOutcome,
+  SessionSourceSynchronizationRequest,
+} from "./session-source-synchronization.js";
+
+export {
+  createSessionSourceFailure,
+  diffSessionSources,
+  matchesScanWindow,
+  reportSessionSourceOutcome,
+  synchronizeSessionSources,
+} from "./session-source-synchronization.js";
+export type {
+  SessionSourceSynchronizationAdapter,
+  SessionSourceSynchronizationBaseline,
+  SessionSourceSynchronizationOutcome,
+  SessionSourceSynchronizationRequest,
+} from "./session-source-synchronization.js";
 
 export type { ParseSessionResult };
 
@@ -45,12 +70,6 @@ export interface AgentScanProgress {
 export interface FileWalkOptions {
   recursive?: boolean;
   scanWindow?: Pick<AgentScanOptions, "from" | "to">;
-}
-
-export function matchesScanWindow(activityTime: number, options?: AgentScanOptions): boolean {
-  if (options?.from != null && activityTime < options.from) return false;
-  if (options?.to != null && activityTime > options.to) return false;
-  return true;
 }
 
 /** 变更检测结果 */
@@ -151,130 +170,6 @@ export type CachedMetaLookup =
   | ReadonlyMap<string, SessionCacheMeta>
   | Record<string, SessionCacheMeta>;
 
-function readCachedMeta(meta: CachedMetaLookup, sessionId: string): SessionCacheMeta | undefined {
-  if (meta instanceof Map) return meta.get(sessionId);
-  return (meta as Record<string, SessionCacheMeta>)[sessionId];
-}
-
-/**
- * Fingerprints compare by exact string equality. Agents encode their head-index
- * and parser versions into the fingerprint precisely so that bumping either one
- * invalidates every cached head — a tolerant comparison would defeat that.
- */
-function fingerprintMatches(ref: SessionSourceRef, cached: SessionCacheMeta | undefined): boolean {
-  return (
-    typeof cached?.sourceFingerprint === "string" && cached.sourceFingerprint === ref.fingerprint
-  );
-}
-
-/**
- * Decides whether a cached session was in scope for this enumeration pass, which
- * is what makes its absence from the refs mean "deleted on disk" rather than
- * "outside the window".
- *
- * `sourceMtimeMs` must hold the same quantity the agent's `listSessionSources`
- * window-filters on, or the two disagree and sessions are dropped or kept wrongly.
- *
- * When it is missing we cannot tell, and the two wrong answers are not
- * symmetric: wrongly removing destroys cached sessions and their messages, while
- * wrongly keeping leaves a stale entry that the next unwindowed pass clears. So
- * an unknown mtime means "not enumerated" — keep it.
- */
-function wasEnumeratedThisPass(
-  cached: SessionCacheMeta | undefined,
-  options: AgentScanOptions | undefined,
-): boolean {
-  if (options?.from == null && options?.to == null) return true;
-  const mtimeMs = cached?.sourceMtimeMs;
-  return typeof mtimeMs === "number" && matchesScanWindow(mtimeMs, options);
-}
-
-/**
- * Single owner of "which sources changed" for file-backed agents. The main
- * thread reaches it through FileSystemSessionSource.checkForChanges; the
- * scan-refresh worker calls it directly, because it holds cached meta received
- * over workerData rather than a live agent metaMap.
- */
-export function diffSessionSources(
-  refs: SessionSourceRef[],
-  cachedSessions: SessionHead[],
-  cachedMeta: CachedMetaLookup,
-  options?: AgentScanOptions,
-): SessionSourceDiff {
-  const cachedIds = new Set(cachedSessions.map((session) => session.id));
-  const enumeratedIds = new Set<string>();
-  const changedIds: string[] = [];
-
-  for (const ref of refs) {
-    enumeratedIds.add(ref.sessionId);
-    const meta = readCachedMeta(cachedMeta, ref.sessionId);
-    // A ref with no cached session has to be parsed even when its meta matches:
-    // the caller's session list is what the refresh merges into.
-    const unchanged =
-      cachedIds.has(ref.sessionId) &&
-      meta?.sourcePath === ref.sourcePath &&
-      fingerprintMatches(ref, meta);
-    if (!unchanged) changedIds.push(ref.sessionId);
-  }
-
-  const removedIds: string[] = [];
-  const failedIds: string[] = [];
-  const sourceOutcomes: SessionSourceAbsenceOutcome[] = [];
-  for (const session of cachedSessions) {
-    if (enumeratedIds.has(session.id)) continue;
-    const meta = readCachedMeta(cachedMeta, session.id);
-    if (!wasEnumeratedThisPass(meta, options)) continue;
-    const source = {
-      sessionId: session.id,
-      sourcePath: typeof meta?.sourcePath === "string" ? meta.sourcePath : "",
-      fingerprint: typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : "",
-    };
-    if (!source.sourcePath) {
-      failedIds.push(session.id);
-      sourceOutcomes.push({
-        status: "failed",
-        failure: createSessionSourceFailure(
-          source,
-          "enumeration",
-          new Error("cached source path is missing"),
-        ),
-      });
-      continue;
-    }
-    try {
-      statSync(source.sourcePath);
-      failedIds.push(session.id);
-      sourceOutcomes.push({
-        status: "failed",
-        failure: createSessionSourceFailure(
-          source,
-          "enumeration",
-          new Error("cached source was not enumerated"),
-        ),
-      });
-    } catch (error) {
-      if (!isMissingSourceError(error)) {
-        failedIds.push(session.id);
-        sourceOutcomes.push({
-          status: "failed",
-          failure: createSessionSourceFailure(source, "enumeration", error),
-        });
-        continue;
-      }
-      removedIds.push(session.id);
-      sourceOutcomes.push({ status: "missing", source });
-    }
-  }
-
-  return { changedIds, removedIds, failedIds, sourceOutcomes };
-}
-
-function isMissingSourceError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null || !("code" in error)) return false;
-  const code = (error as { code?: unknown }).code;
-  return code === "ENOENT" || code === "ENOTDIR";
-}
-
 function failureClass(error: unknown): string {
   if (typeof error === "object" && error !== null && "code" in error) {
     const code = (error as { code?: unknown }).code;
@@ -316,52 +211,6 @@ export function reportAgentScanFailure(failure: AgentScanFailure, baselineRetain
     error_class: failure.errorClass,
     message: failure.message,
     baseline_retained: baselineRetained,
-  });
-}
-
-export function createSessionSourceFailure(
-  source: Pick<SessionSourceRef, "sessionId" | "sourcePath">,
-  stage: SessionSourceFailure["stage"],
-  error: unknown,
-): SessionSourceFailure {
-  return {
-    sessionId: source.sessionId,
-    sourcePath: source.sourcePath,
-    stage,
-    errorClass: failureClass(error),
-    message: failureMessage(error),
-  };
-}
-
-export function reportSessionSourceOutcome(agentName: string, outcome: SessionSourceOutcome): void {
-  if (outcome.status === "parsed") return;
-  if (outcome.status === "filtered") {
-    getCoreDiagnostics()?.info?.("agent.session_source_outcome", {
-      agent: agentName,
-      session_id: outcome.source.sessionId,
-      source_path: outcome.source.sourcePath,
-      outcome: outcome.status,
-      reason: outcome.reason,
-    });
-    return;
-  }
-  if (outcome.status === "missing") {
-    getCoreDiagnostics()?.info?.("agent.session_source_outcome", {
-      agent: agentName,
-      session_id: outcome.source.sessionId,
-      source_path: outcome.source.sourcePath,
-      outcome: outcome.status,
-    });
-    return;
-  }
-  getCoreDiagnostics()?.warn("agent.session_source_outcome", {
-    agent: agentName,
-    session_id: outcome.failure.sessionId,
-    source_path: outcome.failure.sourcePath,
-    outcome: outcome.status,
-    stage: outcome.failure.stage,
-    error_class: outcome.failure.errorClass,
-    message: outcome.failure.message,
   });
 }
 
@@ -462,7 +311,7 @@ export abstract class FileSystemSessionSource<
     } catch (error) {
       if (previousMeta) this.sessionMetaMap.set(source.sessionId, previousMeta);
       else this.sessionMetaMap.delete(source.sessionId);
-      if (isMissingSourceError(error)) return { status: "missing", source };
+      if (isMissingSessionSourceError(error)) return { status: "missing", source };
       return {
         status: "failed",
         failure: createSessionSourceFailure(source, "parsing", error),
@@ -493,29 +342,27 @@ export abstract class FileSystemSessionSource<
     return changedIds;
   }
 
+  synchronizeSessionSources(
+    baseline: SessionSourceSynchronizationBaseline,
+    request: SessionSourceSynchronizationRequest,
+  ): SessionSourceSynchronizationOutcome {
+    return runSessionSourceSynchronization(this, baseline, request);
+  }
+
   scan(options?: AgentScanOptions): SessionHead[] {
     return this.scanSessionSources(options).sessions;
   }
 
   scanSessionSources(options?: AgentScanOptions): SessionSourceScanBatch {
-    const sources = this.listSessionSources(options);
-    const sessions: SessionHead[] = [];
-    const outcomes: SessionSourceOutcome[] = [];
-    options?.onProgress?.({ total: sources.length, processed: 0, sessions: 0 });
-
-    for (const [index, source] of sources.entries()) {
-      const outcome = this.scanSessionSourceOutcome(source, options);
-      outcomes.push(outcome);
-      if (outcome.status === "parsed") sessions.push(outcome.session);
-      else reportSessionSourceOutcome(this.name, outcome);
-      options?.onProgress?.({
-        total: sources.length,
-        processed: index + 1,
-        sessions: sessions.length,
-      });
-    }
-
-    return { sources, outcomes, sessions };
+    const outcome = this.synchronizeSessionSources(
+      { sessions: [], meta: this.sessionMetaMap },
+      { kind: "reload", scanOptions: options },
+    );
+    return {
+      sources: outcome.sources,
+      outcomes: outcome.sourceOutcomes,
+      sessions: outcome.sessions,
+    };
   }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
@@ -549,7 +396,7 @@ export abstract class FileSystemSessionSource<
         try {
           stat = statSync(filePath);
         } catch (error) {
-          if (isMissingSourceError(error)) continue;
+          if (isMissingSessionSourceError(error)) continue;
           throw new SessionScanError(this.name, "reading session source metadata", {
             cause: error,
             sourcePath: filePath,
@@ -593,66 +440,30 @@ export abstract class FileSystemSessionSource<
     }
   }
 
-  /**
-   * 变更检测：枚举当前源 → 交给 diffSessionSources 比对。
-   * 新增、变更、删除三类统一产出 changedIds。
-   */
   checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    const currentRefs = this.listSessionSources();
-    const diff = diffSessionSources(currentRefs, cachedSessions, this.sessionMetaMap);
-    const changedIds = [...new Set([...diff.changedIds, ...diff.removedIds])];
-    const sourceFailures = diff.sourceOutcomes.flatMap((outcome) =>
-      outcome.status === "failed" ? [outcome.failure] : [],
+    const outcome = this.synchronizeSessionSources(
+      { sessions: cachedSessions, meta: this.sessionMetaMap },
+      { kind: "inspect" },
     );
-    for (const outcome of diff.sourceOutcomes) reportSessionSourceOutcome(this.name, outcome);
 
     return {
-      hasChanges: changedIds.length > 0 || sourceFailures.length > 0,
-      changedIds,
+      hasChanges: outcome.detectedSessionIds.length > 0 || outcome.sourceFailures.length > 0,
+      changedIds: outcome.detectedSessionIds,
       timestamp: Date.now(),
-      refs: currentRefs,
-      sourceFailures,
+      refs: outcome.sources,
+      sourceFailures: outcome.sourceFailures,
     };
   }
 
-  /**
-   * 增量扫描：对变更/新增源调用 scanSessionSource 重解析，
-   * 删除已消失的源，合并回 cachedSessions。
-   * refs 未传时回退为自行枚举，供独立调用方（如测试）沿用旧行为。
-   */
   incrementalScan(
     cachedSessions: SessionHead[],
     changedIds: string[],
     refs?: SessionSourceRef[],
   ): SessionHead[] {
-    const sources = refs ?? this.listSessionSources();
-    const sessionMap = new Map(cachedSessions.map((session) => [session.id, session]));
-    const changedSet = new Set(this.expandChangedSessionIds(changedIds, sources));
-    const currentIds = new Set<string>();
-
-    for (const ref of sources) {
-      currentIds.add(ref.sessionId);
-      if (!changedSet.has(ref.sessionId)) continue;
-      const outcome = this.scanSessionSourceOutcome(ref);
-      if (outcome.status === "parsed") {
-        sessionMap.set(outcome.session.id, outcome.session);
-      } else if (outcome.status === "filtered" || outcome.status === "missing") {
-        sessionMap.delete(ref.sessionId);
-        this.sessionMetaMap.delete(ref.sessionId);
-      } else {
-        reportSessionSourceOutcome(this.name, outcome);
-      }
-    }
-
-    // Drop sessions flagged as changed but no longer present on disk.
-    for (const id of changedSet) {
-      if (!currentIds.has(id)) {
-        sessionMap.delete(id);
-        this.sessionMetaMap.delete(id);
-      }
-    }
-
-    return [...sessionMap.values()];
+    return this.synchronizeSessionSources(
+      { sessions: cachedSessions, meta: this.sessionMetaMap },
+      { kind: "known-changes", changedIds, refs },
+    ).sessions;
   }
 }
 

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -16,6 +16,7 @@ export {
   reportAgentScanFailure,
   reportSessionSourceOutcome,
   skippedSession,
+  synchronizeSessionSources,
 } from "./base.js";
 export type {
   AgentScanFailure,
@@ -33,6 +34,10 @@ export type {
   SessionSourceOutcome,
   SessionSourceScanBatch,
   SessionSourceRef,
+  SessionSourceSynchronizationAdapter,
+  SessionSourceSynchronizationBaseline,
+  SessionSourceSynchronizationOutcome,
+  SessionSourceSynchronizationRequest,
   SessionWatchPlan,
   SessionWatchTarget,
 } from "./base.js";

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -1,0 +1,413 @@
+import { statSync } from "node:fs";
+import type { SessionSnapshotCompleteness } from "../discovery/cache/sessions.js";
+import type { SessionHead } from "../types/index.js";
+import { getCoreDiagnostics } from "../utils/diagnostics.js";
+import type {
+  AgentScanOptions,
+  CachedMetaLookup,
+  SessionCacheMeta,
+  SessionSourceAbsenceOutcome,
+  SessionSourceDiff,
+  SessionSourceFailure,
+  SessionSourceOutcome,
+  SessionSourceRef,
+} from "./base.js";
+
+export interface SessionSourceSynchronizationAdapter {
+  readonly name: string;
+  listSessionSources(options?: AgentScanOptions): SessionSourceRef[];
+  scanSessionSourceOutcome(
+    source: SessionSourceRef,
+    options?: AgentScanOptions,
+  ): SessionSourceOutcome;
+  expandChangedSessionIds(changedIds: string[], refs?: SessionSourceRef[]): string[];
+  filterCachedSessions(sessions: SessionHead[]): SessionHead[];
+  getSessionMetaMap(): Map<string, SessionCacheMeta>;
+  setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void;
+}
+
+export interface SessionSourceSynchronizationBaseline {
+  sessions: SessionHead[];
+  meta: CachedMetaLookup;
+}
+
+export type SessionSourceSynchronizationRequest =
+  | { kind: "inspect"; scanOptions?: AgentScanOptions }
+  | { kind: "refresh"; scanOptions?: AgentScanOptions }
+  | { kind: "reload"; scanOptions?: AgentScanOptions }
+  | {
+      kind: "known-changes";
+      changedIds: string[];
+      refs?: SessionSourceRef[];
+      scanOptions?: AgentScanOptions;
+    };
+
+export interface SessionSourceSynchronizationOutcome {
+  sessions: SessionHead[];
+  meta: Record<string, SessionCacheMeta>;
+  sources: SessionSourceRef[];
+  sourceOutcomes: SessionSourceOutcome[];
+  detectedSessionIds: string[];
+  changedSessionIds: string[];
+  explicitRemovedSessionIds: string[];
+  finalizeSessionIds: string[];
+  sourceFailures: SessionSourceFailure[];
+  completeness: SessionSnapshotCompleteness;
+  sourceCount: number;
+  removedSourceCount: number;
+}
+
+function readCachedMeta(meta: CachedMetaLookup, sessionId: string): SessionCacheMeta | undefined {
+  if (meta instanceof Map) return meta.get(sessionId);
+  return (meta as Record<string, SessionCacheMeta>)[sessionId];
+}
+
+/** Parser/index revisions live inside the fingerprint, so comparison must be exact. */
+function fingerprintMatches(ref: SessionSourceRef, cached: SessionCacheMeta | undefined): boolean {
+  return (
+    typeof cached?.sourceFingerprint === "string" && cached.sourceFingerprint === ref.fingerprint
+  );
+}
+
+/** Unknown or out-of-window mtime cannot prove deletion; retain last-known-good facts. */
+function wasEnumeratedThisPass(
+  cached: SessionCacheMeta | undefined,
+  options: AgentScanOptions | undefined,
+): boolean {
+  if (options?.from == null && options?.to == null) return true;
+  const mtimeMs = cached?.sourceMtimeMs;
+  return typeof mtimeMs === "number" && matchesScanWindow(mtimeMs, options);
+}
+
+export function matchesScanWindow(activityTime: number, options?: AgentScanOptions): boolean {
+  if (options?.from != null && activityTime < options.from) return false;
+  if (options?.to != null && activityTime > options.to) return false;
+  return true;
+}
+
+export function isMissingSessionSourceError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function failureClass(error: unknown): string {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string" && code) return code;
+  }
+  if (error instanceof Error && error.name) return error.name;
+  return typeof error;
+}
+
+function failureMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, 500);
+}
+
+export function createSessionSourceFailure(
+  source: Pick<SessionSourceRef, "sessionId" | "sourcePath">,
+  stage: SessionSourceFailure["stage"],
+  error: unknown,
+): SessionSourceFailure {
+  return {
+    sessionId: source.sessionId,
+    sourcePath: source.sourcePath,
+    stage,
+    errorClass: failureClass(error),
+    message: failureMessage(error),
+  };
+}
+
+export function reportSessionSourceOutcome(agentName: string, outcome: SessionSourceOutcome): void {
+  if (outcome.status === "parsed") return;
+  if (outcome.status === "filtered") {
+    getCoreDiagnostics()?.info?.("agent.session_source_outcome", {
+      agent: agentName,
+      session_id: outcome.source.sessionId,
+      source_path: outcome.source.sourcePath,
+      outcome: outcome.status,
+      reason: outcome.reason,
+    });
+    return;
+  }
+  if (outcome.status === "missing") {
+    getCoreDiagnostics()?.info?.("agent.session_source_outcome", {
+      agent: agentName,
+      session_id: outcome.source.sessionId,
+      source_path: outcome.source.sourcePath,
+      outcome: outcome.status,
+    });
+    return;
+  }
+  getCoreDiagnostics()?.warn("agent.session_source_outcome", {
+    agent: agentName,
+    session_id: outcome.failure.sessionId,
+    source_path: outcome.failure.sourcePath,
+    outcome: outcome.status,
+    stage: outcome.failure.stage,
+    error_class: outcome.failure.errorClass,
+    message: outcome.failure.message,
+  });
+}
+
+export function diffSessionSources(
+  refs: SessionSourceRef[],
+  cachedSessions: SessionHead[],
+  cachedMeta: CachedMetaLookup,
+  options?: AgentScanOptions,
+): SessionSourceDiff {
+  const cachedIds = new Set(cachedSessions.map((session) => session.id));
+  const enumeratedIds = new Set<string>();
+  const changedIds: string[] = [];
+
+  for (const ref of refs) {
+    enumeratedIds.add(ref.sessionId);
+    const meta = readCachedMeta(cachedMeta, ref.sessionId);
+    const unchanged =
+      cachedIds.has(ref.sessionId) &&
+      meta?.sourcePath === ref.sourcePath &&
+      fingerprintMatches(ref, meta);
+    if (!unchanged) changedIds.push(ref.sessionId);
+  }
+
+  const removedIds: string[] = [];
+  const failedIds: string[] = [];
+  const sourceOutcomes: SessionSourceAbsenceOutcome[] = [];
+  for (const session of cachedSessions) {
+    if (enumeratedIds.has(session.id)) continue;
+    const meta = readCachedMeta(cachedMeta, session.id);
+    if (!wasEnumeratedThisPass(meta, options)) continue;
+    const source = {
+      sessionId: session.id,
+      sourcePath: typeof meta?.sourcePath === "string" ? meta.sourcePath : "",
+      fingerprint: typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : "",
+    };
+    if (!source.sourcePath) {
+      failedIds.push(session.id);
+      sourceOutcomes.push({
+        status: "failed",
+        failure: createSessionSourceFailure(
+          source,
+          "enumeration",
+          new Error("cached source path is missing"),
+        ),
+      });
+      continue;
+    }
+    try {
+      statSync(source.sourcePath);
+      failedIds.push(session.id);
+      sourceOutcomes.push({
+        status: "failed",
+        failure: createSessionSourceFailure(
+          source,
+          "enumeration",
+          new Error("cached source was not enumerated"),
+        ),
+      });
+    } catch (error) {
+      if (!isMissingSessionSourceError(error)) {
+        failedIds.push(session.id);
+        sourceOutcomes.push({
+          status: "failed",
+          failure: createSessionSourceFailure(source, "enumeration", error),
+        });
+        continue;
+      }
+      removedIds.push(session.id);
+      sourceOutcomes.push({ status: "missing", source });
+    }
+  }
+
+  return { changedIds, removedIds, failedIds, sourceOutcomes };
+}
+
+function cloneMeta(meta: CachedMetaLookup): Map<string, SessionCacheMeta> {
+  return meta instanceof Map ? new Map(meta) : new Map(Object.entries(meta));
+}
+
+function unique(values: Iterable<string>): string[] {
+  return [...new Set(values)];
+}
+
+function sourceForMissingId(
+  sessionId: string,
+  meta: Map<string, SessionCacheMeta>,
+): SessionSourceRef {
+  const cached = meta.get(sessionId);
+  return {
+    sessionId,
+    sourcePath: typeof cached?.sourcePath === "string" ? cached.sourcePath : "",
+    fingerprint: typeof cached?.sourceFingerprint === "string" ? cached.sourceFingerprint : "",
+  };
+}
+
+function buildMeta(
+  sessions: SessionHead[],
+  metaMap: Map<string, SessionCacheMeta>,
+): Record<string, SessionCacheMeta> {
+  const meta: Record<string, SessionCacheMeta> = {};
+  for (const session of sessions) {
+    const value = metaMap.get(session.id);
+    if (value) meta[session.id] = value;
+  }
+  return meta;
+}
+
+function isWindowed(options: AgentScanOptions | undefined): boolean {
+  return options?.from != null || options?.to != null;
+}
+
+export function synchronizeSessionSources(
+  adapter: SessionSourceSynchronizationAdapter,
+  baseline: SessionSourceSynchronizationBaseline,
+  request: SessionSourceSynchronizationRequest,
+): SessionSourceSynchronizationOutcome {
+  adapter.setSessionMetaMap(cloneMeta(baseline.meta));
+  const metaMap = adapter.getSessionMetaMap();
+  const baselineMeta = new Map(metaMap);
+  const baselineSessions = adapter.filterCachedSessions(baseline.sessions);
+  const visibleBaselineIds = new Set(baselineSessions.map((session) => session.id));
+  const filteredBaselineIds = baseline.sessions
+    .map((session) => session.id)
+    .filter((sessionId) => !visibleBaselineIds.has(sessionId));
+  const filteredBaselineOutcomes: SessionSourceOutcome[] = filteredBaselineIds.map((sessionId) => ({
+    status: "filtered",
+    source: sourceForMissingId(sessionId, baselineMeta),
+    reason: "cached session rejected by adapter",
+  }));
+  for (const sessionId of filteredBaselineIds) metaMap.delete(sessionId);
+  const scanOptions = request.scanOptions;
+  const sources =
+    request.kind === "known-changes" && request.refs
+      ? request.refs
+      : adapter.listSessionSources(scanOptions);
+  const sourceById = new Map(sources.map((source) => [source.sessionId, source]));
+  const diff =
+    request.kind === "known-changes"
+      ? { changedIds: request.changedIds, removedIds: [], failedIds: [], sourceOutcomes: [] }
+      : diffSessionSources(sources, baselineSessions, metaMap, scanOptions);
+  const detectedSessionIds = unique([
+    ...filteredBaselineIds,
+    ...diff.changedIds,
+    ...diff.removedIds,
+  ]);
+  const sourceOutcomes: SessionSourceOutcome[] = [
+    ...filteredBaselineOutcomes,
+    ...diff.sourceOutcomes,
+  ];
+  const sourceFailures = sourceOutcomes.flatMap((outcome) =>
+    outcome.status === "failed" ? [outcome.failure] : [],
+  );
+  for (const outcome of sourceOutcomes) reportSessionSourceOutcome(adapter.name, outcome);
+
+  if (request.kind === "inspect") {
+    return {
+      sessions: baselineSessions,
+      meta: buildMeta(baselineSessions, metaMap),
+      sources,
+      sourceOutcomes,
+      detectedSessionIds,
+      changedSessionIds: [],
+      explicitRemovedSessionIds: unique([...filteredBaselineIds, ...diff.removedIds]),
+      finalizeSessionIds: [],
+      sourceFailures,
+      completeness: isWindowed(scanOptions) || sourceFailures.length > 0 ? "partial" : "complete",
+      sourceCount: sources.length,
+      removedSourceCount: diff.removedIds.length,
+    };
+  }
+
+  const sessionsById = new Map(baselineSessions.map((session) => [session.id, session]));
+  const changedSessionIds = new Set(filteredBaselineIds);
+  const explicitRemovedSessionIds = new Set(filteredBaselineIds);
+  for (const outcome of diff.sourceOutcomes) {
+    if (outcome.status !== "missing") continue;
+    sessionsById.delete(outcome.source.sessionId);
+    metaMap.delete(outcome.source.sessionId);
+    changedSessionIds.add(outcome.source.sessionId);
+    explicitRemovedSessionIds.add(outcome.source.sessionId);
+  }
+
+  const requestedIds =
+    request.kind === "reload"
+      ? sources.map((source) => source.sessionId)
+      : request.kind === "known-changes"
+        ? request.changedIds
+        : detectedSessionIds;
+  const synchronizationIds = unique(adapter.expandChangedSessionIds(requestedIds, sources));
+  if (synchronizationIds.length > 0 || request.kind === "reload") {
+    scanOptions?.onProgress?.({
+      total: synchronizationIds.length,
+      processed: 0,
+      sessions: sessionsById.size,
+    });
+  }
+
+  synchronizationIds.forEach((sessionId, index) => {
+    const source = sourceById.get(sessionId);
+    if (!source) {
+      if (!changedSessionIds.has(sessionId)) {
+        const missing: SessionSourceOutcome = {
+          status: "missing",
+          source: sourceForMissingId(sessionId, metaMap),
+        };
+        sourceOutcomes.push(missing);
+        reportSessionSourceOutcome(adapter.name, missing);
+        sessionsById.delete(sessionId);
+        metaMap.delete(sessionId);
+        changedSessionIds.add(sessionId);
+        explicitRemovedSessionIds.add(sessionId);
+      }
+    } else {
+      const outcome = adapter.scanSessionSourceOutcome(source, scanOptions);
+      sourceOutcomes.push(outcome);
+      if (outcome.status === "parsed") {
+        if (outcome.session.id !== source.sessionId) sessionsById.delete(source.sessionId);
+        sessionsById.set(outcome.session.id, outcome.session);
+        if (outcome.session.id !== source.sessionId) metaMap.delete(source.sessionId);
+        if (outcome.session.id === source.sessionId)
+          explicitRemovedSessionIds.delete(source.sessionId);
+        changedSessionIds.add(source.sessionId);
+      } else if (outcome.status === "filtered" || outcome.status === "missing") {
+        sessionsById.delete(source.sessionId);
+        metaMap.delete(source.sessionId);
+        changedSessionIds.add(source.sessionId);
+        explicitRemovedSessionIds.add(source.sessionId);
+        reportSessionSourceOutcome(adapter.name, outcome);
+      } else {
+        sourceFailures.push(outcome.failure);
+        reportSessionSourceOutcome(adapter.name, outcome);
+      }
+    }
+    scanOptions?.onProgress?.({
+      total: synchronizationIds.length,
+      processed: index + 1,
+      sessions: sessionsById.size,
+    });
+  });
+
+  const failedIds = new Set(sourceFailures.map((failure) => failure.sessionId));
+  const finalizeSessionIds = (
+    request.kind === "reload" || (request.kind === "refresh" && !isWindowed(scanOptions))
+      ? sources.map((source) => source.sessionId)
+      : [...changedSessionIds]
+  ).filter((sessionId) => !failedIds.has(sessionId));
+  const sessions = [...sessionsById.values()];
+
+  return {
+    sessions,
+    meta: buildMeta(sessions, metaMap),
+    sources,
+    sourceOutcomes,
+    detectedSessionIds,
+    changedSessionIds: [...changedSessionIds],
+    explicitRemovedSessionIds: [...explicitRemovedSessionIds],
+    finalizeSessionIds,
+    sourceFailures,
+    completeness: isWindowed(scanOptions) || sourceFailures.length > 0 ? "partial" : "complete",
+    sourceCount: sources.length,
+    removedSourceCount: diff.removedIds.length,
+  };
+}

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -12,11 +12,10 @@ import type {
 import {
   createAgentScanFailure,
   createRegisteredAgents,
-  diffSessionSources,
   FileSystemSessionSource,
   reportAgentScanFailure,
-  reportSessionSourceOutcome,
   SessionScanError,
+  synchronizeSessionSources,
 } from "../agents/index.js";
 import { filterSessionsByProjectScope } from "../projects/index.js";
 import {
@@ -402,6 +401,68 @@ export async function finalizeAgentScan(
   };
 }
 
+async function refreshCachedFileAgent(
+  agent: FileSystemSessionSource,
+  cached: CachedResult,
+  options: ScanOptions,
+  timing: AgentScanTiming,
+  agentStart: number,
+  onProgress?: (progress: ScanProgress) => void,
+): Promise<SuccessfulAgentScanResult> {
+  const scanStartedAt = performance.now();
+  const synchronization = synchronizeSessionSources(
+    agent,
+    { sessions: cached.sessions, meta: cached.meta },
+    {
+      kind: "refresh",
+      scanOptions: {
+        onProgress: (progress) => {
+          onProgress?.({
+            agent: agent.name,
+            phase: "incremental",
+            cachedCount: progress.total,
+            newCount: progress.sessions,
+            changedCount: progress.processed,
+          });
+        },
+      },
+    },
+  );
+  timing.scan = performance.now() - scanStartedAt;
+  const hasSourceChanges =
+    synchronization.detectedSessionIds.length > 0 || synchronization.sourceFailures.length > 0;
+
+  if (!hasSourceChanges) {
+    return finalizeAgentScan(agent, synchronization.sessions, {
+      finalization: { kind: "unchanged", cached },
+      options,
+      timing,
+      agentStart,
+      completeness: synchronization.completeness,
+      onProgress,
+    });
+  }
+
+  onProgress?.({
+    agent: agent.name,
+    phase: "incremental",
+    changedCount: synchronization.detectedSessionIds.length,
+  });
+  return finalizeAgentScan(agent, synchronization.sessions, {
+    finalization: {
+      kind: "incremental",
+      cached,
+      changedIds: synchronization.changedSessionIds,
+      cacheTimestamp: Date.now(),
+    },
+    options,
+    timing,
+    agentStart,
+    completeness: synchronization.completeness,
+    onProgress,
+  });
+}
+
 /**
  * 智能扫描单个 Agent
  * 1. 优先使用缓存立即返回
@@ -457,6 +518,10 @@ async function scanAgentSmart(
       });
 
       onProgress?.({ agent: agent.name, phase: "checking" });
+
+      if (agent instanceof FileSystemSessionSource) {
+        return refreshCachedFileAgent(agent, cached, options, timing, agentStart, onProgress);
+      }
 
       const t1 = performance.now();
       const checkResult = await Promise.resolve(
@@ -552,40 +617,13 @@ async function scanAgentFull(
     let sourceFailures: SessionSourceFailure[] = [];
     if (agent instanceof FileSystemSessionSource) {
       const cached = loadCachedSessions(agent.name);
-      if (cached) {
-        restoreAgentCacheMeta(agent, cached);
-      }
-      const batch = agent.scanSessionSources(agentScanOptions);
-      const sessionMap = new Map(cached?.sessions.map((session) => [session.id, session]) ?? []);
-      for (const outcome of batch.outcomes) {
-        if (outcome.status === "parsed") {
-          sessionMap.delete(outcome.source.sessionId);
-          sessionMap.set(outcome.session.id, outcome.session);
-        } else if (outcome.status === "filtered" || outcome.status === "missing") {
-          sessionMap.delete(outcome.source.sessionId);
-          agent.getSessionMetaMap().delete(outcome.source.sessionId);
-        } else {
-          sourceFailures.push(outcome.failure);
-        }
-      }
-      if (cached) {
-        const diff = diffSessionSources(
-          batch.sources,
-          cached.sessions,
-          cached.meta,
-          agentScanOptions,
-        );
-        for (const outcome of diff.sourceOutcomes) {
-          reportSessionSourceOutcome(agent.name, outcome);
-          if (outcome.status === "missing") {
-            sessionMap.delete(outcome.source.sessionId);
-            agent.getSessionMetaMap().delete(outcome.source.sessionId);
-          } else {
-            sourceFailures.push(outcome.failure);
-          }
-        }
-      }
-      heads = [...sessionMap.values()];
+      const synchronization = synchronizeSessionSources(
+        agent,
+        { sessions: cached?.sessions ?? [], meta: cached?.meta ?? new Map() },
+        { kind: "reload", scanOptions: agentScanOptions },
+      );
+      heads = synchronization.sessions;
+      sourceFailures = synchronization.sourceFailures;
     } else {
       heads = agent.scan(agentScanOptions);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export {
   getRegisteredAgents,
   registerAgent,
   reportSessionSourceOutcome,
+  synchronizeSessionSources,
 } from "./agents/index.js";
 export type {
   AgentScanFailure,
@@ -32,6 +33,10 @@ export type {
   SessionSourceOutcome,
   SessionSourceScanBatch,
   SessionSourceRef,
+  SessionSourceSynchronizationAdapter,
+  SessionSourceSynchronizationBaseline,
+  SessionSourceSynchronizationOutcome,
+  SessionSourceSynchronizationRequest,
   SessionWatchPlan,
 } from "./agents/index.js";
 export {

--- a/scripts/critical-coverage.mjs
+++ b/scripts/critical-coverage.mjs
@@ -9,6 +9,10 @@ export const CRITICAL_COVERAGE_SCOPES = [
       { path: "packages/core/src/utils", kind: "directory" },
       { path: "packages/core/src/discovery", kind: "directory" },
       { path: "packages/core/src/agents/base.ts", kind: "file" },
+      {
+        path: "packages/core/src/agents/session-source-synchronization.ts",
+        kind: "file",
+      },
       { path: "packages/cli/src/api", kind: "directory" },
     ],
     thresholds: { lines: 90 },
@@ -22,6 +26,7 @@ export const CRITICAL_COVERAGE_SCOPES = [
       { path: "packages/cli/src/live-scan.ts", kind: "file" },
       { path: "packages/cli/src/live-session-index.ts", kind: "file" },
       { path: "packages/cli/src/pending-search-index-jobs.ts", kind: "file" },
+      { path: "packages/cli/src/scan-refresh-operation.ts", kind: "file" },
       { path: "packages/cli/src/scan-refresh-worker.ts", kind: "file" },
       { path: "packages/cli/src/scan-status-model.ts", kind: "file" },
       { path: "packages/cli/src/search-index-job-runner.ts", kind: "file" },


### PR DESCRIPTION
## Summary

- centralize file-backed Session Source enumeration, diffing, parsing, last-known-good retention, completeness, and removal facts in one core module
- make one-shot scans and scan-refresh workers consume the same synchronization outcome
- replace boolean worker modes with a closed operation union for scans, refreshes, derived recomputation, backfills, and durable checkpoints
- document the synchronization seam and include its critical owners in the coverage gate

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm test:migration`
- `pnpm test`
- `pnpm build`
- `pnpm test:coverage` (1,855 passed, 1 skipped)
- `pnpm perf:check`
- `pnpm test:e2e` (26 passed)
