### PR TITLE
refactor(agents): codify the adapter error taxonomy and stop masking db failures

### DIFF
--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -319,6 +319,23 @@ describe("CursorAgent scan outcomes", () => {
     expect(() => makeScanningAgent(dbPath).scan()).toThrow(SessionScanError);
   });
 
+  it("CS-273: throws instead of returning empty messages when the bubble query fails", () => {
+    const agent = new CursorAgent() as unknown as {
+      loadMessagesFromBubbles(db: unknown, composerId: string, model: string | null): unknown;
+    };
+    const failingDb = {
+      prepare: () => {
+        throw new Error("database is locked");
+      },
+    };
+
+    // A broken database must surface as a scan error, never as a session
+    // that silently renders with zero messages.
+    expect(() => agent.loadMessagesFromBubbles(failingDb, "composer-1", null)).toThrow(
+      SessionScanError,
+    );
+  });
+
   it("returns an empty result for a readable empty database", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -265,6 +265,16 @@ export abstract class BaseAgent {
    */
   commitChangeCheck(): void {}
 
+  /** Wrap an enumeration/database read so failures follow the error taxonomy. */
+  protected scanStep<T>(stage: string, sourcePath: string, read: () => T): T {
+    try {
+      return read();
+    } catch (error) {
+      if (error instanceof SessionScanError) throw error;
+      throw new SessionScanError(this.name, stage, { cause: error, sourcePath });
+    }
+  }
+
   /**
    * 增量扫描（仅扫描变更的会话）
    * @param cachedSessions 缓存的会话列表
@@ -604,6 +614,22 @@ export abstract class SingleFileSessionSource<
  * This is not the same as an agent with no sessions. Callers must keep the last
  * successful snapshot: treating it as an empty result would diff every known
  * session into a removal and wipe the agent from cache, search and the UI.
+ */
+/**
+ * Error taxonomy for adapters — the same failure class must produce the same
+ * user-visible outcome regardless of agent:
+ *
+ * 1. Malformed record inside an otherwise readable source → skip the record;
+ *    visibility comes from counted diagnostics (see readJsonlFile's
+ *    `agent.jsonl_lines_skipped`), never from a hard failure.
+ * 2. One source fails to parse → the scan template converts the throw into a
+ *    `createSessionSourceFailure` ("parsing"), keeping the rest of the scan.
+ * 3. Enumeration or database access fails → throw `SessionScanError` (wrap
+ *    reads in `scanStep`); the scanner surfaces it as an agent scan failure.
+ *
+ * What is never acceptable: catching an I/O or database error and returning
+ * an empty/zero result — that makes a broken source indistinguishable from an
+ * empty one.
  */
 export class SessionScanError extends Error {
   constructor(

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1023,7 +1023,13 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       }
       this.sessionIndexCache = cache;
       this.sessionIndexMtime = mtime;
-    } catch {
+    } catch (error) {
+      // Titles silently falling back to filenames is a confusing failure
+      // mode; keep the degradation but make it visible.
+      getCoreDiagnostics()?.warn("codex.session_index_read_failed", {
+        path: indexPath,
+        message: error instanceof Error ? error.message : String(error),
+      });
       this.sessionIndexCache.clear();
       this.sessionIndexMtime = undefined;
     }

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -988,45 +988,25 @@ export class CursorAgent extends DatabaseSessionSource {
     return resolveSessionTitle(explicit, messageTitle, null);
   }
 
-  /** Count messages from bubbles */
-  private countMessagesFromBubbles(db: SQLiteDatabase, composerId: string): number {
-    try {
-      const rows = db
-        .prepare("SELECT value FROM cursorDiskKV WHERE key LIKE ?")
-        .all(`bubbleId:${composerId}:%`) as Array<{ value: string }>;
-
-      let count = 0;
-      for (const row of rows) {
-        try {
-          const bubble = parseBubbleRow(row.value);
-          // type 1 = user, type 2 = assistant
-          if (bubble?.type === 1 || bubble?.type === 2) {
-            count++;
-          }
-        } catch {
-          // skip malformed bubbles
-        }
-      }
-      return count;
-    } catch {
-      return 0;
-    }
-  }
-
-  /** Load one composer's bubbles, for the detail path that only needs a single session. */
+  /**
+   * Load one composer's bubbles, for the detail path that only needs a
+   * single session. A failing bubble query throws instead of returning [] —
+   * a broken database must not read as an empty session.
+   */
   private loadMessagesFromBubbles(
     db: SQLiteDatabase,
     composerId: string,
     initialModelName: string | null,
   ): Message[] {
-    try {
-      const rows = db
-        .prepare("SELECT rowid AS row_id, key, value FROM cursorDiskKV WHERE key LIKE ?")
-        .all(`bubbleId:${composerId}:%`) as BubbleRow[];
-      return this.messagesFromBubbles(groupBubbleRows(rows), initialModelName);
-    } catch {
-      return [];
-    }
+    const rows = this.scanStep(
+      "reading composer bubbles",
+      this.getDatabasePath() ?? "",
+      () =>
+        db
+          .prepare("SELECT rowid AS row_id, key, value FROM cursorDiskKV WHERE key LIKE ?")
+          .all(`bubbleId:${composerId}:%`) as BubbleRow[],
+    );
+    return this.messagesFromBubbles(groupBubbleRows(rows), initialModelName);
   }
 
   /** Build messages from bubbles already parsed once, in insertion order. */

--- a/packages/core/src/agents/dsh.ts
+++ b/packages/core/src/agents/dsh.ts
@@ -119,7 +119,7 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
       if (!stats) continue;
       if (!matchesScanWindow(Number(stats.mtimeMs), options)) continue;
 
-      const header = this.enumerationStep("reading session headers", artifact.sourcePath, () =>
+      const header = this.scanStep("reading session headers", artifact.sourcePath, () =>
         readDshSessionHeader(artifact.sourcePath, artifact.encoding),
       );
       this.assertStoredIdentity(sessionsRoot, artifact, header);
@@ -337,14 +337,6 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
         artifact.sourcePath,
         `header identifies ${JSON.stringify(expected)}, not ${JSON.stringify(artifact.sourcePath)}`,
       );
-    }
-  }
-
-  private enumerationStep<T>(stage: string, sourcePath: string, read: () => T): T {
-    try {
-      return read();
-    } catch (error) {
-      throw new SessionScanError(this.name, stage, { cause: error, sourcePath });
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes CS-273: the same failure class produced three different user-visible outcomes depending on the agent — a hard scan failure, a diagnostics warning, or a session silently rendering as empty. Investigating showed the architecture already carries most of the intended taxonomy: the base scan template converts per-source parse throws into `createSessionSourceFailure`, and directory enumeration throws `SessionScanError` via `readSessionSourceDirectory`. What was missing:

- **The taxonomy was nowhere written down.** It now lives as JSDoc on `SessionScanError`: (1) malformed records are skipped with counted diagnostics, (2) per-source parse failures become source failures, (3) enumeration/database failures throw `SessionScanError` — and catching an I/O error to return an empty/zero result is never acceptable.
- **The wrapper was private to one adapter.** dsh's `enumerationStep` moves to `BaseAgent.scanStep` (SessionScanError passthrough included); dsh now uses the shared version.
- **The sharpest violation is fixed.** Cursor's `loadMessagesFromBubbles` caught database read failures and returned `[]`, making a locked/broken database indistinguishable from an empty session; it now throws `SessionScanError` (surfacing as a scan failure on the scan path and a proper API error on the detail path). Its sibling `countMessagesFromBubbles` turned out to have no callers at all and is deleted.
- **Codex's silent degradation is visible.** `loadSessionIndex` cleared the title cache on any read error without a trace; it now logs `codex.session_index_read_failed` before degrading.

The remaining per-record bare catches are deliberate taxonomy class 1 (skip + counted diagnostics via `agent.jsonl_lines_skipped`) and stay as they are — rewriting them wholesale would surface previously-swallowed errors across real user data for little gain. The scope decision is recorded in the issue's implementation notes.

## Testing

- New test: a failing bubble query throws `SessionScanError` instead of yielding an empty message list.
- All adapter characterization suites unchanged and green (core 970 tests, cli 531 tests); typecheck, lint, format:check green.