### PR TITLE
fix: preserve database scan windows

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -147,13 +147,14 @@ function makeEngine(
   agent: BaseAgent,
   sessions: SessionHead[] = [],
   workerRunner: WorkerRunner = makeWorkerRunner(),
+  startupScanOptions: { from?: number; to?: number } = {},
 ) {
   const state: LiveSnapshot = {
     agents: [agent],
     byAgent: { [agent.name]: sessions },
     sessions,
   };
-  const engine = new AgentSyncEngine({ workerRunner });
+  const engine = new AgentSyncEngine({ workerRunner, startupScanOptions });
   engine.initialize(state);
   return { engine };
 }
@@ -396,11 +397,12 @@ describe("AgentSyncEngine", () => {
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
     const workerRunner = makeWorkerRunner();
+    const incrementalScan = vi.fn(() => [updated]);
     const agent = makeAgent({
       checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
-      incrementalScan: () => [updated],
+      incrementalScan,
     });
-    const { engine } = makeEngine(agent, [previous], workerRunner);
+    const { engine } = makeEngine(agent, [previous], workerRunner, { from: 1, to: 2 });
     const sessionChanges = vi.fn();
     const statusChanges = vi.fn();
     engine.subscribeSessionsChanged(sessionChanges);
@@ -419,6 +421,10 @@ describe("AgentSyncEngine", () => {
       expect.objectContaining({ type: "scan-status", active: false }),
     );
     expect(workerRunner.discard).toHaveBeenCalledWith("codex");
+    expect(incrementalScan).toHaveBeenCalledWith([previous], [updated.id], undefined, {
+      from: 1,
+      to: 2,
+    });
   });
 
   it("bounds progress broadcasts while preserving phase and completion", async () => {
@@ -785,6 +791,51 @@ describe("AgentSyncEngine", () => {
             session: expect.objectContaining({ id: "changed", title: "after" }),
           }),
         ],
+        removedSessionIds: [],
+      }),
+    ]);
+  });
+
+  it("keeps out-of-window cache rows during a bounded database refresh", async () => {
+    const historical = makeSession("historical");
+    const previous = makeSession("recent", "before");
+    const updated = makeSession("recent", "after");
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () =>
+        workerResult(
+          {
+            sessions: [updated],
+            meta: { recent: { id: "recent", sourcePath: "/database" } },
+          },
+          "partial",
+        ),
+      ),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const agent = makeAgent({
+      checkForChanges: () => ({ hasChanges: true, timestamp: 3 }),
+    });
+    const { engine } = makeEngine(agent, [historical, previous], workerRunner, {
+      from: 2,
+      to: 3,
+    });
+
+    await engine.refresh("codex");
+
+    expect(workerRunner.run).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({
+        operation: { kind: "full-scan" },
+        scanOptions: { from: 2, to: 3 },
+      }),
+    );
+    expect(engine.snapshot().sessions).toEqual([
+      expect.objectContaining({ id: "recent", title: "after" }),
+    ]);
+    expect(searchIndex.enqueue).toHaveBeenCalledWith("scan.refresh", [
+      expect.objectContaining({
+        kind: "changes",
         removedSessionIds: [],
       }),
     ]);

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -105,6 +105,8 @@ function buildPersistenceDiff(
   previousSessions: SessionHead[],
   nextSessions: SessionHead[],
   candidateChangedIds: string[] = [],
+  completeness: SessionSnapshotCompleteness = "complete",
+  explicitRemovedSessionIds: readonly string[] = [],
 ): SessionPersistenceDiff {
   const { changes, removedSessionIds } = computeSessionDiff(
     previousSessions,
@@ -112,7 +114,15 @@ function buildPersistenceDiff(
     candidateChangedIds,
     sessionSignature,
   );
-  return { changedSessions: changes, removedSessionIds };
+  if (completeness === "complete") {
+    return { changedSessions: changes, removedSessionIds };
+  }
+  // A bounded or failed scan cannot prove that an omitted session disappeared.
+  const explicitRemovals = new Set(explicitRemovedSessionIds);
+  return {
+    changedSessions: changes,
+    removedSessionIds: removedSessionIds.filter((sessionId) => explicitRemovals.has(sessionId)),
+  };
 }
 
 function sourceFailureError(failures: SessionSourceFailure[]): Error {
@@ -622,6 +632,7 @@ export class AgentSyncEngine {
     cacheTimestamp: number,
     refreshStartedAt: number,
   ): Promise<RefreshStrategyResult> {
+    const scope = this.startupScanOptions();
     const checkStartedAt = performance.now();
     const checkResult = await Promise.resolve(agent.checkForChanges(cacheTimestamp, baseline));
     const checkDuration = performance.now() - checkStartedAt;
@@ -663,41 +674,49 @@ export class AgentSyncEngine {
     const preciseChangedIds = checkResult.changedIds ?? null;
     const scanStartedAt = performance.now();
     if (preciseChangedIds === null) {
-      const result = await this.runWorker(agent, baseline, { kind: "full-scan" }, {});
+      const result = await this.runWorker(agent, baseline, { kind: "full-scan" }, scope);
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
-      return this.refreshStrategyResult(
-        sessions,
-        result.completeness,
-        {},
-        {
-          // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
-          // signature intact; without the worker-reported ids they would never
-          // persist and checkForChanges would rescan on every startup.
-          persistenceDiff: buildPersistenceDiff(baseline, sessions, result.changedIds ?? []),
-          checkDuration,
-          scanDuration: performance.now() - scanStartedAt,
-          sourceFailures: result.sourceFailures ?? [],
-        },
-      );
+      return this.refreshStrategyResult(sessions, result.completeness, scope, {
+        // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
+        // signature intact; without the worker-reported ids they would never
+        // persist and checkForChanges would rescan on every startup.
+        persistenceDiff: buildPersistenceDiff(
+          baseline,
+          sessions,
+          result.changedIds ?? [],
+          result.completeness,
+          result.explicitRemovedSessionIds,
+        ),
+        checkDuration,
+        scanDuration: performance.now() - scanStartedAt,
+        sourceFailures: result.sourceFailures ?? [],
+      });
     }
     this.options.workerRunner.discard?.(agent.name);
     const sessions = attachMissingProjectIdentities(
-      await Promise.resolve(agent.incrementalScan(baseline, preciseChangedIds, checkResult.refs)),
+      await Promise.resolve(
+        agent.incrementalScan(baseline, preciseChangedIds, checkResult.refs, scope),
+      ),
     );
     const sourceFailures = checkResult.sourceFailures ?? [];
-    return this.refreshStrategyResult(
-      sessions,
-      sourceFailures.length > 0 ? "partial" : "complete",
-      {},
-      {
+    const completeness =
+      scope.from == null && scope.to == null && sourceFailures.length === 0
+        ? "complete"
+        : "partial";
+    return this.refreshStrategyResult(sessions, completeness, scope, {
+      preciseChangedIds,
+      persistenceDiff: buildPersistenceDiff(
+        baseline,
+        sessions,
         preciseChangedIds,
-        persistenceDiff: buildPersistenceDiff(baseline, sessions, preciseChangedIds),
-        checkDuration,
-        scanDuration: performance.now() - scanStartedAt,
-        sourceFailures,
-      },
-    );
+        completeness,
+        preciseChangedIds,
+      ),
+      checkDuration,
+      scanDuration: performance.now() - scanStartedAt,
+      sourceFailures,
+    });
   }
 
   private async scanAgentFully(
@@ -705,21 +724,17 @@ export class AgentSyncEngine {
     previousSessions: SessionHead[],
   ): Promise<RefreshStrategyResult> {
     const scanStartedAt = performance.now();
-    const result = await this.runWorker(agent, previousSessions, { kind: "full-scan" }, {});
+    const scope = this.startupScanOptions();
+    const result = await this.runWorker(agent, previousSessions, { kind: "full-scan" }, scope);
     agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
     const sessions = attachMissingProjectIdentities(result.sessions);
     this.lastRefreshAtByAgent.set(agent.name, Date.now());
-    return this.refreshStrategyResult(
-      sessions,
-      result.completeness,
-      {},
-      {
-        fullScanSessions: sessions,
-        explicitRemovedSessionIds: result.explicitRemovedSessionIds,
-        scanDuration: performance.now() - scanStartedAt,
-        sourceFailures: result.sourceFailures ?? [],
-      },
-    );
+    return this.refreshStrategyResult(sessions, result.completeness, scope, {
+      fullScanSessions: sessions,
+      explicitRemovedSessionIds: result.explicitRemovedSessionIds,
+      scanDuration: performance.now() - scanStartedAt,
+      sourceFailures: result.sourceFailures ?? [],
+    });
   }
 
   private refreshStrategyResult(

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -248,6 +248,11 @@ const workerThreads = vi.hoisted(() => ({
                   sessions = agent.incrementalScan(
                     runData.previousSessions,
                     runData.operation.changedIds,
+                    undefined,
+                    {
+                      ...runData.scanOptions,
+                      onProgress: () => undefined,
+                    },
                   );
                 } else {
                   sessions = agent?.scan?.({
@@ -1513,7 +1518,9 @@ describe("LiveScanStore", () => {
     await vi.advanceTimersByTimeAsync(250);
 
     expect(codex.checkForChanges).toHaveBeenCalledWith(1000, [old, recent]);
-    expect(codex.incrementalScan).toHaveBeenCalledWith([old, recent], ["old"], undefined);
+    expect(codex.incrementalScan).toHaveBeenCalledWith([old, recent], ["old"], undefined, {
+      from: 3000,
+    });
     expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent", "old"]);
     expect(events).toEqual([]);
     expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
@@ -1723,6 +1730,7 @@ describe("LiveScanStore", () => {
       previous ? [previous] : [],
       ["session", "added"],
       undefined,
+      {},
     );
     expect(core.saveCachedSessions).not.toHaveBeenCalled();
     expect(core.saveCachedSessionChanges).not.toHaveBeenCalled();

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -825,7 +825,10 @@ describe("scan refresh worker entry", () => {
 
     await runWorker();
 
-    expect(incrementalScan).toHaveBeenCalledWith([previous], ["previous"]);
+    expect(incrementalScan).toHaveBeenCalledWith([previous], ["previous"], undefined, {
+      fast: true,
+      onProgress: expect.any(Function),
+    });
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: "done",

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -412,7 +412,12 @@ async function run(
   } else if (operation.kind === "incremental-scan") {
     changedIds = operation.changedIds;
     sessions = inheritSmartTags(
-      await Promise.resolve(agent.incrementalScan(previousSessions, operation.changedIds)),
+      await Promise.resolve(
+        agent.incrementalScan(previousSessions, operation.changedIds, undefined, {
+          ...data.scanOptions,
+          onProgress: reportProgress,
+        }),
+      ),
       previousSessions,
     );
   } else if (agent instanceof FileSystemSessionSource) {

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -642,6 +642,7 @@ describe("DatabaseSessionSource", () => {
     readonly name = "fakedb";
     readonly displayName = "Fake DB";
     scanCount = 0;
+    lastScanOptions: AgentScanOptions | undefined;
 
     constructor(private dbPath: string | null) {
       super();
@@ -655,8 +656,9 @@ describe("DatabaseSessionSource", () => {
       return { status: "not-needed" as const, reason: "temporary test database" };
     }
 
-    scan(_options?: AgentScanOptions): SessionHead[] {
+    scan(options?: AgentScanOptions): SessionHead[] {
       this.scanCount += 1;
+      this.lastScanOptions = options;
       return [makeSession("db-1")];
     }
 
@@ -712,8 +714,10 @@ describe("DatabaseSessionSource", () => {
 
   it("incrementalScan delegates to a full scan", () => {
     const agent = new FakeDatabaseSource(makeDb());
-    const sessions = agent.incrementalScan([makeSession("stale")], ["stale"]);
+    const options = { from: 1_000, to: 2_000 };
+    const sessions = agent.incrementalScan([makeSession("stale")], ["stale"], undefined, options);
     expect(agent.scanCount).toBe(1);
+    expect(agent.lastScanOptions).toEqual(options);
     expect(sessions.map((s) => s.id)).toEqual(["db-1"]);
   });
 

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -420,6 +420,33 @@ describe("OpenCodeSqliteAgent", () => {
   });
 });
 
+describe("CS-206: database scans preserve the requested window", () => {
+  it("applies an inclusive upper bound to roots without restricting related rows", () => {
+    const dbPath = createDatabaseWithRootChildren(2);
+    const db = new Database(dbPath);
+    db.prepare("UPDATE session SET time_created = ?, time_updated = ? WHERE id = ?").run(
+      25_000,
+      25_000,
+      "child-0",
+    );
+    db.close();
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+      getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
+    });
+    agent.isAvailable();
+
+    const heads = agent.scan({
+      from: 15_000,
+      to: 20_000,
+    });
+
+    expect(heads.map((head) => head.id)).toEqual(["child-0", "root-0"]);
+  });
+});
+
 describe("CS-180: related session reads stay inside the selected roots", () => {
   it("does not return unrelated historical child rows across the SQLite seam", () => {
     const dbPath = createDatabaseWithRelatedHistory(10_000);

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -254,12 +254,14 @@ export abstract class BaseAgent {
    * 增量扫描（仅扫描变更的会话）
    * @param cachedSessions 缓存的会话列表
    * @param changedIds 变更的会话 ID 列表
+   * @param scanOptions 扫描窗口与解析选项
    * @returns 更新后的会话列表
    */
   abstract incrementalScan(
     cachedSessions: SessionHead[],
     changedIds: string[],
     refs?: SessionSourceRef[],
+    scanOptions?: AgentScanOptions,
   ): Promise<SessionHead[]> | SessionHead[];
 
   filterCachedSessions(sessions: SessionHead[]): SessionHead[] {
@@ -479,6 +481,7 @@ export abstract class FileSystemSessionSource<
     cachedSessions: SessionHead[],
     changedIds: string[],
     refs?: SessionSourceRef[],
+    _scanOptions?: AgentScanOptions,
   ): SessionHead[] {
     return this.synchronizeSessionSources(
       { sessions: cachedSessions, meta: this.sessionMetaMap },
@@ -705,7 +708,12 @@ export abstract class DatabaseSessionSource extends BaseAgent {
   }
 
   /** 增量扫描：数据库型无法增量，直接全量重扫。 */
-  incrementalScan(_cachedSessions: SessionHead[], _changedIds: string[]): SessionHead[] {
-    return this.scan();
+  incrementalScan(
+    _cachedSessions: SessionHead[],
+    _changedIds: string[],
+    _refs?: SessionSourceRef[],
+    scanOptions?: AgentScanOptions,
+  ): SessionHead[] {
+    return this.scan(scanOptions);
   }
 }

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -511,9 +511,10 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     cachedSessions: SessionHead[],
     changedIds: string[],
     refs?: SessionSourceRef[],
+    scanOptions?: AgentScanOptions,
   ): SessionHead[] {
     const visibleSessions = this.removeEmptyCachedSessions(cachedSessions);
-    return super.incrementalScan(visibleSessions, changedIds, refs);
+    return super.incrementalScan(visibleSessions, changedIds, refs, scanOptions);
   }
 
   private hasMessages(session: SessionHead): boolean {

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -156,6 +156,11 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
 
     try {
       const cutoffTime = options?.from ?? Date.now() - 3650 * 24 * 60 * 60 * 1000;
+      const activityPredicate =
+        options?.to == null
+          ? "COALESCE(s.time_updated, s.time_created) >= ?"
+          : "COALESCE(s.time_updated, s.time_created) >= ? AND COALESCE(s.time_updated, s.time_created) <= ?";
+      const activityBindings = options?.to == null ? [cutoffTime] : [cutoffTime, options.to];
 
       const hasMessageTable = Boolean(
         db
@@ -180,22 +185,22 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
             s.id, s.title, s.time_created, s.time_updated, s.slug, s.directory,
             s.version, s.summary_files${parentIdSelect}
           FROM session s
-          WHERE COALESCE(s.time_updated, s.time_created) >= ?
+          WHERE ${activityPredicate}
           ${childPredicate}
           ORDER BY COALESCE(s.time_updated, s.time_created) DESC, s.time_created DESC, s.id DESC
         `)
-          .all(cutoffTime);
+          .all(...activityBindings);
       } else {
         rows = db
           .prepare(`
           SELECT s.id, s.title, s.time_created, s.time_updated, s.slug, s.directory,
             s.version, s.summary_files, 0 AS message_count, NULL AS model_message_data${parentIdSelect}
           FROM session s
-          WHERE COALESCE(s.time_updated, s.time_created) >= ?
+          WHERE ${activityPredicate}
           ${childPredicate}
           ORDER BY COALESCE(s.time_updated, s.time_created) DESC, s.time_created DESC, s.id DESC
         `)
-          .all(cutoffTime);
+          .all(...activityBindings);
       }
 
       if (hasParentId && options?.includeRelatedSessions !== false) {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -847,24 +847,37 @@ describe("scanSessions", () => {
       meta: {},
       timestamp: Date.now(),
     });
-    mockedCreateRegisteredAgents.mockReturnValue([
-      createTestAgent({
-        name: "test",
-        available: true,
-        sessions: refreshedSessions,
-        checkForChangesResult: {
-          hasChanges: true,
-          changedIds: ["fresh"],
-          timestamp: Date.now(),
-        },
-        incrementalScanResult: refreshedSessions,
-      }),
-    ]);
+    const agent = createTestAgent({
+      name: "test",
+      available: true,
+      sessions: refreshedSessions,
+      checkForChangesResult: {
+        hasChanges: true,
+        changedIds: ["fresh"],
+        timestamp: Date.now(),
+      },
+      incrementalScanResult: refreshedSessions,
+    });
+    const incrementalScan = vi.spyOn(agent, "incrementalScan");
+    mockedCreateRegisteredAgents.mockReturnValue([agent]);
 
-    const result = await scanSessions({ useCache: true, smartRefresh: false });
+    const result = await scanSessions({
+      useCache: true,
+      smartRefresh: false,
+      from: 500,
+      to: 1_500,
+      fast: true,
+    });
 
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0]!.id).toBe("fresh");
+    expect(incrementalScan).toHaveBeenCalledWith(cachedSessions, ["fresh"], undefined, {
+      from: 500,
+      to: 1_500,
+      fast: true,
+      includeRelatedSessions: true,
+      onProgress: expect.any(Function),
+    });
     expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
     expect(mockedSaveCachedSessionChanges).toHaveBeenCalledWith(
       "test",
@@ -879,7 +892,7 @@ describe("scanSessions", () => {
           sortIndex: 0,
         },
       ],
-      ["cached"],
+      [],
       {},
     );
   });

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -116,6 +116,28 @@ export interface SessionTagTiming {
   classifySessionTagsMs: number;
 }
 
+function buildAgentScanOptions(
+  agent: BaseAgent,
+  options: ScanOptions,
+  onProgress?: (progress: ScanProgress) => void,
+): AgentScanOptions {
+  return {
+    from: options.from,
+    to: options.to,
+    fast: options.fast,
+    includeRelatedSessions: true,
+    onProgress: (progress) => {
+      onProgress?.({
+        agent: agent.name,
+        phase: "incremental",
+        cachedCount: progress.total,
+        newCount: progress.sessions,
+        changedCount: progress.processed,
+      });
+    },
+  };
+}
+
 interface SuccessfulAgentScanResult {
   status: "complete" | "partial";
   agent: BaseAgent;
@@ -144,6 +166,7 @@ type AgentScanFinalization =
       kind: "incremental";
       cached: CachedResult;
       changedIds: string[];
+      explicitRemovedSessionIds?: string[];
       cacheTimestamp: number;
     };
 
@@ -172,14 +195,16 @@ function saveCachedSessionDiff(
   cachedSessions: SessionHead[],
   updatedSessions: SessionHead[],
   changedIds: string[] = [],
+  completeness: "complete" | "partial" = "complete",
+  explicitRemovedSessionIds: readonly string[] = [],
 ): void {
   const diff = computeSessionDiff(cachedSessions, updatedSessions, changedIds, sessionSignature);
-  saveCachedSessionChanges(
-    agent.name,
-    diff.changes,
-    diff.removedSessionIds,
-    buildAgentCacheMeta(agent),
-  );
+  const explicitRemovals = new Set(explicitRemovedSessionIds);
+  const removedSessionIds =
+    completeness === "complete"
+      ? diff.removedSessionIds
+      : diff.removedSessionIds.filter((sessionId) => explicitRemovals.has(sessionId));
+  saveCachedSessionChanges(agent.name, diff.changes, removedSessionIds, buildAgentCacheMeta(agent));
 }
 
 function getSmartTagWorkerCount(sessionCount: number): number {
@@ -407,6 +432,8 @@ export async function finalizeAgentScan(
         finalization.cached.sessions,
         tagged.sessions,
         finalization.changedIds,
+        context.completeness,
+        finalization.explicitRemovedSessionIds,
       );
     } else if (finalization.kind === "unchanged" && (identityChanged || tagged.changed)) {
       saveCachedSessionDiff(agent, finalization.cached.sessions, tagged.sessions);
@@ -482,6 +509,7 @@ async function refreshCachedFileAgent(
       kind: "incremental",
       cached,
       changedIds: synchronization.changedSessionIds,
+      explicitRemovedSessionIds: synchronization.explicitRemovedSessionIds,
       cacheTimestamp: Date.now(),
     },
     options,
@@ -566,8 +594,14 @@ async function scanAgentSmart(
         });
 
         const t2 = performance.now();
+        const scanOptions = buildAgentScanOptions(agent, options, onProgress);
         const updatedSessions = await Promise.resolve(
-          agent.incrementalScan(cached.sessions, checkResult.changedIds || [], checkResult.refs),
+          agent.incrementalScan(
+            cached.sessions,
+            checkResult.changedIds || [],
+            checkResult.refs,
+            scanOptions,
+          ),
         );
         timing.scan = performance.now() - t2;
 
@@ -581,7 +615,12 @@ async function scanAgentSmart(
           options,
           timing,
           agentStart,
-          completeness: (checkResult.sourceFailures?.length ?? 0) > 0 ? "partial" : "complete",
+          completeness:
+            options.from == null &&
+            options.to == null &&
+            (checkResult.sourceFailures?.length ?? 0) === 0
+              ? "complete"
+              : "partial",
           onProgress,
         });
       }
@@ -627,21 +666,7 @@ async function scanAgentFull(
   try {
     const scanMarker = perf.start(`agent:${agent.name}:scan`);
     const t0 = performance.now();
-    const agentScanOptions: AgentScanOptions = {
-      from: options.from,
-      to: options.to,
-      fast: options.fast,
-      includeRelatedSessions: true,
-      onProgress: (progress) => {
-        onProgress?.({
-          agent: agent.name,
-          phase: "incremental",
-          cachedCount: progress.total,
-          newCount: progress.sessions,
-          changedCount: progress.processed,
-        });
-      },
-    };
+    const agentScanOptions = buildAgentScanOptions(agent, options, onProgress);
     let heads: SessionHead[];
     let sourceFailures: SessionSourceFailure[] = [];
     if (agent instanceof FileSystemSessionSource) {


### PR DESCRIPTION
## Summary

- enforce inclusive upper bounds for OpenCode and ZCode SQLite root scans
- forward scan windows through cached, live-refresh, and worker incremental paths
- treat bounded results as partial snapshots so omitted history is not deleted

## Validation

- pnpm test
- pnpm lint
- pnpm format:check
- pnpm build

Issue: CS-206