### PR TITLE
chore: tighten the DX feedback loops (typecheck task, bundle-test split, CI concurrency)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# Supersede in-flight runs for the same PR branch; keep every run on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     strategy:
@@ -97,7 +102,21 @@ jobs:
 
       - run: pnpm test:migration
 
+      - name: Enforce the initial bundle budget
+        run: pnpm --filter @codesesh/web test:bundle
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - run: pnpm exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - run: pnpm exec playwright install-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
 
       - run: pnpm test:e2e
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,9 @@ pnpm build
 pnpm test
 pnpm test:coverage # includes pnpm check:coverage-scopes
 pnpm test:migration
+pnpm --filter @codesesh/web test:bundle
 pnpm exec playwright install --with-deps chromium
+pnpm exec playwright install-deps chromium
 pnpm test:e2e
 
 # Package artifact and installed-package gates

--- a/README_CN.md
+++ b/README_CN.md
@@ -288,7 +288,9 @@ pnpm build
 pnpm test
 pnpm test:coverage # 内含 pnpm check:coverage-scopes
 pnpm test:migration
+pnpm --filter @codesesh/web test:bundle
 pnpm exec playwright install --with-deps chromium
+pnpm exec playwright install-deps chromium
 pnpm test:e2e
 
 # npm 制品与安装后冒烟门禁

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,9 @@
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt --write \"**/*.{js,mjs,cjs,ts,tsx}\"",
     "format:check": "oxfmt --check \"**/*.{js,mjs,cjs,ts,tsx}\"",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:bundle": "vitest run --config vitest.bundle.config.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",

--- a/apps/web/vitest.bundle.config.ts
+++ b/apps/web/vitest.bundle.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+// Runs against dist/ and therefore depends on a fresh production build; kept
+// out of the default unit suite so `vitest run` needs no build and cannot
+// report a false green against a stale bundle.
+export default defineConfig({
+  test: {
+    name: "web-bundle",
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   test: {
     name: "web",
     passWithNoTests: true,
-    include: ["src/**/*.test.{ts,tsx}", "tests/**/*.test.ts"],
+    // The bundle-budget test lives in vitest.bundle.config.ts: it needs a
+    // fresh production dist, which the unit suite must not depend on.
+    include: ["src/**/*.test.{ts,tsx}"],
     environment: "happy-dom",
   },
 });

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro check && astro build",
+    "typecheck": "astro check",
     "preview": "astro preview",
     "clean": "node ../../scripts/clean.mjs",
     "lint": "oxlint astro.config.ts eslint.config.mjs prettier.config.mjs src && eslint \"src/**/*.astro\"",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "turbo run test",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "typecheck": "turbo run typecheck",
     "typecheck:e2e": "tsc --noEmit -p tsconfig.e2e.json",
     "test:migration": "vitest run --reporter=verbose packages/core/src/discovery/__tests__/migration-smoke.test.ts",
     "package:artifact": "node scripts/package-artifact.mjs",

--- a/scripts/check-quality-task-coverage.mjs
+++ b/scripts/check-quality-task-coverage.mjs
@@ -4,7 +4,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getPnpmInvocation } from "./lib/pnpm-process.mjs";
 
-export const QUALITY_TASKS = ["lint", "lint:fix", "format", "format:check"];
+export const QUALITY_TASKS = ["lint", "lint:fix", "format", "format:check", "typecheck"];
 export const QUALITY_PACKAGES = [
   { name: "codesesh-monorepo", manifest: "package.json", turbo: false },
   { name: "@codesesh/core", manifest: "packages/core/package.json" },

--- a/scripts/check-quality-task-coverage.test.mjs
+++ b/scripts/check-quality-task-coverage.test.mjs
@@ -28,6 +28,7 @@ describe("CS-173: quality task coverage", () => {
       "@codesesh/www#lint:fix has no package script",
       "@codesesh/www#format has no package script",
       "@codesesh/www#format:check has no package script",
+      "@codesesh/www#typecheck has no package script",
     ]);
   });
 

--- a/turbo.json
+++ b/turbo.json
@@ -25,9 +25,14 @@
       "cache": true,
       "dependsOn": ["^build"]
     },
-    "@codesesh/web#test": {
+    "test:bundle": {
       "cache": true,
-      "dependsOn": ["build", "^build"]
+      "dependsOn": ["build"]
+    },
+    "typecheck": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "outputs": []
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
## Summary

Fixes CS-278 — three feedback-loop gaps:

- **Workspace `typecheck` task.** The fastest way to typecheck the 35K-line web app was a full monorepo build. `apps/web` gains `"typecheck": "tsc --noEmit"`, `apps/www` gains `"typecheck": "astro check"`, a cached `typecheck` turbo task (dependsOn `^build` for the core d.ts) and a root `pnpm typecheck` wire them together, and `typecheck` joins `QUALITY_TASKS` so the gap is structurally enforced and cannot reopen.
- **Bundle budget decoupled from the unit suite.** `@codesesh/web#test` depended on its own production build solely because `tests/initial-bundle.test.ts` reads `dist/index.html`; worse, the root `pnpm test:watch` / `pnpm test:coverage` entry points bypass turbo — hard-failing on a clean checkout and silently passing the 300 KB budget against a **stale** dist on a dirty one. The bundle test moves to its own vitest config behind `test:bundle` (turbo `dependsOn: ["build"]`); the unit suite runs buildless, and the CI smoke job runs `test:bundle` explicitly right after `pnpm build`, so the budget gate stays enforced against a fresh bundle.
- **CI concurrency + Playwright cache.** Every push to an open PR restarted a fresh 10-job fan-out beside the still-running previous one, and the smoke job re-downloaded Chromium each run. A `concurrency` group keyed on workflow+ref cancels superseded PR runs (pushes to main are never cancelled), and `~/.cache/ms-playwright` is cached keyed on the lockfile, with `install-deps` still run on cache hits.

Documented CI command lists in both READMEs updated (`check-docs-facts` enforces them).

## Testing

- `node scripts/check-quality-task-coverage.mjs` green with the new task; its unit suite updated for the extended `QUALITY_TASKS`.
- `pnpm typecheck` (6 tasks), buildless `pnpm --filter @codesesh/web test` (780 tests), `test:bundle` against a fresh dist, scripts suite 52 tests, lint/format, `check-docs-facts`/`check-docs-paths` all green.