### PR TITLE
perf(analytics): reuse session trees per request

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -36,6 +36,12 @@ vi.mock("@codesesh/core", async (importOriginal) => {
       coreMocks.attachProjectMetrics(...args);
       return actual.attachProjectMetrics(...args);
     },
+    attachProjectMetricsFromTree: (
+      ...args: Parameters<typeof actual.attachProjectMetricsFromTree>
+    ) => {
+      coreMocks.attachProjectMetrics(...args);
+      return actual.attachProjectMetricsFromTree(...args);
+    },
     buildDashboard: (...args: Parameters<typeof actual.buildDashboard>) => {
       coreMocks.buildDashboard(...args);
       return actual.buildDashboard(...args);

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -11,6 +11,8 @@ import {
   addCalendarDays,
   countCalendarDays,
   createSessionIndex,
+  buildSessionTree,
+  filterSessionTreeByActivityWindow,
   formatSessionReference,
   getSessionAgentKey,
   getSessionRouteKey,
@@ -24,7 +26,7 @@ import {
 import {
   SessionAliasValidationError,
   StateStorageUnavailableError,
-  attachProjectMetrics,
+  attachProjectMetricsFromTree,
   createProjectScopeMatcher,
   deleteBookmark,
   getAgentInfoMap,
@@ -373,9 +375,10 @@ export function handleGetProjects(
     scanResult.sessions,
     ["projects", from, to],
     () => {
-      const sessions = filterSessionsByActivityWindow(scanResult.sessions, from, to);
+      const tree = buildSessionTree(scanResult.sessions);
+      const sessions = filterSessionTreeByActivityWindow(scanResult.sessions, from, to, tree);
       return {
-        projects: attachProjectMetrics(listCachedProjectGroups(sessions), sessions),
+        projects: attachProjectMetricsFromTree(listCachedProjectGroups(sessions), tree, from, to),
       };
     },
   );

--- a/packages/core/src/analytics/__tests__/dashboard-tree-reuse.test.ts
+++ b/packages/core/src/analytics/__tests__/dashboard-tree-reuse.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionHead } from "../../types/session.js";
+
+const treeMocks = vi.hoisted(() => ({ buildSessionTree: vi.fn() }));
+
+vi.mock("../../contract/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../contract/index.js")>();
+  treeMocks.buildSessionTree.mockImplementation(actual.buildSessionTree);
+  return { ...actual, buildSessionTree: treeMocks.buildSessionTree };
+});
+
+import { buildDashboard } from "../dashboard.js";
+
+function makeSession(id: string, activity: number): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: id,
+    directory: "/project",
+    time_created: activity,
+    time_updated: activity,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 1,
+      total_output_tokens: 1,
+      total_cost: 0,
+    },
+  };
+}
+
+describe("dashboard session tree reuse", () => {
+  it("builds one tree for the current and comparison windows", () => {
+    treeMocks.buildSessionTree.mockClear();
+
+    buildDashboard([makeSession("current", 200), makeSession("previous", 100)], {
+      byAgentNames: ["codex"],
+      scope: {},
+      from: 150,
+      to: 250,
+      compare: { from: 50, to: 149 },
+    });
+
+    expect(treeMocks.buildSessionTree).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/analytics/__tests__/projects.test.ts
+++ b/packages/core/src/analytics/__tests__/projects.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { attachProjectMetrics } from "../projects.js";
+import { attachProjectMetrics, attachProjectMetricsFromTree } from "../projects.js";
 import type { ProjectGroup, SessionHead } from "../../types/index.js";
+import { buildSessionTree } from "../../contract/session-tree.js";
 
 function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
   return {
@@ -107,6 +108,25 @@ describe("attachProjectMetrics", () => {
     expect(project?.agentStats).toEqual([
       { name: "claudecode", sessions: 1, messages: 2, tokens: 70, cost: 0 },
     ]);
+  });
+
+  it("reuses a tree when applying a project activity window", () => {
+    const parent = makeSession("parent", { time_created: 100, time_updated: 100 });
+    const child = makeSession("child", {
+      time_created: 1,
+      time_updated: 1,
+      parent_reference: { agentName: "claudecode", sessionId: "parent" },
+    });
+    const outside = makeSession("outside", { time_created: 1, time_updated: 1 });
+
+    const [project] = attachProjectMetricsFromTree(
+      [makeGroup("repo-a")],
+      buildSessionTree([parent, child, outside]),
+      90,
+      110,
+    );
+
+    expect(project).toMatchObject({ sessionCount: 1, messages: 2 });
   });
 
   it("counts an orphaned sub-session as its own session", () => {

--- a/packages/core/src/analytics/dashboard.ts
+++ b/packages/core/src/analytics/dashboard.ts
@@ -20,13 +20,14 @@ import type {
   DashboardRecentSession,
   DashboardTotals,
   ModelDistributionEntry,
+  SessionTree,
   SessionTreeNode,
 } from "../contract/index.js";
 import {
   addCalendarDays,
   buildSessionTree,
   countCalendarDays,
-  filterSessionTreeByActivityWindow,
+  filterSessionTreeEntriesByActivityWindow,
   getProjectIdentityKey,
   getSessionAgentKey,
   toCalendarDayKey,
@@ -137,13 +138,14 @@ function matchesScope(session: SessionHead, scope: DashboardScope): boolean {
 
 /** Top-level nodes (roots ∪ orphans) inside the window that match the scope. */
 function scopedEntries(
-  sessions: SessionHead[],
+  tree: SessionTree,
   scope: DashboardScope,
   from: number | undefined,
   to: number,
 ): SessionTreeNode[] {
-  const tree = buildSessionTree(filterSessionTreeByActivityWindow(sessions, from, to));
-  return tree.entries.filter((node) => matchesScope(node.session, scope));
+  return filterSessionTreeEntriesByActivityWindow(tree, from, to).filter((node) =>
+    matchesScope(node.session, scope),
+  );
 }
 
 function emptyDailyBucket(date: string): DashboardDailyBucket {
@@ -342,6 +344,7 @@ export function buildDashboard(
   options: DashboardOptions,
 ): DashboardAggregate {
   const { byAgentNames, scope, from, to, agentInfoMap, compare } = options;
+  const tree = buildSessionTree(sessions);
 
   const acc = createAccumulator(byAgentNames, scope, to);
   if (from != null) {
@@ -351,12 +354,12 @@ export function buildDashboard(
       acc.daily.set(key, emptyDailyBucket(key));
     }
   }
-  for (const node of scopedEntries(sessions, scope, from, to)) accumulate(node, acc);
+  for (const node of scopedEntries(tree, scope, from, to)) accumulate(node, acc);
 
   let previous: DashboardPreviousTotals | undefined;
   if (compare) {
     const compareAcc = createAccumulator(byAgentNames, scope, compare.to);
-    for (const node of scopedEntries(sessions, scope, compare.from, compare.to)) {
+    for (const node of scopedEntries(tree, scope, compare.from, compare.to)) {
       accumulate(node, compareAcc);
     }
     previous = toPreviousTotals(compareAcc);

--- a/packages/core/src/analytics/projects.ts
+++ b/packages/core/src/analytics/projects.ts
@@ -8,9 +8,17 @@
  * instead of the cache-wide count carried by ProjectGroup.
  */
 import type { ProjectGroup, SessionHead } from "../types/index.js";
-import type { ApiProjectAgentStat, ApiProjectGroup } from "../contract/index.js";
+import type {
+  ApiProjectAgentStat,
+  ApiProjectGroup,
+  SessionTree,
+  SessionTreeNode,
+} from "../contract/index.js";
 import { getProjectIdentityKey } from "../contract/project-identity.js";
-import { buildSessionTree } from "../contract/session-tree.js";
+import {
+  buildSessionTree,
+  filterSessionTreeEntriesByActivityWindow,
+} from "../contract/session-tree.js";
 import { getSessionAgentName } from "./dashboard.js";
 
 interface ProjectMetrics {
@@ -41,9 +49,28 @@ export function attachProjectMetrics(
   projects: ProjectGroup[],
   sessions: SessionHead[],
 ): ApiProjectGroup[] {
+  return attachProjectMetricsToEntries(projects, buildSessionTree(sessions).entries);
+}
+
+export function attachProjectMetricsFromTree(
+  projects: ProjectGroup[],
+  tree: SessionTree,
+  from?: number,
+  to?: number,
+): ApiProjectGroup[] {
+  return attachProjectMetricsToEntries(
+    projects,
+    filterSessionTreeEntriesByActivityWindow(tree, from, to),
+  );
+}
+
+function attachProjectMetricsToEntries(
+  projects: ProjectGroup[],
+  entries: SessionTreeNode[],
+): ApiProjectGroup[] {
   const metrics = new Map<string, ProjectMetrics>();
 
-  for (const node of buildSessionTree(sessions).entries) {
+  for (const node of entries) {
     const identity = node.session.project_identity;
     if (!identity) continue;
 

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -39,6 +39,7 @@ describe("contract browser-safety", () => {
         "countCalendarDays",
         "createSessionIndex",
         "filterSessionTreeByActivityWindow",
+        "filterSessionTreeEntriesByActivityWindow",
         "formatSessionReference",
         "getProjectAgentKey",
         "getProjectIdentityKey",

--- a/packages/core/src/contract/session-tree.ts
+++ b/packages/core/src/contract/session-tree.ts
@@ -267,11 +267,11 @@ export function filterSessionTreeByActivityWindow(
   sessions: SessionHead[],
   from?: number,
   to?: number,
+  tree: SessionTree = buildSessionTree(sessions),
 ): SessionHead[] {
   if (from == null && to == null) return sessions;
 
-  const tree = buildSessionTree(sessions);
-  const pending = tree.entries.filter((node) => hasActivityInWindow(node.session, from, to));
+  const pending = filterSessionTreeEntriesByActivityWindow(tree, from, to);
 
   const visible = new Set<string>();
   while (pending.length > 0) {
@@ -283,6 +283,15 @@ export function filterSessionTreeByActivityWindow(
   }
 
   return sessions.filter((session) => visible.has(sessionKey(session)));
+}
+
+export function filterSessionTreeEntriesByActivityWindow(
+  tree: SessionTree,
+  from?: number,
+  to?: number,
+): SessionTreeNode[] {
+  if (from == null && to == null) return tree.entries;
+  return tree.entries.filter((node) => hasActivityInWindow(node.session, from, to));
 }
 
 interface SessionHierarchyGraph {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,5 +151,5 @@ export {
 } from "./pricing/index.js";
 export { buildDashboard, getSessionActivityTime } from "./analytics/dashboard.js";
 export type { DashboardData, DashboardScope } from "./analytics/dashboard.js";
-export { attachProjectMetrics } from "./analytics/projects.js";
+export { attachProjectMetrics, attachProjectMetricsFromTree } from "./analytics/projects.js";
 export { executeSessionSearch, filterSessionSearchCandidates } from "./search/index.js";


### PR DESCRIPTION
## Summary

- build one session tree for dashboard current and comparison windows
- add a tree-based activity-window entry filter while preserving descendant inclusion
- let project metrics consume a prebuilt tree
- share one request-level tree between project window filtering and metric aggregation

## Performance

- a dashboard aggregation with a comparison window now builds one session tree
- a projects request no longer rebuilds the same filtered hierarchy for metrics

## Validation

- `pnpm --filter @codesesh/core test` (824 passed, 1 skipped)
- `pnpm --filter codesesh test` (490 passed)
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm perf:check`
