### PR TITLE
fix(web): release inactive session projections

### DIFF
--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -233,12 +233,17 @@ describe("useSessionStore", () => {
     expect(result.current.version).toBeGreaterThan(0);
   });
 
-  it("applies live events to the latest window after a rapid switch", async () => {
+  it("releases inactive projections and applies live events to the latest window", async () => {
     const { result, client } = await renderStore();
     const firstWindow = { from: 1_700_000_000_000, to: 1_700_004_000_000 };
     const latestWindow = { from: 1_699_999_000_000, to: 1_700_005_000_000 };
     await act(() => result.current.reload(firstWindow));
     await act(() => result.current.reload(latestWindow));
+    await waitFor(() =>
+      expect(
+        client.getQueryCache().findAll({ queryKey: queryKeys.sessionProjections }),
+      ).toHaveLength(1),
+    );
     const changedSession = { ...SAMPLE_SESSION_HEAD, display_title: "Latest window" };
 
     await act(() =>
@@ -255,9 +260,10 @@ describe("useSessionStore", () => {
 
     expect(result.current.window).toEqual(latestWindow);
     await waitFor(() => expect(result.current.sessions).toEqual([changedSession]));
+    expect(client.getQueryData(queryKeys.sessionProjection(firstWindow))).toBeUndefined();
     expect(
-      client.getQueryData<SessionProjection>(queryKeys.sessionProjection(firstWindow))?.sessions,
-    ).toEqual([SAMPLE_SESSION_HEAD]);
+      client.getQueryData<SessionProjection>(queryKeys.sessionProjection(latestWindow))?.sessions,
+    ).toEqual([changedSession]);
   });
 
   it("applies an incremental live session diff without re-fetching sessions", async () => {

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -4,6 +4,7 @@ import {
   getSessionAgentKey,
 } from "@codesesh/core/contract";
 import {
+  hashKey,
   isCancelledError,
   keepPreviousData,
   queryOptions,
@@ -112,6 +113,17 @@ function sessionProjectionOptions(
       );
       return { window, sessions: sessionResult.sessions };
     },
+  });
+}
+
+function removeOtherSessionProjections(
+  queryClient: QueryClient,
+  activeWindow: AppConfig["window"],
+): void {
+  const activeProjectionHash = hashKey(queryKeys.sessionProjection(activeWindow));
+  queryClient.removeQueries({
+    queryKey: queryKeys.sessionProjections,
+    predicate: (query) => query.queryHash !== activeProjectionHash,
   });
 }
 
@@ -241,6 +253,7 @@ export function useSessionStore() {
           queryClient.cancelQueries({ queryKey: queryKeys.sessionAggregates }),
           queryClient.cancelQueries({ queryKey: queryKeys.projects }),
         ]);
+        removeOtherSessionProjections(queryClient, window);
         await Promise.all([
           queryClient.invalidateQueries({
             queryKey: queryKeys.sessionProjection(window),


### PR DESCRIPTION
## Summary
- discard full session projections for windows that are no longer requested
- preserve the target projection while canceling and replacing older window loads
- keep live updates bound to the latest projection after rapid range switches
- add a regression that verifies only one projection remains cached

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm perf:check
- pnpm --filter @codesesh/web test:bundle
- repository quality, documentation, and release preflight checks