### PR TITLE
fix: make session detail publication atomic

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 21`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 22`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`
@@ -22,6 +22,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 | `cache/schema.ts` | 建表、迁移、事务边界、FTS 完整性检查 |
 | `cache/sessions.ts` | 会话列表和详情快照的读取、写入与清理 |
 | `cache/messages.ts` | `sessions` / `messages` 行与领域对象之间的转换 |
+| `cache/publication-staging.ts` | 大批量详情发布的影子载荷与中断回收 |
 | `cache/search-index-writer.ts` | 详情、工具、文件活动与全文索引的同步写入 |
 | `cache/search.ts` | 搜索查询与结构化过滤 |
 | `cache/search-query-parser.ts` | 搜索语法解析 |
@@ -30,7 +31,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 ## Schema 清单
 
-当前 schema 创建 14 张表（其中 3 张是 FTS5 虚表）和 1 个视图。
+当前 schema 创建 15 张表（其中 3 张是 FTS5 虚表）和 1 个视图。
 
 ### 生命周期与同步状态
 
@@ -60,6 +61,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 | `session_file_activity_path_fts` | trigram FTS5 虚表 | 文件路径匹配 |
 | `session_documents` | 普通表 | 会话标题、聚合文本、内容签名与已索引消息数 |
 | `session_documents_fts` | FTS5 虚表 | 会话级标题和聚合文本搜索 |
+| `search_index_publication_entries` | 普通表 | 大批量发布提交前暂存序列化详情；提交或回滚后清空 |
 
 三个 FTS 表都由对应内容表的 insert/update/delete 触发器维护。批量变化达到阈值时，
 `runSearchIndexWrite()` 会在写事务中重建会话文档和消息索引；文件路径索引仍由触发器
@@ -109,7 +111,9 @@ SessionWatcher / 初始后台刷新
   -> 发布新的内存快照与 SSE 事件
 ```
 
-搜索索引 worker 完成对应的 SQLite 写入后，`AgentSyncEngine` 才发布新内存快照。
+搜索索引 worker 在同一 SQLite 事务中提交会话 head 与详情后，`AgentSyncEngine` 才发布
+新内存快照。大批量详情先分块写入影子表，最终事务再流式提升到正式表，避免为控制内存而
+提前暴露部分新详情。
 
 完整写入会整体协调某个 Agent 的会话集合；精确刷新只 upsert 变更会话并删除已消失
 会话。需要重新索引的会话才会调用适配器的 `getSessionData()`，随后由缓存事务和索引

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 21;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 22;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -56,6 +56,7 @@ describe("cache schema boundary", () => {
       "session_documents",
       "session_file_activity",
       "project_groups_v",
+      "search_index_publication_entries",
     ]) {
       expect(state?.names.has(name)).toBe(true);
     }
@@ -79,7 +80,95 @@ describe("cache schema boundary", () => {
         "publication_id",
       ]),
     );
