### PR TITLE
fix(cursor): bound composer scan cache

### DIFF
--- a/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
@@ -154,6 +154,22 @@ describe("CS-142: Cursor scan shape", () => {
     expect(heads.map((head) => head.id)).toEqual(["new"]);
   });
 
+  it("releases composers excluded from the next scan", () => {
+    const dbPath = createDb([
+      composer("stale"),
+      ...bubbles("stale", [{ suffix: "a", bubble: { type: 1, text: "old" } }]),
+    ]);
+    const agent = makeAgent(dbPath);
+
+    agent.scan({ from: 0 });
+    expect((agent as any).composerCache.has("stale")).toBe(true);
+
+    agent.scan({ from: 3_000 });
+
+    expect((agent as any).composerCache.has("stale")).toBe(false);
+    expect(textOf(agent, "stale")).toEqual(["old"]);
+  });
+
   it("uses the same update-time fallback in heads and details", () => {
     const dbPath = createDb([
       composer("c1", { lastUpdatedAt: undefined, lastSendTime: 2_500 }),

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -487,8 +487,8 @@ export class CursorAgent extends DatabaseSessionSource {
 
   private dbPath: string | null = null;
 
-  // Cache composer data from scan so getSessionData can reuse it
   private composerCache = new Map<string, ComposerData>();
+  private directoryCache = new Map<string, string>();
 
   protected getDatabasePath(): string | null {
     if (!this.dbPath) {
@@ -603,6 +603,8 @@ export class CursorAgent extends DatabaseSessionSource {
   }
 
   scan(options?: AgentScanOptions): SessionHead[] {
+    this.composerCache.clear();
+    this.directoryCache.clear();
     if (!this.dbPath) return [];
 
     const scanMarker = perf.start("cursor:scan");
@@ -678,6 +680,7 @@ export class CursorAgent extends DatabaseSessionSource {
             emitted.set(order, head);
             order += 1;
             this.composerCache.set(composerId, composer);
+            if (directory) this.directoryCache.set(composerId, directory);
             continue;
           }
 
@@ -805,12 +808,8 @@ export class CursorAgent extends DatabaseSessionSource {
           }) ?? 0;
       }
 
-      // Retrieve directory from cache (populated during scan) or build map on demand
-      const cachedDir = this.composerCache.get(`__dir__${composerId}`);
       const directory =
-        (cachedDir as unknown as { directory?: string })?.directory ??
-        this.buildWorkspacePathMap().get(composerId) ??
-        "";
+        this.directoryCache.get(composerId) ?? this.buildWorkspacePathMap().get(composerId) ?? "";
 
       return {
         reference: { agentName: this.name, sessionId: composerId },
@@ -913,14 +912,7 @@ export class CursorAgent extends DatabaseSessionSource {
     const hasModelUsage = Object.keys(modelUsageMap).length > 0;
 
     this.composerCache.set(composerId, composer);
-    this.composerCache.set(`__mapping__${composerId}`, {
-      sessionId: composerId,
-    } as unknown as ComposerData);
-    if (directory) {
-      this.composerCache.set(`__dir__${composerId}`, {
-        directory,
-      } as unknown as ComposerData);
-    }
+    if (directory) this.directoryCache.set(composerId, directory);
     return {
       id: composerId,
       slug: `cursor/${composerId}`,


### PR DESCRIPTION
## Summary

- clear Cursor composer and directory caches at the start of each scan cycle
- separate directory paths from parsed composer data with a type-safe cache
- remove unused mapping entries and unsafe cache value casts
- preserve detail loading by falling back to the Cursor database after cache eviction

## Validation

- `pnpm --filter @codesesh/core test`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
