### PR TITLE
fix(cache): record full-sync completion on a fresh cache

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -840,6 +840,13 @@ describe("cache initialization tracking", () => {
     expect(getAgentLastFullSyncAt("claudecode")).toBe(now);
   });
 
+  it("records full-sync completion even without a prior initialization row", () => {
+    markAgentFullSyncCompleted("claudecode");
+
+    expect(getAgentLastFullSyncAt("claudecode")).toBe(now);
+    expect(isAgentCacheInitialized("claudecode")).toBe(true);
+  });
+
   it("keeps a full-sync marker pending until reconciliation completes", () => {
     markAgentCacheInitialized("claudecode");
     markAgentFullSyncCompleted("claudecode");

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -312,15 +312,6 @@ export function markAgentFullSyncProgress(agentName: string, cursor: string): vo
   });
 }
 
-/** Remove the cursor after the complete unbounded reconciliation commits. */
-function clearAgentFullSyncCursor(agentName: string): void {
-  withCacheDb((db) => {
-    db.prepare("DELETE FROM cache_meta WHERE key = ?").run(
-      `${FULL_SYNC_CURSOR_PREFIX}${agentName}`,
-    );
-  });
-}
-
 export function readAgentLastFullSyncAt(agentName: string): CacheReadOutcome<number | null> {
   if (!hasCacheStorage()) {
     return { status: "success", value: null };
@@ -349,16 +340,25 @@ export function getAgentLastFullSyncAt(agentName: string): number | null {
 
 /** Record that a full (unbounded) history reconciliation just completed for this agent. */
 export function markAgentFullSyncCompleted(agentName: string): void {
+  const completedAt = Date.now();
   withCacheDb((db) => {
-    db.prepare(
-      `
-        UPDATE cache_initialization
-        SET last_sync_at = ?
-        WHERE agent_name = ?
-      `,
-    ).run(Date.now(), agentName);
+    db.transaction(() => {
+      // Upsert: on a fresh cache the initialization row may not exist yet,
+      // and a bare UPDATE would silently record nothing (last_sync_at would
+      // read back as "never synced" and re-trigger a full backfill).
+      db.prepare(
+        `
+          INSERT INTO cache_initialization(agent_name, initialized_at, index_version, last_sync_at)
+          VALUES (?, ?, ?, ?)
+          ON CONFLICT(agent_name) DO UPDATE SET
+            last_sync_at = excluded.last_sync_at
+        `,
+      ).run(agentName, completedAt, CACHE_INITIALIZATION_VERSION, completedAt);
+      db.prepare("DELETE FROM cache_meta WHERE key = ?").run(
+        `${FULL_SYNC_CURSOR_PREFIX}${agentName}`,
+      );
+    }).immediate();
   });
-  clearAgentFullSyncCursor(agentName);
 }
 
 function loadCachedSessionEntryBase(

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -740,8 +740,8 @@ async function scanAgentFull(
       });
       if (persisted !== false) {
         cachePersistence = "persisted";
-        if (isFullWindow && sourceFailures.length === 0) markAgentFullSyncCompleted(agent.name);
         markAgentCacheInitialized(agent.name);
+        if (isFullWindow && sourceFailures.length === 0) markAgentFullSyncCompleted(agent.name);
       } else {
         cachePersistence = "failed";
         getCoreDiagnostics()?.warn("cache.save_failed", {


### PR DESCRIPTION
## Summary

Fixes CS-262: `markAgentFullSyncCompleted` was a bare `UPDATE cache_initialization SET last_sync_at = ...`. On a fresh cache — the one created by an unbounded `codesesh --json` scan — the initialization row does not exist yet (the scanner called `markAgentFullSyncCompleted` *before* `markAgentCacheInitialized`), so the UPDATE touched 0 rows and the subsequent INSERT wrote `last_sync_at = 0`, which `readAgentLastFullSyncAt` reads back as "never synced". The next windowed server start therefore kicked off a full-history backfill of every agent — exactly the multi-GB rescan the 24h `BACKFILL_INTERVAL_MS` guard exists to avoid.

- `markAgentFullSyncCompleted` is now an upsert, so completion is durable regardless of call order, and the `last_sync_at` write plus the full-sync-cursor delete run in a single immediate transaction (previously two separate transactions; a crash in between left a stale cursor). The single-caller `clearAgentFullSyncCursor` helper is inlined.
- The scanner marks the cache initialized before recording full-sync completion, so the dedicated initialization path still owns `initialized_at`/`index_version` on the normal flow.

## Testing

- New test: `markAgentFullSyncCompleted` on a fresh cache (no initialization row) records a readable `last_sync_at` and leaves the cache initialized.
- Existing initialization/full-sync/cursor lifecycle tests unchanged and green.
- `pnpm typecheck`, core 953 tests, cli 521 tests, `pnpm test:migration` (13), lint, format:check all green.