### PR TITLE
chore(release): Prepare v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,111 @@
 # Changelog
 
+## [1.0.3] - 2026-08-16
+
+This release attributes dashboard and project usage to the time of each message instead of the whole session, stops scan, cache and CLI failures from silently degrading published state, and removes repeated parsing, query and render work across agents, the cache and the web UI.
+
+### Bug Fixes
+
+- Attributed usage, tokens and cost to the time of each message rather than the session, so a session spanning several days is no longer charged entirely to one of them. (#424)
+- Stopped agent adapters from reporting database read failures as empty session lists, and gave every scan step a single error taxonomy. (#416)
+- Committed the database change baseline only after a scan succeeds, so an interrupted scan no longer marks changed sources as already processed. (#398)
+- Preserved committed partial scan outcomes and exposed them in scan status. (#382)
+- Preserved scan state when a scan worker is unavailable, and retained the cache baseline after failed writes. (#380, #381)
+- Recorded full-sync completion on a fresh cache, cleared orphaned cache tables, and surfaced cache marker and persistence failures to the CLI instead of continuing silently. (#396, #399, #404)
+- Kept the index batch running past non-fatal jobs, isolated listener fan-out failures, bounded the smart-tag worker lifecycle, and hardened unhandled rejection paths around backfill probes, timer-scheduled refreshes and shutdown. (#397, #402, #403, #405)
+- Covered every session signature field so metadata-only changes are detected, and normalized environment data-root overrides while keeping absolute paths verbatim. (#390, #409)
+- Rejected unknown agents on state writes. (#406)
+- Hardened loopback project identity resolution, normalized Windows scope paths, and handled malformed legacy sessions. (#379)
+- Distinguished session from project load failures in the web UI, and hardened retry, menus and dead-end routes. (#393, #412)
+- Made message collapsibles keyboard accessible and unified the landing agent panel on session detail. (#395)
+
+### Security
+
+- Logged parsed startup flags instead of raw argv, keeping the one unredacted logging sink from capturing future credential-bearing flags. (#417)
+
+### Performance
+
+- Aggregated dashboard model cost from a per-session rollup table and cached dashboard storage aggregates across requests. (#385, #408)
+- Indexed sessions by bare activity time and reused snapshot session trees. (#388, #407)
+- Streamed cached message suffixes over persisted cursor hash chains instead of re-reading whole transcripts. (#386)
+- Cached Codex thread metadata by file fingerprint and Codex child final messages, and avoided duplicate Kimi detail transcript reads. (#383, #384, #401)
+- Tracked transcript part kinds while building instead of rescanning parts. (#420)
+- Resolved session-detail identity off the event loop. (#400)
+- Reduced live session render work by localizing search input and sidebar selection state and splitting live projections. (#394)
+- Repainted the interactive receipt without rebuilding its simulation. (#421)
+
+### Refactor
+
+- Split API handlers into focused modules and extracted the CLI status reporter and index publisher. (#422, #423)
+- Unified four drifted agent timestamp parsers into one shared utility. (#410)
+- Shared the agent tool argument parser and centralized session slugs. (#389, #391)
+- Narrowed the contract change boundaries, named persisted changes, and isolated test fixtures. (#392)
+- Pruned dead exports from the core public barrel. (#419)
+
+### Tests
+
+- Closed coverage gaps around the web api client, theme bootstrap and degraded-server retry. (#413)
+- Guarded session tree titles against HTML injection. (#411)
+- Benchmarked message scan tradeoffs for search. (#387)
+
+### Build
+
+- Patched nanoid, aligned `@types/node` across the workspace, and moved the landing page analytics token into an environment variable. (#418)
+- Added a dedicated typecheck task, split bundle tests out of the default suite, cancelled superseded CI runs and cached Playwright. (#414)
+
+### Documentation
+
+- Added the verification commands to `AGENTS.md` and recorded the dependency decisions. (#415, #418)
+
+### Changelog Detail
+
+- #424 fix(analytics): attribute usage by message time @xingkaixin
+- #423 refactor(cli): Extract status reporter and index publisher @xingkaixin
+- #422 refactor(api): Split handlers into focused modules @xingkaixin
+- #421 perf(web): Repaint receipt without rebuilding the sim @xingkaixin
+- #420 perf(agents): Track part kinds instead of rescanning @xingkaixin
+- #419 chore(core): Prune dead exports from the public barrel @xingkaixin
+- #418 chore(deps): dependency and manifest hygiene @xingkaixin
+- #417 chore(cli): Log parsed startup flags instead of argv @xingkaixin
+- #416 refactor(agents): codify the adapter error taxonomy and stop masking db failures @xingkaixin
+- #415 docs: Add verification commands to AGENTS.md @xingkaixin
+- #414 chore: tighten the DX feedback loops (typecheck task, bundle-test split, CI concurrency) @xingkaixin
+- #413 test: close the coverage gaps around the api client, theme bootstrap, and degraded-server retry @xingkaixin
+- #412 fix(web): robustness details across retry, menus, and dead-end routes @xingkaixin
+- #411 test(web): Guard tree titles against HTML injection @xingkaixin
+- #410 refactor(agents): unify the four drifted timestamp parsers @xingkaixin
+- #409 fix(discovery): normalize env data-root overrides @xingkaixin
+- #408 perf(cache): aggregate dashboard model cost from a per-session rollup @xingkaixin
+- #407 perf(cache): index sessions by bare activity time @xingkaixin
+- #406 fix(api): Reject unknown agents on state writes @xingkaixin
+- #405 fix(cli): Continue index batch past non-fatal jobs @xingkaixin
+- #404 fix(cache): surface cache marker write and read failures @xingkaixin
+- #403 fix(cli): Isolate listener fan-out failures @xingkaixin
+- #402 fix(discovery): Bound smart-tag worker lifecycle @xingkaixin
+- #401 perf(codex): Cache thread meta by file fingerprint @xingkaixin
+- #400 fix(api): resolve session-detail identity off the event loop @xingkaixin
+- #399 fix(cache): Record full-sync completion on fresh cache @xingkaixin
+- #398 fix(agents): commit database change baseline only after the scan succeeds @xingkaixin
+- #397 fix(cli): harden unhandled rejection paths @xingkaixin
+- #396 fix(cache): Clear orphaned cache tables @xingkaixin
+- #395 fix(web): align detail landing interactions @xingkaixin
+- #394 refactor(web): reduce live session render work @xingkaixin
+- #393 fix(web): distinguish API load failures @xingkaixin
+- #392 refactor(contract): narrow change seams @xingkaixin
+- #391 refactor(agents): share tool argument parser @xingkaixin
+- #390 fix(discovery): cover session signature fields @xingkaixin
+- #389 refactor(agents): centralize session slugs @xingkaixin
+- #388 fix(api): reuse snapshot session trees @xingkaixin
+- #387 perf(search): benchmark message scan tradeoffs @xingkaixin
+- #386 fix(discovery): stream cached message suffixes @xingkaixin
+- #385 fix(api): cache dashboard storage aggregates @xingkaixin
+- #384 fix(codex): cache child final messages @xingkaixin
+- #383 Avoid duplicate Kimi detail transcript reads @xingkaixin
+- #382 Fix committed partial scan status @xingkaixin
+- #381 Fix cache persistence baseline handling @xingkaixin
+- #380 fix(scan): preserve state on worker unavailability @xingkaixin
+- #379 fix(projects): harden loopback identity resolution @xingkaixin
+
 ## [1.0.2] - 2026-08-14
 
 This release adds DeepSeek Harness (DSH) as the tenth supported agent.

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -1,5 +1,111 @@
 # Changelog
 
+## [1.0.3] - 2026-08-16
+
+本版本将 Dashboard 与项目统计的用量归属到每条消息的时间而非整个会话，避免扫描、缓存与 CLI 的失败静默劣化已发布状态，并消除 Agent 解析、缓存查询与 Web 渲染中的重复工作。
+
+### 问题修复
+
+- 用量、Token 与成本按每条消息的时间归属，而非按会话归属，跨多天的会话不再被整体计入其中一天。 (#424)
+- Agent 适配器不再把数据库读取失败伪装成空会话列表，并为所有扫描步骤统一错误分类。 (#416)
+- 数据库变更基线仅在扫描成功后提交，扫描中断不再把已变更的数据源标记为已处理。 (#398)
+- 保留已提交的部分扫描结果，并在扫描状态中暴露部分完成的结果。 (#382)
+- 扫描 Worker 不可用时保留扫描状态，写入失败时保留缓存基线。 (#380, #381)
+- 在全新缓存上记录全量同步完成、清理孤儿缓存表，并把缓存标记与持久化失败上报给 CLI，不再静默继续。 (#396, #399, #404)
+- 索引批次遇到非致命任务继续推进，隔离监听器分发失败，限制 smart-tag Worker 生命周期，并加固回填探测、定时刷新与关停路径上的未处理 Promise 拒绝。 (#397, #402, #403, #405)
+- 会话签名覆盖全部字段，仅元数据变化也能被检测到；归一化环境变量指定的数据根目录，同时保持绝对路径原样。 (#390, #409)
+- 状态写入时拒绝未知 Agent。 (#406)
+- 加固环回场景下的 Project Identity 解析，归一化 Windows 作用域路径，并处理格式异常的历史会话。 (#379)
+- Web UI 区分会话与项目的加载失败，并加固重试、菜单与无效路由。 (#393, #412)
+- 消息折叠块支持键盘访问，会话详情的落地 Agent 面板统一实现。 (#395)
+
+### 安全
+
+- 启动日志改为记录解析后的具名参数而非原始 argv，避免日志链路中唯一未脱敏的出口捕获后续可能携带凭据的参数。 (#417)
+
+### 性能
+
+- Dashboard 模型成本改为从会话级 rollup 表聚合，并跨请求缓存 Dashboard 存储聚合结果。 (#385, #408)
+- 会话按裸活动时间建立索引，并复用快照会话树。 (#388, #407)
+- 基于持久化的游标哈希链流式读取缓存消息后缀，不再重读整份转录。 (#386)
+- 按文件指纹缓存 Codex thread 元数据与子会话最终消息，并避免 Kimi 详情转录的重复读取。 (#383, #384, #401)
+- 构建转录时直接跟踪 part 类型，不再重复扫描。 (#420)
+- 会话详情的身份解析移出事件循环。 (#400)
+- 通过局部化搜索输入与侧栏选择状态、拆分实时投影，减少实时会话的渲染工作。 (#394)
+- 交互式收据仅重绘，不再重建其模拟状态。 (#421)
+
+### 重构
+
+- 拆分 API handler 为职责单一的模块，并抽出 CLI 状态上报与索引发布逻辑。 (#422, #423)
+- 将四处漂移的 Agent 时间戳解析统一为共享工具。 (#410)
+- 共享 Agent 工具参数解析器，并集中会话 slug 生成。 (#389, #391)
+- 收敛 contract 的变更边界，为持久化变更命名，并隔离测试夹具。 (#392)
+- 清理 core 公共导出入口中的死导出。 (#419)
+
+### 测试
+
+- 补齐 Web API 客户端、主题引导与服务降级重试的覆盖缺口。 (#413)
+- 防护会话树标题的 HTML 注入。 (#411)
+- 为搜索的消息扫描权衡建立基准测试。 (#387)
+
+### 构建
+
+- 修补 nanoid，统一 workspace 中的 `@types/node`，并将落地页统计 Token 改为从环境变量读取。 (#418)
+- 新增独立的 typecheck 任务，把 bundle 测试从默认套件中拆出，取消被覆盖的 CI 运行并缓存 Playwright。 (#414)
+
+### 文档
+
+- 在 `AGENTS.md` 中补充验证命令，并记录依赖决策。 (#415, #418)
+
+### Changelog Detail
+
+- #424 fix(analytics): attribute usage by message time @xingkaixin
+- #423 refactor(cli): Extract status reporter and index publisher @xingkaixin
+- #422 refactor(api): Split handlers into focused modules @xingkaixin
+- #421 perf(web): Repaint receipt without rebuilding the sim @xingkaixin
+- #420 perf(agents): Track part kinds instead of rescanning @xingkaixin
+- #419 chore(core): Prune dead exports from the public barrel @xingkaixin
+- #418 chore(deps): dependency and manifest hygiene @xingkaixin
+- #417 chore(cli): Log parsed startup flags instead of argv @xingkaixin
+- #416 refactor(agents): codify the adapter error taxonomy and stop masking db failures @xingkaixin
+- #415 docs: Add verification commands to AGENTS.md @xingkaixin
+- #414 chore: tighten the DX feedback loops (typecheck task, bundle-test split, CI concurrency) @xingkaixin
+- #413 test: close the coverage gaps around the api client, theme bootstrap, and degraded-server retry @xingkaixin
+- #412 fix(web): robustness details across retry, menus, and dead-end routes @xingkaixin
+- #411 test(web): Guard tree titles against HTML injection @xingkaixin
+- #410 refactor(agents): unify the four drifted timestamp parsers @xingkaixin
+- #409 fix(discovery): normalize env data-root overrides @xingkaixin
+- #408 perf(cache): aggregate dashboard model cost from a per-session rollup @xingkaixin
+- #407 perf(cache): index sessions by bare activity time @xingkaixin
+- #406 fix(api): Reject unknown agents on state writes @xingkaixin
+- #405 fix(cli): Continue index batch past non-fatal jobs @xingkaixin
+- #404 fix(cache): surface cache marker write and read failures @xingkaixin
+- #403 fix(cli): Isolate listener fan-out failures @xingkaixin
+- #402 fix(discovery): Bound smart-tag worker lifecycle @xingkaixin
+- #401 perf(codex): Cache thread meta by file fingerprint @xingkaixin
+- #400 fix(api): resolve session-detail identity off the event loop @xingkaixin
+- #399 fix(cache): Record full-sync completion on fresh cache @xingkaixin
+- #398 fix(agents): commit database change baseline only after the scan succeeds @xingkaixin
+- #397 fix(cli): harden unhandled rejection paths @xingkaixin
+- #396 fix(cache): Clear orphaned cache tables @xingkaixin
+- #395 fix(web): align detail landing interactions @xingkaixin
+- #394 refactor(web): reduce live session render work @xingkaixin
+- #393 fix(web): distinguish API load failures @xingkaixin
+- #392 refactor(contract): narrow change seams @xingkaixin
+- #391 refactor(agents): share tool argument parser @xingkaixin
+- #390 fix(discovery): cover session signature fields @xingkaixin
+- #389 refactor(agents): centralize session slugs @xingkaixin
+- #388 fix(api): reuse snapshot session trees @xingkaixin
+- #387 perf(search): benchmark message scan tradeoffs @xingkaixin
+- #386 fix(discovery): stream cached message suffixes @xingkaixin
+- #385 fix(api): cache dashboard storage aggregates @xingkaixin
+- #384 fix(codex): cache child final messages @xingkaixin
+- #383 Avoid duplicate Kimi detail transcript reads @xingkaixin
+- #382 Fix committed partial scan status @xingkaixin
+- #381 Fix cache persistence baseline handling @xingkaixin
+- #380 fix(scan): preserve state on worker unavailability @xingkaixin
+- #379 fix(projects): harden loopback identity resolution @xingkaixin
+
 ## [1.0.2] - 2026-08-14
 
 本版本新增 DeepSeek Harness (DSH)，成为第十个受支持的 Agent。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/web",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/www",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codesesh",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Browse local AI coding-agent sessions in one Web UI.",
   "keywords": [
     "ai",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesesh/core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Prepares the v1.0.3 patch release. The range `v1.0.2..main` contains 46 PRs (#379–#424), all `fix` / `perf` / `refactor` / `chore` / `test` / `docs` — no `feat`, no new agent, no CLI behavior change — so this ships as a patch.

- Added the `[1.0.3] - 2026-08-16` section to `CHANGELOG.md` and `CHANGELOG_CN.md`, grouped as Bug Fixes / Security / Performance / Refactor / Tests / Build / Documentation, plus the 46-entry Changelog Detail list.
- Bumped `packages/cli`, `packages/core`, `apps/web` and `apps/www` manifests to `1.0.3`.

Release headlines: usage and cost are now attributed to the time of each message instead of the whole session (#424); scan, cache and CLI failures no longer silently degrade published state (#380, #381, #382, #396, #398, #404, #416); repeated parsing, query and render work was removed across agents, the cache and the web UI.

`README*.md` and the `apps/www` copy were intentionally left untouched — this release has no user-visible new capability, agent-list change or CLI behavior change, and the landing page reads its version from `apps/www/package.json`.

## Upgrade note

`CACHE_SCHEMA_VERSION` moved 27 → 29 (#407 activity-time index, #424 message-level cost facts). Migration paths exist and the migration smoke test passes, but the first launch after upgrading runs a schema migration, which is slightly slower on large histories. `docs/sqlite-storage.md` already documents version 29.

## Test plan

- [x] `node scripts/release-preflight.mjs v1.0.3`
- [x] `node scripts/check-docs-paths.mjs`, `node scripts/check-docs-facts.mjs`, `node scripts/check-quality-task-coverage.mjs`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm test:migration`
- [x] `pnpm perf:check`
- [x] `pnpm --filter @codesesh/web test:bundle`
- [ ] `pnpm test:e2e` — left to CI

Tagging `v1.0.3` (which triggers `release.yml`) is deliberately not part of this PR.