### PR TITLE
refactor(agents): share tool argument parser

### DIFF
--- a/packages/core/src/agents/__tests__/tool-arguments.test.ts
+++ b/packages/core/src/agents/__tests__/tool-arguments.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolArguments } from "../tool-arguments.js";
+
+describe("normalizeToolArguments", () => {
+  it("parses JSON objects, arrays, and scalars", () => {
+    expect(normalizeToolArguments('{"path":"src/index.ts"}')).toEqual({ path: "src/index.ts" });
+    expect(normalizeToolArguments('["a", 1]')).toEqual(["a", 1]);
+    expect(normalizeToolArguments("42")).toBe(42);
+  });
+
+  it("preserves invalid and empty JSON strings", () => {
+    expect(normalizeToolArguments("{invalid")).toBe("{invalid");
+    expect(normalizeToolArguments("")).toBe("");
+  });
+
+  it("returns non-string values unchanged", () => {
+    const value = { path: "src/index.ts" };
+
+    expect(normalizeToolArguments(value)).toBe(value);
+    expect(normalizeToolArguments(null)).toBeNull();
+    expect(normalizeToolArguments(42)).toBe(42);
+  });
+});

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -293,9 +293,13 @@ export abstract class BaseAgent {
 /**
  * 文件型 Agent 基类：每个会话对应磁盘上一个独立文件/目录。
  *
- * 子类只需实现两个文件级原语：
+ * 子类只需实现两个必需的文件级原语：
  *   - listSessionSources(): 枚举所有源 + 计算指纹
  *   - scanSessionSource(): 解析单个源（同时写入 metaMap）
+ *
+ * scanSessionSourceResult() 是可选的富结果扩展点：默认将 scanSessionSource()
+ * 的会话或 null 转成 parsed/skipped 结果；需要保留 filtered 等结果时可覆写，
+ * 例如 KimiAgent。
  *
  * 变更检测 / 增量扫描 / metaMap 管理由本基类统一提供：
  *   checkForChanges 用 listSessionSources 的指纹与缓存 metaMap 比对，

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -18,6 +18,7 @@ import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import { parseAgentTimestampMs } from "../utils/timestamp.js";
 import { asRecord, asString, narrowField } from "../utils/narrow.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
+import { normalizeToolArguments } from "./tool-arguments.js";
 import {
   type ExecInnerCall,
   decodeExecCalls,
@@ -173,17 +174,6 @@ function resolveToolIdentity(
     tool: `${namespaceName}.${toolName || name}`,
     metadata: { name, namespace: namespaceText },
   };
-}
-
-function normalizeToolArguments(raw: unknown): unknown {
-  if (typeof raw === "string") {
-    try {
-      return JSON.parse(raw);
-    } catch {
-      return raw;
-    }
-  }
-  return raw;
 }
 
 function normalizeCustomToolArguments(toolName: string, input: unknown): unknown {

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -29,6 +29,7 @@ import { cleanInternalText } from "../utils/session-normalization.js";
 import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
+import { normalizeToolArguments } from "./tool-arguments.js";
 
 const KIMI_CODE_TOOL_TITLE_MAP: Record<string, string> = {
   Read: "read",
@@ -96,15 +97,6 @@ interface ParsedWire {
 
 function mapToolTitle(toolName: string): string {
   return KIMI_CODE_TOOL_TITLE_MAP[toolName] ?? toolName;
-}
-
-function normalizeToolArguments(raw: unknown): unknown {
-  if (typeof raw !== "string") return raw;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return raw;
-  }
 }
 
 function parseTimestamp(raw: unknown): number | null {

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -30,6 +30,7 @@ import {
   reportFieldMismatch,
 } from "../utils/narrow.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
+import { normalizeToolArguments } from "./tool-arguments.js";
 
 const KIMI_TOOL_TITLE_MAP: Record<string, string> = {
   ReadFile: "read",
@@ -143,17 +144,6 @@ class KimiUsageAccumulator {
     if (stats.total_cost > 0) stats.cost_source = "estimated";
     return stats;
   }
-}
-
-function normalizeToolArguments(raw: unknown): unknown {
-  if (typeof raw === "string") {
-    try {
-      return JSON.parse(raw);
-    } catch {
-      return raw;
-    }
-  }
-  return raw;
 }
 
 function normalizeToolOutputParts(content: unknown, timestampMs: number): MessagePart[] {

--- a/packages/core/src/agents/tool-arguments.ts
+++ b/packages/core/src/agents/tool-arguments.ts
@@ -1,0 +1,8 @@
+export function normalizeToolArguments(raw: unknown): unknown {
+  if (typeof raw !== "string") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}


### PR DESCRIPTION
## Summary

- centralize equivalent Codex, Kimi, and Kimi Code tool argument parsing
- document the optional richer scan-result extension point on file-system agents
- add characterization coverage for JSON and raw argument values

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck:e2e`
- `pnpm test:e2e`