### PR TITLE
fix(core): re-parse cached session heads once missing model pricing arrives

### DIFF
--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../base.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
+import { estimateTokenCost } from "../../utils/cost.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 interface FakeSource {
@@ -193,6 +194,44 @@ describe("FileSystemSessionSource.scan", () => {
   });
 });
 
+describe("FileSystemSessionSource pricing miss capture", () => {
+  class UnpricedModelSource extends FakeFileSystemSource {
+    override scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
+      estimateTokenCost("vendor/nonexistent-model", { input: 10, output: 10 });
+      return super.scanSessionSource(sourcePath, options);
+    }
+  }
+
+  it("records models the head parse could not price into the session meta", () => {
+    const src = source("a");
+    const agent = new UnpricedModelSource([src]);
+
+    const outcome = agent.scanSessionSourceOutcome({
+      sessionId: src.sessionId,
+      sourcePath: src.sourcePath,
+      fingerprint: src.fingerprint,
+    });
+
+    expect(outcome.status).toBe("parsed");
+    expect(agent.getSessionMetaMap().get("a")?.unpricedModels).toEqual([
+      "vendor/nonexistent-model",
+    ]);
+  });
+
+  it("leaves no recorded misses when every model is priced", () => {
+    const src = source("a");
+    const agent = new FakeFileSystemSource([src]);
+
+    agent.scanSessionSourceOutcome({
+      sessionId: src.sessionId,
+      sourcePath: src.sourcePath,
+      fingerprint: src.fingerprint,
+    });
+
+    expect(agent.getSessionMetaMap().get("a")?.unpricedModels).toBeUndefined();
+  });
+});
+
 describe("diffSessionSources", () => {
   function ref(
     id: string,
@@ -240,6 +279,22 @@ describe("diffSessionSources", () => {
       failedIds: [],
       sourceOutcomes: [],
     });
+  });
+
+  it("re-parses a cached head once one of its unpriced models gains pricing", () => {
+    const diff = diffSessionSources([ref("a")], [makeSession("a")], {
+      a: meta("a", { unpricedModels: ["vendor/nonexistent-model", "claude-sonnet-4-6"] }),
+    });
+
+    expect(diff.changedIds).toEqual(["a"]);
+  });
+
+  it("keeps a cached head whose unpriced models are still unpriced", () => {
+    const diff = diffSessionSources([ref("a")], [makeSession("a")], {
+      a: meta("a", { unpricedModels: ["vendor/nonexistent-model"] }),
+    });
+
+    expect(diff.changedIds).toEqual([]);
   });
 
   it("treats a ref with no cached session as changed even when its meta matches", () => {

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -319,7 +319,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
         sessionId: "session-1",
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "claudecode-head-v4",
+          "claudecode-head-v5",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           indexTime.getTime(),

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, statSync, type Dirent, type Stats } from "node:fs";
 import { join } from "node:path";
 import type { SessionHead, SessionDetail, ParseSessionResult } from "../types/index.js";
+import { capturePricingMisses } from "../pricing/cost.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import {
   createSessionSourceFailure,
@@ -49,6 +50,8 @@ export function getParsedSession<T>(result: ParseSessionResult<T>): T | null {
 export interface SessionCacheMeta {
   id: string;
   sourcePath: string;
+  /** Models the head parse could not price; their arrival invalidates the cache. */
+  unpricedModels?: string[];
   [key: string]: unknown;
 }
 
@@ -306,8 +309,11 @@ export abstract class FileSystemSessionSource<
   ): SessionSourceOutcome {
     const previousMeta = this.sessionMetaMap.get(source.sessionId);
     let result: ParseSessionResult<SessionHead>;
+    let unpricedModels: string[] = [];
     try {
-      result = this.scanSessionSourceResult(source, options);
+      ({ result, unpricedModels } = capturePricingMisses(() =>
+        this.scanSessionSourceResult(source, options),
+      ));
     } catch (error) {
       if (previousMeta) this.sessionMetaMap.set(source.sessionId, previousMeta);
       else this.sessionMetaMap.delete(source.sessionId);
@@ -317,7 +323,14 @@ export abstract class FileSystemSessionSource<
         failure: createSessionSourceFailure(source, "parsing", error),
       };
     }
-    if (result.status === "parsed") return { status: "parsed", source, session: result.data };
+    if (result.status === "parsed") {
+      const meta = this.sessionMetaMap.get(result.data.id);
+      if (meta) {
+        if (unpricedModels.length > 0) meta.unpricedModels = unpricedModels;
+        else delete meta.unpricedModels;
+      }
+      return { status: "parsed", source, session: result.data };
+    }
     if (result.status === "filtered") {
       return { status: "filtered", source, reason: result.reason ?? "filtered by agent" };
     }

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -33,7 +33,8 @@ import {
 } from "./base.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
-const HEAD_INDEX_VERSION = "claudecode-head-v4";
+// v5: heads cached before pricing misses were tracked may hold stale zero costs.
+const HEAD_INDEX_VERSION = "claudecode-head-v5";
 
 export function resolveClaudeCodeDataRoot(): string {
   return resolveHomePath("CLAUDE_CONFIG_DIR", ".claude");

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -1,5 +1,6 @@
 import { statSync } from "node:fs";
 import type { SessionSnapshotCompleteness } from "../discovery/cache/sessions.js";
+import { pricingResolver } from "../pricing/resolver.js";
 import type { SessionHead } from "../types/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import type {
@@ -66,6 +67,19 @@ function readCachedMeta(meta: CachedMetaLookup, sessionId: string): SessionCache
 function fingerprintMatches(ref: SessionSourceRef, cached: SessionCacheMeta | undefined): boolean {
   return (
     typeof cached?.sourceFingerprint === "string" && cached.sourceFingerprint === ref.fingerprint
+  );
+}
+
+/**
+ * A head cached while some of its models lacked pricing carries a zero estimate
+ * forever unless re-parsed: the source file never changes again, so the
+ * fingerprint alone cannot see a later pricing arrival.
+ */
+function pricingBecameAvailable(cached: SessionCacheMeta | undefined): boolean {
+  const models = cached?.unpricedModels;
+  if (!Array.isArray(models)) return false;
+  return models.some(
+    (model) => typeof model === "string" && pricingResolver.resolve(model) !== null,
   );
 }
 
@@ -167,7 +181,8 @@ export function diffSessionSources(
     const unchanged =
       cachedIds.has(ref.sessionId) &&
       meta?.sourcePath === ref.sourcePath &&
-      fingerprintMatches(ref, meta);
+      fingerprintMatches(ref, meta) &&
+      !pricingBecameAvailable(meta);
     if (!unchanged) changedIds.push(ref.sessionId);
   }
 

--- a/packages/core/src/pricing/__tests__/cost.test.ts
+++ b/packages/core/src/pricing/__tests__/cost.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyMessageCost,
   applyMessageCosts,
+  capturePricingMisses,
   estimateCostForTokens,
   withEstimatedSessionCost,
 } from "../cost.js";
@@ -33,6 +34,20 @@ describe("pricing", () => {
   it("returns null for unknown models", () => {
     expect(estimateCostForTokens("unknown-model", { input: 1000, output: 1000 })).toBeNull();
     expect(pricingResolver.resolve("unknown-model")).toBeNull();
+  });
+
+  it("captures only resolver misses, and only within the capture window", () => {
+    const { unpricedModels } = capturePricingMisses(() => {
+      estimateCostForTokens("unknown-model", { input: 1000, output: 1000 });
+      estimateCostForTokens("unknown-model", { input: 1, output: 1 });
+      estimateCostForTokens("claude-sonnet-4-6", { input: 1000, output: 1000 });
+      estimateCostForTokens(null, { input: 1000, output: 1000 });
+    });
+
+    expect(unpricedModels).toEqual(["unknown-model"]);
+
+    const outside = capturePricingMisses(() => undefined);
+    expect(outside.unpricedModels).toEqual([]);
   });
 
   it("marks existing message costs as recorded", () => {

--- a/packages/core/src/pricing/cost.ts
+++ b/packages/core/src/pricing/cost.ts
@@ -14,6 +14,24 @@ function positive(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
 }
 
+let pricingMissCapture: Set<string> | null = null;
+
+/**
+ * Records which models {@link estimateCostForTokens} failed to price during
+ * `run`. Cached session heads carry these misses so they can be re-parsed once
+ * pricing for those models becomes available.
+ */
+export function capturePricingMisses<T>(run: () => T): { result: T; unpricedModels: string[] } {
+  const previous = pricingMissCapture;
+  const capture = new Set<string>();
+  pricingMissCapture = capture;
+  try {
+    return { result: run(), unpricedModels: [...capture] };
+  } finally {
+    pricingMissCapture = previous;
+  }
+}
+
 export function estimateCostForTokens(
   model: string | null | undefined,
   usage: CostUsage | undefined,
@@ -21,7 +39,10 @@ export function estimateCostForTokens(
   if (!model || !usage) return null;
 
   const pricing = pricingResolver.resolve(model);
-  if (!pricing) return null;
+  if (!pricing) {
+    pricingMissCapture?.add(model);
+    return null;
+  }
 
   const cacheRead = positive(usage.cache_read);
   const cacheCreate = positive(usage.cache_create);


### PR DESCRIPTION
## Summary

The dashboard model-cost distribution appeared ~2x the KPI total cost. Investigation showed the opposite of the initial suspicion (no parent/child double counting): **the KPI was undercounting**. 88 local claudecode sessions were cached with `total_cost = 0` because they were head-parsed while their models (`claude-fable-5` / `claude-opus-5`) had no pricing entry yet. The head cache fingerprint only covers file mtime/size — a finished session's file never changes again, so the zero cost was pinned forever. The message rows were later re-estimated with pricing available, hence recorded costs matched while estimated ones diverged.

## Root cause

A cached head's cost depends on both the source file **and** the pricing table, but cache invalidation only tracked the former.

## Fix

- `capturePricingMisses()` in `pricing/cost.ts` records which models `estimateCostForTokens` failed to resolve during a head parse.
- `FileSystemSessionSource.scanSessionSourceOutcome` stores those misses in the session cache meta (`unpricedModels`).
- `diffSessionSources` treats a cached head as changed once any of its recorded unpriced models resolves to billable pricing, triggering a one-time re-parse. Convergence is guaranteed: a re-parse either prices the model (cost > 0) or records the same miss again (no pricing yet → not stale).
- `claudecode` head index version bumped to v5 so heads cached before misses were tracked get one forced re-parse.

## Verification

Ran the built CLI against the real local cache: stale zero-cost claudecode rows dropped from 88 to 20 within the first scan cycles; the remainder are blocked by the codex worker OOM killing the shared backfill batch (separate fix, next PR) and heal once backfill completes.

## Tests

- `capturePricingMisses` unit tests (only resolver misses captured, window-scoped).
- `scanSessionSourceOutcome` records/omits `unpricedModels` in meta.
- `diffSessionSources` re-parses when a recorded unpriced model gains pricing, stays cached otherwise.
- Full `@codesesh/core` suite: 758 passed.