### PR TITLE
refactor(search): return structured highlights

### DIFF
--- a/apps/web/src/components/app/SearchResultsPanel.test.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.test.tsx
@@ -94,6 +94,8 @@ describe("SearchResultsPanel", () => {
   });
 
   it("renders safe result snippets and opens the selected result", () => {
+    const snippet = '<script>alert("x")</script><mark>literal</mark> needle & more';
+    const highlightStart = snippet.indexOf("needle");
     const results: SearchResult[] = [
       {
         reference: { agentName: "Codex", sessionId: "s1" },
@@ -101,13 +103,15 @@ describe("SearchResultsPanel", () => {
           display_title: "Renamed session",
           smart_tags: ["bugfix"],
         }),
-        snippet: '<script>alert("x")</script><mark>needle</mark> & more',
+        snippet,
+        snippetHighlights: [{ start: highlightStart, end: highlightStart + "needle".length }],
         matchType: "title",
       },
       {
         reference: { agentName: "Other", sessionId: "s2" },
         session: makeSession("s2"),
         snippet: "",
+        snippetHighlights: [],
         matchType: "file_path",
       },
     ];
@@ -132,8 +136,13 @@ describe("SearchResultsPanel", () => {
     expect(screen.getByText("Renamed session")).toBeTruthy();
     expect(screen.getAllByText("bugfix").some((element) => element.tagName === "SPAN")).toBe(true);
     expect(screen.getByText("needle").tagName).toBe("MARK");
+    expect(Array.from(container.querySelectorAll("mark"), (node) => node.textContent)).toEqual([
+      "needle",
+    ]);
     expect(container.querySelector("script")).toBeNull();
-    expect(container.textContent).toContain('<script>alert("x")</script>needle & more');
+    expect(container.textContent).toContain(
+      '<script>alert("x")</script><mark>literal</mark> needle & more',
+    );
 
     const firstLink = screen.getByText("Renamed session").closest("a");
     const selectedTitle = screen
@@ -158,6 +167,7 @@ describe("SearchResultsPanel", () => {
           parent_reference: { agentName: "codex", sessionId: "parent" },
         }),
         snippet: "",
+        snippetHighlights: [],
         matchType: "title",
         parent: {
           reference: { agentName: "codex", sessionId: "parent" },
@@ -182,6 +192,7 @@ describe("SearchResultsPanel", () => {
           parent_reference: { agentName: "codex", sessionId: "missing" },
         }),
         snippet: "",
+        snippetHighlights: [],
         matchType: "title",
       },
     ];

--- a/apps/web/src/components/app/SearchResultsPanel.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from "react";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
 import { Link } from "react-router-dom";
 import type { AgentInfo, SearchResult } from "../../lib/api";
 import { sessionRoutePath } from "../../lib/session-indexes";
@@ -16,15 +16,22 @@ const SEARCH_MATCH_LABELS: Record<SearchResult["matchType"], string> = {
   file_path: "File path",
 };
 
-function toSafeSnippetHtml(snippet: string): string {
-  return snippet
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;")
-    .replaceAll("&lt;mark&gt;", "<mark>")
-    .replaceAll("&lt;/mark&gt;", "</mark>");
+function renderHighlightedSnippet(
+  snippet: string,
+  highlights: SearchResult["snippetHighlights"],
+): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+
+  for (const { start, end } of highlights) {
+    if (start < cursor || end <= start || end > snippet.length) continue;
+    if (start > cursor) nodes.push(snippet.slice(cursor, start));
+    nodes.push(<mark key={`${start}-${end}`}>{snippet.slice(start, end)}</mark>);
+    cursor = end;
+  }
+
+  if (cursor < snippet.length) nodes.push(snippet.slice(cursor));
+  return nodes;
 }
 
 export function SearchResultsPanel({
@@ -188,12 +195,12 @@ export function SearchResultsPanel({
               {getSessionDisplayTitle(result.session)}
             </h2>
             <SmartTagChips tags={result.session.smart_tags} className="mt-2" />
-            <p
-              className="mt-2 text-xs leading-6 text-[var(--console-text-secondary)]"
-              dangerouslySetInnerHTML={{
-                __html: toSafeSnippetHtml(result.snippet || getSessionDisplayTitle(result.session)),
-              }}
-            />
+            <p className="mt-2 text-xs leading-6 text-[var(--console-text-secondary)]">
+              {renderHighlightedSnippet(
+                result.snippet || getSessionDisplayTitle(result.session),
+                result.snippet ? result.snippetHighlights : [],
+              )}
+            </p>
           </Link>
         );
       })}

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
@@ -29,6 +29,7 @@ const searchResults: SearchResult[] = sessions.slice(0, 2).map((session) => ({
   reference: { agentName: "Codex", sessionId: session.id },
   session,
   snippet: session.title,
+  snippetHighlights: [],
   matchType: "title",
 }));
 

--- a/apps/web/src/hooks/useSessionSearch.test.ts
+++ b/apps/web/src/hooks/useSessionSearch.test.ts
@@ -35,6 +35,7 @@ function makeSearchResult(id: string): SearchResult {
       },
     },
     snippet: "",
+    snippetHighlights: [],
     matchType: "assistant_reply",
   };
 }

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -104,6 +104,7 @@ describe("buildLocalRecentResults", () => {
         },
         session: sBugfixApp,
         snippet: `Recent session · ${sBugfixApp.directory}`,
+        snippetHighlights: [],
         matchType: "recent",
       },
     ]);
