### PR TITLE
fix(cache): surface cache marker write and read failures

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -21,6 +21,9 @@ import type { ScanStatusModel } from "./scan-status-model.js";
 const core = vi.hoisted(() => {
   const getAgentLastFullSyncAt = vi.fn(() => Date.now());
   const isAgentCacheInitialized = vi.fn(() => true);
+  const loadCachedSessionsMock = vi.fn(
+    (_agentName?: string): ReturnType<typeof loadCachedSessions> => null,
+  );
   return {
     getAgentFullSyncCursor: vi.fn(() => null as string | null),
     getAgentLastFullSyncAt,
@@ -37,13 +40,22 @@ const core = vi.hoisted(() => {
       status: "success",
       value: getAgentLastFullSyncAt(),
     })),
-    loadCachedSessions: vi.fn((): ReturnType<typeof loadCachedSessions> => null),
+    loadCachedSessions: loadCachedSessionsMock,
+    readCachedSessions: vi.fn(
+      (
+        agentName: string,
+      ):
+        | { status: "success"; value: ReturnType<typeof loadCachedSessions> }
+        | {
+            status: "failed";
+          } => ({ status: "success", value: loadCachedSessionsMock(agentName) }),
+    ),
     readPendingSearchIndexMaintenance: vi.fn<
       (_agentName: string, _limit: number) => PendingSearchIndexMaintenance | null
     >(() => ({ sessionIds: [], total: 0 })),
-    markAgentFullSyncStarted: vi.fn(),
-    markAgentFullSyncCompleted: vi.fn(),
-    markAgentFullSyncProgress: vi.fn(),
+    markAgentFullSyncStarted: vi.fn(() => true),
+    markAgentFullSyncCompleted: vi.fn(() => true),
+    markAgentFullSyncProgress: vi.fn(() => true),
     sessionSignature: vi.fn(),
   };
 });
@@ -71,6 +83,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     readAgentCacheInitialization: core.readAgentCacheInitialization,
     readAgentLastFullSyncAt: core.readAgentLastFullSyncAt,
     loadCachedSessions: core.loadCachedSessions,
+    readCachedSessions: core.readCachedSessions,
     readPendingSearchIndexMaintenance: core.readPendingSearchIndexMaintenance,
     markAgentFullSyncStarted: core.markAgentFullSyncStarted,
     markAgentFullSyncCompleted: core.markAgentFullSyncCompleted,
