### PR TITLE
fix(ci): make coverage tests deterministic

### DIFF
--- a/scripts/astro-quality-tools.test.mjs
+++ b/scripts/astro-quality-tools.test.mjs
@@ -7,6 +7,8 @@ import { getPnpmInvocation } from "./lib/pnpm-process.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const wwwRoot = join(repoRoot, "apps/www");
+// These real CLI processes share CI CPU with coverage workers.
+const QUALITY_TOOL_TIMEOUT_MS = 20_000;
 const tempDirs = [];
 
 afterEach(() => {
@@ -23,21 +25,25 @@ function runWwwTool(args) {
 }
 
 describe("CS-173: Astro quality tools", () => {
-  it("rejects parser-aware lint and formatting defects in an Astro fixture", () => {
-    const dir = mkdtempSync(join(wwwRoot, ".quality-fixture-"));
-    tempDirs.push(dir);
-    const fixture = join(dir, "invalid.astro");
-    writeFileSync(
-      fixture,
-      '---\nconst label="demo"\n---\n<img src="/demo.png" data-label={label}>\n',
-    );
+  it(
+    "rejects parser-aware lint and formatting defects in an Astro fixture",
+    { timeout: QUALITY_TOOL_TIMEOUT_MS },
+    () => {
+      const dir = mkdtempSync(join(wwwRoot, ".quality-fixture-"));
+      tempDirs.push(dir);
+      const fixture = join(dir, "invalid.astro");
+      writeFileSync(
+        fixture,
+        '---\nconst label="demo"\n---\n<img src="/demo.png" data-label={label}>\n',
+      );
 
-    const lint = runWwwTool(["eslint", fixture]);
-    const format = runWwwTool(["prettier", "--check", fixture]);
+      const lint = runWwwTool(["eslint", fixture]);
+      const format = runWwwTool(["prettier", "--check", fixture]);
 
-    expect(lint.status).not.toBe(0);
-    expect(`${lint.stdout}\n${lint.stderr}`).toContain("astro/jsx-a11y/alt-text");
-    expect(format.status).not.toBe(0);
-    expect(`${format.stdout}\n${format.stderr}`).toContain("Code style issues");
-  });
+      expect(lint.status).not.toBe(0);
+      expect(`${lint.stdout}\n${lint.stderr}`).toContain("astro/jsx-a11y/alt-text");
+      expect(format.status).not.toBe(0);
+      expect(`${format.stdout}\n${format.stderr}`).toContain("Code style issues");
+    },
+  );
 });

--- a/scripts/perf-scale.mjs
+++ b/scripts/perf-scale.mjs
@@ -23,6 +23,7 @@ const MAX_COST_GROWTH = 2.5;
 
 /** Sizes chosen so the largest is still fast when the algorithm is correct. */
 const SIZES = [2_000, 8_000];
+const CONTROL_SIZES = [400, 1_600];
 
 /** Discards a warm-up run and reports the best of a few, to blunt scheduler noise. */
 function measure(run, iterations = 3) {
@@ -36,15 +37,12 @@ function measure(run, iterations = 3) {
   return best;
 }
 
-/** Cost per item, so sizes are directly comparable. */
-function perItemCost(size, run) {
-  return measure(() => run(size)) / size;
-}
-
-function checkGrowth(name, run, sizes = SIZES) {
+/** Normalizes two duration samples by input size and applies the growth policy. */
+function evaluateGrowth(name, sizes, durations) {
   const [small, large] = sizes;
-  const smallCost = perItemCost(small, run);
-  const largeCost = perItemCost(large, run);
+  const [smallDuration, largeDuration] = durations;
+  const smallCost = smallDuration / small;
+  const largeCost = largeDuration / large;
   // A near-zero small measurement would make the ratio meaningless.
   const growth = smallCost > 0 ? largeCost / smallCost : 1;
 
@@ -55,6 +53,14 @@ function checkGrowth(name, run, sizes = SIZES) {
     limit: MAX_COST_GROWTH,
     ok: growth <= MAX_COST_GROWTH,
   };
+}
+
+function checkGrowth(name, run, sizes = SIZES) {
+  return evaluateGrowth(
+    name,
+    sizes,
+    sizes.map((size) => measure(() => run(size))),
+  );
 }
 
 /** Allocates unique paths for labels that all collide — the sidebar's shape. */
@@ -112,6 +118,21 @@ function groupByOwner(size) {
   return grouped.size;
 }
 
+/** The former path allocator, used to prove the isolated gate detects O(N²). */
+function allocateWithRestartedProbes(size) {
+  const used = new Set();
+  for (let index = 0; index < size; index += 1) {
+    const base = "Same title #deadbeef";
+    let path = base;
+    let suffix = 2;
+    while (used.has(path)) {
+      path = `${base} (${suffix})`;
+      suffix += 1;
+    }
+    used.add(path);
+  }
+}
+
 const CASES = [
   ["sidebar path allocation over colliding labels", allocateCollidingPaths],
   ["virtual list height index over every row", measureEveryRow],
@@ -121,11 +142,23 @@ const CASES = [
 function main() {
   const asJson = process.argv.includes("--json");
   const results = CASES.map(([name, run]) => checkGrowth(name, run));
+  const control = checkGrowth(
+    "quadratic detection control",
+    allocateWithRestartedProbes,
+    CONTROL_SIZES,
+  );
+  const controlDetected = !control.ok;
+  const growthRegressionDetected = results.some((result) => !result.ok);
 
   if (asJson) {
     console.log(
       JSON.stringify(
-        { nodeVersion: process.version, maxCostGrowth: MAX_COST_GROWTH, results },
+        {
+          nodeVersion: process.version,
+          maxCostGrowth: MAX_COST_GROWTH,
+          control: { detected: controlDetected, measurement: control },
+          results,
+        },
         null,
         2,
       ),
@@ -138,14 +171,22 @@ function main() {
           `${result.sizes[0]} to ${result.sizes[1]} items (limit ×${result.limit})`,
       );
     }
+    const controlStatus = controlDetected ? "ok" : "FAIL";
+    console.log(
+      `${controlStatus.padEnd(5)} ${control.name}: observed per-item growth ×${control.growth} ` +
+        `(must exceed ×${control.limit})`,
+    );
   }
 
-  if (results.some((result) => !result.ok)) {
-    console.error("\nPer-item cost grew with input size: this shape is no longer linear.");
-    process.exit(1);
+  if (!controlDetected) {
+    console.error("\nGrowth-rate gate did not detect its quadratic control.");
   }
+  if (growthRegressionDetected) {
+    console.error("\nPer-item cost grew with input size: this shape is no longer linear.");
+  }
+  if (!controlDetected || growthRegressionDetected) process.exit(1);
 }
 
-export { CASES, MAX_COST_GROWTH, SIZES, checkGrowth };
+export { CASES, MAX_COST_GROWTH, SIZES, checkGrowth, evaluateGrowth };
 
 if (process.argv[1]?.endsWith("perf-scale.mjs")) main();

--- a/scripts/perf-scale.test.mjs
+++ b/scripts/perf-scale.test.mjs
@@ -1,47 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { CASES, MAX_COST_GROWTH, checkGrowth } from "./perf-scale.mjs";
-
-/** The pre-CS-145 allocator: every collision restarts its probe from 2. */
-function quadraticAllocation(size) {
-  const used = new Set();
-  for (let index = 0; index < size; index += 1) {
-    const base = "Same title #deadbeef";
-    let path = base;
-    let suffix = 2;
-    while (used.has(path)) {
-      path = `${base} (${suffix})`;
-      suffix += 1;
-    }
-    used.add(path);
-  }
-}
-
-function linearWork(size) {
-  let total = 0;
-  for (let index = 0; index < size; index += 1) total += index % 7;
-  return total;
-}
+import { MAX_COST_GROWTH, evaluateGrowth } from "./perf-scale.mjs";
 
 describe("CS-154: growth-rate gate", () => {
-  // Small enough that the quadratic case below stays quick.
   const VERIFY_SIZES = [400, 1_600];
 
-  it("passes work whose per-item cost stays flat", () => {
-    const result = checkGrowth("linear", linearWork, VERIFY_SIZES);
+  it("passes measurements whose per-item cost stays flat", () => {
+    const result = evaluateGrowth("linear", VERIFY_SIZES, [4, 16]);
 
     expect(result.ok).toBe(true);
     expect(result.sizes).toEqual(VERIFY_SIZES);
+    expect(result.growth).toBe(1);
   });
 
-  // Without this, the gate would be decoration.
-  it("fails work that grows quadratically", () => {
-    const result = checkGrowth("quadratic", quadraticAllocation, VERIFY_SIZES);
+  it("fails measurements whose per-item cost grows quadratically", () => {
+    const result = evaluateGrowth("quadratic", VERIFY_SIZES, [16, 256]);
 
     expect(result.ok).toBe(false);
     expect(result.growth).toBeGreaterThan(MAX_COST_GROWTH);
-  });
-
-  it.each(CASES)("keeps %s linear", (_name, run) => {
-    expect(checkGrowth(_name, run).ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- give the real Astro CLI integration check an explicit timeout appropriate for loaded coverage workers
- separate performance sample measurement from the pure growth-rate decision
- keep timing-sensitive workload checks in the isolated perf command instead of the parallel coverage suite
- add a quadratic control to prove the isolated growth gate still detects superlinear behavior

## Verification

- pnpm test:coverage
- pnpm lint
- pnpm format:check
- pnpm typecheck
- pnpm build
- pnpm test
- five consecutive pnpm perf:check runs

The deterministic growth-policy tests now complete in about 1 ms, while the isolated gate detected its quadratic control at 3.93x to 4.18x per-item growth across five local runs.