### PR TITLE
fix(cli): isolate SSE/watcher listener fan-out failures

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -2233,6 +2233,37 @@ describe("LiveScanStore", () => {
     ]);
   });
 
+  it("keeps notifying later subscribers when an earlier one throws", async () => {
+    vi.useFakeTimers();
+    const existing = makeSession("codex-old");
+    const codex = makeAgent("codex", {
+      checkForChanges: vi.fn(() => ({
+        hasChanges: true,
+        changedIds: ["codex-new"],
+        timestamp: 3000,
+      })),
+      incrementalScan: vi.fn(() => [existing, makeSession("codex-new")]),
+    });
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      sessions: [existing],
+      byAgent: { codex: [existing] },
+      agents: [codex],
+    });
+
+    const store = new LiveScanStore({ watchEnabled: false });
+    store.subscribe(() => {
+      throw new Error("subscriber boom");
+    });
+    const events: SessionsUpdatedEvent[] = [];
+    store.subscribe((event) => events.push(event));
+    await store.initialize();
+    await syncEngineOf(store).refresh("codex");
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(events).toEqual([expect.objectContaining({ changedAgents: ["codex"] })]);
+  });
+
   it("coalesces refresh schedules for the same agent into a single run", async () => {
     vi.useFakeTimers();
     const existing = makeSession("existing");

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -187,7 +187,16 @@ export class LiveScanStore {
   }
 
   private emitNow(event: SessionsUpdatedEvent): void {
-    for (const listener of this.listeners) listener(event);
+    // Per-listener isolation: one broken SSE subscriber must not starve the
+    // rest, and on the queueEvent timer path an escaped throw would be an
+    // uncaught exception.
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        appLogger.error("scan.sessions_listener.error", { error });
+      }
+    }
   }
 
   private queueEvent(event: SessionsUpdatedEvent): void {

--- a/packages/cli/src/session-watcher.test.ts
+++ b/packages/cli/src/session-watcher.test.ts
@@ -111,6 +111,42 @@ describe("SessionWatcher", () => {
     }
   });
 
+  it("keeps notifying later listeners when an earlier one throws", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "watcher-test-"));
+    try {
+      const sessionsDir = join(tempDir, "sessions");
+      mkdirSync(sessionsDir, { recursive: true });
+      const sessionFile = join(sessionsDir, "session.jsonl");
+      writeFileSync(sessionFile, "data");
+
+      const watcher = new SessionWatcher();
+      watcher.onAgentsChanged(() => {
+        throw new Error("listener boom");
+      });
+      const changed = vi.fn();
+      watcher.onAgentsChanged(changed);
+
+      watcher.start([
+        source("custom-agent", {
+          status: "supported",
+          targets: [{ path: sessionsDir }],
+        }),
+      ]);
+      const sessionsWatcher = fsWatch.watchers.find((w) => w.path === sessionsDir);
+      writeFileSync(sessionFile, "partial");
+      sessionsWatcher!.listener("change", "session.jsonl");
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_500);
+
+      expect(changed).toHaveBeenCalledWith(new Set(["custom-agent"]));
+
+      await watcher.dispose();
+    } finally {
+      vi.unstubAllEnvs();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("unsubscribe removes the listener", () => {
     const watcher = new SessionWatcher();
     const cb = vi.fn();

--- a/packages/cli/src/session-watcher.ts
+++ b/packages/cli/src/session-watcher.ts
@@ -411,8 +411,14 @@ export class SessionWatcher {
 
   private emitAgentsChanged(agentNames: Set<string>): void {
     if (agentNames.size === 0) return;
+    // Reached from watcher timers; an escaped throw would be an uncaught
+    // exception, and one broken listener must not starve the rest.
     for (const listener of this.listeners) {
-      listener(new Set(agentNames));
+      try {
+        listener(new Set(agentNames));
+      } catch (error) {
+        appLogger.error("watch.agents_listener.error", { error });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes CS-266: two event fan-out paths invoked their listeners with no per-listener guard, unlike the convention already applied in `AgentSyncEngine` (`emitSessionsChanged` / status listeners):

- `LiveScanStore.emitNow` iterated SSE subscribers bare — one throwing listener starved every later-registered browser tab of that event, and on the `queueEvent` timer path the throw escaped `setTimeout` as an uncaught exception.
- `SessionWatcher.emitAgentsChanged` had the same unguarded loop, reached from `pollStablePath`'s timer.

Both now wrap each listener call in try/catch with an error log (`scan.sessions_listener.error` / `watch.agents_listener.error`), matching the engine's pattern: a single bad subscriber affects only itself.

## Testing

- New store test: a throwing subscriber registered first does not prevent later subscribers from receiving the coalesced update event.
- New watcher test: a throwing `onAgentsChanged` listener does not prevent later listeners from firing after write stability.
- `pnpm typecheck`, cli 524 tests, lint, format:check all green.