### PR TITLE
fix(web): preserve bookmark toggle order

### DIFF
--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -213,6 +213,86 @@ describe("useBookmarks", () => {
     expect(consoleError).toHaveBeenCalledWith("Failed to toggle bookmark:", error);
   });
 
+  it("persists overlapping toggles for the same bookmark in intent order", async () => {
+    const addRequest = deferred<void>();
+    const deleteRequest = deferred<void>();
+    const completionOrder: string[] = [];
+    let serverBookmarked = false;
+    vi.mocked(api.fetchBookmarks).mockImplementation(async () => ({
+      bookmarks: serverBookmarked ? [available("racy")] : [],
+    }));
+    vi.mocked(api.upsertBookmark).mockImplementationOnce(async () => {
+      await addRequest.promise;
+      serverBookmarked = true;
+      completionOrder.push("add");
+      return { bookmark: fact("racy") };
+    });
+    vi.mocked(api.deleteBookmark).mockImplementationOnce(async () => {
+      await deleteRequest.promise;
+      serverBookmarked = false;
+      completionOrder.push("delete");
+    });
+    const { result } = renderBookmarks();
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalledOnce());
+
+    act(() => result.current.toggleBookmark(available("racy")));
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "racy")).toBe(true));
+    act(() => result.current.toggleBookmark(available("racy")));
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "racy")).toBe(false));
+    expect(api.deleteBookmark).not.toHaveBeenCalled();
+
+    addRequest.resolve();
+    await addRequest.promise;
+    await waitFor(() => expect(api.deleteBookmark).toHaveBeenCalledOnce());
+    expect(result.current.isSessionBookmarked("cc", "racy")).toBe(false);
+
+    deleteRequest.resolve();
+    await deleteRequest.promise;
+    await waitFor(() => expect(completionOrder).toEqual(["add", "delete"]));
+    expect(serverBookmarked).toBe(false);
+    expect(result.current.isSessionBookmarked("cc", "racy")).toBe(false);
+  });
+
+  it("rolls back only the failed bookmark while another toggle is pending", async () => {
+    const failedRequest = deferred<void>();
+    const successfulRequest = deferred<void>();
+    const error = new Error("first write failed");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let serverBookmarks: BookmarkView[] = [];
+    vi.mocked(api.fetchBookmarks).mockImplementation(async () => ({
+      bookmarks: serverBookmarks,
+    }));
+    vi.mocked(api.upsertBookmark)
+      .mockImplementationOnce(async () => {
+        await failedRequest.promise;
+        return { bookmark: fact("first") };
+      })
+      .mockImplementationOnce(async () => {
+        await successfulRequest.promise;
+        serverBookmarks = [available("second")];
+        return { bookmark: fact("second") };
+      });
+    const { result } = renderBookmarks();
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalledOnce());
+
+    act(() => result.current.toggleBookmark(available("first")));
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "first")).toBe(true));
+    act(() => result.current.toggleBookmark(available("second")));
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "second")).toBe(true));
+    expect(api.upsertBookmark).toHaveBeenCalledTimes(1);
+
+    failedRequest.reject(error);
+    await failedRequest.promise.catch(() => undefined);
+    await waitFor(() => expect(api.upsertBookmark).toHaveBeenCalledTimes(2));
+    expect(result.current.isSessionBookmarked("cc", "first")).toBe(false);
+    expect(result.current.isSessionBookmarked("cc", "second")).toBe(true);
+
+    successfulRequest.resolve();
+    await successfulRequest.promise;
+    await waitFor(() => expect(result.current.bookmarkedSessions).toEqual(serverBookmarks));
+    expect(consoleError).toHaveBeenCalledWith("Failed to toggle bookmark:", error);
+  });
+
   it("converts live sessions into optimistic views but writes only their reference", async () => {
     const request = deferred<{ bookmark: BookmarkRecord }>();
     vi.mocked(api.upsertBookmark).mockReturnValueOnce(request.promise);

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -1,4 +1,10 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  useMutation,
+  useMutationState,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo } from "react";
 import {
   type BookmarkView,
@@ -23,6 +29,8 @@ interface ToggleBookmarkVariables {
 }
 
 const EMPTY_BOOKMARKS: BookmarkView[] = [];
+const BOOKMARK_TOGGLE_MUTATION_KEY = ["bookmarks", "toggle"] as const;
+const BOOKMARK_WRITE_SCOPE = { id: "bookmark-writes" };
 
 function toggledBookmarks(
   bookmarks: BookmarkView[],
@@ -33,7 +41,28 @@ function toggledBookmarks(
   if (isBookmarked) {
     return bookmarks.filter((item) => getSessionBookmarkKey(item.reference) !== key);
   }
-  return [bookmark, ...bookmarks];
+  return [bookmark, ...bookmarks.filter((item) => getSessionBookmarkKey(item.reference) !== key)];
+}
+
+function applyBookmarkToggles(
+  bookmarks: BookmarkView[],
+  toggles: readonly ToggleBookmarkVariables[],
+): BookmarkView[] {
+  return toggles.reduce(
+    (current, { bookmark, isBookmarked }) => toggledBookmarks(current, bookmark, isBookmarked),
+    bookmarks,
+  );
+}
+
+function getPendingBookmarkToggles(queryClient: QueryClient): ToggleBookmarkVariables[] {
+  return queryClient
+    .getMutationCache()
+    .findAll({
+      mutationKey: BOOKMARK_TOGGLE_MUTATION_KEY,
+      exact: true,
+      status: "pending",
+    })
+    .map((mutation) => mutation.state.variables as ToggleBookmarkVariables);
 }
 
 export function useBookmarks() {
@@ -49,7 +78,19 @@ export function useBookmarks() {
       }
     },
   });
-  const bookmarks = bookmarksQuery.data?.bookmarks ?? EMPTY_BOOKMARKS;
+  const confirmedBookmarks = bookmarksQuery.data?.bookmarks ?? EMPTY_BOOKMARKS;
+  const pendingToggles = useMutationState<ToggleBookmarkVariables>({
+    filters: {
+      mutationKey: BOOKMARK_TOGGLE_MUTATION_KEY,
+      exact: true,
+      status: "pending",
+    },
+    select: (mutation) => mutation.state.variables as ToggleBookmarkVariables,
+  });
+  const bookmarks = useMemo(
+    () => applyBookmarkToggles(confirmedBookmarks, pendingToggles),
+    [confirmedBookmarks, pendingToggles],
+  );
 
   const setBookmarks = useCallback(
     (next: BookmarkView[]) => {
@@ -59,6 +100,8 @@ export function useBookmarks() {
   );
 
   const { mutate: mutateBookmark } = useMutation({
+    mutationKey: BOOKMARK_TOGGLE_MUTATION_KEY,
+    scope: BOOKMARK_WRITE_SCOPE,
     mutationFn: async ({ bookmark, isBookmarked }: ToggleBookmarkVariables) => {
       if (isBookmarked) {
         await deleteBookmark(bookmark.reference);
@@ -66,25 +109,30 @@ export function useBookmarks() {
       }
       await upsertBookmark(bookmark.reference);
     },
-    onMutate: async ({ bookmark, isBookmarked }) => {
-      const cancellation = queryClient.cancelQueries({ queryKey: queryKeys.bookmarks });
-      const previous = queryClient.getQueryData<{ bookmarks: BookmarkView[] }>(queryKeys.bookmarks);
-      setBookmarks(toggledBookmarks(previous?.bookmarks ?? [], bookmark, isBookmarked));
+    onMutate: ({ bookmark, isBookmarked }) => {
       logClientEvent(isBookmarked ? "bookmark.delete" : "bookmark.add", {
         agent: bookmark.reference.agentName,
         session: bookmark.reference.sessionId,
       });
-      await cancellation;
-      return previous;
     },
-    onError: (error, _variables, previous) => {
-      if (previous) queryClient.setQueryData(queryKeys.bookmarks, previous);
+    onError: (error) => {
       console.error("Failed to toggle bookmark:", error);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.bookmarks }),
+    onSettled: () => {
+      if (
+        queryClient.isMutating({
+          mutationKey: BOOKMARK_TOGGLE_MUTATION_KEY,
+          exact: true,
+        }) !== 1
+      ) {
+        return;
+      }
+      return queryClient.invalidateQueries({ queryKey: queryKeys.bookmarks });
+    },
   });
 
   const { mutate: migrateBookmarks } = useMutation({
+    scope: BOOKMARK_WRITE_SCOPE,
     mutationFn: importBookmarks,
   });
 
@@ -114,10 +162,17 @@ export function useBookmarks() {
 
   const toggleBookmark = useCallback(
     (bookmark: BookmarkView) => {
+      const confirmed =
+        queryClient.getQueryData<{ bookmarks: BookmarkView[] }>(queryKeys.bookmarks)?.bookmarks ??
+        EMPTY_BOOKMARKS;
+      const current = applyBookmarkToggles(confirmed, getPendingBookmarkToggles(queryClient));
       const key = getSessionBookmarkKey(bookmark.reference);
-      mutateBookmark({ bookmark, isBookmarked: bookmarkKeySet.has(key) });
+      mutateBookmark({
+        bookmark,
+        isBookmarked: current.some((item) => getSessionBookmarkKey(item.reference) === key),
+      });
     },
-    [bookmarkKeySet, mutateBookmark],
+    [mutateBookmark, queryClient],
   );
 
   const toggleSessionBookmark = useCallback(


### PR DESCRIPTION
## Summary

- keep confirmed bookmark data separate from pending optimistic intents
- serialize bookmark writes so rapid toggles reach the server in user order
- remove only the failed optimistic intent instead of restoring a stale list snapshot
- cover overlapping same-bookmark writes and cross-bookmark rollback isolation

## Verification

- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web typecheck`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`