### PR TITLE
fix(codex): cache child final messages

### DIFF
--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1,6 +1,7 @@
 import {
   mkdtempSync,
   mkdirSync,
+  openSync,
   readFileSync,
   rmSync,
   statSync,
@@ -23,6 +24,7 @@ vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
     ...actual,
+    openSync: vi.fn(actual.openSync),
     readFileSync: vi.fn(actual.readFileSync),
     statSync: vi.fn(actual.statSync),
   };
@@ -1633,6 +1635,105 @@ describe("CodexAgent subagent folding", () => {
 
     expect(someCallCount).toBe(0);
     expect(visibleMessages).toHaveLength(400);
+  });
+
+  function childOpenCount(filePath: string): number {
+    return vi.mocked(openSync).mock.calls.filter(([path]) => String(path) === filePath).length;
+  }
+
+  it("caches child final messages until the source or parser changes", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
+    tempDirs.push(tempDir);
+    writeSession(tempDir, PARENT_ID, { threadSource: "user" });
+    writeSession(tempDir, CHILD_ID, {
+      threadSource: "subagent",
+      parentThreadId: PARENT_ID,
+      extra: [
+        '{"timestamp":"2026-04-20T10:03:00Z","type":"response_item","phase":"final_answer","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first child result"}]}}',
+      ],
+    });
+    const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+    agent.scan({ from: 0 });
+    agent.getSessionData(PARENT_ID);
+
+    const openSpy = vi.mocked(openSync);
+    openSpy.mockClear();
+    agent.getSessionData(PARENT_ID);
+    expect(childOpenCount(childFile)).toBe(0);
+
+    const cacheEntry = agent.childFinalMessagesByParent.get(PARENT_ID)?.get(childFile);
+    expect(cacheEntry).toBeDefined();
+    cacheEntry.parserVersion = "codex-parser-old";
+    openSpy.mockClear();
+    agent.getSessionData(PARENT_ID);
+    expect(childOpenCount(childFile)).toBeGreaterThan(0);
+
+    writeSession(tempDir, CHILD_ID, {
+      threadSource: "subagent",
+      parentThreadId: PARENT_ID,
+      extra: [
+        '{"timestamp":"2026-04-20T10:03:00Z","type":"response_item","phase":"final_answer","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"updated child result"}]}}',
+      ],
+    });
+    openSpy.mockClear();
+    const refreshed = agent.getSessionData(PARENT_ID);
+    expect(childOpenCount(childFile)).toBeGreaterThan(0);
+    expect(refreshed.messages).toContainEqual(
+      expect.objectContaining({
+        parts: [expect.objectContaining({ type: "text", text: "updated child result" })],
+      }),
+    );
+  });
+
+  it("caches a child with no final message", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
+    tempDirs.push(tempDir);
+    writeSession(tempDir, PARENT_ID, { threadSource: "user" });
+    writeSession(tempDir, CHILD_ID, {
+      threadSource: "subagent",
+      parentThreadId: PARENT_ID,
+    });
+    const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+    agent.scan({ from: 0 });
+    expect(agent.getSessionData(PARENT_ID).messages).toEqual([]);
+
+    vi.mocked(openSync).mockClear();
+    expect(agent.getSessionData(PARENT_ID).messages).toEqual([]);
+    expect(childOpenCount(childFile)).toBe(0);
+  });
+
+  it("prunes child final message cache entries when a child disappears", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-subagent-"));
+    tempDirs.push(tempDir);
+    writeSession(tempDir, PARENT_ID, { threadSource: "user" });
+    writeSession(tempDir, CHILD_ID, {
+      threadSource: "subagent",
+      parentThreadId: PARENT_ID,
+      extra: [
+        '{"timestamp":"2026-04-20T10:03:00Z","type":"response_item","phase":"final_answer","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"child result"}]}}',
+      ],
+    });
+    const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    agent.sessionIndexCache = new Map();
+    agent.scan({ from: 0 });
+    agent.getSessionData(PARENT_ID);
+    expect(agent.childFinalMessagesByParent.get(PARENT_ID)?.has(childFile)).toBe(true);
+
+    rmSync(childFile);
+    agent.subagentIndex = null;
+    agent.getSessionData(PARENT_ID);
+    expect(agent.childFinalMessagesByParent.has(PARENT_ID)).toBe(false);
   });
 
   it("finds child rollouts when detail parsing starts from cached metadata", () => {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1448,6 +1448,26 @@ describe("CodexAgent subagent folding", () => {
     return `{"timestamp":"2026-04-20T10:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":${input},"output_tokens":${output}},"total_token_usage":{"total_tokens":${total}}}}}`;
   }
 
+  function makeMessage(options: {
+    subagentId?: string;
+    nickname?: string;
+    texts: string[];
+  }): Message {
+    return {
+      id: `message-${options.texts.join("-")}`,
+      role: "assistant",
+      agent: "codex",
+      time_created: 0,
+      mode: null,
+      model: null,
+      provider: null,
+      cost: 0,
+      ...(options.subagentId === undefined ? {} : { subagent_id: options.subagentId }),
+      ...(options.nickname === undefined ? {} : { nickname: options.nickname }),
+      parts: options.texts.map((text) => ({ type: "text", text, time_created: 0 })),
+    };
+  }
+
   afterEach(() => {
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
@@ -1557,6 +1577,62 @@ describe("CodexAgent subagent folding", () => {
       ),
     ).toBe(false);
     expect(data.stats.message_count).toBe(data.messages.length);
+  });
+
+  it("merges child messages with exact id and nickname/text visibility rules", () => {
+    const agent = new CodexAgent() as any;
+    const visibleMessages = [
+      makeMessage({ subagentId: "known-child", nickname: "worker", texts: ["id match"] }),
+      makeMessage({ nickname: "worker", texts: ["prefix", "shared text"] }),
+    ];
+
+    agent.mergeChildMessages(visibleMessages, [
+      makeMessage({ subagentId: "known-child", nickname: "other", texts: ["different"] }),
+      makeMessage({ nickname: "worker", texts: ["shared text"] }),
+      makeMessage({ subagentId: "different-child", nickname: "worker", texts: ["shared text"] }),
+      makeMessage({ nickname: "worker", texts: ["different text"] }),
+    ]);
+
+    expect(
+      visibleMessages.map((message) => {
+        const part = message.parts[0];
+        return part?.type === "text" ? part.text : undefined;
+      }),
+    ).toEqual(["id match", "prefix", "different text"]);
+
+    const identifiedVisible = [
+      makeMessage({ subagentId: "identified", nickname: "worker", texts: ["shared text"] }),
+    ];
+    agent.mergeChildMessages(identifiedVisible, [
+      makeMessage({ nickname: "worker", texts: ["shared text"] }),
+    ]);
+    expect(identifiedVisible).toHaveLength(2);
+
+    const newlyVisible: Message[] = [];
+    agent.mergeChildMessages(newlyVisible, [
+      makeMessage({ nickname: "worker", texts: ["new text"] }),
+      makeMessage({ nickname: "worker", texts: ["new text"] }),
+    ]);
+    expect(newlyVisible).toHaveLength(1);
+  });
+
+  it("merges large child batches without pairwise array scans", () => {
+    const agent = new CodexAgent() as any;
+    const visibleMessages = Array.from({ length: 200 }, (_, index) =>
+      makeMessage({ nickname: `worker-${index}`, texts: [`visible-${index}`] }),
+    );
+    const childMessages = Array.from({ length: 200 }, (_, index) =>
+      makeMessage({ nickname: `child-${index}`, texts: [`child-${index}`] }),
+    );
+    const someSpy = vi.spyOn(Array.prototype, "some");
+
+    someSpy.mockClear();
+    agent.mergeChildMessages(visibleMessages, childMessages);
+    const someCallCount = someSpy.mock.calls.length;
+    someSpy.mockRestore();
+
+    expect(someCallCount).toBe(0);
+    expect(visibleMessages).toHaveLength(400);
   });
 
   it("finds child rollouts when detail parsing starts from cached metadata", () => {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -363,6 +363,46 @@ interface SessionMeta extends FileSessionMeta {
   parentThreadId: string | null;
 }
 
+class ChildMessageVisibilityIndex {
+  private readonly visibleSubagentIds = new Set<string>();
+  private readonly visibleNicknameTexts = new Map<string, Set<string>>();
+
+  constructor(messages: Message[]) {
+    for (const message of messages) this.add(message);
+  }
+
+  hasEquivalent(message: Message): boolean {
+    if (message.subagent_id !== undefined && this.visibleSubagentIds.has(message.subagent_id)) {
+      return true;
+    }
+
+    const nickname = message.nickname;
+    const text = message.parts.find((part) => part.type === "text")?.text;
+    return (
+      nickname !== undefined &&
+      text !== undefined &&
+      this.visibleNicknameTexts.get(nickname)?.has(text) === true
+    );
+  }
+
+  add(message: Message): void {
+    if (message.subagent_id !== undefined) {
+      this.visibleSubagentIds.add(message.subagent_id);
+      return;
+    }
+    if (message.nickname === undefined) return;
+
+    let texts = this.visibleNicknameTexts.get(message.nickname);
+    if (!texts) {
+      texts = new Set();
+      this.visibleNicknameTexts.set(message.nickname, texts);
+    }
+    for (const part of message.parts) {
+      if (part.type === "text") texts.add(part.text);
+    }
+  }
+}
+
 function compareSourceActivityDesc(left: SessionSourceFile, right: SessionSourceFile): number {
   const leftTimestamp = sourceTimestamp(left.file, left.stat.mtimeMs);
   const rightTimestamp = sourceTimestamp(right.file, right.stat.mtimeMs);
@@ -661,19 +701,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     this.applyChildStats(result.stats, meta.id);
 
     const childMessages = this.collectChildMessages(meta.id);
-    for (const message of childMessages) {
-      const messageText = message.parts.find((part) => part.type === "text")?.text;
-      const alreadyVisible = result.messages.some(
-        (existing) =>
-          (message.subagent_id !== undefined && existing.subagent_id === message.subagent_id) ||
-          (existing.subagent_id === undefined &&
-            message.nickname !== undefined &&
-            messageText !== undefined &&
-            existing.nickname === message.nickname &&
-            existing.parts.some((part) => part.type === "text" && part.text === messageText)),
-      );
-      if (!alreadyVisible) result.messages.push(message);
-    }
+    this.mergeChildMessages(result.messages, childMessages);
     result.stats.message_count = result.messages.length;
 
     return {
@@ -740,6 +768,15 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
 
   private collectChildFiles(parentSessionId: string): string[] {
     return this.ensureSubagentIndex().childFilesByParent.get(parentSessionId) ?? [];
+  }
+
+  private mergeChildMessages(visibleMessages: Message[], childMessages: Message[]): void {
+    const visible = new ChildMessageVisibilityIndex(visibleMessages);
+    for (const message of childMessages) {
+      if (visible.hasEquivalent(message)) continue;
+      visibleMessages.push(message);
+      visible.add(message);
+    }
   }
 
   private collectChildMessages(parentSessionId: string): Message[] {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -363,6 +363,12 @@ interface SessionMeta extends FileSessionMeta {
   parentThreadId: string | null;
 }
 
+interface ChildFinalMessageCacheEntry {
+  sourceFingerprint: string;
+  parserVersion: string;
+  message: Message | null;
+}
+
 class ChildMessageVisibilityIndex {
   private readonly visibleSubagentIds = new Set<string>();
   private readonly visibleNicknameTexts = new Map<string, Set<string>>();
@@ -432,6 +438,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   private sessionIndexPath: string | undefined;
   private subagentIndex: SubagentIndex | null = null;
   private subagentStatsByParent = new Map<string, SessionHead["stats"][]>();
+  private childFinalMessagesByParent = new Map<string, Map<string, ChildFinalMessageCacheEntry>>();
 
   // ---- BaseAgent implementation ----
 
@@ -470,6 +477,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     super.setSessionMetaMap(meta);
     this.subagentIndex = null;
     this.subagentStatsByParent.clear();
+    this.childFinalMessagesByParent.clear();
   }
 
   /**
@@ -493,6 +501,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       expanded.add(parentId);
       this.subagentIndex = null;
       this.subagentStatsByParent.delete(parentId);
+      this.childFinalMessagesByParent.delete(parentId);
     }
     return [...expanded];
   }
@@ -780,15 +789,54 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   }
 
   private collectChildMessages(parentSessionId: string): Message[] {
-    return this.collectChildFiles(parentSessionId)
+    const childFiles = this.collectChildFiles(parentSessionId);
+    this.reconcileChildFinalMessageCache(parentSessionId, childFiles);
+    return childFiles
       .flatMap((file) => {
-        const message = this.parseChildFinalMessage(file);
+        const message = this.getChildFinalMessage(parentSessionId, file);
         return message ? [message] : [];
       })
       .sort((left, right) => left.time_created - right.time_created);
   }
 
-  private parseChildFinalMessage(filePath: string): Message | null {
+  private getChildFinalMessage(parentSessionId: string, filePath: string): Message | null {
+    const sourceFingerprint = this.childFinalMessageFingerprint(filePath);
+    let cache = this.childFinalMessagesByParent.get(parentSessionId);
+    if (!cache) {
+      cache = new Map();
+      this.childFinalMessagesByParent.set(parentSessionId, cache);
+    }
+
+    const cached = cache.get(filePath);
+    if (
+      cached?.sourceFingerprint === sourceFingerprint &&
+      cached.parserVersion === PARSER_VERSION
+    ) {
+      return cached.message;
+    }
+
+    const message = this.readChildFinalMessage(filePath);
+    cache.set(filePath, { sourceFingerprint, parserVersion: PARSER_VERSION, message });
+    return message;
+  }
+
+  private reconcileChildFinalMessageCache(parentSessionId: string, childFiles: string[]): void {
+    const cache = this.childFinalMessagesByParent.get(parentSessionId);
+    if (!cache) return;
+
+    const activeFiles = new Set(childFiles);
+    for (const filePath of cache.keys()) {
+      if (!activeFiles.has(filePath)) cache.delete(filePath);
+    }
+    if (cache.size === 0) this.childFinalMessagesByParent.delete(parentSessionId);
+  }
+
+  private childFinalMessageFingerprint(filePath: string): string {
+    const { mtimeMs, size } = statSync(filePath);
+    return JSON.stringify([mtimeMs, size]);
+  }
+
+  private readChildFinalMessage(filePath: string): Message | null {
     const sessionId = extractSessionId(filePath);
     const threadMeta = this.readThreadMeta(filePath);
     type ChildOutput = { id: string; text: string; timestampMs: number; isFinal: boolean };


### PR DESCRIPTION
## Summary
- Replace pairwise child-message visibility scans with a Set/Map index.
- Cache parsed child final messages by source fingerprint and parser version.
- Invalidate and prune cache entries as parent or child sources change.

## Validation
- pnpm test
- pnpm lint
- pnpm format:check
- pnpm --filter @codesesh/core build && pnpm --filter ./packages/cli typecheck && pnpm --filter @codesesh/web build