### PR TITLE
fix(web): align detail landing interactions

### DIFF
--- a/apps/web/src/components/DetailLanding.test.tsx
+++ b/apps/web/src/components/DetailLanding.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAgentCatalog } from "../lib/agents";
-import type { LandingSession } from "./DetailLanding";
+import type { IndexedSession } from "../lib/session-indexes";
 import { DetailLanding } from "./DetailLanding";
 
 afterEach(cleanup);
@@ -14,9 +14,9 @@ describe("DetailLanding", () => {
       total_input_tokens: 5,
       total_output_tokens: 8,
       total_cost: 0.1,
-    } as LandingSession["stats"];
+    } as IndexedSession["stats"];
     Object.defineProperty(stats, "message_count", { get: readMessageCount });
-    const sessions: LandingSession[] = [
+    const sessions: IndexedSession[] = [
       {
         id: "session-1",
         sessionId: "session-1",
@@ -53,5 +53,34 @@ describe("DetailLanding", () => {
     );
 
     expect(readMessageCount).toHaveBeenCalledTimes(readsAfterFirstRender);
+  });
+
+  it("CS-258: reuses the accessible agent panel across landing states", () => {
+    const props = {
+      type: "global" as const,
+      agentCatalog: createAgentCatalog([]),
+      sessions: [],
+      agentItems: [{ key: "codex", name: "Codex", count: 2 }],
+      isBookmarked: vi.fn(() => false),
+      onToggleBookmark: vi.fn(),
+    };
+    const view = render(
+      <MemoryRouter>
+        <DetailLanding {...props} />
+      </MemoryRouter>,
+    );
+    const globalLink = view.getByRole("link", { name: /Codex/ });
+    const globalClassName = globalLink.className;
+
+    expect(globalLink.getAttribute("href")).toBe("/codex");
+    expect(globalClassName).toContain("focus-visible:ring-2");
+
+    view.rerender(
+      <MemoryRouter>
+        <DetailLanding {...props} type="missing-agent" attemptedAgentKey="unknown" />
+      </MemoryRouter>,
+    );
+
+    expect(view.getByRole("link", { name: /Codex/ }).className).toBe(globalClassName);
   });
 });

