### PR TITLE
fix: stabilize Cursor session parsing

### DIFF
--- a/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
@@ -57,19 +57,52 @@ function textOf(agent: CursorAgent, sessionId: string): string[] {
 }
 
 describe("CS-142: Cursor scan shape", () => {
-  it("takes the request id from the key-ordered bubbles", () => {
+  it("uses the composer id consistently in fast and full scans", () => {
     const dbPath = createDb([
       composer("c1"),
-      // Inserted out of key order on purpose: "b" sorts before "c".
       ...bubbles("c1", [
-        { suffix: "c", bubble: { type: 1, text: "second", requestId: "req-from-c" } },
-        { suffix: "b", bubble: { type: 1, text: "first", requestId: "req-from-b" } },
+        { suffix: "a", bubble: { type: 1, text: "question", requestId: "legacy-request" } },
       ]),
     ]);
+    const fastHeads = makeAgent(dbPath).scan({ from: 0, fast: true });
+    const fullHeads = makeAgent(dbPath).scan({ from: 0 });
 
-    const heads = makeAgent(dbPath).scan({ from: 0 });
+    expect(fastHeads.map((head) => head.id)).toEqual(["c1"]);
+    expect(fullHeads.map((head) => head.id)).toEqual(["c1"]);
+  });
 
-    expect(heads.map((head) => head.id)).toEqual(["req-from-b"]);
+  it("resolves legacy request ids to the canonical composer id", () => {
+    const dbPath = createDb([
+      composer("c1"),
+      ...bubbles("c1", [
+        { suffix: "a", bubble: { type: 1, text: "question", requestId: "legacy-request" } },
+      ]),
+    ]);
+    const agent = makeAgent(dbPath);
+
+    const detail = agent.getSessionData("legacy-request");
+
+    expect(detail.id).toBe("c1");
+    expect(detail.reference).toEqual({ agentName: "cursor", sessionId: "c1" });
+    expect(detail.slug).toBe("cursor/c1");
+  });
+
+  it("migrates cached request-id metadata during a full scan", () => {
+    const dbPath = createDb([
+      composer("c1"),
+      ...bubbles("c1", [
+        { suffix: "a", bubble: { type: 1, text: "question", requestId: "legacy-request" } },
+      ]),
+    ]);
+    const agent = makeAgent(dbPath);
+    agent.setSessionMetaMap(
+      new Map([["legacy-request", { id: "legacy-request", sourcePath: dbPath }]]),
+    );
+
+    agent.scan({ from: 0 });
+
+    expect(agent.getSessionMetaMap().has("legacy-request")).toBe(false);
+    expect(agent.getSessionMetaMap().get("c1")?.id).toBe("c1");
   });
 
   it("keeps message order by insertion, not by key", () => {

--- a/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
@@ -121,6 +121,20 @@ describe("CS-142: Cursor scan shape", () => {
     expect(heads.map((head) => head.id)).toEqual(["new"]);
   });
 
+  it("uses the same update-time fallback in heads and details", () => {
+    const dbPath = createDb([
+      composer("c1", { lastUpdatedAt: undefined, lastSendTime: 2_500 }),
+      ...bubbles("c1", [{ suffix: "a", bubble: { type: 1, text: "question" } }]),
+    ]);
+    const agent = makeAgent(dbPath);
+
+    const [head] = agent.scan({ from: 0 });
+    const detail = agent.getSessionData(head!.id);
+
+    expect(head?.time_updated).toBe(2_500);
+    expect(detail.time_updated).toBe(head?.time_updated);
+  });
+
   it("counts messages and totals from the bubbles it parsed", () => {
     const dbPath = createDb([
       composer("c1", { model: "gpt-4" }),

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -90,6 +90,39 @@ describe("CursorAgent parsing", () => {
     });
   });
 
+  it("keeps completed tools successful when output contains message or stderr", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createCursorDb(tempDir);
+
+    insertKv(dbPath, "bubbleId:composer-1:assistant", {
+      type: 2,
+      createdAt: 1_000,
+      toolFormerData: {
+        name: "run_terminal_command_v2",
+        status: "completed",
+        result: JSON.stringify({ message: "Command finished", stderr: "npm progress" }),
+      },
+    });
+
+    const agent = new CursorAgent() as any;
+    agent.dbPath = dbPath;
+    agent.composerCache.set("composer-1", { id: "composer-1", createdAt: 1_000 });
+
+    const tool = agent
+      .getSessionData("composer-1")
+      .messages[0]?.parts.find((part: MessagePart) => part.type === "tool");
+
+    expect(tool).toMatchObject({
+      type: "tool",
+      state: {
+        status: "completed",
+        output: { message: "Command finished", stderr: "npm progress" },
+      },
+    });
+    expect(tool?.type === "tool" ? tool.state.error : undefined).toBeUndefined();
+  });
+
   it("falls back to untitled when no title text is available", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -391,6 +391,12 @@ function isInternalBubble(bubble: BubbleData): boolean {
   return ["eventType", "kind", "subtype", "name"].some((key) => isInternalEventType(bubble[key]));
 }
 
+function composerUpdatedAt(composer: ComposerData): number {
+  return (
+    composer.updatedAt ?? composer.lastUpdatedAt ?? composer.lastSendTime ?? composer.createdAt ?? 0
+  );
+}
+
 /** Build a normalized tool state object from an action entry */
 function buildToolState(action: ActionEntry): ToolPartState {
   let output = action.output;
@@ -625,8 +631,7 @@ export class CursorAgent extends DatabaseSessionSource {
 
           const composerId = composer.id || composer.composerId || "";
           const createdAt = composer.createdAt ?? 0;
-          const updatedAt =
-            composer.updatedAt ?? composer.lastUpdatedAt ?? composer.lastSendTime ?? createdAt;
+          const updatedAt = composerUpdatedAt(composer);
           if (!matchesScanWindow(updatedAt, options)) continue;
 
           const fastTitle = this.extractTitle(composer);
@@ -759,7 +764,7 @@ export class CursorAgent extends DatabaseSessionSource {
 
       const composerId = composer.id || composer.composerId || "";
       const createdAt = composer.createdAt ?? 0;
-      const updatedAt = composer.updatedAt ?? createdAt;
+      const updatedAt = composerUpdatedAt(composer);
 
       // Load messages from bubbles (like agent-dump does)
       const messages = this.loadMessagesFromBubbles(

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -397,6 +397,12 @@ function composerUpdatedAt(composer: ComposerData): number {
   );
 }
 
+function cursorToolStatus(status: string | undefined): ToolPartState["status"] {
+  if (status === "completed") return "completed";
+  if (status === "error" || status === "failed") return "error";
+  return "running";
+}
+
 /** Build a normalized tool state object from an action entry */
 function buildToolState(action: ActionEntry): ToolPartState {
   let output = action.output;
@@ -1118,7 +1124,7 @@ export class CursorAgent extends DatabaseSessionSource {
 
     // Build state
     const state: ToolPartState = {
-      status: toolData.status === "completed" ? "completed" : "running",
+      status: cursorToolStatus(toolData.status),
     };
 
     // Parse input params
@@ -1136,19 +1142,17 @@ export class CursorAgent extends DatabaseSessionSource {
 
     // Parse result/output
     if (toolData.result !== undefined) {
+      let result = toolData.result;
       if (typeof toolData.result === "string") {
         try {
-          const parsed = JSON.parse(toolData.result);
-          state.output = parsed;
-          if (parsed.error || parsed.message || parsed.stderr) {
-            state.error = parsed.error || parsed.message || parsed.stderr;
-            state.status = "error";
-          }
-        } catch {
-          state.output = toolData.result;
-        }
-      } else {
-        state.output = toolData.result;
+          result = JSON.parse(toolData.result);
+        } catch {}
+      }
+      state.output = result;
+      if (state.status === "error") {
+        const resultRecord = asRecord(result);
+        state.error =
+          resultRecord?.error ?? resultRecord?.message ?? resultRecord?.stderr ?? result;
       }
     }
 

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -34,6 +34,7 @@ import {
 } from "../utils/session-normalization.js";
 import { perf } from "../utils/perf.js";
 import { estimateTokenCost } from "../utils/cost.js";
+import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import {
   asArray,
   asNumber,
@@ -748,7 +749,6 @@ export class CursorAgent extends DatabaseSessionSource {
     try {
       // Try cached composer data first
       let composer = this.composerCache.get(sessionId);
-      let resolvedSessionId = sessionId;
 
       if (!composer) {
         // Try loading directly by sessionId (might be composerId)
@@ -760,7 +760,6 @@ export class CursorAgent extends DatabaseSessionSource {
         const composerId = this.findComposerIdByRequestId(db, sessionId);
         if (composerId) {
           composer = this.loadComposer(db, composerId) ?? undefined;
-          resolvedSessionId = sessionId; // Keep the requestId as sessionId
         }
       }
 
@@ -776,7 +775,6 @@ export class CursorAgent extends DatabaseSessionSource {
       const messages = this.loadMessagesFromBubbles(
         db,
         composerId,
-        resolvedSessionId,
         composer.modelConfig?.modelName ?? composer.model ?? null,
       );
 
@@ -815,10 +813,10 @@ export class CursorAgent extends DatabaseSessionSource {
         "";
 
       return {
-        reference: { agentName: this.name, sessionId: resolvedSessionId },
-        id: resolvedSessionId,
+        reference: { agentName: this.name, sessionId: composerId },
+        id: composerId,
         title,
-        slug: `cursor/${resolvedSessionId}`,
+        slug: `cursor/${composerId}`,
         directory,
         time_created: createdAt,
         time_updated: updatedAt || undefined,
@@ -885,8 +883,7 @@ export class CursorAgent extends DatabaseSessionSource {
     workspacePathMap: Map<string, string>,
   ): SessionHead | null {
     const { composer, composerId, createdAt, updatedAt, hasSubagents } = entry;
-    const requestId = this.requestIdFromBubbles(bubbles);
-    const sessionId = requestId || composerId;
+    const legacySessionId = this.legacySessionIdFromBubbles(bubbles);
 
     const parsedMessages = cleanParsedMessages(
       this.messagesFromBubbles(bubbles, composer.modelConfig?.modelName ?? composer.model ?? null),
@@ -897,6 +894,7 @@ export class CursorAgent extends DatabaseSessionSource {
         : parsedSession(parsedMessages),
     );
     if (!messages) return null;
+    if (legacySessionId) this.migrateLegacySessionMeta(legacySessionId, composerId);
 
     const title = this.extractTitle(composer, messages);
     const directory = workspacePathMap.get(composerId) ?? "";
@@ -914,9 +912,9 @@ export class CursorAgent extends DatabaseSessionSource {
     }
     const hasModelUsage = Object.keys(modelUsageMap).length > 0;
 
-    this.composerCache.set(sessionId, composer);
+    this.composerCache.set(composerId, composer);
     this.composerCache.set(`__mapping__${composerId}`, {
-      sessionId,
+      sessionId: composerId,
     } as unknown as ComposerData);
     if (directory) {
       this.composerCache.set(`__dir__${composerId}`, {
@@ -924,8 +922,8 @@ export class CursorAgent extends DatabaseSessionSource {
       } as unknown as ComposerData);
     }
     return {
-      id: sessionId,
-      slug: `cursor/${sessionId}`,
+      id: composerId,
+      slug: `cursor/${composerId}`,
       title,
       directory,
       time_created: createdAt,
@@ -941,13 +939,27 @@ export class CursorAgent extends DatabaseSessionSource {
     };
   }
 
-  /** First request id in key order, matching what agent-dump reports. */
-  private requestIdFromBubbles(bubbles: ComposerBubbles): string | null {
+  private legacySessionIdFromBubbles(bubbles: ComposerBubbles): string | null {
     for (const entry of bubbles.byKey) {
       const requestId = entry.bubble.requestId?.trim();
       if (requestId) return requestId;
     }
     return null;
+  }
+
+  private migrateLegacySessionMeta(legacySessionId: string, sessionId: string): void {
+    if (legacySessionId === sessionId) return;
+    const legacyMeta = this.sessionMetaMap.get(legacySessionId);
+    if (!legacyMeta) return;
+
+    this.sessionMetaMap.delete(legacySessionId);
+    if (!this.sessionMetaMap.has(sessionId)) {
+      this.sessionMetaMap.set(sessionId, { ...legacyMeta, id: sessionId });
+    }
+    getCoreDiagnostics()?.info?.("cursor.session_id_migrated", {
+      legacy_session_id: legacySessionId,
+      session_id: sessionId,
+    });
   }
 
   /** Find composerId by requestId (reverse lookup) */
@@ -1013,7 +1025,6 @@ export class CursorAgent extends DatabaseSessionSource {
   private loadMessagesFromBubbles(
     db: SQLiteDatabase,
     composerId: string,
-    _sessionId: string,
     initialModelName: string | null,
   ): Message[] {
     try {


### PR DESCRIPTION
## Summary

- share one composer update-time fallback between Cursor heads and details
- preserve Cursor-reported tool status instead of treating informational output as errors
- use composer IDs consistently across fast and full scans while resolving legacy request IDs and migrating cached metadata

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`

Issue: CS-211