### PR TITLE
fix(cli): continue search-index batches past non-fatal job failures

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -318,6 +318,7 @@ const workerThreads = vi.hoisted(() => ({
             context: data?.context ?? "",
             durationMs: 0,
             sessions: jobs.length,
+            failedAgents: [],
           });
         }
       });
@@ -365,6 +366,7 @@ const workerThreads = vi.hoisted(() => ({
             context: workerData?.context ?? "",
             durationMs: 0,
             sessions: workerData?.jobs?.length ?? 0,
+            failedAgents: [],
           });
         }
         for (const handler of exitHandlers) handler(0);
@@ -2623,6 +2625,7 @@ describe("LiveScanStore", () => {
       context: "scan.refresh",
       durationMs: 0,
       sessions: 1,
+      failedAgents: [],
     });
 
     const searchIndexWorkers = workerThreads.workers.filter((worker) => worker.workerData.jobs);
@@ -2646,6 +2649,7 @@ describe("LiveScanStore", () => {
       context: "scan.refresh",
       durationMs: 0,
       sessions: 1,
+      failedAgents: [],
     });
     expect(await outcomes).toEqual([
       { status: "fulfilled", value: undefined },

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -101,7 +101,13 @@ describe("SearchIndexJobRunner", () => {
     workerMocks.consumeWorkerMessage.mockImplementation((message) => message === logMessage);
 
     worker.post(logMessage);
-    worker.post({ type: "done", context: "scan.refresh", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "scan.refresh",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
 
     expect(workerMocks.consumeWorkerMessage).toHaveBeenNthCalledWith(1, logMessage);
     await expect(completion).resolves.toBeUndefined();
@@ -113,7 +119,13 @@ describe("SearchIndexJobRunner", () => {
     const worker = startedWorker();
 
     expect(worker.workerData.pricingGenerationId).toBe(17);
-    worker.post({ type: "done", context: "scan.refresh", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "scan.refresh",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
     await completion;
   });
 
@@ -126,6 +138,7 @@ describe("SearchIndexJobRunner", () => {
       context: "scan.refresh",
       durationMs: 1,
       sessions: 1,
+      failedAgents: [],
     });
 
     await expect(completion).resolves.toBeUndefined();
@@ -135,7 +148,13 @@ describe("SearchIndexJobRunner", () => {
     const runner = new SearchIndexJobRunner();
     const first = runner.enqueue("scan.refresh", [makeJob()]);
     const worker = startedWorker();
-    worker.post({ type: "done", context: "scan.refresh", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "scan.refresh",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
     await first;
 
     const second = runner.enqueue("scan.refresh", [makeJob()]);
@@ -144,7 +163,13 @@ describe("SearchIndexJobRunner", () => {
     expect(worker.postedMessages).toEqual([
       expect.objectContaining({ context: "scan.refresh", pricingGenerationId: 17 }),
     ]);
-    worker.post({ type: "done", context: "scan.refresh", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "scan.refresh",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
     await second;
   });
 
@@ -157,14 +182,26 @@ describe("SearchIndexJobRunner", () => {
 
     expect(started).toEqual(["first"]);
 
-    worker.post({ type: "done", context: "first-refresh", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "first-refresh",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
     await first;
 
     expect(started).toEqual(["first", "second"]);
     expect(worker.postedMessages).toEqual([
       expect.objectContaining({ context: "second-refresh", pricingGenerationId: 17 }),
     ]);
-    worker.post({ type: "done", context: "second-refresh", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "second-refresh",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
     await second;
   });
 
@@ -177,18 +214,36 @@ describe("SearchIndexJobRunner", () => {
     ]);
     const foreground = runner.enqueue("scan.backfill", [makeJob()]);
 
-    worker.post({ type: "done", context: "maintenance-one", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "maintenance-one",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
     await firstMaintenance;
     expect(worker.postedMessages).toEqual([expect.objectContaining({ context: "scan.backfill" })]);
 
-    worker.post({ type: "done", context: "scan.backfill", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "scan.backfill",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
     await foreground;
     expect(worker.postedMessages).toEqual([
       expect.objectContaining({ context: "scan.backfill" }),
       expect.objectContaining({ context: "maintenance-two" }),
     ]);
 
-    worker.post({ type: "done", context: "maintenance-two", durationMs: 1, sessions: 1 });
+    worker.post({
+      type: "done",
+      context: "maintenance-two",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
     await secondMaintenance;
   });
 
@@ -203,9 +258,35 @@ describe("SearchIndexJobRunner", () => {
       publicationId: "scan.refresh:codex:1",
       agentName: "codex",
       sessions: 1,
+      fatal: true,
     });
 
     await expect(completion).rejects.toThrow(/failed to persist cache for codex/);
+  });
+
+  it("resolves a batch whose non-fatal failures were reported per agent", async () => {
+    const runner = new SearchIndexJobRunner();
+    const completion = runner.enqueue("scan.initial", [makeJob()]);
+
+    const worker = startedWorker();
+    worker.post({
+      type: "persist-failed",
+      context: "scan.initial",
+      stage: "search_index",
+      publicationId: "generated",
+      agentName: "codex",
+      sessions: 1,
+      fatal: false,
+    });
+    worker.post({
+      type: "done",
+      context: "scan.initial",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: ["codex"],
+    });
+
+    await expect(completion).resolves.toBeUndefined();
   });
 
   it("rejects the batch when the search-index worker is unavailable", async () => {

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -176,16 +176,27 @@ export class SearchIndexJobRunner {
           agent: message.agentName,
           sessions: message.sessions,
         });
-        this.finishBatch(
-          activeBatch,
-          new Error(
-            `Search index worker failed to persist ${message.stage} for ${message.agentName}`,
-          ),
-        );
+        // Non-fatal failures keep the batch running: the worker continues
+        // with the remaining agents and reports them in the done message.
+        if (message.fatal) {
+          this.finishBatch(
+            activeBatch,
+            new Error(
+              `Search index worker failed to persist ${message.stage} for ${message.agentName}`,
+            ),
+          );
+        }
         return;
       }
       if (message.type !== "done") return;
 
+      if (message.failedAgents.length > 0) {
+        appLogger.warn("search_index.batch_partial", {
+          batch_id: activeBatch.id,
+          context: message.context,
+          failed_agents: message.failedAgents,
+        });
+      }
       appLogger.info(`${message.context}.done`, {
         duration_ms: Math.round(message.durationMs),
         sessions: message.sessions,

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -163,14 +163,18 @@ describe("search index worker", () => {
 
     await runWorker();
 
-    expect(mocks.postMessage).toHaveBeenCalledExactlyOnceWith(
+    expect(mocks.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "persist-failed",
         context: "scan.refresh",
         stage: "prepare",
         agentName: "unknown",
         sessions: 1,
+        fatal: false,
       }),
+    );
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", failedAgents: ["unknown"] }),
     );
   });
 
@@ -430,14 +434,18 @@ describe("search index worker", () => {
 
     await runWorker();
 
-    expect(mocks.postMessage).toHaveBeenCalledExactlyOnceWith({
+    expect(mocks.postMessage).toHaveBeenCalledWith({
       type: "persist-failed",
       context: "scan.refresh",
       stage: "cache",
       publicationId: "publication-cache-failure",
       agentName: "codex",
       sessions: 1,
+      fatal: false,
     });
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", failedAgents: ["codex"] }),
+    );
   });
 
   it("CS-137: reports a failed index write and skips the remaining jobs", async () => {
@@ -481,20 +489,91 @@ describe("search index worker", () => {
 
     expect(mocks.markAgentCacheInitialized).not.toHaveBeenCalled();
     expect(mocks.commitDurableSessionPublication).toHaveBeenCalledOnce();
-    expect(mocks.postMessage).toHaveBeenCalledExactlyOnceWith({
+    expect(mocks.postMessage).toHaveBeenCalledWith({
       type: "persist-failed",
       context: "scan.refresh",
       stage: "search_index",
       publicationId: "publication-search-failure",
       agentName: "codex",
       sessions: 2,
+      fatal: false,
     });
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", failedAgents: ["codex"] }),
+    );
     expect(mocks.appLoggerError).toHaveBeenCalledWith(
       "search_index.persist_failed",
       expect.objectContaining({
         stage: "search_index",
         publication_id: "publication-search-failure",
       }),
+    );
+  });
+
+  it("continues with the remaining agents after one fails", async () => {
+    const codex = { ...makeAgent(), name: "codex" };
+    const kimi = { ...makeAgent(), name: "kimi" };
+    mocks.createRegisteredAgents.mockReturnValue([codex, kimi]);
+    mocks.syncSessionSearchIndex
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({ indexed: 1, skipped: 0 });
+    const fullJob = (agentName: string) => ({
+      kind: "full",
+      context: "scan.initial",
+      agentName,
+      sessions: [{ id: `${agentName}-s1` }],
+      meta: {},
+      completeness: "complete",
+      removedSessionIds: [],
+    });
+    mocks.workerData = {
+      context: "scan.initial",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [fullJob("codex"), fullJob("kimi")],
+    };
+
+    await runWorker();
+
+    expect(mocks.syncSessionSearchIndex).toHaveBeenCalledTimes(2);
+    expect(mocks.postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "done", failedAgents: ["codex"] }),
+    );
+  });
+
+  it("aborts the batch when a durable session publication fails", async () => {
+    const agent = makeAgent();
+    mocks.createRegisteredAgents.mockReturnValue([agent]);
+    mocks.commitDurableSessionPublication.mockReturnValue({
+      status: "rolled-back",
+      publicationId: "scan.refresh:codex:1",
+      stage: "search_index",
+    });
+    mocks.workerData = {
+      context: "scan.refresh",
+      agentNames: [],
+      sessionsByAgent: {},
+      metaByAgent: {},
+      jobs: [
+        {
+          kind: "full",
+          context: "scan.refresh",
+          agentName: "codex",
+          sessions: [{ id: "s1" }],
+          meta: {},
+          completeness: "complete",
+          removedSessionIds: [],
+          publicationId: "scan.refresh:codex:1",
+          saveCache: true,
+        },
+      ],
+    };
+
+    await runWorker();
+
+    expect(mocks.postMessage).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ type: "persist-failed", fatal: true }),
     );
   });
 });

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -34,12 +34,15 @@ export type SearchIndexWorkerMessage =
       publicationId: string;
       agentName: string;
       sessions: number;
+      /** True when the job carries a durable publication whose staged state must be rolled back. */
+      fatal: boolean;
     }
   | {
       type: "done";
       context: string;
       durationMs: number;
       sessions: number;
+      failedAgents: string[];
     };
 
 export type SearchIndexWorkerJob =
@@ -125,6 +128,7 @@ function reportPersistFailure(
     publicationId: failure.publicationId,
     agentName: job.agentName,
     sessions: jobSessionCount(job),
+    fatal: jobIsDurablePublication(job),
   } satisfies SearchIndexWorkerMessage);
 }
 
@@ -216,6 +220,10 @@ function postSyncResult(context: string, result: SearchIndexSyncResult): void {
 
 let pricingGenerationId: number | null = null;
 
+function jobIsDurablePublication(job: SearchIndexWorkerJob): boolean {
+  return job.kind !== "maintenance" && job.publicationId != null;
+}
+
 function jobsFromRequest(request: SearchIndexWorkerRunRequest): SearchIndexWorkerJob[] {
   if (request.jobs) return request.jobs;
   return (request.agentNames ?? []).map((agentName): SearchIndexWorkerJob => ({
@@ -238,7 +246,11 @@ function runBatch(request: SearchIndexWorkerRunRequest): void {
   const agents = createRegisteredAgents();
   const jobs = jobsFromRequest(request);
 
+  const failedAgents = new Set<string>();
   for (const job of jobs) {
+    // Later chunks for an agent whose earlier job failed would commit on top
+    // of unknown state; other agents' jobs are independent and keep going.
+    if (failedAgents.has(job.agentName)) continue;
     const agent = agents.find((item) => item.name === job.agentName);
     if (!agent) {
       reportPersistFailure(job, {
@@ -246,7 +258,11 @@ function runBatch(request: SearchIndexWorkerRunRequest): void {
         publicationId:
           job.kind === "maintenance" ? randomUUID() : (job.publicationId ?? randomUUID()),
       });
-      return;
+      // A session publication must reject the whole batch so its staged
+      // state gets rolled back by the caller.
+      if (jobIsDurablePublication(job)) return;
+      failedAgents.add(job.agentName);
+      continue;
     }
 
     if (agent.setSessionMetaMap) {
@@ -256,7 +272,8 @@ function runBatch(request: SearchIndexWorkerRunRequest): void {
     const failure = runJob(job, agent);
     if (failure) {
       reportPersistFailure(job, failure);
-      return;
+      if (jobIsDurablePublication(job)) return;
+      failedAgents.add(job.agentName);
     }
   }
 
@@ -265,6 +282,7 @@ function runBatch(request: SearchIndexWorkerRunRequest): void {
     context: request.context,
     durationMs: performance.now() - startedAt,
     sessions: jobs.reduce((total, job) => total + jobSessionCount(job), 0),
+    failedAgents: [...failedAgents],
   } satisfies SearchIndexWorkerMessage);
 }
 


### PR DESCRIPTION
## Summary

Fixes CS-268: `runBatch` in the search-index worker returned on the first failing job, so when `syncInitialIndex` submitted one job per agent as a single startup batch, a single agent that failed to index suppressed initial indexing for every remaining agent — and the skipped agents never got their `searchIndexMaintenance` enqueue either, leaving search stale until a later background refresh happened to re-enqueue them.

- The worker now records per-job failures and keeps going. Later chunks for an agent whose earlier job already failed are skipped (preserving the CS-137 decision that follow-up chunks must not commit on top of unknown state); other agents' jobs are independent and run to completion.
- A durable session publication (a job carrying an explicit `publicationId`) still hard-aborts the batch: the `persist-failed` message gains a `fatal` flag and the job runner keeps rejecting those batches so the caller rolls the staged publication back.
- The `done` message now carries `failedAgents`; the job runner logs `search_index.batch_partial` with the list and resolves the batch, so a partial batch is visible without punishing the agents that succeeded.

## Testing

- New worker tests: a failed agent does not stop the remaining agents (per-agent `syncSessionSearchIndex` still runs); a durable publication failure posts `fatal: true` and no `done`.
- Updated CS-137 tests: same-agent follow-up chunks stay skipped, and the batch now finishes with the failure flagged instead of aborting silently.
- New runner test: a batch with only non-fatal failures resolves; the fatal path still rejects.
- `pnpm typecheck`, cli 529 tests, lint, format:check all green.