### PR TITLE
feat(api): paginate session snapshots

### DIFF
--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@codesesh/core/contract";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentInfo, AppConfig, ApiProjectGroup } from "../lib/api";
+import type { AgentInfo, AppConfig, ApiProjectGroup, SessionHead } from "../lib/api";
 import * as api from "../lib/api";
 import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
@@ -155,6 +155,35 @@ describe("useSessionStore", () => {
     expect(result.current.validAgentKeys.has("codex")).toBe(false);
     expect(result.current.agentNameMap.get("claudecode")).toBe("Claude Code");
     expect(result.current.version).toBeGreaterThan(0);
+  });
+
+  it("renders the first session page while the complete window keeps loading", async () => {
+    const completeSessions = deferred<{ sessions: SessionHead[] }>();
+    const finalSession = {
+      ...SAMPLE_SESSION_HEAD,
+      id: "final-session",
+      slug: "claudecode/final-session",
+    };
+    vi.mocked(api.fetchSessions).mockImplementation(async (_options, _fetchOptions, progress) => {
+      progress?.onFirstPage?.([SAMPLE_SESSION_HEAD]);
+      return completeSessions.promise;
+    });
+    const { result } = await renderStore();
+
+    let load!: ReturnType<typeof result.current.reload>;
+    act(() => {
+      load = result.current.reload(config.window);
+    });
+
+    await waitFor(() => expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]));
+    expect(result.current.loading).toBe(false);
+
+    completeSessions.resolve({ sessions: [SAMPLE_SESSION_HEAD, finalSession] });
+    await act(() => load);
+
+    await waitFor(() =>
+      expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD, finalSession]),
+    );
   });
 
   it("keeps the latest snapshot when an earlier request finishes late", async () => {

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -4,7 +4,7 @@ import {
   getSessionAgentKey,
 } from "@codesesh/core/contract";
 import { isCancelledError, queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type AgentInfo,
   type AppConfig,
@@ -80,14 +80,49 @@ function snapshotAggregatesOptions(window: AppConfig["window"]) {
   });
 }
 
-function sessionSnapshotOptions(window: AppConfig["window"]) {
+function sameWindow(
+  left: AppConfig["window"] | null | undefined,
+  right: AppConfig["window"] | null | undefined,
+): boolean {
+  return (
+    left != null &&
+    right != null &&
+    left.days === right.days &&
+    left.from === right.from &&
+    left.to === right.to
+  );
+}
+
+function sessionSnapshotOptions(
+  window: AppConfig["window"],
+  onPreview?: (snapshot: SessionStoreSnapshot) => void,
+) {
   return queryOptions({
     queryKey: queryKeys.sessionSnapshot(window),
     staleTime: Infinity,
     queryFn: async ({ signal }): Promise<SessionStoreSnapshot> => {
+      let loadedAggregates: SnapshotAggregates | undefined;
+      let firstPage: SessionHead[] | undefined;
+      const publishPreview = () => {
+        if (!loadedAggregates || !firstPage) return;
+        onPreview?.({ window, ...loadedAggregates, sessions: firstPage });
+      };
       const [aggregates, sessionResult] = await Promise.all([
-        fetchSnapshotAggregates(window, signal),
-        fetchSessions({ from: window.from, to: window.to }, { signal }),
+        fetchSnapshotAggregates(window, signal).then((value) => {
+          loadedAggregates = value;
+          publishPreview();
+          return value;
+        }),
+        fetchSessions(
+          { from: window.from, to: window.to },
+          { signal },
+          {
+            onFirstPage(sessions) {
+              firstPage = sessions;
+              publishPreview();
+            },
+          },
+        ),
       ]);
       return {
         window,
@@ -101,7 +136,9 @@ function sessionSnapshotOptions(window: AppConfig["window"]) {
 export function useSessionStore() {
   const queryClient = useQueryClient();
   const [requestedWindow, setRequestedWindow] = useState<AppConfig["window"] | null>(null);
+  const [previewSnapshot, setPreviewSnapshot] = useState<SessionStoreSnapshot | null>(null);
   const requestedWindowRef = useRef<AppConfig["window"] | null>(null);
+  const reloadVersionRef = useRef(0);
   const configQuery = useQuery({
     queryKey: queryKeys.config,
     retry: 2,
@@ -123,10 +160,19 @@ export function useSessionStore() {
   const refetchConfig = configQuery.refetch;
   const snapshot = snapshotQuery.data;
 
+  useEffect(() => {
+    if (previewSnapshot && sameWindow(snapshot?.window, previewSnapshot.window)) {
+      setPreviewSnapshot(null);
+    }
+  }, [previewSnapshot, snapshot]);
+
   const reload = useCallback(
     async (window: AppConfig["window"]): Promise<SessionStoreSnapshot | null> => {
+      const reloadVersion = reloadVersionRef.current + 1;
+      reloadVersionRef.current = reloadVersion;
       requestedWindowRef.current = window;
       setRequestedWindow(window);
+      setPreviewSnapshot(null);
       try {
         await queryClient.cancelQueries({ queryKey: queryKeys.sessionSnapshots });
         await queryClient.invalidateQueries({
@@ -134,7 +180,11 @@ export function useSessionStore() {
           exact: true,
           refetchType: "none",
         });
-        return await queryClient.fetchQuery(sessionSnapshotOptions(window));
+        return await queryClient.fetchQuery(
+          sessionSnapshotOptions(window, (preview) => {
+            if (reloadVersionRef.current === reloadVersion) setPreviewSnapshot(preview);
+          }),
+        );
       } catch (error) {
         if (isCancelledError(error)) return null;
         throw error;
@@ -227,7 +277,11 @@ export function useSessionStore() {
     await reload(activeWindow);
   }, [configFailed, refetchConfig, reload]);
 
-  const agents = snapshot?.agents ?? EMPTY_SNAPSHOT.agents;
+  const currentSnapshot = sameWindow(snapshot?.window, requestedWindow) ? snapshot : null;
+  const displayedSnapshot =
+    currentSnapshot ??
+    (sameWindow(previewSnapshot?.window, requestedWindow) ? previewSnapshot : null);
+  const agents = displayedSnapshot?.agents ?? EMPTY_SNAPSHOT.agents;
   const agentCatalog = useMemo(() => createAgentCatalog(agents), [agents]);
   const validAgentKeys = useMemo(
     () => new Set(agentCatalog.active.map((agent) => agent.name.toLowerCase())),
@@ -241,14 +295,15 @@ export function useSessionStore() {
 
   return {
     config: configQuery.data ?? null,
-    window: snapshot?.window ?? null,
+    window: displayedSnapshot?.window ?? null,
     agents,
-    sessions: snapshot?.sessions ?? EMPTY_SNAPSHOT.sessions,
-    projects: snapshot?.projects ?? EMPTY_SNAPSHOT.projects,
-    dashboard: snapshot?.dashboard ?? EMPTY_SNAPSHOT.dashboard,
+    sessions: displayedSnapshot?.sessions ?? EMPTY_SNAPSHOT.sessions,
+    projects: displayedSnapshot?.projects ?? EMPTY_SNAPSHOT.projects,
+    dashboard: displayedSnapshot?.dashboard ?? EMPTY_SNAPSHOT.dashboard,
     loading:
       configQuery.isPending ||
-      (!configQuery.isError && (requestedWindow === null || snapshotQuery.isPending)),
+      (!configQuery.isError &&
+        (requestedWindow === null || (snapshotQuery.isPending && displayedSnapshot === null))),
     error,
     version: snapshotQuery.dataUpdatedAt,
     activeAgents: agentCatalog.active,

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SAMPLE_DASHBOARD_DATA } from "@codesesh/core/contract";
+import { SAMPLE_DASHBOARD_DATA, SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
 import type { DashboardFilters } from "./api";
 import {
   fetchAgents,
@@ -26,7 +26,7 @@ describe("abortable list requests", () => {
   ])("forwards the abort signal for %s", async (_name, request) => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({}),
+      json: () => Promise.resolve({ sessions: [] }),
     });
     vi.stubGlobal("fetch", fetchMock);
     const controller = new AbortController();
@@ -34,6 +34,69 @@ describe("abortable list requests", () => {
     await request(controller.signal);
 
     expect(fetchMock.mock.calls[0]?.[1]).toEqual({ signal: controller.signal });
+  });
+});
+
+describe("fetchSessions", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("collects cursor pages and publishes the first page", async () => {
+    const nextSession = {
+      ...SAMPLE_SESSION_HEAD,
+      id: "next-session",
+      slug: "claudecode/next-session",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ sessions: [SAMPLE_SESSION_HEAD], nextCursor: "next-page" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ sessions: [nextSession] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const onFirstPage = vi.fn();
+
+    const result = await fetchSessions({}, undefined, { onFirstPage });
+
+    expect(result.sessions).toEqual([SAMPLE_SESSION_HEAD, nextSession]);
+    expect(onFirstPage).toHaveBeenCalledWith([SAMPLE_SESSION_HEAD]);
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/api/sessions?limit=250",
+      "/api/sessions?limit=250&cursor=next-page",
+    ]);
+  });
+
+  it("restarts pagination when the server snapshot changes", async () => {
+    const latestSession = {
+      ...SAMPLE_SESSION_HEAD,
+      id: "latest-session",
+      slug: "claudecode/latest-session",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ sessions: [SAMPLE_SESSION_HEAD], nextCursor: "stale" }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 409, statusText: "Conflict" })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ sessions: [latestSession] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    const onFirstPage = vi.fn();
+
+    const result = await fetchSessions({}, undefined, { onFirstPage });
+
+    expect(result.sessions).toEqual([latestSession]);
+    expect(onFirstPage).toHaveBeenNthCalledWith(1, [SAMPLE_SESSION_HEAD]);
+    expect(onFirstPage).toHaveBeenNthCalledWith(2, [latestSession]);
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("/api/sessions?limit=250");
   });
 });
 
@@ -143,7 +206,7 @@ describe("fetchSessionData", () => {
   it("forwards the abort signal to fetch", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({}),
+      json: () => Promise.resolve({ sessions: [] }),
     });
     vi.stubGlobal("fetch", fetchMock);
     const controller = new AbortController();
@@ -170,7 +233,7 @@ describe("project identity request filters", () => {
   ])("sends both identity fields for %s requests", async (_name, request) => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({}),
+      json: () => Promise.resolve({ sessions: [] }),
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -21,6 +21,7 @@ export type {
   MessagePart,
   Message,
   SessionDetail,
+  SessionListPage,
   SessionReference,
   ScanStatusEvent,
   BackfillStatus,
@@ -56,6 +57,7 @@ import type {
   ScanStatusEvent,
   SearchResult,
   SessionDetail,
+  SessionListPage,
   SessionReference,
   SessionHead,
   SessionsUpdatedEvent,
@@ -123,6 +125,13 @@ export interface FetchOptions {
   signal?: AbortSignal;
 }
 
+interface SessionFetchProgress {
+  onFirstPage?: (sessions: SessionHead[]) => void;
+}
+
+const SESSION_PAGE_SIZE = 250;
+const SESSION_STALE_RETRY_LIMIT = 2;
+
 /**
  * Which slice of the snapshot a dashboard request covers. Project and agent are
  * independent and either may be absent: no project means every project, no agent
@@ -137,9 +146,21 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(path, withRemoteAccess(init));
   if (!res.ok) {
     const method = init?.method ?? "GET";
-    throw new Error(`${method} ${path} failed: ${res.status} ${res.statusText}`);
+    throw new ApiRequestError(
+      `${method} ${path} failed: ${res.status} ${res.statusText}`,
+      res.status,
+    );
   }
   return res.json() as Promise<T>;
+}
+
+class ApiRequestError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+  }
 }
 
 export async function fetchConfig(options?: FetchOptions): Promise<AppConfig> {
@@ -182,13 +203,40 @@ export async function fetchSessions(
     to?: number;
   } = {},
   fetchOptions?: FetchOptions,
+  progress?: SessionFetchProgress,
 ): Promise<{ sessions: SessionHead[] }> {
-  const params = new URLSearchParams();
-  if (options.agent) params.set("agent", options.agent);
-  if (options.projectKind) params.set("projectKind", options.projectKind);
-  if (options.projectKey) params.set("projectKey", options.projectKey);
-  appendTimeWindow(params, options);
-  return fetchJson(`/api/sessions?${params}`, fetchOptions);
+  const baseParams = new URLSearchParams();
+  if (options.agent) baseParams.set("agent", options.agent);
+  if (options.projectKind) baseParams.set("projectKind", options.projectKind);
+  if (options.projectKey) baseParams.set("projectKey", options.projectKey);
+  appendTimeWindow(baseParams, options);
+
+  let staleRetries = 0;
+  while (true) {
+    try {
+      const sessions: SessionHead[] = [];
+      let cursor: string | undefined;
+      do {
+        const params = new URLSearchParams(baseParams);
+        params.set("limit", String(SESSION_PAGE_SIZE));
+        if (cursor) params.set("cursor", cursor);
+        const page = await fetchJson<SessionListPage>(`/api/sessions?${params}`, fetchOptions);
+        sessions.push(...page.sessions);
+        if (!cursor) progress?.onFirstPage?.([...sessions]);
+        cursor = page.nextCursor;
+      } while (cursor);
+      return { sessions };
+    } catch (error) {
+      if (
+        !(error instanceof ApiRequestError) ||
+        error.status !== 409 ||
+        staleRetries >= SESSION_STALE_RETRY_LIMIT
+      ) {
+        throw error;
+      }
+      staleRetries += 1;
+    }
+  }
 }
 
 export async function fetchSessionData(

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -7,6 +7,7 @@ const coreMocks = vi.hoisted(() => {
     materializeSessionDetailResponse: vi.fn(),
     listFileActivity: vi.fn((): FileActivityResult[] => []),
     listModelCostDistribution: vi.fn((): ModelCostEntry[] | null => null),
+    matchesProjectIdentity: vi.fn(),
     listSessionAliases: vi.fn<
       () => Array<{
         reference: { agentName: string; sessionId: string };
@@ -42,6 +43,10 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     materializeSessionDetailResponse: coreMocks.materializeSessionDetailResponse,
     listFileActivity: coreMocks.listFileActivity,
     listModelCostDistribution: coreMocks.listModelCostDistribution,
+    matchesProjectIdentity: (...args: Parameters<typeof actual.matchesProjectIdentity>) => {
+      coreMocks.matchesProjectIdentity(...args);
+      return actual.matchesProjectIdentity(...args);
+    },
     listSessionAliases: coreMocks.listSessionAliases,
     executeSessionSearch: coreMocks.executeSessionSearch,
   };
@@ -208,6 +213,7 @@ afterEach(() => {
   coreMocks.listFileActivity.mockReturnValue([]);
   coreMocks.listModelCostDistribution.mockReset();
   coreMocks.listModelCostDistribution.mockReturnValue(null);
+  coreMocks.matchesProjectIdentity.mockClear();
   coreMocks.listSessionAliases.mockReset();
   coreMocks.listSessionAliases.mockReturnValue([]);
   // The alias read model caches for the process lifetime; tests stub
@@ -421,6 +427,34 @@ describe("handleGetSessions", () => {
       { error: "cursor is invalid for this request" },
       400,
     );
+  });
+
+  it("reuses filtered candidates across pages from the same snapshot", () => {
+    const sessions = [
+      makeSession("first", {
+        project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
+      }),
+      makeSession("second", {
+        project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
+      }),
+    ];
+    const source = makeScanSource({ sessions, byAgent: { claudecode: sessions } });
+    const firstContext = makeMockContext({
+      query: { limit: "1", projectKind: "path", projectKey: "/workspace" },
+    });
+    handleGetSessions(firstContext, source);
+
+    const nextContext = makeMockContext({
+      query: {
+        limit: "1",
+        cursor: firstContext.json.mock.calls[0]![0].nextCursor,
+        projectKind: "path",
+        projectKey: "/workspace",
+      },
+    });
+    handleGetSessions(nextContext, source);
+
+    expect(coreMocks.matchesProjectIdentity).toHaveBeenCalledTimes(sessions.length);
   });
 
   it("filters by agent", () => {

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -331,8 +331,14 @@ describe("handleGetSessions", () => {
     expect(response.sessions).toHaveLength(2);
   });
 
-  it("omits dashboard-only model usage from list responses", () => {
-    const session = makeSession("usage", { model_usage: { "gpt-5.5": 120 } });
+  it("omits server-only metadata from list responses", () => {
+    const session = makeSession("usage", {
+      model_usage: { "gpt-5.5": 120 },
+      project_identity_resolver_revision: "resolver-v2",
+      project_identity_input_signature: "signature",
+      smart_tags_source_updated_at: 123,
+      smart_tags_classifier_revision: "classifier-v2",
+    });
     const source = makeScanSource({
       sessions: [session],
       byAgent: { claudecode: [session] },
@@ -341,8 +347,80 @@ describe("handleGetSessions", () => {
 
     handleGetSessions(c, source);
 
-    expect(c.json.mock.calls[0]![0].sessions[0]).not.toHaveProperty("model_usage");
+    const response = c.json.mock.calls[0]![0].sessions[0];
+    expect(response).not.toHaveProperty("model_usage");
+    expect(response).not.toHaveProperty("project_identity_resolver_revision");
+    expect(response).not.toHaveProperty("project_identity_input_signature");
+    expect(response).not.toHaveProperty("smart_tags_source_updated_at");
+    expect(response).not.toHaveProperty("smart_tags_classifier_revision");
     expect(session.model_usage).toEqual({ "gpt-5.5": 120 });
+  });
+
+  it("returns cursor pages without changing legacy unpaged requests", () => {
+    const sessions = [makeSession("first"), makeSession("second"), makeSession("third")];
+    const source = makeScanSource({ sessions, byAgent: { claudecode: sessions } });
+    const firstContext = makeMockContext({ query: { limit: "2" } });
+
+    handleGetSessions(firstContext, source);
+
+    const firstPage = firstContext.json.mock.calls[0]![0];
+    expect(firstPage.sessions.map((session: SessionHead) => session.id)).toEqual([
+      "first",
+      "second",
+    ]);
+    expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const secondContext = makeMockContext({
+      query: { limit: "2", cursor: firstPage.nextCursor },
+    });
+    handleGetSessions(secondContext, source);
+
+    expect(secondContext.json.mock.calls[0]![0]).toEqual({ sessions: [sessions[2]] });
+
+    const legacyContext = makeMockContext();
+    handleGetSessions(legacyContext, source);
+    expect(legacyContext.json.mock.calls[0]![0].sessions).toHaveLength(3);
+  });
+
+  it("rejects a cursor after the scan snapshot changes", () => {
+    const initialSessions = [makeSession("first"), makeSession("second")];
+    let snapshot = makeScanResult({
+      sessions: initialSessions,
+      byAgent: { claudecode: initialSessions },
+    });
+    const source: ScanResultSource = { getSnapshot: () => snapshot };
+    const firstContext = makeMockContext({ query: { limit: "1" } });
+    handleGetSessions(firstContext, source);
+    const cursor = firstContext.json.mock.calls[0]![0].nextCursor;
+
+    const updatedSessions = [makeSession("new"), ...initialSessions];
+    snapshot = makeScanResult({
+      sessions: updatedSessions,
+      byAgent: { claudecode: updatedSessions },
+    });
+    const nextContext = makeMockContext({ query: { limit: "1", cursor } });
+    handleGetSessions(nextContext, source);
+
+    expect(nextContext.json).toHaveBeenCalledWith(
+      { error: "session snapshot changed; restart pagination" },
+      409,
+    );
+  });
+
+  it("rejects invalid pagination parameters", () => {
+    const invalidLimit = makeMockContext({ query: { limit: "many" } });
+    handleGetSessions(invalidLimit, makeScanSource());
+    expect(invalidLimit.json).toHaveBeenCalledWith(
+      { error: "limit must be a positive integer" },
+      400,
+    );
+
+    const invalidCursor = makeMockContext({ query: { cursor: "not-a-cursor" } });
+    handleGetSessions(invalidCursor, makeScanSource());
+    expect(invalidCursor.json).toHaveBeenCalledWith(
+      { error: "cursor is invalid for this request" },
+      400,
+    );
   });
 
   it("filters by agent", () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -409,28 +409,38 @@ export function handleGetSessions(
   if (window.kind === "rejected") return window.response;
   const { from, to } = window;
 
-  let sessions: SessionHead[] = [];
-
-  if (sessionQuery.agent.kind === "all") {
-    sessions = [...scanResult.sessions];
-  } else if (sessionQuery.agent.kind === "known") {
-    sessions = [...(scanResult.byAgent[sessionQuery.agent.agentName] ?? [])];
-  } else {
+  if (sessionQuery.agent.kind === "unknown") {
     reportInvalidQueryParameter("sessions", "agent", "empty_result");
   }
 
-  if (projectIdentity) {
-    sessions = sessions.filter((session) =>
-      matchesProjectIdentity(session.project_identity, projectIdentity),
-    );
-  } else if (cwd) {
-    const projectScope = createProjectScopeMatcher(cwd);
-    sessions = sessions.filter((s) => sessionMatchesProjectScope(s, projectScope));
-  }
-  sessions = filterSessionsByActivityWindow(sessions, from, to);
-  if (tag) {
-    sessions = sessions.filter((s) => s.smart_tags?.includes(tag as SmartTag));
-  }
+  const agentFilter =
+    sessionQuery.agent.kind === "known" ? sessionQuery.agent.agentName : sessionQuery.agent.kind;
+  let sessions = getSnapshotAggregation(
+    scanSource,
+    scanResult.sessions,
+    ["sessions", agentFilter, projectIdentity?.kind, projectIdentity?.key, cwd, tag, from, to],
+    () => {
+      let filtered =
+        sessionQuery.agent.kind === "all"
+          ? scanResult.sessions
+          : sessionQuery.agent.kind === "known"
+            ? (scanResult.byAgent[sessionQuery.agent.agentName] ?? [])
+            : [];
+
+      if (projectIdentity) {
+        filtered = filtered.filter((session) =>
+          matchesProjectIdentity(session.project_identity, projectIdentity),
+        );
+      } else if (cwd) {
+        const projectScope = createProjectScopeMatcher(cwd);
+        filtered = filtered.filter((session) => sessionMatchesProjectScope(session, projectScope));
+      }
+      filtered = filterSessionsByActivityWindow(filtered, from, to);
+      return tag
+        ? filtered.filter((session) => session.smart_tags?.includes(tag as SmartTag))
+        : filtered;
+    },
+  );
 
   const aliases = loadAliasView();
   if (q) {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -59,8 +59,10 @@ import {
   optionalQueryValue,
   searchParams,
   SEARCH_LIMIT_POLICY,
+  SESSION_PAGE_LIMIT_POLICY,
   type SessionListDefaults,
 } from "./query-params.js";
+import { paginateSessionSnapshot } from "./session-pagination.js";
 import {
   decorateBookmark,
   decorateFileActivity,
@@ -85,7 +87,7 @@ const KNOWN_AGENT_NAME_SET = new Set(KNOWN_AGENT_NAMES);
 
 function reportInvalidQueryParameter(
   endpoint: string,
-  parameter: "agent" | "limit" | "from" | "to",
+  parameter: "agent" | "cursor" | "limit" | "from" | "to",
   validationOutcome: "empty_result" | "rejected",
 ): void {
   appLogger.warn("api.query_parameter.invalid", {
@@ -237,9 +239,14 @@ function sanitizeClientLogData(value: unknown): Record<string, unknown> {
 }
 
 function toSessionListItem(session: SessionHead): SessionHead {
-  if (!session.model_usage) return session;
-  const item = { ...session };
-  delete item.model_usage;
+  const {
+    model_usage: _modelUsage,
+    project_identity_resolver_revision: _resolverRevision,
+    project_identity_input_signature: _identityInputSignature,
+    smart_tags_source_updated_at: _smartTagsSourceUpdatedAt,
+    smart_tags_classifier_revision: _smartTagsClassifierRevision,
+    ...item
+  } = session;
   return item;
 }
 
@@ -381,7 +388,13 @@ export function handleGetSessions(
   defaults: SessionListDefaults = {},
 ) {
   const scanResult = scanSource.getSnapshot();
-  const sessionQuery = parseSessionQuery(searchParams(c), KNOWN_AGENT_NAMES);
+  const params = searchParams(c);
+  const paginationRequested = params.has("limit") || params.has("cursor");
+  const sessionQuery = parseSessionQuery(params, KNOWN_AGENT_NAMES, SESSION_PAGE_LIMIT_POLICY);
+  if (sessionQuery.limit.kind === "invalid") {
+    reportInvalidQueryParameter("sessions", "limit", "rejected");
+    return c.json({ error: sessionQuery.limit.error }, 400);
+  }
   const q = c.req.query("q")?.toLowerCase();
   const cwd = c.req.query("cwd");
   const projectIdentity = parseProjectIdentityFilter(
@@ -426,6 +439,30 @@ export function handleGetSessions(
       return session.title.toLowerCase().includes(q) || alias?.toLowerCase().includes(q);
     });
   }
+
+  if (paginationRequested) {
+    const page = paginateSessionSnapshot(sessions, {
+      cursor: params.get("cursor") ?? undefined,
+      limit: sessionQuery.limit.value,
+      query: params,
+      snapshotIdentity: scanResult.sessions,
+      viewIdentity: aliases,
+    });
+    if (page.kind === "invalid_cursor") {
+      reportInvalidQueryParameter("sessions", "cursor", "rejected");
+      return c.json({ error: "cursor is invalid for this request" }, 400);
+    }
+    if (page.kind === "stale_snapshot") {
+      return c.json({ error: "session snapshot changed; restart pagination" }, 409);
+    }
+    return c.json({
+      sessions: page.items.map((session) =>
+        toSessionListItem(aliases.decorate(session, getSessionHeadReference(session))),
+      ),
+      ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+    });
+  }
+
   return c.json({
     sessions: sessions.map((session) =>
       toSessionListItem(aliases.decorate(session, getSessionHeadReference(session))),

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -35,6 +35,7 @@ export interface LimitPolicy {
 
 export const SEARCH_LIMIT_POLICY: LimitPolicy = { defaultValue: 50, maxValue: 100 };
 export const FILE_ACTIVITY_LIMIT_POLICY: LimitPolicy = { defaultValue: 50, maxValue: 200 };
+export const SESSION_PAGE_LIMIT_POLICY: LimitPolicy = { defaultValue: 250, maxValue: 500 };
 
 export type AgentFilterOutcome =
   | { kind: "all" }

--- a/packages/cli/src/api/session-pagination.ts
+++ b/packages/cli/src/api/session-pagination.ts
@@ -1,0 +1,99 @@
+import { createHash, randomUUID } from "node:crypto";
+
+interface CursorPayload {
+  version: 1;
+  snapshot: string;
+  view: string;
+  query: string;
+  offset: number;
+}
+
+interface PaginationRequest {
+  cursor?: string;
+  limit: number;
+  query: URLSearchParams;
+  snapshotIdentity: object;
+  viewIdentity: object;
+}
+
+export type PaginationResult<T> =
+  | { kind: "page"; items: T[]; nextCursor?: string }
+  | { kind: "invalid_cursor" }
+  | { kind: "stale_snapshot" };
+
+const identityVersions = new WeakMap<object, string>();
+
+function identityVersion(identity: object): string {
+  const existing = identityVersions.get(identity);
+  if (existing) return existing;
+  const version = randomUUID();
+  identityVersions.set(identity, version);
+  return version;
+}
+
+function queryFingerprint(params: URLSearchParams): string {
+  const canonical = new URLSearchParams(params);
+  canonical.delete("cursor");
+  canonical.delete("limit");
+  canonical.sort();
+  return createHash("sha256").update(canonical.toString()).digest("base64url");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+function decodeCursor(cursor: string): CursorPayload | null {
+  if (!cursor || cursor.length > 512 || !/^[A-Za-z0-9_-]+$/.test(cursor)) return null;
+
+  try {
+    const value = JSON.parse(
+      Buffer.from(cursor, "base64url").toString("utf8"),
+    ) as Partial<CursorPayload>;
+    if (
+      value.version !== 1 ||
+      typeof value.snapshot !== "string" ||
+      typeof value.view !== "string" ||
+      typeof value.query !== "string" ||
+      !Number.isSafeInteger(value.offset) ||
+      value.offset! <= 0
+    ) {
+      return null;
+    }
+    return value as CursorPayload;
+  } catch {
+    return null;
+  }
+}
+
+/** Keeps every page on the same immutable scan and alias read-model versions. */
+export function paginateSessionSnapshot<T>(
+  items: T[],
+  request: PaginationRequest,
+): PaginationResult<T> {
+  const snapshot = identityVersion(request.snapshotIdentity);
+  const view = identityVersion(request.viewIdentity);
+  const query = queryFingerprint(request.query);
+  let offset = 0;
+
+  if (request.cursor) {
+    const cursor = decodeCursor(request.cursor);
+    if (!cursor || cursor.query !== query) return { kind: "invalid_cursor" };
+    if (cursor.snapshot !== snapshot || cursor.view !== view) {
+      return { kind: "stale_snapshot" };
+    }
+    if (cursor.offset >= items.length) return { kind: "invalid_cursor" };
+    offset = cursor.offset;
+  }
+
+  const end = Math.min(offset + request.limit, items.length);
+  const nextCursor =
+    end < items.length
+      ? encodeCursor({ version: 1, snapshot, view, query, offset: end })
+      : undefined;
+  return {
+    kind: "page",
+    items: items.slice(offset, end),
+    ...(nextCursor ? { nextCursor } : {}),
+  };
+}

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -165,6 +165,11 @@ export interface SessionHead {
   smart_tags_classifier_revision?: string;
 }
 
+export interface SessionListPage {
+  sessions: SessionHead[];
+  nextCursor?: string;
+}
+
 export interface ReferencedSessionHead {
   reference: SessionReference;
   session: SessionHead;


### PR DESCRIPTION
## Summary

- add opaque, snapshot-bound cursor pagination to `/api/sessions` while preserving legacy unpaged callers
- trim server-only metadata and reuse filtered candidates across pages
- load 250-session pages in the web client, publish the first page as a preview, and retry if the live snapshot changes

## Performance

- 2,889-session all-time response: 1,808,663 bytes unpaged vs. 169,625 bytes for the first page (90.6% smaller)
- local API TTFB: 15.8 ms unpaged vs. 5.6 ms for the first page
- all-time dashboard p50 remained stable at 2.90 s vs. 2.84 s before the change

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:migration`
- `pnpm perf:check`
- `pnpm test:coverage`
- `pnpm bench:perf -- --iterations 3 --days 0`
