### PR TITLE
fix(docs): validate structure map paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,27 +362,31 @@ node --watch packages/cli/dist/index.js --cwd . --days 3
 
 ### Project Structure
 
-```
-packages/core       Core library (framework-agnostic)
-  agents/           Agent adapters, registry, and registration
-  analytics/        Dashboard aggregation
-  contract/         Browser-safe types and shared pure logic
-  discovery/        Session scanning, SQLite cache, and search index
-  pricing/          Model price registry and cost estimation
-  projects/         Project identity resolution
-  search/           Session search across sources
-  state/            Bookmarks, aliases, and preferences
-  types/            Shared TypeScript types
-  utils/            Utility functions
+```text
+packages/core/src/agents/       Agent adapters, registry, and registration
+packages/core/src/analytics/    Dashboard aggregation
+packages/core/src/contract/     Browser-safe types and shared pure logic
+packages/core/src/discovery/    Session scanning, SQLite cache, and search index
+packages/core/src/pricing/      Model price registry and cost estimation
+packages/core/src/projects/     Project identity resolution
+packages/core/src/search/       Session search across sources
+packages/core/src/state/        Bookmarks, aliases, and preferences
+packages/core/src/types/        Shared TypeScript types
+packages/core/src/utils/        Utility functions
 
-packages/cli        CLI entry point & HTTP server
-  api/              Hono routes and request handlers
-  *-worker.ts       Scan, search-index and smart-tag worker threads
+packages/cli/src/index.ts       CLI argument parsing and startup
+packages/cli/src/server.ts      Hono server and lifecycle
+packages/cli/src/api/           HTTP routes and request handlers
+packages/cli/src/*-worker.ts    Scan, search-index, and smart-tag worker threads
 
-apps/web            React frontend
-  components/       UI components
-  hooks/            Data loading and interaction hooks
-  lib/              API client & utilities
+apps/web/src/components/        Product and UI components
+apps/web/src/hooks/             Client state and data synchronization
+apps/web/src/lib/               HTTP API client and frontend utilities
+apps/web/src/styles/            Global styles
+
+apps/www/src/pages/             Product-site routes
+apps/www/src/components/        Product-site components
+apps/www/public/                Static product-site assets
 ```
 
 `docs/architecture.md` describes how a scan flows through these; `docs/sqlite-storage.md` covers

--- a/README_CN.md
+++ b/README_CN.md
@@ -331,20 +331,31 @@ node --watch packages/cli/dist/index.js --cwd . --days 3
 
 ### 项目结构
 
-```
-packages/core       核心库（framework-agnostic）
-  agents/           各 Agent 适配器（每个 Agent 一个文件）
-  discovery/        会话路径解析 & 文件扫描
-  types/            共享 TypeScript 类型定义
-  utils/            工具函数
+```text
+packages/core/src/agents/       Agent 适配器、注册表与能力声明
+packages/core/src/analytics/    Dashboard 聚合
+packages/core/src/contract/     浏览器安全的共享契约与纯逻辑
+packages/core/src/discovery/    会话扫描、SQLite 缓存与搜索索引
+packages/core/src/pricing/      模型定价与成本估算
+packages/core/src/projects/     项目身份解析
+packages/core/src/search/       跨来源会话搜索
+packages/core/src/state/        收藏、别名与用户偏好
+packages/core/src/types/        共享 TypeScript 类型
+packages/core/src/utils/        通用工具函数
 
-packages/cli        CLI 入口 & HTTP 服务器
-  src/commands/     CLI 子命令
-  src/api/          Hono 路由处理器
+packages/cli/src/index.ts       CLI 参数解析与启动
+packages/cli/src/server.ts      Hono 服务与生命周期
+packages/cli/src/api/           HTTP 路由与请求处理器
+packages/cli/src/*-worker.ts    扫描、搜索索引与智能标签 Worker
 
-apps/web            React 前端
-  src/components/   UI 组件
-  src/lib/          API 客户端 & 工具函数
+apps/web/src/components/        产品与 UI 组件
+apps/web/src/hooks/             客户端状态与数据同步 Hook
+apps/web/src/lib/               HTTP API 客户端与前端工具
+apps/web/src/styles/            全局样式
+
+apps/www/src/pages/             产品站路由
+apps/www/src/components/        产品站组件
+apps/www/public/                产品站静态资源
 ```
 
 ### 扩展新 Agent

--- a/scripts/check-docs-paths.mjs
+++ b/scripts/check-docs-paths.mjs
@@ -2,9 +2,9 @@
  * Verifies that repository paths quoted in documentation still exist.
  *
  * Docs drifted silently once code moved: `discovery/cache.ts` was deleted while
- * two documents still called it the stable entry point. This only checks
- * backticked paths that look like repository files or directories — prose,
- * commands and external references are left alone.
+ * two documents still called it the stable entry point. This checks paths in
+ * inline code and fenced command or structure blocks. Prose and external
+ * references are left alone.
  */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -27,6 +27,21 @@ export const CHECKED_DOCUMENTS = [
 /** Directories a repository path must start with to be checked. */
 const REPO_ROOTS = ["packages/", "apps/", "docs/", "scripts/", ".github/"];
 
+const FENCED_CODE_BLOCK = /```[^\n]*\n([\s\S]*?)```/g;
+
+function cleanCodeToken(token) {
+  return token.replace(/^[([{<'"`]+/, "").replace(/[\])}>'"`,;:]+$/, "");
+}
+
+function extractFencedCodePaths(markdown) {
+  return [...markdown.matchAll(FENCED_CODE_BLOCK)].flatMap((match) =>
+    (match[1] ?? "")
+      .split(/\s+/)
+      .map(cleanCodeToken)
+      .filter((token) => REPO_ROOTS.some((root) => token.startsWith(root))),
+  );
+}
+
 /** Paths that stand for a pattern or a placeholder rather than a file. */
 function isTemplate(path) {
   return path.includes("*") || path.includes("<");
@@ -44,8 +59,7 @@ export function extractRepositoryPaths(markdown) {
   const quoted = markdown.match(/`[^`\n]+`/g) ?? [];
   return [
     ...new Set(
-      quoted
-        .map((token) => token.slice(1, -1).trim())
+      [...quoted.map((token) => token.slice(1, -1).trim()), ...extractFencedCodePaths(markdown)]
         .filter((token) => REPO_ROOTS.some((root) => token.startsWith(root)))
         .filter((token) => !isTemplate(token) && !isBuildOutput(token)),
     ),

--- a/scripts/check-docs-paths.test.mjs
+++ b/scripts/check-docs-paths.test.mjs
@@ -81,6 +81,24 @@ describe("CS-151: documentation path check", () => {
     ]);
   });
 
+  it("checks repository paths inside fenced structure maps", () => {
+    const dir = repo({
+      "docs/guide.md": [
+        "```text",
+        "packages/core/src/analytics/  Dashboard aggregation",
+        "packages/cli/src/commands/    CLI commands",
+        "packages/core/src/agents/<youragent>.ts  Adapter template",
+        "node packages/cli/dist/index.js --version",
+        "```",
+      ].join("\n"),
+      "packages/core/src/analytics/index.ts": "",
+    });
+
+    expect(findMissingPaths(dir, ["docs/guide.md"])).toEqual([
+      { document: "docs/guide.md", path: "packages/cli/src/commands/" },
+    ]);
+  });
+
   it("reports a document that is not there at all", () => {
     const dir = repo({ "README.md": "" });
 


### PR DESCRIPTION
## Summary

- parse repository paths from fenced documentation blocks as well as inline code
- add a regression test for stale paths inside structure maps
- replace ambiguous project-tree entries with complete repository-relative paths
- synchronize the English and Chinese project structure documentation

## Validation

- pnpm lint
- pnpm format:check
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm test:coverage
- pnpm typecheck:e2e
- node scripts/check-quality-task-coverage.mjs
- node scripts/check-docs-paths.mjs
- node scripts/check-docs-facts.mjs
- node scripts/release-preflight.mjs
- pnpm perf:check