### PR TITLE
fix(core): merge search cost bounds atomically

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/search.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search.test.ts
@@ -38,6 +38,36 @@ describe("cache search", () => {
     expect(mergeSearchLists(["a", "b"], ["b", "c"])).toEqual(["a", "b", "c"]);
   });
 
+  it("merges cost values with the comparison mode from the same source", () => {
+    const explicit = mergeSearchQueryOptions("cost:>0.1 cost:<10", {
+      costMin: 3.5,
+      costMax: 8,
+    }).options;
+    expect(explicit.costMin).toBe(3.5);
+    expect(explicit.costMax).toBe(8);
+    expect(explicit.costMinExclusive).toBeUndefined();
+    expect(explicit.costMaxExclusive).toBeUndefined();
+
+    const qualifier = mergeSearchQueryOptions("cost:>0.1 cost:<10", {}).options;
+    expect(qualifier.costMin).toBe(0.1);
+    expect(qualifier.costMax).toBe(10);
+    expect(qualifier.costMinExclusive).toBe(true);
+    expect(qualifier.costMaxExclusive).toBe(true);
+
+    const strictExplicit = mergeSearchQueryOptions("cost:>=0.1", {
+      costMin: 3.5,
+      costMinExclusive: true,
+    }).options;
+    expect(strictExplicit.costMin).toBe(3.5);
+    expect(strictExplicit.costMinExclusive).toBe(true);
+
+    const orphanComparisonMode = mergeSearchQueryOptions("cost:>=1", {
+      costMinExclusive: true,
+    }).options;
+    expect(orphanComparisonMode.costMin).toBe(1);
+    expect(orphanComparisonMode.costMinExclusive).toBeUndefined();
+  });
+
   it("keeps inclusive and exclusive cost bounds distinct", () => {
     const session = makeSessionHead("s1", {
       stats: { ...makeSessionHead("base").stats, total_cost: 1 },

--- a/packages/core/src/discovery/cache/search-query-parser.test.ts
+++ b/packages/core/src/discovery/cache/search-query-parser.test.ts
@@ -23,4 +23,15 @@ describe("parseSearchQuery", () => {
       hasQualifiers: true,
     });
   });
+
+  it("replaces a prior comparison mode with a later range or exact cost", () => {
+    expect(parseSearchQuery("cost:>1 cost:<5 cost:2..3").filters).toEqual({
+      costMin: 2,
+      costMax: 3,
+    });
+    expect(parseSearchQuery("cost:>1 cost:<5 cost:2").filters).toEqual({
+      costMin: 2,
+      costMax: 2,
+    });
+  });
 });

