### PR TITLE
Fix startup delays caused by cache cleanup

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -86,5 +86,12 @@ describe("withCacheDb diagnostics", () => {
 
     expect(withSearchIndexDb(() => "ready")).toBe("ready");
     expect(events.some(({ event }) => event === "sqlite.fts_integrity.started")).toBe(false);
+    expect(events).toContainEqual({
+      event: "sqlite.publication_staging_cleanup.completed",
+      detail: {
+        duration_ms: expect.any(Number),
+        reclaimed: false,
+      },
+    });
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SQLiteDatabase } from "../../../utils/sqlite.js";
 import { getCachePath, setSchemaEnsuredPath } from "../db.js";
 import * as schema from "../schema.js";
 import { saveCachedSessions } from "../sessions.js";
@@ -15,6 +16,23 @@ vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };
 });
+
+function readPublicationCounts(db: SQLiteDatabase) {
+  const sessions = db
+    .prepare("SELECT COUNT(*) AS value FROM sessions WHERE publication_id IS NOT NULL")
+    .get() as { value?: number };
+  const documents = db
+    .prepare("SELECT COUNT(*) AS value FROM session_documents WHERE agent_name = ?")
+    .get("codex") as { value?: number };
+  const payloads = db
+    .prepare("SELECT COUNT(*) AS value FROM search_index_publication_entries")
+    .get() as { value?: number };
+  return {
+    sessions: Number(sessions.value ?? 0),
+    documents: Number(documents.value ?? 0),
+    payloads: Number(payloads.value ?? 0),
+  };
+}
 
 beforeEach(() => {
   setSchemaEnsuredPath(null);
@@ -115,7 +133,7 @@ describe("cache schema boundary", () => {
     expect(secondProbeCount).toBe(firstProbeCount);
   });
 
-  it("reclaims orphaned publication rows on the next schema open", () => {
+  it("defers orphaned publication cleanup until the first search-index write", () => {
     const session = makeSessionHead("orphaned-publication");
     saveCachedSessions("codex", [session]);
     syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
@@ -141,31 +159,36 @@ describe("cache schema boundary", () => {
     }
     setSchemaEnsuredPath(null);
 
-    const counts = schema.withCacheDb((ready) => ({
-      sessions: Number(
-        (
-          ready
-            .prepare("SELECT COUNT(*) AS value FROM sessions WHERE publication_id IS NOT NULL")
-            .get() as { value?: number }
-        ).value ?? 0,
-      ),
-      documents: Number(
-        (
-          ready
-            .prepare("SELECT COUNT(*) AS value FROM session_documents WHERE agent_name = ?")
-            .get("codex") as { value?: number }
-        ).value ?? 0,
-      ),
-      payloads: Number(
-        (
-          ready.prepare("SELECT COUNT(*) AS value FROM search_index_publication_entries").get() as {
-            value?: number;
-          }
-        ).value ?? 0,
-      ),
-    }));
+    const beforeCleanup = schema.withCacheDb(readPublicationCounts);
 
-    expect(counts).toEqual({ sessions: 0, documents: 0, payloads: 0 });
+    expect(beforeCleanup).toEqual({ sessions: 1, documents: 1, payloads: 1 });
+
+    const afterCleanup = schema.withSearchIndexDb(readPublicationCounts);
+
+    expect(afterCleanup).toEqual({ sessions: 0, documents: 0, payloads: 0 });
+  });
+
+  it("skips cleanup scans after an empty staging probe", () => {
+    schema.withCacheDb(() => undefined);
+    const prepare = vi.spyOn(Database.prototype, "prepare");
+
+    schema.withSearchIndexDb(() => undefined);
+    const firstProbeCount = prepare.mock.calls.filter(([sql]) =>
+      String(sql).includes("SELECT 1 FROM search_index_publication_entries LIMIT 1"),
+    ).length;
+    const cleanupStatementCount = prepare.mock.calls.filter(([sql]) =>
+      String(sql).includes("DELETE FROM"),
+    ).length;
+
+    schema.withSearchIndexDb(() => undefined);
+    const secondProbeCount = prepare.mock.calls.filter(([sql]) =>
+      String(sql).includes("SELECT 1 FROM search_index_publication_entries LIMIT 1"),
+    ).length;
+    prepare.mockRestore();
+
+    expect(firstProbeCount).toBe(1);
+    expect(secondProbeCount).toBe(firstProbeCount);
+    expect(cleanupStatementCount).toBe(0);
   });
 
   it("invalidates v21 detail rows so inconsistent publications rebuild", () => {

--- a/packages/core/src/discovery/cache/db.ts
+++ b/packages/core/src/discovery/cache/db.ts
@@ -32,6 +32,7 @@ export type SQLiteStatement = ReturnType<SQLiteDatabase["prepare"]>;
 export interface CacheConnection {
   db: SQLiteDatabase;
   ftsReady: boolean;
+  publicationStagingCleaned: boolean;
 }
 
 const cacheConnections = new Map<string, CacheConnection>();
@@ -44,7 +45,7 @@ export function getCacheConnection(path: string): CacheConnection | null {
   const db = openDb(path);
   if (!db) return null;
 
-  const connection = { db, ftsReady: false };
+  const connection = { db, ftsReady: false, publicationStagingCleaned: false };
   cacheConnections.set(path, connection);
   return connection;
 }

--- a/packages/core/src/discovery/cache/publication-staging.ts
+++ b/packages/core/src/discovery/cache/publication-staging.ts
@@ -80,6 +80,19 @@ export function deletePublicationPayloads(db: SQLiteDatabase, publicationId: str
   );
 }
 
+function hasLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string): boolean {
+  const predicate = publicationId ? "publication_id = ?" : "publication_id IS NOT NULL";
+  const params = publicationId ? [publicationId] : [];
+  return (
+    db.prepare(`SELECT 1 FROM sessions WHERE ${predicate} LIMIT 1`).get(...params) !== undefined
+  );
+}
+
+export function hasPublicationStaging(db: SQLiteDatabase): boolean {
+  const payload = db.prepare("SELECT 1 FROM search_index_publication_entries LIMIT 1").get();
+  return payload !== undefined || hasLegacyPublicationRows(db);
+}
+
 function deleteLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string): void {
   // Schema v21 could leave staged heads and their live detail rows after an interruption.
   const predicate = publicationId
@@ -112,7 +125,9 @@ function deleteLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string)
 }
 
 export function discardPublicationStaging(db: SQLiteDatabase, publicationId?: string): void {
-  deleteLegacyPublicationRows(db, publicationId);
+  if (hasLegacyPublicationRows(db, publicationId)) {
+    deleteLegacyPublicationRows(db, publicationId);
+  }
   if (publicationId) {
     deletePublicationPayloads(db, publicationId);
   } else {

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -38,7 +38,11 @@ import {
   type SessionRow,
 } from "./messages.js";
 import { CACHE_SCHEMA_VERSION } from "./version.js";
-import { createPublicationStagingTable, discardPublicationStaging } from "./publication-staging.js";
+import {
+  createPublicationStagingTable,
+  discardPublicationStaging,
+  hasPublicationStaging,
+} from "./publication-staging.js";
 
 interface MessageToolBackfillRow extends DatabaseRow {
   agent_name?: string;
@@ -100,6 +104,21 @@ function withCacheConnection<T>(fn: (connection: CacheConnection) => T): T | nul
   }
 }
 
+function cleanPublicationStaging(connection: CacheConnection): void {
+  if (connection.publicationStagingCleaned) return;
+
+  const startedAt = performance.now();
+  const reclaimed = hasPublicationStaging(connection.db);
+  if (reclaimed) {
+    connection.db.transaction(() => discardPublicationStaging(connection.db)).immediate();
+  }
+  connection.publicationStagingCleaned = true;
+  getCoreDiagnostics()?.info?.("sqlite.publication_staging_cleanup.completed", {
+    duration_ms: Math.round(performance.now() - startedAt),
+    reclaimed,
+  });
+}
+
 export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
   return withCacheConnection(({ db }) => fn(db));
 }
@@ -131,7 +150,10 @@ export function withSearchDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
 }
 
 export function withSearchIndexDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
-  return withCacheConnection((connection) => runWithFtsRecovery(connection, fn));
+  return withCacheConnection((connection) => {
+    cleanPublicationStaging(connection);
+    return runWithFtsRecovery(connection, fn);
+  });
 }
 
 interface SearchIndexWriteResult<T> {
@@ -1442,11 +1464,6 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   });
 
   createLatestCacheSchema(db);
