### PR TITLE
test(web): guard session-tree titles against HTML injection

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -272,6 +272,42 @@ function dispatch(target: HTMLElement, type: string, init: EventInit & { key?: s
   );
 }
 
+describe("CS-275: untrusted session titles stay inert", () => {
+  afterEach(cleanup);
+
+  // The sidebar's XSS safety rests on two facts about @pierre/trees: node
+  // labels go through vnodes (escaped), and the innerHTML-rendered
+  // `composition` slot stays unset. This test enforces the invariant so a
+  // dependency bump or a future `composition` use cannot silently turn
+  // transcript-derived titles into an HTML sink.
+  function queryDeep(root: ParentNode, selector: string): Element | null {
+    const direct = root.querySelector(selector);
+    if (direct) return direct;
+    for (const element of root.querySelectorAll("*")) {
+      const nested = (element as HTMLElement).shadowRoot;
+      if (nested) {
+        const hit = queryDeep(nested, selector);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  }
+
+  it("renders HTML metacharacters in titles as text, not markup", async () => {
+    const hostileTitle = '<img src=x onerror="globalThis.__cs275 = true"> <b>bold';
+    renderSessionTreeSidebar([makeSession({ id: "hostile", title: hostileTitle })]);
+
+    // The full title survives verbatim as escaped text (the visible label is
+    // split by MiddleTruncate, so assert on the row's aria-label instead).
+    await waitFor(() =>
+      expect(queryDeep(document, `[aria-label='${hostileTitle}']`)).not.toBeNull(),
+    );
+    expect(queryDeep(document, "img")).toBeNull();
+    expect(queryDeep(document, "b")).toBeNull();
+    expect((globalThis as { __cs275?: boolean }).__cs275).toBeUndefined();
+  });
+});
+
 describe("SessionTreeSidebar selection state", () => {
   afterEach(cleanup);
 


### PR DESCRIPTION
## Summary

Fixes CS-275: the session-tree sidebar's XSS safety rests on two facts about the pinned `@pierre/trees` beta — node labels render through vnodes (escaped), and the `composition` prop, which the library renders with `innerHTML`, is deliberately left unset (recorded only as a code comment). Transcript-derived session titles are untrusted input; a beta bump that routes labels through the slot host, or a future contributor feeding `composition` from session data, would silently turn titles into an HTML sink — and nothing in the suite would catch it.

This adds a rendering guard test: a session titled with an `<img onerror=…>` payload is mounted through the real `SessionTreeSidebar` → `FileTree` path, and the test asserts (searching through nested shadow roots) that no `img`/`b` element exists anywhere, the onerror global never ran, and the full title survives verbatim as escaped text. The visible label is split by the library's `MiddleTruncate`, so the verbatim-text assertion anchors on the row's `aria-label`.

The comment's invariant is now enforced rather than remembered. The eventual upgrade to a stable `@pierre/trees` release remains open under the issue.

## Testing

- New guard test green against `1.0.0-beta.6`; full web suite 779 tests, lint, format:check, `tsc --noEmit` all green.