--- a/packages/core/src/discovery/cache/search-query-parser.ts
+++ b/packages/core/src/discovery/cache/search-query-parser.ts
@@ -64,8 +64,8 @@ function parseCostQualifier(value: string, filters: SearchQueryFilters): void {
   const raw = unwrapSearchValue(value);
   const range = raw.match(/^(\d+(?:\.\d+)?)\.\.(\d+(?:\.\d+)?)$/);
   if (range) {
-    filters.costMin = Number(range[1]);
-    filters.costMax = Number(range[2]);
+    setCostMinimum(filters, Number(range[1]), false);
+    setCostMaximum(filters, Number(range[2]), false);
     return;
   }
 
@@ -73,20 +73,30 @@ function parseCostQualifier(value: string, filters: SearchQueryFilters): void {
   if (comparison) {
     const amount = Number(comparison[2]);
     if (comparison[1]?.includes(">")) {
-      filters.costMin = amount;
-      filters.costMinExclusive = comparison[1] === ">";
+      setCostMinimum(filters, amount, comparison[1] === ">");
     } else {
-      filters.costMax = amount;
-      filters.costMaxExclusive = comparison[1] === "<";
+      setCostMaximum(filters, amount, comparison[1] === "<");
     }
     return;
   }
 
   const amount = Number(raw);
   if (!Number.isNaN(amount)) {
-    filters.costMin = amount;
-    filters.costMax = amount;
+    setCostMinimum(filters, amount, false);
+    setCostMaximum(filters, amount, false);
   }
+}
+
+function setCostMinimum(filters: SearchQueryFilters, value: number, exclusive: boolean): void {
+  filters.costMin = value;
+  if (exclusive) filters.costMinExclusive = true;
+  else delete filters.costMinExclusive;
+}
+
+function setCostMaximum(filters: SearchQueryFilters, value: number, exclusive: boolean): void {
+  filters.costMax = value;
+  if (exclusive) filters.costMaxExclusive = true;
+  else delete filters.costMaxExclusive;
 }
 
 function appendUnique<T>(values: T[] | undefined, value: T): T[] {

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -109,8 +109,35 @@ export function mergeSearchLists<T>(
   return values.length > 0 ? [...new Set(values)] : undefined;
 }
 
+function mergeCostLimit(
+  optionValue: number | undefined,
+  optionExclusive: boolean | undefined,
+  qualifierValue: number | undefined,
+  qualifierExclusive: boolean | undefined,
+) {
+  if (optionValue !== undefined) {
+    return { value: optionValue, exclusive: optionExclusive };
+  }
+  if (qualifierValue !== undefined) {
+    return { value: qualifierValue, exclusive: qualifierExclusive };
+  }
+  return { value: undefined, exclusive: undefined };
+}
+
 export function mergeSearchQueryOptions(query: string, options: SearchOptions) {
   const parsed = parseSearchQuery(query);
+  const costMin = mergeCostLimit(
+    options.costMin,
+    options.costMinExclusive,
+    parsed.filters.costMin,
+    parsed.filters.costMinExclusive,
+  );
+  const costMax = mergeCostLimit(
+    options.costMax,
+    options.costMaxExclusive,
+    parsed.filters.costMax,
+    parsed.filters.costMaxExclusive,
+  );
   return {
     text: parsed.text || (parsed.hasQualifiers ? "" : query.trim()),
     options: {
@@ -123,10 +150,10 @@ export function mergeSearchQueryOptions(query: string, options: SearchOptions) {
       tools: mergeSearchLists(options.tools, parsed.filters.tools),
       file: options.file ?? parsed.filters.file,
       fileKind: options.fileKind ?? parsed.filters.fileKind,
-      costMin: options.costMin ?? parsed.filters.costMin,
-      costMax: options.costMax ?? parsed.filters.costMax,
-      costMinExclusive: options.costMinExclusive ?? parsed.filters.costMinExclusive,
-      costMaxExclusive: options.costMaxExclusive ?? parsed.filters.costMaxExclusive,
+      costMin: costMin.value,
+      costMax: costMax.value,
+      costMinExclusive: costMin.exclusive,
+      costMaxExclusive: costMax.exclusive,
     },
     parsed,
   };

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -698,17 +698,9 @@ describe("search characterization: FTS path", () => {
     expect(results.map((r) => r.session.id)).toEqual(["tagmerge-both"]);
   });
 
-  it("scalar qualifier/options merge: explicit costMin wins, but a leftover exclusive-comparison flag from the qualifier still applies", () => {
-    // Quirk: mergeSearchQueryOptions merges costMin/costMax and their
-    // *Exclusive flags independently. An explicit costMin option overrides
-    // the qualifier's costMin value, but if the qualifier used a strict
-    // comparison (cost:>N), its costMinExclusive=true flag survives even
-    // though the numeric value it was paired with did not. Here costMin=3.5
-    // ends up EXCLUSIVE because of the leftover `cost:>0.1` qualifier, so the
-    // session with total_cost exactly 3.5 is excluded even though costMin=3.5
-    // alone would normally read as ">=".
+  it("keeps an explicit inclusive cost bound independent from a strict qualifier", () => {
     const results = search("needle cost:>0.1", { costMin: 3.5, limit: 50 });
-    expect(results.map((r) => r.session.id)).not.toContain("recent-mid");
+    expect(results.map((r) => r.session.id)).toContain("recent-mid");
   });
 });
 


### PR DESCRIPTION
## Summary

- select each cost value and its inclusive or exclusive comparison mode from the same source
- prevent strict query qualifiers from changing explicit inclusive API options
- clear stale comparison modes when a later range or exact-cost qualifier replaces a prior bound
- replace the characterization of the bug with cache, parser, and end-to-end search regressions

## Verification

- pnpm --filter @codesesh/core lint
- pnpm --filter @codesesh/core format:check
- pnpm --filter @codesesh/core typecheck
- pnpm --filter @codesesh/core build
- pnpm --filter @codesesh/core test
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test