### PR TITLE
fix(api): resolve session-detail identity off the event loop

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1776,6 +1776,38 @@ describe("handleGetSessionData", () => {
         agentName: "claudecode",
         sessionId: "s1",
       },
+      {},
+    );
+    expect(c.json).toHaveBeenCalledWith(detail);
+  });
+
+  it("resolves a missing identity off the request path and retries", async () => {
+    coreMocks.materializeSessionDetailResponse
+      .mockReturnValueOnce({ status: "needs-identity", directory: "/workspace/project" })
+      .mockReturnValueOnce({ status: "found", data: detail });
+    const identity = {
+      kind: "path" as const,
+      key: "/workspace/project",
+      displayName: "project",
+    };
+    const resolver = {
+      resolve: vi.fn(async () => ({
+        identity,
+        resolverRevision: "test",
+        inputSignature: "sig",
+      })),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const scanSource = makeScanSource();
+    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+
+    await handleGetSessionData(c, scanSource, resolver);
+
+    expect(resolver.resolve).toHaveBeenCalledWith("/workspace/project");
+    expect(coreMocks.materializeSessionDetailResponse).toHaveBeenLastCalledWith(
+      scanSource.getSnapshot(),
+      { agentName: "claudecode", sessionId: "s1" },
+      { projectIdentityFallback: identity },
     );
     expect(c.json).toHaveBeenCalledWith(detail);
   });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -52,6 +52,7 @@ import {
   buildDashboard,
   type DashboardData,
   type DashboardScope,
+  type ProjectIdentityProjection,
   type ProjectScopeMatcher,
 } from "@codesesh/core";
 import { appLogger } from "../logging.js";
@@ -829,7 +830,11 @@ export async function handleGetFileActivity(
   });
 }
 
