### PR TITLE
fix(core): isolate pre-staged session heads

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 20`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 21`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 20;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 21;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -76,9 +76,10 @@ describe("cache schema boundary", () => {
         "project_identity_resolver_revision",
         "project_identity_input_signature",
         "smart_tags_classifier_revision",
+        "publication_id",
       ]),
     );
-    expect(state?.version).toBe(20);
+    expect(state?.version).toBe(21);
   });
 
   it("exposes capabilities instead of migration steps", () => {
@@ -122,7 +123,7 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 20, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 21, detailVersion: "", pending: true });
   });
 
   it("marks legacy project identities stale by leaving added provenance empty", () => {
@@ -161,7 +162,7 @@ describe("cache schema boundary", () => {
     });
 
     expect(migrated).toEqual({
-      version: 20,
+      version: 21,
       resolverRevision: null,
       inputSignature: null,
       classifierRevision: null,
@@ -231,7 +232,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 20,
+        version: 21,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -427,6 +427,78 @@ describe("durable publication", () => {
   );
 
   it(
+    "keeps pre-staged session heads hidden when a large publication rolls back",
+    () => {
+      const historical = makeSession("historical");
+      saveCachedSessions("codex", [historical], {
+        historical: { id: historical.id, sourcePath: "/historical" },
+      });
+      syncSessionSearchIndex("codex", [historical], () =>
+        makeSessionData(historical.id, "historical content"),
+      );
+
+      const sessions = Array.from({ length: 70 }, (_, index) => makeSession(`rollback-${index}`));
+      const meta = Object.fromEntries(
+        sessions.map((session) => [session.id, { id: session.id, sourcePath: `/${session.id}` }]),
+      );
+      const db = new Database(getCachePath());
+      try {
+        db.exec(`
+          CREATE TRIGGER fail_large_publication_head_write
+          BEFORE INSERT ON sessions
+          WHEN NEW.meta_json IS NOT NULL
+          BEGIN
+            SELECT RAISE(ABORT, 'forced large publication failure');
+          END;
+        `);
+      } finally {
+        db.close();
+      }
+
+      const result = commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions,
+          meta,
+          completeness: "complete",
+          removedSessionIds: [],
+        },
+        (sessionId) => makeSessionData(sessionId, `${sessionId} rollback content`),
+      );
+
+      expect(result).toMatchObject({ status: "rolled-back", stage: "cache" });
+      expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).toEqual([historical.id]);
+      expect(searchSessions("rollback-42 rollback content")).toHaveLength(0);
+      const verifyDb = new Database(getCachePath(), { readonly: true });
+      try {
+        expect(
+          verifyDb
+            .prepare(
+              "SELECT COUNT(*) AS value FROM sessions WHERE agent_name = ? AND publication_id IS NULL",
+            )
+            .get("codex"),
+        ).toEqual({ value: 1 });
+        expect(
+          verifyDb
+            .prepare(
+              "SELECT COUNT(*) AS value FROM sessions WHERE agent_name = ? AND publication_id = ?",
+            )
+            .get("codex", result.publicationId),
+        ).toEqual({ value: 70 });
+        expect(
+          verifyDb
+            .prepare("SELECT COUNT(*) AS value FROM session_documents WHERE agent_name = ?")
+            .get("codex"),
+        ).toEqual({ value: 71 });
+      } finally {
+        verifyDb.close();
+      }
+    },
+    SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "resumes a large backlog without re-parsing sessions from finished chunks",
     () => {
       const sessions = Array.from({ length: 70 }, (_, index) => makeSession(`resume-${index}`));
@@ -1066,7 +1138,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(20);
+    expect(getUserVersion(getCachePath())).toBe(21);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -1854,7 +1926,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(20);
+    expect(getUserVersion(getCachePath())).toBe(21);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -196,7 +196,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(20);
+    expect(getUserVersion(getCachePath())).toBe(21);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -207,7 +207,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(20);
+    expect(getUserVersion(getCachePath())).toBe(21);
   });
 });
 
