### PR TITLE
fix(core): preserve stale pricing caches

### DIFF
--- a/packages/core/src/pricing/__tests__/refresh-generation.test.ts
+++ b/packages/core/src/pricing/__tests__/refresh-generation.test.ts
@@ -45,10 +45,52 @@ afterEach(() => {
 });
 
 describe("CS-148: pricing generations", () => {
+  it("loads stale cache data and derives generation identity from its content", async () => {
+    mkdirSync(join(testHome, ".cache", "codesesh"), { recursive: true });
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
+        generation: 41,
+        data: {
+          "vertex_ai/cs_202_model": {
+            inputCostPerToken: 0.000001,
+            outputCostPerToken: 0.000002,
+          },
+        },
+      }),
+    );
+
+    vi.resetModules();
+    const isolatedPricing = await import("../fetcher.js");
+    const isolatedResolver = await import("../resolver.js");
+    const firstGeneration = isolatedPricing.getPricingGeneration().id;
+
+    expect(isolatedResolver.pricingResolver.resolve("vertex_ai/cs_202_model")).not.toBeNull();
+
+    writeFileSync(
+      cachePath,
+      JSON.stringify({
+        timestamp: Date.now() - 25 * 60 * 60 * 1000,
+        generation: 41,
+        data: {
+          "vertex_ai/cs_202_model": {
+            inputCostPerToken: 0.000003,
+            outputCostPerToken: 0.000004,
+          },
+        },
+      }),
+    );
+    vi.resetModules();
+    const changedPricing = await import("../fetcher.js");
+
+    expect(changedPricing.getPricingGeneration().id).not.toBe(firstGeneration);
+  });
+
   it("CS-194: keeps parent and isolated worker pricing on one generation", async () => {
     const generationBefore = getPricingGeneration().id;
     const pricingBefore = getPricingRegistry().get(MODEL);
-    stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000999) }));
+    stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000777) }));
 
     expect(await refreshPricingCache()).toBe(true);
     expect(existsSync(cachePath)).toBe(false);
