### PR TITLE
fix(web): deduplicate bar chart hover updates

### DIFF
--- a/apps/web/src/components/overview/overview-usage-chart.test.tsx
+++ b/apps/web/src/components/overview/overview-usage-chart.test.tsx
@@ -84,4 +84,25 @@ describe("OverviewUsageChart", () => {
     expect(screen.queryByText("3 sessions · 45 messages")).toBeNull();
     expect(liveSummary.textContent).toBe("");
   });
+
+  it("keeps unrelated daily rows out of hover updates", () => {
+    let unrelatedReads = 0;
+    const observedDaily = [
+      daily[0]!,
+      new Proxy(daily[1]!, {
+        get(target, property, receiver) {
+          if (property === "sessions") unrelatedReads++;
+          return Reflect.get(target, property, receiver);
+        },
+      }),
+    ];
+    render(<OverviewUsageChart daily={observedDaily} />);
+    unrelatedReads = 0;
+
+    fireEvent.focus(
+      within(screen.getByRole("listbox", { name: "Daily usage chart" })).getAllByRole("option")[0]!,
+    );
+
+    expect(unrelatedReads).toBe(0);
+  });
 });

--- a/apps/web/src/components/overview/overview-usage-chart.tsx
+++ b/apps/web/src/components/overview/overview-usage-chart.tsx
@@ -109,21 +109,47 @@ function DayTooltip({
   );
 }
 
