### PR TITLE
fix(web): distinguish API load failures

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -51,6 +51,8 @@ export default function App() {
     agentCatalog,
     sessions,
     projects,
+    projectsError,
+    projectsLoading,
     dashboard,
     window: loadedWindow,
     validAgentKeys,
@@ -61,6 +63,7 @@ export default function App() {
     applyLiveEvent,
     resyncLiveState,
     retryLoad,
+    retryProjects,
   } = sessionStore;
   useWindowedDataLoad({
     window: timeWindow,
@@ -446,8 +449,9 @@ export default function App() {
               viewState,
               agentCatalog,
               projects,
+              projectsError,
+              projectsLoading,
               selectedProjectNavigationId,
-              loading,
               bookmarkedSessions,
               sidebarSessions,
               selectedSidebarSessionReference,
@@ -460,6 +464,7 @@ export default function App() {
               onToggleSidebarSessionBookmark: handleToggleSidebarSessionBookmark,
               onRenameSession: handleRenameSession,
               onRenameBookmarkedSession: handleRenameBookmarkedSession,
+              onRetryProjects: () => void retryProjects(),
             }}
           />
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -284,7 +284,7 @@ export default function App() {
     activeAgent,
     sidebarSessionCount: sidebarSessions.length,
     session,
-    sessionError,
+    sessionError: sessionError?.kind ?? null,
     selectedProjectIdentity: selectedProjectNavigationIdentity,
     selectedProject: selectedProjectNavigation?.project ?? null,
   });
@@ -317,6 +317,7 @@ export default function App() {
         session: sessionDetail.session,
         loading: sessionDetail.sessionLoading,
         error: sessionDetail.sessionError,
+        retry: () => void sessionDetail.refresh(),
       }}
       projectAgentFilter={{
         selectedAgent: selectedProjectAgent,

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -25,15 +25,17 @@ export interface LandingAgentItem {
 }
 
 interface DetailLandingProps {
-  type: "global" | "agent" | "missing-agent" | "missing-session";
+  type: "global" | "agent" | "missing-agent" | "missing-session" | "load-failed";
   agentCatalog: AgentCatalog;
   sessions: LandingSession[];
   agentItems: LandingAgentItem[];
   activeAgentKey?: string;
   attemptedAgentKey?: string;
   attemptedSessionId?: string | null;
+  loadFailureMessage?: string;
   isBookmarked: (agentKey: string, sessionId: string) => boolean;
   onToggleBookmark: (session: LandingSession) => void;
+  onRetry?: () => void;
 }
 
 function getSessionTotalTokens(stats: SessionHead["stats"]) {
@@ -200,8 +202,10 @@ export const DetailLanding = memo(function DetailLanding({
   activeAgentKey,
   attemptedAgentKey,
   attemptedSessionId,
+  loadFailureMessage,
   isBookmarked,
   onToggleBookmark,
+  onRetry,
 }: DetailLandingProps) {
   const { recentSessions, totalMessages, totalTokens, totalCost, costSource, latestUpdatedAt } =
     useMemo(() => {
@@ -294,6 +298,41 @@ export const DetailLanding = memo(function DetailLanding({
             </div>
           </div>
           <DiagnosticItem label="Session" value={sessionId} />
+        </div>
+
+        <RecentSessions
+          sessions={recentSessions}
+          isBookmarked={isBookmarked}
+          onToggleBookmark={onToggleBookmark}
+        />
+      </div>
+    );
+  }
+
+  if (type === "load-failed") {
+    return (
+      <div className="mx-auto max-w-4xl space-y-4">
+        <MissingStateHero
+          code="LOAD / SESSION"
+          title="We couldn't load this session."
+          description="The session request failed before we could determine whether the record exists. It may still be available once the connection or server recovers."
+          aside="Retry this request without leaving the current session path."
+        />
+
+        <div className="flex flex-wrap items-end justify-between gap-3 rounded-md border border-[var(--console-border)] bg-[var(--console-surface-muted)] p-3">
+          <div className="min-w-0 flex-1">
+            <DiagnosticItem
+              label="Request Error"
+              value={loadFailureMessage ?? "Unable to load this session."}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="console-mono shrink-0 rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-3 py-1.5 text-xs text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
+          >
+            Retry
+          </button>
         </div>
 
         <RecentSessions

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -73,7 +73,7 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
       onRangeChange: vi.fn(),
       onSelectCustom: vi.fn(),
     },
-    sessionDetail: { session: null, loading: false, error: null },
+    sessionDetail: { session: null, loading: false, error: null, retry: vi.fn() },
     projectAgentFilter: { onChangeAgent: vi.fn() },
     search: {
       active: false,
@@ -330,7 +330,12 @@ describe("AppRouteContent", () => {
       activeAgentKey: "claudecode",
       activeSessionId: attemptedSessionId,
     };
-    props.sessionDetail = { session: null, loading: false, error: "not found" };
+    props.sessionDetail = {
+      session: null,
+      loading: false,
+      error: { kind: "missing" },
+      retry: vi.fn(),
+    };
     props.sessionsByAgent = new Map([
       ["claudecode", [claudeSession]],
       ["codex", [codexSession]],
@@ -347,6 +352,31 @@ describe("AppRouteContent", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Add bookmark" }));
     expect(props.bookmarks.toggleSessionBookmark).toHaveBeenCalledWith(claudeSession, "claudecode");
+  });
+
+  it("renders a retryable load failure instead of a missing session", () => {
+    const props = makeProps();
+    addRouteAgents(props);
+    const retry = vi.fn();
+    props.viewState = {
+      mode: "session",
+      activeAgentKey: "claudecode",
+      activeSessionId: "unavailable-session",
+    };
+    props.sessionDetail = {
+      session: null,
+      loading: false,
+      error: { kind: "load-failed", message: "server unavailable" },
+      retry,
+    };
+
+    renderContent(props);
+
+    expect(screen.getByRole("heading", { name: "We couldn't load this session." })).toBeTruthy();
+    expect(screen.getByText("server unavailable")).toBeTruthy();
+    expect(screen.queryByText("This session isn't in the index.")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(retry).toHaveBeenCalledTimes(1);
   });
 
   it("renders a missing agent with diagnostics and canonical recovery links", () => {

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -42,6 +42,7 @@ function LazySurface({ children }: { children: ReactNode }) {
 }
 import type { AgentInfo, AppConfig, ApiProjectGroup, SessionHead } from "../../lib/api";
 import type * as Api from "../../lib/api";
+import type { SessionDetailError } from "../../hooks/useSessionDetail";
 import type { AgentCatalog } from "../../lib/agents";
 import type { TimeWindowPreset } from "../../lib/time-window";
 import type { ViewState } from "../../lib/view-state";
@@ -51,7 +52,8 @@ import { getSessionRouteKey } from "../../lib/session-indexes";
 interface SessionDetailModel {
   session: Api.SessionDetail | null;
   loading: boolean;
-  error: string | null;
+  error: SessionDetailError | null;
+  retry: () => void;
 }
 
 /** The overview owns its scope and its own request; the shell only lends it the
@@ -258,7 +260,7 @@ export function AppRouteContent({
   }
   if (viewState.mode === "session") {
     if (sessionDetail.loading) return <SessionDetailSkeleton />;
-    if (sessionDetail.error || !currentSession) {
+    if (sessionDetail.error?.kind === "missing") {
       return (
         <DetailLanding
           type="missing-session"
@@ -272,6 +274,21 @@ export function AppRouteContent({
         />
       );
     }
+    if (sessionDetail.error?.kind === "load-failed") {
+      return (
+        <DetailLanding
+          type="load-failed"
+          agentCatalog={agentCatalog}
+          sessions={sessionsByAgent.get(viewState.activeAgentKey) ?? []}
+          agentItems={landingAgentItems}
+          loadFailureMessage={sessionDetail.error.message}
+          isBookmarked={bookmarks.isBookmarked}
+          onToggleBookmark={toggleLandingBookmark}
+          onRetry={sessionDetail.retry}
+        />
+      );
+    }
+    if (!currentSession) return <SessionDetailSkeleton />;
     return (
       <RenderProfiler
         id="SessionDetail"

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -28,6 +28,7 @@ function createActions(overrides: Partial<AppSidebarActions> = {}): AppSidebarAc
     onToggleSidebarSessionBookmark: vi.fn(),
     onRenameSession: vi.fn(),
     onRenameBookmarkedSession: vi.fn(),
+    onRetryProjects: vi.fn(),
     ...overrides,
   };
 }
@@ -46,8 +47,9 @@ function renderSidebar(
             viewState: { mode: "root", activeAgentKey: null, activeSessionId: null },
             agentCatalog: createAgentCatalog(agents),
             projects,
+            projectsError: null,
+            projectsLoading: false,
             selectedProjectNavigationId: null,
-            loading: false,
             bookmarkedSessions: [],
             sidebarSessions: [],
             selectedSidebarSessionReference: null,
@@ -109,6 +111,31 @@ describe("AppSidebar", () => {
     });
 
     expect(screen.getByText("Scanning projects...")).toBeTruthy();
+  });
+
+  it("shows an empty state only after projects load successfully", () => {
+    renderSidebar({ projects: [] });
+
+    expect(screen.getByText("No projects found")).toBeTruthy();
+
+    cleanup();
+    renderSidebar({ projects: [], projectsLoading: true });
+
+    expect(screen.queryByText("No projects found")).toBeNull();
+  });
+
+  it("keeps project failures local and retryable", () => {
+    const onRetryProjects = vi.fn();
+    renderSidebar(
+      { projects: [], projectsError: "projects unavailable" },
+      createActions({ onRetryProjects }),
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain("Couldn't load projects.");
+    expect(screen.getByText("projects unavailable")).toBeTruthy();
+    expect(screen.queryByText("No projects found")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetryProjects).toHaveBeenCalledTimes(1);
   });
 
   it("omits the sessions section until a project is selected", () => {

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -63,13 +63,33 @@ function ProjectNavList({
   );
 }
 
+function ProjectLoadFailure({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div
+      role="alert"
+      className="rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] px-3 py-2 text-xs text-[var(--console-error)]"
+    >
+      <p>Couldn&apos;t load projects.</p>
+      <p className="console-mono mt-1 break-all text-[11px]">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="console-mono mt-2 rounded-sm border border-[var(--console-error-border)] px-2 py-1 text-[11px] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
 export interface AppSidebarViewModel {
   sidebarCollapsed: boolean;
   viewState: ViewState;
   agentCatalog: AgentCatalog;
   projects: ApiProjectGroup[];
+  projectsError: string | null;
+  projectsLoading: boolean;
   selectedProjectNavigationId: string | null;
-  loading: boolean;
   bookmarkedSessions: BookmarkView[];
   sidebarSessions: SessionHead[];
   selectedSidebarSessionReference: string | null;
@@ -83,6 +103,7 @@ export interface AppSidebarActions {
   onToggleSidebarSessionBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
   onRenameBookmarkedSession: (session: BookmarkView) => void;
+  onRetryProjects: () => void;
 }
 
 export function AppSidebar({
@@ -91,8 +112,9 @@ export function AppSidebar({
     viewState,
     agentCatalog,
     projects,
+    projectsError,
+    projectsLoading,
     selectedProjectNavigationId,
-    loading,
     bookmarkedSessions,
     sidebarSessions,
     selectedSidebarSessionReference,
@@ -105,6 +127,7 @@ export function AppSidebar({
     onToggleSidebarSessionBookmark,
     onRenameSession,
     onRenameBookmarkedSession,
+    onRetryProjects,
   },
 }: {
   model: AppSidebarViewModel;
@@ -149,7 +172,11 @@ export function AppSidebar({
               projects={projects}
               selectedProjectNavigationId={selectedProjectNavigationId}
             />
-            {projects.length === 0 && !loading ? (
+            {projectsError ? (
+              <li>
+                <ProjectLoadFailure message={projectsError} onRetry={onRetryProjects} />
+              </li>
+            ) : projects.length === 0 && !projectsLoading ? (
               <li>
                 <ScanAwareEmptyState scanning="Scanning projects..." empty="No projects found" />
               </li>

--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -7,7 +7,8 @@ import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionDetail } from "./useSessionDetail";
 
-vi.mock("../lib/api", () => ({
+vi.mock("../lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api")>()),
   fetchSessionData: vi.fn(),
   logClientEvent: vi.fn(),
 }));
@@ -60,12 +61,40 @@ describe("useSessionDetail", () => {
     );
   });
 
-  it("sets an error when the fetch fails", async () => {
+  it("classifies a confirmed 404 as a missing session", async () => {
+    vi.mocked(api.fetchSessionData).mockRejectedValue(new api.ApiRequestError("not found", 404));
+    const { result } = renderSessionDetail();
+
+    await waitFor(() => expect(result.current.sessionError).toEqual({ kind: "missing" }));
+    expect(result.current.session).toBeNull();
+  });
+
+  it("keeps network and server failures distinct from missing sessions", async () => {
     vi.mocked(api.fetchSessionData).mockRejectedValue(new Error("nope"));
     const { result } = renderSessionDetail();
 
-    await waitFor(() => expect(result.current.sessionError).toBe("Session not found"));
+    await waitFor(() =>
+      expect(result.current.sessionError).toEqual({ kind: "load-failed", message: "nope" }),
+    );
     expect(result.current.session).toBeNull();
+  });
+
+  it("recovers from a failed detail request with a local retry", async () => {
+    vi.mocked(api.fetchSessionData)
+      .mockRejectedValueOnce(new api.ApiRequestError("server unavailable", 500))
+      .mockResolvedValueOnce(sample);
+    const { result } = renderSessionDetail();
+
+    await waitFor(() =>
+      expect(result.current.sessionError).toEqual({
+        kind: "load-failed",
+        message: "server unavailable",
+      }),
+    );
+    await act(() => result.current.refresh());
+
+    await waitFor(() => expect(result.current.session).toEqual(sample));
+    expect(result.current.sessionError).toBeNull();
   });
 
   it("does not fetch for a non-session route", () => {

--- a/apps/web/src/hooks/useSessionDetail.ts
+++ b/apps/web/src/hooks/useSessionDetail.ts
@@ -1,10 +1,20 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { fetchSessionData, logClientEvent, type SessionDetail } from "../lib/api";
+import { ApiRequestError, fetchSessionData, logClientEvent, type SessionDetail } from "../lib/api";
 import { queryKeys } from "../lib/query-keys";
 import type { ViewState } from "../lib/view-state";
 
 let nextSessionRequestId = 1;
+
+export type SessionDetailError = { kind: "missing" } | { kind: "load-failed"; message: string };
+
+function getSessionDetailError(error: unknown): SessionDetailError {
+  if (error instanceof ApiRequestError && error.status === 404) return { kind: "missing" };
+  return {
+    kind: "load-failed",
+    message: error instanceof Error ? error.message : "Unable to load this session.",
+  };
+}
 
 function mergeSessionDetailUpdate(
   previous: SessionDetail | undefined,
@@ -101,7 +111,7 @@ export function useSessionDetail(viewState: ViewState) {
   return {
     session: route ? (query.data ?? null) : null,
     sessionLoading: route !== null && query.isPending,
-    sessionError: route !== null && query.isError ? "Session not found" : null,
+    sessionError: route !== null && query.isError ? getSessionDetailError(query.error) : null,
     refresh,
   };
 }

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -139,15 +139,16 @@ describe("useSessionStore", () => {
     await waitFor(() => expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]));
   });
 
-  it("commits all window data as one snapshot", async () => {
+  it("keeps projects available alongside the session snapshot", async () => {
     const { result } = await renderStore();
 
     await act(() => result.current.reload(config.window));
 
+    await waitFor(() => expect(result.current.projects).toEqual(projects));
+
     expect(result.current.loading).toBe(false);
     expect(result.current.agents).toEqual(agents);
     expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]);
-    expect(result.current.projects).toEqual(projects);
     expect(result.current.dashboard).toEqual(SAMPLE_DASHBOARD_DATA);
     expect(result.current.activeAgents).toEqual([agents[0]]);
     expect(result.current.agentCatalog.byKey.get("codex")).toBe(agents[1]);
@@ -275,14 +276,14 @@ describe("useSessionStore", () => {
     }
 
     expect(api.fetchAgents).toHaveBeenCalledOnce();
-    expect(api.fetchProjects).toHaveBeenCalledOnce();
+    expect(api.fetchProjects).not.toHaveBeenCalled();
     expect(api.fetchDashboard).toHaveBeenCalledOnce();
 
     now += 1_001;
     await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
 
     expect(api.fetchAgents).toHaveBeenCalledTimes(2);
-    expect(api.fetchProjects).toHaveBeenCalledTimes(2);
+    expect(api.fetchProjects).toHaveBeenCalledOnce();
     expect(api.fetchDashboard).toHaveBeenCalledTimes(2);
   });
 
@@ -372,7 +373,6 @@ describe("useSessionStore", () => {
     client.setQueryData(searchKey, []);
     client.setQueryData(inactiveAggregateKey, {
       agents,
-      projects,
       dashboard: SAMPLE_DASHBOARD_DATA,
     });
 
@@ -445,17 +445,65 @@ describe("useSessionStore", () => {
     expect(result.current.version).toBeGreaterThan(0);
   });
 
-  it("keeps the snapshot usable when projects fail to load", async () => {
+  it("keeps sessions and dashboards available when projects fail", async () => {
     const error = new Error("projects unavailable");
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchProjects).mockRejectedValue(error);
     const { result } = await renderStore();
 
     await act(() => result.current.reload(config.window));
 
+    await waitFor(() => expect(result.current.projectsError).toBe("projects unavailable"));
     expect(result.current.projects).toEqual([]);
     expect(result.current.error).toBeNull();
-    expect(console.error).toHaveBeenCalledWith("Failed to load projects:", error);
+    expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]);
+    expect(result.current.dashboard).toEqual(SAMPLE_DASHBOARD_DATA);
+
+    vi.mocked(api.fetchProjects).mockResolvedValueOnce({ projects });
+    await act(() => result.current.retryProjects());
+
+    await waitFor(() => expect(result.current.projects).toEqual(projects));
+    expect(result.current.projectsError).toBeNull();
+  });
+
+  it("retains the last project list when a refresh fails", async () => {
+    const error = new Error("projects unavailable");
+    const { result } = await renderStore();
+    await act(() => result.current.reload(config.window));
+    await waitFor(() => expect(result.current.projects).toEqual(projects));
+    vi.mocked(api.fetchProjects).mockRejectedValueOnce(error);
+
+    await act(() => result.current.retryProjects());
+
+    await waitFor(() => expect(result.current.projectsError).toBe("projects unavailable"));
+    expect(result.current.projects).toEqual(projects);
+  });
+
+  it("does not surface a cancelled project request as an error", async () => {
+    let firstSignal: AbortSignal | undefined;
+    vi.mocked(api.fetchProjects)
+      .mockImplementationOnce(
+        (_window, options) =>
+          new Promise((_resolve, reject) => {
+            firstSignal = options?.signal;
+            options?.signal?.addEventListener("abort", () => {
+              reject(new DOMException("Aborted", "AbortError"));
+            });
+          }),
+      )
+      .mockResolvedValue({ projects });
+    const { result } = await renderStore();
+    const firstWindow = { from: 1, to: 2 };
+    const nextWindow = { from: 3, to: 4 };
+
+    act(() => {
+      void result.current.reload(firstWindow);
+    });
+    await waitFor(() => expect(firstSignal).toBeDefined());
+    await act(() => result.current.reload(nextWindow));
+
+    await waitFor(() => expect(result.current.projects).toEqual(projects));
+    expect(firstSignal?.aborted).toBe(true);
+    expect(result.current.projectsError).toBeNull();
   });
 
   it("surfaces full reload failures without replacing the snapshot", async () => {

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -5,6 +5,7 @@ import {
 } from "@codesesh/core/contract";
 import {
   isCancelledError,
+  keepPreviousData,
   queryOptions,
   useQuery,
   useQueryClient,
@@ -36,7 +37,6 @@ export interface SessionStoreSnapshot {
   window: AppConfig["window"];
   agents: AgentInfo[];
   sessions: SessionHead[];
-  projects: ApiProjectGroup[];
   dashboard: DashboardData;
 }
 
@@ -45,39 +45,34 @@ export interface LiveSessionApplyResult {
   visibleNewSessions: number;
 }
 
-type SnapshotAggregates = Pick<SessionStoreSnapshot, "agents" | "projects" | "dashboard">;
+type SnapshotAggregates = Pick<SessionStoreSnapshot, "agents" | "dashboard">;
 const LIVE_AGGREGATE_REFRESH_INTERVAL_MS = 2_000;
+const EMPTY_PROJECTS: ApiProjectGroup[] = [];
 
 const EMPTY_SNAPSHOT = {
   agents: [] satisfies AgentInfo[],
   sessions: [] satisfies SessionHead[],
-  projects: [] satisfies ApiProjectGroup[],
   dashboard: null,
 };
 
-async function loadProjects(
-  window: AppConfig["window"],
-  signal: AbortSignal,
-): Promise<ApiProjectGroup[]> {
-  try {
-    return (await fetchProjects(window, { signal })).projects;
-  } catch (error) {
-    if (signal.aborted) throw error;
-    console.error("Failed to load projects:", error);
-    return [];
-  }
+function projectsOptions(window: AppConfig["window"]) {
+  return queryOptions({
+    queryKey: queryKeys.project(window),
+    queryFn: async ({ signal }) => (await fetchProjects(window, { signal })).projects,
+    staleTime: LIVE_AGGREGATE_REFRESH_INTERVAL_MS,
+    retry: false,
+  });
 }
 
 async function fetchSnapshotAggregates(
   window: AppConfig["window"],
   signal: AbortSignal,
 ): Promise<SnapshotAggregates> {
-  const [agents, projects, dashboard] = await Promise.all([
+  const [agents, dashboard] = await Promise.all([
     fetchAgents(window, { signal }),
-    loadProjects(window, signal),
     fetchDashboard(window, {}, { signal }),
   ]);
-  return { agents, projects, dashboard };
+  return { agents, dashboard };
 }
 
 function snapshotAggregatesOptions(window: AppConfig["window"]) {
@@ -104,6 +99,18 @@ async function fetchLiveSnapshotAggregates(
     needsRefresh ? invalidateLiveSessionCollections(queryClient) : Promise.resolve(),
   ]);
   return aggregates;
+}
+
+function refreshLiveProjects(queryClient: QueryClient, window: AppConfig["window"]): void {
+  const options = projectsOptions(window);
+  const state = queryClient.getQueryState(options.queryKey);
+  const needsRefresh =
+    !state ||
+    state.data === undefined ||
+    state.isInvalidated ||
+    Date.now() - state.dataUpdatedAt >= LIVE_AGGREGATE_REFRESH_INTERVAL_MS;
+  if (!needsRefresh) return;
+  void queryClient.fetchQuery(options).catch(() => undefined);
 }
 
 function sameWindow(
@@ -182,6 +189,11 @@ export function useSessionStore() {
     ...sessionSnapshotOptions(requestedWindow ?? {}),
     enabled: false,
   });
+  const projectsQuery = useQuery({
+    ...projectsOptions(requestedWindow ?? {}),
+    enabled: requestedWindow !== null,
+    placeholderData: keepPreviousData,
+  });
   const configFailed = configQuery.isError;
   const refetchConfig = configQuery.refetch;
   const snapshot = snapshotQuery.data;
@@ -200,12 +212,23 @@ export function useSessionStore() {
       setRequestedWindow(window);
       setPreviewSnapshot(null);
       try {
-        await queryClient.cancelQueries({ queryKey: queryKeys.sessionSnapshots });
-        await queryClient.invalidateQueries({
-          queryKey: queryKeys.sessionSnapshot(window),
-          exact: true,
-          refetchType: "none",
-        });
+        await Promise.all([
+          queryClient.cancelQueries({ queryKey: queryKeys.sessionSnapshots }),
+          queryClient.cancelQueries({ queryKey: queryKeys.projects }),
+        ]);
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.sessionSnapshot(window),
+            exact: true,
+            refetchType: "none",
+          }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.project(window),
+            exact: true,
+            refetchType: "none",
+          }),
+        ]);
+        void queryClient.fetchQuery(projectsOptions(window)).catch(() => undefined);
         return await queryClient.fetchQuery(
           sessionSnapshotOptions(window, (preview) => {
             if (reloadVersionRef.current === reloadVersion) setPreviewSnapshot(preview);
@@ -279,6 +302,7 @@ export function useSessionStore() {
         sessions: projection.sessions,
       });
       await invalidateLiveSessionDerivedQueries(queryClient, event);
+      refreshLiveProjects(queryClient, activeWindow);
       const aggregates = await fetchLiveSnapshotAggregates(queryClient, activeWindow);
       const updated =
         queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, (latest) =>
@@ -311,6 +335,18 @@ export function useSessionStore() {
     currentSnapshot ??
     (sameWindow(previewSnapshot?.window, requestedWindow) ? previewSnapshot : null);
   const agents = displayedSnapshot?.agents ?? EMPTY_SNAPSHOT.agents;
+  const projects = projectsQuery.data ?? EMPTY_PROJECTS;
+  const projectsLoading = requestedWindow === null || projectsQuery.isPending;
+  const projectsError =
+    requestedWindow !== null && projectsQuery.isError
+      ? projectsQuery.error instanceof Error
+        ? projectsQuery.error.message
+        : "Unable to load projects."
+      : null;
+  const retryProjects = useCallback(async (): Promise<void> => {
+    if (!requestedWindowRef.current) return;
+    await projectsQuery.refetch({ cancelRefetch: true });
+  }, [projectsQuery]);
   const agentCatalog = useMemo(() => createAgentCatalog(agents), [agents]);
   const validAgentKeys = useMemo(
     () => new Set(agentCatalog.active.map((agent) => agent.name.toLowerCase())),
@@ -327,7 +363,9 @@ export function useSessionStore() {
     window: displayedSnapshot?.window ?? null,
     agents,
     sessions: displayedSnapshot?.sessions ?? EMPTY_SNAPSHOT.sessions,
-    projects: displayedSnapshot?.projects ?? EMPTY_SNAPSHOT.projects,
+    projects,
+    projectsError,
+    projectsLoading,
     dashboard: displayedSnapshot?.dashboard ?? EMPTY_SNAPSHOT.dashboard,
     loading:
       configQuery.isPending ||
@@ -343,5 +381,6 @@ export function useSessionStore() {
     applyLiveEvent,
     resyncLiveState,
     retryLoad,
+    retryProjects,
   };
 }

--- a/apps/web/src/hooks/useWindowedDataLoad.test.ts
+++ b/apps/web/src/hooks/useWindowedDataLoad.test.ts
@@ -13,7 +13,6 @@ const snapshot = {
   window,
   agents: [],
   sessions: [],
-  projects: [],
   dashboard: SAMPLE_DASHBOARD_DATA,
 } satisfies SessionStoreSnapshot;
 
@@ -39,7 +38,6 @@ describe("useWindowedDataLoad", () => {
         duration_ms: expect.any(Number),
         agents: 0,
         sessions: 0,
-        projects: 0,
       }),
     );
   });

--- a/apps/web/src/hooks/useWindowedDataLoad.ts
+++ b/apps/web/src/hooks/useWindowedDataLoad.ts
@@ -21,7 +21,6 @@ export function useWindowedDataLoad({ window, reload }: WindowedDataLoadDeps) {
           duration_ms: Math.round(performance.now() - startedAt),
           agents: snapshot.agents.length,
           sessions: snapshot.sessions.length,
-          projects: snapshot.projects.length,
         });
       })
       .catch((error) => {

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SAMPLE_DASHBOARD_DATA, SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
 import type { DashboardFilters } from "./api";
 import {
+  ApiRequestError,
   fetchAgents,
   fetchConfig,
   fetchDashboard,
@@ -235,6 +236,23 @@ describe("fetchSessionData", () => {
       "/api/sessions/codex/session?messageCursor=prefix%2B%2F%3D",
       { signal: controller.signal },
     );
+  });
+
+  it("exposes failed response status through ApiRequestError", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchSessionData("codex", "missing")).rejects.toEqual(
+      expect.objectContaining({
+        message: "GET /api/sessions/codex/missing failed: 404 Not Found",
+        status: 404,
+      }),
+    );
+    await expect(fetchSessionData("codex", "missing")).rejects.toBeInstanceOf(ApiRequestError);
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -158,7 +158,7 @@ async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-class ApiRequestError extends Error {
+export class ApiRequestError extends Error {
   constructor(
     message: string,
     readonly status: number,

--- a/apps/web/src/lib/build-route-header-model.tsx
+++ b/apps/web/src/lib/build-route-header-model.tsx
@@ -26,7 +26,7 @@ interface RouteHeaderInput {
   activeAgent: AgentInfo | null;
   sidebarSessionCount: number;
   session: SessionDetail | null;
-  sessionError: string | null;
+  sessionError: "missing" | "load-failed" | null;
   selectedProjectIdentity: ProjectRouteIdentity | null;
   selectedProject: ApiProjectGroup | null;
 }
@@ -120,7 +120,7 @@ function routeTitleAndSubtitle(input: RouteHeaderInput): {
   if (viewState.mode === "session") {
     if (input.sessionError) {
       return {
-        title: "Session Not Found",
+        title: input.sessionError === "missing" ? "Session Not Found" : "Session Load Failed",
         subtitle: `Requested /${viewState.activeAgentKey}/${viewState.activeSessionId}`,
       };
     }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -16,6 +16,8 @@ export const queryKeys = {
   dashboards: ["dashboard"] as const,
   dashboard: (window: TimeWindow, filters: DashboardFilters) =>
     ["dashboard", normalizeWindow(window), filters] as const,
+  projects: ["projects"] as const,
+  project: (window: TimeWindow) => ["projects", normalizeWindow(window)] as const,
   search: (query: string, options: SearchRequestOptions) => ["search", query, options] as const,
   searches: ["search"] as const,
   sessionDetails: ["session-detail"] as const,


### PR DESCRIPTION
## Summary
- Classify session detail failures from API status so only confirmed 404 responses render the missing-session state.
- Add a local retry landing for network and server failures.
- Move projects into an independent query that preserves prior data and exposes a retryable sidebar error.

## Root cause
The detail hook converted every query error into a missing session, while the snapshot aggregator caught project failures and replaced them with an empty list.

## Validation
- `pnpm --filter @codesesh/web exec tsc --noEmit`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`