### PR TITLE
perf(cli): reuse refresh cache snapshots

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -198,6 +198,61 @@ afterEach(() => {
 });
 
 describe("AgentSyncEngine", () => {
+  it("loads cached sessions once across a refresh and its backfill decision", async () => {
+    const session = makeSession("cached");
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [session],
+      meta: {},
+      timestamp: Date.now(),
+    });
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async (_agentName, payload) =>
+        workerResult({
+          sessions: payload.previousSessions,
+          meta: payload.meta,
+          changedIds: [],
+        }),
+      ),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(new FakeSyncAgent(), [session], workerRunner, { from: 1 });
+
+    await engine.refresh("codex");
+
+    expect(core.loadCachedSessions).toHaveBeenCalledOnce();
+  });
+
+  it("skips source availability work until the full-sync interval expires", () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-08-12T00:00:00.000Z").getTime();
+    vi.setSystemTime(now);
+    core.getAgentLastFullSyncAt.mockReturnValue(now);
+    const agent = new FakeSyncAgent();
+    const isAvailable = vi.spyOn(agent, "isAvailable");
+    const listSessionSources = vi.spyOn(agent, "listSessionSources");
+    const { engine } = makeEngine(agent, [], makeWorkerRunner(), { from: 1 });
+    const internal = engine as unknown as {
+      needsBackfill(candidate: BaseAgent, cached: ReturnType<typeof loadCachedSessions>): boolean;
+    };
+    const cached = { sessions: [], meta: {}, timestamp: Date.now() };
+
+    expect(internal.needsBackfill(agent, cached)).toBe(false);
+    expect(internal.needsBackfill(agent, cached)).toBe(false);
+
+    expect(isAvailable).toHaveBeenCalledOnce();
+    expect(listSessionSources).toHaveBeenCalledOnce();
+    expect(core.readAgentLastFullSyncAt).toHaveBeenCalledOnce();
+    expect(core.loadCachedSessions).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+
+    expect(internal.needsBackfill(agent, cached)).toBe(true);
+    expect(isAvailable).toHaveBeenCalledTimes(2);
+    expect(listSessionSources).toHaveBeenCalledOnce();
+    expect(core.readAgentLastFullSyncAt).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps the current snapshot when cache initialization cannot be read", async () => {
     core.readAgentCacheInitialization.mockReturnValueOnce({ status: "failed" });
     const previous = makeSession("session", "retained");

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -139,7 +139,7 @@ export class AgentSyncEngine {
   private readonly scheduler: AgentOperationScheduler;
   private readonly sessionIndex = new LiveSessionIndex();
   private readonly backfills = new BackfillLifecycle();
-  private cacheIntegrityCheckedAgents = new Set<string>();
+  private cacheIntegrityValidUntilByAgent = new Map<string, number>();
   private sessionsChangedListeners = new Set<SessionsChangedListener>();
   private statusChangedListeners = new Set<StatusChangedListener>();
   private statusProgressThrottles = new Map<string, LatestValueThrottle<void>>();
@@ -242,7 +242,7 @@ export class AgentSyncEngine {
     }
     this.backfills.cancelAll();
     this.cancelProgressStatuses();
-    this.cacheIntegrityCheckedAgents.clear();
+    this.cacheIntegrityValidUntilByAgent.clear();
     const searchIndexSnapshot = this.searchIndexJobs.snapshot();
     appLogger.info("search_index.shutdown.started", {
       active_batch_id: searchIndexSnapshot.activeBatchId,
@@ -393,9 +393,14 @@ export class AgentSyncEngine {
 
   private async performRefresh(agentName: string): Promise<AgentOperationResult> {
     this.beginAgentScan(agentName);
+    const startedAt = performance.now();
     let failed = false;
+    let cached: CachedSessions | null = null;
+    let result: Exclude<AgentOperationResult, "failed"> | null = null;
     try {
-      return await this.runRefresh(agentName);
+      if (this.findAgent(agentName)) cached = loadCachedSessions(agentName);
+      result = await this.runRefresh(agentName, cached, startedAt);
+      return result;
     } catch (error) {
       this.options.workerRunner.discard?.(agentName);
       failed = true;
@@ -408,12 +413,17 @@ export class AgentSyncEngine {
     } finally {
       if (!failed) this.finishAgentScan(agentName);
       const agent = this.findAgent(agentName);
-      if (agent && this.needsBackfill(agent)) this.enqueueBackfill(agentName);
+      if (agent && this.needsBackfill(agent, cached, failed || result === "committed")) {
+        this.enqueueBackfill(agentName);
+      }
     }
   }
 
-  private async runRefresh(agentName: string): Promise<Exclude<AgentOperationResult, "failed">> {
-    const startedAt = performance.now();
+  private async runRefresh(
+    agentName: string,
+    cached: CachedSessions | null,
+    startedAt: number,
+  ): Promise<Exclude<AgentOperationResult, "failed">> {
     const pendingPathCount = this.scheduler.takePendingSignalCount(agentName);
     const agent = this.findAgent(agentName);
     if (!agent) {
@@ -421,7 +431,6 @@ export class AgentSyncEngine {
       return "skipped";
     }
     const previousSessions = this.sessionIndex.snapshot().byAgent[agentName] ?? [];
-    const cached = loadCachedSessions(agentName);
     const refreshBaseline = cached?.sessions ?? previousSessions;
     const cacheTimestamp = cached?.timestamp ?? this.lastRefreshAtByAgent.get(agentName) ?? 0;
     if (cached) restoreAgentCacheMeta(agent, cached);
@@ -816,10 +825,15 @@ export class AgentSyncEngine {
     });
   }
 
-  private needsBackfill(agent: BaseAgent): boolean {
+  private needsBackfill(
+    agent: BaseAgent,
+    cached?: CachedSessions | null,
+    reloadCached = false,
+  ): boolean {
     const startupScanOptions = this.startupScanOptions();
     if (startupScanOptions.from == null && startupScanOptions.to == null) return false;
-    if (!agent.isAvailable()) return false;
+    const now = Date.now();
+    if ((this.cacheIntegrityValidUntilByAgent.get(agent.name) ?? 0) >= now) return false;
     const lastSync = readAgentLastFullSyncAt(agent.name);
     if (lastSync.status === "failed") {
       appLogger.warn("scan.backfill.cache_state_unavailable", {
@@ -829,14 +843,17 @@ export class AgentSyncEngine {
       return false;
     }
     const lastSyncAt = lastSync.value;
-    if (lastSyncAt == null || Date.now() - lastSyncAt > BACKFILL_INTERVAL_MS) return true;
+    if (lastSyncAt == null || now - lastSyncAt > BACKFILL_INTERVAL_MS) {
+      return agent.isAvailable();
+    }
     if (!(agent instanceof FileSystemSessionSource)) return false;
-    if (this.cacheIntegrityCheckedAgents.has(agent.name)) return false;
+    if (!agent.isAvailable()) return false;
 
-    const cached = loadCachedSessions(agent.name);
+    const cachedSessions =
+      reloadCached || cached === undefined ? loadCachedSessions(agent.name) : cached;
     const sourceCount = agent.listSessionSources().length;
-    const cachedCount = cached?.sessions.length ?? 0;
-    this.cacheIntegrityCheckedAgents.add(agent.name);
+    const cachedCount = cachedSessions?.sessions.length ?? 0;
+    this.cacheIntegrityValidUntilByAgent.set(agent.name, lastSyncAt + BACKFILL_INTERVAL_MS);
     if (sourceCount > 0 && cachedCount / sourceCount < CACHE_TRUNCATION_COVERAGE) {
       appLogger.warn("scan.backfill.cache_truncated", {
         agent: agent.name,
@@ -874,7 +891,14 @@ export class AgentSyncEngine {
     if (current?.status === "running" && current.attemptId === attempt.attemptId) {
       this.flushProgressStatus(`backfill:${attempt.agentName}`);
       if (this.backfills.complete(attempt, result)) {
-        if (result === "failed") this.cacheIntegrityCheckedAgents.delete(attempt.agentName);
+        if (result === "failed") {
+          this.cacheIntegrityValidUntilByAgent.delete(attempt.agentName);
+        } else if (result === "committed") {
+          this.cacheIntegrityValidUntilByAgent.set(
+            attempt.agentName,
+            Date.now() + BACKFILL_INTERVAL_MS,
+          );
+        }
         this.publishBackfillStatus();
       }
     }


### PR DESCRIPTION
## Summary

- load each agent cache once for a refresh and reuse it for the immediate backfill decision
- replace the permanent integrity-check set with an interval-aware validity deadline, avoiding repeated storage reads and source availability scans
- preserve a fresh cache read when a committed or failed refresh may have changed durable state; actual backfill execution still reads its latest baseline

## Performance

- structural regression test confirms the common refresh path drops from two `loadCachedSessions` calls to one
- repeated integrity checks skip both `readAgentLastFullSyncAt` and filesystem source availability work until the 24-hour interval expires

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:migration`
- `pnpm perf:check`
- `pnpm test:coverage` (2,054 passed, 1 skipped)
