### PR TITLE
fix(cli)!: constrain trusted proxy access

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ backup of your history. Session content stays in each agent's own data directory
 | `--tls-cert` | — | — | Path to a TLS certificate; serves remote access over HTTPS |
 | `--tls-key` | — | — | Path to the private key matching `--tls-cert` |
 | `--trust-proxy` | — | `false` | A reverse proxy in front of CodeSesh terminates TLS |
+| `--public-url` | — | — | Public HTTPS origin used with `--trust-proxy` for startup links |
 | `--days` | `-d` | `7` | Only include sessions active in the last N days (`0` = all time) |
 | `--cwd` | — | — | Filter to sessions from a project directory (`.` = current dir) |
 | `--agent` | `-a` | all | Filter to specific agent(s), comma-separated |
@@ -207,10 +208,10 @@ backup of your history. Session content stays in each agent's own data directory
 | `-h` / `--help` | — | — | Show help |
 
 Every CodeSesh server process protects its API with a new access token, including the default
-loopback listener, and includes that token in the printed startup URL. Non-loopback binding and
-`--trust-proxy` are rejected unless `--remote-access` is also present. This includes a loopback
-listener exposed by a same-machine reverse proxy. Treat the startup URL as a password: do not
-publish it or place it in shared shell history.
+loopback listener, and includes that token in the printed startup URL. Non-loopback binding requires
+`--remote-access`. A trusted proxy also requires `--remote-access`, a loopback `--host`, and an
+HTTPS `--public-url`. Treat the startup URL as a password: do not publish it or place it in shared
+shell history.
 
 A token proves who is asking; it does not hide the answer. Without TLS the token and the full
 session content travel the network in the clear, and the token in the URL can end up in reverse
@@ -221,12 +222,14 @@ proxy access logs. Pick one of:
 npx codesesh --host 0.0.0.0 --remote-access --tls-cert ./cert.pem --tls-key ./key.pem
 
 # A reverse proxy terminates TLS; CodeSesh stays bound to loopback
-npx codesesh --host 127.0.0.1 --remote-access --trust-proxy
+npx codesesh --host 127.0.0.1 --remote-access --trust-proxy \
+  --public-url https://codesesh.example.com
 ```
 
-`--trust-proxy` requires every API request to arrive with `X-Forwarded-Proto: https`, and refuses
-it otherwise — so a request that bypassed the proxy is rejected before authentication. This assumes
-the deployment makes CodeSesh unreachable except through that proxy.
+`--trust-proxy` requires every API request to arrive with `X-Forwarded-Proto: https` and refuses it
+otherwise. That header validates the proxy's forwarding configuration; it cannot prove which client
+sent it. CodeSesh therefore enforces a loopback backend so network clients cannot reach the HTTP
+listener directly. The printed and automatically opened startup URL uses `--public-url`.
 
 Using `--remote-access` without either TLS option still starts on a non-loopback address and prints
 a warning that the transport is unencrypted.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -92,6 +92,7 @@ npx codesesh --trace
 | `--tls-cert` | — | — | Path to a TLS certificate; serves remote access over HTTPS            |
 | `--tls-key` | — | — | Path to the private key matching `--tls-cert`                          |
 | `--trust-proxy` | — | `false` | A reverse proxy in front of CodeSesh terminates TLS                    |
+| `--public-url` | — | — | Public HTTPS origin used with `--trust-proxy` for startup links       |
 | `--days`    | `-d`  | `7`     | Only include sessions active in the last N days (`0` = all time) |
 | `--cwd`     | —     | —       | Filter to sessions from a project directory                 |
 | `--agent`   | `-a`  | all     | Filter to specific agent(s), comma-separated                |
@@ -106,11 +107,10 @@ npx codesesh --trace
 | `-v`        | —     | —       | Print version number                                        |
 
 Every CodeSesh server process protects its API with a fresh access token, including the default
-loopback listener, and prints that token in the startup URL. Non-loopback binding and
-`--trust-proxy` both require `--remote-access`. This includes the common setup where CodeSesh
-listens on `127.0.0.1` and a same-machine reverse proxy exposes it publicly. Anyone with the startup
-URL can read the indexed AI session history, so treat it as a password and do not share or persist
-it.
+loopback listener, and prints that token in the startup URL. Non-loopback binding requires
+`--remote-access`. A trusted proxy also requires `--remote-access`, a loopback `--host`, and an
+HTTPS `--public-url`. Anyone with the startup URL can read the indexed AI session history, so treat
+it as a password and do not share or persist it.
 
 A token authenticates the requester but does not encrypt traffic. Without TLS, the token and full
 session content travel over the network in plaintext, and URL tokens may be recorded in proxy logs.
@@ -121,11 +121,13 @@ Use one of these protected transports:
 npx codesesh --host 0.0.0.0 --remote-access --tls-cert ./cert.pem --tls-key ./key.pem
 
 # A reverse proxy terminates TLS; CodeSesh stays bound to loopback
-npx codesesh --host 127.0.0.1 --remote-access --trust-proxy
+npx codesesh --host 127.0.0.1 --remote-access --trust-proxy \
+  --public-url https://codesesh.example.com
 ```
 
