### PR TITLE
perf(cache): aggregate dashboard model cost from a per-session rollup

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 26`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 27`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 26;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 27;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
@@ -127,4 +127,14 @@ describe("listModelCostDistribution", () => {
   it("returns null when no cache database exists", () => {
     expect(listModelCostDistribution()).toBeNull();
   });
+
+  it("drops a removed session's rollup rows from the distribution", () => {
+    seedFixture();
+    expect(listModelCostDistribution({ agent: "codex" })).not.toEqual([]);
+
+    // A complete empty snapshot removes every codex session and its rollup.
+    saveCachedSessions("codex", []);
+
+    expect(listModelCostDistribution({ agent: "codex" })).toEqual([]);
+  });
 });

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -100,7 +100,7 @@ describe("cache schema boundary", () => {
         "publication_id",
       ]),
     );
-    expect(state?.version).toBe(26);
+    expect(state?.version).toBe(27);
   });
 
   it("removes the legacy message FTS objects when upgrading schema 23", () => {
@@ -141,7 +141,7 @@ describe("cache schema boundary", () => {
       ),
     }));
 
-    expect(migrated).toEqual({ objects: [], version: 26 });
+    expect(migrated).toEqual({ objects: [], version: 27 });
   });
 
   it("adds an empty hash chain column when upgrading schema 24", () => {
@@ -170,7 +170,7 @@ describe("cache schema boundary", () => {
       ).content_chain_digest,
     }));
 
-    expect(migrated).toEqual({ version: 26, digest: null });
+    expect(migrated).toEqual({ version: 27, digest: null });
   });
 
   it("reuses one connection for read and write capabilities until invalidated", () => {
@@ -340,7 +340,7 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 26, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 27, detailVersion: "", pending: true });
   });
 
   it("marks legacy project identities stale by leaving added provenance empty", () => {
@@ -379,7 +379,7 @@ describe("cache schema boundary", () => {
     });
 
     expect(migrated).toEqual({
-      version: 26,
+      version: 27,
       resolverRevision: null,
       inputSignature: null,
       classifierRevision: null,
@@ -449,7 +449,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 26,
+        version: 27,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -1360,7 +1360,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(26);
+    expect(getUserVersion(getCachePath())).toBe(27);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -2153,7 +2153,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(26);
+    expect(getUserVersion(getCachePath())).toBe(27);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -258,7 +258,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(26);
+    expect(getUserVersion(getCachePath())).toBe(27);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -269,7 +269,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(26);
+    expect(getUserVersion(getCachePath())).toBe(27);
   });
 });
 
