### PR TITLE
fix(web): stop resting canvas chart loops

### DIFF
--- a/apps/web/src/hooks/useBarField.test.tsx
+++ b/apps/web/src/hooks/useBarField.test.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import { act, cleanup, render } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { stubCanvas, type StubbedCanvas } from "../test/canvas-stub";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stubAnimationFrames, stubCanvas, type StubbedCanvas } from "../test/canvas-stub";
 import { columnProgress, DEFAULT_BAR_LAYOUT, useBarField, type BarHover } from "./useBarField";
 
 const WIDTH = 400;
@@ -51,6 +51,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   canvas.restore();
+  vi.restoreAllMocks();
 });
 
 describe("useBarField", () => {
@@ -114,6 +115,48 @@ describe("useBarField", () => {
     await nextFrame();
 
     expect(canvas.context.roundRect).toHaveBeenCalled();
+  });
+
+  it("stops after growth settles and reuses its resolved palette", () => {
+    const frames = stubAnimationFrames();
+    const readStyle = vi.spyOn(window, "getComputedStyle");
+
+    render(<Harness values={[[100]]} reducedMotion={false} />);
+    expect(frames.pendingCount()).toBe(1);
+
+    act(() => {
+      frames.runNext(performance.now() + 1_000);
+    });
+
+    expect(canvas.context.clearRect).toHaveBeenCalledTimes(1);
+    expect(frames.pendingCount()).toBe(0);
+    expect(readStyle).toHaveBeenCalledTimes(1);
+  });
+
+  it("wakes a settled field for data, hover, and resize changes", () => {
+    const frames = stubAnimationFrames();
+    const { rerender } = render(<Harness values={[[100]]} reducedMotion={false} />);
+    let now = performance.now() + 1_000;
+    act(() => frames.runNext(now));
+    expect(frames.pendingCount()).toBe(0);
+
+    rerender(<Harness values={[[50]]} reducedMotion={false} />);
+    expect(frames.pendingCount()).toBe(1);
+    act(() => frames.runNext((now += 1_000)));
+    expect(frames.pendingCount()).toBe(0);
+
+    rerender(<Harness values={[[50]]} hovered={{ column: 0, band: 0 }} reducedMotion={false} />);
+    expect(frames.pendingCount()).toBe(1);
+    act(() => frames.runNext((now += 16)));
+    expect(canvas.context.stroke).toHaveBeenCalled();
+
+    rerender(<Harness values={[[50]]} reducedMotion={false} />);
+    expect(frames.pendingCount()).toBe(1);
+    act(() => frames.runNext((now += 16)));
+    expect(frames.pendingCount()).toBe(0);
+
+    act(() => canvas.resize());
+    expect(frames.pendingCount()).toBe(1);
   });
 });
 

--- a/apps/web/src/hooks/useBarField.ts
+++ b/apps/web/src/hooks/useBarField.ts
@@ -6,9 +6,11 @@
  * out of whatever is currently on screen, so a change mid-animation continues
  * from where the bar visually is instead of snapping back to zero.
  */
-import { useEffect, useRef, type RefObject } from "react";
+import { useContext, useEffect, useRef, type RefObject } from "react";
 
 import { clamp01, hashUnit, resolveColor, smoothstep, tileWave } from "../lib/chart-shading";
+import { ResolvedThemeContext } from "./useTheme";
+import { useCanvasFrameLoop } from "./useCanvasFrameLoop";
 
 const MAX_DPR = 2;
 const CORNER = 5;
@@ -20,7 +22,7 @@ const COLUMN_STAGGER = 0.05;
 // Leave every column at least 20% of the timeline for its own growth.
 const MAX_STAGGER_SPAN = 0.8;
 /** A crest crosses the field in ~8s: legible drift without reading as busy. */
-const DRIFT_STEP = 0.03;
+const DRIFT_RATE = 0.0018;
 
 const DIM_OTHER_COLUMN = 0.3;
 const DIM_SIBLING_BAND = 0.48;