-    expect(state?.version).toBe(21);
+    expect(state?.version).toBe(22);
+  });
+
+  it("reclaims orphaned publication rows on the next schema open", () => {
+    const session = makeSessionHead("orphaned-publication");
+    saveCachedSessions("codex", [session]);
+    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
+
+    const db = new Database(getCachePath());
+    try {
+      db.prepare("UPDATE sessions SET publication_id = ? WHERE session_id = ?").run(
+        "orphaned",
+        session.id,
+      );
+      db.prepare(
+        `
+          INSERT INTO search_index_publication_entries(
+            publication_id,
+            agent_name,
+            session_id,
+            payload_json
+          ) VALUES (?, ?, ?, ?)
+        `,
+      ).run("orphaned", "codex", session.id, "{}");
+    } finally {
+      db.close();
+    }
+    setSchemaEnsuredPath(null);
+
+    const counts = schema.withCacheDb((ready) => ({
+      sessions: Number(
+        (
+          ready
+            .prepare("SELECT COUNT(*) AS value FROM sessions WHERE publication_id IS NOT NULL")
+            .get() as { value?: number }
+        ).value ?? 0,
+      ),
+      documents: Number(
+        (
+          ready
+            .prepare("SELECT COUNT(*) AS value FROM session_documents WHERE agent_name = ?")
+            .get("codex") as { value?: number }
+        ).value ?? 0,
+      ),
+      payloads: Number(
+        (
+          ready.prepare("SELECT COUNT(*) AS value FROM search_index_publication_entries").get() as {
+            value?: number;
+          }
+        ).value ?? 0,
+      ),
+    }));
+
+    expect(counts).toEqual({ sessions: 0, documents: 0, payloads: 0 });
+  });
+
+  it("invalidates v21 detail rows so inconsistent publications rebuild", () => {
+    const session = makeSessionHead("publication-rebuild");
+    saveCachedSessions("codex", [session]);
+    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
+
+    const db = new Database(getCachePath());
+    try {
+      db.prepare("UPDATE session_documents SET content_hash = ? WHERE session_id = ?").run(
+        "stale-but-matching",
+        session.id,
+      );
+      db.pragma("user_version = 21");
+      db.prepare("UPDATE cache_meta SET value = '21' WHERE key = 'version'").run();
+    } finally {
+      db.close();
+    }
+    setSchemaEnsuredPath(null);
+
+    const migrated = schema.withCacheDb((ready) => ({
+      contentHash: String(
+        (
+          ready
+            .prepare("SELECT content_hash FROM session_documents WHERE session_id = ?")
+            .get(session.id) as { content_hash?: string }
+        ).content_hash ?? "missing",
+      ),
+      pending:
+        ready
+          .prepare("SELECT 1 FROM pending_reindex WHERE agent_name = ? AND session_id = ?")
+          .get("codex", session.id) != null,
+    }));
+
+    expect(migrated).toEqual({ contentHash: "", pending: true });
   });
 
   it("exposes capabilities instead of migration steps", () => {
@@ -123,7 +212,7 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 21, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 22, detailVersion: "", pending: true });
   });
 
   it("marks legacy project identities stale by leaving added provenance empty", () => {
@@ -162,7 +251,7 @@ describe("cache schema boundary", () => {
     });
 
     expect(migrated).toEqual({
-      version: 21,
+      version: 22,
       resolverRevision: null,
       inputSignature: null,
       classifierRevision: null,
@@ -232,7 +321,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 21,
+        version: 22,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -400,6 +400,11 @@ describe("durable publication", () => {
       });
       expect(loadCachedSessions("codex")?.sessions).toHaveLength(70);
       expect(searchSessions("bulk-42 bulk needle")).toHaveLength(1);
+      expect(
+        withCacheDb((db) =>
+          db.prepare("SELECT COUNT(*) AS value FROM search_index_publication_entries").get(),
+        ),
+      ).toEqual({ value: 0 });
 
       const loadAgain = vi.fn((sessionId: string) =>
         makeSessionData(sessionId, `${sessionId} bulk needle`),
@@ -427,7 +432,7 @@ describe("durable publication", () => {
   );
 
   it(
-    "keeps pre-staged session heads hidden when a large publication rolls back",
+    "discards shadow entries when a large publication rolls back",
     () => {
       const historical = makeSession("historical");
       saveCachedSessions("codex", [historical], {
@@ -485,15 +490,97 @@ describe("durable publication", () => {
               "SELECT COUNT(*) AS value FROM sessions WHERE agent_name = ? AND publication_id = ?",
             )
             .get("codex", result.publicationId),
-        ).toEqual({ value: 70 });
+        ).toEqual({ value: 0 });
         expect(
           verifyDb
             .prepare("SELECT COUNT(*) AS value FROM session_documents WHERE agent_name = ?")
             .get("codex"),
-        ).toEqual({ value: 71 });
+        ).toEqual({ value: 1 });
+        expect(
+          verifyDb
+            .prepare(
+              "SELECT COUNT(*) AS value FROM search_index_publication_entries WHERE publication_id = ?",
+            )
+            .get(result.publicationId),
+        ).toEqual({ value: 0 });
       } finally {
         verifyDb.close();
       }
+    },
+    SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps live details aligned with heads when an updated backlog rolls back",
+    () => {
+      const originals = Array.from({ length: 70 }, (_, index) => makeSession(`aligned-${index}`));
+      saveCachedSessions("codex", originals);
+      syncSessionSearchIndex("codex", originals, (sessionId) =>
+        makeSessionData(sessionId, `${sessionId} old detail`),
+      );
+
+      const updated = originals.map((session) => ({
+        ...session,
+        title: `Updated ${session.id}`,
+      }));
+      const db = new Database(getCachePath());
+      try {
+        db.exec(`
+          CREATE TRIGGER fail_updated_backlog_head_write
+          BEFORE UPDATE ON sessions
+          WHEN NEW.title LIKE 'Updated aligned-%'
+          BEGIN
+            SELECT RAISE(ABORT, 'forced updated backlog failure');
+          END;
+        `);
+      } finally {
+        db.close();
+      }
+
+      const failed = commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions: updated,
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+          publicationId: "scan.refresh:codex:aligned",
+        },
+        (sessionId) => makeSessionData(sessionId, `${sessionId} new detail`),
+      );
+
+      expect(failed).toMatchObject({ status: "rolled-back", stage: "cache" });
+      expect(loadCachedSessions("codex")?.sessions[0]?.title).toBe(originals[0]?.title);
+      expect(loadCachedSessionData("codex", "aligned-0")?.messages[0]?.parts).toEqual([
+        { type: "text", text: "aligned-0 old detail" },
+      ]);
+      expect(searchSessions("aligned-0 new detail")).toHaveLength(0);
+
+      const retryDb = new Database(getCachePath());
+      try {
+        retryDb.exec("DROP TRIGGER fail_updated_backlog_head_write");
+      } finally {
+        retryDb.close();
+      }
+      const retryLoader = vi.fn((sessionId: string) =>
+        makeSessionData(sessionId, `${sessionId} new detail`),
+      );
+      const retried = commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions: updated,
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+        },
+        retryLoader,
+      );
+
+      expect(retried.status).toBe("committed");
+      expect(retryLoader).toHaveBeenCalledTimes(70);
+      expect(searchSessions("aligned-0 new detail")).toHaveLength(1);
     },
     SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS,
   );
@@ -1182,7 +1269,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(21);
+    expect(getUserVersion(getCachePath())).toBe(22);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -1970,7 +2057,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(21);
+    expect(getUserVersion(getCachePath())).toBe(22);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -196,7 +196,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(21);
+    expect(getUserVersion(getCachePath())).toBe(22);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -207,7 +207,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(21);
+    expect(getUserVersion(getCachePath())).toBe(22);
   });
 });
 