@@ -215,7 +215,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(20);
+    expect(getUserVersion(getCachePath())).toBe(21);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -427,7 +427,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(20);
+    expect(getUserVersion(getCachePath())).toBe(21);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -180,7 +180,10 @@ const FILE_ACTIVITY_COLUMNS = `
 
 const FILE_ACTIVITY_JOIN = `
   FROM session_file_activity fa
-  JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
+  JOIN sessions s
+    ON s.agent_name = fa.agent_name
+    AND s.session_id = fa.session_id
+    AND s.publication_id IS NULL
 `;
 
 /** Most recent first, then busiest, then path — the tie-break every caller relies on. */
@@ -236,7 +239,10 @@ function fileActivitySql(query: FileActivityQuery, where: string): string {
       ${where}
     ) ranked
     JOIN session_file_activity fa ON fa.rowid = ranked.activity_rowid
-    JOIN sessions s ON s.agent_name = fa.agent_name AND s.session_id = fa.session_id
+    JOIN sessions s
+      ON s.agent_name = fa.agent_name
+      AND s.session_id = fa.session_id
+      AND s.publication_id IS NULL
     WHERE ranked.session_rank = 1
     ORDER BY ${FILE_ACTIVITY_ORDER}
     LIMIT ?

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -144,8 +144,9 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
       smart_tags_json,
       smart_tags_source_updated_at,
       smart_tags_classifier_revision,
-      meta_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      meta_json,
+      publication_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id) DO UPDATE SET
       sort_index = excluded.sort_index,
       slug = excluded.slug,
@@ -174,11 +175,45 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
       smart_tags_json = excluded.smart_tags_json,
       smart_tags_source_updated_at = excluded.smart_tags_source_updated_at,
       smart_tags_classifier_revision = excluded.smart_tags_classifier_revision,
-      meta_json = excluded.meta_json
+      meta_json = excluded.meta_json,
+      publication_id = excluded.publication_id
   `);
 }
 
