### PR TITLE
test: cover agent adapters and route recovery

### DIFF
--- a/apps/web/src/router.test.tsx
+++ b/apps/web/src/router.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+vi.mock("./App", () => ({
+  default: () => {
+    throw new Error("render failed");
+  },
+}));
+
+import { appRouterRoutes } from "./router";
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderRoute(path: string) {
+  const router = createMemoryRouter(appRouterRoutes, { initialEntries: [path] });
+  return render(<RouterProvider router={router} />);
+}
+
+describe("app router recovery", () => {
+  it("shows the route response for malformed URL encoding", async () => {
+    renderRoute("/%E0%A4%A");
+
+    expect((await screen.findByRole("alert")).textContent).toBe("400 Bad Request");
+  });
+
+  it("shows a safe fallback when route rendering throws", async () => {
+    renderRoute("/");
+
+    expect((await screen.findByRole("alert")).textContent).toBe(
+      "The application route failed to render.",
+    );
+  });
+});

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2,12 +2,13 @@ import {
   createBrowserRouter,
   isRouteErrorResponse,
   RouterProvider,
+  type RouteObject,
   useRouteError,
 } from "react-router-dom";
 import App from "./App";
 import { appRouteChildren, validateRouteEncoding } from "./lib/app-routes";
 
-function RouteErrorFallback() {
+export function RouteErrorFallback() {
   const error = useRouteError();
   const message = isRouteErrorResponse(error)
     ? `${error.status} ${error.statusText}`
@@ -15,7 +16,7 @@ function RouteErrorFallback() {
   return <div role="alert">{message}</div>;
 }
 
-const router = createBrowserRouter([
+export const appRouterRoutes = [
   {
     id: "app-shell",
     path: "/",
@@ -24,7 +25,9 @@ const router = createBrowserRouter([
     loader: validateRouteEncoding,
     children: appRouteChildren,
   },
-]);
+] satisfies RouteObject[];
+
+const router = createBrowserRouter(appRouterRoutes);
 
 export function AppRouter() {
   return <RouterProvider router={router} />;

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
@@ -15,6 +15,8 @@ import {
 } from "../../utils/diagnostics.js";
 
 let tempDirs: string[] = [];
+
+const CURSOR_FIXTURE_ROOT = new URL("./fixtures/cursor/", import.meta.url);
 
 function createCursorDb(tempDir: string): string {
   const dbPath = join(tempDir, "state.vscdb");
@@ -149,6 +151,43 @@ describe("CursorAgent parsing", () => {
       },
     });
     expect(tool?.type === "tool" ? tool.state.error : undefined).toBeUndefined();
+  });
+
+  it("normalizes array tool output from subagent actions", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
+    tempDirs.push(tempDir);
+    const dbPath = createCursorDb(tempDir);
+    const fixture = JSON.parse(
+      readFileSync(new URL("subagent-tool-output.json", CURSOR_FIXTURE_ROOT), "utf-8"),
+    );
+    insertKv(dbPath, "bubble:sub-1", fixture);
+
+    const agent = new CursorAgent() as any;
+    agent.dbPath = dbPath;
+    agent.composerCache.set("composer-1", {
+      id: "composer-1",
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      subagentInfos: [{ id: "sub-1", title: "Reader" }],
+    });
+
+    const tool = agent
+      .getSessionData("composer-1")
+      .messages.find((message: { subagent_id?: string }) => message.subagent_id === "sub-1")
+      ?.parts.find((part: MessagePart) => part.type === "tool");
+
+    expect(tool).toMatchObject({
+      type: "tool",
+      tool: "read",
+      state: {
+        status: "completed",
+        output: [
+          { type: "text", text: "first line", time_created: 0 },
+          { type: "text", text: "second line", time_created: 0 },
+          { type: "text", text: "third line", time_created: 0 },
+        ],
+      },
+    });
   });
 
   it("falls back to untitled when no title text is available", () => {

--- a/packages/core/src/agents/__tests__/fixtures/cursor/subagent-tool-output.json
+++ b/packages/core/src/agents/__tests__/fixtures/cursor/subagent-tool-output.json
@@ -1,0 +1,22 @@
+{
+  "chatMessages": [
+    {
+      "role": "assistant",
+      "createdAt": 2000,
+      "actions": [
+        {
+          "type": "tool",
+          "tool": "read_file_v2",
+          "input": { "path": "src/example.ts" },
+          "output": [
+            { "text": "first line <system-reminder>hidden</system-reminder>" },
+            { "content": "second line" },
+            "third line",
+            42
+          ],
+          "state": { "status": "completed" }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/src/agents/__tests__/fixtures/kimi/config.toml
+++ b/packages/core/src/agents/__tests__/fixtures/kimi/config.toml
@@ -1,0 +1,1 @@
+default_model = "kimi-for-coding"

--- a/packages/core/src/agents/__tests__/fixtures/kimi/kimi.json
+++ b/packages/core/src/agents/__tests__/fixtures/kimi/kimi.json
@@ -1,0 +1,3 @@
+{
+  "work_dirs": [{ "path": "/workspace/kimi-fixture" }]
+}

--- a/packages/core/src/agents/__tests__/fixtures/kimi/state.json
+++ b/packages/core/src/agents/__tests__/fixtures/kimi/state.json
@@ -1,0 +1,5 @@
+{
+  "custom_title": "Fixture session",
+  "created_at": 1000,
+  "wire_mtime": 4
+}

--- a/packages/core/src/agents/__tests__/fixtures/kimi/wire.jsonl
+++ b/packages/core/src/agents/__tests__/fixtures/kimi/wire.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":1,"message":{"type":"TurnBegin","payload":{"user_input":["Inspect cost attribution"]}}}
+{"timestamp":2,"message":{"type":"ContentPart","payload":{"type":"text","text":"Usage is attached to this answer."}}}
+{"timestamp":3,"message":{"type":"ContentPart","payload":{"type":"text","text":""},"usage":{"input_tokens":1000,"output_tokens":1000}}}

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -1,7 +1,16 @@
-import { mkdtempSync, mkdirSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { KimiAgent } from "../kimi.js";
 import { diffSessionSources } from "../base.js";
 import type { SessionHead } from "../../types/index.js";
@@ -11,6 +20,8 @@ const PROJECT_HASH = "project-hash";
 const PROJECT_DIR = "/tmp/kimi-project";
 
 let tempDirs: string[] = [];
+
+const KIMI_FIXTURE_ROOT = new URL("./fixtures/kimi/", import.meta.url);
 
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
@@ -72,6 +83,49 @@ afterEach(() => {
   }
   tempDirs = [];
   setCoreDiagnostics(null);
+  vi.unstubAllEnvs();
+});
+
+describe("KimiAgent configuration", () => {
+  it("maps project identity and attributes wire usage with configured pricing", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-fixture-"));
+    tempDirs.push(dataRoot);
+    const projectDir = "/workspace/kimi-fixture";
+    const projectHash = createHash("md5").update(projectDir).digest("hex");
+    const sessionDir = join(dataRoot, "sessions", projectHash, "fixture-session");
+    mkdirSync(sessionDir, { recursive: true });
+    for (const file of ["config.toml", "kimi.json"]) {
+      copyFileSync(new URL(file, KIMI_FIXTURE_ROOT), join(dataRoot, file));
+    }
+    for (const file of ["state.json", "wire.jsonl"]) {
+      copyFileSync(new URL(file, KIMI_FIXTURE_ROOT), join(sessionDir, file));
+    }
+    vi.stubEnv("KIMI_SHARE_DIR", dataRoot);
+
+    const agent = new KimiAgent();
+    expect(agent.isAvailable()).toBe(true);
+
+    const [head] = agent.scan();
+    const detail = agent.getSessionData("fixture-session");
+    const assistant = detail.messages.find((message) => message.role === "assistant");
+
+    expect(head).toMatchObject({
+      id: "fixture-session",
+      directory: projectDir,
+      stats: {
+        total_input_tokens: 1_000,
+        total_output_tokens: 1_000,
+        total_cost: 0.0031,
+        cost_source: "estimated",
+      },
+    });
+    expect(assistant).toMatchObject({
+      model: "kimi-for-coding",
+      tokens: { input: 1_000, output: 1_000 },
+      cost: 0.0031,
+      cost_source: "estimated",
+    });
+  });
 });
 
 describe("KimiAgent cache refresh", () => {

--- a/scripts/critical-coverage.mjs
+++ b/scripts/critical-coverage.mjs
@@ -18,6 +18,11 @@ export const CRITICAL_COVERAGE_SCOPES = [
     thresholds: { lines: 90 },
   },
   {
+    id: "agent-adapters",
+    owners: [{ path: "packages/core/src/agents", kind: "directory" }],
+    thresholds: { lines: 86 },
+  },
+  {
     id: "cli-runtime",
     owners: [
       { path: "packages/cli/src/agent-operation-scheduler.ts", kind: "file" },
@@ -63,6 +68,7 @@ export const CRITICAL_COVERAGE_SCOPES = [
   {
     id: "web-route-recovery",
     owners: [
+      { path: "apps/web/src/router.tsx", kind: "file" },
       { path: "apps/web/src/components/app/AppRouteContent.tsx", kind: "file" },
       { path: "apps/web/src/components/DetailLanding.tsx", kind: "file" },
     ],

--- a/scripts/critical-coverage.test.mjs
+++ b/scripts/critical-coverage.test.mjs
@@ -48,5 +48,16 @@ describe("critical coverage owners", () => {
     expect(getCriticalCoverageThresholds()).toHaveProperty(getCoverageScopePattern(runtime), {
       lines: 91,
     });
+
+    const adapters = CRITICAL_COVERAGE_SCOPES.find(({ id }) => id === "agent-adapters");
+    if (!adapters) throw new Error("agent-adapters coverage scope is missing");
+    expect(adapters.owners).toEqual([{ path: "packages/core/src/agents", kind: "directory" }]);
+    expect(getCriticalCoverageThresholds()).toHaveProperty(getCoverageScopePattern(adapters), {
+      lines: 86,
+    });
+
+    const routeRecovery = CRITICAL_COVERAGE_SCOPES.find(({ id }) => id === "web-route-recovery");
+    if (!routeRecovery) throw new Error("web-route-recovery coverage scope is missing");
+    expect(routeRecovery.owners.map(({ path }) => path)).toContain("apps/web/src/router.tsx");
   });
 });


### PR DESCRIPTION
## Summary

- add file-backed Cursor and Kimi fixtures for array tool output, project mapping, token usage, and estimated cost attribution
- exercise malformed URL and render failures through the assembled application router
- add all agent adapter sources to critical coverage at 86% lines and include router assembly in route-recovery coverage

## Coverage

- Cursor lines: 71.56% → 81.75%
- Kimi lines: 70.57% → 78.57%
- agent adapters: 88.26% lines (86% gate)
- router: 0% → 83.33% lines

## Testing

- `pnpm test:coverage`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web lint`
- package and root format checks