-export function OverviewUsageChart({ daily }: { daily: DashboardDailyBucket[] }) {
+function TokenBars({ daily }: { daily: DashboardDailyBucket[] }) {
   const [hover, setHover] = useState<BarHover | null>(null);
-
   const values = useMemo(
     () => daily.map((bucket) => TOKEN_SERIES.map((series) => bucket[series.key])),
     [daily],
   );
   const itemLabels = useMemo(() => daily.map(bucketSummary), [daily]);
-  const axisMax = niceMax(daily.reduce((peak, bucket) => Math.max(peak, bucketTokens(bucket)), 0));
+  const axisMax = useMemo(
+    () => niceMax(daily.reduce((peak, bucket) => Math.max(peak, bucketTokens(bucket)), 0)),
+    [daily],
+  );
+  const hovered = hover === null ? undefined : daily[hover.column];
 
+  return (
+    <div className="relative mt-[14px]">
+      <TileBarPlot
+        values={values}
+        axisMax={axisMax}
+        colors={TOKEN_COLORS}
+        hovered={hover}
+        onHover={setHover}
+        layout={BAR_LAYOUT}
+        height={BAR_HEIGHT}
+        formatTick={formatCompact}
+        ariaLabel="Daily usage chart"
+        itemLabels={itemLabels}
+      />
+      {hovered && hover ? (
+        <div className="absolute inset-x-0 top-0" style={{ left: TILE_AXIS_WIDTH }}>
+          <DayTooltip bucket={hovered} index={hover.column} count={daily.length} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function OverviewUsageChart({ daily }: { daily: DashboardDailyBucket[] }) {
   const first = daily[0];
   const last = daily[daily.length - 1];
   const range =
     first && last ? ` · ${formatMonthDay(first.date)} → ${formatMonthDay(last.date)}` : "";
-  const hovered = hover === null ? undefined : daily[hover.column];
   const tickStep = Math.max(1, Math.ceil(daily.length / MAX_DATE_TICKS));
 
   return (
@@ -159,25 +185,7 @@ export function OverviewUsageChart({ daily }: { daily: DashboardDailyBucket[] })
         </p>
       ) : (
         <>
-          <div className="relative mt-[14px]">
-            <TileBarPlot
-              values={values}
-              axisMax={axisMax}
-              colors={TOKEN_COLORS}
-              hovered={hover}
-              onHover={setHover}
-              layout={BAR_LAYOUT}
-              height={BAR_HEIGHT}
-              formatTick={formatCompact}
-              ariaLabel="Daily usage chart"
-              itemLabels={itemLabels}
-            />
-            {hovered && hover ? (
-              <div className="absolute inset-x-0 top-0" style={{ left: TILE_AXIS_WIDTH }}>
-                <DayTooltip bucket={hovered} index={hover.column} count={daily.length} />
-              </div>
-            ) : null}
-          </div>
+          <TokenBars daily={daily} />
 
           <CostArea daily={daily} />
 

--- a/apps/web/src/components/ui/tile-bar-plot.test.tsx
+++ b/apps/web/src/components/ui/tile-bar-plot.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stubCanvas, type StubbedCanvas } from "../../test/canvas-stub";
+import { TileBarPlot } from "./tile-bar-plot";
+
+let canvas: StubbedCanvas;
+
+beforeEach(() => {
+  canvas = stubCanvas({ width: 200, height: 100 });
+});
+
+afterEach(() => {
+  cleanup();
+  canvas.restore();
+  vi.restoreAllMocks();
+});
+
+describe("TileBarPlot", () => {
+  it("reports a bar only when the pointer target changes", () => {
+    const onHover = vi.fn();
+    render(
+      <TileBarPlot
+        values={[[100], [100]]}
+        axisMax={100}
+        colors={["#fff"]}
+        hovered={null}
+        onHover={onHover}
+        height={100}
+        ariaLabel="Usage"
+        itemLabels={["Day one", "Day two"]}
+      />,
+    );
+    const surface = screen.getByRole("listbox", { name: "Usage" }).parentElement!;
+
+    fireEvent.pointerMove(surface, { clientX: 50, clientY: 50 });
+    fireEvent.pointerMove(surface, { clientX: 50, clientY: 50 });
+
+    expect(onHover).toHaveBeenCalledOnce();
+    expect(onHover).toHaveBeenLastCalledWith({ column: 0, band: null });
+
+    fireEvent.pointerMove(surface, { clientX: 150, clientY: 50 });
+    expect(onHover).toHaveBeenCalledTimes(2);
+    expect(onHover).toHaveBeenLastCalledWith({ column: 1, band: null });
+  });
+});

--- a/apps/web/src/components/ui/tile-bar-plot.tsx
+++ b/apps/web/src/components/ui/tile-bar-plot.tsx
@@ -5,7 +5,7 @@
  * It renders no labels and no tooltip — the card that owns the data owns those,
  * because a day column and an agent column read very differently.
  */
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import {
   DEFAULT_BAR_LAYOUT,
@@ -21,6 +21,13 @@ const TICK_FRACTIONS = [1, 0.75, 0.5, 0.25, 0] as const;
 
 /** Exported so a card can indent anything that must line up with the plot. */
 export const TILE_AXIS_WIDTH = 38;
+
+function sameHover(left: BarHover | null, right: BarHover | null): boolean {
+  return (
+    left === right ||
+    (left !== null && right !== null && left.column === right.column && left.band === right.band)
+  );
+}
 
 export function TileBarPlot({
   values,
@@ -52,6 +59,7 @@ export function TileBarPlot({
   className?: string;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reportedHover = useRef<BarHover | null>(hovered);
   const reducedMotion = usePrefersReducedMotion();
   const { hitTest } = useBarField(canvasRef, {
     values,
@@ -62,6 +70,15 @@ export function TileBarPlot({
     layout: { ...DEFAULT_BAR_LAYOUT, ...layout },
     reducedMotion,
   });
+  useEffect(() => {
+    reportedHover.current = hovered;
+  }, [hovered]);
+
+  const reportHover = (nextHover: BarHover | null) => {
+    if (sameHover(reportedHover.current, nextHover)) return;
+    reportedHover.current = nextHover;
+    onHover(nextHover);
+  };
 
   return (
     <div className={cn("flex", className)}>
@@ -82,8 +99,8 @@ export function TileBarPlot({
       <div
         className="chart-hatch relative min-w-0 flex-1 touch-none"
         style={{ height }}
-        onPointerMove={(event) => onHover(hitTest(event.clientX, event.clientY))}
-        onPointerLeave={() => onHover(null)}
+        onPointerMove={(event) => reportHover(hitTest(event.clientX, event.clientY))}
+        onPointerLeave={() => reportHover(null)}
       >
         {TICK_FRACTIONS.map((fraction) => (
           <span
@@ -103,7 +120,9 @@ export function TileBarPlot({
           label={ariaLabel}
           itemLabels={itemLabels}
           activeIndex={hovered?.column ?? null}
-          onActiveIndexChange={(column) => onHover(column === null ? null : { column, band: null })}
+          onActiveIndexChange={(column) =>
+            reportHover(column === null ? null : { column, band: null })
+          }
           layout="columns"
         />
       </div>


### PR DESCRIPTION
## Summary

- suppress repeated bar hover callbacks when the column and band are unchanged
- move daily usage hover state into the token bar subtree so unrelated cost, date, and accessibility content stays stable
- memoize token chart derivations across hover updates

## Performance

- two pointer events over the same bar now emit one hover update instead of two
- a hover update no longer rereads unrelated daily rows

## Test plan

- pnpm lint
- pnpm format:check
- pnpm test
- pnpm build

Issue: CS-192