### PR TITLE
fix(search): preserve ranking and inclusive cost

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -67,7 +67,7 @@ import type {
   SessionHead,
   SessionDetail,
 } from "@codesesh/core";
-import type { ModelCostEntry } from "@codesesh/core/contract";
+import type { ModelCostEntry, SearchResult } from "@codesesh/core/contract";
 import { BaseAgent } from "@codesesh/core";
 
 // --- Helpers ---
@@ -552,6 +552,65 @@ describe("handleSearchSessions", () => {
       scanSource.getSnapshot(),
     );
     expect(c.json).toHaveBeenCalledWith({ results: sentinelResults });
+  });
+
+  it("keeps ranked search hits when alias matches fill the limit", () => {
+    const rankedSessions = ["ranked-1", "ranked-2", "ranked-3"].map((id) =>
+      makeSession(id, { slug: `claudecode/${id}` }),
+    );
+    const aliasSessions = ["alias-1", "alias-2", "alias-3"].map((id, index) =>
+      makeSession(id, {
+        slug: `claudecode/${id}`,
+        time_updated: 3_000 - index,
+      }),
+    );
+    coreMocks.executeSessionSearch.mockReturnValue(
+      rankedSessions.map((session) => ({
+        reference: { agentName: "claudecode", sessionId: session.id },
+        session,
+      })),
+    );
+    coreMocks.listSessionAliases.mockReturnValue(
+      aliasSessions.map((session) => makeAlias("claudecode", session.id, `Needle ${session.id}`)),
+    );
+    const sessions = [...rankedSessions, ...aliasSessions];
+    const c = makeMockContext({ query: { q: "needle", limit: "3" } });
+
+    handleSearchSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
+
+    expect(
+      c.json.mock.calls[0]![0].results.map((result: SearchResult) => result.session.id),
+    ).toEqual(["ranked-1", "ranked-2", "alias-1"]);
+  });
+
+  it("keeps ranked order and value when an alias hit overlaps", () => {
+    const rankedSessions = ["ranked-1", "ranked-2", "ranked-3"].map((id) =>
+      makeSession(id, { slug: `claudecode/${id}` }),
+    );
+    const aliasOnly = makeSession("alias-1", {
+      slug: "claudecode/alias-1",
+      time_updated: 1,
+    });
+    coreMocks.executeSessionSearch.mockReturnValue(
+      rankedSessions.map((session) => ({
+        reference: { agentName: "claudecode", sessionId: session.id },
+        session,
+        snippet: "Ranked match",
+        matchType: "assistant_reply" as const,
+      })),
+    );
+    coreMocks.listSessionAliases.mockReturnValue([
+      makeAlias("claudecode", "ranked-2", "Needle overlap"),
+      makeAlias("claudecode", "alias-1", "Needle alias"),
+    ]);
+    const sessions = [...rankedSessions, aliasOnly];
+    const c = makeMockContext({ query: { q: "needle", limit: "3" } });
+
+    handleSearchSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
+
+    const results = c.json.mock.calls[0]![0].results as SearchResult[];
+    expect(results.map((result) => result.session.id)).toEqual(["ranked-1", "ranked-2", "alias-1"]);
+    expect(results[1]?.matchType).toBe("assistant_reply");
   });
 
   it("rejects incomplete project identity filters without calling the search module", () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -451,6 +451,52 @@ function withParentContext(
   });
 }
 