--- a/apps/web/src/components/DetailLanding.tsx
+++ b/apps/web/src/components/DetailLanding.tsx
@@ -3,18 +3,12 @@ import { Link } from "react-router-dom";
 import { findAgent, type AgentCatalog } from "../lib/agents";
 import type { SessionHead } from "../lib/api";
 import { formatCostSource, formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
-import { agentRoutePath, sessionRoutePath } from "../lib/session-indexes";
+import { agentRoutePath, sessionRoutePath, type IndexedSession } from "../lib/session-indexes";
 import { getSessionDisplayTitle } from "../lib/session-title";
 import { AgentIcon } from "./AgentIcon";
 import { BookmarkButton } from "./BookmarkButton";
 import { SmartTagChips } from "./SmartTagChips";
 import { Panel, PanelHeader } from "./ui/panel";
-
-export interface LandingSession extends SessionHead {
-  agentKey: string;
-  sessionId: string;
-  reference: string;
-}
 
 export interface LandingAgentItem {
   key: string;
@@ -27,14 +21,14 @@ export interface LandingAgentItem {
 interface DetailLandingProps {
   type: "global" | "agent" | "missing-agent" | "missing-session" | "load-failed";
   agentCatalog: AgentCatalog;
-  sessions: LandingSession[];
+  sessions: IndexedSession[];
   agentItems: LandingAgentItem[];
   activeAgentKey?: string;
   attemptedAgentKey?: string;
   attemptedSessionId?: string | null;
   loadFailureMessage?: string;
   isBookmarked: (agentKey: string, sessionId: string) => boolean;
-  onToggleBookmark: (session: LandingSession) => void;
+  onToggleBookmark: (session: IndexedSession) => void;
   onRetry?: () => void;
 }
 
@@ -113,10 +107,10 @@ function MissingStateHero({
   );
 }
 
-function RecommendedAgents({ agentItems }: { agentItems: LandingAgentItem[] }) {
+function AgentsPanel({ agentItems }: { agentItems: LandingAgentItem[] }) {
   return (
     <Panel className="p-4">
-      <PanelHeader title="Known Agents" meta={`${agentItems.length} items`} />
+      <PanelHeader title="Agents" meta={`${agentItems.length} items`} />
       <ul className="mt-3 grid gap-2 sm:grid-cols-2">
         {agentItems.map((agent) => (
           <li key={agent.key}>
@@ -151,9 +145,9 @@ function RecentSessions({
   isBookmarked,
   onToggleBookmark,
 }: {
-  sessions: LandingSession[];
+  sessions: IndexedSession[];
   isBookmarked: (agentKey: string, sessionId: string) => boolean;
-  onToggleBookmark: (session: LandingSession) => void;
+  onToggleBookmark: (session: IndexedSession) => void;
 }) {
   if (sessions.length === 0) {
     return <Panel className="p-4 text-sm text-[var(--console-muted)]">No sessions yet</Panel>;
@@ -257,7 +251,7 @@ export const DetailLanding = memo(function DetailLanding({
           ) : null}
         </div>
 
-        <RecommendedAgents agentItems={agentItems} />
+        <AgentsPanel agentItems={agentItems} />
       </div>
     );
   }
@@ -357,34 +351,7 @@ export const DetailLanding = memo(function DetailLanding({
           />
         </div>
 
-        <Panel className="p-4">
-          <PanelHeader title="Agents" meta={`${agentItems.length} items`} />
-          <ul className="mt-3 grid gap-2 sm:grid-cols-2">
-            {agentItems.map((agent) => (
-              <li key={agent.key}>
-                <Link
-                  to={agentRoutePath(agent.key)}
-                  className="flex items-center gap-2 rounded-sm border border-transparent px-2 py-1.5 motion-hover hover:border-[var(--console-border)] hover:bg-[var(--console-surface-muted)]"
-                >
-                  {agent.icon ? (
-                    <AgentIcon
-                      icon={agent.icon}
-                      iconColored={agent.iconColored}
-                      alt={agent.name}
-                      className="size-4 object-contain"
-                    />
-                  ) : null}
-                  <span className="console-mono flex-1 text-xs text-[var(--console-text)]">
-                    {agent.name}
-                  </span>
-                  <span className="console-mono text-[11px] text-[var(--console-muted)]">
-                    {agent.count}
-                  </span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </Panel>
+        <AgentsPanel agentItems={agentItems} />
 
         <RecentSessions
           sessions={recentSessions}

--- a/apps/web/src/components/MarkdownContent.tsx
+++ b/apps/web/src/components/MarkdownContent.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components, Options } from "react-markdown";
 import { resolveLocalMediaSource } from "../lib/local-media-policy";
+import { buildHighlightPattern } from "../lib/search-highlight";
 
 const markdownComponents: Components = {
   a: ({ children }) => <span className="console-markdown-link">{children}</span>,
@@ -51,27 +52,6 @@ interface HastNode {
 
 /** Elements whose text is shown verbatim, so search must not rewrite it. */
 const OPAQUE_TAG_NAMES = new Set(["code", "pre", "mark"]);
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function buildHighlightPattern(query?: string): RegExp | null {
-  const normalized = query?.trim();
-  if (!normalized) return null;
-
-  const terms = Array.from(
-    new Set(
-      (normalized.match(/"[^"]+"|\S+/g) ?? [])
-        .map((term) => term.replace(/^"|"$/g, "").trim())
-        .filter(Boolean)
-        .filter((term) => !/^OR$/i.test(term)),
-    ),
-  );
-
-  if (terms.length === 0) return null;
-  return new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
-}
 
 /** Splits a text node around matches, or returns null when nothing matched. */
 function splitHighlighted(value: string, pattern: RegExp): HastNode[] | null {

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -3,10 +3,9 @@ import type { ApiProjectAgentStat, ApiProjectGroup, AppConfig } from "../lib/api
 import { findAgent, type AgentCatalog } from "../lib/agents";
 import { formatCompact, formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
 import { getProjectPath } from "../lib/projects";
-import { sessionRoutePath } from "../lib/session-indexes";
+import { sessionRoutePath, type IndexedSession } from "../lib/session-indexes";
 import type { TimeWindowPreset } from "../lib/time-window";
 import { AgentIcon } from "./AgentIcon";
-import type { LandingSession } from "./DetailLanding";
 import { OverviewScreen } from "./overview/OverviewScreen";
 import { ProjectTimeline } from "./project-timeline/ProjectTimeline";
 import { Panel } from "./ui/panel";
@@ -229,7 +228,7 @@ export function ProjectDashboardView({
   project: ApiProjectGroup | null;
   agentCatalog: AgentCatalog;
   projectKey: string;
-  sessions: LandingSession[];
+  sessions: IndexedSession[];
   activeAgent?: string;
   onChangeAgent: (agent?: string) => void;
   timeWindow: AppConfig["window"] | null;

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -3,8 +3,8 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentInfo, ApiProjectGroup, SessionDetail } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
+import type { IndexedSession } from "../../lib/session-indexes";
 import { createQueryWrapper } from "../../test/query-wrapper";
-import type { LandingSession } from "../DetailLanding";
 import { AppRouteContent } from "./AppRouteContent";
 
 const sessionDetailRender = vi.hoisted(() => vi.fn());
@@ -112,7 +112,7 @@ function makeSession(id: string): SessionDetail {
   };
 }
 
-function makeLandingSession(agentKey: string, sessionId: string, title: string): LandingSession {
+function makeLandingSession(agentKey: string, sessionId: string, title: string): IndexedSession {
   return {
     id: sessionId,
     sessionId,

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -8,7 +8,7 @@ import {
   type SetStateAction,
 } from "react";
 import { useLocation } from "react-router-dom";
-import { DetailLanding, type LandingAgentItem, type LandingSession } from "../DetailLanding";
+import { DetailLanding, type LandingAgentItem } from "../DetailLanding";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { RenderProfiler } from "../RenderProfiler";
 import { SessionDetailSkeleton } from "../SessionDetailSkeleton";
@@ -47,7 +47,7 @@ import type { AgentCatalog } from "../../lib/agents";
 import type { TimeWindowPreset } from "../../lib/time-window";
 import type { ViewState } from "../../lib/view-state";
 import type { SearchFilterState, SearchLoadState, SearchProjectOption } from "./types";
-import { getSessionRouteKey } from "../../lib/session-indexes";
+import { getSessionRouteKey, type IndexedSession } from "../../lib/session-indexes";
 
 interface SessionDetailModel {
   session: Api.SessionDetail | null;
@@ -98,11 +98,11 @@ interface AppRouteContentProps {
   agentCatalog: AgentCatalog;
   agentNameMap: ReadonlyMap<string, string>;
   projects: ApiProjectGroup[];
-  landingSessions: LandingSession[];
+  landingSessions: IndexedSession[];
   sessions?: SessionHead[];
-  sessionsByAgent: Map<string, LandingSession[]>;
+  sessionsByAgent: Map<string, IndexedSession[]>;
   activeProject: ApiProjectGroup | null;
-  activeProjectSessions: LandingSession[];
+  activeProjectSessions: IndexedSession[];
   overview: OverviewModel;
   sessionDetail: SessionDetailModel;
   projectAgentFilter: ProjectAgentFilterModel;
@@ -159,7 +159,7 @@ export function AppRouteContent({
   }, [currentSessionAgentName, currentSessionId, sessions]);
   const toggleSessionBookmark = bookmarks.toggleSessionBookmark;
   const toggleLandingBookmark = useCallback(
-    (session: LandingSession) => toggleSessionBookmark(session, session.agentKey),
+    (session: IndexedSession) => toggleSessionBookmark(session, session.agentKey),
     [toggleSessionBookmark],
   );
   if (loading) return <SessionDetailSkeleton />;

--- a/apps/web/src/components/session-detail/message-rendering.test.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Message, ToolPart } from "../../lib/api";
+import type { Message, PlanPart, ReasoningPart, ToolPart } from "../../lib/api";
 import type { MessageBlock } from "./blocks";
 
 const normalizeToolStateCalls = vi.hoisted(() => vi.fn());
@@ -25,6 +25,76 @@ afterEach(() => {
 });
 
 describe("MessageItem", () => {
+  it("CS-258: exposes reasoning expansion through a native button", () => {
+    const reasoning: ReasoningPart = { type: "reasoning", text: "Working through the answer" };
+    const message: Message = {
+      id: "m1",
+      role: "assistant",
+      time_created: 1,
+      parts: [reasoning],
+    };
+    const blocks: MessageBlock[] = [{ type: "reasoning", parts: [reasoning] }];
+    const view = render(
+      <MemoryRouter>
+        <MessageItem
+          messageIndex={0}
+          msg={message}
+          blocks={blocks}
+          formatTokens={String}
+          sessionAgentKey="codex"
+          baseDirectory="/repo"
+        />
+      </MemoryRouter>,
+    );
+
+    const toggle = view.getByRole("button", { name: "Thinking" });
+    expect(toggle.tagName).toBe("BUTTON");
+    expect(toggle.tabIndex).toBe(0);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    toggle.focus();
+    expect(document.activeElement).toBe(toggle);
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(view.getByText("Working through the answer")).not.toBeNull();
+  });
+
+  it("CS-258: exposes plan expansion state to assistive technology", () => {
+    const plan: PlanPart = {
+      type: "plan",
+      text: "1. Implement the change",
+      approval_status: "success",
+    };
+    const message: Message = {
+      id: "m1",
+      role: "assistant",
+      time_created: 1,
+      parts: [plan],
+    };
+    const blocks: MessageBlock[] = [{ type: "plan", parts: [plan] }];
+    const view = render(
+      <MemoryRouter>
+        <MessageItem
+          messageIndex={0}
+          msg={message}
+          blocks={blocks}
+          formatTokens={String}
+          sessionAgentKey="codex"
+          baseDirectory="/repo"
+        />
+      </MemoryRouter>,
+    );
+
+    const toggle = view.getByRole("button", { name: "plan" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
   it("reuses normalized tool state when only highlighting changes", () => {
     const tool: ToolPart = {
       type: "tool",

--- a/apps/web/src/components/session-detail/message-rendering.test.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Message, PlanPart, ReasoningPart, ToolPart } from "../../lib/api";
+import { MarkdownContent } from "../MarkdownContent";
 import type { MessageBlock } from "./blocks";
 
 const normalizeToolStateCalls = vi.hoisted(() => vi.fn());
@@ -25,6 +26,40 @@ afterEach(() => {
 });
 
 describe("MessageItem", () => {
+  it("CS-258: matches Markdown highlighting for the same query", () => {
+    const text = "The quick brown fox";
+    const highlightQuery = '"quick brown" OR fox';
+    const reasoning: ReasoningPart = { type: "reasoning", text };
+    const message: Message = {
+      id: "m1",
+      role: "assistant",
+      time_created: 1,
+      parts: [reasoning],
+    };
+    const blocks: MessageBlock[] = [{ type: "reasoning", parts: [reasoning] }];
+    const markdown = render(<MarkdownContent text={text} highlightQuery={highlightQuery} />);
+    const messageItem = render(
+      <MemoryRouter>
+        <MessageItem
+          messageIndex={0}
+          msg={message}
+          blocks={blocks}
+          formatTokens={String}
+          sessionAgentKey="codex"
+          baseDirectory="/repo"
+          highlightQuery={highlightQuery}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(messageItem.getByRole("button", { name: "Thinking" }));
+
+    const markedText = (container: HTMLElement) =>
+      [...container.querySelectorAll("mark")].map((mark) => mark.textContent);
+
+    expect(markedText(messageItem.container)).toEqual(markedText(markdown.container));
+  });
+
   it("CS-258: exposes reasoning expansion through a native button", () => {
     const reasoning: ReasoningPart = { type: "reasoning", text: "Working through the answer" };
     const message: Message = {

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -14,6 +14,7 @@ import type { AgentInfo, Message, PlanPart, ReasoningPart, ToolPart } from "../.
 import type { SessionHead } from "../../lib/api";
 import { formatMessageTime } from "../../lib/format";
 import { getSessionRoutePath } from "../../lib/session-indexes";
+import { buildHighlightPattern } from "../../lib/search-highlight";
 import { AgentIcon } from "../AgentIcon";
 import { MarkdownContent } from "../MarkdownContent";
 import { ToolOutputRenderer } from "../tool-output/ToolOutputRenderer";
@@ -24,7 +25,6 @@ import { isCodexTurnAbortedMessage } from "./codex-abort";
 import { buildCodexPlanDisplay } from "./codex-plan";
 import { getDisplayTextWithRelativePaths } from "./path-extract";
 import { buildBlockTimelineAnchorId, buildMessageTimelineAnchorId } from "./timeline";
-import { escapeRegExp } from "./utils";
 import {
   type ToolStatus,
   getAssistantDisplayLabel,
@@ -55,21 +55,6 @@ const TOOL_STATUS_META: Record<
     icon: LoaderCircle,
   },
 };
-
-function buildHighlightPattern(query?: string): RegExp | null {
-  const normalized = query?.trim();
-  if (!normalized) return null;
-  const terms = Array.from(
-    new Set(
-      (normalized.match(/"[^"]+"|\S+/g) ?? [])
-        .map((term) => term.replace(/^"|"$/g, "").trim())
-        .filter(Boolean)
-        .filter((term) => !/^OR$/i.test(term)),
-    ),
-  );
-  if (terms.length === 0) return null;
-  return new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
-}
 
 function renderHighlightedText(text: string, query?: string) {
   const pattern = buildHighlightPattern(query);

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -314,9 +314,11 @@ const ReasoningSection = memo(function ReasoningSection({
       data-session-timeline-anchor={anchorId}
       className="scroll-mt-20 overflow-hidden rounded-lg border border-[var(--console-thinking-border)] bg-[var(--console-thinking-bg)]"
     >
-      <div
-        className="flex cursor-pointer items-center justify-between bg-[var(--console-surface-muted)] px-3 py-2"
-        onClick={() => setExpanded(!expanded)}
+      <button
+        type="button"
+        className="flex w-full items-center justify-between bg-[var(--console-surface-muted)] px-3 py-2 text-left motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--brand)]"
+        onClick={() => setExpanded((isExpanded) => !isExpanded)}
+        aria-expanded={expanded}
       >
         <span className="console-mono flex items-center gap-2 text-xs font-medium text-[var(--console-muted)]">
           <Lightbulb className="size-3.5" />
@@ -325,7 +327,7 @@ const ReasoningSection = memo(function ReasoningSection({
         <span className="text-[var(--console-muted)]">
           <ChevronDown className="motion-chevron w-4 h-4" data-open={expanded || undefined} />
         </span>
-      </div>
+      </button>
       <Collapsible open={expanded}>
         {() => (
           <div className="border-t border-dashed border-[var(--console-thinking-border)] px-4 py-3">
@@ -413,7 +415,8 @@ const PlanItem = memo(function PlanItem({
             <button
               type="button"
               className="flex w-full items-start gap-2 text-left"
-              onClick={() => setExpanded(!expanded)}
+              onClick={() => setExpanded((isExpanded) => !isExpanded)}
+              aria-expanded={expanded}
             >
               <CalendarRange className="mt-0.5 size-3.5 shrink-0 text-[var(--console-accent)]" />
               <span className="min-w-0 flex-1">

--- a/apps/web/src/lib/search-highlight.test.ts
+++ b/apps/web/src/lib/search-highlight.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildHighlightPattern } from "./search-highlight";
+
+function matches(query: string | undefined, text: string): string[] {
+  const pattern = buildHighlightPattern(query);
+  return pattern ? Array.from(text.matchAll(pattern), (match) => match[0]) : [];
+}
+
+describe("buildHighlightPattern", () => {
+  it("returns null for empty queries", () => {
+    expect(buildHighlightPattern()).toBeNull();
+    expect(buildHighlightPattern("   ")).toBeNull();
+    expect(buildHighlightPattern("OR or")).toBeNull();
+  });
+
+  it("keeps quoted phrases together and ignores OR operators", () => {
+    expect(matches('"quick brown" OR fox', "The quick brown fox")).toEqual(["quick brown", "fox"]);
+  });
+
+  it("matches terms case-insensitively", () => {
+    expect(matches("alpha", "ALPHA alpha")).toEqual(["ALPHA", "alpha"]);
+  });
+
+  it("treats regex metacharacters as literal query text", () => {
+    expect(matches("a+b? [test]", "a+b? [test] aXb test")).toEqual(["a+b?", "[test]"]);
+  });
+});

--- a/apps/web/src/lib/search-highlight.ts
+++ b/apps/web/src/lib/search-highlight.ts
@@ -1,0 +1,20 @@
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildHighlightPattern(query?: string): RegExp | null {
+  const normalized = query?.trim();
+  if (!normalized) return null;
+
+  const terms = Array.from(
+    new Set(
+      (normalized.match(/"[^"]+"|\S+/g) ?? [])
+        .map((term) => term.replace(/^"|"$/g, "").trim())
+        .filter(Boolean)
+        .filter((term) => !/^OR$/i.test(term)),
+    ),
+  );
+
+  if (terms.length === 0) return null;
+  return new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
+}


### PR DESCRIPTION
## Summary

- Make reasoning and plan disclosures expose their expanded state through native buttons.
- Centralize search highlight parsing for Markdown and session-detail text.
- Reuse the agent landing panel and the canonical `IndexedSession` type.

## Root cause

The affected UI paths had diverged through duplicated markup and query parsing, while the reasoning disclosure was implemented as a clickable `div`.

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`

CS-258