### PR TITLE
fix(projects): harden loopback identity resolution

### DIFF
--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -65,6 +65,7 @@ import {
 import { addCalendarDays } from "@codesesh/core/contract";
 import { createApiRoutes } from "../routes.js";
 import { invalidateAliasView } from "../session-aliases-view.js";
+import type { ProjectIdentityResolver } from "../../project-identity-resolver.js";
 
 interface ContextOptions {
   body?: unknown;
@@ -86,6 +87,17 @@ function makeContext(options: ContextOptions = {}) {
       url: `http://localhost/${params.size > 0 ? `?${params.toString()}` : ""}`,
     },
     json: vi.fn((payload: unknown, status = 200) => ({ payload, status })),
+  };
+}
+
+function makeProjectIdentityResolver(): ProjectIdentityResolver {
+  return {
+    resolve: vi.fn(async (cwd: string) => ({
+      identity: { kind: "path" as const, key: cwd, displayName: "repo" },
+      resolverRevision: "project-identity-v2",
+      inputSignature: "test",
+    })),
+    shutdown: vi.fn(async () => {}),
   };
 }
 
@@ -657,7 +669,7 @@ describe("query boundary handlers", () => {
     );
   });
 
-  it("normalizes file activity filters and caps the result limit", () => {
+  it("normalizes file activity filters and caps the result limit", async () => {
     const c = makeContext({
       query: {
         agent: " CoDeX ",
@@ -674,7 +686,8 @@ describe("query boundary handlers", () => {
       },
     });
 
-    handleGetFileActivity(c as never);
+    const resolver = makeProjectIdentityResolver();
+    await handleGetFileActivity(c as never, {}, resolver);
 
     expect(coreMocks.listFileActivity).toHaveBeenCalledWith({
       agent: "codex",
@@ -682,13 +695,17 @@ describe("query boundary handlers", () => {
       projectKind: "path",
       projectKey: "/repo",
       project: "repo",
-      cwd: "/repo",
+      projectScope: {
+        identity: { kind: "path", key: "/repo" },
+        path: "/repo",
+      },
       path: "src/index.ts",
       kind: "edit",
       from: new Date("2026-01-01T00:00:00.000Z").getTime(),
       to: new Date("2026-01-02T00:00:00.000Z").getTime(),
       limit: 200,
     });
+    expect(resolver.resolve).toHaveBeenCalledWith("/repo");
   });
 
   it.each(["1.5", "0", "-1", "", "Infinity", "invalid"])(

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -70,6 +70,7 @@ import {
   type ScanResultSource,
 } from "../handlers.js";
 import { invalidateAliasView } from "../session-aliases-view.js";
+import type { ProjectIdentityResolver } from "../../project-identity-resolver.js";
 import type {
   ChangeCheckResult,
   FileActivityResult,
@@ -198,6 +199,17 @@ function makeScanSource(overrides?: Partial<LiveSnapshot>): ScanResultSource {
     getSnapshot() {
       return result;
     },
+  };
+}
+
+function makeProjectIdentityResolver(): ProjectIdentityResolver {
+  return {
+    resolve: vi.fn(async (cwd: string) => ({
+      identity: { kind: "path" as const, key: cwd, displayName: "project" },
+      resolverRevision: "project-identity-v2",
+      inputSignature: "test",
+    })),
+    shutdown: vi.fn(async () => {}),
   };
 }
 
@@ -532,7 +544,7 @@ describe("handleGetSessions", () => {
     expect(c.json.mock.calls[0]![0].sessions[0].display_title).toBe("Legacy alias");
   });
 
-  it("filters by cwd using project scope match", () => {
+  it("filters by cwd using project scope match", async () => {
     const sessions = [
       makeSession("exact", { directory: "/home/user/project" }),
       makeSession("child", { directory: "/home/user/project/src" }),
@@ -548,7 +560,13 @@ describe("handleGetSessions", () => {
       makeSession("sibling", { directory: "/home/user/projectile" }),
     ];
     const c = makeMockContext({ query: { cwd: "/home/user/project" } });
-    handleGetSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
+    const resolver = makeProjectIdentityResolver();
+    await handleGetSessions(
+      c,
+      makeScanSource({ sessions, byAgent: { claudecode: sessions } }),
+      {},
+      resolver,
+    );
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions.map((session: SessionHead) => session.id)).toEqual([
       "exact",
@@ -556,6 +574,7 @@ describe("handleGetSessions", () => {
       "parent",
       "identity",
     ]);
+    expect(resolver.resolve).toHaveBeenCalledWith("/home/user/project");
   });
 
   it("filters by project identity key", () => {
@@ -679,6 +698,26 @@ describe("handleSearchSessions", () => {
       scanSource.getSnapshot(),
     );
     expect(c.json).toHaveBeenCalledWith({ results: sentinelResults });
+  });
+
+  it("resolves a cwd qualifier before delegating the search", async () => {
+    const scanSource = makeScanSource();
+    const c = makeMockContext({ query: { q: "cwd:/home/user/project needle" } });
+    const resolver = makeProjectIdentityResolver();
+
+    await handleSearchSessions(c, scanSource, {}, resolver);
+
+    expect(resolver.resolve).toHaveBeenCalledWith("/home/user/project");
+    expect(coreMocks.executeSessionSearch).toHaveBeenCalledWith(
+      "cwd:/home/user/project needle",
+      expect.objectContaining({
+        projectScope: {
+          identity: { kind: "path", key: "/home/user/project" },
+          path: "/home/user/project",
+        },
+      }),
+      scanSource.getSnapshot(),
+    );
   });
 
   it("keeps ranked search hits when alias matches fill the limit", () => {

--- a/packages/cli/src/api/__tests__/search-transport.test.ts
+++ b/packages/cli/src/api/__tests__/search-transport.test.ts
@@ -41,11 +41,13 @@ function getCacheDir(): string {
 const now = Date.now();
 
 function makeSessionHead(id: string, title: string, timeUpdated: number): SessionHead {
+  const directory = `/fixtures/${id}`;
   return {
     id,
     slug: `claudecode/${id}`,
     title,
-    directory: `/fixtures/${id}`,
+    directory,
+    project_identity: { kind: "path", key: directory, displayName: id },
     time_created: timeUpdated,
     time_updated: timeUpdated,
     stats: { message_count: 1, total_input_tokens: 0, total_output_tokens: 0, total_cost: 0 },

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -27,10 +27,11 @@ import {
   SessionAliasValidationError,
   StateStorageUnavailableError,
   attachProjectMetricsFromTree,
-  createProjectScopeMatcher,
+  createProjectScopeMatcherFromIdentity,
   deleteBookmark,
   getAgentInfoMap,
   executeSessionSearch,
+  getSearchProjectDirectory,
   importBookmarks,
   listFileActivity,
   listCachedProjectGroups,
@@ -44,11 +45,15 @@ import {
   upsertBookmark,
   matchesProjectScope as sessionMatchesProjectScope,
   matchesProjectIdentity,
+  normalizeProjectDirectory,
+  PROJECT_IDENTITY_RESOLVER_REVISION,
   buildDashboard,
   type DashboardData,
   type DashboardScope,
+  type ProjectScopeMatcher,
 } from "@codesesh/core";
 import { appLogger } from "../logging.js";
+import type { ProjectIdentityResolver } from "../project-identity-resolver.js";
 import { resolveTimeWindow } from "../time-window-resolution.js";
 import {
   filterSessionsByActivityWindow,
@@ -86,6 +91,35 @@ export interface ScanStatusSource {
 
 const KNOWN_AGENT_NAMES = getAgentInfoMap({}).map((agent) => agent.name);
 const KNOWN_AGENT_NAME_SET = new Set(KNOWN_AGENT_NAMES);
+
+async function resolveProjectScope(
+  cwd: string,
+  sessions: readonly SessionHead[],
+  resolver: ProjectIdentityResolver | undefined,
+): Promise<ProjectScopeMatcher> {
+  const normalizedCwd = normalizeProjectDirectory(cwd);
+  const matchingSession = sessions.find(
+    (session) =>
+      normalizeProjectDirectory(session.directory) === normalizedCwd &&
+      session.project_identity != null &&
+      session.project_identity_resolver_revision === PROJECT_IDENTITY_RESOLVER_REVISION &&
+      Boolean(session.project_identity_input_signature),
+  );
+  if (matchingSession?.project_identity) {
+    return createProjectScopeMatcherFromIdentity(cwd, matchingSession.project_identity);
+  }
+  if (!resolver) throw new Error("Project identity resolver is unavailable");
+
+  const projection = await resolver.resolve(cwd);
+  return createProjectScopeMatcherFromIdentity(cwd, projection.identity);
+}
+
+function reportProjectScopeResolutionFailure(endpoint: string, error: unknown): void {
+  appLogger.warn("api.project_scope.unavailable", {
+    endpoint,
+    error: error instanceof Error ? error.message : String(error),
+  });
+}
 
 function reportInvalidQueryParameter(
   endpoint: string,
@@ -385,10 +419,11 @@ export function handleGetProjects(
   return c.json(projects);
 }
 
-export function handleGetSessions(
+export async function handleGetSessions(
   c: Context,
   scanSource: ScanResultSource,
   defaults: SessionListDefaults = {},
+  resolver?: ProjectIdentityResolver,
 ) {
   const scanResult = scanSource.getSnapshot();
   const params = searchParams(c);
@@ -399,7 +434,7 @@ export function handleGetSessions(
     return c.json({ error: sessionQuery.limit.error }, 400);
   }
   const q = c.req.query("q")?.toLowerCase();
-  const cwd = c.req.query("cwd");
+  const cwd = optionalQueryValue(c.req.query("cwd"));
   const projectIdentity = parseProjectIdentityFilter(
     c.req.query("projectKind"),
     c.req.query("projectKey"),
@@ -412,6 +447,16 @@ export function handleGetSessions(
   if (window.kind === "rejected") return window.response;
   const { from, to } = window;
 
+  let projectScope: ProjectScopeMatcher | undefined;
+  if (cwd && !projectIdentity) {
+    try {
+      projectScope = await resolveProjectScope(cwd, scanResult.sessions, resolver);
+    } catch (error) {
+      reportProjectScopeResolutionFailure("sessions", error);
+      return c.json({ error: "Project scope unavailable" }, 503);
+    }
+  }
+
   if (sessionQuery.agent.kind === "unknown") {
     reportInvalidQueryParameter("sessions", "agent", "empty_result");
   }
@@ -421,7 +466,18 @@ export function handleGetSessions(
   let sessions = getSnapshotAggregation(
     scanSource,
     scanResult.sessions,
-    ["sessions", agentFilter, projectIdentity?.kind, projectIdentity?.key, cwd, tag, from, to],
+    [
+      "sessions",
+      agentFilter,
+      projectIdentity?.kind,
+      projectIdentity?.key,
+      projectScope?.identity.kind,
+      projectScope?.identity.key,
+      projectScope?.path,
+      tag,
+      from,
+      to,
+    ],
     () => {
       let filtered =
         sessionQuery.agent.kind === "all"
@@ -434,8 +490,7 @@ export function handleGetSessions(
         filtered = filtered.filter((session) =>
           matchesProjectIdentity(session.project_identity, projectIdentity),
         );
-      } else if (cwd) {
-        const projectScope = createProjectScopeMatcher(cwd);
+      } else if (projectScope) {
         filtered = filtered.filter((session) => sessionMatchesProjectScope(session, projectScope));
       }
       filtered = filterSessionsByActivityWindow(filtered, from, to);
@@ -558,10 +613,11 @@ function mergeAliasSearchResults(
   ].slice(0, limit);
 }
 
-export function handleSearchSessions(
+export async function handleSearchSessions(
   c: Context,
   scanSource: ScanResultSource,
   defaults: SessionListDefaults = {},
+  resolver?: ProjectIdentityResolver,
 ) {
   const query = c.req.query("q")?.trim() ?? "";
   const scanResult = scanSource.getSnapshot();
@@ -583,7 +639,7 @@ export function handleSearchSessions(
     reportInvalidQueryParameter("search", "agent", "empty_result");
     return c.json({ results: [] });
   }
-  const searchOptions = parseSearchOptions(
+  const searchRequestOptions = parseSearchOptions(
     c,
     window,
     {
@@ -592,19 +648,39 @@ export function handleSearchSessions(
     },
     projectIdentity,
   );
+  const cwd = getSearchProjectDirectory(query, searchRequestOptions);
+  let projectScope: ProjectScopeMatcher | undefined;
+  if (cwd) {
+    try {
+      projectScope = await resolveProjectScope(cwd, scanResult.sessions, resolver);
+    } catch (error) {
+      reportProjectScopeResolutionFailure("search", error);
+      return c.json({ error: "Project scope unavailable" }, 503);
+    }
+  }
+  const { cwd: _cwd, ...searchOptions } = searchRequestOptions;
+  const resolvedSearchOptions = projectScope ? { ...searchOptions, projectScope } : searchOptions;
   const aliases = loadAliasView();
-  const results = executeSessionSearch(query, searchOptions, scanResult).map((result) => ({
+  const results = executeSessionSearch(query, resolvedSearchOptions, scanResult).map((result) => ({
     ...result,
     session: aliases.decorate(result.session, result.reference),
   }));
-  const aliasResults = findAliasSearchResults(query, searchOptions, scanResult, aliases);
-  const mergedResults = mergeAliasSearchResults(results, aliasResults, searchOptions.limit ?? 50);
+  const aliasResults = findAliasSearchResults(query, resolvedSearchOptions, scanResult, aliases);
+  const mergedResults = mergeAliasSearchResults(
+    results,
+    aliasResults,
+    resolvedSearchOptions.limit ?? 50,
+  );
   return c.json({
     results: withParentContext(mergedResults, scanResult.sessions, aliases),
   });
 }
 
-export function handleGetFileActivity(c: Context, defaults: SessionListDefaults = {}) {
+export async function handleGetFileActivity(
+  c: Context,
+  defaults: SessionListDefaults = {},
+  resolver?: ProjectIdentityResolver,
+) {
   const sessionQuery = parseSessionQuery(
     searchParams(c),
     KNOWN_AGENT_NAMES,
@@ -628,6 +704,17 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
     return c.json({ activity: [] });
   }
 
+  const cwd = optionalQueryValue(c.req.query("cwd"));
+  let projectScope: ProjectScopeMatcher | undefined;
+  if (cwd) {
+    try {
+      projectScope = await resolveProjectScope(cwd, [], resolver);
+    } catch (error) {
+      reportProjectScopeResolutionFailure("file-activity", error);
+      return c.json({ error: "Project scope unavailable" }, 503);
+    }
+  }
+
   const aliases = loadAliasView();
   return c.json({
     activity: listFileActivity({
@@ -636,7 +723,7 @@ export function handleGetFileActivity(c: Context, defaults: SessionListDefaults 
       projectKind: projectIdentity?.kind,
       projectKey: projectIdentity?.key,
       project: optionalQueryValue(c.req.query("project")),
-      cwd: optionalQueryValue(c.req.query("cwd")),
+      projectScope,
       path: optionalQueryValue(c.req.query("path")),
       kind: parseFileActivityKind(optionalQueryValue(c.req.query("kind"))),
       from: window.from,

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -10,7 +10,7 @@ import {
   isProjectIdentityKind,
   type FileActivityKind,
   type ProjectIdentityRef,
-  type SearchOptions,
+  type SearchRequestOptions,
 } from "@codesesh/core";
 import type { TimeWindow } from "../time-window-resolution.js";
 
@@ -201,7 +201,7 @@ export function parseSearchOptions(
   window: SessionListDefaults,
   request: { agent?: string; limit: number },
   projectIdentity?: ProjectIdentityRef,
-): SearchOptions {
+): SearchRequestOptions {
   const params = searchParams(c);
   return {
     agent: request.agent,

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -20,6 +20,7 @@ import {
   type SessionListDefaults,
 } from "./handlers.js";
 import type { ScanEventSource } from "../scan-source.js";
+import type { ProjectIdentityResolver } from "../project-identity-resolver.js";
 import { SseEventBuffer } from "./sse-event-buffer.js";
 
 export interface ApiRouteOptions {
@@ -27,6 +28,7 @@ export interface ApiRouteOptions {
   defaultSessionTo?: number;
   defaultSessionDays?: number;
   shutdownSignal?: AbortSignal;
+  projectIdentityResolver?: ProjectIdentityResolver;
 }
 
 function createSseResponse(eventSource: ScanEventSource, signal: AbortSignal): Response {
@@ -114,9 +116,15 @@ export function createApiRoutes(
   }
   api.get("/agents", (c) => handleGetAgents(c, scanSource, listDefaults));
   api.get("/projects", (c) => handleGetProjects(c, scanSource, listDefaults));
-  api.get("/sessions", (c) => handleGetSessions(c, scanSource, listDefaults));
-  api.get("/search", (c) => handleSearchSessions(c, scanSource, listDefaults));
-  api.get("/file-activity", (c) => handleGetFileActivity(c, listDefaults));
+  api.get("/sessions", (c) =>
+    handleGetSessions(c, scanSource, listDefaults, options.projectIdentityResolver),
+  );
+  api.get("/search", (c) =>
+    handleSearchSessions(c, scanSource, listDefaults, options.projectIdentityResolver),
+  );
+  api.get("/file-activity", (c) =>
+    handleGetFileActivity(c, listDefaults, options.projectIdentityResolver),
+  );
   api.get("/sessions/:agent/:id", (c) => handleGetSessionData(c, scanSource));
   api.get("/dashboard", (c) => handleGetDashboard(c, scanSource, listDefaults));
   api.get("/bookmarks", (c) => handleGetBookmarks(c, scanSource));

--- a/packages/cli/src/loopback-write-guard.test.ts
+++ b/packages/cli/src/loopback-write-guard.test.ts
@@ -13,7 +13,7 @@ function evaluate(request: Partial<Parameters<typeof evaluateLoopbackWriteReques
 }
 
 describe("evaluateLoopbackWriteRequest", () => {
-  it.each(["GET", "HEAD", "OPTIONS"])("allows safe %s requests", (method) => {
+  it.each(["GET", "HEAD", "OPTIONS"])("rejects cross-origin safe %s requests", (method) => {
     expect(
       evaluate({
         method,
@@ -21,7 +21,11 @@ describe("evaluateLoopbackWriteRequest", () => {
         fetchSite: "cross-site",
         origin: "https://attacker.example",
       }),
-    ).toEqual({ allowed: true });
+    ).toEqual({ allowed: false, reason: "fetch-site", status: 403 });
+  });
+
+  it.each(["GET", "HEAD", "OPTIONS"])("allows metadata-free safe %s requests", (method) => {
+    expect(evaluate({ method, contentType: "text/plain" })).toEqual({ allowed: true });
   });
 
   it.each(["application/json", "Application/JSON; charset=UTF-8"])(

--- a/packages/cli/src/loopback-write-guard.ts
+++ b/packages/cli/src/loopback-write-guard.ts
@@ -1,7 +1,6 @@
 import type { MiddlewareHandler } from "hono";
 import { appLogger } from "./logging.js";
 
-const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const JSON_BODY_METHODS = new Set(["POST", "PUT", "PATCH"]);
 const ALLOWED_FETCH_SITES = new Set(["same-origin", "none"]);
 
@@ -33,8 +32,6 @@ function isSameOrigin(origin: string, requestOrigin: string): boolean {
 
 export function evaluateLoopbackWriteRequest(request: LoopbackWriteRequest): LoopbackWriteDecision {
   const method = request.method.toUpperCase();
-  if (SAFE_METHODS.has(method)) return { allowed: true };
-
   if (JSON_BODY_METHODS.has(method) && mediaType(request.contentType) !== "application/json") {
     return { allowed: false, reason: "content-type", status: 415 };
   }
@@ -58,7 +55,7 @@ export function loopbackWriteGuard(): MiddlewareHandler {
       requestOrigin: url.origin,
     });
     if (!decision.allowed) {
-      appLogger.warn("http.loopback_write.rejected", {
+      appLogger.warn("http.loopback_request.rejected", {
         method: c.req.method,
         path: url.pathname,
         reason: decision.reason,
@@ -66,7 +63,7 @@ export function loopbackWriteGuard(): MiddlewareHandler {
       const error =
         decision.reason === "content-type"
           ? "Write requests require application/json"
-          : "Cross-origin write request rejected";
+          : "Cross-origin API request rejected";
       return c.json({ error }, decision.status);
     }
     await next();

--- a/packages/cli/src/project-identity-resolver.integration.test.ts
+++ b/packages/cli/src/project-identity-resolver.integration.test.ts
@@ -1,0 +1,56 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { ThreadProjectIdentityResolver } from "./project-identity-resolver.js";
+
+const slowWorkerUrl = new URL("./project-identity-resolver.slow-worker.mjs", import.meta.url);
+
+describe("ThreadProjectIdentityResolver integration", () => {
+  it.skipIf(process.platform === "win32")(
+    "keeps timers responsive while a real worker waits on slow git",
+    async () => {
+      const fixtureDir = mkdtempSync(join(tmpdir(), "codesesh-slow-git-"));
+      const binDir = join(fixtureDir, "bin");
+      const gitPath = join(binDir, "git");
+      const previousPath = process.env.PATH;
+      mkdirSync(binDir);
+      writeFileSync(gitPath, "#!/bin/sh\nsleep 0.15\nexit 1\n");
+      chmodSync(gitPath, 0o755);
+      process.env.PATH = [binDir, previousPath].filter(Boolean).join(delimiter);
+
+      const resolver = new ThreadProjectIdentityResolver(slowWorkerUrl, 1);
+      try {
+        let timerFired = false;
+        let resolutionSettled = false;
+        const pending = resolver.resolve(fixtureDir);
+        void pending.then(
+          () => {
+            resolutionSettled = true;
+          },
+          () => {
+            resolutionSettled = true;
+          },
+        );
+
+        await new Promise<void>((resolve) => {
+          setTimeout(() => {
+            timerFired = true;
+            resolve();
+          }, 20);
+        });
+
+        expect(timerFired).toBe(true);
+        expect(resolutionSettled).toBe(false);
+        await expect(pending).resolves.toMatchObject({
+          identity: { kind: "path", key: fixtureDir },
+        });
+      } finally {
+        await resolver.shutdown();
+        if (previousPath === undefined) delete process.env.PATH;
+        else process.env.PATH = previousPath;
+        rmSync(fixtureDir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/packages/cli/src/project-identity-resolver.slow-worker.mjs
+++ b/packages/cli/src/project-identity-resolver.slow-worker.mjs
@@ -1,0 +1,17 @@
+import { spawnSync } from "node:child_process";
+import { parentPort } from "node:worker_threads";
+
+parentPort?.on("message", (message) => {
+  if (message?.type !== "resolve") return;
+
+  spawnSync("git", ["config", "--get", "remote.origin.url"], { cwd: message.cwd });
+  parentPort?.postMessage({
+    type: "resolved",
+    requestId: message.requestId,
+    projection: {
+      identity: { kind: "path", key: message.cwd, displayName: "slow-fixture" },
+      resolverRevision: "test",
+      inputSignature: "test",
+    },
+  });
+});

--- a/packages/cli/src/project-identity-resolver.test.ts
+++ b/packages/cli/src/project-identity-resolver.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const workerMocks = vi.hoisted(() => {
+  type Handler = (message: unknown) => void;
+
+  class FakeWorker {
+    private readonly handlers = new Map<string, Handler>();
+    readonly postedMessages: unknown[] = [];
+    terminated = false;
+
+    constructor(_url: URL) {
+      workers.push(this);
+    }
+
+    on(event: string, handler: Handler): this {
+      this.handlers.set(event, handler);
+      return this;
+    }
+
+    unref(): void {}
+
+    postMessage(message: unknown): void {
+      this.postedMessages.push(message);
+    }
+
+    async terminate(): Promise<number> {
+      this.terminated = true;
+      return 0;
+    }
+
+    emit(event: string, message: unknown): void {
+      this.handlers.get(event)?.(message);
+    }
+  }
+
+  const workers: FakeWorker[] = [];
+  return { FakeWorker, workers, consumeWorkerMessage: vi.fn(() => false) };
+});
+
+vi.mock("node:worker_threads", () => ({ Worker: workerMocks.FakeWorker }));
+vi.mock("./logging.js", () => ({
+  appLogger: { consumeWorkerMessage: workerMocks.consumeWorkerMessage },
+}));
+
+import { ThreadProjectIdentityResolver } from "./project-identity-resolver.js";
+
+const workerUrl = new URL("./project-identity-worker.js", import.meta.url);
+
+function resolved(requestId: number, cwd: string) {
+  return {
+    type: "resolved" as const,
+    requestId,
+    projection: {
+      identity: { kind: "path" as const, key: cwd, displayName: "project" },
+      resolverRevision: "project-identity-v2",
+      inputSignature: "test",
+    },
+  };
+}
+
+beforeEach(() => {
+  workerMocks.workers.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("ThreadProjectIdentityResolver", () => {
+  it("limits concurrent resolution and dispatches queued work when a slot frees", async () => {
+    const resolver = new ThreadProjectIdentityResolver(workerUrl, 2);
+    const first = resolver.resolve("/one");
+    const second = resolver.resolve("/two");
+    const third = resolver.resolve("/three");
+
+    expect(workerMocks.workers).toHaveLength(2);
+    expect(workerMocks.workers.map((worker) => worker.postedMessages)).toEqual([
+      [{ type: "resolve", requestId: 1, cwd: "/one" }],
+      [{ type: "resolve", requestId: 2, cwd: "/two" }],
+    ]);
+
+    workerMocks.workers[0]!.emit("message", resolved(1, "/one"));
+    await expect(first).resolves.toMatchObject({ identity: { key: "/one" } });
+    expect(workerMocks.workers[0]!.postedMessages).toEqual([
+      { type: "resolve", requestId: 1, cwd: "/one" },
+      { type: "resolve", requestId: 3, cwd: "/three" },
+    ]);
+
+    workerMocks.workers[1]!.emit("message", resolved(2, "/two"));
+    workerMocks.workers[0]!.emit("message", resolved(3, "/three"));
+    await expect(second).resolves.toMatchObject({ identity: { key: "/two" } });
+    await expect(third).resolves.toMatchObject({ identity: { key: "/three" } });
+    await resolver.shutdown();
+  });
+
+  it("leaves the event loop free while a worker resolves", async () => {
+    const resolver = new ThreadProjectIdentityResolver(workerUrl, 1);
+    const pending = resolver.resolve("/slow");
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(workerMocks.workers).toHaveLength(1);
+
+    await resolver.shutdown();
+    await expect(pending).rejects.toThrow("Project identity resolver shut down");
+  });
+});

--- a/packages/cli/src/project-identity-resolver.test.ts
+++ b/packages/cli/src/project-identity-resolver.test.ts
@@ -89,15 +89,4 @@ describe("ThreadProjectIdentityResolver", () => {
     await expect(third).resolves.toMatchObject({ identity: { key: "/three" } });
     await resolver.shutdown();
   });
-
-  it("leaves the event loop free while a worker resolves", async () => {
-    const resolver = new ThreadProjectIdentityResolver(workerUrl, 1);
-    const pending = resolver.resolve("/slow");
-
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    expect(workerMocks.workers).toHaveLength(1);
-
-    await resolver.shutdown();
-    await expect(pending).rejects.toThrow("Project identity resolver shut down");
-  });
 });

--- a/packages/cli/src/project-identity-resolver.ts
+++ b/packages/cli/src/project-identity-resolver.ts
@@ -1,0 +1,164 @@
+import { Worker } from "node:worker_threads";
+import type { ProjectIdentityProjection } from "@codesesh/core";
+import { appLogger } from "./logging.js";
+import type {
+  ProjectIdentityWorkerMessage,
+  ProjectIdentityWorkerRequest,
+} from "./project-identity-worker.js";
+
+export const PROJECT_IDENTITY_RESOLVER_MAX_WORKERS = 2;
+
+const SHUTDOWN_ERROR_MESSAGE = "Project identity resolver shut down";
+
+export interface ProjectIdentityResolver {
+  resolve(cwd: string): Promise<ProjectIdentityProjection>;
+  shutdown(): Promise<void>;
+}
+
+interface PendingRequest {
+  requestId: number;
+  cwd: string;
+  resolve: (projection: ProjectIdentityProjection) => void;
+  reject: (error: Error) => void;
+}
+
+interface WorkerSlot {
+  worker: Worker;
+  pending: PendingRequest | null;
+  closed: boolean;
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function isWorkerMessage(message: unknown): message is ProjectIdentityWorkerMessage {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    ((message.type === "resolved" && "requestId" in message && "projection" in message) ||
+      (message.type === "failed" && "requestId" in message && "error" in message))
+  );
+}
+
+export class ThreadProjectIdentityResolver implements ProjectIdentityResolver {
+  private readonly workers = new Set<WorkerSlot>();
+  private readonly queue: PendingRequest[] = [];
+  private nextRequestId = 1;
+  private isShuttingDown = false;
+
+  constructor(
+    private readonly workerUrl: URL,
+    private readonly maxWorkers = PROJECT_IDENTITY_RESOLVER_MAX_WORKERS,
+  ) {}
+
+  resolve(cwd: string): Promise<ProjectIdentityProjection> {
+    if (this.isShuttingDown) return Promise.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
+
+    return new Promise((resolve, reject) => {
+      this.queue.push({ requestId: this.nextRequestId++, cwd, resolve, reject });
+      this.pump();
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.isShuttingDown) return;
+    this.isShuttingDown = true;
+    const error = new Error(SHUTDOWN_ERROR_MESSAGE);
+    for (const request of this.queue.splice(0)) request.reject(error);
+
+    const workers = [...this.workers];
+    this.workers.clear();
+    for (const slot of workers) {
+      slot.closed = true;
+      slot.pending?.reject(error);
+      slot.pending = null;
+    }
+    await Promise.allSettled(workers.map(({ worker }) => worker.terminate()));
+  }
+
+  private pump(): void {
+    while (!this.isShuttingDown && this.queue.length > 0) {
+      const slot = this.idleWorker() ?? this.createWorker();
+      if (!slot) return;
+      const request = this.queue.shift();
+      if (!request) return;
+      slot.pending = request;
+      try {
+        slot.worker.postMessage({
+          type: "resolve",
+          requestId: request.requestId,
+          cwd: request.cwd,
+        } satisfies ProjectIdentityWorkerRequest);
+      } catch (error) {
+        this.closeWorker(slot, toError(error));
+      }
+    }
+  }
+
+  private idleWorker(): WorkerSlot | null {
+    for (const slot of this.workers) {
+      if (!slot.closed && slot.pending == null) return slot;
+    }
+    return null;
+  }
+
+  private createWorker(): WorkerSlot | null {
+    if (this.workers.size >= this.maxWorkers) return null;
+
+    let worker: Worker;
+    try {
+      worker = new Worker(this.workerUrl);
+    } catch (error) {
+      this.rejectQueued(toError(error));
+      return null;
+    }
+
+    const slot: WorkerSlot = { worker, pending: null, closed: false };
+    this.workers.add(slot);
+    worker.unref();
+    worker.on("message", (message: unknown) => {
+      if (appLogger.consumeWorkerMessage(message)) return;
+      this.handleWorkerMessage(slot, message);
+    });
+    worker.on("error", (error) => this.closeWorker(slot, toError(error)));
+    worker.on("exit", (code) => {
+      if (!slot.closed) {
+        this.closeWorker(slot, new Error(`Project identity worker exited with code ${code}`));
+      }
+    });
+    return slot;
+  }
+
+  private handleWorkerMessage(slot: WorkerSlot, message: unknown): void {
+    if (!isWorkerMessage(message) || slot.closed) return;
+    const request = slot.pending;
+    if (!request || message.requestId !== request.requestId) return;
+
+    slot.pending = null;
+    if (message.type === "resolved") request.resolve(message.projection);
+    else request.reject(new Error(message.error));
+    this.pump();
+  }
+
+  private closeWorker(slot: WorkerSlot, error: Error): void {
+    if (slot.closed) return;
+    slot.closed = true;
+    this.workers.delete(slot);
+    const request = slot.pending;
+    slot.pending = null;
+    request?.reject(error);
+    if (!this.isShuttingDown) this.pump();
+  }
+
+  private rejectQueued(error: Error): void {
+    for (const request of this.queue.splice(0)) request.reject(error);
+  }
+}
+
+export function createProjectIdentityResolver(): ProjectIdentityResolver {
+  return new ThreadProjectIdentityResolver(
+    new URL("./project-identity-worker.js", import.meta.url),
+  );
+}

--- a/packages/cli/src/project-identity-worker.test.ts
+++ b/packages/cli/src/project-identity-worker.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  computeIdentityProjection: vi.fn(),
+  handler: undefined as
+    | ((message: { type: string; requestId: number; cwd: string }) => void)
+    | undefined,
+  postMessage: vi.fn(),
+}));
+
+vi.mock("node:worker_threads", () => ({
+  parentPort: {
+    on: (
+      _event: string,
+      handler: (message: { type: string; requestId: number; cwd: string }) => void,
+    ) => {
+      mocks.handler = handler;
+    },
+    postMessage: mocks.postMessage,
+  },
+  threadId: 17,
+}));
+
+vi.mock("@codesesh/core", () => ({
+  computeIdentityProjection: mocks.computeIdentityProjection,
+  setCoreDiagnostics: vi.fn(),
+}));
+
+vi.mock("./logging.js", () => ({
+  appLogger: { forwardToParent: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+async function runWorker() {
+  await import("./project-identity-worker.js");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.handler = undefined;
+});
+
+describe("project identity worker", () => {
+  it("uses the core projection resolver in the worker", async () => {
+    mocks.computeIdentityProjection.mockReturnValue({
+      identity: { kind: "path", key: "/repo", displayName: "repo" },
+      resolverRevision: "project-identity-v2",
+      inputSignature: "test",
+    });
+    await runWorker();
+
+    mocks.handler?.({ type: "resolve", requestId: 7, cwd: "/repo" });
+
+    expect(mocks.computeIdentityProjection).toHaveBeenCalledWith("/repo");
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      type: "resolved",
+      requestId: 7,
+      projection: expect.objectContaining({
+        identity: expect.objectContaining({ kind: "path", key: "/repo" }),
+      }),
+    });
+  });
+
+  it("returns worker failures without terminating the resolver pool", async () => {
+    mocks.computeIdentityProjection.mockImplementation(() => {
+      throw new Error("git timed out");
+    });
+    await runWorker();
+
+    mocks.handler?.({ type: "resolve", requestId: 8, cwd: "/slow" });
+
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      type: "failed",
+      requestId: 8,
+      error: "git timed out",
+    });
+  });
+});

--- a/packages/cli/src/project-identity-worker.ts
+++ b/packages/cli/src/project-identity-worker.ts
@@ -1,0 +1,41 @@
+import "./diagnostics-bridge.js";
+import { parentPort } from "node:worker_threads";
+import { computeIdentityProjection, type ProjectIdentityProjection } from "@codesesh/core";
+
+export interface ProjectIdentityWorkerRequest {
+  type: "resolve";
+  requestId: number;
+  cwd: string;
+}
+
+export type ProjectIdentityWorkerMessage =
+  | {
+      type: "resolved";
+      requestId: number;
+      projection: ProjectIdentityProjection;
+    }
+  | {
+      type: "failed";
+      requestId: number;
+      error: string;
+    };
+
+function resolveIdentity(request: ProjectIdentityWorkerRequest): void {
+  try {
+    parentPort?.postMessage({
+      type: "resolved",
+      requestId: request.requestId,
+      projection: computeIdentityProjection(request.cwd),
+    } satisfies ProjectIdentityWorkerMessage);
+  } catch (error) {
+    parentPort?.postMessage({
+      type: "failed",
+      requestId: request.requestId,
+      error: error instanceof Error ? error.message : String(error),
+    } satisfies ProjectIdentityWorkerMessage);
+  }
+}
+
+parentPort?.on("message", (message: ProjectIdentityWorkerRequest) => {
+  if (message.type === "resolve") resolveIdentity(message);
+});

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -8,6 +8,7 @@ import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
 import { appLogger } from "./logging.js";
+import type { ProjectIdentityResolver } from "./project-identity-resolver.js";
 import { createServer } from "./server.js";
 import { resolveRemoteTransport } from "./remote-access.js";
 
@@ -228,7 +229,7 @@ describe("createServer", () => {
             Origin: "https://attacker.example",
           })
         ).status,
-      ).toBe(200);
+      ).toBe(403);
 
       for (const path of ["/api/agents", "/api/events", "/app.js"]) {
         expect(
@@ -298,6 +299,45 @@ describe("createServer", () => {
         crossSite: 403,
         sameOrigin: 200,
       });
+    } finally {
+      await app.shutdown();
+    }
+  });
+
+  it("CS-242: blocks cross-site GET before resolving a requested directory", async () => {
+    const resolver: ProjectIdentityResolver = {
+      resolve: vi.fn(async (cwd: string) => ({
+        identity: { kind: "path" as const, key: cwd, displayName: "project" },
+        resolverRevision: "project-identity-v2",
+        inputSignature: "test",
+      })),
+      shutdown: vi.fn(async () => {}),
+    };
+    const app = await createServer(0, createStore(), { projectIdentityResolver: resolver });
+
+    try {
+      expect(
+        (
+          await httpRequest(`${app.url}/api/sessions?cwd=/untrusted`, {
+            "Sec-Fetch-Site": "cross-site",
+          })
+        ).status,
+      ).toBe(403);
+      expect(resolver.resolve).not.toHaveBeenCalled();
+
+      expect(
+        (
+          await httpRequest(`${app.url}/api/sessions?cwd=/untrusted`, {
+            Origin: "https://attacker.example",
+          })
+        ).status,
+      ).toBe(403);
+      expect(resolver.resolve).not.toHaveBeenCalled();
+
+      expect(
+        (await httpRequest(`${app.url}/api/sessions?cwd=/untrusted`, { Origin: app.url })).status,
+      ).toBe(200);
+      expect(resolver.resolve).toHaveBeenCalledWith("/untrusted");
     } finally {
       await app.shutdown();
     }

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -13,6 +13,10 @@ import { fileURLToPath } from "node:url";
 import type { ScanResultSource } from "./api/handlers.js";
 import { createApiRoutes, type ApiRouteOptions } from "./api/routes.js";
 import { appLogger } from "./logging.js";
+import {
+  createProjectIdentityResolver,
+  type ProjectIdentityResolver,
+} from "./project-identity-resolver.js";
 import { validateLoopbackAuthority } from "./loopback-authority.js";
 import { loopbackWriteGuard } from "./loopback-write-guard.js";
 import {
@@ -41,6 +45,7 @@ export interface CreateServerOptions {
   transport?: RemoteTransport;
   /** Overrides the auto-detected web build directory; used to pin the static root in tests. */
   webDistPath?: string;
+  projectIdentityResolver?: ProjectIdentityResolver;
 }
 
 function findWebDistPath(): string | null {
@@ -139,6 +144,8 @@ export async function createServer(
     : null;
   const loopbackAuthorityEnabled = !accessPolicy.authenticationRequired;
   const shutdownController = new AbortController();
+  const projectIdentityResolver =
+    options.projectIdentityResolver ?? createProjectIdentityResolver();
   let actualPort: number | null = null;
 
   appLogger.info("server.access_policy", {
@@ -248,6 +255,7 @@ export async function createServer(
     defaultSessionTo: options.defaultSessionTo,
     defaultSessionDays: options.defaultSessionDays,
     shutdownSignal: shutdownController.signal,
+    projectIdentityResolver,
   };
   app.route("/api", createApiRoutes(store, store, routeOptions));
 
@@ -350,8 +358,12 @@ export async function createServer(
         appLogger.info("server.shutdown.phase", { phase: "http-closing", port: actualPort });
         await closeHttpServer(server, actualPort);
       } finally {
-        appLogger.info("server.shutdown.phase", { phase: "store-closing", port: actualPort });
-        await store.shutdown();
+        try {
+          await projectIdentityResolver.shutdown();
+        } finally {
+          appLogger.info("server.shutdown.phase", { phase: "store-closing", port: actualPort });
+          await store.shutdown();
+        }
       }
       appLogger.info("server.shutdown.phase", { phase: "complete", port: actualPort });
     },

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -6,6 +6,7 @@ const bundleCore = process.env.BUNDLE_CORE === "true";
 export default defineConfig({
   entry: [
     "src/index.ts",
+    "src/project-identity-worker.ts",
     "src/search-index-worker.ts",
     "src/scan-refresh-worker.ts",
     "src/smart-tag-worker.ts",

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -79,6 +79,11 @@ describe("session cache integration", () => {
       slug: "codex/old",
       title: "Old session",
       directory: "/workspace/project",
+      project_identity: {
+        kind: "path",
+        key: "/workspace/project",
+        displayName: "project",
+      },
       time_created: 1,
       time_updated: 1,
       stats: {

--- a/packages/core/src/discovery/cache/__tests__/file-activity.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/file-activity.test.ts
@@ -52,6 +52,23 @@ describe("cached file activity", () => {
     ]);
   });
 
+  it("normalizes Windows scope paths before SQL matching", () => {
+    const result = buildFileActivityWhere({
+      projectScope: {
+        identity: { kind: "path", key: "C:/workspace/app" },
+        path: "C:\\workspace\\app",
+      },
+    });
+
+    expect(result.params).toEqual([
+      "path",
+      "C:/workspace/app",
+      "c:/workspace/app",
+      "c:/workspace/app",
+      "c:/workspace/app",
+    ]);
+  });
+
   it("maps rows and highlights paths case-insensitively", () => {
     expect(
       fileActivityFromRow({

--- a/packages/core/src/discovery/cache/__tests__/file-activity.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/file-activity.test.ts
@@ -32,6 +32,26 @@ describe("cached file activity", () => {
     ]);
   });
 
+  it("uses the resolved scope for identity and symmetric directory matching", () => {
+    const result = buildFileActivityWhere({
+      projectScope: {
+        identity: { kind: "git_remote", key: "github.com/acme/app" },
+        path: "/workspace/app/packages/web",
+      },
+    });
+
+    expect(result.where).toContain("s.project_identity_kind = ? AND s.project_identity_key = ?");
+    expect(result.where).toContain("REPLACE(LOWER(s.directory), char(92), '/')");
+    expect(result.where).toContain("instr(?, REPLACE(LOWER(s.directory), char(92), '/') || '/')");
+    expect(result.params).toEqual([
+      "git_remote",
+      "github.com/acme/app",
+      "/workspace/app/packages/web",
+      "/workspace/app/packages/web",
+      "/workspace/app/packages/web",
+    ]);
+  });
+
   it("maps rows and highlights paths case-insensitively", () => {
     expect(
       fileActivityFromRow({

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -56,6 +56,11 @@ function makeSession(id: string): SessionHead & Pick<SessionDetail, "reference">
     slug: `agent/${id}`,
     title: `Session ${id}`,
     directory: FIXTURE_DIR,
+    project_identity: {
+      kind: "path",
+      key: FIXTURE_DIR,
+      displayName: FIXTURE_DIR.split(/[\\/]/).pop()!,
+    },
     time_created: now,
     time_updated: now,
     stats: {
@@ -1205,10 +1210,73 @@ describe("searchSessions", () => {
     const allResults = searchSessions("needle");
     expect(allResults).toHaveLength(2);
 
-    const filteredResults = searchSessions("needle", { cwd: "/tmp/bulk-project" });
+    const filteredResults = searchSessions("needle", {
+      projectScope: {
+        identity: { kind: "path", key: "/tmp/bulk-project" },
+        path: "/tmp/bulk-project",
+      },
+    });
     expect(filteredResults).toHaveLength(1);
     expect(filteredResults[0]?.session.id).toBe("bulk-42");
     expect(highlightedText(filteredResults[0])).toContain("needle");
+  });
+
+  it("keeps ancestor and descendant directory scope matches when identities differ", () => {
+    const scopeRoot = "/tmp/codesesh-scope";
+    const sessions = [
+      {
+        ...makeSession("scope-ancestor"),
+        directory: scopeRoot,
+        project_identity: {
+          kind: "path" as const,
+          key: "/tmp/unrelated-ancestor",
+          displayName: "unrelated-ancestor",
+        },
+      },
+      {
+        ...makeSession("scope-descendant"),
+        directory: `${scopeRoot}/child`,
+        project_identity: {
+          kind: "path" as const,
+          key: "/tmp/unrelated-descendant",
+          displayName: "unrelated-descendant",
+        },
+      },
+      {
+        ...makeSession("scope-sibling"),
+        directory: `${scopeRoot}-sibling`,
+        project_identity: {
+          kind: "path" as const,
+          key: "/tmp/unrelated-sibling",
+          displayName: "unrelated-sibling",
+        },
+      },
+    ];
+    const sessionById = new Map(sessions.map((session) => [session.id, session]));
+
+    saveCachedSessions("claudecode", sessions);
+    syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
+      ...sessionById.get(sessionId)!,
+      messages: [
+        {
+          id: `${sessionId}-m1`,
+          role: "user",
+          time_created: now,
+          parts: [{ type: "text", text: "symmetric scope needle" }],
+        },
+      ],
+    }));
+
+    expect(
+      searchSessions("symmetric scope needle", {
+        projectScope: {
+          identity: { kind: "path", key: "/tmp/no-identity-match" },
+          path: `${scopeRoot}/child`,
+        },
+      })
+        .map(({ session }) => session.id)
+        .sort(),
+    ).toEqual(["scope-ancestor", "scope-descendant"]);
   });
 
   it("writes each full search entry before loading the next one", () => {
@@ -1815,7 +1883,10 @@ describe("searchSessions", () => {
         sessionId: "files",
         projectKind: "git_remote",
         projectKey: "github.com/acme/app",
-        cwd: FIXTURE_DIR,
+        projectScope: {
+          identity: { kind: "path", key: FIXTURE_DIR },
+          path: FIXTURE_DIR,
+        },
         path: "src/App",
         kind: "edit",
         from: now + 9,

--- a/packages/core/src/discovery/cache/__tests__/search.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildSessionSearchFilters,
   mergeSearchLists,
   mergeSearchQueryOptions,
   sessionHeadFromSearchRow,
@@ -8,6 +9,23 @@ import {
 import { makeSessionHead } from "./fixtures.js";
 
 describe("cache search", () => {
+  it("normalizes Windows scope paths before SQL matching", () => {
+    const result = buildSessionSearchFilters({
+      projectScope: {
+        identity: { kind: "path", key: "C:/workspace/app" },
+        path: "C:\\workspace\\app",
+      },
+    });
+
+    expect(result.params).toEqual([
+      "path",
+      "C:/workspace/app",
+      "c:/workspace/app",
+      "c:/workspace/app",
+      "c:/workspace/app",
+    ]);
+  });
+
   it("merges query qualifiers without overriding explicit options", () => {
     const merged = mergeSearchQueryOptions("agent:codex tag:bugfix needle", {
       agent: "claudecode",

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
@@ -22,6 +30,8 @@ import {
 import { listCachedProjectGroups } from "../project-groups.js";
 import type { SessionCacheMeta } from "../../../agents/base.js";
 import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
+import { clearIdentityCache } from "../../../projects/identity.js";
+import { realFs } from "../../../projects/fs.js";
 import { withCacheDb, withSearchIndexDb } from "../schema.js";
 import { getSchemaEnsuredPath, setSchemaEnsuredPath } from "../db.js";
 import type { SessionHead } from "../../../types/index.js";
@@ -62,6 +72,11 @@ function makeSession(id: string): SessionHead {
     slug: `agent/${id}`,
     title: `Session ${id}`,
     directory: FIXTURE_DIR,
+    project_identity: {
+      kind: "path",
+      key: FIXTURE_DIR,
+      displayName: FIXTURE_DIR_NAME,
+    },
     time_created: now,
     time_updated: now,
     stats: {
@@ -179,6 +194,19 @@ describe("loadCachedSessions", () => {
       meta: {},
       timestamp: now,
     });
+  });
+});
+
+describe("session identity persistence invariant", () => {
+  it("fails before opening the cache when a session identity is missing", () => {
+    const spawnSpy = vi.spyOn(realFs, "spawn");
+    const session = { ...makeSession("missing-identity"), project_identity: undefined };
+
+    expect(() => saveCachedSessions("claudecode", [session])).toThrow(
+      "Session claudecode/missing-identity is missing project_identity",
+    );
+    expect(spawnSpy).not.toHaveBeenCalled();
+    expect(existsSync(getCachePath())).toBe(false);
   });
 });
 
@@ -502,6 +530,37 @@ describe("saveCachedSessions", () => {
         lastActivity: now,
       },
     ]);
+  });
+
+  it("resolves legacy identities before schema migrations begin", () => {
+    clearIdentityCache();
+    createLegacyCachedSessionDb(3, {
+      ...makeSession("legacy-without-identity"),
+      project_identity: undefined,
+    });
+    const events: string[] = [];
+    const originalExists = realFs.exists.bind(realFs);
+    const existsSpy = vi.spyOn(realFs, "exists").mockImplementation((path) => {
+      events.push("identity");
+      return originalExists(path);
+    });
+    setCoreDiagnostics({
+      info(event) {
+        if (event === "sqlite.migration.started") events.push("migration");
+      },
+      warn() {},
+    });
+
+    try {
+      expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
+        "legacy-without-identity",
+      ]);
+      expect(events.indexOf("identity")).toBeGreaterThanOrEqual(0);
+      expect(events.indexOf("identity")).toBeLessThan(events.indexOf("migration"));
+    } finally {
+      existsSpy.mockRestore();
+      clearIdentityCache();
+    }
   });
 
   it("backs up populated cache before destructive migration", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -563,6 +563,32 @@ describe("saveCachedSessions", () => {
     }
   });
 
+  it("skips a malformed legacy session without aborting migration", () => {
+    createLegacyCachedSessionDb(3, {
+      ...makeSession("legacy-null-directory"),
+      directory: null as never,
+      project_identity: undefined,
+    });
+    const warnings: Array<{ event: string; detail: unknown }> = [];
+    setCoreDiagnostics({
+      info() {},
+      warn(event, detail) {
+        warnings.push({ event, detail });
+      },
+    });
+
+    try {
+      expect(loadCachedSessions("claudecode")?.sessions).toEqual([]);
+      expect(getUserVersion(getCachePath())).toBe(24);
+      expect(warnings).toContainEqual({
+        event: "sqlite.migration.identity_precompute.missing_directory",
+        detail: { agent_name: "claudecode", session_id: "legacy-null-directory" },
+      });
+    } finally {
+      setCoreDiagnostics(null);
+    }
+  });
+
   it("backs up populated cache before destructive migration", () => {
     createLegacyCachedSessionDb(2);
 

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -8,7 +8,7 @@ import type {
   SessionFileActivity,
 } from "../../types/index.js";
 import type { FileActivityResult, SearchHighlightRange } from "../../contract/index.js";
-import type { ProjectScopeMatcher } from "../../projects/scope.js";
+import { normalizeProjectScopePath, type ProjectScopeMatcher } from "../../projects/scope.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { filePathFtsQuery, hasCacheStorage, likePattern, normalizeFilePathSearch } from "./db.js";
 import { withCacheDb, withCacheDbReadOnly } from "./schema.js";
@@ -63,7 +63,7 @@ export function fileActivityFilters(options: FileActivityOptions): {
     projectLike: options.project ? likePattern(options.project) : null,
     scopeKind: scope?.identity.kind ?? null,
     scopeKey: scope?.identity.key ?? null,
-    scopePath: scope?.path.toLowerCase() ?? null,
+    scopePath: scope ? normalizeProjectScopePath(scope.path).toLowerCase() : null,
     path,
     pathLike: path ? likePattern(path) : null,
   };

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -8,7 +8,7 @@ import type {
   SessionFileActivity,
 } from "../../types/index.js";
 import type { FileActivityResult, SearchHighlightRange } from "../../contract/index.js";
-import { computeIdentity, realFs } from "../../projects/index.js";
+import type { ProjectScopeMatcher } from "../../projects/scope.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { filePathFtsQuery, hasCacheStorage, likePattern, normalizeFilePathSearch } from "./db.js";
 import { withCacheDb, withCacheDbReadOnly } from "./schema.js";
@@ -37,7 +37,7 @@ export interface FileActivityOptions {
   projectKind?: ProjectIdentityKind;
   projectKey?: string;
   project?: string;
-  cwd?: string;
+  projectScope?: ProjectScopeMatcher;
   path?: string;
   kind?: FileActivityKind;
   from?: number;
@@ -49,21 +49,21 @@ export function fileActivityFilters(options: FileActivityOptions): {
   projectKind: ProjectIdentityKind | null;
   projectKey: string | null;
   projectLike: string | null;
-  cwdKind: ProjectIdentityKind | null;
-  cwdKey: string | null;
-  cwdLike: string | null;
+  scopeKind: ProjectIdentityKind | null;
+  scopeKey: string | null;
+  scopePath: string | null;
   path: string;
   pathLike: string | null;
 } {
   const path = options.path ? normalizeFilePathSearch(options.path) : "";
-  const cwdIdentity = options.cwd ? computeIdentity(options.cwd, realFs) : null;
+  const scope = options.projectScope;
   return {
     projectKind: options.projectKind ?? null,
     projectKey: options.projectKey ?? null,
     projectLike: options.project ? likePattern(options.project) : null,
-    cwdKind: cwdIdentity?.kind ?? null,
-    cwdKey: cwdIdentity?.key ?? null,
-    cwdLike: options.cwd ? likePattern(options.cwd) : null,
+    scopeKind: scope?.identity.kind ?? null,
+    scopeKey: scope?.identity.key ?? null,
+    scopePath: scope?.path.toLowerCase() ?? null,
     path,
     pathLike: path ? likePattern(path) : null,
   };
@@ -113,11 +113,18 @@ export function buildFileActivityWhere(options: FileActivityOptions): {
     );
     params.push(filters.projectLike, filters.projectLike, filters.projectLike);
   }
-  if (filters.cwdKey != null) {
+  if (filters.scopeKey != null && filters.scopePath != null) {
+    const normalizedDirectory = "REPLACE(LOWER(s.directory), char(92), '/')";
     clauses.push(
-      "((s.project_identity_kind = ? AND s.project_identity_key = ?) OR LOWER(s.directory) LIKE ? ESCAPE '\\')",
+      `((s.project_identity_kind = ? AND s.project_identity_key = ?) OR ${normalizedDirectory} = ? OR instr(${normalizedDirectory}, ? || '/') = 1 OR instr(?, ${normalizedDirectory} || '/') = 1)`,
     );
-    params.push(filters.cwdKind, filters.cwdKey, filters.cwdLike);
+    params.push(
+      filters.scopeKind,
+      filters.scopeKey,
+      filters.scopePath,
+      filters.scopePath,
+      filters.scopePath,
+    );
   }
   if (filters.pathLike != null) {
     const pathQuery = filePathFtsQuery(filters.path);

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -6,6 +6,7 @@ import type { SessionCacheMeta } from "../../agents/base.js";
 import type {
   Message,
   MessagePart,
+  ProjectIdentity,
   ProjectIdentityKind,
   SessionDetail,
   SessionFileActivity,
@@ -13,7 +14,6 @@ import type {
   ToolPart,
 } from "../../types/index.js";
 import { normalizeMessageParts } from "../../contract/message-part.js";
-import { computeIdentity, realFs } from "../../projects/index.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import type { SQLiteStatement } from "./db.js";
 
@@ -110,6 +110,21 @@ export function sourcePathFromMetaJson(metaJson: string | null | undefined): str
   if (!metaJson) return null;
   const meta = JSON.parse(metaJson) as SessionCacheMeta;
   return sourcePathFromMeta(meta);
+}
+
+export function requireSessionProjectIdentity(
+  agentName: string,
+  session: SessionHead,
+): ProjectIdentity {
+  if (session.project_identity) return session.project_identity;
+  throw new Error(`Session ${agentName}/${session.id} is missing project_identity`);
+}
+
+export function assertSessionProjectIdentities(
+  agentName: string,
+  sessions: Iterable<SessionHead>,
+): void {
+  for (const session of sessions) requireSessionProjectIdentity(agentName, session);
 }
 
 export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
@@ -261,7 +276,7 @@ export function upsertSessionRow(
   sortIndex: number,
   sourcePath: string | null,
 ): void {
-  const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
+  const identity = requireSessionProjectIdentity(agentName, session);
   const activityTime = session.time_updated ?? session.time_created;
   statement.run(
     agentName,

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -4,6 +4,7 @@ import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { SessionHeadChange } from "./db.js";
 import { sessionDetailVersion } from "./detail-version.js";
+import { assertSessionProjectIdentities } from "./messages.js";
 import {
   prepareSessionChangesSearchIndex,
   prepareSessionSnapshotSearchIndex,
@@ -86,6 +87,12 @@ export function commitDurableSessionPublication(
   loadSessionData: (sessionId: string) => SessionDetail,
   searchOptions: SearchIndexSyncOptions = {},
 ): DurableSessionPublicationCommitResult {
+  assertSessionProjectIdentities(
+    publication.agentName,
+    publication.kind === "snapshot"
+      ? publication.sessions
+      : publication.changes.map(({ session }) => session),
+  );
   const publicationId = publication.publicationId ?? randomUUID();
   let failureStage: DurableSessionPublicationFailureStage = "prepare";
   const diagnostics = getCoreDiagnostics();

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -2,7 +2,7 @@
  * Cache storage boundary. Callers request a ready database capability while
  * schema creation, migrations, and search-index maintenance stay internal.
  */
-import type { ProjectIdentityKind, SessionHead } from "../../types/index.js";
+import type { ProjectIdentity, ProjectIdentityKind, SessionHead } from "../../types/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
@@ -79,6 +79,58 @@ interface ProjectIdentityRefreshRow extends DatabaseRow {
   agent_name?: string;
   session_id?: string;
   directory?: string;
+}
+
+type LegacyProjectIdentityResolver = (directory: string) => ProjectIdentity;
+
+// Schema migrations hold an immediate SQLite transaction, so identity discovery
+// must complete before the migration runner starts one.
+function prepareLegacyProjectIdentityResolver(
+  db: SQLiteDatabase,
+  currentVersion: number,
+): LegacyProjectIdentityResolver {
+  const directories = new Set<string>();
+
+  if (currentVersion < 7 && tableExists(db, "cached_sessions")) {
+    const rows = db
+      .prepare("SELECT session_json FROM cached_sessions")
+      .all() as ProjectBackfillSessionRow[];
+    for (const row of rows) {
+      if (!row.session_json) continue;
+      try {
+        const session = JSON.parse(row.session_json) as SessionHead;
+        if (session.directory != null) directories.add(String(session.directory));
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  if (currentVersion < 12) {
+    for (const table of ["session_documents", "sessions", "project_sessions"]) {
+      if (!tableExists(db, table) || !columnExists(db, table, "directory")) continue;
+      const rows = db.prepare(`SELECT directory FROM ${table}`).all() as Array<{
+        directory?: unknown;
+      }>;
+      for (const row of rows) directories.add(String(row.directory ?? ""));
+    }
+  }
+
+  const identities = new Map<string, ProjectIdentity | Error>();
+  for (const directory of directories) {
+    try {
+      identities.set(directory, computeIdentity(directory, realFs));
+    } catch (error) {
+      identities.set(directory, error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  return (directory) => {
+    const identity = identities.get(directory);
+    if (identity instanceof Error) throw identity;
+    if (identity) return identity;
+    throw new Error(`Missing precomputed project identity for legacy directory: ${directory}`);
+  };
 }
 
 function withCacheConnection<T>(fn: (connection: CacheConnection) => T): T | null {
@@ -706,7 +758,10 @@ function hasAnyCacheSchema(db: SQLiteDatabase): boolean {
   ].some((table) => tableExists(db, table));
 }
 
-function backfillProjectSessions(db: SQLiteDatabase): void {
+function backfillProjectSessions(
+  db: SQLiteDatabase,
+  resolveIdentity: LegacyProjectIdentityResolver,
+): void {
   if (!tableExists(db, "cached_sessions") || !tableExists(db, "project_sessions")) {
     return;
   }
@@ -739,7 +794,7 @@ function backfillProjectSessions(db: SQLiteDatabase): void {
 
     try {
       const session = JSON.parse(row.session_json) as SessionHead;
-      const identity = session.project_identity ?? computeIdentity(session.directory, realFs);
+      const identity = session.project_identity ?? resolveIdentity(session.directory);
       upsert.run(
         row.agent_name,
         row.session_id,
@@ -755,7 +810,10 @@ function backfillProjectSessions(db: SQLiteDatabase): void {
   }
 }
 
-function backfillSessionDocumentProjects(db: SQLiteDatabase): void {
+function backfillSessionDocumentProjects(
+  db: SQLiteDatabase,
+  resolveIdentity: LegacyProjectIdentityResolver,
+): void {
   if (
     !tableExists(db, "session_documents") ||
     !columnExists(db, "session_documents", "project_identity_key")
@@ -776,19 +834,25 @@ function backfillSessionDocumentProjects(db: SQLiteDatabase): void {
   `);
 
   for (const row of rows) {
-    const identity = computeIdentity(String(row.directory ?? ""), realFs);
+    const identity = resolveIdentity(String(row.directory ?? ""));
     update.run(identity.kind, identity.key, identity.displayName, Number(row.id));
   }
 }
 
-function migrateProjectIdentity(db: SQLiteDatabase): void {
+function migrateProjectIdentity(
+  db: SQLiteDatabase,
+  resolveIdentity: LegacyProjectIdentityResolver,
+): void {
   ensureLegacySessionDocumentColumns(db);
   createProjectTables(db);
-  backfillProjectSessions(db);
-  backfillSessionDocumentProjects(db);
+  backfillProjectSessions(db, resolveIdentity);
+  backfillSessionDocumentProjects(db, resolveIdentity);
 }
 
-function refreshProjectIdentities(db: SQLiteDatabase): void {
+function refreshProjectIdentities(
+  db: SQLiteDatabase,
+  resolveIdentity: LegacyProjectIdentityResolver,
+): void {
   if (
     tableExists(db, "sessions") &&
     columnExists(db, "sessions", "project_identity_key") &&
@@ -816,7 +880,7 @@ function refreshProjectIdentities(db: SQLiteDatabase): void {
         : null;
 
     for (const row of rows) {
-      const identity = computeIdentity(String(row.directory ?? ""), realFs);
+      const identity = resolveIdentity(String(row.directory ?? ""));
       update.run(identity.kind, identity.key, identity.displayName, row.agent_name, row.session_id);
       updateFileActivity?.run(identity.key, row.agent_name, row.session_id);
     }
@@ -840,16 +904,19 @@ function refreshProjectIdentities(db: SQLiteDatabase): void {
     `);
 
     for (const row of rows) {
-      const identity = computeIdentity(String(row.directory ?? ""), realFs);
+      const identity = resolveIdentity(String(row.directory ?? ""));
       update.run(identity.kind, identity.key, identity.displayName, row.agent_name, row.session_id);
     }
   }
 
-  backfillSessionDocumentProjects(db);
+  backfillSessionDocumentProjects(db, resolveIdentity);
   recreateProjectGroupsView(db);
 }
 
-function backfillStructuredSessions(db: SQLiteDatabase): void {
+function backfillStructuredSessions(
+  db: SQLiteDatabase,
+  resolveIdentity: LegacyProjectIdentityResolver,
+): void {
   createSessionTables(db);
   recreateProjectGroupsView(db);
   const upsertSession = prepareUpsertSession(db);
@@ -867,7 +934,11 @@ function backfillStructuredSessions(db: SQLiteDatabase): void {
       }
 
       try {
-        const session = JSON.parse(row.session_json) as SessionHead;
+        const parsed = JSON.parse(row.session_json) as SessionHead;
+        const session =
+          parsed.project_identity == null
+            ? { ...parsed, project_identity: resolveIdentity(parsed.directory) }
+            : parsed;
         upsertSessionRow(
           upsertSession,
           String(row.agent_name),
@@ -919,7 +990,7 @@ function backfillStructuredSessions(db: SQLiteDatabase): void {
             key: String(row.project_identity_key),
             displayName: String(row.project_display_name),
           }
-        : computeIdentity(directory, realFs);
+        : resolveIdentity(directory);
 
     upsertSessionRow(
       upsertSession,
@@ -1320,6 +1391,8 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
     return;
   }
 
+  const resolveLegacyProjectIdentity = prepareLegacyProjectIdentityResolver(db, currentVersion);
+
   runSchemaMigrations(db, {
     dbPath,
     currentVersion,
@@ -1339,7 +1412,10 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
     migrations: [
       { version: 3, migrate: createCacheTables },
       { version: 4, migrate: createSearchTables },
-      { version: 5, migrate: migrateProjectIdentity },
+      {
+        version: 5,
+        migrate: (migrationDb) => migrateProjectIdentity(migrationDb, resolveLegacyProjectIdentity),
+      },
       {
         version: 6,
         destructive: true,
@@ -1353,7 +1429,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
         version: 7,
         migrate(db) {
           addSessionParentReference(db);
-          backfillStructuredSessions(db);
+          backfillStructuredSessions(db, resolveLegacyProjectIdentity);
         },
       },
       { version: 8, migrate: backfillFileActivity },
@@ -1373,7 +1449,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       {
         version: 12,
         migrate(db) {
-          refreshProjectIdentities(db);
+          refreshProjectIdentities(db, resolveLegacyProjectIdentity);
         },
       },
       { version: 13, migrate: createCacheTables },

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -93,13 +93,20 @@ function prepareLegacyProjectIdentityResolver(
 
   if (currentVersion < 7 && tableExists(db, "cached_sessions")) {
     const rows = db
-      .prepare("SELECT session_json FROM cached_sessions")
+      .prepare("SELECT agent_name, session_id, session_json FROM cached_sessions")
       .all() as ProjectBackfillSessionRow[];
     for (const row of rows) {
       if (!row.session_json) continue;
       try {
         const session = JSON.parse(row.session_json) as SessionHead;
-        if (session.directory != null) directories.add(String(session.directory));
+        if (session.directory != null) {
+          directories.add(String(session.directory));
+        } else {
+          getCoreDiagnostics()?.warn("sqlite.migration.identity_precompute.missing_directory", {
+            agent_name: row.agent_name,
+            session_id: row.session_id,
+          });
+        }
       } catch {
         continue;
       }
@@ -131,6 +138,10 @@ function prepareLegacyProjectIdentityResolver(
     if (identity) return identity;
     throw new Error(`Missing precomputed project identity for legacy directory: ${directory}`);
   };
+}
+
+function getLegacySessionDirectory(session: SessionHead): string | null {
+  return typeof session.directory === "string" ? session.directory : null;
 }
 
 function withCacheConnection<T>(fn: (connection: CacheConnection) => T): T | null {
@@ -794,14 +805,16 @@ function backfillProjectSessions(
 
     try {
       const session = JSON.parse(row.session_json) as SessionHead;
-      const identity = session.project_identity ?? resolveIdentity(session.directory);
+      const directory = getLegacySessionDirectory(session);
+      if (directory == null) continue;
+      const identity = session.project_identity ?? resolveIdentity(directory);
       upsert.run(
         row.agent_name,
         row.session_id,
         identity.kind,
         identity.key,
         identity.displayName,
-        session.directory,
+        directory,
         session.time_updated ?? session.time_created,
       );
     } catch {
@@ -935,9 +948,11 @@ function backfillStructuredSessions(
 
       try {
         const parsed = JSON.parse(row.session_json) as SessionHead;
+        const directory = getLegacySessionDirectory(parsed);
+        if (directory == null) continue;
         const session =
           parsed.project_identity == null
-            ? { ...parsed, project_identity: resolveIdentity(parsed.directory) }
+            ? { ...parsed, project_identity: resolveIdentity(directory) }
             : parsed;
         upsertSessionRow(
           upsertSession,

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -1,6 +1,5 @@
 import type { SessionCacheMeta } from "../../agents/base.js";
 import type { SessionDetail, SessionFileActivity, SessionHead } from "../../types/index.js";
-import { computeIdentity, realFs } from "../../projects/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
@@ -12,6 +11,8 @@ import {
   prepareInsertFileActivity,
   prepareInsertMessageTool,
   prepareUpsertIndexedSession,
+  assertSessionProjectIdentities,
+  requireSessionProjectIdentity,
   upsertSessionRow,
   writeFileActivityRows,
   type StructuredMessageRecord,
@@ -415,10 +416,7 @@ function loadSearchIndexEntry(
   try {
     const data = loadSessionData(change.session.id);
     const messages = normalizeMessages(data);
-    const identity =
-      change.session.project_identity ??
-      data.project_identity ??
-      computeIdentity(change.session.directory, realFs);
+    const identity = requireSessionProjectIdentity(agentName, change.session);
     return {
       session: change.session,
       messages,
@@ -974,6 +972,7 @@ export function syncSessionSearchIndex(
   loadSessionData: (sessionId: string) => SessionDetail,
   options: SearchIndexSyncOptions = {},
 ): SearchIndexSyncResult | null {
+  assertSessionProjectIdentities(agentName, sessions);
   return withSearchIndexDb((db) =>
     executeSearchIndexPlan(
       db,
@@ -1003,6 +1002,11 @@ export function syncSessionSearchIndexChanges(
       durationMs: 0,
     };
   }
+
+  assertSessionProjectIdentities(
+    agentName,
+    changes.map(({ session }) => session),
+  );
 
   return withSearchIndexDb((db) =>
     executeSearchIndexPlan(

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -9,7 +9,7 @@ import type {
   SmartTag,
 } from "../../types/index.js";
 import type { SearchHighlightRange, SearchMatchType, SearchResult } from "../../contract/index.js";
-import type { ProjectScopeMatcher } from "../../projects/scope.js";
+import { normalizeProjectScopePath, type ProjectScopeMatcher } from "../../projects/scope.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { escapeRegExp, filePathFtsQuery, hasCacheStorage, likePattern } from "./db.js";
 import { normalizeToolName, sessionFromRow, type SessionRow } from "./messages.js";
@@ -176,7 +176,7 @@ export function buildSessionSearchFilters(options: SearchOptions): {
     }
   }
   if (options.projectScope) {
-    const scopePath = options.projectScope.path.toLowerCase();
+    const scopePath = normalizeProjectScopePath(options.projectScope.path).toLowerCase();
     const normalizedDirectory = "REPLACE(LOWER(s.directory), char(92), '/')";
     clauses.push(
       `((s.project_identity_kind = ? AND s.project_identity_key = ?) OR ${normalizedDirectory} = ? OR instr(${normalizedDirectory}, ? || '/') = 1 OR instr(?, ${normalizedDirectory} || '/') = 1)`,

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -9,7 +9,7 @@ import type {
   SmartTag,
 } from "../../types/index.js";
 import type { SearchHighlightRange, SearchMatchType, SearchResult } from "../../contract/index.js";
-import { computeIdentity, realFs } from "../../projects/index.js";
+import type { ProjectScopeMatcher } from "../../projects/scope.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { escapeRegExp, filePathFtsQuery, hasCacheStorage, likePattern } from "./db.js";
 import { normalizeToolName, sessionFromRow, type SessionRow } from "./messages.js";
@@ -67,7 +67,7 @@ export interface SearchOptions {
   project?: string;
   projectKind?: ProjectIdentityKind;
   projectKey?: string;
-  cwd?: string;
+  projectScope?: ProjectScopeMatcher;
   tags?: SmartTag[];
   tools?: string[];
   file?: string;
@@ -79,6 +79,10 @@ export interface SearchOptions {
   from?: number;
   to?: number;
   limit?: number;
+}
+
+export interface SearchRequestOptions extends SearchOptions {
+  cwd?: string;
 }
 
 export {
@@ -114,7 +118,6 @@ export function mergeSearchQueryOptions(query: string, options: SearchOptions) {
       project: options.project ?? parsed.filters.project,
       projectKind: options.projectKind ?? parsed.filters.projectKind,
       projectKey: options.projectKey ?? parsed.filters.projectKey,
-      cwd: options.cwd ?? parsed.filters.cwd,
       tags: mergeSearchLists(options.tags, parsed.filters.tags),
       tools: mergeSearchLists(options.tools, parsed.filters.tools),
       file: options.file ?? parsed.filters.file,
@@ -126,6 +129,13 @@ export function mergeSearchQueryOptions(query: string, options: SearchOptions) {
     },
     parsed,
   };
+}
+
+export function getSearchProjectDirectory(
+  query: string,
+  options: SearchRequestOptions,
+): string | undefined {
+  return options.cwd ?? parseSearchQuery(query).filters.cwd;
 }
 
 export function sessionMatchesSearchCost(
@@ -165,12 +175,19 @@ export function buildSessionSearchFilters(options: SearchOptions): {
       clauses.push("0");
     }
   }
-  if (options.cwd) {
-    const identity = computeIdentity(options.cwd, realFs);
+  if (options.projectScope) {
+    const scopePath = options.projectScope.path.toLowerCase();
+    const normalizedDirectory = "REPLACE(LOWER(s.directory), char(92), '/')";
     clauses.push(
-      "((s.project_identity_kind = ? AND s.project_identity_key = ?) OR LOWER(s.directory) LIKE ? ESCAPE '\\')",
+      `((s.project_identity_kind = ? AND s.project_identity_key = ?) OR ${normalizedDirectory} = ? OR instr(${normalizedDirectory}, ? || '/') = 1 OR instr(?, ${normalizedDirectory} || '/') = 1)`,
     );
-    params.push(identity.kind, identity.key, likePattern(options.cwd));
+    params.push(
+      options.projectScope.identity.kind,
+      options.projectScope.identity.key,
+      scopePath,
+      scopePath,
+      scopePath,
+    );
   }
   if (options.project) {
     clauses.push(

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -18,6 +18,7 @@ import {
 } from "./db.js";
 import { withCacheDb, withCacheDbReadOnly, type CacheReadOutcome } from "./schema.js";
 import {
+  assertSessionProjectIdentities,
   messageFromCachedRow,
   prepareUpsertSession,
   sessionFromRow,
@@ -463,6 +464,7 @@ export function saveCachedSessions(
   meta: Record<string, SessionCacheMeta> = {},
   options: SaveCachedSessionsOptions = {},
 ): boolean {
+  assertSessionProjectIdentities(agentName, sessions);
   const persisted = withCacheDb((db) => {
     db.transaction(() =>
       writeCachedSessionSnapshot(db, agentName, sessions, meta, options),
@@ -542,6 +544,10 @@ export function saveCachedSessionChanges(
   removedSessionIds: string[],
   meta: Record<string, SessionCacheMeta> = {},
 ): boolean {
+  assertSessionProjectIdentities(
+    agentName,
+    changes.map(({ session }) => session),
+  );
   const persisted = withCacheDb((db) => {
     db.transaction(() =>
       writeCachedSessionChanges(db, agentName, changes, removedSessionIds, meta),

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -59,6 +59,7 @@ export type {
   DurableSessionPublicationFailureStage,
 } from "./cache/publication.js";
 export {
+  getSearchProjectDirectory,
   mergeSearchQueryOptions,
   parseSearchQuery,
   readPendingSearchIndexMaintenance,
@@ -75,6 +76,7 @@ export type {
   SearchIndexSyncResult,
   SearchMatchType,
   SearchOptions,
+  SearchRequestOptions,
   SearchQueryFilters,
 } from "./cache/search.js";
 export { perf } from "../utils/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export {
   getAgentFullSyncCursor,
   getAgentLastFullSyncAt,
   getCachePath,
+  getSearchProjectDirectory,
   isAgentCacheInitialized,
   readAgentCacheInitialization,
   readAgentLastFullSyncAt,
@@ -97,15 +98,21 @@ export type {
   SearchIndexSyncFailure,
   SearchIndexSyncResult,
   SearchOptions,
+  SearchRequestOptions,
   SessionHeadChange,
   SessionTagTiming,
 } from "./discovery/index.js";
 export {
+  computeIdentityProjection,
   createProjectScopeMatcher,
+  createProjectScopeMatcherFromIdentity,
   isProjectIdentityKind,
   matchesProjectIdentity,
   matchesProjectScope,
+  normalizeProjectDirectory,
+  PROJECT_IDENTITY_RESOLVER_REVISION,
 } from "./projects/index.js";
+export type { ProjectIdentityProjection, ProjectScopeMatcher } from "./projects/index.js";
 export {
   BookmarkStorageUnavailableError,
   deleteBookmark,

--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -7,6 +7,7 @@ import {
   computeIdentity,
   computeIdentityProjection,
   getProjectIdentityKey,
+  IDENTITY_CACHE_MAX_ENTRIES,
   matchesProjectIdentity,
   normalizeGitRemote,
   type IdentityFs,
@@ -290,5 +291,30 @@ describe("computeIdentity caching (realFs)", () => {
     vi.advanceTimersByTime(10 * 60 * 1000);
     computeIdentity(repoDir, realFs);
     expect(spawnSpy).toHaveBeenCalledTimes(spawnsAfterFirstCall * 2);
+  });
+
+  it("keeps the cache bounded and refreshes a hit before eviction", () => {
+    const root = mkdtempSync(join(tmpdir(), "codesesh-identity-cache-lru-"));
+    const directories = Array.from({ length: IDENTITY_CACHE_MAX_ENTRIES + 1 }, (_, index) => {
+      const directory = join(root, String(index));
+      mkdirSync(join(directory, ".git"), { recursive: true });
+      return directory;
+    });
+    const spawnSpy = vi.spyOn(realFs, "spawn").mockReturnValue({ stdout: "", exitCode: 1 });
+
+    try {
+      for (const directory of directories.slice(0, -1)) computeIdentity(directory, realFs);
+      computeIdentity(directories[0], realFs);
+      computeIdentity(directories.at(-1), realFs);
+
+      const spawnsBeforeRefreshCheck = spawnSpy.mock.calls.length;
+      computeIdentity(directories[0], realFs);
+      expect(spawnSpy).toHaveBeenCalledTimes(spawnsBeforeRefreshCheck);
+
+      computeIdentity(directories[1], realFs);
+      expect(spawnSpy.mock.calls.length).toBeGreaterThan(spawnsBeforeRefreshCheck);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -70,6 +70,7 @@ export function normalizeGitRemote(url: string): string | null {
 // must bypass the cache to stay isolated from each other. git remotes change
 // rarely, so a coarse TTL is enough — no file-watch invalidation needed.
 const IDENTITY_CACHE_TTL_MS = 10 * 60 * 1000;
+export const IDENTITY_CACHE_MAX_ENTRIES = 512;
 
 interface IdentityCacheEntry {
   projection: ProjectIdentityProjection;
@@ -94,22 +95,31 @@ export function normalizeProjectDirectory(cwd: string | null | undefined): strin
 
 export function computeIdentityProjection(
   cwd: string | null | undefined,
-  fs: IdentityFs,
+  fs: IdentityFs = realFs,
   resolverRevision = PROJECT_IDENTITY_RESOLVER_REVISION,
 ): ProjectIdentityProjection {
   if (fs !== realFs) return resolveIdentityProjection(cwd, fs, resolverRevision);
 
   const key = normalizeProjectDirectory(cwd);
   const cached = identityCache.get(key);
-  if (
-    cached &&
-    cached.projection.resolverRevision === resolverRevision &&
-    Date.now() - cached.resolvedAt < IDENTITY_CACHE_TTL_MS
-  ) {
-    return cached.projection;
+  if (cached) {
+    if (
+      cached.projection.resolverRevision === resolverRevision &&
+      Date.now() - cached.resolvedAt < IDENTITY_CACHE_TTL_MS
+    ) {
+      identityCache.delete(key);
+      identityCache.set(key, cached);
+      return cached.projection;
+    }
+    identityCache.delete(key);
   }
   const projection = resolveIdentityProjection(cwd, fs, resolverRevision);
   identityCache.set(key, { projection, resolvedAt: Date.now() });
+  while (identityCache.size > IDENTITY_CACHE_MAX_ENTRIES) {
+    const oldestKey = identityCache.keys().next().value;
+    if (oldestKey == null) break;
+    identityCache.delete(oldestKey);
+  }
   return projection;
 }
 

--- a/packages/core/src/projects/scope.test.ts
+++ b/packages/core/src/projects/scope.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { SessionHead } from "../types/index.js";
 import type { IdentityFs } from "./identity.js";
-import { filterSessionsByProjectScope } from "./scope.js";
+import { createProjectScopeMatcherFromIdentity, filterSessionsByProjectScope } from "./scope.js";
 
 function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
   return {
@@ -21,6 +21,15 @@ function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead 
 }
 
 describe("filterSessionsByProjectScope", () => {
+  it("uses slash-separated path syntax for Windows scopes", () => {
+    const scope = createProjectScopeMatcherFromIdentity("C:\\workspace\\app", {
+      kind: "path",
+      key: "C:/workspace/app",
+    });
+
+    expect(scope.path).toBe("C:/workspace/app");
+  });
+
   it("matches exact, query parent, session parent, and project identity scopes", () => {
     const sessions = [
       makeSession("exact", { directory: "/home/user/project" }),

--- a/packages/core/src/projects/scope.ts
+++ b/packages/core/src/projects/scope.ts
@@ -1,6 +1,10 @@
-import { resolve, sep } from "node:path";
 import type { ProjectIdentityRef, SessionHead } from "../types/index.js";
-import { computeIdentity, matchesProjectIdentity, type IdentityFs } from "./identity.js";
+import {
+  computeIdentity,
+  matchesProjectIdentity,
+  normalizeProjectDirectory,
+  type IdentityFs,
+} from "./identity.js";
 import { realFs } from "./fs.js";
 
 export interface ProjectScopeMatcher {
@@ -22,7 +26,7 @@ export function createProjectScopeMatcherFromIdentity(
 ): ProjectScopeMatcher {
   return {
     identity: { kind: identity.kind, key: identity.key },
-    path: normalizeScopePath(queryPath),
+    path: normalizeProjectScopePath(queryPath),
   };
 }
 
@@ -41,7 +45,7 @@ export function filterSessionsByProjectScope(
 }
 
 function isPathScopeMatch(queryPath: string, sessionPath: string): boolean {
-  const session = normalizeScopePath(sessionPath);
+  const session = normalizeProjectScopePath(sessionPath);
   return (
     session === queryPath ||
     session.startsWith(queryPath + "/") ||
@@ -49,6 +53,6 @@ function isPathScopeMatch(queryPath: string, sessionPath: string): boolean {
   );
 }
 
-function normalizeScopePath(path: string): string {
-  return resolve(path).replaceAll(sep, "/");
+export function normalizeProjectScopePath(path: string): string {
+  return normalizeProjectDirectory(path).replaceAll("\\", "/");
 }

--- a/packages/core/src/projects/scope.ts
+++ b/packages/core/src/projects/scope.ts
@@ -13,6 +13,13 @@ export function createProjectScopeMatcher(
   fs: IdentityFs = realFs,
 ): ProjectScopeMatcher {
   const identity = computeIdentity(queryPath, fs);
+  return createProjectScopeMatcherFromIdentity(queryPath, identity);
+}
+
+export function createProjectScopeMatcherFromIdentity(
+  queryPath: string,
+  identity: ProjectIdentityRef,
+): ProjectScopeMatcher {
   return {
     identity: { kind: identity.kind, key: identity.key },
     path: normalizeScopePath(queryPath),

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -108,12 +108,13 @@ function fileToolMessage(
 
 function makeSessionHead(spec: FixtureSpec): SessionHead {
   const timeUpdated = spec.timeUpdated ?? now;
+  const directory = spec.project ? `/projects/${spec.project.key}` : `/fixtures/${spec.id}`;
   return {
     id: spec.id,
     slug: `${spec.agent}/${spec.id}`,
     title: spec.title ?? "plain",
-    directory: spec.project ? `/projects/${spec.project.key}` : `/fixtures/${spec.id}`,
-    project_identity: spec.project,
+    directory,
+    project_identity: spec.project ?? { kind: "path", key: directory, displayName: spec.id },
     time_created: timeUpdated,
     time_updated: timeUpdated,
     smart_tags: spec.tags,
@@ -751,7 +752,13 @@ describe("search characterization: file activity path", () => {
     ],
     [
       "file + cwd",
-      { file: "qualifier-matrix.ts", cwd: `/projects/${PROJ_APP.key}` },
+      {
+        file: "qualifier-matrix.ts",
+        projectScope: {
+          identity: { kind: PROJ_APP.kind, key: PROJ_APP.key },
+          path: `/projects/${PROJ_APP.key}`,
+        },
+      },
       ["file-qualifier-match"],
     ],
     [
@@ -765,7 +772,10 @@ describe("search characterization: file activity path", () => {
         from: now - 15_550,
         projectKind: PROJ_APP.kind,
         projectKey: PROJ_APP.key,
-        cwd: `/projects/${PROJ_APP.key}`,
+        projectScope: {
+          identity: { kind: PROJ_APP.kind, key: PROJ_APP.key },
+          path: `/projects/${PROJ_APP.key}`,
+        },
       },
       ["file-qualifier-match"],
     ],

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -20,11 +20,7 @@ import {
   type SearchOptions,
 } from "../discovery/cache/search.js";
 import { searchFileActivitySessions } from "../discovery/cache/file-activity.js";
-import {
-  createProjectScopeMatcher,
-  matchesProjectScope,
-  type ProjectScopeMatcher,
-} from "../projects/scope.js";
+import { matchesProjectScope, type ProjectScopeMatcher } from "../projects/scope.js";
 import { matchesProjectIdentity } from "../projects/identity.js";
 import { getSessionActivityTime } from "../analytics/dashboard.js";
 
@@ -119,7 +115,7 @@ export function filterSessionSearchCandidates(
   options: SearchOptions,
   sessionSnapshot: SessionHead[] = candidates.map((candidate) => candidate.session),
 ): SearchResult[] {
-  const projectScope = options.cwd ? createProjectScopeMatcher(options.cwd) : null;
+  const projectScope = options.projectScope ?? null;
   const inclusiveCosts = buildInclusiveCostLookup(sessionSnapshot, options);
   const headMatches = candidates.filter((candidate) =>
     matchesSessionSearchFilters(
@@ -157,7 +153,7 @@ function searchRecentSessions(
   const limit = Math.max(0, Math.trunc(options.limit ?? 50));
   if (limit === 0) return [];
 
-  const projectScope = options.cwd ? createProjectScopeMatcher(options.cwd) : null;
+  const projectScope = options.projectScope ?? null;
   const inclusiveCosts = buildInclusiveCostLookup(snapshot.sessions, options);
   const sessions = options.agent ? (snapshot.byAgent[options.agent] ?? []) : snapshot.sessions;
   const results: SearchResult[] = [];


### PR DESCRIPTION
## Summary

- Guard all `/api/*` browser requests, including GET, against cross-site origins.
- Move project identity resolution to a bounded worker-thread pool and bound the identity cache with LRU eviction.
- Require project identities before SQLite transactions and align SQL project scope matching with in-memory semantics.
- Add migration resilience and real-worker non-blocking coverage.

## Root cause

A browser-controlled `cwd` could trigger synchronous git identity resolution on the server event loop, while the identity cache could grow without a bound.

## Validation

- `pnpm --filter @codesesh/core run test`
- `pnpm --filter codesesh run test`
- Typecheck, oxlint, formatting checks, and both package builds