### PR TITLE
fix(cli): bound shutdown with active SSE

### DIFF
--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -26,6 +26,7 @@ export interface ApiRouteOptions {
   defaultSessionFrom?: number;
   defaultSessionTo?: number;
   defaultSessionDays?: number;
+  shutdownSignal?: AbortSignal;
 }
 
 function createSseResponse(eventSource: ScanEventSource, signal: AbortSignal): Response {
@@ -126,7 +127,12 @@ export function createApiRoutes(
   api.delete("/session-aliases/:agent/:id", (c) => handleDeleteSessionAlias(c));
   api.post("/logs", (c) => handlePostClientLog(c));
   if (eventSource) {
-    api.get("/events", (c) => createSseResponse(eventSource, c.req.raw.signal));
+    api.get("/events", (c) => {
+      const signal = options.shutdownSignal
+        ? AbortSignal.any([c.req.raw.signal, options.shutdownSignal])
+        : c.req.raw.signal;
+      return createSseResponse(eventSource, signal);
+    });
   }
 
   return api;

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -340,6 +340,32 @@ describe("createServer", () => {
     }
   });
 
+  it("CS-187: shuts down while an SSE client remains connected", async () => {
+    const unsubscribeSessions = vi.fn();
+    const unsubscribeScanStatus = vi.fn();
+    const store = {
+      ...createStore(),
+      subscribe: () => unsubscribeSessions,
+      subscribeScanStatus: () => unsubscribeScanStatus,
+    };
+    const app = await createServer(0, store);
+    const events = await fetch(`${app.url}/api/events`);
+    const shutdown = app.shutdown();
+
+    const completedBeforeClientCancel = await Promise.race([
+      shutdown.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 2_000)),
+    ]);
+    const subscriptionsClosedBeforeClientCancel =
+      unsubscribeSessions.mock.calls.length === 1 && unsubscribeScanStatus.mock.calls.length === 1;
+    if (!completedBeforeClientCancel) await events.body?.cancel();
+    await shutdown;
+
+    expect(subscriptionsClosedBeforeClientCancel).toBe(true);
+    expect(completedBeforeClientCancel).toBe(true);
+    expect(store.shutdown).toHaveBeenCalledOnce();
+  });
+
   it("CS-131: serves the web build without reading outside its root", async () => {
     const root = mkdtempSync(join(tmpdir(), "codesesh-static-root-"));
     const webDist = join(root, "web");

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -25,6 +25,7 @@ import {
 import type { ScanEventSource } from "./scan-source.js";
 
 const MAX_API_REQUEST_BYTES = 1024 * 1024;
+const SERVER_CLOSE_GRACE_MS = 1_000;
 
 export interface CreateServerOptions {
   defaultSessionFrom?: number;
@@ -98,6 +99,30 @@ function getListeningPort(server: ServerType, fallback: number): number {
   return typeof address === "object" && address !== null ? (address as AddressInfo).port : fallback;
 }
 
+async function closeHttpServer(server: ServerType | null, port: number | null): Promise<void> {
+  if (!server) return;
+
+  let forceCloseTimer: ReturnType<typeof setTimeout> | undefined;
+  const gracefulClose = new Promise<void>((resolve) => server.close(() => resolve()));
+  const forceClose = new Promise<void>((resolve) => {
+    forceCloseTimer = setTimeout(() => {
+      appLogger.warn("server.shutdown.force_close", {
+        port,
+        grace_ms: SERVER_CLOSE_GRACE_MS,
+      });
+      if ("closeAllConnections" in server) server.closeAllConnections();
+      resolve();
+    }, SERVER_CLOSE_GRACE_MS);
+    forceCloseTimer.unref();
+  });
+
+  try {
+    await Promise.race([gracefulClose, forceClose]);
+  } finally {
+    if (forceCloseTimer) clearTimeout(forceCloseTimer);
+  }
+}
+
 export async function createServer(
   port: number,
   store: ScanResultSource & ScanEventSource & { shutdown(): Promise<void> },
@@ -111,6 +136,7 @@ export async function createServer(
     ? (options.remoteAccessToken ?? (options.remoteAccess ? createRemoteAccessToken() : null))
     : null;
   const loopbackAuthorityEnabled = !accessPolicy.authenticationRequired;
+  const shutdownController = new AbortController();
   let actualPort: number | null = null;
 
   appLogger.info("server.access_policy", {
@@ -188,6 +214,7 @@ export async function createServer(
     defaultSessionFrom: options.defaultSessionFrom,
     defaultSessionTo: options.defaultSessionTo,
     defaultSessionDays: options.defaultSessionDays,
+    shutdownSignal: shutdownController.signal,
   };
   app.route("/api", createApiRoutes(store, store, routeOptions));
 
@@ -278,14 +305,15 @@ export async function createServer(
     url,
     shutdown: async () => {
       appLogger.info("server.shutdown", { port: actualPort });
-      await new Promise<void>((resolve) => {
-        if (!server) {
-          resolve();
-          return;
-        }
-        server.close(() => resolve());
-      });
-      await store.shutdown();
+      shutdownController.abort();
+      try {
+        appLogger.info("server.shutdown.phase", { phase: "http-closing", port: actualPort });
+        await closeHttpServer(server, actualPort);
+      } finally {
+        appLogger.info("server.shutdown.phase", { phase: "store-closing", port: actualPort });
+        await store.shutdown();
+      }
+      appLogger.info("server.shutdown.phase", { phase: "complete", port: actualPort });
     },
   };
 }


### PR DESCRIPTION
## Summary

- abort every active SSE stream when server shutdown begins
- bound graceful HTTP shutdown and force-close lingering connections after one second
- always shut down the scan store even if HTTP closing fails

## Root cause

`server.close()` waited for existing connections before the store was shut down. The SSE endpoint kept its response and heartbeat alive indefinitely, so an open browser prevented the close callback and left workers and SQLite resources running.

## Verification

- added an integration test that shuts down with an attached SSE client
- verified SSE subscriptions close before the client disconnects
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`
- `pnpm --filter codesesh test`
- `pnpm --filter codesesh build`

Issue: CS-187
