### PR TITLE
Add CSP and browser security headers

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,30 +9,7 @@
     />
     <link rel="icon" type="image/svg+xml" href="/logo.svg?v=3" />
     <title>CodeSesh</title>
-    <script>
-      // Sets .dark before first paint, reading the same localStorage key and
-      // envelope shape as useUiPreferences (apps/web/src/hooks/useUiPreferences.ts)
-      // so the pre-hydration skeleton below never flashes the wrong theme.
-      (function () {
-        var theme = "system";
-        try {
-          var raw = window.localStorage.getItem("codesesh.ui-preferences");
-          if (raw) {
-            var envelope = JSON.parse(raw);
-            var stored = envelope && envelope.version === 1 && envelope.state && envelope.state.theme;
-            if (stored === "light" || stored === "dark" || stored === "system") theme = stored;
-          }
-        } catch (e) {
-          theme = "system";
-        }
-        var isDark =
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches);
-        if (isDark) document.documentElement.classList.add("dark");
-      })();
-    </script>
+    <script src="/theme-bootstrap.js"></script>
     <style>
       /* Duplicates the light/dark tokens of src/index.css so the pre-hydration
          skeleton below paints in the real palette. Keep both in sync. */

--- a/apps/web/public/theme-bootstrap.js
+++ b/apps/web/public/theme-bootstrap.js
@@ -1,0 +1,19 @@
+// Runs before first paint so the pre-hydration shell uses the persisted theme.
+(() => {
+  let theme = "system";
+  try {
+    const raw = window.localStorage.getItem("codesesh.ui-preferences");
+    if (raw) {
+      const envelope = JSON.parse(raw);
+      const stored = envelope?.version === 1 ? envelope.state?.theme : undefined;
+      if (stored === "light" || stored === "dark" || stored === "system") theme = stored;
+    }
+  } catch {
+    theme = "system";
+  }
+
+  const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+  if (theme === "dark" || (theme === "system" && prefersDark)) {
+    document.documentElement.classList.add("dark");
+  }
+})();

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -450,6 +450,33 @@ describe("createServer", () => {
     expect(store.shutdown).toHaveBeenCalledOnce();
   });
 
+  it("serves the app with restrictive browser security headers", async () => {
+    const webDist = mkdtempSync(join(tmpdir(), "codesesh-security-headers-"));
+    writeFileSync(join(webDist, "index.html"), "<html>app shell</html>");
+    const app = await createServer(0, createStore(), { webDistPath: webDist });
+
+    try {
+      const response = await fetch(app.url);
+      const policy = response.headers.get("Content-Security-Policy") ?? "";
+
+      expect(policy).toContain("default-src 'self'");
+      expect(policy).toContain("script-src 'self'");
+      expect(policy).toContain("script-src-attr 'none'");
+      expect(policy).toContain("style-src 'self' 'unsafe-inline'");
+      expect(policy).toContain("img-src 'self' data:");
+      expect(policy).toContain("font-src 'self' data:");
+      expect(policy).toContain("object-src 'none'");
+      expect(policy).toContain("frame-ancestors 'none'");
+      expect(policy).toContain("base-uri 'none'");
+      expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+      expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+      expect(response.headers.get("X-Frame-Options")).toBe("DENY");
+    } finally {
+      await app.shutdown();
+      rmSync(webDist, { recursive: true, force: true });
+    }
+  });
+
   it("CS-131: serves the web build without reading outside its root", async () => {
     const root = mkdtempSync(join(tmpdir(), "codesesh-static-root-"));
     const webDist = join(root, "web");

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import { compress } from "hono/compress";
+import { secureHeaders } from "hono/secure-headers";
 import { serve } from "@hono/node-server";
 import type { HttpBindings, ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
@@ -152,6 +153,36 @@ export async function createServer(
       `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
     );
   }
+
+  app.use(
+    "*",
+    secureHeaders({
+      contentSecurityPolicy: {
+        defaultSrc: ["'self'"],
+        baseUri: ["'none'"],
+        connectSrc: ["'self'"],
+        fontSrc: ["'self'", "data:"],
+        formAction: ["'self'"],
+        frameAncestors: ["'none'"],
+        imgSrc: ["'self'", "data:"],
+        objectSrc: ["'none'"],
+        scriptSrc: ["'self'"],
+        scriptSrcAttr: ["'none'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+      },
+      crossOriginOpenerPolicy: false,
+      crossOriginResourcePolicy: false,
+      originAgentCluster: false,
+      referrerPolicy: "no-referrer",
+      strictTransportSecurity: false,
+      xContentTypeOptions: "nosniff",
+      xDnsPrefetchControl: false,
+      xDownloadOptions: false,
+      xFrameOptions: "DENY",
+      xPermittedCrossDomainPolicies: false,
+      xXssProtection: false,
+    }),
+  );
 
   if (loopbackAuthorityEnabled) {
     app.use("*", async (c, next) => {


### PR DESCRIPTION
## Summary

- move the pre-paint theme bootstrap into a same-origin static script
- add a restrictive CSP plus nosniff, no-referrer, and anti-framing headers
- allow only the inline styles, data images, and embedded fonts required by the current UI
- cover the response policy and validate all product surfaces in Playwright

## Testing

- `pnpm test:e2e` (26 passed)
- `pnpm --filter codesesh test`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter codesesh lint`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter codesesh build`
- `pnpm --filter @codesesh/web build`
- `pnpm --filter codesesh format:check`
- `pnpm --filter @codesesh/web format:check`