### PR TITLE
docs: enforce Node and CI facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,51 @@ Package-level baselines prevent coverage regressions, while stricter targeted
 thresholds protect the scanning, API, live runtime, hook, and interaction paths.
 The Astro landing page is covered by Playwright rather than Vitest.
 
+### Reproduce Required CI Checks
+
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) is the source of truth. CI runs the main
+job on Node.js 22 and 24 across Linux, macOS, and Windows; the following sequence reproduces its
+gates from the repository root:
+
+<!-- repo-fact:ci-commands:start -->
+
+```bash
+# Dependencies and static gates
+pnpm install --frozen-lockfile
+node scripts/check-quality-task-coverage.mjs
+pnpm lint
+pnpm format:check
+pnpm typecheck:e2e
+node scripts/release-preflight.mjs
+node scripts/check-docs-paths.mjs
+
+# Algorithmic, build, documentation, and clean-rebuild gates
+pnpm perf:check
+pnpm build
+node scripts/check-docs-facts.mjs
+node packages/cli/dist/index.js --version
+pnpm clean
+pnpm build
+
+# Unit, coverage, migration, and browser gates
+pnpm test
+pnpm test:coverage # includes pnpm check:coverage-scopes
+pnpm test:migration
+pnpm exec playwright install --with-deps chromium
+pnpm test:e2e
+
+# Package artifact and installed-package gates
+pnpm package:artifact:test
+pnpm package:artifact
+node scripts/smoke-package-artifact.mjs artifacts/npm/codesesh-*.tgz
+```
+
+<!-- repo-fact:ci-commands:end -->
+
+The workflow limits `perf:check` and the clean-rebuild smoke test to Node.js 24, and runs the CLI
+version smoke test on Node.js 22. A local run covers the commands; the pull request matrix remains
+the cross-platform verification.
+
 ### Performance Benchmark
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -70,10 +70,15 @@ More agents coming soon. See the [extension checklist](#extending).
 
 ### Prerequisites
 
+<!-- repo-fact:node-version:start -->
+
+- Node.js 22+ for the published CLI and building from source
+
+<!-- repo-fact:node-version:end -->
+
 <!-- repo-fact:pnpm-version:start -->
 
-- Node.js 22+ for the published CLI
-- Node.js 24 and pnpm 11.20.0 for building from source
+- pnpm 11.20.0 for building from source
 
 <!-- repo-fact:pnpm-version:end -->
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -70,10 +70,15 @@ CodeSesh 认为，你的会话历史属于**你** —— 你应该在一个地�
 
 ### 环境要求
 
+<!-- repo-fact:node-version:start -->
+
+- 发布后的 CLI 和源码构建均需要 Node.js 22+
+
+<!-- repo-fact:node-version:end -->
+
 <!-- repo-fact:pnpm-version:start -->
 
-- 发布后的 CLI 需要 Node.js 22+
-- 源码构建需要 Node.js 24 和 pnpm 11.20.0
+- 源码构建需要 pnpm 11.20.0
 
 <!-- repo-fact:pnpm-version:end -->
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -258,6 +258,49 @@ pnpm --filter @codesesh/www deploy:cf
 扫描、API、实时运行时、Hook 和交互路径继续使用更严格的定向门槛。
 Astro 落地页由 Playwright 覆盖，不计入 Vitest 覆盖率。
 
+### 复现 CI 必需检查
+
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml) 是事实源。CI 会在 Linux、macOS、Windows
+上分别使用 Node.js 22 和 24 运行主任务；在仓库根目录按以下顺序执行，可复现其中的检查：
+
+<!-- repo-fact:ci-commands:start -->
+
+```bash
+# 依赖与静态门禁
+pnpm install --frozen-lockfile
+node scripts/check-quality-task-coverage.mjs
+pnpm lint
+pnpm format:check
+pnpm typecheck:e2e
+node scripts/release-preflight.mjs
+node scripts/check-docs-paths.mjs
+
+# 算法、构建、文档事实与清理重建门禁
+pnpm perf:check
+pnpm build
+node scripts/check-docs-facts.mjs
+node packages/cli/dist/index.js --version
+pnpm clean
+pnpm build
+
+# 单元测试、覆盖率、迁移与浏览器门禁
+pnpm test
+pnpm test:coverage # 内含 pnpm check:coverage-scopes
+pnpm test:migration
+pnpm exec playwright install --with-deps chromium
+pnpm test:e2e
+
+# npm 制品与安装后冒烟门禁
+pnpm package:artifact:test
+pnpm package:artifact
+node scripts/smoke-package-artifact.mjs artifacts/npm/codesesh-*.tgz
+```
+
+<!-- repo-fact:ci-commands:end -->
+
+工作流只在 Node.js 24 上运行 `perf:check` 和清理重建冒烟，并在 Node.js 22 上运行 CLI
+版本冒烟。本地执行覆盖命令本身；Pull Request 矩阵继续负责跨平台验证。
+
 ### 性能 Benchmark
 
 ```bash

--- a/apps/www/public/llms-full.txt
+++ b/apps/www/public/llms-full.txt
@@ -97,14 +97,15 @@ The command starts a local server and opens the Web UI at:
 http://localhost:4521
 ```
 
