### PR TITLE
fix(claude): filter empty local commands

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -391,7 +391,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
         sessionId: "session-1",
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "claudecode-head-v5",
+          "claudecode-head-v6",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           indexTime.getTime(),
@@ -823,7 +823,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
           message: {
             role: "user",
             content:
-              "Visible request\n<command-name>clear</command-name>\n<local-command-stdout>noise</local-command-stdout>",
+              "<command-name>/review</command-name>\n<command-message>review</command-message>\n<command-args>Visible request</command-args>\n<local-command-caveat>noise</local-command-caveat>\n<local-command-stdout>noise</local-command-stdout>",
           },
         }),
         JSON.stringify({
@@ -857,6 +857,52 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(data.messages[1]?.parts).toEqual([
       expect.objectContaining({ type: "text", text: "Visible answer" }),
     ]);
+  });
+
+  it("filters internal-only local command sessions", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-local-command-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, "local-command.jsonl"),
+      [
+        JSON.stringify({ type: "queue-operation", timestamp: "2026-04-20T10:00:00Z" }),
+        JSON.stringify({
+          type: "user",
+          isMeta: true,
+          timestamp: "2026-04-20T10:00:01Z",
+          cwd: "/tmp/project",
+          message: {
+            role: "user",
+            content: "<local-command-caveat>Internal command context</local-command-caveat>",
+          },
+        }),
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-04-20T10:00:02Z",
+          cwd: "/tmp/project",
+          message: {
+            role: "user",
+            content:
+              "<command-name>/usage</command-name>\n<command-message>usage</command-message>\n<command-args></command-args>",
+          },
+        }),
+        JSON.stringify({
+          type: "system",
+          subtype: "local_command",
+          timestamp: "2026-04-20T10:00:03Z",
+          content: "Internal output",
+        }),
+        JSON.stringify({ type: "last-prompt" }),
+      ].join("\n"),
+    );
+
+    const agent = new ClaudeCodeAgent() as any;
+    agent.basePath = basePath;
+
+    expect(agent.scan()).toEqual([]);
   });
 
   it("falls back to zero and reports a mismatch when a usage field has the wrong type", () => {

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -34,8 +34,8 @@ import {
 } from "./base.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
-// v5: heads cached before pricing misses were tracked may hold stale zero costs.
-const HEAD_INDEX_VERSION = "claudecode-head-v5";
+// v6: heads created from internal-only local commands must be recomputed.
+const HEAD_INDEX_VERSION = "claudecode-head-v6";
 
 export function resolveClaudeCodeDataRoot(): string {
   return resolveHomePath("CLAUDE_CONFIG_DIR", ".claude");
@@ -607,6 +607,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
 
       try {
         if (isInternalEventType(data["type"])) continue;
+        if (data["isMeta"] === true) continue;
         const ts = parseTimestampMs(data);
         if (ts > updatedAt) updatedAt = ts;
 
@@ -623,7 +624,8 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
           if (msg["role"] !== undefined && role === undefined) {
             reportFieldMismatch("claudecode", "message.role");
           }
-          if (role?.trim()) {
+          const userTitle = role === "user" ? this.extractUserMessageTitle(msg["content"]) : null;
+          if (role?.trim() && (role !== "user" || userTitle !== null)) {
             messageCount++;
           }
           if (!model) {
@@ -632,9 +634,8 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
           }
           // Title fallback mirrors the removed extractTitle(): first non-empty
           // visible user text within the first 20 lines.
-          if (messageTitle === null && recordIndex < 20 && role === "user") {
-            const candidate = this.extractUserMessageTitle(msg["content"]);
-            if (candidate) messageTitle = candidate;
+          if (messageTitle === null && recordIndex < 20 && userTitle) {
+            messageTitle = userTitle;
           }
           if (role === "assistant") {
             const usage = extractClaudeUsage(data, msg);

--- a/packages/core/src/utils/__tests__/parse-cleanup.test.ts
+++ b/packages/core/src/utils/__tests__/parse-cleanup.test.ts
@@ -7,6 +7,7 @@ describe("cleanDisplayText", () => {
       "Visible before",
       "<command-name>pwd</command-name>",
       "<command-message>run local command</command-message>",
+      "<local-command-caveat>local command metadata</local-command-caveat>",
       "<local-command-stdout>/tmp/project</local-command-stdout>",
       "<system-reminder>hidden policy reminder</system-reminder>",
       "Visible after",
@@ -17,6 +18,13 @@ describe("cleanDisplayText", () => {
 
   it("returns null when only internal tags remain", () => {
     expect(cleanDisplayText("<command-name>clear</command-name>")).toBeNull();
+  });
+
+  it("unwraps command arguments without discarding their content", () => {
+    expect(cleanDisplayText("<command-args>Review the auth flow</command-args>")).toBe(
+      "Review the auth flow",
+    );
+    expect(cleanDisplayText("<command-args></command-args>")).toBeNull();
   });
 
   it("preserves regular spacing and indentation", () => {

--- a/packages/core/src/utils/parse-cleanup.ts
+++ b/packages/core/src/utils/parse-cleanup.ts
@@ -1,9 +1,12 @@
-const INTERNAL_TAGS = [
+const INTERNAL_BLOCK_TAGS = [
   "command-message",
   "command-name",
+  "local-command-caveat",
   "local-command-stdout",
   "system-reminder",
 ];
+
+const TRANSPARENT_TAGS = ["command-args"];
 
 const INTERNAL_EVENT_TYPES = new Set([
   "progress",
@@ -46,13 +49,17 @@ export function isInternalEventType(value: unknown): boolean {
 export function cleanDisplayText(text: string): string | null {
   let cleaned = text;
 
-  for (const tag of INTERNAL_TAGS) {
+  for (const tag of INTERNAL_BLOCK_TAGS) {
     cleaned = cleaned.replace(blockTagLinePattern(tag), "$1");
     cleaned = cleaned.replace(blockTagPattern(tag), "");
     cleaned = cleaned.replace(openBlockTagPattern(tag), "");
   }
 
-  for (const tag of INTERNAL_TAGS) {
+  for (const tag of INTERNAL_BLOCK_TAGS) {
+    cleaned = cleaned.replace(looseTagPattern(tag), "");
+  }
+
+  for (const tag of TRANSPARENT_TAGS) {
     cleaned = cleaned.replace(looseTagPattern(tag), "");
   }
 


### PR DESCRIPTION
## Summary

- strip Claude internal command metadata while retaining non-empty slash-command arguments
- ignore meta records and count only displayable user content during Claude session discovery
- invalidate stale Claude head-cache entries so internal-only sessions are removed
- add regressions for empty local commands and non-empty command arguments

## Root cause

Claude local commands persist both a meta caveat and a command envelope. The shared cleanup removed `command-name` and `command-message`, but left the `command-args` wrapper. Claude head discovery also counted every record with a message role, including meta records. As a result, an empty `/usage` invocation was indexed as a two-message session while its detail contained only `<command-args></command-args>`.

## Impact

Internal-only local-command sessions no longer appear in session lists, cache, search, or detail routes. Non-empty slash-command arguments remain displayable. The head-index version bump triggers a one-time background refresh of existing Claude entries.

## Validation

- Core test suite: 835 passed, 1 skipped
- Core lint, format check, and build passed
- Verified all seven reported session IDs are absent from a real Claude scan
- Verified the refreshed cache deletes the reported entries and their detail endpoints return 404
- Verified Claude-filtered search has no empty command-argument matches
- Verified 13 sessions with non-empty command arguments remain displayable
