### PR TITLE
refactor(cache): reuse SQLite connections

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -18,7 +18,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 | 模块 | 职责 |
 |------|------|
-| `cache/db.ts` | 缓存路径、共享查询辅助函数、schema/FTS 进程内检查状态 |
+| `cache/db.ts` | 缓存路径、进程内连接生命周期、共享查询辅助函数、schema/FTS 检查状态 |
 | `cache/schema.ts` | 建表、迁移、事务边界、FTS 完整性检查 |
 | `cache/sessions.ts` | 会话列表和详情快照的读取、写入与清理 |
 | `cache/messages.ts` | `sessions` / `messages` 行与领域对象之间的转换 |
@@ -160,7 +160,7 @@ materializeSessionDetailResponse()
 
 ## 迁移与恢复
 
-`withCacheDb()` 首次打开当前数据库路径时调用 `ensureSchema()`：
+`withCacheDb()` 首次打开当前数据库路径时创建进程内连接并调用 `ensureSchema()`：
 
 1. 读取 `PRAGMA user_version`，旧数据库还会兼容读取 `cache_meta.version`。
 2. 破坏性迁移前备份有数据的缓存。
@@ -168,7 +168,9 @@ materializeSessionDetailResponse()
 4. 创建最新 schema，并更新 `user_version` 和 `cache_meta.version`。
 
 迁移实现与目标版本必须以 `cache/schema.ts` 为准；文档不引用易漂移的源码行号。
-搜索边界首次打开数据库时还会检查 FTS 完整性；检查失败则重建对应索引。
+后续读写复用同一模块实例内的连接；worker thread 各自持有独立连接，不跨线程共享。
+搜索边界在每个连接上首次使用时检查 FTS schema，缺表或触发器时重建对应索引。
+`clearCache()` 和 CLI shutdown 会关闭连接；下一次访问会重新建连并执行上述检查。
 
 ## 相关代码
 

