### PR TITLE
fix(core): centralize agent catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # CodeSesh
 
-**用途**：发现、聚合、可视化本地 AI 编码 Agent（Claude Code、Cursor、Kimi、Kimi-Code、Codex、Grok、Pi、OpenCode、ZCode、DSH）的历史会话，通过 Web UI 统一浏览。
+**用途**：发现、聚合、可视化受支持的本地 AI 编码 Agent 历史会话，通过 Web UI 统一浏览。
 
 ## 技术栈
 
@@ -70,10 +70,10 @@ CI（`.github/workflows/ci.yml`）在以上之外还前置这些门禁，本地�
 ## 扩展新 Agent
 
 1. 在 `packages/core/src/agents/` 新增适配器并导出数据根目录解析器。
-2. 在 `packages/core/src/agents/register.ts` 注册图标、根目录解析器、resume 命令能力（不支持时显式为
-   `null`）与工具展示策略类型。
-3. 在 `apps/web/public/icon/agent/` 添加对应 SVG。
-4. 自定义工具展示需新增 `apps/web/src/components/session-detail/tool-strategy/<agent>.ts`
+2. 在 `packages/core/src/contract/agent-catalog.ts` 声明公开身份、图标、来源类型、resume 命令能力与工具展示策略。
+3. 在 `packages/core/src/agents/register.ts` 添加工厂与数据根目录解析器。
+4. 在 `apps/web/public/icon/agent/` 与 `apps/www/public/icon/agent/` 添加对应 SVG。
+5. 自定义工具展示需新增 `apps/web/src/components/session-detail/tool-strategy/<agent>.ts`
    并在同目录的 `apps/web/src/components/session-detail/tool-strategy/index.ts` 注册 builder；使用默认策略则无需新增实现。
 
 注册完备性测试必须覆盖图标与工具展示策略声明。

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > **One place to see every AI coding session you've ever had.**
 
-You've been coding with AI agents — Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, DSH — and the conversations are scattered everywhere on your filesystem. Context is lost. Cost is invisible. History is buried.
+You've been coding with AI agents, and the conversations are scattered everywhere on your filesystem. Context is lost. Cost is invisible. History is buried.
 
 **CodeSesh** fixes that. It scans your local machine, finds every AI agent session, and surfaces them in a unified, beautiful Web UI. Think of it as a time machine for your AI-assisted development workflow.
 
@@ -395,11 +395,12 @@ a new guard.
 
 ### Extending
 
-Agent capabilities have one registration point:
+Agent metadata and runtime construction have separate, explicit declarations:
 
 1. Create `packages/core/src/agents/<youragent>.ts`, implement `BaseAgent`, and export its data-root resolver.
-2. Register it in `packages/core/src/agents/register.ts`, explicitly declaring its icon, data root, resume command support (`null` when unsupported), and whether it uses a custom or default tool display strategy.
-3. Add its SVG to `apps/web/public/icon/agent/`.
-4. For a custom tool display strategy, add `apps/web/src/components/session-detail/tool-strategy/<youragent>.ts` and register its builder in that directory's `index.ts`.
+2. Add its public identity and capabilities to `packages/core/src/contract/agent-catalog.ts`.
+3. Add its factory and data-root resolver to `packages/core/src/agents/register.ts`.
+4. Add its SVG to both `apps/web/public/icon/agent/` and `apps/www/public/icon/agent/`.
+5. For a custom tool display strategy, add `apps/web/src/components/session-detail/tool-strategy/<youragent>.ts` and register its builder in that directory's `index.ts`.
 
 The registration completeness test rejects missing icons, undeclared resume support, and custom strategy mismatches.

--- a/README_CN.md
+++ b/README_CN.md
@@ -7,7 +7,7 @@
 
 > **一个地方，看遍你所有的 AI 编程会话。**
 
-你一直在用 AI Agent 写代码 —— Claude Code、Cursor、Kimi-Cli、Kimi-Code、Codex、Grok、Pi、OpenCode、ZCode、DSH —— 但这些对话分散在文件系统的各个角落。上下文丢失，成本不可见，历史深埋。
+你一直在用 AI Agent 写代码，但这些对话分散在文件系统的各个角落。上下文丢失，成本不可见，历史深埋。
 
 **CodeSesh** 解决这个问题。它扫描你的本地机器，找到所有 AI Agent 会话，并在统一的 Web UI 中呈现。把它理解为你 AI 辅助开发历程的时光机。
 
@@ -360,13 +360,13 @@ apps/www/public/                产品站静态资源
 
 ### 扩展新 Agent
 
-Agent 能力统一在一个注册点声明：
+Agent 元数据与运行时构造分别显式声明：
 
 1. 创建 `packages/core/src/agents/<youragent>.ts`，实现 `BaseAgent` 并导出数据根目录解析器。
-2. 在 `packages/core/src/agents/register.ts` 中注册，显式声明图标、数据根目录、resume
-   命令能力（不支持时填 `null`）以及使用自定义还是默认工具展示策略。
-3. 在 `apps/web/public/icon/agent/` 添加 SVG。
-4. 如使用自定义工具展示策略，在
+2. 在 `packages/core/src/contract/agent-catalog.ts` 中添加公开身份与能力声明。
+3. 在 `packages/core/src/agents/register.ts` 中添加工厂与数据根目录解析器。
+4. 在 `apps/web/public/icon/agent/` 与 `apps/www/public/icon/agent/` 添加 SVG。
+5. 如使用自定义工具展示策略，在
    `apps/web/src/components/session-detail/tool-strategy/<youragent>.ts` 实现，并在同目录
    `index.ts` 注册 builder。
 

--- a/apps/web/tests/agent-registration-completeness.test.ts
+++ b/apps/web/tests/agent-registration-completeness.test.ts
@@ -4,14 +4,15 @@ import { getRegisteredAgents } from "@codesesh/core";
 import { describe, expect, it } from "vitest";
 import { hasCustomToolStrategy } from "../src/components/session-detail/tool-strategy";
 
-const WEB_ROOT = existsSync(resolve(process.cwd(), "public/icon/agent"))
+const REPO_ROOT = existsSync(resolve(process.cwd(), "apps/web"))
   ? process.cwd()
