### PR TITLE
fix(web): bound bar chart stagger progress

### DIFF
--- a/apps/web/src/hooks/useBarField.test.tsx
+++ b/apps/web/src/hooks/useBarField.test.tsx
@@ -2,7 +2,7 @@ import { useRef } from "react";
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { stubCanvas, type StubbedCanvas } from "../test/canvas-stub";
-import { DEFAULT_BAR_LAYOUT, useBarField, type BarHover } from "./useBarField";
+import { columnProgress, DEFAULT_BAR_LAYOUT, useBarField, type BarHover } from "./useBarField";
 
 const WIDTH = 400;
 const HEIGHT = 200;
@@ -114,5 +114,22 @@ describe("useBarField", () => {
     await nextFrame();
 
     expect(canvas.context.roundRect).toHaveBeenCalled();
+  });
+});
+
+describe.each([21, 90])("columnProgress with %i columns", (count) => {
+  it("stays finite, bounded, and monotonic for every column", () => {
+    const timeline = Array.from({ length: 101 }, (_, step) => step / 100);
+
+    for (let column = 0; column < count; column++) {
+      const values = timeline.map((progress) => columnProgress(column, count, progress));
+
+      expect(values.every(Number.isFinite)).toBe(true);
+      expect(values.every((value) => value >= 0 && value <= 1)).toBe(true);
+      expect(values.at(-1)).toBe(1);
+      for (let index = 1; index < values.length; index++) {
+        expect(values[index]).toBeGreaterThanOrEqual(values[index - 1]!);
+      }
+    }
   });
 });

--- a/apps/web/src/hooks/useBarField.ts
+++ b/apps/web/src/hooks/useBarField.ts
@@ -17,6 +17,8 @@ const CAP_BOTTOM = 7;
 
 const GROW_MS = 620;
 const COLUMN_STAGGER = 0.05;
+// Leave every column at least 20% of the timeline for its own growth.
+const MAX_STAGGER_SPAN = 0.8;
 /** A crest crosses the field in ~8s: legible drift without reading as busy. */
 const DRIFT_STEP = 0.03;
 
@@ -43,6 +45,14 @@ export const DEFAULT_BAR_LAYOUT: BarFieldLayout = {
   bandGap: 4,
   minBand: 6,
 };
+
+export function columnProgress(index: number, count: number, progress: number) {
+  const columnIntervals = Math.max(1, count - 1);
+  const stagger = Math.min(COLUMN_STAGGER, MAX_STAGGER_SPAN / columnIntervals);
+  const span = 1 - (count - 1) * stagger;
+  const local = clamp01((progress - index * stagger) / span);
+  return 1 - Math.pow(1 - local, 3);
+}
 
 interface Options {
   /** `[column][band]`; a plain bar chart is one band per column. */
@@ -103,14 +113,11 @@ export function useBarField(
 
     let drift = 0;
 
-    /** Cubic ease-out, offset so column i starts 5% of the duration later. */
-    const columnProgress = (index: number, count: number, now: number) => {
+    const animatedColumnProgress = (index: number, count: number, now: number) => {
       if (!grow.current.running) return 1;
       const progress = clamp01((now - grow.current.startedAt) / GROW_MS);
-      const span = 1 - (count - 1) * COLUMN_STAGGER;
-      const local = clamp01((progress - index * COLUMN_STAGGER) / span);
       if (progress >= 1) grow.current.running = false;
-      return 1 - Math.pow(1 - local, 3);
+      return columnProgress(index, count, progress);
     };
 
     const drawBand = (
@@ -194,7 +201,7 @@ export function useBarField(
       const hover = current.hovered;
 
       current.values.forEach((bands, column) => {
-        const progress = columnProgress(column, count, now);
+        const progress = animatedColumnProgress(column, count, now);
         const x = column * columnW + (columnW - barW) / 2;
         let bottom = h;
 


### PR DESCRIPTION
## Summary

- cap the total column stagger span so long time windows retain positive per-column animation time
- move stagger progress into a pure helper used by the canvas painter
- cover 21-column and 90-column timelines for finite, bounded, monotonic progress

## Testing

- pnpm lint
- pnpm format:check
- pnpm build
- pnpm test