### PR TITLE
test(e2e): discover new specs by default

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -86,13 +86,7 @@ export default defineConfig({
   projects: [
     {
       name: "web-chromium",
-      testMatch: [
-        "aggregation.spec.ts",
-        "browsing.spec.ts",
-        "code-splitting.spec.ts",
-        "live-refresh.spec.ts",
-        "local-media.spec.ts",
-      ],
+      testIgnore: "www.spec.ts",
       metadata: { fixtureSessionPath },
       use: { ...devices["Desktop Chrome"], baseURL: `http://127.0.0.1:${port}` },
     },


### PR DESCRIPTION
## Summary

- replace the web project file allowlist with a complementary exclusion for the WWW spec
- keep the WWW project explicitly scoped to its own spec
- make every future Playwright spec run in the web project by default

## Testing

- verified an unlisted temporary spec is discovered by web-chromium
- pnpm exec playwright test --list
- pnpm test:e2e
- pnpm test
- pnpm lint
- pnpm format:check

Issue: CS-201