-`--trust-proxy` requires `X-Forwarded-Proto: https` on every API request. The listener must remain
-unreachable except through that trusted proxy.
+`--trust-proxy` requires `X-Forwarded-Proto: https` on every API request. That header validates the
+proxy configuration but cannot identify its sender, so CodeSesh enforces a loopback backend rather
+than trusting the header as a network boundary. Startup links use the configured `--public-url`.
 
 ## Requirements
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import {
   formatScanFailureDiagnostics,
 } from "./session-index-output.js";
 import {
+  resolvePublicOrigin,
   resolveRemoteAccessPolicy,
   resolveRemoteTransport,
   type RemoteTransport,
@@ -72,6 +73,10 @@ const main = defineCommand({
       type: "boolean",
       description: "A reverse proxy in front of CodeSesh terminates TLS",
       default: false,
+    },
+    "public-url": {
+      type: "string",
+      description: "Public HTTPS origin served by the trusted reverse proxy",
     },
     agent: {
       type: "string",
@@ -141,6 +146,7 @@ const main = defineCommand({
     const remoteAccess = args["remote-access"] as boolean;
 
     let transport: RemoteTransport;
+    let publicOrigin: string | undefined;
     try {
       transport = resolveRemoteTransport({
         hostname,
@@ -148,6 +154,7 @@ const main = defineCommand({
         tlsKeyPath: args["tls-key"] as string | undefined,
         trustProxy: args["trust-proxy"] as boolean,
       });
+      publicOrigin = resolvePublicOrigin(args["public-url"] as string | undefined, transport);
     } catch (error) {
       console.error(error instanceof Error ? error.message : String(error));
       process.exit(1);
@@ -171,6 +178,7 @@ const main = defineCommand({
       port,
       host: hostname,
       transport: transport.kind,
+      public_url: publicOrigin,
       remote_access: remoteAccess,
       json: jsonOnly,
       no_open: noOpen,
@@ -273,6 +281,7 @@ const main = defineCommand({
         hostname,
         remoteAccess,
         transport,
+        publicUrl: publicOrigin,
       });
     } catch (error) {
       console.error(getServerStartupErrorMessage(error, port));

--- a/packages/cli/src/remote-access.test.ts
+++ b/packages/cli/src/remote-access.test.ts
@@ -7,6 +7,7 @@ import {
   isConfidentialTransport,
   isLoopbackHostname,
   RemoteTransportError,
+  resolvePublicOrigin,
   resolveRemoteAccessPolicy,
   resolveRemoteTransport,
 } from "./remote-access.js";
@@ -124,10 +125,41 @@ describe("CS-140: remote transport", () => {
     ).toThrow(RemoteTransportError);
   });
 
-  it("accepts a trusted proxy as protected", () => {
-    const transport = resolveRemoteTransport({ hostname: "0.0.0.0", trustProxy: true });
+  it("accepts a trusted proxy on a loopback backend", () => {
+    const transport = resolveRemoteTransport({ hostname: "127.0.0.1", trustProxy: true });
 
     expect(transport).toEqual({ kind: "trusted-proxy" });
     expect(isConfidentialTransport(transport)).toBe(true);
+  });
+
+  it("rejects a trusted proxy on a network-reachable backend", () => {
+    expect(() => resolveRemoteTransport({ hostname: "0.0.0.0", trustProxy: true })).toThrow(
+      /loopback --host/,
+    );
+  });
+
+  it("normalizes a trusted proxy's public HTTPS origin", () => {
+    expect(resolvePublicOrigin("https://codesesh.example.com/", { kind: "trusted-proxy" })).toBe(
+      "https://codesesh.example.com",
+    );
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["plaintext", "http://codesesh.example.com"],
+    ["credentials", "https://user@codesesh.example.com"],
+    ["path", "https://codesesh.example.com/app"],
+    ["query", "https://codesesh.example.com?mode=proxy"],
+    ["fragment", "https://codesesh.example.com#app"],
+  ])("rejects a %s trusted proxy public URL", (_name, publicUrl) => {
+    expect(() => resolvePublicOrigin(publicUrl, { kind: "trusted-proxy" })).toThrow(
+      RemoteTransportError,
+    );
+  });
+
+  it("rejects a public URL without a trusted proxy", () => {
+    expect(() => resolvePublicOrigin("https://codesesh.example.com", { kind: "loopback" })).toThrow(
+      /requires --trust-proxy/,
+    );
   });
 });

--- a/packages/cli/src/remote-access.ts
+++ b/packages/cli/src/remote-access.ts
@@ -33,6 +33,14 @@ export interface RemoteTransportRequest {
 
 export class RemoteTransportError extends Error {}
 
+function assertTrustedProxyListener(hostname: string, transport: RemoteTransport): void {
+  if (transport.kind === "trusted-proxy" && !isLoopbackHostname(hostname)) {
+    throw new RemoteTransportError(
+      "--trust-proxy requires a loopback --host so clients cannot reach the HTTP backend directly.",
+    );
+  }
+}
+
 /**
  * Resolves the transport from the CLI flags. Loopback stays plaintext without
  * ceremony: nothing leaves the machine.
@@ -63,7 +71,11 @@ export function resolveRemoteTransport(request: RemoteTransportRequest): RemoteT
     }
   }
 
-  if (request.trustProxy) return { kind: "trusted-proxy" };
+  if (request.trustProxy) {
+    const transport = { kind: "trusted-proxy" } as const;
+    assertTrustedProxyListener(request.hostname, transport);
+    return transport;
+  }
   return isLoopbackHostname(request.hostname) ? { kind: "loopback" } : { kind: "plaintext" };
 }
 
@@ -76,6 +88,7 @@ export function resolveRemoteAccessPolicy(
   hostname: string,
   transport: RemoteTransport,
 ): RemoteAccessPolicy {
+  assertTrustedProxyListener(hostname, transport);
   const bindCategory = isLoopbackHostname(hostname) ? "loopback" : "network";
   const directLoopback = bindCategory === "loopback" && transport.kind === "loopback";
   return {
@@ -84,13 +97,47 @@ export function resolveRemoteAccessPolicy(
   };
 }
 
+export function resolvePublicOrigin(
+  value: string | undefined,
+  transport: RemoteTransport,
+): string | undefined {
+  if (transport.kind !== "trusted-proxy") {
+    if (value) throw new RemoteTransportError("--public-url requires --trust-proxy.");
+    return undefined;
+  }
+  if (!value) {
+    throw new RemoteTransportError(
+      "--trust-proxy requires an HTTPS --public-url for browser startup links.",
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new RemoteTransportError("--public-url must be a valid HTTPS origin.");
+  }
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new RemoteTransportError(
+      "--public-url must be an HTTPS origin without credentials, path, query, or fragment.",
+    );
+  }
+  return url.origin;
+}
+
 const FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
 
 /**
- * Behind a trusted proxy, a request arriving without the proxy's own
- * `X-Forwarded-Proto: https` did not come through it. Trusting the header is
- * only sound because the deployment is expected to make CodeSesh unreachable
- * except via that proxy — which is what --trust-proxy asserts.
+ * The forwarded scheme validates proxy configuration, not client identity.
+ * The enforced loopback listener supplies the network boundary; the access
+ * token still authenticates every request that reaches it.
  */
 export function requireProxyTls(): MiddlewareHandler {
   return async (c, next) => {

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -15,6 +15,7 @@ import { resolveRemoteTransport } from "./remote-access.js";
 const serveOptionsLog = vi.hoisted(
   () => [] as { hostname?: string; port?: number; hasCreateServer: boolean }[],
 );
+const TRUSTED_PROXY_PUBLIC_URL = "https://codesesh.example.com";
 
 function httpRequest(
   url: string,
@@ -682,8 +683,10 @@ describe("createServer", () => {
   it("CS-223: warns trusted proxy operators that access logs can retain tokens", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const app = await createServer(0, createStore(), {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
+      remoteAccess: true,
       accessToken: "proxy-token",
+      publicUrl: TRUSTED_PROXY_PUBLIC_URL,
       transport: { kind: "trusted-proxy" },
     });
 
@@ -695,14 +698,39 @@ describe("createServer", () => {
     }
   });
 
-  it("CS-140: refuses requests that bypassed the trusted proxy", async () => {
+  it("refuses a trusted proxy on a network-reachable listener", async () => {
+    await expect(
+      createServer(0, createStore(), {
+        hostname: "0.0.0.0",
+        remoteAccess: true,
+        accessToken: "proxy-token",
+        publicUrl: TRUSTED_PROXY_PUBLIC_URL,
+        transport: { kind: "trusted-proxy" },
+      }),
+    ).rejects.toThrow(/loopback --host/);
+  });
+
+  it("requires a trusted proxy to declare its public HTTPS origin", async () => {
+    await expect(
+      createServer(0, createStore(), {
+        hostname: "127.0.0.1",
+        remoteAccess: true,
+        accessToken: "proxy-token",
+        transport: { kind: "trusted-proxy" },
+      }),
+    ).rejects.toThrow(/requires an HTTPS --public-url/);
+  });
+
+  it("CS-140: requires forwarded HTTPS on the loopback proxy backend", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const app = await createServer(0, createStore(), {
-      hostname: "0.0.0.0",
+      hostname: "127.0.0.1",
+      remoteAccess: true,
       accessToken: "proxy-token",
+      publicUrl: TRUSTED_PROXY_PUBLIC_URL,
       transport: { kind: "trusted-proxy" },
     });
-    const origin = `http://127.0.0.1:${new URL(app.url).port}`;
+    const origin = app.listenerUrl;
     const authorized = { Authorization: "Bearer proxy-token" };
 
     try {
@@ -721,7 +749,6 @@ describe("createServer", () => {
           })
         ).status,
       ).toBe(200);
-      // The proxy check runs first, so a bypassed request never reaches auth.
       expect(
         (await fetch(`${origin}/api/agents`, { headers: { "X-Forwarded-Proto": "https" } })).status,
       ).toBe(401);
@@ -738,9 +765,10 @@ describe("createServer", () => {
       hostname: "127.0.0.1",
       remoteAccess: true,
       accessToken: "proxy-token",
+      publicUrl: TRUSTED_PROXY_PUBLIC_URL,
       transport: { kind: "trusted-proxy" },
     });
-    const origin = `http://127.0.0.1:${new URL(app.url).port}`;
+    const origin = app.listenerUrl;
     const proxyHeaders = { "X-Forwarded-Proto": "https" };
 
     try {
@@ -750,6 +778,8 @@ describe("createServer", () => {
         authentication: "token",
         loopback_authority: "disabled",
       });
+      expect(app.url).toBe(`${TRUSTED_PROXY_PUBLIC_URL}/?access_token=proxy-token`);
+      expect(app.listenerUrl).toMatch(/^http:\/\/localhost:\d+$/);
       expect((await fetch(`${origin}/api/agents`, { headers: proxyHeaders })).status).toBe(401);
       expect(
         (
@@ -784,9 +814,10 @@ describe("createServer", () => {
       hostname: "127.0.0.1",
       remoteAccess: true,
       accessToken: "proxy-token",
+      publicUrl: TRUSTED_PROXY_PUBLIC_URL,
       transport: { kind: "trusted-proxy" },
     });
-    const origin = `http://127.0.0.1:${new URL(app.url).port}`;
+    const origin = app.listenerUrl;
 
     try {
       expect(
@@ -807,6 +838,7 @@ describe("createServer", () => {
     await expect(
       createServer(0, createStore(), {
         hostname: "127.0.0.1",
+        publicUrl: TRUSTED_PROXY_PUBLIC_URL,
         transport: { kind: "trusted-proxy" },
       }),
     ).rejects.toThrow("Add --remote-access");

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -24,6 +24,7 @@ import {
   accessTokenAuth,
   createAccessToken,
   requireProxyTls,
+  resolvePublicOrigin,
   resolveRemoteAccessPolicy,
   resolveRemoteTransport,
   type RemoteTransport,
@@ -41,6 +42,7 @@ export interface CreateServerOptions {
   hostname?: string;
   remoteAccess?: boolean;
   accessToken?: string;
+  publicUrl?: string;
   /** How the listener is protected; defaults to plaintext for a non-loopback host. */
   transport?: RemoteTransport;
   /** Overrides the auto-detected web build directory; used to pin the static root in tests. */
@@ -134,11 +136,12 @@ export async function createServer(
   port: number,
   store: ScanResultSource & ScanEventSource & { shutdown(): Promise<void> },
   options: CreateServerOptions = {},
-): Promise<{ url: string; shutdown: () => Promise<void> }> {
+): Promise<{ url: string; listenerUrl: string; shutdown: () => Promise<void> }> {
   const app = new Hono<{ Bindings: HttpBindings }>();
   const hostname = options.hostname ?? "127.0.0.1";
   const transport: RemoteTransport = options.transport ?? resolveRemoteTransport({ hostname });
   const accessPolicy = resolveRemoteAccessPolicy(hostname, transport);
+  const publicOrigin = resolvePublicOrigin(options.publicUrl, transport);
   const accessToken = options.accessToken || createAccessToken();
   const loopbackAuthorityEnabled = !accessPolicy.remoteAccessRequired;
   const shutdownController = new AbortController();
@@ -304,18 +307,19 @@ export async function createServer(
     }
   }
 
-  // A trusted proxy publishes its own https origin, so only direct TLS changes
-  // the scheme CodeSesh prints for itself.
+  // The backend stays HTTP behind a trusted proxy; its separately configured
+  // public origin is used only for browser startup.
   const scheme = transport.kind === "tls" ? "https" : "http";
-  const baseUrl =
+  const listenerUrl =
     accessPolicy.bindCategory === "loopback"
       ? `${scheme}://localhost:${actualPort}`
       : `${scheme}://${hostname}:${actualPort}`;
-  const url = `${baseUrl}/?${ACCESS_TOKEN_QUERY_PARAM}=${encodeURIComponent(accessToken)}`;
+  const url = `${publicOrigin ?? listenerUrl}/?${ACCESS_TOKEN_QUERY_PARAM}=${encodeURIComponent(accessToken)}`;
   appLogger.info("server.listen", {
     port: actualPort,
     requested_port: port,
     hostname,
+    public_origin: publicOrigin,
     remote_access: accessPolicy.remoteAccessRequired,
     transport: transport.kind,
   });
@@ -345,6 +349,7 @@ export async function createServer(
 
   return {
     url,
+    listenerUrl,
     shutdown: async () => {
       appLogger.info("server.shutdown", { port: actualPort });
       shutdownController.abort();

--- a/scripts/package-artifact-checks.mjs
+++ b/scripts/package-artifact-checks.mjs
@@ -61,10 +61,17 @@ test("rejects source files outside the publish allowlist", () => {
 });
 
 test("documents the remote access security contract in the published README", () => {
-  for (const flag of ["--remote-access", "--tls-cert", "--tls-key", "--trust-proxy"]) {
+  for (const flag of [
+    "--remote-access",
+    "--tls-cert",
+    "--tls-key",
+    "--trust-proxy",
+    "--public-url",
+  ]) {
     assert.ok(publishedReadme.includes("`" + flag + "`"), `README is missing ${flag}`);
   }
-  assert.match(publishedReadme, /loopback listener exposed by|listens on `127\.0\.0\.1`/i);
+  assert.match(publishedReadme, /enforces a loopback backend/i);
+  assert.match(publishedReadme, /cannot identify its sender/i);
   assert.match(publishedReadme, /plaintext/i);
   assert.match(publishedReadme, /X-Forwarded-Proto: https/);
 });


### PR DESCRIPTION
## Summary

- reject `--trust-proxy` when the HTTP backend binds to a network-reachable host
- require and validate an HTTPS `--public-url` for trusted-proxy startup links
- distinguish the internal listener URL from the public browser URL
- document why forwarded headers validate proxy configuration but cannot establish client identity

## Breaking change

`--trust-proxy` now requires a loopback `--host` and an HTTPS `--public-url`. Deployments that currently bind the plaintext backend to `0.0.0.0` must move the proxy onto the same host and bind CodeSesh to loopback.

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm typecheck:e2e`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm test:migration`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm test:e2e`
- `pnpm perf:check`
- `pnpm package:artifact:test`
- packaged tarball smoke test