### PR TITLE
refactor: remove duplicate message full-text index

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 23`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 24`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`
@@ -31,7 +31,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 ## Schema 清单
 
-当前 schema 创建 15 张表（其中 3 张是 FTS5 虚表）和 1 个视图。
+当前 schema 创建 14 张表（其中 2 张是 FTS5 虚表）和 1 个视图。
 
 ### 生命周期与同步状态
 
@@ -57,15 +57,19 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 | 表 | 类型 | 用途 |
 |----|------|------|
-| `messages_fts` | FTS5 虚表 | 消息级全文匹配 |
 | `session_file_activity_path_fts` | trigram FTS5 虚表 | 文件路径匹配 |
 | `session_documents` | 普通表 | 会话标题、聚合文本、内容签名与已索引消息数 |
 | `session_documents_fts` | FTS5 虚表 | 会话级标题和聚合文本搜索 |
 | `search_index_publication_entries` | 普通表 | 大批量发布提交前暂存序列化详情；提交或回滚后清空 |
 
-三个 FTS 表都由对应内容表的 insert/update/delete 触发器维护。批量变化达到阈值时，
-`runSearchIndexWrite()` 会在写事务中重建会话文档和消息索引；文件路径索引仍由触发器
-增量维护。
+两个 FTS 表都由对应内容表的 insert/update/delete 触发器维护。批量变化达到阈值时，
+`runSearchIndexWrite()` 会在写事务中重建会话文档索引；文件路径索引仍由触发器增量维护。
+搜索先由会话文档索引召回和排序，再在候选会话的消息纯文本中定位首条命中消息，不再
+为同一批内容维护第二套消息级倒排索引。
+
+Schema 24 删除旧消息索引后，SQLite 会把对应页计入 freelist，后续写入可以直接复用；
+数据库文件的字节大小不会因此立即下降。物理压缩需要重写整个数据库，因此不在启动迁移
+中自动执行，避免把一次性磁盘回收变成阻塞式维护。
 
 ### 项目聚合
 

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 23;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 24;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -236,6 +236,9 @@ function readMigratedFacts(): Record<string, unknown> {
       searchDocuments: scalar("SELECT COUNT(*) AS value FROM session_documents"),
       projects: scalar("SELECT COUNT(*) AS value FROM project_sessions"),
       pendingReindex: scalar("SELECT COUNT(*) AS value FROM pending_reindex"),
+      legacyMessageSearchObjects: scalar(
+        "SELECT COUNT(*) AS value FROM sqlite_master WHERE name IN ('messages_fts', 'messages_ai', 'messages_ad', 'messages_au')",
+      ),
       sessionActivityIndexes: (
         db
           .prepare(
@@ -355,6 +358,7 @@ describe("sqlite migration release gate", () => {
         searchDocuments: 1,
         projects: 1,
         pendingReindex: 1,
+        legacyMessageSearchObjects: 0,
         sessionActivityIndexes: ["idx_sessions_agent_activity_order"],
         documentColumns: [
           "agent_name",

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -78,6 +78,7 @@ describe("cache schema boundary", () => {
     ]) {
       expect(state?.names.has(name)).toBe(true);
     }
+    expect(state?.names.has("messages_fts")).toBe(false);
     expect(state?.documentColumns).toEqual([
       "id",
       "agent_name",
@@ -98,7 +99,48 @@ describe("cache schema boundary", () => {
         "publication_id",
       ]),
     );
-    expect(state?.version).toBe(23);
+    expect(state?.version).toBe(24);
+  });
+
+  it("removes the legacy message FTS objects when upgrading schema 23", () => {
+    schema.withCacheDb((db) => {
+      db.exec(`
+        CREATE VIRTUAL TABLE messages_fts USING fts5(
+          content_text,
+          content='messages',
+          content_rowid='rowid'
+        );
+        CREATE TRIGGER messages_ai AFTER INSERT ON messages BEGIN
+          INSERT INTO messages_fts(rowid, content_text) VALUES (new.rowid, new.content_text);
+        END;
+        CREATE TRIGGER messages_ad AFTER DELETE ON messages BEGIN
+          INSERT INTO messages_fts(messages_fts, rowid, content_text)
+          VALUES ('delete', old.rowid, old.content_text);
+        END;
+        CREATE TRIGGER messages_au AFTER UPDATE ON messages BEGIN
+          INSERT INTO messages_fts(messages_fts, rowid, content_text)
+          VALUES ('delete', old.rowid, old.content_text);
+          INSERT INTO messages_fts(rowid, content_text) VALUES (new.rowid, new.content_text);
+        END;
+        PRAGMA user_version = 23;
+        UPDATE cache_meta SET value = '23' WHERE key = 'version';
+      `);
+    });
+    setSchemaEnsuredPath(null);
+
+    const migrated = schema.withCacheDb((db) => ({
+      objects: db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE name IN ('messages_fts', 'messages_ai', 'messages_ad', 'messages_au')",
+        )
+        .all(),
+      version: Number(
+        (db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined)
+          ?.user_version ?? 0,
+      ),
+    }));
+
+    expect(migrated).toEqual({ objects: [], version: 24 });
   });
 
   it("reuses one connection for read and write capabilities until invalidated", () => {
@@ -267,7 +309,7 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 23, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 24, detailVersion: "", pending: true });
   });
 
   it("marks legacy project identities stale by leaving added provenance empty", () => {
@@ -306,7 +348,7 @@ describe("cache schema boundary", () => {
     });
 
     expect(migrated).toEqual({
-      version: 23,
+      version: 24,
       resolverRevision: null,
       inputSignature: null,
       classifierRevision: null,
@@ -376,7 +418,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 23,
+        version: 24,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -1076,7 +1076,7 @@ describe("searchSessions", () => {
     expect(highlightedText(punctuatedResults[0])).toContain("ÉCOLE-needle");
   });
 
-  it("bounds a single message FTS lookup to one row per candidate", () => {
+  it("bounds message enrichment to one row per candidate", () => {
     const sessions = Array.from({ length: 3 }, (_, sessionIndex) => ({
       ...makeSession(`bulk-match-${sessionIndex}`),
       stats: { ...makeSession(`bulk-match-${sessionIndex}`).stats, message_count: 30 },
@@ -1125,9 +1125,13 @@ describe("searchSessions", () => {
     }
 
     const normalizedSql = preparedSql.map((sql) => sql.replace(/\s+/g, " ").trim());
-    const messageLookupSql = normalizedSql.filter((sql) => sql.includes("JOIN messages_fts"));
+    const messageLookupSql = normalizedSql.filter((sql) =>
+      sql.includes("first_message_matches AS MATERIALIZED"),
+    );
     expect(messageLookupSql).toHaveLength(1);
     expect(messageLookupSql[0]).toContain("INDEXED BY idx_messages_session");
+    expect(messageLookupSql[0]).toContain("codesesh_message_matches_terms(m.content_text)");
+    expect(messageLookupSql[0]).not.toContain("messages_fts");
     expect(messageLookupSql[0]).toContain("ORDER BY m.message_index LIMIT 1");
     expect(returnedMessageRows).toBe(sessions.length);
     expect(
@@ -1288,7 +1292,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(23);
+    expect(getUserVersion(getCachePath())).toBe(24);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -2078,7 +2082,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(23);
+    expect(getUserVersion(getCachePath())).toBe(24);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {
@@ -2425,7 +2429,7 @@ describe("searchSessions", () => {
     expect(highlightedText(results[0])).toContain("orphan");
   });
 
-  it("rebuilds affected FTS indexes when update triggers are missing", () => {
+  it("rebuilds the session FTS index when update triggers are missing", () => {
     const session = makeSession("missing-fts-triggers");
     saveCachedSessions("claudecode", [session]);
     syncSessionSearchIndex("claudecode", [session], (sessionId) =>
@@ -2434,34 +2438,25 @@ describe("searchSessions", () => {
 
     const db = new Database(getCachePath());
     try {
-      db.exec(`
-        DROP TRIGGER session_documents_au;
-        DROP TRIGGER messages_au;
-      `);
+      db.exec("DROP TRIGGER session_documents_au");
       db.prepare(
         "UPDATE session_documents SET content_text = ? WHERE agent_name = ? AND session_id = ?",
       ).run("documentrepairneedle", "claudecode", session.id);
-      db.prepare(
-        "UPDATE messages SET content_text = ? WHERE agent_name = ? AND session_id = ?",
-      ).run("messagerepairneedle", "claudecode", session.id);
     } finally {
       db.close();
     }
     setSchemaEnsuredPath(null);
 
-    const matches = withSearchDb((searchDb) => ({
-      documents: searchDb
-        .prepare(
-          "SELECT COUNT(*) AS value FROM session_documents_fts WHERE session_documents_fts MATCH ?",
-        )
-        .get("documentrepairneedle") as { value: number },
-      messages: searchDb
-        .prepare("SELECT COUNT(*) AS value FROM messages_fts WHERE messages_fts MATCH ?")
-        .get("messagerepairneedle") as { value: number },
-    }));
+    const match = withSearchDb(
+      (searchDb) =>
+        searchDb
+          .prepare(
+            "SELECT COUNT(*) AS value FROM session_documents_fts WHERE session_documents_fts MATCH ?",
+          )
+          .get("documentrepairneedle") as { value: number },
+    );
 
-    expect(matches?.documents.value).toBe(1);
-    expect(matches?.messages.value).toBe(1);
+    expect(match?.value).toBe(1);
   });
 
   it("recreates and rebuilds a missing FTS table", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -185,14 +185,10 @@ describe("loadCachedSessions", () => {
 describe("withSearchIndexDb", () => {
   it("provides ready search-index tables", () => {
     const tables = withSearchIndexDb((db) =>
-      db
-        .prepare(
-          "SELECT name FROM sqlite_master WHERE name IN ('session_documents_fts', 'messages_fts')",
-        )
-        .all(),
+      db.prepare("SELECT name FROM sqlite_master WHERE name = 'session_documents_fts'").all(),
     );
 
-    expect(tables).toHaveLength(2);
+    expect(tables).toHaveLength(1);
   });
 });
 
@@ -200,7 +196,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(23);
+    expect(getUserVersion(getCachePath())).toBe(24);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -211,7 +207,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(23);
+    expect(getUserVersion(getCachePath())).toBe(24);
   });
 });
 
@@ -219,7 +215,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(23);
+    expect(getUserVersion(getCachePath())).toBe(24);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -495,7 +491,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(23);
+    expect(getUserVersion(getCachePath())).toBe(24);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -170,7 +170,6 @@ export function runSearchIndexWrite<T>(
   const execute = () => {
     if (rebuild) {
       dropSearchTriggers(db);
-      dropMessageSearchTriggers(db);
     }
 
     const value = write();
@@ -179,10 +178,8 @@ export function runSearchIndexWrite<T>(
     if (rebuild) {
       const rebuildStartedAt = performance.now();
       rebuildSearchIndex(db);
-      rebuildMessageSearchIndex(db);
       rebuildDurationMs = performance.now() - rebuildStartedAt;
       createSearchTriggers(db);
-      createMessageSearchTriggers(db);
     }
 
     return { value, rebuildDurationMs };
@@ -324,48 +321,12 @@ function createMessageToolTables(db: SQLiteDatabase): void {
   `);
 }
 
