### PR TITLE
fix: preserve sync state after cache read failures

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -15,16 +15,32 @@ import type { ScanStatusEvent } from "@codesesh/core/contract";
 import type { WorkerResult, WorkerRunner } from "./worker-runner.js";
 import { appLogger } from "./logging.js";
 
-const core = vi.hoisted(() => ({
-  getAgentFullSyncCursor: vi.fn(() => null as string | null),
-  getAgentLastFullSyncAt: vi.fn(() => Date.now()),
-  isAgentCacheInitialized: vi.fn(() => true),
-  loadCachedSessions: vi.fn((): ReturnType<typeof loadCachedSessions> => null),
-  markAgentFullSyncStarted: vi.fn(),
-  markAgentFullSyncCompleted: vi.fn(),
-  markAgentFullSyncProgress: vi.fn(),
-  sessionSignature: vi.fn(),
-}));
+const core = vi.hoisted(() => {
+  const getAgentLastFullSyncAt = vi.fn(() => Date.now());
+  const isAgentCacheInitialized = vi.fn(() => true);
+  return {
+    getAgentFullSyncCursor: vi.fn(() => null as string | null),
+    getAgentLastFullSyncAt,
+    isAgentCacheInitialized,
+    readAgentCacheInitialization: vi.fn<
+      () => { status: "success"; value: boolean } | { status: "failed" }
+    >(() => ({
+      status: "success",
+      value: isAgentCacheInitialized(),
+    })),
+    readAgentLastFullSyncAt: vi.fn<
+      () => { status: "success"; value: number | null } | { status: "failed" }
+    >(() => ({
+      status: "success",
+      value: getAgentLastFullSyncAt(),
+    })),
+    loadCachedSessions: vi.fn((): ReturnType<typeof loadCachedSessions> => null),
+    markAgentFullSyncStarted: vi.fn(),
+    markAgentFullSyncCompleted: vi.fn(),
+    markAgentFullSyncProgress: vi.fn(),
+    sessionSignature: vi.fn(),
+  };
+});
 
 const searchIndex = vi.hoisted(() => ({
   enqueue: vi.fn<(...args: unknown[]) => Promise<undefined>>(async () => undefined),
@@ -41,6 +57,8 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     getAgentFullSyncCursor: core.getAgentFullSyncCursor,
     getAgentLastFullSyncAt: core.getAgentLastFullSyncAt,
     isAgentCacheInitialized: core.isAgentCacheInitialized,
+    readAgentCacheInitialization: core.readAgentCacheInitialization,
+    readAgentLastFullSyncAt: core.readAgentLastFullSyncAt,
     loadCachedSessions: core.loadCachedSessions,
     markAgentFullSyncStarted: core.markAgentFullSyncStarted,
     markAgentFullSyncCompleted: core.markAgentFullSyncCompleted,
@@ -180,6 +198,71 @@ afterEach(() => {
 });
 
 describe("AgentSyncEngine", () => {
+  it("keeps the current snapshot when cache initialization cannot be read", async () => {
+    core.readAgentCacheInitialization.mockReturnValueOnce({ status: "failed" });
+    const previous = makeSession("session", "retained");
+    const workerRunner = makeWorkerRunner();
+    const warn = vi.spyOn(appLogger, "warn");
+    const { engine } = makeEngine(makeAgent(), [previous], workerRunner);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().sessions).toEqual([previous]);
+    expect(workerRunner.run).not.toHaveBeenCalled();
+    expect(searchIndex.enqueue).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith("scan.refresh.cache_state_unavailable", {
+      agent: "codex",
+      state: "initialization",
+    });
+  });
+
+  it("does not enqueue a backfill when the full-sync timestamp cannot be read", () => {
+    core.readAgentLastFullSyncAt.mockReturnValueOnce({ status: "failed" });
+    const agent = makeAgent();
+    const warn = vi.spyOn(appLogger, "warn");
+    const { engine } = makeEngine(agent, [], makeWorkerRunner(), { from: 1 });
+    const internal = engine as unknown as { needsBackfill(candidate: BaseAgent): boolean };
+
+    expect(internal.needsBackfill(agent)).toBe(false);
+    expect(warn).toHaveBeenCalledWith("scan.backfill.cache_state_unavailable", {
+      agent: "codex",
+      state: "last_full_sync",
+    });
+  });
+
+  it("keeps the refresh baseline when database change detection fails", async () => {
+    const previous = makeSession("session", "retained");
+    const agent = makeAgent({
+      checkForChanges: () => ({
+        status: "failed",
+        hasChanges: false,
+        timestamp: 123,
+        failure: {
+          sourcePath: "/tmp/source.db",
+          errorClass: "SqliteError",
+          message: "database is locked",
+        },
+      }),
+    });
+    const workerRunner = makeWorkerRunner();
+    const warn = vi.spyOn(appLogger, "warn");
+    const { engine } = makeEngine(agent, [previous], workerRunner);
+    const refreshState = engine as unknown as { lastRefreshAtByAgent: Map<string, number> };
+    const baseline = refreshState.lastRefreshAtByAgent.get("codex");
+
+    await engine.refresh("codex");
+
+    expect(refreshState.lastRefreshAtByAgent.get("codex")).toBe(baseline);
+    expect(engine.snapshot().sessions).toEqual([previous]);
+    expect(workerRunner.run).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith("scan.refresh.change_check_failed", {
+      agent: "codex",
+      source_path: "/tmp/source.db",
+      error_class: "SqliteError",
+      message: "database is locked",
+    });
+  });
+
   it("publishes only the latest backfill attempt terminal", async () => {
     const { engine } = makeEngine(makeAgent());
     const internal = engine as unknown as {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -4,12 +4,12 @@ import {
   buildAgentCacheMeta,
   getAgentFullSyncCursor,
   computeSessionDiff,
-  getAgentLastFullSyncAt,
-  isAgentCacheInitialized,
   loadCachedSessions,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
   markAgentFullSyncCompleted,
+  readAgentCacheInitialization,
+  readAgentLastFullSyncAt,
   sessionSignature,
   type AgentScanProgress,
   type BaseAgent,
@@ -427,7 +427,15 @@ export class AgentSyncEngine {
     if (cached) restoreAgentCacheMeta(agent, cached);
     const durableMeta = new Map(agent.getSessionMetaMap());
     const durableLastRefreshAt = this.lastRefreshAtByAgent.get(agentName);
-    const isInitialized = isAgentCacheInitialized(agentName);
+    const initialization = readAgentCacheInitialization(agentName);
+    if (initialization.status === "failed") {
+      appLogger.warn("scan.refresh.cache_state_unavailable", {
+        agent: agentName,
+        state: "initialization",
+      });
+      return "unchanged";
+    }
+    const isInitialized = initialization.value;
     const availabilityStartedAt = performance.now();
     const isAvailable = agent.isAvailable();
     const availabilityDuration = performance.now() - availabilityStartedAt;
@@ -636,6 +644,20 @@ export class AgentSyncEngine {
     const checkStartedAt = performance.now();
     const checkResult = await Promise.resolve(agent.checkForChanges(cacheTimestamp, baseline));
     const checkDuration = performance.now() - checkStartedAt;
+    if (checkResult.status === "failed") {
+      appLogger.warn("scan.refresh.change_check_failed", {
+        agent: agent.name,
+        source_path: checkResult.failure.sourcePath,
+        error_class: checkResult.failure.errorClass,
+        message: checkResult.failure.message,
+      });
+      return this.refreshStrategyResult(
+        baseline,
+        "partial",
+        {},
+        { status: "unchanged", checkDuration },
+      );
+    }
     this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
     if (!checkResult.hasChanges) {
       const scanStartedAt = performance.now();
@@ -798,7 +820,15 @@ export class AgentSyncEngine {
     const startupScanOptions = this.startupScanOptions();
     if (startupScanOptions.from == null && startupScanOptions.to == null) return false;
     if (!agent.isAvailable()) return false;
-    const lastSyncAt = getAgentLastFullSyncAt(agent.name);
+    const lastSync = readAgentLastFullSyncAt(agent.name);
+    if (lastSync.status === "failed") {
+      appLogger.warn("scan.backfill.cache_state_unavailable", {
+        agent: agent.name,
+        state: "last_full_sync",
+      });
+      return false;
+    }
+    const lastSyncAt = lastSync.value;
     if (lastSyncAt == null || Date.now() - lastSyncAt > BACKFILL_INTERVAL_MS) return true;
     if (!(agent instanceof FileSystemSessionSource)) return false;
     if (this.cacheIntegrityCheckedAgents.has(agent.name)) return false;

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -37,6 +37,8 @@ const core = vi.hoisted(() => ({
   filterSessions: vi.fn((sessions: SessionHead[], _options: ScanOptions) => sessions),
   getAgentFullSyncCursor: vi.fn(() => null as string | null),
   getAgentLastFullSyncAt: vi.fn(),
+  readAgentCacheInitialization: vi.fn(),
+  readAgentLastFullSyncAt: vi.fn(),
   resolveAgentRoots: vi.fn((): AgentRoots => ({
     claudecode: "/tmp/claude",
     codex: "/tmp/codex",
@@ -391,6 +393,8 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     getAgentFullSyncCursor: core.getAgentFullSyncCursor,
     getAgentLastFullSyncAt: core.getAgentLastFullSyncAt,
     isAgentCacheInitialized: core.isAgentCacheInitialized,
+    readAgentCacheInitialization: core.readAgentCacheInitialization,
+    readAgentLastFullSyncAt: core.readAgentLastFullSyncAt,
     loadCachedSessions: core.loadCachedSessions,
     markAgentCacheInitialized: core.markAgentCacheInitialized,
     markAgentFullSyncProgress: core.markAgentFullSyncProgress,
@@ -614,6 +618,14 @@ describe("LiveScanStore", () => {
     );
     core.getAgentLastFullSyncAt.mockReturnValue(Date.now());
     core.isAgentCacheInitialized.mockReturnValue(true);
+    core.readAgentCacheInitialization.mockImplementation(() => ({
+      status: "success",
+      value: core.isAgentCacheInitialized(),
+    }));
+    core.readAgentLastFullSyncAt.mockImplementation(() => ({
+      status: "success",
+      value: core.getAgentLastFullSyncAt(),
+    }));
     core.loadCachedSessions.mockReturnValue(null);
     core.markAgentCacheInitialized.mockReset();
     core.markAgentFullSyncStarted.mockReset();

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -712,6 +712,58 @@ describe("DatabaseSessionSource", () => {
     expect(result.hasChanges).toBe(false);
   });
 
+  it("returns a failure without advancing the database change baseline", () => {
+    const dbPath = makeDb();
+    const agent = new FakeDatabaseSource(dbPath);
+    agent.setSessionMetaMap(
+      new Map([
+        [
+          "db-1",
+          {
+            id: "db-1",
+            sourcePath: dbPath,
+            pricingCaptureEpoch: PRICING_CAPTURE_EPOCH,
+            unpricedModels: ["unavailable-model"],
+          },
+        ],
+      ]),
+    );
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    setCoreDiagnostics({
+      warn: (event, detail) => events.push({ event, detail }),
+    });
+    const resolve = vi.spyOn(pricingResolver, "resolve").mockImplementationOnce(() => {
+      throw new Error("pricing registry unavailable");
+    });
+
+    const result = agent.checkForChanges(123, [makeSession("db-1")]);
+
+    resolve.mockRestore();
+    setCoreDiagnostics(null);
+    expect(result).toEqual({
+      status: "failed",
+      hasChanges: false,
+      timestamp: 123,
+      failure: {
+        sourcePath: dbPath,
+        errorClass: "Error",
+        message: "pricing registry unavailable",
+      },
+    });
+    expect(events).toEqual([
+      {
+        event: "agent.change_check_failed",
+        detail: {
+          agent: "fakedb",
+          source_path: dbPath,
+          error_class: "Error",
+          message: "pricing registry unavailable",
+          baseline_advanced: false,
+        },
+      },
+    ]);
+  });
+
   it("incrementalScan delegates to a full scan", () => {
     const agent = new FakeDatabaseSource(makeDb());
     const options = { from: 1_000, to: 2_000 };

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync, type Dirent, type Stats } from "node:fs";
+import { readdirSync, statSync, type Dirent, type Stats } from "node:fs";
 import { join } from "node:path";
 import type { SessionHead, SessionDetail, ParseSessionResult } from "../types/index.js";
 import {
@@ -81,8 +81,14 @@ export interface FileWalkOptions {
   scanWindow?: Pick<AgentScanOptions, "from" | "to">;
 }
 
-/** 变更检测结果 */
-export interface ChangeCheckResult {
+export interface ChangeCheckFailure {
+  sourcePath: string;
+  errorClass: string;
+  message: string;
+}
+
+interface SuccessfulChangeCheck {
+  status?: "checked";
   /** 是否有变更 */
   hasChanges: boolean;
   /** 可精确定位时的变更会话 ID；省略表示只能确认数据源发生过变化 */
@@ -92,7 +98,21 @@ export interface ChangeCheckResult {
   /** 检测过程中已枚举的会话源（可选），供 incrementalScan 复用以避免二次枚举 */
   refs?: SessionSourceRef[];
   sourceFailures?: SessionSourceFailure[];
+  failure?: never;
 }
+
+interface FailedChangeCheck {
+  status: "failed";
+  hasChanges: false;
+  timestamp: number;
+  failure: ChangeCheckFailure;
+  changedIds?: never;
+  refs?: never;
+  sourceFailures?: never;
+}
+
+/** 变更检测结果 */
+export type ChangeCheckResult = SuccessfulChangeCheck | FailedChangeCheck;
 
 export interface SessionSourceRef {
   sessionId: string;
@@ -608,8 +628,9 @@ export function sqliteSourceFiles(dbPath: string): string[] {
 function statOrNull(path: string): { size: number; mtimeMs: number } | null {
   try {
     return statSync(path);
-  } catch {
-    return null;
+  } catch (error) {
+    if (isMissingSessionSourceError(error)) return null;
+    throw error;
   }
 }
 
@@ -675,11 +696,14 @@ export abstract class DatabaseSessionSource extends BaseAgent {
    */
   checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
     const dbPath = this.getDatabasePath();
-    if (!dbPath || !existsSync(dbPath)) {
+    if (!dbPath) {
       return { hasChanges: false, timestamp: Date.now() };
     }
 
     try {
+      if (!statOrNull(dbPath)) {
+        return { hasChanges: false, timestamp: Date.now() };
+      }
       const pricingChanged = cachedSessions.some((session) => {
         const meta = this.sessionMetaMap.get(session.id);
         return (
@@ -702,8 +726,25 @@ export abstract class DatabaseSessionSource extends BaseAgent {
         hasChanges,
         timestamp: Date.now(),
       };
-    } catch {
-      return { hasChanges: false, timestamp: Date.now() };
+    } catch (error) {
+      const failure = {
+        sourcePath: dbPath,
+        errorClass: error instanceof Error ? error.name : typeof error,
+        message: error instanceof Error ? error.message : String(error),
+      };
+      getCoreDiagnostics()?.warn("agent.change_check_failed", {
+        agent: this.name,
+        source_path: failure.sourcePath,
+        error_class: failure.errorClass,
+        message: failure.message,
+        baseline_advanced: false,
+      });
+      return {
+        status: "failed",
+        hasChanges: false,
+        timestamp: sinceTimestamp,
+        failure,
+      };
     }
   }
 

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -23,6 +23,7 @@ export type {
   AgentScanOptions,
   AgentScanProgress,
   CachedMetaLookup,
+  ChangeCheckFailure,
   ChangeCheckResult,
   FileSessionMeta,
   FileWalkOptions,

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -10,6 +10,7 @@ import {
 } from "./base.js";
 import type {
   AgentScanOptions,
+  ChangeCheckResult,
   ParseSessionResult,
   SessionCacheMeta,
   SessionSourceRef,
@@ -489,8 +490,9 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     return refs;
   }
 
-  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]) {
+  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
     const result = super.checkForChanges(sinceTimestamp, cachedSessions);
+    if (result.status === "failed") return result;
     const emptySessionIds = cachedSessions
       .filter((session) => !this.hasMessages(session))
       .map((session) => session.id);

--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -58,7 +58,7 @@ describe("withCacheDb diagnostics", () => {
       throw Object.assign(new Error("datatype mismatch"), { code: "SQLITE_MISMATCH" });
     });
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ status: "failed" });
     expect(events).toEqual([
       {
         event: "cache.read_failed",

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -14,11 +14,14 @@ import {
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
   markAgentFullSyncCompleted,
+  readAgentCacheInitialization,
+  readAgentLastFullSyncAt,
   saveCachedSessionChanges,
   saveCachedSessions,
 } from "../sessions.js";
 import { listCachedProjectGroups } from "../project-groups.js";
 import type { SessionCacheMeta } from "../../../agents/base.js";
+import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
 import { withCacheDb, withSearchIndexDb } from "../schema.js";
 import { getSchemaEnsuredPath, setSchemaEnsuredPath } from "../db.js";
 import type { SessionHead } from "../../../types/index.js";
@@ -135,6 +138,7 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  setCoreDiagnostics(null);
 });
 describe("loadCachedSessions", () => {
   it("returns null when cache db does not exist", () => {
@@ -547,6 +551,28 @@ describe("clearCache", () => {
 });
 
 describe("cache initialization tracking", () => {
+  it("distinguishes cache-state read failures from uninitialized values", () => {
+    markAgentCacheInitialized("claudecode");
+    withCacheDb((db) => {
+      db.exec(`
+        DROP TABLE cache_initialization;
+        CREATE VIEW cache_initialization AS
+          SELECT
+            'claudecode' AS agent_name,
+            missing_cache_state() AS index_version,
+            1 AS last_sync_at;
+      `);
+    });
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    setCoreDiagnostics({
+      warn: (event, detail) => events.push({ event, detail }),
+    });
+
+    expect(readAgentCacheInitialization("claudecode")).toEqual({ status: "failed" });
+    expect(readAgentLastFullSyncAt("claudecode")).toEqual({ status: "failed" });
+    expect(events.filter(({ event }) => event === "cache.read_failed")).toHaveLength(2);
+  });
+
   it("is not initialized and has no full-sync timestamp before any write", () => {
     expect(isAgentCacheInitialized("claudecode")).toBe(false);
     expect(getAgentLastFullSyncAt("claudecode")).toBeNull();

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -264,10 +264,9 @@ function queryFileActivity(
   const queryRows = (db: SQLiteDatabase) =>
     db.prepare(sql).all(...params, options.limit ?? 50) as FileActivityRow[];
 
-  let rows = withCacheDbReadOnly(queryRows);
-  if (rows == null && options.path) {
-    rows = withCacheDb(queryRows);
-  }
+  const read = withCacheDbReadOnly(queryRows);
+  const rows =
+    read.status === "success" ? read.value : options.path ? withCacheDb(queryRows) : null;
 
   return (rows ?? []).map((row) => ({
     ...fileActivityFromRow(row),

--- a/packages/core/src/discovery/cache/model-cost.ts
+++ b/packages/core/src/discovery/cache/model-cost.ts
@@ -97,15 +97,15 @@ export function listModelCostDistribution(options: ModelCostOptions = {}): Model
     LIMIT ?
   `;
 
-  const rows = withCacheDbReadOnly(
+  const read = withCacheDbReadOnly(
     (db: SQLiteDatabase) =>
       db.prepare(sql).all(...params, options.limit ?? DEFAULT_MODEL_COST_LIMIT) as ModelCostRow[],
   );
-  if (rows == null) {
+  if (read.status === "failed") {
     return null;
   }
 
-  return rows.map((row) => ({
+  return read.value.map((row) => ({
     model: String(row.model ?? ""),
     cost: Number(row.cost ?? 0),
     costRecorded: Number(row.cost_recorded ?? 0),

--- a/packages/core/src/discovery/cache/project-groups.ts
+++ b/packages/core/src/discovery/cache/project-groups.ts
@@ -40,10 +40,8 @@ export function listCachedProjectGroups(sessions?: SessionHead[]): ProjectGroup[
       )
       .all() as ProjectGroupRow[];
 
-  let rows = withCacheDbReadOnly(queryRows);
-  if (rows == null) {
-    rows = withCacheDb(queryRows);
-  }
+  const read = withCacheDbReadOnly(queryRows);
+  const rows = read.status === "success" ? read.value : withCacheDb(queryRows);
 
   return (rows ?? []).map((row) => ({
     identityKind: row.identity_kind ?? "path",

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -94,19 +94,21 @@ export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
   }
 }
 
-export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): T | null {
+export type CacheReadOutcome<T> = { status: "success"; value: T } | { status: "failed" };
+
+export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): CacheReadOutcome<T> {
   const db = openDbReadOnly(getCachePath());
-  if (!db) return null;
+  if (!db) return { status: "failed" };
 
   try {
-    return fn(db);
+    return { status: "success", value: fn(db) };
   } catch (error) {
     getCoreDiagnostics()?.warn("cache.read_failed", {
       message: error instanceof Error ? error.message : String(error),
       code: (error as { code?: string })?.code,
       error_class: error instanceof Error ? error.name : typeof error,
     });
-    return null;
+    return { status: "failed" };
   } finally {
     db.close();
   }

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -16,7 +16,7 @@ import {
   type ScalarRow,
   type SessionHeadChange,
 } from "./db.js";
-import { withCacheDb, withCacheDbReadOnly } from "./schema.js";
+import { withCacheDb, withCacheDbReadOnly, type CacheReadOutcome } from "./schema.js";
 import {
   messageFromCachedRow,
   prepareUpsertSession,
@@ -164,21 +164,16 @@ export function loadCachedSessionHeads(
     if (!unique.has(key)) unique.set(key, normalized);
   }
 
-  return (
-    withCacheDbReadOnly((db) => {
-      const resolved: ReferencedSessionHead[] = [];
-      const normalized = [...unique.values()];
-      for (
-        let offset = 0;
-        offset < normalized.length;
-        offset += SESSION_REFERENCE_QUERY_CHUNK_SIZE
-      ) {
-        const chunk = normalized.slice(offset, offset + SESSION_REFERENCE_QUERY_CHUNK_SIZE);
-        const values = chunk.map(() => "(?, ?)").join(", ");
-        const params = chunk.flatMap((reference) => [reference.agentName, reference.sessionId]);
-        const rows = db
-          .prepare(
-            `
+  const outcome = withCacheDbReadOnly((db) => {
+    const resolved: ReferencedSessionHead[] = [];
+    const normalized = [...unique.values()];
+    for (let offset = 0; offset < normalized.length; offset += SESSION_REFERENCE_QUERY_CHUNK_SIZE) {
+      const chunk = normalized.slice(offset, offset + SESSION_REFERENCE_QUERY_CHUNK_SIZE);
+      const values = chunk.map(() => "(?, ?)").join(", ");
+      const params = chunk.flatMap((reference) => [reference.agentName, reference.sessionId]);
+      const rows = db
+        .prepare(
+          `
               WITH requested(agent_name, session_id) AS (
                 VALUES ${values}
               )
@@ -189,47 +184,53 @@ export function loadCachedSessionHeads(
                 AND s.session_id = r.session_id
                 AND s.publication_id IS NULL
             `,
-          )
-          .all(...params) as SessionRow[];
+        )
+        .all(...params) as SessionRow[];
 
-        for (const row of rows) {
-          resolved.push({
-            reference: normalizeSessionReference({
-              agentName: String(row.agent_name ?? ""),
-              sessionId: String(row.session_id ?? ""),
-            }),
-            session: sessionFromRow(row),
-          });
-        }
+      for (const row of rows) {
+        resolved.push({
+          reference: normalizeSessionReference({
+            agentName: String(row.agent_name ?? ""),
+            sessionId: String(row.session_id ?? ""),
+          }),
+          session: sessionFromRow(row),
+        });
       }
-      return resolved;
-    }) ?? []
-  );
+    }
+    return resolved;
+  });
+  return outcome.status === "success" ? outcome.value : [];
+}
+
+export function readAgentCacheInitialization(
+  agentName: string,
+  indexVersion = CACHE_INITIALIZATION_VERSION,
+): CacheReadOutcome<boolean> {
+  if (!hasCacheStorage()) {
+    return { status: "success", value: false };
+  }
+
+  return withCacheDbReadOnly((db) => {
+    if (!tableExists(db, "cache_initialization")) return false;
+    const row = db
+      .prepare(
+        `
+          SELECT index_version
+          FROM cache_initialization
+          WHERE agent_name = ?
+        `,
+      )
+      .get(agentName) as { index_version?: string } | undefined;
+    return row?.index_version === indexVersion;
+  });
 }
 
 export function isAgentCacheInitialized(
   agentName: string,
   indexVersion = CACHE_INITIALIZATION_VERSION,
 ): boolean {
-  if (!hasCacheStorage()) {
-    return false;
-  }
-
-  return (
-    withCacheDbReadOnly((db) => {
-      if (!tableExists(db, "cache_initialization")) return false;
-      const row = db
-        .prepare(
-          `
-            SELECT index_version
-            FROM cache_initialization
-            WHERE agent_name = ?
-          `,
-        )
-        .get(agentName) as { index_version?: string } | undefined;
-      return row?.index_version === indexVersion;
-    }) ?? false
-  );
+  const outcome = readAgentCacheInitialization(agentName, indexVersion);
+  return outcome.status === "success" && outcome.value;
 }
 
 /**
@@ -272,14 +273,13 @@ export function markAgentFullSyncStarted(agentName: string): void {
 export function getAgentFullSyncCursor(agentName: string): string | null {
   if (!hasCacheStorage()) return null;
 
-  return (
-    withCacheDbReadOnly((db) => {
-      const row = db
-        .prepare("SELECT value FROM cache_meta WHERE key = ?")
-        .get(`${FULL_SYNC_CURSOR_PREFIX}${agentName}`) as { value?: string } | undefined;
-      return row?.value || null;
-    }) ?? null
-  );
+  const outcome = withCacheDbReadOnly((db) => {
+    const row = db
+      .prepare("SELECT value FROM cache_meta WHERE key = ?")
+      .get(`${FULL_SYNC_CURSOR_PREFIX}${agentName}`) as { value?: string } | undefined;
+    return row?.value || null;
+  });
+  return outcome.status === "success" ? outcome.value : null;
 }
 
 /** Persist a full-sync cursor only after the corresponding checkpoint is durable. */
@@ -306,27 +306,30 @@ function clearAgentFullSyncCursor(agentName: string): void {
   });
 }
 
-/** Timestamp of the agent's last full (unbounded) history reconciliation, or null if none yet. */
-export function getAgentLastFullSyncAt(agentName: string): number | null {
+export function readAgentLastFullSyncAt(agentName: string): CacheReadOutcome<number | null> {
   if (!hasCacheStorage()) {
-    return null;
+    return { status: "success", value: null };
   }
 
-  return (
-    withCacheDbReadOnly((db) => {
-      if (!tableExists(db, "cache_initialization")) return null;
-      const row = db
-        .prepare(
-          `
-            SELECT last_sync_at
-            FROM cache_initialization
-            WHERE agent_name = ?
-          `,
-        )
-        .get(agentName) as { last_sync_at?: number } | undefined;
-      return row?.last_sync_at || null;
-    }) ?? null
-  );
+  return withCacheDbReadOnly((db) => {
+    if (!tableExists(db, "cache_initialization")) return null;
+    const row = db
+      .prepare(
+        `
+          SELECT last_sync_at
+          FROM cache_initialization
+          WHERE agent_name = ?
+        `,
+      )
+      .get(agentName) as { last_sync_at?: number } | undefined;
+    return row?.last_sync_at || null;
+  });
+}
+
+/** Timestamp of the agent's last full (unbounded) history reconciliation, or null if none yet. */
+export function getAgentLastFullSyncAt(agentName: string): number | null {
+  const outcome = readAgentLastFullSyncAt(agentName);
+  return outcome.status === "success" ? outcome.value : null;
 }
 
 /** Record that a full (unbounded) history reconciliation just completed for this agent. */
@@ -351,7 +354,7 @@ export function loadCachedSessionRawEntry(
     return null;
   }
 
-  return withCacheDbReadOnly((db) => {
+  const outcome = withCacheDbReadOnly((db) => {
     const row = db
       .prepare(
         `
@@ -429,6 +432,7 @@ export function loadCachedSessionRawEntry(
       pendingReindex,
     };
   });
+  return outcome.status === "success" ? outcome.value : null;
 }
 
 export function loadCachedSessionDataEntry(

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -22,6 +22,8 @@ export {
   getAgentLastFullSyncAt,
   getCacheInfo,
   isAgentCacheInitialized,
+  readAgentCacheInitialization,
+  readAgentLastFullSyncAt,
   loadCachedSessionData,
   loadCachedSessionDataEntry,
   loadCachedSessionHeads,
@@ -38,6 +40,7 @@ export type {
   SaveCachedSessionsOptions,
   SessionSnapshotCompleteness,
 } from "./cache/sessions.js";
+export type { CacheReadOutcome } from "./cache/schema.js";
 export { getCachePath } from "./cache/db.js";
 export type { SessionHeadChange } from "./cache/db.js";
 export { listCachedProjectGroups } from "./cache/project-groups.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,8 @@ export {
   getAgentLastFullSyncAt,
   getCachePath,
   isAgentCacheInitialized,
+  readAgentCacheInitialization,
+  readAgentLastFullSyncAt,
   listCachedProjectGroups,
   listFileActivity,
   listModelCostDistribution,
@@ -71,6 +73,7 @@ export {
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,
 } from "./discovery/index.js";
+export type { CacheReadOutcome } from "./discovery/index.js";
 export { PRICING_CAPTURE_EPOCH } from "./pricing/index.js";
 export {
   filterSessionTreeByActivityWindow,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export type {
   AgentRoots,
   AgentScanOptions,
   AgentScanProgress,
+  ChangeCheckFailure,
   ChangeCheckResult,
   SessionCacheMeta,
   SessionSourceFailure,

--- a/packages/core/src/utils/__tests__/sqlite.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite.test.ts
@@ -230,6 +230,22 @@ describe("openDb pragmas", () => {
       db?.close();
     }
   });
+
+  it("sets the same busy_timeout on read-only connections", () => {
+    const dir = mkdtempSync(join(tmpdir(), "codesesh-sqlite-read-busy-timeout-test-"));
+    tempDirs.push(dir);
+    const dbPath = join(dir, "state.db");
+    openDb(dbPath)?.close();
+
+    const db = openDbReadOnly(dbPath);
+    expect(db).not.toBeNull();
+    try {
+      const pragmaCapable = db as unknown as { pragma(sql: string): unknown };
+      expect(pragmaCapable.pragma("busy_timeout")).toEqual([{ timeout: 5000 }]);
+    } finally {
+      db?.close();
+    }
+  });
 });
 
 describe("sqlite open failures", () => {

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -43,6 +43,8 @@ type SQLiteDatabaseConstructor = (
   options?: { readonly?: boolean },
 ) => SQLiteDatabase & SQLitePragmaCapable;
 
+const SQLITE_BUSY_TIMEOUT_MS = 5000;
+
 let DatabaseConstructor: SQLiteDatabaseConstructor | null = null;
 let loadErrorMessage: string | null = null;
 
@@ -270,6 +272,11 @@ export function openDbReadOnly(dbPath: string): SQLiteDatabase | null {
   }
   try {
     const db = DatabaseConstructor(dbPath, { readonly: true });
+    try {
+      db.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+    } catch {
+      // The handle remains usable when SQLite rejects connection-level tuning.
+    }
     return db;
   } catch (error) {
     getCoreDiagnostics()?.warn("sqlite.open_failed", {
@@ -294,7 +301,7 @@ export function openDb(dbPath: string): SQLiteDatabase | null {
     try {
       // busy_timeout first: if a later pragma throws, writes must still wait for
       // concurrent writers instead of failing instantly with SQLITE_BUSY.
-      db.pragma("busy_timeout = 5000");
+      db.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
       db.pragma("journal_mode = WAL");
       db.pragma("synchronous = NORMAL");
       db.pragma("foreign_keys = ON");


### PR DESCRIPTION
## Summary

- apply the SQLite busy timeout to read-only connections and return explicit cache-read outcomes
- keep initialization and backfill decisions unchanged when cache state cannot be observed
- return an explicit database change-check failure without advancing the refresh baseline

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`
- `node scripts/check-docs-facts.mjs`

Closes CS-209