### PR TITLE
fix(web): bound large message and tool rendering

### DIFF
--- a/apps/web/src/components/CopyResumeButton.tsx
+++ b/apps/web/src/components/CopyResumeButton.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy } from "./ui/icons";
 import { useEffect, useState } from "react";
 import { buildResumeCommand } from "../lib/build-resume-command";
+import { writeToClipboard } from "../lib/clipboard";
 
 interface CopyResumeButtonProps {
   /** Session ID, will be shell-quoted into the resume command. */
@@ -16,35 +17,6 @@ interface CopyResumeButtonProps {
    */
   directory?: string | null;
   className?: string;
-}
-
-async function writeToClipboard(text: string): Promise<boolean> {
-  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      // Fall through to legacy fallback (e.g. insecure context where the
-      // Clipboard API is unavailable).
-    }
-  }
-
-  if (typeof document === "undefined") return false;
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.setAttribute("readonly", "");
-  textarea.style.position = "fixed";
-  textarea.style.opacity = "0";
-  document.body.appendChild(textarea);
-  textarea.select();
-  let ok = false;
-  try {
-    ok = document.execCommand("copy");
-  } catch {
-    ok = false;
-  }
-  document.body.removeChild(textarea);
-  return ok;
 }
 
 export function CopyResumeButton({

--- a/apps/web/src/components/MarkdownContent.test.tsx
+++ b/apps/web/src/components/MarkdownContent.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MarkdownContent } from "./MarkdownContent";
 
 afterEach(cleanup);
@@ -94,5 +94,36 @@ describe("CS-136: markdown media stays local", () => {
     expect(view.container.querySelector("img")?.getAttribute("src")).toBe(
       `${window.location.origin}/api/assets/a.png`,
     );
+  });
+});
+
+describe("MarkdownContent render budget", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  it("bounds the initial parse and preserves access to a large message", async () => {
+    const text = Array.from(
+      { length: 3_000 },
+      (_, index) => `## Entry ${index}\n\n${"payload ".repeat(12)}`,
+    ).join("\n\n");
+    const view = render(<MarkdownContent text={text} />);
+
+    const initialRenderedCharacters = view.container.textContent?.length ?? 0;
+    expect(view.queryByText("Entry 2999")).toBeNull();
+    expect(initialRenderedCharacters).toBeLessThan(40_000);
+
+    fireEvent.click(view.getByRole("button", { name: "Render more content" }));
+    expect(view.container.textContent?.length ?? 0).toBeGreaterThan(initialRenderedCharacters);
+    expect(view.queryByText("Entry 2999")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(view.getByRole("button", { name: "Copy full content" }));
+      await Promise.resolve();
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(text);
   });
 });

--- a/apps/web/src/components/MarkdownContent.tsx
+++ b/apps/web/src/components/MarkdownContent.tsx
@@ -3,6 +3,8 @@ import ReactMarkdown from "react-markdown";
 import type { Components, Options } from "react-markdown";
 import { resolveLocalMediaSource } from "../lib/local-media-policy";
 import { buildHighlightPattern } from "../lib/search-highlight";
+import { INITIAL_CONTENT_RENDER_BUDGETS } from "../lib/content-render-budget";
+import { ProgressiveText } from "./ProgressiveContent";
 
 const markdownComponents: Components = {
   a: ({ children }) => <span className="console-markdown-link">{children}</span>,
@@ -119,14 +121,18 @@ export const MarkdownContent = memo(function MarkdownContent({
   }, [highlightQuery]);
 
   return (
-    <div>
-      <ReactMarkdown
-        components={markdownComponents}
-        rehypePlugins={rehypePlugins}
-        urlTransform={transformMediaUrl}
-      >
-        {text}
-      </ReactMarkdown>
-    </div>
+    <ProgressiveText text={text} initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.markdown}>
+      {(visibleText) => (
+        <div>
+          <ReactMarkdown
+            components={markdownComponents}
+            rehypePlugins={rehypePlugins}
+            urlTransform={transformMediaUrl}
+          >
+            {visibleText}
+          </ReactMarkdown>
+        </div>
+      )}
+    </ProgressiveText>
   );
 });

