### PR TITLE
fix(discovery): bound the smart-tag worker lifecycle

### DIFF
--- a/packages/core/src/discovery/__tests__/smart-tag-worker-lifecycle.test.ts
+++ b/packages/core/src/discovery/__tests__/smart-tag-worker-lifecycle.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BaseAgent, SessionCacheMeta } from "../../agents/index.js";
+import type { SessionDetail, SessionHead } from "../../types/index.js";
+
+type WorkerBehavior = "clean-exit-without-message" | "empty-results" | "results";
+
+const workers = vi.hoisted(() => {
+  const state = {
+    behavior: "results" as WorkerBehavior,
+    created: 0,
+    terminated: 0,
+  };
+
+  class FakeWorker {
+    private readonly sessionIds: string[];
+    private readonly handlers = new Map<string, (payload: unknown) => void>();
+
+    constructor(_url: URL | string, options: { workerData: { sessionIds: string[] } }) {
+      this.sessionIds = options.workerData.sessionIds;
+      state.created += 1;
+      queueMicrotask(() => this.run());
+    }
+
+    private run(): void {
+      if (state.behavior === "clean-exit-without-message") {
+        this.handlers.get("exit")?.(0);
+        return;
+      }
+      const results =
+        state.behavior === "empty-results"
+          ? []
+          : this.sessionIds.map((id) => ({ id, tags: ["bugfix"], sourceUpdatedAt: 1000 }));
+      this.handlers.get("message")?.(results);
+      this.handlers.get("exit")?.(0);
+    }
+
+    on(event: string, handler: (payload: unknown) => void): this {
+      this.handlers.set(event, handler);
+      return this;
+    }
+
+    once(event: string, handler: (payload: unknown) => void): this {
+      this.handlers.set(event, handler);
+      return this;
+    }
+
+    terminate(): Promise<number> {
+      state.terminated += 1;
+      return Promise.resolve(0);
+    }
+  }
+
+  return { FakeWorker, state };
+});
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  availableParallelism: vi.fn(() => 3),
+}));
+vi.mock("node:worker_threads", () => ({ Worker: workers.FakeWorker }));
+
+import { finalizeAgentScan } from "../scanner.js";
+
+function makeSession(index: number): SessionHead {
+  return {
+    id: `session-${index}`,
+    slug: `test/session-${index}`,
+    title: `Session ${index}`,
+    directory: "/workspace",
+    time_created: 1000,
+    time_updated: 1000,
+    stats: {
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+  };
+}
+
+function makeAgent(): BaseAgent {
+  const meta = new Map<string, SessionCacheMeta>();
+  return {
+    name: "test",
+    getSessionMetaMap: () => meta,
+    getSessionData: vi.fn(
+      (): SessionDetail => ({ ...makeSession(0), messages: [] }) as unknown as SessionDetail,
+    ),
+  } as unknown as BaseAgent;
+}
+
+async function runScan(agent: BaseAgent, sessions: SessionHead[]) {
+  return finalizeAgentScan(agent, sessions, {
+    finalization: { kind: "unchanged", cached: { sessions, meta: {}, timestamp: 1 } },
+    options: {
+      smartTagWorkerUrl: new URL("file:///smart-tag-worker.js"),
+      writeCache: false,
+    },
+    timing: { total: 0 },
+    agentStart: performance.now(),
+    completeness: "complete",
+  });
+}
+
+afterEach(() => {
+  workers.state.behavior = "results";
+  workers.state.created = 0;
+  workers.state.terminated = 0;
+});
+
+describe("smart tag worker lifecycle", () => {
+  it("terminates workers after a successful classification", async () => {
+    const sessions = Array.from({ length: 50 }, (_, index) => makeSession(index));
+
+    const result = await runScan(makeAgent(), sessions);
+
+    expect(result.heads.every((session) => session.smart_tags?.[0] === "bugfix")).toBe(true);
+    expect(workers.state.created).toBeGreaterThan(0);
+    expect(workers.state.terminated).toBe(workers.state.created);
+  });
+
+  it("falls back to sync tagging when a worker exits cleanly without responding", async () => {
+    workers.state.behavior = "clean-exit-without-message";
+    const agent = makeAgent();
+    const sessions = Array.from({ length: 50 }, (_, index) => makeSession(index));
+
+    const result = await runScan(agent, sessions);
+
+    expect(result.heads).toHaveLength(50);
+    expect(agent.getSessionData).toHaveBeenCalled();
+    expect(workers.state.terminated).toBe(workers.state.created);
+  });
+
+  it("treats an empty worker answer to a non-empty request as a failure", async () => {
+    workers.state.behavior = "empty-results";
+    const agent = makeAgent();
+    const sessions = Array.from({ length: 50 }, (_, index) => makeSession(index));
+
+    const result = await runScan(agent, sessions);
+
+    expect(result.heads).toHaveLength(50);
+    expect(agent.getSessionData).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
+++ b/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
@@ -33,6 +33,10 @@ const workers = vi.hoisted(() => {
     once(): this {
       return this;
     }
+
+    terminate(): Promise<number> {
+      return Promise.resolve(0);
+    }
   }
 
   return { FakeWorker };

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -314,35 +314,57 @@ export function ensureSessionTagsSync(
   return { sessions: tagged, changed, timing };
 }
 
+const SMART_TAG_WORKER_TIMEOUT_MS = 300_000;
+
 async function classifySessionTagsInWorker(
   workerUrl: URL | string,
   agentName: string,
   sessionIds: string[],
   meta: Record<string, SessionCacheMeta>,
 ): Promise<SmartTagWorkerResult[]> {
-  return new Promise((resolveWorker, rejectWorker) => {
-    const worker = new Worker(workerUrl, {
-      workerData: {
-        pricingGenerationId: getPricingGeneration().id,
-        agentName,
-        sessionIds,
-        meta,
-      },
-    });
-    worker.on("message", (message: unknown) => {
-      if (isWorkerLogMessage(message)) {
-        relayWorkerLogMessage(message);
-        return;
-      }
-      resolveWorker(message as SmartTagWorkerResult[]);
-    });
-    worker.once("error", rejectWorker);
-    worker.once("exit", (code) => {
-      if (code !== 0) {
-        rejectWorker(new Error(`Smart tag worker exited with code ${code}`));
-      }
-    });
+  const worker = new Worker(workerUrl, {
+    workerData: {
+      pricingGenerationId: getPricingGeneration().id,
+      agentName,
+      sessionIds,
+      meta,
+    },
   });
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await new Promise<SmartTagWorkerResult[]>((resolveWorker, rejectWorker) => {
+      timer = setTimeout(() => {
+        rejectWorker(
+          new Error(`Smart tag worker timed out after ${SMART_TAG_WORKER_TIMEOUT_MS}ms`),
+        );
+      }, SMART_TAG_WORKER_TIMEOUT_MS);
+      worker.on("message", (message: unknown) => {
+        if (isWorkerLogMessage(message)) {
+          relayWorkerLogMessage(message);
+          return;
+        }
+        const results = message as SmartTagWorkerResult[];
+        // An empty answer to a non-empty request means the worker could not
+        // do the job at all (e.g. unresolvable agent) — fail over to the
+        // synchronous path instead of silently shipping untagged sessions.
+        if (results.length === 0 && sessionIds.length > 0) {
+          rejectWorker(new Error("Smart tag worker returned no results"));
+          return;
+        }
+        resolveWorker(results);
+      });
+      worker.once("error", rejectWorker);
+      // Any exit before a result message — including a clean code 0 — must
+      // reject; the old `code !== 0` guard left the promise pending forever
+      // and hung server startup.
+      worker.once("exit", (code) => {
+        rejectWorker(new Error(`Smart tag worker exited with code ${code} before responding`));
+      });
+    });
+  } finally {
+    if (timer) clearTimeout(timer);
+    worker.terminate().catch(() => {});
+  }
 }
 
 function relayWorkerLogMessage(message: WorkerLogMessage): void {


### PR DESCRIPTION
## Summary

Fixes CS-265: `classifySessionTagsInWorker` created a `Worker` it never terminated, with no timeout, and its `exit` handler only rejected on a non-zero code — a worker that exited cleanly without posting results (the realistic trigger is an OOM kill mid-classification of a large rollout) left the promise pending forever. Those promises are joined with `Promise.all` inside `ensureSessionTags`, so one wedged worker hung `finalizeAgentScan` → `scanSessions` → `LiveScanStore.initialize()`, and the server never started, with no diagnostic. Separately, a worker that could not resolve its agent posted an empty array, which was treated as "nothing changed" — sessions silently shipped untagged instead of falling back to the synchronous classifier.

- Any exit before a result message — including a clean code 0 — now rejects, routing to the existing `ensureSessionTagsSync` fallback.
- A 5-minute timeout rejects a worker that stays alive without ever responding.
- `worker.terminate()` runs in a `finally`, so workers are reaped on success, failure, and timeout alike.
- An empty answer to a non-empty request is treated as a failure (sync fallback) instead of "no changes".

## Testing

- New lifecycle suite: clean-exit-without-response falls back to sync tagging and the scan completes; empty results fall back to sync; every created worker gets terminated on the success path.
- Existing worker-log-relay fake extended with `terminate()`.
- `pnpm typecheck`, core 958 tests, cli 522 tests, lint, format:check all green.