+const ALIAS_SEARCH_RESULT_SHARE = 0.25;
+
+function searchResultKey(result: SearchResult): string {
+  return `${result.reference.agentName}\0${result.reference.sessionId}`;
+}
+
+function uniqueSearchResults(results: SearchResult[]): SearchResult[] {
+  const seen = new Set<string>();
+  return results.filter((result) => {
+    const key = searchResultKey(result);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function mergeAliasSearchResults(
+  rankedResults: SearchResult[],
+  aliasResults: SearchResult[],
+  limit: number,
+): SearchResult[] {
+  if (limit <= 0) return [];
+
+  const ranked = uniqueSearchResults(rankedResults);
+  const rankedKeys = new Set(ranked.map(searchResultKey));
+  const aliases = uniqueSearchResults(aliasResults).filter(
+    (result) => !rankedKeys.has(searchResultKey(result)),
+  );
+  if (ranked.length === 0) return aliases.slice(0, limit);
+  if (aliases.length === 0) return ranked.slice(0, limit);
+
+  // Alias hits have no BM25 score. Keep ranked search dominant while reserving
+  // a bounded share so local renames remain discoverable.
+  const aliasQuota = Math.min(
+    limit - 1,
+    Math.max(1, Math.floor(limit * ALIAS_SEARCH_RESULT_SHARE)),
+  );
+  const rankedQuota = limit - aliasQuota;
+  return [
+    ...ranked.slice(0, rankedQuota),
+    ...aliases.slice(0, aliasQuota),
+    ...ranked.slice(rankedQuota),
+    ...aliases.slice(aliasQuota),
+  ].slice(0, limit);
+}
+
 export function handleSearchSessions(
   c: Context,
   scanSource: ScanResultSource,
@@ -491,16 +537,9 @@ export function handleSearchSessions(
     session: aliases.decorate(result.session, result.reference),
   }));
   const aliasResults = findAliasSearchResults(query, searchOptions, scanResult, aliases);
-  const deduped = new Map<string, (typeof results)[number]>();
-  for (const result of [...aliasResults, ...results]) {
-    deduped.set(`${result.reference.agentName}\0${result.reference.sessionId}`, result);
-  }
+  const mergedResults = mergeAliasSearchResults(results, aliasResults, searchOptions.limit ?? 50);
   return c.json({
-    results: withParentContext(
-      [...deduped.values()].slice(0, searchOptions.limit ?? 50),
-      scanResult.sessions,
-      aliases,
-    ),
+    results: withParentContext(mergedResults, scanResult.sessions, aliases),
   });
 }
 

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -136,7 +136,7 @@ export function findAliasSearchResults(
     });
   }
 
-  return filterSessionSearchCandidates(results, search.options).sort(
+  return filterSessionSearchCandidates(results, search.options, scanResult.sessions).sort(
     (a, b) => getSessionActivityTime(b.session) - getSessionActivityTime(a.session),
   );
 }

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -638,6 +638,50 @@ describe("searchSessions", () => {
     ]);
   });
 
