### PR TITLE
fix(web): bound project timeline rendering

### DIFF
--- a/apps/web/src/components/Projects.tsx
+++ b/apps/web/src/components/Projects.tsx
@@ -370,6 +370,7 @@ export function ProjectDashboardView({
       />
 
       <ProjectTimeline
+        key={`${project.identityKind}:${project.identityKey}:${activeAgent ?? "all"}`}
         sessions={scopedSessions}
         projectName={project.displayName}
         agentCatalog={agentCatalog}

--- a/apps/web/src/components/project-timeline/ProjectTimeline.test.tsx
+++ b/apps/web/src/components/project-timeline/ProjectTimeline.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionHead } from "@codesesh/core/contract";
 import { createAgentCatalog } from "../../lib/agents";
+import { TIMELINE_CHILD_PAGE_SIZE, TIMELINE_MAIN_PAGE_SIZE } from "../../lib/session-timeline";
 import { ProjectTimeline } from "./ProjectTimeline";
 
 const AGENT_CATALOG = createAgentCatalog([
@@ -71,6 +72,51 @@ function renderTimeline(sessions: SessionHead[]) {
 afterEach(cleanup);
 
 describe("ProjectTimeline", () => {
+  it("renders one bounded page of main sessions", () => {
+    const rootCount = 500;
+    const roots = Array.from({ length: rootCount }, (_, index) =>
+      createSession({ id: `large-root-${index}`, time_updated: at(5, 9) + index }),
+    );
+
+    renderTimeline(roots);
+
+    expect(document.querySelectorAll("article")).toHaveLength(TIMELINE_MAIN_PAGE_SIZE);
+    expect(screen.getByText(`Page 1 · ${TIMELINE_MAIN_PAGE_SIZE} shown`)).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next timeline page" }));
+
+    expect(document.querySelectorAll("article")).toHaveLength(TIMELINE_MAIN_PAGE_SIZE);
+    expect(screen.getByText(`Page 2 · ${TIMELINE_MAIN_PAGE_SIZE} shown`)).not.toBeNull();
+  });
+
+  it("derives and renders one bounded page of sub-sessions after expansion", () => {
+    const childCount = 120;
+    const parent = createSession({ id: "large-parent", time_updated: at(6, 8) });
+    const children = Array.from({ length: childCount }, (_, index) =>
+      createSession({
+        id: `large-child-${index}`,
+        time_updated: at(6, 9) + index,
+        parent_reference: { agentName: "codex", sessionId: parent.id },
+      }),
+    );
+
+    renderTimeline([parent, ...children]);
+    fireEvent.click(screen.getByRole("button", { name: /⑂/ }));
+
+    expect(screen.getAllByRole("button", { name: /large-child-/ })).toHaveLength(
+      TIMELINE_CHILD_PAGE_SIZE,
+    );
+    expect(screen.getByRole("button", { name: /large-child-0\b/ })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next sub-session page" }));
+
+    expect(screen.getAllByRole("button", { name: /large-child-/ })).toHaveLength(
+      TIMELINE_CHILD_PAGE_SIZE,
+    );
+    expect(screen.queryByRole("button", { name: /large-child-0\b/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /large-child-40\b/ })).not.toBeNull();
+  });
+
   it("summarises main and sub sessions in the header", () => {
     renderTimeline([PARENT, CHILD, SOLO]);
 

--- a/apps/web/src/components/project-timeline/ProjectTimeline.tsx
+++ b/apps/web/src/components/project-timeline/ProjectTimeline.tsx
@@ -7,7 +7,12 @@ import { useCallback, useMemo, useState } from "react";
 import type { SessionHead, SessionReference } from "@codesesh/core/contract";
 import type { AgentCatalog } from "../../lib/agents";
 import { formatCompact } from "../../lib/format";
-import { buildProjectTimeline, type SubSessionMode } from "../../lib/session-timeline";
+import {
+  buildProjectTimeline,
+  getProjectTimelinePage,
+  TIMELINE_MAIN_PAGE_SIZE,
+  type SubSessionMode,
+} from "../../lib/session-timeline";
 import { SubSessionModeSwitch } from "./sub-session-mode-switch";
 import { TimelineDayGroup } from "./timeline-day-group";
 
@@ -24,7 +29,9 @@ export function ProjectTimeline({
 }) {
   const [mode, setMode] = useState<SubSessionMode>("collapsed");
   const [openIds, setOpenIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [pageOffset, setPageOffset] = useState(0);
   const timeline = useMemo(() => buildProjectTimeline(sessions), [sessions]);
+  const page = useMemo(() => getProjectTimelinePage(timeline, pageOffset), [pageOffset, timeline]);
 
   // Mode changes deliberately leave openIds alone: collapsed -> expanded -> collapsed
   // must restore the rows the user had opened.
@@ -47,8 +54,36 @@ export function ProjectTimeline({
         </div>
       </div>
 
+      {timeline.mainCount > TIMELINE_MAIN_PAGE_SIZE ? (
+        <div className="console-mono flex items-center justify-between gap-3 text-[11px] text-[var(--console-muted)]">
+          <span>
+            Page {page.pageNumber} · {page.shown} shown
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              aria-label="Previous timeline page"
+              disabled={!page.hasPrevious}
+              onClick={() => setPageOffset(page.offset - TIMELINE_MAIN_PAGE_SIZE)}
+              className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-1.5 text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              aria-label="Next timeline page"
+              disabled={!page.hasNext}
+              onClick={() => setPageOffset(page.offset + TIMELINE_MAIN_PAGE_SIZE)}
+              className="rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-1.5 text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       <div className="flex flex-col gap-3">
-        {timeline.days.map((day) => (
+        {page.days.map((day) => (
           <TimelineDayGroup
             key={day.dayKey}
             day={day}

--- a/apps/web/src/components/project-timeline/timeline-child-panel.tsx
+++ b/apps/web/src/components/project-timeline/timeline-child-panel.tsx
@@ -3,27 +3,42 @@
  * child never gets its own slot on the day axis.
  */
 import type { SessionReference } from "@codesesh/core/contract";
+import { useMemo, useState } from "react";
 import { formatClockTime, formatInt, formatUsd } from "../../lib/format";
-import type { TimelineChildRow } from "../../lib/session-timeline";
+import {
+  getTimelineChildPage,
+  TIMELINE_CHILD_PAGE_SIZE,
+  type TimelineRow,
+} from "../../lib/session-timeline";
 
 export function TimelineChildPanel({
   id,
-  rows,
+  row,
   onOpen,
 }: {
   id: string;
-  rows: TimelineChildRow[];
+  row: TimelineRow;
   onOpen: (reference: SessionReference) => void;
 }) {
+  const [pageOffset, setPageOffset] = useState(0);
+  const page = useMemo(() => getTimelineChildPage(row, pageOffset), [pageOffset, row]);
+
   return (
     <div
       id={id}
       // The 66px inset lines the child list up with the parent's title column.
       className="border-t border-dashed border-[var(--console-border-strong)] bg-[var(--console-surface-muted)] p-[10px_16px_12px_66px]"
     >
-      <span className="console-eyebrow">Sub-sessions · derived from this session</span>
+      <div className="flex items-center justify-between gap-3">
+        <span className="console-eyebrow">Sub-sessions · derived from this session</span>
+        {row.childCount > TIMELINE_CHILD_PAGE_SIZE ? (
+          <span className="console-mono text-[10px] text-[var(--console-muted)]">
+            Page {page.pageNumber} · {page.rows.length} shown
+          </span>
+        ) : null}
+      </div>
       <div className="mt-2 flex flex-col gap-1.5 border-l border-dashed border-[var(--console-border-strong)] pl-[14px]">
-        {rows.map((child) => (
+        {page.rows.map((child) => (
           <button
             key={child.routeKey}
             type="button"
@@ -47,6 +62,28 @@ export function TimelineChildPanel({
           </button>
         ))}
       </div>
+      {page.hasPrevious || page.hasNext ? (
+        <div className="mt-2 flex justify-end gap-2">
+          <button
+            type="button"
+            aria-label="Previous sub-session page"
+            disabled={!page.hasPrevious}
+            onClick={() => setPageOffset(page.offset - TIMELINE_CHILD_PAGE_SIZE)}
+            className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 text-[10px] text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            aria-label="Next sub-session page"
+            disabled={!page.hasNext}
+            onClick={() => setPageOffset(page.offset + TIMELINE_CHILD_PAGE_SIZE)}
+            className="console-mono rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] px-2 py-1 text-[10px] text-[var(--console-text)] motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Next
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/project-timeline/timeline-day-group.tsx
+++ b/apps/web/src/components/project-timeline/timeline-day-group.tsx
@@ -4,7 +4,11 @@
  */
 import type { SessionReference } from "@codesesh/core/contract";
 import type { AgentCatalog } from "../../lib/agents";
-import { isRowExpanded, type SubSessionMode, type TimelineDay } from "../../lib/session-timeline";
+import {
+  isRowExpanded,
+  type SubSessionMode,
+  type TimelinePageDay,
+} from "../../lib/session-timeline";
 import { TimelineSessionRow } from "./timeline-session-row";
 
 export function TimelineDayGroup({
@@ -15,7 +19,7 @@ export function TimelineDayGroup({
   onToggle,
   onOpen,
 }: {
-  day: TimelineDay;
+  day: TimelinePageDay;
   mode: SubSessionMode;
   openIds: ReadonlySet<string>;
   agentCatalog: AgentCatalog;

--- a/apps/web/src/components/project-timeline/timeline-session-row.test.tsx
+++ b/apps/web/src/components/project-timeline/timeline-session-row.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildSessionTree } from "@codesesh/core/contract";
 import { createAgentCatalog } from "../../lib/agents";
 import type { TimelineRow } from "../../lib/session-timeline";
 import { TimelineSessionRow } from "./timeline-session-row";
@@ -22,7 +23,7 @@ function createRow(overrides: Partial<TimelineRow> = {}): TimelineRow {
     title: "Refactor the scanner",
     agentKey: "codex",
     childCount: 0,
-    children: [],
+    childRoots: [],
     messageCount: 12,
     tokens: 34_000,
     cost: 1.25,
@@ -31,14 +32,21 @@ function createRow(overrides: Partial<TimelineRow> = {}): TimelineRow {
   };
 }
 
-const CHILD = {
-  routeKey: "codex/child",
-  reference: { agentName: "codex", sessionId: "child" },
-  time: new Date(2026, 7, 6, 9, 30).getTime(),
-  title: "Probe the cache",
-  messageCount: 3,
-  cost: 0.25,
-};
+const CHILD = buildSessionTree([
+  {
+    id: "child",
+    slug: "codex/child",
+    title: "Probe the cache",
+    directory: "/workspace/a",
+    time_created: new Date(2026, 7, 6, 9, 30).getTime(),
+    stats: {
+      message_count: 3,
+      total_input_tokens: 10,
+      total_output_tokens: 5,
+      total_cost: 0.25,
+    },
+  },
+]).roots[0]!;
 
 afterEach(cleanup);
 
@@ -61,7 +69,7 @@ function renderRow(props: Partial<Parameters<typeof TimelineSessionRow>[0]> = {}
 
 describe("TimelineSessionRow", () => {
   it("reports the pill's expansion state and the panel it controls", () => {
-    const row = createRow({ childCount: 1, children: [CHILD] });
+    const row = createRow({ childCount: 1, childRoots: [CHILD] });
     const { onToggle, view } = renderRow({ row });
 
     const pill = screen.getByRole("button", { name: /⑂/ });
@@ -92,7 +100,7 @@ describe("TimelineSessionRow", () => {
 
   it("opens the session from the title block without toggling the panel", () => {
     const { onOpen, onToggle } = renderRow({
-      row: createRow({ childCount: 1, children: [CHILD] }),
+      row: createRow({ childCount: 1, childRoots: [CHILD] }),
     });
 
     fireEvent.click(screen.getByRole("button", { name: /Refactor the scanner/ }));
@@ -103,7 +111,7 @@ describe("TimelineSessionRow", () => {
 
   it("opens a sub-session from the child panel", () => {
     const { onOpen } = renderRow({
-      row: createRow({ childCount: 1, children: [CHILD] }),
+      row: createRow({ childCount: 1, childRoots: [CHILD] }),
       expanded: true,
     });
 
@@ -125,7 +133,7 @@ describe("TimelineSessionRow", () => {
   });
 
   it("omits a kind badge when the adapter reports none", () => {
-    renderRow({ row: createRow({ childCount: 1, children: [CHILD] }), expanded: true });
+    renderRow({ row: createRow({ childCount: 1, childRoots: [CHILD] }), expanded: true });
 
     const childRow = screen.getByRole("button", { name: /Probe the cache/ });
     expect(childRow.textContent).toBe("09:30Probe the cache3 msgs · $0.25");

--- a/apps/web/src/components/project-timeline/timeline-session-row.tsx
+++ b/apps/web/src/components/project-timeline/timeline-session-row.tsx
@@ -87,7 +87,7 @@ export function TimelineSessionRow({
           {hasChildren ? " incl. sub" : ""}
         </span>
       </div>
-      {expanded ? <TimelineChildPanel id={panelId} rows={row.children} onOpen={onOpen} /> : null}
+      {expanded ? <TimelineChildPanel id={panelId} row={row} onOpen={onOpen} /> : null}
     </article>
   );
 }

--- a/apps/web/src/lib/session-timeline.test.ts
+++ b/apps/web/src/lib/session-timeline.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { SessionHead } from "@codesesh/core/contract";
-import { buildProjectTimeline, isRowExpanded, type TimelineRow } from "./session-timeline";
+import {
+  buildProjectTimeline,
+  getProjectTimelinePage,
+  getTimelineChildPage,
+  isRowExpanded,
+  TIMELINE_CHILD_PAGE_SIZE,
+  TIMELINE_MAIN_PAGE_SIZE,
+  type TimelineRow,
+} from "./session-timeline";
 
 const NOW = new Date(2026, 7, 6, 12, 0, 0).getTime();
 
@@ -28,7 +36,7 @@ function createSession(
 }
 
 describe("buildProjectTimeline", () => {
-  it("flattens a deeply nested session chain without recursive traversal", () => {
+  it("pages a deeply nested session chain without flattening every descendant", () => {
     const depth = 12_000;
     const sessions = Array.from({ length: depth }, (_, index) =>
       createSession({
@@ -40,14 +48,21 @@ describe("buildProjectTimeline", () => {
       }),
     );
     const timeline = buildProjectTimeline(sessions, { now: NOW });
-    const row = timeline.days[0]!.rows[0]!;
+    const row = getProjectTimelinePage(timeline).days[0]!.rows[0]!;
+    const firstChildPage = getTimelineChildPage(row);
+    const lastChildPage = getTimelineChildPage(row, depth - 1);
 
     expect(timeline.mainCount).toBe(1);
     expect(timeline.subCount).toBe(depth - 1);
     expect(row.childCount).toBe(depth - 1);
-    expect(row.children).toHaveLength(depth - 1);
-    expect(row.children[0]!.routeKey).toBe("codex/deep-1");
-    expect(row.children.at(-1)!.routeKey).toBe(`codex/deep-${depth - 1}`);
+    expect(row.childRoots).toHaveLength(1);
+    expect("children" in row).toBe(false);
+    expect(firstChildPage.rows).toHaveLength(TIMELINE_CHILD_PAGE_SIZE);
+    expect(firstChildPage.rows[0]!.routeKey).toBe("codex/deep-1");
+    expect(firstChildPage.rows.at(-1)!.routeKey).toBe(`codex/deep-${TIMELINE_CHILD_PAGE_SIZE}`);
+    expect(firstChildPage.hasNext).toBe(true);
+    expect(lastChildPage.rows.at(-1)!.routeKey).toBe(`codex/deep-${depth - 1}`);
+    expect(lastChildPage.hasNext).toBe(false);
   });
 
   it("labels days relative to now", () => {
@@ -91,12 +106,13 @@ describe("buildProjectTimeline", () => {
       { now: NOW },
     );
 
-    const rows = timeline.days.flatMap((day) => day.rows);
+    const rows = getProjectTimelinePage(timeline).days.flatMap((day) => day.rows);
     expect(rows.map((row) => row.routeKey)).toEqual(["codex/root"]);
 
     const root = rows[0]!;
+    const children = getTimelineChildPage(root, 0, 10).rows;
     expect(root.childCount).toBe(3);
-    expect(root.children.map((child) => child.routeKey)).toEqual([
+    expect(children.map((child) => child.routeKey)).toEqual([
       "codex/child-d",
       "codex/child-b",
       "codex/grandchild",
@@ -104,8 +120,8 @@ describe("buildProjectTimeline", () => {
     expect(root.messageCount).toBe(4);
     expect(root.tokens).toBe(60);
     expect(root.cost).toBeCloseTo(2);
-    expect(root.children.every((child) => child.kind === undefined)).toBe(true);
-    expect(root.children[0]).toMatchObject({
+    expect(children.every((child) => child.kind === undefined)).toBe(true);
+    expect(children[0]).toMatchObject({
       reference: { agentName: "codex", sessionId: "child-d" },
       messageCount: 1,
       cost: 0.5,
@@ -125,7 +141,7 @@ describe("buildProjectTimeline", () => {
       { now: NOW },
     );
 
-    const rows = timeline.days[0]!.rows;
+    const rows = getProjectTimelinePage(timeline).days[0]!.rows;
     expect(rows.map((row) => [row.routeKey, row.isOrphan])).toEqual([
       ["codex/orphan", true],
       ["codex/root", false],
@@ -155,7 +171,7 @@ describe("buildProjectTimeline", () => {
       { now: NOW },
     );
 
-    const rows = timeline.days.flatMap((day) => day.rows);
+    const rows = getProjectTimelinePage(timeline).days.flatMap((day) => day.rows);
     expect(rows.map((row) => row.routeKey).toSorted()).toEqual([
       "codex/a",
       "codex/b",
@@ -197,6 +213,42 @@ describe("buildProjectTimeline", () => {
       subCount: 0,
       totalTokens: 0,
     });
+  });
+});
+
+describe("timeline paging", () => {
+  it("bounds main rows while preserving full day counts", () => {
+    const today = Array.from({ length: 45 }, (_, index) =>
+      createSession({ id: `today-${index}`, time_updated: at(6, 9, index) }),
+    );
+    const yesterday = Array.from({ length: 10 }, (_, index) =>
+      createSession({ id: `yesterday-${index}`, time_updated: at(5, 9, index) }),
+    );
+    const timeline = buildProjectTimeline([...today, ...yesterday], { now: NOW });
+
+    const firstPage = getProjectTimelinePage(timeline);
+    const secondPage = getProjectTimelinePage(timeline, TIMELINE_MAIN_PAGE_SIZE);
+
+    expect(firstPage.shown).toBe(TIMELINE_MAIN_PAGE_SIZE);
+    expect(firstPage.days).toHaveLength(1);
+    expect(firstPage.days[0]!.mainCount).toBe(45);
+    expect(firstPage.hasNext).toBe(true);
+    expect(secondPage.days.map((day) => [day.label, day.rows.length, day.mainCount])).toEqual([
+      ["Today", 5, 45],
+      ["Yesterday", 10, 10],
+    ]);
+    expect(secondPage.shown).toBe(15);
+    expect(secondPage.hasPrevious).toBe(true);
+    expect(secondPage.hasNext).toBe(false);
+  });
+
+  it("rejects page limits that cannot advance safely", () => {
+    const timeline = buildProjectTimeline([], { now: NOW });
+
+    expect(() => getProjectTimelinePage(timeline, 0, 0)).toThrow(RangeError);
+    expect(() => getProjectTimelinePage(timeline, 0, Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      RangeError,
+    );
   });
 });
 

--- a/apps/web/src/lib/session-timeline.ts
+++ b/apps/web/src/lib/session-timeline.ts
@@ -1,6 +1,6 @@
 /**
- * View model for the project timeline: turns a flat session snapshot into
- * day-grouped rows whose sub-sessions live inside their parent row. Pure —
+ * View model for the project timeline: keeps a flat session snapshot as
+ * day-grouped tree references and derives bounded row pages from it. Pure —
  * expansion state belongs to the component, never to the model.
  */
 import type { SessionHead, SessionReference, SessionTreeNode } from "@codesesh/core/contract";
@@ -16,6 +16,9 @@ import { formatMonthDay } from "./format";
 import { getSessionDisplayTitle } from "./session-title";
 
 export type SubSessionMode = "collapsed" | "expanded" | "hidden";
+
+export const TIMELINE_MAIN_PAGE_SIZE = 40;
+export const TIMELINE_CHILD_PAGE_SIZE = 40;
 
 export interface TimelineChildRow {
   routeKey: string;
@@ -39,10 +42,10 @@ export interface TimelineRow {
   time: number;
   title: string;
   agentKey: string;
-  /** Descendants at every depth, i.e. `children.length`. */
+  /** Descendants at every depth. */
   childCount: number;
-  /** Flattened descendants, depth-first, siblings oldest first. */
-  children: TimelineChildRow[];
+  /** Direct tree references only; descendant rows are derived one page at a time. */
+  childRoots: readonly SessionTreeNode[];
   /** Inclusive of every descendant — the visible proof of the aggregation rule. */
   messageCount: number;
   tokens: number;
@@ -57,6 +60,16 @@ export interface TimelineDay {
   label: string;
   mainCount: number;
   subCount: number;
+  /** Main-axis tree nodes; render rows are derived only for the visible page. */
+  nodes: readonly SessionTreeNode[];
+}
+
+export interface TimelinePageDay {
+  dayKey: string;
+  dayStart: number;
+  label: string;
+  mainCount: number;
+  subCount: number;
   rows: TimelineRow[];
 }
 
@@ -66,6 +79,23 @@ export interface ProjectTimeline {
   mainCount: number;
   subCount: number;
   totalTokens: number;
+}
+
+export interface TimelinePage {
+  days: TimelinePageDay[];
+  offset: number;
+  pageNumber: number;
+  shown: number;
+  hasPrevious: boolean;
+  hasNext: boolean;
+}
+
+export interface TimelineChildPage {
+  rows: TimelineChildRow[];
+  offset: number;
+  pageNumber: number;
+  hasPrevious: boolean;
+  hasNext: boolean;
 }
 
 function activityTime(session: SessionHead): number {
@@ -99,7 +129,7 @@ function toChildRow(node: SessionTreeNode): TimelineChildRow {
 
 function pushChildrenForDepthFirstTraversal(
   pending: SessionTreeNode[],
-  children: SessionTreeNode[],
+  children: readonly SessionTreeNode[],
 ): void {
   if (children.length === 1) {
     pending.push(children[0]!);
@@ -111,21 +141,29 @@ function pushChildrenForDepthFirstTraversal(
   }
 }
 
-function collectChildRows(node: SessionTreeNode, rows: TimelineChildRow[]): void {
-  const pending: SessionTreeNode[] = [];
-  pushChildrenForDepthFirstTraversal(pending, node.children);
-  while (pending.length > 0) {
-    const child = pending.pop()!;
-    rows.push(toChildRow(child));
-    pushChildrenForDepthFirstTraversal(pending, child.children);
+function getPageBounds(
+  total: number,
+  requestedOffset: number,
+  limit: number,
+): { offset: number; end: number } {
+  if (!Number.isSafeInteger(total) || total < 0) {
+    throw new RangeError("page total must be a non-negative safe integer");
   }
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new RangeError("page limit must be a positive safe integer");
+  }
+  if (total === 0) return { offset: 0, end: 0 };
+  const normalizedRequest =
+    Number.isSafeInteger(requestedOffset) && requestedOffset > 0 ? requestedOffset : 0;
+  const pageOffset = normalizedRequest - (normalizedRequest % limit);
+  const lastPageOffset = Math.floor((total - 1) / limit) * limit;
+  const offset = Math.min(pageOffset, lastPageOffset);
+  return { offset, end: offset + Math.min(limit, total - offset) };
 }
 
 function toRow(node: SessionTreeNode, isOrphan: boolean): TimelineRow {
   const { session, inclusiveStats } = node;
   const reference = referenceOf(session);
-  const children: TimelineChildRow[] = [];
-  collectChildRows(node, children);
 
   return {
     routeKey: getSessionRouteKey(reference.agentName, reference.sessionId),
@@ -134,11 +172,78 @@ function toRow(node: SessionTreeNode, isOrphan: boolean): TimelineRow {
     title: getSessionDisplayTitle(session),
     agentKey: reference.agentName,
     childCount: node.descendantCount,
-    children,
+    childRoots: node.children,
     messageCount: inclusiveStats.messageCount,
     tokens: inclusiveStats.totalTokens,
     cost: inclusiveStats.cost,
     isOrphan,
+  };
+}
+
+export function getTimelineChildPage(
+  row: TimelineRow,
+  requestedOffset = 0,
+  limit = TIMELINE_CHILD_PAGE_SIZE,
+): TimelineChildPage {
+  const { offset, end } = getPageBounds(row.childCount, requestedOffset, limit);
+  const rows: TimelineChildRow[] = [];
+  const pending: SessionTreeNode[] = [];
+  pushChildrenForDepthFirstTraversal(pending, row.childRoots);
+  let index = 0;
+
+  while (pending.length > 0 && index < end) {
+    const child = pending.pop()!;
+    if (index >= offset) rows.push(toChildRow(child));
+    index += 1;
+    pushChildrenForDepthFirstTraversal(pending, child.children);
+  }
+
+  return {
+    rows,
+    offset,
+    pageNumber: Math.floor(offset / limit) + 1,
+    hasPrevious: offset > 0,
+    hasNext: end < row.childCount,
+  };
+}
+
+export function getProjectTimelinePage(
+  timeline: ProjectTimeline,
+  requestedOffset = 0,
+  limit = TIMELINE_MAIN_PAGE_SIZE,
+): TimelinePage {
+  const { offset, end } = getPageBounds(timeline.mainCount, requestedOffset, limit);
+  const pageSize = end - offset;
+  const days: TimelinePageDay[] = [];
+  let skipped = 0;
+  let shown = 0;
+
+  for (const day of timeline.days) {
+    if (shown === pageSize) break;
+    const dayOffset = Math.max(0, offset - skipped);
+    skipped += day.nodes.length;
+    if (dayOffset >= day.nodes.length) continue;
+    const nodes = day.nodes.slice(dayOffset, dayOffset + pageSize - shown);
+    if (nodes.length === 0) continue;
+    const rows = nodes.map((node) => toRow(node, node.session.parent_reference != null));
+    days.push({
+      dayKey: day.dayKey,
+      dayStart: day.dayStart,
+      label: day.label,
+      mainCount: day.mainCount,
+      subCount: day.subCount,
+      rows,
+    });
+    shown += rows.length;
+  }
+
+  return {
+    days,
+    offset,
+    pageNumber: Math.floor(offset / limit) + 1,
+    shown,
+    hasPrevious: offset > 0,
+    hasNext: end < timeline.mainCount,
   };
 }
 
@@ -155,7 +260,7 @@ export function buildProjectTimeline(
     label: formatDayLabel(group.dayStart, now),
     mainCount: group.mainCount,
     subCount: group.subCount,
-    rows: group.nodes.map((node) => toRow(node, tree.mountStateOf(node.session) === "orphan")),
+    nodes: group.nodes,
   }));
 
   return {


### PR DESCRIPTION
## Summary

- keep project timeline models lightweight until rows become visible
- page main sessions and expanded sub-sessions with fixed rendering budgets
- reset timeline state when the project or agent scope changes
- cover wide and deeply nested timelines with bounded-rendering regressions

## Testing

- pnpm lint
- pnpm format:check
- pnpm typecheck
- pnpm typecheck:e2e
- pnpm build
- pnpm test
- pnpm test:coverage
- pnpm test:migration
- pnpm --filter @codesesh/web test:bundle
- pnpm perf:check
- pnpm test:e2e
- pnpm package:artifact:test
- repository documentation and release preflight checks