@@ -163,6 +164,7 @@ describe("buildSearchProjectOptions", () => {
     return {
       reference: { agentName: "codex", sessionId: id },
       snippet: "match",
+      snippetHighlights: [],
       matchType: "title",
       session: {
         id,

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -67,6 +67,7 @@ export function buildLocalRecentResults(
       },
       session: sessionItem,
       snippet: `Recent session · ${sessionItem.directory}`,
+      snippetHighlights: [],
       matchType: "recent" as const,
     });
     if (results.length >= 50) break;

--- a/packages/cli/src/api/__tests__/contract.test.ts
+++ b/packages/cli/src/api/__tests__/contract.test.ts
@@ -59,6 +59,7 @@ describe("cli routes stay wire-compatible with @codesesh/core/contract", () => {
         reference: { agentName: "claudecode", sessionId: SAMPLE_SESSION_HEAD.id },
         session: SAMPLE_SESSION_HEAD,
         snippet: `Recent session · ${SAMPLE_SESSION_HEAD.directory}`,
+        snippetHighlights: [],
         matchType: "recent",
       },
     ]);

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -603,6 +603,7 @@ describe("handleSearchSessions", () => {
         reference: { agentName: "claudecode", sessionId: session.id },
         session,
         snippet: "Ranked match",
+        snippetHighlights: [],
         matchType: "assistant_reply" as const,
       })),
     );

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -132,6 +132,7 @@ export function findAliasSearchResults(
       reference: alias.reference,
       session: aliases.decorate(session, alias.reference),
       snippet: `Alias · ${session.directory}`,
+      snippetHighlights: [],
       matchType: "title",
     });
   }

--- a/packages/core/src/contract/search.ts
+++ b/packages/core/src/contract/search.ts
@@ -14,8 +14,14 @@ export interface SearchResultParent {
   title: string;
 }
 
