### PR TITLE
fix(core): heal missing pricing across agents

### DIFF
--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -1,4 +1,10 @@
-import type { BaseAgent, SessionCacheMeta, SessionHead, SessionSourceRef } from "@codesesh/core";
+import {
+  PRICING_CAPTURE_EPOCH,
+  type BaseAgent,
+  type SessionCacheMeta,
+  type SessionHead,
+  type SessionSourceRef,
+} from "@codesesh/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -83,6 +89,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     createRegisteredAgents: mocks.createRegisteredAgents,
     ensureSessionTagsSync: mocks.ensureSessionTagsSync,
     FileSystemSessionSource: mocks.FileSystemSessionSource,
+    PRICING_CAPTURE_EPOCH: actual.PRICING_CAPTURE_EPOCH,
     buildAgentCacheMeta: actual.buildAgentCacheMeta,
     computeSessionDiff: actual.computeSessionDiff,
     sessionSignature: actual.sessionSignature,
@@ -109,6 +116,10 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
     },
     ...overrides,
   };
+}
+
+function currentPricingMeta(meta: SessionCacheMeta): SessionCacheMeta {
+  return { ...meta, pricingCaptureEpoch: PRICING_CAPTURE_EPOCH };
 }
 
 function makeAgent(overrides: Record<string, unknown> = {}) {
@@ -473,11 +484,11 @@ describe("scan refresh worker entry", () => {
       operation: { kind: "source-refresh", checkpoint: "durable" },
       previousSessions: [unchanged, makeSession(changed.id, { time_created: 1, time_updated: 1 })],
       meta: {
-        unchanged: {
+        unchanged: currentPricingMeta({
           id: unchanged.id,
           sourcePath: "/unchanged",
           sourceFingerprint: "same",
-        },
+        }),
         changed: {
           id: changed.id,
           sourcePath: "/changed",
@@ -525,7 +536,11 @@ describe("scan refresh worker entry", () => {
       operation: { kind: "source-refresh" },
       previousSessions: [parent, makeSession("child")],
       meta: {
-        parent: { id: "parent", sourcePath: "/parent", sourceFingerprint: "same" },
+        parent: currentPricingMeta({
+          id: "parent",
+          sourcePath: "/parent",
+          sourceFingerprint: "same",
+        }),
         child: { id: "child", sourcePath: "/child", sourceFingerprint: "old" },
       },
     });
@@ -726,11 +741,11 @@ describe("scan refresh worker entry", () => {
       operation: { kind: "source-refresh" },
       previousSessions: [session],
       meta: {
-        unchanged: {
+        unchanged: currentPricingMeta({
           id: "unchanged",
           sourcePath: "/unchanged",
           sourceFingerprint: "same",
-        },
+        }),
       },
     });
 
@@ -761,12 +776,12 @@ describe("scan refresh worker entry", () => {
       previousSessions: [recent],
       scanOptions: { from: 5, fast: true },
       meta: {
-        recent: {
+        recent: currentPricingMeta({
           id: "recent",
           sourcePath: "/recent",
           sourceFingerprint: "same",
           sourceMtimeMs: 10,
-        },
+        }),
       },
     });
 
@@ -819,7 +834,11 @@ describe("scan refresh worker entry", () => {
       // (mtime 10) inside it, so only the latter counts as deleted on disk.
       scanOptions: { from: 5, fast: true },
       meta: {
-        unchanged: { id: "unchanged", sourcePath: "/unchanged", sourceFingerprint: "same" },
+        unchanged: currentPricingMeta({
+          id: "unchanged",
+          sourcePath: "/unchanged",
+          sourceFingerprint: "same",
+        }),
         changed: { id: "changed", sourcePath: "/changed", sourceFingerprint: "old" },
         removed: { id: "removed", sourcePath: "/removed", sourceMtimeMs: 10 },
         outside: { id: "outside", sourcePath: "/outside", sourceMtimeMs: 0 },

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -11,6 +11,9 @@ import {
 } from "../base.js";
 import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
+import { PRICING_CAPTURE_EPOCH } from "../../pricing/cost.js";
+import type { ModelPricing } from "../../pricing/fetcher.js";
+import { pricingResolver } from "../../pricing/resolver.js";
 import { estimateTokenCost } from "../../utils/cost.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
@@ -102,6 +105,15 @@ function makeSession(id: string): SessionHead {
     },
   };
 }
+
+const TEST_PRICING: ModelPricing = {
+  inputCostPerToken: 0.001,
+  outputCostPerToken: 0.002,
+  cacheCreateCostPerToken: 0,
+  cacheReadCostPerToken: 0,
+  reasoningCostPerToken: 0,
+  webSearchCostPerRequest: 0,
+};
 
 function source(id: string, fingerprint = "fp-1", overrides: Partial<FakeSource> = {}): FakeSource {
   return {
@@ -216,6 +228,7 @@ describe("FileSystemSessionSource pricing miss capture", () => {
     expect(agent.getSessionMetaMap().get("a")?.unpricedModels).toEqual([
       "vendor/nonexistent-model",
     ]);
+    expect(agent.getSessionMetaMap().get("a")?.pricingCaptureEpoch).toBe(PRICING_CAPTURE_EPOCH);
   });
 
   it("leaves no recorded misses when every model is priced", () => {
@@ -242,7 +255,13 @@ describe("diffSessionSources", () => {
   }
 
   function meta(id: string, overrides: Partial<SessionCacheMeta> = {}): SessionCacheMeta {
-    return { id, sourcePath: `/tmp/${id}.jsonl`, sourceFingerprint: "fp-1", ...overrides };
+    return {
+      id,
+      sourcePath: `/tmp/${id}.jsonl`,
+      sourceFingerprint: "fp-1",
+      pricingCaptureEpoch: PRICING_CAPTURE_EPOCH,
+      ...overrides,
+    };
   }
 
   it("reads cached meta from a Map and from a plain object identically", () => {
@@ -295,6 +314,14 @@ describe("diffSessionSources", () => {
     });
 
     expect(diff.changedIds).toEqual([]);
+  });
+
+  it("re-parses a cached head from before pricing misses were captured", () => {
+    const diff = diffSessionSources([ref("a")], [makeSession("a")], {
+      a: meta("a", { pricingCaptureEpoch: undefined }),
+    });
+
+    expect(diff.changedIds).toEqual(["a"]);
   });
 
   it("treats a ref with no cached session as changed even when its meta matches", () => {
@@ -394,8 +421,16 @@ describe("FileSystemSessionSource.checkForChanges", () => {
   it("reports no changes when fingerprints and paths match", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b")]);
     // Seed metaMap as if a prior scan populated it.
-    agent.scanSessionSource("/tmp/a.jsonl");
-    agent.scanSessionSource("/tmp/b.jsonl");
+    agent.scanSessionSourceOutcome({
+      sessionId: "a",
+      sourcePath: "/tmp/a.jsonl",
+      fingerprint: "fp-1",
+    });
+    agent.scanSessionSourceOutcome({
+      sessionId: "b",
+      sourcePath: "/tmp/b.jsonl",
+      fingerprint: "fp-1",
+    });
 
     const result = agent.checkForChanges(Date.now(), [makeSession("a"), makeSession("b")]);
     expect(result.hasChanges).toBe(false);
@@ -404,7 +439,11 @@ describe("FileSystemSessionSource.checkForChanges", () => {
 
   it("detects added sources", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b")]);
-    agent.scanSessionSource("/tmp/a.jsonl");
+    agent.scanSessionSourceOutcome({
+      sessionId: "a",
+      sourcePath: "/tmp/a.jsonl",
+      fingerprint: "fp-1",
+    });
 
     const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
     expect(result.hasChanges).toBe(true);
@@ -413,7 +452,11 @@ describe("FileSystemSessionSource.checkForChanges", () => {
 
   it("detects removed sources", () => {
     const agent = new FakeFileSystemSource([source("a")]);
-    agent.scanSessionSource("/tmp/a.jsonl");
+    agent.scanSessionSourceOutcome({
+      sessionId: "a",
+      sourcePath: "/tmp/a.jsonl",
+      fingerprint: "fp-1",
+    });
     agent.getSessionMetaMap().set("ghost", {
       id: "ghost",
       sourcePath: "/tmp/ghost-does-not-exist.jsonl",
@@ -614,11 +657,25 @@ describe("DatabaseSessionSource", () => {
     const dbPath = makeDb();
     const agent = new FakeDatabaseSource(dbPath);
     const cached = [makeSession("db-1")];
+    agent.setSessionMetaMap(
+      new Map([
+        ["db-1", { id: "db-1", sourcePath: dbPath, pricingCaptureEpoch: PRICING_CAPTURE_EPOCH }],
+      ]),
+    );
 
     // since far in the future → no changes
     const fresh = agent.checkForChanges(Date.now() + 1_000_000, cached);
     expect(fresh.hasChanges).toBe(false);
     expect(fresh).not.toHaveProperty("changedIds");
+  });
+
+  it("invalidates database heads cached before pricing capture", () => {
+    const dbPath = makeDb();
+    const agent = new FakeDatabaseSource(dbPath);
+    const cached = [makeSession("db-1")];
+    agent.setSessionMetaMap(new Map([["db-1", { id: "db-1", sourcePath: dbPath }]]));
+
+    expect(agent.checkForChanges(Date.now() + 1_000_000, cached).hasChanges).toBe(true);
   });
 
   it("reports an imprecise change when db mtime is newer than since", () => {
@@ -651,6 +708,54 @@ describe("DatabaseSessionSource", () => {
     agent.rememberSession("db-1");
     const meta: SessionCacheMeta | undefined = agent.getSessionMetaMap().get("db-1");
     expect(meta?.sourcePath).toBe("/tmp/fake.db");
+    expect(meta?.pricingCaptureEpoch).toBe(PRICING_CAPTURE_EPOCH);
+  });
+
+  it("re-scans a database session when captured model pricing arrives", () => {
+    const model = "vendor/database-pricing-later";
+    let pricingAvailable = false;
+    const originalResolve = pricingResolver.resolve.bind(pricingResolver);
+    vi.spyOn(pricingResolver, "resolve").mockImplementation((modelName) =>
+      modelName === model ? (pricingAvailable ? TEST_PRICING : null) : originalResolve(modelName),
+    );
+
+    class PricingDatabaseSource extends FakeDatabaseSource {
+      override scan(): SessionHead[] {
+        this.scanCount += 1;
+        const session = this.captureSessionPricingMisses(() => {
+          const cost = estimateTokenCost(model, { input: 100, output: 20 }) ?? 0;
+          return {
+            ...makeSession("db-1"),
+            stats: {
+              ...makeSession("db-1").stats,
+              total_input_tokens: 100,
+              total_output_tokens: 20,
+              total_cost: cost,
+              cost_source: cost > 0 ? ("estimated" as const) : undefined,
+            },
+          };
+        });
+        return [session];
+      }
+    }
+
+    try {
+      const agent = new PricingDatabaseSource(makeDb());
+      const cached = agent.scan();
+      expect(cached[0]?.stats.total_cost).toBe(0);
+      expect(agent.getSessionMetaMap().get("db-1")?.unpricedModels).toEqual([model]);
+      expect(agent.checkForChanges(Date.now() + 1_000_000, cached).hasChanges).toBe(false);
+
+      pricingAvailable = true;
+      expect(agent.checkForChanges(Date.now() + 1_000_000, cached).hasChanges).toBe(true);
+
+      const refreshed = agent.incrementalScan(cached, []);
+      expect(refreshed[0]?.stats.total_cost).toBeGreaterThan(0);
+      expect(agent.getSessionMetaMap().get("db-1")?.unpricedModels).toBeUndefined();
+      expect(agent.checkForChanges(Date.now() + 1_000_000, refreshed).hasChanges).toBe(false);
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 });
 

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -13,6 +13,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CodexAgent } from "../codex.js";
 import type { Message, MessagePart, SessionHead, ToolPart } from "../../types/index.js";
 import { buildSessionTree } from "../../contract/session-tree.js";
+import type { ModelPricing } from "../../pricing/fetcher.js";
+import { pricingResolver } from "../../pricing/resolver.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 // Spies while delegating to the real implementation so regression tests can
@@ -97,6 +99,52 @@ describe("CodexAgent cache refresh", () => {
 
     expect(result.hasChanges).toBe(true);
     expect(result.changedIds).toContain("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb");
+  });
+
+  it("re-prices a cached head after missing model pricing arrives", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const sessionFile = join(tempDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+    const model = "vendor/codex-pricing-later";
+    const pricing: ModelPricing = {
+      inputCostPerToken: 0.001,
+      outputCostPerToken: 0.002,
+      cacheCreateCostPerToken: 0,
+      cacheReadCostPerToken: 0,
+      reasoningCostPerToken: 0,
+      webSearchCostPerRequest: 0,
+    };
+    let pricingAvailable = false;
+    const originalResolve = pricingResolver.resolve.bind(pricingResolver);
+    vi.spyOn(pricingResolver, "resolve").mockImplementation((modelName) =>
+      modelName === model ? (pricingAvailable ? pricing : null) : originalResolve(modelName),
+    );
+    writeFileSync(
+      sessionFile,
+      [
+        `{"timestamp":"2026-04-20T10:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/project","model":"${model}"}}`,
+        '{"timestamp":"2026-04-20T10:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":20},"total_token_usage":{"total_tokens":120}}}}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+    const cached = agent.scan({ from: 0 }) as SessionHead[];
+    expect(cached[0]?.stats.total_cost).toBe(0);
+    expect(agent.getSessionMetaMap().get(sessionId)?.unpricedModels).toEqual([model]);
+    expect(agent.checkForChanges(Date.now(), cached).hasChanges).toBe(false);
+
+    pricingAvailable = true;
+    const changed = agent.checkForChanges(Date.now(), cached);
+    expect(changed.changedIds).toEqual([sessionId]);
+
+    const refreshed = agent.incrementalScan(cached, changed.changedIds ?? [], changed.refs);
+    expect(refreshed[0]?.stats.total_cost).toBeGreaterThan(0);
+    expect(agent.getSessionMetaMap().get(sessionId)?.unpricedModels).toBeUndefined();
+    expect(agent.checkForChanges(Date.now(), refreshed).hasChanges).toBe(false);
   });
 
   it("ignores unrelated session index changes during cache validation", () => {

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -2,9 +2,11 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CursorAgent } from "../cursor.js";
 import { SessionScanError } from "../base.js";
+import type { ModelPricing } from "../../pricing/fetcher.js";
+import { pricingResolver } from "../../pricing/resolver.js";
 import type { MessagePart } from "../../types/index.js";
 import {
   getCoreDiagnostics,
@@ -29,6 +31,7 @@ function insertKv(dbPath: string, key: string, value: unknown): void {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -221,5 +224,62 @@ describe("CursorAgent scan outcomes", () => {
     tempDirs.push(tempDir);
 
     expect(makeScanningAgent(createCursorDb(tempDir)).scan()).toEqual([]);
+  });
+
+  it("re-prices a cached head after missing model pricing arrives", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createCursorDb(tempDir);
+    const model = "vendor/cursor-pricing-later";
+    const pricing: ModelPricing = {
+      inputCostPerToken: 0.001,
+      outputCostPerToken: 0.002,
+      cacheCreateCostPerToken: 0,
+      cacheReadCostPerToken: 0,
+      reasoningCostPerToken: 0,
+      webSearchCostPerRequest: 0,
+    };
+    let pricingAvailable = false;
+    const originalResolve = pricingResolver.resolve.bind(pricingResolver);
+    vi.spyOn(pricingResolver, "resolve").mockImplementation((modelName) =>
+      modelName === model ? (pricingAvailable ? pricing : null) : originalResolve(modelName),
+    );
+
+    insertKv(dbPath, "composerData:composer-1", {
+      id: "composer-1",
+      name: "Pricing session",
+      modelConfig: { modelName: model },
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      inputTokenCount: 100,
+      outputTokenCount: 20,
+    });
+    insertKv(dbPath, "bubbleId:composer-1:user", {
+      type: 1,
+      text: "Price this session",
+      createdAt: 1_100,
+    });
+    insertKv(dbPath, "bubbleId:composer-1:assistant", {
+      type: 2,
+      text: "Done",
+      createdAt: 1_200,
+      modelInfo: { modelName: model },
+      tokenCount: { inputTokens: 100, outputTokens: 20 },
+    });
+
+    const agent = makeScanningAgent(dbPath);
+    const cached = agent.scan();
+    expect(cached[0]?.stats.total_cost).toBe(0);
+    expect(agent.getSessionMetaMap().get("composer-1")?.unpricedModels).toEqual([model]);
+    expect(agent.checkForChanges(Number.MAX_SAFE_INTEGER, cached).hasChanges).toBe(false);
+
+    pricingAvailable = true;
+    const changed = agent.checkForChanges(Number.MAX_SAFE_INTEGER, cached);
+    expect(changed.hasChanges).toBe(true);
+
+    const refreshed = agent.incrementalScan(cached, []);
+    expect(refreshed[0]?.stats.total_cost).toBeGreaterThan(0);
+    expect(agent.getSessionMetaMap().get("composer-1")?.unpricedModels).toBeUndefined();
+    expect(agent.checkForChanges(Number.MAX_SAFE_INTEGER, refreshed).hasChanges).toBe(false);
   });
 });

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -5,6 +5,8 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { OpenCodeSqliteAgent } from "../opencode-sqlite.js";
 import { SessionScanError } from "../base.js";
+import type { ModelPricing } from "../../pricing/fetcher.js";
+import { pricingResolver } from "../../pricing/resolver.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 
 const tempDirs: string[] = [];
@@ -240,6 +242,7 @@ function createDatabaseWithRootChildren(rootCount: number): string {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const tempDir of tempDirs.splice(0)) {
     rmSync(tempDir, { recursive: true, force: true });
   }
@@ -305,6 +308,57 @@ describe("OpenCodeSqliteAgent", () => {
       new Map([["s1", { id: "s1", sourcePath: dbPath, headParserVersion: "legacy" }]]),
     );
     expect(agent.checkForChanges(Number.MAX_SAFE_INTEGER, heads).hasChanges).toBe(true);
+  });
+
+  it("tracks missing pricing per cached SQLite head", () => {
+    const dbPath = createDatabase();
+    const model = "vendor/opencode-pricing-later";
+    const pricing: ModelPricing = {
+      inputCostPerToken: 0.001,
+      outputCostPerToken: 0.002,
+      cacheCreateCostPerToken: 0,
+      cacheReadCostPerToken: 0,
+      reasoningCostPerToken: 0,
+      webSearchCostPerRequest: 0,
+    };
+    let pricingAvailable = false;
+    const originalResolve = pricingResolver.resolve.bind(pricingResolver);
+    vi.spyOn(pricingResolver, "resolve").mockImplementation((modelName) =>
+      modelName === model ? (pricingAvailable ? pricing : null) : originalResolve(modelName),
+    );
+    const db = new Database(dbPath);
+    db.prepare("UPDATE message SET data = ? WHERE id = 'm1'").run(
+      JSON.stringify({
+        role: "user",
+        modelID: model,
+        tokens: { input: 100, output: 20 },
+      }),
+    );
+    db.prepare("UPDATE session SET time_created = ?, time_updated = ? WHERE id = 's1'").run(
+      Date.now() - 1_000,
+      Date.now(),
+    );
+    db.close();
+
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+      getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
+    });
+    agent.isAvailable();
+    const cached = agent.scan({ from: 0 });
+    expect(cached[0]?.stats.total_cost).toBe(0);
+    expect(agent.getSessionMetaMap().get("s1")?.unpricedModels).toEqual([model]);
+    expect(agent.checkForChanges(Number.MAX_SAFE_INTEGER, cached).hasChanges).toBe(false);
+
+    pricingAvailable = true;
+    expect(agent.checkForChanges(Number.MAX_SAFE_INTEGER, cached).hasChanges).toBe(true);
+
+    const refreshed = agent.incrementalScan(cached, []);
+    expect(refreshed[0]?.stats.total_cost).toBeGreaterThan(0);
+    expect(agent.getSessionMetaMap().get("s1")?.unpricedModels).toBeUndefined();
+    expect(agent.checkForChanges(Number.MAX_SAFE_INTEGER, refreshed).hasChanges).toBe(false);
   });
 
   it("falls back to an empty message record and reports drift when message data isn't a JSON object", () => {

--- a/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
+++ b/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
@@ -1,6 +1,7 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { PRICING_CAPTURE_EPOCH } from "../../pricing/cost.js";
 import type { SessionHead } from "../../types/index.js";
 import {
   createSessionSourceFailure,
@@ -38,6 +39,7 @@ function meta(ref: SessionSourceRef, sourceMtimeMs = 2): SessionCacheMeta {
     sourcePath: ref.sourcePath,
     sourceFingerprint: ref.fingerprint,
     sourceMtimeMs,
+    pricingCaptureEpoch: PRICING_CAPTURE_EPOCH,
   };
 }
 

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,7 +1,11 @@
 import { existsSync, readdirSync, statSync, type Dirent, type Stats } from "node:fs";
 import { join } from "node:path";
 import type { SessionHead, SessionDetail, ParseSessionResult } from "../types/index.js";
-import { capturePricingMisses } from "../pricing/cost.js";
+import {
+  capturePricingMisses,
+  PRICING_CAPTURE_EPOCH,
+  pricingBecameAvailable,
+} from "../pricing/cost.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import {
   createSessionSourceFailure,
@@ -52,6 +56,8 @@ export interface SessionCacheMeta {
   sourcePath: string;
   /** Models the head parse could not price; their arrival invalidates the cache. */
   unpricedModels?: string[];
+  /** Pricing-miss capture semantics used when this head was parsed. */
+  pricingCaptureEpoch?: string;
   [key: string]: unknown;
 }
 
@@ -326,6 +332,7 @@ export abstract class FileSystemSessionSource<
     if (result.status === "parsed") {
       const meta = this.sessionMetaMap.get(result.data.id);
       if (meta) {
+        meta.pricingCaptureEpoch = PRICING_CAPTURE_EPOCH;
         if (unpricedModels.length > 0) meta.unpricedModels = unpricedModels;
         else delete meta.unpricedModels;
       }
@@ -628,10 +635,23 @@ export abstract class DatabaseSessionSource extends BaseAgent {
   protected abstract getDatabasePath(): string | null;
 
   /** 记录单个会话的缓存 meta（sourcePath = dbPath）。 */
-  protected rememberSession(sessionId: string): void {
+  protected rememberSession(sessionId: string, additionalMeta: Record<string, unknown> = {}): void {
     const dbPath = this.getDatabasePath();
     if (!dbPath) return;
-    this.sessionMetaMap.set(sessionId, { id: sessionId, sourcePath: dbPath });
+    this.sessionMetaMap.set(sessionId, {
+      ...additionalMeta,
+      id: sessionId,
+      sourcePath: dbPath,
+      pricingCaptureEpoch: PRICING_CAPTURE_EPOCH,
+    });
+  }
+
+  protected captureSessionPricingMisses<T extends SessionHead | null>(scan: () => T): T {
+    const { result, unpricedModels } = capturePricingMisses(scan);
+    if (result) {
+      this.rememberSession(result.id, unpricedModels.length > 0 ? { unpricedModels } : {});
+    }
+    return result;
   }
 
   getSessionMetaMap(): Map<string, SessionCacheMeta> {
@@ -650,13 +670,22 @@ export abstract class DatabaseSessionSource extends BaseAgent {
    * writes entirely. Size is part of the fingerprint because an uncheckpointed
    * commit may land in the same millisecond as the previous one.
    */
-  checkForChanges(sinceTimestamp: number, _cachedSessions: SessionHead[]): ChangeCheckResult {
+  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
     const dbPath = this.getDatabasePath();
     if (!dbPath || !existsSync(dbPath)) {
       return { hasChanges: false, timestamp: Date.now() };
     }
 
     try {
+      const pricingChanged = cachedSessions.some((session) => {
+        const meta = this.sessionMetaMap.get(session.id);
+        return (
+          meta?.pricingCaptureEpoch !== PRICING_CAPTURE_EPOCH ||
+          pricingBecameAvailable(meta.unpricedModels)
+        );
+      });
+      if (pricingChanged) return { hasChanges: true, timestamp: Date.now() };
+
       const fingerprint = sqliteSourceFingerprint(dbPath);
       const previous = this.lastSourceFingerprint;
       this.lastSourceFingerprint = fingerprint;

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -636,38 +636,36 @@ export class CursorAgent extends DatabaseSessionSource {
             Array.isArray(composer.subagentInfos) && composer.subagentInfos.length > 0;
           if (options?.fast) {
             const directory = workspacePathMap.get(composerId) ?? "";
-            const totalCost =
-              estimateTokenCost(composer.modelConfig?.modelName ?? composer.model, {
-                input: composer.inputTokenCount ?? 0,
-                output: composer.outputTokenCount ?? 0,
-              }) ?? 0;
-            const head = getParsedSession(
-              hasFastMessages && fastMessageCount === 0 && !hasSubagents
-                ? filteredSession<SessionHead>("no visible messages")
-                : parsedSession<SessionHead>({
-                    id: composerId,
-                    slug: `cursor/${composerId}`,
-                    title: fastTitle,
-                    directory,
-                    time_created: createdAt,
-                    time_updated: updatedAt || undefined,
-                    stats: {
-                      message_count: fastMessageCount,
-                      total_input_tokens: composer.inputTokenCount ?? 0,
-                      total_output_tokens: composer.outputTokenCount ?? 0,
-                      total_cost: totalCost,
-                      cost_source: totalCost > 0 ? "estimated" : undefined,
-                    },
-                  }),
-            );
+            const head = this.captureSessionPricingMisses(() => {
+              const totalCost =
+                estimateTokenCost(composer.modelConfig?.modelName ?? composer.model, {
+                  input: composer.inputTokenCount ?? 0,
+                  output: composer.outputTokenCount ?? 0,
+                }) ?? 0;
+              return getParsedSession(
+                hasFastMessages && fastMessageCount === 0 && !hasSubagents
+                  ? filteredSession<SessionHead>("no visible messages")
+                  : parsedSession<SessionHead>({
+                      id: composerId,
+                      slug: `cursor/${composerId}`,
+                      title: fastTitle,
+                      directory,
+                      time_created: createdAt,
+                      time_updated: updatedAt || undefined,
+                      stats: {
+                        message_count: fastMessageCount,
+                        total_input_tokens: composer.inputTokenCount ?? 0,
+                        total_output_tokens: composer.outputTokenCount ?? 0,
+                        total_cost: totalCost,
+                        cost_source: totalCost > 0 ? "estimated" : undefined,
+                      },
+                    }),
+              );
+            });
             if (!head) continue;
             emitted.set(order, head);
             order += 1;
             this.composerCache.set(composerId, composer);
-            this.sessionMetaMap.set(composerId, {
-              id: composerId,
-              sourcePath: this.dbPath || "",
-            });
             continue;
           }
 
@@ -690,15 +688,19 @@ export class CursorAgent extends DatabaseSessionSource {
         const entry = wanted.get(bubbles.composerId);
         if (!entry) return;
         wanted.delete(bubbles.composerId);
-        const head = this.buildScanHead(entry, bubbles, workspacePathMap);
+        const head = this.captureSessionPricingMisses(() =>
+          this.buildScanHead(entry, bubbles, workspacePathMap),
+        );
         if (head) emitted.set(entry.order, head);
       });
       // Composers with no bubbles at all still go through the same builder.
       for (const entry of wanted.values()) {
-        const head = this.buildScanHead(
-          entry,
-          { composerId: entry.composerId, byKey: [], byRowId: [] },
-          workspacePathMap,
+        const head = this.captureSessionPricingMisses(() =>
+          this.buildScanHead(
+            entry,
+            { composerId: entry.composerId, byKey: [], byRowId: [] },
+            workspacePathMap,
+          ),
         );
         if (head) emitted.set(entry.order, head);
       }
@@ -910,8 +912,6 @@ export class CursorAgent extends DatabaseSessionSource {
         directory,
       } as unknown as ComposerData);
     }
-    this.sessionMetaMap.set(sessionId, { id: sessionId, sourcePath: this.dbPath || "" });
-
     return {
       id: sessionId,
       slug: `cursor/${sessionId}`,

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -14,6 +14,7 @@ import type {
 } from "./base.js";
 import type { SessionHead, SessionDetail, Message, MessagePart } from "../types/index.js";
 import { normalizeMessageParts } from "../contract/message-part.js";
+import { capturePricingMisses } from "../pricing/cost.js";
 import { columnExists, openDbReadOnly, type SQLiteDatabase } from "../utils/sqlite.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { resolveSessionTitle } from "../utils/title-fallback.js";
@@ -42,6 +43,7 @@ interface OpenCodePartRow {
 interface OpenCodeHeadContext {
   stats: SessionHead["stats"];
   messageTitle: string | null;
+  unpricedModels: Set<string>;
 }
 
 interface OpenCodeSqliteAgentConfig {
@@ -217,20 +219,16 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
       options?.onProgress?.({ total: rows.length, processed: 0, sessions: 0 });
       let processed = 0;
       for (const row of rows) {
-        const head = getParsedSession(
-          this.parseSessionHeadRow(row, hasMessageTable, headContexts.get(String(row.id ?? ""))),
-        );
+        const context = headContexts.get(String(row.id ?? ""));
+        const head = getParsedSession(this.parseSessionHeadRow(row, hasMessageTable, context));
         if (head) {
           heads.push(head);
-
-          // Store session metadata for caching
-          if (this.dbPath) {
-            this.sessionMetaMap.set(head.id, {
-              id: head.id,
-              sourcePath: this.dbPath,
-              headParserVersion: HEAD_PARSER_VERSION,
-            });
-          }
+          this.rememberSession(head.id, {
+            headParserVersion: HEAD_PARSER_VERSION,
+            ...(context && context.unpricedModels.size > 0
+              ? { unpricedModels: [...context.unpricedModels] }
+              : {}),
+          });
         }
         processed += 1;
         options?.onProgress?.({ total: rows.length, processed, sessions: heads.length });
@@ -485,6 +483,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
             total_cost: 0,
           },
           messageTitle: null,
+          unpricedModels: new Set(),
         };
         contexts.set(sessionId, context);
       }
@@ -501,7 +500,10 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
       if (parts.length === 0) continue;
 
       const context = ensureContext(sessionId);
-      accumulateTokenStats(context.stats, msgData, this.name);
+      const { unpricedModels } = capturePricingMisses(() =>
+        accumulateTokenStats(context.stats, msgData, this.name),
+      );
+      for (const model of unpricedModels) context.unpricedModels.add(model);
       context.stats.message_count += 1;
 
       if (!context.messageTitle && String(msgData.role ?? "") === "user") {

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -1,6 +1,6 @@
 import { statSync } from "node:fs";
 import type { SessionSnapshotCompleteness } from "../discovery/cache/sessions.js";
-import { pricingResolver } from "../pricing/resolver.js";
+import { PRICING_CAPTURE_EPOCH, pricingBecameAvailable } from "../pricing/cost.js";
 import type { SessionHead } from "../types/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import type {
@@ -67,19 +67,6 @@ function readCachedMeta(meta: CachedMetaLookup, sessionId: string): SessionCache
 function fingerprintMatches(ref: SessionSourceRef, cached: SessionCacheMeta | undefined): boolean {
   return (
     typeof cached?.sourceFingerprint === "string" && cached.sourceFingerprint === ref.fingerprint
-  );
-}
-
-/**
- * A head cached while some of its models lacked pricing carries a zero estimate
- * forever unless re-parsed: the source file never changes again, so the
- * fingerprint alone cannot see a later pricing arrival.
- */
-function pricingBecameAvailable(cached: SessionCacheMeta | undefined): boolean {
-  const models = cached?.unpricedModels;
-  if (!Array.isArray(models)) return false;
-  return models.some(
-    (model) => typeof model === "string" && pricingResolver.resolve(model) !== null,
   );
 }
 
@@ -182,7 +169,8 @@ export function diffSessionSources(
       cachedIds.has(ref.sessionId) &&
       meta?.sourcePath === ref.sourcePath &&
       fingerprintMatches(ref, meta) &&
-      !pricingBecameAvailable(meta);
+      meta.pricingCaptureEpoch === PRICING_CAPTURE_EPOCH &&
+      !pricingBecameAvailable(meta.unpricedModels);
     if (!unchanged) changedIds.push(ref.sessionId);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ export {
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,
 } from "./discovery/index.js";
+export { PRICING_CAPTURE_EPOCH } from "./pricing/index.js";
 export {
   filterSessionTreeByActivityWindow,
   isChildSession,

--- a/packages/core/src/pricing/cost.ts
+++ b/packages/core/src/pricing/cost.ts
@@ -16,6 +16,16 @@ function positive(value: number | undefined): number {
 
 let pricingMissCapture: Set<string> | null = null;
 
+export const PRICING_CAPTURE_EPOCH = "pricing-capture-v1";
+
+/** Whether a model that previously produced a zero estimate is now billable. */
+export function pricingBecameAvailable(unpricedModels: unknown): boolean {
+  if (!Array.isArray(unpricedModels)) return false;
+  return unpricedModels.some(
+    (model) => typeof model === "string" && pricingResolver.resolve(model) !== null,
+  );
+}
+
 /**
  * Records which models {@link estimateCostForTokens} failed to price during
  * `run`. Cached session heads carry these misses so they can be re-parsed once


### PR DESCRIPTION
## Summary

- add a shared pricing-capture epoch so every agent re-heals legacy cached heads once
- capture missing model pricing per Cursor, OpenCode, and ZCode session
- invalidate cached heads when a previously missing model becomes billable

## Root cause

Pricing-miss metadata was only captured by the filesystem synchronization path. Legacy file-agent caches had no marker proving they used that capture behavior, while database agents stored only a session ID and database path, leaving zero-cost heads permanently cached after pricing became available.

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`

Issue: CS-185
