### PR TITLE
fix(scan): preserve state on worker unavailability

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -15,6 +15,7 @@ import type {
 import type { ScanStatusEvent } from "@codesesh/core/contract";
 import type { WorkerResult, WorkerRunner } from "./worker-runner.js";
 import { appLogger } from "./logging.js";
+import { AgentUnavailableDuringScanError } from "./scan-refresh-error.js";
 
 const core = vi.hoisted(() => {
   const getAgentLastFullSyncAt = vi.fn(() => Date.now());
@@ -1212,6 +1213,49 @@ describe("AgentSyncEngine", () => {
     expect(engine.snapshot().byAgent.codex).toEqual([previous]);
     expect(sessionChanges).not.toHaveBeenCalled();
     expect(searchIndex.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("CS-243: retains the baseline when the worker loses agent availability", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const previous = makeSession("session", "before");
+    const updated = makeSession("session", "after");
+    const workerRunner = makeWorkerRunner();
+    workerRunner.run = vi
+      .fn()
+      .mockRejectedValueOnce(new AgentUnavailableDuringScanError("codex"))
+      .mockResolvedValueOnce(
+        workerResult({ sessions: [updated], meta: {}, changedIds: [updated.id] }),
+      );
+    const warn = vi.spyOn(appLogger, "warn");
+    const { engine } = makeEngine(
+      makeAgent({ checkForChanges: () => ({ hasChanges: true, timestamp: 2 }) }),
+      [previous],
+      workerRunner,
+    );
+    const refreshState = engine as unknown as { lastRefreshAtByAgent: Map<string, number> };
+    const baselineTimestamp = refreshState.lastRefreshAtByAgent.get("codex");
+    const sessionChanges = vi.fn();
+    engine.subscribeSessionsChanged(sessionChanges);
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().byAgent.codex).toEqual([previous]);
+    expect(refreshState.lastRefreshAtByAgent.get("codex")).toBe(baselineTimestamp);
+    expect(sessionChanges).not.toHaveBeenCalled();
+    expect(searchIndex.enqueue).not.toHaveBeenCalled();
+    expect(workerRunner.commit).not.toHaveBeenCalled();
+    expect(workerRunner.discard).toHaveBeenCalledWith("codex");
+    expect(engine.status().agentStatuses.codex).toMatchObject({ status: "failed" });
+    expect(warn).toHaveBeenCalledWith("scan.refresh.worker_agent_unavailable", {
+      agent: "codex",
+      error: "Agent codex became unavailable during scan",
+    });
+
+    await engine.refresh("codex");
+
+    expect(engine.snapshot().byAgent.codex).toEqual([updated]);
+    expect(engine.status().agentStatuses.codex).toMatchObject({ status: "complete" });
+    expect(searchIndex.enqueue).toHaveBeenCalledOnce();
   });
 
   it("CS-138: keeps sessions when the agent becomes unreachable", async () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -39,6 +39,7 @@ import type {
   ScanRefreshOperation,
 } from "./scan-refresh-operation.js";
 import type { ScanRefreshWorkerCheckpoint } from "./scan-refresh-worker.js";
+import { AgentUnavailableDuringScanError } from "./scan-refresh-error.js";
 import type { WorkerRunner } from "./worker-runner.js";
 import { toError } from "./errors.js";
 
@@ -421,7 +422,14 @@ export class AgentSyncEngine {
       this.options.workerRunner.discard?.(agentName);
       failed = true;
       const failure = toError(error);
-      appLogger.error("scan.refresh.error", { agent: agentName, error });
+      if (failure instanceof AgentUnavailableDuringScanError) {
+        appLogger.warn("scan.refresh.worker_agent_unavailable", {
+          agent: agentName,
+          error: failure.message,
+        });
+      } else {
+        appLogger.error("scan.refresh.error", { agent: agentName, error });
+      }
       console.error(`[${agentName}] Session refresh failed:`, error);
       this.flushProgressStatus(`scan:${agentName}`);
       this.publishStatus(this.scanStatus.failAgent(agentName, failure.message));
@@ -685,12 +693,12 @@ export class AgentSyncEngine {
         { status: "unchanged", checkDuration },
       );
     }
-    this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
     if (!checkResult.hasChanges) {
       const scanStartedAt = performance.now();
       const result = await this.runWorker(agent, baseline, { kind: "recompute-derived" }, {});
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
+      this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
       const persistenceDiff = buildPersistenceDiff(baseline, sessions);
       if (
         persistenceDiff.changedSessions.length === 0 &&
@@ -726,6 +734,7 @@ export class AgentSyncEngine {
       const result = await this.runWorker(agent, baseline, { kind: "full-scan" }, scope);
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
+      this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
       return this.refreshStrategyResult(sessions, result.completeness, scope, {
         // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
         // signature intact; without the worker-reported ids they would never
@@ -748,6 +757,7 @@ export class AgentSyncEngine {
         agent.incrementalScan(baseline, preciseChangedIds, checkResult.refs, scope),
       ),
     );
+    this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
     const sourceFailures = checkResult.sourceFailures ?? [];
     const completeness =
       scope.from == null && scope.to == null && sourceFailures.length === 0

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -14,6 +14,7 @@ import {
   type SessionHead,
   type SessionSourceRef,
 } from "@codesesh/core";
+import { AgentUnavailableDuringScanError } from "./scan-refresh-error.js";
 
 // Isolated temp directory for session fixtures so computeIdentity always
 // resolves to a "path" identity regardless of manifests in /tmp.
@@ -1211,6 +1212,33 @@ describe("LiveScanStore", () => {
       completeness: "complete",
       explicitRemovedSessionIds: [],
     });
+  });
+
+  it("rehydrates an unavailable-agent error from the scan worker", async () => {
+    workerThreads.deferScanRefreshWorkers = true;
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+    const refresh = runner.run("codex", {
+      previousSessions: [makeSession("retained")],
+      operation: { kind: "full-scan" },
+      scanOptions: {},
+      meta: {},
+    });
+    const worker = workerThreads.workers.at(-1)!;
+
+    worker.emitMessage({
+      type: "error",
+      requestId: worker.workerData.requestId,
+      generation: worker.workerData.generation,
+      error: "Agent codex became unavailable during scan",
+      errorCode: "agent-unavailable-during-scan",
+      durationMs: 0,
+    });
+
+    await expect(refresh).rejects.toBeInstanceOf(AgentUnavailableDuringScanError);
+    expect(runner.activeCount).toBe(0);
+    expect(worker.terminate).toHaveBeenCalledOnce();
+    await runner.shutdown();
+    workerThreads.deferScanRefreshWorkers = false;
   });
 
   it("consumes scan worker logs without settling the active request", async () => {

--- a/packages/cli/src/scan-refresh-error.ts
+++ b/packages/cli/src/scan-refresh-error.ts
@@ -1,0 +1,12 @@
+export const AGENT_UNAVAILABLE_DURING_SCAN_ERROR_CODE = "agent-unavailable-during-scan";
+
+export type ScanRefreshWorkerErrorCode = typeof AGENT_UNAVAILABLE_DURING_SCAN_ERROR_CODE;
+
+export class AgentUnavailableDuringScanError extends Error {
+  readonly code = AGENT_UNAVAILABLE_DURING_SCAN_ERROR_CODE;
+
+  constructor(agentName: string) {
+    super(`Agent ${agentName} became unavailable during scan`);
+    this.name = "AgentUnavailableDuringScanError";
+  }
+}

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -206,22 +206,30 @@ describe("scan refresh worker entry", () => {
     );
   });
 
-  it("returns an empty result when the agent is unavailable", async () => {
+  it("fails unavailable agents without staging an empty complete snapshot", async () => {
+    const retained = makeSession("retained");
     const agent = makeAgent({ isAvailable: vi.fn(() => false) });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
+    setWorkerData({
+      previousSessions: [retained],
+      meta: { retained: { id: "retained", sourcePath: "/workspace/retained" } },
+    });
 
     await runWorker();
 
-    expect(agent.setSessionMetaMap).toHaveBeenCalledWith(new Map());
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        type: "done",
-        changes: [],
-        removedSessionIds: [],
-        meta: {},
-        removedMetaIds: [],
+        type: "error",
+        error: "Agent codex became unavailable during scan",
+        errorCode: "agent-unavailable-during-scan",
       }),
     );
+    expect(mocks.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: "done" }));
+    expect(agent.scan).not.toHaveBeenCalled();
+    expect(mocks.appLogger.warn).toHaveBeenCalledWith("scan.refresh_worker.agent_unavailable", {
+      agent: "codex",
+      operation: "full-scan",
+    });
   });
 
   it("inherits cached smart tags so an unchanged full rescan reports no changes", async () => {

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -26,6 +26,10 @@ import {
 import { appLogger } from "./logging.js";
 import { MonotonicValueSampler } from "./monotonic-value-sampler.js";
 import {
+  AgentUnavailableDuringScanError,
+  type ScanRefreshWorkerErrorCode,
+} from "./scan-refresh-error.js";
+import {
   isBackfillOperation,
   synchronizesSessionSources,
   usesDurableCheckpoints,
@@ -63,6 +67,7 @@ export type ScanRefreshWorkerMessage =
       requestId: number;
       generation: number;
       error: string;
+      errorCode?: ScanRefreshWorkerErrorCode;
       durationMs: number;
     };
 
@@ -369,7 +374,14 @@ async function run(
     progressEmitter.push(progress, progress.phase ?? "scanning");
   };
 
-  const isAvailable = agent.isAvailable();
+  if (!agent.isAvailable()) {
+    appLogger.warn("scan.refresh_worker.agent_unavailable", {
+      agent: data.agentName,
+      operation: operation.kind,
+    });
+    throw new AgentUnavailableDuringScanError(data.agentName);
+  }
+
   let sessions: SessionHead[];
   let changedIds: string[] | undefined;
   let sourceFailures: SessionSourceFailure[] = [];
@@ -384,9 +396,7 @@ async function run(
       }
     | undefined;
 
-  if (!isAvailable) {
-    sessions = [];
-  } else if (operation.kind === "recompute-derived") {
+  if (operation.kind === "recompute-derived") {
     sessions = previousSessions;
   } else if (sourceSynchronization) {
     if (!(agent instanceof FileSystemSessionSource)) {
@@ -649,11 +659,13 @@ function commitBaseline(data: ScanRefreshWorkerCommitRequest): void {
 }
 
 function postRequestError(data: ScanRefreshWorkerRequest, error: unknown, startedAt: number): void {
+  const errorCode = error instanceof AgentUnavailableDuringScanError ? error.code : undefined;
   parentPort?.postMessage({
     type: "error",
     requestId: data.requestId,
     generation: data.generation,
     error: error instanceof Error ? error.message : String(error),
+    ...(errorCode ? { errorCode } : {}),
     durationMs: performance.now() - startedAt,
   } satisfies ScanRefreshWorkerMessage);
 }

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -17,6 +17,10 @@ import type {
   ScanRefreshWorkerRunRequest,
 } from "./scan-refresh-worker.js";
 import type { ScanRefreshOperation } from "./scan-refresh-operation.js";
+import {
+  AGENT_UNAVAILABLE_DURING_SCAN_ERROR_CODE,
+  AgentUnavailableDuringScanError,
+} from "./scan-refresh-error.js";
 import { toError } from "./errors.js";
 
 export interface WorkerPayload {
@@ -269,7 +273,11 @@ export class ThreadWorkerRunner implements WorkerRunner {
 
     slot.pending.delete(message.requestId);
     if (message.type === "error") {
-      pending.reject(new Error(message.error));
+      pending.reject(
+        message.errorCode === AGENT_UNAVAILABLE_DURING_SCAN_ERROR_CODE
+          ? new AgentUnavailableDuringScanError(slot.agentName)
+          : new Error(message.error),
+      );
       this.invalidateWorker(slot.agentName, slot);
       return;
     }


### PR DESCRIPTION
## Summary

- Fail worker scan requests when agent availability disappears after dispatch.
- Serialize the failure across the worker boundary and discard the uncommitted worker baseline.
- Preserve the refresh snapshot and timestamp, report a failed status, and allow a later refresh to recover.

## Root cause

The worker treated an unavailable data source as an empty complete scan. That result could be published as removals for every cached session.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck:e2e`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm test:migration`