@@ -215,7 +215,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(21);
+    expect(getUserVersion(getCachePath())).toBe(22);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -427,7 +427,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(21);
+    expect(getUserVersion(getCachePath())).toBe(22);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -183,14 +183,8 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
   `);
 }
 
-function prepareIndexedSession(
-  db: SQLiteDatabase,
-  conflictAction: "update" | "ignore",
-): SQLiteStatement {
-  const onConflict =
-    conflictAction === "ignore"
-      ? "DO NOTHING"
-      : `DO UPDATE SET
+function prepareIndexedSession(db: SQLiteDatabase): SQLiteStatement {
+  const onConflict = `DO UPDATE SET
           slug = excluded.slug,
           title = excluded.title,
           directory = excluded.directory,
@@ -256,11 +250,7 @@ function prepareIndexedSession(
 }
 
 export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement {
-  return prepareIndexedSession(db, "update");
-}
-
-export function prepareInsertStagedSession(db: SQLiteDatabase): SQLiteStatement {
-  return prepareIndexedSession(db, "ignore");
+  return prepareIndexedSession(db);
 }
 
 export function upsertSessionRow(
@@ -270,7 +260,6 @@ export function upsertSessionRow(
   metaJson: string | null,
   sortIndex: number,
   sourcePath: string | null,
-  publicationId: string | null = null,
 ): void {
   const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
   const activityTime = session.time_updated ?? session.time_created;
@@ -305,7 +294,7 @@ export function upsertSessionRow(
     session.smart_tags_source_updated_at ?? null,
     session.smart_tags_classifier_revision ?? null,
     metaJson,
-    publicationId,
+    null,
   );
 }
 

--- a/packages/core/src/discovery/cache/publication-staging.ts
+++ b/packages/core/src/discovery/cache/publication-staging.ts
@@ -1,0 +1,121 @@
+import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
+
+interface StagedPublicationRow extends DatabaseRow {
+  session_id?: string;
+  payload_json?: string;
+}
+
+const PUBLICATION_READ_BATCH_SIZE = 64;
+
+export interface PublicationPayload {
+  sessionId: string;
+  json: string;
+}
+
+export function createPublicationStagingTable(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS search_index_publication_entries (
+      publication_id TEXT NOT NULL,
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      PRIMARY KEY (publication_id, agent_name, session_id)
+    );
+  `);
+}
+
+export function stagePublicationPayloads(
+  db: SQLiteDatabase,
+  publicationId: string,
+  agentName: string,
+  payloads: Iterable<PublicationPayload>,
+): number {
+  const upsert = db.prepare(`
+    INSERT INTO search_index_publication_entries(
+      publication_id,
+      agent_name,
+      session_id,
+      payload_json
+    ) VALUES (?, ?, ?, ?)
+    ON CONFLICT(publication_id, agent_name, session_id) DO UPDATE SET
+      payload_json = excluded.payload_json
+  `);
+  let staged = 0;
+  for (const payload of payloads) {
+    upsert.run(publicationId, agentName, payload.sessionId, payload.json);
+    staged += 1;
+  }
+  return staged;
+}
+
+export function* readPublicationPayloads(
+  db: SQLiteDatabase,
+  publicationId: string,
+  agentName: string,
+): Generator<string> {
+  const readBatch = db.prepare(`
+        SELECT session_id, payload_json
+        FROM search_index_publication_entries
+        WHERE publication_id = ? AND agent_name = ? AND session_id > ?
+        ORDER BY session_id
+        LIMIT ?
+      `);
+  let cursor = "";
+  while (true) {
+    const rows = readBatch.all(
+      publicationId,
+      agentName,
+      cursor,
+      PUBLICATION_READ_BATCH_SIZE,
+    ) as StagedPublicationRow[];
+    if (rows.length === 0) return;
+    for (const row of rows) yield String(row.payload_json ?? "");
+    cursor = String(rows.at(-1)?.session_id ?? "");
+  }
+}
+
+export function deletePublicationPayloads(db: SQLiteDatabase, publicationId: string): void {
+  db.prepare("DELETE FROM search_index_publication_entries WHERE publication_id = ?").run(
+    publicationId,
+  );
+}
+
+function deleteLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string): void {
+  // Schema v21 could leave staged heads and their live detail rows after an interruption.
+  const predicate = publicationId
+    ? "staged.publication_id = ?"
+    : "staged.publication_id IS NOT NULL";
+  const params = publicationId ? [publicationId] : [];
+  for (const [table, alias] of [
+    ["message_tools", "target"],
+    ["messages", "target"],
+    ["session_file_activity", "target"],
+    ["session_documents", "target"],
+    ["pending_reindex", "target"],
+  ] as const) {
+    db.prepare(`
+      DELETE FROM ${table} AS ${alias}
+      WHERE EXISTS (
+        SELECT 1
+        FROM sessions AS staged
+        WHERE staged.agent_name = ${alias}.agent_name
+          AND staged.session_id = ${alias}.session_id
+          AND ${predicate}
+      )
+    `).run(...params);
+  }
+  db.prepare(
+    publicationId
+      ? "DELETE FROM sessions WHERE publication_id = ?"
+      : "DELETE FROM sessions WHERE publication_id IS NOT NULL",
+  ).run(...params);
+}
+
+export function discardPublicationStaging(db: SQLiteDatabase, publicationId?: string): void {
+  deleteLegacyPublicationRows(db, publicationId);
+  if (publicationId) {
+    deletePublicationPayloads(db, publicationId);
+  } else {
+    db.prepare("DELETE FROM search_index_publication_entries").run();
+  }
+}

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -7,6 +7,7 @@ import { sessionDetailVersion } from "./detail-version.js";
 import {
   prepareSessionChangesSearchIndex,
   prepareSessionSnapshotSearchIndex,
+  discardPreparedSessionSearchIndex,
   writePreparedSessionSearchIndex,
   type SearchIndexSyncOptions,
   type SearchIndexSyncResult,
@@ -156,6 +157,7 @@ export function commitDurableSessionPublication(
   });
 
   if (!searchIndex) {
+    discardPreparedSessionSearchIndex(publicationId);
     diagnostics?.warn("search_index.publication_stage", {
       ...detail,
       stage: "rolled_back",

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -31,6 +31,7 @@ import {
   type SessionRow,
 } from "./messages.js";
 import { CACHE_SCHEMA_VERSION } from "./version.js";
+import { createPublicationStagingTable, discardPublicationStaging } from "./publication-staging.js";
 
 interface MessageToolBackfillRow extends DatabaseRow {
   agent_name?: string;
@@ -618,6 +619,7 @@ function createLatestCacheSchema(db: SQLiteDatabase): void {
   createSessionTables(db);
   createFileActivityTables(db);
   createProjectTables(db);
+  createPublicationStagingTable(db);
   ensureFtsReady(db);
 }
 
@@ -1044,6 +1046,19 @@ function invalidateSearchContentHashes(db: SQLiteDatabase): void {
   }
 }
 
+function addAtomicPublicationStaging(db: SQLiteDatabase): void {
+  createPublicationStagingTable(db);
+  invalidateSearchContentHashes(db);
+  if (tableExists(db, "sessions") && tableExists(db, "pending_reindex")) {
+    db.exec(`
+      INSERT OR IGNORE INTO pending_reindex(agent_name, session_id)
+      SELECT agent_name, session_id
+      FROM sessions
+      WHERE publication_id IS NULL
+    `);
+  }
+}
+
 function compactSessionDocuments(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents")) {
     createSearchTables(db);
@@ -1394,10 +1409,12 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 19, migrate: addDetailVersion },
       { version: 20, migrate: addProjectIdentityProvenance },
       { version: 21, migrate: addSessionPublicationId },
+      { version: 22, migrate: addAtomicPublicationStaging },
     ],
   });
 
   createLatestCacheSchema(db);
