### PR TITLE
fix(ci): require web build for bundle tests

### DIFF
--- a/apps/web/tests/initial-bundle.test.ts
+++ b/apps/web/tests/initial-bundle.test.ts
@@ -2,11 +2,10 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { gzipSync } from "node:zlib";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 const distDir = join(dirname(fileURLToPath(import.meta.url)), "../dist");
 const indexHtmlPath = join(distDir, "index.html");
-const distExists = existsSync(indexHtmlPath);
 
 /**
  * Budget for what a first paint costs, in gzipped JavaScript. Generous enough
@@ -23,8 +22,15 @@ function initialScripts(): string[] {
   return [...html.matchAll(/(?:src|href)="(\/assets\/[^"]+\.js)"/g)].map((match) => match[1]!);
 }
 
-// Requires `pnpm --filter @codesesh/web build` to have run first.
-describe.skipIf(!distExists)("CS-146: initial bundle", () => {
+describe("CS-146: initial bundle", () => {
+  beforeAll(() => {
+    if (!existsSync(indexHtmlPath)) {
+      throw new Error(
+        "Initial bundle tests require apps/web/dist; run `pnpm --filter @codesesh/web build` first.",
+      );
+    }
+  });
+
   it("stays within the gzipped budget", () => {
     const total = initialScripts().reduce(
       (bytes, path) => bytes + gzipSync(readFileSync(join(distDir, path.slice(1)))).length,

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,10 @@
       "cache": true,
       "dependsOn": ["^build"]
     },
+    "@codesesh/web#test": {
+      "cache": true,
+      "dependsOn": ["build", "^build"]
+    },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
## Summary

- fail the initial bundle budget suite explicitly when the production output is missing
- make the Web test task depend on its own build as well as upstream package builds
- prevent Turbo from racing bundle assertions against a partially written `dist`

## Testing

- verified the targeted bundle test exits non-zero with a build instruction when `apps/web/dist` is absent
- `pnpm exec turbo run test --dry=json`
- `pnpm exec turbo run test --filter @codesesh/web --force`
- `pnpm lint:root`
- `pnpm format:check:root`
- `pnpm exec oxlint apps/web/tests/initial-bundle.test.ts`
- `pnpm exec oxfmt --check apps/web/tests/initial-bundle.test.ts turbo.json`