### PR TITLE
fix(discovery): stream cached message suffixes

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 24`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 25`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 24;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 25;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -1,13 +1,16 @@
 import { rmSync } from "node:fs";
 import { join } from "node:path";
+import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BaseAgent, type ChangeCheckResult, type SessionCacheMeta } from "../../agents/base.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
-import { saveCachedSessions } from "../cache/sessions.js";
+import { readCachedSessionCursor, saveCachedSessions } from "../cache/sessions.js";
+import { withCacheDb } from "../cache/schema.js";
+import { MESSAGE_CURSOR_VERSION } from "../cache/message-cursor.js";
 import { syncSessionSearchIndex } from "../cache/search.js";
 import { materializeSessionDetail, materializeSessionDetailResponse } from "../session-detail.js";
 import type { LiveSnapshot } from "../scanner.js";
-import { setSchemaEnsuredPath } from "../cache/db.js";
+import { getCachePath, setSchemaEnsuredPath } from "../cache/db.js";
 import { setCoreDiagnostics } from "../../utils/diagnostics.js";
 import { SMART_TAG_CLASSIFIER_REVISION } from "../../utils/smart-tags.js";
 
@@ -128,6 +131,24 @@ function makeScanResult(agent: TestAgent, head = makeHead()): LiveSnapshot {
 function persistDetail(head: SessionHead, detail: SessionDetail, fingerprint: string): void {
   saveCachedSessions("test", [head], { [head.id]: makeMeta(fingerprint) });
   syncSessionSearchIndex("test", [head], () => detail);
+}
+
+function withPreparedSqlCapture<T>(run: () => T): { result: T; sql: string[] } {
+  const preparedSql: string[] = [];
+  const originalPrepare = Database.prototype.prepare;
+  const prepareSpy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+    this: Database.Database,
+    source: string,
+  ) {
+    preparedSql.push(source);
+    return originalPrepare.call(this, source);
+  });
+
+  try {
+    return { result: run(), sql: preparedSql.map((sql) => sql.replace(/\s+/g, " ").trim()) };
+  } finally {
+    prepareSpy.mockRestore();
+  }
 }
 
 beforeEach(() => {
@@ -320,6 +341,11 @@ describe("materializeSessionDetail", () => {
   });
 
   it("streams only an unchanged message prefix's appended suffix", () => {
+    const diagnostics: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    setCoreDiagnostics({
+      info: (event, detail) => diagnostics.push({ event, detail }),
+      warn() {},
+    });
     const makeStreamableHead = (messageCount: number, timeUpdated: number) => {
       const head = makeHead({
         time_updated: timeUpdated,
@@ -341,8 +367,9 @@ describe("materializeSessionDetail", () => {
         parts: [{ type: "text" as const, text }],
       })),
     });
+    const firstText = "x".repeat(64 * 1024);
     const firstHead = makeStreamableHead(1, 2000);
-    const firstDetail = makeStreamableDetail(firstHead, ["first"]);
+    const firstDetail = makeStreamableDetail(firstHead, [firstText]);
     persistDetail(firstHead, firstDetail, "first");
     const first = materializeSessionDetailResponse(
       makeScanResult(new TestAgent(firstDetail, new Map([["s1", makeMeta("first")]])), firstHead),
@@ -355,15 +382,17 @@ describe("materializeSessionDetail", () => {
     expect(first.sentMessageCount).toBe(1);
 
     const appendedHead = makeStreamableHead(2, 3000);
-    const appendedDetail = makeStreamableDetail(appendedHead, ["first", "second"]);
+    const appendedDetail = makeStreamableDetail(appendedHead, [firstText, "second"]);
     persistDetail(appendedHead, appendedDetail, "appended");
-    const appended = materializeSessionDetailResponse(
-      makeScanResult(
-        new TestAgent(appendedDetail, new Map([["s1", makeMeta("appended")]])),
-        appendedHead,
+    const { result: appended, sql } = withPreparedSqlCapture(() =>
+      materializeSessionDetailResponse(
+        makeScanResult(
+          new TestAgent(appendedDetail, new Map([["s1", makeMeta("appended")]])),
+          appendedHead,
+        ),
+        { agentName: "test", sessionId: "s1" },
+        { messageCursor: first.data.message_cursor },
       ),
-      { agentName: "test", sessionId: "s1" },
-      { messageCursor: first.data.message_cursor },
     );
 
     expect(appended.status).toBe("found-json");
@@ -372,6 +401,33 @@ describe("materializeSessionDetail", () => {
     expect(appended.messageCount).toBe(2);
     expect(appended.sentMessageCount).toBe(1);
     expect([...appended.messages].map((message) => JSON.parse(message).id)).toEqual(["m2"]);
+    const messageSql = sql.filter((statement) => statement.includes("FROM messages"));
+    expect(
+      messageSql.some(
+        (statement) =>
+          statement.includes("parts_json") && !statement.includes("message_index >= ?"),
+      ),
+    ).toBe(false);
+    expect(
+      messageSql.some(
+        (statement) => statement.includes("parts_json") && statement.includes("message_index >= ?"),
+      ),
+    ).toBe(true);
+    expect(diagnostics).toContainEqual({
+      event: "session_detail.cursor_stream",
+      detail: expect.objectContaining({
+        update: "append",
+        message_count: 2,
+        sent_message_count: 1,
+        parts_json_bytes: expect.any(Number),
+        duration_ms: expect.any(Number),
+      }),
+    });
+    const appendTelemetry = diagnostics.find(
+      ({ event, detail }) =>
+        event === "session_detail.cursor_stream" && detail?.update === "append",
+    );
+    expect(Number(appendTelemetry?.detail?.parts_json_bytes)).toBeLessThan(1_000);
 
     const rewrittenDetail = makeStreamableDetail(appendedHead, ["rewritten", "second"]);
     persistDetail(appendedHead, rewrittenDetail, "rewritten");
@@ -389,6 +445,239 @@ describe("materializeSessionDetail", () => {
     expect(rewritten.data.message_update).toBe("reset");
     expect(rewritten.sentMessageCount).toBe(2);
     expect([...rewritten.messages].map((message) => JSON.parse(message).id)).toEqual(["m1", "m2"]);
+  });
+
+  it("resets cursors when cached message order or length changes", () => {
+    const makeStreamableHead = (messageCount: number, timeUpdated: number) => ({
+      ...makeHead({
+        time_updated: timeUpdated,
+        smart_tags: [],
+        smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+      }),
+      stats: { ...makeHead().stats, message_count: messageCount },
+    });
+    const makeStreamableDetail = (
+      head: SessionHead,
+      messages: Array<{ id: string; text: string }>,
+    ) => ({
+      ...makeDetail("Cached Session"),
+      ...head,
+      reference: { agentName: "test", sessionId: "s1" },
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+      messages: messages.map((message, index) => ({
+        id: message.id,
+        role: "assistant" as const,
+        time_created: 1500 + index,
+        parts: [{ type: "text" as const, text: message.text }],
+      })),
+    });
+    const firstHead = makeStreamableHead(3, 2000);
+    const firstDetail = makeStreamableDetail(firstHead, [
+      { id: "m1", text: "first" },
+      { id: "m2", text: "second" },
+      { id: "m3", text: "third" },
+    ]);
+    persistDetail(firstHead, firstDetail, "first");
+    const first = materializeSessionDetailResponse(
+      makeScanResult(new TestAgent(firstDetail, new Map([["s1", makeMeta("first")]])), firstHead),
+      { agentName: "test", sessionId: "s1" },
+    );
+    expect(first.status).toBe("found-json");
+    if (first.status !== "found-json") return;
+
+    const reorderedHead = makeStreamableHead(3, 3000);
+    const reorderedDetail = makeStreamableDetail(reorderedHead, [
+      { id: "m3", text: "third" },
+      { id: "m1", text: "first" },
+      { id: "m2", text: "second" },
+    ]);
+    persistDetail(reorderedHead, reorderedDetail, "reordered");
+    const reordered = materializeSessionDetailResponse(
+      makeScanResult(
+        new TestAgent(reorderedDetail, new Map([["s1", makeMeta("reordered")]])),
+        reorderedHead,
+      ),
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: first.data.message_cursor },
+    );
+    expect(reordered).toMatchObject({
+      status: "found-json",
+      data: { message_update: "reset" },
+      messageCount: 3,
+      sentMessageCount: 3,
+    });
+    if (reordered.status !== "found-json") return;
+
+    const deletedHead = makeStreamableHead(2, 4000);
+    const deletedDetail = makeStreamableDetail(deletedHead, [
+      { id: "m3", text: "third" },
+      { id: "m2", text: "second" },
+    ]);
+    persistDetail(deletedHead, deletedDetail, "deleted");
+    const deleted = materializeSessionDetailResponse(
+      makeScanResult(
+        new TestAgent(deletedDetail, new Map([["s1", makeMeta("deleted")]])),
+        deletedHead,
+      ),
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: reordered.data.message_cursor },
+    );
+    expect(deleted).toMatchObject({
+      status: "found-json",
+      data: { message_update: "reset" },
+      messageCount: 2,
+      sentMessageCount: 2,
+    });
+    if (deleted.status !== "found-json") return;
+
+    const truncatedHead = makeStreamableHead(1, 5000);
+    const truncatedDetail = makeStreamableDetail(truncatedHead, [{ id: "m3", text: "third" }]);
+    persistDetail(truncatedHead, truncatedDetail, "truncated");
+    const truncated = materializeSessionDetailResponse(
+      makeScanResult(
+        new TestAgent(truncatedDetail, new Map([["s1", makeMeta("truncated")]])),
+        truncatedHead,
+      ),
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: deleted.data.message_cursor },
+    );
+    expect(truncated).toMatchObject({
+      status: "found-json",
+      data: { message_update: "reset" },
+      messageCount: 1,
+      sentMessageCount: 1,
+    });
+  });
+
+  it("resets cursors with missing chains or out-of-range counts", () => {
+    const head = makeHead({
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    });
+    const detail = {
+      ...makeDetail("Cached Session"),
+      ...head,
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    };
+    persistDetail(head, detail, "cached");
+    const agent = new TestAgent(detail, new Map([["s1", makeMeta("cached")]]));
+    const scanResult = makeScanResult(agent, head);
+    const first = materializeSessionDetailResponse(scanResult, {
+      agentName: "test",
+      sessionId: "s1",
+    });
+    expect(first.status).toBe("found-json");
+    if (first.status !== "found-json") return;
+
+    withCacheDb((db) => {
+      db.prepare("UPDATE messages SET content_chain_digest = NULL WHERE agent_name = ?").run(
+        "test",
+      );
+    });
+    const missingChain = materializeSessionDetailResponse(
+      scanResult,
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: first.data.message_cursor },
+    );
+    expect(missingChain).toMatchObject({
+      status: "found-json",
+      data: { message_update: "reset" },
+      messageCount: 1,
+      sentMessageCount: 1,
+    });
+
+    const oversizedCursor = Buffer.from(
+      JSON.stringify({ version: MESSAGE_CURSOR_VERSION, count: 2, digest: "0".repeat(64) }),
+    ).toString("base64url");
+    const oversized = materializeSessionDetailResponse(
+      scanResult,
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: oversizedCursor },
+    );
+    expect(oversized).toMatchObject({
+      status: "found-json",
+      data: { message_update: "reset" },
+      messageCount: 1,
+      sentMessageCount: 1,
+    });
+    expect(agent.reads).toBe(0);
+  });
+
+  it("keeps empty cursor streams appendable", () => {
+    const head = makeHead({
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+      stats: { ...makeHead().stats, message_count: 0 },
+    });
+    const detail = {
+      ...makeDetail("Cached Session"),
+      ...head,
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+      messages: [],
+    };
+    persistDetail(head, detail, "empty");
+    const scanResult = makeScanResult(
+      new TestAgent(detail, new Map([["s1", makeMeta("empty")]])),
+      head,
+    );
+    const first = materializeSessionDetailResponse(scanResult, {
+      agentName: "test",
+      sessionId: "s1",
+    });
+    expect(first).toMatchObject({
+      status: "found-json",
+      data: { message_update: "reset" },
+      messageCount: 0,
+      sentMessageCount: 0,
+    });
+    if (first.status !== "found-json") return;
+
+    const next = materializeSessionDetailResponse(
+      scanResult,
+      { agentName: "test", sessionId: "s1" },
+      { messageCursor: first.data.message_cursor },
+    );
+    expect(next).toMatchObject({
+      status: "found-json",
+      data: { message_update: "append" },
+      messageCount: 0,
+      sentMessageCount: 0,
+    });
+  });
+
+  it("reads cursor metadata and message ranges from one cache snapshot", () => {
+    const head = makeHead({
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    });
+    const detail = {
+      ...makeDetail("Cached Session"),
+      ...head,
+      smart_tags: [],
+      smart_tags_classifier_revision: SMART_TAG_CLASSIFIER_REVISION,
+    };
+    persistDetail(head, detail, "snapshot");
+
+    const snapshot = readCachedSessionCursor("test", "s1", (entry, cursor) => {
+      const writer = new Database(getCachePath());
+      try {
+        writer
+          .prepare("UPDATE messages SET parts_json = ? WHERE agent_name = ? AND session_id = ?")
+          .run(JSON.stringify([]), "test", "s1");
+      } finally {
+        writer.close();
+      }
+      return {
+        digest: entry.messageDigest,
+        partsJson: cursor.messageRows(0)[0]?.parts_json,
+      };
+    });
+
+    expect(snapshot?.digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.parse(String(snapshot?.partsJson))).toEqual(detail.messages[0]?.parts);
   });
 
   it("resets incremental transport while a changed fingerprint is rematerialized", () => {

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -91,6 +91,7 @@ describe("cache schema boundary", () => {
       "indexed_at",
     ]);
     expect(state?.messageColumns).toContain("parts_format_version");
+    expect(state?.messageColumns).toContain("content_chain_digest");
     expect(state?.sessionColumns).toEqual(
       expect.arrayContaining([
         "project_identity_resolver_revision",
@@ -99,7 +100,7 @@ describe("cache schema boundary", () => {
         "publication_id",
       ]),
     );
-    expect(state?.version).toBe(24);
+    expect(state?.version).toBe(25);
   });
 
   it("removes the legacy message FTS objects when upgrading schema 23", () => {
@@ -140,7 +141,36 @@ describe("cache schema boundary", () => {
       ),
     }));
 
-    expect(migrated).toEqual({ objects: [], version: 24 });
+    expect(migrated).toEqual({ objects: [], version: 25 });
+  });
+
+  it("adds an empty hash chain column when upgrading schema 24", () => {
+    const session = makeSessionHead("legacy-chain");
+    saveCachedSessions("codex", [session]);
+    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
+
+    const legacyDb = new Database(getCachePath());
+    try {
+      legacyDb.exec("ALTER TABLE messages DROP COLUMN content_chain_digest");
+      legacyDb.pragma("user_version = 24");
+      legacyDb.prepare("UPDATE cache_meta SET value = '24' WHERE key = 'version'").run();
+    } finally {
+      legacyDb.close();
+    }
+    setSchemaEnsuredPath(null);
+
+    const migrated = schema.withCacheDb((db) => ({
+      version: Number(
+        (db.prepare("PRAGMA user_version").get() as { user_version?: number }).user_version,
+      ),
+      digest: (
+        db
+          .prepare("SELECT content_chain_digest FROM messages WHERE session_id = ?")
+          .get(session.id) as { content_chain_digest?: string | null }
+      ).content_chain_digest,
+    }));
+
+    expect(migrated).toEqual({ version: 25, digest: null });
   });
 
   it("reuses one connection for read and write capabilities until invalidated", () => {
@@ -309,7 +339,7 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 24, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 25, detailVersion: "", pending: true });
   });
 
   it("marks legacy project identities stale by leaving added provenance empty", () => {
@@ -348,7 +378,7 @@ describe("cache schema boundary", () => {
     });
 
     expect(migrated).toEqual({
-      version: 24,
+      version: 25,
       resolverRevision: null,
       inputSignature: null,
       classifierRevision: null,
@@ -418,7 +448,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 24,
+        version: 25,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -53,6 +53,110 @@ describe("search index writer", () => {
     });
   });
 
+  it("recomputes the message hash chain when an indexed prefix changes", () => {
+    const session = {
+      ...makeSessionHead("chain"),
+      stats: { ...makeSessionHead("chain").stats, message_count: 2 },
+    };
+    const firstMeta = { id: session.id, sourcePath: "/chain", sourceFingerprint: "first" };
+    const nextMeta = { ...firstMeta, sourceFingerprint: "next" };
+    const detail = (firstText: string, secondText: string) => ({
+      ...makeSessionData(session.id),
+      ...session,
+      messages: [
+        {
+          id: "m1",
+          role: "user" as const,
+          time_created: 1,
+          parts: [{ type: "text" as const, text: firstText }],
+        },
+        {
+          id: "m2",
+          role: "assistant" as const,
+          time_created: 2,
+          parts: [{ type: "text" as const, text: secondText }],
+        },
+      ],
+    });
+    const readDigests = () =>
+      withCacheDb(
+        (db) =>
+          db
+            .prepare(
+              "SELECT content_chain_digest FROM messages WHERE agent_name = ? AND session_id = ? ORDER BY message_index",
+            )
+            .all("codex", session.id) as Array<{ content_chain_digest?: string | null }>,
+      )?.map((row) => row.content_chain_digest);
+
+    saveCachedSessions("codex", [session], { [session.id]: firstMeta });
+    syncSessionSearchIndex("codex", [session], () => detail("first", "second"));
+    const firstDigests = readDigests();
+
+    saveCachedSessions("codex", [session], { [session.id]: nextMeta });
+    syncSessionSearchIndex("codex", [session], () => detail("rewritten", "second"));
+    const nextDigests = readDigests();
+
+    expect(firstDigests).toHaveLength(2);
+    expect(firstDigests?.every((digest) => /^[a-f0-9]{64}$/.test(digest ?? ""))).toBe(true);
+    expect(nextDigests).toHaveLength(2);
+    expect(nextDigests).not.toEqual(firstDigests);
+  });
+
+  it("rolls back message hash chains with their rows", () => {
+    const session = {
+      ...makeSessionHead("rollback"),
+      stats: { ...makeSessionHead("rollback").stats, message_count: 2 },
+    };
+    const firstMeta = { id: session.id, sourcePath: "/rollback", sourceFingerprint: "first" };
+    const nextMeta = { ...firstMeta, sourceFingerprint: "next" };
+    const detail = (firstText: string, secondText: string) => ({
+      ...makeSessionData(session.id),
+      ...session,
+      messages: [
+        {
+          id: "m1",
+          role: "user" as const,
+          time_created: 1,
+          parts: [{ type: "text" as const, text: firstText }],
+        },
+        {
+          id: "m2",
+          role: "assistant" as const,
+          time_created: 2,
+          parts: [{ type: "text" as const, text: secondText }],
+        },
+      ],
+    });
+
+    saveCachedSessions("codex", [session], { [session.id]: firstMeta });
+    syncSessionSearchIndex("codex", [session], () => detail("first", "second"));
+    const before = loadCachedSessionRawEntry("codex", session.id)?.messageRows.map((row) => ({
+      partsJson: row.parts_json,
+      digest: row.content_chain_digest,
+    }));
+    withCacheDb((db) => {
+      db.exec(`
+        CREATE TRIGGER reject_message_chain_update
+        BEFORE UPDATE OF content_chain_digest ON messages
+        WHEN NEW.agent_name = 'codex' AND NEW.session_id = 'rollback' AND NEW.message_index = 1
+        BEGIN
+          SELECT RAISE(ABORT, 'reject message hash chain update');
+        END;
+      `);
+    });
+    saveCachedSessions("codex", [session], { [session.id]: nextMeta });
+
+    expect(
+      syncSessionSearchIndex("codex", [session], () => detail("rewritten", "second")),
+    ).toBeNull();
+    const after = loadCachedSessionRawEntry("codex", session.id)?.messageRows.map((row) => ({
+      partsJson: row.parts_json,
+      digest: row.content_chain_digest,
+    }));
+
+    expect(after).toEqual(before);
+  });
+
   it("keeps migration reindex work out of foreground publications", () => {
     const session = makeSessionHead("one");
     const loadSession = vi.fn(() => makeSessionData("one", "migration needle"));

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -1360,7 +1360,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(24);
+    expect(getUserVersion(getCachePath())).toBe(25);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -2153,7 +2153,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(24);
+    expect(getUserVersion(getCachePath())).toBe(25);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -224,7 +224,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(24);
+    expect(getUserVersion(getCachePath())).toBe(25);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -235,7 +235,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(24);
+    expect(getUserVersion(getCachePath())).toBe(25);
   });
 });
 
@@ -243,7 +243,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(24);
+    expect(getUserVersion(getCachePath())).toBe(25);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -519,7 +519,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(24);
+    expect(getUserVersion(getCachePath())).toBe(25);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -579,7 +579,7 @@ describe("saveCachedSessions", () => {
 
     try {
       expect(loadCachedSessions("claudecode")?.sessions).toEqual([]);
-      expect(getUserVersion(getCachePath())).toBe(24);
+      expect(getUserVersion(getCachePath())).toBe(25);
       expect(warnings).toContainEqual({
         event: "sqlite.migration.identity_precompute.missing_directory",
         detail: { agent_name: "claudecode", session_id: "legacy-null-directory" },

--- a/packages/core/src/discovery/cache/message-cursor.ts
+++ b/packages/core/src/discovery/cache/message-cursor.ts
@@ -1,0 +1,80 @@
+import { createHash, type Hash } from "node:crypto";
+import type { SessionReference } from "../../contract/index.js";
+
+export const MESSAGE_CURSOR_VERSION = 2;
+
+export interface MessageCursorContent {
+  messageId: string;
+  role: string;
+  timeCreated: number;
+  timeCompleted: number | null | undefined;
+  agent: string | null | undefined;
+  mode: string | null | undefined;
+  model: string | null | undefined;
+  provider: string | null | undefined;
+  tokensJson: string | null | undefined;
+  cost: number | null | undefined;
+  costSource: string | null | undefined;
+  partsJson: string;
+  partsFormatVersion: number | string | null | undefined;
+  subagentId: string | null | undefined;
+  nickname: string | null | undefined;
+}
+
+function updateField(hash: Hash, value: string | number | null | undefined): void {
+  if (value == null) {
+    hash.update("n;");
+    return;
+  }
+  const text = String(value);
+  hash.update(`v${text.length}:`).update(text).update(";");
+}
+
+function updateMessageContent(hash: Hash, content: MessageCursorContent): void {
+  updateField(hash, content.messageId);
+  updateField(hash, content.role);
+  updateField(hash, content.timeCreated);
+  updateField(hash, content.timeCompleted);
+  updateField(hash, content.agent);
+  updateField(hash, content.mode);
+  updateField(hash, content.model);
+  updateField(hash, content.provider);
+  updateField(hash, content.tokensJson);
+  updateField(hash, content.cost);
+  updateField(hash, content.costSource);
+  updateField(hash, content.partsJson);
+  updateField(hash, content.partsFormatVersion);
+  updateField(hash, content.subagentId);
+  updateField(hash, content.nickname);
+}
+
+export function initialMessageCursorDigest(reference: SessionReference): string {
+  const hash = createHash("sha256");
+  hash.update("codesesh-session-messages\0");
+  updateField(hash, MESSAGE_CURSOR_VERSION);
+  updateField(hash, reference.agentName);
+  updateField(hash, reference.sessionId);
+  return hash.digest("hex");
+}
+
+export function advanceMessageCursorDigest(
+  previousDigest: string,
+  content: MessageCursorContent,
+): string {
+  const hash = createHash("sha256");
+  hash.update("codesesh-session-messages-chain\0");
+  updateField(hash, previousDigest);
+  updateMessageContent(hash, content);
+  return hash.digest("hex");
+}
+
+export function computeMessageCursorDigest(
+  reference: SessionReference,
+  messages: Iterable<MessageCursorContent>,
+): string {
+  let digest = initialMessageCursorDigest(reference);
+  for (const message of messages) {
+    digest = advanceMessageCursorDigest(digest, message);
+  }
+  return digest;
+}

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -16,6 +16,7 @@ import type {
 import { normalizeMessageParts } from "../../contract/message-part.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import type { SQLiteStatement } from "./db.js";
+import type { MessageCursorContent } from "./message-cursor.js";
 
 export const MESSAGE_PARTS_FORMAT_VERSION = 1;
 
@@ -68,6 +69,7 @@ export interface MessageBackfillRow extends DatabaseRow {
 
 export interface CachedMessageRow extends MessageBackfillRow {
   parts_format_version?: number | string;
+  content_chain_digest?: string | null;
   tokens_json?: string | null;
   cost?: number | null;
   cost_source?: SessionHead["stats"]["cost_source"] | null;
@@ -92,6 +94,48 @@ export interface StructuredMessageRecord {
   contentText: string;
   toolMetadataJson?: string | null;
   toolNames: string[];
+}
+
+export function messageCursorContentFromCachedRow(row: CachedMessageRow): MessageCursorContent {
+  return {
+    messageId: String(row.message_id),
+    role: String(row.role),
+    timeCreated: Number(row.time_created),
+    timeCompleted: row.time_completed,
+    agent: row.agent,
+    mode: row.mode,
+    model: row.model,
+    provider: row.provider,
+    tokensJson: row.tokens_json,
+    cost: row.cost,
+    costSource: row.cost_source,
+    partsJson: String(row.parts_json),
+    partsFormatVersion: row.parts_format_version,
+    subagentId: row.subagent_id,
+    nickname: row.nickname,
+  };
+}
+
+export function messageCursorContentFromStructuredRecord(
+  record: StructuredMessageRecord,
+): MessageCursorContent {
+  return {
+    messageId: record.id,
+    role: record.role,
+    timeCreated: record.timeCreated,
+    timeCompleted: record.timeCompleted,
+    agent: record.agent,
+    mode: record.mode,
+    model: record.model,
+    provider: record.provider,
+    tokensJson: record.tokensJson,
+    cost: record.cost,
+    costSource: record.costSource,
+    partsJson: record.partsJson,
+    partsFormatVersion: MESSAGE_PARTS_FORMAT_VERSION,
+    subagentId: record.subagentId,
+    nickname: record.nickname,
+  };
 }
 
 export function stringifyOptionalJson(value: unknown): string | null {

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -349,6 +349,7 @@ function createSessionTables(db: SQLiteDatabase): void {
       cost_source TEXT,
       parts_json TEXT NOT NULL,
       parts_format_version INTEGER NOT NULL DEFAULT 0,
+      content_chain_digest TEXT,
       subagent_id TEXT,
       nickname TEXT,
       content_text TEXT NOT NULL,
@@ -1197,6 +1198,13 @@ function addMessagePartsFormatVersion(db: SQLiteDatabase): void {
   db.exec("ALTER TABLE messages ADD COLUMN parts_format_version INTEGER NOT NULL DEFAULT 0");
 }
 
+function addMessageContentChainDigest(db: SQLiteDatabase): void {
+  if (!tableExists(db, "messages") || columnExists(db, "messages", "content_chain_digest")) {
+    return;
+  }
+  db.exec("ALTER TABLE messages ADD COLUMN content_chain_digest TEXT");
+}
+
 function addSessionParentReference(db: SQLiteDatabase): void {
   if (!tableExists(db, "sessions")) return;
 
@@ -1478,6 +1486,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 22, migrate: addAtomicPublicationStaging },
       { version: 23, migrate: replaceSessionActivityIndex },
       { version: 24, migrate: dropLegacyMessageSearchIndex },
+      { version: 25, migrate: addMessageContentChainDigest },
     ],
   });
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -7,6 +7,7 @@ import { SEARCH_INDEX_BULK_SYNC_THRESHOLD, type SessionHeadChange } from "./db.j
 import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import {
   buildSessionContentFromMessages,
+  messageCursorContentFromStructuredRecord,
   MESSAGE_PARTS_FORMAT_VERSION,
   normalizeMessages,
   prepareInsertFileActivity,
@@ -18,6 +19,7 @@ import {
   writeFileActivityRows,
   type StructuredMessageRecord,
 } from "./messages.js";
+import { advanceMessageCursorDigest, initialMessageCursorDigest } from "./message-cursor.js";
 import { runSearchIndexWrite, withCacheDbReadOnly, withSearchIndexDb } from "./schema.js";
 import { sessionDetailVersion } from "./detail-version.js";
 import type { SessionSnapshotCompleteness } from "./sessions.js";
@@ -505,11 +507,12 @@ function writeSearchIndexRows(
       cost_source,
       parts_json,
       parts_format_version,
+      content_chain_digest,
       subagent_id,
       nickname,
       content_text,
       tool_metadata_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id, message_index) DO UPDATE SET
       message_id = excluded.message_id,
       role = excluded.role,
@@ -524,6 +527,7 @@ function writeSearchIndexRows(
       cost_source = excluded.cost_source,
       parts_json = excluded.parts_json,
       parts_format_version = excluded.parts_format_version,
+      content_chain_digest = excluded.content_chain_digest,
       subagent_id = excluded.subagent_id,
       nickname = excluded.nickname,
       content_text = excluded.content_text,
@@ -581,7 +585,15 @@ function writeSearchIndexRows(
     deleteMessageTools.run(agentName, entry.session.id, 0);
     clearPendingReindex.run(agentName, entry.session.id);
     writeFileActivityRows(insertFileActivity, entry.fileActivity);
+    let contentChainDigest = initialMessageCursorDigest({
+      agentName,
+      sessionId: entry.session.id,
+    });
     for (const message of entry.messages) {
+      contentChainDigest = advanceMessageCursorDigest(
+        contentChainDigest,
+        messageCursorContentFromStructuredRecord(message),
+      );
       upsertMessage.run(
         agentName,
         entry.session.id,
@@ -599,6 +611,7 @@ function writeSearchIndexRows(
         message.costSource ?? null,
         message.partsJson,
         MESSAGE_PARTS_FORMAT_VERSION,
+        contentChainDigest,
         message.subagentId ?? null,
         message.nickname ?? null,
         message.contentText,

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -75,12 +75,25 @@ export interface CachedSessionDataEntry {
   meta: SessionCacheMeta | null;
 }
 
-export interface CachedSessionRawEntry {
+interface CachedSessionEntryBase {
   data: Omit<SessionDetail, "messages">;
-  messageRows: CachedMessageRow[];
   meta: SessionCacheMeta | null;
   detailVersion: string | null;
   pendingReindex: boolean;
+}
+
+export interface CachedSessionRawEntry extends CachedSessionEntryBase {
+  messageRows: CachedMessageRow[];
+}
+
+export interface CachedSessionCursorEntry extends CachedSessionEntryBase {
+  messageCount: number;
+  messageDigest: string | null;
+}
+
+export interface CachedSessionCursorReader {
+  messageDigest(messageCount: number): string | null;
+  messageRows(startIndex: number): CachedMessageRow[];
 }
 
 export type SessionSnapshotCompleteness = "complete" | "partial";
@@ -348,92 +361,176 @@ export function markAgentFullSyncCompleted(agentName: string): void {
   clearAgentFullSyncCursor(agentName);
 }
 
+function loadCachedSessionEntryBase(
+  db: SQLiteDatabase,
+  agentName: string,
+  sessionId: string,
+): CachedSessionEntryBase | null {
+  const row = db
+    .prepare(
+      `
+        SELECT
+          sessions.*,
+          documents.detail_version AS detail_version
+        FROM sessions
+        LEFT JOIN session_documents AS documents
+          ON documents.agent_name = sessions.agent_name
+          AND documents.session_id = sessions.session_id
+        WHERE sessions.agent_name = ?
+          AND sessions.session_id = ?
+          AND sessions.publication_id IS NULL
+      `,
+    )
+    .get(agentName, sessionId) as SessionRow | undefined;
+
+  if (!row) return null;
+
+  const pendingReindex =
+    db
+      .prepare("SELECT 1 FROM pending_reindex WHERE agent_name = ? AND session_id = ?")
+      .get(agentName, sessionId) != null;
+  const fileActivityRows = db
+    .prepare(
+      `
+        SELECT agent_name, session_id, project_identity_key, path, kind, count, latest_time
+        FROM session_file_activity
+        WHERE agent_name = ? AND session_id = ?
+        ORDER BY latest_time DESC, count DESC, path
+        LIMIT 500
+      `,
+    )
+    .all(agentName, sessionId) as FileActivityRow[];
+
+  return {
+    data: {
+      ...sessionFromRow(row),
+      reference: { agentName, sessionId },
+      file_activity: fileActivityRows.map((activityRow) => fileActivityFromRow(activityRow)),
+    },
+    meta: parseCachedSessionMeta(row.meta_json),
+    detailVersion: typeof row.detail_version === "string" ? row.detail_version : null,
+    pendingReindex,
+  };
+}
+
+function readCachedSessionMessageRows(
+  db: SQLiteDatabase,
+  agentName: string,
+  sessionId: string,
+  startIndex: number,
+): CachedMessageRow[] {
+  return db
+    .prepare(
+      `
+        SELECT
+          message_id,
+          role,
+          time_created,
+          time_completed,
+          agent,
+          mode,
+          model,
+          provider,
+          tokens_json,
+          cost,
+          cost_source,
+          parts_json,
+          parts_format_version,
+          content_chain_digest,
+          subagent_id,
+          nickname
+        FROM messages
+        WHERE agent_name = ? AND session_id = ? AND message_index >= ?
+        ORDER BY message_index
+      `,
+    )
+    .all(agentName, sessionId, startIndex) as CachedMessageRow[];
+}
+
 export function loadCachedSessionRawEntry(
   agentName: string,
   sessionId: string,
 ): CachedSessionRawEntry | null {
-  if (!hasCacheStorage()) {
-    return null;
-  }
+  if (!hasCacheStorage()) return null;
 
   const outcome = withCacheDbReadOnly((db) => {
-    const row = db
-      .prepare(
-        `
-          SELECT
-            sessions.*,
-            documents.detail_version AS detail_version
-          FROM sessions
-          LEFT JOIN session_documents AS documents
-            ON documents.agent_name = sessions.agent_name
-            AND documents.session_id = sessions.session_id
-          WHERE sessions.agent_name = ?
-            AND sessions.session_id = ?
-            AND sessions.publication_id IS NULL
-        `,
-      )
-      .get(agentName, sessionId) as SessionRow | undefined;
-
-    if (!row) {
-      return null;
-    }
-
-    const pendingReindex =
-      db
-        .prepare("SELECT 1 FROM pending_reindex WHERE agent_name = ? AND session_id = ?")
-        .get(agentName, sessionId) != null;
-
-    const messageRows = db
-      .prepare(
-        `
-          SELECT
-            message_id,
-            role,
-            time_created,
-            time_completed,
-            agent,
-            mode,
-            model,
-            provider,
-            tokens_json,
-            cost,
-            cost_source,
-            parts_json,
-            parts_format_version,
-            subagent_id,
-            nickname
-          FROM messages
-          WHERE agent_name = ? AND session_id = ?
-          ORDER BY message_index
-        `,
-      )
-      .all(agentName, sessionId) as CachedMessageRow[];
-
-    const head = sessionFromRow(row);
-    const fileActivityRows = db
-      .prepare(
-        `
-          SELECT agent_name, session_id, project_identity_key, path, kind, count, latest_time
-          FROM session_file_activity
-          WHERE agent_name = ? AND session_id = ?
-          ORDER BY latest_time DESC, count DESC, path
-          LIMIT 500
-        `,
-      )
-      .all(agentName, sessionId) as FileActivityRow[];
-
-    return {
-      data: {
-        ...head,
-        reference: { agentName, sessionId },
-        file_activity: fileActivityRows.map((activityRow) => fileActivityFromRow(activityRow)),
-      },
-      messageRows,
-      meta: parseCachedSessionMeta(row.meta_json),
-      detailVersion: typeof row.detail_version === "string" ? row.detail_version : null,
-      pendingReindex,
-    };
+    const entry = loadCachedSessionEntryBase(db, agentName, sessionId);
+    return entry
+      ? { ...entry, messageRows: readCachedSessionMessageRows(db, agentName, sessionId, 0) }
+      : null;
   });
+  return outcome.status === "success" ? outcome.value : null;
+}
+
+function readCachedSessionMessageDigest(
+  db: SQLiteDatabase,
+  agentName: string,
+  sessionId: string,
+  messageCount: number,
+): string | null {
+  if (!Number.isSafeInteger(messageCount) || messageCount <= 0) return null;
+  const row = db
+    .prepare(
+      `
+        SELECT content_chain_digest
+        FROM messages
+        WHERE agent_name = ? AND session_id = ? AND message_index = ?
+      `,
+    )
+    .get(agentName, sessionId, messageCount - 1) as { content_chain_digest?: string | null };
+  return typeof row?.content_chain_digest === "string" ? row.content_chain_digest : null;
+}
+
+export function readCachedSessionCursor<T>(
+  agentName: string,
+  sessionId: string,
+  read: (entry: CachedSessionCursorEntry, cursor: CachedSessionCursorReader) => T,
+): T | null {
+  if (!hasCacheStorage()) return null;
+
+  // A deferred transaction keeps cursor metadata and suffix rows in one snapshot.
+  const outcome = withCacheDbReadOnly((db) =>
+    db.transaction(() => {
+      const entryBase = loadCachedSessionEntryBase(db, agentName, sessionId);
+      if (!entryBase) return null;
+      const messageState = db
+        .prepare(
+          `
+            SELECT
+              COUNT(*) AS message_count,
+              (
+                SELECT content_chain_digest
+                FROM messages
+                WHERE agent_name = ? AND session_id = ?
+                ORDER BY message_index DESC
+                LIMIT 1
+              ) AS content_chain_digest
+            FROM messages
+            WHERE agent_name = ? AND session_id = ?
+          `,
+        )
+        .get(agentName, sessionId, agentName, sessionId) as {
+        message_count?: number;
+        content_chain_digest?: string | null;
+      };
+      const entry: CachedSessionCursorEntry = {
+        ...entryBase,
+        messageCount: Number(messageState.message_count ?? 0),
+        messageDigest:
+          typeof messageState.content_chain_digest === "string"
+            ? messageState.content_chain_digest
+            : null,
+      };
+      return read(entry, {
+        messageDigest: (messageCount) =>
+          readCachedSessionMessageDigest(db, agentName, sessionId, messageCount),
+        messageRows: (startIndex) =>
+          Number.isSafeInteger(startIndex) && startIndex >= 0
+            ? readCachedSessionMessageRows(db, agentName, sessionId, startIndex)
+            : [],
+      });
+    })(),
+  );
   return outcome.status === "success" ? outcome.value : null;
 }
 

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 24;
+export const CACHE_SCHEMA_VERSION = 25;

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -1,4 +1,3 @@
-import { createHash, type Hash } from "node:crypto";
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import type { SessionReference } from "../contract/index.js";
 import type { SessionDetail, SessionHead } from "../types/index.js";
@@ -12,8 +11,24 @@ import {
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import { listSessionFileActivity } from "./cache/file-activity.js";
 import { sessionDetailVersion } from "./cache/detail-version.js";
-import { loadCachedSessionRawEntry, type CachedSessionRawEntry } from "./cache/sessions.js";
-import { messageFromCachedRow, messageJsonFromCachedRow } from "./cache/messages.js";
+import {
+  loadCachedSessionRawEntry,
+  readCachedSessionCursor,
+  type CachedSessionCursorEntry,
+  type CachedSessionCursorReader,
+  type CachedSessionRawEntry,
+} from "./cache/sessions.js";
+import {
+  messageCursorContentFromCachedRow,
+  messageFromCachedRow,
+  messageJsonFromCachedRow,
+  type CachedMessageRow,
+} from "./cache/messages.js";
+import {
+  computeMessageCursorDigest,
+  initialMessageCursorDigest,
+  MESSAGE_CURSOR_VERSION,
+} from "./cache/message-cursor.js";
 import type { LiveSnapshot } from "./scanner.js";
 
 export type SessionDetailResult =
@@ -46,7 +61,6 @@ interface SessionDetailContext {
 }
 
 const sessionDetailLookups = new WeakMap<SessionHead[], SessionDetailLookup>();
-const MESSAGE_CURSOR_VERSION = 1;
 const MAX_MESSAGE_CURSOR_LENGTH = 512;
 
 interface MessageCursorPayload {
@@ -83,62 +97,56 @@ function encodeMessageCursor(count: number, digest: string): string {
   );
 }
 
-function createMessageCursorHash(reference: SessionReference): Hash {
-  return createHash("sha256")
-    .update("codesesh-session-messages-v1\0")
-    .update(JSON.stringify([reference.agentName, reference.sessionId]))
-    .update("\n");
+interface CachedMessageStream {
+  cursor: string;
+  update: "append" | "reset";
+  messageRows: CachedMessageRow[];
+  messageCount: number;
 }
 
-function updateMessageCursorField(hash: Hash, value: string | number | null | undefined) {
-  if (value == null) {
-    hash.update("n;");
-    return;
-  }
-  const text = String(value);
-  hash.update(`v${text.length}:`).update(text).update(";");
-}
-
-function updateMessageCursorHash(hash: Hash, row: CachedSessionRawEntry["messageRows"][number]) {
-  updateMessageCursorField(hash, row.message_id);
-  updateMessageCursorField(hash, row.role);
-  updateMessageCursorField(hash, row.time_created);
-  updateMessageCursorField(hash, row.time_completed);
-  updateMessageCursorField(hash, row.agent);
-  updateMessageCursorField(hash, row.mode);
-  updateMessageCursorField(hash, row.model);
-  updateMessageCursorField(hash, row.provider);
-  updateMessageCursorField(hash, row.tokens_json);
-  updateMessageCursorField(hash, row.cost);
-  updateMessageCursorField(hash, row.cost_source);
-  updateMessageCursorField(hash, row.parts_json);
-  updateMessageCursorField(hash, row.parts_format_version);
-  updateMessageCursorField(hash, row.subagent_id);
-  updateMessageCursorField(hash, row.nickname);
-  hash.update("\n");
-}
-
-function projectMessageStream(
+function loadCachedMessageStream(
   reference: SessionReference,
-  rows: CachedSessionRawEntry["messageRows"],
+  entry: CachedSessionCursorEntry,
+  cursor: CachedSessionCursorReader,
   requestedCursor: string | undefined,
-) {
+): CachedMessageStream {
   const requested = parseMessageCursor(requestedCursor);
-  const hash = createMessageCursorHash(reference);
-  let requestedDigest = requested?.count === 0 ? hash.copy().digest("hex") : null;
+  const initialDigest = initialMessageCursorDigest(reference);
+  const hasStoredChain = entry.messageCount === 0 || entry.messageDigest !== null;
+  const canCheckAppend =
+    hasStoredChain && requested !== null && requested.count <= entry.messageCount;
+  const requestedDigest =
+    canCheckAppend && requested
+      ? requested.count === 0
+        ? initialDigest
+        : cursor.messageDigest(requested.count)
+      : null;
+  const canAppend = canCheckAppend && requested !== null && requestedDigest === requested.digest;
+  let startIndex = canAppend ? requested.count : 0;
+  let update: CachedMessageStream["update"] = canAppend ? "append" : "reset";
+  let messageRows = entry.messageCount === 0 ? [] : cursor.messageRows(startIndex);
 
-  for (let index = 0; index < rows.length; index += 1) {
-    updateMessageCursorHash(hash, rows[index]!);
-    if (requested?.count === index + 1) requestedDigest = hash.copy().digest("hex");
+  let messageCount = entry.messageCount;
+  let digest = entry.messageCount === 0 ? initialDigest : entry.messageDigest;
+  if (messageRows.length !== entry.messageCount - startIndex) {
+    startIndex = 0;
+    update = "reset";
+    messageRows = cursor.messageRows(startIndex);
+    messageCount = messageRows.length;
+    digest = null;
   }
 
-  const digest = hash.digest("hex");
-  const canAppend =
-    requested !== null && requested.count <= rows.length && requestedDigest === requested.digest;
+  if (!digest) {
+    digest = computeMessageCursorDigest(
+      reference,
+      messageRows.map((row) => messageCursorContentFromCachedRow(row)),
+    );
+  }
   return {
-    cursor: encodeMessageCursor(rows.length, digest),
-    startIndex: canAppend ? requested.count : 0,
-    update: canAppend ? ("append" as const) : ("reset" as const),
+    cursor: encodeMessageCursor(messageCount, digest),
+    update,
+    messageRows,
+    messageCount,
   };
 }
 
@@ -187,15 +195,17 @@ function getSessionDetailContext(
 }
 
 type CachedDetailState = "fresh" | "stale" | "missing";
+type CachedSessionDetailEntry = Pick<
+  CachedSessionRawEntry,
+  "data" | "detailVersion" | "pendingReindex"
+>;
 
 function cachedDetailState(
-  cachedEntry: CachedSessionRawEntry | null,
+  cachedEntry: CachedSessionDetailEntry | null,
   currentMeta: SessionCacheMeta | undefined,
+  messageCount: number,
 ): CachedDetailState {
-  if (
-    !cachedEntry ||
-    (cachedEntry.messageRows.length === 0 && cachedEntry.data.stats.message_count > 0)
-  ) {
+  if (!cachedEntry || (messageCount === 0 && cachedEntry.data.stats.message_count > 0)) {
     return "missing";
   }
   return !cachedEntry.pendingReindex &&
@@ -228,7 +238,11 @@ function materializeStructuredSessionDetail(
 ): SessionDetailResult {
   const { agent, head } = context;
   const currentMeta = head ? agent.getSessionMetaMap().get(reference.sessionId) : undefined;
-  const cacheState = cachedDetailState(cachedEntry, currentMeta);
+  const cacheState = cachedDetailState(
+    cachedEntry,
+    currentMeta,
+    cachedEntry?.messageRows.length ?? 0,
+  );
   let useCache = cacheState === "fresh";
   let freshness: SessionDetail["detail_freshness"] = useCache ? "fresh" : undefined;
   let data: SessionDetail | null = useCache
@@ -298,12 +312,9 @@ function materializeStructuredSessionDetail(
   };
 }
 
-function* serializeCachedMessages(
-  entry: CachedSessionRawEntry,
-  startIndex = 0,
-): IterableIterator<string> {
-  for (let index = startIndex; index < entry.messageRows.length; index += 1) {
-    yield messageJsonFromCachedRow(entry.messageRows[index]!);
+function* serializeCachedMessages(messageRows: CachedMessageRow[]): IterableIterator<string> {
+  for (const messageRow of messageRows) {
+    yield messageJsonFromCachedRow(messageRow);
   }
 }
 
@@ -324,25 +335,57 @@ export function materializeSessionDetailResponse(
   const context = getSessionDetailContext(scanResult, reference);
   if (!context) return { status: "unknown-agent" };
 
-  const cachedEntry = loadCachedSessionRawEntry(reference.agentName, reference.sessionId);
   const currentMeta = context.head
     ? context.agent.getSessionMetaMap().get(reference.sessionId)
     : undefined;
-  const cacheState = cachedDetailState(cachedEntry, currentMeta);
+  const startedAt = performance.now();
+  const cursorRead = readCachedSessionCursor(
+    reference.agentName,
+    reference.sessionId,
+    (entry, cursor) => {
+      const cacheState = cachedDetailState(entry, currentMeta, entry.messageCount);
+      const stream =
+        cacheState === "fresh" &&
+        entry.data.smart_tags != null &&
+        entry.data.smart_tags_classifier_revision === SMART_TAG_CLASSIFIER_REVISION
+          ? loadCachedMessageStream(reference, entry, cursor, options.messageCursor)
+          : null;
+      return { entry, cacheState, stream };
+    },
+  );
+  const cachedEntry = cursorRead?.entry ?? null;
+  const cacheState = cursorRead?.cacheState ?? "missing";
   if (
     !cachedEntry ||
     cacheState !== "fresh" ||
     cachedEntry.data.smart_tags == null ||
     cachedEntry.data.smart_tags_classifier_revision !== SMART_TAG_CLASSIFIER_REVISION
   ) {
-    const result = materializeStructuredSessionDetail(context, reference, cachedEntry);
+    const result = materializeStructuredSessionDetail(context, reference);
     return result.status === "found"
       ? { ...result, data: { ...result.data, message_update: "reset" } }
       : result;
   }
 
   const data = cachedEntry.data;
-  const stream = projectMessageStream(reference, cachedEntry.messageRows, options.messageCursor);
+  const stream = cursorRead?.stream;
+  if (!stream) {
+    const result = materializeStructuredSessionDetail(context, reference);
+    return result.status === "found"
+      ? { ...result, data: { ...result.data, message_update: "reset" } }
+      : result;
+  }
+  const partsJsonBytes = stream.messageRows.reduce(
+    (total, row) => total + Buffer.byteLength(String(row.parts_json)),
+    0,
+  );
+  getCoreDiagnostics()?.info?.("session_detail.cursor_stream", {
+    update: stream.update,
+    message_count: stream.messageCount,
+    sent_message_count: stream.messageRows.length,
+    parts_json_bytes: partsJsonBytes,
+    duration_ms: Math.round(performance.now() - startedAt),
+  });
   return {
     status: "found-json",
     data: {
@@ -356,8 +399,8 @@ export function materializeSessionDetailResponse(
       file_activity:
         data.file_activity ?? listSessionFileActivity(reference.agentName, reference.sessionId),
     },
-    messages: serializeCachedMessages(cachedEntry, stream.startIndex),
-    messageCount: cachedEntry.messageRows.length,
-    sentMessageCount: cachedEntry.messageRows.length - stream.startIndex,
+    messages: serializeCachedMessages(stream.messageRows),
+    messageCount: stream.messageCount,
+    sentMessageCount: stream.messageRows.length,
   };
 }


### PR DESCRIPTION
## Summary
- Persist a versioned content hash chain with indexed message rows.
- Read cursor metadata, prefix digests, and message suffixes from one SQLite snapshot.
- Reset safely for changed, legacy, or inconsistent message sequences and record cursor stream payload latency.

## Validation
- pnpm test
- pnpm lint
- pnpm format:check
- pnpm --filter @codesesh/core build
- pnpm --filter ./packages/cli typecheck
- pnpm --filter @codesesh/web build