### PR TITLE
fix(api): validate agent keys on bookmark and alias writes

### DIFF
--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -322,6 +322,46 @@ describe("bookmark handlers", () => {
     expect(coreMocks.upsertBookmark).not.toHaveBeenCalled();
   });
 
+  it("rejects writes referencing agents that do not exist", async () => {
+    const put = makeContext({ body: { reference: { agentName: "ghost", sessionId: "s1" } } });
+    await handlePutBookmark(put as never);
+    expect(put.json).toHaveBeenCalledWith({ error: "Unknown agent: ghost" }, 400);
+    expect(coreMocks.upsertBookmark).not.toHaveBeenCalled();
+
+    const del = makeContext({ param: { agent: "ghost", id: "s1" } });
+    await handleDeleteBookmark(del as never);
+    expect(del.json).toHaveBeenCalledWith({ error: "Unknown agent: ghost" }, 400);
+    expect(coreMocks.deleteBookmark).not.toHaveBeenCalled();
+
+    const putAlias = makeContext({
+      param: { agent: "ghost", id: "s1" },
+      body: { alias: "renamed" },
+    });
+    await handlePutSessionAlias(putAlias as never);
+    expect(putAlias.json).toHaveBeenCalledWith({ error: "Unknown agent: ghost" }, 400);
+    expect(coreMocks.upsertSessionAlias).not.toHaveBeenCalled();
+
+    const delAlias = makeContext({ param: { agent: "ghost", id: "s1" } });
+    await handleDeleteSessionAlias(delAlias as never);
+    expect(delAlias.json).toHaveBeenCalledWith({ error: "Unknown agent: ghost" }, 400);
+    expect(coreMocks.deleteSessionAlias).not.toHaveBeenCalled();
+  });
+
+  it("skips unknown agents in bookmark imports and reports the count", async () => {
+    const mixed = makeContext({
+      body: [storedBookmark, { reference: { agentName: "ghost", sessionId: "s9" } }],
+    });
+
+    await handleImportBookmarks(mixed as never, bookmarkScanSource);
+
+    expect(coreMocks.importBookmarks).toHaveBeenCalledWith([storedBookmark]);
+    expect(mixed.json).toHaveBeenCalledWith({
+      bookmarks: [availableBookmark],
+      storageAvailable: true,
+      skippedUnknownAgents: 1,
+    });
+  });
+
   it("stores only identity from current and legacy snapshot payloads", async () => {
     const current = makeContext({
       body: { reference: validReference, session: { stale: true }, bookmarkedAt: 99 },

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -958,10 +958,22 @@ export function handleGetBookmarks(c: Context, scanSource: ScanResultSource) {
   );
 }
 
+/**
+ * Write endpoints must reject unknown agents: rows for agents that do not
+ * exist accumulate in state.db forever — materialization filters on the known
+ * set, so they are never visible and never garbage-collected.
+ */
+function isKnownAgentKey(agentKey: string): boolean {
+  return KNOWN_AGENT_NAME_SET.has(agentKey.trim().toLowerCase());
+}
+
 export async function handlePutBookmark(c: Context) {
   const payload = parseBookmarkReference(await c.req.json().catch(() => null));
   if (!payload) {
     return c.json({ error: "Invalid bookmark payload" }, 400);
+  }
+  if (!isKnownAgentKey(payload.agentName)) {
+    return c.json({ error: `Unknown agent: ${payload.agentName}` }, 400);
   }
 
   return withStorageErrors(
@@ -976,19 +988,28 @@ export async function handleImportBookmarks(c: Context, scanSource: ScanResultSo
     return c.json({ error: "Invalid bookmark payload" }, 400);
   }
 
-  const bookmarks = payload
+  const parsed = payload
     .map((entry) => parseBookmarkImport(entry))
     .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 
-  if (bookmarks.length !== payload.length) {
+  if (parsed.length !== payload.length) {
     return c.json({ error: "Invalid bookmark payload" }, 400);
   }
+
+  // Legacy exports may reference agents this build no longer knows; skip them
+  // (reporting the count) instead of rejecting the rest of the import.
+  const bookmarks = parsed.filter((entry) => isKnownAgentKey(entry.reference.agentName));
+  const skippedUnknownAgents = parsed.length - bookmarks.length;
 
   return withStorageErrors(
     () => {
       const imported = importBookmarks(bookmarks);
       const views = materializeStoredBookmarks(scanSource, imported, loadAliasView());
-      return c.json({ bookmarks: views, storageAvailable: true });
+      return c.json({
+        bookmarks: views,
+        storageAvailable: true,
+        ...(skippedUnknownAgents > 0 ? { skippedUnknownAgents } : {}),
+      });
     },
     () => c.json({ error: "Bookmark storage is unavailable" }, 503),
   );
@@ -999,6 +1020,9 @@ export function handleDeleteBookmark(c: Context) {
   const sessionId = c.req.param("id");
   if (!agentKey || !sessionId) {
     return c.json({ error: "Missing bookmark identifier" }, 400);
+  }
+  if (!isKnownAgentKey(agentKey)) {
+    return c.json({ error: `Unknown agent: ${agentKey}` }, 400);
   }
 
   return withStorageErrors(
@@ -1017,6 +1041,9 @@ export async function handlePutSessionAlias(c: Context) {
   const aliasValue = payload?.alias;
   if (!agentKey || !sessionId || typeof aliasValue !== "string") {
     return c.json({ error: "Invalid session alias payload" }, 400);
+  }
+  if (!isKnownAgentKey(agentKey)) {
+    return c.json({ error: `Unknown agent: ${agentKey}` }, 400);
   }
 
   try {
@@ -1041,6 +1068,9 @@ export function handleDeleteSessionAlias(c: Context) {
   const sessionId = c.req.param("id");
   if (!agentKey || !sessionId) {
     return c.json({ error: "Missing session alias identifier" }, 400);
+  }
+  if (!isKnownAgentKey(agentKey)) {
+    return c.json({ error: `Unknown agent: ${agentKey}` }, 400);
   }
 
   return withStorageErrors(


### PR DESCRIPTION
## Summary

Fixes CS-269: the state-mutating endpoints accepted any non-empty `agent` value while every read endpoint validates through `parseAgentFilter`. Rows referencing agents that do not exist accumulated in `state.db` (`bookmarks`, `session_aliases`) forever — materialization filters on the known-agent set, so those rows were never visible and never garbage-collected: silent unbounded local state that can never resolve back to a session.

- `handlePutBookmark`, `handleDeleteBookmark`, `handlePutSessionAlias`, and `handleDeleteSessionAlias` now check the (already computed) `KNOWN_AGENT_NAME_SET` and return 400 with `Unknown agent: <key>` for anything outside it.
- `POST /bookmarks/import` skips entries referencing unknown agents instead of rejecting the whole batch — legacy exports may reference agents a build no longer ships — and reports an additive `skippedUnknownAgents` count in the response. Malformed entries still reject the batch as before.

## Testing

- New tests: all four write endpoints return 400 for an unknown agent without touching storage; an import mixing a known and an unknown agent stores only the known one and reports `skippedUnknownAgents: 1`.
- `pnpm typecheck`, cli 531 tests, lint, format:check all green.