### PR TITLE
fix(cli): persist backfill checkpoints

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -22,6 +22,7 @@ const core = vi.hoisted(() => ({
   loadCachedSessions: vi.fn((): ReturnType<typeof loadCachedSessions> => null),
   markAgentFullSyncStarted: vi.fn(),
   markAgentFullSyncCompleted: vi.fn(),
+  markAgentFullSyncProgress: vi.fn(),
   sessionSignature: vi.fn(),
 }));
 
@@ -43,6 +44,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     loadCachedSessions: core.loadCachedSessions,
     markAgentFullSyncStarted: core.markAgentFullSyncStarted,
     markAgentFullSyncCompleted: core.markAgentFullSyncCompleted,
+    markAgentFullSyncProgress: core.markAgentFullSyncProgress,
     sessionSignature: core.sessionSignature,
     SMART_TAG_CLASSIFIER_REVISION: "smart-tags-v1",
   };
@@ -172,6 +174,7 @@ afterEach(() => {
   core.isAgentCacheInitialized.mockReturnValue(true);
   core.loadCachedSessions.mockReturnValue(null);
   core.markAgentFullSyncStarted.mockClear();
+  core.markAgentFullSyncProgress.mockClear();
   searchIndex.enqueue.mockImplementation(async () => undefined);
 });
 
@@ -239,6 +242,50 @@ describe("AgentSyncEngine", () => {
       completedAgents: ["codex"],
       failedAgents: [],
     });
