### PR TITLE
fix(cli): authenticate loopback API

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ backup of your history. Session content stays in each agent's own data directory
 |------|-------|---------|-------------|
 | `--port` | `-p` | `4521` | HTTP server starting port; falls back to the next available port if busy |
 | `--host` | — | `127.0.0.1` | HTTP server bind address; default is local-only, set explicitly (e.g. `0.0.0.0`) to expose on the network |
-| `--remote-access` | — | `false` | Enable token-protected access for a non-loopback `--host`; anyone with the startup URL can read session data |
+| `--remote-access` | — | `false` | Allow network or reverse-proxy exposure; API access is token-protected in every mode |
 | `--tls-cert` | — | — | Path to a TLS certificate; serves remote access over HTTPS |
 | `--tls-key` | — | — | Path to the private key matching `--tls-cert` |
 | `--trust-proxy` | — | `false` | A reverse proxy in front of CodeSesh terminates TLS |
@@ -206,10 +206,11 @@ backup of your history. Session content stays in each agent's own data directory
 | `-v` | — | — | Print version number |
 | `-h` / `--help` | — | — | Show help |
 
-Non-loopback binding and `--trust-proxy` are rejected unless `--remote-access` is also present.
-This includes a loopback listener exposed by a same-machine reverse proxy. CodeSesh generates a new
-access token for every process and includes it in the printed startup URL. Treat that URL as a
-password: do not publish it or place it in shared shell history.
+Every CodeSesh server process protects its API with a new access token, including the default
+loopback listener, and includes that token in the printed startup URL. Non-loopback binding and
+`--trust-proxy` are rejected unless `--remote-access` is also present. This includes a loopback
+listener exposed by a same-machine reverse proxy. Treat the startup URL as a password: do not
+publish it or place it in shared shell history.
 
 A token proves who is asking; it does not hide the answer. Without TLS the token and the full
 session content travel the network in the clear, and the token in the URL can end up in reverse

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -88,7 +88,7 @@ npx codesesh --trace
 | ----------- | ----- | ------- | ----------------------------------------------------------- |
 | `--port`    | `-p`  | `4521`  | HTTP server starting port; falls back to the next available port if busy |
 | `--host`    | —     | `127.0.0.1` | HTTP server bind address; non-loopback values require `--remote-access` |
-| `--remote-access` | — | `false` | Enable token-protected access for any remotely exposed transport     |
+| `--remote-access` | — | `false` | Allow network or reverse-proxy exposure; every API mode uses a token |
 | `--tls-cert` | — | — | Path to a TLS certificate; serves remote access over HTTPS            |
 | `--tls-key` | — | — | Path to the private key matching `--tls-cert`                          |
 | `--trust-proxy` | — | `false` | A reverse proxy in front of CodeSesh terminates TLS                    |
@@ -105,10 +105,12 @@ npx codesesh --trace
 | `--clear-cache` | — | `false` | Clear scan cache before starting                            |
 | `-v`        | —     | —       | Print version number                                        |
 
