### PR TITLE
fix(cli): stop permanent startup rescan loop for SQLite-backed agents

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -754,6 +754,46 @@ describe("AgentSyncEngine", () => {
     ]);
   });
 
+  it("persists meta-only changes reported by a full rescan", async () => {
+    // Regression test for the zcode/opencode startup loop: checkForChanges kept
+    // reporting stale cache meta (missing pricingCaptureEpoch), the full rescan
+    // repaired it in memory, but the signature-only persistence diff dropped the
+    // meta-only change, so the repaired meta never reached disk and the next
+    // startup rescanned again.
+    const steady = makeSession("steady");
+    const staleMeta = { steady: { id: "steady", sourcePath: "/database" } };
+    const repairedMeta = {
+      steady: { id: "steady", sourcePath: "/database", pricingCaptureEpoch: "pricing-capture-v1" },
+    };
+    let currentMeta = new Map(Object.entries(staleMeta));
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () =>
+        workerResult({ sessions: [steady], meta: repairedMeta, changedIds: [steady.id] }),
+      ),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const agent = makeAgent({
+      checkForChanges: () => ({ hasChanges: true, timestamp: 2 }),
+      getSessionMetaMap: () => currentMeta,
+      setSessionMetaMap: ((meta: Map<string, never>) => {
+        currentMeta = meta;
+      }) as BaseAgent["setSessionMetaMap"],
+    });
+    const { engine } = makeEngine(agent, [steady], workerRunner);
+
+    await engine.refresh("codex");
+
+    expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.refresh", [
+      expect.objectContaining({
+        kind: "changes",
+        agentName: "codex",
+        changes: [expect.objectContaining({ session: expect.objectContaining({ id: "steady" }) })],
+        meta: repairedMeta,
+      }),
+    ]);
+  });
+
   it("commits successful source updates while reporting retained parse failures", async () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     const changed = makeSession("changed", "before");

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -665,7 +665,10 @@ export class AgentSyncEngine {
         result.completeness,
         {},
         {
-          persistenceDiff: buildPersistenceDiff(baseline, sessions),
+          // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
+          // signature intact; without the worker-reported ids they would never
+          // persist and checkForChanges would rescan on every startup.
+          persistenceDiff: buildPersistenceDiff(baseline, sessions, result.changedIds ?? []),
           checkDuration,
           scanDuration: performance.now() - scanStartedAt,
           sourceFailures: result.sourceFailures ?? [],

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -1187,7 +1187,7 @@ describe("LiveScanStore", () => {
     ).resolves.toEqual({
       sessions: [],
       meta: {},
-      changedIds: undefined,
+      changedIds: [],
       sourceFailures: [],
       completeness: "complete",
       explicitRemovedSessionIds: [],
@@ -1233,7 +1233,7 @@ describe("LiveScanStore", () => {
     await expect(refresh).resolves.toEqual({
       sessions: [],
       meta: {},
-      changedIds: undefined,
+      changedIds: [],
       sourceFailures: [],
       completeness: "complete",
       explicitRemovedSessionIds: [],
@@ -1308,7 +1308,7 @@ describe("LiveScanStore", () => {
         added: { id: "added", sourcePath: "/added" },
         retained: { id: "retained", sourcePath: "/retained" },
       },
-      changedIds: undefined,
+      changedIds: ["added", "removed"],
       sourceFailures: [],
       completeness: "complete",
       explicitRemovedSessionIds: [],

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -224,6 +224,49 @@ describe("scan refresh worker entry", () => {
     );
   });
 
+  it("inherits cached smart tags so an unchanged full rescan reports no changes", async () => {
+    // scan() rebuilds heads without smart tags; without inheritance every
+    // rescan would reclassify (and re-publish) every settled session.
+    const tagged = makeSession("steady", {
+      time_created: 1_000,
+      time_updated: 1_000,
+      smart_tags: ["feature-dev"],
+      smart_tags_source_updated_at: 1_000,
+      smart_tags_classifier_revision: "smart-tags-v1",
+    });
+    const rebuilt = makeSession("steady", { time_created: 1_000, time_updated: 1_000 });
+    const meta = { steady: { id: "steady", sourcePath: "/database" } };
+    const agent = makeGenericAgent({
+      scan: vi.fn(() => [rebuilt]),
+      getSessionMetaMap: vi.fn(() => new Map(Object.entries(meta))),
+    });
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    setWorkerData({ previousSessions: [tagged], meta });
+
+    await runWorker();
+
+    expect(mocks.ensureSessionTagsSync).toHaveBeenCalledWith(
+      agent,
+      [
+        expect.objectContaining({
+          smart_tags: ["feature-dev"],
+          smart_tags_source_updated_at: 1_000,
+          smart_tags_classifier_revision: "smart-tags-v1",
+        }),
+      ],
+      expect.any(Function),
+    );
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: "done",
+        changes: [],
+        removedSessionIds: [],
+        meta: {},
+        removedMetaIds: [],
+      }),
+    );
+  });
+
   it("runs a full scan and forwards progress", async () => {
     const session = makeSession("fresh");
     const scan = vi.fn(

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -178,6 +178,27 @@ function selectBackfillSessions(
 }
 
 /**
+ * scan() rebuilds heads from the source without smart tags, which would force
+ * a full reclassification pass (one getSessionData() per session). Carry the
+ * previous tags over and let the staleness check in ensureSessionTagsSync —
+ * smart_tags_source_updated_at vs time_updated — decide what to recompute.
+ */
+function inheritSmartTags(sessions: SessionHead[], previousSessions: SessionHead[]): SessionHead[] {
+  const previousById = new Map(previousSessions.map((session) => [session.id, session]));
+  return sessions.map((session) => {
+    if (Array.isArray(session.smart_tags)) return session;
+    const previous = previousById.get(session.id);
+    if (!previous || !Array.isArray(previous.smart_tags)) return session;
+    return {
+      ...session,
+      smart_tags: previous.smart_tags,
+      smart_tags_source_updated_at: previous.smart_tags_source_updated_at,
+      smart_tags_classifier_revision: previous.smart_tags_classifier_revision,
+    };
+  });
+}
+
+/**
  * A session still receiving writes will be stale again within seconds, so
  * recomputing its tags every refresh cycle is wasted work — wait for it to
  * settle before paying the getSessionData() parse cost.
@@ -390,7 +411,10 @@ async function run(
     explicitRemovedSessionIds = result.explicitRemovedSessionIds;
   } else if (operation.kind === "incremental-scan") {
     changedIds = operation.changedIds;
-    sessions = await Promise.resolve(agent.incrementalScan(previousSessions, operation.changedIds));
+    sessions = inheritSmartTags(
+      await Promise.resolve(agent.incrementalScan(previousSessions, operation.changedIds)),
+      previousSessions,
+    );
   } else if (agent instanceof FileSystemSessionSource) {
     const result = synchronizeSessionSources(
       agent,
@@ -405,11 +429,14 @@ async function run(
     sourceFailures = result.sourceFailures;
     explicitRemovedSessionIds = result.explicitRemovedSessionIds;
   } else {
-    sessions = await Promise.resolve(
-      agent.scan({
-        ...data.scanOptions,
-        onProgress: reportProgress,
-      }),
+    sessions = inheritSmartTags(
+      await Promise.resolve(
+        agent.scan({
+          ...data.scanOptions,
+          onProgress: reportProgress,
+        }),
+      ),
+      previousSessions,
     );
   }
 

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -16,7 +16,7 @@ import type {
   ScanRefreshWorkerMessage,
   ScanRefreshWorkerRunRequest,
 } from "./scan-refresh-worker.js";
-import { synchronizesSessionSources, type ScanRefreshOperation } from "./scan-refresh-operation.js";
+import type { ScanRefreshOperation } from "./scan-refresh-operation.js";
 import { toError } from "./errors.js";
 
 export interface WorkerPayload {
@@ -284,9 +284,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
           message.removedSessionIds,
         ),
         meta: applyMetaChanges(pending.payload.meta, message.meta, removedMetaIds),
-        changedIds: synchronizesSessionSources(pending.payload.operation)
-          ? replacedSessionIds
-          : undefined,
+        changedIds: replacedSessionIds,
         sourceFailures: message.sourceFailures,
         completeness: message.completeness,
         explicitRemovedSessionIds: message.explicitRemovedSessionIds,


### PR DESCRIPTION
## Problem

Every startup showed `Finalizing session metadata · zcode · 67/84` (and the same for opencode), re-scanning and re-classifying every session even when the source databases had not changed for days (`new_sessions:0, updated_sessions:0, scan_ms:~13000`).

Root cause is a self-sustaining loop between two defects:

1. **Stale cache meta was detected but never repaired on disk.** The cached `meta_json` rows (written by an older version) lack `pricingCaptureEpoch`, so `DatabaseSessionSource.checkForChanges` reports changes on every startup and forces a full rescan. The rescan repairs the meta in memory, but the persistence diff in the full-rescan path (`refreshChangedAgent`) only compared head signatures — meta-only changes were dropped, so the repaired meta never reached the cache and the next startup looped again.
2. **Full rescans discarded cached smart tags.** SQLite-backed agents rebuild every head from the database without the `smart_tags_*` fields, so the finalize pass treated all sessions as stale and ran one `getSessionData()` parse per session (~13s for 84 zcode sessions) — the long "Finalizing session metadata" phase visible in the UI.

Only zcode/opencode were affected: they are the only `DatabaseSessionSource` agents with sessions; filesystem agents take the source-synchronization path which reuses cached heads.

## Fix

- `ThreadWorkerRunner` now returns the worker-reported changed ids for **all** operations (the worker diff already includes meta-only changes), and the full-rescan branch feeds them into `buildPersistenceDiff`, so repaired meta lands in the cache and the loop settles after one refresh.
- Full rescans carry cached smart tags onto rebuilt heads; the existing staleness check (`smart_tags_source_updated_at` vs `time_updated`) decides what to reclassify. Hot sessions also keep their tags instead of losing them until they settle.

## Verification

Against a copy of the real zcode (84 sessions) / opencode (57 sessions) databases with an isolated cache:

| Scenario | Before | After |
|---|---|---|
| Startup with healthy cache | full rescan, 13s finalizing | `unchanged`, ~300ms |
| Startup with stale meta (no `pricingCaptureEpoch`) | full rescan **every** startup, never repaired | one 1.6s rescan persists repaired meta, next startup `unchanged` |

All 1989 workspace tests pass; added regression tests for the persistence gap (engine + runner contract) and tag inheritance (worker integration).