### PR TITLE
fix(web): handle deep session hierarchies

### DIFF
--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -2,7 +2,11 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionHead } from "../lib/api";
 import { getSessionReferenceKey } from "../lib/session-indexes";
-import { buildSessionTreeModel, SessionTreeSidebar } from "./SessionTreeSidebar";
+import {
+  buildSessionTreeModel,
+  MAX_SESSION_TREE_NESTING,
+  SessionTreeSidebar,
+} from "./SessionTreeSidebar";
 
 function makeSession(overrides: Partial<SessionHead> & { id: string }): SessionHead {
   return {
@@ -30,6 +34,34 @@ function groupOrderOf(paths: string[]) {
 }
 
 describe("buildSessionTreeModel group sorting", () => {
+  it("folds a deeply nested session chain without recursive or quadratic paths", () => {
+    const depth = 12_000;
+    const sessions = Array.from({ length: depth }, (_, index) =>
+      makeSession({
+        id: `deep-${index}`,
+        title: "x",
+        ...(index > 0
+          ? { parent_reference: { agentName: "codex", sessionId: `deep-${index - 1}` } }
+          : {}),
+      }),
+    );
+    const model = buildSessionTreeModel(sessions);
+    const deepestPath = model.pathBySessionReference.get(getSessionReferenceKey(sessions.at(-1)!))!;
+    let longestPathLength = 0;
+    let totalPathLength = 0;
+    for (const path of model.pathBySessionReference.values()) {
+      longestPathLength = Math.max(longestPathLength, path.length);
+      totalPathLength += path.length;
+    }
+
+    expect(model.pathBySessionReference.size).toBe(depth);
+    expect(deepestPath).toContain("Deeper sessions/");
+    expect(deepestPath.split("/")).toHaveLength(MAX_SESSION_TREE_NESTING + 3);
+    expect(longestPathLength).toBeLessThan(256);
+    expect(totalPathLength).toBeLessThan(depth * 256);
+    expect(model.paths).toContain(deepestPath);
+  });
+
   it("renders every cycle member once under the Unmounted group", () => {
     const a = makeSession({
       id: "a",

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -40,6 +40,14 @@ interface SessionTreeModel {
   sessionByPath: Map<string, SessionHead>;
 }
 
+interface PendingSessionTreeNode {
+  node: SessionTreeNode;
+  parentPath: string;
+  siblingTitleCounts: Map<string, number>;
+  depth: number;
+  flattened: boolean;
+}
+
 type TreeHostStyle = CSSProperties & Record<`--${string}`, string>;
 
 const SESSION_TREE_CSS = `
@@ -247,6 +255,9 @@ function createPathAllocator() {
 
 /** Sessions the canonical hierarchy cannot mount still need a visible axis. */
 const UNMOUNTED_GROUP_LABEL = "Unmounted";
+const DEEP_SESSION_GROUP_LABEL = "Deeper sessions";
+/** FileTree keys contain every ancestor, so unbounded nesting would retain quadratic text. */
+export const MAX_SESSION_TREE_NESTING = 32;
 
 /**
  * `groupByProject: false` drops the project layer, for listings that already
@@ -305,11 +316,21 @@ export function buildSessionTreeModel(
       groupCountByPath.set(bareGroupPath, `${group.nodes.length}`);
     }
 
-    const appendSession = (
-      node: SessionTreeNode,
-      parentPath: string,
-      siblingTitleCounts: Map<string, number>,
-    ): void => {
+    const rootTitleCounts = new Map<string, number>();
+    const pending: PendingSessionTreeNode[] = [];
+    for (let index = group.nodes.length - 1; index >= 0; index -= 1) {
+      pending.push({
+        node: group.nodes[index]!,
+        parentPath: groupPath,
+        siblingTitleCounts: rootTitleCounts,
+        depth: 0,
+        flattened: false,
+      });
+    }
+
+    while (pending.length > 0) {
+      const frame = pending.pop()!;
+      const { node, parentPath, siblingTitleCounts } = frame;
       const session = node.session;
       const title = getSessionDisplayTitle(session);
       siblingTitleCounts.set(title, (siblingTitleCounts.get(title) ?? 0) + 1);
@@ -320,7 +341,7 @@ export function buildSessionTreeModel(
           : sanitizeSegment(title);
       const basePath = allocateSessionPath(`${parentPath}${leaf}`);
       const reference = getSessionReferenceKey(session);
-      const isDirectory = node.children.length > 0;
+      const isDirectory = !frame.flattened && node.children.length > 0;
       const sessionPath = isDirectory ? `${basePath}/` : basePath;
 
       if (isDirectory) {
@@ -337,15 +358,51 @@ export function buildSessionTreeModel(
       pathBySessionReference.set(reference, sessionPath);
       groupPathBySessionReference.set(reference, groupPath);
 
-      const childTitleCounts = new Map<string, number>();
-      for (const child of node.children) {
-        appendSession(child, sessionPath, childTitleCounts);
-      }
-    };
+      if (node.children.length === 0) continue;
 
-    const rootTitleCounts = new Map<string, number>();
-    for (const node of group.nodes) {
-      appendSession(node, groupPath, rootTitleCounts);
+      if (frame.flattened) {
+        for (let index = node.children.length - 1; index >= 0; index -= 1) {
+          pending.push({
+            node: node.children[index]!,
+            parentPath,
+            siblingTitleCounts,
+            depth: frame.depth,
+            flattened: true,
+          });
+        }
+        continue;
+      }
+
+      const childTitleCounts = new Map<string, number>();
+      if (frame.depth + 1 < MAX_SESSION_TREE_NESTING) {
+        for (let index = node.children.length - 1; index >= 0; index -= 1) {
+          pending.push({
+            node: node.children[index]!,
+            parentPath: sessionPath,
+            siblingTitleCounts: childTitleCounts,
+            depth: frame.depth + 1,
+            flattened: false,
+          });
+        }
+        continue;
+      }
+
+      const overflowBasePath = allocateSessionPath(`${sessionPath}${DEEP_SESSION_GROUP_LABEL}`);
+      const overflowPath = `${overflowBasePath}/`;
+      sortOrderByPath.set(overflowBasePath, order);
+      sortOrderByPath.set(overflowPath, order);
+      groupCountByPath.set(overflowBasePath, `${node.descendantCount}`);
+      groupCountByPath.set(overflowPath, `${node.descendantCount}`);
+      order += 1;
+      for (let index = node.children.length - 1; index >= 0; index -= 1) {
+        pending.push({
+          node: node.children[index]!,
+          parentPath: overflowPath,
+          siblingTitleCounts: childTitleCounts,
+          depth: frame.depth + 1,
+          flattened: true,
+        });
+      }
     }
   }
 

--- a/apps/web/src/lib/session-timeline.test.ts
+++ b/apps/web/src/lib/session-timeline.test.ts
@@ -28,6 +28,28 @@ function createSession(
 }
 
 describe("buildProjectTimeline", () => {
+  it("flattens a deeply nested session chain without recursive traversal", () => {
+    const depth = 12_000;
+    const sessions = Array.from({ length: depth }, (_, index) =>
+      createSession({
+        id: `deep-${index}`,
+        time_updated: NOW + index,
+        ...(index > 0
+          ? { parent_reference: { agentName: "codex", sessionId: `deep-${index - 1}` } }
+          : {}),
+      }),
+    );
+    const timeline = buildProjectTimeline(sessions, { now: NOW });
+    const row = timeline.days[0]!.rows[0]!;
+
+    expect(timeline.mainCount).toBe(1);
+    expect(timeline.subCount).toBe(depth - 1);
+    expect(row.childCount).toBe(depth - 1);
+    expect(row.children).toHaveLength(depth - 1);
+    expect(row.children[0]!.routeKey).toBe("codex/deep-1");
+    expect(row.children.at(-1)!.routeKey).toBe(`codex/deep-${depth - 1}`);
+  });
+
   it("labels days relative to now", () => {
     const timeline = buildProjectTimeline(
       [

--- a/apps/web/src/lib/session-timeline.ts
+++ b/apps/web/src/lib/session-timeline.ts
@@ -97,13 +97,27 @@ function toChildRow(node: SessionTreeNode): TimelineChildRow {
   };
 }
 
+function pushChildrenForDepthFirstTraversal(
+  pending: SessionTreeNode[],
+  children: SessionTreeNode[],
+): void {
+  if (children.length === 1) {
+    pending.push(children[0]!);
+    return;
+  }
+  const ordered = children.toSorted((a, b) => activityTime(a.session) - activityTime(b.session));
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    pending.push(ordered[index]!);
+  }
+}
+
 function collectChildRows(node: SessionTreeNode, rows: TimelineChildRow[]): void {
-  const ordered = node.children.toSorted(
-    (a, b) => activityTime(a.session) - activityTime(b.session),
-  );
-  for (const child of ordered) {
+  const pending: SessionTreeNode[] = [];
+  pushChildrenForDepthFirstTraversal(pending, node.children);
+  while (pending.length > 0) {
+    const child = pending.pop()!;
     rows.push(toChildRow(child));
-    collectChildRows(child, rows);
+    pushChildrenForDepthFirstTraversal(pending, child.children);
   }
 }
 


### PR DESCRIPTION
## Summary

- replace recursive sidebar and project timeline traversal with explicit stacks
- cap visible sidebar nesting at 32 levels and fold deeper sessions into a bounded folder
- keep every session addressable while bounding retained path text to linear growth

## Testing

- added 12,000-level hierarchy regressions for both derivations
- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`
- `pnpm --filter @codesesh/web test:bundle`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`