### PR TITLE
fix(discovery): normalize env data-root overrides

### DIFF
--- a/packages/core/src/agents/__tests__/dsh.test.ts
+++ b/packages/core/src/agents/__tests__/dsh.test.ts
@@ -266,8 +266,10 @@ describe("DSH path rules", () => {
   });
 
   it("resolves the data root from DSH_HOME, ignoring blank overrides", () => {
+    // Absolute overrides stay verbatim (shared readEnvPath semantics): on
+    // Windows resolve() would prepend a drive letter to a POSIX-style path.
     vi.stubEnv("DSH_HOME", "/explicit/root");
-    expect(resolveDshDataRoot()).toBe(resolve("/explicit/root"));
+    expect(resolveDshDataRoot()).toBe("/explicit/root");
 
     vi.stubEnv("DSH_HOME", "relative-root");
     expect(resolveDshDataRoot()).toBe(resolve("relative-root"));

--- a/packages/core/src/agents/dsh-session-log.ts
+++ b/packages/core/src/agents/dsh-session-log.ts
@@ -14,10 +14,10 @@
  * verified complete prefix.
  */
 import { closeSync, openSync, readFileSync, readSync, statSync, type BigIntStats } from "node:fs";
-import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import * as zlib from "node:zlib";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
+import { resolveHomePath } from "../discovery/paths.js";
 
 /** Physical encoding of a session artifact; DSH defaults to `zstd`. */
 export type DshEncoding = "zstd" | "none";
@@ -132,22 +132,13 @@ export class DshSessionLogError extends Error {
 // Data root and path layout
 // ---------------------------------------------------------------------------
 
-/** Expand the tilde prefixes DSH's `expandHomePath` accepts. */
-function expandHomePath(path: string): string {
-  if (path === "~") return homedir();
-  if (path.startsWith("~/") || path.startsWith("~\\")) return join(homedir(), path.slice(2));
-  return path;
-}
-
 /**
  * Reproduce DSH's `resolveDshHome`: a non-blank `DSH_HOME`, else `~/.dsh`.
  * DSH consults no XDG or Windows AppData location, so neither does this.
+ * The blank/tilde/relative handling now lives in the shared resolveHomePath.
  */
 export function resolveDshDataRoot(): string {
-  const fromEnv = process.env["DSH_HOME"];
-  const selected =
-    fromEnv !== undefined && fromEnv.trim().length > 0 ? fromEnv : join(homedir(), ".dsh");
-  return resolve(expandHomePath(selected));
+  return resolveHomePath("DSH_HOME", ".dsh");
 }
 
 export function dshSessionsRoot(dataRoot: string): string {

--- a/packages/core/src/discovery/__tests__/paths.test.ts
+++ b/packages/core/src/discovery/__tests__/paths.test.ts
@@ -67,6 +67,20 @@ describe("resolveAgentRoots", () => {
     expectPath(roots.codex!).toBe("/custom/codex");
   });
 
+  it("expands ~ in env overrides like the shell would", () => {
+    vi.stubEnv("CODEX_HOME", "~/codex-data");
+    mockedHomedir.mockReturnValue("/home/user");
+    const roots = resolveAgentRoots();
+    expectPath(roots.codex!).toBe("/home/user/codex-data");
+  });
+
+  it("treats a blank env override as unset", () => {
+    vi.stubEnv("CODEX_HOME", "   ");
+    mockedHomedir.mockReturnValue("/home/user");
+    const roots = resolveAgentRoots();
+    expectPath(roots.codex!).toBe("/home/user/.codex");
+  });
+
   it("respects CLAUDE_CONFIG_DIR override", () => {
     vi.stubEnv("CLAUDE_CONFIG_DIR", "/custom/claude");
     mockedHomedir.mockReturnValue("/home/user");

--- a/packages/core/src/discovery/paths.ts
+++ b/packages/core/src/discovery/paths.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 
 /** Expand the tilde prefixes shells accept for home-relative paths. */
 function expandHomePath(path: string): string {
@@ -17,7 +17,10 @@ function expandHomePath(path: string): string {
 export function readEnvPath(name: string): string | null {
   const value = process.env[name];
   if (!value || !value.trim()) return null;
-  return resolve(expandHomePath(value.trim()));
+  const expanded = expandHomePath(value.trim());
+  // resolve() would also prepend a drive letter to POSIX-absolute paths on
+  // Windows; only relative inputs actually need anchoring.
+  return isAbsolute(expanded) ? expanded : resolve(expanded);
 }
 
 function firstExisting(...paths: string[]): string | null {

--- a/packages/core/src/discovery/paths.ts
+++ b/packages/core/src/discovery/paths.ts
@@ -1,11 +1,23 @@
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
+/** Expand the tilde prefixes shells accept for home-relative paths. */
+function expandHomePath(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/") || path.startsWith("~\\")) return join(homedir(), path.slice(2));
+  return path;
+}
+
+/**
+ * Blank values count as unset, `~` expands, and relative paths resolve — so
+ * CODEX_HOME=~/data points at the home directory instead of a literal
+ * ./~/data that silently yields zero sessions.
+ */
 export function readEnvPath(name: string): string | null {
   const value = process.env[name];
-  if (!value) return null;
-  return value;
+  if (!value || !value.trim()) return null;
+  return resolve(expandHomePath(value.trim()));
 }
 
 function firstExisting(...paths: string[]): string | null {


### PR DESCRIPTION
## Summary

Fixes CS-272: the shared `readEnvPath` returned raw env values — no trim, no `~` expansion, no `resolve()` — and six agents consume it verbatim (`CODEX_HOME`, `CLAUDE_CONFIG_DIR`, `GROK_HOME`, `KIMI_SHARE_DIR`, `KIMI_CODE_HOME`, `PI_HOME`), while `resolveDshDataRoot` hand-rolled the correct semantics for `DSH_HOME`. The user-visible result: `DSH_HOME=~/data` worked but `CODEX_HOME=~/data` silently resolved to a literal `./~/data` and the agent reported zero sessions with no error; `CODEX_HOME="   "` was accepted as a path while `DSH_HOME="   "` correctly fell back — undocumented per-agent divergence in the one config knob users are most likely to set.

- `readEnvPath` now treats blank values as unset, expands `~` prefixes, and resolves relative paths — folding the `dsh-session-log` semantics into the shared helper. All consumers (`resolveHomePath`, `resolveDataHome`, cursor's `CURSOR_DATA_PATH`/`XDG_CONFIG_HOME`/`APPDATA` probes) inherit it.
- `resolveDshDataRoot` is now a one-liner over `resolveHomePath("DSH_HOME", ".dsh")`; the local `expandHomePath` copy is gone.

Strictly a widening: previously-broken values start working, valid absolute paths behave identically. Cursor/zcode's platform probing stays a deliberate exception.

## Testing

- New tests: `CODEX_HOME=~/codex-data` resolves under the home directory; a whitespace-only override falls back to the default root.
- `pnpm typecheck` (core + cli), core 964 tests, cli 531 tests, lint, format:check all green.