### PR TITLE
fix(api): cache dashboard storage aggregates

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -4,6 +4,7 @@ const coreMocks = vi.hoisted(() => {
   return {
     attachProjectMetrics: vi.fn(),
     buildDashboard: vi.fn(),
+    getAnalyticsRevision: vi.fn(() => "0"),
     materializeSessionDetailResponse: vi.fn(),
     listFileActivity: vi.fn((): FileActivityResult[] => []),
     listModelCostDistribution: vi.fn((): ModelCostEntry[] | null => null),
@@ -46,6 +47,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
       coreMocks.buildDashboard(...args);
       return actual.buildDashboard(...args);
     },
+    getAnalyticsRevision: coreMocks.getAnalyticsRevision,
     materializeSessionDetailResponse: coreMocks.materializeSessionDetailResponse,
     listFileActivity: coreMocks.listFileActivity,
     listModelCostDistribution: coreMocks.listModelCostDistribution,
@@ -226,6 +228,8 @@ function toLocalDateKey(ts: number): string {
 afterEach(() => {
   coreMocks.attachProjectMetrics.mockClear();
   coreMocks.buildDashboard.mockClear();
+  coreMocks.getAnalyticsRevision.mockReset();
+  coreMocks.getAnalyticsRevision.mockReturnValue("0");
   coreMocks.materializeSessionDetailResponse.mockReset();
   coreMocks.listFileActivity.mockReset();
   coreMocks.listFileActivity.mockReturnValue([]);
@@ -1580,6 +1584,23 @@ describe("handleGetDashboard", () => {
     handleGetDashboard(makeMockContext({ query: { from: "2026-07-20", to, days: "3" } }), source);
 
     expect(coreMocks.buildDashboard).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses storage aggregations until the analytics revision changes", () => {
+    const source = makeScanSource();
+    coreMocks.getAnalyticsRevision.mockReturnValue("1");
+
+    handleGetDashboard(makeMockContext(), source);
+    handleGetDashboard(makeMockContext(), source);
+
+    expect(coreMocks.listFileActivity).toHaveBeenCalledTimes(1);
+    expect(coreMocks.listModelCostDistribution).toHaveBeenCalledTimes(1);
+
+    coreMocks.getAnalyticsRevision.mockReturnValue("2");
+    handleGetDashboard(makeMockContext(), source);
+
+    expect(coreMocks.listFileActivity).toHaveBeenCalledTimes(2);
+    expect(coreMocks.listModelCostDistribution).toHaveBeenCalledTimes(2);
   });
 
   it("propagates a null model-cost distribution instead of substituting zeros", () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -30,6 +30,7 @@ import {
   createProjectScopeMatcherFromIdentity,
   deleteBookmark,
   getAgentInfoMap,
+  getAnalyticsRevision,
   executeSessionSearch,
   getSearchProjectDirectory,
   importBookmarks,
@@ -151,6 +152,7 @@ interface SnapshotAggregationCache {
 
 const SNAPSHOT_AGGREGATION_CACHE_LIMIT = 64;
 const snapshotAggregationCaches = new WeakMap<ScanResultSource, SnapshotAggregationCache>();
+type SnapshotAggregationCacheState = "hit" | "miss";
 
 /**
  * LiveScanStore replaces its canonical sessions array whenever the snapshot
@@ -161,6 +163,7 @@ function getSnapshotAggregation<T>(
   sessions: SessionHead[],
   key: readonly unknown[],
   build: () => T,
+  onCacheState?: (state: SnapshotAggregationCacheState) => void,
 ): T {
   let cache = snapshotAggregationCaches.get(source);
   if (!cache || cache.sessions !== sessions) {
@@ -169,7 +172,13 @@ function getSnapshotAggregation<T>(
   }
 
   const cacheKey = JSON.stringify(key);
-  if (cache.values.has(cacheKey)) return cache.values.get(cacheKey) as T;
+  if (cache.values.has(cacheKey)) {
+    const cached = cache.values.get(cacheKey) as T;
+    cache.values.delete(cacheKey);
+    cache.values.set(cacheKey, cached);
+    onCacheState?.("hit");
+    return cached;
+  }
 
   const value = build();
   if (cache.values.size >= SNAPSHOT_AGGREGATION_CACHE_LIMIT) {
@@ -177,7 +186,68 @@ function getSnapshotAggregation<T>(
     if (oldestKey != null) cache.values.delete(oldestKey);
   }
   cache.values.set(cacheKey, value);
+  onCacheState?.("miss");
   return value;
+}
+
+type DashboardStorageAggregation = Pick<DashboardData, "recentFileActivities" | "modelCost">;
+
+function getDashboardStorageAggregation(
+  source: ScanResultSource,
+  sessions: SessionHead[],
+  scope: DashboardScope,
+  from: number | undefined,
+  to: number,
+  cacheTo: number,
+  analyticsRevision: string | null,
+): DashboardStorageAggregation {
+  const build = (): DashboardStorageAggregation => ({
+    recentFileActivities: listFileActivity({
+      agent: scope.agent,
+      projectKind: scope.projectKind,
+      projectKey: scope.projectKey,
+      from,
+      to,
+      limit: 12,
+    }),
+    modelCost: listModelCostDistribution({
+      agent: scope.agent,
+      projectKind: scope.projectKind,
+      projectKey: scope.projectKey,
+      from,
+      to,
+    }),
+  });
+  const startedAt = performance.now();
+  const log = (cache: SnapshotAggregationCacheState | "unavailable") => {
+    appLogger.info("api.dashboard.storage_aggregation", {
+      cache,
+      ...(analyticsRevision === null ? {} : { analytics_revision: analyticsRevision }),
+      duration_ms: Math.round(performance.now() - startedAt),
+    });
+  };
+
+  if (analyticsRevision === null) {
+    const value = build();
+    log("unavailable");
+    return value;
+  }
+
+  return getSnapshotAggregation(
+    source,
+    sessions,
+    [
+      "dashboard-storage",
+      scope.agent,
+      scope.projectKind,
+      scope.projectKey,
+      from,
+      cacheTo,
+      analyticsRevision,
+    ],
+    build,
+    log,
+  );
 }
 
 interface ClientLogPayload {
@@ -976,6 +1046,7 @@ export function handleGetDashboard(
       : { from: addCalendarDays(from, -(days ?? countCalendarDays(from, to))), to: from - 1 };
 
   const fixedTo = dateWindow.to;
+  const cacheTo = fixedTo ?? startOfCalendarDay(to);
   const aggregate = getSnapshotAggregation(
     scanSource,
     scanResult.sessions,
@@ -985,7 +1056,7 @@ export function handleGetDashboard(
       scope.projectKind,
       scope.projectKey,
       from,
-      fixedTo ?? startOfCalendarDay(to),
+      cacheTo,
       compare?.from,
       compare?.to,
     ],
@@ -1003,23 +1074,18 @@ export function handleGetDashboard(
     },
   );
 
+  const storageAggregation = getDashboardStorageAggregation(
+    scanSource,
+    scanResult.sessions,
+    scope,
+    from,
+    to,
+    cacheTo,
+    getAnalyticsRevision(),
+  );
   const data: DashboardData = {
     ...aggregate,
-    recentFileActivities: listFileActivity({
-      agent: scope.agent,
-      projectKind: scope.projectKind,
-      projectKey: scope.projectKey,
-      from,
-      to,
-      limit: 12,
-    }),
-    modelCost: listModelCostDistribution({
-      agent: scope.agent,
-      projectKind: scope.projectKind,
-      projectKey: scope.projectKey,
-      from,
-      to,
-    }),
+    ...storageAggregation,
     window: { from, to, days, compareFrom: compare?.from, compareTo: compare?.to },
   };
 

--- a/packages/core/src/discovery/cache/__tests__/analytics-revision.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/analytics-revision.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-analytics-revision-test-"));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(() => testHomeDir) };
+});
+
+import {
+  advanceAnalyticsRevision,
+  getAnalyticsRevision,
+  readAnalyticsRevision,
+} from "../analytics-revision.js";
+import { getCachePath, setSchemaEnsuredPath } from "../db.js";
+import { withCacheDb } from "../schema.js";
+import { commitDurableSessionPublication } from "../publication.js";
+import { clearCache, saveCachedSessionChanges, saveCachedSessions } from "../sessions.js";
+import { syncSessionSearchIndex, syncSessionSearchIndexChanges } from "../search.js";
+import { openDbReadOnly } from "../../../utils/sqlite.js";
+import { makeSessionData, makeSessionHead } from "./fixtures.js";
+
+function cacheDir(): string {
+  return join(testHomeDir, ".cache", "codesesh");
+}
+
+beforeEach(() => {
+  setSchemaEnsuredPath(null);
+  rmSync(cacheDir(), { recursive: true, force: true });
+});
+
+afterEach(() => {
+  setSchemaEnsuredPath(null);
+  rmSync(cacheDir(), { recursive: true, force: true });
+});
+
+describe("analytics revision", () => {
+  it("advances for durable session, message, activity, and deletion commits", () => {
+    const session = makeSessionHead("one");
+    const detail = {
+      ...makeSessionData(session.id),
+      messages: [
+        {
+          id: "one-message",
+          role: "assistant" as const,
+          time_created: 1,
+          model: "gpt-5",
+          cost: 1,
+          parts: [
+            {
+              type: "tool" as const,
+              tool: "write",
+              state: { status: "completed" as const, input: { path: "src/index.ts" } },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(getAnalyticsRevision()).toBeNull();
+    expect(saveCachedSessions("codex", [session])).toBe(true);
+    expect(getAnalyticsRevision()).toBe("1");
+
+    expect(syncSessionSearchIndex("codex", [session], () => detail)).toMatchObject({
+      indexed: 1,
+    });
+    expect(getAnalyticsRevision()).toBe("2");
+
+    expect(syncSessionSearchIndexChanges("codex", [], [session.id], () => detail)).toMatchObject({
+      deleted: 1,
+    });
+    expect(getAnalyticsRevision()).toBe("3");
+  });
+
+  it("does not advance for an empty change set or a rolled-back transaction", () => {
+    const session = makeSessionHead("one");
+    saveCachedSessions("codex", [session]);
+    expect(getAnalyticsRevision()).toBe("1");
+
+    expect(saveCachedSessionChanges("codex", [], [])).toBe(true);
+    expect(getAnalyticsRevision()).toBe("1");
+
+    withCacheDb((db) => {
+      expect(() =>
+        db
+          .transaction(() => {
+            advanceAnalyticsRevision(db);
+            throw new Error("rollback");
+          })
+          .immediate(),
+      ).toThrow("rollback");
+    });
+    expect(getAnalyticsRevision()).toBe("1");
+  });
+
+  it("advances once when a durable publication commits both cache layers", () => {
+    const session = makeSessionHead("one");
+
+    expect(
+      commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions: [session],
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+        },
+        () => makeSessionData(session.id),
+      ),
+    ).toMatchObject({ status: "committed", searchIndex: { indexed: 1 } });
+    expect(getAnalyticsRevision()).toBe("1");
+  });
+
+  it("is shared by independent database connections and survives cache clearing", () => {
+    const session = makeSessionHead("one");
+    saveCachedSessions("codex", [session]);
+    const secondConnection = openDbReadOnly(getCachePath());
+    expect(secondConnection).not.toBeNull();
+
+    try {
+      expect(readAnalyticsRevision(secondConnection!)).toBe("1");
+      saveCachedSessionChanges(
+        "codex",
+        [{ session: { ...session, title: "Updated" }, sortIndex: 0 }],
+        [],
+      );
+      expect(readAnalyticsRevision(secondConnection!)).toBe("2");
+    } finally {
+      secondConnection?.close();
+    }
+
+    clearCache();
+    expect(getAnalyticsRevision()).toBe("3");
+    const freshConnection = openDbReadOnly(getCachePath());
+    try {
+      expect(readAnalyticsRevision(freshConnection!)).toBe("3");
+    } finally {
+      freshConnection?.close();
+    }
+  });
+});

--- a/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
@@ -90,11 +90,15 @@ describe("listModelCostDistribution", () => {
   it("groups message cost by model and splits recorded from estimated", () => {
     seedFixture();
 
-    expect(listModelCostDistribution()).toEqual([
+    const distribution = listModelCostDistribution();
+    expect(distribution).toEqual([
       { model: "gpt-5", cost: 3, costRecorded: 0, costEstimated: 3 },
       { model: "sonnet", cost: 1.5, costRecorded: 1, costEstimated: 0.5 },
       { model: "haiku", cost: 0.25, costRecorded: 0, costEstimated: 0.25 },
     ]);
+    for (const entry of distribution ?? []) {
+      expect(entry.costRecorded + entry.costEstimated).toBe(entry.cost);
+    }
   });
 
   it("scopes totals by agent, project and activity window", () => {

--- a/packages/core/src/discovery/cache/analytics-revision.ts
+++ b/packages/core/src/discovery/cache/analytics-revision.ts
@@ -1,0 +1,33 @@
+import type { SQLiteDatabase } from "../../utils/sqlite.js";
+import { hasCacheStorage } from "./db.js";
+import { withCacheDbReadOnly } from "./schema.js";
+
+const ANALYTICS_REVISION_KEY = "analytics_revision";
+
+interface AnalyticsRevisionRow {
+  value?: string | number;
+}
+
+export function readAnalyticsRevision(db: SQLiteDatabase): string {
+  const row = db
+    .prepare("SELECT value FROM cache_meta WHERE key = ?")
+    .get(ANALYTICS_REVISION_KEY) as AnalyticsRevisionRow | undefined;
+  return String(row?.value ?? "0");
+}
+
+export function advanceAnalyticsRevision(db: SQLiteDatabase): void {
+  db.prepare(
+    `
+      INSERT INTO cache_meta(key, value)
+      VALUES (?, '1')
+      ON CONFLICT(key) DO UPDATE SET value = CAST(value AS INTEGER) + 1
+    `,
+  ).run(ANALYTICS_REVISION_KEY);
+}
+
+export function getAnalyticsRevision(): string | null {
+  if (!hasCacheStorage()) return null;
+
+  const read = withCacheDbReadOnly((db) => readAnalyticsRevision(db));
+  return read.status === "success" ? read.value : null;
+}

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -3,6 +3,7 @@ import type { SessionCacheMeta } from "../../agents/base.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { SessionHeadChange } from "./db.js";
+import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import { sessionDetailVersion } from "./detail-version.js";
 import { assertSessionProjectIdentities } from "./messages.js";
 import {
@@ -158,6 +159,7 @@ export function commitDurableSessionPublication(
           ...detail,
           stage: "search_staged",
         });
+        advanceAnalyticsRevision(db);
         failureStage = "commit";
         return result;
       })

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -944,13 +944,7 @@ function executeSearchIndexPlan(
 
   if (largeBacklogStrategy === "chunked" && plan.changes.length > SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
     runSearchIndexWrite(db, false, () => {
-      indexed += writeSearchIndexRows(
-        db,
-        plan.agentName,
-        plan.removedSessionIds,
-        [],
-        failures,
-      );
+      indexed += writeSearchIndexRows(db, plan.agentName, plan.removedSessionIds, [], failures);
       if (plan.removedSessionIds.length > 0) advanceAnalyticsRevision(db);
     });
     for (let offset = 0; offset < plan.changes.length; offset += SEARCH_INDEX_COMMIT_CHUNK_SIZE) {

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -4,6 +4,7 @@ import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { SEARCH_INDEX_BULK_SYNC_THRESHOLD, type SessionHeadChange } from "./db.js";
+import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import {
   buildSessionContentFromMessages,
   MESSAGE_PARTS_FORMAT_VERSION,
@@ -943,12 +944,27 @@ function executeSearchIndexPlan(
 
   if (largeBacklogStrategy === "chunked" && plan.changes.length > SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
     runSearchIndexWrite(db, false, () => {
-      indexed += writeSearchIndexRows(db, plan.agentName, plan.removedSessionIds, [], failures);
+      indexed += writeSearchIndexRows(
+        db,
+        plan.agentName,
+        plan.removedSessionIds,
+        [],
+        failures,
+      );
+      if (plan.removedSessionIds.length > 0) advanceAnalyticsRevision(db);
     });
     for (let offset = 0; offset < plan.changes.length; offset += SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
       const chunk = plan.changes.slice(offset, offset + SEARCH_INDEX_COMMIT_CHUNK_SIZE);
       runSearchIndexWrite(db, false, () => {
-        indexed += writeSearchIndexRows(db, plan.agentName, [], loadEntries(chunk), failures);
+        const chunkIndexed = writeSearchIndexRows(
+          db,
+          plan.agentName,
+          [],
+          loadEntries(chunk),
+          failures,
+        );
+        indexed += chunkIndexed;
+        if (chunkIndexed > 0) advanceAnalyticsRevision(db);
       });
     }
     return searchIndexSyncResult(plan, indexed, failures, undefined, "incremental");
@@ -962,6 +978,7 @@ function executeSearchIndexPlan(
       loadEntries(plan.changes),
       failures,
     );
+    if (indexed > 0 || plan.removedSessionIds.length > 0) advanceAnalyticsRevision(db);
   });
   return searchIndexSyncResult(plan, indexed, failures, rebuildDurationMs);
 }

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -16,6 +16,7 @@ import {
   type ScalarRow,
   type SessionHeadChange,
 } from "./db.js";
+import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import { withCacheDb, withCacheDbReadOnly, type CacheReadOutcome } from "./schema.js";
 import {
   assertSessionProjectIdentities,
@@ -469,9 +470,10 @@ export function saveCachedSessions(
 ): boolean {
   assertSessionProjectIdentities(agentName, sessions);
   const persisted = withCacheDb((db) => {
-    db.transaction(() =>
-      writeCachedSessionSnapshot(db, agentName, sessions, meta, options),
-    ).immediate();
+    db.transaction(() => {
+      writeCachedSessionSnapshot(db, agentName, sessions, meta, options);
+      advanceAnalyticsRevision(db);
+    }).immediate();
     deleteLegacyCacheFile();
     return true;
   });
@@ -555,9 +557,12 @@ export function saveCachedSessionChanges(
     changes.map(({ session }) => session),
   );
   const persisted = withCacheDb((db) => {
-    db.transaction(() =>
-      writeCachedSessionChanges(db, agentName, changes, removedSessionIds, meta),
-    ).immediate();
+    db.transaction(() => {
+      writeCachedSessionChanges(db, agentName, changes, removedSessionIds, meta);
+      if (changes.length > 0 || removedSessionIds.length > 0) {
+        advanceAnalyticsRevision(db);
+      }
+    }).immediate();
     deleteLegacyCacheFile();
     return true;
   });
@@ -628,17 +633,21 @@ export function clearCache(): void {
   }
 
   withCacheDb((db) => {
-    db.exec(`
-      DELETE FROM agent_cache;
-      DELETE FROM cache_initialization;
-      DELETE FROM cached_sessions;
-      DELETE FROM session_documents;
-      DELETE FROM session_file_activity;
-      DELETE FROM message_tools;
-      DELETE FROM messages;
-      DELETE FROM sessions;
-      DELETE FROM project_sessions;
-    `);
+    db.transaction(() => {
+      db.exec(`
+        DELETE FROM agent_cache;
+        DELETE FROM cache_initialization;
+        DELETE FROM cached_sessions;
+        DELETE FROM session_documents;
+        DELETE FROM session_file_activity;
+        DELETE FROM message_tools;
+        DELETE FROM messages;
+        DELETE FROM sessions;
+        DELETE FROM project_sessions;
+        DELETE FROM cache_meta WHERE key <> 'analytics_revision';
+      `);
+      advanceAnalyticsRevision(db);
+    }).immediate();
   });
   closeCacheStorage();
 

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -43,6 +43,7 @@ export type {
 export type { CacheReadOutcome } from "./cache/schema.js";
 export { closeCacheStorage, getCachePath } from "./cache/db.js";
 export type { SessionHeadChange } from "./cache/db.js";
+export { getAnalyticsRevision } from "./cache/analytics-revision.js";
 export { listCachedProjectGroups } from "./cache/project-groups.js";
 export {
   listFileActivity,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,7 @@ export {
   ensureSessionTagsSync,
   getAgentFullSyncCursor,
   getAgentLastFullSyncAt,
+  getAnalyticsRevision,
   getCachePath,
   getSearchProjectDirectory,
   isAgentCacheInitialized,


### PR DESCRIPTION
## Summary
- Track a SQLite-backed analytics revision with every dashboard-relevant committed write.
- Cache dashboard model-cost and file-activity aggregates by scope, window, and revision.
- Record cache hit/miss aggregation latency and preserve numeric cost invariants.

## Validation
- pnpm test
- pnpm lint
- pnpm format:check
- pnpm --filter @codesesh/core build
- pnpm --filter ./packages/cli typecheck
- pnpm --filter @codesesh/web build