### PR TITLE
fix(projects): bound catalog pagination

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -57,10 +57,21 @@ const workspaceProject: ApiProjectGroup = {
   agentStats: [],
 };
 
+const workspaceProjectPage = {
+  projects: [workspaceProject],
+  summary: {
+    projects: 1,
+    sessions: 0,
+    tokens: 0,
+    cost: 0,
+    latestActivity: null,
+  },
+};
+
 const responses: Record<string, unknown> = {
   "/api/config": { window: { days: 30 } },
   "/api/agents": [],
-  "/api/projects": { projects: [workspaceProject] },
+  "/api/projects": workspaceProjectPage,
   "/api/sessions": { sessions: [] },
   "/api/dashboard": emptyDashboard,
   "/api/bookmarks": { bookmarks: [] },
@@ -79,18 +90,24 @@ const responses: Record<string, unknown> = {
 };
 
 let requestedUrls: string[] = [];
+let projectDetailResponse: unknown = null;
 
 beforeEach(() => {
   requestedUrls = [];
+  projectDetailResponse = null;
   liveSubscription.onUpdate = undefined;
   responses["/api/agents"] = [];
-  responses["/api/projects"] = { projects: [workspaceProject] };
+  responses["/api/projects"] = workspaceProjectPage;
   responses["/api/sessions"] = { sessions: [] };
   vi.stubGlobal("__APP_VERSION__", "0.0.0-test");
   vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
     const url = String(input);
     requestedUrls.push(url);
-    const body = responses[url.split("?")[0] ?? ""] ?? {};
+    const parsed = new URL(url, "http://localhost");
+    const body =
+      parsed.pathname === "/api/projects" && parsed.searchParams.has("projectKey")
+        ? (projectDetailResponse ?? responses[parsed.pathname] ?? {})
+        : (responses[parsed.pathname] ?? {});
     return new Response(JSON.stringify(body), {
       headers: { "content-type": "application/json" },
     });
@@ -165,6 +182,31 @@ describe("App live updates", () => {
 });
 
 describe("App dashboard scope wiring", () => {
+  it("resolves a project outside the bounded catalog page", async () => {
+    const selectedProject = {
+      ...workspaceProject,
+      identityKey: "/outside-first-page",
+      displayName: "outside-first-page",
+    };
+    projectDetailResponse = {
+      projects: [selectedProject],
+      summary: {
+        projects: 1,
+        sessions: 0,
+        tokens: 0,
+        cost: 0,
+        latestActivity: null,
+      },
+    };
+
+    renderAppAt("/projects/path/%2Foutside-first-page");
+
+    expect(await screen.findByRole("heading", { name: "outside-first-page" })).toBeTruthy();
+    expect(requestedUrls.some((url) => url.includes("projectKey=%2Foutside-first-page"))).toBe(
+      true,
+    );
+  });
+
   it("requests the project scope on a project route", async () => {
     renderAppAt("/projects/path/%2Fworkspace");
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,6 +18,7 @@ import { useSessionSearch } from "./hooks/useSessionSearch";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { useSidebarModel } from "./hooks/useSidebarModel";
 import { useSessionStore } from "./hooks/useSessionStore";
+import { useProjectLookup } from "./hooks/useProjects";
 import { useSessionAliasMutations } from "./hooks/useSessionAliasMutations";
 import { useWindowedDataLoad } from "./hooks/useWindowedDataLoad";
 import { useLiveSync } from "./hooks/useLiveSync";
@@ -47,6 +48,7 @@ export default function App() {
     agentCatalog,
     sessions,
     projects,
+    projectPage,
     projectsError,
     projectsLoading,
     dashboard,
@@ -157,6 +159,15 @@ export default function App() {
     activeProjectKind && activeProjectKey
       ? getProjectIdentityKey({ kind: activeProjectKind, key: activeProjectKey })
       : null;
+  const activeProjectIdentity =
+    activeProjectKind && activeProjectKey
+      ? { kind: activeProjectKind, key: activeProjectKey }
+      : null;
+  const projectLookup = useProjectLookup(loadedWindow, activeProjectIdentity, projects);
+  const resolvedProjects = useMemo(() => {
+    if (!projectLookup.project || projects.includes(projectLookup.project)) return projects;
+    return [...projects, projectLookup.project];
+  }, [projectLookup.project, projects]);
 
   const [projectAgentFilter, setProjectAgentFilter] = useState<{
     identityKey: string;
@@ -179,7 +190,7 @@ export default function App() {
     sessionIndexes,
     session,
     agents: activeAgents,
-    projects,
+    projects: resolvedProjects,
     selectedProjectAgent,
     isSessionBookmarked,
   });
@@ -266,7 +277,7 @@ export default function App() {
     isSearchMode,
     searchSubtitle,
     dashboard,
-    projects,
+    projectCount: projectPage.summary.projects,
     sessionCount: sessions.length,
     activeProject: activeProject?.project ?? null,
     activeAgent,
@@ -287,7 +298,7 @@ export default function App() {
       agents={activeAgents}
       agentCatalog={agentCatalog}
       agentNameMap={agentNameMap}
-      projects={projects}
+      projectPage={projectPage}
       projectsError={projectsError}
       projectsLoading={projectsLoading}
       onRetryProjects={() => void retryProjects()}
@@ -295,6 +306,9 @@ export default function App() {
       childSessionsByParentRouteKey={sessionIndexes.childrenByParentRouteKey}
       sessionsByAgent={sessionIndexes.byLandingAgent}
       activeProject={activeProject?.project ?? null}
+      activeProjectLoading={projectLookup.loading}
+      activeProjectError={projectLookup.error}
+      onRetryActiveProject={() => void projectLookup.retry()}
       activeProjectSessions={activeProjectSessions}
       overview={{
         window: loadedWindow,
@@ -407,7 +421,8 @@ export default function App() {
               mobileNavigationOpen,
               viewState,
               agentCatalog,
-              projects,
+              projects: resolvedProjects,
+              projectCount: projectPage.summary.projects,
               projectsError,
               projectsLoading,
               selectedProjectNavigationId,

--- a/apps/web/src/components/Projects.test.tsx
+++ b/apps/web/src/components/Projects.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiProjectGroup } from "../lib/api";
+import { createAgentCatalog } from "../lib/agents";
+import { createQueryWrapper } from "../test/query-wrapper";
+import { ProjectsOverview } from "./Projects";
+
+const PROJECT_COUNT_ABOVE_ARGUMENT_LIMIT = 200_000;
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function makeProjects(count: number): ApiProjectGroup[] {
+  return Array.from({ length: count }, (_, index) => ({
+    identityKind: "path",
+    identityKey: `/workspace/${index}`,
+    displayName: `project-${index}`,
+    sources: ["codex"],
+    sessionCount: 1,
+    lastActivity: index,
+    messages: 1,
+    tokens: 1,
+    cost: 0,
+    agentStats: [],
+  }));
+}
+
+describe("ProjectsOverview project-count budget", () => {
+  it("keeps rendering bounded above the JavaScript argument limit", () => {
+    const { Wrapper } = createQueryWrapper();
+    const projects = makeProjects(PROJECT_COUNT_ABOVE_ARGUMENT_LIMIT);
+
+    render(
+      <Wrapper>
+        <MemoryRouter>
+          <ProjectsOverview
+            initialPage={{
+              projects,
+              summary: {
+                projects: projects.length,
+                sessions: projects.length,
+                tokens: projects.length,
+                cost: 0,
+                latestActivity: projects.length - 1,
+              },
+            }}
+            window={null}
+            agentCatalog={createAgentCatalog([])}
+            loading={false}
+            error={null}
+            onRetry={() => undefined}
+          />
+        </MemoryRouter>
+      </Wrapper>,
+    );
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(250);
+    expect(screen.getAllByText("200,000")).toHaveLength(2);
+  });
+
+  it("replaces one bounded project page with the next", async () => {
+    const { Wrapper } = createQueryWrapper();
+    const firstProjects = makeProjects(100);
+    const nextProject = makeProjects(1).map((project) => ({
+      ...project,
+      identityKey: "/workspace/next",
+      displayName: "next-project",
+    }));
+    const summary = {
+      projects: 101,
+      sessions: 101,
+      tokens: 101,
+      cost: 0,
+      latestActivity: 100,
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ projects: nextProject, summary }), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <Wrapper>
+        <MemoryRouter>
+          <ProjectsOverview
+            initialPage={{ projects: firstProjects, summary, nextCursor: "next-page" }}
+            window={{ from: 1, to: 2 }}
+            agentCatalog={createAgentCatalog([])}
+            loading={false}
+            error={null}
+            onRetry={() => undefined}
+          />
+        </MemoryRouter>
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => expect(screen.getByText("next-project")).toBeTruthy());
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain("cursor=next-page");
+    expect(screen.getByText(/Page 2/)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from "react-router-dom";
-import type { ApiProjectAgentStat, ApiProjectGroup, AppConfig } from "../lib/api";
+import type { ApiProjectAgentStat, ApiProjectGroup, ApiProjectPage, AppConfig } from "../lib/api";
+import { useProjectPagination } from "../hooks/useProjects";
 import { findAgent, type AgentCatalog } from "../lib/agents";
 import { formatCompact, formatMoney, formatNumber, formatRelativeTime } from "../lib/format";
 import { getProjectPath } from "../lib/projects";
@@ -100,32 +101,39 @@ function ProjectListItem({
 }
 
 export function ProjectsOverview({
-  projects,
+  initialPage,
+  window,
   agentCatalog,
   loading,
   error,
   onRetry,
 }: {
-  projects: ApiProjectGroup[];
+  initialPage: ApiProjectPage;
+  window: AppConfig["window"] | null;
   agentCatalog: AgentCatalog;
   loading: boolean;
   error: string | null;
   onRetry: () => void;
 }) {
-  const totalSessions = projects.reduce((sum, project) => sum + project.sessionCount, 0);
-  const totalTokens = projects.reduce((sum, project) => sum + project.tokens, 0);
-  const totalCost = projects.reduce((sum, project) => sum + project.cost, 0);
-  const latestActivity = Math.max(0, ...projects.map((project) => project.lastActivity ?? 0));
+  const pagination = useProjectPagination(window, initialPage);
+  const page = pagination.page ?? initialPage;
+  const projects = page.projects.slice(0, 250);
+  const currentError = pagination.error ?? error;
+  const retry = pagination.error ? () => void pagination.retry() : onRetry;
 
-  if (projects.length === 0) {
-    if (error) {
+  if (page.summary.projects === 0) {
+    if (currentError) {
       return (
         <div className="mx-auto max-w-6xl">
-          <ResourceLoadFailure title="Couldn't load projects." message={error} onRetry={onRetry} />
+          <ResourceLoadFailure
+            title="Couldn't load projects."
+            message={currentError}
+            onRetry={retry}
+          />
         </div>
       );
     }
-    if (loading) {
+    if (loading || pagination.loading) {
       return (
         <Panel className="mx-auto max-w-6xl p-6 text-sm text-[var(--console-muted)]">
           Loading projects...
@@ -141,18 +149,50 @@ export function ProjectsOverview({
 
   return (
     <div className="mx-auto max-w-6xl space-y-4">
-      {error ? (
-        <ResourceLoadFailure title="Couldn't refresh projects." message={error} onRetry={onRetry} />
+      {currentError ? (
+        <ResourceLoadFailure
+          title="Couldn't refresh projects."
+          message={currentError}
+          onRetry={retry}
+        />
       ) : null}
       <div className="grid gap-3 md:grid-cols-4">
-        <StatCard label="Projects" value={formatNumber(projects.length)} />
-        <StatCard label="Sessions" value={formatNumber(totalSessions)} />
-        <StatCard label="Tokens" value={formatCompact(totalTokens)} />
+        <StatCard label="Projects" value={formatNumber(page.summary.projects)} />
+        <StatCard label="Sessions" value={formatNumber(page.summary.sessions)} />
+        <StatCard label="Tokens" value={formatCompact(page.summary.tokens)} />
         <StatCard
           label="Total Cost"
-          value={formatMoney(totalCost)}
-          hint={latestActivity ? `Latest ${formatRelativeTime(latestActivity)}` : undefined}
+          value={formatMoney(page.summary.cost)}
+          hint={
+            page.summary.latestActivity
+              ? `Latest ${formatRelativeTime(page.summary.latestActivity)}`
+              : undefined
+          }
         />
+      </div>
+
+      <div className="console-mono flex items-center justify-between gap-3 text-[11px] text-[var(--console-muted)]">
+        <span>
+          Page {pagination.pageNumber} · {formatNumber(projects.length)} shown
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled={!pagination.canPrevious}
+            onClick={pagination.previous}
+            className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-1.5 text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            disabled={!pagination.canNext}
+            onClick={pagination.next}
+            className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-1.5 text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
       </div>
 
       <ul className="grid gap-3">
@@ -239,6 +279,9 @@ function ProjectHeader({ project }: { project: ApiProjectGroup }) {
 
 export function ProjectDashboardView({
   project,
+  loading,
+  error,
+  onRetry,
   agentCatalog,
   projectKey,
   sessions,
@@ -250,6 +293,9 @@ export function ProjectDashboardView({
   onSelectCustom,
 }: {
   project: ApiProjectGroup | null;
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
   agentCatalog: AgentCatalog;
   projectKey: string;
   sessions: IndexedSession[];
@@ -261,6 +307,22 @@ export function ProjectDashboardView({
   onSelectCustom: (from: string, to: string) => void;
 }) {
   const navigate = useNavigate();
+
+  if (loading) {
+    return (
+      <Panel className="mx-auto max-w-4xl p-6 text-sm text-[var(--console-muted)]">
+        Loading project...
+      </Panel>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="mx-auto max-w-4xl">
+        <ResourceLoadFailure title="Couldn't load project." message={error} onRetry={onRetry} />
+      </div>
+    );
+  }
 
   if (!project) {
     return (

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -60,7 +60,16 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
     agents: [],
     agentCatalog: createAgentCatalog([]),
     agentNameMap: new Map(),
-    projects: [project],
+    projectPage: {
+      projects: [project],
+      summary: {
+        projects: 1,
+        sessions: 0,
+        tokens: 0,
+        cost: 0,
+        latestActivity: null,
+      },
+    },
     projectsError: null,
     projectsLoading: false,
     onRetryProjects: vi.fn(),
@@ -68,6 +77,9 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
     childSessionsByParentRouteKey: new Map(),
     sessionsByAgent: new Map(),
     activeProject: null,
+    activeProjectLoading: false,
+    activeProjectError: null,
+    onRetryActiveProject: vi.fn(),
     activeProjectSessions: [],
     // A null window keeps the overview's dashboard query idle, so these
     // assertions never depend on the network.
@@ -182,7 +194,16 @@ describe("AppRouteContent", () => {
   it("shows a retryable project failure instead of an empty state", async () => {
     const props = makeProps();
     props.viewState = { mode: "projects", activeAgentKey: null, activeSessionId: null };
-    props.projects = [];
+    props.projectPage = {
+      projects: [],
+      summary: {
+        projects: 0,
+        sessions: 0,
+        tokens: 0,
+        cost: 0,
+        latestActivity: null,
+      },
+    };
     props.projectsError = "projects unavailable";
     renderContent(props);
 

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -40,7 +40,13 @@ function LazySurface({ children }: { children: ReactNode }) {
     </ErrorBoundary>
   );
 }
-import type { AgentInfo, AppConfig, ApiProjectGroup, SessionHead } from "../../lib/api";
+import type {
+  AgentInfo,
+  AppConfig,
+  ApiProjectGroup,
+  ApiProjectPage,
+  SessionHead,
+} from "../../lib/api";
 import type * as Api from "../../lib/api";
 import type { SessionDetailError } from "../../hooks/useSessionDetail";
 import type { AgentCatalog } from "../../lib/agents";
@@ -97,7 +103,7 @@ interface AppRouteContentProps {
   agents: AgentInfo[];
   agentCatalog: AgentCatalog;
   agentNameMap: ReadonlyMap<string, string>;
-  projects: ApiProjectGroup[];
+  projectPage: ApiProjectPage;
   projectsError: string | null;
   projectsLoading: boolean;
   onRetryProjects: () => void;
@@ -105,6 +111,9 @@ interface AppRouteContentProps {
   childSessionsByParentRouteKey: ReadonlyMap<string, SessionHead[]>;
   sessionsByAgent: Map<string, IndexedSession[]>;
   activeProject: ApiProjectGroup | null;
+  activeProjectLoading: boolean;
+  activeProjectError: string | null;
+  onRetryActiveProject: () => void;
   activeProjectSessions: IndexedSession[];
   overview: OverviewModel;
   sessionDetail: SessionDetailModel;
@@ -122,7 +131,7 @@ export function AppRouteContent({
   agents,
   agentCatalog,
   agentNameMap,
-  projects,
+  projectPage,
   projectsError,
   projectsLoading,
   onRetryProjects,
@@ -130,6 +139,9 @@ export function AppRouteContent({
   childSessionsByParentRouteKey,
   sessionsByAgent,
   activeProject,
+  activeProjectLoading,
+  activeProjectError,
+  onRetryActiveProject,
   activeProjectSessions,
   overview,
   sessionDetail,
@@ -206,7 +218,7 @@ export function AppRouteContent({
   }
   if (viewState.mode === "root") {
     return (
-      <RenderProfiler id="OverviewScreen" detail={{ projects: projects.length }}>
+      <RenderProfiler id="OverviewScreen" detail={{ projects: projectPage.summary.projects }}>
         <LazySurface>
           <OverviewScreen
             window={overview.window}
@@ -223,7 +235,8 @@ export function AppRouteContent({
     return (
       <LazySurface>
         <ProjectsOverview
-          projects={projects}
+          initialPage={projectPage}
+          window={overview.window}
           agentCatalog={agentCatalog}
           loading={projectsLoading}
           error={projectsError}
@@ -237,6 +250,9 @@ export function AppRouteContent({
       <LazySurface>
         <ProjectDashboardView
           project={activeProject}
+          loading={activeProjectLoading}
+          error={activeProjectError}
+          onRetry={onRetryActiveProject}
           agentCatalog={agentCatalog}
           projectKey={viewState.activeProjectKey}
           sessions={activeProjectSessions}

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -51,6 +51,7 @@ function renderSidebar(
             viewState: { mode: "root", activeAgentKey: null, activeSessionId: null },
             agentCatalog: createAgentCatalog(agents),
             projects,
+            projectCount: projects.length,
             projectsError: null,
             projectsLoading: false,
             selectedProjectNavigationId: null,
@@ -92,6 +93,25 @@ describe("AppSidebar", () => {
     const projectLink = screen.getByRole("link", { name: /codesesh/ });
     expect(projectLink.getAttribute("href")).toBe("/projects/path/%2Frepo%2Fcodesesh");
     expect(projectLink.textContent).toContain("12");
+  });
+
+  it("bounds project links while keeping the active project reachable", () => {
+    const manyProjects = Array.from({ length: 200 }, (_, index) => ({
+      ...projects[0]!,
+      identityKey: `/repo/${index}`,
+      displayName: `project-${index}`,
+    }));
+    renderSidebar({
+      projects: manyProjects,
+      projectCount: manyProjects.length,
+      selectedProjectNavigationId: "path:/repo/199",
+    });
+
+    expect(screen.getByRole("link", { name: /^Projects 200$/ })).toBeTruthy();
+    expect(
+      screen.getAllByRole("link").filter((link) => link.textContent?.includes("project-")),
+    ).toHaveLength(51);
+    expect(screen.getByRole("link", { name: /project-199/ })).toBeTruthy();
   });
 
   it("marks the dashboard entry active only on the root route", () => {

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -21,6 +21,8 @@ import { SessionTreeSidebar } from "../SessionTreeSidebar";
 import { PanelLeftClose } from "../ui/icons";
 import { Link } from "react-router-dom";
 
+const SIDEBAR_PROJECT_LIMIT = 50;
+
 function navItemClass(isSelected: boolean): string {
   return `flex items-center gap-2 rounded-sm px-3 py-1.5 text-left motion-hover focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none ${
     isSelected
@@ -45,9 +47,20 @@ function ProjectNavList({
   projects: ApiProjectGroup[];
   selectedProjectNavigationId: string | null;
 }) {
+  const visibleProjects = projects.slice(0, SIDEBAR_PROJECT_LIMIT);
+  const selectedProject = selectedProjectNavigationId
+    ? projects.find((project) => {
+        const identity = getProjectGroupIdentity(project);
+        return getProjectIdentityKey(identity) === selectedProjectNavigationId;
+      })
+    : undefined;
+  if (selectedProject && !visibleProjects.includes(selectedProject)) {
+    visibleProjects.push(selectedProject);
+  }
+
   return (
     <>
-      {projects.map((project) => {
+      {visibleProjects.map((project) => {
         const projectIdentity = getProjectGroupIdentity(project);
         const isSelected = selectedProjectNavigationId === getProjectIdentityKey(projectIdentity);
         return (
@@ -77,6 +90,7 @@ export interface AppSidebarViewModel {
   viewState: ViewState;
   agentCatalog: AgentCatalog;
   projects: ApiProjectGroup[];
+  projectCount: number;
   projectsError: string | null;
   projectsLoading: boolean;
   selectedProjectNavigationId: string | null;
@@ -158,6 +172,7 @@ export function AppSidebar({
     viewState,
     agentCatalog,
     projects,
+    projectCount,
     projectsError,
     projectsLoading,
     selectedProjectNavigationId,
@@ -191,6 +206,7 @@ export function AppSidebar({
       ? getSessionRouteKey(viewState.activeAgentKey, viewState.activeSessionId)
       : null;
   const isOverviewSelected = viewState.mode === "root";
+  const isProjectsSelected = viewState.mode === "projects";
   const { selectedSessionReference, selectSession } = useSidebarKeyboardNavigation({
     viewState,
     sessions: sidebarSessions,
@@ -238,6 +254,18 @@ export function AppSidebar({
                   <PanelLeftClose className="size-4" />
                 </button>
               ) : null}
+            </li>
+            <li>
+              <Link
+                to="/projects"
+                data-active={isProjectsSelected ? "true" : undefined}
+                className={navItemClass(isProjectsSelected)}
+              >
+                <span className="console-mono min-w-0 flex-1 truncate text-xs">Projects</span>
+                <span className="console-mono shrink-0 text-[11px] text-[var(--console-muted)]">
+                  {projectCount}
+                </span>
+              </Link>
             </li>
             <ProjectNavList
               projects={projects}

--- a/apps/web/src/hooks/useProjects.test.tsx
+++ b/apps/web/src/hooks/useProjects.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiProjectGroup } from "../lib/api";
+import { createQueryWrapper } from "../test/query-wrapper";
+import { useProjectLookup } from "./useProjects";
+
+const project = {
+  identityKind: "path",
+  identityKey: "/workspace/selected",
+  displayName: "selected",
+  sources: ["codex"],
+  sessionCount: 1,
+  lastActivity: 1,
+  messages: 1,
+  tokens: 1,
+  cost: 0,
+  agentStats: [],
+} satisfies ApiProjectGroup;
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("useProjectLookup", () => {
+  it("loads an exact project that is outside the catalog page", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          projects: [project],
+          summary: {
+            projects: 1,
+            sessions: 1,
+            tokens: 1,
+            cost: 0,
+            latestActivity: 1,
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { Wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(
+      () => useProjectLookup({ from: 1, to: 2 }, { kind: "path", key: project.identityKey }, []),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(result.current.project).toEqual(project));
+    const requestUrl = String(fetchMock.mock.calls[0]?.[0]);
+    expect(requestUrl).toContain("limit=1");
+    expect(requestUrl).toContain("projectKind=path");
+    expect(requestUrl).toContain("projectKey=%2Fworkspace%2Fselected");
+  });
+
+  it("uses a project already present in the bounded page", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { Wrapper } = createQueryWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useProjectLookup({ from: 1, to: 2 }, { kind: "path", key: project.identityKey }, [project]),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.project).toBe(project);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useProjects.ts
+++ b/apps/web/src/hooks/useProjects.ts
@@ -1,0 +1,115 @@
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+import type { ApiProjectGroup, ApiProjectPage, AppConfig } from "../lib/api";
+import { ApiRequestError, fetchProject, fetchProjects } from "../lib/api";
+import { getProjectIdentityKey, type ProjectRouteIdentity } from "../lib/projects";
+import { queryKeys } from "../lib/query-keys";
+
+const PROJECT_QUERY_STALE_TIME_MS = 2_000;
+const EMPTY_CURSORS: string[] = [];
+
+function windowKey(window: AppConfig["window"] | null): string {
+  if (!window) return "unavailable";
+  return `${window.days ?? ""}:${window.from ?? ""}:${window.to ?? ""}`;
+}
+
+export function useProjectPagination(
+  window: AppConfig["window"] | null,
+  initialPage: ApiProjectPage,
+) {
+  const key = windowKey(window);
+  const [navigation, setNavigation] = useState<{ key: string; cursors: string[] }>({
+    key,
+    cursors: [],
+  });
+  const cursors = navigation.key === key ? navigation.cursors : EMPTY_CURSORS;
+  const cursor = cursors.at(-1);
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    queryKey: queryKeys.projectPage(window ?? {}, cursor),
+    queryFn: ({ signal }) => fetchProjects(window ?? undefined, { cursor, signal }),
+    enabled: window != null,
+    initialData: cursor ? undefined : initialPage,
+    placeholderData: cursor ? keepPreviousData : undefined,
+    staleTime: PROJECT_QUERY_STALE_TIME_MS,
+    retry: false,
+  });
+  const page = query.data ?? (cursor ? null : initialPage);
+
+  const next = useCallback(() => {
+    const nextCursor = query.data?.nextCursor;
+    if (!nextCursor || query.isPlaceholderData) return;
+    setNavigation({ key, cursors: [...cursors, nextCursor] });
+  }, [cursors, key, query.data?.nextCursor, query.isPlaceholderData]);
+
+  const previous = useCallback(() => {
+    setNavigation({ key, cursors: cursors.slice(0, -1) });
+  }, [cursors, key]);
+
+  const retry = useCallback(async () => {
+    if (cursor && query.error instanceof ApiRequestError && query.error.status === 409) {
+      setNavigation({ key, cursors: [] });
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.projectPage(window ?? {}),
+        exact: true,
+      });
+      return;
+    }
+    await query.refetch();
+  }, [cursor, key, query, queryClient, window]);
+
+  return {
+    page,
+    pageNumber: cursors.length + 1,
+    loading: query.isPending || query.isPlaceholderData,
+    error:
+      query.isError && query.error instanceof Error
+        ? query.error.message
+        : query.isError
+          ? "Unable to load projects."
+          : null,
+    canPrevious: cursors.length > 0 && !query.isPlaceholderData,
+    canNext: Boolean(query.data?.nextCursor) && !query.isPlaceholderData,
+    next,
+    previous,
+    retry,
+  };
+}
+
+export function useProjectLookup(
+  window: AppConfig["window"] | null,
+  identity: ProjectRouteIdentity | null,
+  projects: ApiProjectGroup[],
+) {
+  const identityKey = identity ? getProjectIdentityKey(identity) : null;
+  const localProject = useMemo(
+    () =>
+      identityKey
+        ? (projects.find(
+            (project) =>
+              getProjectIdentityKey({ kind: project.identityKind, key: project.identityKey }) ===
+              identityKey,
+          ) ?? null)
+        : null,
+    [identityKey, projects],
+  );
+  const query = useQuery({
+    queryKey: queryKeys.projectDetail(window ?? {}, identity ?? { kind: "path", key: "" }),
+    queryFn: ({ signal }) => fetchProject(window!, identity!, { signal }),
+    enabled: window != null && identity != null && localProject == null,
+    staleTime: PROJECT_QUERY_STALE_TIME_MS,
+    retry: false,
+  });
+
+  return {
+    project: localProject ?? query.data ?? null,
+    loading: query.isPending && window != null && identity != null && localProject == null,
+    error:
+      query.isError && query.error instanceof Error
+        ? query.error.message
+        : query.isError
+          ? "Unable to load project."
+          : null,
+    retry: query.refetch,
+  };
+}

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -5,7 +5,13 @@ import {
 } from "@codesesh/core/test-fixtures";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentInfo, AppConfig, ApiProjectGroup, SessionHead } from "../lib/api";
+import type {
+  AgentInfo,
+  AppConfig,
+  ApiProjectGroup,
+  ApiProjectPage,
+  SessionHead,
+} from "../lib/api";
 import * as api from "../lib/api";
 import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
@@ -32,6 +38,16 @@ const agents = [
   { name: "Codex", displayName: "Codex", count: 0 },
 ] as unknown as AgentInfo[];
 const projects = [{ identityKind: "path", identityKey: "p1" }] as unknown as ApiProjectGroup[];
+const projectPage = {
+  projects,
+  summary: {
+    projects: 1,
+    sessions: 0,
+    tokens: 0,
+    cost: 0,
+    latestActivity: null,
+  },
+} satisfies ApiProjectPage;
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -46,7 +62,7 @@ beforeEach(() => {
   vi.mocked(api.fetchConfig).mockResolvedValue(config);
   vi.mocked(api.fetchAgents).mockResolvedValue(agents);
   vi.mocked(api.fetchSessions).mockResolvedValue({ sessions: [SAMPLE_SESSION_HEAD] });
-  vi.mocked(api.fetchProjects).mockResolvedValue({ projects });
+  vi.mocked(api.fetchProjects).mockResolvedValue(projectPage);
   vi.mocked(api.fetchDashboard).mockResolvedValue(SAMPLE_DASHBOARD_DATA);
 });
 
@@ -492,7 +508,7 @@ describe("useSessionStore", () => {
     expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]);
     expect(result.current.dashboard).toEqual(SAMPLE_DASHBOARD_DATA);
 
-    vi.mocked(api.fetchProjects).mockResolvedValueOnce({ projects });
+    vi.mocked(api.fetchProjects).mockResolvedValueOnce(projectPage);
     await act(() => result.current.retryProjects());
 
     await waitFor(() => expect(result.current.projects).toEqual(projects));
@@ -524,7 +540,7 @@ describe("useSessionStore", () => {
             });
           }),
       )
-      .mockResolvedValue({ projects });
+      .mockResolvedValue(projectPage);
     const { result } = await renderStore();
     const firstWindow = { from: 1, to: 2 };
     const nextWindow = { from: 3, to: 4 };

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -18,6 +18,7 @@ import {
   type AppConfig,
   type DashboardData,
   type ApiProjectGroup,
+  type ApiProjectPage,
   type SessionHead,
   type SessionsUpdatedEvent,
   fetchAgents,
@@ -59,6 +60,16 @@ interface SnapshotAggregates {
 
 const LIVE_AGGREGATE_REFRESH_INTERVAL_MS = 2_000;
 const EMPTY_PROJECTS: ApiProjectGroup[] = [];
+const EMPTY_PROJECT_PAGE: ApiProjectPage = {
+  projects: EMPTY_PROJECTS,
+  summary: {
+    projects: 0,
+    sessions: 0,
+    tokens: 0,
+    cost: 0,
+    latestActivity: null,
+  },
+};
 
 const EMPTY_AGGREGATES = {
   agents: [] satisfies AgentInfo[],
@@ -68,8 +79,8 @@ const EMPTY_SESSIONS: SessionHead[] = [];
 
 function projectsOptions(window: AppConfig["window"]) {
   return queryOptions({
-    queryKey: queryKeys.project(window),
-    queryFn: async ({ signal }) => (await fetchProjects(window, { signal })).projects,
+    queryKey: queryKeys.projectPage(window),
+    queryFn: ({ signal }) => fetchProjects(window, { signal }),
     staleTime: LIVE_AGGREGATE_REFRESH_INTERVAL_MS,
     retry: false,
   });
@@ -266,7 +277,7 @@ export function useSessionStore() {
             refetchType: "none",
           }),
           queryClient.invalidateQueries({
-            queryKey: queryKeys.project(window),
+            queryKey: queryKeys.projectPage(window),
             exact: true,
             refetchType: "none",
           }),
@@ -413,7 +424,8 @@ export function useSessionStore() {
     currentSnapshot ??
     (sameWindow(previewSnapshot?.window, requestedWindow) ? previewSnapshot : null);
   const agents = displayedSnapshot?.agents ?? EMPTY_AGGREGATES.agents;
-  const projects = projectsQuery.data ?? EMPTY_PROJECTS;
+  const projectPage = projectsQuery.data ?? EMPTY_PROJECT_PAGE;
+  const projects = projectPage.projects;
   const projectsLoading = requestedWindow === null || projectsQuery.isPending;
   const projectsError =
     requestedWindow !== null && projectsQuery.isError
@@ -442,6 +454,7 @@ export function useSessionStore() {
     agents,
     sessions: displayedSnapshot?.sessions ?? EMPTY_SESSIONS,
     projects,
+    projectPage,
     projectsError,
     projectsLoading,
     dashboard: displayedSnapshot?.dashboard ?? EMPTY_AGGREGATES.dashboard,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -8,6 +8,7 @@ export type {
   FileActivityResult,
   ProjectIdentityKind,
   ProjectIdentity,
+  ProjectIdentityRef,
   MessageTokens,
   ToolPartStatus,
   ToolPartState,
@@ -39,6 +40,8 @@ export type {
   SearchResult,
   SessionsUpdatedEvent,
   ApiProjectGroup,
+  ApiProjectPage,
+  ApiProjectSummary,
   ApiProjectAgentStat,
   BookmarkRecord,
   BookmarkView,
@@ -48,12 +51,14 @@ import { sessionRoutePath } from "@codesesh/core/contract";
 import type {
   AgentInfo,
   ApiProjectGroup,
+  ApiProjectPage,
   AppConfig,
   BookmarkRecord,
   BookmarkView,
   DashboardData,
   FileActivityKind,
   ProjectIdentityKind,
+  ProjectIdentityRef,
   ScanStatusEvent,
   SearchResult,
   SessionDetail,
@@ -129,6 +134,11 @@ export interface SessionDetailFetchOptions extends FetchOptions {
   messageCursor?: string;
 }
 
+export interface ProjectPageOptions extends FetchOptions {
+  cursor?: string;
+  project?: ProjectIdentityRef;
+}
+
 interface SessionFetchProgress {
   onFirstPage?: (sessions: SessionHead[]) => void;
 }
@@ -191,11 +201,29 @@ export async function fetchAgents(
 
 export async function fetchProjects(
   window?: AppConfig["window"],
-  options?: FetchOptions,
-): Promise<{ projects: ApiProjectGroup[] }> {
+  options?: ProjectPageOptions,
+): Promise<ApiProjectPage> {
   const params = new URLSearchParams();
   appendTimeWindow(params, window);
-  return fetchJson(`/api/projects?${params}`, options);
+  params.set("limit", options?.project ? "1" : "100");
+  if (options?.cursor) params.set("cursor", options.cursor);
+  if (options?.project) {
+    params.set("projectKind", options.project.kind);
+    params.set("projectKey", options.project.key);
+  }
+  return fetchJson(
+    `/api/projects?${params}`,
+    options?.signal ? { signal: options.signal } : undefined,
+  );
+}
+
+export async function fetchProject(
+  window: AppConfig["window"],
+  project: ProjectIdentityRef,
+  options?: FetchOptions,
+): Promise<ApiProjectGroup | null> {
+  const page = await fetchProjects(window, { ...options, project });
+  return page.projects[0] ?? null;
 }
 
 export async function fetchSessions(

--- a/apps/web/src/lib/build-route-header-model.test.tsx
+++ b/apps/web/src/lib/build-route-header-model.test.tsx
@@ -13,7 +13,7 @@ function createInput(
     isSearchMode: false,
     searchSubtitle: "Search results",
     dashboard: null,
-    projects: [],
+    projectCount: 0,
     sessionCount: 0,
     activeProject: null,
     activeAgent: null,

--- a/apps/web/src/lib/build-route-header-model.tsx
+++ b/apps/web/src/lib/build-route-header-model.tsx
@@ -20,7 +20,7 @@ interface RouteHeaderInput {
   isSearchMode: boolean;
   searchSubtitle: string;
   dashboard: DashboardData | null;
-  projects: ApiProjectGroup[];
+  projectCount: number;
   sessionCount: number;
   activeProject: ApiProjectGroup | null;
   activeAgent: AgentInfo | null;
@@ -87,8 +87,8 @@ function routeTitleAndSubtitle(input: RouteHeaderInput): {
       title: "Projects",
       subtitle: (
         <span>
-          <Count value={input.projects.length} /> projects across{" "}
-          <Count value={input.sessionCount} /> sessions
+          <Count value={input.projectCount} /> projects across <Count value={input.sessionCount} />{" "}
+          sessions
         </span>
       ),
     };

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -1,4 +1,4 @@
-import type { AppConfig, DashboardFilters, SearchRequestOptions } from "./api";
+import type { AppConfig, DashboardFilters, ProjectIdentityRef, SearchRequestOptions } from "./api";
 
 type TimeWindow = AppConfig["window"];
 
@@ -17,7 +17,10 @@ export const queryKeys = {
   dashboard: (window: TimeWindow, filters: DashboardFilters) =>
     ["dashboard", normalizeWindow(window), filters] as const,
   projects: ["projects"] as const,
-  project: (window: TimeWindow) => ["projects", normalizeWindow(window)] as const,
+  projectPage: (window: TimeWindow, cursor?: string) =>
+    ["projects", "page", normalizeWindow(window), cursor ?? null] as const,
+  projectDetail: (window: TimeWindow, project: ProjectIdentityRef) =>
+    ["projects", "detail", normalizeWindow(window), project] as const,
   search: (query: string, options: SearchRequestOptions) => ["search", query, options] as const,
   searches: ["search"] as const,
   sessionDetails: ["session-detail"] as const,

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1155,6 +1155,111 @@ describe("handleGetFileActivity", () => {
 });
 
 describe("handleGetProjects", () => {
+  it("bounds every response and keeps catalog totals outside the page", () => {
+    const sessions = Array.from({ length: 101 }, (_, index) =>
+      makeSession(`project-${index}`, {
+        time_updated: 1_000 - index,
+        project_identity: {
+          kind: "path",
+          key: `/workspace/${index}`,
+          displayName: `project-${index}`,
+        },
+      }),
+    );
+    const source = makeScanSource({ sessions, byAgent: { claudecode: sessions } });
+    const firstContext = makeMockContext();
+
+    handleGetProjects(firstContext, source);
+
+    const firstPage = firstContext.json.mock.calls[0]![0];
+    expect(firstPage.projects).toHaveLength(100);
+    expect(firstPage.summary).toMatchObject({ projects: 101, sessions: 101 });
+    expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const secondContext = makeMockContext({ query: { cursor: firstPage.nextCursor } });
+    handleGetProjects(secondContext, source);
+
+    expect(secondContext.json.mock.calls[0]![0]).toEqual({
+      projects: [expect.objectContaining({ identityKey: "/workspace/100" })],
+      summary: expect.objectContaining({ projects: 101, sessions: 101 }),
+    });
+  });
+
+  it("rejects a project cursor after the scan snapshot changes", () => {
+    const initialSessions = [
+      makeSession("one", {
+        project_identity: { kind: "path", key: "/workspace/one", displayName: "one" },
+      }),
+      makeSession("two", {
+        project_identity: { kind: "path", key: "/workspace/two", displayName: "two" },
+      }),
+    ];
+    let snapshot = makeScanResult({
+      sessions: initialSessions,
+      byAgent: { claudecode: initialSessions },
+    });
+    const source: ScanResultSource = { getSnapshot: () => snapshot };
+    const firstContext = makeMockContext({ query: { limit: "1" } });
+    handleGetProjects(firstContext, source);
+    const cursor = firstContext.json.mock.calls[0]![0].nextCursor;
+
+    const updatedSessions = [
+      makeSession("new", {
+        project_identity: { kind: "path", key: "/workspace/new", displayName: "new" },
+      }),
+      ...initialSessions,
+    ];
+    snapshot = makeScanResult({
+      sessions: updatedSessions,
+      byAgent: { claudecode: updatedSessions },
+    });
+    const nextContext = makeMockContext({ query: { limit: "1", cursor } });
+
+    handleGetProjects(nextContext, source);
+
+    expect(nextContext.json).toHaveBeenCalledWith(
+      { error: "project snapshot changed; restart pagination" },
+      409,
+    );
+  });
+
+  it("looks up one project without expanding the catalog page", () => {
+    const sessions = [
+      makeSession("one", {
+        project_identity: { kind: "path", key: "/workspace/one", displayName: "one" },
+      }),
+      makeSession("two", {
+        project_identity: { kind: "path", key: "/workspace/two", displayName: "two" },
+      }),
+    ];
+    const c = makeMockContext({
+      query: { projectKind: "path", projectKey: "/workspace/two" },
+    });
+
+    handleGetProjects(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
+
+    expect(c.json.mock.calls[0]![0]).toEqual({
+      projects: [expect.objectContaining({ identityKey: "/workspace/two" })],
+      summary: expect.objectContaining({ projects: 1, sessions: 1 }),
+    });
+  });
+
+  it("rejects invalid project pagination parameters", () => {
+    const invalidLimit = makeMockContext({ query: { limit: "many" } });
+    handleGetProjects(invalidLimit, makeScanSource());
+    expect(invalidLimit.json).toHaveBeenCalledWith(
+      { error: "limit must be a positive integer" },
+      400,
+    );
+
+    const invalidCursor = makeMockContext({ query: { cursor: "not-a-cursor" } });
+    handleGetProjects(invalidCursor, makeScanSource());
+    expect(invalidCursor.json).toHaveBeenCalledWith(
+      { error: "cursor is invalid for this request" },
+      400,
+    );
+  });
+
   it("reuses project aggregation for the same snapshot and window", () => {
     const source = makeScanSource();
 

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -25,6 +25,7 @@ import {
   matchesProjectIdentity,
   normalizeProjectDirectory,
   PROJECT_IDENTITY_RESOLVER_REVISION,
+  summarizeProjects,
   buildDashboard,
   type DashboardData,
   type DashboardScope,
@@ -44,15 +45,17 @@ import {
   parseDateWindow,
   parseFileActivityKind,
   parseProjectIdentityFilter,
+  parseLimit,
   parseSessionQuery,
   parseSearchOptions,
   optionalQueryValue,
+  PROJECT_PAGE_LIMIT_POLICY,
   searchParams,
   SEARCH_LIMIT_POLICY,
   SESSION_PAGE_LIMIT_POLICY,
   type SessionListDefaults,
 } from "./query-params.js";
-import { paginateSessionSnapshot } from "./session-pagination.js";
+import { paginateSnapshot } from "./snapshot-pagination.js";
 import type { ScanResultSource, ScanStatusSource } from "./scan-sources.js";
 import {
   getDashboardCostFacts,
@@ -209,35 +212,72 @@ export function handleGetProjects(
   defaults: SessionListDefaults = {},
 ) {
   const scanResult = scanSource.getSnapshot();
+  const params = searchParams(c);
+  const limit = parseLimit(params.get("limit"), PROJECT_PAGE_LIMIT_POLICY);
+  if (limit.kind === "invalid") {
+    reportInvalidQueryParameter("projects", "limit", "rejected");
+    return c.json({ error: limit.error }, 400);
+  }
+  const projectIdentity = parseProjectIdentityFilter(
+    c.req.query("projectKind"),
+    c.req.query("projectKey"),
+  );
+  if (projectIdentity === null) {
+    return c.json({ error: "projectKind and projectKey must form a valid project identity" }, 400);
+  }
   const window = parseDateWindowRequest(c, "projects", defaults);
   if (window.kind === "rejected") return window.response;
   const { from, to } = window;
   const analyticsRevision = getAnalyticsRevision();
-  const projects = getSnapshotAggregation(
+  const catalog = getSnapshotAggregation(
     scanSource,
     scanResult.sessions,
     ["projects", from, to, analyticsRevision],
     () => {
       const tree = getSnapshotSessionTree(scanSource, scanResult.sessions);
       const costFacts = listDashboardCostFacts({ from, to, includeModelCosts: false });
-      return {
-        projects: attachProjectMetricsFromTree(
-          listCachedProjectGroups(scanResult.sessions),
-          tree,
-          from,
-          to,
-          costFacts,
-        ).filter(
-          (project) =>
-            project.sessionCount > 0 ||
-            project.messages > 0 ||
-            project.tokens > 0 ||
-            project.cost > 0,
-        ),
-      };
+      const projects = attachProjectMetricsFromTree(
+        listCachedProjectGroups(scanResult.sessions),
+        tree,
+        from,
+        to,
+        costFacts,
+      ).filter(
+        (project) =>
+          project.sessionCount > 0 ||
+          project.messages > 0 ||
+          project.tokens > 0 ||
+          project.cost > 0,
+      );
+      return { projects, summary: summarizeProjects(projects) };
     },
   );
-  return c.json(projects);
+  const projects = projectIdentity
+    ? catalog.projects.filter(
+        (project) =>
+          project.identityKind === projectIdentity.kind &&
+          project.identityKey === projectIdentity.key,
+      )
+    : catalog.projects;
+  const page = paginateSnapshot(projects, {
+    cursor: params.get("cursor") ?? undefined,
+    limit: limit.value,
+    query: params,
+    snapshotIdentity: scanResult.sessions,
+    viewIdentity: catalog.projects,
+  });
+  if (page.kind === "invalid_cursor") {
+    reportInvalidQueryParameter("projects", "cursor", "rejected");
+    return c.json({ error: "cursor is invalid for this request" }, 400);
+  }
+  if (page.kind === "stale_snapshot") {
+    return c.json({ error: "project snapshot changed; restart pagination" }, 409);
+  }
+  return c.json({
+    projects: page.items,
+    summary: projectIdentity ? summarizeProjects(projects) : catalog.summary,
+    ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+  });
 }
 
 export async function handleGetSessions(
@@ -334,7 +374,7 @@ export async function handleGetSessions(
   }
 
   if (paginationRequested) {
-    const page = paginateSessionSnapshot(sessions, {
+    const page = paginateSnapshot(sessions, {
       cursor: params.get("cursor") ?? undefined,
       limit: sessionQuery.limit.value,
       query: params,

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -35,6 +35,7 @@ export interface LimitPolicy {
 
 export const SEARCH_LIMIT_POLICY: LimitPolicy = { defaultValue: 50, maxValue: 100 };
 export const FILE_ACTIVITY_LIMIT_POLICY: LimitPolicy = { defaultValue: 50, maxValue: 200 };
+export const PROJECT_PAGE_LIMIT_POLICY: LimitPolicy = { defaultValue: 100, maxValue: 250 };
 export const SESSION_PAGE_LIMIT_POLICY: LimitPolicy = { defaultValue: 250, maxValue: 500 };
 
 export type AgentFilterOutcome =
@@ -133,7 +134,7 @@ function parseAgentFilter(
   return { kind: "unknown" };
 }
 
-function parseLimit(value: string | null, policy: LimitPolicy): LimitOutcome {
+export function parseLimit(value: string | null, policy: LimitPolicy): LimitOutcome {
   if (value === null) return { kind: "default", value: policy.defaultValue };
   const normalized = value.trim();
   if (!/^\d+$/.test(normalized)) {

--- a/packages/cli/src/api/snapshot-pagination.ts
+++ b/packages/cli/src/api/snapshot-pagination.ts
@@ -66,11 +66,8 @@ function decodeCursor(cursor: string): CursorPayload | null {
   }
 }
 
-/** Keeps every page on the same immutable scan and alias read-model versions. */
-export function paginateSessionSnapshot<T>(
-  items: T[],
-  request: PaginationRequest,
-): PaginationResult<T> {
+/** Keeps every page on the same immutable scan and derived-view versions. */
+export function paginateSnapshot<T>(items: T[], request: PaginationRequest): PaginationResult<T> {
   const snapshot = identityVersion(request.snapshotIdentity);
   const view = identityVersion(request.viewIdentity);
   const query = queryFingerprint(request.query);

--- a/packages/core/src/analytics/__tests__/projects.test.ts
+++ b/packages/core/src/analytics/__tests__/projects.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { attachProjectMetrics, attachProjectMetricsFromTree } from "../projects.js";
+import {
+  attachProjectMetrics,
+  attachProjectMetricsFromTree,
+  summarizeProjects,
+} from "../projects.js";
+import type { ApiProjectGroup } from "../../contract/index.js";
 import type { ProjectGroup, SessionHead } from "../../types/index.js";
 import { buildSessionTree } from "../../contract/session-tree.js";
 import type { DashboardCostFacts } from "../cost-facts.js";
@@ -57,6 +62,26 @@ function makeGroup(identityKey: string, overrides?: Partial<ProjectGroup>): Proj
     ...overrides,
   };
 }
+
+describe("summarizeProjects", () => {
+  it("folds catalogs larger than the JavaScript argument limit", () => {
+    const project = {
+      ...makeGroup("repo-a", { sessionCount: 2, lastActivity: 100 }),
+      messages: 3,
+      tokens: 5,
+      cost: 0.25,
+      agentStats: [],
+    } satisfies ApiProjectGroup;
+
+    expect(summarizeProjects(Array(200_000).fill(project))).toEqual({
+      projects: 200_000,
+      sessions: 400_000,
+      tokens: 1_000_000,
+      cost: 50_000,
+      latestActivity: 100,
+    });
+  });
+});
 
 describe("attachProjectMetrics", () => {
   it("sums messages, tokens and cost per project", () => {

--- a/packages/core/src/analytics/projects.ts
+++ b/packages/core/src/analytics/projects.ts
@@ -11,6 +11,7 @@ import type { ProjectGroup, SessionHead } from "../types/index.js";
 import type {
   ApiProjectAgentStat,
   ApiProjectGroup,
+  ApiProjectSummary,
   SessionTree,
   SessionTreeNode,
 } from "../contract/index.js";
@@ -30,6 +31,30 @@ interface ProjectMetrics {
   cost: number;
   hasEstimatedCost: boolean;
   agentStats: Map<string, ApiProjectAgentStat>;
+}
+
+export function summarizeProjects(projects: readonly ApiProjectGroup[]): ApiProjectSummary {
+  const summary: ApiProjectSummary = {
+    projects: projects.length,
+    sessions: 0,
+    tokens: 0,
+    cost: 0,
+    latestActivity: null,
+  };
+
+  for (const project of projects) {
+    summary.sessions += project.sessionCount;
+    summary.tokens += project.tokens;
+    summary.cost += project.cost;
+    if (project.lastActivity != null) {
+      summary.latestActivity =
+        summary.latestActivity == null
+          ? project.lastActivity
+          : Math.max(summary.latestActivity, project.lastActivity);
+    }
+  }
+
+  return summary;
 }
 
 function emptyMetrics(): ProjectMetrics {

--- a/packages/core/src/contract/api.ts
+++ b/packages/core/src/contract/api.ts
@@ -23,3 +23,17 @@ export interface ApiProjectGroup extends ProjectGroup {
   cost_source?: CostSource;
   agentStats: ApiProjectAgentStat[];
 }
+
+export interface ApiProjectSummary {
+  projects: number;
+  sessions: number;
+  tokens: number;
+  cost: number;
+  latestActivity: number | null;
+}
+
+export interface ApiProjectPage {
+  projects: ApiProjectGroup[];
+  summary: ApiProjectSummary;
+  nextCursor?: string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,6 +154,10 @@ export {
 export { buildDashboard, getSessionActivityTime } from "./analytics/dashboard.js";
 export type { DashboardData, DashboardScope } from "./analytics/dashboard.js";
 export type { DashboardCostFacts } from "./analytics/cost-facts.js";
-export { attachProjectMetrics, attachProjectMetricsFromTree } from "./analytics/projects.js";
+export {
+  attachProjectMetrics,
+  attachProjectMetricsFromTree,
+  summarizeProjects,
+} from "./analytics/projects.js";
 export { executeSessionSearch, filterSessionSearchCandidates } from "./search/index.js";
 export type { SessionSearchContext, SessionSearchFilterContext } from "./search/index.js";

--- a/scripts/benchmark-performance.mjs
+++ b/scripts/benchmark-performance.mjs
@@ -515,7 +515,18 @@ async function installFixtureRoutes(context, fixture) {
 
     if (pathname === "/api/config") return json({ window: { days: 0 } });
     if (pathname === "/api/agents") return json([fixture.agent]);
-    if (pathname === "/api/projects") return json({ projects: [fixture.project] });
+    if (pathname === "/api/projects") {
+      return json({
+        projects: [fixture.project],
+        summary: {
+          projects: 1,
+          sessions: fixture.project.sessionCount,
+          tokens: fixture.project.tokens,
+          cost: fixture.project.cost,
+          latestActivity: fixture.project.lastActivity,
+        },
+      });
+    }
     if (pathname === "/api/dashboard") return json(fixture.dashboard);
     if (pathname === "/api/bookmarks") return json({ bookmarks: [] });
     if (pathname === "/api/status") return json(fixture.scanStatus);


### PR DESCRIPTION
## Summary

- paginate project catalog responses while returning complete aggregate totals
- keep overview and sidebar project rendering within fixed budgets
- resolve projects outside the first page through an exact identity lookup
- reuse snapshot-aware cursors for both session and project pagination

## Testing

- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm format:check`
- `pnpm test:e2e`