### PR TITLE
fix: harden Codex and Claude session parsing

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -969,6 +969,16 @@ describe("ClaudeCodeAgent head parsing", () => {
     expect(head?.time_created).toBe(statSync(sessionFile).mtimeMs);
   });
 
+  it("preserves explicit timezone offsets", () => {
+    const [head] = writeSession([
+      userLine("First", "2026-04-20T10:00:00+08:00"),
+      userLine("Second", "2026-04-20T10:02:30+08:00"),
+    ]).agent.scan();
+
+    expect(head?.time_created).toBe(Date.parse("2026-04-20T10:00:00+08:00"));
+    expect(head?.time_updated).toBe(Date.parse("2026-04-20T10:02:30+08:00"));
+  });
+
   it("only considers the first 20 records for the fallback title", () => {
     // Malformed records still advance the window, matching the pre-streaming
     // behaviour where the index came from the raw non-blank line list.

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -530,6 +530,32 @@ describe("CodexAgent cache refresh", () => {
     expect(head?.model_usage).toEqual({ "gpt-5.5": 125 });
   });
 
+  it("uses the session metadata model while parsing details", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const sessionFile = join(tempDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+
+    writeFileSync(
+      sessionFile,
+      [
+        '{"timestamp":"2026-04-20T10:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/project","model":"gpt-5.5"}}',
+        '{"timestamp":"2026-04-20T10:01:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}}',
+        '{"timestamp":"2026-04-20T10:02:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":20},"total_token_usage":{"total_tokens":120}}}}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    const [head] = agent.scan();
+    const detail = agent.getSessionData(sessionId);
+
+    expect(detail.messages[0]?.model).toBe("gpt-5.5");
+    expect(detail.stats.total_cost).toBe(head?.stats.total_cost);
+    expect(detail.stats.total_cost).toBeGreaterThan(0);
+  });
+
   it("prices Codex cached input with cache read rates", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     const sessionFile = join(

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -502,6 +502,30 @@ describe("CodexAgent cache refresh", () => {
     expect(head?.time_updated).toBe(new Date("2026-04-20T10:02:30Z").getTime());
   });
 
+  it("preserves explicit timezone offsets", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionFile = join(
+      tempDir,
+      "rollout-2026-04-20T10-00-00-019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa.jsonl",
+    );
+    writeFileSync(
+      sessionFile,
+      [
+        '{"timestamp":"2026-04-20T10:00:00+08:00","type":"session_meta","payload":{"cwd":"/tmp/project"}}',
+        '{"timestamp":"2026-04-20T10:02:30+08:00","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.sessionIndexCache = new Map();
+    const head = agent.parseSessionHead(sessionFile);
+
+    expect(head?.time_created).toBe(Date.parse("2026-04-20T10:00:00+08:00"));
+    expect(head?.time_updated).toBe(Date.parse("2026-04-20T10:02:30+08:00"));
+  });
+
   it("aggregates model usage from token count events", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     const sessionFile = join(

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1671,4 +1671,38 @@ describe("CodexAgent subagent folding", () => {
       parent_reference: { agentName: "codex", sessionId: PARENT_ID },
     });
   });
+
+  it("parses oversized subagent metadata in fast scans", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
+    tempDirs.push(tempDir);
+
+    writeSession(tempDir, PARENT_ID, { threadSource: "user" });
+    const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
+    writeFileSync(
+      childFile,
+      [
+        JSON.stringify({
+          timestamp: "2026-04-20T10:00:00Z",
+          type: "session_meta",
+          payload: {
+            cwd: "/tmp/project",
+            thread_source: "subagent",
+            parent_thread_id: PARENT_ID,
+            instructions: "x".repeat(70 * 1024),
+          },
+        }),
+        '{"timestamp":"2026-04-20T10:01:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"child done"}]}}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+
+    const heads = agent.scan({ from: 0, fast: true });
+    expect(heads.find((head: SessionHead) => head.id === CHILD_ID)).toMatchObject({
+      parent_reference: { agentName: "codex", sessionId: PARENT_ID },
+    });
+  });
 });

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -22,6 +22,7 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { parseAgentTimestampMs } from "../utils/timestamp.js";
 import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
 import {
   matchesScanWindow,
@@ -77,13 +78,7 @@ function parseTimestampMs(data: Record<string, unknown>): number {
     if (raw !== undefined && raw !== null) reportFieldMismatch("claudecode", "timestamp");
     return 0;
   }
-  const trimmed = value.trim();
-  if (!trimmed) return 0;
-  try {
-    return new Date(trimmed.includes("Z") ? trimmed : trimmed + "Z").getTime();
-  } catch {
-    return 0;
-  }
+  return parseAgentTimestampMs(value, "claudecode");
 }
 
 /** Reads a numeric usage field; a present-but-wrong-typed field is a schema drift signal. */

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -15,6 +15,7 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
+import { parseAgentTimestampMs } from "../utils/timestamp.js";
 import { asRecord, asString, narrowField } from "../utils/narrow.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
 import {
@@ -85,13 +86,7 @@ function extractSessionId(filename: string): string {
 // ---------------------------------------------------------------------------
 
 function parseTimestampMs(data: Record<string, unknown>): number {
-  const ts = String(data["timestamp"] ?? "").trim();
-  if (!ts) return 0;
-  try {
-    return new Date(ts.includes("Z") ? ts : ts.replace(" ", "T") + "Z").getTime();
-  } catch {
-    return 0;
-  }
+  return parseAgentTimestampMs(String(data["timestamp"] ?? ""), "codex");
 }
 
 function extractModelName(raw: unknown): string | null {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1,4 +1,4 @@
-import { closeSync, existsSync, openSync, readFileSync, readSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import {
   SingleFileSessionSource,
@@ -14,6 +14,7 @@ import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../utils/jso
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import { asRecord, asString, narrowField } from "../utils/narrow.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
 import {
@@ -123,6 +124,16 @@ function extractThreadMeta(firstRecord: Record<string, unknown>): ThreadMeta | n
   const parentThreadId = asString(payload["parent_thread_id"]) ?? null;
   const agentNickname = asString(payload["agent_nickname"]) ?? null;
   return { threadSource, parentThreadId, agentNickname };
+}
+
+function readLeadingJsonlLines(filePath: string, limit: number): string[] {
+  const lines: string[] = [];
+  for (const line of readJsonlFileLines(filePath)) {
+    if (!line.trim()) continue;
+    lines.push(line);
+    if (lines.length === limit) break;
+  }
+  return lines;
 }
 
 function extractTokenUsage(payload: Record<string, unknown>): {
@@ -453,12 +464,14 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
 
   private readThreadMeta(filePath: string): ThreadMeta | null {
     try {
-      const firstLine = this.readFilePrefix(filePath)
-        .split("\n")
-        .filter((l) => l.trim())[0];
+      const firstLine = readLeadingJsonlLines(filePath, 1)[0];
       if (!firstLine) return null;
       return extractThreadMeta(JSON.parse(firstLine));
-    } catch {
+    } catch (error) {
+      getCoreDiagnostics()?.warn("codex.thread_meta_read_failed", {
+        filePath,
+        message: error instanceof Error ? error.message : String(error),
+      });
       return null;
     }
   }
@@ -927,17 +940,6 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
 
   // ---- Session head parsing ----
 
-  private readFilePrefix(filePath: string, bytes = 64 * 1024): string {
-    const fd = openSync(filePath, "r");
-    try {
-      const buffer = Buffer.alloc(bytes);
-      const bytesRead = readSync(fd, buffer, 0, bytes, 0);
-      return buffer.subarray(0, bytesRead).toString("utf-8");
-    } finally {
-      closeSync(fd);
-    }
-  }
-
   protected parseFileSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {
     return this.parseSessionHead(filePath, options);
   }
@@ -1126,8 +1128,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   }
 
   private parseFastSessionHeadResult(filePath: string): ParseSessionResult<SessionHead> {
-    const prefix = this.readFilePrefix(filePath);
-    const lines = prefix.split("\n").filter((l) => l.trim());
+    const lines = readLeadingJsonlLines(filePath, 20);
     if (lines.length === 0) return skippedSession("empty file");
 
     const sessionId = extractSessionId(filePath);
@@ -1135,7 +1136,12 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     let firstRecord: Record<string, unknown>;
     try {
       firstRecord = JSON.parse(lines[0]!);
-    } catch {
+    } catch (error) {
+      getCoreDiagnostics()?.warn("codex.fast_head_first_record_failed", {
+        filePath,
+        firstLineLength: lines[0]?.length ?? 0,
+        message: error instanceof Error ? error.message : String(error),
+      });
       return skippedSession("malformed first record");
     }
 

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -354,7 +354,6 @@ interface SessionMeta extends FileSessionMeta {
   indexMtimeMs: number | null;
   headIndexVersion: string;
   parserVersion: string;
-  model: string | null;
   parentThreadId: string | null;
 }
 
@@ -558,7 +557,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     let totalCost = 0;
 
     let pendingPlan: MessagePart | null = null;
-    let activeModel: string | null = meta.model;
+    let activeModel: string | null = null;
 
     // Token-count dedup state (matches codeburn strategy)
     let prevCumulativeTotal = 0;
@@ -570,7 +569,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     for (const record of readJsonlFile(meta.sourcePath)) {
       try {
         const recordType = String(record["type"] ?? "");
-        if (recordType === "turn_context") {
+        if (recordType === "session_meta" || recordType === "turn_context") {
           const payload = extractPayload(record);
           activeModel = extractModelName(payload["model"]) ?? activeModel;
         }
@@ -866,7 +865,6 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
         indexMtimeMs: indexMtime,
         headIndexVersion: HEAD_INDEX_VERSION,
         parserVersion: PARSER_VERSION,
-        model: null,
         parentThreadId: head.parent_reference?.sessionId ?? null,
       },
     });
@@ -969,7 +967,6 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     // candidate, count messages, extract models, and pre-accumulate tokens.
     let updatedAt = 0;
     let messageCount = 0;
-    let model: string | null = null;
     let activeModel: string | null = null;
     const modelUsageMap: Record<string, number> = {};
     let totalInputTokens = 0;
@@ -1027,7 +1024,6 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
           const nextModel = extractModelName(payload["model"]);
           if (nextModel) {
             activeModel = nextModel;
-            model ??= nextModel;
           }
           continue;
         }
@@ -1043,7 +1039,6 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
           const m = info?.["model"] ?? p["model"];
           if (typeof m === "string" && m.trim()) {
             activeModel = m.trim();
-            model ??= activeModel;
           }
         }
 

--- a/packages/core/src/utils/timestamp.ts
+++ b/packages/core/src/utils/timestamp.ts
@@ -1,0 +1,19 @@
+import { getCoreDiagnostics } from "./diagnostics.js";
+
+const TIMEZONE_SUFFIX_PATTERN = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+export function parseAgentTimestampMs(value: string, agentName: string): number {
+  const timestamp = value.trim().replace(" ", "T");
+  if (!timestamp) return 0;
+
+  const normalized = TIMEZONE_SUFFIX_PATTERN.test(timestamp) ? timestamp : `${timestamp}Z`;
+  const timestampMs = Date.parse(normalized);
+  if (Number.isFinite(timestampMs)) return timestampMs;
+
+  getCoreDiagnostics()?.warn("agent.timestamp_parse_failed", {
+    agentName,
+    value,
+    normalized,
+  });
+  return 0;
+}


### PR DESCRIPTION
## Summary

- honor Codex session metadata models in detail messages and cost calculation
- stream complete leading JSONL records so oversized metadata keeps subagent hierarchy in fast scans
- preserve explicit numeric timezone offsets in Codex and Claude timestamps, with diagnostics for invalid values

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`

Issue: CS-210