+  it("filters indexed parents by inclusive child cost", () => {
+    const parent = {
+      ...makeSession("inclusive-parent"),
+      slug: "codex/inclusive-parent",
+      stats: { ...makeSession("inclusive-parent").stats, total_cost: 0 },
+    };
+    const child = {
+      ...makeSession("inclusive-child"),
+      slug: "codex/inclusive-child",
+      parent_reference: { agentName: "codex", sessionId: "inclusive-parent" },
+      stats: { ...makeSession("inclusive-child").stats, total_cost: 2 },
+    };
+    const details = new Map<string, SessionDetail>([
+      [
+        parent.id,
+        {
+          ...parent,
+          reference: { agentName: "codex", sessionId: parent.id },
+          messages: [
+            {
+              id: "parent-message",
+              role: "user",
+              time_created: now,
+              parts: [{ type: "text", text: "inclusivecostneedle" }],
+            },
+          ],
+        },
+      ],
+      [
+        child.id,
+        {
+          ...child,
+          reference: { agentName: "codex", sessionId: child.id },
+          messages: [],
+        },
+      ],
+    ]);
+    syncSessionSearchIndex("codex", [parent, child], (sessionId) => details.get(sessionId)!);
+
+    expect(
+      searchSessions("inclusivecostneedle cost:>1").map((result) => result.session.id),
+    ).toEqual(["inclusive-parent"]);
+  });
+
   it("creates cache storage when syncing search index first", () => {
     const session = makeSession("first-search");
 

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -126,8 +126,11 @@ export function mergeSearchQueryOptions(query: string, options: SearchOptions) {
   };
 }
 
-export function sessionMatchesSearchCost(session: SessionHead, options: SearchOptions): boolean {
-  const cost = session.stats.total_cost;
+export function sessionMatchesSearchCost(
+  session: SessionHead,
+  options: SearchOptions,
+  cost = session.stats.total_cost,
+): boolean {
   if (options.costMin != null) {
     if (options.costMinExclusive ? cost <= options.costMin : cost < options.costMin) {
       return false;
@@ -216,19 +219,46 @@ export function buildSessionSearchFilters(options: SearchOptions): {
     clauses.push("s.activity_time <= ?");
     params.push(options.to);
   }
-  if (options.costMin != null) {
-    clauses.push(options.costMinExclusive ? "s.total_cost > ?" : "s.total_cost >= ?");
-    params.push(options.costMin);
-  }
-  if (options.costMax != null) {
-    clauses.push(options.costMaxExclusive ? "s.total_cost < ?" : "s.total_cost <= ?");
-    params.push(options.costMax);
-  }
+  appendInclusiveCostFilter(clauses, params, options);
 
   return {
     where: clauses.length > 0 ? ` AND ${clauses.join(" AND ")}` : "",
     params,
   };
+}
+
+function appendInclusiveCostFilter(
+  clauses: string[],
+  params: unknown[],
+  options: SearchOptions,
+): void {
+  const predicates: string[] = [];
+  if (options.costMin != null) {
+    predicates.push(options.costMinExclusive ? "SUM(own_cost) > ?" : "SUM(own_cost) >= ?");
+    params.push(options.costMin);
+  }
+  if (options.costMax != null) {
+    predicates.push(options.costMaxExclusive ? "SUM(own_cost) < ?" : "SUM(own_cost) <= ?");
+    params.push(options.costMax);
+  }
+  if (predicates.length === 0) return;
+
+  // UNION makes malformed parent cycles converge while preserving one row per session.
+  clauses.push(`EXISTS (
+    WITH RECURSIVE session_subtree(agent_name, session_id, own_cost) AS (
+      SELECT s.agent_name, s.session_id, s.total_cost
+      UNION
+      SELECT child.agent_name, child.session_id, child.total_cost
+      FROM sessions child
+      JOIN session_subtree parent
+        ON child.parent_agent_name = parent.agent_name
+        AND child.parent_session_id = parent.session_id
+      WHERE child.publication_id IS NULL
+    )
+    SELECT SUM(own_cost)
+    FROM session_subtree
+    HAVING ${predicates.join(" AND ")}
+  )`);
 }
 
 export interface SessionSearchReference {

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -25,6 +25,7 @@ import type {
   SmartTag,
 } from "../../types/index.js";
 import type { SearchOptions } from "../../discovery/cache/search.js";
+import type { SearchResult } from "../../contract/index.js";
 import { searchSessions, syncSessionSearchIndex } from "../../discovery/cache/search.js";
 import { compareSessionActivityDesc, mergeSortedSessions } from "../../contract/session-index.js";
 import {
@@ -541,6 +542,32 @@ describe("search characterization: recent (empty-query) path", () => {
     );
   });
 
+  it("filters recent parents by inclusive child cost", () => {
+    const parent = makeSessionHead({
+      id: "cost-parent",
+      agent: "codex",
+      cost: 0,
+      messages: [],
+    });
+    const child = {
+      ...makeSessionHead({
+        id: "cost-child",
+        agent: "codex",
+        cost: 2,
+        messages: [],
+      }),
+      parent_reference: { agentName: "codex", sessionId: "cost-parent" },
+    };
+    const snapshot = {
+      sessions: [parent, child],
+      byAgent: { codex: [parent, child] },
+    };
+
+    const results = executeSessionSearch("", { costMin: 1 }, snapshot);
+
+    expect(results.map((result) => result.session.id)).toEqual(["cost-parent", "cost-child"]);
+  });
+
   it("reads the global ordered snapshot only until the result limit", () => {
     const ordered = Array.from({ length: 100 }, (_, index) =>
       makeSessionHead({
@@ -772,6 +799,36 @@ describe("search candidate filtering", () => {
     });
 
     expect(results.map((result) => result.session.id)).toEqual(["file-qualifier-match"]);
+  });
+
+  it("uses the full snapshot for alias-style inclusive cost filters", () => {
+    const parent = makeSessionHead({
+      id: "alias-cost-parent",
+      agent: "codex",
+      cost: 0,
+      messages: [],
+    });
+    const child = {
+      ...makeSessionHead({
+        id: "alias-cost-child",
+        agent: "codex",
+        cost: 2,
+        messages: [],
+      }),
+      parent_reference: { agentName: "codex", sessionId: parent.id },
+    };
+    const candidates: SearchResult[] = [
+      {
+        reference: { agentName: "codex", sessionId: parent.id },
+        session: parent,
+        snippet: "Alias",
+        matchType: "title",
+      },
+    ];
+
+    const results = filterSessionSearchCandidates(candidates, { costMin: 1 }, [parent, child]);
+
+    expect(results.map((result) => result.session.id)).toEqual([parent.id]);
   });
 });
 

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -5,7 +5,12 @@
  * paths), and cross-source result merging.
  */
 import type { SessionHead } from "../types/index.js";
-import { getSessionAgentKey, type SearchResult } from "../contract/index.js";
+import {
+  buildSessionTree,
+  getSessionAgentKey,
+  getSessionRouteKey,
+  type SearchResult,
+} from "../contract/index.js";
 import {
   filterIndexedSessionReferences,
   mergeSearchQueryOptions,
@@ -55,6 +60,7 @@ function matchesRecentSearchFilters(
   session: SessionHead,
   options: SearchOptions,
   projectScope: ProjectScopeMatcher | null,
+  inclusiveCost: number,
 ): boolean {
   if (options.projectKind || options.projectKey) {
     if (
@@ -84,7 +90,7 @@ function matchesRecentSearchFilters(
   if (options.tags?.length && !options.tags.every((tag) => session.smart_tags?.includes(tag))) {
     return false;
   }
-  if (!sessionMatchesSearchCost(session, options)) return false;
+  if (!sessionMatchesSearchCost(session, options, inclusiveCost)) return false;
   return true;
 }
 
@@ -95,12 +101,13 @@ export function matchesSessionSearchFilters(
   session: SessionHead,
   options: SearchOptions,
   projectScope: ProjectScopeMatcher | null = null,
+  inclusiveCost = session.stats.total_cost,
 ): boolean {
   if (options.agent && agentName !== options.agent) return false;
   const activity = getSessionActivityTime(session);
   if (options.from != null && activity < options.from) return false;
   if (options.to != null && activity > options.to) return false;
-  return matchesRecentSearchFilters(session, options, projectScope);
+  return matchesRecentSearchFilters(session, options, projectScope, inclusiveCost);
 }
 
 function sessionReferenceKey(agentName: string, sessionId: string): string {
@@ -110,14 +117,17 @@ function sessionReferenceKey(agentName: string, sessionId: string): string {
 export function filterSessionSearchCandidates(
   candidates: SearchResult[],
   options: SearchOptions,
+  sessionSnapshot: SessionHead[] = candidates.map((candidate) => candidate.session),
 ): SearchResult[] {
   const projectScope = options.cwd ? createProjectScopeMatcher(options.cwd) : null;
+  const inclusiveCosts = buildInclusiveCostLookup(sessionSnapshot, options);
   const headMatches = candidates.filter((candidate) =>
     matchesSessionSearchFilters(
       candidate.reference.agentName,
       candidate.session,
       options,
       projectScope,
+      inclusiveCostFor(candidate.reference.agentName, candidate.session, inclusiveCosts),
     ),
   );
   if (!options.file && !options.fileKind && !options.tools?.length) return headMatches;
@@ -148,12 +158,23 @@ function searchRecentSessions(
   if (limit === 0) return [];
 
   const projectScope = options.cwd ? createProjectScopeMatcher(options.cwd) : null;
+  const inclusiveCosts = buildInclusiveCostLookup(snapshot.sessions, options);
   const sessions = options.agent ? (snapshot.byAgent[options.agent] ?? []) : snapshot.sessions;
   const results: SearchResult[] = [];
 
   for (const session of sessions) {
     const agentName = options.agent ?? getSessionAgentKey(session);
-    if (!matchesSessionSearchFilters(agentName, session, options, projectScope)) continue;
+    if (
+      !matchesSessionSearchFilters(
+        agentName,
+        session,
+        options,
+        projectScope,
+        inclusiveCostFor(agentName, session, inclusiveCosts),
+      )
+    ) {
+      continue;
+    }
     results.push({
       reference: { agentName, sessionId: session.id },
       session,
@@ -164,6 +185,25 @@ function searchRecentSessions(
   }
 
   return results;
+}
+
+function buildInclusiveCostLookup(
+  sessions: SessionHead[],
+  options: SearchOptions,
+): ReturnType<typeof buildSessionTree>["byRouteKey"] | null {
+  if (options.costMin == null && options.costMax == null) return null;
+  return buildSessionTree(sessions).byRouteKey;
+}
+
+function inclusiveCostFor(
+  agentName: string,
+  session: SessionHead,
+  lookup: ReturnType<typeof buildSessionTree>["byRouteKey"] | null,
+): number {
+  return (
+    lookup?.get(getSessionRouteKey(agentName, session.id))?.inclusiveStats.cost ??
+    session.stats.total_cost
+  );
 }
 
 // `options.file` already carries the qualifier's `file:`/`path:` value once


### PR DESCRIPTION
## Summary

- reserve a bounded alias-result share without discarding ranked search hits or hybridizing duplicate positions
- evaluate cost qualifiers against inclusive parent/child cost in live, alias, SQLite, FTS, and file-activity paths
- derive inclusive cost from existing hierarchy facts instead of introducing another persisted value to invalidate

## Testing

- `pnpm --filter @codesesh/core test`
- `pnpm --filter codesesh test`
- core and CLI typecheck, lint, and format checks
- `pnpm build`