### PR TITLE
perf(cache): index sessions by bare activity time

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 25`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 26`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 25;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 26;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -100,7 +100,7 @@ describe("cache schema boundary", () => {
         "publication_id",
       ]),
     );
-    expect(state?.version).toBe(25);
+    expect(state?.version).toBe(26);
   });
 
   it("removes the legacy message FTS objects when upgrading schema 23", () => {
@@ -141,7 +141,7 @@ describe("cache schema boundary", () => {
       ),
     }));
 
-    expect(migrated).toEqual({ objects: [], version: 25 });
+    expect(migrated).toEqual({ objects: [], version: 26 });
   });
 
   it("adds an empty hash chain column when upgrading schema 24", () => {
@@ -170,7 +170,7 @@ describe("cache schema boundary", () => {
       ).content_chain_digest,
     }));
 
-    expect(migrated).toEqual({ version: 25, digest: null });
+    expect(migrated).toEqual({ version: 26, digest: null });
   });
 
   it("reuses one connection for read and write capabilities until invalidated", () => {
@@ -340,7 +340,7 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 25, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 26, detailVersion: "", pending: true });
   });
 
   it("marks legacy project identities stale by leaving added provenance empty", () => {
@@ -379,7 +379,7 @@ describe("cache schema boundary", () => {
     });
 
     expect(migrated).toEqual({
-      version: 25,
+      version: 26,
       resolverRevision: null,
       inputSignature: null,
       classifierRevision: null,
@@ -449,7 +449,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 25,
+        version: 26,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -1360,7 +1360,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(25);
+    expect(getUserVersion(getCachePath())).toBe(26);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -2153,7 +2153,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(25);
+    expect(getUserVersion(getCachePath())).toBe(26);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -258,7 +258,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(25);
+    expect(getUserVersion(getCachePath())).toBe(26);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -269,7 +269,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(25);
+    expect(getUserVersion(getCachePath())).toBe(26);
   });
 });
 
@@ -277,7 +277,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(25);
+    expect(getUserVersion(getCachePath())).toBe(26);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -553,7 +553,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(25);
+    expect(getUserVersion(getCachePath())).toBe(26);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -613,7 +613,7 @@ describe("saveCachedSessions", () => {
 
     try {
       expect(loadCachedSessions("claudecode")?.sessions).toEqual([]);
-      expect(getUserVersion(getCachePath())).toBe(25);
+      expect(getUserVersion(getCachePath())).toBe(26);
       expect(warnings).toContainEqual({
         event: "sqlite.migration.identity_precompute.missing_directory",
         detail: { agent_name: "claudecode", session_id: "legacy-null-directory" },
@@ -839,6 +839,28 @@ describe("cache initialization tracking", () => {
     markAgentFullSyncCompleted("claudecode");
 
     expect(getAgentLastFullSyncAt("claudecode")).toBe(now);
+  });
+
+  it("CS-271: plans the unfiltered recent-session query from the activity index", () => {
+    markAgentCacheInitialized("claudecode");
+
+    const plan = withCacheDb((db) =>
+      db
+        .prepare(
+          `
+            EXPLAIN QUERY PLAN
+            SELECT * FROM sessions s
+            WHERE s.publication_id IS NULL
+            ORDER BY s.activity_time DESC
+            LIMIT ?
+          `,
+        )
+        .all(50),
+    ) as Array<{ detail: string }>;
+
+    const details = plan.map((row) => row.detail).join("\n");
+    expect(details).toContain("idx_sessions_activity");
+    expect(details).not.toContain("TEMP B-TREE");
   });
 
   it("distinguishes cached-session read failures from an empty cache", () => {

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -339,6 +339,9 @@ function createSessionTables(db: SQLiteDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_sessions_agent_activity_order
       ON sessions(agent_name, activity_time DESC, session_id);
 
+    CREATE INDEX IF NOT EXISTS idx_sessions_activity
+      ON sessions(activity_time DESC, agent_name, session_id);
+
     CREATE INDEX IF NOT EXISTS idx_sessions_project
       ON sessions(project_identity_kind, project_identity_key, activity_time);
 
@@ -1165,6 +1168,19 @@ function replaceSessionActivityIndex(db: SQLiteDatabase): void {
   `);
 }
 
+/**
+ * The unfiltered "recent sessions" query orders by bare activity_time; every
+ * existing index leads with agent_name, so the planner fell back to a full
+ * scan plus a temp B-tree sort (verified via EXPLAIN QUERY PLAN, CS-271).
+ */
+function addSessionActivityIndex(db: SQLiteDatabase): void {
+  if (!tableExists(db, "sessions")) return;
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_sessions_activity
+      ON sessions(activity_time DESC, agent_name, session_id)
+  `);
+}
+
 function compactSessionDocuments(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents")) {
     createSearchTables(db);
@@ -1500,6 +1516,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 23, migrate: replaceSessionActivityIndex },
       { version: 24, migrate: dropLegacyMessageSearchIndex },
       { version: 25, migrate: addMessageContentChainDigest },
+      { version: 26, migrate: addSessionActivityIndex },
     ],
   });
 

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 25;
+export const CACHE_SCHEMA_VERSION = 26;


### PR DESCRIPTION
## Summary

Fixes CS-271: the empty-query branch of `searchSessions` — the search UI's default "recent sessions" state — runs `ORDER BY s.activity_time DESC LIMIT 50`, but every existing index leads with `agent_name`, `project_identity_*`, or `parent_*`. With no agent/project filter SQLite planned a full table scan plus a temp B-tree sort, so the cost of opening search grew linearly with total session count.

Verified with `EXPLAIN QUERY PLAN` before committing to the fix (per the repo's klip-0 precedent):
- before: `SCAN s` + `USE TEMP B-TREE FOR ORDER BY`
- after: `SCAN s USING INDEX idx_sessions_activity` (streams the LIMIT rows in index order)
- agent-filtered queries still choose `idx_sessions_agent_activity_order` — no regression.

Changes: `idx_sessions_activity ON sessions(activity_time DESC, agent_name, session_id)` added to the base DDL and as schema migration 26 (`CACHE_SCHEMA_VERSION` 25 → 26), following the `replaceSessionActivityIndex` precedent. Cost is write amplification on session upsert plus a slightly larger DB file.

## Testing

- New guard test asserts the recent-session query plan uses `idx_sessions_activity` and contains no temp B-tree.
- Schema-version pins updated across migration/search/lifecycle suites; `pnpm test:migration` (13) green.
- `pnpm typecheck` (core + cli), core 961 tests, cli 531 tests, lint, format:check all green.