@@ -81,7 +123,7 @@ describe("CS-148: pricing generations", () => {
 
     expect(publishPendingPricing()).toBe(true);
     expect(estimateTokenCost(MODEL, MILLION_INPUT)).toBe(999);
-    expect(getPricingGeneration().id).toBe(generationBefore + 1);
+    expect(getPricingGeneration().id).not.toBe(generationBefore);
   });
 
   it("reports nothing to publish when no refresh completed", () => {
@@ -154,7 +196,7 @@ describe("CS-148: pricing generations", () => {
     expect(hasPendingPricing()).toBe(false);
   });
 
-  it("publishes the disk cache and generation in one step", async () => {
+  it("publishes the disk cache in one step", async () => {
     stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000123) }));
 
     await refreshPricingCache();
@@ -165,11 +207,9 @@ describe("CS-148: pricing generations", () => {
     // A truncated write would not parse.
     const parsed = JSON.parse(raw) as {
       timestamp: number;
-      generation: number;
       data: Record<string, unknown>;
     };
     expect(typeof parsed.timestamp).toBe("number");
-    expect(parsed.generation).toBe(getPricingGeneration().id);
     expect(Object.keys(parsed.data).length).toBeGreaterThan(0);
     expect(existsSync(`${cachePath}.${process.pid}.tmp`)).toBe(false);
   });

--- a/packages/core/src/pricing/fetcher.ts
+++ b/packages/core/src/pricing/fetcher.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -42,13 +43,31 @@ export interface PricingGeneration {
   pricing: Map<string, ModelPricing>;
 }
 
-let published: PricingGeneration = { id: 1, pricing: loadSnapshot() };
+let published = createPricingGeneration(loadSnapshot());
 /** A completed refresh waiting for a safe point to become current. */
 let pending: Map<string, ModelPricing> | null = null;
 published = readDiskCache() ?? published;
 
-function normalizeKey(key: string): string {
-  return key.trim().toLowerCase();
+export function normalizeModelKey(key: string): string {
+  return key.trim().toLowerCase().replaceAll("_", "-");
+}
+
+function createPricingGeneration(pricing: Map<string, ModelPricing>): PricingGeneration {
+  const hash = createHash("sha256");
+  const entries = [...pricing.entries()].sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+  for (const [name, modelPricing] of entries) {
+    hash.update(name);
+    hash.update("\0");
+    hash.update(JSON.stringify(modelPricing));
+    hash.update("\n");
+  }
+
+  return {
+    id: Number.parseInt(hash.digest("hex").slice(0, 13), 16) || 1,
+    pricing,
+  };
 }
 
 function costNumber(value: unknown, fallback: number): number {
@@ -68,7 +87,7 @@ function loadSnapshot(): Map<string, ModelPricing> {
   const snapshot = snapshotData as unknown as Record<string, SnapshotEntry>;
   for (const [name, entry] of Object.entries(snapshot)) {
     const [input, output, cacheCreate, cacheRead, reasoning, webSearch] = entry;
-    map.set(normalizeKey(name), {
+    indexPricing(map, name, {
       inputCostPerToken: input,
       outputCostPerToken: output,
       cacheCreateCostPerToken: cacheCreate ?? input * 1.25,
@@ -114,7 +133,7 @@ function normalizeCachedPricing(raw: Record<string, unknown>): ModelPricing | nu
 }
 
 function indexPricing(map: Map<string, ModelPricing>, name: string, pricing: ModelPricing) {
-  const normalized = normalizeKey(name);
+  const normalized = normalizeModelKey(name);
   map.set(normalized, pricing);
 
   const slashIndex = normalized.indexOf("/");
@@ -135,32 +154,27 @@ function parseLiteLLMData(data: Record<string, LiteLLMEntry>): Map<string, Model
 
 interface PricingCache {
   timestamp: number;
-  generation?: number;
   data: Record<string, Record<string, unknown>>;
 }
 
-function readDiskCache(allowStale = false): PricingGeneration | null {
+function readDiskCache(): PricingGeneration | null {
   const path = getCachePath();
   if (!existsSync(path)) return null;
 
   try {
     const cached = JSON.parse(readFileSync(path, "utf-8")) as PricingCache;
     if (!Number.isFinite(cached.timestamp)) return null;
-    if (!allowStale && Date.now() - cached.timestamp > CACHE_TTL_MS) return null;
     if (cached.data == null || typeof cached.data !== "object" || Array.isArray(cached.data)) {
       return null;
     }
-
-    const generation = cached.generation ?? 2;
-    if (!Number.isSafeInteger(generation) || generation < 1) return null;
 
     const next = loadSnapshot();
     for (const [name, rawPricing] of Object.entries(cached.data)) {
       const pricing = normalizeCachedPricing(rawPricing);
       if (!pricing) continue;
-      next.set(normalizeKey(name), pricing);
+      indexPricing(next, name, pricing);
     }
-    return { id: generation, pricing: next };
+    return createPricingGeneration(next);
   } catch {
     return null;
   }
@@ -182,7 +196,7 @@ export function synchronizePricingGeneration(expectedId: number): void {
   }
   if (published.id === expectedId) return;
 
-  const cached = readDiskCache(true);
+  const cached = readDiskCache();
   if (cached?.id !== expectedId) {
     throw new Error(
       `Pricing generation ${expectedId} is unavailable (current ${published.id}, cached ${cached?.id ?? "none"})`,
@@ -203,13 +217,7 @@ export function synchronizePricingGeneration(expectedId: number): void {
 export function publishPendingPricing(): boolean {
   if (!pending) return false;
 
-  const nextId = published.id + 1;
-  if (!Number.isSafeInteger(nextId)) {
-    getCoreDiagnostics()?.warn("pricing.generation_exhausted", { generation: published.id });
-    return false;
-  }
-
-  const next = { id: nextId, pricing: pending } satisfies PricingGeneration;
+  const next = createPricingGeneration(pending);
   if (!writeDiskCacheAtomically(getCachePath(), next)) return false;
 
   published = next;
@@ -240,7 +248,6 @@ function writeDiskCacheAtomically(path: string, generation: PricingGeneration): 
   const temporaryPath = `${path}.${process.pid}.tmp`;
   const payload = JSON.stringify({
     timestamp: Date.now(),
-    generation: generation.id,
     data: Object.fromEntries(generation.pricing),
   });
   try {

--- a/packages/core/src/pricing/resolver.ts
+++ b/packages/core/src/pricing/resolver.ts
@@ -1,5 +1,10 @@
 import aliasesData from "./data/aliases.json";
-import { getPricingRegistry, hasBillablePricing, type ModelPricing } from "./fetcher.js";
+import {
+  getPricingRegistry,
+  hasBillablePricing,
+  normalizeModelKey,
+  type ModelPricing,
+} from "./fetcher.js";
 
 const BUILTIN_ALIASES = Object.fromEntries(
   Object.entries(aliasesData as Record<string, string>).map(([key, value]) => [
@@ -7,10 +12,6 @@ const BUILTIN_ALIASES = Object.fromEntries(
     normalizeModelKey(value),
   ]),
 );
-
-function normalizeModelKey(model: string): string {
-  return model.trim().toLowerCase().replaceAll("_", "-");
-}
 
 function stripVersion(model: string): string {
   return model.replace(/@.*$/, "").replace(/-\d{8}$/, "");


### PR DESCRIPTION
## Summary

- keep expired LiteLLM registries available during startup
- derive pricing generation IDs from normalized registry content
- share model-key normalization between cache indexing and resolution

## Root cause

Cache TTL was used as an availability check during module initialization, so an expired but valid registry was discarded before the asynchronous refresh could replace it. Process-local generation counters and divergent underscore normalization compounded the inconsistency.

## Validation

- `pnpm --filter @codesesh/core test`
- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core format:check`

Issue: CS-202