@@ -69,8 +71,10 @@ export function useBarField(
   canvasRef: RefObject<HTMLCanvasElement | null>,
   { values, axisMax, colors, highlight, hovered, layout, reducedMotion }: Options,
 ) {
-  const state = useRef({ values, axisMax, colors, highlight, hovered, layout });
-  state.current = { values, axisMax, colors, highlight, hovered, layout };
+  const theme = useContext(ResolvedThemeContext);
+  const frameLoop = useCanvasFrameLoop(canvasRef, reducedMotion);
+  const colorsKey = colors.join("\0");
+  const state = useRef({ values, axisMax, hovered, layout });
 
   const drawn = useRef(new Map<string, number>());
   const from = useRef(new Map<string, number>());
@@ -79,24 +83,32 @@ export function useBarField(
   const redraw = useRef<() => void>(() => {});
 
   useEffect(() => {
+    state.current = { values, axisMax, hovered, layout };
+    if (reducedMotion) redraw.current();
+    else frameLoop.requestFrame();
+  }, [axisMax, frameLoop, hovered, layout, reducedMotion, values]);
+
+  useEffect(() => {
     from.current = new Map(drawn.current);
     if (reducedMotion) {
       grow.current.running = false;
       redraw.current();
     } else {
       grow.current = { startedAt: performance.now(), running: true };
+      frameLoop.requestFrame();
     }
-  }, [values, axisMax, reducedMotion]);
-
-  useEffect(() => {
-    if (reducedMotion) redraw.current();
-  }, [hovered, reducedMotion]);
+  }, [axisMax, frameLoop, reducedMotion, values]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     const host = canvas?.parentElement;
     const ctx = canvas?.getContext("2d");
     if (!canvas || !host || !ctx) return;
+
+    const style = getComputedStyle(canvas);
+    const colorTokens = colorsKey ? colorsKey.split("\0") : [];
+    const palette = colorTokens.map((color) => resolveColor(style, color));
+    const highlightColor = resolveColor(style, highlight);
 
     const layoutCanvas = () => {
       const w = host.clientWidth;
@@ -182,15 +194,15 @@ export function useBarField(
     };
 
     const draw = (now: number) => {
+      drift = now * DRIFT_RATE;
       const { w, h } = size.current;
       if (!w || !h) return;
       const current = state.current;
       ctx.clearRect(0, 0, w, h);
-      if (!current.values.length || current.axisMax <= 0) return;
-
-      const style = getComputedStyle(canvas);
-      const palette = current.colors.map((color) => resolveColor(style, color));
-      const highlightColor = resolveColor(style, current.highlight);
+      if (!current.values.length || current.axisMax <= 0) {
+        grow.current.running = false;
+        return;
+      }
 
       const { barRatio, barMax, bandGap, minBand } = current.layout;
       const count = current.values.length;
@@ -248,25 +260,28 @@ export function useBarField(
     };
     redraw.current = renderStatic;
 
-    let frame = 0;
-    const loop = (now: number) => {
-      drift += DRIFT_STEP;
+    frameLoop.setFrameHandler((now) => {
       draw(now);
-      frame = requestAnimationFrame(loop);
-    };
+      if (grow.current.running) return "active";
+      return state.current.hovered === null ? "stop" : "idle";
+    });
 
     layoutCanvas();
-    const observer = new ResizeObserver(renderStatic);
+    const onResize = () => {
+      layoutCanvas();
+      if (reducedMotion) draw(performance.now());
+      else frameLoop.requestFrame();
+    };
+    const observer = new ResizeObserver(onResize);
     observer.observe(host);
 
     if (reducedMotion) draw(performance.now());
-    else frame = requestAnimationFrame(loop);
 
     return () => {
-      cancelAnimationFrame(frame);
+      frameLoop.setFrameHandler(null);
       observer.disconnect();
     };
-  }, [canvasRef, reducedMotion]);
+  }, [canvasRef, colorsKey, frameLoop, highlight, reducedMotion, theme]);
 
   const hitTest = (clientX: number, clientY: number): BarHover | null => {
     const canvas = canvasRef.current;

--- a/apps/web/src/hooks/useCanvasFrameLoop.test.tsx
+++ b/apps/web/src/hooks/useCanvasFrameLoop.test.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { stubAnimationFrames } from "../test/canvas-stub";
+import { useCanvasFrameLoop, type CanvasFrameDemand } from "./useCanvasFrameLoop";
+
+function Harness({
+  onFrame,
+  reducedMotion = false,
+}: {
+  onFrame: (time: number) => CanvasFrameDemand;
+  reducedMotion?: boolean;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const frames = useCanvasFrameLoop(ref, reducedMotion);
+
+  useEffect(() => {
+    frames.setFrameHandler(onFrame);
+    return () => frames.setFrameHandler(null);
+  }, [frames, onFrame]);
+
+  return <div ref={ref} />;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("useCanvasFrameLoop", () => {
+  it("runs active frames immediately, throttles idle frames, and stops", () => {
+    vi.useFakeTimers();
+    const frames = stubAnimationFrames();
+    const onFrame = vi
+      .fn<() => CanvasFrameDemand>()
+      .mockReturnValueOnce("active")
+      .mockReturnValueOnce("idle")
+      .mockReturnValue("stop");
+
+    render(<Harness onFrame={onFrame} />);
+    expect(frames.pendingCount()).toBe(1);
+
+    act(() => frames.runNext(0));
+    expect(frames.pendingCount()).toBe(1);
+
+    act(() => frames.runNext(16));
+    expect(frames.pendingCount()).toBe(0);
+
+    act(() => vi.advanceTimersByTime(49));
+    expect(frames.pendingCount()).toBe(0);
+    act(() => vi.advanceTimersByTime(1));
+    expect(frames.pendingCount()).toBe(1);
+
+    act(() => frames.runNext(66));
+    expect(frames.pendingCount()).toBe(0);
+    expect(onFrame).toHaveBeenCalledTimes(3);
+  });
+
+  it("suspends frames while offscreen or hidden and wakes when visible", () => {
+    let intersectionCallback: IntersectionObserverCallback | undefined;
+    let observer: IntersectionObserver | undefined;
+    const disconnect = vi.fn();
+    const visibility = vi.spyOn(document, "visibilityState", "get");
+    visibility.mockReturnValue("visible");
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+          observer = this as unknown as IntersectionObserver;
+        }
+        observe() {}
+        disconnect = disconnect;
+      },
+    );
+    const frames = stubAnimationFrames();
+
+    render(<Harness onFrame={() => "active"} />);
+    expect(frames.pendingCount()).toBe(1);
+
+    act(() => {
+      intersectionCallback?.([{ isIntersecting: false } as IntersectionObserverEntry], observer!);
+    });
+    expect(frames.pendingCount()).toBe(0);
+
+    act(() => {
+      intersectionCallback?.([{ isIntersecting: true } as IntersectionObserverEntry], observer!);
+    });
+    expect(frames.pendingCount()).toBe(1);
+
+    visibility.mockReturnValue("hidden");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(frames.pendingCount()).toBe(0);
+
+    visibility.mockReturnValue("visible");
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+    expect(frames.pendingCount()).toBe(1);
+
+    cleanup();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("does not schedule frames when reduced motion is enabled", () => {
+    const frames = stubAnimationFrames();
+
+    render(<Harness onFrame={() => "active"} reducedMotion />);
+
+    expect(frames.pendingCount()).toBe(0);
+  });
+});

--- a/apps/web/src/hooks/useCanvasFrameLoop.ts
+++ b/apps/web/src/hooks/useCanvasFrameLoop.ts
@@ -1,0 +1,118 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+export type CanvasFrameDemand = "active" | "idle" | "stop";
+
+type FrameHandler = (time: number) => CanvasFrameDemand;
+
+interface FrameLoopApi {
+  requestFrame: () => void;
+  setFrameHandler: (handler: FrameHandler | null) => void;
+}
+
+interface FrameLoopController {
+  api: FrameLoopApi;
+  setEnabled: (enabled: boolean) => void;
+}
+
+const IDLE_FRAME_DELAY_MS = 1000 / 20;
+
+function createFrameLoopController(): FrameLoopController {
+  let enabled = false;
+  let frameHandler: FrameHandler | null = null;
+  let animationFrame = 0;
+  let idleTimer = 0;
+
+  const stop = () => {
+    if (animationFrame) cancelAnimationFrame(animationFrame);
+    if (idleTimer) window.clearTimeout(idleTimer);
+    animationFrame = 0;
+    idleTimer = 0;
+  };
+
+  const requestFrame = () => {
+    if (!enabled || frameHandler === null || animationFrame) return;
+    if (idleTimer) {
+      window.clearTimeout(idleTimer);
+      idleTimer = 0;
+    }
+    animationFrame = requestAnimationFrame(runFrame);
+  };
+
+  const scheduleIdleFrame = () => {
+    if (!enabled || frameHandler === null || idleTimer || animationFrame) return;
+    idleTimer = window.setTimeout(() => {
+      idleTimer = 0;
+      requestFrame();
+    }, IDLE_FRAME_DELAY_MS);
+  };
+
+  function runFrame(time: number) {
+    animationFrame = 0;
+    if (!enabled || frameHandler === null) return;
+
+    const demand = frameHandler(time);
+    if (demand === "active") requestFrame();
+    else if (demand === "idle") scheduleIdleFrame();
+  }
+
+  return {
+    api: {
+      requestFrame,
+      setFrameHandler: (handler) => {
+        frameHandler = handler;
+        if (handler === null) stop();
+        else requestFrame();
+      },
+    },
+    setEnabled: (nextEnabled) => {
+      if (enabled === nextEnabled) return;
+      enabled = nextEnabled;
+      if (enabled) requestFrame();
+      else stop();
+    },
+  };
+}
+
+export function useCanvasFrameLoop(
+  targetRef: RefObject<Element | null>,
+  reducedMotion: boolean,
+): FrameLoopApi {
+  const controllerRef = useRef<FrameLoopController | null>(null);
+  if (controllerRef.current === null) controllerRef.current = createFrameLoopController();
+  const controller = controllerRef.current;
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target || reducedMotion) {
+      controller.setEnabled(false);
+      return;
+    }
+
+    let inViewport = true;
+    let pageVisible = document.visibilityState === "visible";
+    const sync = () => controller.setEnabled(inViewport && pageVisible);
+    const onVisibilityChange = () => {
+      pageVisible = document.visibilityState === "visible";
+      sync();
+    };
+    const observer =
+      typeof IntersectionObserver === "undefined"
+        ? null
+        : new IntersectionObserver(([entry]) => {
+            inViewport = entry?.isIntersecting ?? false;
+            sync();
+          });
+
+    observer?.observe(target);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    sync();
+
+    return () => {
+      controller.setEnabled(false);
+      observer?.disconnect();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [controller, reducedMotion, targetRef]);
+
+  return controller.api;
+}

--- a/apps/web/src/hooks/useDonutRing.test.tsx
+++ b/apps/web/src/hooks/useDonutRing.test.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import { act, cleanup, render } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { stubCanvas, type StubbedCanvas } from "../test/canvas-stub";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stubAnimationFrames, stubCanvas, type StubbedCanvas } from "../test/canvas-stub";
 import { useDonutRing } from "./useDonutRing";
 
 /** The ring's logical space, so a client coordinate is also a ring coordinate. */
