### PR TITLE
fix(grok): filter sessions without visible messages

### DIFF
--- a/packages/core/src/agents/__tests__/grok.test.ts
+++ b/packages/core/src/agents/__tests__/grok.test.ts
@@ -53,7 +53,9 @@ function xaiUpdate(
 }
 
 interface SessionFixtureOptions {
-  updates: Record<string, unknown>[];
+  updates?: Record<string, unknown>[];
+  chatHistory?: Record<string, unknown>[];
+  summaryChatMessageCount?: number;
   title?: string;
   parentSessionId?: string;
 }
@@ -75,14 +77,22 @@ function writeGrokSession(options: SessionFixtureOptions) {
       created_at: CREATED_AT,
       updated_at: "2026-08-05T08:30:00.000Z",
       last_active_at: "2026-08-05T08:29:00.000Z",
-      num_messages: options.updates.length,
-      num_chat_messages: 40,
+      num_messages: options.updates?.length ?? 0,
+      num_chat_messages: options.summaryChatMessageCount ?? 40,
       current_model_id: "grok-4.5",
       parent_session_id: options.parentSessionId,
     }),
   );
   const updatesPath = join(sessionDir, "updates.jsonl");
-  writeFileSync(updatesPath, options.updates.map((update) => JSON.stringify(update)).join("\n"));
+  if (options.updates) {
+    writeFileSync(updatesPath, options.updates.map((update) => JSON.stringify(update)).join("\n"));
+  }
+  if (options.chatHistory) {
+    writeFileSync(
+      join(sessionDir, "chat_history.jsonl"),
+      options.chatHistory.map((message) => JSON.stringify(message)).join("\n"),
+    );
+  }
 
   const agent = new GrokAgent();
   expect(agent.isAvailable()).toBe(true);
@@ -117,6 +127,27 @@ function turnUsage(
 }
 
 describe("GrokAgent", () => {
+  it.each([
+    { label: "missing", updates: undefined },
+    { label: "empty", updates: [] },
+  ])("filters sessions with a $label authoritative update stream", ({ updates }) => {
+    const { agent } = writeGrokSession({
+      updates,
+      summaryChatMessageCount: 2,
+      title: "Internal context only",
+      chatHistory: [
+        { type: "system", content: "Internal system prompt" },
+        {
+          type: "user",
+          synthetic_reason: "system_reminder",
+          content: [{ type: "text", text: "<system-reminder>Internal reminder</system-reminder>" }],
+        },
+      ],
+    });
+
+    expect(agent.scan()).toEqual([]);
+  });
+
   it("parses ACP messages, tools, plans, usage, and parent sessions", () => {
     const updates = [
       acpUpdate(CREATED_AT_MS + 1_000, "prompt-0", "user_message_chunk", {

--- a/packages/core/src/agents/grok.ts
+++ b/packages/core/src/agents/grok.ts
@@ -31,7 +31,7 @@ import { cleanInternalText } from "../utils/session-normalization.js";
 import { basenameTitle, resolveSessionTitle } from "../utils/title-fallback.js";
 import { TranscriptBuilder, type TranscriptResult } from "./transcript-builder.js";
 
-const HEAD_INDEX_VERSION = "grok-head-v1";
+const HEAD_INDEX_VERSION = "grok-head-v2";
 const PARSER_VERSION = "grok-parser-v1";
 const SUMMARY_FILE = "summary.json";
 const UPDATES_FILE = "updates.jsonl";
@@ -56,7 +56,6 @@ interface GrokSummary {
   title: string | null;
   createdAt: number;
   updatedAt: number;
-  messageCount: number;
   currentModel: string | null;
   parentSessionId: string | null;
 }
@@ -138,7 +137,6 @@ function parseSummary(source: SessionSourceFile): GrokSummary | null {
     title: generatedTitle || sessionSummary || null,
     createdAt,
     updatedAt,
-    messageCount: safeCount(summary?.num_chat_messages),
     currentModel: asString(summary?.current_model_id)?.trim() || null,
     parentSessionId: parentSessionId === id ? null : parentSessionId,
   };
@@ -879,7 +877,7 @@ export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
     const updatesPath = join(sessionDir, UPDATES_FILE);
     const existingUpdatesPath = existsSync(updatesPath) ? updatesPath : null;
     const headData = scanHeadData(existingUpdatesPath, summary.createdAt);
-    const messageCount = headData.visibleMessageCount || summary.messageCount;
+    const messageCount = headData.visibleMessageCount;
     if (messageCount === 0) return filteredSession("no visible messages");
 
     const title = resolveSessionTitle(


### PR DESCRIPTION
## Summary

- derive Grok session visibility and message counts exclusively from the authoritative `updates.jsonl` stream
- filter sessions whose authoritative stream is missing or empty, even when `summary.json` reports internal chat messages
- bump the Grok head-index version so stale cached sessions are recomputed
- add regression coverage for internal-only system context

## Root cause

The Grok adapter used `visibleMessageCount || num_chat_messages`. Grok defines `updates.jsonl` as the authoritative conversation log, while `chat_history.jsonl` contains the raw context sent to the model. For the affected session, the update stream was missing and the raw history contained only a system prompt and a synthetic system reminder. The summary fallback therefore published a session head with two messages, but detail parsing correctly produced no displayable messages.

## Impact

Internal-only Grok records no longer appear as empty sessions. Session-list message counts and session-detail messages now share the same source of truth.

## Validation

- `pnpm --filter @codesesh/core test` (835 passed, 1 skipped)
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core build`
- verified against the affected local session: 6 valid Grok sessions remain, the target is absent, and all remaining head/detail message counts match
- verified in the Web UI: the Grok list contains 6 sessions and the removed session route returns the existing Session Not Found state