+export interface SearchHighlightRange {
+  start: number;
+  end: number;
+}
+
 export interface SearchResult extends ReferencedSessionHead {
   snippet: string;
+  snippetHighlights: SearchHighlightRange[];
   matchType: SearchMatchType;
   /** Present when the hit is a sub-session AND its parent is in the snapshot.
    *  Renders as 父 › 子 in the results list. */

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -61,6 +61,12 @@ function getStatePath(): string {
   return join(getStateDir(), "state.db");
 }
 
+function highlightedText(
+  result: { snippet: string; snippetHighlights: Array<{ start: number; end: number }> } | undefined,
+): string[] {
+  return result?.snippetHighlights.map(({ start, end }) => result.snippet.slice(start, end)) ?? [];
+}
+
 function makeSession(): SessionHead {
   return {
     id: "legacy-smoke",
@@ -276,14 +282,14 @@ function expectMigratedBehavior(structured: boolean): void {
   ]);
   expect(results).toHaveLength(1);
   expect(results[0]?.session.id).toBe("legacy-smoke");
-  expect(results[0]?.snippet).toContain("<mark>needle</mark>");
+  expect(highlightedText(results[0])).toContain("needle");
 
   if (structured) {
     const toolResults = searchSessions("tool:read");
     const fileResults = searchFileActivitySessions("legacy.ts");
     expect(toolResults.map((result) => result.session.id)).toEqual(["legacy-smoke"]);
     expect(fileResults.map((result) => result.session.id)).toEqual(["legacy-smoke"]);
-    expect(fileResults[0]?.snippet).toContain("<mark>legacy.ts</mark>");
+    expect(highlightedText(fileResults[0])).toContain("legacy.ts");
   }
 }
 

--- a/packages/core/src/discovery/cache/__tests__/file-activity.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/file-activity.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildFileActivityWhere,
   fileActivityFromRow,
-  highlightFilePath,
+  findFilePathHighlightRanges,
 } from "../file-activity.js";
 
 describe("cached file activity", () => {
@@ -50,6 +50,6 @@ describe("cached file activity", () => {
       count: 2,
       latestTime: 30,
     });
-    expect(highlightFilePath("src/App.tsx", "app")).toBe("src/<mark>App</mark>.tsx");
+    expect(findFilePathHighlightRanges("src/App.tsx", "app")).toEqual([{ start: 4, end: 7 }]);
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -82,6 +82,12 @@ function makeSessionData(id: string, text: string): SessionDetail {
   };
 }
 
+function highlightedText(
+  result: { snippet: string; snippetHighlights: Array<{ start: number; end: number }> } | undefined,
+): string[] {
+  return result?.snippetHighlights.map(({ start, end }) => result.snippet.slice(start, end)) ?? [];
+}
+
 function createLegacyCacheTables(db: Database.Database): void {
   db.exec(`
     CREATE TABLE cache_meta (
@@ -860,7 +866,20 @@ describe("searchSessions", () => {
       total_output_tokens: 7,
       total_cost: 0.03,
     });
-    expect(results[0]?.snippet).toContain("<mark>sqlite</mark>");
+    expect(highlightedText(results[0])).toContain("sqlite");
+  });
+
+  it("exposes literal mark text beside a highlighted match", () => {
+    const session = makeSession("literal-mark");
+    saveCachedSessions("claudecode", [session]);
+    syncSessionSearchIndex("claudecode", [session], (sessionId) =>
+      makeSessionData(sessionId, "literal <mark>text</mark> before sqlite"),
+    );
+
+    const results = searchSessions("sqlite");
+
+    expect(results[0]?.snippet).toContain("literal <mark>text</mark>");
+    expect(highlightedText(results[0])).toEqual(["sqlite"]);
   });
 
   it("filters indexed search by complete project identity", () => {
@@ -1041,7 +1060,7 @@ describe("searchSessions", () => {
     expect(searchSessions("userneedle")[0]?.matchType).toBe("user_message");
     expect(searchSessions("assistantneedle")[0]?.matchType).toBe("assistant_reply");
     expect(searchSessions("toolneedle")[0]?.matchType).toBe("tool_output");
-    expect(searchSessions('"quoted phrase"')[0]?.snippet).toContain("<mark>quoted phrase</mark>");
+    expect(highlightedText(searchSessions('"quoted phrase"')[0])).toContain("quoted phrase");
 
     const allTermResults = searchSessions("assistantneedle reply");
     expect(allTermResults[0]?.session.id).toBe("assistant");
@@ -1050,11 +1069,11 @@ describe("searchSessions", () => {
     const orResults = searchSessions("alphaneedle OR betaneedle");
     expect(orResults[0]?.session.id).toBe("or-first");
     expect(orResults[0]?.matchType).toBe("assistant_reply");
-    expect(orResults[0]?.snippet).toContain("<mark>betaneedle</mark>");
+    expect(highlightedText(orResults[0])).toContain("betaneedle");
 
     const punctuatedResults = searchSessions('"école-needle"');
     expect(punctuatedResults[0]?.matchType).toBe("user_message");
-    expect(punctuatedResults[0]?.snippet).toContain("<mark>ÉCOLE-needle</mark>");
+    expect(highlightedText(punctuatedResults[0])).toContain("ÉCOLE-needle");
   });
 
   it("bounds a single message FTS lookup to one row per candidate", () => {
@@ -1185,7 +1204,7 @@ describe("searchSessions", () => {
     const filteredResults = searchSessions("needle", { cwd: "/tmp/bulk-project" });
     expect(filteredResults).toHaveLength(1);
     expect(filteredResults[0]?.session.id).toBe("bulk-42");
-    expect(filteredResults[0]?.snippet).toContain("<mark>needle</mark>");
+    expect(highlightedText(filteredResults[0])).toContain("needle");
   });
 
   it("writes each full search entry before loading the next one", () => {
@@ -1803,7 +1822,7 @@ describe("searchSessions", () => {
     const searchResults = searchFileActivitySessions("src/new.ts");
     expect(searchResults).toHaveLength(1);
     expect(searchResults[0]?.session.id).toBe("files");
-    expect(searchResults[0]?.snippet).toContain("<mark>src/new.ts</mark>");
+    expect(highlightedText(searchResults[0])).toContain("src/new.ts");
 
     const directWriteResults = searchFileActivitySessions("src/direct.ts");
     expect(directWriteResults).toHaveLength(1);
@@ -1927,7 +1946,8 @@ describe("searchSessions", () => {
 
     expect(results).toHaveLength(1);
     // Equal latest_time and count, so the path breaks the tie.
-    expect(results[0]?.snippet).toContain("</mark>/a.ts");
+    expect(results[0]?.snippet).toContain("src/tie/a.ts");
+    expect(highlightedText(results[0])).toEqual(["src/tie"]);
   });
 
   it("uses latest-time indexes for recent file activity query plans", () => {
@@ -2401,7 +2421,7 @@ describe("searchSessions", () => {
 
     expect(results).toHaveLength(1);
     expect(results[0]?.session.id).toBe("fts-empty");
-    expect(results[0]?.snippet).toContain("<mark>orphan</mark>");
+    expect(highlightedText(results[0])).toContain("orphan");
   });
 
   it("rebuilds affected FTS indexes when update triggers are missing", () => {

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -7,7 +7,7 @@ import type {
   ProjectIdentityKind,
   SessionFileActivity,
 } from "../../types/index.js";
-import type { FileActivityResult } from "../../contract/index.js";
+import type { FileActivityResult, SearchHighlightRange } from "../../contract/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { filePathFtsQuery, hasCacheStorage, likePattern, normalizeFilePathSearch } from "./db.js";
@@ -283,15 +283,13 @@ export function listSessionFileActivity(
   );
 }
 
-export function highlightFilePath(path: string, query: string): string {
+export function findFilePathHighlightRanges(path: string, query: string): SearchHighlightRange[] {
   const needle = normalizeFilePathSearch(query);
-  if (!needle) return path;
+  if (!needle) return [];
   const lower = path.toLowerCase();
   const index = lower.indexOf(needle.toLowerCase());
-  if (index < 0) return path;
-  return `${path.slice(0, index)}<mark>${path.slice(index, index + needle.length)}</mark>${path.slice(
-    index + needle.length,
-  )}`;
+  if (index < 0) return [];
+  return [{ start: index, end: index + needle.length }];
 }
 
 export function searchFileActivitySessions(
@@ -312,10 +310,17 @@ export function searchFileActivitySessions(
     true,
   );
 
-  return rows.map((row) => ({
-    reference: row.reference,
-    session: row.session,
-    snippet: `${row.kind} ${highlightFilePath(row.path, path)} · ${row.count} events`,
-    matchType: "file_path",
-  }));
+  return rows.map((row) => {
+    const prefix = `${row.kind} `;
+    return {
+      reference: row.reference,
+      session: row.session,
+      snippet: `${prefix}${row.path} · ${row.count} events`,
+      snippetHighlights: findFilePathHighlightRanges(row.path, path).map((range) => ({
+        start: prefix.length + range.start,
+        end: prefix.length + range.end,
+      })),
+      matchType: "file_path",
+    };
+  });
 }

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -8,7 +8,7 @@ import type {
   SessionHead,
   SmartTag,
 } from "../../types/index.js";
-import type { SearchMatchType, SearchResult } from "../../contract/index.js";
+import type { SearchHighlightRange, SearchMatchType, SearchResult } from "../../contract/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { escapeRegExp, filePathFtsQuery, hasCacheStorage, likePattern } from "./db.js";
@@ -349,21 +349,51 @@ function textMatchesTerms(text: string, terms: { terms: string[]; mode: "all" | 
   return terms.terms.every((term) => lower.includes(term));
 }
 
-function highlightTerm(text: string, term: string): string {
-  return text.replace(new RegExp(escapeRegExp(term), "gi"), (match) => `<mark>${match}</mark>`);
+interface SearchSnippet {
+  snippet: string;
+  snippetHighlights: SearchHighlightRange[];
 }
 
-function buildTermSnippet(text: string, terms: { terms: string[]; mode: "all" | "any" }): string {
+function findHighlightRanges(text: string, terms: string[]): SearchHighlightRange[] {
+  const ranges = terms.flatMap((term) =>
+    Array.from(text.matchAll(new RegExp(escapeRegExp(term), "giu")), (match) => ({
+      start: match.index,
+      end: match.index + match[0].length,
+    })),
+  );
+  ranges.sort((left, right) => left.start - right.start || right.end - left.end);
+
+  return ranges.reduce<SearchHighlightRange[]>((merged, range) => {
+    const previous = merged.at(-1);
+    if (previous && range.start <= previous.end) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      merged.push(range);
+    }
+    return merged;
+  }, []);
+}
+
+function buildTermSnippet(
+  text: string,
+  terms: { terms: string[]; mode: "all" | "any" },
+): SearchSnippet {
   const lower = text.toLowerCase();
   const term = terms.terms.find((item) => lower.includes(item)) ?? terms.terms[0] ?? "";
-  if (!term) return text.slice(0, 180);
+  if (!term) {
+    return { snippet: text.slice(0, 180), snippetHighlights: [] };
+  }
 
   const index = lower.indexOf(term);
   const start = Math.max(0, index - 80);
   const end = Math.min(text.length, index + term.length + 80);
-  return `${start > 0 ? "… " : ""}${highlightTerm(text.slice(start, end), term)}${
+  const snippet = `${start > 0 ? "… " : ""}${text.slice(start, end)}${
     end < text.length ? " …" : ""
   }`;
+  return {
+    snippet,
+    snippetHighlights: findHighlightRanges(snippet, terms.terms),
+  };
 }
 
 function messageMatchType(row: MessageSearchRow): SearchMatchType {
@@ -381,7 +411,7 @@ function fetchMessageSearchMatches(
   rows: SearchResultRow[],
   ftsQuery: string,
   terms: { terms: string[]; mode: "all" | "any" },
-): Map<string, { snippet: string; matchType: SearchMatchType }> {
+): Map<string, SearchSnippet & { matchType: SearchMatchType }> {
   const candidates = rows.filter((row) => !textMatchesTerms(String(row.title ?? ""), terms));
   if (candidates.length === 0) {
     return new Map();
@@ -432,7 +462,7 @@ function fetchMessageSearchMatches(
       `,
     )
     .all(...candidateParams, ftsQuery) as MessageSearchRow[];
-  const matches = new Map<string, { snippet: string; matchType: SearchMatchType }>();
+  const matches = new Map<string, SearchSnippet & { matchType: SearchMatchType }>();
 
   for (const message of messageRows) {
     const key = searchResultRowKey(message);
@@ -442,7 +472,7 @@ function fetchMessageSearchMatches(
     if (!textMatchesTerms(text, terms)) continue;
 
     matches.set(key, {
-      snippet: buildTermSnippet(text, terms),
+      ...buildTermSnippet(text, terms),
       matchType: messageMatchType(message),
     });
   }
@@ -453,19 +483,20 @@ function fetchMessageSearchMatches(
 function resolveSearchMatch(
   row: SearchResultRow,
   terms: { terms: string[]; mode: "all" | "any" },
-  messageMatches: Map<string, { snippet: string; matchType: SearchMatchType }>,
-): { snippet: string; matchType: SearchMatchType } {
+  messageMatches: Map<string, SearchSnippet & { matchType: SearchMatchType }>,
+): SearchSnippet & { matchType: SearchMatchType } {
   const title = String(row.title ?? "");
 
   if (terms.terms.length === 0) {
     return {
       snippet: `Recent session · ${String(row.directory ?? "")}`,
+      snippetHighlights: [],
       matchType: "recent",
     };
   }
 
   if (textMatchesTerms(title, terms)) {
-    return { snippet: buildTermSnippet(title, terms), matchType: "title" };
+    return { ...buildTermSnippet(title, terms), matchType: "title" };
   }
 
   const messageMatch = messageMatches.get(searchResultRowKey(row));
@@ -475,6 +506,7 @@ function resolveSearchMatch(
 
   return {
     snippet: String(row.snippet ?? ""),
+    snippetHighlights: findHighlightRanges(String(row.snippet ?? ""), terms.terms),
     matchType: "assistant_reply",
   };
 }
@@ -489,7 +521,7 @@ function rowsToSearchResults(
   const messageMatches =
     terms.terms.length > 0 && ftsQuery
       ? fetchMessageSearchMatches(db, rows, ftsQuery, terms)
-      : new Map<string, { snippet: string; matchType: SearchMatchType }>();
+      : new Map<string, SearchSnippet & { matchType: SearchMatchType }>();
 
   return rows.map((row) => {
     const match = resolveSearchMatch(row, terms, messageMatches);
@@ -500,6 +532,7 @@ function rowsToSearchResults(
       },
       session: sessionHeadFromSearchRow(row),
       snippet: match.snippet,
+      snippetHighlights: match.snippetHighlights,
       matchType: match.matchType,
     };
   });
@@ -543,8 +576,8 @@ export function searchSessions(query: string, options: SearchOptions = {}): Sear
           SELECT
             ${searchSessionColumns()},
             COALESCE(
-              NULLIF(snippet(session_documents_fts, 1, '<mark>', '</mark>', ' … ', 18), ''),
-              highlight(session_documents_fts, 0, '<mark>', '</mark>')
+              NULLIF(snippet(session_documents_fts, 1, '', '', ' … ', 18), ''),
+              highlight(session_documents_fts, 0, '', '')
             ) AS snippet
           FROM session_documents_fts
           JOIN session_documents d ON d.id = session_documents_fts.rowid

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -790,6 +790,7 @@ describe("search candidate filtering", () => {
       reference: { agentName: spec.agent, sessionId: spec.id },
       session: snapshot.byAgent[spec.agent]!.find((session) => session.id === spec.id)!,
       snippet: "Alias",
+      snippetHighlights: [],
       matchType: "title" as const,
     }));
 
@@ -822,6 +823,7 @@ describe("search candidate filtering", () => {
         reference: { agentName: "codex", sessionId: parent.id },
         session: parent,
         snippet: "Alias",
+        snippetHighlights: [],
         matchType: "title",
       },
     ];

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -179,6 +179,7 @@ function searchRecentSessions(
       reference: { agentName, sessionId: session.id },
       session,
       snippet: `Recent session · ${session.directory}`,
+      snippetHighlights: [],
       matchType: "recent",
     });
     if (results.length >= limit) break;


### PR DESCRIPTION
## Summary

- return plain search snippets with structured UTF-16 highlight ranges
- render matched ranges as React mark elements without raw HTML
- preserve literal mark and script text while highlighting real matches

## Testing

- pnpm --filter @codesesh/core test
- pnpm --filter codesesh test
- pnpm --filter @codesesh/web test
- pnpm --filter @codesesh/core lint
- pnpm --filter codesesh lint
- pnpm --filter @codesesh/web lint
- pnpm --filter @codesesh/core build
- pnpm --filter codesesh typecheck
- pnpm --filter @codesesh/web build