### PR TITLE
perf(web): stream incremental live session updates

### DIFF
--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -117,6 +117,42 @@ describe("useSessionDetail", () => {
     expect(api.fetchSessionData).toHaveBeenCalledTimes(2);
   });
 
+  it("requests and merges only messages appended by a live update", async () => {
+    const firstMessage = { id: "m1" };
+    const nextMessage = { id: "m2" };
+    const initial = {
+      id: "abc",
+      messages: [firstMessage],
+      message_cursor: "cursor-1",
+      message_update: "reset",
+    } as unknown as SessionDetail;
+    const appended = {
+      id: "abc",
+      messages: [nextMessage],
+      message_cursor: "cursor-2",
+      message_update: "append",
+    } as unknown as SessionDetail;
+    vi.mocked(api.fetchSessionData).mockResolvedValueOnce(initial).mockResolvedValueOnce(appended);
+    const { client, result } = renderSessionDetail();
+    await waitFor(() => expect(result.current.session).toEqual(initial));
+
+    await act(() =>
+      client.invalidateQueries({
+        queryKey: queryKeys.sessionDetail("claudecode", "claudecode/abc"),
+        exact: true,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.session?.messages).toEqual([firstMessage, nextMessage]),
+    );
+    expect(api.fetchSessionData).toHaveBeenLastCalledWith(
+      "claudecode",
+      "claudecode/abc",
+      expect.objectContaining({ messageCursor: "cursor-1" }),
+    );
+  });
+
   it("keeps the current route when an older request resolves last", async () => {
     const requestA = deferred<SessionDetail>();
     const requestB = deferred<SessionDetail>();

--- a/apps/web/src/hooks/useSessionDetail.ts
+++ b/apps/web/src/hooks/useSessionDetail.ts
@@ -1,10 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { fetchSessionData, logClientEvent } from "../lib/api";
+import { fetchSessionData, logClientEvent, type SessionDetail } from "../lib/api";
 import { queryKeys } from "../lib/query-keys";
 import type { ViewState } from "../lib/view-state";
 
 let nextSessionRequestId = 1;
+
+function mergeSessionDetailUpdate(
+  previous: SessionDetail | undefined,
+  next: SessionDetail,
+): SessionDetail {
+  if (next.message_update !== "append" || !previous?.message_cursor) return next;
+  return { ...next, messages: [...previous.messages, ...next.messages] };
+}
 
 function sessionRoute(viewState: ViewState) {
   if (viewState.mode !== "session") return null;
@@ -15,9 +23,11 @@ function sessionRoute(viewState: ViewState) {
 }
 
 export function useSessionDetail(viewState: ViewState) {
+  const queryClient = useQueryClient();
   const route = sessionRoute(viewState);
+  const queryKey = queryKeys.sessionDetail(route?.agent ?? "", route?.sessionId ?? "");
   const query = useQuery({
-    queryKey: queryKeys.sessionDetail(route?.agent ?? "", route?.sessionId ?? ""),
+    queryKey,
     enabled: route !== null,
     staleTime: Infinity,
     queryFn: async ({ signal }) => {
@@ -45,7 +55,12 @@ export function useSessionDetail(viewState: ViewState) {
       });
 
       try {
-        const data = await fetchSessionData(route.agent, route.sessionId, { signal });
+        const previous = queryClient.getQueryData<SessionDetail>(queryKey);
+        const response = await fetchSessionData(route.agent, route.sessionId, {
+          signal,
+          messageCursor: previous?.message_cursor,
+        });
+        const data = mergeSessionDetailUpdate(previous, response);
         if (signal.aborted) throw new DOMException("Aborted", "AbortError");
         logClientEvent("session.open.done", {
           request_id: requestId,

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -260,6 +260,32 @@ describe("useSessionStore", () => {
     expect(result.current.version).toBeGreaterThan(0);
   });
 
+  it("reuses aggregate data across consecutive live event batches", async () => {
+    let now = Date.now();
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { result } = await renderStore();
+    await act(() => result.current.reload(config.window));
+    vi.mocked(api.fetchAgents).mockClear();
+    vi.mocked(api.fetchProjects).mockClear();
+    vi.mocked(api.fetchDashboard).mockClear();
+
+    for (let batch = 0; batch < 3; batch += 1) {
+      now += 500;
+      await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
+    }
+
+    expect(api.fetchAgents).toHaveBeenCalledOnce();
+    expect(api.fetchProjects).toHaveBeenCalledOnce();
+    expect(api.fetchDashboard).toHaveBeenCalledOnce();
+
+    now += 1_001;
+    await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
+
+    expect(api.fetchAgents).toHaveBeenCalledTimes(2);
+    expect(api.fetchProjects).toHaveBeenCalledTimes(2);
+    expect(api.fetchDashboard).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps window-external backfill sessions out of the active snapshot", async () => {
     const window = { from: 100, to: 200, days: 7 };
     const recentSession = {
@@ -334,7 +360,7 @@ describe("useSessionStore", () => {
     expect(update?.visibleNewSessions).toBe(1);
   });
 
-  it("invalidates project dashboards, server searches, and inactive aggregate caches", async () => {
+  it("invalidates project dashboards and searches without expiring unrelated windows", async () => {
     const { result, client } = await renderStore();
     await act(() => result.current.reload(config.window));
     const projectDashboardKey = queryKeys.dashboard(config.window, {
@@ -354,7 +380,7 @@ describe("useSessionStore", () => {
 
     expect(client.getQueryState(projectDashboardKey)?.isInvalidated).toBe(true);
     expect(client.getQueryState(searchKey)?.isInvalidated).toBe(true);
-    expect(client.getQueryState(inactiveAggregateKey)?.isInvalidated).toBe(true);
+    expect(client.getQueryState(inactiveAggregateKey)?.isInvalidated).toBe(false);
   });
 
   it("invalidates only session details changed by a live event", async () => {

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -3,7 +3,13 @@ import {
   formatSessionReference,
   getSessionAgentKey,
 } from "@codesesh/core/contract";
-import { isCancelledError, queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  isCancelledError,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type AgentInfo,
@@ -21,6 +27,7 @@ import {
 import { createAgentCatalog } from "../lib/agents";
 import { queryKeys } from "../lib/query-keys";
 import {
+  invalidateLiveSessionCollections,
   invalidateLiveSessionDerivedQueries,
   invalidateSessionDerivedQueries,
 } from "../lib/session-query-consistency";
@@ -39,6 +46,7 @@ export interface LiveSessionApplyResult {
 }
 
 type SnapshotAggregates = Pick<SessionStoreSnapshot, "agents" | "projects" | "dashboard">;
+const LIVE_AGGREGATE_REFRESH_INTERVAL_MS = 2_000;
 
 const EMPTY_SNAPSHOT = {
   agents: [] satisfies AgentInfo[],
@@ -76,8 +84,26 @@ function snapshotAggregatesOptions(window: AppConfig["window"]) {
   return queryOptions({
     queryKey: queryKeys.sessionSnapshotAggregates(window),
     queryFn: ({ signal }) => fetchSnapshotAggregates(window, signal),
-    staleTime: 100,
+    staleTime: LIVE_AGGREGATE_REFRESH_INTERVAL_MS,
   });
+}
+
+async function fetchLiveSnapshotAggregates(
+  queryClient: QueryClient,
+  window: AppConfig["window"],
+): Promise<SnapshotAggregates> {
+  const options = snapshotAggregatesOptions(window);
+  const state = queryClient.getQueryState(options.queryKey);
+  const needsRefresh =
+    !state ||
+    state.data === undefined ||
+    state.isInvalidated ||
+    Date.now() - state.dataUpdatedAt >= LIVE_AGGREGATE_REFRESH_INTERVAL_MS;
+  const [aggregates] = await Promise.all([
+    queryClient.fetchQuery(options),
+    needsRefresh ? invalidateLiveSessionCollections(queryClient) : Promise.resolve(),
+  ]);
+  return aggregates;
 }
 
 function sameWindow(
@@ -201,7 +227,10 @@ export function useSessionStore() {
       const current = queryClient.getQueryData<SessionStoreSnapshot>(snapshotKey);
       if (!current) {
         const refreshed = await reload(activeWindow);
-        await invalidateLiveSessionDerivedQueries(queryClient, event);
+        await Promise.all([
+          invalidateLiveSessionDerivedQueries(queryClient, event),
+          invalidateLiveSessionCollections(queryClient),
+        ]);
         return refreshed ? { snapshot: refreshed, visibleNewSessions: 0 } : null;
       }
 
@@ -250,7 +279,7 @@ export function useSessionStore() {
         sessions: projection.sessions,
       });
       await invalidateLiveSessionDerivedQueries(queryClient, event);
-      const aggregates = await queryClient.fetchQuery(snapshotAggregatesOptions(activeWindow));
+      const aggregates = await fetchLiveSnapshotAggregates(queryClient, activeWindow);
       const updated =
         queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, (latest) =>
           latest ? { ...latest, ...aggregates } : latest,

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -217,6 +217,25 @@ describe("fetchSessionData", () => {
       signal: controller.signal,
     });
   });
+
+  it("sends an opaque message cursor without forwarding it as a fetch option", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ messages: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const controller = new AbortController();
+
+    await fetchSessionData("codex", "session", {
+      signal: controller.signal,
+      messageCursor: "prefix+/=",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/codex/session?messageCursor=prefix%2B%2F%3D",
+      { signal: controller.signal },
+    );
+  });
 });
 
 describe("project identity request filters", () => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -125,6 +125,10 @@ export interface FetchOptions {
   signal?: AbortSignal;
 }
 
+export interface SessionDetailFetchOptions extends FetchOptions {
+  messageCursor?: string;
+}
+
 interface SessionFetchProgress {
   onFirstPage?: (sessions: SessionHead[]) => void;
 }
@@ -242,9 +246,14 @@ export async function fetchSessions(
 export async function fetchSessionData(
   agent: string,
   sessionId: string,
-  options?: FetchOptions,
+  options?: SessionDetailFetchOptions,
 ): Promise<SessionDetail> {
-  return fetchJson(`/api/sessions${sessionRoutePath({ agentName: agent, sessionId })}`, options);
+  const path = `/api/sessions${sessionRoutePath({ agentName: agent, sessionId })}`;
+  const fetchOptions: FetchOptions | undefined = options ? { signal: options.signal } : undefined;
+  if (!options?.messageCursor) return fetchJson(path, fetchOptions);
+
+  const params = new URLSearchParams({ messageCursor: options.messageCursor });
+  return fetchJson(`${path}?${params}`, fetchOptions);
 }
 
 export async function fetchDashboard(

--- a/apps/web/src/lib/session-query-consistency.ts
+++ b/apps/web/src/lib/session-query-consistency.ts
@@ -10,6 +10,13 @@ function invalidateSessionCollections(queryClient: QueryClient) {
   ];
 }
 
+export async function invalidateLiveSessionCollections(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: queryKeys.dashboards }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
+  ]);
+}
+
 export async function invalidateSessionDerivedQueries(queryClient: QueryClient): Promise<void> {
   await Promise.all([
     ...invalidateSessionCollections(queryClient),
@@ -36,10 +43,9 @@ export async function invalidateLiveSessionDerivedQueries(
     );
   }
 
-  await Promise.all([
-    ...invalidateSessionCollections(queryClient),
-    ...Array.from(changedDetailKeys.values(), (queryKey) =>
+  await Promise.all(
+    Array.from(changedDetailKeys.values(), (queryKey) =>
       queryClient.invalidateQueries({ queryKey, exact: true }),
     ),
-  ]);
+  );
 }

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1615,6 +1615,23 @@ describe("handleGetSessionData", () => {
     expect(c.json).toHaveBeenCalledWith(detail);
   });
 
+  it("forwards an incremental message cursor to detail materialization", async () => {
+    coreMocks.materializeSessionDetailResponse.mockReturnValue({ status: "found", data: detail });
+    const scanSource = makeScanSource();
+    const c = makeMockContext({
+      param: { agent: "claudecode", id: "s1" },
+      query: { messageCursor: "known-prefix" },
+    });
+
+    await handleGetSessionData(c, scanSource);
+
+    expect(coreMocks.materializeSessionDetailResponse).toHaveBeenCalledWith(
+      scanSource.getSnapshot(),
+      { agentName: "claudecode", sessionId: "s1" },
+      { messageCursor: "known-prefix" },
+    );
+  });
+
   it("streams cached message JSON lazily while preserving aliases", async () => {
     const { messages: _messages, ...detailHeader } = detail;
     let serializedMessages = 0;
@@ -1646,6 +1663,7 @@ describe("handleGetSessionData", () => {
       data: detailHeader,
       messages: messages(),
       messageCount: 200,
+      sentMessageCount: 200,
     });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
 
@@ -1690,6 +1708,7 @@ describe("handleGetSessionData", () => {
       data: detailHeader,
       messages: { [Symbol.iterator]: () => iterator },
       messageCount: 2,
+      sentMessageCount: 2,
     });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
 

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -657,10 +657,14 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
   }
 
   try {
-    const result = materializeSessionDetailResponse(scanSource.getSnapshot(), {
+    const reference = {
       agentName,
       sessionId,
-    });
+    };
+    const messageCursor = optionalQueryValue(c.req.query("messageCursor"));
+    const result = messageCursor
+      ? materializeSessionDetailResponse(scanSource.getSnapshot(), reference, { messageCursor })
+      : materializeSessionDetailResponse(scanSource.getSnapshot(), reference);
     if (result.status === "unknown-agent") {
       return c.json({ error: `Unknown agent: ${agentName}` }, 404);
     }
@@ -677,6 +681,9 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       agent: agentName,
       session_id: sessionId,
       messages: result.status === "found-json" ? result.messageCount : result.data.messages.length,
+      sent_messages:
+        result.status === "found-json" ? result.sentMessageCount : result.data.messages.length,
+      message_update: result.data.message_update ?? "reset",
       duration_ms: Math.round(performance.now() - startedAt),
     });
     const aliases = loadAliasView();

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -194,6 +194,8 @@ export interface SessionDetail {
   summary_files?: unknown;
   stats: SessionStats;
   messages: Message[];
+  message_cursor?: string;
+  message_update?: "reset" | "append";
   smart_tags?: SmartTag[];
   smart_tags_source_updated_at?: number;
   smart_tags_classifier_revision?: string;

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -319,6 +319,110 @@ describe("materializeSessionDetail", () => {
     expect(agent.reads).toBe(0);
   });
 
+  it("streams only an unchanged message prefix's appended suffix", () => {
+    const makeStreamableHead = (messageCount: number, timeUpdated: number) => {
+      const head = makeHead({
+        time_updated: timeUpdated,
+        smart_tags: [],
+        smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+      });
+      return { ...head, stats: { ...head.stats, message_count: messageCount } };
+    };
+    const makeStreamableDetail = (head: SessionHead, texts: string[]) => ({
+      ...makeDetail("Cached Session"),
+      ...head,
+      reference: { agentName: "test", sessionId: "s1" },
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+      messages: texts.map((text, index) => ({
+        id: `m${index + 1}`,
+        role: "assistant" as const,
+        time_created: 1500 + index,
+        parts: [{ type: "text" as const, text }],
+      })),
+    });
+    const firstHead = makeStreamableHead(1, 2000);
+    const firstDetail = makeStreamableDetail(firstHead, ["first"]);
+    persistDetail(firstHead, firstDetail, "first");
+    const first = materializeSessionDetailResponse(
+      makeScanResult(new TestAgent(firstDetail, new Map([["s1", makeMeta("first")]])), firstHead),
+      { agentName: "test", sessionId: "s1" },
+    );
+
+    expect(first.status).toBe("found-json");
+    if (first.status !== "found-json") return;
+    expect(first.data.message_update).toBe("reset");
+    expect(first.sentMessageCount).toBe(1);
+
+    const appendedHead = makeStreamableHead(2, 3000);
+    const appendedDetail = makeStreamableDetail(appendedHead, ["first", "second"]);
+    persistDetail(appendedHead, appendedDetail, "appended");
+    const appended = materializeSessionDetailResponse(
+      makeScanResult(
+        new TestAgent(appendedDetail, new Map([["s1", makeMeta("appended")]])),
+        appendedHead,
+      ),
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: first.data.message_cursor },
+    );
+
+    expect(appended.status).toBe("found-json");
+    if (appended.status !== "found-json") return;
+    expect(appended.data.message_update).toBe("append");
+    expect(appended.messageCount).toBe(2);
+    expect(appended.sentMessageCount).toBe(1);
+    expect([...appended.messages].map((message) => JSON.parse(message).id)).toEqual(["m2"]);
+
+    const rewrittenDetail = makeStreamableDetail(appendedHead, ["rewritten", "second"]);
+    persistDetail(appendedHead, rewrittenDetail, "rewritten");
+    const rewritten = materializeSessionDetailResponse(
+      makeScanResult(
+        new TestAgent(rewrittenDetail, new Map([["s1", makeMeta("rewritten")]])),
+        appendedHead,
+      ),
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: appended.data.message_cursor },
+    );
+
+    expect(rewritten.status).toBe("found-json");
+    if (rewritten.status !== "found-json") return;
+    expect(rewritten.data.message_update).toBe("reset");
+    expect(rewritten.sentMessageCount).toBe(2);
+    expect([...rewritten.messages].map((message) => JSON.parse(message).id)).toEqual(["m1", "m2"]);
+  });
+
+  it("resets incremental transport while a changed fingerprint is rematerialized", () => {
+    const head = makeHead({
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    });
+    const cached = {
+      ...makeDetail("Cached Session"),
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    };
+    persistDetail(head, cached, "cached");
+    const first = materializeSessionDetailResponse(
+      makeScanResult(new TestAgent(cached, new Map([["s1", makeMeta("cached")]])), head),
+      { agentName: "test", sessionId: "s1" },
+    );
+    expect(first.status).toBe("found-json");
+    if (first.status !== "found-json") return;
+
+    saveCachedSessions("test", [head], { s1: makeMeta("changed") });
+    const source = makeDetail("Source Session");
+    const result = materializeSessionDetailResponse(
+      makeScanResult(new TestAgent(source, new Map([["s1", makeMeta("changed")]])), head),
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: first.data.message_cursor },
+    );
+
+    expect(result).toMatchObject({
+      status: "found",
+      data: { title: "Source Session", message_update: "reset" },
+    });
+  });
+
   it("indexes heads once per scan snapshot instead of calling Array.find", () => {
     const heads = Array.from({ length: 100 }, (_, index) =>
       makeHead({ id: `s${index}`, slug: `test/s${index}` }),

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -1,3 +1,4 @@
+import { createHash, type Hash } from "node:crypto";
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import type { SessionReference } from "../contract/index.js";
 import type { SessionDetail, SessionHead } from "../types/index.js";
@@ -27,7 +28,12 @@ export type SessionDetailResponseResult =
       data: Omit<SessionDetail, "messages">;
       messages: Iterable<string>;
       messageCount: number;
+      sentMessageCount: number;
     };
+
+export interface SessionDetailResponseOptions {
+  messageCursor?: string;
+}
 
 interface SessionDetailLookup {
   agentsByName: Map<string, BaseAgent>;
@@ -40,6 +46,101 @@ interface SessionDetailContext {
 }
 
 const sessionDetailLookups = new WeakMap<SessionHead[], SessionDetailLookup>();
+const MESSAGE_CURSOR_VERSION = 1;
+const MAX_MESSAGE_CURSOR_LENGTH = 512;
+
+interface MessageCursorPayload {
+  version: typeof MESSAGE_CURSOR_VERSION;
+  count: number;
+  digest: string;
+}
+
+function parseMessageCursor(value: string | undefined): MessageCursorPayload | null {
+  if (!value || value.length > MAX_MESSAGE_CURSOR_LENGTH) return null;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(value, "base64url").toString("utf8"),
+    ) as Partial<MessageCursorPayload>;
+    if (
+      payload.version !== MESSAGE_CURSOR_VERSION ||
+      !Number.isSafeInteger(payload.count) ||
+      payload.count == null ||
+      payload.count < 0 ||
+      typeof payload.digest !== "string" ||
+      !/^[a-f0-9]{64}$/.test(payload.digest)
+    ) {
+      return null;
+    }
+    return payload as MessageCursorPayload;
+  } catch {
+    return null;
+  }
+}
+
+function encodeMessageCursor(count: number, digest: string): string {
+  return Buffer.from(JSON.stringify({ version: MESSAGE_CURSOR_VERSION, count, digest })).toString(
+    "base64url",
+  );
+}
+
+function createMessageCursorHash(reference: SessionReference): Hash {
+  return createHash("sha256")
+    .update("codesesh-session-messages-v1\0")
+    .update(JSON.stringify([reference.agentName, reference.sessionId]))
+    .update("\n");
+}
+
+function updateMessageCursorField(hash: Hash, value: string | number | null | undefined) {
+  if (value == null) {
+    hash.update("n;");
+    return;
+  }
+  const text = String(value);
+  hash.update(`v${text.length}:`).update(text).update(";");
+}
+
+function updateMessageCursorHash(hash: Hash, row: CachedSessionRawEntry["messageRows"][number]) {
+  updateMessageCursorField(hash, row.message_id);
+  updateMessageCursorField(hash, row.role);
+  updateMessageCursorField(hash, row.time_created);
+  updateMessageCursorField(hash, row.time_completed);
+  updateMessageCursorField(hash, row.agent);
+  updateMessageCursorField(hash, row.mode);
+  updateMessageCursorField(hash, row.model);
+  updateMessageCursorField(hash, row.provider);
+  updateMessageCursorField(hash, row.tokens_json);
+  updateMessageCursorField(hash, row.cost);
+  updateMessageCursorField(hash, row.cost_source);
+  updateMessageCursorField(hash, row.parts_json);
+  updateMessageCursorField(hash, row.parts_format_version);
+  updateMessageCursorField(hash, row.subagent_id);
+  updateMessageCursorField(hash, row.nickname);
+  hash.update("\n");
+}
+
+function projectMessageStream(
+  reference: SessionReference,
+  rows: CachedSessionRawEntry["messageRows"],
+  requestedCursor: string | undefined,
+) {
+  const requested = parseMessageCursor(requestedCursor);
+  const hash = createMessageCursorHash(reference);
+  let requestedDigest = requested?.count === 0 ? hash.copy().digest("hex") : null;
+
+  for (let index = 0; index < rows.length; index += 1) {
+    updateMessageCursorHash(hash, rows[index]!);
+    if (requested?.count === index + 1) requestedDigest = hash.copy().digest("hex");
+  }
+
+  const digest = hash.digest("hex");
+  const canAppend =
+    requested !== null && requested.count <= rows.length && requestedDigest === requested.digest;
+  return {
+    cursor: encodeMessageCursor(rows.length, digest),
+    startIndex: canAppend ? requested.count : 0,
+    update: canAppend ? ("append" as const) : ("reset" as const),
+  };
+}
 
 function sessionReferenceKey(agentName: string, sessionId: string): string {
   return `${agentName}\0${sessionId}`;
@@ -197,9 +298,12 @@ function materializeStructuredSessionDetail(
   };
 }
 
-function* serializeCachedMessages(entry: CachedSessionRawEntry): IterableIterator<string> {
-  for (const messageRow of entry.messageRows) {
-    yield messageJsonFromCachedRow(messageRow);
+function* serializeCachedMessages(
+  entry: CachedSessionRawEntry,
+  startIndex = 0,
+): IterableIterator<string> {
+  for (let index = startIndex; index < entry.messageRows.length; index += 1) {
+    yield messageJsonFromCachedRow(entry.messageRows[index]!);
   }
 }
 
@@ -215,6 +319,7 @@ export function materializeSessionDetail(
 export function materializeSessionDetailResponse(
   scanResult: LiveSnapshot,
   reference: SessionReference,
+  options: SessionDetailResponseOptions = {},
 ): SessionDetailResponseResult {
   const context = getSessionDetailContext(scanResult, reference);
   if (!context) return { status: "unknown-agent" };
@@ -230,22 +335,29 @@ export function materializeSessionDetailResponse(
     cachedEntry.data.smart_tags == null ||
     cachedEntry.data.smart_tags_classifier_revision !== SMART_TAG_CLASSIFIER_REVISION
   ) {
-    return materializeStructuredSessionDetail(context, reference, cachedEntry);
+    const result = materializeStructuredSessionDetail(context, reference, cachedEntry);
+    return result.status === "found"
+      ? { ...result, data: { ...result.data, message_update: "reset" } }
+      : result;
   }
 
   const data = cachedEntry.data;
+  const stream = projectMessageStream(reference, cachedEntry.messageRows, options.messageCursor);
   return {
     status: "found-json",
     data: {
       ...data,
       reference,
       detail_freshness: "fresh",
+      message_cursor: stream.cursor,
+      message_update: stream.update,
       project_identity: getProjectIdentity(data, context.head),
       smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
       file_activity:
         data.file_activity ?? listSessionFileActivity(reference.agentName, reference.sessionId),
     },
-    messages: serializeCachedMessages(cachedEntry),
+    messages: serializeCachedMessages(cachedEntry, stream.startIndex),
     messageCount: cachedEntry.messageRows.length,
+    sentMessageCount: cachedEntry.messageRows.length - stream.startIndex,
   };
 }


### PR DESCRIPTION
## Summary

- add an opaque message cursor that validates the complete known transcript prefix and streams only appended messages
- merge append responses into the active React Query detail while falling back to a full reset for rewritten, shortened, stale, or rematerialized transcripts
- throttle agents, projects, dashboard, and related collection refreshes to one round per two-second live-update window
- log total and transmitted message counts for live detail requests

## Performance

- three consecutive 500 ms live batches now share one aggregate request round instead of issuing three rounds
- a two-message append sends one message instead of retransmitting the full transcript

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:migration`
- `pnpm perf:check`
- `pnpm test:coverage` (2,060 passed, 1 skipped)
