### PR TITLE
refactor(web): reduce live session render work

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -35,12 +35,7 @@ import { ScanStatusNotice } from "./components/app/ScanStatusNotice";
 import { formatSearchSubtitle } from "./lib/scan-format";
 import { findAgent } from "./lib/agents";
 import { getProjectIdentityKey } from "./lib/projects";
-import {
-  buildSessionIndexes,
-  getSessionAgentKey,
-  getSessionReferenceKey,
-  getSessionRouteKey,
-} from "./lib/session-indexes";
+import { buildSessionIndexes, getSessionAgentKey } from "./lib/session-indexes";
 
 export default function App() {
   const navigate = useNavigate();
@@ -72,9 +67,6 @@ export default function App() {
   });
 
   const setScanStatus = useScanStatusPublisher();
-  const [selectedSidebarSessionReference, setSelectedSidebarSessionReference] = useState<
-    string | null
-  >(null);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const {
     shortcutHintDismissed,
@@ -190,7 +182,6 @@ export default function App() {
     activeProjectSessions,
     selectedProjectNavigation,
     sidebarSessions,
-    sidebarSessionLookup,
     bookmarkedSidebarSessionReferences,
   } = sidebar;
   const selectedProjectNavigationIdentity = selectedProjectNavigation?.identity ?? null;
@@ -198,7 +189,6 @@ export default function App() {
 
   const handleSelectFlatSidebarSession = useCallback(
     (sessionItem: SessionHead) => {
-      setSelectedSidebarSessionReference(getSessionReferenceKey(sessionItem));
       navigate(getSessionRoutePath(sessionItem));
     },
     [navigate],
@@ -258,24 +248,6 @@ export default function App() {
     if (!aliasTarget) return;
     await removeAlias(aliasTarget);
   }, [aliasTarget, removeAlias]);
-
-  useEffect(() => {
-    if (isSearchMode) return;
-
-    if (viewState.mode === "session") {
-      setSelectedSidebarSessionReference(
-        getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionId),
-      );
-      return;
-    }
-
-    if (viewState.mode === "agent") {
-      setSelectedSidebarSessionReference(null);
-      return;
-    }
-
-    setSelectedSidebarSessionReference(null);
-  }, [isSearchMode, viewState.mode, viewState.activeAgentKey, viewState.activeSessionId]);
 
   const searchSubtitle =
     searchState.status === "failed"
@@ -354,10 +326,6 @@ export default function App() {
   useKeyboardShortcuts({
     viewState,
     navigate,
-    sidebarSessions,
-    sidebarSessionLookup,
-    selectedSidebarSessionReference,
-    setSelectedSidebarSessionReference,
     selectedProjectNavigationIdentity,
     shortcutHelpOpen,
     setShortcutHelpOpen,
@@ -434,8 +402,11 @@ export default function App() {
               selectedProjectNavigationId,
               bookmarkedSessions,
               sidebarSessions,
-              selectedSidebarSessionReference,
+              sidebarSessionLookup: sidebar.sidebarSessionLookup,
               bookmarkedSidebarSessionReferences,
+              isSearchMode,
+              shortcutHelpOpen,
+              dismissShortcutHint,
             }}
             actions={{
               onCollapse: () => setSidebarCollapsed(true),

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 declare const __APP_VERSION__: string;
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PanelLeftOpen } from "./components/ui/icons";
 import { Link, useLocation, useMatches, useNavigate } from "react-router-dom";
 import type { BookmarkView, SessionHead } from "./lib/api";
@@ -27,6 +27,7 @@ import { useUiPreferences } from "./hooks/useUiPreferences";
 import { ResolvedThemeContext, useTheme } from "./hooks/useTheme";
 import { buildRouteHeaderModel } from "./lib/build-route-header-model";
 import { AppSidebar } from "./components/app/AppSidebar";
+import { SearchControls, type SearchControlsHandle } from "./components/app/SearchControls";
 import { ShortcutHelpDialog } from "./components/app/ShortcutHelpDialog";
 import { ThemeToggle } from "./components/app/ThemeToggle";
 import { AppRouteContent } from "./components/app/AppRouteContent";
@@ -111,21 +112,26 @@ export default function App() {
   );
 
   const search = useSessionSearch(sessionIndexes, loadedWindow);
+  const searchControlsRef = useRef<SearchControlsHandle>(null);
   const {
-    draftSearchQuery,
     activeSearchQuery,
     searchMode,
     searchState,
     searchResults,
     searchLoading,
     selectedSearchIndex,
-    searchInputRef,
-    setDraftSearchQuery,
     setSelectedSearchIndex,
     openSearch,
     submitSearch,
     closeSearch,
   } = search;
+  const openSearchAndFocus = useCallback(() => {
+    openSearch();
+    searchControlsRef.current?.focusAndSelect();
+  }, [openSearch]);
+  const clearSearchInput = useCallback(() => {
+    searchControlsRef.current?.clear();
+  }, []);
   const isSearchMode = searchMode;
   const detailHighlightQuery = isSearchMode
     ? activeSearchQuery
@@ -361,8 +367,8 @@ export default function App() {
     searchResults,
     selectedSearchIndex,
     setSelectedSearchIndex,
-    setDraftSearchQuery,
-    openSearch,
+    clearSearchInput,
+    openSearch: openSearchAndFocus,
     closeSearch,
   });
 
@@ -385,33 +391,7 @@ export default function App() {
                 </span>
               </Link>
             </div>
-            <form
-              className="order-3 col-span-2 flex w-full items-center justify-center gap-2 sm:order-none sm:col-span-1 sm:mx-auto sm:max-w-[560px]"
-              onSubmit={(event) => {
-                event.preventDefault();
-                submitSearch();
-              }}
-            >
-              <label className="flex min-w-0 flex-1 items-center rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 focus-within:border-[var(--brand-line)] focus-within:ring-2 focus-within:ring-[var(--brand)]">
-                <span className="sr-only">Search Sessions</span>
-                <input
-                  ref={searchInputRef}
-                  type="search"
-                  name="session-search"
-                  autoComplete="off"
-                  value={draftSearchQuery}
-                  onChange={(event) => setDraftSearchQuery(event.target.value)}
-                  placeholder="Search sessions…  /"
-                  className="console-mono w-full min-w-0 bg-transparent text-xs text-[var(--console-text)] outline-none placeholder:text-[var(--console-muted)]"
-                />
-              </label>
-              <button
-                type="submit"
-                className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
-              >
-                Search
-              </button>
-            </form>
+            <SearchControls ref={searchControlsRef} onSubmit={submitSearch} />
             <div className="flex items-center justify-end gap-2">
               <ThemeToggle theme={theme} onChange={setTheme} />
               <button

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from "react-router-dom";
 import type { AgentInfo, ApiProjectGroup, BookmarkView, ScanStatusEvent } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
 import { ScanStatusProvider } from "../../hooks/useScanStatus";
+import { buildSidebarSessionLookup } from "../../lib/session-indexes";
 import { AppSidebar, type AppSidebarActions, type AppSidebarViewModel } from "./AppSidebar";
 
 afterEach(cleanup);
@@ -52,8 +53,11 @@ function renderSidebar(
             selectedProjectNavigationId: null,
             bookmarkedSessions: [],
             sidebarSessions: [],
-            selectedSidebarSessionReference: null,
+            sidebarSessionLookup: buildSidebarSessionLookup([]),
             bookmarkedSidebarSessionReferences: new Set(),
+            isSearchMode: false,
+            shortcutHelpOpen: false,
+            dismissShortcutHint: vi.fn(),
             ...model,
           }}
           actions={actions}

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -1,8 +1,14 @@
+import { useCallback } from "react";
 import type { BookmarkView, ApiProjectGroup, SessionHead } from "../../lib/api";
 import { useScanStatus } from "../../hooks/useScanStatus";
+import { useSidebarKeyboardNavigation } from "../../hooks/useSidebarKeyboardNavigation";
 import { findAgent, type AgentCatalog } from "../../lib/agents";
 import { getSessionBookmarkKey } from "../../lib/bookmarks";
-import { getSessionRoutePath, getSessionRouteKey } from "../../lib/session-indexes";
+import {
+  getSessionRoutePath,
+  getSessionRouteKey,
+  type SidebarSessionLookup,
+} from "../../lib/session-indexes";
 import { getSessionDisplayTitle } from "../../lib/session-title";
 import { getProjectGroupIdentity, getProjectIdentityKey, getProjectPath } from "../../lib/projects";
 import type { ViewState } from "../../lib/view-state";
@@ -92,8 +98,11 @@ export interface AppSidebarViewModel {
   selectedProjectNavigationId: string | null;
   bookmarkedSessions: BookmarkView[];
   sidebarSessions: SessionHead[];
-  selectedSidebarSessionReference: string | null;
+  sidebarSessionLookup: SidebarSessionLookup;
   bookmarkedSidebarSessionReferences: Set<string>;
+  isSearchMode: boolean;
+  shortcutHelpOpen: boolean;
+  dismissShortcutHint: () => void;
 }
 
 export interface AppSidebarActions {
@@ -117,8 +126,11 @@ export function AppSidebar({
     selectedProjectNavigationId,
     bookmarkedSessions,
     sidebarSessions,
-    selectedSidebarSessionReference,
+    sidebarSessionLookup,
     bookmarkedSidebarSessionReferences,
+    isSearchMode,
+    shortcutHelpOpen,
+    dismissShortcutHint,
   },
   actions: {
     onCollapse,
@@ -138,6 +150,22 @@ export function AppSidebar({
       ? getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionId)
       : null;
   const isOverviewSelected = viewState.mode === "root";
+  const { selectedSessionReference, selectSession } = useSidebarKeyboardNavigation({
+    viewState,
+    sessions: sidebarSessions,
+    sessionLookup: sidebarSessionLookup,
+    isSearchMode,
+    shortcutHelpOpen,
+    dismissShortcutHint,
+    onOpenSession: onSelectFlatSidebarSession,
+  });
+  const handleSelectSession = useCallback(
+    (session: SessionHead) => {
+      selectSession(session);
+      onSelectFlatSidebarSession(session);
+    },
+    [onSelectFlatSidebarSession, selectSession],
+  );
 
   return (
     <aside
@@ -284,8 +312,8 @@ export function AppSidebar({
                 <SessionTreeSidebar
                   sessions={sidebarSessions}
                   activeSessionReference={activeSessionReference}
-                  selectedSessionReference={selectedSidebarSessionReference}
-                  onSelectSession={onSelectFlatSidebarSession}
+                  selectedSessionReference={selectedSessionReference}
+                  onSelectSession={handleSelectSession}
                   bookmarkedSessionReferences={bookmarkedSidebarSessionReferences}
                   onToggleBookmark={onToggleSidebarSessionBookmark}
                   onRenameSession={onRenameSession}

--- a/apps/web/src/components/app/SearchControls.test.tsx
+++ b/apps/web/src/components/app/SearchControls.test.tsx
@@ -1,0 +1,34 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SearchControls, type SearchControlsHandle } from "./SearchControls";
+
+afterEach(cleanup);
+
+describe("SearchControls", () => {
+  it("keeps draft input local and submits it as a semantic query", () => {
+    const onSubmit = vi.fn();
+    render(<SearchControls onSubmit={onSubmit} />);
+
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "  query  " } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(onSubmit).toHaveBeenCalledWith("  query  ");
+  });
+
+  it("lets keyboard commands focus, select, and clear the input", () => {
+    const ref = createRef<SearchControlsHandle>();
+    render(<SearchControls ref={ref} onSubmit={vi.fn()} />);
+
+    const input = screen.getByRole<HTMLInputElement>("searchbox");
+    fireEvent.change(input, { target: { value: "query" } });
+    act(() => ref.current?.focusAndSelect());
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+
+    act(() => ref.current?.clear());
+    expect(input.value).toBe("");
+  });
+});

--- a/apps/web/src/components/app/SearchControls.tsx
+++ b/apps/web/src/components/app/SearchControls.tsx
@@ -1,0 +1,63 @@
+import { forwardRef, useImperativeHandle, useRef, useState, type FormEvent } from "react";
+import { RenderProfiler } from "../RenderProfiler";
+
+export interface SearchControlsHandle {
+  clear(): void;
+  focusAndSelect(): void;
+}
+
+export const SearchControls = forwardRef<
+  SearchControlsHandle,
+  { onSubmit: (query: string) => void }
+>(function SearchControls({ onSubmit }, ref) {
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      clear() {
+        setQuery("");
+      },
+      focusAndSelect() {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      },
+    }),
+    [],
+  );
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit(query);
+  };
+
+  return (
+    <RenderProfiler id="SearchControls">
+      <form
+        className="order-3 col-span-2 flex w-full items-center justify-center gap-2 sm:order-none sm:col-span-1 sm:mx-auto sm:max-w-[560px]"
+        onSubmit={submit}
+      >
+        <label className="flex min-w-0 flex-1 items-center rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 focus-within:border-[var(--brand-line)] focus-within:ring-2 focus-within:ring-[var(--brand)]">
+          <span className="sr-only">Search Sessions</span>
+          <input
+            ref={inputRef}
+            type="search"
+            name="session-search"
+            autoComplete="off"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search sessions…  /"
+            className="console-mono w-full min-w-0 bg-transparent text-xs text-[var(--console-text)] outline-none placeholder:text-[var(--console-muted)]"
+          />
+        </label>
+        <button
+          type="submit"
+          className="console-mono rounded-sm border border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] px-3 py-1 text-xs text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
+        >
+          Search
+        </button>
+      </form>
+    </RenderProfiler>
+  );
+});

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
@@ -2,7 +2,6 @@ import { cleanup, fireEvent, renderHook } from "@testing-library/react";
 import type { NavigateFunction } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SearchResult, SessionHead } from "../lib/api";
-import { buildSidebarSessionLookup, getSessionReferenceKey } from "../lib/session-indexes";
 import type { ViewState } from "../lib/view-state";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 
@@ -41,10 +40,6 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
       activeSessionId: null,
     } satisfies ViewState,
     navigate: vi.fn() as unknown as NavigateFunction,
-    sidebarSessions: sessions,
-    sidebarSessionLookup: buildSidebarSessionLookup(sessions),
-    selectedSidebarSessionReference: null,
-    setSelectedSidebarSessionReference: vi.fn(),
     selectedProjectNavigationIdentity: null,
     shortcutHelpOpen: false,
     setShortcutHelpOpen: vi.fn(),
@@ -103,7 +98,6 @@ describe("useKeyboardShortcuts", () => {
     const { unmount } = renderHook(() => useKeyboardShortcuts(helpDeps));
 
     dispatchKey("j");
-    expect(helpDeps.setSelectedSidebarSessionReference).not.toHaveBeenCalled();
     expect(dispatchKey("Escape").defaultPrevented).toBe(true);
     expect(helpDeps.setShortcutHelpOpen).toHaveBeenCalledWith(false);
     unmount();
@@ -115,7 +109,6 @@ describe("useKeyboardShortcuts", () => {
     input.focus();
 
     fireEvent.keyDown(input, { key: "j" });
-    expect(editableDeps.setSelectedSidebarSessionReference).not.toHaveBeenCalled();
     fireEvent.keyDown(input, { key: "Escape" });
     expect(document.activeElement).not.toBe(input);
     input.remove();
@@ -177,38 +170,8 @@ describe("useKeyboardShortcuts", () => {
     });
   });
 
-  it("moves through sidebar sessions and opens agent or project routes", () => {
-    const deps = makeDeps();
-    const { unmount } = renderHook(() => useKeyboardShortcuts(deps));
-
-    dispatchKey("j");
-    expect(deps.setSelectedSidebarSessionReference).toHaveBeenNthCalledWith(1, "codex/s1");
-    dispatchKey("k");
-    expect(deps.setSelectedSidebarSessionReference).toHaveBeenNthCalledWith(2, "codex/s3");
-    dispatchKey("g");
-    expect(deps.setSelectedSidebarSessionReference).toHaveBeenNthCalledWith(3, "codex/s1");
-    dispatchKey("G");
-    expect(deps.setSelectedSidebarSessionReference).toHaveBeenNthCalledWith(4, "codex/s3");
-    unmount();
-
-    const agentDeps = makeDeps({ selectedSidebarSessionReference: "codex/s2" });
-    const agentHook = renderHook(() => useKeyboardShortcuts(agentDeps));
-    dispatchKey("Enter");
-    expect(agentDeps.navigate).toHaveBeenCalledWith("/codex/s2");
-    agentHook.unmount();
-
-    const projectDeps = makeDeps({
-      selectedSidebarSessionReference: "codex/s2",
-    });
-    renderHook(() => useKeyboardShortcuts(projectDeps));
-    dispatchKey("Enter");
-    expect(projectDeps.navigate).toHaveBeenCalledWith("/codex/s2");
-  });
-
-  it("does nothing without navigable results or sessions", () => {
+  it("does nothing without navigable search results", () => {
     const deps = makeDeps({
-      sidebarSessions: [],
-      sidebarSessionLookup: buildSidebarSessionLookup([]),
       isSearchMode: true,
       searchResults: [],
     });
@@ -218,22 +181,5 @@ describe("useKeyboardShortcuts", () => {
     dispatchKey("Enter");
 
     expect(deps.navigate).not.toHaveBeenCalled();
-    expect(deps.setSelectedSidebarSessionReference).not.toHaveBeenCalled();
-  });
-
-  it("opens the selected agent when project sessions share a native id", () => {
-    const codex = makeSession("same");
-    const claude = { ...makeSession("same"), slug: "claude/same" };
-    const projectSessions = [codex, claude];
-    const deps = makeDeps({
-      sidebarSessions: projectSessions,
-      sidebarSessionLookup: buildSidebarSessionLookup(projectSessions),
-      selectedSidebarSessionReference: getSessionReferenceKey(claude),
-    });
-    renderHook(() => useKeyboardShortcuts(deps));
-
-    dispatchKey("Enter");
-
-    expect(deps.navigate).toHaveBeenCalledWith("/claude/same");
   });
 });

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
@@ -54,7 +54,7 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
     searchResults,
     selectedSearchIndex: 0,
     setSelectedSearchIndex: vi.fn(),
-    setDraftSearchQuery: vi.fn(),
+    clearSearchInput: vi.fn(),
     openSearch: vi.fn(),
     closeSearch: vi.fn(),
     ...overrides,
@@ -127,7 +127,7 @@ describe("useKeyboardShortcuts", () => {
 
     dispatchKey("Escape");
     expect(searchDeps.closeSearch).toHaveBeenCalledOnce();
-    expect(searchDeps.setDraftSearchQuery).toHaveBeenCalledWith("");
+    expect(searchDeps.clearSearchInput).toHaveBeenCalledOnce();
     unmount();
 
     const projectDeps = makeDeps({

--- a/apps/web/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,22 +1,14 @@
 import { useEffect, useEffectEvent } from "react";
 import type { NavigateFunction } from "react-router-dom";
-import type { SearchResult, SessionHead } from "../lib/api";
-import {
-  agentRoutePath,
-  getSessionReferenceKey,
-  sessionRoutePath,
-  type SidebarSessionLookup,
-} from "../lib/session-indexes";
+import type { SearchResult } from "../lib/api";
+import { agentRoutePath, sessionRoutePath } from "../lib/session-indexes";
+import { isEditableTarget } from "../lib/keyboard";
 import { getProjectPath, type ProjectRouteIdentity } from "../lib/projects";
 import type { ViewState } from "../lib/view-state";
 
 interface KeyboardShortcutsDeps {
   viewState: ViewState;
   navigate: NavigateFunction;
-  sidebarSessions: SessionHead[];
-  sidebarSessionLookup: SidebarSessionLookup;
-  selectedSidebarSessionReference: string | null;
-  setSelectedSidebarSessionReference: (reference: string | null) => void;
   selectedProjectNavigationIdentity: ProjectRouteIdentity | null;
   shortcutHelpOpen: boolean;
   setShortcutHelpOpen: (open: boolean) => void;
@@ -31,31 +23,16 @@ interface KeyboardShortcutsDeps {
   closeSearch: () => void;
 }
 
-function isEditableTarget(target: EventTarget | null) {
-  if (!(target instanceof HTMLElement)) return false;
-  const tagName = target.tagName.toLowerCase();
-  return (
-    tagName === "input" ||
-    tagName === "textarea" ||
-    tagName === "select" ||
-    target.isContentEditable
-  );
-}
-
 /**
  * Owns the global keydown listener: Cmd/Ctrl+K opens search, `/` focuses search,
  * `?` toggles the shortcuts panel, Esc backs out of search/detail/help, and
- * j/k/g/G/Enter move through either the search results or the sidebar session
- * list depending on the current mode.
+ * j/k/g/G/Enter move through search results. Sidebar navigation is local to
+ * the sidebar so selection does not rerender route content.
  */
 export function useKeyboardShortcuts(deps: KeyboardShortcutsDeps) {
   const {
     viewState,
     navigate,
-    sidebarSessions,
-    sidebarSessionLookup,
-    selectedSidebarSessionReference,
-    setSelectedSidebarSessionReference,
     selectedProjectNavigationIdentity,
     shortcutHelpOpen,
     setShortcutHelpOpen,
@@ -170,56 +147,6 @@ export function useKeyboardShortcuts(deps: KeyboardShortcutsDeps) {
         });
       }
       return;
-    }
-
-    if (sidebarSessions.length === 0) return;
-
-    const moveSidebarSelection = (offset: number) => {
-      dismissShortcutHint();
-      const currentIndex =
-        selectedSidebarSessionReference != null
-          ? (sidebarSessionLookup.indexByReference.get(selectedSidebarSessionReference) ?? -1)
-          : -1;
-      const baseIndex =
-        currentIndex >= 0 ? currentIndex : offset >= 0 ? -1 : sidebarSessions.length;
-      const nextIndex = Math.max(0, Math.min(baseIndex + offset, sidebarSessions.length - 1));
-      const nextSession = sidebarSessions[nextIndex];
-      setSelectedSidebarSessionReference(nextSession ? getSessionReferenceKey(nextSession) : null);
-    };
-
-    if (key === "j") {
-      event.preventDefault();
-      moveSidebarSelection(1);
-      return;
-    }
-    if (key === "k") {
-      event.preventDefault();
-      moveSidebarSelection(-1);
-      return;
-    }
-    if (key === "g") {
-      event.preventDefault();
-      dismissShortcutHint();
-      const first = sidebarSessions[0];
-      setSelectedSidebarSessionReference(first ? getSessionReferenceKey(first) : null);
-      return;
-    }
-    if (key === "G") {
-      event.preventDefault();
-      dismissShortcutHint();
-      const last = sidebarSessions.at(-1);
-      setSelectedSidebarSessionReference(last ? getSessionReferenceKey(last) : null);
-      return;
-    }
-    if (key === "Enter") {
-      const selected =
-        selectedSidebarSessionReference != null
-          ? sidebarSessionLookup.byReference.get(selectedSidebarSessionReference)
-          : null;
-      if (!selected) return;
-      event.preventDefault();
-      dismissShortcutHint();
-      navigate(`/${selected.slug}`);
     }
   });
 

--- a/apps/web/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/web/src/hooks/useKeyboardShortcuts.ts
@@ -26,7 +26,7 @@ interface KeyboardShortcutsDeps {
   searchResults: SearchResult[];
   selectedSearchIndex: number;
   setSelectedSearchIndex: React.Dispatch<React.SetStateAction<number>>;
-  setDraftSearchQuery: (query: string) => void;
+  clearSearchInput: () => void;
   openSearch: () => void;
   closeSearch: () => void;
 }
@@ -65,7 +65,7 @@ export function useKeyboardShortcuts(deps: KeyboardShortcutsDeps) {
     searchResults,
     selectedSearchIndex,
     setSelectedSearchIndex,
-    setDraftSearchQuery,
+    clearSearchInput,
     openSearch,
     closeSearch,
   } = deps;
@@ -119,7 +119,7 @@ export function useKeyboardShortcuts(deps: KeyboardShortcutsDeps) {
       event.preventDefault();
       if (isSearchMode) {
         closeSearch();
-        setDraftSearchQuery("");
+        clearSearchInput();
         return;
       }
       if (viewState.mode === "session" && viewState.activeAgentKey) {

--- a/apps/web/src/hooks/useSessionSearch.test.ts
+++ b/apps/web/src/hooks/useSessionSearch.test.ts
@@ -64,10 +64,9 @@ describe("useSessionSearch", () => {
     expect(result.current.searchResults).toEqual([]);
   });
 
-  it("submitSearch activates the trimmed draft query", () => {
+  it("submitSearch activates the trimmed query", () => {
     const { result } = renderSearch();
-    act(() => result.current.setDraftSearchQuery("  hello  "));
-    act(() => result.current.submitSearch());
+    act(() => result.current.submitSearch("  hello  "));
 
     expect(result.current.activeSearchQuery).toBe("hello");
     expect(result.current.searchMode).toBe(true);
@@ -76,8 +75,7 @@ describe("useSessionSearch", () => {
   it("runs a server search for an active query", async () => {
     vi.mocked(api.fetchSearchResults).mockResolvedValue({ results: serverResults });
     const { result } = renderSearch();
-    act(() => result.current.setDraftSearchQuery("hello"));
-    act(() => result.current.submitSearch());
+    act(() => result.current.submitSearch("hello"));
 
     await waitFor(() => expect(result.current.searchResults).toEqual(serverResults));
     expect(api.fetchSearchResults).toHaveBeenCalledWith("hello", expect.any(Object), {
@@ -89,8 +87,7 @@ describe("useSessionSearch", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchSearchResults).mockRejectedValueOnce(new Error("Search unavailable"));
     const { result } = renderSearch();
-    act(() => result.current.setDraftSearchQuery("hello"));
-    act(() => result.current.submitSearch());
+    act(() => result.current.submitSearch("hello"));
 
     await waitFor(() =>
       expect(api.logClientEvent).toHaveBeenCalledWith(
@@ -129,8 +126,7 @@ describe("useSessionSearch", () => {
         project: { kind: "git_remote", key: "github.com/acme/app" },
       }),
     );
-    act(() => result.current.setDraftSearchQuery("hello"));
-    act(() => result.current.submitSearch());
+    act(() => result.current.submitSearch("hello"));
 
     await waitFor(() =>
       expect(api.fetchSearchResults).toHaveBeenCalledWith(
@@ -146,8 +142,7 @@ describe("useSessionSearch", () => {
 
   it("closeSearch exits and clears the active query", () => {
     const { result } = renderSearch();
-    act(() => result.current.setDraftSearchQuery("hello"));
-    act(() => result.current.submitSearch());
+    act(() => result.current.submitSearch("hello"));
     act(() => result.current.closeSearch());
 
     expect(result.current.searchMode).toBe(false);
@@ -157,8 +152,7 @@ describe("useSessionSearch", () => {
   it("refresh re-fetches server results while searching", async () => {
     vi.mocked(api.fetchSearchResults).mockResolvedValue({ results: serverResults });
     const { result } = renderSearch();
-    act(() => result.current.setDraftSearchQuery("hello"));
-    act(() => result.current.submitSearch());
+    act(() => result.current.submitSearch("hello"));
     await waitFor(() => expect(result.current.searchResults).toEqual(serverResults));
 
     const next = [makeSearchResult("s2")];

--- a/apps/web/src/hooks/useSessionSearch.ts
+++ b/apps/web/src/hooks/useSessionSearch.ts
@@ -21,21 +21,18 @@ import { queryKeys } from "../lib/query-keys";
 const EMPTY_SEARCH_RESULTS: SearchResult[] = [];
 
 /**
- * Owns the session-search domain: query/filters state, the local-vs-server
- * result engine, keyboard-selection state, and result-scroll behaviour.
- * Exposes semantic actions (open/submit/close); the global keydown handler
- * stays in App and drives selection via the returned state + setters.
+ * Owns the committed session-search domain: query/filters state, the
+ * local-vs-server result engine, keyboard-selection state, and result-scroll
+ * behaviour. The search control owns its uncommitted input text.
  */
 export function useSessionSearch(
   sessionIndexes: SessionIndexes,
   timeWindow: AppConfig["window"] | null = null,
 ) {
-  const [draftSearchQuery, setDraftSearchQuery] = useState("");
   const [activeSearchQuery, setActiveSearchQuery] = useState("");
   const [searchMode, setSearchMode] = useState(false);
   const [searchFilters, setSearchFilters] = useState<SearchFilterState>({});
   const [selectedSearchIndex, setSelectedSearchIndex] = useState(0);
-  const searchInputRef = useRef<HTMLInputElement | null>(null);
   const searchResultRefs = useRef(new Map<string, HTMLAnchorElement>());
 
   const costMin = useMemo(
@@ -139,17 +136,13 @@ export function useSessionSearch(
 
   const openSearch = useCallback(() => {
     setSearchMode(true);
-    window.setTimeout(() => {
-      searchInputRef.current?.focus();
-      searchInputRef.current?.select();
-    }, 0);
   }, []);
 
-  const submitSearch = useCallback(() => {
-    setActiveSearchQuery(draftSearchQuery.trim());
+  const submitSearch = useCallback((query: string) => {
+    setActiveSearchQuery(query.trim());
     setSearchMode(true);
     setSelectedSearchIndex(0);
-  }, [draftSearchQuery]);
+  }, []);
 
   const closeSearch = useCallback(() => {
     setSearchMode(false);
@@ -171,7 +164,6 @@ export function useSessionSearch(
   }, [searchMode, serverSearchQuery, usesServerSearch]);
 
   return {
-    draftSearchQuery,
     activeSearchQuery,
     searchMode,
     searchFilters,
@@ -181,9 +173,7 @@ export function useSessionSearch(
     projectOptions,
     usesServerSearch,
     selectedSearchIndex,
-    searchInputRef,
     registerResultRef,
-    setDraftSearchQuery,
     setSearchFilters,
     setSelectedSearchIndex,
     openSearch,

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -12,6 +12,7 @@ import { createQueryWrapper } from "../test/query-wrapper";
 import {
   useSessionStore,
   type LiveSessionApplyResult,
+  type SessionProjection,
   type SessionStoreSnapshot,
 } from "./useSessionStore";
 
@@ -233,7 +234,7 @@ describe("useSessionStore", () => {
     expect(result.current.window).toEqual(latestWindow);
     await waitFor(() => expect(result.current.sessions).toEqual([changedSession]));
     expect(
-      client.getQueryData<SessionStoreSnapshot>(queryKeys.sessionSnapshot(firstWindow))?.sessions,
+      client.getQueryData<SessionProjection>(queryKeys.sessionProjection(firstWindow))?.sessions,
     ).toEqual([SAMPLE_SESSION_HEAD]);
   });
 
@@ -275,16 +276,16 @@ describe("useSessionStore", () => {
       await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
     }
 
-    expect(api.fetchAgents).toHaveBeenCalledOnce();
+    await waitFor(() => expect(api.fetchAgents).toHaveBeenCalledOnce());
     expect(api.fetchProjects).not.toHaveBeenCalled();
-    expect(api.fetchDashboard).toHaveBeenCalledOnce();
+    await waitFor(() => expect(api.fetchDashboard).toHaveBeenCalledOnce());
 
     now += 1_001;
     await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
 
-    expect(api.fetchAgents).toHaveBeenCalledTimes(2);
-    expect(api.fetchProjects).toHaveBeenCalledOnce();
-    expect(api.fetchDashboard).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(api.fetchAgents).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(api.fetchProjects).toHaveBeenCalledOnce());
+    await waitFor(() => expect(api.fetchDashboard).toHaveBeenCalledTimes(2));
   });
 
   it("keeps window-external backfill sessions out of the active snapshot", async () => {
@@ -362,24 +363,29 @@ describe("useSessionStore", () => {
   });
 
   it("invalidates project dashboards and searches without expiring unrelated windows", async () => {
+    let now = Date.now();
+    vi.spyOn(Date, "now").mockImplementation(() => now);
     const { result, client } = await renderStore();
     await act(() => result.current.reload(config.window));
     const projectDashboardKey = queryKeys.dashboard(config.window, {
       project: { kind: "path", key: "p1" },
     });
     const searchKey = queryKeys.search("needle", {});
-    const inactiveAggregateKey = queryKeys.sessionSnapshotAggregates({ from: 10, to: 20 });
+    const inactiveAggregateKey = queryKeys.sessionAggregate({ from: 10, to: 20 });
     client.setQueryData(projectDashboardKey, SAMPLE_DASHBOARD_DATA);
     client.setQueryData(searchKey, []);
     client.setQueryData(inactiveAggregateKey, {
       agents,
       dashboard: SAMPLE_DASHBOARD_DATA,
     });
+    now += 2_001;
 
     await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
 
-    expect(client.getQueryState(projectDashboardKey)?.isInvalidated).toBe(true);
-    expect(client.getQueryState(searchKey)?.isInvalidated).toBe(true);
+    await waitFor(() =>
+      expect(client.getQueryState(projectDashboardKey)?.isInvalidated).toBe(true),
+    );
+    await waitFor(() => expect(client.getQueryState(searchKey)?.isInvalidated).toBe(true));
     expect(client.getQueryState(inactiveAggregateKey)?.isInvalidated).toBe(false);
   });
 
@@ -520,20 +526,54 @@ describe("useSessionStore", () => {
     expect(result.current.sessions).toEqual([]);
   });
 
-  it("surfaces live refresh failures without replacing the snapshot", async () => {
+  it("keeps the projection available when a live aggregate refresh fails", async () => {
     const error = new Error("dashboard unavailable");
+    let now = Date.now();
+    vi.spyOn(Date, "now").mockImplementation(() => now);
     const { result } = await renderStore();
     await act(() => result.current.reload(config.window));
+    vi.mocked(api.fetchDashboard).mockClear();
+    now += 2_001;
     vi.mocked(api.fetchDashboard).mockRejectedValueOnce(error);
 
-    await act(async () => {
-      await expect(result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT)).rejects.toBe(
-        error,
-      );
-    });
+    await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
 
+    await waitFor(() => expect(api.fetchDashboard).toHaveBeenCalledOnce());
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(result.current.version).toBeGreaterThan(0);
+  });
+
+  it("does not republish the session projection when live aggregates finish", async () => {
+    let now = Date.now();
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { result, client } = await renderStore();
+    await act(() => result.current.reload(config.window));
+    const changedSession = { ...SAMPLE_SESSION_HEAD, display_title: "Renamed" };
+    const liveAgents = deferred<AgentInfo[]>();
+    vi.mocked(api.fetchAgents).mockClear().mockReturnValueOnce(liveAgents.promise);
+    vi.mocked(api.fetchDashboard).mockClear();
+    now += 2_001;
+
+    await act(() =>
+      result.current.applyLiveEvent({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        changedSessionHeads: [
+          {
+            reference: { agentName: "claudecode", sessionId: changedSession.id },
+            session: changedSession,
+          },
+        ],
+      }),
+    );
+
+    const projectionKey = queryKeys.sessionProjection(config.window);
+    const projectionAfterLive = client.getQueryData<SessionProjection>(projectionKey);
+    expect(projectionAfterLive?.sessions).toEqual([changedSession]);
+    await waitFor(() => expect(api.fetchAgents).toHaveBeenCalledOnce());
+
+    liveAgents.resolve(agents);
+    await waitFor(() => expect(result.current.agents).toEqual(agents));
+    expect(client.getQueryData<SessionProjection>(projectionKey)).toBe(projectionAfterLive);
   });
 });

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -40,20 +40,30 @@ export interface SessionStoreSnapshot {
   dashboard: DashboardData;
 }
 
+export interface SessionProjection {
+  window: AppConfig["window"];
+  sessions: SessionHead[];
+}
+
 export interface LiveSessionApplyResult {
   snapshot: SessionStoreSnapshot;
   visibleNewSessions: number;
 }
 
-type SnapshotAggregates = Pick<SessionStoreSnapshot, "agents" | "dashboard">;
+interface SnapshotAggregates {
+  window: AppConfig["window"];
+  agents: AgentInfo[];
+  dashboard: DashboardData;
+}
+
 const LIVE_AGGREGATE_REFRESH_INTERVAL_MS = 2_000;
 const EMPTY_PROJECTS: ApiProjectGroup[] = [];
 
-const EMPTY_SNAPSHOT = {
+const EMPTY_AGGREGATES = {
   agents: [] satisfies AgentInfo[],
-  sessions: [] satisfies SessionHead[],
   dashboard: null,
 };
+const EMPTY_SESSIONS: SessionHead[] = [];
 
 function projectsOptions(window: AppConfig["window"]) {
   return queryOptions({
@@ -72,28 +82,67 @@ async function fetchSnapshotAggregates(
     fetchAgents(window, { signal }),
     fetchDashboard(window, {}, { signal }),
   ]);
-  return { agents, dashboard };
+  return { window, agents, dashboard };
 }
 
 function snapshotAggregatesOptions(window: AppConfig["window"]) {
   return queryOptions({
-    queryKey: queryKeys.sessionSnapshotAggregates(window),
+    queryKey: queryKeys.sessionAggregate(window),
     queryFn: ({ signal }) => fetchSnapshotAggregates(window, signal),
     staleTime: LIVE_AGGREGATE_REFRESH_INTERVAL_MS,
   });
 }
 
+function sessionProjectionOptions(
+  window: AppConfig["window"],
+  onFirstPage?: (projection: SessionProjection) => void,
+) {
+  return queryOptions({
+    queryKey: queryKeys.sessionProjection(window),
+    staleTime: Infinity,
+    queryFn: async ({ signal }): Promise<SessionProjection> => {
+      const sessionResult = await fetchSessions(
+        { from: window.from, to: window.to },
+        { signal },
+        {
+          onFirstPage(sessions) {
+            onFirstPage?.({ window, sessions });
+          },
+        },
+      );
+      return { window, sessions: sessionResult.sessions };
+    },
+  });
+}
+
+function createSnapshot(
+  window: AppConfig["window"],
+  aggregates: SnapshotAggregates,
+  sessions: SessionHead[],
+): SessionStoreSnapshot {
+  return { window, agents: aggregates.agents, dashboard: aggregates.dashboard, sessions };
+}
+
 async function fetchLiveSnapshotAggregates(
   queryClient: QueryClient,
   window: AppConfig["window"],
+  forceRefresh: boolean,
 ): Promise<SnapshotAggregates> {
   const options = snapshotAggregatesOptions(window);
   const state = queryClient.getQueryState(options.queryKey);
   const needsRefresh =
+    forceRefresh ||
     !state ||
     state.data === undefined ||
     state.isInvalidated ||
     Date.now() - state.dataUpdatedAt >= LIVE_AGGREGATE_REFRESH_INTERVAL_MS;
+  if (forceRefresh) {
+    await queryClient.invalidateQueries({
+      queryKey: options.queryKey,
+      exact: true,
+      refetchType: "none",
+    });
+  }
   const [aggregates] = await Promise.all([
     queryClient.fetchQuery(options),
     needsRefresh ? invalidateLiveSessionCollections(queryClient) : Promise.resolve(),
@@ -126,51 +175,13 @@ function sameWindow(
   );
 }
 
-function sessionSnapshotOptions(
-  window: AppConfig["window"],
-  onPreview?: (snapshot: SessionStoreSnapshot) => void,
-) {
-  return queryOptions({
-    queryKey: queryKeys.sessionSnapshot(window),
-    staleTime: Infinity,
-    queryFn: async ({ signal }): Promise<SessionStoreSnapshot> => {
-      let loadedAggregates: SnapshotAggregates | undefined;
-      let firstPage: SessionHead[] | undefined;
-      const publishPreview = () => {
-        if (!loadedAggregates || !firstPage) return;
-        onPreview?.({ window, ...loadedAggregates, sessions: firstPage });
-      };
-      const [aggregates, sessionResult] = await Promise.all([
-        fetchSnapshotAggregates(window, signal).then((value) => {
-          loadedAggregates = value;
-          publishPreview();
-          return value;
-        }),
-        fetchSessions(
-          { from: window.from, to: window.to },
-          { signal },
-          {
-            onFirstPage(sessions) {
-              firstPage = sessions;
-              publishPreview();
-            },
-          },
-        ),
-      ]);
-      return {
-        window,
-        ...aggregates,
-        sessions: sessionResult.sessions,
-      };
-    },
-  });
-}
-
 export function useSessionStore() {
   const queryClient = useQueryClient();
   const [requestedWindow, setRequestedWindow] = useState<AppConfig["window"] | null>(null);
   const [previewSnapshot, setPreviewSnapshot] = useState<SessionStoreSnapshot | null>(null);
+  const [loadError, setLoadError] = useState<unknown>(null);
   const requestedWindowRef = useRef<AppConfig["window"] | null>(null);
+  const liveAggregateWindowRef = useRef<AppConfig["window"] | null>(null);
   const reloadVersionRef = useRef(0);
   const configQuery = useQuery({
     queryKey: queryKeys.config,
@@ -185,8 +196,12 @@ export function useSessionStore() {
       }
     },
   });
-  const snapshotQuery = useQuery({
-    ...sessionSnapshotOptions(requestedWindow ?? {}),
+  const projectionQuery = useQuery({
+    ...sessionProjectionOptions(requestedWindow ?? {}),
+    enabled: false,
+  });
+  const aggregatesQuery = useQuery({
+    ...snapshotAggregatesOptions(requestedWindow ?? {}),
     enabled: false,
   });
   const projectsQuery = useQuery({
@@ -196,29 +211,44 @@ export function useSessionStore() {
   });
   const configFailed = configQuery.isError;
   const refetchConfig = configQuery.refetch;
-  const snapshot = snapshotQuery.data;
+  const querySnapshot =
+    requestedWindow !== null &&
+    projectionQuery.data &&
+    aggregatesQuery.data &&
+    sameWindow(projectionQuery.data.window, requestedWindow) &&
+    sameWindow(aggregatesQuery.data.window, requestedWindow)
+      ? createSnapshot(requestedWindow, aggregatesQuery.data, projectionQuery.data.sessions)
+      : null;
 
   useEffect(() => {
-    if (previewSnapshot && sameWindow(snapshot?.window, previewSnapshot.window)) {
+    if (previewSnapshot && sameWindow(querySnapshot?.window, previewSnapshot.window)) {
       setPreviewSnapshot(null);
     }
-  }, [previewSnapshot, snapshot]);
+  }, [previewSnapshot, querySnapshot]);
 
   const reload = useCallback(
     async (window: AppConfig["window"]): Promise<SessionStoreSnapshot | null> => {
       const reloadVersion = reloadVersionRef.current + 1;
       reloadVersionRef.current = reloadVersion;
       requestedWindowRef.current = window;
+      liveAggregateWindowRef.current = null;
       setRequestedWindow(window);
       setPreviewSnapshot(null);
+      setLoadError(null);
       try {
         await Promise.all([
-          queryClient.cancelQueries({ queryKey: queryKeys.sessionSnapshots }),
+          queryClient.cancelQueries({ queryKey: queryKeys.sessionProjections }),
+          queryClient.cancelQueries({ queryKey: queryKeys.sessionAggregates }),
           queryClient.cancelQueries({ queryKey: queryKeys.projects }),
         ]);
         await Promise.all([
           queryClient.invalidateQueries({
-            queryKey: queryKeys.sessionSnapshot(window),
+            queryKey: queryKeys.sessionProjection(window),
+            exact: true,
+            refetchType: "none",
+          }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.sessionAggregate(window),
             exact: true,
             refetchType: "none",
           }),
@@ -229,13 +259,30 @@ export function useSessionStore() {
           }),
         ]);
         void queryClient.fetchQuery(projectsOptions(window)).catch(() => undefined);
-        return await queryClient.fetchQuery(
-          sessionSnapshotOptions(window, (preview) => {
-            if (reloadVersionRef.current === reloadVersion) setPreviewSnapshot(preview);
+        let loadedAggregates: SnapshotAggregates | undefined;
+        let firstPage: SessionProjection | undefined;
+        const publishPreview = () => {
+          if (!loadedAggregates || !firstPage) return;
+          if (reloadVersionRef.current !== reloadVersion) return;
+          setPreviewSnapshot(createSnapshot(window, loadedAggregates, firstPage.sessions));
+        };
+        const [aggregates, projection] = await Promise.all([
+          queryClient.fetchQuery(snapshotAggregatesOptions(window)).then((value) => {
+            loadedAggregates = value;
+            publishPreview();
+            return value;
           }),
-        );
+          queryClient.fetchQuery(
+            sessionProjectionOptions(window, (firstPageProjection) => {
+              firstPage = firstPageProjection;
+              publishPreview();
+            }),
+          ),
+        ]);
+        return createSnapshot(window, aggregates, projection.sessions);
       } catch (error) {
         if (isCancelledError(error)) return null;
+        if (reloadVersionRef.current === reloadVersion) setLoadError(error);
         throw error;
       }
     },
@@ -246,9 +293,11 @@ export function useSessionStore() {
     async (event: SessionsUpdatedEvent): Promise<LiveSessionApplyResult | null> => {
       const activeWindow = requestedWindowRef.current;
       if (!activeWindow) return null;
-      const snapshotKey = queryKeys.sessionSnapshot(activeWindow);
-      const current = queryClient.getQueryData<SessionStoreSnapshot>(snapshotKey);
-      if (!current) {
+      const projectionKey = queryKeys.sessionProjection(activeWindow);
+      const aggregateKey = queryKeys.sessionAggregate(activeWindow);
+      const currentProjection = queryClient.getQueryData<SessionProjection>(projectionKey);
+      const currentAggregates = queryClient.getQueryData<SnapshotAggregates>(aggregateKey);
+      if (!currentProjection || !currentAggregates) {
         const refreshed = await reload(activeWindow);
         await Promise.all([
           invalidateLiveSessionDerivedQueries(queryClient, event),
@@ -257,7 +306,7 @@ export function useSessionStore() {
         return refreshed ? { snapshot: refreshed, visibleNewSessions: 0 } : null;
       }
 
-      const projection = applySessionWindowChanges(current.sessions, {
+      const projection = applySessionWindowChanges(currentProjection.sessions, {
         changedSessionHeads: event.changedSessionHeads,
         projectionRelatedSessionHeads: event.projectionRelatedSessionHeads,
         projectionSessionOrder: event.projectionSessionOrder,
@@ -274,7 +323,7 @@ export function useSessionStore() {
         ),
       );
       const previousSessionKeys = new Set(
-        current.sessions.map((session) =>
+        currentProjection.sessions.map((session) =>
           formatSessionReference({
             agentName: getSessionAgentKey(session),
             sessionId: session.id,
@@ -288,7 +337,7 @@ export function useSessionStore() {
       console.debug("live.session_projection", {
         window_from: activeWindow.from,
         window_to: activeWindow.to,
-        before_sessions: current.sessions.length,
+        before_sessions: currentProjection.sessions.length,
         changed_sessions: event.changedSessionHeads.length,
         projection_related_sessions: event.projectionRelatedSessionHeads?.length ?? 0,
         removed_sessions: event.removedSessionRefs.length,
@@ -297,18 +346,28 @@ export function useSessionStore() {
         visible_removed_sessions: projection.visibleRemovedSessions,
         visible_new_sessions: visibleNewSessions,
       });
-      queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, {
-        ...current,
+      queryClient.setQueryData<SessionProjection>(projectionKey, {
+        ...currentProjection,
         sessions: projection.sessions,
       });
       await invalidateLiveSessionDerivedQueries(queryClient, event);
       refreshLiveProjects(queryClient, activeWindow);
-      const aggregates = await fetchLiveSnapshotAggregates(queryClient, activeWindow);
-      const updated =
-        queryClient.setQueryData<SessionStoreSnapshot>(snapshotKey, (latest) =>
-          latest ? { ...latest, ...aggregates } : latest,
-        ) ?? null;
-      return updated ? { snapshot: updated, visibleNewSessions } : null;
+      const liveRefreshVersion = reloadVersionRef.current;
+      const forceAggregateRefresh = !sameWindow(liveAggregateWindowRef.current, activeWindow);
+      void fetchLiveSnapshotAggregates(queryClient, activeWindow, forceAggregateRefresh)
+        .then(() => {
+          if (
+            reloadVersionRef.current === liveRefreshVersion &&
+            sameWindow(requestedWindowRef.current, activeWindow)
+          ) {
+            liveAggregateWindowRef.current = activeWindow;
+          }
+        })
+        .catch(() => undefined);
+      return {
+        snapshot: createSnapshot(activeWindow, currentAggregates, projection.sessions),
+        visibleNewSessions,
+      };
     },
     [queryClient, reload],
   );
@@ -330,11 +389,11 @@ export function useSessionStore() {
     await reload(activeWindow);
   }, [configFailed, refetchConfig, reload]);
 
-  const currentSnapshot = sameWindow(snapshot?.window, requestedWindow) ? snapshot : null;
+  const currentSnapshot = sameWindow(querySnapshot?.window, requestedWindow) ? querySnapshot : null;
   const displayedSnapshot =
     currentSnapshot ??
     (sameWindow(previewSnapshot?.window, requestedWindow) ? previewSnapshot : null);
-  const agents = displayedSnapshot?.agents ?? EMPTY_SNAPSHOT.agents;
+  const agents = displayedSnapshot?.agents ?? EMPTY_AGGREGATES.agents;
   const projects = projectsQuery.data ?? EMPTY_PROJECTS;
   const projectsLoading = requestedWindow === null || projectsQuery.isPending;
   const projectsError =
@@ -354,7 +413,7 @@ export function useSessionStore() {
   );
   const error = configQuery.isError
     ? "Failed to load configuration. The CLI may be restarting or unavailable."
-    : snapshotQuery.isError
+    : loadError
       ? "Failed to load session data for the selected time window."
       : null;
 
@@ -362,17 +421,19 @@ export function useSessionStore() {
     config: configQuery.data ?? null,
     window: displayedSnapshot?.window ?? null,
     agents,
-    sessions: displayedSnapshot?.sessions ?? EMPTY_SNAPSHOT.sessions,
+    sessions: displayedSnapshot?.sessions ?? EMPTY_SESSIONS,
     projects,
     projectsError,
     projectsLoading,
-    dashboard: displayedSnapshot?.dashboard ?? EMPTY_SNAPSHOT.dashboard,
+    dashboard: displayedSnapshot?.dashboard ?? EMPTY_AGGREGATES.dashboard,
     loading:
       configQuery.isPending ||
       (!configQuery.isError &&
-        (requestedWindow === null || (snapshotQuery.isPending && displayedSnapshot === null))),
+        (requestedWindow === null ||
+          ((projectionQuery.isPending || aggregatesQuery.isPending) &&
+            displayedSnapshot === null))),
     error,
-    version: snapshotQuery.dataUpdatedAt,
+    version: projectionQuery.dataUpdatedAt,
     activeAgents: agentCatalog.active,
     agentCatalog,
     validAgentKeys,

--- a/apps/web/src/hooks/useSidebarKeyboardNavigation.test.tsx
+++ b/apps/web/src/hooks/useSidebarKeyboardNavigation.test.tsx
@@ -1,0 +1,110 @@
+import { act, cleanup, fireEvent, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionHead } from "../lib/api";
+import { buildSidebarSessionLookup, getSessionReferenceKey } from "../lib/session-indexes";
+import type { ViewState } from "../lib/view-state";
+import { useSidebarKeyboardNavigation } from "./useSidebarKeyboardNavigation";
+
+afterEach(cleanup);
+
+function makeSession(id: string): SessionHead {
+  return {
+    id,
+    slug: `codex/${id}`,
+    title: id,
+    directory: "/workspace",
+    time_created: 1,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+const sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
+
+function makeDeps(overrides: Record<string, unknown> = {}) {
+  return {
+    viewState: {
+      mode: "root",
+      activeAgentKey: null,
+      activeSessionId: null,
+    } satisfies ViewState,
+    sessions,
+    sessionLookup: buildSidebarSessionLookup(sessions),
+    isSearchMode: false,
+    shortcutHelpOpen: false,
+    dismissShortcutHint: vi.fn(),
+    onOpenSession: vi.fn(),
+    ...overrides,
+  };
+}
+
+function dispatchKey(key: string, init: KeyboardEventInit = {}) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...init });
+  act(() => window.dispatchEvent(event));
+  return event;
+}
+
+describe("useSidebarKeyboardNavigation", () => {
+  it("keeps j/k selection local and opens the selected session", () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useSidebarKeyboardNavigation(deps));
+
+    expect(dispatchKey("j").defaultPrevented).toBe(true);
+    expect(result.current.selectedSessionReference).toBe("codex/s1");
+    dispatchKey("G");
+    expect(result.current.selectedSessionReference).toBe("codex/s3");
+    dispatchKey("k");
+    expect(result.current.selectedSessionReference).toBe("codex/s2");
+    dispatchKey("g");
+    expect(result.current.selectedSessionReference).toBe("codex/s1");
+
+    expect(dispatchKey("Enter").defaultPrevented).toBe(true);
+    expect(deps.onOpenSession).toHaveBeenCalledWith(sessions[0]);
+  });
+
+  it("uses the session reference when native ids overlap", () => {
+    const codex = makeSession("same");
+    const claude = { ...makeSession("same"), slug: "claude/same" };
+    const projectSessions = [codex, claude];
+    const deps = makeDeps({
+      sessions: projectSessions,
+      sessionLookup: buildSidebarSessionLookup(projectSessions),
+      viewState: {
+        mode: "session",
+        activeAgentKey: "claude",
+        activeSessionId: "same",
+      } satisfies ViewState,
+    });
+    const { result } = renderHook(() => useSidebarKeyboardNavigation(deps));
+
+    expect(result.current.selectedSessionReference).toBe(getSessionReferenceKey(claude));
+    dispatchKey("Enter");
+    expect(deps.onOpenSession).toHaveBeenCalledWith(claude);
+  });
+
+  it("does not handle keys while search, help, or an editable control is active", () => {
+    const searchDeps = makeDeps({ isSearchMode: true });
+    const { result, unmount } = renderHook(() => useSidebarKeyboardNavigation(searchDeps));
+    dispatchKey("j");
+    expect(result.current.selectedSessionReference).toBeNull();
+    unmount();
+
+    const helpDeps = makeDeps({ shortcutHelpOpen: true });
+    const helpHook = renderHook(() => useSidebarKeyboardNavigation(helpDeps));
+    dispatchKey("j");
+    expect(helpHook.result.current.selectedSessionReference).toBeNull();
+    helpHook.unmount();
+
+    const deps = makeDeps();
+    renderHook(() => useSidebarKeyboardNavigation(deps));
+    const input = document.createElement("input");
+    document.body.append(input);
+    fireEvent.keyDown(input, { key: "j" });
+    expect(deps.dismissShortcutHint).not.toHaveBeenCalled();
+    input.remove();
+  });
+});

--- a/apps/web/src/hooks/useSidebarKeyboardNavigation.ts
+++ b/apps/web/src/hooks/useSidebarKeyboardNavigation.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useEffectEvent, useState } from "react";
+import type { SessionHead } from "../lib/api";
+import { isEditableTarget } from "../lib/keyboard";
+import {
+  getSessionReferenceKey,
+  getSessionRouteKey,
+  type SidebarSessionLookup,
+} from "../lib/session-indexes";
+import type { ViewState } from "../lib/view-state";
+
+interface SidebarKeyboardNavigationOptions {
+  viewState: ViewState;
+  sessions: SessionHead[];
+  sessionLookup: SidebarSessionLookup;
+  isSearchMode: boolean;
+  shortcutHelpOpen: boolean;
+  dismissShortcutHint: () => void;
+  onOpenSession: (session: SessionHead) => void;
+}
+
+export function useSidebarKeyboardNavigation({
+  viewState,
+  sessions,
+  sessionLookup,
+  isSearchMode,
+  shortcutHelpOpen,
+  dismissShortcutHint,
+  onOpenSession,
+}: SidebarKeyboardNavigationOptions) {
+  const [selectedSessionReference, setSelectedSessionReference] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isSearchMode) return;
+    if (viewState.mode === "session") {
+      setSelectedSessionReference(
+        getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionId),
+      );
+      return;
+    }
+    setSelectedSessionReference(null);
+  }, [isSearchMode, viewState.mode, viewState.activeAgentKey, viewState.activeSessionId]);
+
+  const selectSession = useCallback((session: SessionHead) => {
+    setSelectedSessionReference(getSessionReferenceKey(session));
+  }, []);
+
+  const handleKeydown = useEffectEvent((event: KeyboardEvent) => {
+    if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+    if (event.isComposing || isEditableTarget(event.target)) return;
+    if (isSearchMode || shortcutHelpOpen || sessions.length === 0) return;
+
+    const moveSelection = (offset: number) => {
+      dismissShortcutHint();
+      const currentIndex =
+        selectedSessionReference == null
+          ? -1
+          : (sessionLookup.indexByReference.get(selectedSessionReference) ?? -1);
+      const baseIndex = currentIndex >= 0 ? currentIndex : offset >= 0 ? -1 : sessions.length;
+      const nextIndex = Math.max(0, Math.min(baseIndex + offset, sessions.length - 1));
+      const nextSession = sessions[nextIndex];
+      setSelectedSessionReference(nextSession ? getSessionReferenceKey(nextSession) : null);
+    };
+
+    if (event.key === "j") {
+      event.preventDefault();
+      moveSelection(1);
+      return;
+    }
+    if (event.key === "k") {
+      event.preventDefault();
+      moveSelection(-1);
+      return;
+    }
+    if (event.key === "g") {
+      event.preventDefault();
+      dismissShortcutHint();
+      const first = sessions[0];
+      setSelectedSessionReference(first ? getSessionReferenceKey(first) : null);
+      return;
+    }
+    if (event.key === "G") {
+      event.preventDefault();
+      dismissShortcutHint();
+      const last = sessions.at(-1);
+      setSelectedSessionReference(last ? getSessionReferenceKey(last) : null);
+      return;
+    }
+    if (event.key !== "Enter" || selectedSessionReference == null) return;
+
+    const selected = sessionLookup.byReference.get(selectedSessionReference);
+    if (!selected) return;
+    event.preventDefault();
+    dismissShortcutHint();
+    onOpenSession(selected);
+  });
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, []);
+
+  return { selectedSessionReference, selectSession };
+}

--- a/apps/web/src/hooks/useUiPreferences.test.ts
+++ b/apps/web/src/hooks/useUiPreferences.test.ts
@@ -118,6 +118,23 @@ describe("useUiPreferences", () => {
       state: { shortcutHintDismissed: true, sidebarCollapsed: false, theme: "system" },
     });
   });
+
+  it("does not update again after the shortcut hint is dismissed", () => {
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useUiPreferences();
+    });
+
+    act(() => result.current.dismissShortcutHint());
+    act(() => result.current.dismissShortcutHint());
+
+    expect(renders).toBe(2);
+    expect(JSON.parse(window.localStorage.getItem(UI_PREFERENCES_STORAGE_KEY)!)).toEqual({
+      version: 1,
+      state: { shortcutHintDismissed: true, sidebarCollapsed: false, theme: "system" },
+    });
+  });
 });
 
 describe("parseUiPreferences", () => {

--- a/apps/web/src/hooks/useUiPreferences.ts
+++ b/apps/web/src/hooks/useUiPreferences.ts
@@ -109,6 +109,7 @@ export function useUiPreferences() {
   }, []);
 
   const dismissShortcutHint = useCallback(() => {
+    if (preferencesRef.current.shortcutHintDismissed) return;
     updatePreferences({ ...preferencesRef.current, shortcutHintDismissed: true });
   }, [updatePreferences]);
 

--- a/apps/web/src/lib/keyboard.ts
+++ b/apps/web/src/lib/keyboard.ts
@@ -1,0 +1,10 @@
+export function isEditableTarget(target: EventTarget | null): target is HTMLElement {
+  if (!(target instanceof HTMLElement)) return false;
+  const tagName = target.tagName.toLowerCase();
+  return (
+    tagName === "input" ||
+    tagName === "textarea" ||
+    tagName === "select" ||
+    target.isContentEditable
+  );
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -23,9 +23,10 @@ export const queryKeys = {
   sessionDetails: ["session-detail"] as const,
   sessionDetail: (agent: string, sessionId: string) =>
     ["session-detail", agent, sessionId] as const,
-  sessionSnapshots: ["session-snapshot"] as const,
-  sessionSnapshot: (window: TimeWindow) => ["session-snapshot", normalizeWindow(window)] as const,
-  sessionSnapshotAggregateQueries: ["session-snapshot-aggregates"] as const,
-  sessionSnapshotAggregates: (window: TimeWindow) =>
-    ["session-snapshot-aggregates", normalizeWindow(window)] as const,
+  sessionProjections: ["session-projection"] as const,
+  sessionProjection: (window: TimeWindow) =>
+    ["session-projection", normalizeWindow(window)] as const,
+  sessionAggregates: ["session-aggregates"] as const,
+  sessionAggregate: (window: TimeWindow) =>
+    ["session-aggregates", normalizeWindow(window)] as const,
 } as const;

--- a/apps/web/src/lib/session-query-consistency.ts
+++ b/apps/web/src/lib/session-query-consistency.ts
@@ -4,7 +4,7 @@ import { queryKeys } from "./query-keys";
 
 function invalidateSessionCollections(queryClient: QueryClient) {
   return [
-    queryClient.invalidateQueries({ queryKey: queryKeys.sessionSnapshotAggregateQueries }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.sessionAggregates }),
     queryClient.invalidateQueries({ queryKey: queryKeys.dashboards }),
     queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
   ];

--- a/scripts/benchmark-performance.mjs
+++ b/scripts/benchmark-performance.mjs
@@ -28,6 +28,8 @@ const cliPath = join(repoRoot, "packages/cli/dist/index.js");
 const cacheDir = join(homedir(), ".cache", "codesesh");
 const cacheFiles = ["codesesh.db", "codesesh.db-wal", "codesesh.db-shm", "scan-cache.json"];
 const activeCacheBackups = new Set();
+const PROFILE_SCENARIOS = ["typing", "sidebar", "live"];
+const PROFILE_TYPING_TEXT = "performance-baseline";
 
 function parseArgs(argv) {
   const options = {
@@ -38,8 +40,10 @@ function parseArgs(argv) {
     headless: true,
     reactProfile: false,
     coldStart: false,
+    fixtureSessions: 0,
     target: "auto",
     navigation: "direct",
+    profileScenarios: [],
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -74,6 +78,12 @@ function parseArgs(argv) {
     } else if (arg === "--navigation" && next) {
       options.navigation = next;
       index += 1;
+    } else if (arg === "--profile-scenarios" && next) {
+      options.profileScenarios = next.split(",").filter(Boolean);
+      index += 1;
+    } else if (arg === "--fixture-sessions" && next) {
+      options.fixtureSessions = Number(next);
+      index += 1;
     }
   }
 
@@ -86,11 +96,23 @@ function parseArgs(argv) {
   if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 1000) {
     throw new Error("--timeout must be at least 1000ms");
   }
+  if (!Number.isInteger(options.fixtureSessions) || options.fixtureSessions < 0) {
+    throw new Error("--fixture-sessions must be a non-negative integer");
+  }
   if (!["auto", "latest", "smallest", "largest", "lightest", "heaviest"].includes(options.target)) {
     throw new Error("--target must be one of: auto, latest, smallest, largest, lightest, heaviest");
   }
   if (!["direct", "click"].includes(options.navigation)) {
     throw new Error("--navigation must be one of: direct, click");
+  }
+  if (options.profileScenarios.includes("all")) {
+    options.profileScenarios = [...PROFILE_SCENARIOS];
+  }
+  if (options.profileScenarios.some((scenario) => !PROFILE_SCENARIOS.includes(scenario))) {
+    throw new Error(`--profile-scenarios must contain only: ${PROFILE_SCENARIOS.join(", ")}, all`);
+  }
+  if (options.profileScenarios.length > 0 && !options.reactProfile) {
+    throw new Error("--profile-scenarios requires --react-profile");
   }
 
   return options;
@@ -169,6 +191,35 @@ function printReactProfileSummary(label, entries) {
       `  [${group.source}] ${group.id}: commits ${group.commits}, total ${formatMs(group.totalActualDuration)}, max ${formatMs(group.maxActualDuration)}, avg ${formatMs(group.avgActualDuration)}`,
     );
   }
+}
+
+async function collectReactProfileEntries(page) {
+  return page.evaluate(() => {
+    const entries = window.__CODESHESH_RENDER_PROFILE__ ?? [];
+    window.__CODESHESH_RENDER_PROFILE__ = [];
+    return entries;
+  });
+}
+
+async function runProfileScenario(page, label, action) {
+  await collectReactProfileEntries(page);
+  const startedAt = performance.now();
+  await action();
+  await page.evaluate(
+    () =>
+      new Promise((resolvePromise) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolvePromise)),
+      ),
+  );
+  const entries = await collectReactProfileEntries(page);
+  const durationMs = performance.now() - startedAt;
+  printReactProfileSummary(`React profile: ${label}`, entries);
+  return {
+    label,
+    durationMs,
+    entries,
+    summary: summarizeReactProfile(entries),
+  };
 }
 
 function withTimeout(promise, timeoutMs, label) {
@@ -348,6 +399,183 @@ async function waitForWindowedSessions(url, timeoutMs) {
   return lastResult;
 }
 
+function createFixtureData(sessionCount) {
+  const now = Date.now();
+  const agent = { name: "codex", displayName: "Codex", count: sessionCount };
+  const project = {
+    identityKind: "path",
+    identityKey: "/benchmark/project",
+    displayName: "benchmark/project",
+    sources: ["/benchmark/project"],
+    sessionCount,
+    lastActivity: now,
+    messages: sessionCount,
+    tokens: sessionCount * 100,
+    cost: 0,
+    agentStats: [
+      {
+        name: "codex",
+        sessions: sessionCount,
+        messages: sessionCount,
+        tokens: sessionCount * 100,
+        cost: 0,
+      },
+    ],
+  };
+  const sessions = Array.from({ length: sessionCount }, (_, index) => {
+    const id = `benchmark-${String(index).padStart(4, "0")}`;
+    return {
+      id,
+      slug: `codex/${id}`,
+      title: `Benchmark session ${index}`,
+      directory: "/benchmark/project",
+      project_identity: {
+        kind: "path",
+        key: project.identityKey,
+        displayName: project.displayName,
+      },
+      time_created: now - index * 1_000,
+      time_updated: now - index * 1_000,
+      stats: {
+        message_count: 1,
+        total_input_tokens: 50,
+        total_output_tokens: 50,
+        total_cost: 0,
+      },
+    };
+  });
+  const dashboard = {
+    totals: {
+      sessions: sessionCount,
+      messages: sessionCount,
+      tokens: sessionCount * 100,
+      cost: 0,
+      costRecorded: 0,
+      costEstimated: 0,
+      cacheReadTokens: 0,
+    },
+    scopeCounts: { projects: 1, agents: 1 },
+    perAgent: [
+      {
+        name: "codex",
+        displayName: "Codex",
+        sessions: sessionCount,
+        messages: sessionCount,
+        tokens: sessionCount * 100,
+        cost: 0,
+      },
+    ],
+    dailyActivity: [],
+    modelDistribution: [],
+    modelCost: null,
+    perProject: [],
+    projectRollup: { projects: 1, sessions: sessionCount, tokens: sessionCount * 100, cost: 0 },
+    recentSessions: [],
+    recentFileActivities: [],
+    window: { days: 0, to: now },
+  };
+  const scanStatus = {
+    type: "scan-status",
+    active: false,
+    phase: "idle",
+    pendingAgents: [],
+    scanningAgents: [],
+    completedAgents: [],
+    agentStatuses: {},
+    totalAgents: 1,
+    updatedAt: now,
+    backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
+  };
+  return { agent, dashboard, project, scanStatus, sessions };
+}
+
+function createFixtureSessionDetail(session) {
+  return {
+    ...session,
+    reference: { agentName: "codex", sessionId: session.id },
+    messages: [
+      {
+        id: `${session.id}-message`,
+        role: "user",
+        time_created: session.time_created,
+        parts: [{ type: "text", text: session.title }],
+      },
+    ],
+  };
+}
+
+async function installFixtureRoutes(context, fixture) {
+  await context.route("**/api/**", async (route) => {
+    const { pathname } = new URL(route.request().url());
+    const json = (body) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+
+    if (pathname === "/api/config") return json({ window: { days: 0 } });
+    if (pathname === "/api/agents") return json([fixture.agent]);
+    if (pathname === "/api/projects") return json({ projects: [fixture.project] });
+    if (pathname === "/api/dashboard") return json(fixture.dashboard);
+    if (pathname === "/api/bookmarks") return json({ bookmarks: [] });
+    if (pathname === "/api/status") return json(fixture.scanStatus);
+    if (pathname === "/api/search") return json({ results: [] });
+    if (pathname === "/api/logs") return json({});
+
+    if (pathname === "/api/sessions") return json({ sessions: fixture.sessions });
+    if (pathname.startsWith("/api/sessions/")) {
+      const sessionId = decodeURIComponent(pathname.split("/").at(-1) ?? "");
+      const session = fixture.sessions.find((candidate) => candidate.id === sessionId);
+      return session
+        ? json(createFixtureSessionDetail(session))
+        : route.fulfill({ status: 404, contentType: "application/json", body: "{}" });
+    }
+
+    return route.continue();
+  });
+}
+
+async function installBenchmarkEventSource(context) {
+  await context.addInitScript(() => {
+    const sources = [];
+
+    class BenchmarkEventSource {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSED = 2;
+
+      readyState = BenchmarkEventSource.OPEN;
+      onopen = null;
+      onerror = null;
+      listeners = new Map();
+
+      constructor() {
+        sources.push(this);
+        queueMicrotask(() => this.onopen?.());
+      }
+
+      addEventListener(type, listener) {
+        const listeners = this.listeners.get(type) ?? [];
+        listeners.push(listener);
+        this.listeners.set(type, listeners);
+      }
+
+      close() {
+        this.readyState = BenchmarkEventSource.CLOSED;
+      }
+    }
+
+    window.EventSource = BenchmarkEventSource;
+    window.__CODESHESH_BENCHMARK_EMIT__ = (type, payload) => {
+      const event = { data: JSON.stringify(payload) };
+      for (const source of sources) {
+        if (source.readyState !== BenchmarkEventSource.OPEN) continue;
+        for (const listener of source.listeners.get(type) ?? []) listener(event);
+      }
+    };
+  });
+}
+
 function getSessionMessageCount(session) {
   const value = Number(session?.stats?.message_count);
   return Number.isFinite(value) ? value : 0;
@@ -416,6 +644,93 @@ async function clickSessionLink(page, targetPath) {
   }, targetPath);
 }
 
+async function openSidebarProject(page, timeoutMs) {
+  if (await page.locator("file-tree-container").count()) return;
+  const projectLink = page.locator('aside a[href^="/projects/"]').first();
+  await projectLink.waitFor({ state: "visible", timeout: timeoutMs });
+  await projectLink.click();
+  await page.locator("file-tree-container").waitFor({ state: "visible", timeout: timeoutMs });
+  await page.locator('input[name="session-search"]').blur();
+}
+
+function createLiveEvent(session, index, totalSessions) {
+  const [agentName] = String(session.slug).split("/");
+  const reference = { agentName, sessionId: session.id };
+  return {
+    type: "sessions-updated",
+    changedAgents: [agentName],
+    newSessions: 0,
+    updatedSessions: 1,
+    removedSessions: 0,
+    totalSessions,
+    timestamp: (session.time_updated ?? session.time_created) + index + 1,
+    changedSessionHeads: [
+      {
+        reference,
+        session: {
+          ...session,
+          display_title: `Benchmark live update ${index + 1}`,
+          time_updated: (session.time_updated ?? session.time_created) + index + 1,
+        },
+      },
+    ],
+    projectionRelatedSessionHeads: [],
+    projectionSessionOrder: [reference],
+    removedSessionRefs: [],
+  };
+}
+
+async function runProfileScenarios(page, sessions, options) {
+  const results = [];
+
+  for (const scenario of options.profileScenarios) {
+    if (scenario === "typing") {
+      const input = page.locator('input[name="session-search"]');
+      await input.fill("");
+      results.push(
+        await runProfileScenario(page, "typing 20 characters", async () => {
+          await input.pressSequentially(PROFILE_TYPING_TEXT);
+        }),
+      );
+      continue;
+    }
+
+    if (scenario === "sidebar") {
+      await openSidebarProject(page, options.timeoutMs);
+      results.push(
+        await runProfileScenario(page, "sidebar 20 j/k moves", async () => {
+          await page.locator("body").click({ position: { x: 1_000, y: 800 } });
+          for (let index = 0; index < 20; index += 1) {
+            await page.keyboard.press(index % 2 === 0 ? "j" : "k");
+          }
+        }),
+      );
+      continue;
+    }
+
+    if (scenario === "live") {
+      const session = sessions[0];
+      if (!session) throw new Error("Live profiling requires at least one session");
+      results.push(
+        await runProfileScenario(page, "20 live update events", async () => {
+          for (let index = 0; index < 20; index += 1) {
+            const event = createLiveEvent(session, index, sessions.length);
+            await page.evaluate((payload) => {
+              if (!window.__CODESHESH_BENCHMARK_EMIT__) {
+                throw new Error("Benchmark EventSource is not installed");
+              }
+              window.__CODESHESH_BENCHMARK_EMIT__("sessions-updated", payload);
+            }, event);
+            await page.waitForTimeout(550);
+          }
+        }),
+      );
+    }
+  }
+
+  return results;
+}
+
 async function waitForSessionDetailVisible(page, target, timeoutMs) {
   try {
     await withTimeout(
@@ -459,6 +774,7 @@ async function runIteration(iteration, options) {
   const port = options.port || (await findFreePort());
   const url = `http://localhost:${port}`;
   const cacheBackup = options.coldStart ? moveCacheAside() : null;
+  const fixture = options.fixtureSessions > 0 ? createFixtureData(options.fixtureSessions) : null;
   let cli = null;
   let browser = null;
 
@@ -472,6 +788,8 @@ async function runIteration(iteration, options) {
 
     browser = await launchBrowser(options.headless);
     const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    if (fixture) await installFixtureRoutes(context, fixture);
+    if (options.profileScenarios.includes("live")) await installBenchmarkEventSource(context);
     if (options.reactProfile) {
       await context.addInitScript(() => {
         window.localStorage.setItem("codeseshProfiler", "1");
@@ -487,7 +805,7 @@ async function runIteration(iteration, options) {
     const dashboardReadyMs = performance.now() - startedAt;
     console.log(`#${iteration} dashboard visible in ${formatMs(dashboardReadyMs)}`);
 
-    const { sessions } = await waitForWindowedSessions(url, options.timeoutMs);
+    const { sessions } = fixture ?? (await waitForWindowedSessions(url, options.timeoutMs));
     if (!Array.isArray(sessions) || sessions.length === 0) {
       const windowLabel = options.days === 0 ? "all time" : `the last ${options.days} days`;
       const retryHint =
@@ -497,6 +815,9 @@ async function runIteration(iteration, options) {
       throw new Error(`No sessions found in ${windowLabel}. ${retryHint}`);
     }
     console.log(`#${iteration} loaded ${sessions.length} windowed sessions`);
+
+    const profileScenarios =
+      options.profileScenarios.length > 0 ? await runProfileScenarios(page, sessions, options) : [];
 
     const target = selectBenchmarkTarget(sessions, options.target);
     const [agentKey, sessionId] = String(target.slug).split("/");
@@ -544,15 +865,16 @@ async function runIteration(iteration, options) {
     const sessionClickMs = performance.now() - clickStartedAt;
     console.log(`#${iteration} session detail visible in ${formatMs(sessionClickMs)}`);
 
-    const reactProfileEntries = options.reactProfile
-      ? await withTimeout(
-          page.evaluate(() => window.__CODESHESH_RENDER_PROFILE__ ?? []),
-          2000,
-          "React profile collection",
-        ).catch(() => [])
+    const navigationReactProfileEntries = options.reactProfile
+      ? await withTimeout(collectReactProfileEntries(page), 2000, "React profile collection").catch(
+          () => [],
+        )
       : [];
     if (options.reactProfile) {
-      printReactProfileSummary(`#${iteration} React profile`, reactProfileEntries);
+      printReactProfileSummary(
+        `#${iteration} navigation React profile`,
+        navigationReactProfileEntries,
+      );
     }
 
     await browser.close();
@@ -568,8 +890,9 @@ async function runIteration(iteration, options) {
       serverReadyMs,
       dashboardReadyMs,
       sessionClickMs,
-      reactProfileEntries,
-      reactProfileSummary: summarizeReactProfile(reactProfileEntries),
+      profileScenarios,
+      reactProfileEntries: navigationReactProfileEntries,
+      reactProfileSummary: summarizeReactProfile(navigationReactProfileEntries),
     };
   } catch (error) {
     const output = cli?.getOutput() ?? "";


### PR DESCRIPTION
## Summary

- add a deterministic 500-session Chrome profiling harness for typing, sidebar navigation, and live updates
- keep draft search text and sidebar keyboard selection inside their owning controls
- split live session projections from aggregate query data so aggregate completion does not republish session state
- preserve the live aggregate refresh cadence and avoid an incremental index that profiling does not justify

## Why

The prior baseline showed top-level commits for every input character and sidebar move, plus five extra session-tree commits while aggregate work completed. The new query boundary keeps the immediately visible session projection independent from asynchronous aggregate refreshes.

## Performance result

With the repeatable hot 500-session fixture:

- typing 20 characters: `MainContent` commits dropped from 20 to 0
- 20 live events: `MainContent` and `SessionTreeSidebar` commits dropped from 25 to 20
- the tree builder remains about 1ms per live event, so this PR intentionally does not add incremental-index state

## Validation

- `pnpm test` (core: 950 passed, 1 skipped; web: 770 passed; CLI: 518 passed)
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm bench:perf -- --react-profile --fixture-sessions 500 --profile-scenarios all --days 0 --iterations 1`