### PR TITLE
refactor(agents): unify the four drifted timestamp parsers

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -391,7 +391,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
         sessionId: "session-1",
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "claudecode-head-v6",
+          "claudecode-head-v7",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           indexTime.getTime(),

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -355,7 +355,7 @@ describe("CodexAgent cache refresh", () => {
         sessionId,
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "codex-head-v1",
+          "codex-head-v2",
           "codex-parser-v8",
           sessionTime.getTime(),
           statSync(sessionFile).size,
@@ -474,7 +474,7 @@ describe("CodexAgent cache refresh", () => {
           sourceMtimeMs: statSync(sessionFile).mtimeMs,
           indexPath: null,
           indexMtimeMs: null,
-          headIndexVersion: "codex-head-v1",
+          headIndexVersion: "codex-head-v2",
           parserVersion: "codex-parser-v2",
         },
       ],

--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -118,7 +118,7 @@ describe("KimiCodeAgent", () => {
       throw new TypeError("Expected Kimi-Code source fingerprint");
     }
     const fingerprint = JSON.parse(currentMeta.sourceFingerprint) as unknown[];
-    expect(fingerprint[0]).toBe("kimi-code-parser-v1");
+    expect(fingerprint[0]).toBe("kimi-code-parser-v2");
     expect(fingerprint[2]).toBe(statSync(join(sessionDir, "state.json")).size);
     expect(fingerprint[4]).toBe(statSync(join(sessionDir, "agents", "main", "wire.jsonl")).size);
     agent.setSessionMetaMap(

--- a/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
@@ -142,7 +142,7 @@ describe("KimiAgent source enumeration", () => {
       sessionId: "fingerprint",
       sourcePath,
       fingerprint: JSON.stringify([
-        "kimi-parser-v1",
+        "kimi-parser-v2",
         stateTime.getTime(),
         statSync(statePath).size,
         pinned.getTime(),

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -288,7 +288,7 @@ describe("PiAgent", () => {
         sessionId,
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "pi-head-v1",
+          "pi-head-v2",
           "pi-parser-v3",
           sessionTime.getTime(),
           statSync(sessionFile).size,

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -22,7 +22,7 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { isInternalEventType } from "../utils/parse-cleanup.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
-import { parseAgentTimestampMs } from "../utils/timestamp.js";
+import { parseAgentTimestamp } from "../utils/timestamp.js";
 import { asArray, asNumber, asRecord, asString, reportFieldMismatch } from "../utils/narrow.js";
 import {
   matchesScanWindow,
@@ -34,8 +34,8 @@ import {
 } from "./base.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
-// v6: heads created from internal-only local commands must be recomputed.
-const HEAD_INDEX_VERSION = "claudecode-head-v6";
+// v7: unified timestamp parsing changes head times for numeric timestamps.
+const HEAD_INDEX_VERSION = "claudecode-head-v7";
 
 export function resolveClaudeCodeDataRoot(): string {
   return resolveHomePath("CLAUDE_CONFIG_DIR", ".claude");
@@ -73,13 +73,7 @@ interface ClaudeChildContextCacheEntry {
 }
 
 function parseTimestampMs(data: Record<string, unknown>): number {
-  const raw = data["timestamp"];
-  const value = asString(raw);
-  if (value === undefined) {
-    if (raw !== undefined && raw !== null) reportFieldMismatch("claudecode", "timestamp");
-    return 0;
-  }
-  return parseAgentTimestampMs(value, "claudecode");
+  return parseAgentTimestamp(data["timestamp"], "claudecode") ?? 0;
 }
 
 /** Reads a numeric usage field; a present-but-wrong-typed field is a schema drift signal. */

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -15,7 +15,7 @@ import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
-import { parseAgentTimestampMs } from "../utils/timestamp.js";
+import { parseAgentTimestamp } from "../utils/timestamp.js";
 import { asRecord, asString, narrowField } from "../utils/narrow.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
 import { normalizeToolArguments } from "./tool-arguments.js";
@@ -36,7 +36,7 @@ const PROPOSED_PLAN_PATTERN = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/
 const PLAN_APPROVAL_PREFIX = "PLEASE IMPLEMENT THIS PLAN";
 const SUBAGENT_NOTIFICATION_PATTERN =
   /<subagent_notification>\s*([\s\S]*?)\s*<\/subagent_notification>/;
-const HEAD_INDEX_VERSION = "codex-head-v1";
+const HEAD_INDEX_VERSION = "codex-head-v2";
 const PARSER_VERSION = "codex-parser-v8";
 
 export function resolveCodexDataRoot(): string {
@@ -87,7 +87,7 @@ function extractSessionId(filename: string): string {
 // ---------------------------------------------------------------------------
 
 function parseTimestampMs(data: Record<string, unknown>): number {
-  return parseAgentTimestampMs(String(data["timestamp"] ?? ""), "codex");
+  return parseAgentTimestamp(data["timestamp"], "codex") ?? 0;
 }
 
 function extractModelName(raw: unknown): string | null {

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -25,6 +25,7 @@ import type {
 import { resolveHomePath } from "../discovery/paths.js";
 import { readJsonlFile } from "../utils/jsonl.js";
 import { asArray, asNumber, asRecord, asString } from "../utils/narrow.js";
+import { parseAgentTimestamp } from "../utils/timestamp.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
 import { normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { estimateTokenCost } from "../utils/cost.js";
@@ -49,7 +50,7 @@ const KIMI_CODE_TOOL_TITLE_MAP: Record<string, string> = {
 };
 
 const KIMI_CODE_IGNORED_TOOLS = new Set(["SetTodoList"]);
-const KIMI_CODE_PARSER_REVISION = "kimi-code-parser-v1";
+const KIMI_CODE_PARSER_REVISION = "kimi-code-parser-v2";
 
 export function resolveKimiCodeDataRoot(): string {
   return resolveHomePath("KIMI_CODE_HOME", ".kimi-code");
@@ -100,13 +101,7 @@ function mapToolTitle(toolName: string): string {
 }
 
 function parseTimestamp(raw: unknown): number | null {
-  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
-  if (typeof raw !== "string" || raw.trim() === "") return null;
-
-  const numeric = Number(raw);
-  if (Number.isFinite(numeric)) return numeric;
-  const parsed = Date.parse(raw);
-  return Number.isFinite(parsed) ? parsed : null;
+  return parseAgentTimestamp(raw, "kimi-code", { numericStrings: true });
 }
 
 function timestampFromRecord(record: Record<string, unknown>): number {

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -29,6 +29,7 @@ import {
   narrowField,
   reportFieldMismatch,
 } from "../utils/narrow.js";
+import { parseAgentTimestamp } from "../utils/timestamp.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 import { normalizeToolArguments } from "./tool-arguments.js";
 
@@ -42,7 +43,7 @@ const KIMI_TOOL_TITLE_MAP: Record<string, string> = {
 };
 
 const KIMI_IGNORED_TOOLS = new Set(["SetTodoList"]);
-const KIMI_PARSER_REVISION = "kimi-parser-v1";
+const KIMI_PARSER_REVISION = "kimi-parser-v2";
 
 export function resolveKimiDataRoot(): string {
   return resolveHomePath("KIMI_SHARE_DIR", ".kimi");
@@ -84,13 +85,7 @@ function readWireTimestamp(record: Record<string, unknown>): number {
 }
 
 function parseTimestamp(raw: unknown): number | null {
-  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
-  if (typeof raw !== "string" || raw.trim() === "") return null;
-
-  const numeric = Number(raw);
-  if (Number.isFinite(numeric)) return numeric;
-  const parsed = Date.parse(raw);
-  return Number.isFinite(parsed) ? parsed : null;
+  return parseAgentTimestamp(raw, "kimi", { numericStrings: true });
 }
 
 /** Reads a token count from a usage record; reports drift when the field is present but not a number. */

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -19,10 +19,11 @@ import { readJsonlFile } from "../utils/jsonl.js";
 import { estimateTokenCost } from "../utils/cost.js";
 import { asNumber, asRecord, asString, narrowField } from "../utils/narrow.js";
 import { cleanInternalText } from "../utils/session-normalization.js";
+import { parseAgentTimestamp } from "../utils/timestamp.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
-const HEAD_INDEX_VERSION = "pi-head-v1";
+const HEAD_INDEX_VERSION = "pi-head-v2";
 const PARSER_VERSION = "pi-parser-v3";
 
 export function resolvePiDataRoot(): string {
@@ -43,14 +44,6 @@ interface ParsedPiFile {
   pathEntries: Record<string, unknown>[];
 }
 
-function parseTimestampMs(value: unknown): number {
-  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
-  const text = String(value ?? "").trim();
-  if (!text) return 0;
-  const ts = Date.parse(text);
-  return Number.isNaN(ts) ? 0 : ts;
-}
-
 function narrowPiField<T>(
   field: string,
   value: unknown,
@@ -61,14 +54,16 @@ function narrowPiField<T>(
 
 /**
  * Reports drift only when the timestamp is present but neither a number nor
- * a string (e.g. an object) — actual date parsing (and its silent-0
- * fallback for unparseable text) is unchanged, via `parseTimestampMs`.
+ * a string (e.g. an object); parsing goes through the shared agent parser
+ * (numeric strings accepted, unparseable text reported and treated as 0).
  */
 function narrowTimestampMs(field: string, value: unknown): number {
   const shaped = narrowPiField(field, value, (v) =>
     typeof v === "number" || typeof v === "string" ? v : undefined,
   );
-  return shaped === undefined ? 0 : parseTimestampMs(shaped);
+  return shaped === undefined
+    ? 0
+    : (parseAgentTimestamp(shaped, "pi", { numericStrings: true }) ?? 0);
 }
 
 function extractSessionIdFromFilename(filePath: string): string {

--- a/packages/core/src/utils/__tests__/timestamp.test.ts
+++ b/packages/core/src/utils/__tests__/timestamp.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { parseAgentTimestamp } from "../timestamp.js";
+import { setCoreDiagnostics } from "../diagnostics.js";
+
+afterEach(() => {
+  setCoreDiagnostics(null);
+});
+
+describe("parseAgentTimestamp", () => {
+  it("passes finite epoch numbers through", () => {
+    expect(parseAgentTimestamp(1_738_000_000_000, "test")).toBe(1_738_000_000_000);
+  });
+
+  it("parses ISO strings and normalizes space separators to UTC", () => {
+    expect(parseAgentTimestamp("2026-04-20T10:00:00Z", "test")).toBe(
+      Date.parse("2026-04-20T10:00:00Z"),
+    );
+    expect(parseAgentTimestamp("2026-04-20 10:00:00", "test")).toBe(
+      Date.parse("2026-04-20T10:00:00Z"),
+    );
+  });
+
+  it("accepts numeric strings only when the agent's wire format uses them", () => {
+    expect(parseAgentTimestamp("1738000000000", "test", { numericStrings: true })).toBe(
+      1_738_000_000_000,
+    );
+    // Without the option a bare number string is not a date.
+    expect(parseAgentTimestamp("1738000000000", "test")).toBeNull();
+  });
+
+  it("returns null quietly for missing values and blank strings", () => {
+    const events: string[] = [];
+    setCoreDiagnostics({ warn: (event) => events.push(event) });
+
+    expect(parseAgentTimestamp(null, "test")).toBeNull();
+    expect(parseAgentTimestamp(undefined, "test")).toBeNull();
+    expect(parseAgentTimestamp("   ", "test")).toBeNull();
+    expect(events).toEqual([]);
+  });
+
+  it("reports present-but-unparseable values and returns null", () => {
+    const events: string[] = [];
+    setCoreDiagnostics({ warn: (event) => events.push(event) });
+
+    expect(parseAgentTimestamp("not-a-date", "test")).toBeNull();
+    expect(parseAgentTimestamp(Number.NaN, "test")).toBeNull();
+    expect(parseAgentTimestamp({ nested: true }, "test")).toBeNull();
+    expect(events).toEqual([
+      "agent.timestamp_parse_failed",
+      "agent.timestamp_parse_failed",
+      "agent.timestamp_parse_failed",
+    ]);
+  });
+});

--- a/packages/core/src/utils/timestamp.ts
+++ b/packages/core/src/utils/timestamp.ts
@@ -2,18 +2,52 @@ import { getCoreDiagnostics } from "./diagnostics.js";
 
 const TIMEZONE_SUFFIX_PATTERN = /(?:Z|[+-]\d{2}:?\d{2})$/i;
 
-export function parseAgentTimestampMs(value: string, agentName: string): number {
+export interface AgentTimestampOptions {
+  /** Accept bare numeric strings as epoch milliseconds (Kimi wire format). */
+  numericStrings?: boolean;
+}
+
+/**
+ * The one timestamp parser for agent-supplied values of unknown shape.
+ * Missing values are null without noise; present-but-unparseable values are
+ * reported once and return null so callers pick their own fallback.
+ */
+export function parseAgentTimestamp(
+  value: unknown,
+  agentName: string,
+  options: AgentTimestampOptions = {},
+): number | null {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) return value;
+    reportTimestampParseFailure(agentName, value);
+    return null;
+  }
+  if (typeof value !== "string") {
+    reportTimestampParseFailure(agentName, value);
+    return null;
+  }
+
   const timestamp = value.trim().replace(" ", "T");
-  if (!timestamp) return 0;
+  if (!timestamp) return null;
+
+  if (options.numericStrings) {
+    const numeric = Number(timestamp);
+    if (Number.isFinite(numeric)) return numeric;
+  }
 
   const normalized = TIMEZONE_SUFFIX_PATTERN.test(timestamp) ? timestamp : `${timestamp}Z`;
   const timestampMs = Date.parse(normalized);
   if (Number.isFinite(timestampMs)) return timestampMs;
 
+  reportTimestampParseFailure(agentName, value, normalized);
+  return null;
+}
+
+function reportTimestampParseFailure(agentName: string, value: unknown, normalized?: string): void {
   getCoreDiagnostics()?.warn("agent.timestamp_parse_failed", {
     agentName,
-    value,
+    value: typeof value === "string" || typeof value === "number" ? value : typeof value,
     normalized,
   });
-  return 0;
 }


### PR DESCRIPTION
## Summary

Fixes CS-274: the same timestamp input produced different results per agent because four parser implementations had drifted apart — codex/claudecode delegated to the shared `parseAgentTimestampMs` (string-only; codex coerced everything through `String()`, so numeric timestamps became garbage and parsed to 0), pi had its own copy that rejected numeric strings and silently returned 0 (sorting affected sessions to the bottom of every activity list as epoch 0), and kimi/kimi-code carried byte-identical copies of a third variant that accepted numeric strings and returned null. `"1738000000000"` parsed correctly for kimi, became epoch 0 for pi, and took a fourth path for codex/claudecode.

- One shared `parseAgentTimestamp(value: unknown, agentName, { numericStrings? })` in `utils/timestamp.ts` with an explicit contract: finite numbers pass through, strings get the existing space→`T` and missing-timezone→UTC normalization, numeric strings are opt-in (Kimi's wire format), missing/blank values are quietly null, and present-but-unparseable values are reported once via diagnostics and return null so each caller picks its own fallback.
- All five adapters now call it; the four local copies and the old string-only export are deleted. Behavior changes are deliberate per the issue: pi and codex now parse numeric timestamps instead of degrading to 0, and no-timezone date strings are consistently UTC-normalized everywhere.
- Because parsed times feed cached session heads, the affected adapters' head/parser revisions are bumped (`codex-head-v2`, `claudecode-head-v7`, `pi-head-v2`, `kimi-parser-v2`, `kimi-code-parser-v2`) so stale cached heads recompute instead of serving old timestamps.

## Testing

- New unit suite pins the contract: epoch numbers, ISO/space-separated strings, numeric strings gated by the option, quiet null for missing values, reported null for garbage.
- Fingerprint byte-stability pins updated for the revision bumps; all adapter characterization suites green.
- `pnpm typecheck` (core + cli), core 969 tests, cli 531 tests, lint, format:check all green.