### PR TITLE
Preserve sidebar keyboard selection on live updates

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,16 +1,24 @@
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ApiProjectGroup, DashboardData } from "./lib/api";
+import { SAMPLE_SESSIONS_UPDATED_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
+import type { ApiProjectGroup, DashboardData, SessionsUpdatedEvent } from "./lib/api";
 import App from "./App";
 import { appRouteChildren } from "./lib/app-routes";
 import { createQueryClient } from "./lib/query-client";
 import { ScanStatusProvider } from "./hooks/useScanStatus";
 
+const liveSubscription = vi.hoisted(() => ({
+  onUpdate: undefined as ((event: SessionsUpdatedEvent) => void) | undefined,
+}));
+
 vi.mock("./lib/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./lib/api")>()),
-  subscribeSessionUpdates: () => () => undefined,
+  subscribeSessionUpdates: (onUpdate: (event: SessionsUpdatedEvent) => void) => {
+    liveSubscription.onUpdate = onUpdate;
+    return () => undefined;
+  },
   logClientEvent: () => undefined,
 }));
 
@@ -74,6 +82,10 @@ let requestedUrls: string[] = [];
 
 beforeEach(() => {
   requestedUrls = [];
+  liveSubscription.onUpdate = undefined;
+  responses["/api/agents"] = [];
+  responses["/api/projects"] = { projects: [workspaceProject] };
+  responses["/api/sessions"] = { sessions: [] };
   vi.stubGlobal("__APP_VERSION__", "0.0.0-test");
   vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
     const url = String(input);
@@ -87,6 +99,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -95,13 +108,14 @@ function renderAppAt(path: string) {
     [{ id: "app-shell", path: "/", Component: App, children: appRouteChildren }],
     { initialEntries: [path] },
   );
-  return render(
+  const view = render(
     <QueryClientProvider client={createQueryClient()}>
       <ScanStatusProvider>
         <RouterProvider router={router} />
       </ScanStatusProvider>
     </QueryClientProvider>,
   );
+  return { ...view, router };
 }
 
 function dashboardRequests(): URLSearchParams[] {
@@ -109,6 +123,46 @@ function dashboardRequests(): URLSearchParams[] {
     .filter((url) => url.startsWith("/api/dashboard"))
     .map((url) => new URLSearchParams(url.split("?")[1] ?? ""));
 }
+
+describe("App live updates", () => {
+  it("preserves keyboard selection when a live update replaces the session list", async () => {
+    const sidebarSession = {
+      ...SAMPLE_SESSION_HEAD,
+      id: "sidebar-session",
+      slug: "claudecode/sidebar-session",
+      project_identity: { kind: "path" as const, key: "/workspace", displayName: "workspace" },
+    };
+    responses["/api/agents"] = [{ name: "claudecode", displayName: "Claude Code", count: 1 }];
+    responses["/api/sessions"] = { sessions: [sidebarSession] };
+    const { router } = renderAppAt("/projects/path/%2Fworkspace");
+
+    await waitFor(() => expect(document.querySelector("file-tree-container")).toBeTruthy());
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "j", cancelable: true }));
+
+    vi.useFakeTimers();
+    await act(async () => {
+      liveSubscription.onUpdate?.({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        changedAgents: ["claudecode"],
+        newSessions: 0,
+        newSessionRefs: [],
+        totalSessions: 1,
+        changedSessionHeads: [
+          {
+            reference: { agentName: "claudecode", sessionId: sidebarSession.id },
+            session: { ...sidebarSession, display_title: "Live title" },
+          },
+        ],
+        projectionSessionOrder: [{ agentName: "claudecode", sessionId: sidebarSession.id }],
+      });
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    vi.useRealTimers();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", cancelable: true }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/claudecode/sidebar-session"));
+  });
+});
 
 describe("App dashboard scope wiring", () => {
   it("requests the project scope on a project route", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -274,13 +274,7 @@ export default function App() {
     }
 
     setSelectedSidebarSessionReference(null);
-  }, [
-    isSearchMode,
-    viewState.mode,
-    viewState.activeAgentKey,
-    viewState.activeSessionId,
-    sidebarSessions,
-  ]);
+  }, [isSearchMode, viewState.mode, viewState.activeAgentKey, viewState.activeSessionId]);
 
   const searchSubtitle =
     searchState.status === "failed"


### PR DESCRIPTION
## Summary

- stop route-selection synchronization from reacting to unrelated session-list replacements
- keep a keyboard-selected sidebar session stable across SSE projections
- add an integration regression that opens the preserved selection after a live update

## Testing

- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web build`
- `pnpm --filter @codesesh/web format:check`