### PR TITLE
fix(cli): allow proxy authority on loopback

### DIFF
--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -482,6 +482,7 @@ describe("createServer", () => {
         bind_category: "loopback",
         transport: "trusted-proxy",
         authentication: "token",
+        loopback_authority: "disabled",
       });
       expect((await fetch(`${origin}/api/agents`, { headers: proxyHeaders })).status).toBe(401);
       expect(
@@ -509,6 +510,30 @@ describe("createServer", () => {
       await app.shutdown();
       warnSpy.mockRestore();
       logSpy.mockRestore();
+    }
+  });
+
+  it("CS-186: accepts a proxy's public authority on an authenticated loopback listener", async () => {
+    const app = await createServer(0, createStore(), {
+      hostname: "127.0.0.1",
+      remoteAccess: true,
+      remoteAccessToken: "proxy-token",
+      transport: { kind: "trusted-proxy" },
+    });
+    const origin = `http://127.0.0.1:${new URL(app.url).port}`;
+
+    try {
+      expect(
+        (
+          await httpRequest(`${origin}/api/agents`, {
+            Host: "codesesh.example.com",
+            "X-Forwarded-Proto": "https",
+            Authorization: "Bearer proxy-token",
+          })
+        ).status,
+      ).toBe(200);
+    } finally {
+      await app.shutdown();
     }
   });
 

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -110,12 +110,14 @@ export async function createServer(
   const remoteAccessToken = accessPolicy.authenticationRequired
     ? (options.remoteAccessToken ?? (options.remoteAccess ? createRemoteAccessToken() : null))
     : null;
+  const loopbackAuthorityEnabled = !accessPolicy.authenticationRequired;
   let actualPort: number | null = null;
 
   appLogger.info("server.access_policy", {
     bind_category: accessPolicy.bindCategory,
     transport: transport.kind,
     authentication: remoteAccessToken ? "token" : "none",
+    loopback_authority: loopbackAuthorityEnabled ? "enabled" : "disabled",
   });
 
   if (accessPolicy.authenticationRequired && !remoteAccessToken) {
@@ -124,7 +126,7 @@ export async function createServer(
     );
   }
 
-  if (accessPolicy.bindCategory === "loopback") {
+  if (loopbackAuthorityEnabled) {
     app.use("*", async (c, next) => {
       const decision = validateLoopbackAuthority(c.env.incoming.rawHeaders, hostname, actualPort);
       if (!decision.allowed) {


### PR DESCRIPTION
## Summary

- enforce loopback authority validation only for unauthenticated local listeners
- preserve token and trusted-proxy TLS checks for authenticated reverse-proxy deployments
- cover a public proxy Host header on a loopback-bound listener

## Root cause

The loopback authority middleware was selected from the bind address alone. A trusted-proxy deployment still binds to loopback, so the middleware rejected the proxy's public Host header before token authentication and forwarded-TLS validation could run.

## Verification

- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`
- `pnpm --filter codesesh test`
- `pnpm --filter codesesh build`

Issue: CS-186
