### PR TITLE
fix(core): stop permanent codex source-failure loop on startup

### DIFF
--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -888,10 +888,9 @@ describe("scan refresh worker entry", () => {
         removedMetaIds: ["removed"],
         completeness: "partial",
         explicitRemovedSessionIds: ["removed"],
-        sourceFailures: [
-          expect.objectContaining({ sessionId: "moved", stage: "parsing" }),
-          expect.objectContaining({ sessionId: "missing", stage: "parsing" }),
-        ],
+        // `missing` has no retained baseline session, so its parse failure is
+        // logged and skipped instead of being reported as a source failure.
+        sourceFailures: [expect.objectContaining({ sessionId: "moved", stage: "parsing" })],
       }),
     );
     expect(mocks.appLogger.warn).toHaveBeenCalledWith(

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -353,6 +353,22 @@ describe("diffSessionSources", () => {
     });
   });
 
+  it("removes a cached session whose meta records no source path", () => {
+    const diff = diffSessionSources([], [makeSession("orphan")], {});
+
+    expect(diff).toEqual({
+      changedIds: [],
+      removedIds: ["orphan"],
+      failedIds: [],
+      sourceOutcomes: [
+        {
+          status: "missing",
+          source: { sessionId: "orphan", sourcePath: "", fingerprint: "" },
+        },
+      ],
+    });
+  });
+
   it("treats an existing cached path omitted by enumeration as failed, not removed", () => {
     const directory = mkdtempSync(join(tmpdir(), "codesesh-source-outcome-"));
     const sourcePath = join(directory, "half-written.jsonl");

--- a/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
+++ b/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
@@ -215,6 +215,30 @@ describe("synchronizeSessionSources", () => {
     expect(adapter.scannedIds).toEqual(["retry", "retry"]);
   });
 
+  it("skips a source that fails to parse without any retained baseline session", () => {
+    const goodRef = source("good");
+    const emptyRef = source("empty");
+    const failure = createSessionSourceFailure(emptyRef, "parsing", new Error("empty file"));
+    const adapter = new MemorySourceAdapter(
+      [goodRef, emptyRef],
+      new Map<string, SessionSourceOutcome>([
+        ["good", parsed(goodRef, session("good"))],
+        ["empty", { status: "failed", failure }],
+      ]),
+    );
+
+    const outcome = synchronizeSessionSources(
+      adapter,
+      { sessions: [], meta: {} },
+      { kind: "refresh" },
+    );
+
+    expect(outcome.sessions.map(({ id }) => id)).toEqual(["good"]);
+    expect(outcome.sourceFailures).toEqual([]);
+    expect(outcome.completeness).toBe("complete");
+    expect(outcome.sourceOutcomes).toContainEqual({ status: "failed", failure });
+  });
+
   it("reloads every enumerated source and removes explicitly filtered sessions", () => {
     const visibleRef = source("visible");
     const filteredRef = source("filtered");

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -187,15 +187,11 @@ export function diffSessionSources(
       fingerprint: typeof meta?.sourceFingerprint === "string" ? meta.sourceFingerprint : "",
     };
     if (!source.sourcePath) {
-      failedIds.push(session.id);
-      sourceOutcomes.push({
-        status: "failed",
-        failure: createSessionSourceFailure(
-          source,
-          "enumeration",
-          new Error("cached source path is missing"),
-        ),
-      });
+      // No path can ever be re-checked, so keeping this entry would fail on
+      // every future pass; a complete enumeration finding neither file nor
+      // path proves the entry is unrecoverable.
+      removedIds.push(session.id);
+      sourceOutcomes.push({ status: "missing", source });
       continue;
     }
     try {

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -376,7 +376,10 @@ export function synchronizeSessionSources(
         explicitRemovedSessionIds.add(source.sessionId);
         reportSessionSourceOutcome(adapter.name, outcome);
       } else {
-        sourceFailures.push(outcome.failure);
+        // "last-known-good data retained" is only a failure when data exists;
+        // a source that never produced a session (empty or malformed file) is
+        // logged and skipped so it cannot poison every future pass.
+        if (visibleBaselineIds.has(source.sessionId)) sourceFailures.push(outcome.failure);
         reportSessionSourceOutcome(adapter.name, outcome);
       }
     }


### PR DESCRIPTION
## Summary

Every startup reported `[codex] Backfill failed: Error: 2 session sources failed; last-known-good data retained`. Runtime logs showed two failing sources that could never converge:

1. A cached session (`codex/s1`, a leaked test fixture row) whose meta records **no source path**. `diffSessionSources` marked it `failed` on every pass, and since failures retain last-known-good data, the entry could never be removed — a permanent failure loop.
2. A **0-byte rollout file** (`rollout-2026-05-12T21-27-23-….jsonl`). Parsing reported `empty file`, which was escalated to a source failure even though no cached session existed for it, so there was no last-known-good data to protect.

## Changes

- `diffSessionSources`: a cached session whose meta has no source path is treated as **removed** instead of permanently failed. No path can ever be re-checked, and a complete enumeration finding neither file nor path proves the entry is unrecoverable, so the cache now self-heals.
- `synchronizeSessionSources`: a parsing failure only counts as a source failure when a baseline session is actually retained. Sources that never produced a session (empty or malformed files) are logged via `agent.session_source_outcome` and skipped.

Parse failures for sessions that *do* have retained data keep the existing retain-and-report semantics.

## Verification

- `pnpm --filter @codesesh/core test` (781 passed), `pnpm --filter codesesh test` (463 passed), with new tests covering both semantics.
- Runtime verified: rebuilt and started the server; codex backfill now completes (`scan.backfill.done`, result `committed`), the leaked `s1` row was removed from the durable cache, and the empty file is logged as a warn outcome without failing the scan.