### PR TITLE
chore(cli): log parsed startup flags instead of raw argv

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -164,13 +164,19 @@ const main = defineCommand({
       perf.enable();
     }
 
+    // Parsed named fields only — raw argv is the one unredacted sink in the
+    // logging pipeline, and would capture any future credential-bearing flag.
     appLogger.info("cli.start", {
       version: VERSION,
-      argv: process.argv.slice(2),
       port,
+      host: hostname,
+      transport: transport.kind,
+      remote_access: remoteAccess,
       json: jsonOnly,
       no_open: noOpen,
       cache: useCache,
+      clear_cache: clearCache,
+      trace,
       log_path: appLogger.getLogPath(),
     });
 


### PR DESCRIPTION
## Summary

Fixes CS-280: `cli.start` wrote the full raw `process.argv` to the on-disk log. Today's flag set carries no secret (`--tls-key` is a path, the remote-access token is generated in-process), so the current exposure is only project-path leakage into the owner-only log directory — but the shape is the problem: every other sink in the logging pipeline is disciplined (`sanitizeClientLogData` truncates client data, `redactStartupUrl` strips query params), while argv was the one unredacted path. The day a credential-bearing flag is added, it would land verbatim in rotated logs by default.

The startup record now logs the parsed named fields only — version, port, host, transport kind, remote-access/json/no-open/cache/clear-cache/trace flags, and the log path — dropping the raw vector.

## Testing

- `pnpm typecheck`, cli 531 tests, lint, format:check all green (log-shape change only; nothing parses these records).