### PR TITLE
fix(core): attribute surplus codex usage to models in cost breakdown

### DIFF
--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -303,7 +303,7 @@ describe("CodexAgent cache refresh", () => {
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
           "codex-head-v1",
-          "codex-parser-v7",
+          "codex-parser-v8",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           "Indexed title",

--- a/packages/core/src/agents/__tests__/transcript-builder.test.ts
+++ b/packages/core/src/agents/__tests__/transcript-builder.test.ts
@@ -190,4 +190,71 @@ describe("TranscriptBuilder", () => {
       },
     });
   });
+
+  it("attaches usage to the latest assistant without tokens", () => {
+    const builder = new TranscriptBuilder();
+    builder.appendMessage({
+      id: "a1",
+      role: "assistant",
+      timestampMs: 1,
+      parts: [{ type: "text", text: "turn" }],
+    });
+
+    expect(
+      builder.attachUsageToLatestAssistant(
+        { input: 10, output: 5 },
+        { model: "sol", cost: 0.1, costSource: "estimated" },
+      ),
+    ).toBe(true);
+    expect(builder.finish().messages[0]).toMatchObject({
+      model: "sol",
+      tokens: { input: 10, output: 5 },
+      cost: 0.1,
+      cost_source: "estimated",
+    });
+  });
+
+  it("folds surplus usage into the latest same-model assistant", () => {
+    const builder = new TranscriptBuilder();
+    builder.appendMessage({
+      id: "a1",
+      role: "assistant",
+      timestampMs: 1,
+      parts: [{ type: "text", text: "turn" }],
+    });
+    builder.attachUsageToLatestAssistant(
+      { input: 10, output: 5, reasoning: 2 },
+      { model: "sol", cost: 0.1, costSource: "estimated" },
+    );
+
+    expect(
+      builder.attachUsageToLatestAssistant(
+        { input: 4, output: 1, cache_read: 8 },
+        { model: "sol", cost: 0.05, costSource: "estimated" },
+      ),
+    ).toBe(true);
+    expect(builder.finish().messages[0]).toMatchObject({
+      tokens: { input: 14, output: 6, reasoning: 2, cache_read: 8 },
+      cost: 0.15000000000000002,
+      cost_source: "estimated",
+    });
+  });
+
+  it("drops surplus usage when no assistant matches the model", () => {
+    const builder = new TranscriptBuilder();
+    builder.appendMessage({
+      id: "a1",
+      role: "assistant",
+      timestampMs: 1,
+      model: "luna",
+      tokens: { input: 10 },
+      cost: 0.1,
+      parts: [{ type: "text", text: "turn" }],
+    });
+
+    expect(builder.attachUsageToLatestAssistant({ input: 4 }, { model: "sol", cost: 0.05 })).toBe(
+      false,
+    );
+    expect(builder.finish().messages[0]).toMatchObject({ tokens: { input: 10 }, cost: 0.1 });
+  });
 });

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -34,7 +34,7 @@ const PLAN_APPROVAL_PREFIX = "PLEASE IMPLEMENT THIS PLAN";
 const SUBAGENT_NOTIFICATION_PATTERN =
   /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
 const HEAD_INDEX_VERSION = "codex-head-v1";
-const PARSER_VERSION = "codex-parser-v7";
+const PARSER_VERSION = "codex-parser-v8";
 
 export function resolveCodexDataRoot(): string {
   return resolveHomePath("CODEX_HOME", ".codex");

--- a/packages/core/src/agents/transcript-builder.ts
+++ b/packages/core/src/agents/transcript-builder.ts
@@ -37,6 +37,17 @@ export interface TranscriptResult {
   stats: SessionStats;
 }
 
+function mergeTokens(base: Message["tokens"], extra: Message["tokens"]): Message["tokens"] {
+  if (!base) return extra;
+  if (!extra) return base;
+  const merged = { ...base };
+  for (const key of Object.keys(extra) as (keyof NonNullable<Message["tokens"]>)[]) {
+    const value = extra[key];
+    if (typeof value === "number") merged[key] = (merged[key] ?? 0) + value;
+  }
+  return merged;
+}
+
 export class TranscriptBuilder {
   private readonly messages: Message[] = [];
   private readonly pendingToolCalls = new Map<string, ToolPart>();
@@ -166,16 +177,31 @@ export class TranscriptBuilder {
     tokens: Message["tokens"],
     options: { model?: string | null; cost?: number; costSource?: Message["cost_source"] } = {},
   ): boolean {
+    let mergeTarget: Message | null = null;
     for (let index = this.messages.length - 1; index >= 0; index -= 1) {
       const message = this.messages[index]!;
-      if (message.role !== "assistant" || message.tokens) continue;
-      message.tokens = tokens;
-      if (options.model !== undefined) message.model ??= options.model;
-      if (options.cost !== undefined) message.cost = options.cost;
-      if (options.costSource !== undefined) message.cost_source = options.costSource;
-      return true;
+      if (message.role !== "assistant") continue;
+      if (!message.tokens) {
+        message.tokens = tokens;
+        if (options.model !== undefined) message.model ??= options.model;
+        if (options.cost !== undefined) message.cost = options.cost;
+        if (options.costSource !== undefined) message.cost_source = options.costSource;
+        return true;
+      }
+      if (!mergeTarget && (message.model ?? null) === (options.model ?? null)) {
+        mergeTarget = message;
+      }
     }
-    return false;
+    // A turn can report usage more often than it produces assistant messages;
+    // folding the surplus into the latest same-model message keeps its tokens
+    // and cost attributed instead of silently dropping them.
+    if (!mergeTarget) return false;
+    mergeTarget.tokens = mergeTokens(mergeTarget.tokens, tokens);
+    if (options.cost !== undefined) {
+      mergeTarget.cost = (mergeTarget.cost ?? 0) + options.cost;
+      if (options.costSource !== undefined) mergeTarget.cost_source ??= options.costSource;
+    }
+    return true;
   }
 
   finish(baseStats?: SessionStats): TranscriptResult {


### PR DESCRIPTION
## Summary

In the dashboard's **Cost by Model** card, roughly $1k of Codex spend (7-day window) landed in the **Other** bucket: the Codex agent totalled $1,544 while `gpt-5.6-sol` only showed $594.

Per-model cost is aggregated from cached message rows, but `attachUsageToLatestAssistant` only attached usage to the latest assistant message *without* tokens and silently dropped the event otherwise. Codex emits one `token_count` event per API call, so a tool-loop turn produces far more usage events than assistant messages — a sampled session had **1,726 token_count events against 103 assistant messages**. The session head total (computed independently) kept the full spend, and the unattributed difference surfaced as "Other".

## Changes

- `TranscriptBuilder.attachUsageToLatestAssistant`: when every assistant message already carries tokens, fold the surplus tokens and cost into the latest assistant with a matching model instead of dropping the event. Attachment to the latest token-less assistant is unchanged, and events whose model never produced a message are still dropped, so cost cannot be attributed to the wrong model.
- Bump codex parser to v8 so cached heads and message projections are invalidated and re-projected with the restored attribution.

## Verification

- Full workspace test suite passes (`pnpm test`, 5 packages), with new TranscriptBuilder tests for attach, fold, and model-mismatch drop.
- Runtime verified against the real cache: message-level codex cost attribution in the 7-day window went from **$632 / $1,633 (39%)** to **$1,602 / $1,633 (98%)** after reindex; the residual ~2% is usage reported before the first assistant message exists, below the card's 1% remainder threshold.