### PR TITLE
fix(cli): harden unhandled rejection paths

### DIFF
--- a/packages/cli/src/agent-operation-scheduler.test.ts
+++ b/packages/cli/src/agent-operation-scheduler.test.ts
@@ -123,6 +123,23 @@ describe("AgentOperationScheduler", () => {
     await expect(next).resolves.toBe("committed");
   });
 
+  it("logs a rejection from a timer-scheduled refresh instead of leaking it", async () => {
+    vi.useFakeTimers();
+    const error = vi.spyOn(appLogger, "error");
+    const scheduler = new AgentOperationScheduler(async () => {
+      throw new Error("refresh boom");
+    });
+
+    scheduler.schedule("codex", 10);
+    await vi.advanceTimersByTimeAsync(10);
+    await scheduler.waitForIdle();
+
+    expect(error).toHaveBeenCalledWith(
+      "scan.refresh.uncaught",
+      expect.objectContaining({ agent: "codex" }),
+    );
+  });
+
   it("cancels timers and skips queued operations after stop", async () => {
     vi.useFakeTimers();
     const first = deferredResult();

--- a/packages/cli/src/agent-operation-scheduler.ts
+++ b/packages/cli/src/agent-operation-scheduler.ts
@@ -61,7 +61,11 @@ export class AgentOperationScheduler {
     state.timer = setTimeout(() => {
       state.timer = null;
       state.timerDeadline = 0;
-      void this.refresh(agentName);
+      // A rejection here has no awaiter — without the catch it would escape
+      // as an unhandled rejection and take down the process.
+      this.refresh(agentName).catch((error) => {
+        appLogger.error("scan.refresh.uncaught", { agent: agentName, error });
+      });
     }, effectiveDelayMs);
   }
 

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -315,6 +315,22 @@ describe("AgentSyncEngine", () => {
     });
   });
 
+  it("completes the refresh when the backfill probe throws", async () => {
+    const warn = vi.spyOn(appLogger, "warn");
+    const { engine } = makeEngine(makeAgent(), []);
+    const internal = engine as unknown as { needsBackfill: () => boolean };
+    internal.needsBackfill = () => {
+      throw new Error("probe boom");
+    };
+
+    await expect(engine.refresh("codex")).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      "scan.refresh.backfill_probe_failed",
+      expect.objectContaining({ agent: "codex" }),
+    );
+  });
+
   it("does not enqueue a backfill when the full-sync timestamp cannot be read", () => {
     core.readAgentLastFullSyncAt.mockReturnValueOnce({ status: "failed" });
     const agent = makeAgent();

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -504,14 +504,21 @@ export class AgentSyncEngine {
         if (durableCommitted) this.finishCommittedAgentScan(agentName, completion);
         else this.finishAgentScan(agentName, completion);
       }
+    } catch (error) {
+      if (!durableCommitted) throw error;
+      this.reportPostCommitError("scan.refresh", agentName, error);
+    }
+    // The backfill probe touches the agent's filesystem (isAvailable /
+    // listSessionSources) and may throw on transient errors; that must not
+    // fail — let alone reject — an otherwise finished refresh.
+    try {
       const agent = this.findAgent(agentName);
       if (agent && this.needsBackfill(agent, cached, failed || result === "committed")) {
         this.enqueueBackfill(agentName);
       }
       if (agent) this.searchIndexMaintenance.enqueue(agentName);
     } catch (error) {
-      if (!durableCommitted) throw error;
-      this.reportPostCommitError("scan.refresh", agentName, error);
+      appLogger.warn("scan.refresh.backfill_probe_failed", { agent: agentName, error });
     }
     return result;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,13 @@ import {
 import { createRegisteredAgents, perf } from "@codesesh/core";
 import { startPricingRefresh } from "./pricing-refresh.js";
 
+// Node's default reaction to an unhandled rejection is to terminate without
+// touching the app log; record it first, then let the crash proceed.
+process.on("unhandledRejection", (reason) => {
+  appLogger.error("process.unhandled_rejection", { error: reason });
+  throw reason;
+});
+
 const main = defineCommand({
   meta: {
     name: "codesesh",
@@ -281,12 +288,16 @@ const main = defineCommand({
       await app.shutdown();
       process.exit(0);
     };
-    process.once("SIGINT", (signal) => {
-      void shutdown(signal);
-    });
-    process.once("SIGTERM", (signal) => {
-      void shutdown(signal);
-    });
+    // If shutdown rejects, process.exit(0) inside it never runs; log and
+    // exit non-zero instead of leaving an unhandled rejection behind.
+    const shutdownOnSignal = (signal: NodeJS.Signals) => {
+      shutdown(signal).catch((error) => {
+        appLogger.error("cli.shutdown_failed", { signal, error });
+        process.exit(1);
+      });
+    };
+    process.once("SIGINT", shutdownOnSignal);
+    process.once("SIGTERM", shutdownOnSignal);
 
     console.log(`  ${url}`);
     console.log("");


### PR DESCRIPTION
## Summary

Fixes CS-260: several promise-rejection paths in the CLI escape as unhandled rejections, and since the process installs no `unhandledRejection` handler, Node's default behavior terminates the whole CLI + HTTP server (dropping every SSE client) on a transient failure.

- **`AgentSyncEngine.performRefresh`**: the post-scan backfill probe (`needsBackfill` → `agent.isAvailable()` / `listSessionSources()`) can throw `SessionScanError` on transient filesystem errors (EACCES/EMFILE); the surrounding catch rethrows when `durableCommitted` is false — the most common refresh outcome. The probe now runs in its own guarded block that logs `scan.refresh.backfill_probe_failed` and degrades to "no backfill".
- **`AgentOperationScheduler`**: the debounce timer fired `void this.refresh(agentName)` with no rejection handler; a rejection now lands in a `scan.refresh.uncaught` error log instead of escaping.
- **`index.ts`**: `void shutdown(signal)` on SIGINT/SIGTERM meant a rejecting `app.shutdown()` skipped `process.exit(0)` and leaked the rejection; failures are now logged and exit non-zero. A process-level `unhandledRejection` backstop records the reason in the app log before rethrowing, preserving fail-fast semantics for genuinely unknown bugs.

## Testing

- New test: a throwing backfill probe no longer rejects `engine.refresh` and logs the degradation.
- New test: a rejecting timer-scheduled refresh is logged instead of leaking.
- `pnpm --filter codesesh typecheck && test && lint && format:check` all green (36 files, 520 tests).