@@ -347,6 +360,40 @@ describe("AgentSyncEngine", () => {
       "scan.refresh.backfill_probe_failed",
       expect.objectContaining({ agent: "codex" }),
     );
+  });
+
+  it("does not enqueue a backfill when cached sessions cannot be read", () => {
+    core.readCachedSessions.mockReturnValueOnce({ status: "failed" });
+    const agent = new FakeSyncAgent();
+    const warn = vi.spyOn(appLogger, "warn");
+    const { engine } = makeEngine(agent, [], makeWorkerRunner(), { from: 1 });
+    const internal = engine as unknown as { needsBackfill(candidate: BaseAgent): boolean };
+
+    expect(internal.needsBackfill(agent)).toBe(false);
+    expect(warn).toHaveBeenCalledWith("scan.backfill.cache_state_unavailable", {
+      agent: "codex",
+      state: "cached_sessions",
+    });
+  });
+
+  it("does not report a backfill checkpoint that failed to persist", () => {
+    core.markAgentFullSyncProgress.mockReturnValueOnce(false);
+    const warn = vi.spyOn(appLogger, "warn");
+    const { engine } = makeEngine(makeAgent());
+    const internal = engine as unknown as {
+      handleBackfillCheckpoint(agentName: string, checkpoint: unknown): void;
+    };
+
+    internal.handleBackfillCheckpoint("codex", {
+      stage: "finalizing",
+      backfillCursor: "cursor-1",
+      changes: [],
+    });
+
+    expect(warn).toHaveBeenCalledWith("scan.backfill.checkpoint_not_durable", {
+      agent: "codex",
+      cursor: "cursor-1",
+    });
   });
 
   it("does not enqueue a backfill when the full-sync timestamp cannot be read", () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -8,6 +8,7 @@ import {
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
   markAgentFullSyncCompleted,
+  readCachedSessions,
   readAgentCacheInitialization,
   readAgentLastFullSyncAt,
   sessionSignature,
@@ -470,7 +471,8 @@ export class AgentSyncEngine {
     let result: AgentOperationResult = "failed";
     let completion: ScanCompletion = { completeness: "complete" };
     try {
-      if (this.findAgent(agentName)) cached = loadCachedSessions(agentName);
+      if (this.findAgent(agentName))
+        cached = this.readCachedSessionsOrWarn("scan.refresh", agentName);
       const refresh = await this.runRefresh(agentName, cached, startedAt, (committedCompletion) => {
         durableCommitted = true;
         completion = committedCompletion;
@@ -941,12 +943,32 @@ export class AgentSyncEngine {
     checkpoint: ScanRefreshWorkerCheckpoint,
   ): void {
     if (checkpoint.stage !== "finalizing" || !checkpoint.backfillCursor) return;
-    markAgentFullSyncProgress(agentName, checkpoint.backfillCursor);
+    if (!markAgentFullSyncProgress(agentName, checkpoint.backfillCursor)) {
+      // Without a durable cursor the next restart re-walks the whole history;
+      // do not log the checkpoint as if it landed.
+      appLogger.warn("scan.backfill.checkpoint_not_durable", {
+        agent: agentName,
+        cursor: checkpoint.backfillCursor,
+      });
+      return;
+    }
     appLogger.debug("scan.backfill.checkpoint", {
       agent: agentName,
       cursor: checkpoint.backfillCursor,
       sessions: checkpoint.changes.length,
     });
+  }
+
+  private readCachedSessionsOrWarn(scope: string, agentName: string): CachedSessions | null {
+    const outcome = readCachedSessions(agentName);
+    if (outcome.status === "failed") {
+      appLogger.warn(`${scope}.cache_state_unavailable`, {
+        agent: agentName,
+        state: "cached_sessions",
+      });
+      return null;
+    }
+    return outcome.value;
   }
 
   private needsBackfill(
@@ -973,8 +995,20 @@ export class AgentSyncEngine {
     if (!(agent instanceof FileSystemSessionSource)) return false;
     if (!agent.isAvailable()) return false;
 
-    const cachedSessions =
-      reloadCached || cached === undefined ? loadCachedSessions(agent.name) : cached;
+    let cachedSessions = cached;
+    if (reloadCached || cached === undefined) {
+      const outcome = readCachedSessions(agent.name);
+      if (outcome.status === "failed") {
+        // A broken cache read must not masquerade as a truncated cache and
+        // trigger a full-history backfill against unknown state.
+        appLogger.warn("scan.backfill.cache_state_unavailable", {
+          agent: agent.name,
+          state: "cached_sessions",
+        });
+        return false;
+      }
+      cachedSessions = outcome.value;
+    }
     const sourceCount = agent.listSessionSources().length;
     const cachedCount = cachedSessions?.sessions.length ?? 0;
     this.cacheIntegrityValidUntilByAgent.set(agent.name, lastSyncAt + BACKFILL_INTERVAL_MS);
@@ -1044,14 +1078,19 @@ export class AgentSyncEngine {
     const agent = this.findAgent(agentName);
     if (!agent || !agent.isAvailable()) return "skipped";
     const snapshot = this.sessionIndex.snapshot();
-    const cached = loadCachedSessions(agentName);
+    const cached = this.readCachedSessionsOrWarn("scan.backfill", agentName);
     const baseline = cached?.sessions ?? snapshot.byAgent[agentName] ?? [];
     const meta = cached?.meta ?? buildAgentCacheMeta(agent);
     const backfillCursor = getAgentFullSyncCursor(agentName);
     if (cached) restoreAgentCacheMeta(agent, cached);
     let durableCommitted = false;
     try {
-      markAgentFullSyncStarted(agentName);
+      if (!markAgentFullSyncStarted(agentName)) {
+        appLogger.warn("scan.backfill.cache_state_unavailable", {
+          agent: agentName,
+          state: "full_sync_started",
+        });
+      }
       const operation: BackfillScanRefreshOperation =
         agent instanceof FileSystemSessionSource
           ? { kind: "source-backfill", cursor: backfillCursor, checkpoint: "durable" }
@@ -1116,7 +1155,9 @@ export class AgentSyncEngine {
       });
       durableCommitted = publication.durableCommitted;
       this.options.workerRunner.commit?.(agentName);
-      markAgentFullSyncCompleted(agentName);
+      if (!markAgentFullSyncCompleted(agentName)) {
+        appLogger.warn("scan.backfill.completion_not_durable", { agent: agentName });
+      }
       appLogger.info(
         result.sourceFailures?.length ? "scan.backfill.partial" : "scan.backfill.done",
         {
@@ -1151,7 +1192,7 @@ export class AgentSyncEngine {
     const snapshot = this.sessionIndex.snapshot();
     return snapshot.agents.flatMap((agent) => {
       if (!(agent.name in snapshot.byAgent)) return [];
-      const cached = loadCachedSessions(agent.name);
+      const cached = this.readCachedSessionsOrWarn("search.index", agent.name);
       return [
         cached
           ? {

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -33,35 +33,42 @@ const fsWatch = vi.hoisted(() => ({
   }>,
 }));
 
-const core = vi.hoisted(() => ({
-  closeCacheStorage: vi.fn(),
-  createRegisteredAgents: vi.fn(),
-  filterSessions: vi.fn((sessions: SessionHead[], _options: ScanOptions) => sessions),
-  getAgentFullSyncCursor: vi.fn(() => null as string | null),
-  getAgentLastFullSyncAt: vi.fn(),
-  readAgentCacheInitialization: vi.fn(),
-  readAgentLastFullSyncAt: vi.fn(),
-  resolveAgentRoots: vi.fn((): AgentRoots => ({
-    claudecode: "/tmp/claude",
-    codex: "/tmp/codex",
-    cursor: "/tmp/cursor",
-    kimi: "/tmp/kimi",
-    opencode: "/tmp/opencode",
-    pi: "/tmp/pi",
-    zcode: "/tmp/zcode",
-  })),
-  isAgentCacheInitialized: vi.fn(),
-  loadCachedSessions: vi.fn(),
-  markAgentCacheInitialized: vi.fn(),
-  markAgentFullSyncProgress: vi.fn(),
-  markAgentFullSyncStarted: vi.fn(),
-  markAgentFullSyncCompleted: vi.fn(),
-  scanSessions: vi.fn(),
-  saveCachedSessions: vi.fn(),
-  saveCachedSessionChanges: vi.fn(),
-  syncSessionSearchIndex: vi.fn(),
-  syncSessionSearchIndexChanges: vi.fn(),
-}));
+const core = vi.hoisted(() => {
+  const loadCachedSessions = vi.fn();
+  return {
+    readCachedSessions: vi.fn((agentName: string) => ({
+      status: "success" as const,
+      value: loadCachedSessions(agentName),
+    })),
+    closeCacheStorage: vi.fn(),
+    createRegisteredAgents: vi.fn(),
+    filterSessions: vi.fn((sessions: SessionHead[], _options: ScanOptions) => sessions),
+    getAgentFullSyncCursor: vi.fn(() => null as string | null),
+    getAgentLastFullSyncAt: vi.fn(),
+    readAgentCacheInitialization: vi.fn(),
+    readAgentLastFullSyncAt: vi.fn(),
+    resolveAgentRoots: vi.fn((): AgentRoots => ({
+      claudecode: "/tmp/claude",
+      codex: "/tmp/codex",
+      cursor: "/tmp/cursor",
+      kimi: "/tmp/kimi",
+      opencode: "/tmp/opencode",
+      pi: "/tmp/pi",
+      zcode: "/tmp/zcode",
+    })),
+    isAgentCacheInitialized: vi.fn(),
+    loadCachedSessions,
+    markAgentCacheInitialized: vi.fn(),
+    markAgentFullSyncProgress: vi.fn(() => true),
+    markAgentFullSyncStarted: vi.fn(() => true),
+    markAgentFullSyncCompleted: vi.fn(() => true),
+    scanSessions: vi.fn(),
+    saveCachedSessions: vi.fn(),
+    saveCachedSessionChanges: vi.fn(),
+    syncSessionSearchIndex: vi.fn(),
+    syncSessionSearchIndexChanges: vi.fn(),
+  };
+});
 
 const workerThreads = vi.hoisted(() => ({
   deferSearchIndexWorkers: false,
@@ -399,6 +406,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     readAgentCacheInitialization: core.readAgentCacheInitialization,
     readAgentLastFullSyncAt: core.readAgentLastFullSyncAt,
     loadCachedSessions: core.loadCachedSessions,
+    readCachedSessions: core.readCachedSessions,
     markAgentCacheInitialized: core.markAgentCacheInitialized,
     markAgentFullSyncProgress: core.markAgentFullSyncProgress,
     markAgentFullSyncStarted: core.markAgentFullSyncStarted,

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -302,6 +302,7 @@ describe("cache schema boundary", () => {
     expect(Object.keys(schema).sort()).toEqual([
       "runSearchIndexWrite",
       "withCacheDb",
+      "withCacheDbOutcome",
       "withCacheDbReadOnly",
       "withSearchDb",
       "withSearchIndexDb",

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -24,6 +24,7 @@ import {
   markAgentFullSyncCompleted,
   readAgentCacheInitialization,
   readAgentLastFullSyncAt,
+  readCachedSessions,
   saveCachedSessionChanges,
   saveCachedSessions,
 } from "../sessions.js";
@@ -838,6 +839,42 @@ describe("cache initialization tracking", () => {
     markAgentFullSyncCompleted("claudecode");
 
     expect(getAgentLastFullSyncAt("claudecode")).toBe(now);
+  });
+
+  it("distinguishes cached-session read failures from an empty cache", () => {
+    expect(readCachedSessions("claudecode")).toEqual({ status: "success", value: null });
+
+    markAgentCacheInitialized("claudecode");
+    withCacheDb((db) => {
+      db.exec(`
+        DROP TABLE agent_cache;
+        CREATE VIEW agent_cache AS
+          SELECT 'claudecode' AS agent_name, missing_cache_state() AS timestamp;
+      `);
+    });
+    const events: Array<{ event: string }> = [];
+    setCoreDiagnostics({ warn: (event) => events.push({ event }) });
+
+    expect(readCachedSessions("claudecode")).toEqual({ status: "failed" });
+    expect(loadCachedSessions("claudecode")).toBeNull();
+    setCoreDiagnostics(null);
+  });
+
+  it("reports a full-sync cursor write that never reached disk", () => {
+    markAgentCacheInitialized("claudecode");
+    expect(markAgentFullSyncProgress("claudecode", "session-1")).toBe(true);
+
+    withCacheDb((db) => {
+      db.exec(`
+        DROP TABLE cache_meta;
+        CREATE VIEW cache_meta AS SELECT missing_cache_state() AS key, '' AS value;
+      `);
+    });
+    const events: Array<{ event: string }> = [];
+    setCoreDiagnostics({ warn: (event) => events.push({ event }) });
+
+    expect(markAgentFullSyncProgress("claudecode", "session-2")).toBe(false);
+    setCoreDiagnostics(null);
   });
 
   it("records full-sync completion even without a prior initialization row", () => {

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -188,6 +188,19 @@ export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
 
 export type CacheReadOutcome<T> = { status: "success"; value: T } | { status: "failed" };
 
+/**
+ * Like withCacheDb (schema-ensuring, so it can be the first cache touch at
+ * startup and still run migrations) but with an explicit failure outcome
+ * instead of a null that shadows legitimate empty results.
+ */
+export function withCacheDbOutcome<T>(fn: (db: SQLiteDatabase) => T): CacheReadOutcome<T> {
+  let result: CacheReadOutcome<T> = { status: "failed" };
+  withCacheConnection(({ db }) => {
+    result = { status: "success", value: fn(db) };
+  });
+  return result;
+}
+
 export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): CacheReadOutcome<T> {
   const cachePath = getCachePath();
   if (!hasCacheStorage()) return { status: "failed" };

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -17,7 +17,12 @@ import {
   type PersistedSessionHeadChange,
 } from "./db.js";
 import { advanceAnalyticsRevision } from "./analytics-revision.js";
-import { withCacheDb, withCacheDbReadOnly, type CacheReadOutcome } from "./schema.js";
+import {
+  withCacheDb,
+  withCacheDbOutcome,
+  withCacheDbReadOnly,
+  type CacheReadOutcome,
+} from "./schema.js";
 import {
   assertSessionProjectIdentities,
   messageFromCachedRow,
@@ -125,12 +130,16 @@ export function deleteLegacyCacheFile(): void {
   }
 }
 
-export function loadCachedSessions(agentName: string): CachedResult | null {
+/**
+ * Distinguishes "no cache yet" (success with null) from "the database read
+ * failed" so callers can log the degradation instead of silently rescanning.
+ */
+export function readCachedSessions(agentName: string): CacheReadOutcome<CachedResult | null> {
   if (!hasCacheStorage()) {
-    return null;
+    return { status: "success", value: null };
   }
 
-  return withCacheDb((db) => {
+  return withCacheDbOutcome((db) => {
     const timestampRow = db
       .prepare("SELECT timestamp AS value FROM agent_cache WHERE agent_name = ?")
       .get(agentName) as ScalarRow | undefined;
@@ -165,6 +174,11 @@ export function loadCachedSessions(agentName: string): CachedResult | null {
 
     return { sessions, meta, timestamp };
   });
+}
+
+export function loadCachedSessions(agentName: string): CachedResult | null {
+  const outcome = readCachedSessions(agentName);
+  return outcome.status === "success" ? outcome.value : null;
 }
 
 export function loadCachedSessionHeads(
@@ -271,9 +285,12 @@ export function markAgentCacheInitialized(
   });
 }
 
-/** Mark a full-history reconciliation as incomplete until it commits. */
-export function markAgentFullSyncStarted(agentName: string): void {
-  withCacheDb((db) => {
+/**
+ * Mark a full-history reconciliation as incomplete until it commits.
+ * Returns whether the write reached disk, like saveCachedSessions.
+ */
+export function markAgentFullSyncStarted(agentName: string): boolean {
+  const persisted = withCacheDb((db) => {
     db.prepare(
       `
         UPDATE cache_initialization
@@ -281,7 +298,9 @@ export function markAgentFullSyncStarted(agentName: string): void {
         WHERE agent_name = ?
       `,
     ).run(agentName);
+    return true;
   });
+  return persisted ?? false;
 }
 
 /** Return the last durable source position reached by an incomplete full sync. */
@@ -297,11 +316,16 @@ export function getAgentFullSyncCursor(agentName: string): string | null {
   return outcome.status === "success" ? outcome.value : null;
 }
 
-/** Persist a full-sync cursor only after the corresponding checkpoint is durable. */
-export function markAgentFullSyncProgress(agentName: string, cursor: string): void {
-  if (!cursor) return;
+/**
+ * Persist a full-sync cursor only after the corresponding checkpoint is
+ * durable. Returns whether the write reached disk — a dropped cursor means
+ * every restart re-walks the whole history, so callers must not report the
+ * checkpoint as durable on false.
+ */
+export function markAgentFullSyncProgress(agentName: string, cursor: string): boolean {
+  if (!cursor) return true;
 
-  withCacheDb((db) => {
+  const persisted = withCacheDb((db) => {
     db.prepare(
       `
         INSERT INTO cache_meta(key, value)
@@ -309,7 +333,9 @@ export function markAgentFullSyncProgress(agentName: string, cursor: string): vo
         ON CONFLICT(key) DO UPDATE SET value = excluded.value
       `,
     ).run(`${FULL_SYNC_CURSOR_PREFIX}${agentName}`, cursor);
+    return true;
   });
+  return persisted ?? false;
 }
 
 export function readAgentLastFullSyncAt(agentName: string): CacheReadOutcome<number | null> {
@@ -338,10 +364,13 @@ export function getAgentLastFullSyncAt(agentName: string): number | null {
   return outcome.status === "success" ? outcome.value : null;
 }
 
-/** Record that a full (unbounded) history reconciliation just completed for this agent. */
-export function markAgentFullSyncCompleted(agentName: string): void {
+/**
+ * Record that a full (unbounded) history reconciliation just completed for
+ * this agent. Returns whether the write reached disk.
+ */
+export function markAgentFullSyncCompleted(agentName: string): boolean {
   const completedAt = Date.now();
-  withCacheDb((db) => {
+  const persisted = withCacheDb((db) => {
     db.transaction(() => {
       // Upsert: on a fresh cache the initialization row may not exist yet,
       // and a bare UPDATE would silently record nothing (last_sync_at would
@@ -358,7 +387,9 @@ export function markAgentFullSyncCompleted(agentName: string): void {
         `${FULL_SYNC_CURSOR_PREFIX}${agentName}`,
       );
     }).immediate();
+    return true;
   });
+  return persisted ?? false;
 }
 
 function loadCachedSessionEntryBase(

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -28,6 +28,7 @@ export {
   loadCachedSessionDataEntry,
   loadCachedSessionHeads,
   loadCachedSessions,
+  readCachedSessions,
   markAgentCacheInitialized,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -763,7 +763,13 @@ async function scanAgentFull(
       if (persisted !== false) {
         cachePersistence = "persisted";
         markAgentCacheInitialized(agent.name);
-        if (isFullWindow && sourceFailures.length === 0) markAgentFullSyncCompleted(agent.name);
+        if (
+          isFullWindow &&
+          sourceFailures.length === 0 &&
+          !markAgentFullSyncCompleted(agent.name)
+        ) {
+          getCoreDiagnostics()?.warn("cache.full_sync_marker_failed", { agent: agent.name });
+        }
       } else {
         cachePersistence = "failed";
         getCoreDiagnostics()?.warn("cache.save_failed", {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,7 @@ export {
   listFileActivity,
   listModelCostDistribution,
   loadCachedSessions,
+  readCachedSessions,
   loadCachedSessionHeads,
   markAgentCacheInitialized,
   markAgentFullSyncProgress,


### PR DESCRIPTION
## Summary

Fixes CS-267: a locked or corrupt cache database turned into invisible behavior changes because the cache layer swallowed failures on both the write and read side.

- **Write side**: `markAgentFullSyncStarted/Progress/Completed` returned `void`, dropping the `null` that `withCacheConnection` produces on failure. `handleBackfillCheckpoint` then logged `scan.backfill.checkpoint` as if the cursor were durable — a cursor that never advances means every restart re-walks the whole history. All three markers now return `boolean` (like `saveCachedSessions`); the engine logs `scan.backfill.checkpoint_not_durable` / `completion_not_durable` / a started-marker warning instead of pretending the write landed, and the scanner reports `cache.full_sync_marker_failed`.
- **Read side**: `loadCachedSessions` returned `null` for both "no cache row" and "the database read failed". New `readCachedSessions` returns the `CacheReadOutcome` shape already used by `readAgentCacheInitialization`; `loadCachedSessions` stays as the convenience wrapper. It runs through a new `withCacheDbOutcome` helper that keeps the schema-ensuring connection path — the cached-session load is often the first cache touch at startup and must still trigger migrations (a read-only connection broke the legacy-migration suite).
- **Engine reactions**: refresh/backfill/search-index loads log `*.cache_state_unavailable` on read failure instead of silently degrading; `needsBackfill` now returns `false` on a failed read — previously the failure masqueraded as a truncated cache (0 cached sessions) and triggered a full-history backfill against unknown state.

## Testing

- New lifecycle tests: `readCachedSessions` distinguishes an empty cache from a poisoned `agent_cache` table; a cursor write that never reaches disk reports `false`.
- New engine tests: a failed cached-session read does not enqueue a backfill and logs the degradation; a non-durable checkpoint logs `checkpoint_not_durable` instead of the success line.
- Schema-boundary capability list updated for `withCacheDbOutcome`.
- `pnpm typecheck` (core + cli), core 960 tests, cli 526 tests, lint, format:check all green.