### PR TITLE
Guard remote writes from cross-site requests

### DIFF
--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -345,6 +345,32 @@ describe("createServer", () => {
           })
         ).status,
       ).toBe(401);
+      expect(
+        (
+          await fetch(`${requestOrigin}/api/logs`, {
+            method: "POST",
+            headers: {
+              Authorization: "Bearer test-access-token",
+              "Content-Type": "application/json",
+              "Sec-Fetch-Site": "cross-site",
+            },
+            body: JSON.stringify({ event: "cross-site-probe" }),
+          })
+        ).status,
+      ).toBe(403);
+      expect(
+        (
+          await fetch(`${requestOrigin}/api/logs`, {
+            method: "POST",
+            headers: {
+              Authorization: "Bearer test-access-token",
+              "Content-Type": "application/json",
+              Origin: requestOrigin,
+            },
+            body: JSON.stringify({ event: "same-origin-probe" }),
+          })
+        ).status,
+      ).toBe(200);
 
       await app.shutdown();
     } finally {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -191,10 +191,6 @@ export async function createServer(
     }
   });
 
-  if (loopbackAuthorityEnabled) {
-    app.use("/api/*", loopbackWriteGuard());
-  }
-
   // Ordered before authentication: a request that bypassed the proxy must be
   // refused outright, not given a chance to present a token in the clear.
   if (transport.kind === "trusted-proxy") {
@@ -203,6 +199,7 @@ export async function createServer(
   if (remoteAccessToken) {
     app.use("/api/*", remoteAccessAuth(remoteAccessToken));
   }
+  app.use("/api/*", loopbackWriteGuard());
   app.use(
     "/api/*",
     bodyLimit({


### PR DESCRIPTION
## Summary

- apply the write-request guard to authenticated remote deployments as well as loopback
- keep proxy enforcement and authentication ahead of write validation
- verify authenticated cross-site writes fail while same-origin JSON remains valid

## Testing

- `pnpm --filter codesesh test`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh build`
- `pnpm --filter codesesh format:check`