### PR TITLE
fix(api): reject invalid date filters

### DIFF
--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -49,14 +49,17 @@ import {
 import {
   handleDeleteBookmark,
   handleDeleteSessionAlias,
+  handleGetAgents,
   handleGetBookmarks,
   handleGetDashboard,
   handleGetFileActivity,
+  handleGetProjects,
   handleGetSessions,
   handleImportBookmarks,
   handlePostClientLog,
   handlePutBookmark,
   handlePutSessionAlias,
+  handleSearchSessions,
   type ScanResultSource,
 } from "../handlers.js";
 import { addCalendarDays } from "@codesesh/core/contract";
@@ -576,6 +579,41 @@ describe("session alias handlers", () => {
 });
 
 describe("query boundary handlers", () => {
+  const dateHandlers: Array<{
+    endpoint: string;
+    invoke: (context: ReturnType<typeof makeContext>) => unknown;
+  }> = [
+    { endpoint: "agents", invoke: (context) => handleGetAgents(context as never, scanSource) },
+    { endpoint: "projects", invoke: (context) => handleGetProjects(context as never, scanSource) },
+    { endpoint: "sessions", invoke: (context) => handleGetSessions(context as never, scanSource) },
+    { endpoint: "search", invoke: (context) => handleSearchSessions(context as never, scanSource) },
+    { endpoint: "file-activity", invoke: (context) => handleGetFileActivity(context as never) },
+    {
+      endpoint: "dashboard",
+      invoke: (context) => handleGetDashboard(context as never, scanSource),
+    },
+  ];
+
+  for (const { endpoint, invoke } of dateHandlers) {
+    for (const parameter of ["from", "to"] as const) {
+      it(`rejects an invalid ${parameter} parameter on ${endpoint}`, () => {
+        const context = makeContext({ query: { [parameter]: "not-a-date" } });
+
+        invoke(context);
+
+        expect(context.json).toHaveBeenCalledWith(
+          { error: `${parameter} must be a valid date` },
+          400,
+        );
+        expect(loggerMocks.warn).toHaveBeenCalledWith("api.query_parameter.invalid", {
+          endpoint,
+          parameter,
+          validation_outcome: "rejected",
+        });
+      });
+    }
+  }
+
   it("reports rejected and empty-result parameter outcomes", () => {
     const sessions = makeContext({ query: { agent: "nonexistent" } });
     handleGetSessions(sessions as never, scanSource);

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -509,12 +509,11 @@ describe("handleGetSessions", () => {
     expect(response.sessions[0].id).toBe("old-active");
   });
 
-  it("ignores invalid from date", () => {
+  it("rejects an invalid from date", () => {
     const c = makeMockContext({ query: { from: "not-a-date" } });
     handleGetSessions(c, makeScanSource());
-    const response = c.json.mock.calls[0]![0];
-    // Invalid date → filter not applied
-    expect(response.sessions).toHaveLength(2);
+
+    expect(c.json).toHaveBeenCalledWith({ error: "from must be a valid date" }, 400);
   });
 });
 

--- a/packages/cli/src/api/__tests__/query-params.test.ts
+++ b/packages/cli/src/api/__tests__/query-params.test.ts
@@ -1,7 +1,38 @@
 import { describe, expect, it } from "vitest";
-import { parseSessionQuery, SEARCH_LIMIT_POLICY } from "../query-params.js";
+import {
+  parseDateParam,
+  parseDateWindow,
+  parseSessionQuery,
+  SEARCH_LIMIT_POLICY,
+} from "../query-params.js";
 
 describe("session query contract", () => {
+  it("distinguishes default, valid, and invalid date values", () => {
+    expect(parseDateParam(undefined, 1000)).toEqual({ kind: "default", value: 1000 });
+    expect(parseDateParam("   ", 1000)).toEqual({ kind: "default", value: 1000 });
+    expect(parseDateParam("2026-08-12", 1000)).toEqual({
+      kind: "valid",
+      value: new Date("2026-08-12").getTime(),
+    });
+    expect(parseDateParam("not-a-date", 1000)).toEqual({
+      kind: "invalid",
+      error: "must be a valid date",
+    });
+  });
+
+  it("identifies the first invalid date window parameter", () => {
+    expect(parseDateWindow(new URLSearchParams("from=bad&to=also-bad"), {})).toEqual({
+      kind: "invalid",
+      parameter: "from",
+      error: "must be a valid date",
+    });
+    expect(parseDateWindow(new URLSearchParams("to=bad"), { from: 1000 })).toEqual({
+      kind: "invalid",
+      parameter: "to",
+      error: "must be a valid date",
+    });
+  });
+
   it("distinguishes an absent agent from known and unknown values", () => {
     expect(parseSessionQuery(new URLSearchParams(), ["claudecode"]).agent).toEqual({
       kind: "all",

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -51,7 +51,7 @@ import { resolveTimeWindow } from "../time-window-resolution.js";
 import {
   filterSessionsByActivityWindow,
   FILE_ACTIVITY_LIMIT_POLICY,
-  parseDateParam,
+  parseDateWindow,
   parseFileActivityKind,
   parseProjectIdentityFilter,
   parseSessionQuery,
@@ -85,7 +85,7 @@ const KNOWN_AGENT_NAME_SET = new Set(KNOWN_AGENT_NAMES);
 
 function reportInvalidQueryParameter(
   endpoint: string,
-  parameter: "agent" | "limit",
+  parameter: "agent" | "limit" | "from" | "to",
   validationOutcome: "empty_result" | "rejected",
 ): void {
   appLogger.warn("api.query_parameter.invalid", {
@@ -93,6 +93,17 @@ function reportInvalidQueryParameter(
     parameter,
     validation_outcome: validationOutcome,
   });
+}
+
+function parseDateWindowRequest(c: Context, endpoint: string, defaults: SessionListDefaults) {
+  const outcome = parseDateWindow(searchParams(c), defaults);
+  if (outcome.kind === "valid") return outcome;
+
+  reportInvalidQueryParameter(endpoint, outcome.parameter, "rejected");
+  return {
+    kind: "rejected" as const,
+    response: c.json({ error: `${outcome.parameter} ${outcome.error}` }, 400),
+  };
 }
 
 interface SnapshotAggregationCache {
@@ -310,8 +321,9 @@ export function handleGetAgents(
   defaults: SessionListDefaults = {},
 ) {
   const scanResult = scanSource.getSnapshot();
-  const from = parseDateParam(c.req.query("from"), defaults.from);
-  const to = parseDateParam(c.req.query("to"), defaults.to);
+  const window = parseDateWindowRequest(c, "agents", defaults);
+  if (window.kind === "rejected") return window.response;
+  const { from, to } = window;
   const agents = getSnapshotAggregation(
     scanSource,
     scanResult.sessions,
@@ -335,8 +347,9 @@ export function handleGetProjects(
   defaults: SessionListDefaults = {},
 ) {
   const scanResult = scanSource.getSnapshot();
-  const from = parseDateParam(c.req.query("from"), defaults.from);
-  const to = parseDateParam(c.req.query("to"), defaults.to);
+  const window = parseDateWindowRequest(c, "projects", defaults);
+  if (window.kind === "rejected") return window.response;
+  const { from, to } = window;
   const projects = getSnapshotAggregation(
     scanSource,
     scanResult.sessions,
@@ -368,8 +381,9 @@ export function handleGetSessions(
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
   const tag = c.req.query("tag")?.toLowerCase();
-  const from = parseDateParam(c.req.query("from"), defaults.from);
-  const to = parseDateParam(c.req.query("to"), defaults.to);
+  const window = parseDateWindowRequest(c, "sessions", defaults);
+  if (window.kind === "rejected") return window.response;
+  const { from, to } = window;
 
   let sessions: SessionHead[] = [];
 
@@ -456,13 +470,15 @@ export function handleSearchSessions(
   if (projectIdentity === null) {
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
+  const window = parseDateWindowRequest(c, "search", defaults);
+  if (window.kind === "rejected") return window.response;
   if (sessionQuery.agent.kind === "unknown") {
     reportInvalidQueryParameter("search", "agent", "empty_result");
     return c.json({ results: [] });
   }
   const searchOptions = parseSearchOptions(
     c,
-    defaults,
+    window,
     {
       agent: sessionQuery.agent.kind === "known" ? sessionQuery.agent.agentName : undefined,
       limit: sessionQuery.limit.value,
@@ -505,6 +521,8 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
   if (projectIdentity === null) {
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
+  const window = parseDateWindowRequest(c, "file-activity", defaults);
+  if (window.kind === "rejected") return window.response;
   if (sessionQuery.agent.kind === "unknown") {
     reportInvalidQueryParameter("file-activity", "agent", "empty_result");
     return c.json({ activity: [] });
@@ -521,8 +539,8 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
       cwd: optionalQueryValue(c.req.query("cwd")),
       path: optionalQueryValue(c.req.query("path")),
       kind: parseFileActivityKind(optionalQueryValue(c.req.query("kind"))),
-      from: parseDateParam(c.req.query("from"), defaults.from),
-      to: parseDateParam(c.req.query("to"), defaults.to),
+      from: window.from,
+      to: window.to,
       limit: sessionQuery.limit.value,
     }).map((activity) => decorateFileActivity(activity, aliases)),
   });
@@ -741,6 +759,8 @@ export function handleGetDashboard(
   if (projectIdentity === null) {
     return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
   }
+  const dateWindow = parseDateWindowRequest(c, "dashboard", defaults);
+  if (dateWindow.kind === "rejected") return dateWindow.response;
   const { from, to, days } = resolveTimeWindow({
     mode: "dashboard",
     query: {
@@ -761,7 +781,7 @@ export function handleGetDashboard(
       ? undefined
       : { from: addCalendarDays(from, -(days ?? countCalendarDays(from, to))), to: from - 1 };
 
-  const fixedTo = parseDateParam(c.req.query("to"), defaults.to);
+  const fixedTo = dateWindow.to;
   const aggregate = getSnapshotAggregation(
     scanSource,
     scanResult.sessions,

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -46,6 +46,15 @@ export type LimitOutcome =
   | { kind: "valid"; value: number }
   | { kind: "invalid"; error: string };
 
+export type DateParamOutcome =
+  | { kind: "default"; value: number | undefined }
+  | { kind: "valid"; value: number }
+  | { kind: "invalid"; error: string };
+
+export type DateWindowOutcome =
+  | { kind: "valid"; from: number | undefined; to: number | undefined }
+  | { kind: "invalid"; parameter: "from" | "to"; error: string };
+
 export interface SessionQuery {
   agent: AgentFilterOutcome;
 }
@@ -77,10 +86,26 @@ export function optionalQueryValue(value: string | undefined): string | undefine
 export function parseDateParam(
   value: string | undefined,
   fallback: number | undefined,
-): number | undefined {
-  if (value == null) return fallback;
-  const ts = new Date(value).getTime();
-  return Number.isNaN(ts) ? fallback : ts;
+): DateParamOutcome {
+  const normalized = optionalQueryValue(value);
+  if (normalized == null) return { kind: "default", value: fallback };
+  const timestamp = new Date(normalized).getTime();
+  return Number.isNaN(timestamp)
+    ? { kind: "invalid", error: "must be a valid date" }
+    : { kind: "valid", value: timestamp };
+}
+
+export function parseDateWindow(
+  params: URLSearchParams,
+  defaults: SessionListDefaults,
+): DateWindowOutcome {
+  const from = parseDateParam(params.get("from") ?? undefined, defaults.from);
+  if (from.kind === "invalid") return { ...from, parameter: "from" };
+
+  const to = parseDateParam(params.get("to") ?? undefined, defaults.to);
+  if (to.kind === "invalid") return { ...to, parameter: "to" };
+
+  return { kind: "valid", from: from.value, to: to.value };
 }
 
 export function parseNumberParam(value: string | undefined): number | undefined {
@@ -168,7 +193,7 @@ export function parseProjectIdentityFilter(
 
 export function parseSearchOptions(
   c: Context,
-  defaults: SessionListDefaults,
+  window: SessionListDefaults,
   request: { agent?: string; limit: number },
   projectIdentity?: ProjectIdentityRef,
 ): SearchOptions {
@@ -187,8 +212,8 @@ export function parseSearchOptions(
     ),
     costMin: parseNumberParam(params.get("costMin") ?? undefined),
     costMax: parseNumberParam(params.get("costMax") ?? undefined),
-    from: parseDateParam(params.get("from") ?? undefined, defaults.from),
-    to: parseDateParam(params.get("to") ?? undefined, defaults.to),
+    from: window.from,
+    to: window.to,
     limit: request.limit,
   };
 }


### PR DESCRIPTION
## Summary

- model date parameters as explicit default, valid, or invalid outcomes instead of silently falling back
- validate from/to consistently across agents, projects, sessions, search, file activity, and dashboard handlers
- return 400 responses and emit the existing invalid-query diagnostic with the rejected parameter name

## Testing

- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`
- focused API tests: 131 passed
- runtime reproduction confirmed the previous `from=not-a-date` request returned 200 with an unfiltered payload; the fixed path returns 400 and logs `api.query_parameter.invalid`