@@ -51,6 +51,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   canvas.restore();
+  vi.restoreAllMocks();
 });
 
 describe("useDonutRing", () => {
@@ -96,5 +97,27 @@ describe("useDonutRing", () => {
     await nextFrame();
 
     expect(canvas.context.clearRect).toHaveBeenCalled();
+  });
+
+  it("stops after morphing and wakes for hover without rereading styles", () => {
+    const frames = stubAnimationFrames();
+    const readStyle = vi.spyOn(window, "getComputedStyle");
+    const { rerender } = render(<Harness shares={[0.5, 0.5]} reducedMotion={false} />);
+    let now = performance.now() + 1_000;
+
+    act(() => frames.runNext(now));
+    expect(frames.pendingCount()).toBe(0);
+    expect(readStyle).toHaveBeenCalledTimes(1);
+
+    rerender(<Harness shares={[0.5, 0.5]} hovered={1} reducedMotion={false} />);
+    expect(frames.pendingCount()).toBe(1);
+    act(() => frames.runNext((now += 16)));
+    expect(canvas.context.translate).toHaveBeenCalled();
+    expect(readStyle).toHaveBeenCalledTimes(1);
+
+    rerender(<Harness shares={[0.5, 0.5]} reducedMotion={false} />);
+    expect(frames.pendingCount()).toBe(1);
+    act(() => frames.runNext((now += 16)));
+    expect(frames.pendingCount()).toBe(0);
   });
 });

