### PR TITLE
perf(codex): stop re-reading every rollout on each windowed scan

### DIFF
--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -274,8 +274,59 @@ describe("CodexAgent cache refresh", () => {
 
     for (const { file } of files) {
       const callsForFile = statSpy.mock.calls.filter((call) => call[0] === file);
-      expect(callsForFile.length).toBe(1);
+      // One stat from the rollout listing, one from thread-meta fingerprinting;
+      // the guard is against per-session rescans, i.e. O(files²) growth.
+      expect(callsForFile.length).toBe(2);
     }
+  });
+
+  it("reuses cached thread meta when rebuilding the subagent index", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const parentId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const otherParentId = "019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb";
+    const childId = "019dcccc-cccc-7ccc-cccc-cccccccccccc";
+    const parentFile = join(tempDir, `rollout-2026-04-20T10-00-00-${parentId}.jsonl`);
+    const otherParentFile = join(tempDir, `rollout-2026-04-20T10-01-00-${otherParentId}.jsonl`);
+    const childFile = join(tempDir, `rollout-2026-04-20T10-05-00-${childId}.jsonl`);
+    const meta = (payload: Record<string, unknown>) =>
+      `${JSON.stringify({ type: "session_meta", payload })}\n`;
+    writeFileSync(parentFile, meta({ id: parentId }));
+    writeFileSync(otherParentFile, meta({ id: otherParentId }));
+    writeFileSync(
+      childFile,
+      meta({ id: childId, thread_source: "subagent", parent_thread_id: parentId }),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    const window = { from: Date.now() - 24 * 60 * 60 * 1000 };
+    const openSpy = vi.mocked(openSync);
+
+    openSpy.mockClear();
+    let sources = agent.listScanSources(window);
+    expect(sources.map((ref: { file: string }) => ref.file).sort()).toEqual(
+      [parentFile, otherParentFile, childFile].sort(),
+    );
+    expect(openSpy.mock.calls.length).toBe(3);
+
+    // A new scan cycle drops the index but must rebuild it from cached meta.
+    agent.setSessionMetaMap(new Map());
+    openSpy.mockClear();
+    sources = agent.listScanSources(window);
+    expect(sources).toHaveLength(3);
+    expect(openSpy.mock.calls.length).toBe(0);
+
+    // A changed file invalidates only its own cache entry.
+    writeFileSync(
+      childFile,
+      meta({ id: childId, thread_source: "subagent", parent_thread_id: otherParentId, v: 2 }),
+    );
+    agent.setSessionMetaMap(new Map());
+    openSpy.mockClear();
+    agent.listScanSources(window);
+    expect(openSpy.mock.calls.length).toBe(1);
+    expect(agent.ensureSubagentIndex().childFilesByParent.get(otherParentId)).toEqual([childFile]);
   });
 
   it("keeps source references and fingerprints byte-for-byte stable", () => {

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -122,9 +122,13 @@ function extractThreadMeta(firstRecord: Record<string, unknown>): ThreadMeta | n
   return { threadSource, parentThreadId, agentNickname };
 }
 
+// Leading-line reads want a few KB, not the default 1 MiB streaming buffer;
+// readJsonlFileLines keeps accumulating chunks if a single line runs longer.
+const LEADING_READ_CHUNK_BYTES = 64 * 1024;
+
 function readLeadingJsonlLines(filePath: string, limit: number): string[] {
   const lines: string[] = [];
-  for (const line of readJsonlFileLines(filePath)) {
+  for (const line of readJsonlFileLines(filePath, LEADING_READ_CHUNK_BYTES)) {
     if (!line.trim()) continue;
     lines.push(line);
     if (lines.length === limit) break;
@@ -427,6 +431,12 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   private sessionIndexMtime: number | null | undefined;
   private sessionIndexPath: string | undefined;
   private subagentIndex: SubagentIndex | null = null;
+  // Thread meta lives in a rollout's immutable first line; fingerprinting by
+  // (mtime, size) lets index rebuilds stat files instead of re-reading them.
+  private readonly threadMetaByPath = new Map<
+    string,
+    { fingerprint: string; meta: ThreadMeta | null }
+  >();
   private subagentStatsByParent = new Map<string, SessionHead["stats"][]>();
   private childFinalMessagesByParent = new Map<string, Map<string, ChildFinalMessageCacheEntry>>();
 
@@ -498,9 +508,14 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
 
   private readThreadMeta(filePath: string): ThreadMeta | null {
     try {
+      const { mtimeMs, size } = statSync(filePath);
+      const fingerprint = `${mtimeMs}:${size}`;
+      const cached = this.threadMetaByPath.get(filePath);
+      if (cached && cached.fingerprint === fingerprint) return cached.meta;
       const firstLine = readLeadingJsonlLines(filePath, 1)[0];
-      if (!firstLine) return null;
-      return extractThreadMeta(JSON.parse(firstLine));
+      const meta = firstLine ? extractThreadMeta(JSON.parse(firstLine)) : null;
+      this.threadMetaByPath.set(filePath, { fingerprint, meta });
+      return meta;
     } catch (error) {
       getCoreDiagnostics()?.warn("codex.thread_meta_read_failed", {
         filePath,
@@ -729,7 +744,8 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     if (this.subagentIndex) return this.subagentIndex;
     this.basePath ??= this.findBasePath();
     const index: SubagentIndex = { childFilesByParent: new Map(), subagentFiles: new Set() };
-    for (const file of this.listRolloutFilePaths()) {
+    const paths = this.listRolloutFilePaths();
+    for (const file of paths) {
       const threadMeta = this.readThreadMeta(file);
       if (threadMeta?.threadSource !== "subagent") continue;
       index.subagentFiles.add(file);
@@ -737,6 +753,12 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       const files = index.childFilesByParent.get(threadMeta.parentThreadId);
       if (files) files.push(file);
       else index.childFilesByParent.set(threadMeta.parentThreadId, [file]);
+    }
+    if (this.threadMetaByPath.size > paths.length) {
+      const active = new Set(paths);
+      for (const path of this.threadMetaByPath.keys()) {
+        if (!active.has(path)) this.threadMetaByPath.delete(path);
+      }
     }
     this.subagentIndex = index;
     return index;
@@ -832,6 +854,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     type ChildOutput = { id: string; text: string; timestampMs: number; isFinal: boolean };
     let latestOutput: ChildOutput | null = null;
     let finalOutput: ChildOutput | null = null;
+    let fallbackMtimeMs: number | null = null;
 
     for (const record of readJsonlFile(filePath)) {
       try {
@@ -848,7 +871,9 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
           id: asString(payload["id"]) ?? `codex-subagent-${sessionId}`,
           text,
           timestampMs:
-            parseTimestampMs(record) || parseTimestampMs(payload) || statSync(filePath).mtimeMs,
+            parseTimestampMs(record) ||
+            parseTimestampMs(payload) ||
+            (fallbackMtimeMs ??= statSync(filePath).mtimeMs),
           isFinal:
             String(record["phase"] ?? "") === "final_answer" ||
             String(payload["phase"] ?? "") === "final_answer",


### PR DESCRIPTION
## Summary

Fixes CS-264: every windowed Codex scan rebuilt the subagent index by reading the first line of *every* rollout file the user has ever created — `ensureSubagentIndex` walked the whole data root, each `readThreadMeta` paid open+read+close plus a 1 MiB buffer allocation, and `setSessionMetaMap` nulled the index every scan cycle so the full pass repeated each refresh. On a machine with a few thousand rollouts that is thousands of syscalls and GBs of transient buffer churn per cycle, entirely outside the requested window.

- `readThreadMeta` results are now cached per path, fingerprinted by `(mtimeMs, size)` — a rollout's first line is immutable in an append-only log, so a matching fingerprint skips the read entirely. The cache survives `setSessionMetaMap`; index rebuilds cost one `statSync` per file instead of a full read. Entries for deleted files are evicted during the rebuild.
- Leading-line reads use a 64 KiB chunk instead of the 1 MiB streaming default (the reader still accumulates chunks for oversized lines).
- `readChildFinalMessage`'s per-record `statSync` timestamp fallback is hoisted to at most one stat per file.

Index semantics are unchanged — full-corpus enumeration is kept because a subagent child's mtime can predate the scan window while its parent stays in-window, so child discovery inherently needs every file's thread meta; the win is eliminating the repeated reads, not the walk.

## Testing

- New test: a second windowed scan cycle after `setSessionMetaMap` rebuilds the index with zero file opens; rewriting one child file re-reads only that file and the new parent linkage is honored.
- The existing "stats each rollout file once" guard is updated to two stats per file (listing + fingerprint) with a comment — the guard's target remains O(files²) rescans.
- `pnpm typecheck` (core + cli), core 955 tests, cli 522 tests, lint, format:check all green.