### PR TITLE
fix(cli): bound project identity workload

### DIFF
--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -78,6 +78,7 @@ interface ContextOptions {
 
 function makeContext(options: ContextOptions = {}) {
   const params = new URLSearchParams(options.query ?? {});
+  const url = `http://localhost/${params.size > 0 ? `?${params.toString()}` : ""}`;
   return {
     req: {
       json: () =>
@@ -86,7 +87,8 @@ function makeContext(options: ContextOptions = {}) {
           : Promise.resolve(options.body),
       param: (key: string) => options.param?.[key],
       query: (key: string) => options.query?.[key],
-      url: `http://localhost/${params.size > 0 ? `?${params.toString()}` : ""}`,
+      url,
+      raw: new Request(url),
     },
     json: vi.fn((payload: unknown, status = 200) => ({ payload, status })),
   };
@@ -745,7 +747,7 @@ describe("query boundary handlers", () => {
       to: new Date("2026-01-02T00:00:00.000Z").getTime(),
       limit: 200,
     });
-    expect(resolver.resolve).toHaveBeenCalledWith("/repo");
+    expect(resolver.resolve).toHaveBeenCalledWith("/repo", expect.any(AbortSignal));
   });
 
   it.each(["1.5", "0", "-1", "", "Infinity", "invalid"])(

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -92,7 +92,11 @@ import {
   type ScanResultSource,
 } from "../handlers.js";
 import { invalidateAliasView } from "../session-aliases-view.js";
-import type { ProjectIdentityResolver } from "../../project-identity-resolver.js";
+import {
+  ProjectIdentityQueueFullError,
+  ProjectIdentityRequestAbortedError,
+  type ProjectIdentityResolver,
+} from "../../project-identity-resolver.js";
 import type {
   ChangeCheckResult,
   DashboardCostFacts,
@@ -138,15 +142,18 @@ function makeMockContext(
   overrides: {
     query?: Record<string, string>;
     param?: Record<string, string>;
+    signal?: AbortSignal;
   } = {},
 ) {
   const jsonFn = vi.fn().mockReturnValue({ status: 200 });
   const params = new URLSearchParams(overrides.query ?? {});
+  const url = `http://localhost/${params.size ? `?${params.toString()}` : ""}`;
   return {
     req: {
       query: (key: string) => overrides.query?.[key] ?? "",
       param: (key: string) => overrides.param?.[key] ?? "",
-      url: `http://localhost/${params.size ? `?${params.toString()}` : ""}`,
+      url,
+      raw: new Request(url, { signal: overrides.signal }),
     },
     json: jsonFn,
   } as any;
@@ -601,7 +608,51 @@ describe("handleGetSessions", () => {
       "parent",
       "identity",
     ]);
-    expect(resolver.resolve).toHaveBeenCalledWith("/home/user/project");
+    expect(resolver.resolve).toHaveBeenCalledWith("/home/user/project", expect.any(AbortSignal));
+  });
+
+  it("returns 429 when project identity capacity is exhausted", async () => {
+    const c = makeMockContext({ query: { cwd: "/home/user/project" } });
+    const resolver = makeProjectIdentityResolver();
+    vi.mocked(resolver.resolve).mockRejectedValue(new ProjectIdentityQueueFullError());
+
+    await handleGetSessions(c, makeScanSource(), {}, resolver);
+
+    expect(c.json).toHaveBeenCalledWith({ error: "Project scope busy; retry later" }, 429);
+  });
+
+  it("returns 503 when project identity resolution fails", async () => {
+    const c = makeMockContext({ query: { cwd: "/home/user/project" } });
+    const resolver = makeProjectIdentityResolver();
+    vi.mocked(resolver.resolve).mockRejectedValue(new Error("worker failed"));
+
+    await handleGetSessions(c, makeScanSource(), {}, resolver);
+
+    expect(c.json).toHaveBeenCalledWith({ error: "Project scope unavailable" }, 503);
+  });
+
+  it("propagates request cancellation into project identity resolution", async () => {
+    const controller = new AbortController();
+    const c = makeMockContext({
+      query: { cwd: "/home/user/project" },
+      signal: controller.signal,
+    });
+    const resolver = makeProjectIdentityResolver();
+    vi.mocked(resolver.resolve).mockImplementation(
+      async (_cwd, signal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new ProjectIdentityRequestAbortedError()),
+            { once: true },
+          );
+        }),
+    );
+
+    const response = handleGetSessions(c, makeScanSource(), {}, resolver);
+    controller.abort();
+
+    await expect(response).rejects.toBeInstanceOf(ProjectIdentityRequestAbortedError);
   });
 
   it("filters by project identity key", () => {
@@ -734,7 +785,7 @@ describe("handleSearchSessions", () => {
 
     await handleSearchSessions(c, scanSource, {}, resolver);
 
-    expect(resolver.resolve).toHaveBeenCalledWith("/home/user/project");
+    expect(resolver.resolve).toHaveBeenCalledWith("/home/user/project", expect.any(AbortSignal));
     expect(coreMocks.executeSessionSearch).toHaveBeenCalledWith(
       "cwd:/home/user/project needle",
       expect.objectContaining({
@@ -1868,7 +1919,7 @@ describe("handleGetSessionData", () => {
 
     await handleGetSessionData(c, scanSource, resolver);
 
-    expect(resolver.resolve).toHaveBeenCalledWith("/workspace/project");
+    expect(resolver.resolve).toHaveBeenCalledWith("/workspace/project", expect.any(AbortSignal));
     expect(coreMocks.materializeSessionDetailResponse).toHaveBeenLastCalledWith(
       scanSource.getSnapshot(),
       { agentName: "claudecode", sessionId: "s1" },

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -32,7 +32,11 @@ import {
   type ProjectScopeMatcher,
 } from "@codesesh/core";
 import { appLogger } from "../logging.js";
-import type { ProjectIdentityResolver } from "../project-identity-resolver.js";
+import {
+  ProjectIdentityQueueFullError,
+  ProjectIdentityRequestAbortedError,
+  type ProjectIdentityResolver,
+} from "../project-identity-resolver.js";
 import { resolveTimeWindow } from "../time-window-resolution.js";
 import {
   filterSessionsByActivityWindow,
@@ -76,6 +80,7 @@ async function resolveProjectScope(
   cwd: string,
   sessions: readonly SessionHead[],
   resolver: ProjectIdentityResolver | undefined,
+  signal: AbortSignal,
 ): Promise<ProjectScopeMatcher> {
   const normalizedCwd = normalizeProjectDirectory(cwd);
   const matchingSession = sessions.find(
@@ -90,7 +95,7 @@ async function resolveProjectScope(
   }
   if (!resolver) throw new Error("Project identity resolver is unavailable");
 
-  const projection = await resolver.resolve(cwd);
+  const projection = await resolver.resolve(cwd, signal);
   return createProjectScopeMatcherFromIdentity(cwd, projection.identity);
 }
 
@@ -99,6 +104,15 @@ function reportProjectScopeResolutionFailure(endpoint: string, error: unknown): 
     endpoint,
     error: error instanceof Error ? error.message : String(error),
   });
+}
+
+function projectScopeResolutionFailureResponse(c: Context, endpoint: string, error: unknown) {
+  if (error instanceof ProjectIdentityRequestAbortedError) throw error;
+  reportProjectScopeResolutionFailure(endpoint, error);
+  if (error instanceof ProjectIdentityQueueFullError) {
+    return c.json({ error: "Project scope busy; retry later" }, 429);
+  }
+  return c.json({ error: "Project scope unavailable" }, 503);
 }
 
 function reportInvalidQueryParameter(
@@ -257,10 +271,14 @@ export async function handleGetSessions(
   let projectScope: ProjectScopeMatcher | undefined;
   if (cwd && !projectIdentity) {
     try {
-      projectScope = await resolveProjectScope(cwd, scanResult.sessions, resolver);
+      projectScope = await resolveProjectScope(
+        cwd,
+        scanResult.sessions,
+        resolver,
+        c.req.raw.signal,
+      );
     } catch (error) {
-      reportProjectScopeResolutionFailure("sessions", error);
-      return c.json({ error: "Project scope unavailable" }, 503);
+      return projectScopeResolutionFailureResponse(c, "sessions", error);
     }
   }
 
@@ -384,10 +402,14 @@ export async function handleSearchSessions(
   let projectScope: ProjectScopeMatcher | undefined;
   if (cwd) {
     try {
-      projectScope = await resolveProjectScope(cwd, scanResult.sessions, resolver);
+      projectScope = await resolveProjectScope(
+        cwd,
+        scanResult.sessions,
+        resolver,
+        c.req.raw.signal,
+      );
     } catch (error) {
-      reportProjectScopeResolutionFailure("search", error);
-      return c.json({ error: "Project scope unavailable" }, 503);
+      return projectScopeResolutionFailureResponse(c, "search", error);
     }
   }
   const { cwd: _cwd, ...searchOptions } = searchRequestOptions;
@@ -457,10 +479,9 @@ export async function handleGetFileActivity(
   let projectScope: ProjectScopeMatcher | undefined;
   if (cwd) {
     try {
-      projectScope = await resolveProjectScope(cwd, [], resolver);
+      projectScope = await resolveProjectScope(cwd, [], resolver, c.req.raw.signal);
     } catch (error) {
-      reportProjectScopeResolutionFailure("file-activity", error);
-      return c.json({ error: "Project scope unavailable" }, 503);
+      return projectScopeResolutionFailureResponse(c, "file-activity", error);
     }
   }
 
@@ -515,7 +536,11 @@ export async function handleGetSessionData(
       // Identity resolution probes the filesystem and spawns git; it must run
       // on the worker resolver, never synchronously on the request path.
       if (!resolver) throw new Error("Project identity resolver is unavailable");
-      result = materialize((await resolver.resolve(result.directory)).identity);
+      try {
+        result = materialize((await resolver.resolve(result.directory, c.req.raw.signal)).identity);
+      } catch (error) {
+        return projectScopeResolutionFailureResponse(c, "session-data", error);
+      }
     }
     if (result.status === "needs-identity") {
       throw new Error("Project identity fallback was not applied");

--- a/packages/cli/src/project-identity-resolver.integration.test.ts
+++ b/packages/cli/src/project-identity-resolver.integration.test.ts
@@ -19,7 +19,7 @@ describe("ThreadProjectIdentityResolver integration", () => {
       chmodSync(gitPath, 0o755);
       process.env.PATH = [binDir, previousPath].filter(Boolean).join(delimiter);
 
-      const resolver = new ThreadProjectIdentityResolver(slowWorkerUrl, 1);
+      const resolver = new ThreadProjectIdentityResolver(slowWorkerUrl, { maxWorkers: 1 });
       try {
         let timerFired = false;
         let resolutionSettled = false;

--- a/packages/cli/src/project-identity-resolver.test.ts
+++ b/packages/cli/src/project-identity-resolver.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const workerMocks = vi.hoisted(() => {
   type Handler = (message: unknown) => void;
@@ -34,15 +34,28 @@ const workerMocks = vi.hoisted(() => {
   }
 
   const workers: FakeWorker[] = [];
-  return { FakeWorker, workers, consumeWorkerMessage: vi.fn(() => false) };
+  return {
+    FakeWorker,
+    workers,
+    consumeWorkerMessage: vi.fn(() => false),
+    warn: vi.fn(),
+  };
 });
 
 vi.mock("node:worker_threads", () => ({ Worker: workerMocks.FakeWorker }));
 vi.mock("./logging.js", () => ({
-  appLogger: { consumeWorkerMessage: workerMocks.consumeWorkerMessage },
+  appLogger: {
+    consumeWorkerMessage: workerMocks.consumeWorkerMessage,
+    warn: workerMocks.warn,
+  },
 }));
 
-import { ThreadProjectIdentityResolver } from "./project-identity-resolver.js";
+import {
+  ProjectIdentityQueueFullError,
+  ProjectIdentityRequestAbortedError,
+  ProjectIdentityTimeoutError,
+  ThreadProjectIdentityResolver,
+} from "./project-identity-resolver.js";
 
 const workerUrl = new URL("./project-identity-worker.js", import.meta.url);
 
@@ -63,9 +76,13 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("ThreadProjectIdentityResolver", () => {
   it("limits concurrent resolution and dispatches queued work when a slot frees", async () => {
-    const resolver = new ThreadProjectIdentityResolver(workerUrl, 2);
+    const resolver = new ThreadProjectIdentityResolver(workerUrl, { maxWorkers: 2 });
     const first = resolver.resolve("/one");
     const second = resolver.resolve("/two");
     const third = resolver.resolve("/three");
@@ -87,6 +104,118 @@ describe("ThreadProjectIdentityResolver", () => {
     workerMocks.workers[0]!.emit("message", resolved(3, "/three"));
     await expect(second).resolves.toMatchObject({ identity: { key: "/two" } });
     await expect(third).resolves.toMatchObject({ identity: { key: "/three" } });
+    await resolver.shutdown();
+  });
+
+  it("coalesces normalized directories while preserving subscriber cancellation", async () => {
+    const resolver = new ThreadProjectIdentityResolver(workerUrl, { maxWorkers: 1 });
+    const controller = new AbortController();
+    const first = resolver.resolve("/project/../project", controller.signal);
+    const second = resolver.resolve("/project/");
+
+    expect(workerMocks.workers).toHaveLength(1);
+    expect(workerMocks.workers[0]!.postedMessages).toEqual([
+      { type: "resolve", requestId: 1, cwd: "/project" },
+    ]);
+
+    controller.abort();
+    await expect(first).rejects.toBeInstanceOf(ProjectIdentityRequestAbortedError);
+    expect(workerMocks.workers[0]!.terminated).toBe(false);
+
+    workerMocks.workers[0]!.emit("message", resolved(1, "/project"));
+    await expect(second).resolves.toMatchObject({ identity: { key: "/project" } });
+    await resolver.shutdown();
+  });
+
+  it("rejects new unique work when the bounded queue is full", async () => {
+    const resolver = new ThreadProjectIdentityResolver(workerUrl, {
+      maxWorkers: 1,
+      maxQueuedRequests: 1,
+    });
+    const first = resolver.resolve("/one");
+    const second = resolver.resolve("/two");
+    const coalesced = resolver.resolve("/two");
+
+    await expect(resolver.resolve("/three")).rejects.toBeInstanceOf(ProjectIdentityQueueFullError);
+    expect(workerMocks.warn).toHaveBeenCalledWith("project_identity.queue.full", {
+      active_workers: 1,
+      queued_requests: 1,
+      request_capacity: 2,
+    });
+
+    workerMocks.workers[0]!.emit("message", resolved(1, "/one"));
+    workerMocks.workers[0]!.emit("message", resolved(2, "/two"));
+    await expect(first).resolves.toMatchObject({ identity: { key: "/one" } });
+    await expect(second).resolves.toMatchObject({ identity: { key: "/two" } });
+    await expect(coalesced).resolves.toMatchObject({ identity: { key: "/two" } });
+    await resolver.shutdown();
+  });
+
+  it("terminates a timed-out worker and replaces it for queued work", async () => {
+    vi.useFakeTimers();
+    const resolver = new ThreadProjectIdentityResolver(workerUrl, {
+      maxWorkers: 1,
+      timeoutMs: 100,
+    });
+    const first = resolver.resolve("/one");
+    const second = resolver.resolve("/two");
+    const firstRejected = expect(first).rejects.toBeInstanceOf(ProjectIdentityTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await firstRejected;
+
+    expect(workerMocks.workers[0]!.terminated).toBe(true);
+    expect(workerMocks.workers).toHaveLength(2);
+    expect(workerMocks.workers[1]!.postedMessages).toEqual([
+      { type: "resolve", requestId: 2, cwd: "/two" },
+    ]);
+
+    workerMocks.workers[1]!.emit("message", resolved(2, "/two"));
+    await expect(second).resolves.toMatchObject({ identity: { key: "/two" } });
+    await resolver.shutdown();
+  });
+
+  it("removes aborted queued work without consuming queue capacity", async () => {
+    const resolver = new ThreadProjectIdentityResolver(workerUrl, {
+      maxWorkers: 1,
+      maxQueuedRequests: 1,
+    });
+    const controller = new AbortController();
+    const first = resolver.resolve("/one");
+    const aborted = resolver.resolve("/two", controller.signal);
+
+    controller.abort();
+    await expect(aborted).rejects.toBeInstanceOf(ProjectIdentityRequestAbortedError);
+    const third = resolver.resolve("/three");
+
+    workerMocks.workers[0]!.emit("message", resolved(1, "/one"));
+    expect(workerMocks.workers[0]!.postedMessages.at(-1)).toEqual({
+      type: "resolve",
+      requestId: 3,
+      cwd: "/three",
+    });
+    workerMocks.workers[0]!.emit("message", resolved(3, "/three"));
+    await expect(first).resolves.toMatchObject({ identity: { key: "/one" } });
+    await expect(third).resolves.toMatchObject({ identity: { key: "/three" } });
+    await resolver.shutdown();
+  });
+
+  it("terminates active work when its final subscriber aborts", async () => {
+    const resolver = new ThreadProjectIdentityResolver(workerUrl, { maxWorkers: 1 });
+    const controller = new AbortController();
+    const aborted = resolver.resolve("/one", controller.signal);
+    const second = resolver.resolve("/two");
+
+    controller.abort();
+    await expect(aborted).rejects.toBeInstanceOf(ProjectIdentityRequestAbortedError);
+    await vi.waitFor(() => expect(workerMocks.workers).toHaveLength(2));
+
+    expect(workerMocks.workers[0]!.terminated).toBe(true);
+    expect(workerMocks.workers[1]!.postedMessages).toEqual([
+      { type: "resolve", requestId: 2, cwd: "/two" },
+    ]);
+    workerMocks.workers[1]!.emit("message", resolved(2, "/two"));
+    await expect(second).resolves.toMatchObject({ identity: { key: "/two" } });
     await resolver.shutdown();
   });
 });

--- a/packages/cli/src/project-identity-resolver.ts
+++ b/packages/cli/src/project-identity-resolver.ts
@@ -1,5 +1,5 @@
 import { Worker } from "node:worker_threads";
-import type { ProjectIdentityProjection } from "@codesesh/core";
+import { normalizeProjectDirectory, type ProjectIdentityProjection } from "@codesesh/core";
 import { appLogger } from "./logging.js";
 import type {
   ProjectIdentityWorkerMessage,
@@ -7,29 +7,73 @@ import type {
 } from "./project-identity-worker.js";
 
 export const PROJECT_IDENTITY_RESOLVER_MAX_WORKERS = 2;
+export const PROJECT_IDENTITY_RESOLVER_MAX_QUEUED_REQUESTS = 8;
+export const PROJECT_IDENTITY_RESOLVER_TIMEOUT_MS = 2_000;
 
 const SHUTDOWN_ERROR_MESSAGE = "Project identity resolver shut down";
 
 export interface ProjectIdentityResolver {
-  resolve(cwd: string): Promise<ProjectIdentityProjection>;
+  resolve(cwd: string, signal?: AbortSignal): Promise<ProjectIdentityProjection>;
   shutdown(): Promise<void>;
+}
+
+export interface ProjectIdentityResolverOptions {
+  maxWorkers?: number;
+  maxQueuedRequests?: number;
+  timeoutMs?: number;
+}
+
+export class ProjectIdentityQueueFullError extends Error {
+  constructor() {
+    super("Project identity resolver queue is full");
+    this.name = "ProjectIdentityQueueFullError";
+  }
+}
+
+export class ProjectIdentityTimeoutError extends Error {
+  constructor() {
+    super("Project identity resolution timed out");
+    this.name = "ProjectIdentityTimeoutError";
+  }
+}
+
+export class ProjectIdentityRequestAbortedError extends Error {
+  constructor() {
+    super("Project identity resolution was aborted");
+    this.name = "ProjectIdentityRequestAbortedError";
+  }
+}
+
+interface RequestSubscriber {
+  resolve: (projection: ProjectIdentityProjection) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  abortHandler?: () => void;
 }
 
 interface PendingRequest {
   requestId: number;
   cwd: string;
-  resolve: (projection: ProjectIdentityProjection) => void;
-  reject: (error: Error) => void;
+  subscribers: Set<RequestSubscriber>;
+  timeout: ReturnType<typeof setTimeout> | null;
 }
 
 interface WorkerSlot {
   worker: Worker;
   pending: PendingRequest | null;
   closed: boolean;
+  retirement: Promise<void> | null;
 }
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function requireSafeInteger(value: number, minimum: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new RangeError(`${name} must be a safe integer greater than or equal to ${minimum}`);
+  }
+  return value;
 }
 
 function isWorkerMessage(message: unknown): message is ProjectIdentityWorkerMessage {
@@ -45,37 +89,105 @@ function isWorkerMessage(message: unknown): message is ProjectIdentityWorkerMess
 export class ThreadProjectIdentityResolver implements ProjectIdentityResolver {
   private readonly workers = new Set<WorkerSlot>();
   private readonly queue: PendingRequest[] = [];
+  private readonly requestsByDirectory = new Map<string, PendingRequest>();
+  private readonly maxWorkers: number;
+  private readonly maxOutstandingRequests: number;
+  private readonly timeoutMs: number;
   private nextRequestId = 1;
   private isShuttingDown = false;
 
   constructor(
     private readonly workerUrl: URL,
-    private readonly maxWorkers = PROJECT_IDENTITY_RESOLVER_MAX_WORKERS,
-  ) {}
+    options: ProjectIdentityResolverOptions = {},
+  ) {
+    this.maxWorkers = requireSafeInteger(
+      options.maxWorkers ?? PROJECT_IDENTITY_RESOLVER_MAX_WORKERS,
+      1,
+      "maxWorkers",
+    );
+    const maxQueuedRequests = requireSafeInteger(
+      options.maxQueuedRequests ?? PROJECT_IDENTITY_RESOLVER_MAX_QUEUED_REQUESTS,
+      0,
+      "maxQueuedRequests",
+    );
+    this.timeoutMs = requireSafeInteger(
+      options.timeoutMs ?? PROJECT_IDENTITY_RESOLVER_TIMEOUT_MS,
+      1,
+      "timeoutMs",
+    );
+    this.maxOutstandingRequests = requireSafeInteger(
+      this.maxWorkers + maxQueuedRequests,
+      this.maxWorkers,
+      "request capacity",
+    );
+  }
 
-  resolve(cwd: string): Promise<ProjectIdentityProjection> {
+  resolve(cwd: string, signal?: AbortSignal): Promise<ProjectIdentityProjection> {
     if (this.isShuttingDown) return Promise.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
+    if (signal?.aborted) return Promise.reject(new ProjectIdentityRequestAbortedError());
 
-    return new Promise((resolve, reject) => {
-      this.queue.push({ requestId: this.nextRequestId++, cwd, resolve, reject });
-      this.pump();
-    });
+    const normalizedCwd = normalizeProjectDirectory(cwd);
+    let request = this.requestsByDirectory.get(normalizedCwd);
+    if (!request) {
+      if (this.requestsByDirectory.size >= this.maxOutstandingRequests) {
+        appLogger.warn("project_identity.queue.full", {
+          active_workers: this.activeWorkerCount(),
+          queued_requests: this.queue.length,
+          request_capacity: this.maxOutstandingRequests,
+        });
+        return Promise.reject(new ProjectIdentityQueueFullError());
+      }
+      request = {
+        requestId: this.nextRequestId++,
+        cwd: normalizedCwd,
+        subscribers: new Set(),
+        timeout: null,
+      };
+      this.requestsByDirectory.set(normalizedCwd, request);
+      this.queue.push(request);
+    }
+
+    const resolution = this.subscribe(request, signal);
+    this.pump();
+    return resolution;
   }
 
   async shutdown(): Promise<void> {
     if (this.isShuttingDown) return;
     this.isShuttingDown = true;
     const error = new Error(SHUTDOWN_ERROR_MESSAGE);
-    for (const request of this.queue.splice(0)) request.reject(error);
+    while (this.queue.length > 0) this.rejectRequest(this.queue[0]!, error);
 
-    const workers = [...this.workers];
+    const retirements = [...this.workers].map((slot) => this.retireWorker(slot, error));
+    await Promise.allSettled(retirements);
     this.workers.clear();
-    for (const slot of workers) {
-      slot.closed = true;
-      slot.pending?.reject(error);
-      slot.pending = null;
-    }
-    await Promise.allSettled(workers.map(({ worker }) => worker.terminate()));
+  }
+
+  private subscribe(
+    request: PendingRequest,
+    signal?: AbortSignal,
+  ): Promise<ProjectIdentityProjection> {
+    return new Promise((resolve, reject) => {
+      const subscriber: RequestSubscriber = { resolve, reject, signal };
+      request.subscribers.add(subscriber);
+      if (!signal) return;
+
+      subscriber.abortHandler = () => this.abortSubscriber(request, subscriber);
+      signal.addEventListener("abort", subscriber.abortHandler, { once: true });
+    });
+  }
+
+  private abortSubscriber(request: PendingRequest, subscriber: RequestSubscriber): void {
+    if (!request.subscribers.delete(subscriber)) return;
+    this.removeAbortHandler(subscriber);
+    subscriber.reject(new ProjectIdentityRequestAbortedError());
+    if (request.subscribers.size > 0) return;
+
+    const slot = this.workerForRequest(request);
+    if (slot) slot.pending = null;
+    this.releaseRequest(request);
+    if (slot) void this.retireWorker(slot);
+    else this.pump();
   }
 
   private pump(): void {
@@ -85,6 +197,15 @@ export class ThreadProjectIdentityResolver implements ProjectIdentityResolver {
       const request = this.queue.shift();
       if (!request) return;
       slot.pending = request;
+      request.timeout = setTimeout(() => {
+        if (slot.pending !== request || slot.closed) return;
+        appLogger.warn("project_identity.request.timeout", {
+          request_id: request.requestId,
+          timeout_ms: this.timeoutMs,
+        });
+        void this.retireWorker(slot, new ProjectIdentityTimeoutError());
+      }, this.timeoutMs);
+      request.timeout.unref();
       try {
         slot.worker.postMessage({
           type: "resolve",
@@ -92,7 +213,7 @@ export class ThreadProjectIdentityResolver implements ProjectIdentityResolver {
           cwd: request.cwd,
         } satisfies ProjectIdentityWorkerRequest);
       } catch (error) {
-        this.closeWorker(slot, toError(error));
+        void this.retireWorker(slot, toError(error));
       }
     }
   }
@@ -102,6 +223,14 @@ export class ThreadProjectIdentityResolver implements ProjectIdentityResolver {
       if (!slot.closed && slot.pending == null) return slot;
     }
     return null;
+  }
+
+  private activeWorkerCount(): number {
+    let count = 0;
+    for (const slot of this.workers) {
+      if (!slot.closed && slot.pending != null) count += 1;
+    }
+    return count;
   }
 
   private createWorker(): WorkerSlot | null {
@@ -115,17 +244,24 @@ export class ThreadProjectIdentityResolver implements ProjectIdentityResolver {
       return null;
     }
 
-    const slot: WorkerSlot = { worker, pending: null, closed: false };
+    const slot: WorkerSlot = {
+      worker,
+      pending: null,
+      closed: false,
+      retirement: null,
+    };
     this.workers.add(slot);
     worker.unref();
     worker.on("message", (message: unknown) => {
       if (appLogger.consumeWorkerMessage(message)) return;
       this.handleWorkerMessage(slot, message);
     });
-    worker.on("error", (error) => this.closeWorker(slot, toError(error)));
+    worker.on("error", (error) => {
+      void this.retireWorker(slot, toError(error));
+    });
     worker.on("exit", (code) => {
       if (!slot.closed) {
-        this.closeWorker(slot, new Error(`Project identity worker exited with code ${code}`));
+        this.closeExitedWorker(slot, new Error(`Project identity worker exited with code ${code}`));
       }
     });
     return slot;
@@ -137,23 +273,86 @@ export class ThreadProjectIdentityResolver implements ProjectIdentityResolver {
     if (!request || message.requestId !== request.requestId) return;
 
     slot.pending = null;
-    if (message.type === "resolved") request.resolve(message.projection);
-    else request.reject(new Error(message.error));
+    if (message.type === "resolved") this.resolveRequest(request, message.projection);
+    else this.rejectRequest(request, new Error(message.error));
     this.pump();
   }
 
-  private closeWorker(slot: WorkerSlot, error: Error): void {
-    if (slot.closed) return;
+  private closeExitedWorker(slot: WorkerSlot, error: Error): void {
     slot.closed = true;
     this.workers.delete(slot);
     const request = slot.pending;
     slot.pending = null;
-    request?.reject(error);
+    if (request) this.rejectRequest(request, error);
     if (!this.isShuttingDown) this.pump();
   }
 
+  private retireWorker(slot: WorkerSlot, error?: Error): Promise<void> {
+    if (slot.retirement) return slot.retirement;
+    slot.closed = true;
+    const request = slot.pending;
+    slot.pending = null;
+    if (request && error) this.rejectRequest(request, error);
+
+    const retirement = (async () => {
+      try {
+        await slot.worker.terminate();
+      } catch (terminationError) {
+        appLogger.warn("project_identity.worker.termination_failed", {
+          error: toError(terminationError).message,
+        });
+      } finally {
+        this.workers.delete(slot);
+        if (!this.isShuttingDown) this.pump();
+      }
+    })();
+    slot.retirement = retirement;
+    return retirement;
+  }
+
+  private workerForRequest(request: PendingRequest): WorkerSlot | null {
+    for (const slot of this.workers) {
+      if (slot.pending === request) return slot;
+    }
+    return null;
+  }
+
+  private resolveRequest(request: PendingRequest, projection: ProjectIdentityProjection): void {
+    this.releaseRequest(request);
+    for (const subscriber of request.subscribers) {
+      this.removeAbortHandler(subscriber);
+      subscriber.resolve(projection);
+    }
+    request.subscribers.clear();
+  }
+
+  private rejectRequest(request: PendingRequest, error: Error): void {
+    this.releaseRequest(request);
+    for (const subscriber of request.subscribers) {
+      this.removeAbortHandler(subscriber);
+      subscriber.reject(error);
+    }
+    request.subscribers.clear();
+  }
+
+  private releaseRequest(request: PendingRequest): void {
+    if (request.timeout) clearTimeout(request.timeout);
+    request.timeout = null;
+    if (this.requestsByDirectory.get(request.cwd) === request) {
+      this.requestsByDirectory.delete(request.cwd);
+    }
+    const queueIndex = this.queue.indexOf(request);
+    if (queueIndex >= 0) this.queue.splice(queueIndex, 1);
+  }
+
+  private removeAbortHandler(subscriber: RequestSubscriber): void {
+    if (subscriber.signal && subscriber.abortHandler) {
+      subscriber.signal.removeEventListener("abort", subscriber.abortHandler);
+    }
+  }
+
   private rejectQueued(error: Error): void {
-    for (const request of this.queue.splice(0)) request.reject(error);
+    while (this.queue.length > 0) this.rejectRequest(this.queue[0]!, error);
   }
 }
 

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -405,7 +405,7 @@ describe("createServer", () => {
           })
         ).status,
       ).toBe(200);
-      expect(resolver.resolve).toHaveBeenCalledWith("/untrusted");
+      expect(resolver.resolve).toHaveBeenCalledWith("/untrusted", expect.any(AbortSignal));
     } finally {
       await app.shutdown();
     }


### PR DESCRIPTION
## Summary

- coalesce concurrent project identity requests for normalized directories
- cap queued work, time out stalled workers, and replace them after termination
- propagate HTTP request cancellation and return 429 when resolver capacity is exhausted

## Testing

- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`