### PR TITLE
fix(logging): serialize worker log writes

### DIFF
--- a/packages/cli/src/diagnostics-bridge.ts
+++ b/packages/cli/src/diagnostics-bridge.ts
@@ -1,4 +1,5 @@
 import { setCoreDiagnostics } from "@codesesh/core";
+import { parentPort, threadId } from "node:worker_threads";
 import { appLogger } from "./logging.js";
 
 /**
@@ -8,6 +9,8 @@ import { appLogger } from "./logging.js";
  * search-index-worker, smart-tag-worker) — since core's module-level
  * diagnostics singleton is per-thread, not shared across workers.
  */
+if (parentPort) appLogger.forwardToParent(parentPort, threadId);
+
 setCoreDiagnostics({
   info(event, detail) {
     appLogger.info(event, detail);

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1194,6 +1194,54 @@ describe("LiveScanStore", () => {
     });
   });
 
+  it("consumes scan worker logs without settling the active request", async () => {
+    workerThreads.deferScanRefreshWorkers = true;
+    const consumeWorkerMessage = vi
+      .spyOn(appLogger, "consumeWorkerMessage")
+      .mockImplementation((message) =>
+        Boolean(message && typeof message === "object" && "event" in message),
+      );
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+    const refresh = runner.run("codex", {
+      previousSessions: [],
+      operation: { kind: "full-scan" },
+      scanOptions: {},
+      meta: {},
+    });
+    const worker = workerThreads.workers.at(-1)!;
+    const logMessage = { type: "codesesh.worker-log", event: "scan.worker" };
+
+    worker.emitMessage(logMessage);
+
+    expect(consumeWorkerMessage).toHaveBeenCalledWith(logMessage);
+    expect(runner.activeCount).toBe(1);
+
+    worker.emitMessage({
+      type: "done",
+      requestId: worker.workerData.requestId,
+      generation: worker.workerData.generation,
+      changes: [],
+      removedSessionIds: [],
+      meta: {},
+      removedMetaIds: [],
+      sourceFailures: [],
+      completeness: "complete",
+      explicitRemovedSessionIds: [],
+      durationMs: 0,
+    });
+
+    await expect(refresh).resolves.toEqual({
+      sessions: [],
+      meta: {},
+      changedIds: undefined,
+      sourceFailures: [],
+      completeness: "complete",
+      explicitRemovedSessionIds: [],
+    });
+    runner.commit("codex");
+    await runner.shutdown();
+  });
+
   it("rejects a scan worker request when its checkpoint cannot commit", async () => {
     workerThreads.deferScanRefreshWorkers = true;
     const agent = makeFileSystemAgent("codex");

--- a/packages/cli/src/logging.test.ts
+++ b/packages/cli/src/logging.test.ts
@@ -1,5 +1,6 @@
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
@@ -9,8 +10,16 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AppLogger } from "./logging.js";
+
+const coreMocks = vi.hoisted(() => ({ restrictPrivateFile: vi.fn() }));
+
+vi.mock("@codesesh/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codesesh/core")>();
+  coreMocks.restrictPrivateFile.mockImplementation(actual.restrictPrivateFile);
+  return { ...actual, restrictPrivateFile: coreMocks.restrictPrivateFile };
+});
 
 const tempDirs: string[] = [];
 