+  db.transaction(() => discardPublicationStaging(db)).immediate();
 
   // Only stamp when behind: every thread's first connection runs ensureSchema,
   // and an unconditional PRAGMA user_version write would contend for the write

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -10,7 +10,6 @@ import {
   MESSAGE_PARTS_FORMAT_VERSION,
   normalizeMessages,
   prepareInsertFileActivity,
-  prepareInsertStagedSession,
   prepareInsertMessageTool,
   prepareUpsertIndexedSession,
   upsertSessionRow,
@@ -20,6 +19,12 @@ import {
 import { runSearchIndexWrite, withSearchIndexDb } from "./schema.js";
 import { sessionDetailVersion } from "./detail-version.js";
 import type { SessionSnapshotCompleteness } from "./sessions.js";
+import {
+  deletePublicationPayloads,
+  discardPublicationStaging,
+  readPublicationPayloads,
+  stagePublicationPayloads,
+} from "./publication-staging.js";
 
 export interface SearchIndexSyncOptions {
   isBulk?: boolean;
@@ -95,7 +100,6 @@ interface LoadedSearchIndexEntry {
 
 interface SearchIndexRowWriteOptions {
   verifySupersession?: boolean;
-  publicationId?: string;
 }
 
 interface PreparedSearchIndexPublication {
@@ -105,8 +109,9 @@ interface PreparedSearchIndexPublication {
   changed: number;
   removedSessionIds: string[];
   entries: LoadedSearchIndexEntry[];
-  /** Entries already written durably in chunks before the atomic commit. */
-  preIndexed: number;
+  publicationId?: string;
+  /** Full entries stored outside the live tables until the atomic commit. */
+  preStaged: number;
   failures: SearchIndexSyncFailure[];
   needsRebuild: boolean;
   startedAt: number;
@@ -312,7 +317,7 @@ function writeSearchIndexRows(
   failures: SearchIndexSyncFailure[],
   options: SearchIndexRowWriteOptions = {},
 ): number {
-  const { verifySupersession = true, publicationId } = options;
+  const { verifySupersession = true } = options;
   const deleteRow = db.prepare(
     "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
   );
@@ -325,9 +330,7 @@ function writeSearchIndexRows(
   const deleteFileActivity = db.prepare(
     "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
   );
-  const writeIndexedSession = publicationId
-    ? prepareInsertStagedSession(db)
-    : prepareUpsertIndexedSession(db);
+  const writeIndexedSession = prepareUpsertIndexedSession(db);
   const insertFileActivity = prepareInsertFileActivity(db);
   const insertMessageTool = prepareInsertMessageTool(db);
   const upsertMessage = db.prepare(`
@@ -419,15 +422,7 @@ function writeSearchIndexRows(
         continue;
       }
     }
-    upsertSessionRow(
-      writeIndexedSession,
-      agentName,
-      entry.session,
-      null,
-      entry.sortIndex,
-      null,
-      publicationId ?? null,
-    );
+    upsertSessionRow(writeIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
     deleteFileActivity.run(agentName, entry.session.id);
     deleteMessageTools.run(agentName, entry.session.id, 0);
     clearPendingReindex.run(agentName, entry.session.id);
@@ -479,11 +474,9 @@ function writeSearchIndexRows(
  * Loaded entries carry full message bodies, so a backlog larger than one commit
  * chunk cannot be held in memory at once — a first-time index of a large agent
  * (multi-GB codex rollouts) used to OOM the search-index worker. Larger
- * backlogs are written durably in chunks up front instead; an interrupted run
- * keeps its finished chunks and a retry skips them via their content hashes.
- * Supersession is not verified during pre-staging: publication jobs are
- * serialized, and the atomic commit that follows writes the very meta these
- * detail versions were derived from, which would make the check vacuous anyway.
+ * backlogs are serialized into a shadow table in chunks. The final transaction
+ * streams those payloads into the live tables, keeping memory bounded without
+ * publishing any detail facts ahead of their session heads.
  */
 function loadOrPreStageEntries(
   db: SQLiteDatabase,
@@ -493,13 +486,13 @@ function loadOrPreStageEntries(
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
   publicationId?: string,
-): { entries: LoadedSearchIndexEntry[]; preIndexed: number } {
+): { entries: LoadedSearchIndexEntry[]; preStaged: number } {
   if (changes.length <= SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
     return {
       entries: [
         ...loadSearchIndexEntries(agentName, changes, loadSessionData, detailVersionFor, failures),
       ],
-      preIndexed: 0,
+      preStaged: 0,
     };
   }
 
@@ -507,26 +500,35 @@ function loadOrPreStageEntries(
     throw new Error("Large durable publications require a publication id");
   }
 
-  let preIndexed = 0;
+  let preStaged = 0;
   for (let offset = 0; offset < changes.length; offset += SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
     const chunk = changes.slice(offset, offset + SEARCH_INDEX_COMMIT_CHUNK_SIZE);
     runSearchIndexWrite(db, false, () => {
-      preIndexed += writeSearchIndexRows(
-        db,
+      const entries = loadSearchIndexEntries(
         agentName,
-        [],
-        loadSearchIndexEntries(agentName, chunk, loadSessionData, detailVersionFor, failures),
+        chunk,
+        loadSessionData,
+        detailVersionFor,
         failures,
-        { verifySupersession: false, publicationId },
+      );
+      preStaged += stagePublicationPayloads(
+        db,
+        publicationId,
+        agentName,
+        (function* () {
+          for (const entry of entries) {
+            yield { sessionId: entry.session.id, json: JSON.stringify(entry) };
+          }
+        })(),
       );
     });
   }
   getCoreDiagnostics()?.info?.("search_index.pre_staged", {
     agent: agentName,
     changed: changes.length,
-    indexed: preIndexed,
+    staged: preStaged,
   });
-  return { entries: [], preIndexed };
+  return { entries: [], preStaged };
 }
 
 export function prepareSessionSnapshotSearchIndex(
@@ -566,7 +568,7 @@ export function prepareSessionSnapshotSearchIndex(
   const changedCount = removedSessionIds.length + changes.length;
   const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
   const failures: SearchIndexSyncFailure[] = [];
-  const { entries, preIndexed } = loadOrPreStageEntries(
+  const { entries, preStaged } = loadOrPreStageEntries(
     db,
     agentName,
     changes,
@@ -583,10 +585,10 @@ export function prepareSessionSnapshotSearchIndex(
     changed: changes.length,
     removedSessionIds,
     entries,
-    preIndexed,
+    publicationId: options.publicationId,
+    preStaged,
     failures,
-    // Pre-staged chunks wrote through the live FTS triggers; no rebuild needed.
-    needsRebuild: preIndexed === 0 && isBulk && changedCount > 0,
+    needsRebuild: isBulk && changedCount > 0,
     startedAt,
   };
 }
@@ -612,7 +614,7 @@ export function prepareSessionChangesSearchIndex(
   const changedCount = uniqueRemovedSessionIds.length + toUpsert.length;
   const isBulk = shouldBulkSyncSearchIndex(options, changedCount);
   const failures: SearchIndexSyncFailure[] = [];
-  const { entries, preIndexed } = loadOrPreStageEntries(
+  const { entries, preStaged } = loadOrPreStageEntries(
     db,
     agentName,
     toUpsert,
@@ -629,10 +631,10 @@ export function prepareSessionChangesSearchIndex(
     changed: toUpsert.length,
     removedSessionIds: uniqueRemovedSessionIds,
     entries,
-    preIndexed,
+    publicationId: options.publicationId,
+    preStaged,
     failures,
-    // Pre-staged chunks wrote through the live FTS triggers; no rebuild needed.
-    needsRebuild: preIndexed === 0 && isBulk && changedCount > 0,
+    needsRebuild: isBulk && changedCount > 0,
     startedAt,
   };
 }
@@ -641,18 +643,32 @@ export function writePreparedSessionSearchIndex(
   db: SQLiteDatabase,
   publication: PreparedSearchIndexPublication,
 ): SearchIndexSyncResult {
-  let indexed = publication.preIndexed;
+  let indexed = 0;
   const { rebuildDurationMs } = runSearchIndexWrite(
     db,
     publication.needsRebuild,
     () => {
+      const entries = (function* (): Generator<LoadedSearchIndexEntry> {
+        yield* publication.entries;
+        if (!publication.publicationId || publication.preStaged === 0) return;
+        for (const payload of readPublicationPayloads(
+          db,
+          publication.publicationId,
+          publication.agentName,
+        )) {
+          yield JSON.parse(payload) as LoadedSearchIndexEntry;
+        }
+      })();
       indexed += writeSearchIndexRows(
         db,
         publication.agentName,
         publication.removedSessionIds,
-        publication.entries,
+        entries,
         publication.failures,
       );
+      if (publication.publicationId) {
+        deletePublicationPayloads(db, publication.publicationId);
+      }
     },
     "caller",
   );
@@ -669,6 +685,12 @@ export function writePreparedSessionSearchIndex(
     durationMs: performance.now() - publication.startedAt,
     rebuildDurationMs,
   };
+}
+
+export function discardPreparedSessionSearchIndex(publicationId: string): void {
+  withSearchIndexDb((db) =>
+    db.transaction(() => discardPublicationStaging(db, publicationId)).immediate(),
+  );
 }
 
 export function syncSessionSearchIndex(

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 21;
+export const CACHE_SCHEMA_VERSION = 22;


### PR DESCRIPTION
## Summary

- stage large session-detail payloads in a shadow table instead of live search tables
- promote session heads and details in the same SQLite transaction, with rollback and startup reclamation
- migrate schema v22 to force recovery of detail rows that may have been left inconsistent by v21

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`

Closes CS-208