### PR TITLE
Fix web failure recovery paths

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -60,6 +60,7 @@ export default function App() {
     reload,
     applyLiveEvent,
     resyncLiveState,
+    retryLoad,
   } = sessionStore;
   useWindowedDataLoad({
     window: timeWindow,
@@ -306,6 +307,7 @@ export default function App() {
     <AppRouteContent
       loading={loading}
       error={error}
+      onRetry={() => void retryLoad()}
       viewState={viewState}
       detailHighlightQuery={detailHighlightQuery}
       agents={activeAgents}
@@ -566,7 +568,7 @@ export default function App() {
             </section>
 
             <section className="console-scrollbar bg-grid min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8">
-              <ErrorBoundary>
+              <ErrorBoundary key={location.pathname}>
                 <RenderProfiler
                   id="MainContent"
                   detail={{

--- a/apps/web/src/components/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function Surface({ failed }: { failed: boolean }) {
+  if (failed) throw new Error("broken surface");
+  return <p>Recovered surface</p>;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("ErrorBoundary", () => {
+  it("recovers when its reset key changes", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const view = render(
+      <ErrorBoundary key="/broken">
+        <Surface failed />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+
+    view.rerender(
+      <ErrorBoundary key="/healthy">
+        <Surface failed={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Recovered surface")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -47,6 +47,7 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
   return {
     loading: false,
     error: null,
+    onRetry: vi.fn(),
     viewState: {
       mode: "root",
       activeAgentKey: null,
@@ -148,6 +149,17 @@ function renderContent(props: Parameters<typeof AppRouteContent>[0]) {
 }
 
 describe("AppRouteContent", () => {
+  it("offers a retry action when the initial load fails", () => {
+    const props = makeProps();
+    props.error = "Failed to load configuration.";
+
+    renderContent(props);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(screen.getByRole("alert").textContent).toContain(props.error);
+    expect(props.onRetry).toHaveBeenCalledTimes(1);
+  });
+
   it("renders the overview on the root route", async () => {
     renderContent(makeProps());
 

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useMemo, type Dispatch, type ReactNode, type SetStateAction } from "react";
+import { useLocation } from "react-router-dom";
 import { DetailLanding, type LandingAgentItem, type LandingSession } from "../DetailLanding";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { RenderProfiler } from "../RenderProfiler";
@@ -24,8 +25,9 @@ const SearchResultsPanel = lazy(() =>
 
 /** Keeps a failed chunk load contained to the surface that needed it. */
 function LazySurface({ children }: { children: ReactNode }) {
+  const location = useLocation();
   return (
-    <ErrorBoundary>
+    <ErrorBoundary key={location.pathname}>
       <Suspense fallback={<SessionDetailSkeleton />}>{children}</Suspense>
     </ErrorBoundary>
   );
@@ -79,6 +81,7 @@ interface BookmarkContentModel {
 interface AppRouteContentProps {
   loading: boolean;
   error: string | null;
+  onRetry: () => void;
   viewState: ViewState;
   detailHighlightQuery: string;
   agents: AgentInfo[];
@@ -100,6 +103,7 @@ interface AppRouteContentProps {
 export function AppRouteContent({
   loading,
   error,
+  onRetry,
   viewState,
   detailHighlightQuery,
   agents,
@@ -156,8 +160,18 @@ export function AppRouteContent({
   }
   if (error) {
     return (
-      <div className="mx-auto max-w-4xl rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6 text-sm text-[var(--console-error)]">
-        {error}
+      <div
+        role="alert"
+        className="mx-auto max-w-4xl rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6 text-sm text-[var(--console-error)]"
+      >
+        <p>{error}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="console-mono mt-4 rounded-sm border border-[var(--console-error-border)] px-3 py-1.5 text-xs motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
+        >
+          Retry
+        </button>
       </div>
     );
   }

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -75,14 +75,37 @@ describe("useSessionStore", () => {
   it("surfaces config failures", async () => {
     const error = new Error("config unavailable");
     vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(api.fetchConfig).mockRejectedValueOnce(error);
+    vi.mocked(api.fetchConfig).mockRejectedValue(error);
     const { Wrapper } = createQueryWrapper();
     const { result } = renderHook(() => useSessionStore(), { wrapper: Wrapper });
 
-    await waitFor(() => expect(result.current.error).toContain("Failed to load data"));
+    await waitFor(() => expect(result.current.error).toContain("Failed to load configuration"), {
+      timeout: 2_000,
+    });
 
     expect(result.current.loading).toBe(false);
+    expect(api.fetchConfig).toHaveBeenCalledTimes(3);
     expect(console.error).toHaveBeenCalledWith("Failed to load config:", error);
+
+    vi.mocked(api.fetchConfig).mockResolvedValue(config);
+    await act(() => result.current.retryLoad());
+
+    await waitFor(() => expect(result.current.config).toEqual(config));
+    expect(result.current.error).toBeNull();
+    expect(api.fetchConfig).toHaveBeenCalledTimes(4);
+  });
+
+  it("recovers from a transient config failure automatically", async () => {
+    const error = new Error("config unavailable");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchConfig).mockRejectedValueOnce(error).mockResolvedValue(config);
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSessionStore(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.config).toEqual(config));
+
+    expect(result.current.error).toBeNull();
+    expect(api.fetchConfig).toHaveBeenCalledTimes(2);
   });
 
   it("ignores live events until a window has been selected", async () => {
@@ -390,7 +413,7 @@ describe("useSessionStore", () => {
     });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.error).toContain("Failed to load data");
+    expect(result.current.error).toContain("Failed to load session data");
     expect(result.current.sessions).toEqual([]);
   });
 

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -104,6 +104,8 @@ export function useSessionStore() {
   const requestedWindowRef = useRef<AppConfig["window"] | null>(null);
   const configQuery = useQuery({
     queryKey: queryKeys.config,
+    retry: 2,
+    retryDelay: 250,
     queryFn: async ({ signal }) => {
       try {
         return await fetchConfig({ signal });
@@ -117,6 +119,8 @@ export function useSessionStore() {
     ...sessionSnapshotOptions(requestedWindow ?? {}),
     enabled: false,
   });
+  const configFailed = configQuery.isError;
+  const refetchConfig = configQuery.refetch;
   const snapshot = snapshotQuery.data;
 
   const reload = useCallback(
@@ -214,13 +218,26 @@ export function useSessionStore() {
     return refreshed;
   }, [queryClient, reload]);
 
+  const retryLoad = useCallback(async (): Promise<void> => {
+    const activeWindow = requestedWindowRef.current;
+    if (configFailed || !activeWindow) {
+      await refetchConfig();
+      return;
+    }
+    await reload(activeWindow);
+  }, [configFailed, refetchConfig, reload]);
+
   const agents = snapshot?.agents ?? EMPTY_SNAPSHOT.agents;
   const agentCatalog = useMemo(() => createAgentCatalog(agents), [agents]);
   const validAgentKeys = useMemo(
     () => new Set(agentCatalog.active.map((agent) => agent.name.toLowerCase())),
     [agentCatalog.active],
   );
-  const error = configQuery.error ?? snapshotQuery.error;
+  const error = configQuery.isError
+    ? "Failed to load configuration. The CLI may be restarting or unavailable."
+    : snapshotQuery.isError
+      ? "Failed to load session data for the selected time window."
+      : null;
 
   return {
     config: configQuery.data ?? null,
@@ -232,7 +249,7 @@ export function useSessionStore() {
     loading:
       configQuery.isPending ||
       (!configQuery.isError && (requestedWindow === null || snapshotQuery.isPending)),
-    error: error ? "Failed to load data. Is the CLI server running?" : null,
+    error,
     version: snapshotQuery.dataUpdatedAt,
     activeAgents: agentCatalog.active,
     agentCatalog,
@@ -241,5 +258,6 @@ export function useSessionStore() {
     reload,
     applyLiveEvent,
     resyncLiveState,
+    retryLoad,
   };
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -184,6 +184,7 @@ describe("project identity request filters", () => {
 
 class FakeEventSource {
   static instances: FakeEventSource[] = [];
+  static readonly CONNECTING = 0;
   static readonly CLOSED = 2;
 
   readyState = 0;
@@ -219,6 +220,11 @@ class FakeEventSource {
 
   fail() {
     this.readyState = FakeEventSource.CLOSED;
+    this.onerror?.();
+  }
+
+  interrupt() {
+    this.readyState = FakeEventSource.CONNECTING;
     this.onerror?.();
   }
 }
@@ -343,5 +349,35 @@ describe("subscribeSessionUpdates", () => {
 
     expect(onReconnect).toHaveBeenCalledTimes(1);
     expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports native reconnect interruptions only after the delay threshold", () => {
+    const onDisconnect = vi.fn();
+    subscribeSessionUpdates(() => {}, undefined, undefined, onDisconnect);
+
+    latest().open();
+    latest().interrupt();
+    vi.advanceTimersByTime(4_999);
+
+    expect(onDisconnect).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a pending disconnect notice when native reconnect succeeds", () => {
+    const onReconnect = vi.fn();
+    const onDisconnect = vi.fn();
+    subscribeSessionUpdates(() => {}, undefined, onReconnect, onDisconnect);
+
+    latest().open();
+    latest().interrupt();
+    vi.advanceTimersByTime(4_999);
+    latest().open();
+    vi.advanceTimersByTime(1);
+
+    expect(onDisconnect).not.toHaveBeenCalled();
+    expect(onReconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -306,6 +306,7 @@ export function logClientEvent(event: string, data: Record<string, unknown> = {}
 
 const INITIAL_RETRY_MS = 1_000;
 const MAX_RETRY_MS = 30_000;
+const DISCONNECT_NOTICE_DELAY_MS = 5_000;
 
 function jitter(delayMs: number): number {
   const spread = delayMs * 0.2;
@@ -320,10 +321,23 @@ export function subscribeSessionUpdates(
 ): () => void {
   let disposed = false;
   let retryTimer: ReturnType<typeof setTimeout> | undefined;
+  let disconnectTimer: ReturnType<typeof setTimeout> | undefined;
   let retryDelayMs = INITIAL_RETRY_MS;
   let hasConnectedOnce = false;
   let disconnectNotified = false;
   let currentSource: EventSource | undefined;
+
+  const clearDisconnectTimer = () => {
+    if (disconnectTimer === undefined) return;
+    clearTimeout(disconnectTimer);
+    disconnectTimer = undefined;
+  };
+
+  const notifyDisconnect = () => {
+    if (disconnectNotified) return;
+    disconnectNotified = true;
+    onDisconnect?.();
+  };
 
   const connect = () => {
     const source = new EventSource(remoteAccessUrl("/api/events"));
@@ -347,22 +361,28 @@ export function subscribeSessionUpdates(
     });
 
     source.onopen = () => {
+      clearDisconnectTimer();
       retryDelayMs = INITIAL_RETRY_MS;
+      const recoveredFromDisconnect = disconnectNotified;
       disconnectNotified = false;
-      if (hasConnectedOnce) {
+      if (hasConnectedOnce || recoveredFromDisconnect) {
         onReconnect?.();
       }
       hasConnectedOnce = true;
     };
 
     source.onerror = () => {
-      if (source.readyState !== EventSource.CLOSED) return;
+      if (source.readyState !== EventSource.CLOSED) {
+        disconnectTimer ??= setTimeout(() => {
+          disconnectTimer = undefined;
+          if (!disposed && currentSource === source) notifyDisconnect();
+        }, DISCONNECT_NOTICE_DELAY_MS);
+        return;
+      }
+      clearDisconnectTimer();
       source.close();
       if (disposed) return;
-      if (!disconnectNotified) {
-        disconnectNotified = true;
-        onDisconnect?.();
-      }
+      notifyDisconnect();
       const delay = jitter(retryDelayMs);
       retryDelayMs = Math.min(retryDelayMs * 2, MAX_RETRY_MS);
       retryTimer = setTimeout(connect, delay);
@@ -376,6 +396,7 @@ export function subscribeSessionUpdates(
     if (retryTimer !== undefined) {
       clearTimeout(retryTimer);
     }
+    clearDisconnectTimer();
     currentSource?.close();
   };
 }


### PR DESCRIPTION
## Summary

- retry transient config loads and expose a manual retry action with contextual errors
- reset app and lazy-surface error boundaries when the route changes
- surface sustained native EventSource reconnects without flashing on short interruptions

## Testing

- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web build`
- `pnpm --filter @codesesh/web format:check`