### PR TITLE
refactor: consolidate shared failure and tool logic

### DIFF
--- a/apps/web/src/components/session-detail/tool-strategy/kimi.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/kimi.ts
@@ -5,15 +5,10 @@
  */
 import type { ToolPart } from "../../../lib/api";
 import { buildKimiEditDiffBlocks, extractEditDiff } from "../diff";
-import {
-  getDisplayPath,
-  getDisplayTextWithRelativePaths,
-  getFilePathFromInput,
-} from "../path-extract";
+import { getDisplayPath, getFilePathFromInput } from "../path-extract";
 import {
   type NormalizedToolState,
   type ToolDisplayStrategy,
-  getOutputOrErrorText,
   toPlainText,
   toRecord,
 } from "../tool-normalize";
@@ -22,8 +17,9 @@ import {
   buildFileEditStrategy,
   buildFileReadStrategy,
   buildFileWriteStrategy,
+  buildSearchToolStrategy,
+  buildShellToolStrategy,
 } from "./shared";
-import { FileSearch, SquareTerminal } from "../../ui/icons";
 
 export function buildKimiToolStrategy(
   tool: ToolPart,
@@ -37,57 +33,34 @@ export function buildKimiToolStrategy(
   const displayPath = getDisplayPath(filePath, baseDirectory);
 
   if (toolKey === "glob") {
-    const pattern = toPlainText(input.pattern);
-    return {
-      ...defaultStrategy,
-      Icon: FileSearch,
+    return buildSearchToolStrategy({
+      defaultStrategy,
+      state,
       title: tool.title || "glob",
-      secondaryText: pattern || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: getOutputOrErrorText(state),
-        language: "text",
-        isCode: false,
-      },
-    };
+      pattern: toPlainText(input.pattern),
+      baseDirectory,
+    });
   }
 
   if (toolKey === "grep") {
-    const path = toPlainText(input.path);
-    const pattern = toPlainText(input.pattern);
-    const details = [getDisplayPath(path, baseDirectory), pattern].filter(Boolean).join(" · ");
-    return {
-      ...defaultStrategy,
-      Icon: FileSearch,
+    return buildSearchToolStrategy({
+      defaultStrategy,
+      state,
       title: tool.title || "grep",
-      secondaryText: details || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: getOutputOrErrorText(state),
-        language: "text",
-        isCode: false,
-      },
-    };
+      path: toPlainText(input.path),
+      pattern: toPlainText(input.pattern),
+      baseDirectory,
+    });
   }
 
   if (toolKey === "shell") {
-    const command = toPlainText(input.command);
-    const displayCommand = getDisplayTextWithRelativePaths(command, baseDirectory);
-    return {
-      ...defaultStrategy,
-      Icon: SquareTerminal,
+    return buildShellToolStrategy({
+      defaultStrategy,
+      state,
       title: tool.title || "bash",
-      secondaryText: displayCommand ? `(${displayCommand})` : undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: getOutputOrErrorText(state),
-        language: "text",
-        isCode: false,
-      },
-    };
+      command: toPlainText(input.command),
+      baseDirectory,
+    });
   }
 
   if (toolKey === "readfile") {

--- a/apps/web/src/components/session-detail/tool-strategy/opencode.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/opencode.ts
@@ -5,15 +5,10 @@
  */
 import type { ToolPart } from "../../../lib/api";
 import { extractEditDiff } from "../diff";
-import {
-  getDisplayPath,
-  getDisplayTextWithRelativePaths,
-  getFilePathFromInput,
-} from "../path-extract";
+import { getDisplayPath, getFilePathFromInput } from "../path-extract";
 import {
   type NormalizedToolState,
   type ToolDisplayStrategy,
-  getOutputOrErrorText,
   toPlainText,
   toRecord,
 } from "../tool-normalize";
@@ -22,9 +17,10 @@ import {
   buildFileEditStrategy,
   buildFileReadStrategy,
   buildFileWriteStrategy,
+  buildSearchToolStrategy,
+  buildShellToolStrategy,
   buildSkillToolStrategy,
 } from "./shared";
-import { FileSearch, SquareTerminal } from "../../ui/icons";
 
 export function buildOpencodeToolStrategy(
   tool: ToolPart,
@@ -38,63 +34,35 @@ export function buildOpencodeToolStrategy(
   const displayPath = getDisplayPath(filePath, baseDirectory);
 
   if (toolKey === "glob") {
-    const pattern = toPlainText(input.pattern);
-    return {
-      ...defaultStrategy,
-      Icon: FileSearch,
+    return buildSearchToolStrategy({
+      defaultStrategy,
+      state,
       title: tool.tool || "glob",
-      secondaryText: pattern || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: getOutputOrErrorText(state),
-        language: "text",
-        isCode: false,
-      },
-    };
+      pattern: toPlainText(input.pattern),
+      baseDirectory,
+    });
   }
 
   if (toolKey === "grep") {
-    const path = toPlainText(input.path);
-    const pattern = toPlainText(input.pattern);
-    const details = [getDisplayPath(path, baseDirectory), pattern].filter(Boolean).join(" · ");
-    return {
-      ...defaultStrategy,
-      Icon: FileSearch,
+    return buildSearchToolStrategy({
+      defaultStrategy,
+      state,
       title: tool.tool || "grep",
-      secondaryText: details || undefined,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: getOutputOrErrorText(state),
-        language: "text",
-        isCode: false,
-      },
-    };
+      path: toPlainText(input.path),
+      pattern: toPlainText(input.pattern),
+      baseDirectory,
+    });
   }
 
   if (toolKey === "bash") {
-    const description = toPlainText(input.description);
-    const command = toPlainText(input.command);
-    const displayCommand = getDisplayTextWithRelativePaths(command, baseDirectory);
-    const secondaryText = description
-      ? `${description}${displayCommand ? ` (${displayCommand})` : ""}`
-      : displayCommand
-        ? `(${displayCommand})`
-        : undefined;
-    return {
-      ...defaultStrategy,
-      Icon: SquareTerminal,
+    return buildShellToolStrategy({
+      defaultStrategy,
+      state,
       title: tool.tool || "bash",
-      secondaryText,
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: getOutputOrErrorText(state),
-        language: "text",
-        isCode: false,
-      },
-    };
+      command: toPlainText(input.command),
+      description: toPlainText(input.description),
+      baseDirectory,
+    });
   }
 
   if (toolKey === "read") {

--- a/apps/web/src/components/session-detail/tool-strategy/shared.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/shared.ts
@@ -22,8 +22,15 @@ import {
   toRecord,
   toStringValue,
 } from "../tool-normalize";
-import { getDisplayTextWithRelativePaths } from "../path-extract";
-import { BookOpenText, FilePenLine, NotebookPen, SquareTerminal, Wrench } from "../../ui/icons";
+import { getDisplayPath, getDisplayTextWithRelativePaths } from "../path-extract";
+import {
+  BookOpenText,
+  FilePenLine,
+  FileSearch,
+  NotebookPen,
+  SquareTerminal,
+  Wrench,
+} from "../../ui/icons";
 
 export type { NormalizedToolState, ToolDisplayStrategy, ToolStatus };
 
@@ -88,6 +95,26 @@ interface FileEditStrategyOptions extends FileStrategyContext {
   details?: ToolDetailItem[];
 }
 
+interface SearchToolStrategyOptions {
+  defaultStrategy: ToolDisplayStrategy;
+  state: NormalizedToolState;
+  title: string;
+  path?: string;
+  pattern?: string;
+  baseDirectory?: string;
+}
+
+interface ShellToolStrategyOptions {
+  defaultStrategy: ToolDisplayStrategy;
+  state: NormalizedToolState;
+  title: string;
+  command: string;
+  description?: string;
+  baseDirectory?: string;
+  includeCommandDetail?: boolean;
+  emptyOutputMarker?: string;
+}
+
 function buildFileToolStrategy(options: FileToolStrategyOptions): ToolDisplayStrategy {
   return {
     ...options.defaultStrategy,
@@ -134,6 +161,54 @@ export function buildFileEditStrategy(options: FileEditStrategyOptions): ToolDis
     Icon: FilePenLine,
     title: "edit",
   });
+}
+
+export function buildSearchToolStrategy(options: SearchToolStrategyOptions): ToolDisplayStrategy {
+  const secondaryText = [getDisplayPath(options.path ?? "", options.baseDirectory), options.pattern]
+    .filter(Boolean)
+    .join(" · ");
+
+  return {
+    ...options.defaultStrategy,
+    Icon: FileSearch,
+    title: options.title,
+    secondaryText: secondaryText || undefined,
+    showInputPreview: false,
+    outputContent: {
+      kind: "plain",
+      text: getOutputOrErrorText(options.state),
+      language: "text",
+      isCode: false,
+    },
+  };
+}
+
+export function buildShellToolStrategy(options: ShellToolStrategyOptions): ToolDisplayStrategy {
+  const displayCommand = getDisplayTextWithRelativePaths(options.command, options.baseDirectory);
+  const secondaryText = options.description
+    ? `${options.description}${displayCommand ? ` (${displayCommand})` : ""}`
+    : displayCommand
+      ? `(${displayCommand})`
+      : undefined;
+  const outputText = getOutputOrErrorText(options.state);
+
+  return {
+    ...options.defaultStrategy,
+    Icon: SquareTerminal,
+    title: options.title,
+    secondaryText,
+    details:
+      options.includeCommandDetail && options.command
+        ? [{ label: "Command", value: displayCommand || options.command }]
+        : options.defaultStrategy.details,
+    showInputPreview: false,
+    outputContent: {
+      kind: "plain",
+      text: options.emptyOutputMarker === outputText ? "No output captured." : outputText,
+      language: "text",
+      isCode: false,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/session-detail/tool-strategy/zcode.ts
+++ b/apps/web/src/components/session-detail/tool-strategy/zcode.ts
@@ -6,11 +6,7 @@
 import type { ToolPart } from "../../../lib/api";
 import type { ToolDetailItem } from "../codex-tool";
 import { buildStructuredDiffFromTexts, buildZCodeEditDiffBlocks } from "../diff";
-import {
-  getDisplayPath,
-  getDisplayTextWithRelativePaths,
-  getFilePathFromInput,
-} from "../path-extract";
+import { getDisplayPath, getFilePathFromInput } from "../path-extract";
 import {
   type NormalizedToolState,
   type ToolDisplayStrategy,
@@ -25,16 +21,10 @@ import {
   buildFileEditStrategy,
   buildFileReadStrategy,
   buildFileWriteStrategy,
+  buildSearchToolStrategy,
+  buildShellToolStrategy,
 } from "./shared";
-import {
-  Bot,
-  CircleHelp,
-  FilePlus2,
-  FileSearch,
-  ListTodo,
-  SquareTerminal,
-  Wrench,
-} from "../../ui/icons";
+import { Bot, CircleHelp, FilePlus2, FileSearch, ListTodo, Wrench } from "../../ui/icons";
 
 function stripRecommendedMarker(value: string) {
   return value.replace(/\s*[(（](?:Recommended|推荐)[)）]\s*$/i, "").trim();
@@ -151,27 +141,16 @@ export function buildZCodeToolStrategy(
   if (toolKey === "bash" || toolKey === "shell") {
     const description = toPlainText(input.description);
     const command = toPlainText(input.command);
-    const displayCommand = getDisplayTextWithRelativePaths(command, baseDirectory);
-    const cleanedOutput =
-      outputText === "(Bash completed with no output)" ? "No output captured." : outputText;
-    return {
-      ...defaultStrategy,
-      Icon: SquareTerminal,
+    return buildShellToolStrategy({
+      defaultStrategy,
+      state,
       title: "bash",
-      secondaryText: description
-        ? `${description}${displayCommand ? ` (${displayCommand})` : ""}`
-        : displayCommand
-          ? `(${displayCommand})`
-          : undefined,
-      details: command ? [{ label: "Command", value: displayCommand || command }] : [],
-      showInputPreview: false,
-      outputContent: {
-        kind: "plain",
-        text: cleanedOutput,
-        language: "text",
-        isCode: false,
-      },
-    };
+      command,
+      description,
+      baseDirectory,
+      includeCommandDetail: true,
+      emptyOutputMarker: "(Bash completed with no output)",
+    });
   }
 
   if (toolKey === "read" || toolKey === "readfile") {
@@ -218,19 +197,14 @@ export function buildZCodeToolStrategy(
   }
 
   if (toolKey === "glob" || toolKey === "grep") {
-    const path = toPlainText(input.path);
-    const pattern = toPlainText(input.pattern);
-    const secondaryText = [getDisplayPath(path, baseDirectory), pattern]
-      .filter(Boolean)
-      .join(" · ");
-    return {
-      ...defaultStrategy,
-      Icon: FileSearch,
+    return buildSearchToolStrategy({
+      defaultStrategy,
+      state,
       title: toolKey,
-      secondaryText: secondaryText || undefined,
-      showInputPreview: false,
-      outputContent: { kind: "plain", text: outputText, language: "text", isCode: false },
-    };
+      path: toPlainText(input.path),
+      pattern: toPlainText(input.pattern),
+      baseDirectory,
+    });
   }
 
   if (toolKey === "todowrite" || toolKey === "todolist") {

--- a/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
+++ b/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { PRICING_CAPTURE_EPOCH } from "../../pricing/cost.js";
 import type { SessionHead } from "../../types/index.js";
 import {
+  createAgentScanFailure,
   createSessionSourceFailure,
   synchronizeSessionSources,
   type SessionCacheMeta,
@@ -11,6 +12,28 @@ import {
   type SessionSourceRef,
   type SessionSourceSynchronizationAdapter,
 } from "../base.js";
+
+describe("failure normalization", () => {
+  it("describes agent and source failures with the same bounded fields", () => {
+    const error = Object.assign(new Error("x".repeat(600)), { code: "E_FIXTURE" });
+    const sourceFailure = createSessionSourceFailure(
+      { sessionId: "failed", sourcePath: "/sessions/failed.json" },
+      "parsing",
+      error,
+    );
+    const agentFailure = createAgentScanFailure("fixture", "scan", error);
+
+    expect({
+      errorClass: agentFailure.errorClass,
+      message: agentFailure.message,
+    }).toEqual({
+      errorClass: sourceFailure.errorClass,
+      message: sourceFailure.message,
+    });
+    expect(agentFailure.errorClass).toBe("E_FIXTURE");
+    expect(agentFailure.message).toHaveLength(500);
+  });
+});
 
 function session(id: string, title = id): SessionHead {
   return {

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -9,6 +9,7 @@ import {
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import {
   createSessionSourceFailure,
+  describeFailure,
   isMissingSessionSourceError,
   matchesScanWindow,
   synchronizeSessionSources as runSessionSourceSynchronization,
@@ -199,20 +200,6 @@ export type CachedMetaLookup =
   | ReadonlyMap<string, SessionCacheMeta>
   | Record<string, SessionCacheMeta>;
 
-function failureClass(error: unknown): string {
-  if (typeof error === "object" && error !== null && "code" in error) {
-    const code = (error as { code?: unknown }).code;
-    if (typeof code === "string" && code) return code;
-  }
-  if (error instanceof Error && error.name) return error.name;
-  return typeof error;
-}
-
-function failureMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.slice(0, 500);
-}
-
 export function createAgentScanFailure(
   agentName: string,
   stage: string,
@@ -227,8 +214,7 @@ export function createAgentScanFailure(
     ...((scanError?.sourcePath ?? sourcePath)
       ? { sourcePath: scanError?.sourcePath ?? sourcePath }
       : {}),
-    errorClass: failureClass(cause),
-    message: failureMessage(cause),
+    ...describeFailure(cause),
   };
 }
 

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -92,6 +92,8 @@ export function isMissingSessionSourceError(error: unknown): boolean {
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
+const FAILURE_MESSAGE_LIMIT = 500;
+
 function failureClass(error: unknown): string {
   if (typeof error === "object" && error !== null && "code" in error) {
     const code = (error as { code?: unknown }).code;
@@ -103,7 +105,14 @@ function failureClass(error: unknown): string {
 
 function failureMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
-  return message.slice(0, 500);
+  return message.slice(0, FAILURE_MESSAGE_LIMIT);
+}
+
+export function describeFailure(error: unknown) {
+  return {
+    errorClass: failureClass(error),
+    message: failureMessage(error),
+  };
 }
 
 export function createSessionSourceFailure(
@@ -115,8 +124,7 @@ export function createSessionSourceFailure(
     sessionId: source.sessionId,
     sourcePath: source.sourcePath,
     stage,
-    errorClass: failureClass(error),
-    message: failureMessage(error),
+    ...describeFailure(error),
   };
 }
 


### PR DESCRIPTION
## Summary

- normalize agent and session-source failures through one bounded failure description
- centralize shared search tool rendering for OpenCode, Kimi, and ZCode
- centralize shared shell rendering while preserving agent-specific titles, details, and empty-output behavior

## Testing

- `pnpm --filter @codesesh/core test`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter @codesesh/web build`
- package format checks