-function createMessageSearchTables(db: SQLiteDatabase): void {
-  if (!tableExists(db, "messages")) {
-    createSessionTables(db);
-  }
-
-  db.exec(`
-    CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-      content_text,
-      content='messages',
-      content_rowid='rowid'
-    );
-  `);
-
-  createMessageSearchTriggers(db);
-}
-
-function createMessageSearchTriggers(db: SQLiteDatabase): void {
-  db.exec(`
-    CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
-      INSERT INTO messages_fts(rowid, content_text)
-      VALUES (new.rowid, new.content_text);
-    END;
-
-    CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
-      INSERT INTO messages_fts(messages_fts, rowid, content_text)
-      VALUES ('delete', old.rowid, old.content_text);
-    END;
-
-    CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
-      INSERT INTO messages_fts(messages_fts, rowid, content_text)
-      VALUES ('delete', old.rowid, old.content_text);
-      INSERT INTO messages_fts(rowid, content_text)
-      VALUES (new.rowid, new.content_text);
-    END;
-  `);
-}
-
-function dropMessageSearchTriggers(db: SQLiteDatabase): void {
+function dropLegacyMessageSearchIndex(db: SQLiteDatabase): void {
   db.exec(`
     DROP TRIGGER IF EXISTS messages_ai;
     DROP TRIGGER IF EXISTS messages_ad;
     DROP TRIGGER IF EXISTS messages_au;
+    DROP TABLE IF EXISTS messages_fts;
   `);
 }
 
@@ -1239,17 +1200,6 @@ function rebuildSearchIndex(db: SQLiteDatabase): void {
   db.exec("INSERT INTO session_documents_fts(session_documents_fts) VALUES ('rebuild')");
 }
 
-function rebuildMessageSearchIndex(db: SQLiteDatabase): void {
-  if (!tableExists(db, "messages_fts")) {
-    return;
-  }
-  db.exec("INSERT INTO messages_fts(messages_fts) VALUES ('rebuild')");
-}
-
-const SEARCH_FTS_INDEXES = ["session_documents_fts", "messages_fts"] as const;
-
-type SearchFtsIndex = (typeof SEARCH_FTS_INDEXES)[number];
-
 function triggerExists(db: SQLiteDatabase, triggerName: string): boolean {
   return (
     db
@@ -1262,20 +1212,12 @@ function hasAllTriggers(db: SQLiteDatabase, triggerNames: string[]): boolean {
   return triggerNames.every((triggerName) => triggerExists(db, triggerName));
 }
 
-function rebuildSearchFtsIndexes(
-  db: SQLiteDatabase,
-  indexes: SearchFtsIndex[],
-  reason: "corruption" | "schema_missing",
-): void {
-  if (indexes.length === 0) return;
-
+function rebuildSearchFtsIndex(db: SQLiteDatabase, reason: "corruption" | "schema_missing"): void {
+  const indexes = ["session_documents_fts"];
   const startedAt = performance.now();
   getCoreDiagnostics()?.info?.("sqlite.fts_rebuild.started", { indexes, reason });
   try {
-    for (const index of indexes) {
-      if (index === "session_documents_fts") rebuildSearchIndex(db);
-      else rebuildMessageSearchIndex(db);
-    }
+    rebuildSearchIndex(db);
     getCoreDiagnostics()?.info?.("sqlite.fts_rebuild.completed", {
       indexes,
       reason,
@@ -1296,40 +1238,31 @@ function ensureFtsReady(db: SQLiteDatabase): void {
   const needsSearchRebuild =
     !tableExists(db, "session_documents_fts") ||
     !hasAllTriggers(db, ["session_documents_ai", "session_documents_ad", "session_documents_au"]);
-  const needsMessageSearchRebuild =
-    !tableExists(db, "messages_fts") ||
-    !hasAllTriggers(db, ["messages_ai", "messages_ad", "messages_au"]);
 
   createSearchTables(db);
-  createMessageSearchTables(db);
-
-  const indexes: SearchFtsIndex[] = [];
-  if (needsSearchRebuild) indexes.push("session_documents_fts");
-  if (needsMessageSearchRebuild) indexes.push("messages_fts");
-  rebuildSearchFtsIndexes(db, indexes, "schema_missing");
+  if (needsSearchRebuild) rebuildSearchFtsIndex(db, "schema_missing");
 }
 
 function ensureFtsConsistency(db: SQLiteDatabase): void {
   const startedAt = performance.now();
   getCoreDiagnostics()?.info?.("sqlite.fts_integrity.started", {
-    indexes: 2,
+    indexes: 1,
   });
   try {
     db.exec(
       "INSERT INTO session_documents_fts(session_documents_fts, rank) VALUES ('integrity-check', 1)",
     );
-    db.exec("INSERT INTO messages_fts(messages_fts, rank) VALUES ('integrity-check', 1)");
     getCoreDiagnostics()?.info?.("sqlite.fts_integrity.completed", {
-      indexes: 2,
+      indexes: 1,
       duration_ms: Math.round(performance.now() - startedAt),
     });
   } catch (error) {
     getCoreDiagnostics()?.warn("sqlite.fts_integrity.failed", {
-      indexes: 2,
+      indexes: 1,
       duration_ms: Math.round(performance.now() - startedAt),
       message: error instanceof Error ? error.message : String(error),
     });
-    rebuildSearchFtsIndexes(db, [...SEARCH_FTS_INDEXES], "corruption");
+    rebuildSearchFtsIndex(db, "corruption");
   }
 }
 
@@ -1425,13 +1358,6 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       },
       { version: 8, migrate: backfillFileActivity },
       {
-        version: 9,
-        migrate(db) {
-          createMessageSearchTables(db);
-          rebuildMessageSearchIndex(db);
-        },
-      },
-      {
         version: 10,
         migrate(db) {
           createFileActivityPathSearchTables(db);
@@ -1460,6 +1386,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 21, migrate: addSessionPublicationId },
       { version: 22, migrate: addAtomicPublicationStaging },
       { version: 23, migrate: replaceSessionActivityIndex },
+      { version: 24, migrate: dropLegacyMessageSearchIndex },
     ],
   });
 

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -411,7 +411,6 @@ function searchResultRowKey(row: Pick<SearchResultRow, "agent_name" | "session_i
 function fetchMessageSearchMatches(
   db: SQLiteDatabase,
   rows: SearchResultRow[],
-  ftsQuery: string,
   terms: { terms: string[]; mode: "all" | "any" },
 ): Map<string, SearchSnippet & { matchType: SearchMatchType }> {
   const candidates = rows.filter((row) => !textMatchesTerms(String(row.title ?? ""), terms));
@@ -441,10 +440,8 @@ function fetchMessageSearchMatches(
             (
               SELECT m.rowid
               FROM messages m INDEXED BY idx_messages_session
-              JOIN messages_fts ON messages_fts.rowid = m.rowid
               WHERE m.agent_name = c.agent_name
                 AND m.session_id = c.session_id
-                AND messages_fts MATCH ?
                 AND codesesh_message_matches_terms(m.content_text)
               ORDER BY m.message_index
               LIMIT 1
@@ -463,7 +460,7 @@ function fetchMessageSearchMatches(
         JOIN messages m ON m.rowid = f.message_rowid
       `,
     )
-    .all(...candidateParams, ftsQuery) as MessageSearchRow[];
+    .all(...candidateParams) as MessageSearchRow[];
   const matches = new Map<string, SearchSnippet & { matchType: SearchMatchType }>();
 
   for (const message of messageRows) {
@@ -517,12 +514,11 @@ function rowsToSearchResults(
   db: SQLiteDatabase,
   rows: SearchResultRow[],
   textQuery: string,
-  ftsQuery = toFtsQuery(textQuery),
 ): SearchResult[] {
   const terms = parseTextTerms(textQuery);
   const messageMatches =
-    terms.terms.length > 0 && ftsQuery
-      ? fetchMessageSearchMatches(db, rows, ftsQuery, terms)
+    terms.terms.length > 0
+      ? fetchMessageSearchMatches(db, rows, terms)
       : new Map<string, SearchSnippet & { matchType: SearchMatchType }>();
 
   return rows.map((row) => {
@@ -593,7 +589,7 @@ export function searchSessions(query: string, options: SearchOptions = {}): Sear
       )
       .all(ftsQuery, ...filters.params, search.options.limit ?? 50) as SearchResultRow[];
 
-    return rowsToSearchResults(db, rows, normalizedQuery, ftsQuery);
+    return rowsToSearchResults(db, rows, normalizedQuery);
   });
 
   return results ?? [];

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 23;
+export const CACHE_SCHEMA_VERSION = 24;


### PR DESCRIPTION
## Summary

- remove the redundant `messages_fts` table and its insert/update/delete triggers
- keep `session_documents_fts` as the single content recall and ranking index
- resolve the first matching message by scanning only the already bounded candidate sessions
- migrate the cache schema to version 24 and document SQLite freelist behavior

## Why

Both content FTS indexes covered the same underlying message text. The session-level index already performs recall and ranking; the message-level index was only used afterward to locate a snippet and match type. On the current cache it consumes about 443 MiB and duplicates trigger, rebuild, and integrity-check work.

## Behavior and storage impact

- the public search contract, session recall, and ranking remain unchanged
- read-only checks on the current 10 GiB cache put candidate message enrichment at roughly 60–130 ms instead of 20–40 ms for representative queries
- a v23 clone migrated in 6.3 seconds and released 442.6 MiB to SQLite's freelist
- the database file does not shrink immediately without a full `VACUUM`; that blocking rewrite is intentionally not run during startup

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`
- `pnpm --filter @codesesh/core build`