### PR TITLE
fix(web): surface resource load failures

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -137,6 +137,8 @@ export default function App() {
   const bookmarks = useBookmarks();
   const {
     bookmarkedSessions,
+    loading: bookmarksLoading,
+    error: bookmarksError,
     isSessionBookmarked,
     toggleBookmark,
     toggleSessionBookmark,
@@ -281,6 +283,9 @@ export default function App() {
       agentCatalog={agentCatalog}
       agentNameMap={agentNameMap}
       projects={projects}
+      projectsError={projectsError}
+      projectsLoading={projectsLoading}
+      onRetryProjects={() => void retryProjects()}
       landingSessions={sessionIndexes.landingSessions}
       sessions={sessions}
       sessionsByAgent={sessionIndexes.byLandingAgent}
@@ -401,6 +406,8 @@ export default function App() {
               projectsLoading,
               selectedProjectNavigationId,
               bookmarkedSessions,
+              bookmarksError,
+              bookmarksLoading,
               sidebarSessions,
               sidebarSessionLookup: sidebar.sidebarSessionLookup,
               bookmarkedSidebarSessionReferences,
@@ -416,6 +423,7 @@ export default function App() {
               onRenameSession: handleRenameSession,
               onRenameBookmarkedSession: handleRenameBookmarkedSession,
               onRetryProjects: () => void retryProjects(),
+              onRetryBookmarks: () => void refreshBookmarks(),
             }}
           />
 

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -8,6 +8,7 @@ import type { TimeWindowPreset } from "../lib/time-window";
 import { AgentIcon } from "./AgentIcon";
 import { OverviewScreen } from "./overview/OverviewScreen";
 import { ProjectTimeline } from "./project-timeline/ProjectTimeline";
+import { ResourceLoadFailure } from "./ResourceLoadFailure";
 import { Panel } from "./ui/panel";
 
 function StatCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
@@ -101,9 +102,15 @@ function ProjectListItem({
 export function ProjectsOverview({
   projects,
   agentCatalog,
+  loading,
+  error,
+  onRetry,
 }: {
   projects: ApiProjectGroup[];
   agentCatalog: AgentCatalog;
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
 }) {
   const totalSessions = projects.reduce((sum, project) => sum + project.sessionCount, 0);
   const totalTokens = projects.reduce((sum, project) => sum + project.tokens, 0);
@@ -111,6 +118,20 @@ export function ProjectsOverview({
   const latestActivity = Math.max(0, ...projects.map((project) => project.lastActivity ?? 0));
 
   if (projects.length === 0) {
+    if (error) {
+      return (
+        <div className="mx-auto max-w-6xl">
+          <ResourceLoadFailure title="Couldn't load projects." message={error} onRetry={onRetry} />
+        </div>
+      );
+    }
+    if (loading) {
+      return (
+        <Panel className="mx-auto max-w-6xl p-6 text-sm text-[var(--console-muted)]">
+          Loading projects...
+        </Panel>
+      );
+    }
     return (
       <Panel className="mx-auto max-w-6xl p-6 text-sm text-[var(--console-muted)]">
         No projects found
@@ -120,6 +141,9 @@ export function ProjectsOverview({
 
   return (
     <div className="mx-auto max-w-6xl space-y-4">
+      {error ? (
+        <ResourceLoadFailure title="Couldn't refresh projects." message={error} onRetry={onRetry} />
+      ) : null}
       <div className="grid gap-3 md:grid-cols-4">
         <StatCard label="Projects" value={formatNumber(projects.length)} />
         <StatCard label="Sessions" value={formatNumber(totalSessions)} />

--- a/apps/web/src/components/ResourceLoadFailure.tsx
+++ b/apps/web/src/components/ResourceLoadFailure.tsx
@@ -1,0 +1,28 @@
+export function ResourceLoadFailure({
+  title,
+  message,
+  onRetry,
+  className = "",
+}: {
+  title: string;
+  message: string;
+  onRetry: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="alert"
+      className={`rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-4 text-[var(--console-error)] ${className}`}
+    >
+      <p className="text-sm font-medium">{title}</p>
+      <p className="console-mono mt-1 break-words text-[11px]">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="console-mono mt-3 rounded-sm border border-[var(--console-error-border)] bg-[var(--console-surface)] px-2.5 py-1 text-[11px] font-semibold motion-hover hover:bg-[var(--console-error-bg)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -61,6 +61,9 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
     agentCatalog: createAgentCatalog([]),
     agentNameMap: new Map(),
     projects: [project],
+    projectsError: null,
+    projectsLoading: false,
+    onRetryProjects: vi.fn(),
     landingSessions: [],
     sessionsByAgent: new Map(),
     activeProject: null,
@@ -173,6 +176,21 @@ describe("AppRouteContent", () => {
       await screen.findByTestId("dashboard", {}, { timeout: LAZY_SURFACE_TIMEOUT_MS }),
     ).toBeTruthy();
     expect(screen.getByRole("combobox", { name: "Filter by agent" })).toBeTruthy();
+  });
+
+  it("shows a retryable project failure instead of an empty state", async () => {
+    const props = makeProps();
+    props.viewState = { mode: "projects", activeAgentKey: null, activeSessionId: null };
+    props.projects = [];
+    props.projectsError = "projects unavailable";
+    renderContent(props);
+
+    const alert = await screen.findByRole("alert", {}, { timeout: LAZY_SURFACE_TIMEOUT_MS });
+    expect(alert.textContent).toContain("Couldn't load projects.");
+    expect(alert.textContent).toContain("projects unavailable");
+    expect(screen.queryByText("No projects found")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(props.onRetryProjects).toHaveBeenCalledOnce();
   });
 
   // The route surfaces load on demand, so these assertions wait for the chunk.

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -98,6 +98,9 @@ interface AppRouteContentProps {
   agentCatalog: AgentCatalog;
   agentNameMap: ReadonlyMap<string, string>;
   projects: ApiProjectGroup[];
+  projectsError: string | null;
+  projectsLoading: boolean;
+  onRetryProjects: () => void;
   landingSessions: IndexedSession[];
   sessions?: SessionHead[];
   sessionsByAgent: Map<string, IndexedSession[]>;
@@ -120,6 +123,9 @@ export function AppRouteContent({
   agentCatalog,
   agentNameMap,
   projects,
+  projectsError,
+  projectsLoading,
+  onRetryProjects,
   landingSessions,
   sessions = [],
   sessionsByAgent,
@@ -223,7 +229,13 @@ export function AppRouteContent({
   if (viewState.mode === "projects") {
     return (
       <LazySurface>
-        <ProjectsOverview projects={projects} agentCatalog={agentCatalog} />
+        <ProjectsOverview
+          projects={projects}
+          agentCatalog={agentCatalog}
+          loading={projectsLoading}
+          error={projectsError}
+          onRetry={onRetryProjects}
+        />
       </LazySurface>
     );
   }

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -30,6 +30,7 @@ function createActions(overrides: Partial<AppSidebarActions> = {}): AppSidebarAc
     onRenameSession: vi.fn(),
     onRenameBookmarkedSession: vi.fn(),
     onRetryProjects: vi.fn(),
+    onRetryBookmarks: vi.fn(),
     ...overrides,
   };
 }
@@ -52,6 +53,8 @@ function renderSidebar(
             projectsLoading: false,
             selectedProjectNavigationId: null,
             bookmarkedSessions: [],
+            bookmarksError: null,
+            bookmarksLoading: false,
             sidebarSessions: [],
             sidebarSessionLookup: buildSidebarSessionLookup([]),
             bookmarkedSidebarSessionReferences: new Set(),
@@ -140,6 +143,27 @@ describe("AppSidebar", () => {
     expect(screen.queryByText("No projects found")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(onRetryProjects).toHaveBeenCalledTimes(1);
+  });
+
+  it("distinguishes bookmark failures from an empty list", () => {
+    const onRetryBookmarks = vi.fn();
+    renderSidebar(
+      { bookmarkedSessions: [], bookmarksError: "bookmarks unavailable" },
+      createActions({ onRetryBookmarks }),
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain("Couldn't load bookmarks.");
+    expect(screen.getByText("bookmarks unavailable")).toBeTruthy();
+    expect(screen.queryByText("No bookmarks yet")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetryBookmarks).toHaveBeenCalledOnce();
+  });
+
+  it("does not show an empty bookmark state while loading", () => {
+    renderSidebar({ bookmarkedSessions: [], bookmarksLoading: true });
+
+    expect(screen.getByText("Loading bookmarks...")).toBeTruthy();
+    expect(screen.queryByText("No bookmarks yet")).toBeNull();
   });
 
   it("omits the sessions section until a project is selected", () => {

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -14,6 +14,7 @@ import { getProjectGroupIdentity, getProjectIdentityKey, getProjectPath } from "
 import type { ViewState } from "../../lib/view-state";
 import { AgentIcon } from "../AgentIcon";
 import { RenderProfiler } from "../RenderProfiler";
+import { ResourceLoadFailure } from "../ResourceLoadFailure";
 import { SessionActionsMenu } from "../SessionActionsMenu";
 import { SessionTreeSidebar } from "../SessionTreeSidebar";
 import { PanelLeftClose } from "../ui/icons";
@@ -69,25 +70,6 @@ function ProjectNavList({
   );
 }
 
-function ProjectLoadFailure({ message, onRetry }: { message: string; onRetry: () => void }) {
-  return (
-    <div
-      role="alert"
-      className="rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] px-3 py-2 text-xs text-[var(--console-error)]"
-    >
-      <p>Couldn&apos;t load projects.</p>
-      <p className="console-mono mt-1 break-all text-[11px]">{message}</p>
-      <button
-        type="button"
-        onClick={onRetry}
-        className="console-mono mt-2 rounded-sm border border-[var(--console-error-border)] px-2 py-1 text-[11px] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
-      >
-        Retry
-      </button>
-    </div>
-  );
-}
-
 export interface AppSidebarViewModel {
   sidebarCollapsed: boolean;
   viewState: ViewState;
@@ -97,6 +79,8 @@ export interface AppSidebarViewModel {
   projectsLoading: boolean;
   selectedProjectNavigationId: string | null;
   bookmarkedSessions: BookmarkView[];
+  bookmarksError: string | null;
+  bookmarksLoading: boolean;
   sidebarSessions: SessionHead[];
   sidebarSessionLookup: SidebarSessionLookup;
   bookmarkedSidebarSessionReferences: Set<string>;
@@ -113,6 +97,7 @@ export interface AppSidebarActions {
   onRenameSession: (session: SessionHead) => void;
   onRenameBookmarkedSession: (session: BookmarkView) => void;
   onRetryProjects: () => void;
+  onRetryBookmarks: () => void;
 }
 
 export function AppSidebar({
@@ -125,6 +110,8 @@ export function AppSidebar({
     projectsLoading,
     selectedProjectNavigationId,
     bookmarkedSessions,
+    bookmarksError,
+    bookmarksLoading,
     sidebarSessions,
     sidebarSessionLookup,
     bookmarkedSidebarSessionReferences,
@@ -140,6 +127,7 @@ export function AppSidebar({
     onRenameSession,
     onRenameBookmarkedSession,
     onRetryProjects,
+    onRetryBookmarks,
   },
 }: {
   model: AppSidebarViewModel;
@@ -202,7 +190,12 @@ export function AppSidebar({
             />
             {projectsError ? (
               <li>
-                <ProjectLoadFailure message={projectsError} onRetry={onRetryProjects} />
+                <ResourceLoadFailure
+                  title="Couldn't load projects."
+                  message={projectsError}
+                  onRetry={onRetryProjects}
+                  className="px-3 py-2"
+                />
               </li>
             ) : projects.length === 0 && !projectsLoading ? (
               <li>
@@ -214,7 +207,19 @@ export function AppSidebar({
 
         <section>
           <h3 className="console-eyebrow mb-3">BOOKMARKS</h3>
-          {bookmarkedSessions.length === 0 ? (
+          {bookmarksError ? (
+            <ResourceLoadFailure
+              title="Couldn't load bookmarks."
+              message={bookmarksError}
+              onRetry={onRetryBookmarks}
+              className="mb-2 px-3 py-2"
+            />
+          ) : null}
+          {bookmarkedSessions.length === 0 && bookmarksLoading ? (
+            <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
+              Loading bookmarks...
+            </span>
+          ) : bookmarkedSessions.length === 0 && !bookmarksError ? (
             <span className="console-mono block rounded-sm px-3 py-1.5 text-xs text-[var(--console-muted)]">
               No bookmarks yet
             </span>

--- a/apps/web/src/components/overview/OverviewScreen.test.tsx
+++ b/apps/web/src/components/overview/OverviewScreen.test.tsx
@@ -119,6 +119,20 @@ describe("OverviewScreen", () => {
     await waitFor(() => expect(screen.queryByTestId("overview-skeleton")).toBeNull());
   });
 
+  it("shows a dashboard failure and retries it in place", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchDashboard).mockRejectedValueOnce(new Error("dashboard unavailable"));
+    renderScreen();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Couldn't load the dashboard.");
+    expect(alert.textContent).toContain("dashboard unavailable");
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await screen.findByRole("heading", { name: "Agents" });
+    expect(api.fetchDashboard).toHaveBeenCalledTimes(2);
+  });
+
   it("renders the full card set for the global scope", async () => {
     renderScreen();
 

--- a/apps/web/src/components/overview/OverviewScreen.tsx
+++ b/apps/web/src/components/overview/OverviewScreen.tsx
@@ -17,6 +17,7 @@ import type { AgentCatalog } from "../../lib/agents";
 import type { AppConfig, DashboardFilters } from "../../lib/api";
 import type { TimeWindowPreset } from "../../lib/time-window";
 import { useDashboard } from "../../hooks/useDashboard";
+import { ResourceLoadFailure } from "../ResourceLoadFailure";
 import { OverviewAgentDistribution } from "./overview-agent-distribution";
 import { OverviewCostBreakdown } from "./overview-cost-breakdown";
 import { OverviewFilterBar } from "./overview-filter-bar";
@@ -47,7 +48,7 @@ export function OverviewScreen({
   const agent = onAgentChange ? controlledAgent : ownAgent;
 
   const filters: DashboardFilters = { project, agent };
-  const { dashboard, error } = useDashboard(window, filters);
+  const { dashboard, error, retry } = useDashboard(window, filters);
 
   return (
     <div data-testid="dashboard" className="mx-auto max-w-6xl space-y-4">
@@ -63,13 +64,13 @@ export function OverviewScreen({
       />
 
       {error ? (
-        <p
-          role="alert"
-          className="rounded-lg border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-4 text-sm text-[var(--console-error)]"
-        >
-          {error}
-        </p>
-      ) : dashboard ? (
+        <ResourceLoadFailure
+          title="Couldn't load the dashboard."
+          message={error}
+          onRetry={() => void retry()}
+        />
+      ) : null}
+      {dashboard ? (
         <>
           <OverviewKpiGrid totals={dashboard.totals} rangeDays={dashboard.window.days} />
           <OverviewUsageChart daily={dashboard.dailyActivity} />
@@ -82,7 +83,7 @@ export function OverviewScreen({
             />
           </div>
         </>
-      ) : (
+      ) : error ? null : (
         <OverviewSkeleton />
       )}
     </div>

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -314,17 +314,20 @@ describe("useBookmarks", () => {
     await request.promise;
   });
 
-  it("reports load and explicit refresh failures", async () => {
+  it("surfaces load failures and recovers through explicit refresh", async () => {
     const error = new Error("offline");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
     const { result } = renderBookmarks();
-    await waitFor(() =>
-      expect(consoleError).toHaveBeenCalledWith("Failed to load bookmarks:", error),
-    );
+    await waitFor(() => expect(result.current.error).toBe("offline"));
 
-    vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
+    expect(result.current.bookmarkedSessions).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(consoleError).toHaveBeenCalledWith("Failed to load bookmarks:", error);
+
+    vi.mocked(api.fetchBookmarks).mockResolvedValueOnce({ bookmarks: [available("recovered")] });
     await act(() => result.current.refresh());
-    expect(consoleError).toHaveBeenLastCalledWith("Failed to load bookmarks:", error);
+    await waitFor(() => expect(result.current.error).toBeNull());
+    expect(result.current.isSessionBookmarked("cc", "recovered")).toBe(true);
   });
 });

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -186,9 +186,16 @@ export function useBookmarks() {
   const refresh = useCallback(async () => {
     await refreshBookmarks();
   }, [refreshBookmarks]);
+  const error = bookmarksQuery.isError
+    ? bookmarksQuery.error instanceof Error
+      ? bookmarksQuery.error.message
+      : "Unable to load bookmarks."
+    : null;
 
   return {
     bookmarkedSessions: bookmarks,
+    loading: bookmarksQuery.isPending,
+    error,
     isSessionBookmarked,
     toggleBookmark,
     toggleSessionBookmark,

--- a/apps/web/src/hooks/useDashboard.test.ts
+++ b/apps/web/src/hooks/useDashboard.test.ts
@@ -106,10 +106,11 @@ describe("useDashboard", () => {
     const { Wrapper } = createQueryWrapper();
     const { result } = renderHook(() => useDashboard(window, globalScope), { wrapper: Wrapper });
 
-    await waitFor(() => expect(result.current.error).toBe("Failed to load dashboard"));
+    await waitFor(() => expect(result.current.error).toBe("dashboard unavailable"));
 
     expect(result.current.dashboard).toBeNull();
     expect(result.current.loading).toBe(false);
+    expect(result.current.retry).toBeTypeOf("function");
     expect(console.error).toHaveBeenCalledWith("Failed to load dashboard:", error);
   });
 });

--- a/apps/web/src/hooks/useDashboard.ts
+++ b/apps/web/src/hooks/useDashboard.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
 import {
   type AppConfig,
   type DashboardData,
@@ -12,7 +13,12 @@ export type { DashboardFilters };
 export function useDashboard(
   window: AppConfig["window"] | null,
   filters: DashboardFilters,
-): { dashboard: DashboardData | null; loading: boolean; error: string | null } {
+): {
+  dashboard: DashboardData | null;
+  loading: boolean;
+  error: string | null;
+  retry: () => Promise<void>;
+} {
   const isEnabled = window !== null;
 
   const query = useQuery({
@@ -28,10 +34,20 @@ export function useDashboard(
       }
     },
   });
+  const refetch = query.refetch;
+  const retry = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
 
   return {
     dashboard: isEnabled ? (query.data ?? null) : null,
     loading: isEnabled && query.isPending,
-    error: isEnabled && query.isError ? "Failed to load dashboard" : null,
+    error:
+      isEnabled && query.isError
+        ? query.error instanceof Error
+          ? query.error.message
+          : "Unable to load dashboard."
+        : null,
+    retry,
   };
 }


### PR DESCRIPTION
## Summary

- expose bookmark and dashboard loading, error, and retry state
- propagate project query failures to the projects route
- distinguish failed resources from successful empty collections
- retain confirmed data during refresh failures and offer local retry actions
- share one accessible failure surface across bookmarks, projects, and dashboards

## Verification

- `pnpm --filter @codesesh/web lint`
- `pnpm --filter @codesesh/web format:check`
- `pnpm --filter @codesesh/web typecheck`
- `pnpm --filter @codesesh/web test`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`