### PR TITLE
fix: preserve accurate cost sources

### DIFF
--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -288,6 +288,32 @@ describe("OpenCodeSqliteAgent", () => {
     });
   });
 
+  it("leaves zero-cost heads and details without a cost source", () => {
+    const dbPath = createDatabaseWithMessageData(
+      JSON.stringify({
+        role: "assistant",
+        modelID: "claude-sonnet-4-6",
+        tokens: { input: 0, output: 0 },
+      }),
+    );
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+      getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
+    });
+
+    expect(agent.isAvailable()).toBe(true);
+    const [head] = agent.scan({ from: 0 });
+    const detail = agent.getSessionData("s1");
+
+    expect(head?.stats.total_cost).toBe(0);
+    expect(head?.stats.cost_source).toBeUndefined();
+    expect(detail.stats.total_cost).toBe(0);
+    expect(detail.stats.cost_source).toBeUndefined();
+    expect(detail.messages[0]?.cost_source).toBeUndefined();
+  });
+
   it("invalidates cached heads from an older parser revision", () => {
     const dbPath = createDatabase();
     const agent = new OpenCodeSqliteAgent({

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -272,7 +272,7 @@ describe("PiAgent", () => {
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
           "pi-head-v1",
-          "pi-parser-v1",
+          "pi-parser-v2",
           sessionTime.getTime(),
           statSync(sessionFile).size,
         ]),
@@ -382,6 +382,8 @@ describe("PiAgent", () => {
       model_usage: { "claude-sonnet-4-5": 135 },
     });
     expect(data.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(data.stats.cost_source).toBe("recorded");
+    expect(assistant).toMatchObject({ cost: 0.25, cost_source: "recorded" });
     expect(assistant?.parts[0]).toMatchObject({
       type: "reasoning",
       text: "Need to read package.json",
@@ -399,6 +401,50 @@ describe("PiAgent", () => {
         output: [{ type: "text", text: "package output" }],
       },
     });
+  });
+
+  it("marks locally priced usage as estimated across messages, heads, and details", () => {
+    const sessionId = "019deeee-eeee-7eee-eeee-eeeeeeeeeeee";
+    const { agent } = writePiSession(sessionId, [
+      {
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: TS,
+        cwd: "/tmp/project",
+      },
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: TS,
+        message: { role: "user", content: "Estimate this session" },
+      },
+      {
+        type: "message",
+        id: "assistant-1",
+        parentId: "user-1",
+        timestamp: TS,
+        message: {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          usage: { input: 100, output: 20, totalTokens: 120 },
+          content: [{ type: "text", text: "Estimated reply" }],
+        },
+      },
+    ]);
+
+    const [head] = agent.scan();
+    const detail = agent.getSessionData(sessionId);
+    const assistant = detail.messages[1];
+
+    expect(head?.stats.cost_source).toBe("estimated");
+    expect(head?.stats.total_cost).toBeGreaterThan(0);
+    expect(detail.stats.cost_source).toBe("estimated");
+    expect(detail.stats.total_cost).toBe(head?.stats.total_cost);
+    expect(assistant?.cost_source).toBe("estimated");
+    expect(assistant?.cost).toBe(detail.stats.total_cost);
   });
 
   it("drops a message with a non-string role and reports the drift", () => {

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -23,7 +23,7 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const HEAD_INDEX_VERSION = "pi-head-v1";
-const PARSER_VERSION = "pi-parser-v1";
+const PARSER_VERSION = "pi-parser-v2";
 
 export function resolvePiDataRoot(): string {
   return resolveHomePath("PI_HOME", ".pi");
@@ -195,7 +195,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
         total_cache_read_tokens: state.totalCacheReadTokens || undefined,
         total_cache_create_tokens: state.totalCacheCreateTokens || undefined,
         total_cost: state.totalCost,
-        cost_source: state.totalCost > 0 ? "recorded" : undefined,
+        cost_source: state.costSource,
       },
       messages: state.messages,
     };
@@ -252,7 +252,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
         total_cache_read_tokens: state.totalCacheReadTokens || undefined,
         total_cache_create_tokens: state.totalCacheCreateTokens || undefined,
         total_cost: state.totalCost,
-        cost_source: state.totalCost > 0 ? "recorded" : undefined,
+        cost_source: state.costSource,
       },
       model_usage: modelUsage,
     });
@@ -332,6 +332,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
     totalCacheReadTokens: number;
     totalCacheCreateTokens: number;
     totalCost: number;
+    costSource: Message["cost_source"];
     modelUsage: Record<string, number>;
   } {
     const builder = new TranscriptBuilder({ messageDefaults: "sparse" });
@@ -366,6 +367,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
       totalCacheReadTokens: result.stats.total_cache_read_tokens ?? 0,
       totalCacheCreateTokens: result.stats.total_cache_create_tokens ?? 0,
       totalCost: result.stats.total_cost,
+      costSource: result.stats.cost_source,
       modelUsage,
     };
   }
@@ -394,7 +396,9 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
       if (parts.length === 0) return null;
       const usage = this.normalizeUsage(message["usage"]);
       const model = typeof message["model"] === "string" ? message["model"].trim() : null;
-      const cost = usage.cost ?? estimateTokenCost(model, usage.tokens) ?? 0;
+      const estimatedCost = usage.cost === null ? estimateTokenCost(model, usage.tokens) : null;
+      const cost = usage.cost ?? estimatedCost ?? 0;
+      const costSource = cost > 0 ? (usage.cost === null ? "estimated" : "recorded") : undefined;
       return {
         message: {
           id,
@@ -406,7 +410,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
           model,
           tokens: usage.tokens,
           cost: cost || undefined,
-          costSource: cost > 0 ? "recorded" : undefined,
+          costSource,
         },
         totalTokens: usage.totalTokens,
         model,


### PR DESCRIPTION
## Summary

- mark Pi costs estimated when they come from the local pricing table
- derive Pi head and detail cost sources from transcript message stats
- invalidate stale Pi parser caches
- lock OpenCode zero-cost sessions to an undefined cost source

## Validation

- pnpm lint
- pnpm format:check
- pnpm build
- pnpm test