### PR TITLE
refactor(contract): narrow change seams

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -2,7 +2,7 @@ import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SAMPLE_SESSIONS_UPDATED_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
+import { SAMPLE_SESSIONS_UPDATED_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
 import type { ApiProjectGroup, DashboardData, SessionsUpdatedEvent } from "./lib/api";
 import App from "./App";
 import { appRouteChildren } from "./lib/app-routes";

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
+import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import type { AgentInfo, ApiProjectGroup, BookmarkView, ScanStatusEvent } from "../../lib/api";

--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -1,4 +1,4 @@
-import { SAMPLE_SESSIONS_UPDATED_EVENT } from "@codesesh/core/contract";
+import { SAMPLE_SESSIONS_UPDATED_EVENT } from "@codesesh/core/test-fixtures";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionsUpdatedEvent } from "../lib/api";

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -2,7 +2,7 @@ import {
   SAMPLE_DASHBOARD_DATA,
   SAMPLE_SESSION_HEAD,
   SAMPLE_SESSIONS_UPDATED_EVENT,
-} from "@codesesh/core/contract";
+} from "@codesesh/core/test-fixtures";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentInfo, AppConfig, ApiProjectGroup, SessionHead } from "../lib/api";

--- a/apps/web/src/hooks/useSidebarModel.test.ts
+++ b/apps/web/src/hooks/useSidebarModel.test.ts
@@ -1,4 +1,4 @@
-import { SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
+import { SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
 import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentInfo, ApiProjectGroup, SessionHead } from "../lib/api";

--- a/apps/web/src/hooks/useWindowedDataLoad.test.ts
+++ b/apps/web/src/hooks/useWindowedDataLoad.test.ts
@@ -1,4 +1,4 @@
-import { SAMPLE_DASHBOARD_DATA } from "@codesesh/core/contract";
+import { SAMPLE_DASHBOARD_DATA } from "@codesesh/core/test-fixtures";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AppConfig } from "../lib/api";

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SAMPLE_DASHBOARD_DATA, SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
+import { SAMPLE_DASHBOARD_DATA, SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
 import type { DashboardFilters } from "./api";
 import {
   fetchAgents,

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -16,7 +16,7 @@ import {
   type ScanOptions,
   type LiveSnapshot,
   type SessionHead,
-  type SessionHeadChange,
+  type PersistedSessionHeadChange,
   type SessionSourceFailure,
   type SessionSnapshotCompleteness,
 } from "@codesesh/core";
@@ -69,7 +69,7 @@ type StatusChangedListener = (event: ScanStatusEvent) => void;
 type CachedSessions = NonNullable<ReturnType<typeof loadCachedSessions>>;
 
 interface SessionPersistenceDiff {
-  changedSessions: SessionHeadChange[];
+  changedSessions: PersistedSessionHeadChange[];
   removedSessionIds: string[];
 }
 

--- a/packages/cli/src/api/__tests__/contract.test.ts
+++ b/packages/cli/src/api/__tests__/contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { SAMPLE_SCAN_STATUS_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/contract";
+import { SAMPLE_SCAN_STATUS_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
 import type { LiveSnapshot } from "@codesesh/core";
 import { createApiRoutes } from "../routes.js";
 import type { ScanResultSource } from "../handlers.js";

--- a/packages/cli/src/api/__tests__/routes.test.ts
+++ b/packages/cli/src/api/__tests__/routes.test.ts
@@ -2,9 +2,8 @@ import { describe, it, expect, vi } from "vitest";
 import {
   SAMPLE_SCAN_STATUS_EVENT,
   SAMPLE_SESSIONS_UPDATED_EVENT,
-  type ScanStatusEvent,
-  type SessionsUpdatedEvent,
-} from "@codesesh/core/contract";
+} from "@codesesh/core/test-fixtures";
+import type { ScanStatusEvent, SessionsUpdatedEvent } from "@codesesh/core/contract";
 import { createApiRoutes } from "../routes.js";
 import { MAX_PENDING_CRITICAL_SSE_FRAMES } from "../sse-event-buffer.js";
 import type { LiveSnapshot } from "@codesesh/core";

--- a/packages/cli/src/pending-search-index-jobs.ts
+++ b/packages/cli/src/pending-search-index-jobs.ts
@@ -1,4 +1,8 @@
-import type { SearchIndexSyncOptions, SessionCacheMeta, SessionHeadChange } from "@codesesh/core";
+import type {
+  PersistedSessionHeadChange,
+  SearchIndexSyncOptions,
+  SessionCacheMeta,
+} from "@codesesh/core";
 import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 
 type FullSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "full" }>;
@@ -17,7 +21,7 @@ interface PendingChanges {
   context: string;
   agentName: string;
   publicationId?: string;
-  changesBySessionId: Map<string, SessionHeadChange>;
+  changesBySessionId: Map<string, PersistedSessionHeadChange>;
   removedSessionIds: Set<string>;
   meta: Record<string, SessionCacheMeta>;
   searchIndexOptions?: SearchIndexSyncOptions;

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -18,7 +18,7 @@ import {
   type ScanOptions,
   type SessionCacheMeta,
   type SessionHead,
-  type SessionHeadChange,
+  type PersistedSessionHeadChange,
   type SessionSourceFailure,
   type SessionSnapshotCompleteness,
   type SessionTagTiming,
@@ -53,7 +53,7 @@ export type ScanRefreshWorkerMessage =
       type: "done";
       requestId: number;
       generation: number;
-      changes: SessionHeadChange[];
+      changes: PersistedSessionHeadChange[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       removedMetaIds: string[];
@@ -80,7 +80,7 @@ export type ScanRefreshWorkerCheckpoint =
     }
   | {
       stage: "finalizing";
-      changes: SessionHeadChange[];
+      changes: PersistedSessionHeadChange[];
       meta: Record<string, SessionCacheMeta>;
       backfillCursor?: string;
     };

--- a/packages/cli/src/search-index-maintenance-scheduler.ts
+++ b/packages/cli/src/search-index-maintenance-scheduler.ts
@@ -1,7 +1,7 @@
 import {
   loadCachedSessions,
   readPendingSearchIndexMaintenance,
-  type SessionHeadChange,
+  type PersistedSessionHeadChange,
 } from "@codesesh/core";
 import type { SearchIndexMaintenanceStatus } from "@codesesh/core/contract";
 import { toError } from "./errors.js";
@@ -99,7 +99,7 @@ export class SearchIndexMaintenanceScheduler {
     const sessionsById = new Map(
       cached.sessions.map((session, sortIndex) => [session.id, { session, sortIndex }]),
     );
-    const changes = pending.sessionIds.flatMap((sessionId): SessionHeadChange[] => {
+    const changes = pending.sessionIds.flatMap((sessionId): PersistedSessionHeadChange[] => {
       const change = sessionsById.get(sessionId);
       return change ? [change] : [];
     });

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -12,7 +12,7 @@ import {
   type SearchIndexSyncResult,
   type SearchIndexSyncOptions,
   type SessionCacheMeta,
-  type SessionHeadChange,
+  type PersistedSessionHeadChange,
   type SessionHead,
   type SessionSnapshotCompleteness,
   type DurableSessionPublicationFailureStage,
@@ -59,7 +59,7 @@ export type SearchIndexWorkerJob =
       kind: "changes";
       context: string;
       agentName: string;
-      changes: SessionHeadChange[];
+      changes: PersistedSessionHeadChange[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       publicationId?: string;
@@ -69,7 +69,7 @@ export type SearchIndexWorkerJob =
       kind: "maintenance";
       context: string;
       agentName: string;
-      changes: SessionHeadChange[];
+      changes: PersistedSessionHeadChange[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       searchIndexOptions?: SearchIndexSyncOptions;

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -6,7 +6,7 @@ import { createServer as createNodeServer, type Server as NodeServer } from "nod
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/contract";
+import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/test-fixtures";
 import { appLogger } from "./logging.js";
 import type { ProjectIdentityResolver } from "./project-identity-resolver.js";
 import { createServer } from "./server.js";

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -5,7 +5,7 @@ import {
   type ScanOptions,
   type SessionCacheMeta,
   type SessionHead,
-  type SessionHeadChange,
+  type PersistedSessionHeadChange,
   type SessionSourceFailure,
   type SessionSnapshotCompleteness,
 } from "@codesesh/core";
@@ -71,7 +71,7 @@ const SHUTDOWN_ERROR_MESSAGE = "Scan refresh worker shut down";
 
 function applySessionChanges(
   previousSessions: SessionHead[],
-  changes: SessionHeadChange[],
+  changes: PersistedSessionHeadChange[],
   removedSessionIds: string[],
 ): SessionHead[] {
   if (changes.length === 0 && removedSessionIds.length === 0) return previousSessions;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,11 @@
       "types": "./dist/repository-facts.d.ts",
       "import": "./dist/repository-facts.mjs",
       "require": "./dist/repository-facts.js"
+    },
+    "./test-fixtures": {
+      "types": "./dist/test-fixtures.d.ts",
+      "import": "./dist/test-fixtures.mjs",
+      "require": "./dist/test-fixtures.js"
     }
   },
   "scripts": {

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -4,7 +4,12 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const distEntry = join(dirname(fileURLToPath(import.meta.url)), "../../../dist/contract/index.mjs");
+const testFixturesEntry = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../dist/test-fixtures.mjs",
+);
 const distExists = existsSync(distEntry);
+const testFixturesExist = existsSync(testFixturesEntry);
 
 // Requires `pnpm --filter @codesesh/core build` to have run first — the
 // contract package runtime must remain browser-safe.
@@ -24,10 +29,6 @@ describe("contract browser-safety", () => {
     expect(Object.keys(contract).sort()).toEqual(
       [
         "PROJECT_IDENTITY_KINDS",
-        "SAMPLE_DASHBOARD_DATA",
-        "SAMPLE_SCAN_STATUS_EVENT",
-        "SAMPLE_SESSIONS_UPDATED_EVENT",
-        "SAMPLE_SESSION_HEAD",
         "UNKNOWN_AGENT_NAME",
         "addCalendarDays",
         "agentRoutePath",
@@ -61,6 +62,19 @@ describe("contract browser-safety", () => {
         "startOfCalendarDay",
         "toCalendarDayKey",
         "updateSessionIndex",
+      ].sort(),
+    );
+  });
+
+  it.skipIf(!testFixturesExist)("exposes fixtures from the explicit test-only entry", async () => {
+    const fixtures = await import(testFixturesEntry);
+
+    expect(Object.keys(fixtures).sort()).toEqual(
+      [
+        "SAMPLE_DASHBOARD_DATA",
+        "SAMPLE_SCAN_STATUS_EVENT",
+        "SAMPLE_SESSIONS_UPDATED_EVENT",
+        "SAMPLE_SESSION_HEAD",
       ].sort(),
     );
   });

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -13,4 +13,3 @@ export * from "./session-reference.js";
 export * from "./session-index.js";
 export * from "./session-tree.js";
 export type * from "./api.js";
-export * from "./fixtures.js";

--- a/packages/core/src/discovery/cache/db.ts
+++ b/packages/core/src/discovery/cache/db.ts
@@ -10,7 +10,7 @@ const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
 export const SEARCH_INDEX_BULK_SYNC_THRESHOLD = 100;
 
-export interface SessionHeadChange {
+export interface PersistedSessionHeadChange {
   session: SessionHead;
   sortIndex: number;
 }

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { SessionCacheMeta } from "../../agents/base.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
-import type { SessionHeadChange } from "./db.js";
+import type { PersistedSessionHeadChange } from "./db.js";
 import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import { sessionDetailVersion } from "./detail-version.js";
 import { assertSessionProjectIdentities } from "./messages.js";
@@ -35,7 +35,7 @@ export type DurableSessionPublication =
   | {
       kind: "changes";
       agentName: string;
-      changes: SessionHeadChange[];
+      changes: PersistedSessionHeadChange[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       publicationId?: string;

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -3,7 +3,7 @@ import type { SessionDetail, SessionFileActivity, SessionHead } from "../../type
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
-import { SEARCH_INDEX_BULK_SYNC_THRESHOLD, type SessionHeadChange } from "./db.js";
+import { SEARCH_INDEX_BULK_SYNC_THRESHOLD, type PersistedSessionHeadChange } from "./db.js";
 import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import {
   buildSessionContentFromMessages,
@@ -133,7 +133,7 @@ type SearchIndexPlanRequest =
   | { kind: "snapshot"; sessions: SessionHead[] }
   | {
       kind: "changes";
-      changes: SessionHeadChange[];
+      changes: PersistedSessionHeadChange[];
       removedSessionIds: readonly string[];
     };
 
@@ -141,7 +141,7 @@ interface SearchIndexPlan {
   agentName: string;
   mode: "bulk" | "incremental";
   sessionCount: number;
-  changes: SessionHeadChange[];
+  changes: PersistedSessionHeadChange[];
   removedSessionIds: string[];
   detailVersionBySessionId: Map<string, string>;
   needsRebuild: boolean;
@@ -151,7 +151,7 @@ interface SearchIndexPlan {
 interface SearchIndexPlanInput {
   agentName: string;
   sessionCount: number;
-  candidates: SessionHeadChange[];
+  candidates: PersistedSessionHeadChange[];
   removedSessionIds: string[];
   state: SearchIndexState;
   options: SearchIndexSyncOptions;
@@ -411,7 +411,7 @@ export function readPendingSearchIndexMaintenance(
 
 function loadSearchIndexEntry(
   agentName: string,
-  change: SessionHeadChange,
+  change: PersistedSessionHeadChange,
   loadSessionData: (sessionId: string) => SessionDetail,
   detailVersion: string,
   failures: SearchIndexSyncFailure[],
@@ -448,7 +448,7 @@ function loadSearchIndexEntry(
 
 function* loadSearchIndexEntries(
   agentName: string,
-  changes: Iterable<SessionHeadChange>,
+  changes: Iterable<PersistedSessionHeadChange>,
   loadSessionData: (sessionId: string) => SessionDetail,
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
@@ -648,7 +648,7 @@ function writeSearchIndexRows(
 function loadOrPreStageEntries(
   db: SQLiteDatabase,
   agentName: string,
-  changes: SessionHeadChange[],
+  changes: PersistedSessionHeadChange[],
   loadSessionData: (sessionId: string) => SessionDetail,
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
@@ -705,7 +705,7 @@ function readSearchIndexPlanInput(
   options: SearchIndexSyncOptions,
 ): SearchIndexPlanInput {
   const startedAt = performance.now();
-  let candidates: SessionHeadChange[];
+  let candidates: PersistedSessionHeadChange[];
   let removedSessionIds: string[];
   let sessionCount: number;
 
@@ -850,7 +850,7 @@ export function prepareSessionSnapshotSearchIndex(
 export function prepareSessionChangesSearchIndex(
   db: SQLiteDatabase,
   agentName: string,
-  changes: SessionHeadChange[],
+  changes: PersistedSessionHeadChange[],
   removedSessionIds: string[],
   loadSessionData: (sessionId: string) => SessionDetail,
   options: SearchIndexSyncOptions = {},
@@ -946,7 +946,7 @@ function executeSearchIndexPlan(
 ): SearchIndexSyncResult {
   let indexed = 0;
   const failures: SearchIndexSyncFailure[] = [];
-  const loadEntries = (changes: SessionHeadChange[]) =>
+  const loadEntries = (changes: PersistedSessionHeadChange[]) =>
     loadSearchIndexEntries(
       plan.agentName,
       changes,
@@ -1009,7 +1009,7 @@ export function syncSessionSearchIndex(
 
 export function syncSessionSearchIndexChanges(
   agentName: string,
-  changes: SessionHeadChange[],
+  changes: PersistedSessionHeadChange[],
   removedSessionIds: string[],
   loadSessionData: (sessionId: string) => SessionDetail,
   options: SearchIndexSyncOptions = {},

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -14,7 +14,7 @@ import {
   getLegacyCachePath,
   hasCacheStorage,
   type ScalarRow,
-  type SessionHeadChange,
+  type PersistedSessionHeadChange,
 } from "./db.js";
 import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import { withCacheDb, withCacheDbReadOnly, type CacheReadOutcome } from "./schema.js";
@@ -645,7 +645,7 @@ export function writeCachedSessionSnapshot(
  */
 export function saveCachedSessionChanges(
   agentName: string,
-  changes: SessionHeadChange[],
+  changes: PersistedSessionHeadChange[],
   removedSessionIds: string[],
   meta: Record<string, SessionCacheMeta> = {},
 ): boolean {
@@ -670,7 +670,7 @@ export function saveCachedSessionChanges(
 export function writeCachedSessionChanges(
   db: SQLiteDatabase,
   agentName: string,
-  changes: SessionHeadChange[],
+  changes: PersistedSessionHeadChange[],
   removedSessionIds: string[],
   meta: Record<string, SessionCacheMeta> = {},
 ): void {

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -42,7 +42,7 @@ export type {
 } from "./cache/sessions.js";
 export type { CacheReadOutcome } from "./cache/schema.js";
 export { closeCacheStorage, getCachePath } from "./cache/db.js";
-export type { SessionHeadChange } from "./cache/db.js";
+export type { PersistedSessionHeadChange } from "./cache/db.js";
 export { getAnalyticsRevision } from "./cache/analytics-revision.js";
 export { listCachedProjectGroups } from "./cache/project-groups.js";
 export {

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -15,7 +15,7 @@ import type {
   SessionReference,
   SessionStats,
 } from "../types/index.js";
-import type { SessionHeadChange } from "./cache/db.js";
+import type { PersistedSessionHeadChange } from "./cache/db.js";
 import {
   computeIdentityProjection,
   normalizeProjectDirectory,
@@ -173,7 +173,7 @@ export function sortSessions(sessions: SessionHead[]): SessionHead[] {
 }
 
 export interface SessionDiffResult {
-  changes: SessionHeadChange[];
+  changes: PersistedSessionHeadChange[];
   removedSessionIds: string[];
   counts: { new: number; updated: number; removed: number };
 }
@@ -207,7 +207,7 @@ export function computeSessionDiff(
   const cachedMap = new Map(cachedSessions.map((session) => [session.id, session]));
   const updatedIds = new Set(updatedSessions.map((session) => session.id));
   const changedIdSet = new Set(changedIds);
-  const changes: SessionHeadChange[] = [];
+  const changes: PersistedSessionHeadChange[] = [];
   const removedSessionIds: string[] = [];
   let newCount = 0;
   let updatedCount = 0;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,7 +101,7 @@ export type {
   SearchIndexSyncResult,
   SearchOptions,
   SearchRequestOptions,
-  SessionHeadChange,
+  PersistedSessionHeadChange,
   SessionTagTiming,
 } from "./discovery/index.js";
 export {

--- a/packages/core/src/test-fixtures.ts
+++ b/packages/core/src/test-fixtures.ts
@@ -1,6 +1,6 @@
-import type { DashboardData } from "./dashboard.js";
-import type { AgentScanStatus, ScanStatusEvent, SessionsUpdatedEvent } from "./events.js";
-import type { SessionHead } from "./session.js";
+import type { DashboardData } from "./contract/dashboard.js";
+import type { AgentScanStatus, ScanStatusEvent, SessionsUpdatedEvent } from "./contract/events.js";
+import type { SessionHead } from "./contract/session.js";
 
 export const SAMPLE_SESSION_HEAD = {
   id: "session-1",

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -4,7 +4,12 @@ import { defineConfig } from "tsup";
 const isWatch = process.argv.includes("--watch");
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/contract/index.ts", "src/repository-facts.ts"],
+  entry: [
+    "src/index.ts",
+    "src/contract/index.ts",
+    "src/repository-facts.ts",
+    "src/test-fixtures.ts",
+  ],
   format: ["esm", "cjs"],
   dts: false,
   clean: !isWatch,


### PR DESCRIPTION
## Summary

- rename the persistence `{ session, sortIndex }` shape to `PersistedSessionHeadChange`
- retain `SessionHeadChange` for the browser contract's referenced session updates
- move sample fixtures to the explicit `@codesesh/core/test-fixtures` export

## Why

The same type name described two incompatible shapes, and test samples were part of the production browser contract surface.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck:e2e`
- `pnpm test:e2e`