--- a/apps/web/src/components/ProgressiveContent.tsx
+++ b/apps/web/src/components/ProgressiveContent.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Check, Copy } from "./ui/icons";
+import { writeToClipboard } from "../lib/clipboard";
+import {
+  buildTextRenderPreview,
+  growContentRenderBudget,
+  type ContentRenderBudget,
+} from "../lib/content-render-budget";
+
+type CopySource = string | (() => string);
+
+interface ContentRenderControlsProps {
+  copySource: CopySource;
+  onRenderMore: () => void;
+  rendered: number;
+  total: number;
+  unit: "characters" | "lines";
+}
+
+export function ContentRenderControls({
+  copySource,
+  onRenderMore,
+  rendered,
+  total,
+  unit,
+}: ContentRenderControlsProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1_500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <div className="console-mono mt-2 flex flex-wrap items-center gap-2 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2.5 py-2 text-[11px] text-[var(--console-muted)]">
+      <span>
+        Showing {rendered.toLocaleString()} of {total.toLocaleString()} {unit}
+      </span>
+      <button
+        type="button"
+        onClick={onRenderMore}
+        aria-label="Render more content"
+        className="motion-hover motion-press rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 font-semibold text-[var(--console-text)] hover:border-[var(--console-border-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
+      >
+        Render more
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const text = typeof copySource === "function" ? copySource() : copySource;
+          void writeToClipboard(text).then((ok) => {
+            if (ok) setCopied(true);
+          });
+        }}
+        aria-label={copied ? "Full content copied" : "Copy full content"}
+        className="motion-hover motion-press inline-flex items-center gap-1 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 font-semibold text-[var(--console-text)] hover:border-[var(--console-border-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
+      >
+        {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        {copied ? "Copied" : "Copy full"}
+      </button>
+      <span className="sr-only" aria-live="polite">
+        {copied ? "Full content copied" : ""}
+      </span>
+    </div>
+  );
+}
+
+interface ProgressiveTextProps {
+  text: string;
+  initialBudget: ContentRenderBudget;
+  children: (visibleText: string) => ReactNode;
+}
+
+interface ProgressiveRenderTotals {
+  characters?: number;
+  lines?: number;
+}
+
+export function useProgressiveRenderBudget(
+  source: unknown,
+  initialBudget: ContentRenderBudget,
+  totals: ProgressiveRenderTotals,
+) {
+  const [state, setState] = useState(() => ({ source, budget: initialBudget }));
+  const budget = Object.is(state.source, source) ? state.budget : initialBudget;
+
+  useEffect(() => {
+    setState((current) =>
+      Object.is(current.source, source) ? current : { source, budget: initialBudget },
+    );
+  }, [initialBudget, source]);
+
+  return {
+    budget,
+    renderMore: () =>
+      setState({
+        source,
+        budget: growContentRenderBudget(
+          budget,
+          totals.characters ?? Number.MAX_SAFE_INTEGER,
+          totals.lines ?? Number.MAX_SAFE_INTEGER,
+        ),
+      }),
+  };
+}
+
+export function ProgressiveText({ text, initialBudget, children }: ProgressiveTextProps) {
+  const { budget, renderMore } = useProgressiveRenderBudget(text, initialBudget, {
+    characters: text.length,
+    lines: text.length + 1,
+  });
+  const preview = useMemo(() => buildTextRenderPreview(text, budget), [budget, text]);
+
+  return (
+    <>
+      {children(preview.text)}
+      {preview.truncated ? (
+        <ContentRenderControls
+          copySource={text}
+          onRenderMore={renderMore}
+          rendered={preview.renderedCharacters}
+          total={text.length}
+          unit="characters"
+        />
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -17,6 +17,7 @@ import { getSessionRoutePath } from "../../lib/session-indexes";
 import { buildHighlightPattern } from "../../lib/search-highlight";
 import { AgentIcon } from "../AgentIcon";
 import { MarkdownContent } from "../MarkdownContent";
+import { ProgressiveText } from "../ProgressiveContent";
 import { ToolOutputRenderer } from "../tool-output/ToolOutputRenderer";
 import { Collapsible } from "../ui/Collapsible";
 import { Link } from "react-router-dom";
@@ -25,6 +26,7 @@ import { isCodexTurnAbortedMessage } from "./codex-abort";
 import { buildCodexPlanDisplay } from "./codex-plan";
 import { getDisplayTextWithRelativePaths } from "./path-extract";
 import { buildBlockTimelineAnchorId, buildMessageTimelineAnchorId } from "./timeline";
+import { INITIAL_CONTENT_RENDER_BUDGETS } from "../../lib/content-render-budget";
 import {
   type ToolStatus,
   getAssistantDisplayLabel,
@@ -316,9 +318,13 @@ const ReasoningSection = memo(function ReasoningSection({
       <Collapsible open={expanded}>
         {() => (
           <div className="border-t border-dashed border-[var(--console-thinking-border)] px-4 py-3">
-            <div className="console-mono whitespace-pre-wrap text-xs leading-relaxed text-[var(--console-muted)]">
-              {renderHighlightedText(fullText, highlightQuery)}
-            </div>
+            <ProgressiveText text={fullText} initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.plain}>
+              {(visibleText) => (
+                <div className="console-mono whitespace-pre-wrap text-xs leading-relaxed text-[var(--console-muted)]">
+                  {renderHighlightedText(visibleText, highlightQuery)}
+                </div>
+              )}
+            </ProgressiveText>
           </div>
         )}
       </Collapsible>
@@ -567,9 +573,18 @@ const ToolItem = memo(function ToolItem({
                         <span className="console-mono shrink-0 text-[11px] font-semibold uppercase tracking-wide text-[var(--console-muted)] md:w-24">
                           {detail.label}
                         </span>
-                        <span className="console-mono whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-text)]">
-                          {renderHighlightedText(detail.value, highlightQuery)}
-                        </span>
+                        <div className="min-w-0 flex-1">
+                          <ProgressiveText
+                            text={detail.value}
+                            initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.plain}
+                          >
+                            {(visibleText) => (
+                              <span className="console-mono whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-text)]">
+                                {renderHighlightedText(visibleText, highlightQuery)}
+                              </span>
+                            )}
+                          </ProgressiveText>
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -582,9 +597,16 @@ const ToolItem = memo(function ToolItem({
                 <span className="console-mono text-[11px] text-[var(--console-muted)]">
                   Input Preview
                 </span>
-                <pre className="console-mono mt-1 max-h-[200px] overflow-x-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-muted)]">
-                  {renderHighlightedText(inputPreviewText, highlightQuery)}
-                </pre>
+                <ProgressiveText
+                  text={inputPreviewText}
+                  initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.plain}
+                >
+                  {(visibleText) => (
+                    <pre className="console-mono mt-1 max-h-[200px] overflow-x-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-[var(--console-muted)]">
+                      {renderHighlightedText(visibleText, highlightQuery)}
+                    </pre>
+                  )}
+                </ProgressiveText>
               </div>
             ) : null}
           </div>

--- a/apps/web/src/components/tool-output/CodeHighlighter.tsx
+++ b/apps/web/src/components/tool-output/CodeHighlighter.tsx
@@ -1,6 +1,8 @@
 import { lazy, Suspense } from "react";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { CODE_METRICS } from "./code-metrics";
+import { ProgressiveText } from "../ProgressiveContent";
+import { INITIAL_CONTENT_RENDER_BUDGETS } from "../../lib/content-render-budget";
 
 export interface CodeHighlighterProps {
   language: string;
@@ -27,10 +29,14 @@ function PlainCode({ text }: { text: string }) {
 
 export function CodeHighlighter({ language, text }: CodeHighlighterProps) {
   return (
-    <ErrorBoundary fallback={<PlainCode text={text} />}>
-      <Suspense fallback={<PlainCode text={text} />}>
-        <PrismHighlighter language={language} text={text} />
-      </Suspense>
-    </ErrorBoundary>
+    <ProgressiveText text={text} initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.code}>
+      {(visibleText) => (
+        <ErrorBoundary fallback={<PlainCode text={visibleText} />}>
+          <Suspense fallback={<PlainCode text={visibleText} />}>
+            <PrismHighlighter language={language} text={visibleText} />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </ProgressiveText>
   );
 }

--- a/apps/web/src/components/tool-output/FileSectionsOutput.tsx
+++ b/apps/web/src/components/tool-output/FileSectionsOutput.tsx
@@ -1,6 +1,8 @@
 import { CodeHighlighter } from "./CodeHighlighter";
 import type { FileSectionItem } from "./types";
 import { UnifiedDiffOutput } from "./UnifiedDiffOutput";
+import { ProgressiveText } from "../ProgressiveContent";
+import { INITIAL_CONTENT_RENDER_BUDGETS } from "../../lib/content-render-budget";
 
 interface FileSectionsOutputProps {
   sections: FileSectionItem[];
@@ -11,9 +13,13 @@ function renderSectionContent(section: FileSectionItem) {
 
   if (!section.isCode || section.language === "text") {
     return (
-      <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre-wrap break-all p-3 text-xs leading-relaxed text-[var(--console-text)]">
-        {outputText}
-      </pre>
+      <ProgressiveText text={outputText} initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.plain}>
+        {(visibleText) => (
+          <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre-wrap break-all p-3 text-xs leading-relaxed text-[var(--console-text)]">
+            {visibleText}
+          </pre>
+        )}
+      </ProgressiveText>
     );
   }
 

--- a/apps/web/src/components/tool-output/MediaOutput.tsx
+++ b/apps/web/src/components/tool-output/MediaOutput.tsx
@@ -1,4 +1,6 @@
 import type { MediaItem } from "./types";
+import { ProgressiveText } from "../ProgressiveContent";
+import { INITIAL_CONTENT_RENDER_BUDGETS } from "../../lib/content-render-budget";
 
 export function MediaOutput({ items, text }: { items: MediaItem[]; text?: string }) {
   return (
@@ -24,9 +26,13 @@ export function MediaOutput({ items, text }: { items: MediaItem[]; text?: string
         ))}
       </div>
       {text ? (
-        <pre className="console-mono whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed text-[var(--console-text)]">
-          {text}
-        </pre>
+        <ProgressiveText text={text} initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.plain}>
+          {(visibleText) => (
+            <pre className="console-mono whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed text-[var(--console-text)]">
+              {visibleText}
+            </pre>
+          )}
+        </ProgressiveText>
       ) : null}
     </div>
   );

--- a/apps/web/src/components/tool-output/StructuredDiffOutput.tsx
+++ b/apps/web/src/components/tool-output/StructuredDiffOutput.tsx
@@ -1,48 +1,142 @@
+import { useMemo } from "react";
 import { diffToneClass } from "./diff-tone";
 import type { DiffBlock } from "./types";
+import { ContentRenderControls, useProgressiveRenderBudget } from "../ProgressiveContent";
+import {
+  INITIAL_CONTENT_RENDER_BUDGETS,
+  type ContentRenderBudget,
+} from "../../lib/content-render-budget";
 
 interface StructuredDiffOutputProps {
   blocks: DiffBlock[];
 }
 
-function getBlockKey(block: DiffBlock) {
-  return `${block.label}:${block.lines.map((l) => `${l.type}:${l.text}`).join("\n")}`;
+interface StructuredDiffPreview {
+  blocks: DiffBlock[];
+  renderedLines: number;
+  truncated: boolean;
+}
+
+function getStructuredDiffLineCount(blocks: DiffBlock[]) {
+  let lines = 0;
+  for (const block of blocks) {
+    lines += block.lines.length + 1;
+  }
+  return lines;
+}
+
+function buildStructuredDiffPreview(
+  blocks: DiffBlock[],
+  budget: ContentRenderBudget,
+): StructuredDiffPreview {
+  const visibleBlocks: DiffBlock[] = [];
+  let renderedCharacters = 0;
+  let renderedLines = 0;
+  let truncated = false;
+
+  for (const block of blocks) {
+    if (renderedLines >= budget.maxLines || renderedCharacters >= budget.maxCharacters) {
+      truncated = true;
+      break;
+    }
+
+    const remainingLabelCharacters = budget.maxCharacters - renderedCharacters;
+    const label = block.label.slice(0, remainingLabelCharacters);
+    renderedCharacters += label.length;
+    renderedLines += 1;
+    const lines: DiffBlock["lines"] = [];
+
+    for (const line of block.lines) {
+      if (renderedLines >= budget.maxLines || renderedCharacters >= budget.maxCharacters) {
+        truncated = true;
+        break;
+      }
+      const remainingTextCharacters = budget.maxCharacters - renderedCharacters - 1;
+      if (remainingTextCharacters < 0) {
+        truncated = true;
+        break;
+      }
+      const text = line.text.slice(0, remainingTextCharacters);
+      lines.push(text === line.text ? line : { ...line, text });
+      renderedCharacters += text.length + 1;
+      renderedLines += 1;
+      if (text !== line.text) {
+        truncated = true;
+        break;
+      }
+    }
+
+    visibleBlocks.push({ ...block, label, lines });
+    if (label !== block.label || lines.length !== block.lines.length) {
+      truncated = true;
+      break;
+    }
+  }
+
+  return { blocks: visibleBlocks, renderedLines, truncated };
+}
+
+function serializeStructuredDiff(blocks: DiffBlock[]) {
+  const lines: string[] = [];
+  for (const block of blocks) {
+    lines.push(`diff ${block.label}`);
+    for (const line of block.lines) {
+      const prefix = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
+      lines.push(`${prefix}${line.text}`);
+    }
+  }
+  return lines.join("\n");
 }
 
 export function StructuredDiffOutput({ blocks }: StructuredDiffOutputProps) {
+  const totalLines = useMemo(() => getStructuredDiffLineCount(blocks), [blocks]);
+  const { budget, renderMore } = useProgressiveRenderBudget(
+    blocks,
+    INITIAL_CONTENT_RENDER_BUDGETS.diff,
+    { lines: totalLines },
+  );
+  const preview = useMemo(() => buildStructuredDiffPreview(blocks, budget), [blocks, budget]);
+
   return (
-    <div className="space-y-3">
-      {blocks.map((block) => {
-        const lineOccurrences = new Map<string, number>();
-        return (
-          <div
-            key={getBlockKey(block)}
-            className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)]"
-          >
-            <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
-              <span className="console-mono text-[11px] font-semibold text-[var(--console-muted)]">
-                {block.label}
-              </span>
+    <>
+      <div className="space-y-3">
+        {preview.blocks.map((block, blockIndex) => {
+          return (
+            <div
+              key={`${block.label.slice(0, 80)}:${blockIndex}`}
+              className="overflow-hidden rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)]"
+            >
+              <div className="border-b border-[var(--console-border)] bg-[var(--console-surface-muted)] px-3 py-1.5">
+                <span className="console-mono text-[11px] font-semibold text-[var(--console-muted)]">
+                  {block.label}
+                </span>
+              </div>
+              <pre className="console-mono max-h-[280px] overflow-auto whitespace-pre p-3 text-xs leading-relaxed">
+                {block.lines.map((line, lineIndex) => {
+                  return (
+                    <span
+                      key={`${line.type}:${lineIndex}`}
+                      className={`block rounded-[2px] px-1 ${diffToneClass(line.type)}`}
+                    >
+                      {line.type === "add" ? "+" : line.type === "remove" ? "-" : " "}
+                      {line.text || " "}
+                    </span>
+                  );
+                })}
+              </pre>
             </div>
-            <pre className="console-mono max-h-[280px] overflow-auto whitespace-pre p-3 text-xs leading-relaxed">
-              {block.lines.map((line) => {
-                const key = `${line.type}:${line.text}`;
-                const occ = lineOccurrences.get(key) ?? 0;
-                lineOccurrences.set(key, occ + 1);
-                return (
-                  <span
-                    key={`${key}:${occ}`}
-                    className={`block rounded-[2px] px-1 ${diffToneClass(line.type)}`}
-                  >
-                    {line.type === "add" ? "+" : line.type === "remove" ? "-" : " "}
-                    {line.text || " "}
-                  </span>
-                );
-              })}
-            </pre>
-          </div>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+      {preview.truncated ? (
+        <ContentRenderControls
+          copySource={() => serializeStructuredDiff(blocks)}
+          onRenderMore={renderMore}
+          rendered={preview.renderedLines}
+          total={totalLines}
+          unit="lines"
+        />
+      ) : null}
+    </>
   );
 }

--- a/apps/web/src/components/tool-output/ToolOutputRenderer.test.tsx
+++ b/apps/web/src/components/tool-output/ToolOutputRenderer.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildSemanticOutputContent } from "../session-detail/tool-normalize";
 import { ToolOutputRenderer } from "./ToolOutputRenderer";
 import type { ToolOutputContent } from "./types";
@@ -179,5 +179,59 @@ describe("ToolOutputRenderer", () => {
     expect(view.getByText("owner")).toBeTruthy();
     expect(view.getByText("agent")).toBeTruthy();
     expect(view.getByText("coverage")).toBeTruthy();
+  });
+
+  it("bounds large code and unified diff output before expensive rendering", () => {
+    const codeText = `${"const value = 1;\n".repeat(3_000)}final_code_marker`;
+    const code = renderOutput({
+      kind: "plain",
+      text: codeText,
+      language: "typescript",
+      isCode: true,
+    });
+
+    expect(code.container.textContent).not.toContain("final_code_marker");
+    expect(code.getByRole("button", { name: "Render more content" })).toBeTruthy();
+    code.unmount();
+
+    const diffText = Array.from({ length: 5_000 }, (_, index) => `+changed line ${index}`).join(
+      "\n",
+    );
+    const diff = renderOutput({
+      kind: "plain",
+      text: diffText,
+      language: "diff",
+      isCode: true,
+    });
+
+    expect(diff.queryByText("+changed line 4999")).toBeNull();
+    expect(diff.container.querySelectorAll("pre > span").length).toBeLessThanOrEqual(800);
+    expect(diff.getByRole("button", { name: "Render more content" })).toBeTruthy();
+  });
+
+  it("bounds structured diff lines and copies the complete diff", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+    const lines = Array.from({ length: 2_000 }, (_, index) => ({
+      type: "add" as const,
+      text: `changed line ${index}`,
+    }));
+    const view = renderOutput({
+      kind: "structured-diff",
+      blocks: [{ label: "src/large.ts", lines }],
+    });
+
+    expect(view.queryByText("+changed line 1999")).toBeNull();
+    expect(view.container.querySelectorAll("pre > span").length).toBeLessThanOrEqual(799);
+
+    await act(async () => {
+      fireEvent.click(view.getByRole("button", { name: "Copy full content" }));
+      await Promise.resolve();
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `diff src/large.ts\n${lines.map((line) => `+${line.text}`).join("\n")}`,
+    );
   });
 });

--- a/apps/web/src/components/tool-output/ToolOutputRenderer.tsx
+++ b/apps/web/src/components/tool-output/ToolOutputRenderer.tsx
@@ -7,6 +7,8 @@ import { StructuredDiffOutput } from "./StructuredDiffOutput";
 import { TaskListOutput } from "./TaskListOutput";
 import type { ToolOutputContent } from "./types";
 import { UnifiedDiffOutput } from "./UnifiedDiffOutput";
+import { ProgressiveText } from "../ProgressiveContent";
+import { INITIAL_CONTENT_RENDER_BUDGETS } from "../../lib/content-render-budget";
 
 interface ToolOutputRendererProps {
   outputContent: ToolOutputContent;
@@ -41,9 +43,13 @@ export function ToolOutputRenderer({ outputContent }: ToolOutputRendererProps) {
 
   if (!outputContent.isCode || outputContent.language === "text") {
     return (
-      <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed text-[var(--console-text)]">
-        {outputText}
-      </pre>
+      <ProgressiveText text={outputText} initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.plain}>
+        {(visibleText) => (
+          <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre-wrap break-words rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed text-[var(--console-text)]">
+            {visibleText}
+          </pre>
+        )}
+      </ProgressiveText>
     );
   }
 

--- a/apps/web/src/components/tool-output/UnifiedDiffOutput.tsx
+++ b/apps/web/src/components/tool-output/UnifiedDiffOutput.tsx
@@ -1,4 +1,6 @@
 import { type DiffTone, diffToneClass } from "./diff-tone";
+import { ProgressiveText } from "../ProgressiveContent";
+import { INITIAL_CONTENT_RENDER_BUDGETS } from "../../lib/content-render-budget";
 
 interface UnifiedDiffOutputProps {
   text: string;
@@ -18,23 +20,28 @@ function getUnifiedDiffLineTone(line: string): DiffTone {
 }
 
 export function UnifiedDiffOutput({ text }: UnifiedDiffOutputProps) {
-  const lines = text.split("\n");
-  const lineOccurrences = new Map<string, number>();
-
   return (
-    <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed">
-      {lines.map((line) => {
-        const occurrence = lineOccurrences.get(line) ?? 0;
-        lineOccurrences.set(line, occurrence + 1);
+    <ProgressiveText text={text} initialBudget={INITIAL_CONTENT_RENDER_BUDGETS.diff}>
+      {(visibleText) => {
+        const lines = visibleText.split("\n");
+        const lineOccurrences = new Map<string, number>();
         return (
-          <span
-            key={getLineKey(line, occurrence)}
-            className={`block rounded-[2px] px-1 ${diffToneClass(getUnifiedDiffLineTone(line))}`}
-          >
-            {line || " "}
-          </span>
+          <pre className="console-mono max-h-[420px] overflow-auto whitespace-pre rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-sunken)] p-3 text-xs leading-relaxed">
+            {lines.map((line) => {
+              const occurrence = lineOccurrences.get(line) ?? 0;
+              lineOccurrences.set(line, occurrence + 1);
+              return (
+                <span
+                  key={getLineKey(line, occurrence)}
+                  className={`block rounded-[2px] px-1 ${diffToneClass(getUnifiedDiffLineTone(line))}`}
+                >
+                  {line || " "}
+                </span>
+              );
+            })}
+          </pre>
         );
-      })}
-    </pre>
+      }}
+    </ProgressiveText>
   );
 }

--- a/apps/web/src/lib/clipboard.ts
+++ b/apps/web/src/lib/clipboard.ts
@@ -1,0 +1,27 @@
+export async function writeToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the legacy path when the Clipboard API is blocked.
+    }
+  }
+
+  if (typeof document === "undefined") return false;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  }
+  document.body.removeChild(textarea);
+  return copied;
+}

--- a/apps/web/src/lib/content-render-budget.test.ts
+++ b/apps/web/src/lib/content-render-budget.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { buildTextRenderPreview, growContentRenderBudget } from "./content-render-budget";
+
+describe("content render budget", () => {
+  it("limits text by characters", () => {
+    expect(buildTextRenderPreview("abcdefgh", { maxCharacters: 5, maxLines: 10 })).toEqual({
+      text: "abcde",
+      renderedCharacters: 5,
+      renderedLines: 1,
+      truncated: true,
+    });
+  });
+
+  it("limits text by complete lines", () => {
+    expect(buildTextRenderPreview("one\ntwo\nthree", { maxCharacters: 100, maxLines: 2 })).toEqual({
+      text: "one\ntwo",
+      renderedCharacters: 7,
+      renderedLines: 2,
+      truncated: true,
+    });
+  });
+
+  it("does not leave a dangling carriage return or surrogate", () => {
+    expect(buildTextRenderPreview("line\r\nnext", { maxCharacters: 5, maxLines: 10 }).text).toBe(
+      "line",
+    );
+    expect(buildTextRenderPreview("abc😀tail", { maxCharacters: 4, maxLines: 10 }).text).toBe(
+      "abc",
+    );
+  });
+
+  it("doubles each budget without exceeding the source", () => {
+    const grown = growContentRenderBudget({ maxCharacters: 5, maxLines: 3 }, 17, 9);
+
+    expect(grown).toEqual({ maxCharacters: 10, maxLines: 6 });
+    expect(growContentRenderBudget(grown, 17, 9)).toEqual({
+      maxCharacters: 17,
+      maxLines: 9,
+    });
+  });
+});

--- a/apps/web/src/lib/content-render-budget.ts
+++ b/apps/web/src/lib/content-render-budget.ts
@@ -1,0 +1,67 @@
+export interface ContentRenderBudget {
+  maxCharacters: number;
+  maxLines: number;
+}
+
+export interface TextRenderPreview {
+  text: string;
+  renderedCharacters: number;
+  renderedLines: number;
+  truncated: boolean;
+}
+
+export const INITIAL_CONTENT_RENDER_BUDGETS = {
+  markdown: { maxCharacters: 24_000, maxLines: 400 },
+  code: { maxCharacters: 32_000, maxLines: 600 },
+  diff: { maxCharacters: 64_000, maxLines: 800 },
+  plain: { maxCharacters: 64_000, maxLines: 1_000 },
+} as const satisfies Record<string, ContentRenderBudget>;
+
+export function buildTextRenderPreview(
+  text: string,
+  budget: ContentRenderBudget,
+): TextRenderPreview {
+  if (!text) {
+    return { text, renderedCharacters: 0, renderedLines: 0, truncated: false };
+  }
+
+  const maxCharacters = Math.max(1, Math.min(text.length, Math.trunc(budget.maxCharacters)));
+  const maxLines = Math.max(1, Math.min(text.length + 1, Math.trunc(budget.maxLines)));
+  let end = maxCharacters;
+  let renderedLines = 1;
+
+  for (let index = 0; index < end; index += 1) {
+    if (text.charCodeAt(index) !== 10) continue;
+    if (renderedLines === maxLines) {
+      end = index;
+      break;
+    }
+    renderedLines += 1;
+  }
+
+  if (end > 0 && end < text.length && text.charCodeAt(end - 1) === 13) end -= 1;
+  if (end > 0 && end < text.length && text.charCodeAt(end - 1) >= 0xd800) {
+    const lastCodeUnit = text.charCodeAt(end - 1);
+    if (lastCodeUnit <= 0xdbff) end -= 1;
+  }
+
+  return {
+    text: text.slice(0, end),
+    renderedCharacters: end,
+    renderedLines,
+    truncated: end < text.length,
+  };
+}
+
+export function growContentRenderBudget(
+  current: ContentRenderBudget,
+  totalCharacters: number,
+  totalLines = totalCharacters + 1,
+): ContentRenderBudget {
+  const grow = (value: number, total: number) =>
+    value >= Math.ceil(total / 2) ? total : value * 2;
+  return {
+    maxCharacters: grow(current.maxCharacters, Math.max(1, totalCharacters)),
+    maxLines: grow(current.maxLines, Math.max(1, totalLines)),
+  };
+}


### PR DESCRIPTION
## Summary

- add shared character and line budgets for progressively rendering large content
- keep Markdown parsing, syntax highlighting, and diff DOM creation within the initial budget
- preserve full-content access through incremental expansion and clipboard copy
- cover large Markdown, code, unified diff, and structured diff inputs with regression tests

## Verification

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm perf:check
- pnpm --filter @codesesh/web test:bundle

A 337,888-character Markdown fixture reduced initial rendered text from about 320,000 to 10,545 characters and local render time from about 378 ms to 36 ms.