### PR TITLE
fix(web): robustness details across retry, menus, and dead-end routes

### DIFF
--- a/apps/web/src/components/ErrorBoundary.test.tsx
+++ b/apps/web/src/components/ErrorBoundary.test.tsx
@@ -31,4 +31,16 @@ describe("ErrorBoundary", () => {
 
     expect(screen.getByText("Recovered surface")).toBeTruthy();
   });
+
+  it("CS-276: offers a reload action from the default fallback", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    render(
+      <ErrorBoundary>
+        <Surface failed />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reload page" })).toBeTruthy();
+  });
 });

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -30,13 +30,26 @@ export class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback;
       }
       return (
-        <div className="rounded-md border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6">
+        <div
+          role="alert"
+          className="rounded-md border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6"
+        >
           <h3 className="console-mono mb-2 text-sm font-semibold text-[var(--console-error)]">
             Something went wrong
           </h3>
-          <p className="console-mono text-xs text-[var(--console-text-secondary)]">
+          <p className="console-mono mb-3 text-xs text-[var(--console-text-secondary)]">
             {this.state.error?.message || "Unknown error"}
           </p>
+          {/* A full reload rather than a state reset: it also recovers stale
+              lazy chunks after a redeploy, and cannot loop on a
+              deterministic render error. */}
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="console-mono rounded border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 text-xs text-[var(--console-text)]"
+          >
+            Reload page
+          </button>
         </div>
       );
     }

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -532,7 +532,6 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   const sortOrderRef = useRef(modelData.sortOrderByPath);
   const groupCountByPathRef = useRef(modelData.groupCountByPath);
   const sessionByPathRef = useRef(modelData.sessionByPath);
-  const bookmarkedSessionReferencesRef = useRef(bookmarkedSessionReferences);
   const onSelectSessionRef = useRef(onSelectSession);
   const onToggleBookmarkRef = useRef(onToggleBookmark);
   const onRenameSessionRef = useRef(onRenameSession);
@@ -587,10 +586,6 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   useEffect(() => {
     onSelectSessionRef.current = onSelectSession;
   }, [onSelectSession]);
-
-  useEffect(() => {
-    bookmarkedSessionReferencesRef.current = bookmarkedSessionReferences;
-  }, [bookmarkedSessionReferences]);
 
   useEffect(() => {
     onToggleBookmarkRef.current = onToggleBookmark;
@@ -736,9 +731,9 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
             >
               {menuSession ? (
                 <SessionActionMenuItems
-                  bookmarked={bookmarkedSessionReferencesRef.current.has(
-                    getSessionReferenceKey(menuSession),
-                  )}
+                  // Read the prop directly: a ref read during render lags one
+                  // update behind, leaving an open menu with a stale label.
+                  bookmarked={bookmarkedSessionReferences.has(getSessionReferenceKey(menuSession))}
                   onRename={() => onRenameSessionRef.current(menuSession)}
                   onToggleBookmark={() => onToggleBookmarkRef.current(menuSession)}
                 />

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
   type SetStateAction,
 } from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { DetailLanding, type LandingAgentItem } from "../DetailLanding";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { RenderProfiler } from "../RenderProfiler";
@@ -322,5 +322,23 @@ export function AppRouteContent({
       />
     );
   }
-  return <div className="text-sm text-[var(--console-muted)]">Invalid route.</div>;
+  return (
+    <div
+      role="alert"
+      className="rounded-md border border-[var(--console-border)] bg-[var(--console-surface)] p-6"
+    >
+      <h3 className="console-mono mb-2 text-sm font-semibold text-[var(--console-text)]">
+        Page not found
+      </h3>
+      <p className="console-mono mb-3 text-xs text-[var(--console-text-secondary)]">
+        This address does not match any dashboard, agent, or session route.
+      </p>
+      <Link
+        to="/"
+        className="console-mono text-xs text-[var(--console-accent)] underline underline-offset-2"
+      >
+        Back to dashboard
+      </Link>
+    </div>
+  );
 }

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -96,6 +96,28 @@ describe("useSessionStore", () => {
     expect(api.fetchConfig).toHaveBeenCalledTimes(4);
   });
 
+  it("CS-276: resolves retryLoad even when the reload fails again", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchSessions).mockRejectedValue(new Error("api down"));
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSessionStore(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.config).toEqual(config), { timeout: 2_000 });
+    // Register the active window with a first load that fails.
+    await act(async () => {
+      await result.current.reload(config.window).catch(() => {});
+    });
+
+    // The server is still down; the retry must record the failure in state
+    // instead of rejecting out of the button handler.
+    await expect(act(() => result.current.retryLoad())).resolves.toBeUndefined();
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        "Failed to load session data for the selected time window.",
+      ),
+    );
+  });
+
   it("recovers from a transient config failure automatically", async () => {
     const error = new Error("config unavailable");
     vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -386,7 +386,13 @@ export function useSessionStore() {
       await refetchConfig();
       return;
     }
-    await reload(activeWindow);
+    try {
+      await reload(activeWindow);
+    } catch {
+      // reload already recorded the failure in loadError and the retry
+      // surface re-renders from that state; rethrowing would only leak an
+      // unhandled rejection from the button handler.
+    }
   }, [configFailed, refetchConfig, reload]);
 
   const currentSnapshot = sameWindow(querySnapshot?.window, requestedWindow) ? querySnapshot : null;

