### PR TITLE
perf(web): stabilize render hot paths

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -33,7 +33,7 @@ import { AppRouteContent } from "./components/app/AppRouteContent";
 import { ScanStatusNotice } from "./components/app/ScanStatusNotice";
 import { formatSearchSubtitle } from "./lib/scan-format";
 import { findAgent } from "./lib/agents";
-import { getProjectIdentityKey, type ProjectRouteIdentity } from "./lib/projects";
+import { getProjectIdentityKey } from "./lib/projects";
 import {
   buildSessionIndexes,
   getSessionAgentKey,
@@ -67,7 +67,6 @@ export default function App() {
     reload,
   });
 
-  const [, setSelectedProjectIdentity] = useState<ProjectRouteIdentity | null>(null);
   const setScanStatus = useScanStatusPublisher();
   const [selectedSidebarSessionReference, setSelectedSidebarSessionReference] = useState<
     string | null
@@ -103,13 +102,6 @@ export default function App() {
     });
   }, [location.pathname, viewState.mode, viewState.activeAgentKey, viewState.activeSessionId]);
 
-  useEffect(() => {
-    if (viewState.mode !== "project") return;
-    setSelectedProjectIdentity({
-      kind: viewState.activeProjectKind,
-      key: viewState.activeProjectKey,
-    });
-  }, [viewState]);
   const sessionIndexes = useMemo(
     () => buildSessionIndexes(sessions, activeAgents),
     [sessions, activeAgents],
@@ -462,7 +454,6 @@ export default function App() {
             }}
             actions={{
               onCollapse: () => setSidebarCollapsed(true),
-              onSelectProject: setSelectedProjectIdentity,
               onToggleBookmark: toggleBookmark,
               onSelectFlatSidebarSession: handleSelectFlatSidebarSession,
               onToggleSidebarSessionBookmark: handleToggleSidebarSessionBookmark,

--- a/apps/web/src/components/DetailLanding.test.tsx
+++ b/apps/web/src/components/DetailLanding.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAgentCatalog } from "../lib/agents";
+import type { LandingSession } from "./DetailLanding";
+import { DetailLanding } from "./DetailLanding";
+
+afterEach(cleanup);
+
+describe("DetailLanding", () => {
+  it("reuses session aggregates across unrelated parent renders", () => {
+    const readMessageCount = vi.fn(() => 3);
+    const stats = {
+      total_input_tokens: 5,
+      total_output_tokens: 8,
+      total_cost: 0.1,
+    } as LandingSession["stats"];
+    Object.defineProperty(stats, "message_count", { get: readMessageCount });
+    const sessions: LandingSession[] = [
+      {
+        id: "session-1",
+        sessionId: "session-1",
+        agentKey: "codex",
+        reference: "codex/session-1",
+        slug: "codex/session-1",
+        title: "Session",
+        directory: "/repo",
+        time_created: 1,
+        time_updated: 2,
+        stats,
+      },
+    ];
+    const props = {
+      type: "global" as const,
+      agentCatalog: createAgentCatalog([]),
+      sessions,
+      agentItems: [],
+      isBookmarked: vi.fn(() => false),
+      onToggleBookmark: vi.fn(),
+    };
+    const view = render(
+      <MemoryRouter>
+        <DetailLanding {...props} />
+      </MemoryRouter>,
+    );
+    const readsAfterFirstRender = readMessageCount.mock.calls.length;
+    expect(readsAfterFirstRender).toBeGreaterThan(0);
+
+    view.rerender(
+      <MemoryRouter>
+        <DetailLanding {...props} />
+      </MemoryRouter>,
+    );
+
+    expect(readMessageCount).toHaveBeenCalledTimes(readsAfterFirstRender);
+  });
+});

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { findAgent, type AgentCatalog } from "../lib/agents";
 import type { SessionHead } from "../lib/api";
@@ -191,7 +192,7 @@ function RecentSessions({
   );
 }
 
-export function DetailLanding({
+export const DetailLanding = memo(function DetailLanding({
   type,
   agentCatalog,
   sessions,
@@ -202,21 +203,35 @@ export function DetailLanding({
   isBookmarked,
   onToggleBookmark,
 }: DetailLandingProps) {
-  const sortedSessions = sessions.toSorted(
-    (a, b) => (b.time_updated || b.time_created || 0) - (a.time_updated || a.time_created || 0),
-  );
-  const recentSessions = sortedSessions.slice(0, 5);
-
-  const totalMessages = sessions.reduce((sum, item) => sum + item.stats.message_count, 0);
-  const totalTokens = sessions.reduce((sum, item) => sum + getSessionTotalTokens(item.stats), 0);
-  const totalCost = sessions.reduce((sum, item) => sum + item.stats.total_cost, 0);
-  const costSource =
-    totalCost > 0
-      ? sessions.some((item) => item.stats.cost_source === "estimated")
-        ? "estimated"
-        : "recorded"
-      : undefined;
-  const latestUpdatedAt = sortedSessions[0]?.time_updated || sortedSessions[0]?.time_created;
+  const { recentSessions, totalMessages, totalTokens, totalCost, costSource, latestUpdatedAt } =
+    useMemo(() => {
+      const sortedSessions = sessions.toSorted(
+        (a, b) => (b.time_updated || b.time_created || 0) - (a.time_updated || a.time_created || 0),
+      );
+      let totalMessages = 0;
+      let totalTokens = 0;
+      let totalCost = 0;
+      let hasEstimatedCost = false;
+      for (const session of sessions) {
+        totalMessages += session.stats.message_count;
+        totalTokens += getSessionTotalTokens(session.stats);
+        totalCost += session.stats.total_cost;
+        hasEstimatedCost ||= session.stats.cost_source === "estimated";
+      }
+      return {
+        recentSessions: sortedSessions.slice(0, 5),
+        totalMessages,
+        totalTokens,
+        totalCost,
+        costSource:
+          totalCost > 0
+            ? hasEstimatedCost
+              ? ("estimated" as const)
+              : ("recorded" as const)
+            : undefined,
+        latestUpdatedAt: sortedSessions[0]?.time_updated || sortedSessions[0]?.time_created,
+      };
+    }, [sessions]);
 
   if (type === "missing-agent") {
     const requestedPath = `/${attemptedAgentKey || "unknown"}${attemptedSessionId ? `/${attemptedSessionId}` : ""}`;
@@ -386,4 +401,4 @@ export function DetailLanding({
       />
     </div>
   );
-}
+});

--- a/apps/web/src/components/RenderProfiler.test.ts
+++ b/apps/web/src/components/RenderProfiler.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("RenderProfiler", () => {
+  it("reads its disabled production flag once per module load", async () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+    vi.resetModules();
+    const { isRenderProfilerEnabled } = await import("./RenderProfiler");
+    const readsAfterLoad = getItem.mock.calls.length;
+
+    expect(isRenderProfilerEnabled()).toBe(false);
+    expect(isRenderProfilerEnabled()).toBe(false);
+    expect(getItem).toHaveBeenCalledTimes(readsAfterLoad);
+    expect(readsAfterLoad).toBe(1);
+  });
+});

--- a/apps/web/src/components/RenderProfiler.tsx
+++ b/apps/web/src/components/RenderProfiler.tsx
@@ -12,6 +12,19 @@ const PROFILER_LOG_STORAGE_KEY = "codeseshProfilerLog";
 const PROFILER_SLOW_COMMIT_MS = 16;
 const PROFILER_MAX_ENTRIES = 500;
 
+function readStorageFlag(key: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+
+const RENDER_PROFILER_ENABLED = readStorageFlag(PROFILER_STORAGE_KEY);
+const RENDER_PROFILER_LOG_ENABLED =
+  RENDER_PROFILER_ENABLED && readStorageFlag(PROFILER_LOG_STORAGE_KEY);
+
 interface RenderProfileEntry {
   id: string;
   source: "react-profiler" | "commit-latency" | "custom-timing";
@@ -31,23 +44,11 @@ declare global {
 }
 
 export function isRenderProfilerEnabled() {
-  if (typeof window === "undefined") return false;
-
-  try {
-    return window.localStorage.getItem(PROFILER_STORAGE_KEY) === "1";
-  } catch {
-    return false;
-  }
+  return RENDER_PROFILER_ENABLED;
 }
 
 function shouldLogRenderProfilerEntries() {
-  if (typeof window === "undefined") return false;
-
-  try {
-    return window.localStorage.getItem(PROFILER_LOG_STORAGE_KEY) === "1";
-  } catch {
-    return false;
-  }
+  return RENDER_PROFILER_LOG_ENABLED;
 }
 
 function pushProfileEntry(entry: RenderProfileEntry) {

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -7,10 +7,13 @@ import { createQueryWrapper } from "../../test/query-wrapper";
 import type { LandingSession } from "../DetailLanding";
 import { AppRouteContent } from "./AppRouteContent";
 
+const sessionDetailRender = vi.hoisted(() => vi.fn());
+
 vi.mock("../SessionDetail", () => ({
-  SessionDetail: ({ session }: { session: SessionDetail }) => (
-    <div data-testid="session-detail">{session.id}</div>
-  ),
+  SessionDetail: (props: { session: SessionDetail; childSessions: SessionDetail[] }) => {
+    sessionDetailRender(props);
+    return <div data-testid="session-detail">{props.session.id}</div>;
+  },
 }));
 
 const LAZY_SURFACE_TIMEOUT_MS = 5_000;
@@ -135,7 +138,10 @@ function addRouteAgents(props: ReturnType<typeof makeProps>): void {
   props.agentNameMap = props.agentCatalog.displayNameByKey;
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  sessionDetailRender.mockClear();
+});
 
 function renderContent(props: Parameters<typeof AppRouteContent>[0]) {
   const { Wrapper } = createQueryWrapper();
@@ -221,7 +227,11 @@ describe("AppRouteContent", () => {
       activeSessionId: "session-a",
     };
     props.sessionDetail.session = makeSession("session-a");
-    const view = renderContent(props);
+    const view = render(
+      <MemoryRouter>
+        <AppRouteContent {...props} />
+      </MemoryRouter>,
+    );
     const firstDetail = await screen.findByTestId(
       "session-detail",
       {},
@@ -241,6 +251,39 @@ describe("AppRouteContent", () => {
     );
 
     expect(await screen.findByTestId("session-detail")).not.toBe(firstDetail);
+  });
+
+  it("keeps child session identity stable across unrelated detail rerenders", async () => {
+    const props = makeProps();
+    const parent = makeSession("parent");
+    const child = {
+      ...makeSession("child"),
+      slug: "claudecode/child",
+      parent_reference: parent.reference,
+    };
+    props.viewState = {
+      mode: "session",
+      activeAgentKey: "claudecode",
+      activeSessionId: parent.id,
+    };
+    props.sessionDetail.session = parent;
+    props.sessions = [child];
+    const view = render(
+      <MemoryRouter>
+        <AppRouteContent {...props} />
+      </MemoryRouter>,
+    );
+    await screen.findByTestId("session-detail", {}, { timeout: LAZY_SURFACE_TIMEOUT_MS });
+    const firstChildren = sessionDetailRender.mock.calls.at(-1)?.[0].childSessions;
+
+    props.detailHighlightQuery = "unrelated";
+    view.rerender(
+      <MemoryRouter>
+        <AppRouteContent {...props} />
+      </MemoryRouter>,
+    );
+
+    expect(sessionDetailRender.mock.calls.at(-1)?.[0].childSessions).toBe(firstChildren);
   });
 
   it("renders an agent landing with encoded session links and full-reference bookmark actions", () => {

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -1,4 +1,12 @@
-import { lazy, Suspense, useMemo, type Dispatch, type ReactNode, type SetStateAction } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useMemo,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from "react";
 import { useLocation } from "react-router-dom";
 import { DetailLanding, type LandingAgentItem, type LandingSession } from "../DetailLanding";
 import { ErrorBoundary } from "../ErrorBoundary";
@@ -132,6 +140,26 @@ export function AppRouteContent({
       })),
     [agents],
   );
+  const currentSession = viewState.mode === "session" ? sessionDetail.session : null;
+  const currentSessionAgentName = currentSession?.reference.agentName;
+  const currentSessionId = currentSession?.reference.sessionId;
+  const childSessions = useMemo(() => {
+    if (!currentSessionAgentName || !currentSessionId) return [];
+    const parentRouteKey = getSessionRouteKey(currentSessionAgentName, currentSessionId);
+    return sessions.filter(
+      (candidate) =>
+        candidate.parent_reference &&
+        getSessionRouteKey(
+          candidate.parent_reference.agentName,
+          candidate.parent_reference.sessionId,
+        ) === parentRouteKey,
+    );
+  }, [currentSessionAgentName, currentSessionId, sessions]);
+  const toggleSessionBookmark = bookmarks.toggleSessionBookmark;
+  const toggleLandingBookmark = useCallback(
+    (session: LandingSession) => toggleSessionBookmark(session, session.agentKey),
+    [toggleSessionBookmark],
+  );
   if (loading) return <SessionDetailSkeleton />;
   if (search.active) {
     const resultCount = search.state.status === "loaded" ? search.state.results.length : 0;
@@ -224,13 +252,13 @@ export function AppRouteContent({
         agentItems={landingAgentItems}
         activeAgentKey={viewState.activeAgentKey}
         isBookmarked={bookmarks.isBookmarked}
-        onToggleBookmark={(session) => bookmarks.toggleSessionBookmark(session, session.agentKey)}
+        onToggleBookmark={toggleLandingBookmark}
       />
     );
   }
   if (viewState.mode === "session") {
     if (sessionDetail.loading) return <SessionDetailSkeleton />;
-    if (sessionDetail.error || !sessionDetail.session) {
+    if (sessionDetail.error || !currentSession) {
       return (
         <DetailLanding
           type="missing-session"
@@ -240,19 +268,10 @@ export function AppRouteContent({
           activeAgentKey={viewState.activeAgentKey}
           attemptedSessionId={viewState.activeSessionId}
           isBookmarked={bookmarks.isBookmarked}
-          onToggleBookmark={(session) => bookmarks.toggleSessionBookmark(session, session.agentKey)}
+          onToggleBookmark={toggleLandingBookmark}
         />
       );
     }
-    const currentSession = sessionDetail.session;
-    const childSessions = sessions.filter(
-      (candidate) =>
-        candidate.parent_reference &&
-        getSessionRouteKey(
-          candidate.parent_reference.agentName,
-          candidate.parent_reference.sessionId,
-        ) === getSessionRouteKey(currentSession.reference.agentName, currentSession.id),
-    );
     return (
       <RenderProfiler
         id="SessionDetail"

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -23,7 +23,6 @@ const projects = [
 function createActions(overrides: Partial<AppSidebarActions> = {}): AppSidebarActions {
   return {
     onCollapse: vi.fn(),
-    onSelectProject: vi.fn(),
     onToggleBookmark: vi.fn(),
     onSelectFlatSidebarSession: vi.fn(),
     onToggleSidebarSessionBookmark: vi.fn(),

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -33,11 +33,9 @@ function ScanAwareEmptyState({ scanning, empty }: { scanning: string; empty: str
 function ProjectNavList({
   projects,
   selectedProjectNavigationId,
-  onSelectProject,
 }: {
   projects: ApiProjectGroup[];
   selectedProjectNavigationId: string | null;
-  onSelectProject: (identity: ReturnType<typeof getProjectGroupIdentity>) => void;
 }) {
   return (
     <>
@@ -48,7 +46,6 @@ function ProjectNavList({
           <li key={`${project.identityKind}:${project.identityKey}`}>
             <Link
               to={getProjectPath(projectIdentity)}
-              onClick={() => onSelectProject(projectIdentity)}
               data-active={isSelected ? "true" : undefined}
               className={`min-w-0 ${navItemClass(isSelected)}`}
             >
@@ -81,7 +78,6 @@ export interface AppSidebarViewModel {
 
 export interface AppSidebarActions {
   onCollapse: () => void;
-  onSelectProject: (identity: ReturnType<typeof getProjectGroupIdentity>) => void;
   onToggleBookmark: (session: BookmarkView) => void;
   onSelectFlatSidebarSession: (session: SessionHead) => void;
   onToggleSidebarSessionBookmark: (session: SessionHead) => void;
@@ -104,7 +100,6 @@ export function AppSidebar({
   },
   actions: {
     onCollapse,
-    onSelectProject,
     onToggleBookmark,
     onSelectFlatSidebarSession,
     onToggleSidebarSessionBookmark,
@@ -153,7 +148,6 @@ export function AppSidebar({
             <ProjectNavList
               projects={projects}
               selectedProjectNavigationId={selectedProjectNavigationId}
-              onSelectProject={onSelectProject}
             />
             {projects.length === 0 && !loading ? (
               <li>

--- a/apps/web/src/components/session-detail/message-rendering.test.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.test.tsx
@@ -1,0 +1,67 @@
+import { cleanup, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Message, ToolPart } from "../../lib/api";
+import type { MessageBlock } from "./blocks";
+
+const normalizeToolStateCalls = vi.hoisted(() => vi.fn());
+
+vi.mock("./tool-strategy", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./tool-strategy")>();
+  return {
+    ...actual,
+    normalizeToolState: (...args: Parameters<typeof actual.normalizeToolState>) => {
+      normalizeToolStateCalls();
+      return actual.normalizeToolState(...args);
+    },
+  };
+});
+
+import { MessageItem } from "./message-rendering";
+
+afterEach(() => {
+  cleanup();
+  normalizeToolStateCalls.mockClear();
+});
+
+describe("MessageItem", () => {
+  it("reuses normalized tool state when only highlighting changes", () => {
+    const tool: ToolPart = {
+      type: "tool",
+      tool: "Write",
+      state: {
+        status: "completed",
+        input: { file_path: "/repo/output.txt", content: "payload".repeat(1_000) },
+        output: "written",
+      },
+    };
+    const message: Message = {
+      id: "m1",
+      role: "assistant",
+      time_created: 1,
+      parts: [tool],
+    };
+    const blocks: MessageBlock[] = [{ type: "tool", parts: [tool] }];
+    const props = {
+      messageIndex: 0,
+      msg: message,
+      blocks,
+      formatTokens: (value: number) => String(value),
+      sessionAgentKey: "codex",
+      baseDirectory: "/repo",
+    };
+    const view = render(
+      <MemoryRouter>
+        <MessageItem {...props} highlightQuery="first" />
+      </MemoryRouter>,
+    );
+
+    view.rerender(
+      <MemoryRouter>
+        <MessageItem {...props} highlightQuery="second" />
+      </MemoryRouter>,
+    );
+
+    expect(normalizeToolStateCalls).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import {
   Bot,
   CalendarRange,
@@ -289,7 +289,7 @@ function AbortToolItem() {
   );
 }
 
-function ReasoningSection({
+const ReasoningSection = memo(function ReasoningSection({
   anchorId,
   parts,
   highlightQuery,
@@ -299,10 +299,14 @@ function ReasoningSection({
   highlightQuery?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const fullText = parts
-    .map((part) => part.text)
-    .filter(Boolean)
-    .join("\n\n");
+  const fullText = useMemo(
+    () =>
+      parts
+        .map((part) => part.text)
+        .filter(Boolean)
+        .join("\n\n"),
+    [parts],
+  );
 
   return (
     <div
@@ -333,9 +337,9 @@ function ReasoningSection({
       </Collapsible>
     </div>
   );
-}
+});
 
-function ToolsSection({
+const ToolsSection = memo(function ToolsSection({
   parts,
   anchorIds,
   sessionAgentKey,
@@ -364,9 +368,9 @@ function ToolsSection({
       </div>
     </div>
   );
-}
+});
 
-function PlansSection({
+const PlansSection = memo(function PlansSection({
   anchorId,
   parts,
   highlightQuery,
@@ -382,11 +386,17 @@ function PlansSection({
       ))}
     </div>
   );
-}
+});
 
-function PlanItem({ part, highlightQuery }: { part: PlanPart; highlightQuery?: string }) {
+const PlanItem = memo(function PlanItem({
+  part,
+  highlightQuery,
+}: {
+  part: PlanPart;
+  highlightQuery?: string;
+}) {
   const [expanded, setExpanded] = useState(false);
-  const display = buildCodexPlanDisplay(part);
+  const display = useMemo(() => buildCodexPlanDisplay(part), [part]);
   const statusMeta =
     display.approvalStatus === "fail" ? TOOL_STATUS_META.error : TOOL_STATUS_META.completed;
   const StatusIcon = statusMeta.icon;
@@ -455,9 +465,9 @@ function PlanItem({ part, highlightQuery }: { part: PlanPart; highlightQuery?: s
       </Collapsible>
     </div>
   );
-}
+});
 
-function ToolItem({
+const ToolItem = memo(function ToolItem({
   tool,
   anchorId,
   sessionAgentKey,
@@ -471,9 +481,15 @@ function ToolItem({
   highlightQuery?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const state = normalizeToolState(tool);
-  const strategy = getToolDisplayStrategy(sessionAgentKey, tool, state, baseDirectory);
-  const inputPreviewText = getDisplayTextWithRelativePaths(state.inputText || "{}", baseDirectory);
+  const state = useMemo(() => normalizeToolState(tool), [tool]);
+  const strategy = useMemo(
+    () => getToolDisplayStrategy(sessionAgentKey, tool, state, baseDirectory),
+    [baseDirectory, sessionAgentKey, state, tool],
+  );
+  const inputPreviewText = useMemo(
+    () => getDisplayTextWithRelativePaths(state.inputText || "{}", baseDirectory),
+    [baseDirectory, state.inputText],
+  );
   const statusMeta = TOOL_STATUS_META[state.status];
   const StatusIcon = statusMeta.icon;
   const ToolIcon = strategy.Icon;
@@ -588,4 +604,4 @@ function ToolItem({
       </Collapsible>
     </div>
   );
-}
+});

--- a/apps/web/src/components/session-detail/path-extract.ts
+++ b/apps/web/src/components/session-detail/path-extract.ts
@@ -106,14 +106,24 @@ export function getDisplayPath(filePath: string, baseDirectory?: string) {
   return normalizedPath;
 }
 
+let relativePathPatternCache: { base: string; pattern: RegExp } | null = null;
+
+function getRelativePathPattern(base: string): RegExp {
+  if (relativePathPatternCache?.base !== base) {
+    relativePathPatternCache = {
+      base,
+      pattern: new RegExp(`${escapeRegExp(base)}(?=$|/|[\\s"'\\)\\]}:;,])`, "g"),
+    };
+  }
+  relativePathPatternCache.pattern.lastIndex = 0;
+  return relativePathPatternCache.pattern;
+}
+
 export function getDisplayTextWithRelativePaths(text: string, baseDirectory?: string) {
   const normalizedBase = (baseDirectory ?? "").replace(/\/+$/, "");
   if (!text || !normalizedBase) return text;
 
-  return text.replace(
-    new RegExp(`${escapeRegExp(normalizedBase)}(?=$|/|[\\s"'\\)\\]}:;,])`, "g"),
-    ".",
-  );
+  return text.replace(getRelativePathPattern(normalizedBase), ".");
 }
 
 export function formatTrackedPath(path: string, baseDirectory: string) {

--- a/apps/web/src/hooks/useSidebarModel.test.ts
+++ b/apps/web/src/hooks/useSidebarModel.test.ts
@@ -146,4 +146,13 @@ describe("useSidebarModel", () => {
     });
     expect(result.current.activeProjectSessions).toHaveLength(2);
   });
+
+  it("keeps bookmark set identity when only the route object identity changes", () => {
+    const { result, rerender } = renderModel(projectView);
+    const first = result.current.bookmarkedSidebarSessionReferences;
+
+    rerender({ viewState: { ...projectView }, selectedProjectAgent: undefined });
+
+    expect(result.current.bookmarkedSidebarSessionReferences).toBe(first);
+  });
 });

--- a/apps/web/src/hooks/useSidebarModel.ts
+++ b/apps/web/src/hooks/useSidebarModel.ts
@@ -124,14 +124,6 @@ export function useSidebarModel({
       selectedProjectAgent,
     );
     const sidebarSessionLookup = buildSidebarSessionLookup(sidebarSessions);
-    const bookmarkedSidebarSessionReferences = new Set(
-      sidebarSessions
-        .filter((sessionItem) =>
-          isSessionBookmarked(getSessionAgentKey(sessionItem), sessionItem.id),
-        )
-        .map(getSessionReferenceKey),
-    );
-
     return {
       activeAgentKey,
       activeAgent,
@@ -141,17 +133,20 @@ export function useSidebarModel({
       selectedProjectNavigation,
       sidebarSessions,
       sidebarSessionLookup,
-      bookmarkedSidebarSessionReferences,
     };
-  }, [
-    agents,
-    isSessionBookmarked,
-    projects,
-    selectedProjectAgent,
-    session,
-    sessionIndexes,
-    viewState,
-  ]);
+  }, [agents, projects, selectedProjectAgent, session, sessionIndexes, viewState]);
 
-  return model;
+  const bookmarkedSidebarSessionReferences = useMemo(
+    () =>
+      new Set(
+        model.sidebarSessions
+          .filter((sessionItem) =>
+            isSessionBookmarked(getSessionAgentKey(sessionItem), sessionItem.id),
+          )
+          .map(getSessionReferenceKey),
+      ),
+    [isSessionBookmarked, model.sidebarSessions],
+  );
+
+  return { ...model, bookmarkedSidebarSessionReferences };
 }


### PR DESCRIPTION
## Summary

- memoize child-session, landing-summary, sidebar-bookmark, tool, plan, and reasoning derivations so unrelated shell renders retain stable inputs
- reuse the active base-directory path pattern instead of compiling a regular expression for every tool render
- remove the write-only project selection state and its sidebar callback chain
- read render-profiler storage flags once per module load instead of synchronously on every profiled render

## Performance

- unrelated detail rerenders retain the same child-session array and sidebar bookmark set identities
- changing only the highlight query normalizes a large tool input once instead of twice
- repeated landing renders reuse the existing aggregate calculation
- the disabled profiler path performs one storage read per module load

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:migration`
- `pnpm perf:check`
- `pnpm test:coverage` (2,065 passed, 1 skipped)
