### PR TITLE
fix(web): index child session lookups

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -292,7 +292,7 @@ export default function App() {
       projectsLoading={projectsLoading}
       onRetryProjects={() => void retryProjects()}
       landingSessions={sessionIndexes.landingSessions}
-      sessions={sessions}
+      childSessionsByParentRouteKey={sessionIndexes.childrenByParentRouteKey}
       sessionsByAgent={sessionIndexes.byLandingAgent}
       activeProject={activeProject?.project ?? null}
       activeProjectSessions={activeProjectSessions}

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentInfo, ApiProjectGroup, SessionDetail } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
-import type { IndexedSession } from "../../lib/session-indexes";
+import { getSessionRouteKey, type IndexedSession } from "../../lib/session-indexes";
 import { createQueryWrapper } from "../../test/query-wrapper";
 import { AppRouteContent } from "./AppRouteContent";
 
@@ -65,6 +65,7 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
     projectsLoading: false,
     onRetryProjects: vi.fn(),
     landingSessions: [],
+    childSessionsByParentRouteKey: new Map(),
     sessionsByAgent: new Map(),
     activeProject: null,
     activeProjectSessions: [],
@@ -285,7 +286,9 @@ describe("AppRouteContent", () => {
       activeSessionId: parent.id,
     };
     props.sessionDetail.session = parent;
-    props.sessions = [child];
+    props.childSessionsByParentRouteKey = new Map([
+      [getSessionRouteKey("claudecode", "parent"), [child]],
+    ]);
     const view = render(
       <MemoryRouter>
         <AppRouteContent {...props} />

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -102,7 +102,7 @@ interface AppRouteContentProps {
   projectsLoading: boolean;
   onRetryProjects: () => void;
   landingSessions: IndexedSession[];
-  sessions?: SessionHead[];
+  childSessionsByParentRouteKey: ReadonlyMap<string, SessionHead[]>;
   sessionsByAgent: Map<string, IndexedSession[]>;
   activeProject: ApiProjectGroup | null;
   activeProjectSessions: IndexedSession[];
@@ -127,7 +127,7 @@ export function AppRouteContent({
   projectsLoading,
   onRetryProjects,
   landingSessions,
-  sessions = [],
+  childSessionsByParentRouteKey,
   sessionsByAgent,
   activeProject,
   activeProjectSessions,
@@ -154,15 +154,8 @@ export function AppRouteContent({
   const childSessions = useMemo(() => {
     if (!currentSessionAgentName || !currentSessionId) return [];
     const parentRouteKey = getSessionRouteKey(currentSessionAgentName, currentSessionId);
-    return sessions.filter(
-      (candidate) =>
-        candidate.parent_reference &&
-        getSessionRouteKey(
-          candidate.parent_reference.agentName,
-          candidate.parent_reference.sessionId,
-        ) === parentRouteKey,
-    );
-  }, [currentSessionAgentName, currentSessionId, sessions]);
+    return childSessionsByParentRouteKey.get(parentRouteKey) ?? [];
+  }, [childSessionsByParentRouteKey, currentSessionAgentName, currentSessionId]);
   const toggleSessionBookmark = bookmarks.toggleSessionBookmark;
   const toggleLandingBookmark = useCallback(
     (session: IndexedSession) => toggleSessionBookmark(session, session.agentKey),

--- a/apps/web/src/lib/session-indexes.ts
+++ b/apps/web/src/lib/session-indexes.ts
@@ -26,6 +26,7 @@ export interface SessionProjectOption {
 
 export interface SessionIndexes {
   byRouteKey: Map<string, SessionHead>;
+  childrenByParentRouteKey: Map<string, SessionHead[]>;
   byAgent: Map<string, SessionHead[]>;
   byProjectIdentityKey: Map<string, SessionHead[]>;
   byProjectAgentKey: Map<string, SessionHead[]>;
@@ -117,6 +118,7 @@ export function buildSessionIndexes(sessions: SessionHead[], agents: AgentInfo[]
 
   return {
     byRouteKey: canonical.byRouteKey,
+    childrenByParentRouteKey: canonical.childrenByParentRouteKey,
     byAgent,
     byProjectIdentityKey: canonical.byProjectIdentityKey,
     byProjectAgentKey: canonical.byProjectAgentKey,

--- a/packages/core/src/contract/__tests__/session-index.test.ts
+++ b/packages/core/src/contract/__tests__/session-index.test.ts
@@ -81,6 +81,25 @@ describe("canonical session index", () => {
     ).toEqual(["remote"]);
   });
 
+  it("keeps child sessions under their parent's full reference", () => {
+    const codexChild = createSession("codex-child", 100, {
+      parent_reference: { agentName: "codex", sessionId: "shared-parent" },
+    });
+    const claudeChild = createSession("claude-child", 200, {
+      slug: "claude/claude-child",
+      parent_reference: { agentName: "claude", sessionId: "shared-parent" },
+    });
+
+    const index = createSessionIndex([codexChild, claudeChild]);
+
+    expect(
+      index.childrenByParentRouteKey.get(getSessionRouteKey("codex", "shared-parent")),
+    ).toEqual([codexChild]);
+    expect(
+      index.childrenByParentRouteKey.get(getSessionRouteKey("claude", "shared-parent")),
+    ).toEqual([claudeChild]);
+  });
+
   it("places malformed legacy slugs in the explicit unknown agent bucket", () => {
     const malformed = createSession("malformed", 100, { slug: "" });
 

--- a/packages/core/src/contract/session-index.ts
+++ b/packages/core/src/contract/session-index.ts
@@ -14,6 +14,7 @@ export interface CanonicalSessionIndex {
   sourceSessions: SessionHead[];
   sessionsByActivity: SessionHead[];
   byRouteKey: Map<string, SessionHead>;
+  childrenByParentRouteKey: Map<string, SessionHead[]>;
   byAgent: Map<string, SessionHead[]>;
   byProjectIdentityKey: Map<string, SessionHead[]>;
   byProjectAgentKey: Map<string, SessionHead[]>;
@@ -83,6 +84,7 @@ function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
 
 export function createSessionIndex(sourceSessions: SessionHead[]): CanonicalSessionIndex {
   const byRouteKey = new Map<string, SessionHead>();
+  const childrenByParentRouteKey = new Map<string, SessionHead[]>();
   const byAgent = new Map<string, SessionHead[]>();
   const byProjectIdentityKey = new Map<string, SessionHead[]>();
   const byProjectAgentKey = new Map<string, SessionHead[]>();
@@ -91,6 +93,13 @@ export function createSessionIndex(sourceSessions: SessionHead[]): CanonicalSess
     const agentName = getSessionAgentKey(session);
     const routeKey = getSessionRouteKey(agentName, session.id);
     if (!byRouteKey.has(routeKey)) byRouteKey.set(routeKey, session);
+    if (session.parent_reference) {
+      pushMapValue(
+        childrenByParentRouteKey,
+        getSessionRouteKey(session.parent_reference.agentName, session.parent_reference.sessionId),
+        session,
+      );
+    }
   }
 
   const sessionsByActivity = sortSessionsByActivity(sourceSessions);
@@ -110,6 +119,7 @@ export function createSessionIndex(sourceSessions: SessionHead[]): CanonicalSess
     sourceSessions,
     sessionsByActivity,
     byRouteKey,
+    childrenByParentRouteKey,
     byAgent,
     byProjectIdentityKey,
     byProjectAgentKey,


### PR DESCRIPTION
## Summary
- add parent-reference child groups to the canonical session index
- use the shared index for session detail child lookup instead of filtering every loaded session
- preserve child ordering and isolate equal parent IDs by full agent/session reference
- add contract and detail rendering regressions

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm perf:check
- pnpm --filter @codesesh/web test:bundle
- repository quality, documentation, and release preflight checks