### PR TITLE
fix: deduplicate session tree route keys

### DIFF
--- a/packages/core/src/contract/__tests__/session-tree.test.ts
+++ b/packages/core/src/contract/__tests__/session-tree.test.ts
@@ -112,6 +112,18 @@ describe("buildSessionTree", () => {
     expect(ids(tree.byRouteKey.get("codex/root")!.children)).toEqual(["child"]);
   });
 
+  it("deduplicates repeated route keys before building the hierarchy", () => {
+    const tree = buildSessionTree([
+      makeSession("root", 1, { messages: 1, cost: 1 }),
+      makeSession("root", 2, { messages: 10, cost: 10 }),
+      makeSession("child", 3, { parent: "root", messages: 2, cost: 2 }),
+    ]);
+
+    expect(ids(tree.entries)).toEqual(["root"]);
+    expect(tree.byRouteKey.size).toBe(2);
+    expect(tree.entries[0]?.inclusiveStats).toMatchObject({ messageCount: 3, cost: 3 });
+  });
+
   it("counts descendants at every depth", () => {
     const tree = buildSessionTree([
       makeSession("root", 1),

--- a/packages/core/src/contract/session-tree.ts
+++ b/packages/core/src/contract/session-tree.ts
@@ -147,16 +147,17 @@ function rollUpSubtree(entry: SessionTreeNode): void {
 
 export function buildSessionTree(sessions: SessionHead[]): SessionTree {
   const byRouteKey = new Map<string, SessionTreeNode>();
-  const nodes = sessions.map<SessionTreeNode>((session) => ({
-    session,
-    children: [],
-    descendantCount: 0,
-    inclusiveStats: ownStats(session),
-  }));
-  for (const node of nodes) {
-    const key = sessionKey(node.session);
-    if (!byRouteKey.has(key)) byRouteKey.set(key, node);
+  for (const session of sessions) {
+    const key = sessionKey(session);
+    if (byRouteKey.has(key)) continue;
+    byRouteKey.set(key, {
+      session,
+      children: [],
+      descendantCount: 0,
+      inclusiveStats: ownStats(session),
+    });
   }
+  const nodes = [...byRouteKey.values()];
 
   // A session whose parent chain re-enters itself can never reach a root, so it
   // is mounted nowhere. Memoized so the walk stays linear over long chains.


### PR DESCRIPTION
## Summary

- build session tree nodes from the unique route-key index
- preserve first-session precedence and input order
- prevent duplicate heads from inflating entries and inclusive stats

## Validation

- pnpm lint
- pnpm format:check
- pnpm build
- pnpm test