-  const publicationCleanupStartedAt = performance.now();
-  db.transaction(() => discardPublicationStaging(db)).immediate();
-  getCoreDiagnostics()?.info?.("sqlite.publication_staging_cleanup.completed", {
-    duration_ms: Math.round(performance.now() - publicationCleanupStartedAt),
-  });
 
   // Only stamp when behind: every thread's first connection runs ensureSchema,
   // and an unconditional PRAGMA user_version write would contend for the write

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -1442,7 +1442,11 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   });
 
   createLatestCacheSchema(db);
+  const publicationCleanupStartedAt = performance.now();
   db.transaction(() => discardPublicationStaging(db)).immediate();
+  getCoreDiagnostics()?.info?.("sqlite.publication_staging_cleanup.completed", {
+    duration_ms: Math.round(performance.now() - publicationCleanupStartedAt),
+  });
 
   // Only stamp when behind: every thread's first connection runs ensureSchema,
   // and an unconditional PRAGMA user_version write would contend for the write


### PR DESCRIPTION
## Summary

- log orphaned publication-staging cleanup duration
- move cleanup out of cache restoration and into the first search-index write
- skip legacy child-table scans when no legacy staged session exists
- add regression coverage for deferred cleanup, the empty fast path, and diagnostics

## Root cause

The CLI waits for cache restoration before it starts the HTTP server and opens the browser. The first cache read also initialized the SQLite schema and synchronously reclaimed publication payloads left behind when the search-index worker was interrupted.

On the reproduced 10 GB cache, 290 orphaned payloads occupied 341.63 MB. Synchronous cleanup took 9.115 seconds of a 9.195-second startup, while server startup and browser launch were negligible.

## Impact

The Web UI can now become ready from the last durable session snapshot while the search-index worker reclaims orphaned shadow data before its first write. Empty staging state is probed once per connection and does not scan or delete from large child tables.

## Validation

- `pnpm --filter @codesesh/core test` (834 passed, 1 skipped)
- `pnpm --filter codesesh test` (490 passed)
- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter codesesh build`
- fault injection with 341.63 MB of interrupted staging: startup reached ready in 40 ms and returned HTTP 200 in 7 ms before background cleanup
- default all-agent startup reached ready in 66 ms, down from 6.6–9.5 seconds