@@ -277,7 +277,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(26);
+    expect(getUserVersion(getCachePath())).toBe(27);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -553,7 +553,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(26);
+    expect(getUserVersion(getCachePath())).toBe(27);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -613,7 +613,7 @@ describe("saveCachedSessions", () => {
 
     try {
       expect(loadCachedSessions("claudecode")?.sessions).toEqual([]);
-      expect(getUserVersion(getCachePath())).toBe(26);
+      expect(getUserVersion(getCachePath())).toBe(27);
       expect(warnings).toContainEqual({
         event: "sqlite.migration.identity_precompute.missing_directory",
         detail: { agent_name: "claudecode", session_id: "legacy-null-directory" },

--- a/packages/core/src/discovery/cache/model-cost.ts
+++ b/packages/core/src/discovery/cache/model-cost.ts
@@ -64,14 +64,17 @@ function buildModelCostWhere(options: ModelCostOptions): {
  * Sub-session messages are included on purpose: a parent's cost is defined to
  * cover its whole subtree. An unset `cost_source` counts as estimated, so
  * `costRecorded + costEstimated === cost` always holds.
+ *
+ * Reads the per-(session, model) rollup maintained alongside message writes
+ * (CS-270) — sessions×models rows instead of a full messages-table scan.
  */
 const MODEL_COST_SQL = `
   SELECT
     m.model AS model,
-    SUM(COALESCE(m.cost, 0)) AS cost,
-    SUM(CASE WHEN m.cost_source = 'recorded' THEN COALESCE(m.cost, 0) ELSE 0 END) AS cost_recorded,
-    SUM(CASE WHEN m.cost_source = 'recorded' THEN 0 ELSE COALESCE(m.cost, 0) END) AS cost_estimated
-  FROM messages m
+    SUM(m.cost) AS cost,
+    SUM(m.cost_recorded) AS cost_recorded,
+    SUM(m.cost - m.cost_recorded) AS cost_estimated
+  FROM session_model_cost m
   JOIN sessions s
     ON s.agent_name = m.agent_name
     AND s.session_id = m.session_id

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -380,7 +380,29 @@ function createSessionTables(db: SQLiteDatabase): void {
       ON messages(agent_name, session_id, message_index);
   `);
 
+  createSessionModelCostTable(db);
   createMessageToolTables(db);
+}
+
+/**
+ * Per-(session, model) cost rollup maintained in the same transaction that
+ * writes message rows, so dashboard model-cost aggregation reads
+ * sessions×models rows instead of scanning the full messages table (CS-270).
+ */
+function createSessionModelCostTable(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_model_cost (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      cost REAL NOT NULL,
+      cost_recorded REAL NOT NULL,
+      PRIMARY KEY (agent_name, session_id, model),
+      FOREIGN KEY (agent_name, session_id)
+        REFERENCES sessions(agent_name, session_id)
+        ON DELETE CASCADE
+    );
+  `);
 }
 
 function createMessageToolTables(db: SQLiteDatabase): void {
@@ -1181,6 +1203,23 @@ function addSessionActivityIndex(db: SQLiteDatabase): void {
   `);
 }
 
+function addSessionModelCostRollup(db: SQLiteDatabase): void {
+  createSessionModelCostTable(db);
+  if (!tableExists(db, "messages")) return;
+  db.exec(`
+    INSERT OR REPLACE INTO session_model_cost(agent_name, session_id, model, cost, cost_recorded)
+    SELECT
+      agent_name,
+      session_id,
+      model,
+      SUM(COALESCE(cost, 0)),
+      SUM(CASE WHEN cost_source = 'recorded' THEN COALESCE(cost, 0) ELSE 0 END)
+    FROM messages
+    WHERE model IS NOT NULL AND model <> ''
+    GROUP BY agent_name, session_id, model
+  `);
+}
+
 function compactSessionDocuments(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents")) {
     createSearchTables(db);
@@ -1517,6 +1556,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 24, migrate: dropLegacyMessageSearchIndex },
       { version: 25, migrate: addMessageContentChainDigest },
       { version: 26, migrate: addSessionActivityIndex },
+      { version: 27, migrate: addSessionModelCostRollup },
     ],
   });
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -486,6 +486,23 @@ function writeSearchIndexRows(
   const deleteFileActivity = db.prepare(
     "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
   );
+  const deleteModelCost = db.prepare(
+    "DELETE FROM session_model_cost WHERE agent_name = ? AND session_id = ?",
+  );
+  // Derived from the message rows just written, in the same transaction, so
+  // the rollup can never drift from its source (CS-270).
+  const rebuildModelCost = db.prepare(`
+    INSERT INTO session_model_cost(agent_name, session_id, model, cost, cost_recorded)
+    SELECT
+      agent_name,
+      session_id,
+      model,
+      SUM(COALESCE(cost, 0)),
+      SUM(CASE WHEN cost_source = 'recorded' THEN COALESCE(cost, 0) ELSE 0 END)
+    FROM messages
+    WHERE agent_name = ? AND session_id = ? AND model IS NOT NULL AND model <> ''
+    GROUP BY agent_name, session_id, model
+  `);
   const writeIndexedSession = prepareUpsertIndexedSession(db);
   const insertFileActivity = prepareInsertFileActivity(db);
   const insertMessageTool = prepareInsertMessageTool(db);
@@ -566,6 +583,7 @@ function writeSearchIndexRows(
     deleteFileActivity.run(agentName, sessionId);
     deleteMessageTools.run(agentName, sessionId, 0);
     deleteMessages.run(agentName, sessionId, 0);
+    deleteModelCost.run(agentName, sessionId);
     clearPendingReindex.run(agentName, sessionId);
   }
 
@@ -622,6 +640,8 @@ function writeSearchIndexRows(
       }
     }
     deleteMessages.run(agentName, entry.session.id, entry.messages.length);
