### PR TITLE
fix(api): reuse snapshot session trees

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 const coreMocks = vi.hoisted(() => {
   return {
     attachProjectMetrics: vi.fn(),
+    buildSessionTree: vi.fn(),
     buildDashboard: vi.fn(),
+    filterSessionSearchCandidates: vi.fn(),
     getAnalyticsRevision: vi.fn(() => "0"),
     materializeSessionDetailResponse: vi.fn(),
     listFileActivity: vi.fn((): FileActivityResult[] => []),
@@ -21,6 +23,7 @@ const coreMocks = vi.hoisted(() => {
         _query: string,
         _options?: unknown,
         _scanResult?: unknown,
+        _context?: unknown,
       ): Array<{
         reference: { agentName: string; sessionId: string };
         session: SessionHead;
@@ -47,6 +50,12 @@ vi.mock("@codesesh/core", async (importOriginal) => {
       coreMocks.buildDashboard(...args);
       return actual.buildDashboard(...args);
     },
+    filterSessionSearchCandidates: (
+      ...args: Parameters<typeof actual.filterSessionSearchCandidates>
+    ) => {
+      coreMocks.filterSessionSearchCandidates(...args);
+      return actual.filterSessionSearchCandidates(...args);
+    },
     getAnalyticsRevision: coreMocks.getAnalyticsRevision,
     materializeSessionDetailResponse: coreMocks.materializeSessionDetailResponse,
     listFileActivity: coreMocks.listFileActivity,
@@ -57,6 +66,17 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     },
     listSessionAliases: coreMocks.listSessionAliases,
     executeSessionSearch: coreMocks.executeSessionSearch,
+  };
+});
+
+vi.mock("@codesesh/core/contract", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@codesesh/core/contract")>();
+  return {
+    ...actual,
+    buildSessionTree: (...args: Parameters<typeof actual.buildSessionTree>) => {
+      coreMocks.buildSessionTree(...args);
+      return actual.buildSessionTree(...args);
+    },
   };
 });
 
@@ -227,7 +247,9 @@ function toLocalDateKey(ts: number): string {
 
 afterEach(() => {
   coreMocks.attachProjectMetrics.mockClear();
+  coreMocks.buildSessionTree.mockClear();
   coreMocks.buildDashboard.mockClear();
+  coreMocks.filterSessionSearchCandidates.mockClear();
   coreMocks.getAnalyticsRevision.mockReset();
   coreMocks.getAnalyticsRevision.mockReturnValue("0");
   coreMocks.materializeSessionDetailResponse.mockReset();
@@ -997,6 +1019,64 @@ describe("handleSearchSessions", () => {
 
     expect(c.json.mock.calls[0]![0].results[0].parent.title).toBe("Renamed parent");
   });
+
+  it("reuses one snapshot tree for cost, alias, and parent context", async () => {
+    const parent = makeSession("p1", {
+      slug: "claudecode/p1",
+      stats: {
+        message_count: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 0,
+      },
+    });
+    const child = makeSession("c1", {
+      slug: "claudecode/c1",
+      parent_reference: { agentName: "claudecode", sessionId: "p1" },
+      stats: {
+        message_count: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 2,
+      },
+    });
+    const sessions = [parent, child];
+    let snapshot = makeScanResult({
+      sessions,
+      byAgent: { claudecode: sessions },
+    });
+    const source: ScanResultSource = { getSnapshot: () => snapshot };
+    coreMocks.listSessionAliases.mockReturnValue([makeAlias("claudecode", "p1", "Needle parent")]);
+    coreMocks.executeSessionSearch.mockImplementation((_query, _options, _scanResult, context) => {
+      expect((context as { sessionTree?: unknown } | undefined)?.sessionTree).toBeDefined();
+      return [{ reference: { agentName: "claudecode", sessionId: "c1" }, session: child }];
+    });
+
+    await handleSearchSessions(makeMockContext({ query: { q: "needle cost:>1" } }), source);
+    await handleSearchSessions(makeMockContext({ query: { q: "needle cost:>1" } }), source);
+
+    expect(coreMocks.buildSessionTree).toHaveBeenCalledTimes(1);
+    const searchContext = coreMocks.executeSessionSearch.mock.calls[0]![3] as {
+      sessionTree: unknown;
+    };
+    expect(coreMocks.filterSessionSearchCandidates).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        sessionSnapshot: sessions,
+        sessionTree: searchContext.sessionTree,
+      }),
+    );
+
+    const replacementSessions = [...sessions];
+    snapshot = makeScanResult({
+      sessions: replacementSessions,
+      byAgent: { claudecode: replacementSessions },
+    });
+    await handleSearchSessions(makeMockContext({ query: { q: "needle cost:>1" } }), source);
+
+    expect(coreMocks.buildSessionTree).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("handleGetFileActivity", () => {
@@ -1030,6 +1110,24 @@ describe("handleGetProjects", () => {
     handleGetProjects(makeMockContext(), source);
 
     expect(coreMocks.attachProjectMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains a recently used aggregation when the cache reaches capacity", () => {
+    const source = makeScanSource();
+    const queryFor = (day: number) => ({
+      from: new Date(0).toISOString(),
+      to: new Date((day + 1) * 86400000).toISOString(),
+    });
+
+    for (let day = 0; day < 64; day += 1) {
+      handleGetProjects(makeMockContext({ query: queryFor(day) }), source);
+    }
+    handleGetProjects(makeMockContext({ query: queryFor(0) }), source);
+    handleGetProjects(makeMockContext({ query: queryFor(64) }), source);
+    handleGetProjects(makeMockContext({ query: queryFor(0) }), source);
+    handleGetProjects(makeMockContext({ query: queryFor(1) }), source);
+
+    expect(coreMocks.attachProjectMetrics).toHaveBeenCalledTimes(66);
   });
 
   it("lets request dates override the default time window", () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -15,8 +15,8 @@ import {
   filterSessionTreeByActivityWindow,
   formatSessionReference,
   getSessionAgentKey,
-  getSessionRouteKey,
   normalizeSessionReference,
+  type SessionTree,
   type AppConfig,
   type ScanStatusEvent,
   type SearchResult,
@@ -31,6 +31,7 @@ import {
   deleteBookmark,
   getAgentInfoMap,
   getAnalyticsRevision,
+  mergeSearchQueryOptions,
   executeSessionSearch,
   getSearchProjectDirectory,
   importBookmarks,
@@ -147,12 +148,25 @@ function parseDateWindowRequest(c: Context, endpoint: string, defaults: SessionL
 
 interface SnapshotAggregationCache {
   sessions: SessionHead[];
+  sessionTree?: SessionTree;
   values: Map<string, unknown>;
 }
 
 const SNAPSHOT_AGGREGATION_CACHE_LIMIT = 64;
 const snapshotAggregationCaches = new WeakMap<ScanResultSource, SnapshotAggregationCache>();
 type SnapshotAggregationCacheState = "hit" | "miss";
+
+function getSnapshotAggregationCache(
+  source: ScanResultSource,
+  sessions: SessionHead[],
+): SnapshotAggregationCache {
+  let cache = snapshotAggregationCaches.get(source);
+  if (!cache || cache.sessions !== sessions) {
+    cache = { sessions, values: new Map() };
+    snapshotAggregationCaches.set(source, cache);
+  }
+  return cache;
+}
 
 /**
  * LiveScanStore replaces its canonical sessions array whenever the snapshot
@@ -165,11 +179,7 @@ function getSnapshotAggregation<T>(
   build: () => T,
   onCacheState?: (state: SnapshotAggregationCacheState) => void,
 ): T {
-  let cache = snapshotAggregationCaches.get(source);
-  if (!cache || cache.sessions !== sessions) {
-    cache = { sessions, values: new Map() };
-    snapshotAggregationCaches.set(source, cache);
-  }
+  const cache = getSnapshotAggregationCache(source, sessions);
 
   const cacheKey = JSON.stringify(key);
   if (cache.values.has(cacheKey)) {
@@ -188,6 +198,11 @@ function getSnapshotAggregation<T>(
   cache.values.set(cacheKey, value);
   onCacheState?.("miss");
   return value;
+}
+
+function getSnapshotSessionTree(source: ScanResultSource, sessions: SessionHead[]): SessionTree {
+  const cache = getSnapshotAggregationCache(source, sessions);
+  return (cache.sessionTree ??= buildSessionTree(sessions));
 }
 
 type DashboardStorageAggregation = Pick<DashboardData, "recentFileActivities" | "modelCost">;
@@ -479,7 +494,7 @@ export function handleGetProjects(
     scanResult.sessions,
     ["projects", from, to],
     () => {
-      const tree = buildSessionTree(scanResult.sessions);
+      const tree = getSnapshotSessionTree(scanSource, scanResult.sessions);
       const sessions = filterSessionTreeByActivityWindow(scanResult.sessions, from, to, tree);
       return {
         projects: attachProjectMetricsFromTree(listCachedProjectGroups(sessions), tree, from, to),
@@ -615,22 +630,16 @@ export async function handleGetSessions(
  */
 function withParentContext(
   results: SearchResult[],
-  sessions: SessionHead[],
+  getSessionTree: () => SessionTree,
   aliases: AliasView,
 ): SearchResult[] {
   if (!results.some((result) => result.session.parent_reference)) return results;
-
-  const byRouteKey = new Map(
-    sessions.map((session) => [
-      getSessionRouteKey(getSessionAgentKey(session), session.id),
-      session,
-    ]),
-  );
+  const byRouteKey = getSessionTree().byRouteKey;
 
   return results.map((result) => {
     const parentReference = result.session.parent_reference;
     if (!parentReference) return result;
-    const parent = byRouteKey.get(formatSessionReference(parentReference));
+    const parent = byRouteKey.get(formatSessionReference(parentReference))?.session;
     if (!parent) return result;
     const reference = normalizeSessionReference(parentReference);
     return { ...result, parent: { reference, title: aliases.get(reference) ?? parent.title } };
@@ -731,18 +740,35 @@ export async function handleSearchSessions(
   const { cwd: _cwd, ...searchOptions } = searchRequestOptions;
   const resolvedSearchOptions = projectScope ? { ...searchOptions, projectScope } : searchOptions;
   const aliases = loadAliasView();
-  const results = executeSessionSearch(query, resolvedSearchOptions, scanResult).map((result) => ({
+  let sessionTree: SessionTree | undefined;
+  const getSessionTree = () =>
+    (sessionTree ??= getSnapshotSessionTree(scanSource, scanResult.sessions));
+  const effectiveSearchOptions = mergeSearchQueryOptions(query, resolvedSearchOptions).options;
+  const searchContext =
+    effectiveSearchOptions.costMin != null || effectiveSearchOptions.costMax != null
+      ? { sessionTree: getSessionTree() }
+      : undefined;
+  const searchResults = searchContext
+    ? executeSessionSearch(query, resolvedSearchOptions, scanResult, searchContext)
+    : executeSessionSearch(query, resolvedSearchOptions, scanResult);
+  const results = searchResults.map((result) => ({
     ...result,
     session: aliases.decorate(result.session, result.reference),
   }));
-  const aliasResults = findAliasSearchResults(query, resolvedSearchOptions, scanResult, aliases);
+  const aliasResults = findAliasSearchResults(
+    query,
+    resolvedSearchOptions,
+    scanResult,
+    aliases,
+    searchContext,
+  );
   const mergedResults = mergeAliasSearchResults(
     results,
     aliasResults,
     resolvedSearchOptions.limit ?? 50,
   );
   return c.json({
-    results: withParentContext(mergedResults, scanResult.sessions, aliases),
+    results: withParentContext(mergedResults, getSessionTree, aliases),
   });
 }
 

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -12,6 +12,7 @@ import {
   StateStorageUnavailableError,
   type FileActivityResult,
   type LiveSnapshot,
+  type SessionSearchContext,
   type SearchOptions,
 } from "@codesesh/core";
 import { appLogger } from "../logging.js";
@@ -107,6 +108,7 @@ export function findAliasSearchResults(
   options: SearchOptions,
   scanResult: LiveSnapshot,
   aliases: AliasView,
+  context: SessionSearchContext = {},
 ): SearchResult[] {
   const search = mergeSearchQueryOptions(query, options);
   const needle = search.text.trim().toLowerCase();
@@ -137,7 +139,8 @@ export function findAliasSearchResults(
     });
   }
 
-  return filterSessionSearchCandidates(results, search.options, scanResult.sessions).sort(
-    (a, b) => getSessionActivityTime(b.session) - getSessionActivityTime(a.session),
-  );
+  return filterSessionSearchCandidates(results, search.options, {
+    sessionSnapshot: scanResult.sessions,
+    sessionTree: context.sessionTree,
+  }).sort((a, b) => getSessionActivityTime(b.session) - getSessionActivityTime(a.session));
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -164,3 +164,4 @@ export { buildDashboard, getSessionActivityTime } from "./analytics/dashboard.js
 export type { DashboardData, DashboardScope } from "./analytics/dashboard.js";
 export { attachProjectMetrics, attachProjectMetricsFromTree } from "./analytics/projects.js";
 export { executeSessionSearch, filterSessionSearchCandidates } from "./search/index.js";
+export type { SessionSearchContext, SessionSearchFilterContext } from "./search/index.js";

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -25,7 +25,7 @@ import type {
   SmartTag,
 } from "../../types/index.js";
 import type { SearchOptions } from "../../discovery/cache/search.js";
-import type { SearchResult } from "../../contract/index.js";
+import { buildSessionTree, type SearchResult } from "../../contract/index.js";
 import { closeCacheStorage } from "../../discovery/cache/db.js";
 import { searchSessions, syncSessionSearchIndex } from "../../discovery/cache/search.js";
 import { compareSessionActivityDesc, mergeSortedSessions } from "../../contract/session-index.js";
@@ -839,7 +839,41 @@ describe("search candidate filtering", () => {
       },
     ];
 
-    const results = filterSessionSearchCandidates(candidates, { costMin: 1 }, [parent, child]);
+    const results = filterSessionSearchCandidates(
+      candidates,
+      { costMin: 1 },
+      {
+        sessionSnapshot: [parent, child],
+      },
+    );
+
+    expect(results.map((result) => result.session.id)).toEqual([parent.id]);
+  });
+
+  it("uses a supplied session tree for inclusive cost filters", () => {
+    const parent = makeSessionHead({
+      id: "provided-tree-parent",
+      agent: "codex",
+      cost: 0,
+      messages: [],
+    });
+    const child = {
+      ...makeSessionHead({
+        id: "provided-tree-child",
+        agent: "codex",
+        cost: 0,
+        messages: [],
+      }),
+      parent_reference: { agentName: "codex", sessionId: parent.id },
+    };
+    const snapshot = {
+      sessions: [parent, child],
+      byAgent: { codex: [parent, child] },
+    };
+    const sessionTree = buildSessionTree([parent, child]);
+    sessionTree.byRouteKey.get(`codex/${parent.id}`)!.inclusiveStats.cost = 1;
+
+    const results = executeSessionSearch("", { costMin: 1 }, snapshot, { sessionTree });
 
     expect(results.map((result) => result.session.id)).toEqual([parent.id]);
   });

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -2,5 +2,7 @@ export {
   executeSessionSearch,
   filterSessionSearchCandidates,
   matchesSessionSearchFilters,
+  type SessionSearchContext,
+  type SessionSearchFilterContext,
   type SessionSearchSnapshot,
 } from "./session-search.js";

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -10,6 +10,7 @@ import {
   getSessionAgentKey,
   getSessionRouteKey,
   type SearchResult,
+  type SessionTree,
 } from "../contract/index.js";
 import {
   filterIndexedSessionReferences,
@@ -31,15 +32,24 @@ export interface SessionSearchSnapshot {
   byAgent: Record<string, SessionHead[]>;
 }
 
+export interface SessionSearchContext {
+  sessionTree?: SessionTree;
+}
+
+export interface SessionSearchFilterContext extends SessionSearchContext {
+  sessionSnapshot?: SessionHead[];
+}
+
 export function executeSessionSearch(
   query: string,
   options: SearchOptions,
   snapshot: SessionSearchSnapshot,
+  context: SessionSearchContext = {},
 ): SearchResult[] {
   const merged = mergeSearchQueryOptions(query, options);
 
   if (!needsIndexedSearch(merged.text, merged.options)) {
-    return searchRecentSessions(snapshot, merged.options);
+    return searchRecentSessions(snapshot, merged.options, context);
   }
 
   return searchIndexedSessions(query, merged.text, merged.parsed, merged.options);
@@ -113,10 +123,12 @@ function sessionReferenceKey(agentName: string, sessionId: string): string {
 export function filterSessionSearchCandidates(
   candidates: SearchResult[],
   options: SearchOptions,
-  sessionSnapshot: SessionHead[] = candidates.map((candidate) => candidate.session),
+  context: SessionSearchFilterContext = {},
 ): SearchResult[] {
   const projectScope = options.projectScope ?? null;
-  const inclusiveCosts = buildInclusiveCostLookup(sessionSnapshot, options);
+  const sessionSnapshot =
+    context.sessionSnapshot ?? candidates.map((candidate) => candidate.session);
+  const inclusiveCosts = buildInclusiveCostLookup(sessionSnapshot, options, context.sessionTree);
   const headMatches = candidates.filter((candidate) =>
     matchesSessionSearchFilters(
       candidate.reference.agentName,
@@ -149,12 +161,13 @@ export function filterSessionSearchCandidates(
 function searchRecentSessions(
   snapshot: SessionSearchSnapshot,
   options: SearchOptions,
+  context: SessionSearchContext,
 ): SearchResult[] {
   const limit = Math.max(0, Math.trunc(options.limit ?? 50));
   if (limit === 0) return [];
 
   const projectScope = options.projectScope ?? null;
-  const inclusiveCosts = buildInclusiveCostLookup(snapshot.sessions, options);
+  const inclusiveCosts = buildInclusiveCostLookup(snapshot.sessions, options, context.sessionTree);
   const sessions = options.agent ? (snapshot.byAgent[options.agent] ?? []) : snapshot.sessions;
   const results: SearchResult[] = [];
 
@@ -187,9 +200,10 @@ function searchRecentSessions(
 function buildInclusiveCostLookup(
   sessions: SessionHead[],
   options: SearchOptions,
+  sessionTree?: SessionTree,
 ): ReturnType<typeof buildSessionTree>["byRouteKey"] | null {
   if (options.costMin == null && options.costMax == null) return null;
-  return buildSessionTree(sessions).byRouteKey;
+  return (sessionTree ?? buildSessionTree(sessions)).byRouteKey;
 }
 
 function inclusiveCostFor(


### PR DESCRIPTION
## Summary
- Cache one `SessionTree` for each live sessions snapshot.
- Reuse it for project aggregation, inclusive-cost filtering, alias filtering, and parent context.
- Add regression coverage for snapshot invalidation and LRU hot-key retention.

## Root cause
Search consumers independently rebuilt route and inclusive-cost structures from the same snapshot. The existing snapshot aggregation cache had already gained LRU refresh behavior, but lacked a regression test for a hot entry at capacity.

## Validation
- `pnpm test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter codesesh typecheck`
- 25,000-session target-path benchmark: one tree build, 58.77 ms on this machine.