### PR TITLE
fix(cli): recover rejected scan queues

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -205,6 +205,42 @@ describe("AgentSyncEngine", () => {
     });
   });
 
+  it("marks a rejected backfill failed and continues the queue", async () => {
+    const { engine } = makeEngine(makeAgent());
+    const internal = engine as unknown as {
+      backfills: { stateFor(agentName: string): { status: string } | undefined };
+      enqueueBackfill(agentName: string): void;
+      runBackfill(attempt: { agentName: string; attemptId: number }): Promise<unknown>;
+    };
+    const runBackfill = vi
+      .spyOn(internal, "runBackfill")
+      .mockRejectedValueOnce(new Error("backfill callback rejected"))
+      .mockResolvedValueOnce("committed");
+    const logError = vi.spyOn(appLogger, "error").mockImplementation(() => undefined);
+    engine.subscribeStatusChanged(() => {
+      throw new Error("status listener rejected");
+    });
+
+    try {
+      internal.enqueueBackfill("codex");
+      internal.enqueueBackfill("kimi");
+      await vi.waitFor(() => expect(internal.backfills.stateFor("kimi")?.status).toBe("committed"));
+      expect(logError).toHaveBeenCalledWith(
+        "scan.backfill.queue_error",
+        expect.objectContaining({ agent: "codex", error: expect.any(Error) }),
+      );
+      expect(logError).toHaveBeenCalledWith(
+        "scan.status_listener.error",
+        expect.objectContaining({ error: expect.any(Error) }),
+      );
+    } finally {
+      logError.mockRestore();
+    }
+
+    expect(internal.backfills.stateFor("codex")?.status).toBe("failed");
+    expect(runBackfill).toHaveBeenCalledTimes(2);
+  });
+
   it("bounds backfill progress and publishes its terminal immediately", async () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -329,7 +329,13 @@ export class AgentSyncEngine {
 
   private publishStatus(event: ScanStatusEvent | null): void {
     if (!event || this.isShuttingDown) return;
-    for (const listener of this.statusChangedListeners) listener(event);
+    for (const listener of this.statusChangedListeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        appLogger.error("scan.status_listener.error", { error });
+      }
+    }
   }
 
   private publishProgressStatus(key: string, phase: string, event: ScanStatusEvent | null): void {
@@ -809,16 +815,30 @@ export class AgentSyncEngine {
     const attempt = this.backfills.startNext();
     if (!attempt) return;
     this.publishBackfillStatus();
-    void this.runBackfill(attempt).then((result) => {
-      if (this.isShuttingDown) return;
-      const current = this.backfills.stateFor(attempt.agentName);
-      if (current?.status !== "running" || current.attemptId !== attempt.attemptId) return;
+    void this.runBackfill(attempt)
+      .then((result) => this.completeBackfillAttempt(attempt, result))
+      .catch((error) => this.rejectBackfillAttempt(attempt, error));
+  }
+
+  private completeBackfillAttempt(
+    attempt: BackfillAttemptRef,
+    result: BackfillTerminalStatus,
+  ): void {
+    if (this.isShuttingDown) return;
+    const current = this.backfills.stateFor(attempt.agentName);
+    if (current?.status === "running" && current.attemptId === attempt.attemptId) {
       this.flushProgressStatus(`backfill:${attempt.agentName}`);
-      if (!this.backfills.complete(attempt, result)) return;
-      if (result === "failed") this.cacheIntegrityCheckedAgents.delete(attempt.agentName);
-      this.publishBackfillStatus();
-      this.pumpBackfillQueue();
-    });
+      if (this.backfills.complete(attempt, result)) {
+        if (result === "failed") this.cacheIntegrityCheckedAgents.delete(attempt.agentName);
+        this.publishBackfillStatus();
+      }
+    }
+    this.pumpBackfillQueue();
+  }
+
+  private rejectBackfillAttempt(attempt: BackfillAttemptRef, error: unknown): void {
+    appLogger.error("scan.backfill.queue_error", { agent: attempt.agentName, error });
+    this.completeBackfillAttempt(attempt, "failed");
   }
 
   private runBackfill(attempt: BackfillAttemptRef): Promise<BackfillTerminalStatus> {

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -401,6 +401,45 @@ describe("scan refresh worker entry", () => {
     );
   });
 
+  it("reports a rejected commit and continues processing later requests", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([makeAgent({ scan: vi.fn(() => []) })]);
+    setWorkerData({ generation: 4 });
+
+    await runWorker();
+    await vi.waitFor(() =>
+      expect(mocks.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "done", requestId: 1, generation: 4 }),
+      ),
+    );
+    mocks.workerMessageHandler?.({ type: "commit", requestId: 1, generation: 5 });
+    mocks.workerMessageHandler?.({ type: "commit", requestId: 1, generation: 4 });
+    mocks.workerMessageHandler?.({
+      type: "run",
+      requestId: 2,
+      agentName: "codex",
+      generation: 5,
+      pricingGenerationId: 17,
+      operation: { kind: "recompute-derived" },
+      scanOptions: {},
+    });
+
+    await vi.waitFor(() =>
+      expect(mocks.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          requestId: 1,
+          generation: 5,
+          error: "Worker commit generation mismatch: expected 4, received 5",
+        }),
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(mocks.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "done", requestId: 2, generation: 5 }),
+      ),
+    );
+  });
+
   it("emits a durable head checkpoint before metadata finalization", async () => {
     const session = makeSession("fresh", { time_updated: 1 });
     const agent = makeAgent({

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -618,13 +618,7 @@ async function handleRequest(data: ScanRefreshWorkerRunRequest): Promise<void> {
     await run(data, progressEmitter);
   } catch (error) {
     progressEmitter.flush();
-    parentPort?.postMessage({
-      type: "error",
-      requestId: data.requestId,
-      generation: data.generation ?? 0,
-      error: error instanceof Error ? error.message : String(error),
-      durationMs: performance.now() - startedAt,
-    } satisfies ScanRefreshWorkerMessage);
+    postRequestError(data, error, startedAt);
   } finally {
     progressEmitter.cancel();
   }
@@ -649,10 +643,35 @@ function commitBaseline(data: ScanRefreshWorkerCommitRequest): void {
   workerBaseline.staged = null;
 }
 
+function postRequestError(data: ScanRefreshWorkerRequest, error: unknown, startedAt: number): void {
+  parentPort?.postMessage({
+    type: "error",
+    requestId: data.requestId,
+    generation: data.generation,
+    error: error instanceof Error ? error.message : String(error),
+    durationMs: performance.now() - startedAt,
+  } satisfies ScanRefreshWorkerMessage);
+}
+
+function handleCommit(data: ScanRefreshWorkerCommitRequest): void {
+  const startedAt = performance.now();
+  try {
+    commitBaseline(data);
+  } catch (error) {
+    postRequestError(data, error, startedAt);
+  }
+}
+
 function enqueueRequest(data: ScanRefreshWorkerRequest): void {
-  requestTail = requestTail.then(() =>
-    data.type === "commit" ? commitBaseline(data) : handleRequest(data),
-  );
+  requestTail = requestTail
+    .then(() => (data.type === "commit" ? handleCommit(data) : handleRequest(data)))
+    .catch((error) => {
+      appLogger.error("scan.refresh_worker.request_error", {
+        request_id: data.requestId,
+        request_type: data.type,
+        error,
+      });
+    });
 }
 
 const initialRequest = workerData as Partial<ScanRefreshWorkerRequest> | undefined;


### PR DESCRIPTION
## Summary

- report commit protocol errors without rejecting the worker request tail
- keep the request tail fulfilled after unexpected handler failures
- mark rejected backfills failed and continue pumping queued agents
- isolate status listener failures from scan lifecycle state

## Root cause

The worker serialized requests through a promise tail with no rejection recovery. A synchronous commit exception permanently rejected that tail, so every later request callback was skipped. The backfill pump likewise ignored rejections from its async completion chain, leaving one attempt running and all later attempts queued.

## Validation

- `pnpm --filter codesesh test`
- `pnpm --filter codesesh typecheck`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`

Issue: CS-203