### PR TITLE
fix(cli): retry failed alias loads

### DIFF
--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -174,8 +174,8 @@ const bookmarkScanSource: ScanResultSource = {
 
 beforeEach(() => {
   vi.resetAllMocks();
-  // The alias read model is cached for the process lifetime; each test needs a
-  // clean slate or it inherits the previous test's listSessionAliases stub.
+  // Successful alias reads are cached for the process lifetime; each test needs
+  // a clean slate or it inherits the previous test's listSessionAliases stub.
   invalidateAliasView();
   coreMocks.listBookmarks.mockReturnValue([]);
   coreMocks.listFileActivity.mockReturnValue([]);
@@ -272,7 +272,6 @@ describe("bookmark handlers", () => {
     handleGetBookmarks(makeContext() as never, bookmarkScanSource);
     expect(loggerMocks.warn).not.toHaveBeenCalled();
 
-    invalidateAliasView();
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw new Error("corrupt aliases");
     });
@@ -281,7 +280,6 @@ describe("bookmark handlers", () => {
       error: "corrupt aliases",
     });
 
-    invalidateAliasView();
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw "invalid aliases";
     });
@@ -865,23 +863,21 @@ describe("session alias caching", () => {
     ).not.toHaveProperty("display_title");
   });
 
-  it("caches an unavailable store but retries it after invalidation", () => {
-    coreMocks.listSessionAliases.mockImplementation(() => {
+  it("retries an unavailable store and caches the recovered view", () => {
+    coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw new StateStorageUnavailableError();
     });
-
-    handleGetSessions(makeContext() as never, scanSource);
-    handleGetSessions(makeContext() as never, scanSource);
-    expect(coreMocks.listSessionAliases).toHaveBeenCalledTimes(1);
-
-    invalidateAliasView();
     coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
+
+    handleGetSessions(makeContext() as never, scanSource);
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
     const recovered = makeContext();
     handleGetBookmarks(recovered as never, bookmarkScanSource);
+    handleGetSessions(makeContext() as never, scanSource);
 
     expect(getResponsePayload<{ bookmarks: BookmarkView[] }>(recovered).bookmarks[0]).toMatchObject(
       { session: { display_title: "Renamed" } },
     );
+    expect(coreMocks.listSessionAliases).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -261,7 +261,7 @@ afterEach(() => {
   coreMocks.matchesProjectIdentity.mockClear();
   coreMocks.listSessionAliases.mockReset();
   coreMocks.listSessionAliases.mockReturnValue([]);
-  // The alias read model caches for the process lifetime; tests stub
+  // Successful alias reads are cached for the process lifetime; tests stub
   // listSessionAliases per case and need a fresh load each time.
   invalidateAliasView();
   coreMocks.executeSessionSearch.mockReset();

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -32,21 +32,7 @@ function aliasKey(reference: SessionReference): string {
   return `${reference.agentName.toLowerCase()}\0${reference.sessionId}`;
 }
 
-function loadAliasMap(): Map<string, SessionAlias> {
-  try {
-    return new Map(listSessionAliases().map((alias) => [aliasKey(alias.reference), alias]));
-  } catch (error) {
-    if (!(error instanceof StateStorageUnavailableError)) {
-      appLogger.warn("api.session_aliases.load_failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-    return new Map();
-  }
-}
-
-function buildAliasView(): AliasView {
-  const aliases = loadAliasMap();
+function buildAliasView(aliases: Map<string, SessionAlias>): AliasView {
   return {
     size: aliases.size,
     get: (reference) => aliases.get(aliasKey(reference))?.alias,
@@ -58,17 +44,38 @@ function buildAliasView(): AliasView {
   };
 }
 
+function readAliasView(): AliasView | null {
+  try {
+    return buildAliasView(
+      new Map(listSessionAliases().map((alias) => [aliasKey(alias.reference), alias])),
+    );
+  } catch (error) {
+    if (!(error instanceof StateStorageUnavailableError)) {
+      appLogger.warn("api.session_aliases.load_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return null;
+  }
+}
+
+const EMPTY_ALIAS_VIEW = buildAliasView(new Map());
+
 /**
  * Aliases change only through this process's own PUT/DELETE handlers, so the
  * read model is built once and reused until one of them invalidates it. Six read
  * handlers call this per request; without the cache each one re-queries the whole
- * table. A storage failure is cached too — it does not heal between requests, and
- * invalidateAliasView() is what lets a recovered store be retried.
+ * table. Failed reads return an empty view for that request but are not published,
+ * so a recovered store is retried on the next request.
  */
 let cachedView: AliasView | null = null;
 
 export function loadAliasView(): AliasView {
-  return (cachedView ??= buildAliasView());
+  if (cachedView) return cachedView;
+  const loaded = readAliasView();
+  if (!loaded) return EMPTY_ALIAS_VIEW;
+  cachedView = loaded;
+  return loaded;
 }
 
 export function invalidateAliasView(): void {


### PR DESCRIPTION
## Summary

- distinguish failed alias reads from successful empty results
- avoid publishing transient failures into the process-wide alias cache
- retry on the next request and cache the recovered view

## Verification

- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`
- `pnpm --filter codesesh typecheck`
- `pnpm --filter codesesh build`
- `pnpm --filter codesesh test`
- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`