### PR TITLE
Fix committed partial scan status

### DIFF
--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -96,6 +96,51 @@ describe("formatScanStatusLabel", () => {
     ).toBe("Scanning full session history · codex · 1 history scan queued");
   });
 
+  it("shows a partial refresh as completed rather than failed", () => {
+    expect(
+      formatScanStatusLabel({
+        active: false,
+        backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
+        agentStatuses: {
+          codex: {
+            agentName: "codex",
+            status: "complete",
+            completeness: "partial",
+            sourceFailureCount: 1,
+            sourceFailureSummary: "SyntaxError: truncated JSON",
+            updatedAt: 1,
+          },
+        },
+      } as unknown as ScanStatusEvent),
+    ).toBe(
+      "Session refresh completed with partial data · codex · 1 source failed · SyntaxError: truncated JSON",
+    );
+  });
+
+  it("shows a completed partial full-history refresh", () => {
+    expect(
+      formatScanStatusLabel({
+        active: false,
+        backfill: {
+          active: false,
+          pendingAgents: [],
+          completedAgents: ["codex"],
+          failedAgents: [],
+          partialAgents: {
+            codex: {
+              completeness: "partial",
+              sourceFailureCount: 2,
+              sourceFailureSummary: "SyntaxError: truncated JSON",
+            },
+          },
+        },
+        agentStatuses: {},
+      } as unknown as ScanStatusEvent),
+    ).toBe(
+      "Full-history refresh completed with partial data · codex · 2 sources failed · SyntaxError: truncated JSON",
+    );
+  });
+
   it("shows backfill finalization progress", () => {
     expect(
       formatScanStatusLabel({

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -4,6 +4,17 @@
  */
 import type { AppConfig, ScanStatusEvent } from "./api";
 
+function formatPartialCompletion(
+  completion: Pick<
+    NonNullable<ScanStatusEvent["agentStatuses"][string]>,
+    "sourceFailureCount" | "sourceFailureSummary"
+  >,
+): string {
+  const count = completion.sourceFailureCount;
+  const countLabel = count == null ? null : `${count} source${count === 1 ? "" : "s"} failed`;
+  return [countLabel, completion.sourceFailureSummary].filter((value) => value != null).join(" · ");
+}
+
 export function formatIsoDate(ts: number): string {
   const d = new Date(ts);
   const y = d.getFullYear();
@@ -98,6 +109,22 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
         : `Checking for new or changed sessions · ${completed}/${total} agents ready`;
     }
     return "Checking for new or changed sessions";
+  }
+
+  const partialBackfill = Object.entries(status.backfill?.partialAgents ?? {}).find(
+    ([, completion]) => completion.completeness === "partial",
+  );
+  if (partialBackfill) {
+    const [agentName, completion] = partialBackfill;
+    const detail = formatPartialCompletion(completion);
+    return `Full-history refresh completed with partial data · ${agentName}${detail ? ` · ${detail}` : ""}`;
+  }
+  const partialAgent = Object.values(status.agentStatuses ?? {}).find(
+    (agentStatus) => agentStatus.status === "complete" && agentStatus.completeness === "partial",
+  );
+  if (partialAgent) {
+    const detail = formatPartialCompletion(partialAgent);
+    return `Session refresh completed with partial data · ${partialAgent.agentName}${detail ? ` · ${detail}` : ""}`;
   }
 
   if (status.searchIndexMaintenance?.active) {

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -16,6 +16,7 @@ import type { ScanStatusEvent } from "@codesesh/core/contract";
 import type { WorkerResult, WorkerRunner } from "./worker-runner.js";
 import { appLogger } from "./logging.js";
 import { AgentUnavailableDuringScanError } from "./scan-refresh-error.js";
+import type { ScanStatusModel } from "./scan-status-model.js";
 
 const core = vi.hoisted(() => {
   const getAgentLastFullSyncAt = vi.fn(() => Date.now());
@@ -504,6 +505,56 @@ describe("AgentSyncEngine", () => {
 
     expect(core.markAgentFullSyncProgress).toHaveBeenCalledOnce();
     expect(core.markAgentFullSyncProgress).toHaveBeenCalledWith("codex", next.id);
+    expect(core.markAgentFullSyncCompleted).toHaveBeenCalledWith("codex");
+  });
+
+  it("commits source failures in backfill as a partial snapshot", async () => {
+    const previous = makeSession("session", "before");
+    const updated = makeSession("session", "after");
+    const failure: SessionSourceFailure = {
+      sessionId: previous.id,
+      sourcePath: "/session",
+      stage: "parsing",
+      errorClass: "SyntaxError",
+      message: "Unexpected end of JSON input",
+    };
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () =>
+        workerResult(
+          {
+            sessions: [updated],
+            meta: {},
+            changedIds: [updated.id],
+            sourceFailures: [failure],
+          },
+          "partial",
+        ),
+      ),
+      commit: vi.fn(),
+      discard: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(new FakeSyncAgent(), [previous], workerRunner);
+    const internal = engine as unknown as { enqueueBackfill(agentName: string): void };
+
+    internal.enqueueBackfill("codex");
+    await vi.waitFor(() => expect(engine.status().backfill.completedAgents).toEqual(["codex"]));
+
+    expect(engine.snapshot().byAgent.codex).toEqual([expect.objectContaining({ title: "after" })]);
+    expect(engine.status().backfill).toMatchObject({
+      completedAgents: ["codex"],
+      failedAgents: [],
+      partialAgents: {
+        codex: {
+          completeness: "partial",
+          sourceFailureCount: 1,
+          sourceFailureSummary: "SyntaxError: Unexpected end of JSON input",
+        },
+      },
+    });
+    expect(workerRunner.commit).toHaveBeenCalledWith("codex");
+    expect(workerRunner.discard).not.toHaveBeenCalled();
     expect(core.markAgentFullSyncCompleted).toHaveBeenCalledWith("codex");
   });
 
@@ -1099,8 +1150,7 @@ describe("AgentSyncEngine", () => {
     );
   });
 
-  it("commits successful source updates while reporting retained parse failures", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  it("commits successful source updates as a partial snapshot", async () => {
     const changed = makeSession("changed", "before");
     const updated = makeSession("changed", "after");
     const retained = makeSession("retained");
@@ -1135,6 +1185,8 @@ describe("AgentSyncEngine", () => {
           "partial",
         ),
       ),
+      commit: vi.fn(),
+      discard: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(new FakeSyncAgent(), [changed, retained], workerRunner);
@@ -1162,10 +1214,71 @@ describe("AgentSyncEngine", () => {
     );
     expect(engine.status().agentStatuses.codex).toEqual(
       expect.objectContaining({
-        status: "failed",
-        error: "1 session source failed; last-known-good data retained",
+        status: "complete",
+        completeness: "partial",
+        sourceFailureCount: 1,
+        sourceFailureSummary: "SyntaxError: Unexpected end of JSON input",
       }),
     );
+    expect(workerRunner.commit).toHaveBeenCalledWith("codex");
+    expect(workerRunner.discard).not.toHaveBeenCalled();
+  });
+
+  it("keeps a committed refresh complete when post-commit notifications throw", async () => {
+    const previous = makeSession("session", "before");
+    const updated = makeSession("session", "after");
+    core.loadCachedSessions.mockReturnValue({
+      sessions: [previous],
+      meta: { session: { id: "session", sourcePath: "/session", sourceFingerprint: "old" } },
+      timestamp: 1,
+    });
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () =>
+        workerResult({
+          sessions: [updated],
+          meta: { session: { id: "session", sourcePath: "/session", sourceFingerprint: "new" } },
+          changedIds: [updated.id],
+        }),
+      ),
+      commit: vi.fn(),
+      discard: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(new FakeSyncAgent(), [previous], workerRunner);
+    engine.subscribeSessionsChanged(() => {
+      throw new Error("session event broadcast failed");
+    });
+    const scanStatus = (engine as unknown as { scanStatus: ScanStatusModel }).scanStatus;
+    const finishAgent = vi.spyOn(scanStatus, "finishAgent").mockImplementationOnce(() => {
+      throw new Error("terminal status publication failed");
+    });
+    const logError = vi.spyOn(appLogger, "error").mockImplementation(() => undefined);
+    const logInfo = vi.spyOn(appLogger, "info").mockImplementation((event) => {
+      if (event === "scan.refresh.done") throw new Error("post-commit reporting failed");
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      await engine.refresh("codex");
+
+      expect(engine.snapshot().byAgent.codex).toEqual([
+        expect.objectContaining({ id: updated.id, title: updated.title }),
+      ]);
+      expect(engine.status().agentStatuses.codex).toMatchObject({ status: "complete" });
+      expect(workerRunner.commit).toHaveBeenCalledWith("codex");
+      expect(workerRunner.discard).not.toHaveBeenCalled();
+      expect(finishAgent).toHaveBeenCalledTimes(2);
+      expect(logError).toHaveBeenCalledWith(
+        "scan.refresh.post_commit_error",
+        expect.objectContaining({ agent: "codex", error: expect.any(Error) }),
+      );
+    } finally {
+      consoleError.mockRestore();
+      logInfo.mockRestore();
+      logError.mockRestore();
+      finishAgent.mockRestore();
+    }
   });
 
   it("keeps the previous snapshot when search indexing fails", async () => {
@@ -1173,12 +1286,14 @@ describe("AgentSyncEngine", () => {
     searchIndex.enqueue.mockRejectedValueOnce(new Error("index failed"));
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
+    const workerRunner = makeWorkerRunner();
     const { engine } = makeEngine(
       makeAgent({
         checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
         incrementalScan: () => [updated],
       }),
       [previous],
+      workerRunner,
     );
     const sessionChanges = vi.fn();
     engine.subscribeSessionsChanged(sessionChanges);
@@ -1191,6 +1306,9 @@ describe("AgentSyncEngine", () => {
       "[codex] Session refresh failed:",
       expect.objectContaining({ message: "index failed" }),
     );
+    expect(workerRunner.commit).not.toHaveBeenCalled();
+    expect(workerRunner.discard).toHaveBeenCalledWith("codex");
+    expect(engine.status().agentStatuses.codex).toMatchObject({ status: "failed" });
   });
 
   it("CS-138: keeps the previous snapshot when a scan fails", async () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -20,7 +20,11 @@ import {
   type SessionSourceFailure,
   type SessionSnapshotCompleteness,
 } from "@codesesh/core";
-import type { ScanStatusEvent, SessionsUpdatedEvent } from "@codesesh/core/contract";
+import type {
+  ScanCompletion,
+  ScanStatusEvent,
+  SessionsUpdatedEvent,
+} from "@codesesh/core/contract";
 import { AgentOperationScheduler, type AgentOperationResult } from "./agent-operation-scheduler.js";
 import {
   BackfillLifecycle,
@@ -76,11 +80,18 @@ interface SessionPublication {
   candidateChangedIds: string[];
   indexJob: SearchIndexWorkerJob;
   onPublishing?: () => void;
+  onCommitted?: (result: SessionPublicationResult) => void;
 }
 
 interface SessionPublicationResult {
+  durableCommitted: true;
   event: SessionsUpdatedEvent | null;
   diffDuration: number;
+}
+
+interface RefreshResult {
+  result: Exclude<AgentOperationResult, "failed">;
+  completion: ScanCompletion;
 }
 
 interface RefreshStrategyResult {
@@ -103,6 +114,8 @@ const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 const BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const CACHE_TRUNCATION_COVERAGE = 0.5;
 const STATUS_PROGRESS_INTERVAL_MS = 100;
+// SSE carries one compact summary; logs retain the complete failure list.
+const SOURCE_FAILURE_SUMMARY_MAX_LENGTH = 160;
 
 function buildPersistenceDiff(
   previousSessions: SessionHead[],
@@ -128,9 +141,21 @@ function buildPersistenceDiff(
   };
 }
 
-function sourceFailureError(failures: SessionSourceFailure[]): Error {
-  const noun = failures.length === 1 ? "source" : "sources";
-  return new Error(`${failures.length} session ${noun} failed; last-known-good data retained`);
+function buildScanCompletion(
+  completeness: SessionSnapshotCompleteness,
+  sourceFailures: readonly SessionSourceFailure[],
+): ScanCompletion {
+  if (sourceFailures.length === 0) return { completeness };
+  const firstFailure = sourceFailures[0]!;
+  const summary = `${firstFailure.errorClass}: ${firstFailure.message}`;
+  return {
+    completeness: "partial",
+    sourceFailureCount: sourceFailures.length,
+    sourceFailureSummary:
+      summary.length > SOURCE_FAILURE_SUMMARY_MAX_LENGTH
+        ? `${summary.slice(0, SOURCE_FAILURE_SUMMARY_MAX_LENGTH - 1)}…`
+        : summary,
+  };
 }
 
 function restoreAgentCacheMeta(agent: BaseAgent, cached: CachedSessions): void {
@@ -339,10 +364,10 @@ export class AgentSyncEngine {
     this.publishStatus(this.scanStatus.queueAgentPublication(agentName));
   }
 
-  private finishAgentScan(agentName: string): void {
+  private finishAgentScan(agentName: string, completion: ScanCompletion): void {
     this.flushProgressStatus(`scan:${agentName}`);
     const count = this.sessionIndex.snapshot().byAgent[agentName]?.length;
-    this.publishStatus(this.scanStatus.finishAgent(agentName, count));
+    this.publishStatus(this.scanStatus.finishAgent(agentName, count, completion));
   }
 
   private finishScanBatch(): void {
@@ -405,55 +430,103 @@ export class AgentSyncEngine {
 
   private emitSessionsChanged(change: AgentSessionsChanged): void {
     if (this.isShuttingDown) return;
-    for (const listener of this.sessionsChangedListeners) listener(change);
+    for (const listener of this.sessionsChangedListeners) {
+      try {
+        listener(change);
+      } catch (error) {
+        this.reportPostCommitError("session.publication", change.agentName, error);
+      }
+    }
+  }
+
+  private reportPostCommitError(
+    operation: "scan.refresh" | "scan.backfill" | "session.publication",
+    agentName: string,
+    error: unknown,
+  ): void {
+    appLogger.error(`${operation}.post_commit_error`, { agent: agentName, error });
+  }
+
+  private finishCommittedAgentScan(agentName: string, completion: ScanCompletion): void {
+    try {
+      this.finishAgentScan(agentName, completion);
+    } catch (error) {
+      this.reportPostCommitError("scan.refresh", agentName, error);
+      // finishAgent is idempotent, so one retry restores the terminal projection.
+      try {
+        this.finishAgentScan(agentName, completion);
+      } catch (recoveryError) {
+        this.reportPostCommitError("scan.refresh", agentName, recoveryError);
+      }
+    }
   }
 
   private async performRefresh(agentName: string): Promise<AgentOperationResult> {
     this.beginAgentScan(agentName);
     const startedAt = performance.now();
     let failed = false;
+    let durableCommitted = false;
     let cached: CachedSessions | null = null;
-    let result: Exclude<AgentOperationResult, "failed"> | null = null;
+    let result: AgentOperationResult = "failed";
+    let completion: ScanCompletion = { completeness: "complete" };
     try {
       if (this.findAgent(agentName)) cached = loadCachedSessions(agentName);
-      result = await this.runRefresh(agentName, cached, startedAt);
-      return result;
+      const refresh = await this.runRefresh(agentName, cached, startedAt, (committedCompletion) => {
+        durableCommitted = true;
+        completion = committedCompletion;
+        result = "committed";
+      });
+      result = refresh.result;
+      completion = refresh.completion;
     } catch (error) {
-      this.options.workerRunner.discard?.(agentName);
-      failed = true;
-      const failure = toError(error);
-      if (failure instanceof AgentUnavailableDuringScanError) {
-        appLogger.warn("scan.refresh.worker_agent_unavailable", {
-          agent: agentName,
-          error: failure.message,
-        });
+      if (durableCommitted) {
+        this.reportPostCommitError("scan.refresh", agentName, error);
+        result = "committed";
       } else {
-        appLogger.error("scan.refresh.error", { agent: agentName, error });
+        this.options.workerRunner.discard?.(agentName);
+        failed = true;
+        const failure = toError(error);
+        if (failure instanceof AgentUnavailableDuringScanError) {
+          appLogger.warn("scan.refresh.worker_agent_unavailable", {
+            agent: agentName,
+            error: failure.message,
+          });
+        } else {
+          appLogger.error("scan.refresh.error", { agent: agentName, error });
+        }
+        console.error(`[${agentName}] Session refresh failed:`, error);
+        this.flushProgressStatus(`scan:${agentName}`);
+        this.publishStatus(this.scanStatus.failAgent(agentName, failure.message));
       }
-      console.error(`[${agentName}] Session refresh failed:`, error);
-      this.flushProgressStatus(`scan:${agentName}`);
-      this.publishStatus(this.scanStatus.failAgent(agentName, failure.message));
-      return "failed";
-    } finally {
-      if (!failed) this.finishAgentScan(agentName);
+    }
+    try {
+      if (!failed) {
+        if (durableCommitted) this.finishCommittedAgentScan(agentName, completion);
+        else this.finishAgentScan(agentName, completion);
+      }
       const agent = this.findAgent(agentName);
       if (agent && this.needsBackfill(agent, cached, failed || result === "committed")) {
         this.enqueueBackfill(agentName);
       }
       if (agent) this.searchIndexMaintenance.enqueue(agentName);
+    } catch (error) {
+      if (!durableCommitted) throw error;
+      this.reportPostCommitError("scan.refresh", agentName, error);
     }
+    return result;
   }
 
   private async runRefresh(
     agentName: string,
     cached: CachedSessions | null,
     startedAt: number,
-  ): Promise<Exclude<AgentOperationResult, "failed">> {
+    onDurableCommit: (completion: ScanCompletion) => void,
+  ): Promise<RefreshResult> {
     const pendingPathCount = this.scheduler.takePendingSignalCount(agentName);
     const agent = this.findAgent(agentName);
     if (!agent) {
       appLogger.warn("scan.refresh.missing_agent", { agent: agentName });
-      return "skipped";
+      return { result: "skipped", completion: { completeness: "complete" } };
     }
     const previousSessions = this.sessionIndex.snapshot().byAgent[agentName] ?? [];
     const refreshBaseline = cached?.sessions ?? previousSessions;
@@ -467,7 +540,7 @@ export class AgentSyncEngine {
         agent: agentName,
         state: "initialization",
       });
-      return "unchanged";
+      return { result: "unchanged", completion: { completeness: "complete" } };
     }
     const isInitialized = initialization.value;
     const availabilityStartedAt = performance.now();
@@ -492,7 +565,10 @@ export class AgentSyncEngine {
     }
     if (strategyResult.status === "unchanged") {
       this.options.workerRunner.commit?.(agentName);
-      return "unchanged";
+      return {
+        result: "unchanged",
+        completion: buildScanCompletion(strategyResult.completeness, strategyResult.sourceFailures),
+      };
     }
 
     const nextSessions = attachMissingProjectIdentities(strategyResult.nextSessions);
@@ -544,7 +620,12 @@ export class AgentSyncEngine {
           saveCache: true,
           ...(searchIndexOptions ? { searchIndexOptions } : {}),
         };
+    const completion = buildScanCompletion(
+      strategyResult.completeness,
+      strategyResult.sourceFailures,
+    );
     this.queueAgentPublication(agentName);
+    let publicationCommitted = false;
     let publication: SessionPublicationResult;
     try {
       publication = await this.commitSessionPublication({
@@ -554,11 +635,17 @@ export class AgentSyncEngine {
         candidateChangedIds: strategyResult.preciseChangedIds ?? [],
         indexJob: persistentJob,
         onPublishing: () => this.beginAgentPublishing(agentName),
+        onCommitted: () => {
+          publicationCommitted = true;
+          onDurableCommit(completion);
+        },
       });
     } catch (error) {
-      agent.setSessionMetaMap(durableMeta);
-      if (durableLastRefreshAt == null) this.lastRefreshAtByAgent.delete(agentName);
-      else this.lastRefreshAtByAgent.set(agentName, durableLastRefreshAt);
+      if (!publicationCommitted) {
+        agent.setSessionMetaMap(durableMeta);
+        if (durableLastRefreshAt == null) this.lastRefreshAtByAgent.delete(agentName);
+        else this.lastRefreshAtByAgent.set(agentName, durableLastRefreshAt);
+      }
       throw error;
     }
     this.options.workerRunner.commit?.(agentName);
@@ -592,9 +679,8 @@ export class AgentSyncEngine {
         agent: agentName,
         failures: strategyResult.sourceFailures,
       });
-      throw sourceFailureError(strategyResult.sourceFailures);
     }
-    return "committed";
+    return { result: "committed", completion };
   }
 
   /**
@@ -978,6 +1064,7 @@ export class AgentSyncEngine {
       );
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const fullSessions = attachMissingProjectIdentities(result.sessions);
+      const completion = buildScanCompletion(result.completeness, result.sourceFailures ?? []);
       this.flushProgressStatus(`backfill:${agentName}`);
       const updatePublicationPhase = (phase: "publish-queued" | "publishing") => {
         if (
@@ -994,7 +1081,7 @@ export class AgentSyncEngine {
         }
       };
       updatePublicationPhase("publish-queued");
-      await this.commitSessionPublication({
+      const publication = await this.commitSessionPublication({
         context: "scan.backfill",
         agentName,
         sessions: fullSessions,
@@ -1010,20 +1097,39 @@ export class AgentSyncEngine {
           saveCache: true,
         },
         onPublishing: () => updatePublicationPhase("publishing"),
+        onCommitted: () => {
+          durableCommitted = true;
+          if (completion.completeness === "partial") {
+            this.backfills.recordCompletion(attempt, completion);
+          }
+        },
       });
-      durableCommitted = true;
+      durableCommitted = publication.durableCommitted;
       this.options.workerRunner.commit?.(agentName);
-      if (result.sourceFailures?.length) throw sourceFailureError(result.sourceFailures);
       markAgentFullSyncCompleted(agentName);
-      appLogger.info("scan.backfill.done", {
-        agent: agentName,
-        duration_ms: Math.round(performance.now() - startedAt),
-        sessions: fullSessions.length,
-        changed: result.changedIds?.length ?? 0,
-      });
+      appLogger.info(
+        result.sourceFailures?.length ? "scan.backfill.partial" : "scan.backfill.done",
+        {
+          agent: agentName,
+          duration_ms: Math.round(performance.now() - startedAt),
+          sessions: fullSessions.length,
+          changed: result.changedIds?.length ?? 0,
+          failed_sources: result.sourceFailures?.length ?? 0,
+        },
+      );
+      if (result.sourceFailures?.length) {
+        appLogger.warn("scan.backfill.source_failures", {
+          agent: agentName,
+          failures: result.sourceFailures,
+        });
+      }
       return "committed";
     } catch (error) {
-      if (!durableCommitted) agent.setSessionMetaMap(new Map(Object.entries(meta)));
+      if (durableCommitted) {
+        this.reportPostCommitError("scan.backfill", agentName, error);
+        return "committed";
+      }
+      agent.setSessionMetaMap(new Map(Object.entries(meta)));
       this.options.workerRunner.discard?.(agentName);
       appLogger.error("scan.backfill.error", { agent: agentName, error });
       console.error(`[${agentName}] Backfill failed:`, error);
@@ -1125,6 +1231,8 @@ export class AgentSyncEngine {
       publication.candidateChangedIds,
     );
     const diffDuration = performance.now() - diffStartedAt;
+    const result: SessionPublicationResult = { durableCommitted: true, event, diffDuration };
+    publication.onCommitted?.(result);
     this.emitSessionsChanged({
       agentName: publication.agentName,
       sessions: this.sessionIndex.snapshot().byAgent[publication.agentName] ?? [],
@@ -1137,7 +1245,7 @@ export class AgentSyncEngine {
       sessions: publication.sessions.length,
       has_event: event != null,
     });
-    return { event, diffDuration };
+    return result;
   }
 
   private findAgent(agentName: string): BaseAgent | undefined {

--- a/packages/cli/src/api/sse-event-buffer.ts
+++ b/packages/cli/src/api/sse-event-buffer.ts
@@ -10,7 +10,22 @@ export const MAX_PENDING_CRITICAL_SSE_FRAMES = 64;
 function scanStatusMilestone(status: ScanStatusEvent): string {
   const agentStates = Object.entries(status.agentStatuses)
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([agentName, agentStatus]) => [agentName, agentStatus.status, agentStatus.error ?? null]);
+    .map(([agentName, agentStatus]) => [
+      agentName,
+      agentStatus.status,
+      agentStatus.error ?? null,
+      agentStatus.completeness ?? null,
+      agentStatus.sourceFailureCount ?? null,
+      agentStatus.sourceFailureSummary ?? null,
+    ]);
+  const partialBackfills = Object.entries(status.backfill.partialAgents ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([agentName, completion]) => [
+      agentName,
+      completion.completeness,
+      completion.sourceFailureCount ?? null,
+      completion.sourceFailureSummary ?? null,
+    ]);
   return JSON.stringify([
     status.active,
     status.phase,
@@ -25,6 +40,7 @@ function scanStatusMilestone(status: ScanStatusEvent): string {
     status.backfill.completedAgents,
     status.backfill.failedAgents,
     status.backfill.progress?.phase ?? null,
+    partialBackfills,
     status.searchIndexMaintenance?.active ?? false,
     status.searchIndexMaintenance?.currentAgent ?? null,
     status.searchIndexMaintenance?.pendingAgents ?? [],

--- a/packages/cli/src/backfill-lifecycle.test.ts
+++ b/packages/cli/src/backfill-lifecycle.test.ts
@@ -58,6 +58,29 @@ describe("BackfillLifecycle", () => {
     expectValidStatus(lifecycle);
   });
 
+  it("retains partial snapshot completion after a committed attempt", () => {
+    const lifecycle = new BackfillLifecycle();
+    lifecycle.enqueue("codex");
+    const attempt = lifecycle.startNext()!;
+
+    expect(
+      lifecycle.recordCompletion(attempt, {
+        completeness: "partial",
+        sourceFailureCount: 1,
+        sourceFailureSummary: "SyntaxError: truncated JSON",
+      }),
+    ).toBe(true);
+    lifecycle.complete(attempt, "committed");
+
+    expect(lifecycle.status().partialAgents).toEqual({
+      codex: {
+        completeness: "partial",
+        sourceFailureCount: 1,
+        sourceFailureSummary: "SyntaxError: truncated JSON",
+      },
+    });
+  });
+
   it("ignores progress and results from an older attempt", () => {
     const lifecycle = new BackfillLifecycle();
     lifecycle.enqueue("codex");

--- a/packages/cli/src/backfill-lifecycle.ts
+++ b/packages/cli/src/backfill-lifecycle.ts
@@ -1,4 +1,4 @@
-import type { BackfillProgress, BackfillStatus } from "@codesesh/core/contract";
+import type { BackfillProgress, BackfillStatus, ScanCompletion } from "@codesesh/core/contract";
 
 export type BackfillTerminalStatus = "committed" | "failed" | "skipped";
 
@@ -8,9 +8,16 @@ export interface BackfillAttemptRef {
 }
 
 export type BackfillAttemptState =
-  | (BackfillAttemptRef & { status: "queued" })
-  | (BackfillAttemptRef & { status: "running"; progress?: BackfillProgress })
-  | (BackfillAttemptRef & { status: BackfillTerminalStatus | "cancelled" });
+  | (BackfillAttemptRef & { status: "queued"; completion?: ScanCompletion })
+  | (BackfillAttemptRef & {
+      status: "running";
+      progress?: BackfillProgress;
+      completion?: ScanCompletion;
+    })
+  | (BackfillAttemptRef & {
+      status: BackfillTerminalStatus | "cancelled";
+      completion?: ScanCompletion;
+    });
 
 export class BackfillLifecycle {
   private readonly attempts = new Map<string, BackfillAttemptState>();
@@ -52,9 +59,17 @@ export class BackfillLifecycle {
     return true;
   }
 
+  recordCompletion(attempt: BackfillAttemptRef, completion: ScanCompletion): boolean {
+    const current = this.matchingRunningAttempt(attempt);
+    if (!current) return false;
+    this.attempts.set(attempt.agentName, { ...current, completion: { ...completion } });
+    return true;
+  }
+
   complete(attempt: BackfillAttemptRef, status: BackfillTerminalStatus): boolean {
-    if (!this.matchingRunningAttempt(attempt)) return false;
-    this.attempts.set(attempt.agentName, { ...attempt, status });
+    const current = this.matchingRunningAttempt(attempt);
+    if (!current) return false;
+    this.attempts.set(attempt.agentName, { ...current, status });
     return true;
   }
 
@@ -74,9 +89,10 @@ export class BackfillLifecycle {
   stateFor(agentName: string): BackfillAttemptState | undefined {
     const state = this.attempts.get(agentName);
     if (!state) return undefined;
+    const completion = state.completion ? { completion: { ...state.completion } } : {};
     return state.status === "running" && state.progress
-      ? { ...state, progress: { ...state.progress } }
-      : { ...state };
+      ? { ...state, progress: { ...state.progress }, ...completion }
+      : { ...state, ...completion };
   }
 
   status(): BackfillStatus {
@@ -85,6 +101,12 @@ export class BackfillLifecycle {
       .filter((attempt) => attempt.status === "queued")
       .sort((left, right) => left.attemptId - right.attemptId);
     const running = states.find((attempt) => attempt.status === "running");
+    const partialAgents: Record<string, ScanCompletion> = {};
+    for (const attempt of states) {
+      if (attempt.status === "committed" && attempt.completion?.completeness === "partial") {
+        partialAgents[attempt.agentName] = { ...attempt.completion };
+      }
+    }
     const status: BackfillStatus = {
       active: running != null || queued.length > 0,
       pendingAgents: queued.map((attempt) => attempt.agentName),
@@ -94,6 +116,7 @@ export class BackfillLifecycle {
       failedAgents: states
         .filter((attempt) => attempt.status === "failed")
         .map((attempt) => attempt.agentName),
+      ...(Object.keys(partialAgents).length > 0 ? { partialAgents } : {}),
     };
     if (running) {
       status.currentAgent = running.agentName;

--- a/packages/cli/src/scan-status-model.test.ts
+++ b/packages/cli/src/scan-status-model.test.ts
@@ -225,6 +225,27 @@ describe("ScanStatusModel", () => {
     expect(complete.completedAgents).toEqual(["codex", "claude"]);
   });
 
+  it("keeps partial snapshot completion separate from a completed lifecycle", () => {
+    const model = new ScanStatusModel();
+    model.startBatch(["codex"], "scanning", { codex: 1 });
+    model.beginAgent("codex", 1);
+
+    const complete = model.finishAgent("codex", 1, {
+      completeness: "partial",
+      sourceFailureCount: 1,
+      sourceFailureSummary: "SyntaxError: truncated JSON",
+    });
+
+    expect(complete.agentStatuses.codex).toEqual(
+      expect.objectContaining({
+        status: "complete",
+        completeness: "partial",
+        sourceFailureCount: 1,
+        sourceFailureSummary: "SyntaxError: truncated JSON",
+      }),
+    );
+  });
+
   it("returns detached snapshots", () => {
     const model = new ScanStatusModel();
     model.startBatch(["codex"], "initializing", { codex: 1 });
@@ -301,6 +322,27 @@ describe("ScanStatusModel", () => {
       completedAgents: ["codex"],
       failedAgents: [],
     });
+  });
+
+  it("copies partial backfill completion into the status snapshot", () => {
+    const model = new ScanStatusModel();
+    const status = model.updateBackfill({
+      active: false,
+      pendingAgents: [],
+      completedAgents: ["codex"],
+      failedAgents: [],
+      partialAgents: {
+        codex: {
+          completeness: "partial",
+          sourceFailureCount: 1,
+          sourceFailureSummary: "SyntaxError: truncated JSON",
+        },
+      },
+    });
+
+    status.backfill.partialAgents!.codex!.sourceFailureCount = 2;
+
+    expect(model.snapshot().backfill.partialAgents?.codex?.sourceFailureCount).toBe(1);
   });
 
   it("tracks search-index maintenance independently from session scanning", () => {

--- a/packages/cli/src/scan-status-model.ts
+++ b/packages/cli/src/scan-status-model.ts
@@ -1,6 +1,7 @@
 import type { AgentScanProgress } from "@codesesh/core";
 import type {
   BackfillStatus,
+  ScanCompletion,
   ScanStatusEvent,
   SearchIndexMaintenanceStatus,
 } from "@codesesh/core/contract";
@@ -39,6 +40,16 @@ export class ScanStatusModel {
       backfill.progress = { ...this.status.backfill.progress };
     } else {
       delete backfill.progress;
+    }
+    if (this.status.backfill.partialAgents) {
+      backfill.partialAgents = Object.fromEntries(
+        Object.entries(this.status.backfill.partialAgents).map(([agentName, completion]) => [
+          agentName,
+          { ...completion },
+        ]),
+      );
+    } else {
+      delete backfill.partialAgents;
     }
     return {
       type: "scan-status",
@@ -216,7 +227,11 @@ export class ScanStatusModel {
     });
   }
 
-  finishAgent(agentName: string, sessionCount?: number): ScanStatusEvent {
+  finishAgent(
+    agentName: string,
+    sessionCount?: number,
+    completion: ScanCompletion = { completeness: "complete" },
+  ): ScanStatusEvent {
     const pendingAgents = this.status.pendingAgents.filter((agent) => agent !== agentName);
     const scanningAgents = this.status.scanningAgents.filter((agent) => agent !== agentName);
     const completedAgents = [...new Set([...this.status.completedAgents, agentName])];
@@ -229,6 +244,7 @@ export class ScanStatusModel {
       [agentName]: {
         agentName,
         status: "complete" as const,
+        ...completion,
         total,
         processed: total,
         sessions: sessionCount ?? previousStatus?.sessions ?? 0,
@@ -302,6 +318,7 @@ export class ScanStatusModel {
             : {
                 ...status,
                 status: "complete",
+                completeness: status.completeness ?? "complete",
                 completedAt: status.completedAt ?? now,
                 updatedAt: now,
               },
@@ -321,6 +338,16 @@ export class ScanStatusModel {
         completedAgents: [...backfill.completedAgents],
         failedAgents: [...backfill.failedAgents],
         progress: backfill.progress ? { ...backfill.progress } : undefined,
+        ...(backfill.partialAgents
+          ? {
+              partialAgents: Object.fromEntries(
+                Object.entries(backfill.partialAgents).map(([agentName, completion]) => [
+                  agentName,
+                  { ...completion },
+                ]),
+              ),
+            }
+          : {}),
       },
       updatedAt: Date.now(),
     });

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -97,6 +97,9 @@ export interface AgentScanStatus {
     | "indexing"
     | "complete"
     | "failed";
+  completeness?: ScanCompletion["completeness"];
+  sourceFailureCount?: number;
+  sourceFailureSummary?: string;
   error?: string;
   total?: number;
   processed?: number;
@@ -104,6 +107,13 @@ export interface AgentScanStatus {
   startedAt?: number;
   updatedAt: number;
   completedAt?: number;
+}
+
+/** Snapshot completeness is independent from whether the operation completed. */
+export interface ScanCompletion {
+  completeness: "complete" | "partial";
+  sourceFailureCount?: number;
+  sourceFailureSummary?: string;
 }
 
 /**
@@ -125,6 +135,7 @@ export interface BackfillStatus {
   progress?: BackfillProgress;
   completedAgents: string[];
   failedAgents: string[];
+  partialAgents?: Record<string, ScanCompletion>;
 }
 
 export interface SearchIndexMaintenanceStatus {


### PR DESCRIPTION
## Summary

- Report source failures as committed partial refresh and backfill outcomes.
- Preserve worker state and scan lifecycle after the publication boundary.
- Surface bounded source-failure counts and summaries in scan status.

## Root cause

CS-245 threw source failures after publication and worker commit, so the outer failure path discarded a committed worker and reported the scan as failed.

## Validation

- pnpm test
- pnpm lint
- pnpm format:check
- pnpm --filter codesesh typecheck
- pnpm --filter @codesesh/web build