### PR TITLE
perf(agents): track transcript part kinds instead of rescanning

### DIFF
--- a/packages/core/src/agents/transcript-builder.ts
+++ b/packages/core/src/agents/transcript-builder.ts
@@ -48,9 +48,17 @@ function mergeTokens(base: Message["tokens"], extra: Message["tokens"]): Message
   return merged;
 }
 
+interface PartFlags {
+  hasText: boolean;
+  hasTool: boolean;
+}
+
 export class TranscriptBuilder {
   private readonly messages: Message[] = [];
   private readonly pendingToolCalls = new Map<string, ToolPart>();
+  // Tracks per-message part kinds so grouping checks are O(1) instead of
+  // rescanning the growing parts array on every append (CS-283).
+  private readonly partFlags = new WeakMap<Message, PartFlags>();
   private currentAssistant: Message | null = null;
   private latestTextAssistant: Message | null = null;
 
@@ -64,11 +72,14 @@ export class TranscriptBuilder {
   appendMessage(input: TranscriptMessageInput): Message {
     const message = this.createMessage(input);
     this.messages.push(message);
-    this.registerToolCalls(message.parts);
+    for (const part of message.parts) {
+      this.registerToolCall(part);
+      this.notePart(message, part);
+    }
 
     if (message.role === "assistant") {
       this.currentAssistant = message;
-      if (message.parts.some((part) => part.type === "text")) {
+      if (this.flagsFor(message).hasText) {
         this.latestTextAssistant = message;
       }
     } else if (message.role === "user") {
@@ -88,13 +99,14 @@ export class TranscriptBuilder {
     } = {},
   ): Message {
     const current = this.currentAssistant;
+    const currentFlags = current === null ? null : this.flagsFor(current);
     const canReuse =
       current !== null &&
       (options.grouping === "current" ||
         (part.type === "text"
-          ? !current.parts.some((item) => item.type === "tool")
+          ? !currentFlags!.hasTool
           : part.type === "reasoning"
-            ? !current.parts.some((item) => item.type === "text" || item.type === "tool")
+            ? !currentFlags!.hasText && !currentFlags!.hasTool
             : false));
 
     const message = canReuse
@@ -103,7 +115,7 @@ export class TranscriptBuilder {
 
     if (canReuse) {
       if (options.deduplicateTail) this.appendPartIfNew(message, part);
-      else message.parts.push(part);
+      else this.pushPart(message, part);
       this.applyMissingMetadata(message, input);
     }
     if (part.type === "text") {
@@ -137,7 +149,7 @@ export class TranscriptBuilder {
         });
 
     if (target) {
-      message.parts.push(part);
+      this.pushPart(message, part);
       this.applyMissingMetadata(message, input);
       if (options.markModeAsTool) message.mode = "tool";
       this.registerToolCall(part);
@@ -149,7 +161,7 @@ export class TranscriptBuilder {
 
   appendToCurrentAssistant(part: MessagePart): boolean {
     if (!this.currentAssistant) return false;
-    this.currentAssistant.parts.push(part);
+    this.pushPart(this.currentAssistant, part);
     return true;
   }
 
@@ -239,10 +251,6 @@ export class TranscriptBuilder {
     };
   }
 
-  private registerToolCalls(parts: MessagePart[]): void {
-    for (const part of parts) this.registerToolCall(part);
-  }
-
   private registerToolCall(part: MessagePart): void {
     if (part.type === "tool" && part.callID) {
       this.pendingToolCalls.set(part.callID, part);
@@ -254,7 +262,27 @@ export class TranscriptBuilder {
     if ("text" in part && tail?.type === part.type && "text" in tail && tail.text === part.text) {
       return;
     }
+    this.pushPart(message, part);
+  }
+
+  private pushPart(message: Message, part: MessagePart): void {
     message.parts.push(part);
+    this.notePart(message, part);
+  }
+
+  private notePart(message: Message, part: MessagePart): void {
+    const flags = this.flagsFor(message);
+    if (part.type === "text") flags.hasText = true;
+    else if (part.type === "tool") flags.hasTool = true;
+  }
+
+  private flagsFor(message: Message): PartFlags {
+    let flags = this.partFlags.get(message);
+    if (!flags) {
+      flags = { hasText: false, hasTool: false };
+      this.partFlags.set(message, flags);
+    }
+    return flags;
   }
 
   private applyMissingMetadata(message: Message, input: AssistantMessageInput): void {


### PR DESCRIPTION
## Summary

Fixes CS-283: `TranscriptBuilder.appendAssistantPart` decided grouping by running `.some()` over the current assistant message's growing `parts` array on every append — O(P²) per assistant message for codex/claudecode (which don't pass `grouping: "current"`), while grok/kimi/kimi-code short-circuited to O(P) for identical behavior.

Per-message `{hasText, hasTool}` flags now live in a `WeakMap` keyed by the message, updated at every part-append site through a single `pushPart` helper. A per-message map rather than two builder-level booleans because `currentAssistant` can be re-pointed at an *older* message (`appendToolCall`'s latest-text target), where builder-level flags would go stale. Initial parts and the `latestTextAssistant` seed derive from the same flags, and the dedup path notes the part kind even when it skips the push (a deduped tail implies the kind already exists). Grouping semantics are unchanged and the per-adapter asymmetry is gone.

Practical magnitude is modest (per-turn part counts are usually small) — this is an S-sized cleanup that also removes the behavioral asymmetry between adapters.

## Testing

- The existing grouping-semantics suites (codex, claudecode, base, and the other adapters) pass unchanged — core 970 tests, cli 531 tests, typecheck, lint, format:check all green.