### PR TITLE
fix: normalize project identity inputs

### DIFF
--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -54,6 +54,9 @@ describe("normalizeGitRemote", () => {
     expect(normalizeGitRemote("https://github.com/xingkaixin/codesesh.git")).toBe(
       "github.com/xingkaixin/codesesh",
     );
+    expect(normalizeGitRemote("ssh://git@github.com:22/xingkaixin/codesesh.git")).toBe(
+      "github.com/xingkaixin/codesesh",
+    );
   });
 });
 
@@ -121,6 +124,19 @@ describe("computeIdentity", () => {
     expect(computeIdentity("/workspace/tool/src", fs)).toEqual({
       kind: "manifest_path",
       key: "/workspace/tool",
+      displayName: "tool",
+    });
+  });
+
+  it("treats a backslash inside an absolute POSIX path as a filename character", () => {
+    const project = "/Users/test/we\\ird/tool";
+    const fs = createFs({
+      [`${project}/package.json`]: JSON.stringify({ name: "tool" }),
+    });
+
+    expect(computeIdentity(`${project}/src`, fs)).toEqual({
+      kind: "manifest_path",
+      key: project,
       displayName: "tool",
     });
   });

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -11,7 +11,7 @@ export interface IdentityFs {
   spawn(cmd: string, args: string[], opts: { cwd: string }): { stdout: string; exitCode: number };
 }
 
-export const PROJECT_IDENTITY_RESOLVER_REVISION = "project-identity-v1";
+export const PROJECT_IDENTITY_RESOLVER_REVISION = "project-identity-v2";
 
 export interface ProjectIdentityProjection {
   identity: ProjectIdentity;
@@ -48,10 +48,19 @@ export {
 
 export function normalizeGitRemote(url: string): string | null {
   if (!url) return null;
-  let value = url.trim().replace(/\.git$/, "");
-  const sshMatch = value.match(/^[^@]+@([^:]+):(.+)$/);
-  if (sshMatch) value = `${sshMatch[1]}/${sshMatch[2]}`;
-  value = value.replace(/^[a-z]+:\/\/(?:[^@/]*@)?/i, "");
+  let value = url.trim();
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(value)) {
+    try {
+      const parsed = new URL(value);
+      value = `${parsed.hostname}${parsed.pathname}`;
+    } catch {
+      return null;
+    }
+  } else {
+    const sshMatch = value.match(/^[^@]+@([^:]+):(.+)$/);
+    if (sshMatch) value = `${sshMatch[1]}/${sshMatch[2]}`;
+  }
+  value = value.replace(/\.git$/, "");
   if (!value.includes("/")) return null;
   return value.toLowerCase();
 }
@@ -230,7 +239,7 @@ function synthesizeCodexScratchIdentity(
 }
 
 function getPathOps(input: string): PathOps {
-  if (/^[a-zA-Z]:[\\/]/.test(input) || input.startsWith("\\\\") || input.includes("\\")) {
+  if (/^[a-zA-Z]:[\\/]/.test(input) || input.startsWith("\\\\")) {
     return path.win32;
   }
   if (input.startsWith("/")) return path.posix;

--- a/packages/core/src/projects/scope.test.ts
+++ b/packages/core/src/projects/scope.test.ts
@@ -34,12 +34,26 @@ describe("filterSessionsByProjectScope", () => {
           displayName: "project",
         },
       }),
+      makeSession("identity-without-directory", {
+        directory: "",
+        project_identity: {
+          kind: "path",
+          key: "/home/user/project",
+          displayName: "project",
+        },
+      }),
       makeSession("sibling", { directory: "/home/user/projectile" }),
     ];
 
     const result = filterSessionsByProjectScope(sessions, "/home/user/project");
 
-    expect(result.map((session) => session.id)).toEqual(["exact", "child", "parent", "identity"]);
+    expect(result.map((session) => session.id)).toEqual([
+      "exact",
+      "child",
+      "parent",
+      "identity",
+      "identity-without-directory",
+    ]);
   });
 
   it("computes the query project identity once for all sessions", () => {

--- a/packages/core/src/projects/scope.ts
+++ b/packages/core/src/projects/scope.ts
@@ -20,9 +20,8 @@ export function createProjectScopeMatcher(
 }
 
 export function matchesProjectScope(session: SessionHead, scope: ProjectScopeMatcher): boolean {
-  if (!session.directory) return false;
   if (matchesProjectIdentity(session.project_identity, scope.identity)) return true;
-  return isPathScopeMatch(scope.path, session.directory);
+  return session.directory ? isPathScopeMatch(scope.path, session.directory) : false;
 }
 
 export function filterSessionsByProjectScope(


### PR DESCRIPTION
## Summary

- normalize URL-style Git remotes through the URL parser and omit SSH ports
- distinguish Windows paths by drive or UNC roots instead of any backslash
- allow exact project identities to match sessions whose directory is empty
- bump the identity resolver revision so stale projections are recomputed

## Validation

- pnpm --filter @codesesh/core test
- pnpm lint
- pnpm format:check
- pnpm build

Issue: CS-207