### PR TITLE
chore(release): prepare v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.0.2] - 2026-08-14
+
+This release adds DeepSeek Harness (DSH) as the tenth supported agent.
+
+### Features
+
+- Discovered and read DeepSeek Harness sessions from `DSH_HOME/sessions` (default `~/.dsh`) on macOS, Linux and Windows, decoding its multi-frame Zstandard logs frame by frame without writing to the artifact; compressed logs need Node `^22.19.0 || >=24.0.0` for the native Zstandard decoder. (#377)
+- Registered DSH with its own tool display strategy, preferring the contextual hunks DSH attaches to edit results; it declares no resume command because its launcher takes profile-specific arguments. (#377)
+
+### Documentation
+
+- Listed DSH among the supported agents across the READMEs, architecture docs and the landing page. (#377)
+
+### Changelog Detail
+
+- #377 feat: support DeepSeek Harness session discovery @xingkaixin
+
 ## [1.0.1] - 2026-08-13
 
 This release hardens the scan, cache and sync pipelines against partial or failed runs, closes a set of remote-access and browser security gaps, removes startup and rendering bottlenecks on large histories, and redesigns the dashboard charts.

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.0.2] - 2026-08-14
+
+本版本新增 DeepSeek Harness (DSH)，成为第十个受支持的 Agent。
+
+### 新功能
+
+- 在 macOS、Linux 与 Windows 上从 `DSH_HOME/sessions`（默认 `~/.dsh`）发现并读取 DeepSeek Harness 会话，逐帧解码其多帧 Zstandard 日志且不写入原始文件；读取压缩日志需要 Node `^22.19.0 || >=24.0.0` 提供的原生 Zstandard 解码器。 (#377)
+- 注册 DSH 及其工具展示策略，编辑卡片优先使用 DSH 随工具结果附带的上下文 hunk；因其启动器接受 profile 相关参数，未声明 resume 命令。 (#377)
+
+### 文档
+
+- 在 README、架构文档与产品落地页中列出 DSH。 (#377)
+
+### Changelog Detail
+
+- #377 feat: support DeepSeek Harness session discovery @xingkaixin
+
 ## [1.0.1] - 2026-08-13
 
 本版本强化扫描、缓存与同步链路在部分失败或中断场景下的正确性，修补远程访问与浏览器安全缺口，消除大规模历史下的启动与渲染瓶颈，并重新设计 Dashboard 图表。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/web",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/www",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/www/public/index.md
+++ b/apps/www/public/index.md
@@ -100,4 +100,4 @@ The initial scan persists backfill progress. Later starts restore from the SQLit
 
 ## 中文说明
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放九种 AI 编码 Agent 的本地会话。会话内容与 SQLite 索引保留在用户电脑上，无需账号、云同步或会话遥测。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放十种 AI 编码 Agent 的本地会话。会话内容与 SQLite 索引保留在用户电脑上，无需账号、云同步或会话遥测。

--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -67,4 +67,4 @@ It persists scan progress, restores from a SQLite cache, incrementally watches c
 
 ## Chinese Summary
 
-CodeSesh 将九种 AI 编码 Agent 的本地会话按项目组织到同一个 SQLite 索引中，提供结构化搜索、文件活动索引和完整会话回放。会话数据不上传，无需账号、云同步或会话遥测。
+CodeSesh 将十种 AI 编码 Agent 的本地会话按项目组织到同一个 SQLite 索引中，提供结构化搜索、文件活动索引和完整会话回放。会话数据不上传，无需账号、云同步或会话遥测。

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -124,7 +124,7 @@ export const copy = {
     meta: {
       title: "CodeSesh：搜索与回放本地 AI 编码历史",
       description:
-        "CodeSesh 把九种 AI 编码 Agent 的本地会话按项目组织，提供结构化搜索、完整回放与本地 SQLite 索引，让工程上下文可查、可追溯。",
+        "CodeSesh 把十种 AI 编码 Agent 的本地会话按项目组织，提供结构化搜索、完整回放与本地 SQLite 索引，让工程上下文可查、可追溯。",
     },
     header: {
       tour: "产品导览",
@@ -142,7 +142,7 @@ export const copy = {
     hero: {
       eyebrow: "本地运行 / 零配置 / 10 个 Agent",
       title: ["你和 AI 写过的", "每一次对话，都还在。"],
-      body: "CodeSesh 扫描九种 AI 编码 Agent 的本地会话，把分散的历史收进同一个索引：按项目组织、结构化搜索、逐条回放。",
+      body: "CodeSesh 扫描十种 AI 编码 Agent 的本地会话，把分散的历史收进同一个索引：按项目组织、结构化搜索、逐条回放。",
       privacy: "会话内容与索引留在本机，无需账号、云同步或会话遥测。",
       command: "npx codesesh",
       endpoint: "http://localhost:4521",
@@ -188,7 +188,7 @@ export const copy = {
             {
               icon: "eye",
               title: "统一时间线",
-              description: "九种 Agent 的历史会话进入同一个界面。",
+              description: "十种 Agent 的历史会话进入同一个界面。",
             },
             {
               icon: "timer",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codesesh",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Browse local AI coding-agent sessions in one Web UI.",
   "keywords": [
     "ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## What

Prepares the v1.0.2 release inside the repository. npm publish and the GitHub Release are handled by CI once the `v1.0.2` tag is pushed.

- Adds the `1.0.2` changelog block to `CHANGELOG.md` and `CHANGELOG_CN.md`. Only one PR landed after `v1.0.1`: #377 (DeepSeek Harness support).
- Bumps `packages/cli`, `packages/core`, `apps/web` and `apps/www` to `1.0.2`.
- Fixes Chinese landing copy left behind by #377: the English copy and the hero eyebrow already say ten agents, while the Chinese body still said nine (`landing.ts` x3, `public/index.md`, `public/llms.txt`).

READMEs need no change here — #377 already updated the agent lists.

## Test plan

- `node scripts/release-preflight.mjs v1.0.2` → every manifest is 1.0.2
- `node scripts/check-docs-facts.mjs`
- `pnpm lint`, `pnpm format:check`, `pnpm test` (755 tests passed)