+    deleteModelCost.run(agentName, entry.session.id);
+    rebuildModelCost.run(agentName, entry.session.id);
     upsertRow.run(
       agentName,
       entry.session.id,

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -622,6 +622,9 @@ export function writeCachedSessionSnapshot(
     "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
   );
   const deleteMessages = db.prepare("DELETE FROM messages WHERE agent_name = ? AND session_id = ?");
+  const deleteModelCost = db.prepare(
+    "DELETE FROM session_model_cost WHERE agent_name = ? AND session_id = ?",
+  );
   const deleteMessageTools = db.prepare(
     "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ?",
   );
@@ -652,6 +655,7 @@ export function writeCachedSessionSnapshot(
     deleteSearchDocument.run(agentName, sessionId);
     deleteMessageTools.run(agentName, sessionId);
     deleteMessages.run(agentName, sessionId);
+    deleteModelCost.run(agentName, sessionId);
     deleteFileActivity.run(agentName, sessionId);
     deleteSession.run(agentName, sessionId);
   }
@@ -710,6 +714,9 @@ export function writeCachedSessionChanges(
     "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
   );
   const deleteMessages = db.prepare("DELETE FROM messages WHERE agent_name = ? AND session_id = ?");
+  const deleteModelCost = db.prepare(
+    "DELETE FROM session_model_cost WHERE agent_name = ? AND session_id = ?",
+  );
   const deleteMessageTools = db.prepare(
     "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ?",
   );
@@ -729,6 +736,7 @@ export function writeCachedSessionChanges(
     deleteSearchDocument.run(agentName, sessionId);
     deleteMessageTools.run(agentName, sessionId);
     deleteMessages.run(agentName, sessionId);
+    deleteModelCost.run(agentName, sessionId);
     deleteFileActivity.run(agentName, sessionId);
     deleteSession.run(agentName, sessionId);
   }
@@ -772,6 +780,7 @@ export function clearCache(): void {
         DELETE FROM session_file_activity;
         DELETE FROM message_tools;
         DELETE FROM messages;
+        DELETE FROM session_model_cost;
         DELETE FROM sessions;
         DELETE FROM project_sessions;
         -- analytics_revision is an invalidation counter, not cached data.

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 26;
+export const CACHE_SCHEMA_VERSION = 27;


### PR DESCRIPTION
## Summary

Fixes CS-270: `MODEL_COST_SQL` joined the entire `messages` table (the largest table, no message-side predicate, no usable index) to produce ≤20 rows. CS-248/#385 added a result cache, but its key rolls on every scan-driven snapshot swap and index publication, so live instances re-paid the full scan constantly.

Measured before committing to the fix (per the issue's stage-1 gate): on 200k synthetic message rows the aggregation costs ~138 ms per cold run (plan: `SCAN messages` + per-row session probe + two temp B-trees) and grows linearly with message count. The rollup query on the equivalent 10k rollup rows runs in ~6 ms and scales with sessions×models instead of messages.

- New `session_model_cost(agent_name, session_id, model, cost, cost_recorded)` table, rebuilt for each session inside the same transaction that writes its message rows (`writeSearchIndexRows`) with an `INSERT … SELECT` from the just-written messages — derived by SQL from its own source, so it cannot drift. Session removal paths and `clearCache` delete rollup rows alongside message rows.
- Schema migration 27 backfills the rollup from existing messages (`CACHE_SCHEMA_VERSION` 26 → 27, docs fact updated).
- `listModelCostDistribution` now reads the rollup joined to `sessions`; the documented cost-attribution semantics are unchanged — sub-session messages still count toward their own session rows, unset `cost_source` still counts as estimated, and `costRecorded + costEstimated === cost` still holds (`cost_estimated = cost - cost_recorded`).

## Testing

- The existing model-cost suite drives the real write path (`syncSessionSearchIndex`), so its passing results are an equivalence check of rollup vs. the old full-table aggregation, including recorded/estimated splits and agent/project/window scoping.
- New test: removing a session drops its rollup rows from the distribution.
- `pnpm typecheck` (core + cli), core 962 tests, cli 531 tests, `pnpm test:migration` (13), lint, format:check all green.