### PR TITLE
fix(cli): bound active SSE connections

### DIFF
--- a/packages/cli/src/api/__tests__/routes.test.ts
+++ b/packages/cli/src/api/__tests__/routes.test.ts
@@ -1,16 +1,128 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const loggerMocks = vi.hoisted(() => ({ warn: vi.fn() }));
+
+vi.mock("../../logging.js", () => ({ appLogger: loggerMocks }));
 import {
   SAMPLE_SCAN_STATUS_EVENT,
   SAMPLE_SESSIONS_UPDATED_EVENT,
 } from "@codesesh/core/test-fixtures";
 import type { ScanStatusEvent, SessionsUpdatedEvent } from "@codesesh/core/contract";
-import { createApiRoutes } from "../routes.js";
+import { createApiRoutes, MAX_ACTIVE_SSE_CONNECTIONS } from "../routes.js";
 import { MAX_PENDING_CRITICAL_SSE_FRAMES } from "../sse-event-buffer.js";
 import type { LiveSnapshot } from "@codesesh/core";
 import type { ScanResultSource } from "../handlers.js";
 import type { ScanEventSource } from "../../scan-source.js";
 
 describe("createApiRoutes", () => {
+  beforeEach(() => {
+    loggerMocks.warn.mockClear();
+  });
+
+  it("bounds active SSE clients and restores capacity after cancellation", async () => {
+    const unsubscribeSessions = vi.fn();
+    const unsubscribeScanStatus = vi.fn();
+    const eventSource: ScanEventSource = {
+      getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
+      subscribe: vi.fn(() => unsubscribeSessions),
+      subscribeScanStatus: vi.fn(() => unsubscribeScanStatus),
+    };
+    const app = createApiRoutes(
+      { getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }) },
+      eventSource,
+    );
+
+    const responses = await Promise.all(
+      Array.from({ length: MAX_ACTIVE_SSE_CONNECTIONS }, () => app.request("/events")),
+    );
+    const rejected = await app.request("/events");
+
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    expect(rejected.status).toBe(429);
+    expect(rejected.headers.get("Retry-After")).toBe("1");
+    expect(await rejected.json()).toEqual({ error: "Too many active event streams" });
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS);
+    expect(eventSource.subscribeScanStatus).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS);
+    expect(loggerMocks.warn).toHaveBeenCalledWith("api.sse.connection_limit_reached", {
+      active_connections: MAX_ACTIVE_SSE_CONNECTIONS,
+      connection_limit: MAX_ACTIVE_SSE_CONNECTIONS,
+    });
+
+    await responses[0]!.body?.cancel();
+    const replacement = await app.request("/events");
+
+    expect(replacement.status).toBe(200);
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS + 1);
+    expect(eventSource.subscribeScanStatus).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS + 1);
+
+    await Promise.all([
+      ...responses.slice(1).map((response) => response.body?.cancel()),
+      replacement.body?.cancel(),
+    ]);
+    expect(unsubscribeSessions).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS + 1);
+    expect(unsubscribeScanStatus).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS + 1);
+  });
+
+  it("releases every SSE connection when the server shuts down", async () => {
+    const unsubscribeSessions = vi.fn();
+    const unsubscribeScanStatus = vi.fn();
+    const eventSource: ScanEventSource = {
+      getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
+      subscribe: vi.fn(() => unsubscribeSessions),
+      subscribeScanStatus: vi.fn(() => unsubscribeScanStatus),
+    };
+    const shutdownController = new AbortController();
+    const app = createApiRoutes(
+      { getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }) },
+      eventSource,
+      { shutdownSignal: shutdownController.signal },
+    );
+    const responses = await Promise.all(
+      Array.from({ length: MAX_ACTIVE_SSE_CONNECTIONS }, () => app.request("/events")),
+    );
+
+    expect((await app.request("/events")).status).toBe(429);
+    shutdownController.abort();
+
+    expect(unsubscribeSessions).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS);
+    expect(unsubscribeScanStatus).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS);
+    const afterShutdown = await app.request("/events");
+    expect(afterShutdown.status).toBe(200);
+    const reader = afterShutdown.body!.getReader();
+    let done = false;
+    while (!done) ({ done } = await reader.read());
+    expect(done).toBe(true);
+
+    await Promise.all(responses.map((response) => response.body?.cancel()));
+  });
+
+  it("releases SSE capacity when subscription setup fails", async () => {
+    const unsubscribeSessions = vi.fn();
+    const eventSource: ScanEventSource = {
+      getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
+      subscribe: vi.fn(() => unsubscribeSessions),
+      subscribeScanStatus: vi.fn(() => {
+        throw new Error("status subscription failed");
+      }),
+    };
+    const app = createApiRoutes(
+      { getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }) },
+      eventSource,
+    );
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      for (let index = 0; index <= MAX_ACTIVE_SSE_CONNECTIONS; index += 1) {
+        expect((await app.request("/events")).status).toBe(500);
+      }
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS + 1);
+    expect(unsubscribeSessions).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS + 1);
+  });
+
   it("returns a Hono instance with route handlers", () => {
     const scanSource: ScanResultSource = {
       getSnapshot() {

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -23,7 +23,10 @@ import {
 } from "./bookmark-handlers.js";
 import type { ScanEventSource } from "../scan-source.js";
 import type { ProjectIdentityResolver } from "../project-identity-resolver.js";
+import { appLogger } from "../logging.js";
 import { SseEventBuffer } from "./sse-event-buffer.js";
+
+export const MAX_ACTIVE_SSE_CONNECTIONS = 32;
 
 export interface ApiRouteOptions {
   defaultSessionFrom?: number;
@@ -33,7 +36,35 @@ export interface ApiRouteOptions {
   projectIdentityResolver?: ProjectIdentityResolver;
 }
 
-function createSseResponse(eventSource: ScanEventSource, signal: AbortSignal): Response {
+interface SseConnectionBudget {
+  acquire(): (() => void) | null;
+  activeCount(): number;
+}
+
+function createSseConnectionBudget(maxConnections: number): SseConnectionBudget {
+  let activeConnections = 0;
+  return {
+    acquire() {
+      if (activeConnections >= maxConnections) return null;
+      activeConnections += 1;
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        activeConnections -= 1;
+      };
+    },
+    activeCount() {
+      return activeConnections;
+    },
+  };
+}
+
+function createSseResponse(
+  eventSource: ScanEventSource,
+  signal: AbortSignal,
+  releaseConnection: () => void,
+): Response {
   let cancelStream = () => {};
   let drainStream = () => {};
 
@@ -45,16 +76,17 @@ function createSseResponse(eventSource: ScanEventSource, signal: AbortSignal): R
         let unsubscribeScanStatus = () => {};
         let abortStream = () => {};
         let heartbeat: ReturnType<typeof setInterval> | undefined;
-        let buffer: SseEventBuffer;
+        let buffer: SseEventBuffer | undefined;
 
         const cleanup = () => {
           if (isClosed) return false;
           isClosed = true;
-          buffer.close();
+          buffer?.close();
           if (heartbeat) clearInterval(heartbeat);
           unsubscribeSessions();
           unsubscribeScanStatus();
           signal.removeEventListener("abort", abortStream);
+          releaseConnection();
           return true;
         };
         abortStream = () => {
@@ -65,23 +97,28 @@ function createSseResponse(eventSource: ScanEventSource, signal: AbortSignal): R
         });
         drainStream = () => buffer.drain();
 
-        buffer.enqueue("connected", { timestamp: Date.now() });
-        buffer.enqueueScanStatus(eventSource.getScanStatus());
+        try {
+          buffer.enqueue("connected", { timestamp: Date.now() });
+          buffer.enqueueScanStatus(eventSource.getScanStatus());
 
-        unsubscribeSessions = eventSource.subscribe((event) => {
-          buffer.enqueue(event.type, event);
-        });
-        unsubscribeScanStatus = eventSource.subscribeScanStatus((event) => {
-          buffer.enqueueScanStatus(event);
-        });
+          unsubscribeSessions = eventSource.subscribe((event) => {
+            buffer?.enqueue(event.type, event);
+          });
+          unsubscribeScanStatus = eventSource.subscribeScanStatus((event) => {
+            buffer?.enqueueScanStatus(event);
+          });
 
-        heartbeat = setInterval(() => buffer.enqueueHeartbeat(), 15000);
-        cancelStream = () => {
+          heartbeat = setInterval(() => buffer?.enqueueHeartbeat(), 15000);
+          cancelStream = () => {
+            cleanup();
+          };
+
+          if (signal.aborted) abortStream();
+          else signal.addEventListener("abort", abortStream, { once: true });
+        } catch (error) {
           cleanup();
-        };
-
-        if (signal.aborted) abortStream();
-        else signal.addEventListener("abort", abortStream, { once: true });
+          throw error;
+        }
       },
       pull() {
         drainStream();
@@ -106,6 +143,7 @@ export function createApiRoutes(
   options: ApiRouteOptions = {},
 ): Hono {
   const api = new Hono();
+  const sseConnections = createSseConnectionBudget(MAX_ACTIVE_SSE_CONNECTIONS);
   const listDefaults: SessionListDefaults = {
     from: options.defaultSessionFrom,
     to: options.defaultSessionTo,
@@ -140,10 +178,24 @@ export function createApiRoutes(
   api.post("/logs", (c) => handlePostClientLog(c));
   if (eventSource) {
     api.get("/events", (c) => {
+      const releaseConnection = sseConnections.acquire();
+      if (!releaseConnection) {
+        appLogger.warn("api.sse.connection_limit_reached", {
+          active_connections: sseConnections.activeCount(),
+          connection_limit: MAX_ACTIVE_SSE_CONNECTIONS,
+        });
+        c.header("Retry-After", "1");
+        return c.json({ error: "Too many active event streams" }, 429);
+      }
       const signal = options.shutdownSignal
         ? AbortSignal.any([c.req.raw.signal, options.shutdownSignal])
         : c.req.raw.signal;
-      return createSseResponse(eventSource, signal);
+      try {
+        return createSseResponse(eventSource, signal, releaseConnection);
+      } catch (error) {
+        releaseConnection();
+        throw error;
+      }
     });
   }
 


### PR DESCRIPTION
## Summary

- cap each server instance at 32 concurrent SSE streams
- return 429 with retry guidance when the connection budget is exhausted
- release connection capacity exactly once on cancellation, abort, overflow, setup failure, and shutdown

## Testing

- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`