### PR TITLE
fix: harden API and bookmark edge cases

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1560,6 +1560,31 @@ describe("handleGetSessionData", () => {
     expect(serializedMessages).toBe(200);
   });
 
+  it("errors the response body and closes iteration when cached message reads fail", async () => {
+    const { messages: _messages, ...detailHeader } = detail;
+    const iterator = {
+      next: vi
+        .fn()
+        .mockReturnValueOnce({ done: false, value: JSON.stringify({ id: "m1" }) })
+        .mockImplementationOnce(() => {
+          throw new Error("cached message read failed");
+        }),
+      return: vi.fn(() => ({ done: true, value: undefined })),
+    };
+    coreMocks.materializeSessionDetailResponse.mockReturnValue({
+      status: "found-json",
+      data: detailHeader,
+      messages: { [Symbol.iterator]: () => iterator },
+      messageCount: 2,
+    });
+    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+
+    const response = (await handleGetSessionData(c, makeScanSource())) as Response;
+
+    await expect(response.text()).rejects.toThrow("cached message read failed");
+    expect(iterator.return).toHaveBeenCalledOnce();
+  });
+
   it("returns 400 when agent name is missing", async () => {
     const c = makeMockContext({ param: { agent: "", id: "s1" } });
     await handleGetSessionData(c, makeScanSource());

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -515,6 +515,13 @@ describe("handleGetSessions", () => {
 
     expect(c.json).toHaveBeenCalledWith({ error: "from must be a valid date" }, 400);
   });
+
+  it("rejects a date window whose start is after its end", () => {
+    const c = makeMockContext({ query: { from: "2026-08-13", to: "2026-08-12" } });
+    handleGetSessions(c, makeScanSource());
+
+    expect(c.json).toHaveBeenCalledWith({ error: "from must not be after to" }, 400);
+  });
 });
 
 describe("handleSearchSessions", () => {

--- a/packages/cli/src/api/__tests__/query-params.test.ts
+++ b/packages/cli/src/api/__tests__/query-params.test.ts
@@ -33,6 +33,14 @@ describe("session query contract", () => {
     });
   });
 
+  it("rejects a date window whose start is after its end", () => {
+    expect(parseDateWindow(new URLSearchParams("from=2026-08-13&to=2026-08-12"), {})).toEqual({
+      kind: "invalid",
+      parameter: "from",
+      error: "must not be after to",
+    });
+  });
+
   it("distinguishes an absent agent from known and unknown values", () => {
     expect(parseSessionQuery(new URLSearchParams(), ["claudecode"]).agent).toEqual({
       kind: "all",

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -258,6 +258,8 @@ function createSessionDetailJsonResponse(
 ): Response {
   const encoder = new TextEncoder();
   const headerJson = JSON.stringify(data);
+  const headerPrefix =
+    headerJson === "{}" ? '{"messages":[' : `${headerJson.slice(0, -1)},"messages":[`;
   const iterator = messages[Symbol.iterator]();
   let wroteHeader = false;
   let wroteMessage = false;
@@ -266,21 +268,30 @@ function createSessionDetailJsonResponse(
     new ReadableStream<Uint8Array>({
       pull(controller) {
         if (!wroteHeader) {
-          controller.enqueue(encoder.encode(`${headerJson.slice(0, -1)},"messages":[`));
+          controller.enqueue(encoder.encode(headerPrefix));
           wroteHeader = true;
           return;
         }
 
         const batch: string[] = [];
         let batchLength = 0;
-        let next = iterator.next();
-        while (!next.done) {
-          const prefix = wroteMessage ? "," : "";
-          batch.push(prefix, next.value);
-          batchLength += prefix.length + next.value.length;
-          wroteMessage = true;
-          if (batchLength >= SESSION_DETAIL_STREAM_BATCH_CHARS) break;
+        let next: IteratorResult<string>;
+        try {
           next = iterator.next();
+          while (!next.done) {
+            const prefix = wroteMessage ? "," : "";
+            batch.push(prefix, next.value);
+            batchLength += prefix.length + next.value.length;
+            wroteMessage = true;
+            if (batchLength >= SESSION_DETAIL_STREAM_BATCH_CHARS) break;
+            next = iterator.next();
+          }
+        } catch (error) {
+          try {
+            iterator.return?.();
+          } catch {}
+          controller.error(error);
+          return;
         }
 
         if (next.done) {

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -105,6 +105,10 @@ export function parseDateWindow(
   const to = parseDateParam(params.get("to") ?? undefined, defaults.to);
   if (to.kind === "invalid") return { ...to, parameter: "to" };
 
+  if (from.value != null && to.value != null && from.value > to.value) {
+    return { kind: "invalid", parameter: "from", error: "must not be after to" };
+  }
+
   return { kind: "valid", from: from.value, to: to.value };
 }
 

--- a/packages/core/src/state/__tests__/bookmarks.test.ts
+++ b/packages/core/src/state/__tests__/bookmarks.test.ts
@@ -99,6 +99,26 @@ describe("bookmarks state storage", () => {
     expect(listBookmarks()).toEqual([makeBookmark()]);
   });
 
+  it("returns the inserted bookmark even when it is deleted before a follow-up read", () => {
+    listBookmarks();
+    const db = new Database(getStatePath());
+    try {
+      db.exec(`
+        CREATE TRIGGER delete_bookmark_after_insert
+        AFTER INSERT ON bookmarks
+        WHEN NEW.session_id = 'racy'
+        BEGIN
+          DELETE FROM bookmarks
+          WHERE agent_name = NEW.agent_name AND session_id = NEW.session_id;
+        END;
+      `);
+    } finally {
+      db.close();
+    }
+
+    expect(upsertBookmark(makeBookmark("racy").reference)).toEqual(makeBookmark("racy"));
+  });
+
   it("imports facts idempotently and preserves existing timestamps", () => {
     upsertBookmark(makeBookmark("s1").reference);
 

--- a/packages/core/src/state/bookmarks.ts
+++ b/packages/core/src/state/bookmarks.ts
@@ -82,22 +82,20 @@ export function upsertBookmark(reference: SessionReference): BookmarkRecord {
   }
 
   return withStateDb((db) => {
-    db.prepare(
-      `
-        INSERT INTO bookmarks(agent_name, session_id, bookmarked_at)
-        VALUES (?, ?, ?)
-        ON CONFLICT(agent_name, session_id) DO NOTHING
-      `,
-    ).run(normalized.agentName, normalized.sessionId, Date.now());
     const row = db
       .prepare(
         `
-          SELECT agent_name, session_id, bookmarked_at
-          FROM bookmarks
-          WHERE agent_name = ? AND session_id = ?
+          INSERT INTO bookmarks(agent_name, session_id, bookmarked_at)
+          VALUES (?, ?, ?)
+          ON CONFLICT(agent_name, session_id) DO UPDATE
+          SET bookmarked_at = bookmarks.bookmarked_at
+          RETURNING agent_name, session_id, bookmarked_at
         `,
       )
-      .get(normalized.agentName, normalized.sessionId) as BookmarkRow;
+      .get(normalized.agentName, normalized.sessionId, Date.now()) as BookmarkRow | undefined;
+    if (!row) {
+      throw new Error("Bookmark upsert returned no row");
+    }
     return toBookmarkRecord(row);
   });
 }


### PR DESCRIPTION
## Summary

- reject inverted API date windows with a 400 response
- explicitly error session-detail streams and close failed iterators
- preserve valid JSON framing for empty detail headers
- make bookmark upserts atomic with one UPSERT RETURNING statement

## Validation

- pnpm lint
- pnpm format:check
- pnpm build
- pnpm test