-Non-loopback binding and `--trust-proxy` both require `--remote-access`. This includes the common
-setup where CodeSesh listens on `127.0.0.1` and a same-machine reverse proxy exposes it publicly.
-CodeSesh prints a startup URL containing a fresh access token. Anyone with that URL can read the
-indexed AI session history, so treat it as a password and do not share or persist it.
+Every CodeSesh server process protects its API with a fresh access token, including the default
+loopback listener, and prints that token in the startup URL. Non-loopback binding and
+`--trust-proxy` both require `--remote-access`. This includes the common setup where CodeSesh
+listens on `127.0.0.1` and a same-machine reverse proxy exposes it publicly. Anyone with the startup
+URL can read the indexed AI session history, so treat it as a password and do not share or persist
+it.
 
 A token authenticates the requester but does not encrypt traffic. Without TLS, the token and full
 session content travel over the network in plaintext, and URL tokens may be recorded in proxy logs.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -153,9 +153,9 @@ const main = defineCommand({
       process.exit(1);
     }
 
-    if (resolveRemoteAccessPolicy(hostname, transport).authenticationRequired && !remoteAccess) {
+    if (resolveRemoteAccessPolicy(hostname, transport).remoteAccessRequired && !remoteAccess) {
       console.error(
-        `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
+        `Refusing to expose CodeSesh on ${hostname} without explicit remote access. Add --remote-access to continue.`,
       );
       process.exit(1);
     }

--- a/packages/cli/src/remote-access.test.ts
+++ b/packages/cli/src/remote-access.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  createRemoteAccessToken,
+  createAccessToken,
   isConfidentialTransport,
   isLoopbackHostname,
   RemoteTransportError,
@@ -27,25 +27,25 @@ describe("remote access", () => {
   );
 
   it("creates a fresh 256-bit URL-safe token", () => {
-    const first = createRemoteAccessToken();
-    const second = createRemoteAccessToken();
+    const first = createAccessToken();
+    const second = createAccessToken();
 
     expect(first).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(second).not.toBe(first);
   });
 
-  it("resolves authentication from the complete exposure boundary", () => {
+  it("resolves remote opt-in from the exposure boundary", () => {
     expect(resolveRemoteAccessPolicy("127.0.0.1", { kind: "loopback" })).toEqual({
       bindCategory: "loopback",
-      authenticationRequired: false,
+      remoteAccessRequired: false,
     });
     expect(resolveRemoteAccessPolicy("127.0.0.1", { kind: "trusted-proxy" })).toEqual({
       bindCategory: "loopback",
-      authenticationRequired: true,
+      remoteAccessRequired: true,
     });
     expect(resolveRemoteAccessPolicy("0.0.0.0", { kind: "plaintext" })).toEqual({
       bindCategory: "network",
-      authenticationRequired: true,
+      remoteAccessRequired: true,
     });
   });
 });

--- a/packages/cli/src/remote-access.ts
+++ b/packages/cli/src/remote-access.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { isIP } from "node:net";
 import type { Context, MiddlewareHandler } from "hono";
 
-export const REMOTE_ACCESS_QUERY_PARAM = "access_token";
+export const ACCESS_TOKEN_QUERY_PARAM = "access_token";
 
 /**
  * How a remote listener's traffic is protected. A token proves who is asking;
@@ -21,7 +21,7 @@ export type RemoteTransport =
 
 export interface RemoteAccessPolicy {
   bindCategory: "loopback" | "network";
-  authenticationRequired: boolean;
+  remoteAccessRequired: boolean;
 }
 
 export interface RemoteTransportRequest {
@@ -77,9 +77,10 @@ export function resolveRemoteAccessPolicy(
   transport: RemoteTransport,
 ): RemoteAccessPolicy {
   const bindCategory = isLoopbackHostname(hostname) ? "loopback" : "network";
+  const directLoopback = bindCategory === "loopback" && transport.kind === "loopback";
   return {
     bindCategory,
-    authenticationRequired: bindCategory === "network" || transport.kind !== "loopback",
+    remoteAccessRequired: !directLoopback,
   };
 }
 
@@ -101,7 +102,7 @@ export function requireProxyTls(): MiddlewareHandler {
   };
 }
 
-export function createRemoteAccessToken(): string {
+export function createAccessToken(): string {
   return randomBytes(32).toString("base64url");
 }
 
@@ -130,13 +131,13 @@ function requestToken(c: Context): string | undefined {
   const bearer = bearerToken(c);
   if (bearer) return bearer;
   if (c.req.method !== "GET") return undefined;
-  return c.req.query(REMOTE_ACCESS_QUERY_PARAM);
+  return c.req.query(ACCESS_TOKEN_QUERY_PARAM);
 }
 
-export function remoteAccessAuth(expectedToken: string): MiddlewareHandler {
+export function accessTokenAuth(expectedToken: string): MiddlewareHandler {
   return async (c, next) => {
     if (!tokenMatches(requestToken(c), expectedToken)) {
-      return c.json({ error: "Remote access authentication required" }, 401);
+      return c.json({ error: "API access token required" }, 401);
     }
     await next();
   };

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -33,6 +33,18 @@ function httpRequest(
   });
 }
 
+function getServerAccess(startupUrl: string) {
+  const url = new URL(startupUrl);
+  const token = url.searchParams.get("access_token");
+  if (!token) throw new Error("Expected an access token in the startup URL");
+
+  return {
+    origin: url.origin,
+    token,
+    authorization: { Authorization: `Bearer ${token}` },
+  };
+}
+
 vi.mock("@hono/node-server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@hono/node-server")>();
   return {
@@ -182,7 +194,7 @@ describe("createServer", () => {
   it("reports the actual port when binding to port 0", async () => {
     const app = await createServer(0, createStore());
 
-    expect(app.url).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(app.url).toMatch(/^http:\/\/localhost:\d+\/\?access_token=[A-Za-z0-9_-]{43}$/);
     expect(app.url).not.toBe("http://localhost:0");
 
     await app.shutdown();
@@ -195,7 +207,8 @@ describe("createServer", () => {
     try {
       app = await createServer(port, createStore(), { portFallbackAttempts: 2 });
 
-      expect(app.url).toBe(`http://localhost:${port + 1}`);
+      expect(new URL(app.url).origin).toBe(`http://localhost:${port + 1}`);
+      expect(getServerAccess(app.url).token).toMatch(/^[A-Za-z0-9_-]{43}$/);
     } finally {
       await app?.shutdown();
       await close(blocker);
@@ -206,9 +219,28 @@ describe("createServer", () => {
     const app = await createServer(0, createStore());
 
     expect(serveOptionsLog.at(-1)?.hostname).toBe("127.0.0.1");
-    expect(app.url).toMatch(/^http:\/\/localhost:\d+$/);
+    expect(new URL(app.url).hostname).toBe("localhost");
+    expect(getServerAccess(app.url).token).toMatch(/^[A-Za-z0-9_-]{43}$/);
 
     await app.shutdown();
+  });
+
+  it("protects the default loopback API with a generated access token", async () => {
+    const app = await createServer(0, createStore());
+    const access = getServerAccess(app.url);
+
+    try {
+      expect((await fetch(`${access.origin}/api/agents`)).status).toBe(401);
+      expect(
+        (
+          await fetch(`${access.origin}/api/agents`, {
+            headers: access.authorization,
+          })
+        ).status,
+      ).toBe(200);
+    } finally {
+      await app.shutdown();
+    }
   });
 
   it("CS-160: enforces loopback authority before API, SSE, and static routes", async () => {
@@ -216,15 +248,24 @@ describe("createServer", () => {
     writeFileSync(join(webDist, "index.html"), "<html>app shell</html>");
     writeFileSync(join(webDist, "app.js"), "console.log('bundle')");
     const app = await createServer(0, createStore(), { webDistPath: webDist });
+    const access = getServerAccess(app.url);
     const port = new URL(app.url).port;
 
     try {
       for (const authority of [`localhost:${port}`, `127.0.0.1:${port}`, `[::1]:${port}`]) {
-        expect((await httpRequest(`${app.url}/api/agents`, { Host: authority })).status).toBe(200);
+        expect(
+          (
+            await httpRequest(`${access.origin}/api/agents`, {
+              ...access.authorization,
+              Host: authority,
+            })
+          ).status,
+        ).toBe(200);
       }
       expect(
         (
-          await httpRequest(`${app.url}/api/agents`, {
+          await httpRequest(`${access.origin}/api/agents`, {
+            ...access.authorization,
             Host: `localhost:${port}`,
             Origin: "https://attacker.example",
           })
@@ -234,7 +275,7 @@ describe("createServer", () => {
       for (const path of ["/api/agents", "/api/events", "/app.js"]) {
         expect(
           (
-            await httpRequest(`${app.url}${path}`, {
+            await httpRequest(`${access.origin}${path}`, {
               Host: `attacker.example:${port}`,
             })
           ).status,
@@ -248,40 +289,58 @@ describe("createServer", () => {
 
   it("CS-193: rejects unsafe loopback writes without breaking same-origin JSON", async () => {
     const app = await createServer(0, createStore());
+    const access = getServerAccess(app.url);
     const body = JSON.stringify({ event: "csrf-probe" });
 
     try {
-      const textPlain = await fetch(`${app.url}/api/logs`, {
-        method: "POST",
-        headers: { Connection: "close", "Content-Type": "text/plain", Origin: app.url },
-        body,
-      });
-      const bookmarkImport = await fetch(`${app.url}/api/bookmarks/import`, {
-        method: "POST",
-        headers: { Connection: "close", "Content-Type": "text/plain", Origin: app.url },
-        body: "[]",
-      });
-      const crossOrigin = await fetch(`${app.url}/api/logs`, {
+      const textPlain = await fetch(`${access.origin}/api/logs`, {
         method: "POST",
         headers: {
+          ...access.authorization,
+          Connection: "close",
+          "Content-Type": "text/plain",
+          Origin: access.origin,
+        },
+        body,
+      });
+      const bookmarkImport = await fetch(`${access.origin}/api/bookmarks/import`, {
+        method: "POST",
+        headers: {
+          ...access.authorization,
+          Connection: "close",
+          "Content-Type": "text/plain",
+          Origin: access.origin,
+        },
+        body: "[]",
+      });
+      const crossOrigin = await fetch(`${access.origin}/api/logs`, {
+        method: "POST",
+        headers: {
+          ...access.authorization,
           Connection: "close",
           "Content-Type": "application/json",
           Origin: "https://attacker.example",
         },
         body,
       });
-      const crossSite = await fetch(`${app.url}/api/logs`, {
+      const crossSite = await fetch(`${access.origin}/api/logs`, {
         method: "POST",
         headers: {
+          ...access.authorization,
           Connection: "close",
           "Content-Type": "application/json",
           "Sec-Fetch-Site": "cross-site",
         },
         body,
       });
-      const sameOrigin = await fetch(`${app.url}/api/logs`, {
+      const sameOrigin = await fetch(`${access.origin}/api/logs`, {
         method: "POST",
-        headers: { Connection: "close", "Content-Type": "application/json", Origin: app.url },
+        headers: {
+          ...access.authorization,
+          Connection: "close",
+          "Content-Type": "application/json",
+          Origin: access.origin,
+        },
         body,
       });
       const statuses = {
@@ -314,11 +373,13 @@ describe("createServer", () => {
       shutdown: vi.fn(async () => {}),
     };
     const app = await createServer(0, createStore(), { projectIdentityResolver: resolver });
+    const access = getServerAccess(app.url);
 
     try {
       expect(
         (
-          await httpRequest(`${app.url}/api/sessions?cwd=/untrusted`, {
+          await httpRequest(`${access.origin}/api/sessions?cwd=/untrusted`, {
+            ...access.authorization,
             "Sec-Fetch-Site": "cross-site",
           })
         ).status,
@@ -327,7 +388,8 @@ describe("createServer", () => {
 
       expect(
         (
-          await httpRequest(`${app.url}/api/sessions?cwd=/untrusted`, {
+          await httpRequest(`${access.origin}/api/sessions?cwd=/untrusted`, {
+            ...access.authorization,
             Origin: "https://attacker.example",
           })
         ).status,
@@ -335,7 +397,12 @@ describe("createServer", () => {
       expect(resolver.resolve).not.toHaveBeenCalled();
 
       expect(
-        (await httpRequest(`${app.url}/api/sessions?cwd=/untrusted`, { Origin: app.url })).status,
+        (
+          await httpRequest(`${access.origin}/api/sessions?cwd=/untrusted`, {
+            ...access.authorization,
+            Origin: access.origin,
+          })
+        ).status,
       ).toBe(200);
       expect(resolver.resolve).toHaveBeenCalledWith("/untrusted");
     } finally {
@@ -356,7 +423,7 @@ describe("createServer", () => {
       const app = await createServer(0, createStore(), {
         hostname: "0.0.0.0",
         remoteAccess: true,
-        remoteAccessToken: "test-access-token",
+        accessToken: "test-access-token",
       });
       const startupUrl = new URL(app.url);
       const requestOrigin = `http://127.0.0.1:${startupUrl.port}`;
@@ -422,7 +489,7 @@ describe("createServer", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const app = await createServer(0, createStore(), {
       hostname: "0.0.0.0",
-      remoteAccessToken: "test-access-token",
+      accessToken: "test-access-token",
     });
     const startupUrl = new URL(app.url);
     const requestOrigin = `http://127.0.0.1:${startupUrl.port}`;
@@ -446,15 +513,16 @@ describe("createServer", () => {
 
   it("compresses large JSON API responses but leaves the SSE stream untouched", async () => {
     const app = await createServer(0, createLargeSessionsStore());
+    const access = getServerAccess(app.url);
 
     try {
-      const sessionsResponse = await fetch(`${app.url}/api/sessions`, {
-        headers: { "Accept-Encoding": "gzip" },
+      const sessionsResponse = await fetch(`${access.origin}/api/sessions`, {
+        headers: { ...access.authorization, "Accept-Encoding": "gzip" },
       });
       expect(sessionsResponse.headers.get("Content-Encoding")).toBe("gzip");
 
-      const eventsResponse = await fetch(`${app.url}/api/events`, {
-        headers: { "Accept-Encoding": "gzip" },
+      const eventsResponse = await fetch(`${access.origin}/api/events`, {
+        headers: { ...access.authorization, "Accept-Encoding": "gzip" },
       });
       expect(eventsResponse.headers.get("Content-Encoding")).toBeNull();
       expect(eventsResponse.headers.get("Content-Type")).toContain("text/event-stream");
@@ -473,7 +541,10 @@ describe("createServer", () => {
       subscribeScanStatus: () => unsubscribeScanStatus,
     };
     const app = await createServer(0, store);
-    const events = await fetch(`${app.url}/api/events`);
+    const access = getServerAccess(app.url);
+    const events = await fetch(`${access.origin}/api/events`, {
+      headers: access.authorization,
+    });
     const shutdown = app.shutdown();
 
     const completedBeforeClientCancel = await Promise.race([
@@ -494,9 +565,10 @@ describe("createServer", () => {
     const webDist = mkdtempSync(join(tmpdir(), "codesesh-security-headers-"));
     writeFileSync(join(webDist, "index.html"), "<html>app shell</html>");
     const app = await createServer(0, createStore(), { webDistPath: webDist });
+    const { origin } = getServerAccess(app.url);
 
     try {
-      const response = await fetch(app.url);
+      const response = await fetch(origin);
       const policy = response.headers.get("Content-Security-Policy") ?? "";
 
       expect(policy).toContain("default-src 'self'");
@@ -528,18 +600,19 @@ describe("createServer", () => {
     writeFileSync(join(root, "private.txt"), outsideMarker);
 
     const app = await createServer(0, createStore(), { webDistPath: webDist });
+    const { origin } = getServerAccess(app.url);
     const encodedDot = "%2e";
     const separators = ["/", "\\", "%2f", "%5c"];
 
     try {
-      expect(await (await fetch(`${app.url}/app.js`)).text()).toContain("bundle");
+      expect(await (await fetch(`${origin}/app.js`)).text()).toContain("bundle");
       // SPA fallback still resolves unknown routes to the app shell.
-      expect(await (await fetch(`${app.url}/sessions/anything`)).text()).toContain("app shell");
+      expect(await (await fetch(`${origin}/sessions/anything`)).text()).toContain("app shell");
 
       for (const separator of separators) {
         for (const dots of ["..", `${encodedDot}${encodedDot}`]) {
           const escape = `${dots}${separator}`.repeat(4);
-          const response = await fetch(`${app.url}/${escape}private.txt`);
+          const response = await fetch(`${origin}/${escape}private.txt`);
           expect(await response.text()).not.toContain(outsideMarker);
         }
       }
@@ -560,7 +633,7 @@ describe("createServer", () => {
     });
     const app = await createServer(0, createStore(), {
       hostname: "0.0.0.0",
-      remoteAccessToken: "tls-token",
+      accessToken: "tls-token",
       transport,
     });
 
@@ -593,7 +666,7 @@ describe("createServer", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const app = await createServer(0, createStore(), {
       hostname: "0.0.0.0",
-      remoteAccessToken: "plaintext-token",
+      accessToken: "plaintext-token",
       transport: { kind: "plaintext" },
     });
 
@@ -610,7 +683,7 @@ describe("createServer", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const app = await createServer(0, createStore(), {
       hostname: "0.0.0.0",
-      remoteAccessToken: "proxy-token",
+      accessToken: "proxy-token",
       transport: { kind: "trusted-proxy" },
     });
 
@@ -626,7 +699,7 @@ describe("createServer", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const app = await createServer(0, createStore(), {
       hostname: "0.0.0.0",
-      remoteAccessToken: "proxy-token",
+      accessToken: "proxy-token",
       transport: { kind: "trusted-proxy" },
     });
     const origin = `http://127.0.0.1:${new URL(app.url).port}`;
@@ -664,7 +737,7 @@ describe("createServer", () => {
     const app = await createServer(0, createStore(), {
       hostname: "127.0.0.1",
       remoteAccess: true,
-      remoteAccessToken: "proxy-token",
+      accessToken: "proxy-token",
       transport: { kind: "trusted-proxy" },
     });
     const origin = `http://127.0.0.1:${new URL(app.url).port}`;
@@ -710,7 +783,7 @@ describe("createServer", () => {
     const app = await createServer(0, createStore(), {
       hostname: "127.0.0.1",
       remoteAccess: true,
-      remoteAccessToken: "proxy-token",
+      accessToken: "proxy-token",
       transport: { kind: "trusted-proxy" },
     });
     const origin = `http://127.0.0.1:${new URL(app.url).port}`;

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -20,9 +20,9 @@ import {
 import { validateLoopbackAuthority } from "./loopback-authority.js";
 import { loopbackWriteGuard } from "./loopback-write-guard.js";
 import {
-  createRemoteAccessToken,
-  REMOTE_ACCESS_QUERY_PARAM,
-  remoteAccessAuth,
+  ACCESS_TOKEN_QUERY_PARAM,
+  accessTokenAuth,
+  createAccessToken,
   requireProxyTls,
   resolveRemoteAccessPolicy,
   resolveRemoteTransport,
@@ -40,7 +40,7 @@ export interface CreateServerOptions {
   portFallbackAttempts?: number;
   hostname?: string;
   remoteAccess?: boolean;
-  remoteAccessToken?: string;
+  accessToken?: string;
   /** How the listener is protected; defaults to plaintext for a non-loopback host. */
   transport?: RemoteTransport;
   /** Overrides the auto-detected web build directory; used to pin the static root in tests. */
@@ -139,10 +139,8 @@ export async function createServer(
   const hostname = options.hostname ?? "127.0.0.1";
   const transport: RemoteTransport = options.transport ?? resolveRemoteTransport({ hostname });
   const accessPolicy = resolveRemoteAccessPolicy(hostname, transport);
-  const remoteAccessToken = accessPolicy.authenticationRequired
-    ? (options.remoteAccessToken ?? (options.remoteAccess ? createRemoteAccessToken() : null))
-    : null;
-  const loopbackAuthorityEnabled = !accessPolicy.authenticationRequired;
+  const accessToken = options.accessToken || createAccessToken();
+  const loopbackAuthorityEnabled = !accessPolicy.remoteAccessRequired;
   const shutdownController = new AbortController();
   const projectIdentityResolver =
     options.projectIdentityResolver ?? createProjectIdentityResolver();
@@ -151,13 +149,13 @@ export async function createServer(
   appLogger.info("server.access_policy", {
     bind_category: accessPolicy.bindCategory,
     transport: transport.kind,
-    authentication: remoteAccessToken ? "token" : "none",
+    authentication: "token",
     loopback_authority: loopbackAuthorityEnabled ? "enabled" : "disabled",
   });
 
-  if (accessPolicy.authenticationRequired && !remoteAccessToken) {
+  if (accessPolicy.remoteAccessRequired && !options.remoteAccess && !options.accessToken) {
     throw new Error(
-      `Refusing to expose CodeSesh on ${hostname} without authentication. Add --remote-access to continue.`,
+      `Refusing to expose CodeSesh on ${hostname} without explicit remote access. Add --remote-access to continue.`,
     );
   }
 
@@ -234,9 +232,7 @@ export async function createServer(
   if (transport.kind === "trusted-proxy") {
     app.use("/api/*", requireProxyTls());
   }
-  if (remoteAccessToken) {
-    app.use("/api/*", remoteAccessAuth(remoteAccessToken));
-  }
+  app.use("/api/*", accessTokenAuth(accessToken));
   app.use("/api/*", loopbackWriteGuard());
   app.use(
     "/api/*",
@@ -315,18 +311,16 @@ export async function createServer(
     accessPolicy.bindCategory === "loopback"
       ? `${scheme}://localhost:${actualPort}`
       : `${scheme}://${hostname}:${actualPort}`;
-  const url = remoteAccessToken
-    ? `${baseUrl}/?${REMOTE_ACCESS_QUERY_PARAM}=${encodeURIComponent(remoteAccessToken)}`
-    : baseUrl;
+  const url = `${baseUrl}/?${ACCESS_TOKEN_QUERY_PARAM}=${encodeURIComponent(accessToken)}`;
   appLogger.info("server.listen", {
     port: actualPort,
     requested_port: port,
     hostname,
-    remote_access: Boolean(remoteAccessToken),
+    remote_access: accessPolicy.remoteAccessRequired,
     transport: transport.kind,
   });
 
-  if (accessPolicy.authenticationRequired) {
+  if (accessPolicy.remoteAccessRequired) {
     appLogger.warn("server.listen.remote_access", {
       hostname,
       port: actualPort,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ import { defineConfig, devices } from "playwright/test";
 
 const FIXTURE_PROJECT_DIR_TOKEN = "__E2E_PROJECT_DIR__";
 const E2E_HOME_ENV = "CODESESH_PLAYWRIGHT_HOME";
+const E2E_STARTUP_URL_ENV = "CODESESH_E2E_STARTUP_URL_PATH";
 const port = Number(process.env.CODESESH_E2E_PORT ?? 4387);
 const wwwPort = Number(process.env.CODESESH_WWW_E2E_PORT ?? 4388);
 const inheritedE2eHome = process.env[E2E_HOME_ENV];
@@ -12,6 +13,7 @@ const e2eHome = inheritedE2eHome ?? mkdtempSync(join(tmpdir(), "codesesh-e2e-hom
 const fixtureTemplateRoot = resolve("tests/e2e/fixtures");
 const fixtureRoot = join(e2eHome, "fixtures");
 const e2eProjectDir = join(e2eHome, "codesesh-e2e");
+const startupUrlPath = join(e2eHome, "startup-url.txt");
 const fixtureSessionPath = join(fixtureRoot, "claude/projects/codesesh-e2e/e2e-dashboard.jsonl");
 const codexFixtureSessionPath = join(
   fixtureRoot,
@@ -35,6 +37,7 @@ if (!inheritedE2eHome) {
     );
   }
 }
+process.env[E2E_STARTUP_URL_ENV] = startupUrlPath;
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -54,8 +57,8 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `pnpm build && node packages/cli/dist/index.js --port ${port} --agent claudecode,codex --days 0 --noOpen --cache false`,
-      url: `http://127.0.0.1:${port}/api/config`,
+      command: `pnpm build && node tests/e2e/start-cli-server.mjs --port ${port} --agent claudecode,codex --days 0 --noOpen --cache false`,
+      url: `http://127.0.0.1:${port}`,
       reuseExistingServer: false,
       timeout: 60_000,
       env: {
@@ -67,6 +70,7 @@ export default defineConfig({
         LOCALAPPDATA: join(e2eHome, "AppData", "Local"),
         CODESESH_STATE_STORE: "memory",
         CODESESH_STATE_DIR: join(e2eHome, "state"),
+        CODESESH_E2E_STARTUP_URL_PATH: startupUrlPath,
         CLAUDE_CONFIG_DIR: join(fixtureRoot, "claude"),
         CODEX_HOME: join(fixtureRoot, "codex"),
         KIMI_SHARE_DIR: join(e2eHome, ".kimi"),

--- a/scripts/smoke-package-artifact.mjs
+++ b/scripts/smoke-package-artifact.mjs
@@ -172,26 +172,34 @@ async function smoke(tarballPath) {
       stderr += chunk;
     });
 
-    const origin = await waitFor(
-      () => stdout.match(/http:\/\/localhost:\d+/)?.[0],
+    const startupUrl = await waitFor(
+      () => stdout.match(/http:\/\/localhost:\d+\/\?access_token=[A-Za-z0-9_-]+/)?.[0],
       "the packaged CLI server",
     );
-    const configResponse = await fetch(`${origin}/api/config`);
+    const access = new URL(startupUrl);
+    const token = access.searchParams.get("access_token");
+    assert(token, "Packaged CLI startup URL did not include an access token");
+    const authorization = { Authorization: `Bearer ${token}` };
+    const configResponse = await fetch(`${access.origin}/api/config`, {
+      headers: authorization,
+    });
     assert(configResponse.ok, `Packaged API returned ${configResponse.status}`);
     await configResponse.json();
 
     await waitFor(async () => {
-      const response = await fetch(`${origin}/api/sessions?days=0`);
+      const response = await fetch(`${access.origin}/api/sessions?days=0`, {
+        headers: authorization,
+      });
       if (!response.ok) return false;
       return JSON.stringify(await response.json()).includes("Artifact package smoke session");
     }, "the scan and search-index workers");
 
-    const htmlResponse = await fetch(origin);
+    const htmlResponse = await fetch(access.origin);
     assert(htmlResponse.ok, `Packaged Web root returned ${htmlResponse.status}`);
     const html = await htmlResponse.text();
     const assetPath = html.match(/(?:src|href)=["'](\/assets\/[^"']+)["']/)?.[1];
     assert(assetPath, "Packaged Web HTML did not reference a hashed asset");
-    const assetResponse = await fetch(new URL(assetPath, origin));
+    const assetResponse = await fetch(new URL(assetPath, access.origin));
     assert(assetResponse.ok, `Packaged Web asset returned ${assetResponse.status}`);
 
     const databasePath = join(homeDir, ".cache", "codesesh", "codesesh.db");

--- a/tests/e2e/degraded-server.spec.ts
+++ b/tests/e2e/degraded-server.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test as base } from "playwright/test";
-import { monitorBrowserErrors } from "./test-fixtures.js";
+import { configureApiAccess, monitorBrowserErrors } from "./test-fixtures.js";
 
 // Network failures unavoidably log resource/console errors; those are the
 // scenario, not a defect. Anything else — above all an "Uncaught (in
@@ -13,6 +13,7 @@ base("keeps the retry surface clean while the API is down", async ({ page }) => 
   // The failing branch waits out react-query's retry backoff before the error
   // surface appears; CI runners need more than the default 30s budget.
   base.setTimeout(120_000);
+  await configureApiAccess(page.context());
   const errors = monitorBrowserErrors(page);
   let failing = true;
   await page.route("**/api/config**", (route) =>

--- a/tests/e2e/start-cli-server.mjs
+++ b/tests/e2e/start-cli-server.mjs
@@ -1,0 +1,39 @@
+import { spawn } from "node:child_process";
+import { rmSync, writeFileSync } from "node:fs";
+
+const startupUrlPath = process.env.CODESESH_E2E_STARTUP_URL_PATH;
+if (!startupUrlPath) throw new Error("Missing CODESESH_E2E_STARTUP_URL_PATH");
+
+rmSync(startupUrlPath, { force: true });
+
+const child = spawn(process.execPath, ["packages/cli/dist/index.js", ...process.argv.slice(2)], {
+  env: process.env,
+  stdio: ["inherit", "pipe", "inherit"],
+});
+let output = "";
+let captured = false;
+
+child.stdout.setEncoding("utf8");
+child.stdout.on("data", (chunk) => {
+  process.stdout.write(chunk);
+  if (captured) return;
+
+  output = `${output}${chunk}`.slice(-8_192);
+  for (const match of output.matchAll(/https?:\/\/\S+/g)) {
+    const url = new URL(match[0]);
+    if (!url.searchParams.has("access_token")) continue;
+    writeFileSync(startupUrlPath, url.href, { mode: 0o600 });
+    captured = true;
+    break;
+  }
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => child.kill(signal));
+}
+
+child.once("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});
+child.once("exit", (code) => process.exit(code ?? 1));

--- a/tests/e2e/test-fixtures.ts
+++ b/tests/e2e/test-fixtures.ts
@@ -1,4 +1,33 @@
-import { expect, test as base, type Page } from "playwright/test";
+import { readFile } from "node:fs/promises";
+import { expect, test as base, type BrowserContext, type Page } from "playwright/test";
+
+const ACCESS_TOKEN_STORAGE_KEY = "codesesh:remote-access-token";
+
+async function readServerAccessToken(): Promise<string> {
+  const path = process.env.CODESESH_E2E_STARTUP_URL_PATH;
+  if (!path) throw new Error("Missing CODESESH_E2E_STARTUP_URL_PATH");
+
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      const token = new URL(await readFile(path, "utf8")).searchParams.get("access_token");
+      if (token) return token;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error("Timed out waiting for the CodeSesh startup access token");
+}
+
+export async function configureApiAccess(context: BrowserContext): Promise<void> {
+  const token = await readServerAccessToken();
+  await context.setExtraHTTPHeaders({ Authorization: `Bearer ${token}` });
+  await context.addInitScript(({ key, value }) => window.sessionStorage.setItem(key, value), {
+    key: ACCESS_TOKEN_STORAGE_KEY,
+    value: token,
+  });
+}
 
 export function monitorBrowserErrors(page: Page): string[] {
   const errors: string[] = [];
@@ -10,10 +39,20 @@ export function monitorBrowserErrors(page: Page): string[] {
 }
 
 type BrowserErrorFixtures = {
+  apiAccess: void;
   browserErrorGate: void;
 };
 
 export const test = base.extend<BrowserErrorFixtures>({
+  apiAccess: [
+    async ({ context }, use, testInfo) => {
+      if (testInfo.project.name === "web-chromium") {
+        await configureApiAccess(context);
+      }
+      await use();
+    },
+    { auto: true },
+  ],
   browserErrorGate: [
     async ({ page }, use) => {
       const errors = monitorBrowserErrors(page);


### PR DESCRIPTION
## Summary

- require a generated access token for API requests on the default loopback listener
- keep remote exposure opt-in and loopback authority validation independent from authentication
- carry the real startup token through the browser E2E harness without adding a production bypass
- document that every server mode protects API access with a token

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm typecheck:e2e`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm test:migration`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm test:e2e`
- `pnpm perf:check`
- `pnpm package:artifact:test`
- `pnpm package:artifact`