### PR TITLE
fix(cli): retry partial backfills

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -601,8 +601,14 @@ describe("AgentSyncEngine", () => {
     };
     const workerRunner: WorkerRunner = {
       activeCount: 0,
-      run: vi.fn(async () =>
-        workerResult(
+      run: vi.fn(async (_agentName, payload) => {
+        payload.onCheckpoint?.({
+          stage: "finalizing",
+          changes: [{ session: updated, sortIndex: 0 }],
+          meta: {},
+          backfillCursor: "cursor-2",
+        });
+        return workerResult(
           {
             sessions: [updated],
             meta: {},
@@ -610,14 +616,21 @@ describe("AgentSyncEngine", () => {
             sourceFailures: [failure],
           },
           "partial",
-        ),
-      ),
+        );
+      }),
       commit: vi.fn(),
       discard: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
-    const { engine } = makeEngine(new FakeSyncAgent(), [previous], workerRunner);
-    const internal = engine as unknown as { enqueueBackfill(agentName: string): void };
+    core.getAgentFullSyncCursor.mockReturnValueOnce("cursor-1");
+    const { engine } = makeEngine(new FakeSyncAgent(), [previous], workerRunner, { from: 1 });
+    const internal = engine as unknown as {
+      cacheIntegrityValidUntilByAgent: Map<string, number>;
+      enqueueBackfill(agentName: string): void;
+      scheduler: { schedule(agentName: string, delayMs: number): void };
+    };
+    const schedule = vi.spyOn(internal.scheduler, "schedule").mockImplementation(() => undefined);
+    const info = vi.spyOn(appLogger, "info");
 
     internal.enqueueBackfill("codex");
     await vi.waitFor(() => expect(engine.status().backfill.completedAgents).toEqual(["codex"]));
@@ -636,7 +649,20 @@ describe("AgentSyncEngine", () => {
     });
     expect(workerRunner.commit).toHaveBeenCalledWith("codex");
     expect(workerRunner.discard).not.toHaveBeenCalled();
-    expect(core.markAgentFullSyncCompleted).toHaveBeenCalledWith("codex");
+    expect(workerRunner.run).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({
+        operation: { kind: "source-backfill", cursor: "cursor-1", checkpoint: "durable" },
+      }),
+    );
+    expect(core.markAgentFullSyncProgress).toHaveBeenCalledWith("codex", "cursor-2");
+    expect(core.markAgentFullSyncCompleted).not.toHaveBeenCalled();
+    expect(internal.cacheIntegrityValidUntilByAgent.has("codex")).toBe(false);
+    expect(schedule).toHaveBeenCalledWith("codex", 5 * 60 * 1000);
+    expect(info).toHaveBeenCalledWith("scan.backfill.retry_scheduled", {
+      agent: "codex",
+      delay_ms: 5 * 60 * 1000,
+    });
   });
 
   it("cancels backfill lifecycle before awaiting shutdown", async () => {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -112,6 +112,7 @@ const REFRESH_DEBOUNCE_MS = 200;
 const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
 const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 const BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const PARTIAL_BACKFILL_RETRY_DELAY_MS = 5 * 60 * 1000;
 const CACHE_TRUNCATION_COVERAGE = 0.5;
 // SSE carries one compact summary; logs retain the complete failure list.
 const SOURCE_FAILURE_SUMMARY_MAX_LENGTH = 160;
@@ -926,10 +927,19 @@ export class AgentSyncEngine {
         if (result === "failed") {
           this.cacheIntegrityValidUntilByAgent.delete(attempt.agentName);
         } else if (result === "committed") {
-          this.cacheIntegrityValidUntilByAgent.set(
-            attempt.agentName,
-            Date.now() + BACKFILL_INTERVAL_MS,
-          );
+          if (current.completion?.completeness === "partial") {
+            this.cacheIntegrityValidUntilByAgent.delete(attempt.agentName);
+            this.scheduler.schedule(attempt.agentName, PARTIAL_BACKFILL_RETRY_DELAY_MS);
+            appLogger.info("scan.backfill.retry_scheduled", {
+              agent: attempt.agentName,
+              delay_ms: PARTIAL_BACKFILL_RETRY_DELAY_MS,
+            });
+          } else {
+            this.cacheIntegrityValidUntilByAgent.set(
+              attempt.agentName,
+              Date.now() + BACKFILL_INTERVAL_MS,
+            );
+          }
         }
         this.statusReporter.publishBackfillStatus();
       }
@@ -1025,11 +1035,11 @@ export class AgentSyncEngine {
       });
       durableCommitted = publication.durableCommitted;
       this.options.workerRunner.commit?.(agentName);
-      if (!markAgentFullSyncCompleted(agentName)) {
+      if (completion.completeness === "complete" && !markAgentFullSyncCompleted(agentName)) {
         appLogger.warn("scan.backfill.completion_not_durable", { agent: agentName });
       }
       appLogger.info(
-        result.sourceFailures?.length ? "scan.backfill.partial" : "scan.backfill.done",
+        completion.completeness === "partial" ? "scan.backfill.partial" : "scan.backfill.done",
         {
           agent: agentName,
           duration_ms: Math.round(performance.now() - startedAt),


### PR DESCRIPTION
## Summary

- separate durable partial publication from full-history reconciliation completion
- preserve and advance the durable backfill cursor without writing a full-sync marker for partial results
- schedule one coalesced five-minute retry instead of suppressing reconciliation for 24 hours

## Testing

- pnpm --filter codesesh format:check
- pnpm --filter codesesh lint
- pnpm --filter codesesh typecheck
- pnpm --filter codesesh test
- pnpm --filter @codesesh/core test