### PR TITLE
fix: keep worker pricing generations consistent

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1307,6 +1307,7 @@ describe("LiveScanStore", () => {
     expect(runRequest).toMatchObject({
       type: "run",
       generation: 1,
+      pricingGenerationId: expect.any(Number),
       operation: { kind: "recompute-derived" },
     });
     expect(runRequest).not.toHaveProperty("previousSessions");

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -48,6 +48,7 @@ const mocks = vi.hoisted(() => {
     postMessage: vi.fn(),
     attachMissingProjectIdentities: vi.fn((sessions: SessionHead[]) => sessions),
     createRegisteredAgents: vi.fn(),
+    synchronizePricingGeneration: vi.fn(),
     ensureSessionTagsSync: vi.fn(
       (
         _agent: BaseAgent,
@@ -87,6 +88,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
   return {
     attachMissingProjectIdentities: mocks.attachMissingProjectIdentities,
     createRegisteredAgents: mocks.createRegisteredAgents,
+    synchronizePricingGeneration: mocks.synchronizePricingGeneration,
     ensureSessionTagsSync: mocks.ensureSessionTagsSync,
     FileSystemSessionSource: mocks.FileSystemSessionSource,
     PRICING_CAPTURE_EPOCH: actual.PRICING_CAPTURE_EPOCH,
@@ -151,6 +153,7 @@ function setWorkerData(overrides: Record<string, unknown> = {}) {
     type: "run",
     requestId: 1,
     agentName: "codex",
+    pricingGenerationId: 17,
     previousSessions: [],
     operation: { kind: "full-scan" },
     scanOptions: { fast: true },
@@ -176,6 +179,17 @@ beforeEach(() => {
 });
 
 describe("scan refresh worker entry", () => {
+  it("synchronizes pricing before creating agents", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([]);
+
+    await runWorker();
+
+    expect(mocks.synchronizePricingGeneration).toHaveBeenCalledWith(17);
+    expect(mocks.synchronizePricingGeneration.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.createRegisteredAgents.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it("reports an unknown agent as an error", async () => {
     mocks.createRegisteredAgents.mockReturnValue([]);
 
@@ -284,6 +298,7 @@ describe("scan refresh worker entry", () => {
       requestId: 2,
       agentName: "codex",
       generation: 5,
+      pricingGenerationId: 17,
       operation: { kind: "recompute-derived" },
       scanOptions: {},
     });
@@ -301,6 +316,7 @@ describe("scan refresh worker entry", () => {
     );
     expect(scan).toHaveBeenCalledTimes(1);
     expect(mocks.createRegisteredAgents).toHaveBeenCalledTimes(1);
+    expect(mocks.synchronizePricingGeneration).toHaveBeenCalledTimes(2);
   });
 
   it("fails closed when an operation skips the committed generation", async () => {
@@ -319,6 +335,7 @@ describe("scan refresh worker entry", () => {
       requestId: 2,
       agentName: "codex",
       generation: 4,
+      pricingGenerationId: 17,
       operation: { kind: "recompute-derived" },
       scanOptions: {},
     });

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -11,6 +11,7 @@ import {
   sessionSignature,
   SMART_TAG_CLASSIFIER_REVISION,
   sortSessions,
+  synchronizePricingGeneration,
   synchronizeSessionSources,
   type AgentScanProgress,
   type BaseAgent,
@@ -84,6 +85,7 @@ export interface ScanRefreshWorkerRunRequest {
   requestId: number;
   agentName: string;
   generation: number;
+  pricingGenerationId: number;
   previousSessions?: SessionHead[];
   operation: ScanRefreshOperation;
   scanOptions: Pick<ScanOptions, "from" | "to" | "fast">;
@@ -585,6 +587,7 @@ async function handleRequest(data: ScanRefreshWorkerRunRequest): Promise<void> {
     },
   );
   try {
+    synchronizePricingGeneration(data.pricingGenerationId);
     await run(data, progressEmitter);
   } catch (error) {
     progressEmitter.flush();
@@ -630,6 +633,7 @@ if (
   initialRequest?.type === "run" &&
   typeof initialRequest.requestId === "number" &&
   typeof initialRequest.agentName === "string" &&
+  typeof initialRequest.pricingGenerationId === "number" &&
   initialRequest.operation != null &&
   Array.isArray(initialRequest.previousSessions) &&
   initialRequest.meta != null

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -5,8 +5,10 @@ const workerMocks = vi.hoisted(() => {
   type Handler = (arg: never) => void;
   class FakeWorker {
     private handlers = new Map<string, Handler>();
+    readonly workerData: Record<string, unknown>;
 
-    constructor() {
+    constructor(_url: URL, options?: { workerData?: Record<string, unknown> }) {
+      this.workerData = options?.workerData ?? {};
       workers.push(this);
     }
 
@@ -33,6 +35,7 @@ const workerMocks = vi.hoisted(() => {
 
 vi.mock("node:worker_threads", () => ({ Worker: workerMocks.FakeWorker }));
 vi.mock("node:fs", () => ({ existsSync: () => workerMocks.workerExists }));
+vi.mock("@codesesh/core", () => ({ getPricingGeneration: () => ({ id: 17 }) }));
 vi.mock("./logging.js", () => ({
   appLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   logSearchIndexSync: vi.fn(),
@@ -64,6 +67,16 @@ beforeEach(() => {
 });
 
 describe("SearchIndexJobRunner", () => {
+  it("pins each worker batch to the current pricing generation", async () => {
+    const runner = new SearchIndexJobRunner();
+    const completion = runner.enqueue("scan.refresh", [makeJob()]);
+    const worker = startedWorker();
+
+    expect(worker.workerData.pricingGenerationId).toBe(17);
+    worker.post({ type: "done", context: "scan.refresh", durationMs: 1, sessions: 1 });
+    await completion;
+  });
+
   it("resolves the batch when the worker reports done", async () => {
     const runner = new SearchIndexJobRunner();
     const completion = runner.enqueue("scan.refresh", [makeJob()]);

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
+import { getPricingGeneration } from "@codesesh/core";
 import { toError } from "./errors.js";
 import { appLogger, logSearchIndexSync } from "./logging.js";
 import { PendingSearchIndexJobs, type SearchIndexJobBatch } from "./pending-search-index-jobs.js";
@@ -99,6 +100,7 @@ export class SearchIndexJobRunner {
 
     const worker = new Worker(workerUrl, {
       workerData: {
+        pricingGenerationId: getPricingGeneration().id,
         context: batch.context,
         jobs: batch.jobs,
         agentNames: [],

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   commitDurableSessionPublication: vi.fn(),
   createRegisteredAgents: vi.fn(),
   markAgentCacheInitialized: vi.fn(),
+  synchronizePricingGeneration: vi.fn(),
   syncSessionSearchIndex: vi.fn(),
   appLoggerInfo: vi.fn(),
   appLoggerWarn: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock("@codesesh/core", () => ({
   createRegisteredAgents: mocks.createRegisteredAgents,
   markAgentCacheInitialized: mocks.markAgentCacheInitialized,
   sessionDetailVersion: (meta: { id?: string }) => `detail:${meta.id ?? "none"}`,
+  synchronizePricingGeneration: mocks.synchronizePricingGeneration,
   syncSessionSearchIndex: mocks.syncSessionSearchIndex,
   // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
   setCoreDiagnostics: vi.fn(),
@@ -46,6 +48,7 @@ function makeAgent() {
 }
 
 async function runWorker() {
+  mocks.workerData = { pricingGenerationId: 17, ...mocks.workerData };
   await import("./search-index-worker.js");
 }
 
@@ -66,6 +69,17 @@ beforeEach(() => {
 });
 
 describe("search index worker", () => {
+  it("synchronizes pricing before creating agents", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([]);
+
+    await runWorker();
+
+    expect(mocks.synchronizePricingGeneration).toHaveBeenCalledWith(17);
+    expect(mocks.synchronizePricingGeneration.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.createRegisteredAgents.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it("builds legacy full jobs", async () => {
     const agent = makeAgent();
     mocks.createRegisteredAgents.mockReturnValue([agent]);

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -6,6 +6,7 @@ import {
   createRegisteredAgents,
   markAgentCacheInitialized,
   sessionDetailVersion,
+  synchronizePricingGeneration,
   syncSessionSearchIndex,
   type SearchIndexSyncResult,
   type SearchIndexSyncOptions,
@@ -65,6 +66,7 @@ export type SearchIndexWorkerJob =
     };
 
 interface SearchIndexWorkerData {
+  pricingGenerationId: number;
   jobs?: SearchIndexWorkerJob[];
   context: string;
   agentNames: string[];
@@ -76,6 +78,7 @@ type WorkerAgent = ReturnType<typeof createRegisteredAgents>[number];
 
 const data = workerData as SearchIndexWorkerData;
 const startedAt = performance.now();
+synchronizePricingGeneration(data.pricingGenerationId);
 const agents = createRegisteredAgents();
 const jobs =
   data.jobs ??

--- a/packages/cli/src/smart-tag-worker.test.ts
+++ b/packages/cli/src/smart-tag-worker.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   workerData: {} as Record<string, unknown>,
   postMessage: vi.fn(),
   createRegisteredAgents: vi.fn(),
+  synchronizePricingGeneration: vi.fn(),
   classifySessionTags: vi.fn(() => ["bugfix"]),
   getSmartTagSourceTimestamp: vi.fn(() => 42),
 }));
@@ -19,11 +20,13 @@ vi.mock("@codesesh/core", () => ({
   createRegisteredAgents: mocks.createRegisteredAgents,
   classifySessionTags: mocks.classifySessionTags,
   getSmartTagSourceTimestamp: mocks.getSmartTagSourceTimestamp,
+  synchronizePricingGeneration: mocks.synchronizePricingGeneration,
   // diagnostics-bridge.js (imported by the worker for its side effect) needs this export.
   setCoreDiagnostics: vi.fn(),
 }));
 
 async function runWorker() {
+  mocks.workerData = { pricingGenerationId: 17, ...mocks.workerData };
   await import("./smart-tag-worker.js");
 }
 
@@ -38,6 +41,17 @@ beforeEach(() => {
 });
 
 describe("smart tag worker", () => {
+  it("synchronizes pricing before creating agents", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([]);
+
+    await runWorker();
+
+    expect(mocks.synchronizePricingGeneration).toHaveBeenCalledWith(17);
+    expect(mocks.synchronizePricingGeneration.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.createRegisteredAgents.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it("classifies sessions and isolates per-session failures", async () => {
     const sessionData = { messages: [] };
     const agent = {

--- a/packages/cli/src/smart-tag-worker.ts
+++ b/packages/cli/src/smart-tag-worker.ts
@@ -4,10 +4,12 @@ import {
   createRegisteredAgents,
   classifySessionTags,
   getSmartTagSourceTimestamp,
+  synchronizePricingGeneration,
   type SessionCacheMeta,
 } from "@codesesh/core";
 
 interface SmartTagWorkerData {
+  pricingGenerationId: number;
   agentName: string;
   sessionIds: string[];
   meta: Record<string, Record<string, unknown>>;
@@ -21,6 +23,7 @@ interface SmartTagWorkerResult {
 }
 
 const data = workerData as SmartTagWorkerData;
+synchronizePricingGeneration(data.pricingGenerationId);
 const agents = createRegisteredAgents();
 const agent = agents.find((a) => a.name === data.agentName);
 const results: SmartTagWorkerResult[] = [];

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -1,12 +1,13 @@
 import { Worker } from "node:worker_threads";
-import type {
-  AgentScanProgress,
-  ScanOptions,
-  SessionCacheMeta,
-  SessionHead,
-  SessionHeadChange,
-  SessionSourceFailure,
-  SessionSnapshotCompleteness,
+import {
+  getPricingGeneration,
+  type AgentScanProgress,
+  type ScanOptions,
+  type SessionCacheMeta,
+  type SessionHead,
+  type SessionHeadChange,
+  type SessionSourceFailure,
+  type SessionSnapshotCompleteness,
 } from "@codesesh/core";
 import { appLogger } from "./logging.js";
 import type {
@@ -134,6 +135,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       requestId: this.nextRequestId++,
       agentName,
       generation,
+      pricingGenerationId: getPricingGeneration().id,
       operation: payload.operation,
       scanOptions: payload.scanOptions,
       ...(existingSlot ? {} : { previousSessions: payload.previousSessions, meta: payload.meta }),

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -25,6 +25,7 @@ import {
   SMART_TAG_CLASSIFIER_REVISION,
 } from "../utils/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
+import { getPricingGeneration } from "../pricing/index.js";
 import {
   loadCachedSessions,
   markAgentCacheInitialized,
@@ -273,7 +274,12 @@ async function classifySessionTagsInWorker(
 ): Promise<SmartTagWorkerResult[]> {
   return new Promise((resolveWorker, rejectWorker) => {
     const worker = new Worker(workerUrl, {
-      workerData: { agentName, sessionIds, meta },
+      workerData: {
+        pricingGenerationId: getPricingGeneration().id,
+        agentName,
+        sessionIds,
+        meta,
+      },
     });
     worker.once("message", (results: SmartTagWorkerResult[]) => resolveWorker(results));
     worker.once("error", rejectWorker);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -137,6 +137,7 @@ export {
   hasPendingPricing,
   publishPendingPricing,
   refreshPricingCache,
+  synchronizePricingGeneration,
   type PricingGeneration,
 } from "./pricing/index.js";
 export { buildDashboard, getSessionActivityTime } from "./analytics/dashboard.js";

--- a/packages/core/src/pricing/__tests__/refresh-generation.test.ts
+++ b/packages/core/src/pricing/__tests__/refresh-generation.test.ts
@@ -12,8 +12,13 @@ vi.mock("node:os", async (importOriginal) => {
 
 const { setCoreDiagnostics } = await import("../../utils/diagnostics.js");
 const { estimateTokenCost } = await import("../../utils/cost.js");
-const { getPricingGeneration, hasPendingPricing, publishPendingPricing, refreshPricingCache } =
-  await import("../fetcher.js");
+const {
+  getPricingGeneration,
+  getPricingRegistry,
+  hasPendingPricing,
+  publishPendingPricing,
+  refreshPricingCache,
+} = await import("../fetcher.js");
 
 const MODEL = "claude-sonnet-4-5";
 const MILLION_INPUT = { input: 1_000_000, output: 0 };
@@ -40,12 +45,34 @@ afterEach(() => {
 });
 
 describe("CS-148: pricing generations", () => {
+  it("CS-194: keeps parent and isolated worker pricing on one generation", async () => {
+    const generationBefore = getPricingGeneration().id;
+    const pricingBefore = getPricingRegistry().get(MODEL);
+    stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000999) }));
+
+    expect(await refreshPricingCache()).toBe(true);
+    expect(existsSync(cachePath)).toBe(false);
+
+    vi.resetModules();
+    const workerPricing = await import("../fetcher.js");
+    expect(workerPricing.getPricingGeneration().id).toBe(generationBefore);
+    expect(workerPricing.getPricingRegistry().get(MODEL)).toEqual(pricingBefore);
+
+    expect(publishPendingPricing()).toBe(true);
+    const publishedGeneration = getPricingGeneration();
+    expect(workerPricing.getPricingGeneration().id).toBe(generationBefore);
+
+    workerPricing.synchronizePricingGeneration(publishedGeneration.id);
+    expect(workerPricing.getPricingGeneration()).toEqual(publishedGeneration);
+  });
+
   it("does not change live prices until the refresh is published", async () => {
     const before = estimateTokenCost(MODEL, MILLION_INPUT);
     const generationBefore = getPricingGeneration().id;
     stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000999) }));
 
     expect(await refreshPricingCache()).toBe(true);
+    expect(existsSync(cachePath)).toBe(false);
 
     // A scan in flight keeps the prices it started with.
     expect(estimateTokenCost(MODEL, MILLION_INPUT)).toBe(before);
@@ -127,15 +154,22 @@ describe("CS-148: pricing generations", () => {
     expect(hasPendingPricing()).toBe(false);
   });
 
-  it("replaces the disk cache in one step", async () => {
+  it("publishes the disk cache and generation in one step", async () => {
     stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000123) }));
 
     await refreshPricingCache();
+    expect(existsSync(cachePath)).toBe(false);
+    expect(publishPendingPricing()).toBe(true);
 
     const raw = readFileSync(cachePath, "utf8");
     // A truncated write would not parse.
-    const parsed = JSON.parse(raw) as { timestamp: number; data: Record<string, unknown> };
+    const parsed = JSON.parse(raw) as {
+      timestamp: number;
+      generation: number;
+      data: Record<string, unknown>;
+    };
     expect(typeof parsed.timestamp).toBe("number");
+    expect(parsed.generation).toBe(getPricingGeneration().id);
     expect(Object.keys(parsed.data).length).toBeGreaterThan(0);
     expect(existsSync(`${cachePath}.${process.pid}.tmp`)).toBe(false);
   });
@@ -148,16 +182,19 @@ describe("CS-148: pricing generations", () => {
     const events: string[] = [];
     setCoreDiagnostics({ warn: (event) => events.push(event) });
     stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000321) }));
+    const generationBefore = getPricingGeneration();
 
     try {
-      // The in-memory refresh still succeeds; only the cache write fails.
       expect(await refreshPricingCache()).toBe(true);
+      expect(publishPendingPricing()).toBe(false);
     } finally {
       setCoreDiagnostics(null);
       rmSync(cachePath, { recursive: true, force: true });
     }
 
     expect(events).toContain("pricing.cache_write_failed");
+    expect(getPricingGeneration()).toBe(generationBefore);
+    expect(hasPendingPricing()).toBe(true);
     expect(existsSync(`${cachePath}.${process.pid}.tmp`)).toBe(false);
   });
 });

--- a/packages/core/src/pricing/fetcher.ts
+++ b/packages/core/src/pricing/fetcher.ts
@@ -45,7 +45,7 @@ export interface PricingGeneration {
 let published: PricingGeneration = { id: 1, pricing: loadSnapshot() };
 /** A completed refresh waiting for a safe point to become current. */
 let pending: Map<string, ModelPricing> | null = null;
-loadDiskCache();
+published = readDiskCache() ?? published;
 
 function normalizeKey(key: string): string {
   return key.trim().toLowerCase();
@@ -133,26 +133,36 @@ function parseLiteLLMData(data: Record<string, LiteLLMEntry>): Map<string, Model
   return map;
 }
 
-function loadDiskCache() {
+interface PricingCache {
+  timestamp: number;
+  generation?: number;
+  data: Record<string, Record<string, unknown>>;
+}
+
+function readDiskCache(allowStale = false): PricingGeneration | null {
   const path = getCachePath();
-  if (!existsSync(path)) return;
+  if (!existsSync(path)) return null;
 
   try {
-    const cached = JSON.parse(readFileSync(path, "utf-8")) as {
-      timestamp: number;
-      data: Record<string, Record<string, unknown>>;
-    };
-    if (Date.now() - cached.timestamp <= CACHE_TTL_MS) {
-      const next = loadSnapshot();
-      for (const [name, rawPricing] of Object.entries(cached.data)) {
-        const pricing = normalizeCachedPricing(rawPricing);
-        if (!pricing) continue;
-        next.set(normalizeKey(name), pricing);
-      }
-      published = { id: published.id + 1, pricing: next };
+    const cached = JSON.parse(readFileSync(path, "utf-8")) as PricingCache;
+    if (!Number.isFinite(cached.timestamp)) return null;
+    if (!allowStale && Date.now() - cached.timestamp > CACHE_TTL_MS) return null;
+    if (cached.data == null || typeof cached.data !== "object" || Array.isArray(cached.data)) {
+      return null;
     }
+
+    const generation = cached.generation ?? 2;
+    if (!Number.isSafeInteger(generation) || generation < 1) return null;
+
+    const next = loadSnapshot();
+    for (const [name, rawPricing] of Object.entries(cached.data)) {
+      const pricing = normalizeCachedPricing(rawPricing);
+      if (!pricing) continue;
+      next.set(normalizeKey(name), pricing);
+    }
+    return { id: generation, pricing: next };
   } catch {
-    // ignore malformed cache
+    return null;
   }
 }
 
@@ -165,13 +175,44 @@ export function getPricingGeneration(): PricingGeneration {
   return published;
 }
 
+/** Aligns an isolated worker with the generation selected by its parent. */
+export function synchronizePricingGeneration(expectedId: number): void {
+  if (!Number.isSafeInteger(expectedId) || expectedId < 1) {
+    throw new Error(`Invalid pricing generation: ${expectedId}`);
+  }
+  if (published.id === expectedId) return;
+
+  const cached = readDiskCache(true);
+  if (cached?.id !== expectedId) {
+    throw new Error(
+      `Pricing generation ${expectedId} is unavailable (current ${published.id}, cached ${cached?.id ?? "none"})`,
+    );
+  }
+
+  published = cached;
+  getCoreDiagnostics()?.info?.("pricing.generation.synchronized", {
+    generation: published.id,
+    models: published.pricing.size,
+  });
+}
+
 /**
  * Makes a completed refresh current. Owners call this between scans, never
  * during one, so a scan cannot span two generations.
  */
 export function publishPendingPricing(): boolean {
   if (!pending) return false;
-  published = { id: published.id + 1, pricing: pending };
+
+  const nextId = published.id + 1;
+  if (!Number.isSafeInteger(nextId)) {
+    getCoreDiagnostics()?.warn("pricing.generation_exhausted", { generation: published.id });
+    return false;
+  }
+
+  const next = { id: nextId, pricing: pending } satisfies PricingGeneration;
+  if (!writeDiskCacheAtomically(getCachePath(), next)) return false;
+
+  published = next;
   pending = null;
   getCoreDiagnostics()?.info?.("pricing.generation.published", {
     generation: published.id,
@@ -195,19 +236,25 @@ export function hasBillablePricing(pricing: ModelPricing): boolean {
 }
 
 /** Replaces the cache in one step, so an interrupted write cannot truncate it. */
-function writeDiskCacheAtomically(path: string, pricing: Map<string, ModelPricing>): void {
+function writeDiskCacheAtomically(path: string, generation: PricingGeneration): boolean {
   const temporaryPath = `${path}.${process.pid}.tmp`;
-  const payload = JSON.stringify({ timestamp: Date.now(), data: Object.fromEntries(pricing) });
+  const payload = JSON.stringify({
+    timestamp: Date.now(),
+    generation: generation.id,
+    data: Object.fromEntries(generation.pricing),
+  });
   try {
     ensurePrivateDirectory(getCacheDir());
     writeFileSync(temporaryPath, payload);
     restrictPrivateFile(temporaryPath);
     renameSync(temporaryPath, path);
+    return true;
   } catch (error) {
     rmSync(temporaryPath, { force: true });
     getCoreDiagnostics()?.warn("pricing.cache_write_failed", {
       message: error instanceof Error ? error.message : String(error),
     });
+    return false;
   }
 }
 
@@ -252,7 +299,6 @@ export async function refreshPricingCache(options: RefreshPricingOptions = {}): 
     }
 
     pending = next;
-    writeDiskCacheAtomically(path, next);
     getCoreDiagnostics()?.info?.("pricing.refresh.completed", {
       generation: published.id,
       models: next.size,


### PR DESCRIPTION
## Summary

- defer pricing cache writes until the pending generation is safely published
- persist and synchronize generation IDs across isolated worker modules
- pin scan refresh, search index, and smart tag workers to the parent generation

## Testing

- `pnpm --filter @codesesh/core test`
- `pnpm --filter codesesh test`
- `pnpm --filter @codesesh/core lint && pnpm --filter @codesesh/core format:check`
- `pnpm --filter codesesh lint && pnpm --filter codesesh format:check`
- `pnpm --filter @codesesh/core build && pnpm --filter codesesh build`