### PR TITLE
fix(cli): reject cross-site loopback writes

### DIFF
--- a/packages/cli/src/loopback-write-guard.test.ts
+++ b/packages/cli/src/loopback-write-guard.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { evaluateLoopbackWriteRequest } from "./loopback-write-guard.js";
+
+const REQUEST_ORIGIN = "http://localhost:4521";
+
+function evaluate(request: Partial<Parameters<typeof evaluateLoopbackWriteRequest>[0]> = {}) {
+  return evaluateLoopbackWriteRequest({
+    method: "POST",
+    contentType: "application/json",
+    requestOrigin: REQUEST_ORIGIN,
+    ...request,
+  });
+}
+
+describe("evaluateLoopbackWriteRequest", () => {
+  it.each(["GET", "HEAD", "OPTIONS"])("allows safe %s requests", (method) => {
+    expect(
+      evaluate({
+        method,
+        contentType: "text/plain",
+        fetchSite: "cross-site",
+        origin: "https://attacker.example",
+      }),
+    ).toEqual({ allowed: true });
+  });
+
+  it.each(["application/json", "Application/JSON; charset=UTF-8"])(
+    "accepts the JSON media type %s",
+    (contentType) => {
+      expect(evaluate({ contentType })).toEqual({ allowed: true });
+    },
+  );
+
+  it.each([undefined, "", "text/plain", "application/x-www-form-urlencoded"])(
+    "rejects the non-JSON media type %j",
+    (contentType) => {
+      expect(evaluate({ contentType })).toEqual({
+        allowed: false,
+        reason: "content-type",
+        status: 415,
+      });
+    },
+  );
+
+  it.each(["same-origin", "none"])("allows Sec-Fetch-Site: %s", (fetchSite) => {
+    expect(evaluate({ fetchSite })).toEqual({ allowed: true });
+  });
+
+  it.each(["same-site", "cross-site", "invalid"])("rejects Sec-Fetch-Site: %s", (fetchSite) => {
+    expect(evaluate({ fetchSite })).toEqual({
+      allowed: false,
+      reason: "fetch-site",
+      status: 403,
+    });
+  });
+
+  it("requires a supplied Origin to match the request", () => {
+    expect(evaluate({ origin: REQUEST_ORIGIN })).toEqual({ allowed: true });
+    expect(evaluate({ origin: "https://attacker.example" })).toEqual({
+      allowed: false,
+      reason: "origin",
+      status: 403,
+    });
+    expect(evaluate({ origin: "null" })).toEqual({
+      allowed: false,
+      reason: "origin",
+      status: 403,
+    });
+  });
+
+  it("allows non-browser clients that omit fetch metadata and Origin", () => {
+    expect(evaluate()).toEqual({ allowed: true });
+  });
+
+  it("does not require a media type for a bodyless DELETE", () => {
+    expect(evaluate({ method: "DELETE", contentType: undefined })).toEqual({ allowed: true });
+    expect(evaluate({ method: "DELETE", contentType: undefined, fetchSite: "cross-site" })).toEqual(
+      { allowed: false, reason: "fetch-site", status: 403 },
+    );
+  });
+});

--- a/packages/cli/src/loopback-write-guard.ts
+++ b/packages/cli/src/loopback-write-guard.ts
@@ -1,0 +1,74 @@
+import type { MiddlewareHandler } from "hono";
+import { appLogger } from "./logging.js";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const JSON_BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
+const ALLOWED_FETCH_SITES = new Set(["same-origin", "none"]);
+
+export type LoopbackWriteRejection = "content-type" | "fetch-site" | "origin";
+
+export type LoopbackWriteDecision =
+  | { allowed: true }
+  | { allowed: false; reason: LoopbackWriteRejection; status: 403 | 415 };
+
+interface LoopbackWriteRequest {
+  method: string;
+  contentType?: string;
+  fetchSite?: string;
+  origin?: string;
+  requestOrigin: string;
+}
+
+function mediaType(contentType: string | undefined): string | null {
+  return contentType?.split(";", 1)[0]?.trim().toLowerCase() || null;
+}
+
+function isSameOrigin(origin: string, requestOrigin: string): boolean {
+  try {
+    return new URL(origin).origin === requestOrigin;
+  } catch {
+    return false;
+  }
+}
+
+export function evaluateLoopbackWriteRequest(request: LoopbackWriteRequest): LoopbackWriteDecision {
+  const method = request.method.toUpperCase();
+  if (SAFE_METHODS.has(method)) return { allowed: true };
+
+  if (JSON_BODY_METHODS.has(method) && mediaType(request.contentType) !== "application/json") {
+    return { allowed: false, reason: "content-type", status: 415 };
+  }
+  if (request.fetchSite && !ALLOWED_FETCH_SITES.has(request.fetchSite)) {
+    return { allowed: false, reason: "fetch-site", status: 403 };
+  }
+  if (request.origin && !isSameOrigin(request.origin, request.requestOrigin)) {
+    return { allowed: false, reason: "origin", status: 403 };
+  }
+  return { allowed: true };
+}
+
+export function loopbackWriteGuard(): MiddlewareHandler {
+  return async (c, next) => {
+    const url = new URL(c.req.url);
+    const decision = evaluateLoopbackWriteRequest({
+      method: c.req.method,
+      contentType: c.req.header("Content-Type"),
+      fetchSite: c.req.header("Sec-Fetch-Site"),
+      origin: c.req.header("Origin"),
+      requestOrigin: url.origin,
+    });
+    if (!decision.allowed) {
+      appLogger.warn("http.loopback_write.rejected", {
+        method: c.req.method,
+        path: url.pathname,
+        reason: decision.reason,
+      });
+      const error =
+        decision.reason === "content-type"
+          ? "Write requests require application/json"
+          : "Cross-origin write request rejected";
+      return c.json({ error }, decision.status);
+    }
+    await next();
+  };
+}

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -245,6 +245,64 @@ describe("createServer", () => {
     }
   });
 
