### PR TITLE
fix(web): restore narrow-screen navigation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -68,6 +68,7 @@ export default function App() {
 
   const setScanStatus = useScanStatusPublisher();
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
+  const [mobileNavigationOpen, setMobileNavigationOpen] = useState(false);
   const {
     shortcutHintDismissed,
     sidebarCollapsed,
@@ -97,6 +98,10 @@ export default function App() {
       session: viewState.activeSessionId,
     });
   }, [location.pathname, viewState.mode, viewState.activeAgentKey, viewState.activeSessionId]);
+
+  useEffect(() => {
+    setMobileNavigationOpen(false);
+  }, [location.pathname]);
 
   const sessionIndexes = useMemo(
     () => buildSessionIndexes(sessions, activeAgents),
@@ -399,6 +404,7 @@ export default function App() {
           <AppSidebar
             model={{
               sidebarCollapsed,
+              mobileNavigationOpen,
               viewState,
               agentCatalog,
               projects,
@@ -417,6 +423,7 @@ export default function App() {
             }}
             actions={{
               onCollapse: () => setSidebarCollapsed(true),
+              onMobileNavigationOpenChange: setMobileNavigationOpen,
               onToggleBookmark: toggleBookmark,
               onSelectFlatSidebarSession: handleSelectFlatSidebarSession,
               onToggleSidebarSessionBookmark: handleToggleSidebarSessionBookmark,
@@ -429,6 +436,16 @@ export default function App() {
 
           <main id="main" tabIndex={-1} className="flex min-w-0 flex-1 flex-col outline-none">
             <section className="flex shrink-0 items-start gap-3 border-b border-[var(--console-border)] bg-[var(--console-surface)]/70 px-4 py-4 backdrop-blur-sm md:px-8">
+              <button
+                type="button"
+                aria-expanded={mobileNavigationOpen}
+                aria-label="Open navigation"
+                title="Open navigation"
+                onClick={() => setMobileNavigationOpen(true)}
+                className="mt-0.5 inline-flex shrink-0 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1 text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none min-[1025px]:hidden"
+              >
+                <PanelLeftOpen className="size-4" />
+              </button>
               {sidebarCollapsed ? (
                 <button
                   type="button"
@@ -436,7 +453,7 @@ export default function App() {
                   aria-label="Expand sidebar"
                   title="Expand sidebar"
                   onClick={() => setSidebarCollapsed(false)}
-                  className="mt-0.5 hidden shrink-0 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1 text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none lg:inline-flex"
+                  className="mt-0.5 hidden shrink-0 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1 text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none min-[1025px]:inline-flex"
                 >
                   <PanelLeftOpen className="size-4" />
                 </button>

--- a/apps/web/src/components/DrawerDialog.test.tsx
+++ b/apps/web/src/components/DrawerDialog.test.tsx
@@ -15,4 +15,16 @@ describe("DrawerDialog", () => {
     expect(document.querySelector(".motion-backdrop")).not.toBeNull();
     expect(document.querySelector(".motion-drawer")).not.toBeNull();
   });
+
+  it("exposes the opening side to placement and motion styles", () => {
+    render(
+      <DrawerDialog open onOpenChange={vi.fn()} title="Left drawer" variant="mobile" side="left">
+        Drawer content
+      </DrawerDialog>,
+    );
+
+    const drawer = document.querySelector(".motion-drawer");
+    expect(drawer?.getAttribute("data-drawer-side")).toBe("left");
+    expect(drawer?.classList.contains("left-0")).toBe(true);
+  });
 });

--- a/apps/web/src/components/DrawerDialog.tsx
+++ b/apps/web/src/components/DrawerDialog.tsx
@@ -13,17 +13,24 @@ const VARIANT_STYLES = {
   },
 } as const;
 
+const SIDE_STYLES = {
+  left: "left-0 border-r",
+  right: "right-0 border-l",
+} as const;
+
 export function DrawerDialog({
   open,
   onOpenChange,
   title,
   variant,
+  side = "right",
   children,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   title: string;
   variant: keyof typeof VARIANT_STYLES;
+  side?: keyof typeof SIDE_STYLES;
   children: ReactNode;
 }) {
   const styles = VARIANT_STYLES[variant];
@@ -33,7 +40,8 @@ export function DrawerDialog({
       <Dialog.Portal>
         <Dialog.Backdrop className={`motion-backdrop fixed inset-0 ${styles.backdrop}`} />
         <Dialog.Popup
-          className={`motion-drawer fixed bottom-0 right-0 top-0 overscroll-contain border-l border-[var(--console-border)] bg-[var(--console-bg)] shadow-[var(--shadow-drawer)] outline-none ${styles.popup}`}
+          data-drawer-side={side}
+          className={`motion-drawer fixed bottom-0 top-0 overscroll-contain border-[var(--console-border)] bg-[var(--console-bg)] shadow-[var(--shadow-drawer)] outline-none ${SIDE_STYLES[side]} ${styles.popup}`}
         >
           <div className="mb-3 flex items-center justify-between gap-3">
             <Dialog.Title className="console-mono text-xs font-semibold uppercase tracking-[0.16em] text-[var(--console-text)]">

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -24,6 +24,7 @@ const projects = [
 function createActions(overrides: Partial<AppSidebarActions> = {}): AppSidebarActions {
   return {
     onCollapse: vi.fn(),
+    onMobileNavigationOpenChange: vi.fn(),
     onToggleBookmark: vi.fn(),
     onSelectFlatSidebarSession: vi.fn(),
     onToggleSidebarSessionBookmark: vi.fn(),
@@ -46,6 +47,7 @@ function renderSidebar(
         <AppSidebar
           model={{
             sidebarCollapsed: false,
+            mobileNavigationOpen: false,
             viewState: { mode: "root", activeAgentKey: null, activeSessionId: null },
             agentCatalog: createAgentCatalog(agents),
             projects,
@@ -71,6 +73,18 @@ function renderSidebar(
 }
 
 describe("AppSidebar", () => {
+  it("renders navigation in a mobile drawer without the desktop collapse control", () => {
+    const onMobileNavigationOpenChange = vi.fn();
+    renderSidebar({ mobileNavigationOpen: true }, createActions({ onMobileNavigationOpenChange }));
+
+    expect(screen.getByRole("dialog", { name: "Navigation" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Dashboard/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Collapse sidebar" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close navigation" }));
+    expect(onMobileNavigationOpenChange.mock.calls[0]?.[0]).toBe(false);
+  });
+
   it("lists projects under the global dashboard entry", () => {
     renderSidebar();
 

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, type ReactNode } from "react";
 import type { BookmarkView, ApiProjectGroup, SessionHead } from "../../lib/api";
 import { useScanStatus } from "../../hooks/useScanStatus";
 import { useSidebarKeyboardNavigation } from "../../hooks/useSidebarKeyboardNavigation";
@@ -13,6 +13,7 @@ import { getSessionDisplayTitle } from "../../lib/session-title";
 import { getProjectGroupIdentity, getProjectIdentityKey, getProjectPath } from "../../lib/projects";
 import type { ViewState } from "../../lib/view-state";
 import { AgentIcon } from "../AgentIcon";
+import { DrawerDialog } from "../DrawerDialog";
 import { RenderProfiler } from "../RenderProfiler";
 import { ResourceLoadFailure } from "../ResourceLoadFailure";
 import { SessionActionsMenu } from "../SessionActionsMenu";
@@ -72,6 +73,7 @@ function ProjectNavList({
 
 export interface AppSidebarViewModel {
   sidebarCollapsed: boolean;
+  mobileNavigationOpen: boolean;
   viewState: ViewState;
   agentCatalog: AgentCatalog;
   projects: ApiProjectGroup[];
@@ -91,6 +93,7 @@ export interface AppSidebarViewModel {
 
 export interface AppSidebarActions {
   onCollapse: () => void;
+  onMobileNavigationOpenChange: (open: boolean) => void;
   onToggleBookmark: (session: BookmarkView) => void;
   onSelectFlatSidebarSession: (session: SessionHead) => void;
   onToggleSidebarSessionBookmark: (session: SessionHead) => void;
@@ -100,9 +103,58 @@ export interface AppSidebarActions {
   onRetryBookmarks: () => void;
 }
 
+function SidebarFrame({
+  collapsed,
+  mobileOpen,
+  onMobileOpenChange,
+  children,
+}: {
+  collapsed: boolean;
+  mobileOpen: boolean;
+  onMobileOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}) {
+  useEffect(() => {
+    if (!mobileOpen || typeof window.matchMedia !== "function") return;
+    const desktop = window.matchMedia("(min-width: 1025px)");
+    const closeOnDesktop = () => {
+      if (desktop.matches) onMobileOpenChange(false);
+    };
+    desktop.addEventListener("change", closeOnDesktop);
+    closeOnDesktop();
+    return () => desktop.removeEventListener("change", closeOnDesktop);
+  }, [mobileOpen, onMobileOpenChange]);
+
+  if (mobileOpen) {
+    return (
+      <DrawerDialog
+        open
+        onOpenChange={onMobileOpenChange}
+        title="Navigation"
+        variant="mobile"
+        side="left"
+      >
+        {children}
+      </DrawerDialog>
+    );
+  }
+
+  return (
+    <aside
+      aria-label="Primary navigation"
+      className={`w-64 shrink-0 flex-col border-r border-[var(--console-border)] bg-[var(--console-sidebar-bg)] ${
+        collapsed ? "hidden" : "hidden min-[1025px]:flex"
+      }`}
+    >
+      {children}
+    </aside>
+  );
+}
+
 export function AppSidebar({
   model: {
     sidebarCollapsed,
+    mobileNavigationOpen,
     viewState,
     agentCatalog,
     projects,
@@ -121,6 +173,7 @@ export function AppSidebar({
   },
   actions: {
     onCollapse,
+    onMobileNavigationOpenChange,
     onToggleBookmark,
     onSelectFlatSidebarSession,
     onToggleSidebarSessionBookmark,
@@ -156,10 +209,10 @@ export function AppSidebar({
   );
 
   return (
-    <aside
-      className={`w-64 shrink-0 flex-col border-r border-[var(--console-border)] bg-[var(--console-sidebar-bg)] ${
-        sidebarCollapsed ? "hidden" : "hidden lg:flex"
-      }`}
+    <SidebarFrame
+      collapsed={sidebarCollapsed}
+      mobileOpen={mobileNavigationOpen}
+      onMobileOpenChange={onMobileNavigationOpenChange}
     >
       <div className="console-scrollbar flex-1 space-y-8 overflow-y-auto px-4 py-6">
         <section>
@@ -173,16 +226,18 @@ export function AppSidebar({
                 <img src="/logo.svg?v=3" alt="Dashboard" className="size-3.5 rounded-[2px]" />
                 <span className="console-mono line-clamp-1 flex-1 text-xs">Dashboard</span>
               </Link>
-              <button
-                type="button"
-                aria-expanded="true"
-                aria-label="Collapse sidebar"
-                title="Collapse sidebar"
-                onClick={onCollapse}
-                className="shrink-0 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1 text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
-              >
-                <PanelLeftClose className="size-4" />
-              </button>
+              {!mobileNavigationOpen ? (
+                <button
+                  type="button"
+                  aria-expanded="true"
+                  aria-label="Collapse sidebar"
+                  title="Collapse sidebar"
+                  onClick={onCollapse}
+                  className="shrink-0 rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-1 text-[var(--console-muted)] motion-hover hover:bg-[var(--console-surface-muted)] hover:text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
+                >
+                  <PanelLeftClose className="size-4" />
+                </button>
+              ) : null}
             </li>
             <ProjectNavList
               projects={projects}
@@ -329,6 +384,6 @@ export function AppSidebar({
           </section>
         ) : null}
       </div>
-    </aside>
+    </SidebarFrame>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -620,6 +620,11 @@
     transform: translateX(100%);
   }
 
+  .motion-drawer[data-drawer-side="left"][data-starting-style],
+  .motion-drawer[data-drawer-side="left"][data-ending-style] {
+    transform: translateX(-100%);
+  }
+
   .motion-drawer[data-ending-style] {
     transition-duration: 180ms;
   }

--- a/tests/e2e/browsing.spec.ts
+++ b/tests/e2e/browsing.spec.ts
@@ -1,5 +1,19 @@
 import { expect, test } from "./test-fixtures.js";
 
+test("keeps project navigation reachable on narrow viewports", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Open navigation" }).click();
+  const navigation = page.getByRole("dialog", { name: "Navigation" });
+  await expect(navigation).toBeVisible();
+
+  await navigation.getByRole("link", { name: /codesesh-e2e/ }).click();
+
+  await expect(page.getByRole("heading", { level: 1, name: "codesesh-e2e" })).toBeVisible();
+  await expect(navigation).not.toBeVisible();
+});
+
 test("keeps project navigation aligned with the overview route", async ({ page }) => {
   await page.goto("/projects");
   await expect(page.getByRole("heading", { level: 1, name: "Projects" })).toBeVisible();


### PR DESCRIPTION
## Summary
- add an accessible navigation trigger and modal drawer below the desktop sidebar breakpoint
- reuse one sidebar content tree across desktop and mobile presentations
- close mobile navigation after route or viewport changes and animate drawers from their placement side
- cover narrow navigation with component and Playwright regressions

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm perf:check
- pnpm --filter @codesesh/web test:bundle
- pnpm test:e2e
- repository quality, documentation, and release preflight checks