-Published CLI requirement:
+Published CLI and source build requirement:
 
+<!-- repo-fact:node-version:start -->
 - Node.js 22+
+<!-- repo-fact:node-version:end -->
 
-Source build requirement:
+Source build package manager:
 
 <!-- repo-fact:pnpm-version:start -->
-- Node.js 24
 - pnpm 11.20.0
 <!-- repo-fact:pnpm-version:end -->
 
@@ -124,8 +125,14 @@ CodeSesh runs on the user's machine and uses a local SQLite index with a local W
 
 ### How do you install and start CodeSesh?
 
+The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port.
+
+<!-- repo-fact:node-version:start -->
+The published CLI and source development require Node.js 22+.
+<!-- repo-fact:node-version:end -->
+
 <!-- repo-fact:pnpm-version:start -->
-The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port. The published CLI requires Node.js 22+; source development uses Node.js 24 and pnpm 11.20.0.
+Source development uses pnpm 11.20.0.
 <!-- repo-fact:pnpm-version:end -->
 
 ## Common CLI Usage

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -126,7 +126,11 @@ unreachable except through that trusted proxy.
 
 ## Requirements
 
+<!-- repo-fact:node-version:start -->
+
 - Node.js 22+
+
+<!-- repo-fact:node-version:end -->
 
 ## Links
 

--- a/scripts/check-docs-facts.mjs
+++ b/scripts/check-docs-facts.mjs
@@ -16,6 +16,8 @@ const FACT_SPECS = [
   { document: "README.md", fact: "pnpm-version" },
   { document: "README_CN.md", fact: "pnpm-version" },
   { document: "apps/www/public/llms-full.txt", fact: "pnpm-version" },
+  { document: "README.md", fact: "ci-commands" },
+  { document: "README_CN.md", fact: "ci-commands" },
 ];
 
 export const CHECKED_FACT_DOCUMENTS = [...new Set(FACT_SPECS.map(({ document }) => document))];
@@ -42,6 +44,16 @@ export function readMinimumNodeVersion(repoRoot) {
     throw new Error("packages/cli/package.json engines.node must be an exact >=x.y.z version");
   }
   return match[1];
