### PR TITLE
fix(web): ignore stale alias results

### DIFF
--- a/apps/web/src/components/SessionAliasDialog.test.tsx
+++ b/apps/web/src/components/SessionAliasDialog.test.tsx
@@ -1,8 +1,18 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionAliasDialog } from "./SessionAliasDialog";
 
 afterEach(cleanup);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 describe("SessionAliasDialog", () => {
   it("starts editing from the current visible title", () => {
@@ -93,5 +103,121 @@ describe("SessionAliasDialog", () => {
     expect(errorMessage.id).toBe("session-alias-error");
     expect(input.getAttribute("aria-invalid")).toBe("true");
     expect(input.getAttribute("aria-describedby")).toBe("session-alias-error");
+  });
+
+  it("ignores a completed save from the previous target", async () => {
+    const firstRequest = deferred<void>();
+    const secondRequest = deferred<void>();
+    const onClose = vi.fn();
+    const onSave = vi
+      .fn()
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+    const { rerender } = render(
+      <SessionAliasDialog
+        target={{ agentKey: "codex", sessionId: "session-1", title: "First" }}
+        onClose={onClose}
+        onSave={onSave}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "Session title" }), {
+      target: { value: "Renamed first" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save title" }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce());
+
+    rerender(
+      <SessionAliasDialog
+        target={{ agentKey: "codex", sessionId: "session-2", title: "Second" }}
+        onClose={onClose}
+        onSave={onSave}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    expect((screen.getByRole("textbox", { name: "Session title" }) as HTMLInputElement).value).toBe(
+      "Second",
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "Session title" }), {
+      target: { value: "Renamed second" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save title" }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      firstRequest.resolve();
+      await firstRequest.promise;
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect((screen.getByRole("button", { name: "Saving…" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+
+    await act(async () => {
+      secondRequest.resolve();
+      await secondRequest.promise;
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a rejected save from the previous target", async () => {
+    const request = deferred<void>();
+    const onClose = vi.fn();
+    const onSave = vi.fn().mockReturnValue(request.promise);
+    const { rerender } = render(
+      <SessionAliasDialog
+        target={{ agentKey: "codex", sessionId: "session-1", title: "First" }}
+        onClose={onClose}
+        onSave={onSave}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "Session title" }), {
+      target: { value: "Renamed first" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save title" }));
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce());
+
+    rerender(
+      <SessionAliasDialog
+        target={{ agentKey: "codex", sessionId: "session-2", title: "Second" }}
+        onClose={onClose}
+        onSave={onSave}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    await act(async () => {
+      request.reject(new Error("First failed"));
+      await request.promise.catch(() => undefined);
+    });
+
+    expect(screen.queryByText("First failed")).toBeNull();
+    expect((screen.getByRole("button", { name: "Save title" }) as HTMLButtonElement).disabled).toBe(
+      false,
+    );
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("submits at most one request while saving", async () => {
+    const request = deferred<void>();
+    const onSave = vi.fn().mockReturnValue(request.promise);
+    render(
+      <SessionAliasDialog
+        target={{ agentKey: "codex", sessionId: "session-1", title: "Source title" }}
+        onClose={vi.fn()}
+        onSave={onSave}
+        onRemove={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Session title" });
+    fireEvent.change(input, { target: { value: "New title" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce());
+    await act(async () => {
+      request.resolve();
+      await request.promise;
+    });
   });
 });

--- a/apps/web/src/components/SessionAliasDialog.tsx
+++ b/apps/web/src/components/SessionAliasDialog.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@base-ui/react/dialog";
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 export interface SessionAliasTarget {
   agentKey: string;
@@ -22,42 +22,49 @@ export function SessionAliasDialog({
   const [alias, setAlias] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const activeRequest = useRef<symbol | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    activeRequest.current = null;
     setAlias(target?.displayTitle ?? target?.title ?? "");
     setError(null);
+    setSaving(false);
   }, [target]);
 
+  const runOperation = async (operation: () => Promise<void>, fallbackError: string) => {
+    if (activeRequest.current) return;
+    const request = Symbol();
+    activeRequest.current = request;
+    setSaving(true);
+    setError(null);
+    try {
+      await operation();
+      if (activeRequest.current === request) onClose();
+    } catch (operationError) {
+      if (activeRequest.current !== request) return;
+      setError(operationError instanceof Error ? operationError.message : fallbackError);
+    } finally {
+      if (activeRequest.current === request) {
+        activeRequest.current = null;
+        setSaving(false);
+      }
+    }
+  };
+
   const saveAlias = async () => {
+    if (!target) return;
     const nextAlias = alias.trim();
-    if (!nextAlias || nextAlias === target?.title.trim()) {
+    if (!nextAlias || nextAlias === target.title.trim()) {
       await removeAlias();
       return;
     }
 
-    setSaving(true);
-    setError(null);
-    try {
-      await onSave(nextAlias);
-      onClose();
-    } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : "Could not rename this session.");
-    } finally {
-      setSaving(false);
-    }
+    await runOperation(() => onSave(nextAlias), "Could not rename this session.");
   };
 
   const removeAlias = async () => {
-    setSaving(true);
-    setError(null);
-    try {
-      await onRemove();
-      onClose();
-    } catch (removeError) {
-      setError(removeError instanceof Error ? removeError.message : "Could not restore the title.");
-    } finally {
-      setSaving(false);
-    }
+    if (!target) return;
+    await runOperation(onRemove, "Could not restore the title.");
   };
 
   return (


### PR DESCRIPTION
## Summary

- bind alias mutations to the dialog target that started them
- ignore stale success, error, and cleanup effects after the target changes
- keep a newer request disabled when an older request settles
- block duplicate Enter submissions while a save is pending

## Verification

- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web typecheck`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm lint && pnpm typecheck && pnpm build`
- `pnpm test`