### PR TITLE
fix(core): surface failed change checks

### DIFF
--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -665,6 +665,60 @@ describe("scanSessions", () => {
     }
   });
 
+  it("retains the cached baseline when change detection fails", async () => {
+    const cached = makeSession("cached");
+    mockedLoadCachedSessions.mockReturnValue({ sessions: [cached], meta: {}, timestamp: 123 });
+    const agent = createTestAgent({
+      name: "test",
+      available: true,
+      sessions: [],
+      checkForChangesResult: {
+        status: "failed",
+        hasChanges: false,
+        timestamp: 123,
+        failure: {
+          sourcePath: "/sessions/test.db",
+          errorClass: "SqliteError",
+          message: "database is locked",
+        },
+      },
+    });
+    const commitChangeCheck = vi.spyOn(agent, "commitChangeCheck");
+    mockedCreateRegisteredAgents.mockReturnValue([agent]);
+    const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
+    setCoreDiagnostics({ warn: (event, detail) => events.push({ event, detail }) });
+
+    try {
+      const result = await scanSessions({ useCache: true });
+
+      expect(result.sessions.map((session) => session.id)).toEqual(["cached"]);
+      expect(result.byAgent.test?.map((session) => session.id)).toEqual(["cached"]);
+      expect(result.cacheTimestamps).toEqual({ test: 123 });
+      expect(result.scanFailures?.test).toEqual({
+        agentName: "test",
+        stage: "checking for changes",
+        sourcePath: "/sessions/test.db",
+        errorClass: "SqliteError",
+        message: "database is locked",
+      });
+      expect(commitChangeCheck).not.toHaveBeenCalled();
+      expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
+      expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
+      expect(events).toContainEqual({
+        event: "agent.scan_failed",
+        detail: expect.objectContaining({
+          agent: "test",
+          stage: "checking for changes",
+          source_path: "/sessions/test.db",
+          error_class: "SqliteError",
+          baseline_retained: true,
+        }),
+      });
+    } finally {
+      setCoreDiagnostics(null);
+    }
+  });
+
   it("does not publish a false empty baseline when a forced scan fails", async () => {
     const cached = makeSession("cached");
     mockedLoadCachedSessions.mockReturnValue({ sessions: [cached], meta: {}, timestamp: 123 });

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -167,6 +167,29 @@ interface FailedAgentScanResult {
 
 type AgentScanResult = SuccessfulAgentScanResult | FailedAgentScanResult;
 
+function finalizeAgentScanFailure(
+  agent: BaseAgent,
+  failure: AgentScanFailure,
+  options: ScanOptions,
+  cached: CachedResult | null,
+  timing: AgentScanTiming,
+  startedAt: number,
+): FailedAgentScanResult {
+  const retainedHeads = cached
+    ? filterSessions(agent.filterCachedSessions(cached.sessions), options)
+    : undefined;
+  reportAgentScanFailure(failure, retainedHeads !== undefined);
+  timing.total = performance.now() - startedAt;
+  return {
+    status: "failed",
+    agent,
+    failure,
+    ...(retainedHeads !== undefined ? { retainedHeads } : {}),
+    ...(cached ? { cacheTimestamp: cached.timestamp } : {}),
+    timing,
+  };
+}
+
 type AgentScanFinalization =
   | { kind: "cache-only"; cached: CachedResult }
   | { kind: "unchanged"; cached: CachedResult }
@@ -640,6 +663,23 @@ async function scanAgentSmart(
       );
       timing.checkChanges = performance.now() - t1;
 
+      if (checkResult.status === "failed") {
+        return finalizeAgentScanFailure(
+          agent,
+          {
+            agentName: agent.name,
+            stage: "checking for changes",
+            sourcePath: checkResult.failure.sourcePath,
+            errorClass: checkResult.failure.errorClass,
+            message: checkResult.failure.message,
+          },
+          options,
+          cached,
+          timing,
+          agentStart,
+        );
+      }
+
       if (checkResult.hasChanges) {
         onProgress?.({
           agent: agent.name,
@@ -811,19 +851,8 @@ async function scanAgentOutcome(
   } catch (error) {
     const cached = (options.useCache ?? true) ? loadCachedSessions(agent.name) : null;
     if (cached) restoreAgentCacheMeta(agent, cached);
-    const retainedHeads = cached
-      ? filterSessions(agent.filterCachedSessions(cached.sessions), options)
-      : undefined;
     const failure = createAgentScanFailure(agent.name, "scanning sessions", error);
-    reportAgentScanFailure(failure, retainedHeads !== undefined);
-    return {
-      status: "failed",
-      agent,
-      failure,
-      ...(retainedHeads !== undefined ? { retainedHeads } : {}),
-      ...(cached ? { cacheTimestamp: cached.timestamp } : {}),
-      timing: { total: performance.now() - startedAt },
-    };
+    return finalizeAgentScanFailure(agent, failure, options, cached, { total: 0 }, startedAt);
   }
 }
 


### PR DESCRIPTION
## Summary

- surface explicit database change-check failures as agent scan failures
- retain cached session heads without advancing the change baseline
- cover diagnostics, cache preservation, and commit behavior with a regression test

## Testing

- pnpm --filter @codesesh/core format:check
- pnpm --filter @codesesh/core lint
- pnpm --filter @codesesh/core typecheck
- pnpm --filter @codesesh/core test
- pnpm typecheck
- pnpm --filter codesesh test