+}
+
+export function readRequiredCiCommands(repoRoot) {
+  const workflow = readFileSync(join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  return unique(
+    workflow
+      .split("\n")
+      .map((line) => line.trim().replace(/^(?:-\s+)?run:\s*/, ""))
+      .filter((line) => /^(?:pnpm(?:\s|$)|node (?:packages|scripts)\/)/.test(line)),
+  );
 }
 
 function unique(values) {
@@ -93,7 +105,22 @@ function normalizeDocumentedNodeVersion(version) {
   return [...parts, ...Array(3 - parts.length).fill("0")].join(".");
 }
 
+function parseDocumentedCiCommands(region) {
+  return unique(
+    region
+      .split("\n")
+      .map((line) => line.trim().replace(/\s+#.*$/, ""))
+      .filter((line) => /^(?:pnpm(?:\s|$)|node (?:packages|scripts)\/)/.test(line)),
+  );
+}
+
 function validateRegion(fact, region, repositoryFacts) {
+  if (fact === "ci-commands") {
+    const documented = parseDocumentedCiCommands(region);
+    const missing = repositoryFacts.ciCommands.filter((command) => !documented.includes(command));
+    return missing.length > 0 ? `missing ${JSON.stringify(missing)}` : null;
+  }
+
   if (fact === "node-version") {
     const versions = [...region.matchAll(/\bNode\.js\s+(\d+(?:\.\d+){0,2})\+/g)].map((match) =>
       normalizeDocumentedNodeVersion(match[1]),
@@ -161,6 +188,7 @@ function validateRegion(fact, region, repositoryFacts) {
 export function findDocumentationFactMismatches(repoRoot, coreFacts) {
   const repositoryFacts = {
     ...coreFacts,
+    ciCommands: readRequiredCiCommands(repoRoot),
     minimumNodeVersion: readMinimumNodeVersion(repoRoot),
     pnpmVersion: readPnpmVersion(repoRoot),
   };

--- a/scripts/check-docs-facts.mjs
+++ b/scripts/check-docs-facts.mjs
@@ -9,6 +9,10 @@ const FACT_SPECS = [
   { document: "docs/scanning-and-caching.md", fact: "agent-source-kinds" },
   { document: "docs/architecture.md", fact: "agent-source-kinds" },
   { document: "docs/sqlite-storage.md", fact: "cache-schema-version" },
+  { document: "README.md", fact: "node-version" },
+  { document: "README_CN.md", fact: "node-version" },
+  { document: "apps/www/public/llms-full.txt", fact: "node-version" },
+  { document: "packages/cli/README.md", fact: "node-version" },
   { document: "README.md", fact: "pnpm-version" },
   { document: "README_CN.md", fact: "pnpm-version" },
   { document: "apps/www/public/llms-full.txt", fact: "pnpm-version" },
@@ -28,6 +32,15 @@ export function readPnpmVersion(repoRoot) {
   const manifest = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
   const match = /^pnpm@(\d+\.\d+\.\d+)$/.exec(manifest.packageManager ?? "");
   if (!match) throw new Error("package.json packageManager must be an exact pnpm version");
+  return match[1];
+}
+
+export function readMinimumNodeVersion(repoRoot) {
+  const manifest = JSON.parse(readFileSync(join(repoRoot, "packages/cli/package.json"), "utf8"));
+  const match = /^>=(\d+\.\d+\.\d+)$/.exec(manifest.engines?.node ?? "");
+  if (!match) {
+    throw new Error("packages/cli/package.json engines.node must be an exact >=x.y.z version");
+  }
   return match[1];
 }
 
@@ -75,7 +88,25 @@ function parseSourceKindNames(region) {
   return { filesystem: splitNames(filesystem.trim()), sqlite: splitNames(sqlite.trim()) };
 }
 
+function normalizeDocumentedNodeVersion(version) {
+  const parts = version.split(".");
+  return [...parts, ...Array(3 - parts.length).fill("0")].join(".");
+}
+
 function validateRegion(fact, region, repositoryFacts) {
+  if (fact === "node-version") {
+    const versions = [...region.matchAll(/\bNode\.js\s+(\d+(?:\.\d+){0,2})\+/g)].map((match) =>
+      normalizeDocumentedNodeVersion(match[1]),
+    );
+    if (versions.length === 0) return "marker contains no `Node.js x+` declaration";
+    const stale = unique(
+      versions.filter((version) => version !== repositoryFacts.minimumNodeVersion),
+    );
+    return stale.length > 0
+      ? `expected Node.js ${repositoryFacts.minimumNodeVersion}; documented ${stale.join(", ")}`
+      : null;
+  }
+
   if (fact === "pnpm-version") {
     const versions = [...region.matchAll(/\bpnpm\s+(\d+\.\d+\.\d+)\b/g)].map((match) => match[1]);
     if (versions.length === 0) return "marker contains no `pnpm x.y.z` declaration";
@@ -128,7 +159,11 @@ function validateRegion(fact, region, repositoryFacts) {
 }
 
 export function findDocumentationFactMismatches(repoRoot, coreFacts) {
-  const repositoryFacts = { ...coreFacts, pnpmVersion: readPnpmVersion(repoRoot) };
+  const repositoryFacts = {
+    ...coreFacts,
+    minimumNodeVersion: readMinimumNodeVersion(repoRoot),
+    pnpmVersion: readPnpmVersion(repoRoot),
+  };
   const mismatches = [];
 
   for (const { document, fact } of FACT_SPECS) {

--- a/scripts/check-docs-facts.test.mjs
+++ b/scripts/check-docs-facts.test.mjs
@@ -35,16 +35,18 @@ function fixtureRepo(packageManager = "pnpm@11.20.0", nodeEngine = ">=22.0.0") {
   const agentsList = marked("agents", "- Claude Code\n- Cursor");
   const node = marked("node-version", "- Node.js 22+");
   const pnpm = marked("pnpm-version", "- pnpm 11.20.0");
+  const ciCommands = marked("ci-commands", "```bash\npnpm lint\npnpm test\n```");
   const sourceKinds = marked(
     "agent-source-kinds",
     "- 文件型：Claude Code\n- 单 SQLite 数据库型：Cursor",
   );
   const files = {
     "package.json": JSON.stringify({ packageManager }),
+    ".github/workflows/ci.yml": "steps:\n  - name: Lint\n    run: pnpm lint\n  - run: pnpm test\n",
     "packages/cli/package.json": JSON.stringify({ engines: { node: nodeEngine } }),
     "packages/cli/README.md": node,
-    "README.md": `${agentsTable}\n${node}\n${pnpm}`,
-    "README_CN.md": `${agentsTable}\n${node}\n${pnpm}`,
+    "README.md": `${agentsTable}\n${node}\n${pnpm}\n${ciCommands}`,
+    "README_CN.md": `${agentsTable}\n${node}\n${pnpm}\n${ciCommands}`,
     "apps/www/public/llms-full.txt": `${agentsList}\n${node}\n${node}\n${pnpm}\n${pnpm}`,
     "docs/scanning-and-caching.md": sourceKinds,
     "docs/architecture.md": sourceKinds,
@@ -119,6 +121,29 @@ describe("CS-172: semantic documentation facts", () => {
 
     expect(nodeMismatches).toHaveLength(5);
     expect(nodeMismatches[0].message).toContain("expected Node.js 24.0.0");
+  });
+
+  it("reports a CI command that is absent from a README checklist", () => {
+    const dir = fixtureRepo();
+    writeFileSync(
+      join(dir, ".github/workflows/ci.yml"),
+      "steps:\n  - run: pnpm lint\n  - run: pnpm test\n  - run: pnpm test:e2e\n",
+    );
+
+    expect(findDocumentationFactMismatches(dir, coreFacts)).toEqual(
+      expect.arrayContaining([
+        {
+          document: "README.md",
+          fact: "ci-commands",
+          message: 'missing ["pnpm test:e2e"]',
+        },
+        {
+          document: "README_CN.md",
+          fact: "ci-commands",
+          message: 'missing ["pnpm test:e2e"]',
+        },
+      ]),
+    );
   });
 
   it("requires an explicit marker in every checked document", () => {

--- a/scripts/check-docs-facts.test.mjs
+++ b/scripts/check-docs-facts.test.mjs
@@ -25,7 +25,7 @@ function marked(fact, contents) {
   return `<!-- repo-fact:${fact}:start -->\n${contents}\n<!-- repo-fact:${fact}:end -->`;
 }
 
-function fixtureRepo(packageManager = "pnpm@11.20.0") {
+function fixtureRepo(packageManager = "pnpm@11.20.0", nodeEngine = ">=22.0.0") {
   const dir = mkdtempSync(join(tmpdir(), "codesesh-docs-facts-"));
   tempDirs.push(dir);
   const agentsTable = marked(
@@ -33,16 +33,19 @@ function fixtureRepo(packageManager = "pnpm@11.20.0") {
     "| Agent | Status |\n|---|---|\n| Claude Code | Supported |\n| Cursor | Supported |",
   );
   const agentsList = marked("agents", "- Claude Code\n- Cursor");
-  const pnpm = marked("pnpm-version", "- Node.js 24 and pnpm 11.20.0");
+  const node = marked("node-version", "- Node.js 22+");
+  const pnpm = marked("pnpm-version", "- pnpm 11.20.0");
   const sourceKinds = marked(
     "agent-source-kinds",
     "- 文件型：Claude Code\n- 单 SQLite 数据库型：Cursor",
   );
   const files = {
     "package.json": JSON.stringify({ packageManager }),
-    "README.md": `${agentsTable}\n${pnpm}`,
-    "README_CN.md": `${agentsTable}\n${pnpm}`,
-    "apps/www/public/llms-full.txt": `${agentsList}\n${pnpm}\n${pnpm}`,
+    "packages/cli/package.json": JSON.stringify({ engines: { node: nodeEngine } }),
+    "packages/cli/README.md": node,
+    "README.md": `${agentsTable}\n${node}\n${pnpm}`,
+    "README_CN.md": `${agentsTable}\n${node}\n${pnpm}`,
+    "apps/www/public/llms-full.txt": `${agentsList}\n${node}\n${node}\n${pnpm}\n${pnpm}`,
     "docs/scanning-and-caching.md": sourceKinds,
     "docs/architecture.md": sourceKinds,
     "docs/sqlite-storage.md": marked(
@@ -107,6 +110,17 @@ describe("CS-172: semantic documentation facts", () => {
     expect(pnpmMismatches[0].message).toContain("expected pnpm 11.21.0");
   });
 
+  it("reports every marked Node baseline after engines changes", () => {
+    const mismatches = findDocumentationFactMismatches(
+      fixtureRepo("pnpm@11.20.0", ">=24.0.0"),
+      coreFacts,
+    );
+    const nodeMismatches = mismatches.filter(({ fact }) => fact === "node-version");
+
+    expect(nodeMismatches).toHaveLength(5);
+    expect(nodeMismatches[0].message).toContain("expected Node.js 24.0.0");
+  });
+
   it("requires an explicit marker in every checked document", () => {
     const dir = fixtureRepo();
     writeFileSync(join(dir, "README.md"), marked("agents", "- Claude Code\n- Cursor"));
@@ -123,6 +137,7 @@ describe("CS-172: semantic documentation facts", () => {
       expect.arrayContaining([
         "README.md",
         "README_CN.md",
+        "packages/cli/README.md",
         "docs/architecture.md",
         "apps/www/public/llms-full.txt",
       ]),


### PR DESCRIPTION
## Summary

- correct the source-build baseline to Node.js 22 and separate it from the pnpm version fact
- derive the documented Node baseline from the CLI package engine requirement
- document every required CI command in the English and Chinese READMEs
- derive repository commands from the CI workflow and reject incomplete README checklists
- keep the AI-facing and published-package documentation aligned with the same Node fact

## Testing

- `pnpm exec vitest run scripts/check-docs-facts.test.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm package:artifact:test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test:coverage`