-export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement {
+function prepareIndexedSession(
+  db: SQLiteDatabase,
+  conflictAction: "update" | "ignore",
+): SQLiteStatement {
+  const onConflict =
+    conflictAction === "ignore"
+      ? "DO NOTHING"
+      : `DO UPDATE SET
+          slug = excluded.slug,
+          title = excluded.title,
+          directory = excluded.directory,
+          parent_agent_name = excluded.parent_agent_name,
+          parent_session_id = excluded.parent_session_id,
+          project_identity_kind = excluded.project_identity_kind,
+          project_identity_key = excluded.project_identity_key,
+          project_display_name = excluded.project_display_name,
+          project_identity_resolver_revision = excluded.project_identity_resolver_revision,
+          project_identity_input_signature = excluded.project_identity_input_signature,
+          time_created = excluded.time_created,
+          time_updated = excluded.time_updated,
+          activity_time = excluded.activity_time,
+          message_count = excluded.message_count,
+          total_input_tokens = excluded.total_input_tokens,
+          total_output_tokens = excluded.total_output_tokens,
+          total_cache_read_tokens = excluded.total_cache_read_tokens,
+          total_cache_create_tokens = excluded.total_cache_create_tokens,
+          total_cost = excluded.total_cost,
+          cost_source = excluded.cost_source,
+          total_tokens = excluded.total_tokens,
+          model_usage_json = excluded.model_usage_json,
+          smart_tags_json = excluded.smart_tags_json,
+          smart_tags_source_updated_at = excluded.smart_tags_source_updated_at,
+          smart_tags_classifier_revision = excluded.smart_tags_classifier_revision,
+          publication_id = excluded.publication_id`;
   return db.prepare(`
     INSERT INTO sessions(
       agent_name,
@@ -210,35 +245,19 @@ export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement
       smart_tags_json,
       smart_tags_source_updated_at,
       smart_tags_classifier_revision,
-      meta_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(agent_name, session_id) DO UPDATE SET
-      slug = excluded.slug,
-      title = excluded.title,
-      directory = excluded.directory,
-      parent_agent_name = excluded.parent_agent_name,
-      parent_session_id = excluded.parent_session_id,
-      project_identity_kind = excluded.project_identity_kind,
-      project_identity_key = excluded.project_identity_key,
-      project_display_name = excluded.project_display_name,
-      project_identity_resolver_revision = excluded.project_identity_resolver_revision,
-      project_identity_input_signature = excluded.project_identity_input_signature,
-      time_created = excluded.time_created,
-      time_updated = excluded.time_updated,
-      activity_time = excluded.activity_time,
-      message_count = excluded.message_count,
-      total_input_tokens = excluded.total_input_tokens,
-      total_output_tokens = excluded.total_output_tokens,
-      total_cache_read_tokens = excluded.total_cache_read_tokens,
-      total_cache_create_tokens = excluded.total_cache_create_tokens,
-      total_cost = excluded.total_cost,
-      cost_source = excluded.cost_source,
-      total_tokens = excluded.total_tokens,
-      model_usage_json = excluded.model_usage_json,
-      smart_tags_json = excluded.smart_tags_json,
-      smart_tags_source_updated_at = excluded.smart_tags_source_updated_at,
-      smart_tags_classifier_revision = excluded.smart_tags_classifier_revision
+      meta_json,
+      publication_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(agent_name, session_id) ${onConflict}
   `);
+}
+
+export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement {
+  return prepareIndexedSession(db, "update");
+}
+
+export function prepareInsertStagedSession(db: SQLiteDatabase): SQLiteStatement {
+  return prepareIndexedSession(db, "ignore");
 }
 
 export function upsertSessionRow(
@@ -248,6 +267,7 @@ export function upsertSessionRow(
   metaJson: string | null,
   sortIndex: number,
   sourcePath: string | null,
+  publicationId: string | null = null,
 ): void {
   const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
   const activityTime = session.time_updated ?? session.time_created;
@@ -282,6 +302,7 @@ export function upsertSessionRow(
     session.smart_tags_source_updated_at ?? null,
     session.smart_tags_classifier_revision ?? null,
     metaJson,
+    publicationId,
   );
 }
 

--- a/packages/core/src/discovery/cache/model-cost.ts
+++ b/packages/core/src/discovery/cache/model-cost.ts
@@ -72,7 +72,10 @@ const MODEL_COST_SQL = `
     SUM(CASE WHEN m.cost_source = 'recorded' THEN COALESCE(m.cost, 0) ELSE 0 END) AS cost_recorded,
     SUM(CASE WHEN m.cost_source = 'recorded' THEN 0 ELSE COALESCE(m.cost, 0) END) AS cost_estimated
   FROM messages m
-  JOIN sessions s ON s.agent_name = m.agent_name AND s.session_id = m.session_id
+  JOIN sessions s
+    ON s.agent_name = m.agent_name
+    AND s.session_id = m.session_id
+    AND s.publication_id IS NULL
 `;
 
 /**

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -59,9 +59,11 @@ function publicationSessionCount(publication: DurableSessionPublication): number
 function publicationSearchOptions(
   publication: DurableSessionPublication,
   options: SearchIndexSyncOptions,
+  publicationId: string,
 ): SearchIndexSyncOptions {
   return {
     ...options,
+    publicationId,
     ...(publication.kind === "snapshot"
       ? {
           completeness: publication.completeness,
@@ -93,7 +95,7 @@ export function commitDurableSessionPublication(
   diagnostics?.info?.("search_index.publication_stage", { ...detail, stage: "started" });
 
   const searchIndex = withSearchIndexDb((db) => {
-    const options = publicationSearchOptions(publication, searchOptions);
+    const options = publicationSearchOptions(publication, searchOptions, publicationId);
     const prepared =
       publication.kind === "snapshot"
         ? prepareSessionSnapshotSearchIndex(

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -222,6 +222,7 @@ function createSessionTables(db: SQLiteDatabase): void {
       smart_tags_source_updated_at INTEGER,
       smart_tags_classifier_revision TEXT,
       meta_json TEXT,
+      publication_id TEXT,
       PRIMARY KEY (agent_name, session_id)
     );
 
@@ -510,6 +511,14 @@ function addProjectIdentityProvenance(db: SQLiteDatabase): void {
   }
 }
 
+function addSessionPublicationId(db: SQLiteDatabase): void {
+  if (!tableExists(db, "sessions")) return;
+  if (!columnExists(db, "sessions", "publication_id")) {
+    db.exec("ALTER TABLE sessions ADD COLUMN publication_id TEXT");
+  }
+  recreateProjectGroupsView(db);
+}
+
 function dropSearchTriggers(db: SQLiteDatabase): void {
   db.exec(`
     DROP TRIGGER IF EXISTS session_documents_ai;
@@ -580,6 +589,10 @@ function createProjectGroupsView(db: SQLiteDatabase): void {
   const hasParentReference =
     columnExists(db, "sessions", "parent_agent_name") &&
     columnExists(db, "sessions", "parent_session_id");
+  const predicates = [
+    ...(hasParentReference ? ["parent_agent_name IS NULL OR parent_session_id IS NULL"] : []),
+    ...(columnExists(db, "sessions", "publication_id") ? ["publication_id IS NULL"] : []),
+  ];
   db.exec(`
     CREATE VIEW IF NOT EXISTS project_groups_v AS
       SELECT
@@ -590,7 +603,7 @@ function createProjectGroupsView(db: SQLiteDatabase): void {
         COUNT(*) AS session_count,
         MAX(activity_time) AS last_activity
       FROM sessions
-      ${hasParentReference ? "WHERE parent_agent_name IS NULL OR parent_session_id IS NULL" : ""}
+      ${predicates.length > 0 ? `WHERE ${predicates.map((predicate) => `(${predicate})`).join(" AND ")}` : ""}
       GROUP BY project_identity_kind, project_identity_key;
   `);
 }
@@ -1380,6 +1393,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 18, migrate: addSessionParentReference },
       { version: 19, migrate: addDetailVersion },
       { version: 20, migrate: addProjectIdentityProvenance },
+      { version: 21, migrate: addSessionPublicationId },
     ],
   });
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -10,6 +10,7 @@ import {
   MESSAGE_PARTS_FORMAT_VERSION,
   normalizeMessages,
   prepareInsertFileActivity,
+  prepareInsertStagedSession,
   prepareInsertMessageTool,
   prepareUpsertIndexedSession,
   upsertSessionRow,
@@ -26,6 +27,7 @@ export interface SearchIndexSyncOptions {
   detailVersions?: Readonly<Record<string, string>>;
   completeness?: SessionSnapshotCompleteness;
   removedSessionIds?: readonly string[];
+  publicationId?: string;
 }
 
 export interface SearchIndexSyncFailure {
@@ -89,6 +91,11 @@ interface LoadedSearchIndexEntry {
   fileActivity: SessionFileActivity[];
   sortIndex: number;
   detailVersion: string;
+}
+
+interface SearchIndexRowWriteOptions {
+  verifySupersession?: boolean;
+  publicationId?: string;
 }
 
 interface PreparedSearchIndexPublication {
@@ -303,8 +310,9 @@ function writeSearchIndexRows(
   removedSessionIds: string[],
   entries: Iterable<LoadedSearchIndexEntry>,
   failures: SearchIndexSyncFailure[],
-  verifySupersession = true,
+  options: SearchIndexRowWriteOptions = {},
 ): number {
+  const { verifySupersession = true, publicationId } = options;
   const deleteRow = db.prepare(
     "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
   );
@@ -317,7 +325,9 @@ function writeSearchIndexRows(
   const deleteFileActivity = db.prepare(
     "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
   );
-  const upsertIndexedSession = prepareUpsertIndexedSession(db);
+  const writeIndexedSession = publicationId
+    ? prepareInsertStagedSession(db)
+    : prepareUpsertIndexedSession(db);
   const insertFileActivity = prepareInsertFileActivity(db);
   const insertMessageTool = prepareInsertMessageTool(db);
   const upsertMessage = db.prepare(`
@@ -409,7 +419,15 @@ function writeSearchIndexRows(
         continue;
       }
     }
-    upsertSessionRow(upsertIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
+    upsertSessionRow(
+      writeIndexedSession,
+      agentName,
+      entry.session,
+      null,
+      entry.sortIndex,
+      null,
+      publicationId ?? null,
+    );
     deleteFileActivity.run(agentName, entry.session.id);
     deleteMessageTools.run(agentName, entry.session.id, 0);
     clearPendingReindex.run(agentName, entry.session.id);
@@ -474,6 +492,7 @@ function loadOrPreStageEntries(
   loadSessionData: (sessionId: string) => SessionDetail,
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
+  publicationId?: string,
 ): { entries: LoadedSearchIndexEntry[]; preIndexed: number } {
   if (changes.length <= SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
     return {
@@ -482,6 +501,10 @@ function loadOrPreStageEntries(
       ],
       preIndexed: 0,
     };
+  }
+
+  if (!publicationId) {
+    throw new Error("Large durable publications require a publication id");
   }
 
   let preIndexed = 0;
@@ -494,7 +517,7 @@ function loadOrPreStageEntries(
         [],
         loadSearchIndexEntries(agentName, chunk, loadSessionData, detailVersionFor, failures),
         failures,
-        false,
+        { verifySupersession: false, publicationId },
       );
     });
   }
@@ -550,6 +573,7 @@ export function prepareSessionSnapshotSearchIndex(
     loadSessionData,
     (sessionId) => targetDetailVersion(searchIndexState, sessionId, options),
     failures,
+    options.publicationId,
   );
 
   return {
@@ -595,6 +619,7 @@ export function prepareSessionChangesSearchIndex(
     loadSessionData,
     (sessionId) => targetDetailVersion(searchIndexState, sessionId, options),
     failures,
+    options.publicationId,
   );
 
   return {

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -258,6 +258,7 @@ export function filterIndexedSessionReferences(
             SELECT s.agent_name, s.session_id
             FROM sessions s
             WHERE (${referenceClauses.join(" OR ")})
+              AND s.publication_id IS NULL
               ${filters.where}
           `,
         )
@@ -493,6 +494,7 @@ export function searchSessions(query: string, options: SearchOptions = {}): Sear
               '' AS snippet
             FROM sessions s
             WHERE 1 = 1
+              AND s.publication_id IS NULL
               ${filters.where}
             ORDER BY s.activity_time DESC
             LIMIT ?
@@ -518,6 +520,7 @@ export function searchSessions(query: string, options: SearchOptions = {}): Sear
           JOIN session_documents d ON d.id = session_documents_fts.rowid
           JOIN sessions s ON s.agent_name = d.agent_name AND s.session_id = d.session_id
           WHERE session_documents_fts MATCH ?
+            AND s.publication_id IS NULL
             ${filters.where}
           ORDER BY bm25(session_documents_fts, 8.0, 1.0), s.activity_time DESC
           LIMIT ?

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -129,7 +129,7 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
         `
           SELECT ${SESSION_HEAD_SELECT_COLUMNS}
           FROM sessions s
-          WHERE s.agent_name = ?
+          WHERE s.agent_name = ? AND s.publication_id IS NULL
           ORDER BY s.sort_index, s.activity_time DESC
         `,
       )
@@ -186,6 +186,7 @@ export function loadCachedSessionHeads(
               JOIN sessions s
                 ON s.agent_name = r.agent_name
                 AND s.session_id = r.session_id
+                AND s.publication_id IS NULL
             `,
           )
           .all(...params) as SessionRow[];
@@ -360,7 +361,9 @@ export function loadCachedSessionRawEntry(
           LEFT JOIN session_documents AS documents
             ON documents.agent_name = sessions.agent_name
             AND documents.session_id = sessions.session_id
-          WHERE sessions.agent_name = ? AND sessions.session_id = ?
+          WHERE sessions.agent_name = ?
+            AND sessions.session_id = ?
+            AND sessions.publication_id IS NULL
         `,
       )
       .get(agentName, sessionId) as SessionRow | undefined;
@@ -535,7 +538,7 @@ export function writeCachedSessionSnapshot(
         `
           SELECT session_id
           FROM sessions
-          WHERE agent_name = ?
+          WHERE agent_name = ? AND publication_id IS NULL
           ORDER BY activity_time DESC, sort_index, session_id
         `,
       )
@@ -661,9 +664,9 @@ export function getCacheInfo(): { lastScanTime: number | null; size: number } {
     const timestampRow = db.prepare("SELECT MAX(timestamp) AS value FROM agent_cache").get() as
       | ScalarRow
       | undefined;
-    const sizeRow = db.prepare("SELECT COUNT(*) AS value FROM sessions").get() as
-      | ScalarRow
-      | undefined;
+    const sizeRow = db
+      .prepare("SELECT COUNT(*) AS value FROM sessions WHERE publication_id IS NULL")
+      .get() as ScalarRow | undefined;
 
     const lastScanTime = Number(timestampRow?.value ?? 0) || null;
     const size = Number(sizeRow?.value ?? 0);

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 20;
+export const CACHE_SCHEMA_VERSION = 21;

--- a/scripts/check-docs-facts.test.mjs
+++ b/scripts/check-docs-facts.test.mjs
@@ -10,7 +10,7 @@ import {
 
 const tempDirs = [];
 const coreFacts = {
-  cacheSchemaVersion: 20,
+  cacheSchemaVersion: 21,
   agents: [
     { name: "claudecode", displayName: "Claude Code", sourceKind: "filesystem" },
     { name: "cursor", displayName: "Cursor", sourceKind: "sqlite" },
@@ -47,7 +47,7 @@ function fixtureRepo(packageManager = "pnpm@11.20.0") {
     "docs/architecture.md": sourceKinds,
     "docs/sqlite-storage.md": marked(
       "cache-schema-version",
-      "- 当前 schema：`CACHE_SCHEMA_VERSION = 20`",
+      "- 当前 schema：`CACHE_SCHEMA_VERSION = 21`",
     ),
   };
 
@@ -76,13 +76,13 @@ describe("CS-172: semantic documentation facts", () => {
   it("reports a schema bump that was not copied to documentation", () => {
     const mismatches = findDocumentationFactMismatches(fixtureRepo(), {
       ...coreFacts,
-      cacheSchemaVersion: 21,
+      cacheSchemaVersion: 22,
     });
 
     expect(mismatches).toContainEqual({
       document: "docs/sqlite-storage.md",
       fact: "cache-schema-version",
-      message: "expected CACHE_SCHEMA_VERSION = 21; documented 20",
+      message: "expected CACHE_SCHEMA_VERSION = 22; documented 21",
     });
   });
 


### PR DESCRIPTION
## Summary

- mark bulk-prestaged session heads with a publication ID instead of exposing them as live cache rows
- keep published reads isolated across cache restore, search, file activity, model cost, and project grouping
- add schema v21 migration and regression coverage for rollback and resumable bulk indexing

## Root cause

Bulk search-index prestaging wrote Session Head rows to the live `sessions` table before the cache publication transaction began. A later rollback left those rows visible after restart. Search projection rows cannot omit their parent Session Head because message and file-activity rows enforce foreign keys, so staged parents now have an explicit unpublished state.

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `pnpm test:migration`

Issue: CS-184
