### PR TITLE
Block agent scans from following symlinks

### DIFF
--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import Database from "better-sqlite3";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -133,6 +133,22 @@ describe("BaseAgent", () => {
 });
 
 describe("FileSystemSessionSource.scan", () => {
+  it("ignores a session-file symlink outside the scan root", () => {
+    const directory = mkdtempSync(join(tmpdir(), "codesesh-walk-symlink-"));
+    const root = join(directory, "root");
+    const target = join(directory, "outside.jsonl");
+    const link = join(root, "linked.jsonl");
+    try {
+      mkdirSync(root);
+      writeFileSync(target, "outside");
+      symlinkSync(target, link);
+
+      expect(new FakeFileSystemSource().walk(root)).toEqual([]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it("raises a root-level failure when source enumeration cannot complete", () => {
     const agent = new FakeFileSystemSource();
     try {

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
@@ -32,6 +32,7 @@ function insertKv(dbPath: string, key: string, value: unknown): void {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -39,6 +40,33 @@ afterEach(() => {
 });
 
 describe("CursorAgent parsing", () => {
+  it("ignores workspace metadata in a linked workspace directory", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dataRoot = join(tempDir, "cursor");
+    const workspaceStorage = join(dataRoot, "workspaceStorage");
+    const outsideWorkspace = join(tempDir, "outside-workspace");
+    mkdirSync(workspaceStorage, { recursive: true });
+    mkdirSync(outsideWorkspace);
+    writeFileSync(
+      join(outsideWorkspace, "workspace.json"),
+      JSON.stringify({ folder: "file:///outside/project" }),
+    );
+    const db = new Database(join(outsideWorkspace, "state.vscdb"));
+    db.exec("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+    db.prepare("INSERT INTO ItemTable (key, value) VALUES (?, ?)").run(
+      "composer.composerData",
+      JSON.stringify({ allComposers: [{ composerId: "outside-composer" }] }),
+    );
+    db.close();
+    symlinkSync(outsideWorkspace, join(workspaceStorage, "linked-workspace"));
+    vi.stubEnv("CURSOR_DATA_PATH", dataRoot);
+
+    const map = (new CursorAgent() as any).buildWorkspacePathMap();
+
+    expect(map).toEqual(new Map());
+  });
+
   it("cleans internal tags and keeps normalized tool names", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -432,7 +432,7 @@ export abstract class FileSystemSessionSource<
           if (options.recursive !== false) walk(filePath);
           continue;
         }
-        if (!isSessionFile(entry)) continue;
+        if (!entry.isFile() || !isSessionFile(entry)) continue;
 
         let stat: Stats;
         try {

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join, normalize } from "node:path";
 import {
@@ -542,7 +542,7 @@ export class CursorAgent extends DatabaseSessionSource {
     for (const name of entryNames) {
       const wsDir = join(wsStoragePath, name);
       try {
-        if (!statSync(wsDir).isDirectory()) continue;
+        if (!lstatSync(wsDir).isDirectory()) continue;
       } catch {
         continue;
       }


### PR DESCRIPTION
## Summary

- restrict shared session-file discovery to real regular files
- reject symlinked Cursor workspace directories before reading metadata or databases
- cover file and directory escapes with real filesystem regressions

## Testing

- `pnpm --filter @codesesh/core test`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter @codesesh/core format:check`