### PR TITLE
Refactor session slug construction

### DIFF
--- a/apps/web/src/components/InteractiveReceipt.tsx
+++ b/apps/web/src/components/InteractiveReceipt.tsx
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useMemo, useRef } from "react";
+import { getSessionAgentKey } from "@codesesh/core/contract";
 import type { SessionDetail } from "../lib/api";
 import { getSessionDisplayTitle } from "../lib/session-title";
 import {
@@ -181,7 +182,7 @@ function formatReceiptSubtitle(tags?: SessionDetail["smart_tags"]) {
 }
 
 function createReceiptPayload(session: SessionDetail, toc: SessionDetailToc): ReceiptPayload {
-  const agent = session.slug?.split("/")[0] || "codesesh";
+  const agent = getSessionAgentKey(session);
   return {
     id: session.id,
     title: getSessionDisplayTitle(session) || "Untitled session",

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -32,7 +32,7 @@ interface FakeSource {
  * algorithm without touching the disk. Only the two primitives are faked.
  */
 class FakeFileSystemSource extends FileSystemSessionSource {
-  readonly name = "fake";
+  readonly name: string = "fake";
   readonly displayName = "Fake";
   lastScanOptions: AgentScanOptions | undefined;
 
@@ -46,6 +46,10 @@ class FakeFileSystemSource extends FileSystemSessionSource {
 
   walk(root: string) {
     return this.walkFiles(root, () => true);
+  }
+
+  sessionSlugForTest(sessionId: string): string {
+    return this.sessionSlug(sessionId);
   }
 
   isAvailable(): boolean {
@@ -89,6 +93,10 @@ class FakeFileSystemSource extends FileSystemSessionSource {
   }
 }
 
+class NormalizedNameSource extends FakeFileSystemSource {
+  override readonly name = " FaKe ";
+}
+
 function makeSession(id: string): SessionHead {
   return {
     id,
@@ -129,6 +137,11 @@ describe("BaseAgent", () => {
   it("getUri returns correct format", () => {
     const agent = new FakeFileSystemSource();
     expect(agent.getUri("abc123")).toBe("fake://abc123");
+  });
+
+  it("formats session slugs from its normalized registered identity", () => {
+    const agent = new NormalizedNameSource();
+    expect(agent.sessionSlugForTest("nested/session")).toBe("fake/nested/session");
   });
 });
 

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -1,5 +1,6 @@
 import { readdirSync, statSync, type Dirent, type Stats } from "node:fs";
 import { join } from "node:path";
+import { formatSessionReference } from "../contract/session-reference.js";
 import type { SessionHead, SessionDetail, ParseSessionResult } from "../types/index.js";
 import {
   capturePricingMisses,
@@ -282,6 +283,10 @@ export abstract class BaseAgent {
 
   getUri(sessionId: string): string {
     return `${this.name}://${sessionId}`;
+  }
+
+  protected sessionSlug(sessionId: string): string {
+    return formatSessionReference({ agentName: this.name, sessionId });
   }
 }
 

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -319,7 +319,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       reference: { agentName: this.name, sessionId: meta.id },
       id: meta.id,
       title: meta.title,
-      slug: `claudecode/${meta.id}`,
+      slug: this.sessionSlug(meta.id),
       directory: meta.directory,
       parent_reference:
         meta.parentSessionId == null
@@ -684,7 +684,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
 
     return parsedSession({
       id: sessionId,
-      slug: `claudecode/${sessionId}`,
+      slug: this.sessionSlug(sessionId),
       title,
       directory,
       parent_reference:

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -717,7 +717,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       reference: { agentName: this.name, sessionId: meta.id },
       id: meta.id,
       title: meta.title,
-      slug: `codex/${meta.id}`,
+      slug: this.sessionSlug(meta.id),
       directory: meta.directory,
       parent_reference:
         meta.parentThreadId == null
@@ -1188,7 +1188,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
 
     return parsedSession({
       id: sessionId,
-      slug: `codex/${sessionId}`,
+      slug: this.sessionSlug(sessionId),
       title,
       directory,
       parent_reference:
@@ -1240,7 +1240,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
 
     return parsedSession({
       id: sessionId,
-      slug: `codex/${sessionId}`,
+      slug: this.sessionSlug(sessionId),
       title,
       directory,
       parent_reference:

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -661,7 +661,7 @@ export class CursorAgent extends DatabaseSessionSource {
                   ? filteredSession<SessionHead>("no visible messages")
                   : parsedSession<SessionHead>({
                       id: composerId,
-                      slug: `cursor/${composerId}`,
+                      slug: this.sessionSlug(composerId),
                       title: fastTitle,
                       directory,
                       time_created: createdAt,
@@ -815,7 +815,7 @@ export class CursorAgent extends DatabaseSessionSource {
         reference: { agentName: this.name, sessionId: composerId },
         id: composerId,
         title,
-        slug: `cursor/${composerId}`,
+        slug: this.sessionSlug(composerId),
         directory,
         time_created: createdAt,
         time_updated: updatedAt || undefined,
@@ -915,7 +915,7 @@ export class CursorAgent extends DatabaseSessionSource {
     if (directory) this.directoryCache.set(composerId, directory);
     return {
       id: composerId,
-      slug: `cursor/${composerId}`,
+      slug: this.sessionSlug(composerId),
       title,
       directory,
       time_created: createdAt,

--- a/packages/core/src/agents/dsh.ts
+++ b/packages/core/src/agents/dsh.ts
@@ -167,7 +167,7 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
 
     const head: SessionHead = {
       id: header.id,
-      slug: `${this.name}/${header.id}`,
+      slug: this.sessionSlug(header.id),
       title: this.resolveTitle(header, projection),
       directory: header.cwd ?? "",
       ...(header.parentSession
@@ -211,7 +211,7 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
       reference: { agentName: this.name, sessionId: header.id },
       id: header.id,
       title: this.resolveTitle(header, projection),
-      slug: `${this.name}/${header.id}`,
+      slug: this.sessionSlug(header.id),
       directory: header.cwd ?? "",
       ...(header.parentSession
         ? { parent_reference: { agentName: this.name, sessionId: header.parentSession } }

--- a/packages/core/src/agents/grok.ts
+++ b/packages/core/src/agents/grok.ts
@@ -889,7 +889,7 @@ export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
     const fingerprint = this.sourceFingerprint(source);
     const head: SessionHead = {
       id: summary.id,
-      slug: `grok/${summary.id}`,
+      slug: this.sessionSlug(summary.id),
       title,
       directory: summary.cwd,
       parent_reference: summary.parentSessionId
@@ -928,7 +928,7 @@ export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
       reference: { agentName: this.name, sessionId: meta.id },
       id: meta.id,
       title: meta.title,
-      slug: `grok/${meta.id}`,
+      slug: this.sessionSlug(meta.id),
       directory: meta.directory,
       parent_reference: meta.parentSessionId
         ? { agentName: this.name, sessionId: meta.parentSessionId }

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -569,7 +569,7 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     this.sessionMetaMap.set(meta.id, meta);
     return parsedSession({
       id: meta.id,
-      slug: `${this.name}/${meta.id}`,
+      slug: this.sessionSlug(meta.id),
       title: meta.title,
       directory: meta.workDir,
       time_created: meta.createdAt,
@@ -589,7 +589,7 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
       reference: { agentName: this.name, sessionId: meta.id },
       id: meta.id,
       title: meta.title,
-      slug: `${this.name}/${meta.id}`,
+      slug: this.sessionSlug(meta.id),
       directory: meta.workDir,
       time_created: meta.createdAt,
       time_updated: meta.activityAt,

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -421,7 +421,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     const stats = this.extractStats(meta.sourcePath);
     return parsedSession({
       id: meta.id,
-      slug: `kimi/${meta.id}`,
+      slug: this.sessionSlug(meta.id),
       title: meta.title,
       directory: meta.cwd,
       time_created: meta.createdAt,
@@ -826,7 +826,7 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
       reference: { agentName: this.name, sessionId: meta.id },
       id: meta.id,
       title: meta.title,
-      slug: `kimi/${meta.id}`,
+      slug: this.sessionSlug(meta.id),
       directory: meta.cwd,
       time_created: meta.createdAt,
       time_updated: meta.activityAt,

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -264,7 +264,7 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
 
     return parsedSession({
       id,
-      slug: `${this.name}/${id}`,
+      slug: this.sessionSlug(id),
       title: resolveSessionTitle(String(row.title ?? ""), messageTitle, null),
       directory: String(row.directory ?? ""),
       parent_reference:

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -184,7 +184,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
       reference: { agentName: this.name, sessionId: meta.id },
       id: meta.id,
       title: meta.title,
-      slug: `pi/${meta.id}`,
+      slug: this.sessionSlug(meta.id),
       directory: meta.directory,
       time_created: meta.createdAt,
       time_updated: meta.updatedAt,
@@ -240,7 +240,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
     const modelUsage = Object.keys(state.modelUsage).length > 0 ? state.modelUsage : undefined;
     return parsedSession({
       id: parsed.sessionId,
-      slug: `pi/${parsed.sessionId}`,
+      slug: this.sessionSlug(parsed.sessionId),
       title: parsed.title,
       directory: parsed.directory,
       time_created: parsed.createdAt,

--- a/packages/core/src/contract/__tests__/session-reference.test.ts
+++ b/packages/core/src/contract/__tests__/session-reference.test.ts
@@ -42,6 +42,7 @@ describe("session references", () => {
 
   it("provides one explicit fallback for malformed legacy slugs", () => {
     expect(getSessionAgentKey({ slug: "" })).toBe("unknown");
+    expect(getSessionAgentKey({ slug: null })).toBe("unknown");
     expect(getSessionAgentKey({ slug: "codex/session" })).toBe("codex");
   });
 });

--- a/packages/core/src/contract/session-reference.ts
+++ b/packages/core/src/contract/session-reference.ts
@@ -29,8 +29,8 @@ export function formatSessionReference(reference: SessionReference): string {
   return `${normalized.agentName}/${normalized.sessionId}`;
 }
 
-export function getSessionAgentKey(session: { slug: string }): string {
-  return parseSessionReference(session.slug)?.agentName ?? UNKNOWN_AGENT_NAME;
+export function getSessionAgentKey(session: { slug?: string | null }): string {
+  return parseSessionReference(session.slug ?? "")?.agentName ?? UNKNOWN_AGENT_NAME;
 }
 
 /**

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -148,6 +148,7 @@ export interface Message {
 /** Lightweight metadata for session listing */
 export interface SessionHead {
   id: string;
+  /** Serialized session reference. Adapters must not construct this string manually. */
   slug: string;
   title: string;
   display_title?: string;


### PR DESCRIPTION
## Summary
- Centralize adapter session-slug construction in `BaseAgent`.
- Reuse the shared session-reference parser in the interactive receipt.
- Preserve existing slug values while handling absent detail slugs consistently.

## Validation
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm --filter codesesh typecheck`