### PR TITLE
perf(cache): derive restored session order

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 22`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 23`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 22;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 23;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -236,6 +236,13 @@ function readMigratedFacts(): Record<string, unknown> {
       searchDocuments: scalar("SELECT COUNT(*) AS value FROM session_documents"),
       projects: scalar("SELECT COUNT(*) AS value FROM project_sessions"),
       pendingReindex: scalar("SELECT COUNT(*) AS value FROM pending_reindex"),
+      sessionActivityIndexes: (
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_sessions_agent_activity%'",
+          )
+          .all() as Array<{ name: string }>
+      ).map(({ name }) => name),
       documentColumns: (
         db.prepare("PRAGMA table_info(session_documents)").all() as Array<{ name: string }>
       )
@@ -348,6 +355,7 @@ describe("sqlite migration release gate", () => {
         searchDocuments: 1,
         projects: 1,
         pendingReindex: 1,
+        sessionActivityIndexes: ["idx_sessions_agent_activity_order"],
         documentColumns: [
           "agent_name",
           "content_hash",

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -80,7 +80,7 @@ describe("cache schema boundary", () => {
         "publication_id",
       ]),
     );
-    expect(state?.version).toBe(22);
+    expect(state?.version).toBe(23);
   });
 
   it("reuses one connection for read and write capabilities until invalidated", () => {
@@ -244,7 +244,7 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 22, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 23, detailVersion: "", pending: true });
   });
 
   it("marks legacy project identities stale by leaving added provenance empty", () => {
@@ -283,7 +283,7 @@ describe("cache schema boundary", () => {
     });
 
     expect(migrated).toEqual({
-      version: 22,
+      version: 23,
       resolverRevision: null,
       inputSignature: null,
       classifierRevision: null,
@@ -353,7 +353,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 22,
+        version: 23,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -1288,7 +1288,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(22);
+    expect(getUserVersion(getCachePath())).toBe(23);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -2078,7 +2078,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(22);
+    expect(getUserVersion(getCachePath())).toBe(23);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -200,7 +200,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(22);
+    expect(getUserVersion(getCachePath())).toBe(23);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -211,7 +211,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(22);
+    expect(getUserVersion(getCachePath())).toBe(23);
   });
 });
 
@@ -219,7 +219,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(22);
+    expect(getUserVersion(getCachePath())).toBe(23);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -341,6 +341,70 @@ describe("saveCachedSessions", () => {
     ]);
   });
 