--- a/apps/web/src/hooks/useDonutRing.ts
+++ b/apps/web/src/hooks/useDonutRing.ts
@@ -5,7 +5,7 @@
  * The displayed angles are the source of truth, so a data change eases from
  * whatever is on screen right now, mid-flight included.
  */
-import { useEffect, useRef, type RefObject } from "react";
+import { useContext, useEffect, useRef, type RefObject } from "react";
 
 import {
   clamp01,
@@ -16,6 +16,8 @@ import {
   tileWave,
   withAlpha,
 } from "../lib/chart-shading";
+import { useCanvasFrameLoop } from "./useCanvasFrameLoop";
+import { ResolvedThemeContext } from "./useTheme";
 
 /** The ring lives in a fixed 200×200 space, so the tile grid never depends on
  *  the rendered size and can be built once for the module. */
@@ -30,7 +32,7 @@ const CORNER = 6;
 const CELL = 4.6;
 const MAX_DPR = 2;
 
-const DRIFT_STEP = 0.03;
+const DRIFT_RATE = 0.0018;
 const MORPH_MS = 500;
 const EXPLODE = 6;
 const BASE_ALPHA = 0.72;
@@ -113,8 +115,9 @@ export function useDonutRing(
   canvasRef: RefObject<HTMLCanvasElement | null>,
   { shares, colors, hovered, reducedMotion }: Options,
 ) {
-  const colorsRef = useRef(colors);
-  colorsRef.current = colors;
+  const theme = useContext(ResolvedThemeContext);
+  const frameLoop = useCanvasFrameLoop(canvasRef, reducedMotion);
+  const colorsKey = colors.join("\0");
   const hoveredRef = useRef(hovered);
 
   const morph = useRef({
@@ -138,19 +141,25 @@ export function useDonutRing(
     } else {
       current.startedAt = performance.now();
       current.running = true;
+      frameLoop.requestFrame();
     }
-  }, [shares, reducedMotion]);
+  }, [frameLoop, reducedMotion, shares]);
 
   useEffect(() => {
     hoveredRef.current = hovered;
     if (reducedMotion) redraw.current();
-  }, [hovered, reducedMotion]);
+    else frameLoop.requestFrame();
+  }, [frameLoop, hovered, reducedMotion]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     const host = canvas?.parentElement;
     const ctx = canvas?.getContext("2d");
     if (!canvas || !host || !ctx) return;
