### PR TITLE
fix: harden scan and index pipelines

### DIFF
--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -93,7 +93,7 @@ describe("search index worker", () => {
     );
     mocks.workerData = {
       context: "startup",
-      agentNames: ["codex", "unknown"],
+      agentNames: ["codex"],
       sessionsByAgent: { codex: [{ id: "s1" }] },
       metaByAgent: { codex: { s1: { id: "s1" } } },
     };
@@ -108,6 +108,39 @@ describe("search index worker", () => {
     });
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: "done", context: "startup", sessions: 1 }),
+    );
+  });
+
+  it("rejects a job for an unknown agent instead of reporting done", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([]);
+    mocks.workerData = {
+      context: "scan.refresh",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [
+        {
+          kind: "full",
+          context: "scan.refresh",
+          agentName: "unknown",
+          sessions: [{ id: "s1" }],
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+        },
+      ],
+    };
+
+    await runWorker();
+
+    expect(mocks.postMessage).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        type: "persist-failed",
+        context: "scan.refresh",
+        stage: "prepare",
+        agentName: "unknown",
+        sessions: 1,
+      }),
     );
   });
 

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -207,7 +207,14 @@ function postSyncResult(context: string, result: SearchIndexSyncResult): void {
 let persistFailed = false;
 for (const job of jobs) {
   const agent = agents.find((item) => item.name === job.agentName);
-  if (!agent) continue;
+  if (!agent) {
+    reportPersistFailure(job, {
+      stage: "prepare",
+      publicationId: job.publicationId ?? randomUUID(),
+    });
+    persistFailed = true;
+    break;
+  }
 
   if (agent.setSessionMetaMap) {
     agent.setSessionMetaMap(new Map(Object.entries(job.meta)));

--- a/packages/cli/src/session-watcher.test.ts
+++ b/packages/cli/src/session-watcher.test.ts
@@ -145,6 +145,42 @@ describe("SessionWatcher", () => {
     }
   });
 
+  it("closes a fallback watcher when its directory is deleted", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "watcher-fallback-delete-"));
+    const childDir = join(tempDir, "child");
+    mkdirSync(childDir);
+    fsWatch.watch.mockImplementation((path, options, listener) => {
+      if (options.recursive) {
+        const error = Object.assign(new Error("recursive watch unavailable"), {
+          code: "ERR_FEATURE_UNAVAILABLE_ON_PLATFORM",
+        });
+        throw error;
+      }
+      return registerMockWatcher(path, options, listener);
+    });
+
+    try {
+      const watcher = new SessionWatcher();
+      watcher.start([
+        source("custom-agent", {
+          status: "supported",
+          targets: [{ path: tempDir }],
+        }),
+      ]);
+      const rootWatcher = fsWatch.watchers.find((entry) => entry.path === tempDir)!;
+      const childWatcher = fsWatch.watchers.find((entry) => entry.path === childDir)!;
+
+      rmSync(childDir, { recursive: true });
+      rootWatcher.listener("rename", "child");
+      await Promise.resolve();
+
+      expect(childWatcher.close).toHaveBeenCalledOnce();
+      await watcher.dispose();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("distinguishes unsupported and unnecessary watch capabilities", () => {
     const watcher = new SessionWatcher();
 

--- a/packages/cli/src/session-watcher.ts
+++ b/packages/cli/src/session-watcher.ts
@@ -26,6 +26,12 @@ interface WatchScope {
   targetPath: string;
 }
 
+interface WatchRegistration {
+  path: string;
+  recursive: boolean;
+  watcher: FSWatcher;
+}
+
 interface StablePathState {
   path: string;
   agentNames: Set<string>;
@@ -135,7 +141,7 @@ function resolveWatchEventPath(watchPath: string, filename: string | Buffer | nu
 }
 
 export class SessionWatcher {
-  private watchers: FSWatcher[] = [];
+  private watchers: WatchRegistration[] = [];
   private fallbackWatchScopes = new Map<string, WatchScope[]>();
   private stablePaths = new Map<string, StablePathState>();
   private listeners = new Set<AgentsChangedListener>();
@@ -220,7 +226,7 @@ export class SessionWatcher {
     }
     this.stablePaths.clear();
 
-    await Promise.all(this.watchers.map((watcher) => watcher.close()));
+    await Promise.all(this.watchers.map(({ watcher }) => watcher.close()));
     this.watchers = [];
     this.fallbackWatchScopes.clear();
     this.listeners.clear();
@@ -248,7 +254,7 @@ export class SessionWatcher {
         this.reportWatchError("watch.error", { path, recursive, error });
       });
 
-      this.watchers.push(watcher);
+      this.watchers.push({ path, recursive, watcher });
       return true;
     } catch (error) {
       if (recursive && isRecursiveWatchUnavailable(error)) {
@@ -304,7 +310,22 @@ export class SessionWatcher {
       if (statSync(path).isDirectory()) {
         this.watchDirectoryTree(path, scopes);
       }
-    } catch {}
+    } catch {
+      this.unwatchFallbackTree(path);
+    }
+  }
+
+  private unwatchFallbackTree(path: string): void {
+    const active: WatchRegistration[] = [];
+    for (const registration of this.watchers) {
+      if (registration.recursive || !isSameOrChildPath(path, registration.path)) {
+        active.push(registration);
+        continue;
+      }
+      registration.watcher.close();
+      this.fallbackWatchScopes.delete(registration.path);
+    }
+    this.watchers = active;
   }
 
   private handleWatchEvent(

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -587,6 +587,26 @@ describe("CS-180: related session reads stay inside the selected roots", () => {
       db.close();
     }
   });
+
+  it("includes every descendant in root detail stats", () => {
+    const dbPath = createDatabaseWithRelatedHistory(0);
+    const db = new Database(dbPath);
+    db.prepare("UPDATE message SET data = ?").run(
+      JSON.stringify({ role: "assistant", cost: 1, tokens: { input: 1, output: 0 } }),
+    );
+    db.close();
+    const agent = new OpenCodeSqliteAgent({
+      name: "test-agent",
+      displayName: "Test Agent",
+      findDbPath: () => dbPath,
+      getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
+    });
+
+    expect(agent.getSessionData("recent-root").stats).toMatchObject({
+      total_input_tokens: 4,
+      total_cost: 4,
+    });
+  });
 });
 
 describe("CS-138: unreadable databases are not empty scans", () => {

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -202,6 +202,23 @@ describe("PiAgent", () => {
     expect(windowed.map((ref) => ref.sourcePath)).toEqual([newFile]);
   });
 
+  it("uses the same session id for source enumeration and parsed heads", () => {
+    const filenameSessionId = "filename-session";
+    const headerSessionId = "header-session";
+    const { agent } = writePiSession(filenameSessionId, [
+      { type: "session", id: headerSessionId, timestamp: TS, cwd: "/tmp/project" },
+      {
+        type: "message",
+        id: "message-1",
+        parentId: null,
+        timestamp: TS,
+        message: { role: "user", content: "Compare source ids" },
+      },
+    ]);
+
+    expect(agent.listSessionSources()[0]?.sessionId).toBe(agent.scan()[0]?.id);
+  });
+
   it("stats each session file once during a scan", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
     tempDirs.push(tempDir);
@@ -272,7 +289,7 @@ describe("PiAgent", () => {
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
           "pi-head-v1",
-          "pi-parser-v2",
+          "pi-parser-v3",
           sessionTime.getTime(),
           statSync(sessionFile).size,
         ]),
@@ -561,7 +578,7 @@ describe("PiAgent", () => {
     });
   });
 
-  it("takes the first session record as the header when several are present", () => {
+  it("takes metadata from the first session record when several are present", () => {
     const { agent, sessionId } = writePiSession("019deeee-eeee-7eee-eeee-eeeeeeeeeeee", [
       { type: "session", version: 3, id: "first", timestamp: TS, cwd: "/tmp/first" },
       { type: "session", version: 3, id: "second", timestamp: TS, cwd: "/tmp/second" },
@@ -576,9 +593,8 @@ describe("PiAgent", () => {
 
     const [head] = agent.scan();
 
-    expect(head?.id).toBe("first");
+    expect(head?.id).toBe(sessionId);
     expect(head?.directory).toBe("/tmp/first");
-    expect(sessionId).toBeTruthy();
   });
 
   it("skips files that are empty or missing a session header", () => {

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -544,9 +544,9 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
   private sumChildTokenStats(db: SQLiteDatabase, parentSessionId: string): SessionHead["stats"][] {
     if (!columnExists(db, "session", "parent_id")) return [];
 
-    const childRows = db
-      .prepare("SELECT id FROM session WHERE parent_id = ?")
-      .all(parentSessionId) as Record<string, unknown>[];
+    const childRows = this.readRelatedSessionRows(db, [parentSessionId]).filter(
+      (row) => String(row.id ?? "") !== parentSessionId,
+    );
 
     const results: SessionHead["stats"][] = [];
     for (const child of childRows) {

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -23,7 +23,7 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
 const HEAD_INDEX_VERSION = "pi-head-v1";
-const PARSER_VERSION = "pi-parser-v2";
+const PARSER_VERSION = "pi-parser-v3";
 
 export function resolvePiDataRoot(): string {
   return resolveHomePath("PI_HOME", ".pi");
@@ -280,7 +280,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
     const pathEntries = buildCurrentPathEntries(entries);
     if (pathEntries.length === 0) throw new Error("empty session tree");
 
-    const sessionId = String(header["id"] ?? extractSessionIdFromFilename(filePath)).trim();
+    const sessionId = extractSessionIdFromFilename(filePath);
     if (!sessionId) throw new Error("missing session id");
 
     const stat = this.sessionSourceFile(filePath).stat;

--- a/packages/core/src/utils/__tests__/file-activity.test.ts
+++ b/packages/core/src/utils/__tests__/file-activity.test.ts
@@ -80,4 +80,31 @@ describe("file activity extraction", () => {
       expect.objectContaining({ path: "src/b.ts", kind: "delete", count: 1 }),
     ]);
   });
+
+  it("keeps read activity when the input also contains typed content", () => {
+    const messages: Message[] = [
+      {
+        id: "m1",
+        role: "assistant",
+        time_created: 10,
+        parts: [
+          {
+            type: "tool",
+            tool: "Read",
+            state: {
+              status: "completed",
+              input: {
+                file_path: "src/a.ts",
+                content: [{ type: "text", text: "file contents" }],
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    expect(extractFileActivityOccurrences(messages)).toEqual([
+      expect.objectContaining({ path: "src/a.ts", kind: "read" }),
+    ]);
+  });
 });

--- a/packages/core/src/utils/file-activity.ts
+++ b/packages/core/src/utils/file-activity.ts
@@ -12,6 +12,14 @@ interface CodexPatchEntry {
   oldPath: string;
 }
 
+const CODEX_PATCH_TYPES = new Set([
+  "edit_file",
+  "update_file",
+  "write_file",
+  "delete_file",
+  "move_file",
+]);
+
 function toRecord(value: unknown) {
   if (value && typeof value === "object" && !Array.isArray(value)) {
     return value as Record<string, unknown>;
@@ -140,11 +148,13 @@ function classifyToolKind(part: ToolPart): FileActivityKind | null {
 function normalizeCodexPatchEntry(entry: unknown): CodexPatchEntry | null {
   const record = toRecord(entry);
   const type = toStringValue(record.type);
-  if (!type) return null;
+  const path = toStringValue(record.path);
+  const oldPath = toStringValue(record.old_path);
+  if (!CODEX_PATCH_TYPES.has(type) || (!path && !oldPath)) return null;
   return {
     type,
-    path: toStringValue(record.path),
-    oldPath: toStringValue(record.old_path),
+    path,
+    oldPath,
   };
 }
 
@@ -184,6 +194,7 @@ export function extractFileActivityOccurrences(
       const currentToolIndex = toolIndex;
       toolIndex += 1;
 
+      const kind = classifyToolKind(part);
       const patchEntries = getCodexPatchEntries(inputValue);
       if (patchEntries.length > 0) {
         for (const entry of patchEntries) {
@@ -201,7 +212,6 @@ export function extractFileActivityOccurrences(
         continue;
       }
 
-      const kind = classifyToolKind(part);
       if (!kind) continue;
 
       for (const path of extractPathsFromToolInput(inputValue)) {


### PR DESCRIPTION
## Summary

- keep Pi source and parsed session IDs aligned
- include every OpenCode descendant in detail token and cost totals
- distinguish structured patch entries from typed tool content
- release non-recursive watchers for deleted directory trees
- reject search-index jobs that reference unknown agents

## Validation

- pnpm lint
- pnpm format:check
- pnpm build
- pnpm test