+  });
+
+  it("persists cursors from durable backfill finalization checkpoints", async () => {
+    core.getAgentFullSyncCursor.mockReturnValueOnce("previous");
+    const next = makeSession("next");
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async (_agentName, payload) => {
+        expect(payload.operation).toEqual({
+          kind: "source-backfill",
+          cursor: "previous",
+          checkpoint: "durable",
+        });
+        expect(payload.onCheckpoint).toEqual(expect.any(Function));
+        payload.onCheckpoint?.({
+          stage: "scanned",
+          sessions: [],
+          meta: {},
+          completeness: "complete",
+        });
+        payload.onCheckpoint?.({ stage: "finalizing", changes: [], meta: {} });
+        payload.onCheckpoint?.({
+          stage: "finalizing",
+          changes: [{ session: next, sortIndex: 0 }],
+          meta: {},
+          backfillCursor: next.id,
+        });
+        return workerResult({ sessions: [next], meta: {} });
+      }),
+      commit: vi.fn(),
+      discard: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(new FakeSyncAgent(), [], workerRunner);
+    const internal = engine as unknown as { enqueueBackfill(agentName: string): void };
+    const statuses: ScanStatusEvent[] = [];
+    engine.subscribeStatusChanged((status) => statuses.push(status));
+
+    internal.enqueueBackfill("codex");
+    await vi.waitFor(() => expect(statuses.at(-1)?.backfill.completedAgents).toEqual(["codex"]));
+
+    expect(core.markAgentFullSyncProgress).toHaveBeenCalledOnce();
+    expect(core.markAgentFullSyncProgress).toHaveBeenCalledWith("codex", next.id);
+    expect(core.markAgentFullSyncCompleted).toHaveBeenCalledWith("codex");
   });
 
   it("cancels backfill lifecycle before awaiting shutdown", async () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -7,6 +7,7 @@ import {
   getAgentLastFullSyncAt,
   isAgentCacheInitialized,
   loadCachedSessions,
+  markAgentFullSyncProgress,
   markAgentFullSyncStarted,
   markAgentFullSyncCompleted,
   sessionSignature,
@@ -32,7 +33,11 @@ import { appLogger, logSearchIndexSync } from "./logging.js";
 import { SearchIndexJobRunner } from "./search-index-job-runner.js";
 import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 import { ScanStatusModel } from "./scan-status-model.js";
-import type { ScanRefreshOperation } from "./scan-refresh-operation.js";
+import type {
+  BackfillScanRefreshOperation,
+  ScanRefreshOperation,
+} from "./scan-refresh-operation.js";
+import type { ScanRefreshWorkerCheckpoint } from "./scan-refresh-worker.js";
 import type { WorkerRunner } from "./worker-runner.js";
 import { toError } from "./errors.js";
 
@@ -738,6 +743,7 @@ export class AgentSyncEngine {
     runOptions: {
       backfillAttempt?: BackfillAttemptRef;
       meta?: CachedSessions["meta"];
+      onCheckpoint?: (checkpoint: ScanRefreshWorkerCheckpoint) => void;
     } = {},
   ) {
     return this.options.workerRunner.run(agent.name, {
@@ -747,6 +753,20 @@ export class AgentSyncEngine {
       meta: runOptions.meta ?? buildAgentCacheMeta(agent),
       onProgress: (progress) =>
         this.updateAgentScanProgress(agent.name, progress, runOptions.backfillAttempt),
+      onCheckpoint: runOptions.onCheckpoint,
+    });
+  }
+
+  private handleBackfillCheckpoint(
+    agentName: string,
+    checkpoint: ScanRefreshWorkerCheckpoint,
+  ): void {
+    if (checkpoint.stage !== "finalizing" || !checkpoint.backfillCursor) return;
+    markAgentFullSyncProgress(agentName, checkpoint.backfillCursor);
+    appLogger.debug("scan.backfill.checkpoint", {
+      agent: agentName,
+      cursor: checkpoint.backfillCursor,
+      sessions: checkpoint.changes.length,
     });
   }
 
@@ -816,10 +836,15 @@ export class AgentSyncEngine {
     let durableCommitted = false;
     try {
       markAgentFullSyncStarted(agentName);
-      const operation: ScanRefreshOperation =
+      const operation: BackfillScanRefreshOperation =
         agent instanceof FileSystemSessionSource
-          ? { kind: "source-backfill", cursor: backfillCursor }
-          : { kind: "full-backfill", cursor: backfillCursor };
+          ? { kind: "source-backfill", cursor: backfillCursor, checkpoint: "durable" }
+          : { kind: "full-backfill", cursor: backfillCursor, checkpoint: "durable" };
+      appLogger.info("scan.backfill.started", {
+        agent: agentName,
+        cursor: backfillCursor ?? undefined,
+        durable_checkpoints: operation.checkpoint === "durable",
+      });
       const result = await this.runWorker(
         agent,
         baseline,
@@ -828,6 +853,7 @@ export class AgentSyncEngine {
         {
           backfillAttempt: attempt,
           meta,
+          onCheckpoint: (checkpoint) => this.handleBackfillCheckpoint(agentName, checkpoint),
         },
       );
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -560,7 +560,7 @@ describe("scan refresh worker entry", () => {
       time_created: 3_000,
       time_updated: 3_000,
       smart_tags: [],
-      smart_tags_source_updated_at: 3_000,
+      smart_tags_source_updated_at: 1,
       smart_tags_classifier_revision: "smart-tags-v1",
     });
     const cursor = makeSession("cursor", {
@@ -598,7 +598,11 @@ describe("scan refresh worker entry", () => {
 
     await runWorker();
 
-    expect(mocks.ensureSessionTagsSync).toHaveBeenCalledWith(agent, [next], expect.any(Function));
+    expect(mocks.ensureSessionTagsSync).toHaveBeenCalledWith(
+      agent,
+      [newest, next],
+      expect.any(Function),
+    );
     expect(mocks.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "checkpoint",


### PR DESCRIPTION
## Summary

- enable durable checkpoints for full and source backfill operations
- persist each finalization cursor emitted by the scan worker
- keep stale sessions before a restored cursor eligible for re-finalization

## Root cause

Backfill scheduling read the stored cursor but never requested durable worker checkpoints or installed a checkpoint callback. As a result, `markAgentFullSyncProgress` had no production caller and interrupted backfills always restarted finalization from the beginning.

## Verification

- added an engine test for checkpoint wiring and cursor persistence
- extended the worker integration test to cover stale sessions before the cursor
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`
- `pnpm --filter codesesh test`
- `pnpm --filter codesesh build`

Issue: CS-188