+  it("derives restored order from session activity", () => {
+    const older = { ...makeSession("older"), time_created: now - 2_000, time_updated: now - 2_000 };
+    const newer = { ...makeSession("newer"), time_created: now - 1_000, time_updated: now - 1_000 };
+
+    saveCachedSessions("claudecode", [older, newer]);
+
+    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
+      "newer",
+      "older",
+    ]);
+  });
+
+  it("does not rewrite retained sort indexes for a partial snapshot", () => {
+    const retained = [makeSession("one"), makeSession("two"), makeSession("three")];
+    saveCachedSessions("claudecode", retained);
+    const db = new Database(getCachePath());
+    try {
+      db.exec(`
+        CREATE TABLE sort_index_updates (count INTEGER NOT NULL);
+        INSERT INTO sort_index_updates(count) VALUES (0);
+        CREATE TRIGGER count_sort_index_updates
+        AFTER UPDATE OF sort_index ON sessions
+        BEGIN
+          UPDATE sort_index_updates SET count = count + 1;
+        END;
+      `);
+    } finally {
+      db.close();
+    }
+
+    saveCachedSessions("claudecode", [retained[0]!], {}, { completeness: "partial" });
+
+    const auditDb = new Database(getCachePath(), { readonly: true });
+    try {
+      const row = auditDb.prepare("SELECT count FROM sort_index_updates").get() as {
+        count: number;
+      };
+      expect(row.count).toBe(1);
+    } finally {
+      auditDb.close();
+    }
+  });
+
+  it("uses the activity-order index without a temporary sort", () => {
+    saveCachedSessions("claudecode", [makeSession("one")]);
+    const db = new Database(getCachePath(), { readonly: true });
+    try {
+      const plan = db
+        .prepare(
+          `EXPLAIN QUERY PLAN
+           SELECT session_id
+           FROM sessions
+           WHERE agent_name = ? AND publication_id IS NULL
+           ORDER BY activity_time DESC, session_id`,
+        )
+        .all("claudecode") as Array<{ detail: string }>;
+      const details = plan.map(({ detail }) => detail).join("\n");
+      expect(details).toContain("idx_sessions_agent_activity_order");
+      expect(details).not.toContain("USE TEMP B-TREE");
+    } finally {
+      db.close();
+    }
+  });
+
   it("preserves other agents", () => {
     saveCachedSessions("cursor", [makeSession("cursor-1")]);
     saveCachedSessions("claudecode", [makeSession("claude-1")]);
@@ -431,7 +495,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(22);
+    expect(getUserVersion(getCachePath())).toBe(23);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -95,7 +95,10 @@ describe("cached sessions", () => {
     });
     saveCachedSessions("codex", [makeSessionHead("parent"), child]);
 
-    expect(loadCachedSessions("codex")?.sessions[1]?.parent_reference).toEqual({
+    const restoredChild = loadCachedSessions("codex")?.sessions.find(
+      (session) => session.id === "child",
+    );
+    expect(restoredChild?.parent_reference).toEqual({
       agentName: "codex",
       sessionId: "parent",
     });

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -241,8 +241,8 @@ function createSessionTables(db: SQLiteDatabase): void {
       PRIMARY KEY (agent_name, session_id)
     );
 
-    CREATE INDEX IF NOT EXISTS idx_sessions_agent_activity
-      ON sessions(agent_name, activity_time);
+    CREATE INDEX IF NOT EXISTS idx_sessions_agent_activity_order
+      ON sessions(agent_name, activity_time DESC, session_id);
 
     CREATE INDEX IF NOT EXISTS idx_sessions_project
       ON sessions(project_identity_kind, project_identity_key, activity_time);
@@ -1073,6 +1073,15 @@ function addAtomicPublicationStaging(db: SQLiteDatabase): void {
   }
 }
 
+function replaceSessionActivityIndex(db: SQLiteDatabase): void {
+  if (!tableExists(db, "sessions")) return;
+  db.exec(`
+    DROP INDEX IF EXISTS idx_sessions_agent_activity;
+    CREATE INDEX IF NOT EXISTS idx_sessions_agent_activity_order
+      ON sessions(agent_name, activity_time DESC, session_id);
+  `);
+}
+
 function compactSessionDocuments(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents")) {
     createSearchTables(db);
@@ -1428,6 +1437,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 20, migrate: addProjectIdentityProvenance },
       { version: 21, migrate: addSessionPublicationId },
       { version: 22, migrate: addAtomicPublicationStaging },
+      { version: 23, migrate: replaceSessionActivityIndex },
     ],
   });
 

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -131,7 +131,7 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
           SELECT ${SESSION_HEAD_SELECT_COLUMNS}
           FROM sessions s
           WHERE s.agent_name = ? AND s.publication_id IS NULL
-          ORDER BY s.sort_index, s.activity_time DESC
+          ORDER BY s.activity_time DESC, s.session_id
         `,
       )
       .all(agentName) as SessionRow[];
@@ -499,9 +499,6 @@ export function writeCachedSessionSnapshot(
     ON CONFLICT(agent_name) DO UPDATE SET timestamp = excluded.timestamp
   `);
   const upsertSession = prepareUpsertSession(db);
-  const updateSortIndex = db.prepare(
-    "UPDATE sessions SET sort_index = ? WHERE agent_name = ? AND session_id = ?",
-  );
   const sessionIds = new Set(sessions.map((session) => session.id));
   const existingSessionIds = db
     .prepare("SELECT session_id FROM sessions WHERE agent_name = ?")
@@ -536,22 +533,6 @@ export function writeCachedSessionSnapshot(
       sourcePathFromMeta(sessionMeta),
     );
   });
-
-  if (completeness === "partial" && sessions.length > 0) {
-    const mergedRows = db
-      .prepare(
-        `
-          SELECT session_id
-          FROM sessions
-          WHERE agent_name = ? AND publication_id IS NULL
-          ORDER BY activity_time DESC, sort_index, session_id
-        `,
-      )
-      .all(agentName) as SessionRow[];
-    mergedRows.forEach((row, index) => {
-      updateSortIndex.run(index, agentName, String(row.session_id));
-    });
-  }
 }
 
 /** Returns whether the write reached disk; callers must not publish on `false`. */

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 22;
+export const CACHE_SCHEMA_VERSION = 23;


### PR DESCRIPTION
## Summary

- derive cache restore order from session activity instead of persisted `sort_index`
- remove full-agent `sort_index` rewrites from partial snapshot publication
- migrate cache schema to a covering activity-order index and remove the redundant legacy index
- add write-amplification, restore-order, query-plan, and migration coverage

## Testing

- `pnpm --filter @codesesh/core test`
- `pnpm test:migration`
- `pnpm lint`
- `pnpm format:check`
- `pnpm perf:check`
- `pnpm build`