### PR TITLE
fix(cli): minimize credential and path exposure

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -69,6 +69,7 @@ import type {
 } from "@codesesh/core";
 import type { ModelCostEntry, SearchResult } from "@codesesh/core/contract";
 import { BaseAgent } from "@codesesh/core";
+import { appLogger } from "../../logging.js";
 
 // --- Helpers ---
 
@@ -1619,13 +1620,22 @@ describe("handleGetSessionData", () => {
   });
 
   it("maps materialization errors to 500", async () => {
+    const errorSpy = vi.spyOn(appLogger, "error").mockImplementation(() => {});
     coreMocks.materializeSessionDetailResponse.mockImplementation(() => {
-      throw new Error("DB not found");
+      throw new Error("ENOENT: open '/Users/private/.claude/session.json'");
     });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
 
-    await handleGetSessionData(c, makeScanSource());
+    try {
+      await handleGetSessionData(c, makeScanSource());
 
-    expect(c.json).toHaveBeenCalledWith({ error: "DB not found" }, 500);
+      expect(c.json).toHaveBeenCalledWith({ error: "Failed to load session" }, 500);
+      expect(errorSpy).toHaveBeenCalledWith(
+        "api.session_data.error",
+        expect.objectContaining({ error: "ENOENT: open '/Users/private/.claude/session.json'" }),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -648,7 +648,7 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       duration_ms: Math.round(performance.now() - startedAt),
       error: message,
     });
-    return c.json({ error: message }, 500);
+    return c.json({ error: "Failed to load session" }, 500);
   }
 }
 

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -566,6 +566,22 @@ describe("createServer", () => {
     }
   });
 
+  it("CS-223: warns trusted proxy operators that access logs can retain tokens", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const app = await createServer(0, createStore(), {
+      hostname: "0.0.0.0",
+      remoteAccessToken: "proxy-token",
+      transport: { kind: "trusted-proxy" },
+    });
+
+    try {
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("反向代理的访问日志"));
+    } finally {
+      await app.shutdown();
+      warnSpy.mockRestore();
+    }
+  });
+
   it("CS-140: refuses requests that bypassed the trusted proxy", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const app = await createServer(0, createStore(), {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -332,6 +332,13 @@ export async function createServer(
           `  使用 --tls-cert/--tls-key 直接启用 TLS，或在受信反向代理后使用 --trust-proxy。\n`,
       );
     }
+    if (transport.kind === "trusted-proxy") {
+      appLogger.warn("server.listen.proxy_logging", { hostname, port: actualPort });
+      console.warn(
+        `⚠ URL 中的访问令牌会用于 SSE 重连，并可能写入受信反向代理的访问日志。\n` +
+          `  请在代理配置中关闭查询参数日志，或对 access_token 参数脱敏。\n`,
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

- warn trusted-proxy operators that URL access tokens may be retained in proxy logs
- return a stable session-load error instead of exposing filesystem details
- preserve full materialization errors in structured server logs

## Testing

- pnpm --filter codesesh lint
- pnpm --filter codesesh test
- pnpm --filter codesesh build