+
+    const style = getComputedStyle(canvas);
+    const colorTokens = colorsKey ? colorsKey.split("\0") : [];
+    const palette = colorTokens.map((color) => resolveColor(style, color));
 
     let scale = 1;
     const layout = () => {
@@ -217,14 +226,13 @@ export function useDonutRing(
       ctx.restore();
     };
 
-    const draw = () => {
+    const draw = (now: number) => {
+      drift = now * DRIFT_RATE;
       ctx.setTransform(scale, 0, 0, scale, 0, 0);
       ctx.clearRect(0, 0, LOGICAL, LOGICAL);
       const current = arcsFrom(morph.current.displayed);
       arcs.current = current;
 
-      const style = getComputedStyle(canvas);
-      const palette = colorsRef.current.map((color) => resolveColor(style, color));
       const hover = hoveredRef.current;
       const anyHovered = hover !== null;
 
@@ -238,30 +246,33 @@ export function useDonutRing(
 
     const renderStatic = () => {
       layout();
-      draw();
+      draw(performance.now());
     };
     redraw.current = renderStatic;
 
-    let frame = 0;
-    const loop = () => {
-      drift += DRIFT_STEP;
-      advanceMorph(performance.now());
-      draw();
-      frame = requestAnimationFrame(loop);
-    };
+    frameLoop.setFrameHandler((now) => {
+      advanceMorph(now);
+      draw(now);
+      if (morph.current.running) return "active";
+      return hoveredRef.current === null ? "stop" : "idle";
+    });
 
     layout();
-    const observer = new ResizeObserver(renderStatic);
+    const onResize = () => {
+      layout();
+      if (reducedMotion) draw(performance.now());
+      else frameLoop.requestFrame();
+    };
+    const observer = new ResizeObserver(onResize);
     observer.observe(host);
 
-    if (reducedMotion) draw();
-    else frame = requestAnimationFrame(loop);
+    if (reducedMotion) draw(performance.now());
 
     return () => {
-      cancelAnimationFrame(frame);
+      frameLoop.setFrameHandler(null);
       observer.disconnect();
     };
-  }, [canvasRef, reducedMotion]);
+  }, [canvasRef, colorsKey, frameLoop, reducedMotion, theme]);
 
   const hitTest = (clientX: number, clientY: number): number | null => {
     const canvas = canvasRef.current;

--- a/apps/web/src/hooks/useTileField.test.tsx
+++ b/apps/web/src/hooks/useTileField.test.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 import { act, cleanup, render } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { stubCanvas, type StubbedCanvas } from "../test/canvas-stub";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stubAnimationFrames, stubCanvas, type StubbedCanvas } from "../test/canvas-stub";
 import { useTileField } from "./useTileField";
 
 const WIDTH = 360;
@@ -41,6 +41,8 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   canvas.restore();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 const CELL = Math.max(3, Math.round(WIDTH / 180));
@@ -59,12 +61,6 @@ function litCellCount(): number {
 function resetDraws() {
   canvas.context.fillRect.mockClear();
   canvas.context.clearRect.mockClear();
-}
-
-async function litInNextFrame(): Promise<number> {
-  resetDraws();
-  await nextFrame();
-  return litCellCount();
 }
 
 describe("useTileField", () => {
@@ -107,19 +103,60 @@ describe("useTileField", () => {
     expect(litCellCount()).toBe(0);
   });
 
-  it("lights the field around the pointer and lets it decay again", async () => {
-    render(<Harness values={[0, 0]} max={1} reducedMotion={false} />);
-    await nextFrame();
-    expect(await litInNextFrame()).toBe(0);
+  it("lights the field around the pointer and decays on idle frames", () => {
+    vi.useFakeTimers();
+    const frames = stubAnimationFrames();
+    const { container } = render(<Harness values={[0, 0]} max={1} reducedMotion={false} />);
+    const host = container.querySelector("canvas")!.parentElement!;
+    let now = performance.now() + 1_000;
 
-    window.dispatchEvent(new MouseEvent("pointermove", { clientX: 180, clientY: 40 }));
-    await nextFrame();
-    const glowing = await litInNextFrame();
+    act(() => frames.runNext(now));
+    expect(frames.pendingCount()).toBe(0);
+
+    host.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 180, clientY: 40 }));
+    resetDraws();
+    act(() => frames.runNext((now += 50)));
+    const glowing = litCellCount();
     expect(glowing).toBeGreaterThan(0);
 
-    document.dispatchEvent(new MouseEvent("pointerleave"));
-    for (let i = 0; i < 12; i++) await nextFrame();
+    host.dispatchEvent(new MouseEvent("pointerleave"));
+    let decayed = glowing;
+    for (let i = 0; i < 12; i++) {
+      if (frames.pendingCount() === 0) act(() => vi.advanceTimersByTime(51));
+      resetDraws();
+      act(() => frames.runNext((now += 50)));
+      decayed = litCellCount();
+    }
 
-    expect(await litInNextFrame()).toBeLessThan(glowing);
+    expect(decayed).toBeLessThan(glowing);
+  });
+
+  it("stops after reshaping and wakes locally without rereading its palette", () => {
+    const frames = stubAnimationFrames();
+    const readStyle = vi.spyOn(window, "getComputedStyle");
+    const { container, rerender } = render(
+      <Harness values={[1, 1]} max={1} reducedMotion={false} />,
+    );
+    const host = container.querySelector("canvas")!.parentElement!;
+    let now = performance.now() + 1_000;
+
+    act(() => frames.runNext(now));
+    expect(frames.pendingCount()).toBe(0);
+    expect(readStyle).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new MouseEvent("pointermove", { clientX: 180, clientY: 40 }));
+    expect(frames.pendingCount()).toBe(0);
+
+    host.dispatchEvent(new MouseEvent("pointermove", { bubbles: true, clientX: 180, clientY: 40 }));
+    expect(frames.pendingCount()).toBe(1);
+    act(() => frames.runNext((now += 50)));
+    expect(readStyle).toHaveBeenCalledTimes(1);
+
+    host.dispatchEvent(new MouseEvent("pointerleave"));
+    rerender(<Harness values={[0.5, 0.5]} max={1} reducedMotion={false} />);
+    expect(frames.pendingCount()).toBe(1);
+
+    act(() => canvas.resize());
+    expect(frames.pendingCount()).toBe(1);
   });
 });