+  it("CS-193: rejects unsafe loopback writes without breaking same-origin JSON", async () => {
+    const app = await createServer(0, createStore());
+    const body = JSON.stringify({ event: "csrf-probe" });
+
+    try {
+      const textPlain = await fetch(`${app.url}/api/logs`, {
+        method: "POST",
+        headers: { Connection: "close", "Content-Type": "text/plain", Origin: app.url },
+        body,
+      });
+      const bookmarkImport = await fetch(`${app.url}/api/bookmarks/import`, {
+        method: "POST",
+        headers: { Connection: "close", "Content-Type": "text/plain", Origin: app.url },
+        body: "[]",
+      });
+      const crossOrigin = await fetch(`${app.url}/api/logs`, {
+        method: "POST",
+        headers: {
+          Connection: "close",
+          "Content-Type": "application/json",
+          Origin: "https://attacker.example",
+        },
+        body,
+      });
+      const crossSite = await fetch(`${app.url}/api/logs`, {
+        method: "POST",
+        headers: {
+          Connection: "close",
+          "Content-Type": "application/json",
+          "Sec-Fetch-Site": "cross-site",
+        },
+        body,
+      });
+      const sameOrigin = await fetch(`${app.url}/api/logs`, {
+        method: "POST",
+        headers: { Connection: "close", "Content-Type": "application/json", Origin: app.url },
+        body,
+      });
+      const statuses = {
+        textPlain: textPlain.status,
+        bookmarkImport: bookmarkImport.status,
+        crossOrigin: crossOrigin.status,
+        crossSite: crossSite.status,
+        sameOrigin: sameOrigin.status,
+      };
+
+      expect(statuses).toEqual({
+        textPlain: 415,
+        bookmarkImport: 415,
+        crossOrigin: 403,
+        crossSite: 403,
+        sameOrigin: 200,
+      });
+    } finally {
+      await app.shutdown();
+    }
+  });
+
   it("refuses a non-loopback hostname without remote access", async () => {
     await expect(createServer(0, createStore(), { hostname: "0.0.0.0" })).rejects.toThrow(
       "Add --remote-access",

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -13,6 +13,7 @@ import type { ScanResultSource } from "./api/handlers.js";
 import { createApiRoutes, type ApiRouteOptions } from "./api/routes.js";
 import { appLogger } from "./logging.js";
 import { validateLoopbackAuthority } from "./loopback-authority.js";
+import { loopbackWriteGuard } from "./loopback-write-guard.js";
 import {
   createRemoteAccessToken,
   REMOTE_ACCESS_QUERY_PARAM,
@@ -189,6 +190,10 @@ export async function createServer(
       });
     }
   });
+
+  if (loopbackAuthorityEnabled) {
+    app.use("/api/*", loopbackWriteGuard());
+  }
 
   // Ordered before authentication: a request that bypassed the proxy must be
   // refused outright, not given a chance to present a token in the clear.


### PR DESCRIPTION
## Summary

- guard every unauthenticated loopback API mutation before route handlers run
- require JSON media types for POST, PUT, and PATCH requests
- reject mismatched Origin values and Fetch Metadata sites other than same-origin or none
- preserve bodyless DELETE requests and non-browser clients that omit browser-only metadata

## Security impact

This blocks cross-site pages from importing bookmarks or injecting client logs through CORS-safelisted POST bodies. The Fetch Metadata policy follows the W3C Sec-Fetch-Site relationship model: https://www.w3.org/TR/fetch-metadata/

## Test plan

- pnpm lint
- pnpm format:check
- pnpm test
- pnpm build

Issue: CS-193