--- a/apps/web/src/lib/build-route-header-model.tsx
+++ b/apps/web/src/lib/build-route-header-model.tsx
@@ -142,12 +142,6 @@ function routeTitleAndSubtitle(input: RouteHeaderInput): {
   if (viewState.mode === "missingAgent") {
     return { title: "Agent Not Found", subtitle: `Requested /${viewState.attemptedKey}` };
   }
-  if (viewState.mode === "missingSession") {
-    return {
-      title: "Session Not Found",
-      subtitle: `Session not found in /${viewState.activeAgentKey}`,
-    };
-  }
   return { title: "CodeSesh", subtitle: "Select an agent to browse sessions" };
 }
 
@@ -193,9 +187,6 @@ function routeBreadcrumbs(input: RouteHeaderInput): BreadcrumbItem[] {
     to: viewState.mode === "session" ? `/${viewState.activeAgentKey}` : undefined,
   };
   if (viewState.mode === "agent") return [dashboard, { label: agentLabel }];
-  if (viewState.mode === "missingSession") {
-    return [dashboard, agent, { label: viewState.attemptedSessionId }];
-  }
   if (viewState.mode === "session") {
     return [
       dashboard,

--- a/apps/web/src/lib/view-state.ts
+++ b/apps/web/src/lib/view-state.ts
@@ -15,12 +15,8 @@ export type ViewState =
   | { mode: "agent"; activeAgentKey: string; activeSessionId: null }
   | { mode: "session"; activeAgentKey: string; activeSessionId: string }
   | { mode: "missingAgent"; activeAgentKey: null; activeSessionId: null; attemptedKey: string }
-  | {
-      mode: "missingSession";
-      activeAgentKey: string;
-      activeSessionId: string;
-      attemptedSessionId: string;
-    }
+  // An unknown session id keeps mode "session"; the 404 is resolved later by
+  // useSessionDetail and rendered by the session surface itself.
   | { mode: "invalidRoute"; activeAgentKey: null; activeSessionId: null };
 
 export interface ViewRouteMatch {


### PR DESCRIPTION
## Summary

Fixes CS-276 — four independent robustness details:

- **Retry button leaked unhandled rejections.** `useSessionStore.reload` records the failure in `loadError` and then rethrows; `retryLoad` awaited it and `App.tsx` fired it as `void retryLoad()`, so every Retry click while the CLI was still down produced an unhandled rejection. `retryLoad` now swallows after the state is recorded — the retry surface re-renders from `loadError`, and the rethrow had no consumer on this path.
- **Stale bookmark state in the tree context menu.** The sidebar read `bookmarkedSessionReferencesRef.current` during render (the ref syncs in an effect, i.e. after commit), so an open menu showed the previous bookmark label/star when the set changed underneath it. The JSX now reads the prop directly; the ref and its sync effect are gone. The `onSelectSession`/`onToggleBookmark` ref mirrors stay — they are only read inside callbacks.
- **Dead-end error surfaces.** The wildcard 404 rendered a bare "Invalid route." sentence; it is now a `role="alert"` panel with a link back to the dashboard. `ErrorBoundary`'s default fallback gains a "Reload page" action — the one recovery that also fixes stale lazy chunks after a redeploy, and that cannot loop on a deterministic render error.
- **Unreachable `missingSession` view state removed.** `viewStateFromRouteMatches` never constructs it (unknown session ids resolve to a 404 via `useSessionDetail`), yet two header-model branches switched on it — permanently dead and misleading for exhaustive-looking `mode` switches. The union member and both branches are deleted; the compiler verified nothing else referenced it.

## Testing

- New test: a `retryLoad` whose reload fails again resolves (no rejection escapes the button handler) and records the load error.
- New test: the `ErrorBoundary` default fallback exposes the reload action with `role="alert"`.
- Full web suite 781 tests, lint, format:check, `tsc --noEmit` all green.