### PR TITLE
fix(web): use inclusive session costs

### DIFF
--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -133,6 +133,22 @@ describe("buildLocalRecentResults", () => {
     );
   });
 
+  it("includes a parent when descendant cost reaches costMin", () => {
+    const parent = makeSession("parent");
+    const child = makeSession("child", {
+      parent_reference: { agentName: "claudecode", sessionId: parent.id },
+      stats: {
+        message_count: 1,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost: 2,
+      },
+    });
+    const results = buildLocalRecentResults(buildIndexes([parent, child]), {}, 1);
+
+    expect(results.map((result) => result.session.id)).toEqual(["parent", "child"]);
+  });
+
   it("caps results at 50", () => {
     const many = Array.from({ length: 60 }, (_, index) =>
       makeSession(`s-many-${index}`, {

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -1,5 +1,6 @@
+import { buildSessionTree } from "@codesesh/core/contract";
 import { type SearchRequestOptions, type SearchResult } from "./api";
-import { type SessionIndexes, getSessionAgentKey } from "./session-indexes";
+import { type SessionIndexes, getSessionAgentKey, getSessionRouteKey } from "./session-indexes";
 import { getProjectIdentityKey } from "./projects";
 import type { SearchFilterState, SearchProjectOption } from "../components/app/types";
 
@@ -46,10 +47,13 @@ export function buildLocalRecentResults(
         ? agentSessions
         : projectSessions
       : (agentSessions ?? projectSessions ?? sessionIndexes.sessionsByActivity);
+  const inclusiveCosts =
+    costMin === undefined ? null : buildSessionTree(sessionIndexes.sessionsByActivity).byRouteKey;
   const results: SearchResult[] = [];
 
   for (const sessionItem of sourceSessions) {
-    if (filters.agent && getSessionAgentKey(sessionItem) !== filters.agent) continue;
+    const agentKey = getSessionAgentKey(sessionItem);
+    if (filters.agent && agentKey !== filters.agent) continue;
     if (
       projectIdentityKey &&
       (!sessionItem.project_identity ||
@@ -58,11 +62,14 @@ export function buildLocalRecentResults(
       continue;
     }
     if (filters.tag && !sessionItem.smart_tags?.includes(filters.tag)) continue;
-    if (costMin !== undefined && sessionItem.stats.total_cost < costMin) continue;
+    const cost =
+      inclusiveCosts?.get(getSessionRouteKey(agentKey, sessionItem.id))?.inclusiveStats.cost ??
+      sessionItem.stats.total_cost;
+    if (costMin !== undefined && cost < costMin) continue;
 
     results.push({
       reference: {
-        agentName: getSessionAgentKey(sessionItem),
+        agentName: agentKey,
         sessionId: sessionItem.id,
       },
       session: sessionItem,


### PR DESCRIPTION
## Summary

- apply the shared session hierarchy rollup to local cost filtering
- include parent sessions when descendant spend reaches the selected threshold
- preserve existing agent, project, tag, ordering, and result-limit behavior

## Testing

- pnpm --filter @codesesh/web format:check
- pnpm --filter @codesesh/web lint
- pnpm --filter @codesesh/web typecheck
- pnpm --filter @codesesh/web test
- pnpm --filter @codesesh/web build
- pnpm --filter @codesesh/web test:bundle