-export async function handleGetSessionData(c: Context, scanSource: ScanResultSource) {
+export async function handleGetSessionData(
+  c: Context,
+  scanSource: ScanResultSource,
+  resolver?: ProjectIdentityResolver,
+) {
   const startedAt = performance.now();
   const agentName = c.req.param("agent");
   const sessionId = c.req.param("id");
@@ -848,9 +853,21 @@ export async function handleGetSessionData(c: Context, scanSource: ScanResultSou
       sessionId,
     };
     const messageCursor = optionalQueryValue(c.req.query("messageCursor"));
-    const result = messageCursor
-      ? materializeSessionDetailResponse(scanSource.getSnapshot(), reference, { messageCursor })
-      : materializeSessionDetailResponse(scanSource.getSnapshot(), reference);
+    const materialize = (fallback?: ProjectIdentityProjection["identity"]) =>
+      materializeSessionDetailResponse(scanSource.getSnapshot(), reference, {
+        ...(messageCursor ? { messageCursor } : {}),
+        ...(fallback ? { projectIdentityFallback: fallback } : {}),
+      });
+    let result = materialize();
+    if (result.status === "needs-identity") {
+      // Identity resolution probes the filesystem and spawns git; it must run
+      // on the worker resolver, never synchronously on the request path.
+      if (!resolver) throw new Error("Project identity resolver is unavailable");
+      result = materialize((await resolver.resolve(result.directory)).identity);
+    }
+    if (result.status === "needs-identity") {
+      throw new Error("Project identity fallback was not applied");
+    }
     if (result.status === "unknown-agent") {
       return c.json({ error: `Unknown agent: ${agentName}` }, 404);
     }

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -125,7 +125,9 @@ export function createApiRoutes(
   api.get("/file-activity", (c) =>
     handleGetFileActivity(c, listDefaults, options.projectIdentityResolver),
   );
-  api.get("/sessions/:agent/:id", (c) => handleGetSessionData(c, scanSource));
+  api.get("/sessions/:agent/:id", (c) =>
+    handleGetSessionData(c, scanSource, options.projectIdentityResolver),
+  );
   api.get("/dashboard", (c) => handleGetDashboard(c, scanSource, listDefaults));
   api.get("/bookmarks", (c) => handleGetBookmarks(c, scanSource));
   api.put("/bookmarks", (c) => handlePutBookmark(c));

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -284,6 +284,30 @@ describe("materializeSessionDetail", () => {
     expect(agent.reads).toBe(1);
   });
 
+  it("asks the caller to resolve identity instead of probing the filesystem", () => {
+    const detail = { ...makeDetail(), project_identity: undefined };
+    const head = { ...makeHead(), project_identity: undefined };
+    const agent = new TestAgent(detail, new Map([["s1", makeMeta("source")]]));
+    const scanResult = makeScanResult(agent, head);
+    const reference = { agentName: "test", sessionId: "s1" };
+
+    expect(materializeSessionDetail(scanResult, reference)).toEqual({
+      status: "needs-identity",
+      directory: "/workspace/project",
+    });
+    expect(materializeSessionDetailResponse(scanResult, reference, {})).toEqual({
+      status: "needs-identity",
+      directory: "/workspace/project",
+    });
+
+    const resolved = materializeSessionDetail(scanResult, reference, {
+      projectIdentityFallback: projectIdentity,
+    });
+    expect(resolved.status).toBe("found");
+    if (resolved.status !== "found") return;
+    expect(resolved.data.project_identity).toEqual(projectIdentity);
+  });
+
   it("derives the same file activity for cached and source details", () => {
     const head = makeHead();
     const detail = makeDetail();

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -1,7 +1,6 @@
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import type { SessionReference } from "../contract/index.js";
-import type { SessionDetail, SessionHead } from "../types/index.js";
-import { computeIdentity, realFs } from "../projects/index.js";
+import type { ProjectIdentity, SessionDetail, SessionHead } from "../types/index.js";
 import {
   classifySessionTags,
   extractSessionFileActivity,
@@ -34,7 +33,14 @@ import type { LiveSnapshot } from "./scanner.js";
 export type SessionDetailResult =
   | { status: "found"; data: SessionDetail }
   | { status: "unknown-agent" }
-  | { status: "not-ready" };
+  | { status: "not-ready" }
+  /**
+   * The session has no identity on its head or cached detail. Resolving one
+   * requires filesystem/git probing, which must not run on this synchronous
+   * path — the caller resolves `directory` asynchronously and retries with
+   * `projectIdentityFallback`.
+   */
+  | { status: "needs-identity"; directory: string };
 
 export type SessionDetailResponseResult =
   | SessionDetailResult
@@ -48,6 +54,8 @@ export type SessionDetailResponseResult =
 
 export interface SessionDetailResponseOptions {
   messageCursor?: string;
+  /** Pre-resolved identity used when neither the head nor the cache has one. */
+  projectIdentityFallback?: ProjectIdentity;
 }
 
 interface SessionDetailLookup {
@@ -217,8 +225,9 @@ function cachedDetailState(
 function getProjectIdentity(
   data: Pick<SessionDetail, "directory" | "project_identity">,
   head: SessionHead | undefined,
-) {
-  return head?.project_identity ?? data.project_identity ?? computeIdentity(data.directory, realFs);
+  fallback: ProjectIdentity | undefined,
+): ProjectIdentity | null {
+  return head?.project_identity ?? data.project_identity ?? fallback ?? null;
 }
 
 function getSmartTags(data: SessionDetail) {
@@ -235,6 +244,7 @@ function materializeStructuredSessionDetail(
   context: SessionDetailContext,
   reference: SessionReference,
   cachedEntry = loadCachedSessionRawEntry(reference.agentName, reference.sessionId),
+  identityFallback?: ProjectIdentity,
 ): SessionDetailResult {
   const { agent, head } = context;
   const currentMeta = head ? agent.getSessionMetaMap().get(reference.sessionId) : undefined;
@@ -281,7 +291,8 @@ function materializeStructuredSessionDetail(
     return { status: "not-ready" };
   }
 
-  const projectIdentity = getProjectIdentity(data, head);
+  const projectIdentity = getProjectIdentity(data, head, identityFallback);
+  if (!projectIdentity) return { status: "needs-identity", directory: data.directory };
   const fileActivity =
     data.file_activity ??
     (useCache
@@ -321,10 +332,16 @@ function* serializeCachedMessages(messageRows: CachedMessageRow[]): IterableIter
 export function materializeSessionDetail(
   scanResult: LiveSnapshot,
   reference: SessionReference,
+  options: Pick<SessionDetailResponseOptions, "projectIdentityFallback"> = {},
 ): SessionDetailResult {
   const context = getSessionDetailContext(scanResult, reference);
   if (!context) return { status: "unknown-agent" };
-  return materializeStructuredSessionDetail(context, reference);
+  return materializeStructuredSessionDetail(
+    context,
+    reference,
+    undefined,
+    options.projectIdentityFallback,
+  );
 }
 
 export function materializeSessionDetailResponse(
@@ -361,16 +378,28 @@ export function materializeSessionDetailResponse(
     cachedEntry.data.smart_tags == null ||
     cachedEntry.data.smart_tags_classifier_revision !== SMART_TAG_CLASSIFIER_REVISION
   ) {
-    const result = materializeStructuredSessionDetail(context, reference);
+    const result = materializeStructuredSessionDetail(
+      context,
+      reference,
+      undefined,
+      options.projectIdentityFallback,
+    );
     return result.status === "found"
       ? { ...result, data: { ...result.data, message_update: "reset" } }
       : result;
   }
 
   const data = cachedEntry.data;
+  const projectIdentity = getProjectIdentity(data, context.head, options.projectIdentityFallback);
+  if (!projectIdentity) return { status: "needs-identity", directory: data.directory };
   const stream = cursorRead?.stream;
   if (!stream) {
-    const result = materializeStructuredSessionDetail(context, reference);
+    const result = materializeStructuredSessionDetail(
+      context,
+      reference,
+      undefined,
+      options.projectIdentityFallback,
+    );
     return result.status === "found"
       ? { ...result, data: { ...result.data, message_update: "reset" } }
       : result;
@@ -394,7 +423,7 @@ export function materializeSessionDetailResponse(
       detail_freshness: "fresh",
       message_cursor: stream.cursor,
       message_update: stream.update,
-      project_identity: getProjectIdentity(data, context.head),
+      project_identity: projectIdentity,
       smart_tags_source_updated_at: getSmartTagSourceTimestamp(data),
       file_activity:
         data.file_activity ?? listSessionFileActivity(reference.agentName, reference.sessionId),


### PR DESCRIPTION
## Summary

Fixes CS-263 (decision drift from CS-242): `GET /api/sessions/:agent/:id` was the one remaining endpoint that could fall back to a synchronous `computeIdentity` — walking parent directories and spawning up to two `git` subprocesses (1s timeout each) on the request path, blocking the single-threaded event loop for up to ~2s and stalling SSE heartbeats plus every concurrent request. CS-242 migrated `/api/sessions`, `/api/search`, and `/api/file-activity` to the bounded worker resolver but left this path behind.

- Core: `session-detail.ts` no longer imports `computeIdentity`/`realFs` at all — the synchronous probe is structurally impossible now. When neither the session head nor the cached detail carries an identity, materialization returns a new `{ status: "needs-identity", directory }` result, and `SessionDetailResponseOptions` gains `projectIdentityFallback` for the retry.
- CLI: `handleGetSessionData` receives the same `ProjectIdentityResolver` the CS-242 endpoints use; on `needs-identity` it resolves the directory on the worker and retries with the resolved identity as the fallback.

The fallback fires only for sessions absent from the current snapshot whose cached row predates identity enforcement (the current schema is NOT NULL on identity columns), so the resolver round-trip is rare — but the blocking path is now closed by construction, not by luck.

## Testing

- New core test: missing head+detail identity yields `needs-identity` from both materializers, and `projectIdentityFallback` produces `found` with that identity.
- New handler test: a `needs-identity` result triggers one resolver round-trip and a retry carrying the fallback.
- `pnpm typecheck` (core + cli), core 954 tests, cli 522 tests, lint, format:check all green.