-  : resolve(process.cwd(), "apps/web");
-const PUBLIC_ROOT = resolve(WEB_ROOT, "public");
-const AGENT_ICON_ROOT = resolve(PUBLIC_ROOT, "icon/agent");
+  : resolve(process.cwd(), "../..");
+const WEB_PUBLIC_ROOT = resolve(REPO_ROOT, "apps/web/public");
+const WWW_PUBLIC_ROOT = resolve(REPO_ROOT, "apps/www/public");
+const AGENT_ICON_ROOT = resolve(WEB_PUBLIC_ROOT, "icon/agent");
 
 function registrationName(registration: ReturnType<typeof getRegisteredAgents>[number]): string {
-  return registration.create().name;
+  return registration.name;
 }
 
 describe("agent registration completeness", () => {
@@ -33,13 +34,18 @@ describe("agent registration completeness", () => {
     expect(incomplete).toEqual([]);
   });
 
-  it("keeps the agent icon directory aligned with registered icons", () => {
+  it("provides every registered icon to the app and product site", () => {
     const registeredIcons = [
       ...new Set(
         getRegisteredAgents().map((registration) => {
-          const iconPath = resolve(PUBLIC_ROOT, registration.icon.replace(/^\/+/, ""));
-          expect(existsSync(iconPath), `${registrationName(registration)} icon`).toBe(true);
-          return basename(iconPath);
+          const relativeIconPath = registration.icon.replace(/^\/+/, "");
+          for (const publicRoot of [WEB_PUBLIC_ROOT, WWW_PUBLIC_ROOT]) {
+            expect(
+              existsSync(resolve(publicRoot, relativeIconPath)),
+              `${registrationName(registration)} icon in ${publicRoot}`,
+            ).toBe(true);
+          }
+          return basename(relativeIconPath);
         }),
       ),
     ].toSorted();

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
+    "@codesesh/core": "workspace:*",
     "@hugeicons/core-free-icons": "^4.2.3",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "22.20.1",

--- a/apps/www/public/index.md
+++ b/apps/www/public/index.md
@@ -2,7 +2,7 @@
 
 CodeSesh turns local AI coding history into searchable, replayable engineering memory.
 
-It discovers sessions from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, and DSH, then organizes them by project in one local index.
+It discovers sessions from supported local AI coding agents, then organizes them by project in one local index.
 
 ## Start
 
@@ -54,9 +54,10 @@ Read messages, tool calls, and file changes in sequence. Filter by message type 
 
 ## Supported Agents
 
+<!-- repo-fact:agents:start -->
 - Claude Code
 - Cursor
-- Kimi
+- Kimi-Cli
 - Kimi-Code
 - Codex
 - Grok
@@ -64,6 +65,7 @@ Read messages, tool calls, and file changes in sequence. Filter by message type 
 - OpenCode
 - ZCode
 - DSH
+<!-- repo-fact:agents:end -->
 
 ## Data Boundary
 

--- a/apps/www/public/llms-full.txt
+++ b/apps/www/public/llms-full.txt
@@ -1,6 +1,6 @@
 # CodeSesh: AI-Readable Product Knowledge
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It works with local sessions created by Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, and DSH, then presents them in one unified Web UI.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It works with sessions created by supported local AI coding agents, then presents them in one unified Web UI.
 
 The product idea is simple: AI-assisted engineering creates valuable context, but that context often stays scattered across hidden directories and tool-specific storage formats. CodeSesh turns those local records into reusable engineering memory.
 
@@ -14,7 +14,7 @@ CodeSesh runs on the developer's machine. It does not require an account, cloud 
 
 ## One-Line Description
 
-CodeSesh turns local AI coding history from Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, and DSH into project-aware, structurally searchable, replayable engineering memory.
+CodeSesh turns local AI coding history from supported agents into project-aware, structurally searchable, replayable engineering memory.
 
 ## Primary Audience
 
@@ -31,7 +31,7 @@ Typical users have one or more of these needs:
 
 ## Core Problem
 
-Modern AI coding tools save session history in different local formats and directories. A developer may have useful context inside Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, and DSH at the same time. Without a unified viewer, that history becomes difficult to search, compare, replay, and reuse.
+Modern AI coding tools save session history in different local formats and directories. A developer may have useful context inside several supported agents at the same time. Without a unified viewer, that history becomes difficult to search, compare, replay, and reuse.
 
 This matters because AI coding sessions often contain:
 
@@ -114,11 +114,11 @@ Source build package manager:
 
 ### What is CodeSesh?
 
-CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, and DSH into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
+CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns records from supported local agents into a project-aware engineering memory layer for recovering decisions, file activity, and complete collaboration paths.
 
 ### Which AI coding tools does CodeSesh support?
 
-CodeSesh currently supports Claude Code, Cursor, Kimi-Cli, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, and DSH. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
+The complete supported-agent list appears above. Each tool connects through an agent adapter in the core package, then contributes sessions to unified lists, project browsing, structured search indexes, file activity, smart tags, token statistics, and full replay views.
 
 ### Does CodeSesh upload local AI session data?
 
@@ -242,7 +242,7 @@ CodeSesh uses a local SQLite-backed cache and search index to restore session li
 
 ### Agent Resume Commands
 
-When an agent declares a resume capability, session details can copy a worktree-aware command for returning to that local context. CodeSesh currently declares resume commands for Claude Code, OpenCode, Kimi-Cli, Kimi-Code, Codex, Grok, and Pi. Cursor, ZCode, and DSH explicitly declare no resume command.
+When an agent declares a resume capability, session details can copy a worktree-aware command for returning to that local context. Unsupported agents explicitly declare no resume command in the shared catalog.
 
 ### Local Session Ownership
 
@@ -303,7 +303,9 @@ Adding a new AI agent follows the core adapter model:
 
 1. Create an adapter file in `packages/core/src/agents/`.
 2. Implement the required agent interface.
-3. Register it in `packages/core/src/agents/register.ts`.
+3. Add its public identity and capabilities to `packages/core/src/contract/agent-catalog.ts`.
+4. Add its runtime factory and data-root resolver to `packages/core/src/agents/register.ts`.
+5. Add its icon to both app public directories.
 
 The new agent can then appear in the UI through the shared discovery and presentation pipeline.
 
@@ -348,7 +350,7 @@ CodeSesh is relevant for queries like:
 
 ## Chinese Summary
 
-CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码 Agent 的历史会话。它支持 Claude Code、Cursor、Kimi-Cli、Kimi-Code、Codex、Grok、Pi、OpenCode、ZCode、DSH，把分散在本地文件系统里的会话沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
+CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放受支持 AI 编码 Agent 的历史会话，把分散在本地文件系统里的会话沉淀成按项目组织、可结构化检索、可复盘的工程记忆。
 
 核心价值包括：跨 Agent 统一时间线、结构化全局搜索、项目浏览模式、项目化会话树、智能标签、会话收藏、完整回放、文件活动索引、Token 与成本可见、SQLite 迁移与本地索引、零配置启动、本地私有、实时刷新。
 

--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -17,9 +17,10 @@ CodeSesh scans supported local AI coding session stores and presents them throug
 
 ## Supported Agents
 
+<!-- repo-fact:agents:start -->
 - Claude Code
 - Cursor
-- Kimi
+- Kimi-Cli
 - Kimi-Code
 - Codex
 - Grok
@@ -27,6 +28,7 @@ CodeSesh scans supported local AI coding session stores and presents them throug
 - OpenCode
 - ZCode
 - DSH
+<!-- repo-fact:agents:end -->
 
 ## Core Capabilities
 

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -1,3 +1,5 @@
+import { AGENT_CATALOG } from "@codesesh/core/contract";
+
 export type Locale = "en" | "zh";
 
 export type HeadingCopy = string | string[];
@@ -106,25 +108,22 @@ export const localeRoutes = {
   zh: "/zh/",
 } satisfies Record<Locale, string>;
 
-export const agents = [
-  { name: "Claude Code", icon: "/icon/agent/claudecode.svg", iconColored: true },
-  { name: "Cursor", icon: "/icon/agent/cursor.svg" },
-  { name: "Kimi", icon: "/icon/agent/kimi.svg" },
-  { name: "Kimi-Code", icon: "/icon/agent/kimi.svg" },
-  { name: "Codex", icon: "/icon/agent/codex.svg" },
-  { name: "Grok", icon: "/icon/agent/grok.svg" },
-  { name: "Pi", icon: "/icon/agent/pi.svg" },
-  { name: "OpenCode", icon: "/icon/agent/opencode.svg" },
-  { name: "ZCode", icon: "/icon/agent/zcode.svg" },
-  { name: "DSH", icon: "/icon/agent/dsh.svg", iconColored: true },
-] as const;
+const agentDisplayNames = AGENT_CATALOG.map(({ displayName }) => displayName);
+const agentCount = agentDisplayNames.length;
+const agentNamesEn = `${agentDisplayNames.slice(0, -1).join(", ")}, and ${agentDisplayNames.at(-1)}`;
+const agentNamesZh = `${agentDisplayNames.slice(0, -1).join("、")}和${agentDisplayNames.at(-1)}`;
+
+export const agents = AGENT_CATALOG.map((entry) => ({
+  name: entry.displayName,
+  icon: entry.icon,
+  ...("iconColored" in entry ? { iconColored: entry.iconColored } : {}),
+}));
 
 export const copy = {
   zh: {
     meta: {
       title: "CodeSesh：搜索与回放本地 AI 编码历史",
-      description:
-        "CodeSesh 把十种 AI 编码 Agent 的本地会话按项目组织，提供结构化搜索、完整回放与本地 SQLite 索引，让工程上下文可查、可追溯。",
+      description: `CodeSesh 把 ${agentCount} 种 AI 编码 Agent 的本地会话按项目组织，提供结构化搜索、完整回放与本地 SQLite 索引，让工程上下文可查、可追溯。`,
     },
     header: {
       tour: "产品导览",
@@ -140,9 +139,9 @@ export const copy = {
       themeSwitchTo: "，点击切换到{next}",
     },
     hero: {
-      eyebrow: "本地运行 / 零配置 / 10 个 Agent",
+      eyebrow: `本地运行 / 零配置 / ${agentCount} 个 Agent`,
       title: ["你和 AI 写过的", "每一次对话，都还在。"],
-      body: "CodeSesh 扫描十种 AI 编码 Agent 的本地会话，把分散的历史收进同一个索引：按项目组织、结构化搜索、逐条回放。",
+      body: `CodeSesh 扫描 ${agentCount} 种 AI 编码 Agent 的本地会话，把分散的历史收进同一个索引：按项目组织、结构化搜索、逐条回放。`,
       privacy: "会话内容与索引留在本机，无需账号、云同步或会话遥测。",
       command: "npx codesesh",
       endpoint: "http://localhost:4521",
@@ -188,7 +187,7 @@ export const copy = {
             {
               icon: "eye",
               title: "统一时间线",
-              description: "十种 Agent 的历史会话进入同一个界面。",
+              description: `${agentCount} 种 Agent 的历史会话进入同一个界面。`,
             },
             {
               icon: "timer",
@@ -272,8 +271,7 @@ export const copy = {
       items: [
         {
           question: "CodeSesh 是什么？",
-          answer:
-            "CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码会话历史。它把 Claude Code、Cursor、Kimi、Kimi-Code、Codex、Grok、Pi、OpenCode、ZCode 和 DSH 的本地记录整理成按项目组织的工程记忆层。",
+          answer: `CodeSesh 是一个本地开发者工具，用来发现、聚合、搜索和回放 AI 编码会话历史。它把 ${agentNamesZh} 的本地记录整理成按项目组织的工程记忆层。`,
         },
         {
           question: "CodeSesh 会上传本地 AI 会话数据吗？",
@@ -306,8 +304,7 @@ export const copy = {
   en: {
     meta: {
       title: "CodeSesh: Search and Replay Local AI Coding History",
-      description:
-        "CodeSesh organizes local sessions from ten AI coding agents by project, with structured search, full replay, and a local SQLite index.",
+      description: `CodeSesh organizes local sessions from ${agentCount} AI coding agents by project, with structured search, full replay, and a local SQLite index.`,
     },
     header: {
       tour: "Tour",
@@ -323,9 +320,9 @@ export const copy = {
       themeSwitchTo: ". Switch to {next}.",
     },
     hero: {
-      eyebrow: "Local / Zero config / 10 agents",
+      eyebrow: `Local / Zero config / ${agentCount} agents`,
       title: ["Every AI coding session", "is still here."],
-      body: "CodeSesh scans local histories from ten AI coding agents and puts them in one index: organized by project, structurally searchable, and replayable message by message.",
+      body: `CodeSesh scans local histories from ${agentCount} AI coding agents and puts them in one index: organized by project, structurally searchable, and replayable message by message.`,
       privacy:
         "Session content and indexes stay local. No account, cloud sync, or session telemetry.",
       command: "npx codesesh",
@@ -372,7 +369,7 @@ export const copy = {
             {
               icon: "eye",
               title: "Unified timeline",
-              description: "Browse histories from ten AI coding agents in one interface.",
+              description: `Browse histories from ${agentCount} AI coding agents in one interface.`,
             },
             {
               icon: "timer",
@@ -459,8 +456,7 @@ export const copy = {
       items: [
         {
           question: "What is CodeSesh?",
-          answer:
-            "CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, and DSH into a project-aware engineering memory layer.",
+          answer: `CodeSesh is a local developer tool for discovering, aggregating, searching, and replaying AI coding session history. It turns local records from ${agentNamesEn} into a project-aware engineering memory layer.`,
         },
         {
           question: "Does CodeSesh upload local AI session data?",

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -10,7 +10,7 @@
 > - 产品能力与 CLI 参数：[`README.md`](../README.md)
 > - 扫描与缓存架构：[`docs/architecture.md`](./architecture.md)、[`docs/scanning-and-caching.md`](./scanning-and-caching.md)
 > - SQLite 存储与搜索索引：[`docs/sqlite-storage.md`](./sqlite-storage.md)
-> - 支持的 Agent 清单：`packages/core/src/agents/register.ts`
+> - 支持的 Agent 清单：`packages/core/src/contract/agent-catalog.ts`
 > - 发布流程：[`docs/release-guide.md`](./release-guide.md)
 
 ## 1. 概述
@@ -23,7 +23,7 @@ CodeSesh 是一个本地 CLI 工具，用于发现、聚合和可视化多种 AI
 
 当前存在两个独立项目：
 
-- **agent-dump** (Python)：从本地文件系统发现并导出 5 种 Coding Agent（Claude Code、Codex、OpenCode、Cursor、Kimi）的会话记录，统一为 JSON 格式（立项时的范围；当前支持的 Agent 以 `packages/core/src/agents/register.ts` 为准）
+- **agent-dump** (Python)：从本地文件系统发现并导出 5 种 Coding Agent（Claude Code、Codex、OpenCode、Cursor、Kimi）的会话记录，统一为 JSON 格式（立项时的范围；当前支持的 Agent 以 `packages/core/src/contract/agent-catalog.ts` 为准）
 - **agent-view** (React)：将导出的 JSON 会话文件可视化为网页，支持消息时间线、工具输出渲染、TOC 过滤等
 
 CodeSesh 将两者的能力整合为一个 TypeScript monorepo，提供从会话发现到可视化的端到端体验，无需 Python 环境。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,8 @@ CLI Entry (packages/cli/src/index.ts --json)
 | 模块 | 职责 |
 |------|------|
 | `packages/core/src/discovery/scanner.ts` | 初始快照恢复与一次性扫描编排 |
-| `packages/core/src/agents/register.ts` | Agent 注册、数据根目录与能力声明 |
+| `packages/core/src/contract/agent-catalog.ts` | Agent 公开身份与能力声明 |
+| `packages/core/src/agents/register.ts` | Agent 工厂与数据根目录注册 |
 | `packages/cli/src/live-scan.ts` | 运行中快照、订阅和生命周期入口 |
 | `packages/cli/src/agent-sync-engine.ts` | 持续 refresh、backfill、持久化后发布 |
 | `packages/cli/src/session-watcher.ts` | 文件事件监听、稳定性等待与归并 |

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:app": "pnpm --filter codesesh build",
     "run:app": "pnpm --filter codesesh start",
     "dev": "turbo run dev",
-    "dev:www": "pnpm --filter @codesesh/www dev",
+    "dev:www": "pnpm --filter @codesesh/core build && pnpm --filter @codesesh/www dev",
     "serve": "node --watch packages/cli/dist/index.js",
     "clean": "turbo run clean",
     "lint": "pnpm lint:root && turbo run lint",
@@ -22,7 +22,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "typecheck": "turbo run typecheck",
-    "typecheck:e2e": "tsc --noEmit -p tsconfig.e2e.json",
+    "typecheck:e2e": "pnpm --filter @codesesh/core build && tsc --noEmit -p tsconfig.e2e.json",
     "test:migration": "vitest run --reporter=verbose packages/core/src/discovery/__tests__/migration-smoke.test.ts",
     "package:artifact": "node scripts/package-artifact.mjs",
     "package:artifact:test": "node --test scripts/package-artifact-checks.mjs",
@@ -33,9 +33,10 @@
     "bench:session-index": "pnpm --filter @codesesh/core build && node scripts/benchmark-session-index.mjs",
     "check:coverage-scopes": "node scripts/critical-coverage.mjs",
     "test:coverage": "pnpm check:coverage-scopes && vitest run --coverage",
-    "deploy:www": "pnpm --filter @codesesh/www deploy:cf"
+    "deploy:www": "pnpm --filter @codesesh/core build && pnpm --filter @codesesh/www deploy:cf"
   },
   "devDependencies": {
+    "@codesesh/core": "workspace:*",
     "@types/node": "22.20.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><strong>One place to see every AI coding session you've ever had.</strong></p>
 
-CodeSesh scans your local machine, finds every AI agent session (Claude Code, Cursor, Kimi, Kimi-Code, Codex, Grok, Pi, OpenCode, ZCode, DSH), and surfaces them in a unified, beautiful Web UI.
+CodeSesh scans your local machine, finds sessions from supported AI coding agents, and surfaces them in a unified Web UI.
 
 ## Quick Start
 
@@ -41,11 +41,13 @@ Your browser will open at `http://localhost:4521` with all your sessions ready t
 
 ## Supported Agents
 
+<!-- repo-fact:agents:start -->
+
 | Agent       | Status       |
 | ----------- | ------------ |
 | Claude Code | ✅ Supported |
 | Cursor      | ✅ Supported |
-| Kimi        | ✅ Supported |
+| Kimi-Cli    | ✅ Supported |
 | Kimi-Code   | ✅ Supported |
 | Codex       | ✅ Supported |
 | Grok        | ✅ Supported |
@@ -53,6 +55,8 @@ Your browser will open at `http://localhost:4521` with all your sessions ready t
 | OpenCode    | ✅ Supported |
 | ZCode       | ✅ Supported |
 | DSH         | ✅ Supported |
+
+<!-- repo-fact:agents:end -->
 
 ## Usage
 

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
+import { AGENT_CATALOG } from "@codesesh/core/contract";
 
 const coreMocks = vi.hoisted(() => {
   return {
@@ -312,18 +313,9 @@ describe("handleGetAgents", () => {
       { from: now - 7 * 86400000 },
     );
     const response = c.json.mock.calls[0]![0];
-    expect(response.map((agent: { name: string }) => agent.name)).toEqual([
-      "claudecode",
-      "opencode",
-      "zcode",
-      "kimi",
-      "kimi-code",
-      "codex",
-      "grok",
-      "pi",
-      "dsh",
-      "cursor",
-    ]);
+    expect(response.map((agent: { name: string }) => agent.name)).toEqual(
+      AGENT_CATALOG.map(({ name }) => name),
+    );
     expect(response.find((agent: { name: string }) => agent.name === "claudecode")?.count).toBe(1);
     expect(response.find((agent: { name: string }) => agent.name === "codex")?.count).toBe(0);
   });

--- a/packages/cli/src/session-watcher.test.ts
+++ b/packages/cli/src/session-watcher.test.ts
@@ -252,9 +252,12 @@ describe("SessionWatcher", () => {
         targets: [{ path: tempDir }],
       }) as unknown as BaseAgent;
       registerAgent({
+        name: "registered-test-agent",
+        displayName: "Registered Test Agent",
         icon: "/test-agent.svg",
         resolveDataRoot: () => tempDir,
         resumeCommandPrefix: null,
+        sourceKind: "filesystem",
         toolStrategy: "default",
         create: () => adapter,
       });

--- a/packages/core/src/agents/__tests__/registry.test.ts
+++ b/packages/core/src/agents/__tests__/registry.test.ts
@@ -1,82 +1,39 @@
 import { describe, expect, it } from "vitest";
+import { AGENT_CATALOG } from "../../contract/agent-catalog.js";
+import { DatabaseSessionSource, FileSystemSessionSource } from "../base.js";
 import "../register.js";
-import { getAgentInfoMap } from "../registry.js";
+import { getAgentInfoMap, getRegisteredAgents } from "../registry.js";
 
 describe("agent registry", () => {
-  it("derives public agent metadata from registered agent instances", () => {
-    expect(getAgentInfoMap({ claudecode: 2, codex: 1 })).toEqual([
-      {
-        name: "claudecode",
-        displayName: "Claude Code",
-        icon: "/icon/agent/claudecode.svg",
-        iconColored: true,
-        resumeCommandPrefix: "claude --resume",
-        count: 2,
-      },
-      {
-        name: "opencode",
-        displayName: "OpenCode",
-        icon: "/icon/agent/opencode.svg",
-        resumeCommandPrefix: "opencode -s",
-        count: 0,
-      },
-      {
-        name: "zcode",
-        displayName: "ZCode",
-        icon: "/icon/agent/zcode.svg",
-        resumeCommandPrefix: null,
-        count: 0,
-      },
-      {
-        name: "kimi",
-        displayName: "Kimi-Cli",
-        icon: "/icon/agent/kimi.svg",
-        resumeCommandPrefix: "kimi -r",
-        count: 0,
-      },
-      {
-        name: "kimi-code",
-        displayName: "Kimi-Code",
-        icon: "/icon/agent/kimi.svg",
-        resumeCommandPrefix: "kimi -r",
-        count: 0,
-      },
-      {
-        name: "codex",
-        displayName: "Codex",
-        icon: "/icon/agent/codex.svg",
-        resumeCommandPrefix: "codex resume",
-        count: 1,
-      },
-      {
-        name: "grok",
-        displayName: "Grok",
-        icon: "/icon/agent/grok.svg",
-        resumeCommandPrefix: "grok --resume",
-        count: 0,
-      },
-      {
-        name: "pi",
-        displayName: "Pi",
-        icon: "/icon/agent/pi.svg",
-        resumeCommandPrefix: "pi --session",
-        count: 0,
-      },
-      {
-        name: "dsh",
-        displayName: "DSH",
-        icon: "/icon/agent/dsh.svg",
-        iconColored: true,
-        resumeCommandPrefix: null,
-        count: 0,
-      },
-      {
-        name: "cursor",
-        displayName: "Cursor",
-        icon: "/icon/agent/cursor.svg",
-        resumeCommandPrefix: null,
-        count: 0,
-      },
-    ]);
+  it("projects public metadata from the catalog", () => {
+    const counts: Record<string, number> = { claudecode: 2, codex: 1 };
+
+    expect(getAgentInfoMap(counts)).toEqual(
+      AGENT_CATALOG.map((entry) => ({
+        name: entry.name,
+        displayName: entry.displayName,
+        icon: entry.icon,
+        iconColored: "iconColored" in entry ? entry.iconColored : undefined,
+        resumeCommandPrefix: entry.resumeCommandPrefix,
+        count: counts[entry.name] ?? 0,
+      })),
+    );
+  });
+
+  it("keeps every factory identity aligned with its catalog entry", () => {
+    expect(
+      getRegisteredAgents().map((registration) => {
+        const agent = registration.create();
+        return { name: agent.name, displayName: agent.displayName };
+      }),
+    ).toEqual(AGENT_CATALOG.map(({ name, displayName }) => ({ name, displayName })));
+  });
+
+  it("keeps declared source kinds aligned with runtime implementations", () => {
+    for (const registration of getRegisteredAgents()) {
+      const SourceClass =
+        registration.sourceKind === "sqlite" ? DatabaseSessionSource : FileSystemSessionSource;
+      expect(registration.create()).toBeInstanceOf(SourceClass);
+    }
   });
 });

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   SingleFileSessionSource,
   filteredSession,
@@ -115,9 +116,11 @@ function extractClaudeUsage(
   };
 }
 
+const AGENT_METADATA = getAgentCatalogEntry("claudecode");
+
 export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
-  readonly name = "claudecode";
-  readonly displayName = "Claude Code";
+  readonly name = AGENT_METADATA.name;
+  readonly displayName = AGENT_METADATA.displayName;
 
   private basePath: string | null = null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   SingleFileSessionSource,
   filteredSession,
@@ -422,9 +423,11 @@ function sourceTimestamp(filePath: string, fallback: number): number {
 // CodexAgent
 // ---------------------------------------------------------------------------
 
+const AGENT_METADATA = getAgentCatalogEntry("codex");
+
 export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
-  readonly name = "codex";
-  readonly displayName = "Codex";
+  readonly name = AGENT_METADATA.name;
+  readonly displayName = AGENT_METADATA.displayName;
 
   private basePath: string | null = null;
   private sessionIndexCache = new Map<string, string>();

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -1,6 +1,7 @@
 import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join, normalize } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   DatabaseSessionSource,
   filteredSession,
@@ -481,9 +482,11 @@ function convertActionToPart(action: ActionEntry, timestampMs: number): MessageP
 // CursorAgent
 // ---------------------------------------------------------------------------
 
+const AGENT_METADATA = getAgentCatalogEntry("cursor");
+
 export class CursorAgent extends DatabaseSessionSource {
-  readonly name = "cursor";
-  readonly displayName = "Cursor";
+  readonly name = AGENT_METADATA.name;
+  readonly displayName = AGENT_METADATA.displayName;
 
   private dbPath: string | null = null;
 

--- a/packages/core/src/agents/dsh.ts
+++ b/packages/core/src/agents/dsh.ts
@@ -9,6 +9,7 @@
  */
 import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   FileSystemSessionSource,
   SessionScanError,
@@ -87,9 +88,11 @@ function sameFile(left: string, right: string): boolean {
   }
 }
 
+const AGENT_METADATA = getAgentCatalogEntry("dsh");
+
 export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
-  readonly name = "dsh";
-  readonly displayName = "DSH";
+  readonly name = AGENT_METADATA.name;
+  readonly displayName = AGENT_METADATA.displayName;
 
   getSessionWatchPlan(): SessionWatchPlan {
     const dataRoot = resolveDshDataRoot();

--- a/packages/core/src/agents/grok.ts
+++ b/packages/core/src/agents/grok.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   FileSystemSessionSource,
   filteredSession,
@@ -817,9 +818,11 @@ function parseTranscript(meta: GrokSessionMeta): TranscriptResult {
   return replay.finish(meta.stats);
 }
 
+const AGENT_METADATA = getAgentCatalogEntry("grok");
+
 export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
-  readonly name = "grok";
-  readonly displayName = "Grok";
+  readonly name = AGENT_METADATA.name;
+  readonly displayName = AGENT_METADATA.displayName;
 
   private basePath: string | null = null;
 

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   FileSystemSessionSource,
   filteredSession,
@@ -336,9 +337,11 @@ function readState(stateFile: string): Record<string, unknown> | null {
   }
 }
 
+const AGENT_METADATA = getAgentCatalogEntry("kimi-code");
+
 export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
-  readonly name = "kimi-code";
-  readonly displayName = "Kimi-Code";
+  readonly name = AGENT_METADATA.name;
+  readonly displayName = AGENT_METADATA.displayName;
 
   private basePath: string | null = null;
   private workDirBySessionPath = new Map<string, string>();

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   FileSystemSessionSource,
   getParsedSession,
@@ -218,9 +219,11 @@ function extractFirstUserTitle(contextFile: string | null, wireFile: string | nu
   return null;
 }
 
+const AGENT_METADATA = getAgentCatalogEntry("kimi");
+
 export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
-  readonly name = "kimi";
-  readonly displayName = "Kimi-Cli";
+  readonly name = AGENT_METADATA.name;
+  readonly displayName = AGENT_METADATA.displayName;
 
   private basePath: string | null = null;
   private projectMap = new Map<string, string>();

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -1,7 +1,10 @@
 import { join } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import { firstExisting, resolveDataHome } from "../discovery/paths.js";
 import { isSqliteAvailable } from "../utils/sqlite.js";
 import { OpenCodeSqliteAgent } from "./opencode-sqlite.js";
+
+const AGENT_METADATA = getAgentCatalogEntry("opencode");
 
 export function resolveOpenCodeDataRoot(): string {
   return join(resolveDataHome(), "opencode");
@@ -26,8 +29,8 @@ function getOpenCodeSessionWatchPlan() {
 export class OpenCodeAgent extends OpenCodeSqliteAgent {
   constructor() {
     super({
-      name: "opencode",
-      displayName: "OpenCode",
+      name: AGENT_METADATA.name,
+      displayName: AGENT_METADATA.displayName,
       findDbPath: findOpenCodeDbPath,
       getSessionWatchPlan: getOpenCodeSessionWatchPlan,
     });

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   SingleFileSessionSource,
   filteredSession,
@@ -131,9 +132,11 @@ function buildCurrentPathEntries(entries: Record<string, unknown>[]): Record<str
   return path.reverse();
 }
 
+const AGENT_METADATA = getAgentCatalogEntry("pi");
+
 export class PiAgent extends SingleFileSessionSource<SessionMeta> {
-  readonly name = "pi";
-  readonly displayName = "Pi";
+  readonly name = AGENT_METADATA.name;
+  readonly displayName = AGENT_METADATA.displayName;
 
   private basePath: string | null = null;
 

--- a/packages/core/src/agents/register.ts
+++ b/packages/core/src/agents/register.ts
@@ -1,4 +1,5 @@
-import { registerAgent } from "./registry.js";
+import { AGENT_CATALOG, type AgentName } from "../contract/agent-catalog.js";
+import { registerAgent, type AgentRegistration } from "./registry.js";
 import { ClaudeCodeAgent, resolveClaudeCodeDataRoot } from "./claudecode.js";
 import { OpenCodeAgent, resolveOpenCodeDataRoot } from "./opencode.js";
 import { KimiAgent, resolveKimiDataRoot } from "./kimi.js";
@@ -10,86 +11,51 @@ import { ZCodeAgent, resolveZCodeDataRoot } from "./zcode.js";
 import { GrokAgent, resolveGrokDataRoot } from "./grok.js";
 import { DshAgent, resolveDshDataRoot } from "./dsh.js";
 
-registerAgent({
-  icon: "/icon/agent/claudecode.svg",
-  iconColored: true,
-  resolveDataRoot: resolveClaudeCodeDataRoot,
-  resumeCommandPrefix: "claude --resume",
-  toolStrategy: "custom",
-  create: () => new ClaudeCodeAgent(),
-});
+type AgentRuntimeRegistration = Pick<AgentRegistration, "create" | "resolveDataRoot">;
 
-registerAgent({
-  icon: "/icon/agent/opencode.svg",
-  resolveDataRoot: resolveOpenCodeDataRoot,
-  resumeCommandPrefix: "opencode -s",
-  toolStrategy: "custom",
-  create: () => new OpenCodeAgent(),
-});
+const RUNTIME_REGISTRATIONS = {
+  claudecode: {
+    create: () => new ClaudeCodeAgent(),
+    resolveDataRoot: resolveClaudeCodeDataRoot,
+  },
+  cursor: {
+    create: () => new CursorAgent(),
+    resolveDataRoot: resolveCursorDataRoot,
+  },
+  kimi: {
+    create: () => new KimiAgent(),
+    resolveDataRoot: resolveKimiDataRoot,
+  },
+  "kimi-code": {
+    create: () => new KimiCodeAgent(),
+    resolveDataRoot: resolveKimiCodeDataRoot,
+  },
+  codex: {
+    create: () => new CodexAgent(),
+    resolveDataRoot: resolveCodexDataRoot,
+  },
+  grok: {
+    create: () => new GrokAgent(),
+    resolveDataRoot: resolveGrokDataRoot,
+  },
+  pi: {
+    create: () => new PiAgent(),
+    resolveDataRoot: resolvePiDataRoot,
+  },
+  opencode: {
+    create: () => new OpenCodeAgent(),
+    resolveDataRoot: resolveOpenCodeDataRoot,
+  },
+  zcode: {
+    create: () => new ZCodeAgent(),
+    resolveDataRoot: resolveZCodeDataRoot,
+  },
+  dsh: {
+    create: () => new DshAgent(),
+    resolveDataRoot: resolveDshDataRoot,
+  },
+} satisfies Record<AgentName, AgentRuntimeRegistration>;
 
-registerAgent({
-  icon: "/icon/agent/zcode.svg",
-  resolveDataRoot: resolveZCodeDataRoot,
-  resumeCommandPrefix: null,
-  toolStrategy: "custom",
-  create: () => new ZCodeAgent(),
-});
-
-registerAgent({
-  icon: "/icon/agent/kimi.svg",
-  resolveDataRoot: resolveKimiDataRoot,
-  resumeCommandPrefix: "kimi -r",
-  toolStrategy: "custom",
-  create: () => new KimiAgent(),
-});
-
-registerAgent({
-  icon: "/icon/agent/kimi.svg",
-  resolveDataRoot: resolveKimiCodeDataRoot,
-  resumeCommandPrefix: "kimi -r",
-  toolStrategy: "custom",
-  create: () => new KimiCodeAgent(),
-});
-
-registerAgent({
-  icon: "/icon/agent/codex.svg",
-  resolveDataRoot: resolveCodexDataRoot,
-  resumeCommandPrefix: "codex resume",
-  toolStrategy: "custom",
-  create: () => new CodexAgent(),
-});
-
-registerAgent({
-  icon: "/icon/agent/grok.svg",
-  resolveDataRoot: resolveGrokDataRoot,
-  resumeCommandPrefix: "grok --resume",
-  toolStrategy: "custom",
-  create: () => new GrokAgent(),
-});
-
-registerAgent({
-  icon: "/icon/agent/pi.svg",
-  resolveDataRoot: resolvePiDataRoot,
-  resumeCommandPrefix: "pi --session",
-  toolStrategy: "custom",
-  create: () => new PiAgent(),
-});
-
-registerAgent({
-  icon: "/icon/agent/dsh.svg",
-  iconColored: true,
-  resolveDataRoot: resolveDshDataRoot,
-  // The DSH launcher hands inner arguments to a profile, so no single resume
-  // command holds across installations.
-  resumeCommandPrefix: null,
-  toolStrategy: "custom",
-  create: () => new DshAgent(),
-});
-
-registerAgent({
-  icon: "/icon/agent/cursor.svg",
-  resolveDataRoot: resolveCursorDataRoot,
-  resumeCommandPrefix: null,
-  toolStrategy: "custom",
-  create: () => new CursorAgent(),
-});
+for (const catalogEntry of AGENT_CATALOG) {
+  registerAgent({ ...catalogEntry, ...RUNTIME_REGISTRATIONS[catalogEntry.name] });
+}

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -1,16 +1,12 @@
 import type { BaseAgent } from "./base.js";
 import type { AgentInfo } from "../types/index.js";
+import type { AgentCatalogEntry } from "../contract/agent-catalog.js";
 
-export type AgentToolStrategy = "custom" | "default";
+export type { AgentToolStrategy } from "../contract/agent-catalog.js";
 
-export interface AgentRegistration {
+export interface AgentRegistration extends AgentCatalogEntry {
   create: () => BaseAgent;
-  icon: string;
-  /** Icon uses brand colors that work on both themes; render it as-is instead of tinting with currentColor. */
-  iconColored?: boolean;
   resolveDataRoot: () => string | null;
-  resumeCommandPrefix: string | null;
-  toolStrategy: AgentToolStrategy;
 }
 
 export type AgentRoots = Readonly<Record<string, string | null>>;
@@ -31,23 +27,17 @@ export function getRegisteredAgents(): readonly AgentRegistration[] {
 
 export function resolveAgentRoots(): AgentRoots {
   return Object.fromEntries(
-    registrations.map((registration) => [
-      registration.create().name,
-      registration.resolveDataRoot(),
-    ]),
+    registrations.map((registration) => [registration.name, registration.resolveDataRoot()]),
   );
 }
 
 export function getAgentInfoMap(sessionsByAgent: Record<string, number>): AgentInfo[] {
-  return registrations.map((registration) => {
-    const agent = registration.create();
-    return {
-      name: agent.name,
-      displayName: agent.displayName,
-      icon: registration.icon,
-      iconColored: registration.iconColored,
-      resumeCommandPrefix: registration.resumeCommandPrefix,
-      count: sessionsByAgent[agent.name] ?? 0,
-    };
-  });
+  return registrations.map((registration) => ({
+    name: registration.name,
+    displayName: registration.displayName,
+    icon: registration.icon,
+    iconColored: registration.iconColored,
+    resumeCommandPrefix: registration.resumeCommandPrefix,
+    count: sessionsByAgent[registration.name] ?? 0,
+  }));
 }

--- a/packages/core/src/agents/zcode.ts
+++ b/packages/core/src/agents/zcode.ts
@@ -1,8 +1,11 @@
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
+import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import { firstExisting } from "../discovery/paths.js";
 import { isSqliteAvailable } from "../utils/sqlite.js";
 import { OpenCodeSqliteAgent } from "./opencode-sqlite.js";
+
+const AGENT_METADATA = getAgentCatalogEntry("zcode");
 
 export function resolveZCodeDataRoot(): string | null {
   const currentPlatform = platform();
@@ -28,8 +31,8 @@ function getZCodeSessionWatchPlan() {
 export class ZCodeAgent extends OpenCodeSqliteAgent {
   constructor() {
     super({
-      name: "zcode",
-      displayName: "ZCode",
+      name: AGENT_METADATA.name,
+      displayName: AGENT_METADATA.displayName,
       findDbPath: findZCodeDbPath,
       getSessionWatchPlan: getZCodeSessionWatchPlan,
     });

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -28,6 +28,7 @@ describe("contract browser-safety", () => {
     const contract = await import(distEntry);
     expect(Object.keys(contract).sort()).toEqual(
       [
+        "AGENT_CATALOG",
         "PROJECT_IDENTITY_KINDS",
         "UNKNOWN_AGENT_NAME",
         "addCalendarDays",
@@ -48,6 +49,7 @@ describe("contract browser-safety", () => {
         "getSessionRouteKey",
         "getSessionRoutePath",
         "groupSessionsByCalendarDay",
+        "getAgentCatalogEntry",
         "isProjectIdentityKind",
         "matchesProjectIdentity",
         "mergeSessionsUpdatedEvents",

--- a/packages/core/src/contract/agent-catalog.test.ts
+++ b/packages/core/src/contract/agent-catalog.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_CATALOG, getAgentCatalogEntry } from "./agent-catalog.js";
+
+describe("agent catalog", () => {
+  it("has unique runtime and display identities", () => {
+    const names = AGENT_CATALOG.map(({ name }) => name);
+    const displayNames = AGENT_CATALOG.map(({ displayName }) => displayName);
+
+    expect(AGENT_CATALOG.length).toBeGreaterThan(0);
+    expect(new Set(names).size).toBe(names.length);
+    expect(new Set(displayNames).size).toBe(displayNames.length);
+    expect(getAgentCatalogEntry("kimi").displayName).toBe("Kimi-Cli");
+  });
+});

--- a/packages/core/src/contract/agent-catalog.ts
+++ b/packages/core/src/contract/agent-catalog.ts
@@ -1,0 +1,108 @@
+export type AgentSourceKind = "filesystem" | "sqlite";
+
+export type AgentToolStrategy = "custom" | "default";
+
+export interface AgentCatalogEntry {
+  name: string;
+  displayName: string;
+  icon: string;
+  /** Brand-colored icons render as-is instead of inheriting the current text color. */
+  iconColored?: boolean;
+  sourceKind: AgentSourceKind;
+  resumeCommandPrefix: string | null;
+  toolStrategy: AgentToolStrategy;
+}
+
+export const AGENT_CATALOG = [
+  {
+    name: "claudecode",
+    displayName: "Claude Code",
+    icon: "/icon/agent/claudecode.svg",
+    iconColored: true,
+    sourceKind: "filesystem",
+    resumeCommandPrefix: "claude --resume",
+    toolStrategy: "custom",
+  },
+  {
+    name: "cursor",
+    displayName: "Cursor",
+    icon: "/icon/agent/cursor.svg",
+    sourceKind: "sqlite",
+    resumeCommandPrefix: null,
+    toolStrategy: "custom",
+  },
+  {
+    name: "kimi",
+    displayName: "Kimi-Cli",
+    icon: "/icon/agent/kimi.svg",
+    sourceKind: "filesystem",
+    resumeCommandPrefix: "kimi -r",
+    toolStrategy: "custom",
+  },
+  {
+    name: "kimi-code",
+    displayName: "Kimi-Code",
+    icon: "/icon/agent/kimi.svg",
+    sourceKind: "filesystem",
+    resumeCommandPrefix: "kimi -r",
+    toolStrategy: "custom",
+  },
+  {
+    name: "codex",
+    displayName: "Codex",
+    icon: "/icon/agent/codex.svg",
+    sourceKind: "filesystem",
+    resumeCommandPrefix: "codex resume",
+    toolStrategy: "custom",
+  },
+  {
+    name: "grok",
+    displayName: "Grok",
+    icon: "/icon/agent/grok.svg",
+    sourceKind: "filesystem",
+    resumeCommandPrefix: "grok --resume",
+    toolStrategy: "custom",
+  },
+  {
+    name: "pi",
+    displayName: "Pi",
+    icon: "/icon/agent/pi.svg",
+    sourceKind: "filesystem",
+    resumeCommandPrefix: "pi --session",
+    toolStrategy: "custom",
+  },
+  {
+    name: "opencode",
+    displayName: "OpenCode",
+    icon: "/icon/agent/opencode.svg",
+    sourceKind: "sqlite",
+    resumeCommandPrefix: "opencode -s",
+    toolStrategy: "custom",
+  },
+  {
+    name: "zcode",
+    displayName: "ZCode",
+    icon: "/icon/agent/zcode.svg",
+    sourceKind: "sqlite",
+    resumeCommandPrefix: null,
+    toolStrategy: "custom",
+  },
+  {
+    name: "dsh",
+    displayName: "DSH",
+    icon: "/icon/agent/dsh.svg",
+    iconColored: true,
+    sourceKind: "filesystem",
+    // DSH delegates launch arguments to installation-specific profiles.
+    resumeCommandPrefix: null,
+    toolStrategy: "custom",
+  },
+] as const satisfies readonly AgentCatalogEntry[];
+
+export type AgentName = (typeof AGENT_CATALOG)[number]["name"];
+
+export function getAgentCatalogEntry(name: AgentName): AgentCatalogEntry {
+  const entry = AGENT_CATALOG.find((candidate) => candidate.name === name);
+  if (!entry) throw new Error(`Unknown agent catalog entry: ${name}`);
+  return entry;
+}

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -1,6 +1,7 @@
 export type * from "./session.js";
 export * from "./message-part.js";
 export type * from "./agent.js";
+export * from "./agent-catalog.js";
 export type * from "./file-activity.js";
 export type * from "./search.js";
 export type * from "./bookmarks.js";

--- a/packages/core/src/repository-facts.test.ts
+++ b/packages/core/src/repository-facts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getCoreRepositoryFacts } from "./repository-facts.js";
 
 describe("repository facts", () => {
-  it("derives a complete, unambiguous agent snapshot from the runtime registry", () => {
+  it("derives a complete, unambiguous agent snapshot from the catalog", () => {
     const facts = getCoreRepositoryFacts();
     const names = facts.agents.map(({ name }) => name);
     const displayNames = facts.agents.map(({ displayName }) => displayName);

--- a/packages/core/src/repository-facts.ts
+++ b/packages/core/src/repository-facts.ts
@@ -1,9 +1,7 @@
-import "./agents/register.js";
-import { DatabaseSessionSource, FileSystemSessionSource, type BaseAgent } from "./agents/base.js";
-import { createRegisteredAgents } from "./agents/registry.js";
+import { AGENT_CATALOG, type AgentSourceKind } from "./contract/agent-catalog.js";
 import { CACHE_SCHEMA_VERSION } from "./discovery/cache/version.js";
 
-export type AgentSourceKind = "filesystem" | "sqlite";
+export type { AgentSourceKind } from "./contract/agent-catalog.js";
 
 export interface RepositoryAgentFact {
   name: string;
@@ -16,19 +14,13 @@ export interface CoreRepositoryFacts {
   agents: RepositoryAgentFact[];
 }
 
-function getAgentSourceKind(agent: BaseAgent): AgentSourceKind {
-  if (agent instanceof DatabaseSessionSource) return "sqlite";
-  if (agent instanceof FileSystemSessionSource) return "filesystem";
-  throw new Error(`Registered agent ${agent.name} has no documented source kind`);
-}
-
 export function getCoreRepositoryFacts(): CoreRepositoryFacts {
   return {
     cacheSchemaVersion: CACHE_SCHEMA_VERSION,
-    agents: createRegisteredAgents().map((agent) => ({
-      name: agent.name,
-      displayName: agent.displayName,
-      sourceKind: getAgentSourceKind(agent),
+    agents: AGENT_CATALOG.map(({ name, displayName, sourceKind }) => ({
+      name,
+      displayName,
+      sourceKind,
     })),
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     devDependencies:
+      '@codesesh/core':
+        specifier: workspace:*
+        version: link:packages/core
       '@types/node':
         specifier: 22.20.1
         version: 22.20.1
@@ -161,6 +164,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.10
         version: 0.9.10(@typescript/typescript6@6.0.2)(prettier-plugin-astro@0.14.1)(prettier@3.9.6)
+      '@codesesh/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@hugeicons/core-free-icons':
         specifier: ^4.2.3
         version: 4.2.3

--- a/scripts/check-docs-facts.mjs
+++ b/scripts/check-docs-facts.mjs
@@ -5,7 +5,10 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const FACT_SPECS = [
   { document: "README.md", fact: "agents" },
   { document: "README_CN.md", fact: "agents" },
+  { document: "packages/cli/README.md", fact: "agents" },
   { document: "apps/www/public/llms-full.txt", fact: "agents" },
+  { document: "apps/www/public/llms.txt", fact: "agents" },
+  { document: "apps/www/public/index.md", fact: "agents" },
   { document: "docs/scanning-and-caching.md", fact: "agent-source-kinds" },
   { document: "docs/architecture.md", fact: "agent-source-kinds" },
   { document: "docs/sqlite-storage.md", fact: "cache-schema-version" },

--- a/scripts/check-docs-facts.test.mjs
+++ b/scripts/check-docs-facts.test.mjs
@@ -44,10 +44,12 @@ function fixtureRepo(packageManager = "pnpm@11.20.0", nodeEngine = ">=22.0.0") {
     "package.json": JSON.stringify({ packageManager }),
     ".github/workflows/ci.yml": "steps:\n  - name: Lint\n    run: pnpm lint\n  - run: pnpm test\n",
     "packages/cli/package.json": JSON.stringify({ engines: { node: nodeEngine } }),
-    "packages/cli/README.md": node,
+    "packages/cli/README.md": `${agentsTable}\n${node}`,
     "README.md": `${agentsTable}\n${node}\n${pnpm}\n${ciCommands}`,
     "README_CN.md": `${agentsTable}\n${node}\n${pnpm}\n${ciCommands}`,
     "apps/www/public/llms-full.txt": `${agentsList}\n${node}\n${node}\n${pnpm}\n${pnpm}`,
+    "apps/www/public/llms.txt": agentsList,
+    "apps/www/public/index.md": agentsList,
     "docs/scanning-and-caching.md": sourceKinds,
     "docs/architecture.md": sourceKinds,
     "docs/sqlite-storage.md": marked(
@@ -91,7 +93,7 @@ describe("CS-172: semantic documentation facts", () => {
     });
   });
 
-  it("reports a newly registered agent in both support and source-kind declarations", () => {
+  it("reports a newly cataloged agent in both support and source-kind declarations", () => {
     const mismatches = findDocumentationFactMismatches(fixtureRepo(), {
       ...coreFacts,
       agents: [
@@ -100,7 +102,7 @@ describe("CS-172: semantic documentation facts", () => {
       ],
     });
 
-    expect(mismatches).toHaveLength(5);
+    expect(mismatches).toHaveLength(8);
     expect(mismatches.every(({ message }) => message.includes('missing ["Fixture"]'))).toBe(true);
   });
 
@@ -165,6 +167,8 @@ describe("CS-172: semantic documentation facts", () => {
         "packages/cli/README.md",
         "docs/architecture.md",
         "apps/www/public/llms-full.txt",
+        "apps/www/public/llms.txt",
+        "apps/www/public/index.md",
       ]),
     );
   });

--- a/tests/e2e/www.spec.ts
+++ b/tests/e2e/www.spec.ts
@@ -1,18 +1,8 @@
 import { expect, test } from "./test-fixtures.js";
+import { AGENT_CATALOG } from "@codesesh/core/contract";
 
 const siteUrl = "https://codesesh.xingkaixin.me";
-const supportedAgents = [
-  "Claude Code",
-  "Cursor",
-  "Kimi",
-  "Kimi-Code",
-  "Codex",
-  "Grok",
-  "Pi",
-  "OpenCode",
-  "ZCode",
-  "DSH",
-] as const;
+const supportedAgents = AGENT_CATALOG.map(({ displayName }) => displayName);
 
 const locales = [
   { route: "/", language: "en", canonical: `${siteUrl}/` },


### PR DESCRIPTION
## Summary

- introduce a browser-safe Agent Catalog as the canonical source for built-in identities and declared capabilities
- derive runtime registration, repository facts, product-site content, and end-to-end expectations from the catalog
- validate app and product-site icons plus all documented supported-agent lists
- correct the Kimi-Cli label and update extension guidance

## Testing

- pnpm lint
- pnpm format:check
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm test:coverage
- pnpm test:migration
- pnpm --filter @codesesh/web test:bundle
- pnpm test:e2e
- pnpm typecheck:e2e
- repository quality, documentation, release, and performance gates