### PR TITLE
perf(cli): reuse the search index worker

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -2529,11 +2529,19 @@ describe("LiveScanStore", () => {
     const outcomes = Promise.allSettled([active, ...pending]);
 
     const activeWorker = workerThreads.workers.find((worker) => worker.workerData.jobs)!;
-    activeWorker.emitDone();
+    activeWorker.emitMessage({
+      type: "done",
+      context: "scan.refresh",
+      durationMs: 0,
+      sessions: 1,
+    });
 
     const searchIndexWorkers = workerThreads.workers.filter((worker) => worker.workerData.jobs);
-    expect(searchIndexWorkers).toHaveLength(2);
-    expect(searchIndexWorkers[1]?.workerData.jobs).toEqual([
+    expect(searchIndexWorkers).toEqual([activeWorker]);
+    const nextBatch = activeWorker.postMessage.mock.calls.at(-1)?.[0] as
+      | { jobs?: unknown[] }
+      | undefined;
+    expect(nextBatch?.jobs).toEqual([
       expect.objectContaining({
         kind: "changes",
         changes: [
@@ -2544,7 +2552,12 @@ describe("LiveScanStore", () => {
       }),
     ]);
 
-    searchIndexWorkers[1]!.emitDone();
+    activeWorker.emitMessage({
+      type: "done",
+      context: "scan.refresh",
+      durationMs: 0,
+      sessions: 1,
+    });
     expect(await outcomes).toEqual([
       { status: "fulfilled", value: undefined },
       { status: "fulfilled", value: undefined },

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -6,6 +6,7 @@ const workerMocks = vi.hoisted(() => {
   class FakeWorker {
     private handlers = new Map<string, Handler>();
     readonly workerData: Record<string, unknown>;
+    readonly postedMessages: unknown[] = [];
 
     constructor(_url: URL, options?: { workerData?: Record<string, unknown> }) {
       this.workerData = options?.workerData ?? {};
@@ -18,6 +19,10 @@ const workerMocks = vi.hoisted(() => {
     }
 
     unref(): void {}
+
+    postMessage(message: unknown): void {
+      this.postedMessages.push(message);
+    }
 
     async terminate(): Promise<number> {
       return 0;
@@ -113,6 +118,39 @@ describe("SearchIndexJobRunner", () => {
     });
 
     await expect(completion).resolves.toBeUndefined();
+  });
+
+  it("reuses one worker for consecutive batches", async () => {
+    const runner = new SearchIndexJobRunner();
+    const first = runner.enqueue("scan.refresh", [makeJob()]);
+    const worker = startedWorker();
+    worker.post({ type: "done", context: "scan.refresh", durationMs: 1, sessions: 1 });
+    await first;
+
+    const second = runner.enqueue("scan.refresh", [makeJob()]);
+
+    expect(workerMocks.workers).toEqual([worker]);
+    expect(worker.postedMessages).toEqual([
+      expect.objectContaining({ context: "scan.refresh", pricingGenerationId: 17 }),
+    ]);
+    worker.post({ type: "done", context: "scan.refresh", durationMs: 1, sessions: 1 });
+    await second;
+  });
+
+  it("dispatches a queued batch after the active batch completes", async () => {
+    const runner = new SearchIndexJobRunner();
+    const first = runner.enqueue("first-refresh", [makeJob()]);
+    const worker = startedWorker();
+    const second = runner.enqueue("second-refresh", [makeJob()]);
+
+    worker.post({ type: "done", context: "first-refresh", durationMs: 1, sessions: 1 });
+    await first;
+
+    expect(worker.postedMessages).toEqual([
+      expect.objectContaining({ context: "second-refresh", pricingGenerationId: 17 }),
+    ]);
+    worker.post({ type: "done", context: "second-refresh", durationMs: 1, sessions: 1 });
+    await second;
   });
 
   it("CS-137: rejects the batch when the worker reports a persistence failure", async () => {

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -5,7 +5,11 @@ import { getPricingGeneration } from "@codesesh/core";
 import { toError } from "./errors.js";
 import { appLogger, logSearchIndexSync } from "./logging.js";
 import { PendingSearchIndexJobs, type SearchIndexJobBatch } from "./pending-search-index-jobs.js";
-import type { SearchIndexWorkerJob, SearchIndexWorkerMessage } from "./search-index-worker.js";
+import type {
+  SearchIndexWorkerJob,
+  SearchIndexWorkerMessage,
+  SearchIndexWorkerRunRequest,
+} from "./search-index-worker.js";
 
 const SHUTDOWN_ERROR_MESSAGE = "Live scan store shut down";
 
@@ -29,7 +33,7 @@ export class SearchIndexJobRunner {
 
     const batchId = this.nextBatchId++;
     const completion = this.pendingJobs.enqueue(batchId, context, jobs);
-    if (this.worker) {
+    if (this.activeBatch) {
       const snapshot = this.snapshot();
       appLogger.debug("search_index.worker_queued", {
         batch_id: batchId,
@@ -68,7 +72,7 @@ export class SearchIndexJobRunner {
   }
 
   private startNextBatch(): void {
-    if (this.isShuttingDown || this.worker) return;
+    if (this.isShuttingDown || this.activeBatch) return;
     const batch = this.pendingJobs.take();
     if (!batch) return;
 
@@ -86,10 +90,28 @@ export class SearchIndexJobRunner {
       return;
     }
 
+    const request: SearchIndexWorkerRunRequest = {
+      type: "run",
+      pricingGenerationId: getPricingGeneration().id,
+      context: batch.context,
+      jobs: batch.jobs,
+    };
+    const existingWorker = this.worker;
+    if (existingWorker) {
+      this.activeBatch = batch;
+      try {
+        existingWorker.postMessage(request);
+      } catch (error) {
+        this.invalidateWorker(existingWorker, toError(error));
+      }
+      return;
+    }
+
     const workerUrl = this.workerUrl();
     if (!workerUrl) {
       appLogger.warn("search_index.worker_missing", { context: batch.context });
       this.settle(batch, new Error("Search index worker is unavailable"));
+      this.startNextBatch();
       return;
     }
     appLogger.info("search_index.worker_started", {
@@ -98,37 +120,38 @@ export class SearchIndexJobRunner {
       jobs: batch.jobs.length,
     });
 
-    const worker = new Worker(workerUrl, {
-      workerData: {
-        pricingGenerationId: getPricingGeneration().id,
-        context: batch.context,
-        jobs: batch.jobs,
-        agentNames: [],
-        sessionsByAgent: {},
-        metaByAgent: {},
-      },
-    });
+    let worker: Worker;
+    try {
+      worker = new Worker(workerUrl, { workerData: request });
+    } catch (error) {
+      this.settle(batch, toError(error));
+      this.startNextBatch();
+      return;
+    }
     worker.unref();
     this.worker = worker;
     this.activeBatch = batch;
 
     worker.on("message", (message: SearchIndexWorkerMessage) => {
       if (appLogger.consumeWorkerMessage(message)) return;
+      if (this.worker !== worker) return;
+      const activeBatch = this.activeBatch;
+      if (!activeBatch) return;
       if (message.type === "sync-result") {
         logSearchIndexSync(message.context, message.result);
         return;
       }
       if (message.type === "persist-failed") {
         appLogger.error("search_index.persist_failed", {
-          batch_id: batch.id,
+          batch_id: activeBatch.id,
           context: message.context,
           stage: message.stage,
           publication_id: message.publicationId,
           agent: message.agentName,
           sessions: message.sessions,
         });
-        this.settle(
-          batch,
+        this.finishBatch(
+          activeBatch,
           new Error(
             `Search index worker failed to persist ${message.stage} for ${message.agentName}`,
           ),
@@ -141,31 +164,57 @@ export class SearchIndexJobRunner {
         duration_ms: Math.round(message.durationMs),
         sessions: message.sessions,
       });
-      this.settle(batch);
+      this.finishBatch(activeBatch);
     });
     worker.on("error", (error) => {
-      appLogger.error("search_index.worker_error", { context: batch.context, error });
-      this.settle(batch, toError(error));
+      appLogger.error("search_index.worker_error", {
+        context: this.activeBatch?.context ?? batch.context,
+        error,
+      });
+      this.invalidateWorker(worker, toError(error));
     });
-    worker.on("exit", (code) => this.finishWorker(worker, batch, code));
+    worker.on("exit", (code) => this.finishWorker(worker, code));
   }
 
-  private finishWorker(worker: Worker, batch: SearchIndexJobBatch, code: number): void {
+  private finishBatch(batch: SearchIndexJobBatch, error?: Error): void {
+    if (this.activeBatch !== batch) return;
+    this.activeBatch = null;
+    this.settle(batch, error);
+    this.startNextBatch();
+  }
+
+  private invalidateWorker(worker: Worker, error: Error): void {
+    if (this.worker !== worker) return;
+    this.worker = null;
+    const batch = this.activeBatch;
+    this.activeBatch = null;
+    if (batch) this.settle(batch, error);
+    void worker.terminate();
+    this.startNextBatch();
+  }
+
+  private finishWorker(worker: Worker, code: number): void {
+    const batch = this.worker === worker ? this.activeBatch : null;
     appLogger.info("search_index.worker_exited", {
-      batch_id: batch.id,
-      context: batch.context,
+      batch_id: batch?.id,
+      context: batch?.context,
       code,
       shutting_down: this.isShuttingDown || undefined,
     });
-    if (this.worker === worker) this.worker = null;
-    if (this.activeBatch === batch) this.activeBatch = null;
+    if (this.worker !== worker) return;
+    this.worker = null;
+    this.activeBatch = null;
 
-    const error =
-      code === 0
-        ? new Error("Search index worker exited before completing its batch")
-        : new Error(`Search index worker exited with code ${code}`);
-    if (code !== 0) appLogger.warn("search_index.worker_exit", { context: batch.context, code });
-    this.settle(batch, error);
+    if (batch) {
+      const error =
+        code === 0
+          ? new Error("Search index worker exited before completing its batch")
+          : new Error(`Search index worker exited with code ${code}`);
+      if (code !== 0) {
+        appLogger.warn("search_index.worker_exit", { context: batch.context, code });
+      }
+      this.settle(batch, error);
+    }
     this.startNextBatch();
   }
 

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -11,10 +11,16 @@ const mocks = vi.hoisted(() => ({
   appLoggerInfo: vi.fn(),
   appLoggerWarn: vi.fn(),
   appLoggerError: vi.fn(),
+  messageHandler: undefined as ((message: Record<string, unknown>) => void) | undefined,
 }));
 
 vi.mock("node:worker_threads", () => ({
-  parentPort: { postMessage: mocks.postMessage },
+  parentPort: {
+    postMessage: mocks.postMessage,
+    on: (_event: string, handler: (message: Record<string, unknown>) => void) => {
+      mocks.messageHandler = handler;
+    },
+  },
   threadId: 17,
   get workerData() {
     return mocks.workerData;
@@ -50,13 +56,14 @@ function makeAgent() {
 }
 
 async function runWorker() {
-  mocks.workerData = { pricingGenerationId: 17, ...mocks.workerData };
+  mocks.workerData = { type: "run", pricingGenerationId: 17, ...mocks.workerData };
   await import("./search-index-worker.js");
 }
 
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
+  mocks.messageHandler = undefined;
   mocks.commitDurableSessionPublication.mockReturnValue({
     status: "committed",
     publicationId: "publication-default",
@@ -79,6 +86,27 @@ describe("search index worker", () => {
     expect(mocks.synchronizePricingGeneration).toHaveBeenCalledWith(17);
     expect(mocks.synchronizePricingGeneration.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.createRegisteredAgents.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("reuses module initialization while isolating agents between batches", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([]);
+
+    await runWorker();
+    mocks.messageHandler?.({
+      type: "run",
+      pricingGenerationId: 17,
+      context: "second-refresh",
+      jobs: [],
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+    });
+
+    expect(mocks.synchronizePricingGeneration).toHaveBeenCalledOnce();
+    expect(mocks.createRegisteredAgents).toHaveBeenCalledTimes(2);
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", context: "second-refresh" }),
     );
   });
 

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -65,32 +65,17 @@ export type SearchIndexWorkerJob =
       searchIndexOptions?: SearchIndexSyncOptions;
     };
 
-interface SearchIndexWorkerData {
+export interface SearchIndexWorkerRunRequest {
+  type: "run";
   pricingGenerationId: number;
   jobs?: SearchIndexWorkerJob[];
   context: string;
-  agentNames: string[];
-  sessionsByAgent: Record<string, SessionHead[]>;
-  metaByAgent: Record<string, Record<string, SessionCacheMeta>>;
+  agentNames?: string[];
+  sessionsByAgent?: Record<string, SessionHead[]>;
+  metaByAgent?: Record<string, Record<string, SessionCacheMeta>>;
 }
 
 type WorkerAgent = ReturnType<typeof createRegisteredAgents>[number];
-
-const data = workerData as SearchIndexWorkerData;
-const startedAt = performance.now();
-synchronizePricingGeneration(data.pricingGenerationId);
-const agents = createRegisteredAgents();
-const jobs =
-  data.jobs ??
-  data.agentNames.map((agentName): SearchIndexWorkerJob => ({
-    kind: "full",
-    context: data.context,
-    agentName,
-    sessions: data.sessionsByAgent[agentName] ?? [],
-    meta: data.metaByAgent[agentName] ?? {},
-    completeness: "complete",
-    removedSessionIds: [],
-  }));
 
 function jobSessionCount(job: SearchIndexWorkerJob): number {
   return job.kind === "full" ? job.sessions.length : job.changes.length;
@@ -204,35 +189,60 @@ function postSyncResult(context: string, result: SearchIndexSyncResult): void {
   } satisfies SearchIndexWorkerMessage);
 }
 
-let persistFailed = false;
-for (const job of jobs) {
-  const agent = agents.find((item) => item.name === job.agentName);
-  if (!agent) {
-    reportPersistFailure(job, {
-      stage: "prepare",
-      publicationId: job.publicationId ?? randomUUID(),
-    });
-    persistFailed = true;
-    break;
-  }
+let pricingGenerationId: number | null = null;
 
-  if (agent.setSessionMetaMap) {
-    agent.setSessionMetaMap(new Map(Object.entries(job.meta)));
-  }
-
-  const failure = runJob(job, agent);
-  if (failure) {
-    reportPersistFailure(job, failure);
-    persistFailed = true;
-    break;
-  }
+function jobsFromRequest(request: SearchIndexWorkerRunRequest): SearchIndexWorkerJob[] {
+  if (request.jobs) return request.jobs;
+  return (request.agentNames ?? []).map((agentName): SearchIndexWorkerJob => ({
+    kind: "full",
+    context: request.context,
+    agentName,
+    sessions: request.sessionsByAgent?.[agentName] ?? [],
+    meta: request.metaByAgent?.[agentName] ?? {},
+    completeness: "complete",
+    removedSessionIds: [],
+  }));
 }
 
-if (!persistFailed) {
+function runBatch(request: SearchIndexWorkerRunRequest): void {
+  const startedAt = performance.now();
+  if (pricingGenerationId !== request.pricingGenerationId) {
+    synchronizePricingGeneration(request.pricingGenerationId);
+    pricingGenerationId = request.pricingGenerationId;
+  }
+  const agents = createRegisteredAgents();
+  const jobs = jobsFromRequest(request);
+
+  for (const job of jobs) {
+    const agent = agents.find((item) => item.name === job.agentName);
+    if (!agent) {
+      reportPersistFailure(job, {
+        stage: "prepare",
+        publicationId: job.publicationId ?? randomUUID(),
+      });
+      return;
+    }
+
+    if (agent.setSessionMetaMap) {
+      agent.setSessionMetaMap(new Map(Object.entries(job.meta)));
+    }
+
+    const failure = runJob(job, agent);
+    if (failure) {
+      reportPersistFailure(job, failure);
+      return;
+    }
+  }
+
   parentPort?.postMessage({
     type: "done",
-    context: data.context,
+    context: request.context,
     durationMs: performance.now() - startedAt,
     sessions: jobs.reduce((total, job) => total + jobSessionCount(job), 0),
   } satisfies SearchIndexWorkerMessage);
 }
+
+parentPort?.on("message", (message: SearchIndexWorkerRunRequest) => {
+  if (message.type === "run") runBatch(message);
+});
+runBatch(workerData as SearchIndexWorkerRunRequest);


### PR DESCRIPTION
## Summary

- keep the search-index worker alive and dispatch later batches through messages
- reuse module and schema initialization across batches while synchronizing pricing only when its generation changes
- recreate registered agent adapters for every batch to isolate mutable adapter state
- preserve pending-batch coalescing, shutdown, persistence-failure, and worker-recovery behavior

## Validation

- `pnpm --filter codesesh test` (490 passed)
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm perf:check`
