### PR TITLE
Fix cache persistence baseline handling

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,11 @@ import { LiveScanStore } from "./live-scan.js";
 import { printScanResults } from "./output.js";
 import { VERSION } from "./version.js";
 import { appLogger } from "./logging.js";
-import { buildSessionIndexOutput, formatScanFailureDiagnostics } from "./session-index-output.js";
+import {
+  buildSessionIndexOutput,
+  formatCacheFailureDiagnostics,
+  formatScanFailureDiagnostics,
+} from "./session-index-output.js";
 import {
   resolveRemoteAccessPolicy,
   resolveRemoteTransport,
@@ -231,6 +235,7 @@ const main = defineCommand({
         process.exitCode = 1;
         return;
       }
+      for (const diagnostic of formatCacheFailureDiagnostics(result)) console.error(diagnostic);
       const output = buildSessionIndexOutput(result, { from: listDefaultFrom, to: listDefaultTo });
       appLogger.info("cli.json_output", {
         sessions: output.sessions.length,

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -700,6 +700,24 @@ describe("LiveScanStore", () => {
     ]);
   });
 
+  it("serves initial memory results while preserving cache failure diagnostics", async () => {
+    const codex = makeAgent("codex");
+    const fresh = makeSession("fresh", { time_updated: 2_000 });
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [fresh],
+      byAgent: { codex: [fresh] },
+      agents: [codex],
+      cacheFailures: { codex: { agentName: "codex" } },
+    });
+
+    const store = new LiveScanStore({ watchEnabled: false });
+    await store.initialize();
+
+    expect(store.getSnapshot().sessions).toEqual([fresh]);
+    expect(store.getSnapshot().cacheFailures).toEqual({ codex: { agentName: "codex" } });
+  });
+
   it("can initialize from cache and refresh sessions in the background", async () => {
     vi.useFakeTimers();
     const cached = makeSession("cached", { title: "cached", time_updated: 1000 });

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -58,6 +58,27 @@ describe("LiveSessionIndex", () => {
     expect(index.snapshot().scanFailures).toBeUndefined();
   });
 
+  it("retains a cache persistence failure until a durable publication succeeds", () => {
+    const codex = makeAgent("codex");
+    const cached = makeSession("cached", 1);
+    const refreshed = makeSession("refreshed", 2);
+    const index = new LiveSessionIndex();
+    index.initialize({
+      agents: [codex],
+      byAgent: { codex: [cached] },
+      sessions: [cached],
+      cacheFailures: { codex: { agentName: "codex" } },
+    });
+
+    expect(index.snapshot().cacheFailures).toEqual({ codex: { agentName: "codex" } });
+    expect(index.snapshot().byAgent.codex).toEqual([cached]);
+
+    index.commitAgentSessions("codex", [refreshed]);
+
+    expect(index.snapshot().cacheFailures).toBeUndefined();
+    expect(index.snapshot().byAgent.codex).toEqual([refreshed]);
+  });
+
   it("initializes sorted views for the allowed agent catalog", () => {
     const codex = makeAgent("codex");
     const kimi = makeAgent("kimi");

--- a/packages/cli/src/live-session-index.ts
+++ b/packages/cli/src/live-session-index.ts
@@ -2,6 +2,7 @@ import {
   computeSessionDiff,
   mergeSortedSessions,
   sessionSignature,
+  type AgentCacheFailure,
   sortSessions,
   type AgentScanFailure,
   type BaseAgent,
@@ -20,6 +21,7 @@ export class LiveSessionIndex {
   private agentsByName = new Map<string, BaseAgent>();
   private byAgent: Record<string, SessionHead[]> = {};
   private sessions: SessionHead[] = [];
+  private cacheFailures: Record<string, AgentCacheFailure> = {};
   private scanFailures: Record<string, AgentScanFailure> = {};
   private signatureCaches = new Map<string, Map<string, string>>();
 
@@ -34,6 +36,7 @@ export class LiveSessionIndex {
       (agent) => !options.allowedAgents || options.allowedAgents.has(agent.name.toLowerCase()),
     );
     this.agentsByName = new Map(this.agents.map((agent) => [agent.name, agent]));
+    this.cacheFailures = { ...snapshot.cacheFailures };
     this.scanFailures = { ...snapshot.scanFailures };
     this.byAgent = Object.fromEntries(
       this.agents.flatMap((agent) => {
@@ -50,6 +53,7 @@ export class LiveSessionIndex {
       agents: this.agents,
       byAgent: this.byAgent,
       sessions: this.sessions,
+      ...(Object.keys(this.cacheFailures).length > 0 ? { cacheFailures: this.cacheFailures } : {}),
       ...(Object.keys(this.scanFailures).length > 0 ? { scanFailures: this.scanFailures } : {}),
     };
   }
@@ -63,6 +67,7 @@ export class LiveSessionIndex {
     nextSessions: SessionHead[],
     candidateChangedIds: string[] = [],
   ): SessionsUpdatedEvent | null {
+    delete this.cacheFailures[agentName];
     delete this.scanFailures[agentName];
     const previousSessions = this.byAgent[agentName] ?? [];
     const previousGlobalSessions = this.sessions;

--- a/packages/cli/src/session-index-output.test.ts
+++ b/packages/cli/src/session-index-output.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { LiveSnapshot, SessionHead } from "@codesesh/core";
-import { buildSessionIndexOutput, formatScanFailureDiagnostics } from "./session-index-output.js";
+import {
+  buildSessionIndexOutput,
+  formatCacheFailureDiagnostics,
+  formatScanFailureDiagnostics,
+} from "./session-index-output.js";
 
 function makeSession(id: string, activity: number): SessionHead {
   return {
@@ -100,6 +104,18 @@ describe("scan failure diagnostics", () => {
       }),
     ).toEqual([
       "[codex] Scan failed during enumerating session sources at /sessions (EACCES): permission denied",
+    ]);
+  });
+});
+
+describe("cache failure diagnostics", () => {
+  it("reports degraded persistence without treating the scan as failed", () => {
+    expect(
+      formatCacheFailureDiagnostics({
+        cacheFailures: { codex: { agentName: "codex" } },
+      }),
+    ).toEqual([
+      "[codex] Cache persistence failed; serving in-memory results without advancing the durable baseline",
     ]);
   });
 });

--- a/packages/cli/src/session-index-output.ts
+++ b/packages/cli/src/session-index-output.ts
@@ -38,6 +38,15 @@ export function formatScanFailureDiagnostics(
   });
 }
 
+export function formatCacheFailureDiagnostics(
+  snapshot: Pick<LiveSnapshot, "cacheFailures">,
+): string[] {
+  return Object.values(snapshot.cacheFailures ?? {}).map(
+    (failure) =>
+      `[${failure.agentName}] Cache persistence failed; serving in-memory results without advancing the durable baseline`,
+  );
+}
+
 export function buildSessionIndexOutput(
   snapshot: Pick<LiveSnapshot, "sessions" | "byAgent">,
   window: SessionIndexWindow = {},

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -238,6 +238,8 @@ const mockedSaveCachedSessions = vi.mocked(saveCachedSessions);
 beforeEach(() => {
   vi.clearAllMocks();
   mockedLoadCachedSessions.mockReturnValue(null);
+  mockedSaveCachedSessionChanges.mockReturnValue(true);
+  mockedSaveCachedSessions.mockReturnValue(true);
 });
 
 function createTestAgent(overrides: {
@@ -349,6 +351,7 @@ describe("finalizeAgentScan", () => {
 
     expect(result.heads.map((session) => session.id)).toEqual(["current"]);
     expect(result.heads[0]?.project_identity).toBeDefined();
+    expect(result.cachePersistence).toBe("not-requested");
     expect(result.cacheTimestamp).toBe(123);
     expect(agent.getSessionData).not.toHaveBeenCalled();
     expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
@@ -378,6 +381,7 @@ describe("finalizeAgentScan", () => {
     });
 
     expect(result.refreshed).toBe(true);
+    expect(result.cachePersistence).toBe("persisted");
     expect(result.cacheTimestamp).toBe(456);
     expect(mockedSaveCachedSessionChanges).toHaveBeenCalledWith(
       "test",
@@ -390,6 +394,64 @@ describe("finalizeAgentScan", () => {
       ["old"],
       {},
     );
+  });
+
+  it("serves fresh heads without advancing the durable timestamp when an incremental write fails", async () => {
+    const cachedSessions = [makeSession("old")];
+    const updatedSessions = [makeSession("new")];
+    const agent = createTestAgent({ name: "test", available: true, sessions: updatedSessions });
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    mockedSaveCachedSessionChanges.mockReturnValue(false);
+    setCoreDiagnostics({ warn: (event, detail) => events.push({ event, detail }) });
+
+    try {
+      const result = await finalizeAgentScan(agent, updatedSessions, {
+        finalization: {
+          kind: "incremental",
+          cached: { sessions: cachedSessions, meta: {}, timestamp: 123 },
+          changedIds: ["new"],
+          cacheTimestamp: 456,
+        },
+        options: { includeSmartTags: false },
+        timing: { total: 0 },
+        agentStart: performance.now(),
+        completeness: "complete",
+      });
+
+      expect(result.heads.map((session) => session.id)).toEqual(["new"]);
+      expect(result.refreshed).toBe(true);
+      expect(result.cachePersistence).toBe("failed");
+      expect(result.cacheTimestamp).toBe(123);
+      expect(events).toContainEqual({
+        event: "cache.save_failed",
+        detail: { agent: "test", changed_sessions: 1, removed_sessions: 1 },
+      });
+    } finally {
+      setCoreDiagnostics(null);
+    }
+  });
+
+  it("does not advance an incremental durable timestamp when cache writes are disabled", async () => {
+    const cachedSessions = [makeSession("old")];
+    const updatedSessions = [makeSession("new")];
+    const agent = createTestAgent({ name: "test", available: true, sessions: updatedSessions });
+
+    const result = await finalizeAgentScan(agent, updatedSessions, {
+      finalization: {
+        kind: "incremental",
+        cached: { sessions: cachedSessions, meta: {}, timestamp: 123 },
+        changedIds: ["new"],
+        cacheTimestamp: 456,
+      },
+      options: { includeSmartTags: false, writeCache: false },
+      timing: { total: 0 },
+      agentStart: performance.now(),
+      completeness: "complete",
+    });
+
+    expect(result.cachePersistence).toBe("not-requested");
+    expect(result.cacheTimestamp).toBe(123);
+    expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
   });
 
   it("does not rewrite an unchanged cache when tag maintenance is disabled", async () => {
@@ -895,6 +957,43 @@ describe("scanSessions", () => {
       [],
       {},
     );
+  });
+
+  it("retains the durable baseline after a failed incremental cache write", async () => {
+    const cachedSessions = [makeSession("cached")];
+    const refreshedSessions = [makeSession("fresh")];
+    const checkForChanges = vi.fn(() => ({
+      hasChanges: true,
+      changedIds: ["fresh"],
+      timestamp: 456,
+    }));
+    const agent = createTestAgent({
+      name: "test",
+      available: true,
+      sessions: refreshedSessions,
+      incrementalScanResult: refreshedSessions,
+    });
+    agent.checkForChanges = checkForChanges;
+    mockedLoadCachedSessions.mockReturnValue({
+      sessions: cachedSessions,
+      meta: {},
+      timestamp: 123,
+    });
+    mockedSaveCachedSessionChanges.mockReturnValueOnce(false).mockReturnValue(true);
+    mockedCreateRegisteredAgents.mockReturnValue([agent]);
+
+    const failed = await scanSessions({ useCache: true, includeSmartTags: false });
+    const recovered = await scanSessions({ useCache: true, includeSmartTags: false });
+
+    expect(failed.sessions.map((session) => session.id)).toEqual(["fresh"]);
+    expect(failed.cacheTimestamps).toEqual({ test: 123 });
+    expect(failed.cacheFailures).toEqual({ test: { agentName: "test" } });
+    expect(failed.scanFailures).toBeUndefined();
+    expect(recovered.sessions.map((session) => session.id)).toEqual(["fresh"]);
+    expect(recovered.cacheTimestamps).toEqual({ test: 456 });
+    expect(recovered.cacheFailures).toBeUndefined();
+    expect(checkForChanges).toHaveBeenNthCalledWith(1, 123, cachedSessions);
+    expect(checkForChanges).toHaveBeenNthCalledWith(2, 123, cachedSessions);
   });
 
   it("writes only changed sessions after smart refresh", async () => {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -457,7 +457,10 @@ export function loadCachedSessionData(agentName: string, sessionId: string): Ses
   return loadCachedSessionDataEntry(agentName, sessionId)?.data ?? null;
 }
 
-/** Returns whether the write reached disk; callers must not publish on `false`. */
+/**
+ * Returns whether the write reached disk; on `false`, callers must not mark the cache initialized
+ * or a full sync complete.
+ */
 export function saveCachedSessions(
   agentName: string,
   sessions: SessionHead[],
@@ -537,7 +540,10 @@ export function writeCachedSessionSnapshot(
   });
 }
 
-/** Returns whether the write reached disk; callers must not publish on `false`. */
+/**
+ * Returns whether the write reached disk. On `false`, callers may serve the in-memory result
+ * but must not advance the persistence timestamp, initialization marker, or durable baseline.
+ */
 export function saveCachedSessionChanges(
   agentName: string,
   changes: SessionHeadChange[],

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -1,6 +1,6 @@
 export { firstExisting, readEnvPath, resolveDataHome, resolveHomePath } from "./paths.js";
 export { ensureSessionTagsSync, filterSessions, scanSessions } from "./scanner.js";
-export type { LiveSnapshot, ScanOptions, SessionTagTiming } from "./scanner.js";
+export type { AgentCacheFailure, LiveSnapshot, ScanOptions, SessionTagTiming } from "./scanner.js";
 export {
   materializeSessionDetail,
   materializeSessionDetailResponse,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -74,7 +74,12 @@ export interface LiveSnapshot {
   agents: BaseAgent[];
   timings?: Record<string, AgentScanTiming>;
   cacheTimestamps?: Record<string, number>;
+  cacheFailures?: Record<string, AgentCacheFailure>;
   scanFailures?: Record<string, AgentScanFailure>;
+}
+
+export interface AgentCacheFailure {
+  agentName: string;
 }
 
 /** 扫描状态更新回调 */
@@ -138,10 +143,13 @@ function buildAgentScanOptions(
   };
 }
 
+type CachePersistence = "persisted" | "failed" | "not-requested";
+
 interface SuccessfulAgentScanResult {
   status: "complete" | "partial";
   agent: BaseAgent;
   heads: SessionHead[];
+  cachePersistence: CachePersistence;
   fromCache?: boolean;
   refreshed?: boolean;
   timing?: AgentScanTiming;
@@ -197,14 +205,27 @@ function saveCachedSessionDiff(
   changedIds: string[] = [],
   completeness: "complete" | "partial" = "complete",
   explicitRemovedSessionIds: readonly string[] = [],
-): void {
+): boolean {
   const diff = computeSessionDiff(cachedSessions, updatedSessions, changedIds, sessionSignature);
   const explicitRemovals = new Set(explicitRemovedSessionIds);
   const removedSessionIds =
     completeness === "complete"
       ? diff.removedSessionIds
       : diff.removedSessionIds.filter((sessionId) => explicitRemovals.has(sessionId));
-  saveCachedSessionChanges(agent.name, diff.changes, removedSessionIds, buildAgentCacheMeta(agent));
+  const persisted = saveCachedSessionChanges(
+    agent.name,
+    diff.changes,
+    removedSessionIds,
+    buildAgentCacheMeta(agent),
+  );
+  if (persisted === false) {
+    getCoreDiagnostics()?.warn("cache.save_failed", {
+      agent: agent.name,
+      changed_sessions: diff.changes.length,
+      removed_sessions: removedSessionIds.length,
+    });
+  }
+  return persisted;
 }
 
 function getSmartTagWorkerCount(sessionCount: number): number {
@@ -425,18 +446,25 @@ export async function finalizeAgentScan(
     timing.tags = performance.now() - tagsStart;
   }
 
+  let cachePersistence: CachePersistence = "not-requested";
   if (options.writeCache !== false) {
     if (finalization.kind === "incremental") {
-      saveCachedSessionDiff(
-        agent,
-        finalization.cached.sessions,
-        tagged.sessions,
-        finalization.changedIds,
-        context.completeness,
-        finalization.explicitRemovedSessionIds,
-      );
+      cachePersistence =
+        saveCachedSessionDiff(
+          agent,
+          finalization.cached.sessions,
+          tagged.sessions,
+          finalization.changedIds,
+          context.completeness,
+          finalization.explicitRemovedSessionIds,
+        ) === false
+          ? "failed"
+          : "persisted";
     } else if (finalization.kind === "unchanged" && (identityChanged || tagged.changed)) {
-      saveCachedSessionDiff(agent, finalization.cached.sessions, tagged.sessions);
+      cachePersistence =
+        saveCachedSessionDiff(agent, finalization.cached.sessions, tagged.sessions) === false
+          ? "failed"
+          : "persisted";
     }
   }
 
@@ -450,10 +478,14 @@ export async function finalizeAgentScan(
     status: context.completeness,
     agent,
     heads,
+    cachePersistence,
     fromCache: true,
     ...(isIncremental ? { refreshed: true } : {}),
     timing,
-    cacheTimestamp: isIncremental ? finalization.cacheTimestamp : finalization.cached.timestamp,
+    cacheTimestamp:
+      isIncremental && cachePersistence === "persisted"
+        ? finalization.cacheTimestamp
+        : finalization.cached.timestamp,
   };
 }
 
@@ -698,15 +730,18 @@ async function scanAgentFull(
     // 收集元数据
     const meta = buildAgentCacheMeta(agent);
 
+    let cachePersistence: CachePersistence = "not-requested";
     if (options.writeCache !== false) {
       const isFullWindow = options.from == null && options.to == null;
       const persisted = saveCachedSessions(agent.name, tagged.sessions, meta, {
         completeness: isFullWindow && sourceFailures.length === 0 ? "complete" : "partial",
       });
-      if (persisted) {
+      if (persisted !== false) {
+        cachePersistence = "persisted";
         if (isFullWindow && sourceFailures.length === 0) markAgentFullSyncCompleted(agent.name);
         markAgentCacheInitialized(agent.name);
       } else {
+        cachePersistence = "failed";
         getCoreDiagnostics()?.warn("cache.save_failed", {
           agent: agent.name,
           sessions: tagged.sessions.length,
@@ -725,6 +760,7 @@ async function scanAgentFull(
           : "partial",
       agent,
       heads: filtered,
+      cachePersistence,
       fromCache: false,
       timing,
     };
@@ -774,6 +810,7 @@ export async function scanSessions(
   const allSessions: SessionHead[] = [];
   const availableAgents: BaseAgent[] = [];
   const cacheTimestamps: Record<string, number> = {};
+  const cacheFailures: Record<string, AgentCacheFailure> = {};
   const scanFailures: Record<string, AgentScanFailure> = {};
 
   const agentFilter = options.agents?.length
@@ -807,6 +844,9 @@ export async function scanSessions(
       } else {
         byAgent[result.agent.name] = result.heads;
         allSessions.push(...result.heads);
+        if (result.cachePersistence === "failed") {
+          cacheFailures[result.agent.name] = { agentName: result.agent.name };
+        }
       }
       if (result.timing) {
         timings[result.agent.name] = result.timing;
@@ -824,6 +864,7 @@ export async function scanSessions(
     agents: availableAgents,
     timings,
     cacheTimestamps: Object.keys(cacheTimestamps).length > 0 ? cacheTimestamps : undefined,
+    cacheFailures: Object.keys(cacheFailures).length > 0 ? cacheFailures : undefined,
     scanFailures: Object.keys(scanFailures).length > 0 ? scanFailures : undefined,
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,6 +86,7 @@ export {
 } from "./contract/index.js";
 export type {
   FileActivityResult,
+  AgentCacheFailure,
   LiveSnapshot,
   SaveCachedSessionsOptions,
   ScanOptions,


### PR DESCRIPTION
## Summary

- retain the last durable cache timestamp when an incremental write fails
- expose cache persistence failures without withholding in-memory sessions
- emit a non-fatal diagnostic for `--json` output

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck:e2e`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm test:migration`