### PR TITLE
fix(core): pre-stage large search-index backlogs in durable chunks

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -375,6 +375,115 @@ describe("durable publication", () => {
     }
   });
 
+  it(
+    "pre-stages a backlog larger than one commit chunk and commits it fully",
+    () => {
+      const sessions = Array.from({ length: 70 }, (_, index) => makeSession(`bulk-${index}`));
+
+      const result = commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions,
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+        },
+        (sessionId) => makeSessionData(sessionId, `${sessionId} bulk needle`),
+      );
+
+      expect(result.status).toBe("committed");
+      expect(result.status === "committed" && result.searchIndex).toMatchObject({
+        changed: 70,
+        indexed: 70,
+        skipped: 0,
+      });
+      expect(loadCachedSessions("codex")?.sessions).toHaveLength(70);
+      expect(searchSessions("bulk-42 bulk needle")).toHaveLength(1);
+
+      const loadAgain = vi.fn((sessionId: string) =>
+        makeSessionData(sessionId, `${sessionId} bulk needle`),
+      );
+      const unchanged = commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions,
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+        },
+        loadAgain,
+      );
+
+      expect(unchanged.status).toBe("committed");
+      expect(unchanged.status === "committed" && unchanged.searchIndex).toMatchObject({
+        changed: 0,
+        indexed: 0,
+      });
+      expect(loadAgain).not.toHaveBeenCalled();
+    },
+    SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "resumes a large backlog without re-parsing sessions from finished chunks",
+    () => {
+      const sessions = Array.from({ length: 70 }, (_, index) => makeSession(`resume-${index}`));
+      const failingIds = new Set(["resume-68", "resume-69"]);
+
+      const firstPass = commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions,
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+        },
+        (sessionId) => {
+          if (failingIds.has(sessionId)) throw new Error(`cannot parse ${sessionId}`);
+          return makeSessionData(sessionId, `${sessionId} resume needle`);
+        },
+      );
+
+      expect(firstPass.status).toBe("committed");
+      expect(firstPass.status === "committed" && firstPass.searchIndex).toMatchObject({
+        changed: 70,
+        indexed: 68,
+        skipped: 2,
+      });
+
+      const retryLoader = vi.fn((sessionId: string) =>
+        makeSessionData(sessionId, `${sessionId} resume needle`),
+      );
+      const secondPass = commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions,
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+        },
+        retryLoader,
+      );
+
+      expect(secondPass.status).toBe("committed");
+      expect(secondPass.status === "committed" && secondPass.searchIndex).toMatchObject({
+        changed: 2,
+        indexed: 2,
+        skipped: 0,
+      });
+      expect(retryLoader.mock.calls.map(([sessionId]) => sessionId).sort()).toEqual([
+        "resume-68",
+        "resume-69",
+      ]);
+      expect(searchSessions("resume-69 resume needle")).toHaveLength(1);
+    },
+    SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS,
+  );
+
   it("commits partial snapshots and incremental changes through the same interface", () => {
     const historical = makeSession("historical");
     const recent = makeSession("recent");

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -98,6 +98,8 @@ interface PreparedSearchIndexPublication {
   changed: number;
   removedSessionIds: string[];
   entries: LoadedSearchIndexEntry[];
+  /** Entries already written durably in chunks before the atomic commit. */
+  preIndexed: number;
   failures: SearchIndexSyncFailure[];
   needsRebuild: boolean;
   startedAt: number;
@@ -301,6 +303,7 @@ function writeSearchIndexRows(
   removedSessionIds: string[],
   entries: Iterable<LoadedSearchIndexEntry>,
   failures: SearchIndexSyncFailure[],
+  verifySupersession = true,
 ): number {
   const deleteRow = db.prepare(
     "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
@@ -397,12 +400,14 @@ function writeSearchIndexRows(
 
   let indexed = 0;
   for (const entry of entries) {
-    const current = readCurrentMeta.get(agentName, entry.session.id) as
-      | { meta_json?: string | null }
-      | undefined;
-    if (entry.detailVersion !== detailVersionFromMetaJson(current?.meta_json)) {
-      failures.push({ sessionId: entry.session.id, reason: "superseded" });
-      continue;
+    if (verifySupersession) {
+      const current = readCurrentMeta.get(agentName, entry.session.id) as
+        | { meta_json?: string | null }
+        | undefined;
+      if (entry.detailVersion !== detailVersionFromMetaJson(current?.meta_json)) {
+        failures.push({ sessionId: entry.session.id, reason: "superseded" });
+        continue;
+      }
     }
     upsertSessionRow(upsertIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
     deleteFileActivity.run(agentName, entry.session.id);
@@ -452,6 +457,55 @@ function writeSearchIndexRows(
   return indexed;
 }
 
+/**
+ * Loaded entries carry full message bodies, so a backlog larger than one commit
+ * chunk cannot be held in memory at once — a first-time index of a large agent
+ * (multi-GB codex rollouts) used to OOM the search-index worker. Larger
+ * backlogs are written durably in chunks up front instead; an interrupted run
+ * keeps its finished chunks and a retry skips them via their content hashes.
+ * Supersession is not verified during pre-staging: publication jobs are
+ * serialized, and the atomic commit that follows writes the very meta these
+ * detail versions were derived from, which would make the check vacuous anyway.
+ */
+function loadOrPreStageEntries(
+  db: SQLiteDatabase,
+  agentName: string,
+  changes: SessionHeadChange[],
+  loadSessionData: (sessionId: string) => SessionDetail,
+  detailVersionFor: (sessionId: string) => string,
+  failures: SearchIndexSyncFailure[],
+): { entries: LoadedSearchIndexEntry[]; preIndexed: number } {
+  if (changes.length <= SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
+    return {
+      entries: [
+        ...loadSearchIndexEntries(agentName, changes, loadSessionData, detailVersionFor, failures),
+      ],
+      preIndexed: 0,
+    };
+  }
+
+  let preIndexed = 0;
+  for (let offset = 0; offset < changes.length; offset += SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
+    const chunk = changes.slice(offset, offset + SEARCH_INDEX_COMMIT_CHUNK_SIZE);
+    runSearchIndexWrite(db, false, () => {
+      preIndexed += writeSearchIndexRows(
+        db,
+        agentName,
+        [],
+        loadSearchIndexEntries(agentName, chunk, loadSessionData, detailVersionFor, failures),
+        failures,
+        false,
+      );
+    });
+  }
+  getCoreDiagnostics()?.info?.("search_index.pre_staged", {
+    agent: agentName,
+    changed: changes.length,
+    indexed: preIndexed,
+  });
+  return { entries: [], preIndexed };
+}
+
 export function prepareSessionSnapshotSearchIndex(
   db: SQLiteDatabase,
   agentName: string,
@@ -489,15 +543,14 @@ export function prepareSessionSnapshotSearchIndex(
   const changedCount = removedSessionIds.length + changes.length;
   const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
   const failures: SearchIndexSyncFailure[] = [];
-  const entries = [
-    ...loadSearchIndexEntries(
-      agentName,
-      changes,
-      loadSessionData,
-      (sessionId) => targetDetailVersion(searchIndexState, sessionId, options),
-      failures,
-    ),
-  ];
+  const { entries, preIndexed } = loadOrPreStageEntries(
+    db,
+    agentName,
+    changes,
+    loadSessionData,
+    (sessionId) => targetDetailVersion(searchIndexState, sessionId, options),
+    failures,
+  );
 
   return {
     agentName,
@@ -506,8 +559,10 @@ export function prepareSessionSnapshotSearchIndex(
     changed: changes.length,
     removedSessionIds,
     entries,
+    preIndexed,
     failures,
-    needsRebuild: isBulk && changedCount > 0,
+    // Pre-staged chunks wrote through the live FTS triggers; no rebuild needed.
+    needsRebuild: preIndexed === 0 && isBulk && changedCount > 0,
     startedAt,
   };
 }
@@ -533,15 +588,14 @@ export function prepareSessionChangesSearchIndex(
   const changedCount = uniqueRemovedSessionIds.length + toUpsert.length;
   const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
   const failures: SearchIndexSyncFailure[] = [];
-  const entries = [
-    ...loadSearchIndexEntries(
-      agentName,
-      toUpsert,
-      loadSessionData,
-      (sessionId) => targetDetailVersion(searchIndexState, sessionId, options),
-      failures,
-    ),
-  ];
+  const { entries, preIndexed } = loadOrPreStageEntries(
+    db,
+    agentName,
+    toUpsert,
+    loadSessionData,
+    (sessionId) => targetDetailVersion(searchIndexState, sessionId, options),
+    failures,
+  );
 
   return {
     agentName,
@@ -550,8 +604,10 @@ export function prepareSessionChangesSearchIndex(
     changed: toUpsert.length,
     removedSessionIds: uniqueRemovedSessionIds,
     entries,
+    preIndexed,
     failures,
-    needsRebuild: isBulk && changedCount > 0,
+    // Pre-staged chunks wrote through the live FTS triggers; no rebuild needed.
+    needsRebuild: preIndexed === 0 && isBulk && changedCount > 0,
     startedAt,
   };
 }
@@ -560,12 +616,12 @@ export function writePreparedSessionSearchIndex(
   db: SQLiteDatabase,
   publication: PreparedSearchIndexPublication,
 ): SearchIndexSyncResult {
-  let indexed = 0;
+  let indexed = publication.preIndexed;
   const { rebuildDurationMs } = runSearchIndexWrite(
     db,
     publication.needsRebuild,
     () => {
-      indexed = writeSearchIndexRows(
+      indexed += writeSearchIndexRows(
         db,
         publication.agentName,
         publication.removedSessionIds,


### PR DESCRIPTION
## Summary

Fixes the recurring `[codex] Session refresh failed: ERR_WORKER_OUT_OF_MEMORY` crash. The codex scan path itself is already streaming and healthy — the OOM happened in the **search-index worker**: `commitDurableSessionPublication` eagerly loaded every changed session's full detail (`prepareSession*SearchIndex` spread the lazy entry generator into an array) before opening the atomic commit transaction. A first-time index of codex (2211 sessions, 8.6 GB of rollout files locally, largest 441 MB) exceeded the 4 GB worker heap on every retry, which:

- left codex permanently absent from the messages table (and thus from the model-cost chart / search), and
- killed the shared backfill batch, blocking historical re-scans for **all** agents.

## Fix

Backlogs larger than one commit chunk (`SEARCH_INDEX_COMMIT_CHUNK_SIZE`, 64) are now pre-staged: written durably chunk by chunk through the live FTS triggers before the atomic commit, using the same idempotent chunked-write machinery the plain `syncSessionSearchIndex` path already documents for large backlogs. Memory is bounded to a single chunk of loaded entries. An interrupted run keeps its finished chunks and a retry skips them via content hashes — progress is monotonic even across crashes, instead of restarting from zero and OOMing again.

Supersession is not re-verified during pre-staging: publication jobs are serialized and the atomic commit writes the very meta these detail versions derive from, which makes the in-transaction check vacuous on this path (it remains load-bearing for the plain sync paths, which are unchanged).

Small batches (≤ 64) keep today's fully atomic behavior — all existing rollback/atomicity tests pass unchanged.

## Verification

Ran the built CLI against the real local data: codex indexed all 2211 sessions in 232 s with `failed_sources: 0`, zero OOM across refresh and backfill, 103 k message rows written (previously 0), and the `search_index.pre_staged` diagnostic fired for the backfill batches. The backfill queue is no longer blocked for other agents.

## Tests

- Pre-staged 70-session snapshot publication commits fully with correct `changed/indexed/skipped` counters and is a no-op on the second pass.
- Resume: a publication with parse failures in the last chunk commits the rest; the retry re-parses only the failed sessions (asserted via loader call args).
- Full `@codesesh/core` and `codesesh` (cli) suites pass.