--- a/packages/cli/src/api/__tests__/search-transport.test.ts
+++ b/packages/cli/src/api/__tests__/search-transport.test.ts
@@ -31,7 +31,7 @@ vi.mock("node:os", async (importOriginal) => {
 // must only be imported dynamically, after the node:os mock above is
 // registered and testHomeDir exists, or that eager read races the mock and
 // throws (accessing testHomeDir before its own initialization).
-const { syncSessionSearchIndex } = await import("@codesesh/core");
+const { closeCacheStorage, syncSessionSearchIndex } = await import("@codesesh/core");
 const { createApiRoutes } = await import("../routes.js");
 
 function getCacheDir(): string {
@@ -79,6 +79,7 @@ async function search(app: ReturnType<typeof createApiRoutes>, qs: string) {
 }
 
 beforeAll(() => {
+  closeCacheStorage();
   rmSync(getCacheDir(), { recursive: true, force: true });
   syncSessionSearchIndex("claudecode", [ftsTitle], () => ({
     ...ftsTitle,
@@ -88,6 +89,7 @@ beforeAll(() => {
 });
 
 afterAll(() => {
+  closeCacheStorage();
   rmSync(getCacheDir(), { recursive: true, force: true });
 });
 

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -33,6 +33,7 @@ const fsWatch = vi.hoisted(() => ({
 }));
 
 const core = vi.hoisted(() => ({
+  closeCacheStorage: vi.fn(),
   createRegisteredAgents: vi.fn(),
   filterSessions: vi.fn((sessions: SessionHead[], _options: ScanOptions) => sessions),
   getAgentFullSyncCursor: vi.fn(() => null as string | null),
@@ -388,6 +389,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core")>();
   return {
     ...actual,
+    closeCacheStorage: core.closeCacheStorage,
     createRegisteredAgents: core.createRegisteredAgents,
     filterSessions: core.filterSessions,
     getAgentFullSyncCursor: core.getAgentFullSyncCursor,
@@ -2391,6 +2393,7 @@ describe("LiveScanStore", () => {
 
     await vi.advanceTimersByTimeAsync(10_000);
     expect(codex.checkForChanges).not.toHaveBeenCalled();
+    expect(core.closeCacheStorage).toHaveBeenCalledOnce();
   });
 
   it("terminates an active scan worker before shutdown completes", async () => {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
+  closeCacheStorage,
   createRegisteredAgents,
   scanSessions,
   type LiveSnapshot,
@@ -166,6 +167,7 @@ export class LiveScanStore {
       await this.watcher.dispose();
       this.watcher = null;
     }
+    closeCacheStorage();
   }
 
   private emit(event: SessionsUpdatedEvent): void {

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -294,16 +294,16 @@ function expectMigratedBehavior(structured: boolean): void {
 }
 
 beforeEach(() => {
+  setSchemaEnsuredPath(null);
   rmSync(getCacheDir(), { recursive: true, force: true });
   rmSync(getStateDir(), { recursive: true, force: true });
-  setSchemaEnsuredPath(null);
   setStateSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
+  setSchemaEnsuredPath(null);
   rmSync(getCacheDir(), { recursive: true, force: true });
   rmSync(getStateDir(), { recursive: true, force: true });
-  setSchemaEnsuredPath(null);
   setStateSchemaEnsuredPath(null);
 });
 

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -131,14 +131,14 @@ function persistDetail(head: SessionHead, detail: SessionDetail, fingerprint: st
 }
 
 beforeEach(() => {
-  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
 });
 
 afterEach(() => {
   setCoreDiagnostics(null);
-  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
 });
 
 describe("materializeSessionDetail", () => {

--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../../utils/diagnostics.js";
+import { closeCacheStorage } from "../db.js";
 import { withCacheDb, withCacheDbReadOnly, withSearchIndexDb } from "../schema.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-diag-test-"));
@@ -13,6 +14,7 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 afterEach(() => {
+  closeCacheStorage();
   setCoreDiagnostics(null);
 });
 

--- a/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
@@ -77,13 +77,13 @@ function seedFixture(): void {
 }
 
 beforeEach(() => {
-  rmSync(join(testHomeDir, ".cache", "codesesh"), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(join(testHomeDir, ".cache", "codesesh"), { recursive: true, force: true });
 });
 
 afterEach(() => {
-  rmSync(join(testHomeDir, ".cache", "codesesh"), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(join(testHomeDir, ".cache", "codesesh"), { recursive: true, force: true });
 });
 
 describe("listModelCostDistribution", () => {

--- a/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
@@ -33,14 +33,14 @@ function getCacheDir(): string {
 }
 
 beforeEach(() => {
-  rmSync(getCacheDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(getCacheDir(), { recursive: true, force: true });
   mockedWithCacheDb.mockClear();
 });
 
 afterEach(() => {
-  rmSync(getCacheDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(getCacheDir(), { recursive: true, force: true });
 });
 
 describe("cached project groups", () => {

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -17,13 +17,13 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 beforeEach(() => {
-  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
 });
 
 afterEach(() => {
-  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
 });
 
 describe("cache schema boundary", () => {
@@ -81,6 +81,38 @@ describe("cache schema boundary", () => {
       ]),
     );
     expect(state?.version).toBe(22);
+  });
+
+  it("reuses one connection for read and write capabilities until invalidated", () => {
+    const writeConnection = schema.withCacheDb((db) => db);
+    const nextWriteConnection = schema.withCacheDb((db) => db);
+    const readConnection = schema.withCacheDbReadOnly((db) => db);
+
+    expect(nextWriteConnection).toBe(writeConnection);
+    expect(readConnection).toEqual({ status: "success", value: writeConnection });
+
+    setSchemaEnsuredPath(null);
+
+    expect(schema.withCacheDb((db) => db)).not.toBe(writeConnection);
+  });
+
+  it("checks the FTS schema only on the first search for a connection", () => {
+    schema.withCacheDb(() => undefined);
+    const prepare = vi.spyOn(Database.prototype, "prepare");
+
+    schema.withSearchDb(() => undefined);
+    const firstProbeCount = prepare.mock.calls.filter(([sql]) =>
+      String(sql).includes("sqlite_master"),
+    ).length;
+
+    schema.withSearchDb(() => undefined);
+    const secondProbeCount = prepare.mock.calls.filter(([sql]) =>
+      String(sql).includes("sqlite_master"),
+    ).length;
+    prepare.mockRestore();
+
+    expect(firstProbeCount).toBeGreaterThan(0);
+    expect(secondProbeCount).toBe(firstProbeCount);
   });
 
   it("reclaims orphaned publication rows on the next schema open", () => {

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -17,8 +17,8 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 afterEach(() => {
-  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
 });
 
 describe("search index writer", () => {

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -120,14 +120,14 @@ function getUserVersion(dbPath: string): number {
 }
 
 beforeEach(() => {
+  setSchemaEnsuredPath(null);
   rmSync(getCacheDir(), { recursive: true, force: true });
   dateNowSpy.mockReturnValue(now);
-  setSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
-  rmSync(getCacheDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(getCacheDir(), { recursive: true, force: true });
 });
 
 describe("session detail re-indexing", () => {
@@ -1563,6 +1563,7 @@ describe("searchSessions", () => {
     } finally {
       db.close();
     }
+    setSchemaEnsuredPath(null);
 
     saveCachedSessions("claudecode", [updated]);
     syncSessionSearchIndex("claudecode", [updated], () => ({
@@ -2446,6 +2447,7 @@ describe("searchSessions", () => {
     } finally {
       db.close();
     }
+    setSchemaEnsuredPath(null);
 
     const matches = withSearchDb((searchDb) => ({
       documents: searchDb
@@ -2475,6 +2477,7 @@ describe("searchSessions", () => {
     } finally {
       db.close();
     }
+    setSchemaEnsuredPath(null);
 
     expect(searchSessions("tablerepairneedle")[0]?.session.id).toBe(session.id);
   });

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -130,14 +130,14 @@ function getMigrationBackups(): string[] {
 }
 
 beforeEach(() => {
+  setSchemaEnsuredPath(null);
   rmSync(getCacheDir(), { recursive: true, force: true });
   dateNowSpy.mockReturnValue(now);
-  setSchemaEnsuredPath(null);
 });
 
 afterEach(() => {
-  rmSync(getCacheDir(), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(getCacheDir(), { recursive: true, force: true });
   setCoreDiagnostics(null);
 });
 describe("loadCachedSessions", () => {
@@ -537,7 +537,11 @@ describe("saveCachedSessionChanges", () => {
 describe("clearCache", () => {
   it("clears sqlite rows", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
+    const connection = withCacheDb((db) => db);
     clearCache();
+    const reopened = withCacheDb((db) => db);
+
+    expect(reopened).not.toBe(connection);
     expect(loadCachedSessions("claudecode")).toBeNull();
     expect(getCacheInfo()).toEqual({ lastScanTime: null, size: 0 });
   });

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -24,8 +24,8 @@ vi.mock("node:os", async (importOriginal) => {
 
 afterEach(() => {
   setCoreDiagnostics(null);
-  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
   setSchemaEnsuredPath(null);
+  rmSync(join(testHomeDir, ".cache"), { recursive: true, force: true });
 });
 
 describe("cached sessions", () => {

--- a/packages/core/src/discovery/cache/db.ts
+++ b/packages/core/src/discovery/cache/db.ts
@@ -1,11 +1,9 @@
-/**
- * Cache infrastructure: cache paths and shared query helpers.
- * Lower-level than schema.ts — no DB handles here.
- */
+/** Cache paths, process-local connections, and shared query helpers. */
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
+import { getCoreDiagnostics } from "../../utils/diagnostics.js";
+import { openDb, type DatabaseRow, type SQLiteDatabase } from "../../utils/sqlite.js";
 import type { SessionHead } from "../../types/index.js";
 
 const CACHE_FILENAME = "codesesh.db";
@@ -31,17 +29,59 @@ export interface CacheRow extends DatabaseRow {
 
 export type SQLiteStatement = ReturnType<SQLiteDatabase["prepare"]>;
 
-// One-shot per-process ensureSchema guard; reset by clearCache. Once a path
-// has been schema-checked, withCacheDb skips ensureSchema's DDL exec (which
-// otherwise runs unconditionally on every open) so read-heavy callers stop
-// contending for the write lock.
+export interface CacheConnection {
+  db: SQLiteDatabase;
+  ftsReady: boolean;
+}
+
+const cacheConnections = new Map<string, CacheConnection>();
 let schemaEnsuredPath: string | null = null;
+
+export function getCacheConnection(path: string): CacheConnection | null {
+  const cached = cacheConnections.get(path);
+  if (cached) return cached;
+
+  const db = openDb(path);
+  if (!db) return null;
+
+  const connection = { db, ftsReady: false };
+  cacheConnections.set(path, connection);
+  return connection;
+}
+
+export function discardCacheConnection(path: string, connection: CacheConnection): void {
+  if (cacheConnections.get(path) !== connection) return;
+  cacheConnections.delete(path);
+  closeConnection(path, connection);
+}
+
+function closeConnection(path: string, connection: CacheConnection): void {
+  try {
+    connection.db.close();
+  } catch (error) {
+    getCoreDiagnostics()?.warn("cache.close_failed", {
+      dbPath: path,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export function closeCacheStorage(): void {
+  const connections = [...cacheConnections];
+  cacheConnections.clear();
+  schemaEnsuredPath = null;
+  for (const [path, connection] of connections) closeConnection(path, connection);
+}
 
 export function getSchemaEnsuredPath(): string | null {
   return schemaEnsuredPath;
 }
 
 export function setSchemaEnsuredPath(path: string | null): void {
+  if (path === null) {
+    closeCacheStorage();
+    return;
+  }
   schemaEnsuredPath = path;
 }
 

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -9,15 +9,22 @@ import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import {
   columnExists,
   getUserVersion,
-  openDb,
-  openDbReadOnly,
   runSchemaMigrations,
   setUserVersion,
   tableExists,
   type DatabaseRow,
   type SQLiteDatabase,
 } from "../../utils/sqlite.js";
-import { getCachePath, getSchemaEnsuredPath, setSchemaEnsuredPath, type CacheRow } from "./db.js";
+import {
+  discardCacheConnection,
+  getCacheConnection,
+  getCachePath,
+  getSchemaEnsuredPath,
+  hasCacheStorage,
+  setSchemaEnsuredPath,
+  type CacheConnection,
+  type CacheRow,
+} from "./db.js";
 import {
   messageFromBackfillRow,
   prepareInsertFileActivity,
@@ -70,17 +77,17 @@ interface ProjectIdentityRefreshRow extends DatabaseRow {
   directory?: string;
 }
 
-export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
+function withCacheConnection<T>(fn: (connection: CacheConnection) => T): T | null {
   const cachePath = getCachePath();
-  const db = openDb(cachePath);
-  if (!db) return null;
+  const connection = getCacheConnection(cachePath);
+  if (!connection) return null;
 
   try {
     if (getSchemaEnsuredPath() !== cachePath) {
-      ensureSchema(db, cachePath);
+      ensureSchema(connection.db, cachePath);
       setSchemaEnsuredPath(cachePath);
     }
-    return fn(db);
+    return fn(connection);
   } catch (error) {
     getCoreDiagnostics()?.warn("cache.write_failed", {
       message: error instanceof Error ? error.message : String(error),
@@ -88,38 +95,43 @@ export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
       error_class: error instanceof Error ? error.name : typeof error,
       stack: error instanceof Error ? error.stack : undefined,
     });
+    discardCacheConnection(cachePath, connection);
     return null;
-  } finally {
-    db.close();
   }
+}
+
+export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
+  return withCacheConnection(({ db }) => fn(db));
 }
 
 export type CacheReadOutcome<T> = { status: "success"; value: T } | { status: "failed" };
 
 export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): CacheReadOutcome<T> {
-  const db = openDbReadOnly(getCachePath());
-  if (!db) return { status: "failed" };
+  const cachePath = getCachePath();
+  if (!hasCacheStorage()) return { status: "failed" };
+
+  const connection = getCacheConnection(cachePath);
+  if (!connection) return { status: "failed" };
 
   try {
-    return { status: "success", value: fn(db) };
+    return { status: "success", value: fn(connection.db) };
   } catch (error) {
     getCoreDiagnostics()?.warn("cache.read_failed", {
       message: error instanceof Error ? error.message : String(error),
       code: (error as { code?: string })?.code,
       error_class: error instanceof Error ? error.name : typeof error,
     });
+    discardCacheConnection(cachePath, connection);
     return { status: "failed" };
-  } finally {
-    db.close();
   }
 }
 
 export function withSearchDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
-  return withCacheDb((db) => runWithFtsRecovery(db, fn));
+  return withCacheConnection((connection) => runWithFtsRecovery(connection, fn));
 }
 
 export function withSearchIndexDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
-  return withCacheDb((db) => runWithFtsRecovery(db, fn));
+  return withCacheConnection((connection) => runWithFtsRecovery(connection, fn));
 }
 
 interface SearchIndexWriteResult<T> {
@@ -1299,8 +1311,12 @@ function isFtsCorruptionError(error: unknown): boolean {
   );
 }
 
-function runWithFtsRecovery<T>(db: SQLiteDatabase, fn: (db: SQLiteDatabase) => T): T {
-  ensureFtsReady(db);
+function runWithFtsRecovery<T>(connection: CacheConnection, fn: (db: SQLiteDatabase) => T): T {
+  const { db } = connection;
+  if (!connection.ftsReady) {
+    ensureFtsReady(db);
+    connection.ftsReady = true;
+  }
   try {
     return fn(db);
   } catch (error) {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -9,10 +9,10 @@ import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import { tableExists, type SQLiteDatabase } from "../../utils/sqlite.js";
 import {
+  closeCacheStorage,
   getCachePath,
   getLegacyCachePath,
   hasCacheStorage,
-  setSchemaEnsuredPath,
   type ScalarRow,
   type SessionHeadChange,
 } from "./db.js";
@@ -628,7 +628,7 @@ export function writeCachedSessionChanges(
 }
 
 export function clearCache(): void {
-  setSchemaEnsuredPath(null);
+  closeCacheStorage();
   if (!hasCacheStorage()) {
     deleteLegacyCacheFile();
     return;
@@ -647,6 +647,7 @@ export function clearCache(): void {
       DELETE FROM project_sessions;
     `);
   });
+  closeCacheStorage();
 
   deleteLegacyCacheFile();
 

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -41,7 +41,7 @@ export type {
   SessionSnapshotCompleteness,
 } from "./cache/sessions.js";
 export type { CacheReadOutcome } from "./cache/schema.js";
-export { getCachePath } from "./cache/db.js";
+export { closeCacheStorage, getCachePath } from "./cache/db.js";
 export type { SessionHeadChange } from "./cache/db.js";
 export { listCachedProjectGroups } from "./cache/project-groups.js";
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
   clearCache,
+  closeCacheStorage,
   commitDurableSessionPublication,
   computeSessionDiff,
   ensureSessionTagsSync,

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -26,6 +26,7 @@ import type {
 } from "../../types/index.js";
 import type { SearchOptions } from "../../discovery/cache/search.js";
 import type { SearchResult } from "../../contract/index.js";
+import { closeCacheStorage } from "../../discovery/cache/db.js";
 import { searchSessions, syncSessionSearchIndex } from "../../discovery/cache/search.js";
 import { compareSessionActivityDesc, mergeSortedSessions } from "../../contract/session-index.js";
 import {
@@ -447,17 +448,17 @@ function trackedSessions(sessions: SessionHead[]) {
   };
 }
 
-// Sync once for the whole file rather than per-test: core memoizes "schema
-// already ensured for this db path" at module scope, and that memo is only
-// reset via setSchemaEnsuredPath, which isn't part of this test's concern
-// here. All fixtures are read-only for the rest of the file, so a single
-// shared index is sufficient and faster.
+// Sync once for the whole file rather than per-test. All fixtures are
+// read-only for the rest of the file, so a single shared index is sufficient
+// and faster.
 beforeAll(() => {
+  closeCacheStorage();
   rmSync(getCacheDir(), { recursive: true, force: true });
   syncFixturesToSqlite();
 });
 
 afterAll(() => {
+  closeCacheStorage();
   rmSync(getCacheDir(), { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

- reuse one process-local SQLite connection per cache path across read and write capabilities
- memoize FTS schema readiness per connection and invalidate handles on cache reset or CLI shutdown
- document connection ownership, worker-thread isolation, and FTS validation timing

## Validation

- pnpm lint
- pnpm format:check
- pnpm build
- pnpm test
- pnpm test:coverage
- pnpm test:migration
- pnpm perf:check
- pnpm bench:perf -- --iterations 3

The deterministic regression tests verify connection identity reuse, reconnection after invalidation, and that repeated searches do not repeat sqlite_master probes. The warm dashboard benchmark p50 moved from 5,441 ms to 2,940 ms; detail p50 was effectively unchanged within run-to-run noise.