--- a/apps/web/src/hooks/useTileField.ts
+++ b/apps/web/src/hooks/useTileField.ts
@@ -6,9 +6,11 @@
  * The curve lives outside React so a data change reflows the field in place
  * instead of remounting the canvas.
  */
-import { useEffect, useRef, type RefObject } from "react";
+import { useContext, useEffect, useRef, type RefObject } from "react";
 
 import { curveAt, resampleCurve, SAMPLES, topFraction } from "../lib/curve";
+import { useCanvasFrameLoop } from "./useCanvasFrameLoop";
+import { ResolvedThemeContext } from "./useTheme";
 
 const MAX_DPR = 2;
 const RESHAPE_MS = 460;
@@ -57,6 +59,8 @@ interface Grid {
   rows: number;
   width: number;
   height: number;
+  left: number;
+  top: number;
   /** Drawing unit: tile geometry snaps to this so edges never land mid-pixel. */
   step: number;
   glow: Float32Array;
@@ -73,8 +77,8 @@ export function useTileField(
   canvasRef: RefObject<HTMLCanvasElement | null>,
   { values, max, reducedMotion }: Options,
 ) {
-  const reducedRef = useRef(reducedMotion);
-  reducedRef.current = reducedMotion;
+  const theme = useContext(ResolvedThemeContext);
+  const frameLoop = useCanvasFrameLoop(canvasRef, reducedMotion);
 
   const curve = useRef({
     from: resampleCurve(values),
@@ -107,18 +111,27 @@ export function useTileField(
     state.startedAt = performance.now();
     state.duration = reducedMotion ? 0 : RESHAPE_MS;
     if (reducedMotion) redraw.current();
-  }, [values, max, reducedMotion]);
+    else frameLoop.requestFrame();
+  }, [frameLoop, max, reducedMotion, values]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     const host = canvas?.parentElement;
     const ctx = canvas?.getContext("2d");
     if (!canvas || !host || !ctx) return;
+    const pointerState = pointer.current;
+
+    const style = getComputedStyle(canvas);
+    const rest = style.getPropertyValue("--tile-rest").trim();
+    const wash = style.getPropertyValue("--tile-wash").trim();
+    const ink = style.getPropertyValue("--tile-ink").trim();
+    const ramp = buildRamp(wash, ink);
 
     const layout = () => {
       const width = host.clientWidth;
       const height = host.clientHeight;
       if (!width || !height) return;
+      const bounds = host.getBoundingClientRect();
       const dpr = Math.min(MAX_DPR, window.devicePixelRatio || 1);
       canvas.width = Math.round(width * dpr);
       canvas.height = Math.round(height * dpr);
@@ -139,25 +152,12 @@ export function useTileField(
         rows,
         width,
         height,
+        left: bounds.left,
+        top: bounds.top,
         step: 1 / dpr,
         glow: new Float32Array(count),
         spark,
       };
-    };
-
-    let ramp: string[] = [];
-    let rampKey = "";
-    let rest = "";
-    const readPalette = () => {
-      const style = getComputedStyle(canvas);
-      rest = style.getPropertyValue("--tile-rest").trim();
-      const wash = style.getPropertyValue("--tile-wash").trim();
-      const ink = style.getPropertyValue("--tile-ink").trim();
-      const key = `${wash}|${ink}`;
-      if (key !== rampKey) {
-        rampKey = key;
-        ramp = buildRamp(wash, ink);
-      }
     };
 
     const advanceCurve = (now: number) => {
@@ -167,24 +167,25 @@ export function useTileField(
         state.current[s] = state.from[s]! + (state.to[s]! - state.from[s]!) * t;
       }
       state.currentMax = state.fromMax + (state.toMax - state.fromMax) * t;
+      if (t >= 1) state.duration = 0;
+      return t < 1;
     };
 
-    const advancePointer = () => {
+    const advancePointer = (frameScale: number) => {
       const p = pointer.current;
       const previousX = p.smoothX;
       const previousY = p.smoothY;
-      p.smoothX += (p.x - previousX) * POINTER_SMOOTHING;
-      p.smoothY += (p.y - previousY) * POINTER_SMOOTHING;
+      const smoothing = 1 - Math.pow(1 - POINTER_SMOOTHING, frameScale);
+      p.smoothX += (p.x - previousX) * smoothing;
+      p.smoothY += (p.y - previousY) * smoothing;
       p.speed = Math.hypot(p.smoothX - previousX, p.smoothY - previousY);
     };
 
-    const draw = (now: number) => {
+    const draw = (now: number, frameScale = 1) => {
       const g = grid.current;
-      if (!g) return;
-      readPalette();
+      if (!g) return false;
       const state = curve.current;
       const { cell, cols, rows, width, height, step, glow, spark } = g;
-      const reduced = reducedRef.current;
       // fillRect antialiases regardless of imageSmoothingEnabled, so a tile whose
       // edge lands mid-pixel shimmers as it resizes. Quantise to device pixels.
       const snap = (value: number) => Math.round(value / step) * step;
@@ -203,9 +204,12 @@ export function useTileField(
 
       const p = pointer.current;
       const radius = height * (RADIUS_MIN + Math.min(1, p.speed / 25) * (RADIUS_MAX - RADIUS_MIN));
-      const glowActive = !reduced && p.inside;
+      const glowActive = !reducedMotion && p.inside;
+      const glowRise = 1 - Math.pow(1 - GLOW_RISE, frameScale);
+      const glowDecay = 1 - Math.pow(1 - GLOW_DECAY, frameScale);
       const shimmerPhase = now * 0.0018;
       let level = -1;
+      let hasGlow = false;
 
       for (let col = 0; col < cols; col++) {
         const fx = cols > 1 ? (col + 0.5) / cols : 0.5;
@@ -226,12 +230,13 @@ export function useTileField(
           if (glowActive) {
             const distance = Math.hypot(cx - p.smoothX, y + cell / 2 - p.smoothY);
             const target = distance < radius ? 1 - distance / radius : 0;
-            lit += (target - lit) * (target > lit ? GLOW_RISE : GLOW_DECAY);
+            lit += (target - lit) * (target > lit ? glowRise : glowDecay);
             glow[i] = lit;
           } else if (lit > 0) {
-            lit *= 1 - GLOW_DECAY;
+            lit *= 1 - glowDecay;
             glow[i] = lit < 0.002 ? 0 : lit;
           }
+          if (glow[i]! > 0) hasGlow = true;
 
           // Size carries the low-frequency structure only. Shimmer and sparks are
           // high-frequency and drive colour alone — quantised size cannot express
@@ -240,7 +245,7 @@ export function useTileField(
           if (solid <= 0.02) continue;
 
           let tint = solid;
-          if (!reduced) {
+          if (!reducedMotion) {
             tint *= 1 + 0.07 * Math.sin(fy * Math.PI * 3 - shimmerPhase);
             if (spark[i] && lit > 0.02) tint *= 1 + 0.25 * lit * Math.sin(now * 0.012 + i);
             tint = Math.min(1, tint);
@@ -257,6 +262,7 @@ export function useTileField(
           ctx.fillRect(x + offset, y + offset, size, size);
         }
       }
+      return hasGlow;
     };
 
     const renderStatic = () => {
@@ -267,45 +273,67 @@ export function useTileField(
     redraw.current = renderStatic;
 
     const onPointerMove = (event: PointerEvent) => {
-      const rect = canvas.getBoundingClientRect();
+      const g = grid.current;
+      if (!g) return;
       const p = pointer.current;
-      p.x = event.clientX - rect.left;
-      p.y = event.clientY - rect.top;
+      if (!p.inside) {
+        const bounds = host.getBoundingClientRect();
+        g.left = bounds.left;
+        g.top = bounds.top;
+      }
+      p.x = event.clientX - g.left;
+      p.y = event.clientY - g.top;
       if (!p.inside) {
         p.smoothX = p.x;
         p.smoothY = p.y;
       }
       p.inside = true;
+      frameLoop.requestFrame();
     };
     const onPointerOut = () => {
       pointer.current.inside = false;
+      frameLoop.requestFrame();
     };
 
-    let frame = 0;
-    const loop = (now: number) => {
-      advanceCurve(now);
-      advancePointer();
-      draw(now);
-      frame = requestAnimationFrame(loop);
-    };
+    let lastFrameTime = 0;
+    frameLoop.setFrameHandler((now) => {
+      const frameScale = lastFrameTime === 0 ? 1 : Math.min(3, (now - lastFrameTime) / (1000 / 60));
+      lastFrameTime = now;
+      const curveActive = advanceCurve(now);
+      advancePointer(frameScale);
+      const glowActive = draw(now, frameScale);
+      if (curveActive) return "active";
+      if (pointer.current.inside || glowActive) return "idle";
+      lastFrameTime = 0;
+      return "stop";
+    });
 
     layout();
-    const observer = new ResizeObserver(renderStatic);
+    const onResize = () => {
+      layout();
+      if (reducedMotion) {
+        advanceCurve(performance.now());
+        draw(performance.now());
+      } else {
+        frameLoop.requestFrame();
+      }
+    };
+    const observer = new ResizeObserver(onResize);
     observer.observe(host);
 
     if (reducedMotion) {
       renderStatic();
     } else {
-      window.addEventListener("pointermove", onPointerMove, { passive: true });
-      document.addEventListener("pointerleave", onPointerOut);
-      frame = requestAnimationFrame(loop);
+      host.addEventListener("pointermove", onPointerMove, { passive: true });
+      host.addEventListener("pointerleave", onPointerOut);
     }
 
     return () => {
-      cancelAnimationFrame(frame);
+      frameLoop.setFrameHandler(null);
       observer.disconnect();
-      window.removeEventListener("pointermove", onPointerMove);
-      document.removeEventListener("pointerleave", onPointerOut);
+      host.removeEventListener("pointermove", onPointerMove);
+      host.removeEventListener("pointerleave", onPointerOut);
+      pointerState.inside = false;
     };
-  }, [canvasRef, reducedMotion]);
+  }, [canvasRef, frameLoop, reducedMotion, theme]);
 }

--- a/apps/web/src/lib/chart-shading.ts
+++ b/apps/web/src/lib/chart-shading.ts
@@ -3,9 +3,9 @@
  * same way — a field of small squares whose size is driven by a slowly drifting
  * wave — so the wave, the jitter hash and the colour lookup live here once.
  *
- * A canvas cannot read `var(--chart-1)`, so every colour is resolved against the
- * live computed style on each frame; that is also what makes a theme switch land
- * without re-mounting the chart.
+ * A canvas cannot read `var(--chart-1)`, so colours are resolved against the live
+ * computed style when chart inputs or the theme change, then reused while frames
+ * are painted.
  */
 
 export const TAU = Math.PI * 2;

--- a/apps/web/src/test/canvas-stub.ts
+++ b/apps/web/src/test/canvas-stub.ts
@@ -2,7 +2,7 @@
  * happy-dom has no 2D context and reports every element as 0×0, so a canvas
  * chart would never paint a single frame under test. This installs the smallest
  * environment the painters need: a recording context, a fixed layout box and a
- * ResizeObserver that does nothing.
+ * controllable ResizeObserver.
  */
 import { vi } from "vitest";
 
@@ -29,7 +29,35 @@ type ContextMethod = (typeof CONTEXT_METHODS)[number];
 
 export interface StubbedCanvas {
   context: Record<ContextMethod, ReturnType<typeof vi.fn>>;
+  resize: () => void;
   restore: () => void;
+}
+
+export function stubAnimationFrames() {
+  let nextId = 1;
+  const pending = new Map<number, FrameRequestCallback>();
+  const request = vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+    const id = nextId++;
+    pending.set(id, callback);
+    return id;
+  });
+  const cancel = vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+    pending.delete(id);
+  });
+
+  return {
+    pendingCount: () => pending.size,
+    runNext: (time: number) => {
+      const next = pending.entries().next().value as [number, FrameRequestCallback] | undefined;
+      if (!next) throw new Error("No animation frame is pending");
+      pending.delete(next[0]);
+      next[1](time);
+    },
+    restore: () => {
+      request.mockRestore();
+      cancel.mockRestore();
+    },
+  };
 }
 
 function defineSize(size: { width: number; height: number }): () => void {
@@ -71,7 +99,13 @@ export function stubCanvas(size: { width: number; height: number }): StubbedCanv
   const restoreSize = defineSize(size);
 
   const previousObserver = globalThis.ResizeObserver;
+  let resizeCallback: ResizeObserverCallback | undefined;
+  let resizeObserver: ResizeObserver | undefined;
   globalThis.ResizeObserver = class {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallback = callback;
+      resizeObserver = this as unknown as ResizeObserver;
+    }
     observe() {}
     disconnect() {}
     unobserve() {}
@@ -79,6 +113,7 @@ export function stubCanvas(size: { width: number; height: number }): StubbedCanv
 
   return {
     context,
+    resize: () => resizeCallback?.([], resizeObserver!),
     restore: () => {
       getContext.mockRestore();
       rect.mockRestore();


### PR DESCRIPTION
## Summary

- add a shared demand-driven canvas frame loop with active, idle, and stopped states
- suspend chart work outside the viewport or while the page is hidden
- stop settled bar, donut, and tile charts while preserving data, hover, resize, and theme wakeups
- cache resolved palettes and keep tile pointer work local to each chart host

## Performance

- settled charts now keep zero animation frames pending instead of recursively scheduling forever
- hover drift and glow decay run at 20 fps; morph and growth remain full-rate while active
- computed styles are resolved once per chart input or theme change rather than once per frame

## Test plan

- pnpm lint
- pnpm format:check
- pnpm test
- pnpm build

Issue: CS-191