### PR TITLE
fix(agents): commit database change baseline only after the scan succeeds

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -116,6 +116,7 @@ function makeAgent(overrides: Partial<BaseAgent> = {}): BaseAgent {
     isAvailable: () => true,
     scan: () => [],
     checkForChanges: () => ({ hasChanges: false, timestamp: Date.now() }),
+    commitChangeCheck: () => undefined,
     incrementalScan: (sessions) => sessions,
     getSessionData: () => ({ messages: [] }) as never,
     getSessionMetaMap: () => new Map(),
@@ -313,6 +314,23 @@ describe("AgentSyncEngine", () => {
       agent: "codex",
       state: "initialization",
     });
+  });
+
+  it("commits the change check only after the consuming scan succeeds", async () => {
+    const commitChangeCheck = vi.fn();
+    const agent = makeAgent({
+      commitChangeCheck,
+      checkForChanges: () => ({ hasChanges: true, timestamp: Date.now() }),
+    });
+    const workerRunner = makeWorkerRunner();
+    vi.mocked(workerRunner.run).mockRejectedValueOnce(new Error("worker crashed"));
+    const { engine } = makeEngine(agent, [makeSession("session")], workerRunner);
+
+    await engine.refresh("codex");
+    expect(commitChangeCheck).not.toHaveBeenCalled();
+
+    await engine.refresh("codex");
+    expect(commitChangeCheck).toHaveBeenCalledOnce();
   });
 
   it("completes the refresh when the backfill probe throws", async () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -791,6 +791,7 @@ export class AgentSyncEngine {
       const result = await this.runWorker(agent, baseline, { kind: "recompute-derived" }, {});
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
+      agent.commitChangeCheck();
       this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
       const persistenceDiff = buildPersistenceDiff(baseline, sessions);
       if (
@@ -827,6 +828,7 @@ export class AgentSyncEngine {
       const result = await this.runWorker(agent, baseline, { kind: "full-scan" }, scope);
       agent.setSessionMetaMap(new Map(Object.entries(result.meta)));
       const sessions = attachMissingProjectIdentities(result.sessions);
+      agent.commitChangeCheck();
       this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
       return this.refreshStrategyResult(sessions, result.completeness, scope, {
         // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
@@ -850,6 +852,7 @@ export class AgentSyncEngine {
         agent.incrementalScan(baseline, preciseChangedIds, checkResult.refs, scope),
       ),
     );
+    agent.commitChangeCheck();
     this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
     const sourceFailures = checkResult.sourceFailures ?? [];
     const completeness =

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -562,6 +562,7 @@ function makeAgent(name: string, overrides: Record<string, unknown> = {}) {
     // Database-style agents detect changes via checkForChanges and rescan via
     // incrementalScan (which delegates to scan), mirroring DatabaseSessionSource.
     checkForChanges: vi.fn(() => ({ hasChanges: true, changedIds: [], timestamp: 0 })),
+    commitChangeCheck: vi.fn(),
     incrementalScan: vi.fn(() => (agent.scan as () => SessionHead[])()),
   };
   agent.scan = vi.fn(() => []);

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -735,6 +735,31 @@ describe("DatabaseSessionSource", () => {
     expect(stale).not.toHaveProperty("changedIds");
   });
 
+  it("re-detects a database change when the consuming scan never commits", () => {
+    const dbPath = makeDb();
+    const agent = new FakeDatabaseSource(dbPath);
+    const cached = [makeSession("db-1")];
+    agent.setSessionMetaMap(
+      new Map([
+        ["db-1", { id: "db-1", sourcePath: dbPath, pricingCaptureEpoch: PRICING_CAPTURE_EPOCH }],
+      ]),
+    );
+
+    // A successful pass commits its observation as the baseline.
+    agent.checkForChanges(Date.now() + 1_000_000, cached);
+    agent.commitChangeCheck();
+
+    writeFileSync(dbPath, "changed-once");
+    expect(agent.checkForChanges(0, cached).hasChanges).toBe(true);
+    // The scan consuming that check failed → no commit → still flagged.
+    expect(agent.checkForChanges(0, cached).hasChanges).toBe(true);
+
+    agent.commitChangeCheck();
+    // since=0 would read "changed" via the mtime fallback; false proves the
+    // committed fingerprint is now the comparison baseline.
+    expect(agent.checkForChanges(0, cached).hasChanges).toBe(false);
+  });
+
   it("reports no changes when database path is missing", () => {
     const agent = new FakeDatabaseSource(null);
     const result = agent.checkForChanges(0, [makeSession("db-1")]);
@@ -915,8 +940,10 @@ describe("CS-139: WAL-mode change detection", () => {
 
   it("sees a commit that has not been checkpointed", () => {
     const { db, agent } = createWalDatabase();
-    // Establish the baseline the way a running server would.
+    // Establish the baseline the way a running server would: a check whose
+    // consuming scan succeeded gets committed by the orchestrator.
     agent.checkForChanges(0, []);
+    agent.commitChangeCheck();
     expect(agent.checkForChanges(0, []).hasChanges).toBe(false);
 
     db.prepare("INSERT INTO session VALUES (?)").run("s2");
@@ -928,6 +955,7 @@ describe("CS-139: WAL-mode change detection", () => {
   it("does not report a change caused by its own read-only scan", () => {
     const { db, agent } = createWalDatabase();
     agent.checkForChanges(0, []);
+    agent.commitChangeCheck();
 
     agent.scan();
 

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -258,6 +258,14 @@ export abstract class BaseAgent {
   ): Promise<ChangeCheckResult> | ChangeCheckResult;
 
   /**
+   * Commit the observation made by the latest checkForChanges. Called by the
+   * scan orchestrator only after the scan consuming that check succeeded, so
+   * a failed scan leaves the baseline behind and the next check re-detects
+   * the same change instead of silently skipping it.
+   */
+  commitChangeCheck(): void {}
+
+  /**
    * 增量扫描（仅扫描变更的会话）
    * @param cachedSessions 缓存的会话列表
    * @param changedIds 变更的会话 ID 列表
@@ -649,6 +657,7 @@ function latestSqliteSourceMtime(dbPath: string): number {
 export abstract class DatabaseSessionSource extends BaseAgent {
   protected sessionMetaMap = new Map<string, SessionCacheMeta>();
   private lastSourceFingerprint: string | null = null;
+  private pendingSourceFingerprint: string | null = null;
 
   /** 返回数据库文件路径（供 mtime 检测）。 */
   protected abstract getDatabasePath(): string | null;
@@ -681,6 +690,12 @@ export abstract class DatabaseSessionSource extends BaseAgent {
     this.sessionMetaMap = meta;
   }
 
+  override commitChangeCheck(): void {
+    if (this.pendingSourceFingerprint == null) return;
+    this.lastSourceFingerprint = this.pendingSourceFingerprint;
+    this.pendingSourceFingerprint = null;
+  }
+
   /**
    * 变更检测：数据库内部变更难以按行定位，按库文件集合的指纹判定。
    *
@@ -710,7 +725,9 @@ export abstract class DatabaseSessionSource extends BaseAgent {
 
       const fingerprint = sqliteSourceFingerprint(dbPath);
       const previous = this.lastSourceFingerprint;
-      this.lastSourceFingerprint = fingerprint;
+      // Advancing the baseline here would make a failed scan look "unchanged"
+      // on the next pass; stash it until the orchestrator commits the scan.
+      this.pendingSourceFingerprint = fingerprint;
       // Nothing to compare against on the first pass — fall back to the caller's
       // baseline, which also covers a WAL written while the process was down.
       const hasChanges =

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -636,6 +636,7 @@ async function scanAgentSmart(
           ),
         );
         timing.scan = performance.now() - t2;
+        agent.commitChangeCheck();
 
         return finalizeAgentScan(agent, updatedSessions, {
           finalization: {
@@ -657,6 +658,7 @@ async function scanAgentSmart(
         });
       }
 
+      agent.commitChangeCheck();
       return finalizeAgentScan(agent, cached.sessions, {
         finalization: { kind: "unchanged", cached },
         options,


### PR DESCRIPTION
## Summary

Fixes CS-261: `DatabaseSessionSource.checkForChanges` advanced `lastSourceFingerprint` the moment the check ran — before the scan consuming that check had done any work. The check runs on the main-thread agent instance while the actual scan runs in a worker; when the worker scan failed, nothing reset the fingerprint, so the next refresh compared against the already-advanced baseline, reported "unchanged", and took the recompute-derived path that reuses the previous sessions without re-reading the database. For SQLite-backed agents (Cursor, OpenCode, zcode) every session written since the last successful pass stayed invisible in the UI, cache, and search index until the agent wrote to its database again or CodeSesh restarted.

- `checkForChanges` now stashes the observed fingerprint as pending instead of committing it, and a new `BaseAgent.commitChangeCheck()` (no-op by default, overridden by `DatabaseSessionSource`) promotes it to the comparison baseline.
- The orchestrators call `commitChangeCheck()` only after the consuming scan succeeds: `AgentSyncEngine.refreshChangedAgent` at its three post-scan bookkeeping points (mirroring `lastRefreshAtByAgent`), and the startup scanner on its incremental/unchanged cache paths.
- A failed scan now leaves the baseline behind, so the next check re-detects the same change and rescans — the worst case is one redundant rescan, never silent data loss.

## Testing

- New core test: a database change stays flagged across repeated checks until `commitChangeCheck()`, and reads as unchanged afterwards (proving the fingerprint, not the mtime fallback, is the baseline).
- New engine test: `commitChangeCheck` is not called when the worker scan rejects, and is called once after the following successful refresh.
- Existing WAL-mode change-detection tests updated to the new commit contract.
- `pnpm typecheck` (core + cli), core 952 tests, cli 521 tests, lint, format:check all green.