### PR TITLE
fix(core): correct Kimi session facts

### DIFF
--- a/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
@@ -97,7 +97,7 @@ describe("KimiAgent source enumeration", () => {
     expect(transcriptReadsSince(marks)).toEqual([]);
   });
 
-  it("skips the transcript title fallback when state.json carries a title", () => {
+  it("reads context once for stats when state.json carries a title", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
     tempDirs.push(basePath);
     createSessionDir(basePath, "titled", "Explicit title");
@@ -108,7 +108,7 @@ describe("KimiAgent source enumeration", () => {
     const head = agent.scanSessionSource(sourcePath);
 
     expect(head?.title).toBe("Explicit title");
-    expect(transcriptReadsSince(marks)).not.toContain(join(sourcePath, "context.jsonl"));
+    expect(transcriptReadsSince(marks)).toEqual([join(sourcePath, "context.jsonl")]);
   });
 
   it("still falls back to the first user message when no explicit title exists", () => {
@@ -122,7 +122,7 @@ describe("KimiAgent source enumeration", () => {
     expect(head?.title).toBe("first message of untitled");
   });
 
-  it("keeps the fingerprint bound to metadata and transcript mtimes only", () => {
+  it("fingerprints the parser revision, metadata, and transcript snapshots", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
     tempDirs.push(basePath);
     const sourcePath = createSessionDir(basePath, "fingerprint", "Fingerprint");
@@ -141,16 +141,25 @@ describe("KimiAgent source enumeration", () => {
     expect(before).toEqual({
       sessionId: "fingerprint",
       sourcePath,
-      fingerprint: JSON.stringify([stateTime.getTime(), pinned.getTime(), null]),
+      fingerprint: JSON.stringify([
+        "kimi-parser-v1",
+        stateTime.getTime(),
+        statSync(statePath).size,
+        pinned.getTime(),
+        statSync(contextPath).size,
+        null,
+        null,
+      ]),
     });
 
-    // Rewriting the transcript body without moving its mtime must not move the
-    // fingerprint: enumeration only observes mtimes, never content.
-    writeFileSync(contextPath, JSON.stringify({ role: "user", content: "rewritten" }) + "\n");
+    writeFileSync(
+      contextPath,
+      JSON.stringify({ role: "user", content: "a longer rewritten message" }) + "\n",
+    );
     utimesSync(contextPath, pinned, pinned);
 
     expect(statSync(contextPath).mtimeMs).toBe(pinned.getTime());
-    expect(agent.listSessionSources()[0]?.fingerprint).toBe(before?.fingerprint);
+    expect(agent.listSessionSources()[0]?.fingerprint).not.toBe(before?.fingerprint);
   });
 });
 
@@ -215,5 +224,20 @@ describe("KimiAgent stats extraction", () => {
       total_output_tokens: 5,
       total_tokens: 42,
     });
+  });
+
+  it("reads usage totals from a context-only session", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-stats-"));
+    tempDirs.push(basePath);
+    const sourcePath = createSessionDir(basePath, "context-only", "Context only");
+    writeFileSync(
+      join(sourcePath, "context.jsonl"),
+      JSON.stringify({ role: "_usage", token_count: 42 }) + "\n",
+    );
+
+    const agent = createAgent(basePath);
+    const head = agent.scanSessionSource(sourcePath);
+
+    expect(head?.stats.total_tokens).toBe(42);
   });
 });

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -37,7 +37,13 @@ function createAgent(basePath: string): KimiAgent {
   return agent as KimiAgent;
 }
 
-function createSessionDir(basePath: string, id: string, title: string, mtimeMs: number): string {
+function createSessionDir(
+  basePath: string,
+  id: string,
+  title: string,
+  mtimeMs: number,
+  createdAtMs = mtimeMs,
+): string {
   const sessionDir = join(basePath, PROJECT_HASH, id);
   mkdirSync(sessionDir, { recursive: true });
 
@@ -47,6 +53,7 @@ function createSessionDir(basePath: string, id: string, title: string, mtimeMs: 
     statePath,
     JSON.stringify({
       custom_title: title,
+      created_at: createdAtMs,
       wire_mtime: Math.floor(mtimeMs / 1000),
     }),
   );
@@ -118,7 +125,7 @@ describe("KimiAgent cache refresh", () => {
     expect(agent.getSessionMetaMap().has("deleted-session")).toBe(false);
   });
 
-  it("bounds listSessionSources to the createdAt window when options are passed", () => {
+  it("bounds listSessionSources to the activityAt window when options are passed", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
     tempDirs.push(basePath);
     const oldTime = Date.now() - 30 * 24 * 60 * 60 * 1000;
@@ -148,10 +155,21 @@ describe("KimiAgent cache refresh", () => {
     const [head] = agent.scan();
     const meta = agent.getSessionMetaMap().get("windowed");
 
-    // diffSessionSources compares this against the scan window to tell
-    // "outside the window" apart from "deleted on disk", so it has to match
-    // the createdAt that listSessionSources filters on.
-    expect(meta?.sourceMtimeMs).toBe(head?.time_created);
+    expect(meta?.sourceMtimeMs).toBe(head?.time_updated);
+  });
+
+  it("keeps creation time separate from transcript activity", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    createSessionDir(basePath, "separate-times", "Separate times", 5_000, 1_000);
+
+    const agent = createAgent(basePath);
+    const [head] = agent.scan();
+
+    expect(head).toMatchObject({
+      time_created: 1_000,
+      time_updated: 5_000,
+    });
   });
 
   it("keeps out-of-window sessions out of the change set during a windowed refresh", () => {
@@ -233,6 +251,57 @@ describe("KimiAgent cache refresh", () => {
         output: [{ type: "text", text: '{ "name": "codesesh-monorepo" }' }],
       },
     });
+  });
+
+  it("preserves wire timestamps on assistant messages", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
+    tempDirs.push(basePath);
+    const sessionDir = createSessionDir(basePath, "wire-times", "Wire times", 6_000, 1_000);
+    rmSync(join(sessionDir, "context.jsonl"));
+    writeFileSync(
+      join(sessionDir, "wire.jsonl"),
+      [
+        JSON.stringify({
+          timestamp: 1,
+          message: { type: "TurnBegin", payload: { user_input: ["First"] } },
+        }),
+        JSON.stringify({
+          timestamp: 2,
+          message: { type: "ContentPart", payload: { type: "think", think: "Reason" } },
+        }),
+        JSON.stringify({
+          timestamp: 3,
+          message: { type: "TurnBegin", payload: { user_input: ["Second"] } },
+        }),
+        JSON.stringify({
+          timestamp: 4,
+          message: { type: "ContentPart", payload: { type: "text", text: "Answer" } },
+        }),
+        JSON.stringify({
+          timestamp: 5,
+          message: { type: "TurnBegin", payload: { user_input: ["Third"] } },
+        }),
+        JSON.stringify({
+          timestamp: 6,
+          message: {
+            type: "ToolCall",
+            payload: {
+              id: "call-1",
+              function: { name: "ReadFile", arguments: '{"path":"package.json"}' },
+            },
+          },
+        }),
+        "",
+      ].join("\n"),
+    );
+
+    const agent = createAgent(basePath);
+    agent.scan();
+
+    const assistantMessages = agent
+      .getSessionData("wire-times")
+      .messages.filter((message) => message.role === "assistant");
+    expect(assistantMessages.map((message) => message.time_created)).toEqual([2_000, 4_000, 6_000]);
   });
 
   it("uses the first user message as fallback title", () => {
@@ -341,7 +410,7 @@ describe("KimiAgent cache refresh", () => {
     });
   });
 
-  it("falls back to file mtime and reports drift when state.json wire_mtime is not a number", () => {
+  it("falls back to filesystem times and reports drift when wire_mtime is not a number", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
     tempDirs.push(basePath);
     const sessionDir = join(basePath, PROJECT_HASH, "mtime-drift");
@@ -363,7 +432,7 @@ describe("KimiAgent cache refresh", () => {
     const agent = createAgent(basePath);
     const [head] = agent.scan();
 
-    expect(head?.time_created).toBe(statSync(statePath).mtimeMs);
+    expect(head?.time_created).toBe(statSync(sessionDir).birthtimeMs);
     expect(calls).toContainEqual({
       event: "agent.field_shape_mismatch",
       detail: { agentName: "kimi", field: "session.wire_mtime" },

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -41,6 +41,7 @@ const KIMI_TOOL_TITLE_MAP: Record<string, string> = {
 };
 
 const KIMI_IGNORED_TOOLS = new Set(["SetTodoList"]);
+const KIMI_PARSER_REVISION = "kimi-parser-v1";
 
 export function resolveKimiDataRoot(): string {
   return resolveHomePath("KIMI_SHARE_DIR", ".kimi");
@@ -61,17 +62,13 @@ interface SessionSource {
   contextFile: string | null;
   wireFile: string | null;
   createdAt: number;
+  activityAt: number;
   metaFile: string;
   explicitTitle: string;
 }
 
 interface SessionMeta extends SessionCacheMeta, SessionSource {
   title: string;
-  /**
-   * Mirrors createdAt, which is what listSessionSources window-filters on.
-   * diffSessionSources compares this against the scan window to tell "outside
-   * the window" apart from "deleted on disk"; the two must be the same quantity.
-   */
   sourceMtimeMs: number;
 }
 
@@ -83,6 +80,16 @@ function readWireMtime(record: Record<string, unknown>): number | null {
 /** Reads a wire record's `timestamp`; reports drift when the field is present but not a number. */
 function readWireTimestamp(record: Record<string, unknown>): number {
   return narrowField("kimi", "wire.timestamp", record.timestamp, asNumber) ?? 0;
+}
+
+function parseTimestamp(raw: unknown): number | null {
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+
+  const numeric = Number(raw);
+  if (Number.isFinite(numeric)) return numeric;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 /** Reads a token count from a usage record; reports drift when the field is present but not a number. */
@@ -274,25 +281,31 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       let explicitTitle = "";
       let wireMtime: number | null = null;
       let metaFile = "";
+      let metadata: Record<string, unknown> = {};
 
       if (existsSync(statePath)) {
-        const state = asRecord(JSON.parse(readFileSync(statePath, "utf-8"))) ?? {};
-        explicitTitle = String(state.custom_title ?? "");
-        wireMtime = readWireMtime(state);
+        metadata = asRecord(JSON.parse(readFileSync(statePath, "utf-8"))) ?? {};
+        explicitTitle = String(metadata.custom_title ?? "");
+        wireMtime = readWireMtime(metadata);
         metaFile = statePath;
       } else if (existsSync(metaPath)) {
-        const meta = asRecord(JSON.parse(readFileSync(metaPath, "utf-8"))) ?? {};
-        explicitTitle = String(meta.title ?? "");
-        wireMtime = readWireMtime(meta);
+        metadata = asRecord(JSON.parse(readFileSync(metaPath, "utf-8"))) ?? {};
+        explicitTitle = String(metadata.title ?? "");
+        wireMtime = readWireMtime(metadata);
         metaFile = metaPath;
       }
 
+      const sessionStat = statSync(sessionDir);
       const createdAt =
-        wireMtime !== null
-          ? wireMtime * 1000
-          : metaFile
-            ? statSync(metaFile).mtimeMs
-            : statSync(sessionDir).mtimeMs;
+        parseTimestamp(metadata.createdAt) ??
+        parseTimestamp(metadata.created_at) ??
+        (sessionStat.birthtimeMs > 0 ? sessionStat.birthtimeMs : sessionStat.ctimeMs);
+      const activityAt = Math.max(
+        createdAt,
+        wireMtime === null ? 0 : wireMtime * 1000,
+        existingContextFile ? statSync(existingContextFile).mtimeMs : 0,
+        existingWireFile ? statSync(existingWireFile).mtimeMs : 0,
+      );
 
       return parsedSession({
         id: sessionId,
@@ -301,6 +314,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
         contextFile: existingContextFile,
         wireFile: existingWireFile,
         createdAt,
+        activityAt,
         metaFile,
         explicitTitle,
       });
@@ -322,7 +336,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       normalizeTitleText(source.explicitTitle) ??
       resolveSessionTitle(null, extractFirstUserTitle(source.contextFile, source.wireFile), null);
 
-    return parsedSession({ ...source, title, sourceMtimeMs: source.createdAt });
+    return parsedSession({ ...source, title, sourceMtimeMs: source.activityAt });
   }
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
@@ -330,7 +344,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     const refs: SessionSourceRef[] = [];
     for (const dir of this.listSessionDirs()) {
       const source = getParsedSession(this.resolveSessionSourceResult(dir));
-      if (!source || !matchesScanWindow(source.createdAt, options)) continue;
+      if (!source || !matchesScanWindow(source.activityAt, options)) continue;
       refs.push({
         sessionId: source.id,
         sourcePath: source.sourcePath,
@@ -363,7 +377,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       title: meta.title,
       directory: meta.cwd,
       time_created: meta.createdAt,
-      time_updated: meta.createdAt,
+      time_updated: meta.activityAt,
       stats,
     });
   }
@@ -503,7 +517,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
             if (text) {
               builder.appendAssistantPart(
                 { type: "reasoning", text, time_created: timestampMs },
-                { id: `wire-${seq}`, timestampMs: 0, agent: "kimi" },
+                { id: `wire-${seq}`, timestampMs, agent: "kimi" },
                 { grouping: "current" },
               );
             }
@@ -512,7 +526,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
             if (text) {
               builder.appendAssistantPart(
                 { type: "text", text, time_created: timestampMs },
-                { id: `wire-${seq}`, timestampMs: 0, agent: "kimi" },
+                { id: `wire-${seq}`, timestampMs, agent: "kimi" },
                 { grouping: "current" },
               );
             }
@@ -549,7 +563,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
 
           builder.appendToolCall(
             toolPart,
-            { id: `wire-${seq}`, timestampMs: 0, agent: "kimi" },
+            { id: `wire-${seq}`, timestampMs, agent: "kimi" },
             { markModeAsTool: true, target: "current" },
           );
           openToolCallId = callId;
@@ -604,10 +618,21 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
 
   private sourceFingerprint(meta: Pick<SessionSource, "metaFile" | "contextFile" | "wireFile">) {
     return JSON.stringify([
-      this.readFileMtimeMs(meta.metaFile),
-      this.readFileMtimeMs(meta.contextFile),
-      this.readFileMtimeMs(meta.wireFile),
+      KIMI_PARSER_REVISION,
+      ...this.fileSnapshot(meta.metaFile),
+      ...this.fileSnapshot(meta.contextFile),
+      ...this.fileSnapshot(meta.wireFile),
     ]);
+  }
+
+  private fileSnapshot(filePath: string | null): [number | null, number | null] {
+    if (!filePath) return [null, null];
+    try {
+      const stat = statSync(filePath);
+      return [stat.mtimeMs, stat.size];
+    } catch {
+      return [null, null];
+    }
   }
 
   private buildContextAssistantMessage(
@@ -739,40 +764,37 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       message_count: 0,
     };
 
-    const wirePath = join(sessionDir, "wire.jsonl");
-    if (!existsSync(wirePath)) return stats;
-
-    // The `_usage` running total is read from context.jsonl when it exists.
-    // Otherwise it lives in wire.jsonl — the same file this pass already walks,
-    // so fold it in here rather than reading wire.jsonl a second time.
     const contextPath = join(sessionDir, "context.jsonl");
     const hasContext = existsSync(contextPath);
-
-    try {
-      for (const record of readJsonlFile(wirePath)) {
-        const tokenUsage = asRecord(asRecord(record.message)?.usage);
-        if (tokenUsage) {
-          const inputTokens = extractTokenField(tokenUsage, "input_tokens");
-          const outputTokens = extractTokenField(tokenUsage, "output_tokens");
-          stats.total_input_tokens += inputTokens;
-          stats.total_output_tokens += outputTokens;
-          const cost = estimateTokenCost(this.defaultModel, {
-            input: inputTokens,
-            output: outputTokens,
-          });
-          if (cost !== null) totalCost += cost;
-        }
-        if (!hasContext) this.applyUsageTotal(record, stats);
-      }
-    } catch {
-      // skip unreadable wire logs
-    }
 
     if (hasContext) {
       try {
         for (const record of readJsonlFile(contextPath)) this.applyUsageTotal(record, stats);
       } catch {
         // skip unreadable context logs
+      }
+    }
+
+    const wirePath = join(sessionDir, "wire.jsonl");
+    if (existsSync(wirePath)) {
+      try {
+        for (const record of readJsonlFile(wirePath)) {
+          const tokenUsage = asRecord(asRecord(record.message)?.usage);
+          if (tokenUsage) {
+            const inputTokens = extractTokenField(tokenUsage, "input_tokens");
+            const outputTokens = extractTokenField(tokenUsage, "output_tokens");
+            stats.total_input_tokens += inputTokens;
+            stats.total_output_tokens += outputTokens;
+            const cost = estimateTokenCost(this.defaultModel, {
+              input: inputTokens,
+              output: outputTokens,
+            });
+            if (cost !== null) totalCost += cost;
+          }
+          if (!hasContext) this.applyUsageTotal(record, stats);
+        }
+      } catch {
+        // skip unreadable wire logs
       }
     }
 
@@ -797,7 +819,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       slug: `kimi/${meta.id}`,
       directory: meta.cwd,
       time_created: meta.createdAt,
-      time_updated: meta.createdAt,
+      time_updated: meta.activityAt,
       stats: transcript.stats,
       messages: transcript.messages,
     };


### PR DESCRIPTION
## Summary

- separate Kimi session creation and activity timestamps and preserve wire assistant message times
- version fingerprints with metadata and transcript file sizes
- retain context-only usage totals when no wire log exists

## Testing

- `pnpm --filter @codesesh/core test`
- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core format:check`