### PR TITLE
perf(claudecode): preserve valid child index

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -45,6 +45,18 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
   };
 }
 
+function writeMinimalClaudeSession(filePath: string): void {
+  writeFileSync(
+    filePath,
+    JSON.stringify({
+      type: "user",
+      timestamp: "2026-04-20T10:00:00Z",
+      cwd: "/tmp/project",
+      message: { role: "user", content: "Inspect the repository" },
+    }),
+  );
+}
+
 afterEach(() => {
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
@@ -228,6 +240,66 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(
       readSpy.mock.calls.filter((call) => String(call[0]).endsWith(".meta.json")),
     ).toHaveLength(1);
+  });
+
+  it("keeps the child index when restored session metadata is equivalent", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-child-index-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const parentId = "parent-session";
+    const childId = "child-session";
+    const childDir = join(projectDir, parentId, "subagents");
+    mkdirSync(childDir, { recursive: true });
+    writeMinimalClaudeSession(join(projectDir, parentId + ".jsonl"));
+    writeMinimalClaudeSession(join(childDir, "agent-" + childId + ".jsonl"));
+    writeFileSync(
+      join(childDir, "agent-" + childId + ".meta.json"),
+      JSON.stringify({ agentId: childId, toolUseId: "tool-child" }),
+    );
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+    agent.scan();
+    const restoredMeta = new Map(agent.getSessionMetaMap());
+    const walkSpy = vi.spyOn(agent, "walkFiles");
+
+    agent.setSessionMetaMap(restoredMeta);
+    agent.ensureChildIndex();
+
+    expect(walkSpy).not.toHaveBeenCalled();
+    expect(agent.childSessionIdByToolUseId.get("tool-child")).toBe(childId);
+  });
+
+  it("rebuilds the child index when restored session sources change", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-child-change-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    const parentId = "parent-session";
+    const childId = "added-child";
+    const childDir = join(projectDir, parentId, "subagents");
+    mkdirSync(projectDir, { recursive: true });
+    writeMinimalClaudeSession(join(projectDir, parentId + ".jsonl"));
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+    agent.scan();
+
+    mkdirSync(childDir, { recursive: true });
+    writeMinimalClaudeSession(join(childDir, "agent-" + childId + ".jsonl"));
+    writeFileSync(
+      join(childDir, "agent-" + childId + ".meta.json"),
+      JSON.stringify({ agentId: childId, toolUseId: "tool-added-child" }),
+    );
+    const refreshedAgent = new ClaudeCodeAgent() as any;
+    refreshedAgent.basePath = basePath;
+    refreshedAgent.scan();
+    const walkSpy = vi.spyOn(agent, "walkFiles");
+
+    agent.setSessionMetaMap(new Map(refreshedAgent.getSessionMetaMap()));
+    agent.ensureChildIndex();
+
+    expect(walkSpy).toHaveBeenCalledOnce();
+    expect(agent.childSessionIdByToolUseId.get("tool-added-child")).toBe(childId);
   });
 
   it("drops a window-only child when its parent is outside the window", () => {

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -55,6 +55,7 @@ interface SessionMeta extends FileSessionMeta {
   headIndexVersion: string;
   model: string | null | undefined;
   parentSessionId: string | null;
+  toolUseId: string | null;
 }
 
 interface ClaudeChildContext {
@@ -265,7 +266,9 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   }
 
   setSessionMetaMap(meta: Map<string, SessionCacheMeta>): void {
+    const childIndexInputsChanged = this.childIndexReady && this.didChildIndexInputsChange(meta);
     super.setSessionMetaMap(meta);
+    if (!childIndexInputsChanged) return;
     this.childContextsBySource.clear();
     this.childSessionIdByToolUseId.clear();
     this.childIndexReady = false;
@@ -337,6 +340,30 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     return this.readSessionSourceDirectory(this.basePath)
       .filter((entry) => entry.isDirectory())
       .map((entry) => join(this.basePath!, entry.name));
+  }
+
+  private didChildIndexInputsChange(meta: Map<string, SessionCacheMeta>): boolean {
+    if (meta.size !== this.sessionMetaMap.size) return true;
+
+    for (const [sessionId, next] of meta) {
+      const current = this.sessionMetaMap.get(sessionId);
+      if (!current || current.sourcePath !== next.sourcePath) return true;
+      if (
+        basename(dirname(next.sourcePath)) === "subagents" &&
+        (current.title !== next["title"] ||
+          current.parentSessionId !== next["parentSessionId"] ||
+          this.readToolUseId(current) !== this.readToolUseId(next))
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private readToolUseId(meta: SessionCacheMeta): string | null {
+    const value = meta["toolUseId"];
+    return typeof value === "string" && value.length > 0 ? value : null;
   }
 
   private ensureChildIndex(): void {
@@ -477,6 +504,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
         headIndexVersion: HEAD_INDEX_VERSION,
         model: head.stats.total_tokens ? "unknown" : undefined,
         parentSessionId: head.parent_reference?.sessionId ?? null,
+        toolUseId: child?.toolUseId ?? null,
       },
     });
   }


### PR DESCRIPTION
## Summary

- preserve Claude Code's child-session index when restored session metadata has equivalent child inputs
- invalidate the index only when session identity, source paths, or child context fields change
- persist child `toolUseId` in session metadata so transcript edits do not cause unrelated index rebuilds
- cover both equivalent metadata restoration and real source-directory changes

## Testing

- `pnpm --filter @codesesh/core test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm perf:check`
- `pnpm build`