@@ -25,6 +34,7 @@ describe("AppLogger", () => {
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
+    vi.restoreAllMocks();
   });
 
   it("writes structured log lines", () => {
@@ -33,7 +43,7 @@ describe("AppLogger", () => {
 
     logger.info("test.event", { duration_ms: 12, ok: true });
 
-    const line = readFileSync(join(logDir, "codesesh.log"), "utf8").trim();
+    const line = readFileSync(logger.getLogPath(), "utf8").trim();
     expect(JSON.parse(line)).toMatchObject({
       level: "info",
       event: "test.event",
@@ -52,7 +62,101 @@ describe("AppLogger", () => {
 
     const files = readdirSync(logDir).filter((name) => name.endsWith(".log"));
     expect(files.length).toBeLessThanOrEqual(2);
-    expect(files).toContain("codesesh.log");
+    expect(files).toContain(`codesesh-${process.pid}.log`);
+  });
+
+  it("forwards worker entries to a single file owner", () => {
+    const workerLogDir = createTempDir();
+    const ownerLogDir = createTempDir();
+    const messages: unknown[] = [];
+    const workerLogger = new AppLogger({ logDir: workerLogDir });
+    const ownerLogger = new AppLogger({ logDir: ownerLogDir });
+    workerLogger.forwardToParent({ postMessage: (message) => messages.push(message) }, 7);
+
+    workerLogger.warn("worker.warning", { session: "one" });
+
+    expect(existsSync(workerLogger.getLogPath())).toBe(false);
+    expect(messages).toHaveLength(1);
+    expect(ownerLogger.consumeWorkerMessage(messages[0])).toBe(true);
+    expect(ownerLogger.consumeWorkerMessage({ type: "done" })).toBe(false);
+    expect(JSON.parse(readFileSync(ownerLogger.getLogPath(), "utf8"))).toMatchObject({
+      level: "warn",
+      event: "worker.warning",
+      session: "one",
+      thread_id: 7,
+    });
+  });
+
+  it("preserves all worker entries across owner rotations", () => {
+    const ownerLogDir = createTempDir();
+    const owner = new AppLogger({ logDir: ownerLogDir, maxBytes: 300, maxFiles: 200 });
+    const messages: unknown[] = [];
+    const workers = Array.from({ length: 4 }, (_, threadId) => {
+      const logger = new AppLogger({ logDir: createTempDir() });
+      logger.forwardToParent({ postMessage: (message) => messages.push(message) }, threadId + 1);
+      return logger;
+    });
+
+    for (const [worker, logger] of workers.entries()) {
+      for (let index = 0; index < 30; index += 1) {
+        logger.info("worker.rotation", { worker, index });
+      }
+    }
+    for (const message of messages) owner.consumeWorkerMessage(message);
+
+    const records = readdirSync(ownerLogDir)
+      .filter((name) => name.endsWith(".log"))
+      .flatMap((name) =>
+        readFileSync(join(ownerLogDir, name), "utf8")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as { worker: number; index: number }),
+      );
+    const uniqueEntries = new Set(records.map(({ worker, index }) => `${worker}:${index}`));
+
+    expect(records).toHaveLength(120);
+    expect(uniqueEntries.size).toBe(120);
+  });
+
+  it("does not remove another process's rotated logs", () => {
+    const logDir = createTempDir();
+    const foreignActiveLog = join(logDir, `codesesh-${process.pid + 1}.log`);
+    const foreignLog = join(logDir, `codesesh-${process.pid + 1}-foreign-1.log`);
+    writeFileSync(foreignActiveLog, "foreign active\n");
+    writeFileSync(foreignLog, "foreign\n");
+    const logger = new AppLogger({ logDir, maxBytes: 120, maxFiles: 1 });
+
+    for (let index = 0; index < 4; index += 1) {
+      logger.info("test.rotate", { index, text: "x".repeat(80) });
+    }
+
+    expect(existsSync(foreignActiveLog)).toBe(true);
+    expect(existsSync(foreignLog)).toBe(true);
+  });
+
+  it("restricts the active file only when it is created", () => {
+    coreMocks.restrictPrivateFile.mockClear();
+    const logger = new AppLogger({ logDir: createTempDir(), maxBytes: 10_000 });
+
+    logger.info("test.first");
+    logger.info("test.second");
+
+    expect(coreMocks.restrictPrivateFile).toHaveBeenCalledExactlyOnceWith(logger.getLogPath());
+  });
+
+  it("reports a file write failure once instead of dropping it silently", () => {
+    const root = createTempDir();
+    const blocker = join(root, "not-a-directory");
+    writeFileSync(blocker, "x");
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const logger = new AppLogger({ logDir: blocker });
+
+    logger.info("test.failure");
+    logger.info("test.failure-again");
+
+    expect(stderr).toHaveBeenCalledOnce();
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("Failed to write log"));
   });
 });
 

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -3,12 +3,20 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import {
   ensurePrivateDirectory,
+  isWorkerLogMessage,
   restrictExistingPrivateFiles,
   restrictPrivateFile,
+  WORKER_LOG_MESSAGE_TYPE,
+  type WorkerLogLevel,
+  type WorkerLogMessage,
 } from "@codesesh/core";
 import type { SearchIndexSyncResult } from "@codesesh/core";
 
-type LogLevel = "debug" | "info" | "warn" | "error";
+type LogLevel = WorkerLogLevel;
+
+interface WorkerLogPort {
+  postMessage(message: WorkerLogMessage): void;
+}
 
 const LEVEL_WEIGHT: Record<LogLevel, number> = {
   debug: 10,
@@ -77,6 +85,8 @@ export class AppLogger {
   private readonly currentPath: string;
   private rotationIndex = 0;
   private restrictedExistingLogs = false;
+  private workerTarget: { port: WorkerLogPort; threadId: number } | null = null;
+  private writeFailureReported = false;
 
   constructor(options: LoggerOptions = {}) {
     this.logDir = options.logDir ?? process.env.CODESESH_LOG_DIR ?? getDefaultLogDir();
@@ -84,11 +94,29 @@ export class AppLogger {
     this.maxBytes =
       options.maxBytes ?? parsePositiveInt(process.env.CODESESH_LOG_MAX_BYTES, 5_000_000);
     this.maxFiles = options.maxFiles ?? parsePositiveInt(process.env.CODESESH_LOG_MAX_FILES, 5);
-    this.currentPath = join(this.logDir, "codesesh.log");
+    this.currentPath = join(this.logDir, `codesesh-${process.pid}.log`);
   }
 
   getLogPath(): string {
     return this.currentPath;
+  }
+
+  forwardToParent(port: WorkerLogPort, threadId: number): void {
+    this.workerTarget = { port, threadId };
+  }
+
+  consumeWorkerMessage(message: unknown): boolean {
+    if (!isWorkerLogMessage(message)) return false;
+    if (LEVEL_WEIGHT[message.level] < LEVEL_WEIGHT[this.level]) return true;
+    this.appendRecord({
+      ...message.data,
+      ts: message.ts,
+      level: message.level,
+      event: message.event,
+      pid: message.pid,
+      thread_id: message.threadId,
+    });
+    return true;
   }
 
   debug(event: string, data: Record<string, unknown> = {}): void {
@@ -110,20 +138,54 @@ export class AppLogger {
   private write(level: LogLevel, event: string, data: Record<string, unknown>): void {
     if (LEVEL_WEIGHT[level] < LEVEL_WEIGHT[this.level]) return;
 
+    const ts = new Date().toISOString();
+    const normalizedData = toLogValue(data) as Record<string, unknown>;
+    if (this.workerTarget) {
+      try {
+        this.workerTarget.port.postMessage({
+          type: WORKER_LOG_MESSAGE_TYPE,
+          ts,
+          level,
+          event,
+          pid: process.pid,
+          threadId: this.workerTarget.threadId,
+          data: normalizedData,
+        });
+      } catch (error) {
+        this.reportWriteFailure(error);
+      }
+      return;
+    }
+
+    this.appendRecord({
+      ...normalizedData,
+      ts,
+      level,
+      event,
+      pid: process.pid,
+    });
+  }
+
+  private appendRecord(record: Record<string, unknown>): void {
     try {
       ensurePrivateDirectory(this.logDir);
       this.restrictExistingLogs();
-      const line = `${JSON.stringify({
-        ts: new Date().toISOString(),
-        level,
-        event,
-        pid: process.pid,
-        ...(toLogValue(data) as Record<string, unknown>),
-      })}\n`;
-      this.rotateIfNeeded(Buffer.byteLength(line));
+      const line = `${JSON.stringify(record)}\n`;
+      const restrictCurrentFile = this.rotateIfNeeded(Buffer.byteLength(line));
       appendFileSync(this.currentPath, line, "utf8");
-      // Logs carry project paths and error detail.
-      restrictPrivateFile(this.currentPath);
+      if (restrictCurrentFile) restrictPrivateFile(this.currentPath);
+      this.writeFailureReported = false;
+    } catch (error) {
+      this.reportWriteFailure(error);
+    }
+  }
+
+  private reportWriteFailure(error: unknown): void {
+    if (this.writeFailureReported) return;
+    this.writeFailureReported = true;
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      process.stderr.write(`[codesesh] Failed to write log ${this.currentPath}: ${message}\n`);
     } catch {}
   }
 
@@ -137,28 +199,30 @@ export class AppLogger {
     );
   }
 
-  private rotateIfNeeded(nextBytes: number): void {
+  private rotateIfNeeded(nextBytes: number): boolean {
     if (!existsSync(this.currentPath)) {
       this.removeExpiredLogs();
-      return;
+      return true;
     }
 
     const currentSize = statSync(this.currentPath).size;
-    if (currentSize + nextBytes <= this.maxBytes) return;
+    if (currentSize + nextBytes <= this.maxBytes) return false;
 
     this.rotationIndex += 1;
     const rotatedPath = join(
       this.logDir,
-      `codesesh-${timestampForFile()}-${process.pid}-${this.rotationIndex}.log`,
+      `codesesh-${process.pid}-${timestampForFile()}-${this.rotationIndex}.log`,
     );
     renameSync(this.currentPath, rotatedPath);
     restrictPrivateFile(rotatedPath);
     this.removeExpiredLogs();
+    return true;
   }
 
   private removeExpiredLogs(): void {
+    const ownedPrefix = `codesesh-${process.pid}-`;
     const rotated = readdirSync(this.logDir)
-      .filter((name) => /^codesesh-.+\.log$/.test(name))
+      .filter((name) => name.startsWith(ownedPrefix) && name.endsWith(".log"))
       .map((name) => {
         const path = join(this.logDir, name);
         return { path, mtimeMs: statSync(path).mtimeMs };

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -65,6 +65,7 @@ const mocks = vi.hoisted(() => {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
+      forwardToParent: vi.fn(),
     },
   };
 });
@@ -76,6 +77,7 @@ vi.mock("node:worker_threads", () => ({
       if (event === "message") mocks.workerMessageHandler = handler;
     }),
   },
+  threadId: 17,
   get workerData() {
     return mocks.workerData;
   },
@@ -184,6 +186,10 @@ describe("scan refresh worker entry", () => {
 
     await runWorker();
 
+    expect(mocks.appLogger.forwardToParent).toHaveBeenCalledWith(
+      expect.objectContaining({ postMessage: mocks.postMessage }),
+      17,
+    );
     expect(mocks.synchronizePricingGeneration).toHaveBeenCalledWith(17);
     expect(mocks.synchronizePricingGeneration.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.createRegisteredAgents.mock.invocationCallOrder[0]!,

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { SearchIndexWorkerJob, SearchIndexWorkerMessage } from "./search-index-worker.js";
+import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 
 const workerMocks = vi.hoisted(() => {
   type Handler = (arg: never) => void;
@@ -23,21 +23,30 @@ const workerMocks = vi.hoisted(() => {
       return 0;
     }
 
-    post(message: SearchIndexWorkerMessage): void {
-      (this.handlers.get("message") as ((arg: SearchIndexWorkerMessage) => void) | undefined)?.(
-        message,
-      );
+    post(message: unknown): void {
+      (this.handlers.get("message") as ((arg: unknown) => void) | undefined)?.(message);
     }
   }
   const workers: FakeWorker[] = [];
-  return { workers, FakeWorker, workerExists: true };
+  return {
+    workers,
+    FakeWorker,
+    workerExists: true,
+    consumeWorkerMessage: vi.fn((_message: unknown) => false),
+  };
 });
 
 vi.mock("node:worker_threads", () => ({ Worker: workerMocks.FakeWorker }));
 vi.mock("node:fs", () => ({ existsSync: () => workerMocks.workerExists }));
 vi.mock("@codesesh/core", () => ({ getPricingGeneration: () => ({ id: 17 }) }));
 vi.mock("./logging.js", () => ({
-  appLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  appLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    consumeWorkerMessage: workerMocks.consumeWorkerMessage,
+  },
   logSearchIndexSync: vi.fn(),
 }));
 
@@ -64,9 +73,24 @@ beforeEach(() => {
   workerMocks.workers.length = 0;
   workerMocks.workerExists = true;
   vi.clearAllMocks();
+  workerMocks.consumeWorkerMessage.mockReturnValue(false);
 });
 
 describe("SearchIndexJobRunner", () => {
+  it("consumes worker logs without settling the active batch", async () => {
+    const runner = new SearchIndexJobRunner();
+    const completion = runner.enqueue("scan.refresh", [makeJob()]);
+    const worker = startedWorker();
+    const logMessage = { type: "codesesh.worker-log" };
+    workerMocks.consumeWorkerMessage.mockImplementation((message) => message === logMessage);
+
+    worker.post(logMessage);
+    worker.post({ type: "done", context: "scan.refresh", durationMs: 1, sessions: 1 });
+
+    expect(workerMocks.consumeWorkerMessage).toHaveBeenNthCalledWith(1, logMessage);
+    await expect(completion).resolves.toBeUndefined();
+  });
+
   it("pins each worker batch to the current pricing generation", async () => {
     const runner = new SearchIndexJobRunner();
     const completion = runner.enqueue("scan.refresh", [makeJob()]);

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -113,6 +113,7 @@ export class SearchIndexJobRunner {
     this.activeBatch = batch;
 
     worker.on("message", (message: SearchIndexWorkerMessage) => {
+      if (appLogger.consumeWorkerMessage(message)) return;
       if (message.type === "sync-result") {
         logSearchIndexSync(message.context, message.result);
         return;

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("node:worker_threads", () => ({
   parentPort: { postMessage: mocks.postMessage },
+  threadId: 17,
   get workerData() {
     return mocks.workerData;
   },
@@ -33,6 +34,7 @@ vi.mock("@codesesh/core", () => ({
 
 vi.mock("./logging.js", () => ({
   appLogger: {
+    forwardToParent: vi.fn(),
     info: mocks.appLoggerInfo,
     warn: mocks.appLoggerWarn,
     error: mocks.appLoggerError,

--- a/packages/cli/src/smart-tag-worker.test.ts
+++ b/packages/cli/src/smart-tag-worker.test.ts
@@ -11,8 +11,17 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("node:worker_threads", () => ({
   parentPort: { postMessage: mocks.postMessage },
+  threadId: 17,
   get workerData() {
     return mocks.workerData;
+  },
+}));
+
+vi.mock("./logging.js", () => ({
+  appLogger: {
+    forwardToParent: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -222,8 +222,9 @@ export class ThreadWorkerRunner implements WorkerRunner {
     };
     worker.unref();
     this.workers.set(agentName, slot);
-    worker.on("message", (message: ScanRefreshWorkerMessage) => {
-      this.handleMessage(slot, message);
+    worker.on("message", (message: unknown) => {
+      if (appLogger.consumeWorkerMessage(message)) return;
+      this.handleMessage(slot, message as ScanRefreshWorkerMessage);
     });
     worker.on("error", (error) => {
       this.closeWorker(agentName, slot, toError(error));

--- a/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
+++ b/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
@@ -1,0 +1,111 @@
+import { availableParallelism } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BaseAgent, SessionCacheMeta } from "../../agents/index.js";
+import type { SessionHead } from "../../types/index.js";
+import { setCoreDiagnostics } from "../../utils/index.js";
+
+const workers = vi.hoisted(() => {
+  class FakeWorker {
+    private readonly sessionIds: string[];
+
+    constructor(_url: URL | string, options: { workerData: { sessionIds: string[] } }) {
+      this.sessionIds = options.workerData.sessionIds;
+    }
+
+    on(event: string, handler: (message: unknown) => void): this {
+      if (event === "message") {
+        queueMicrotask(() => {
+          handler({
+            type: "codesesh.worker-log",
+            ts: "2026-08-12T00:00:00.000Z",
+            level: "info",
+            event: "smart_tags.worker",
+            pid: 42,
+            threadId: 3,
+            data: { sessions: this.sessionIds.length },
+          });
+          handler(this.sessionIds.map((id) => ({ id, tags: ["bugfix"], sourceUpdatedAt: 1000 })));
+        });
+      }
+      return this;
+    }
+
+    once(): this {
+      return this;
+    }
+  }
+
+  return { FakeWorker };
+});
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  availableParallelism: vi.fn(() => 3),
+}));
+vi.mock("node:worker_threads", () => ({ Worker: workers.FakeWorker }));
+
+import { finalizeAgentScan } from "../scanner.js";
+
+function makeSession(index: number): SessionHead {
+  return {
+    id: `session-${index}`,
+    slug: `test/session-${index}`,
+    title: `Session ${index}`,
+    directory: "/workspace",
+    time_created: 1000,
+    time_updated: 1000,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+afterEach(() => {
+  setCoreDiagnostics(null);
+});
+
+describe("smart tag worker logging", () => {
+  it("relays log messages without mistaking them for worker results", async () => {
+    expect(availableParallelism()).toBe(3);
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    setCoreDiagnostics({
+      info: (event, detail) => events.push({ event, detail }),
+      warn: vi.fn(),
+    });
+    const sessions = Array.from({ length: 50 }, (_, index) => makeSession(index));
+    const meta = new Map<string, SessionCacheMeta>();
+    const agent = {
+      name: "test",
+      getSessionMetaMap: () => meta,
+      getSessionData: vi.fn(),
+    } as unknown as BaseAgent;
+
+    const result = await finalizeAgentScan(agent, sessions, {
+      finalization: { kind: "unchanged", cached: { sessions, meta: {}, timestamp: 1 } },
+      options: {
+        smartTagWorkerUrl: new URL("file:///smart-tag-worker.js"),
+        writeCache: false,
+      },
+      timing: { total: 0 },
+      agentStart: performance.now(),
+      completeness: "complete",
+    });
+
+    expect(result.heads).toHaveLength(50);
+    expect(result.heads.every((session) => session.smart_tags?.[0] === "bugfix")).toBe(true);
+    expect(agent.getSessionData).not.toHaveBeenCalled();
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({
+      event: "smart_tags.worker",
+      detail: expect.objectContaining({
+        sessions: 25,
+        worker_pid: 42,
+        worker_thread_id: 3,
+        worker_level: "info",
+      }),
+    });
+  });
+});

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -21,8 +21,10 @@ import { filterSessionsByProjectScope } from "../projects/index.js";
 import {
   classifySessionTags,
   getSmartTagSourceTimestamp,
+  isWorkerLogMessage,
   perf,
   SMART_TAG_CLASSIFIER_REVISION,
+  type WorkerLogMessage,
 } from "../utils/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import { getPricingGeneration } from "../pricing/index.js";
@@ -281,7 +283,13 @@ async function classifySessionTagsInWorker(
         meta,
       },
     });
-    worker.once("message", (results: SmartTagWorkerResult[]) => resolveWorker(results));
+    worker.on("message", (message: unknown) => {
+      if (isWorkerLogMessage(message)) {
+        relayWorkerLogMessage(message);
+        return;
+      }
+      resolveWorker(message as SmartTagWorkerResult[]);
+    });
     worker.once("error", rejectWorker);
     worker.once("exit", (code) => {
       if (code !== 0) {
@@ -289,6 +297,21 @@ async function classifySessionTagsInWorker(
       }
     });
   });
+}
+
+function relayWorkerLogMessage(message: WorkerLogMessage): void {
+  const detail = {
+    ...message.data,
+    worker_ts: message.ts,
+    worker_pid: message.pid,
+    worker_thread_id: message.threadId,
+    worker_level: message.level,
+  };
+  if (message.level === "warn" || message.level === "error") {
+    getCoreDiagnostics()?.warn(message.event, detail);
+    return;
+  }
+  getCoreDiagnostics()?.info?.(message.event, detail);
 }
 
 async function ensureSessionTags(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,11 +126,15 @@ export {
   classifySessionTags,
   ensurePrivateDirectory,
   getSmartTagSourceTimestamp,
+  isWorkerLogMessage,
   SMART_TAG_CLASSIFIER_REVISION,
   perf,
   restrictExistingPrivateFiles,
   restrictPrivateFile,
   setCoreDiagnostics,
+  WORKER_LOG_MESSAGE_TYPE,
+  type WorkerLogLevel,
+  type WorkerLogMessage,
 } from "./utils/index.js";
 export {
   getPricingGeneration,

--- a/packages/core/src/utils/__tests__/worker-log.test.ts
+++ b/packages/core/src/utils/__tests__/worker-log.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  WORKER_LOG_MESSAGE_TYPE,
+  isWorkerLogMessage,
+  type WorkerLogMessage,
+} from "../worker-log.js";
+
+const message: WorkerLogMessage = {
+  type: WORKER_LOG_MESSAGE_TYPE,
+  ts: "2026-08-12T00:00:00.000Z",
+  level: "info",
+  event: "worker.ready",
+  pid: 42,
+  threadId: 3,
+  data: { sessions: 2 },
+};
+
+describe("worker log protocol", () => {
+  it("accepts a complete worker log message", () => {
+    expect(isWorkerLogMessage(message)).toBe(true);
+  });
+
+  it.each([
+    null,
+    [],
+    { ...message, type: "done" },
+    { ...message, level: "fatal" },
+    { ...message, event: "" },
+    { ...message, pid: 0 },
+    { ...message, threadId: -1 },
+    { ...message, data: [] },
+  ])("rejects an invalid worker message %#", (candidate) => {
+    expect(isWorkerLogMessage(candidate)).toBe(false);
+  });
+});

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -20,6 +20,12 @@ export {
 } from "./smart-tags.js";
 export { estimateTokenCost } from "./cost.js";
 export {
+  WORKER_LOG_MESSAGE_TYPE,
+  isWorkerLogMessage,
+  type WorkerLogLevel,
+  type WorkerLogMessage,
+} from "./worker-log.js";
+export {
   extractFileActivityOccurrences,
   extractSessionFileActivity,
   summarizeFileActivity,

--- a/packages/core/src/utils/worker-log.ts
+++ b/packages/core/src/utils/worker-log.ts
@@ -1,0 +1,36 @@
+export const WORKER_LOG_MESSAGE_TYPE = "codesesh.worker-log";
+
+export type WorkerLogLevel = "debug" | "info" | "warn" | "error";
+
+export interface WorkerLogMessage {
+  type: typeof WORKER_LOG_MESSAGE_TYPE;
+  ts: string;
+  level: WorkerLogLevel;
+  event: string;
+  pid: number;
+  threadId: number;
+  data: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isWorkerLogMessage(value: unknown): value is WorkerLogMessage {
+  if (!isRecord(value) || value.type !== WORKER_LOG_MESSAGE_TYPE) return false;
+  return (
+    typeof value.ts === "string" &&
+    value.ts.length > 0 &&
+    (value.level === "debug" ||
+      value.level === "info" ||
+      value.level === "warn" ||
+      value.level === "error") &&
+    typeof value.event === "string" &&
+    value.event.length > 0 &&
+    Number.isSafeInteger(value.pid) &&
+    Number(value.pid) > 0 &&
+    Number.isSafeInteger(value.threadId) &&
+    Number(value.threadId) >= 0 &&
+    isRecord(value.data)
+  );
+}


### PR DESCRIPTION
## Summary

- forward worker diagnostics through a typed parent-thread log protocol so only the main thread writes and rotates files
- isolate active and rotated logs by process, preserve foreign process logs, and report the first write failure
- restrict file permissions only on creation or rotation and cover every worker message path

## Testing

- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`
- runtime stress test with four real workers: reproduced 822/1200 persisted records before the fix and verified 1200/1200 unique records after it