### PR TITLE
fix(sessions): require identity before publication

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,12 @@ _Avoid_: Session Tree, parent-child graph
 用于列表、分组、搜索和统计的轻量 Session 摘要，不包含完整消息正文；其中的统计只归属于该 Session，不包含 descendant Session 的汇总。
 _Avoid_: Session metadata
 
+**Identified Session Head**:
+已具备 Project Identity 的 Session Head；只有这种完成态可以写入 SQLite、进入 Live Snapshot
+或通过公开列表契约返回。Agent 适配器刚解析出的 Session Head 可以暂时没有 Project
+Identity，但扫描编排必须先补全它。
+_Avoid_: Published session, resolved session
+
 **Inclusive Session Stats**:
 从 Session Hierarchy 派生的统计汇总，包含目标 Session 与每个可挂载 descendant Session 恰好一次。
 _Avoid_: Session stats, parent stats
@@ -54,7 +60,7 @@ _Avoid_: Project path, bare project key
 _Avoid_: Project folder, workspace
 
 **Live Snapshot**:
-CodeSesh 当前已发布、可供查询和浏览的一组 Session Head 及其派生统计。
+CodeSesh 当前已发布、可供查询和浏览的一组 Identified Session Head 及其派生统计。
 _Avoid_: Cache, session list
 
 **Session Alias**:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,9 +21,11 @@ CLI Entry (packages/cli/src/index.ts)
        -> 后续文件事件继续触发对应 Agent 的 refresh
 ```
 
-初始 SQLite 快照可以立即被 API 读取。后台结果只有在对应持久化事务成功后才进入内存
-快照，因此客户端不会先看到无法从 SQLite 重建的状态。详细的变更检测、回填、失败保留
-和发布规则见 [scanning-and-caching.md](./scanning-and-caching.md)。
+初始 SQLite 快照可以立即被 API 读取。缓存行与后台扫描结果都必须先具备 Project
+Identity；SQLite 解码器与 `LiveSessionIndex` 分别在持久化恢复和内存发布边界拒绝不完整
+Session Head。后台结果只有在对应持久化事务成功后才进入内存快照，因此客户端不会先看到
+无法从 SQLite 重建的状态。详细的变更检测、回填、失败保留和发布规则见
+[scanning-and-caching.md](./scanning-and-caching.md)。
 
 ## 一次性 JSON 模式
 

--- a/docs/scanning-and-caching.md
+++ b/docs/scanning-and-caching.md
@@ -69,7 +69,7 @@ worker 只读取该联合类型，不按具体类身份选择策略；包装 Age
 
 ```text
 loadCachedSessions()
-  -> 从 agent_cache + sessions 恢复 SessionHead[] / SessionCacheMeta
+  -> 从 agent_cache + sessions 恢复 IdentifiedSessionHead[] / SessionCacheMeta
   -> 启动 HTTP 服务
   -> startBackgroundRefresh()
   -> 逐 Agent 核对真实数据源并更新快照
@@ -146,7 +146,12 @@ last-known-good 顺序不会泄漏到编排器。
 
 ## 持久化与发布
 
-刷新结果先计算 `changedSessions` 和 `removedSessionIds`，再交给 search-index worker：
+Agent 适配器可以先产出尚无 Project Identity 的 `SessionHead`，但扫描编排必须在计算发布
+结果前补全身份。缓存读侧会拒绝缺少身份的损坏行，`LiveSessionIndex` 也会拒绝不完整输入，
+因此 SQLite、Live Snapshot 和公开列表只包含 `IdentifiedSessionHead`。
+
+刷新结果完成身份解析后计算 `changedSessions` 和 `removedSessionIds`，再交给
+search-index worker：
 
 ```text
 saveCachedSessionChanges()
@@ -171,7 +176,8 @@ saveCachedSessionChanges()
 3. 指纹不一致、消息缺失或会话待 reindex 时调用适配器 `getSessionData()` 回源。
 
 所以一致性模型是“materialized detail + 源指纹失效 + 回源兜底”，不是“详情永远实时
-读取源文件”。完整规则见 [sqlite-storage.md](./sqlite-storage.md#3-读取会话详情)。
+读取源文件”。Project Identity 已在快照发布前完成，详情 HTTP 请求不会再执行文件系统或
+Git 身份探测。完整规则见 [sqlite-storage.md](./sqlite-storage.md#3-读取会话详情)。
 
 ## 窗口扫描与 backfill
 
@@ -219,6 +225,7 @@ pnpm bench:perf -- --iterations 3
 ## 正确性不变量
 
 - 新快照只能在对应 SQLite 写入成功后发布。
+- Session Head 必须具备 Project Identity 后才能写入 SQLite 或进入 Live Snapshot。
 - 文件型会话是否变化由 source fingerprint 决定，不由全局 mtime 截断决定。
 - one-shot 与 worker 文件源路径必须消费同一 synchronization outcome，不能各自实现 diff/merge。
 - 数据库型 Agent 检测到数据库变化后必须全量重扫。

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -7,6 +7,7 @@ import {
 import type {
   AggregateSessionSourceCapability,
   BaseAgent,
+  IdentifiedSessionHead,
   loadCachedSessions,
   LiveSnapshot,
   PendingSearchIndexMaintenance,
@@ -105,7 +106,7 @@ vi.mock("./search-index-job-runner.js", () => ({
 
 import { AgentSyncEngine } from "./agent-sync-engine.js";
 
-function makeSession(id: string, title = id): SessionHead {
+function makeSession(id: string, title = id): IdentifiedSessionHead {
   const session: SessionHead = {
     reference: { agentName: "codex", sessionId: id },
     id,
@@ -212,7 +213,7 @@ function makeWorkerRunner(): WorkerRunner {
 
 function makeEngine(
   agent: BaseAgent,
-  sessions: SessionHead[] = [],
+  sessions: IdentifiedSessionHead[] = [],
   workerRunner: WorkerRunner = makeWorkerRunner(),
   startupScanOptions: { from?: number; to?: number } = {},
 ) {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -13,6 +13,7 @@ import {
   sessionSignature,
   type BaseAgent,
   type AggregateSessionSourceCapability,
+  type IdentifiedSessionHead,
   type ScanOptions,
   type LiveSnapshot,
   type SessionHead,
@@ -51,7 +52,7 @@ export type { AgentOperationResult } from "./agent-operation-scheduler.js";
 
 export interface AgentSessionsChanged {
   agentName: string;
-  sessions: SessionHead[];
+  sessions: IdentifiedSessionHead[];
   event: SessionsUpdatedEvent | null;
 }
 
@@ -69,14 +70,14 @@ type StatusChangedListener = (event: ScanStatusEvent) => void;
 type CachedSessions = NonNullable<ReturnType<typeof loadCachedSessions>>;
 
 interface SessionPersistenceDiff {
-  changedSessions: PersistedSessionHeadChange[];
+  changedSessions: PersistedSessionHeadChange<IdentifiedSessionHead>[];
   removedSessionIds: string[];
 }
 
 interface SessionPublication {
   context: "scan.refresh" | "scan.backfill";
   agentName: string;
-  sessions: SessionHead[];
+  sessions: IdentifiedSessionHead[];
   candidateChangedIds: string[];
   indexJob: SearchIndexWorkerJob;
   onPublishing?: () => void;
@@ -96,8 +97,8 @@ interface RefreshResult {
 
 interface RefreshStrategyResult {
   status: "continue" | "unchanged";
-  nextSessions: SessionHead[];
-  fullScanSessions: SessionHead[] | null;
+  nextSessions: IdentifiedSessionHead[];
+  fullScanSessions: IdentifiedSessionHead[] | null;
   preciseChangedIds: string[] | null;
   persistenceDiff: SessionPersistenceDiff | null;
   checkDuration: number;
@@ -119,7 +120,7 @@ const SOURCE_FAILURE_SUMMARY_MAX_LENGTH = 160;
 
 function buildPersistenceDiff(
   previousSessions: SessionHead[],
-  nextSessions: SessionHead[],
+  nextSessions: IdentifiedSessionHead[],
   candidateChangedIds: string[] = [],
   completeness: SessionSnapshotCompleteness = "complete",
   explicitRemovedSessionIds: readonly string[] = [],
@@ -594,7 +595,7 @@ export class AgentSyncEngine {
 
   private async initializeAgent(
     agent: BaseAgent,
-    previousSessions: SessionHead[],
+    previousSessions: IdentifiedSessionHead[],
   ): Promise<RefreshStrategyResult> {
     this.statusReporter.setScanPhase("initializing");
     const scanStartedAt = performance.now();
@@ -654,7 +655,7 @@ export class AgentSyncEngine {
   private async refreshChangedAgent(
     agent: BaseAgent,
     source: AggregateSessionSourceCapability,
-    baseline: SessionHead[],
+    baseline: IdentifiedSessionHead[],
     cacheTimestamp: number,
     refreshStartedAt: number,
   ): Promise<RefreshStrategyResult> {
@@ -766,7 +767,7 @@ export class AgentSyncEngine {
 
   private async scanAgentFully(
     agent: BaseAgent,
-    previousSessions: SessionHead[],
+    previousSessions: IdentifiedSessionHead[],
   ): Promise<RefreshStrategyResult> {
     const scanStartedAt = performance.now();
     const scope = this.startupScanOptions();
@@ -783,7 +784,7 @@ export class AgentSyncEngine {
   }
 
   private refreshStrategyResult(
-    nextSessions: SessionHead[],
+    nextSessions: IdentifiedSessionHead[],
     completeness: SessionSnapshotCompleteness,
     scope: Pick<ScanOptions, "from" | "to">,
     overrides: Partial<Omit<RefreshStrategyResult, "nextSessions" | "completeness" | "scope">> = {},

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -102,6 +102,7 @@ import type {
   ChangeCheckResult,
   DashboardCostFacts,
   FileActivityResult,
+  IdentifiedSessionHead,
   LiveSnapshot,
   SessionCacheMeta,
   SessionHead,
@@ -113,16 +114,25 @@ import { appLogger } from "../../logging.js";
 
 // --- Helpers ---
 
-function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
+function makeSession(
+  id: string,
+  overrides?: Partial<IdentifiedSessionHead>,
+): IdentifiedSessionHead {
   const identity = createSessionIdentity(
     overrides?.reference ?? { agentName: "agent", sessionId: id },
   );
+  const directory = overrides?.directory ?? "/home/user/project";
   return {
     ...identity,
     title: `Session ${id}`,
     time_created: Date.now(),
     time_updated: Date.now(),
-    directory: "/home/user/project",
+    directory,
+    project_identity: {
+      kind: "path",
+      key: directory,
+      displayName: "project",
+    },
     stats: {
       message_count: 0,
       total_input_tokens: 0,
@@ -2027,37 +2037,6 @@ describe("handleGetSessionData", () => {
         sessionId: "s1",
       },
       {},
-    );
-    expect(c.json).toHaveBeenCalledWith(detail);
-  });
-
-  it("resolves a missing identity off the request path and retries", async () => {
-    coreMocks.materializeSessionDetailResponse
-      .mockReturnValueOnce({ status: "needs-identity", directory: "/workspace/project" })
-      .mockReturnValueOnce({ status: "found", data: detail });
-    const identity = {
-      kind: "path" as const,
-      key: "/workspace/project",
-      displayName: "project",
-    };
-    const resolver = {
-      resolve: vi.fn(async () => ({
-        identity,
-        resolverRevision: "test",
-        inputSignature: "sig",
-      })),
-      shutdown: vi.fn(async () => undefined),
-    };
-    const scanSource = makeScanSource();
-    const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
-
-    await handleGetSessionData(c, scanSource, resolver);
-
-    expect(resolver.resolve).toHaveBeenCalledWith("/workspace/project", expect.any(AbortSignal));
-    expect(coreMocks.materializeSessionDetailResponse).toHaveBeenLastCalledWith(
-      scanSource.getSnapshot(),
-      { agentName: "claudecode", sessionId: "s1" },
-      { projectIdentityFallback: identity },
     );
     expect(c.json).toHaveBeenCalledWith(detail);
   });

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -1,5 +1,5 @@
 import type { Context } from "hono";
-import type { SessionHead, SmartTag } from "@codesesh/core";
+import type { IdentifiedSessionHead, SessionHead, SmartTag } from "@codesesh/core";
 import {
   addCalendarDays,
   countCalendarDays,
@@ -28,7 +28,6 @@ import {
   buildDashboard,
   type DashboardData,
   type DashboardScope,
-  type ProjectIdentityProjection,
   type ProjectScopeMatcher,
 } from "@codesesh/core";
 import { appLogger } from "../logging.js";
@@ -80,7 +79,7 @@ export const KNOWN_AGENT_NAME_SET = new Set(KNOWN_AGENT_NAMES);
 
 async function resolveProjectScope(
   cwd: string,
-  sessions: readonly SessionHead[],
+  sessions: readonly IdentifiedSessionHead[],
   resolver: ProjectIdentityResolver | undefined,
   signal: AbortSignal,
 ): Promise<ProjectScopeMatcher> {
@@ -88,11 +87,10 @@ async function resolveProjectScope(
   const matchingSession = sessions.find(
     (session) =>
       normalizeProjectDirectory(session.directory) === normalizedCwd &&
-      session.project_identity != null &&
       session.project_identity_resolver_revision === PROJECT_IDENTITY_RESOLVER_REVISION &&
       Boolean(session.project_identity_input_signature),
   );
-  if (matchingSession?.project_identity) {
+  if (matchingSession) {
     return createProjectScopeMatcherFromIdentity(cwd, matchingSession.project_identity);
   }
   if (!resolver) throw new Error("Project identity resolver is unavailable");
@@ -145,7 +143,7 @@ interface ClientLogPayload {
   data?: unknown;
 }
 
-function toSessionListItem(session: SessionHead): SessionHead {
+function toSessionListItem(session: IdentifiedSessionHead): IdentifiedSessionHead {
   const {
     model_usage: _modelUsage,
     project_identity_resolver_revision: _resolverRevision,
@@ -539,11 +537,7 @@ export async function handleGetFileActivity(
   });
 }
 
-export async function handleGetSessionData(
-  c: Context,
-  scanSource: ScanResultSource,
-  resolver?: ProjectIdentityResolver,
-) {
+export async function handleGetSessionData(c: Context, scanSource: ScanResultSource) {
   const startedAt = performance.now();
   const agentName = c.req.param("agent");
   const sessionId = c.req.param("id");
@@ -562,25 +556,11 @@ export async function handleGetSessionData(
       sessionId,
     };
     const messageCursor = optionalQueryValue(c.req.query("messageCursor"));
-    const materialize = (fallback?: ProjectIdentityProjection["identity"]) =>
-      materializeSessionDetailResponse(scanSource.getSnapshot(), reference, {
-        ...(messageCursor ? { messageCursor } : {}),
-        ...(fallback ? { projectIdentityFallback: fallback } : {}),
-      });
-    let result = materialize();
-    if (result.status === "needs-identity") {
-      // Identity resolution probes the filesystem and spawns git; it must run
-      // on the worker resolver, never synchronously on the request path.
-      if (!resolver) throw new Error("Project identity resolver is unavailable");
-      try {
-        result = materialize((await resolver.resolve(result.directory, c.req.raw.signal)).identity);
-      } catch (error) {
-        return projectScopeResolutionFailureResponse(c, "session-data", error);
-      }
-    }
-    if (result.status === "needs-identity") {
-      throw new Error("Project identity fallback was not applied");
-    }
+    const result = materializeSessionDetailResponse(
+      scanSource.getSnapshot(),
+      reference,
+      messageCursor ? { messageCursor } : {},
+    );
     if (result.status === "unknown-agent") {
       return c.json({ error: `Unknown agent: ${agentName}` }, 404);
     }

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -224,10 +224,10 @@ export function parseSearchOptions(
   };
 }
 
-export function filterSessionsByActivityWindow(
-  sessions: SessionHead[],
+export function filterSessionsByActivityWindow<T extends SessionHead>(
+  sessions: T[],
   from: number | undefined,
   to: number | undefined,
-): SessionHead[] {
+): T[] {
   return filterSessionTreeByActivityWindow(sessions, from, to);
 }

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -165,9 +165,7 @@ export function createApiRoutes(
   api.get("/file-activity", (c) =>
     handleGetFileActivity(c, listDefaults, options.projectIdentityResolver),
   );
-  api.get("/sessions/:agent/:id", (c) =>
-    handleGetSessionData(c, scanSource, options.projectIdentityResolver),
-  );
+  api.get("/sessions/:agent/:id", (c) => handleGetSessionData(c, scanSource));
   api.get("/dashboard", (c) => handleGetDashboard(c, scanSource, listDefaults));
   api.get("/bookmarks", (c) => handleGetBookmarks(c, scanSource));
   api.put("/bookmarks", (c) => handlePutBookmark(c));

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -7,6 +7,7 @@ import {
   FileSystemSessionSource,
   type AgentScanOptions,
   type ChangeCheckResult,
+  type IdentifiedSessionHead,
   type AgentRoots,
   type ScanOptions,
   type SessionCacheMeta,
@@ -494,7 +495,7 @@ function registerMockWatcher(
   };
 }
 
-function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
+function makeSession(id: string, overrides: Partial<SessionHead> = {}): IdentifiedSessionHead {
   const identity = createSessionIdentity(
     overrides.reference ?? { agentName: "codex", sessionId: id },
   );

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { BaseAgent, LiveSnapshot, SessionHead } from "@codesesh/core";
+import type { BaseAgent, IdentifiedSessionHead, LiveSnapshot } from "@codesesh/core";
 import { LiveSessionIndex } from "./live-session-index.js";
 
 function makeAgent(name: string): BaseAgent {
@@ -9,13 +9,19 @@ function makeAgent(name: string): BaseAgent {
   } as BaseAgent;
 }
 
-function makeSession(id: string, updatedAt: number, title = id, agentName = "codex"): SessionHead {
+function makeSession(
+  id: string,
+  updatedAt: number,
+  title = id,
+  agentName = "codex",
+): IdentifiedSessionHead {
   return {
     reference: { agentName, sessionId: id },
     id,
     slug: `${agentName}/${id}`,
     title,
     directory: "/workspace",
+    project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
     time_created: updatedAt,
     time_updated: updatedAt,
     stats: {
@@ -27,11 +33,32 @@ function makeSession(id: string, updatedAt: number, title = id, agentName = "cod
   };
 }
 
-function snapshot(agents: BaseAgent[], byAgent: Record<string, SessionHead[]>): LiveSnapshot {
+function snapshot(
+  agents: BaseAgent[],
+  byAgent: Record<string, IdentifiedSessionHead[]>,
+): LiveSnapshot {
   return { agents, byAgent, sessions: Object.values(byAgent).flat() };
 }
 
 describe("LiveSessionIndex", () => {
+  it("rejects unresolved project identities at snapshot boundaries", () => {
+    const codex = makeAgent("codex");
+    const unresolved = {
+      ...makeSession("unresolved", 1),
+      project_identity: undefined,
+    } as unknown as IdentifiedSessionHead;
+    const index = new LiveSessionIndex();
+
+    expect(() => index.initialize(snapshot([codex], { codex: [unresolved] }))).toThrow(
+      "Session codex/unresolved is missing project_identity",
+    );
+
+    index.initialize(snapshot([codex], { codex: [] }));
+    expect(() => index.commitAgentSessions("codex", [unresolved])).toThrow(
+      "Session codex/unresolved is missing project_identity",
+    );
+  });
+
   it("rejects conflicting session identities at snapshot boundaries", () => {
     const codex = makeAgent("codex");
     const conflicting = { ...makeSession("session", 1), id: "other" };

--- a/packages/cli/src/live-session-index.ts
+++ b/packages/cli/src/live-session-index.ts
@@ -6,10 +6,11 @@ import {
   sortSessions,
   type AgentScanFailure,
   type BaseAgent,
+  type IdentifiedSessionHead,
   type LiveSnapshot,
-  type SessionHead,
 } from "@codesesh/core";
 import {
+  assertIdentifiedSessionHead,
   assertSessionIdentity,
   createSessionProjectionContext,
   type SessionsUpdatedEvent,
@@ -23,8 +24,8 @@ export interface LiveSessionIndexOptions {
 export class LiveSessionIndex {
   private agents: BaseAgent[] = [];
   private agentsByName = new Map<string, BaseAgent>();
-  private byAgent: Record<string, SessionHead[]> = {};
-  private sessions: SessionHead[] = [];
+  private byAgent: Record<string, IdentifiedSessionHead[]> = {};
+  private sessions: IdentifiedSessionHead[] = [];
   private cacheFailures: Record<string, AgentCacheFailure> = {};
   private scanFailures: Record<string, AgentScanFailure> = {};
   private signatureCaches = new Map<string, Map<string, string>>();
@@ -46,7 +47,10 @@ export class LiveSessionIndex {
       this.agents.flatMap((agent) => {
         if (this.scanFailures[agent.name] && !(agent.name in snapshot.byAgent)) return [];
         const sessions = snapshot.byAgent[agent.name] ?? [];
-        for (const session of sessions) assertSessionIdentity(session, agent.name);
+        for (const session of sessions) {
+          assertSessionIdentity(session, agent.name);
+          assertIdentifiedSessionHead(session);
+        }
         return [[agent.name, sortSessions(sessions)]];
       }),
     );
@@ -70,10 +74,13 @@ export class LiveSessionIndex {
 
   commitAgentSessions(
     agentName: string,
-    nextSessions: SessionHead[],
+    nextSessions: IdentifiedSessionHead[],
     candidateChangedIds: string[] = [],
   ): SessionsUpdatedEvent | null {
-    for (const session of nextSessions) assertSessionIdentity(session, agentName);
+    for (const session of nextSessions) {
+      assertSessionIdentity(session, agentName);
+      assertIdentifiedSessionHead(session);
+    }
     delete this.cacheFailures[agentName];
     delete this.scanFailures[agentName];
     const previousSessions = this.byAgent[agentName] ?? [];

--- a/packages/cli/src/pending-search-index-jobs.test.ts
+++ b/packages/cli/src/pending-search-index-jobs.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from "vitest";
-import type { SessionCacheMeta, SessionHead } from "@codesesh/core";
+import type { IdentifiedSessionHead, SessionCacheMeta } from "@codesesh/core";
 import { PendingSearchIndexJobs } from "./pending-search-index-jobs.js";
 import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 
-function makeSession(id: string, title: string): SessionHead {
+function makeSession(id: string, title: string): IdentifiedSessionHead {
   return {
     reference: { agentName: "agent", sessionId: id },
     id,
     slug: `agent/${id}`,
     title,
     directory: "/tmp/project",
+    project_identity: { kind: "path", key: "/tmp/project", displayName: "project" },
     time_created: 1,
     stats: {
       message_count: 1,

--- a/packages/cli/src/pending-search-index-jobs.ts
+++ b/packages/cli/src/pending-search-index-jobs.ts
@@ -1,4 +1,5 @@
 import type {
+  IdentifiedSessionHead,
   PersistedSessionHeadChange,
   SearchIndexSyncOptions,
   SessionCacheMeta,
@@ -21,7 +22,7 @@ interface PendingChanges {
   context: string;
   agentName: string;
   publicationId?: string;
-  changesBySessionId: Map<string, PersistedSessionHeadChange>;
+  changesBySessionId: Map<string, PersistedSessionHeadChange<IdentifiedSessionHead>>;
   removedSessionIds: Set<string>;
   meta: Record<string, SessionCacheMeta>;
   searchIndexOptions?: SearchIndexSyncOptions;

--- a/packages/cli/src/search-index-maintenance-scheduler.ts
+++ b/packages/cli/src/search-index-maintenance-scheduler.ts
@@ -1,6 +1,7 @@
 import {
   loadCachedSessions,
   readPendingSearchIndexMaintenance,
+  type IdentifiedSessionHead,
   type PersistedSessionHeadChange,
 } from "@codesesh/core";
 import type { SearchIndexMaintenanceStatus } from "@codesesh/core/contract";
@@ -102,10 +103,12 @@ export class SearchIndexMaintenanceScheduler {
         { session, sortIndex },
       ]),
     );
-    const changes = pending.sessionIds.flatMap((sessionId): PersistedSessionHeadChange[] => {
-      const change = sessionsById.get(sessionId);
-      return change ? [change] : [];
-    });
+    const changes = pending.sessionIds.flatMap(
+      (sessionId): PersistedSessionHeadChange<IdentifiedSessionHead>[] => {
+        const change = sessionsById.get(sessionId);
+        return change ? [change] : [];
+      },
+    );
     if (changes.length === 0) {
       throw new Error(`No cached sessions matched pending maintenance for ${agentName}`);
     }

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -9,11 +9,11 @@ import {
   synchronizePricingGeneration,
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,
+  type IdentifiedSessionHead,
   type SearchIndexSyncResult,
   type SearchIndexSyncOptions,
   type SessionCacheMeta,
   type PersistedSessionHeadChange,
-  type SessionHead,
   type SessionSnapshotCompleteness,
   type DurableSessionPublicationFailureStage,
 } from "@codesesh/core";
@@ -50,7 +50,7 @@ export type SearchIndexWorkerJob =
       kind: "full";
       context: string;
       agentName: string;
-      sessions: SessionHead[];
+      sessions: IdentifiedSessionHead[];
       meta: Record<string, SessionCacheMeta>;
       completeness: SessionSnapshotCompleteness;
       removedSessionIds: string[];
@@ -62,7 +62,7 @@ export type SearchIndexWorkerJob =
       kind: "changes";
       context: string;
       agentName: string;
-      changes: PersistedSessionHeadChange[];
+      changes: PersistedSessionHeadChange<IdentifiedSessionHead>[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       publicationId?: string;
@@ -72,7 +72,7 @@ export type SearchIndexWorkerJob =
       kind: "maintenance";
       context: string;
       agentName: string;
-      changes: PersistedSessionHeadChange[];
+      changes: PersistedSessionHeadChange<IdentifiedSessionHead>[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       searchIndexOptions?: SearchIndexSyncOptions;
@@ -84,7 +84,7 @@ export interface SearchIndexWorkerRunRequest {
   jobs?: SearchIndexWorkerJob[];
   context: string;
   agentNames?: string[];
-  sessionsByAgent?: Record<string, SessionHead[]>;
+  sessionsByAgent?: Record<string, IdentifiedSessionHead[]>;
   metaByAgent?: Record<string, Record<string, SessionCacheMeta>>;
 }
 

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -140,6 +140,11 @@ function createLargeSessionsStore() {
     slug: `codex/session-${index}`,
     title: `Session with a reasonably descriptive title ${index}`,
     directory: "/repo/some/nested/project/directory",
+    project_identity: {
+      kind: "path" as const,
+      key: "/repo/some/nested/project/directory",
+      displayName: "project",
+    },
     time_created: index,
     stats: {
       message_count: 1,

--- a/packages/cli/src/session-index-output.test.ts
+++ b/packages/cli/src/session-index-output.test.ts
@@ -1,18 +1,19 @@
 import { describe, expect, it } from "vitest";
-import type { LiveSnapshot, SessionHead } from "@codesesh/core";
+import type { IdentifiedSessionHead, LiveSnapshot } from "@codesesh/core";
 import {
   buildSessionIndexOutput,
   formatCacheFailureDiagnostics,
   formatScanFailureDiagnostics,
 } from "./session-index-output.js";
 
-function makeSession(id: string, activity: number): SessionHead {
+function makeSession(id: string, activity: number): IdentifiedSessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
     id,
     slug: `codex/${id}`,
     title: id,
     directory: "/workspace",
+    project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
     time_created: activity,
     time_updated: activity,
     stats: {
@@ -24,7 +25,9 @@ function makeSession(id: string, activity: number): SessionHead {
   };
 }
 
-function makeSnapshot(sessions: SessionHead[]): Pick<LiveSnapshot, "sessions" | "byAgent"> {
+function makeSnapshot(
+  sessions: IdentifiedSessionHead[],
+): Pick<LiveSnapshot, "sessions" | "byAgent"> {
   return { sessions, byAgent: { codex: sessions } };
 }
 
@@ -32,6 +35,7 @@ function makeSnapshot(sessions: SessionHead[]): Pick<LiveSnapshot, "sessions" | 
 const DOCUMENTED_SESSION_FIELDS = [
   "directory",
   "id",
+  "project_identity",
   "reference",
   "slug",
   "stats",

--- a/packages/cli/src/session-index-output.ts
+++ b/packages/cli/src/session-index-output.ts
@@ -8,8 +8,8 @@
 import {
   filterSessionTreeByActivityWindow,
   getAgentInfoMap,
+  type IdentifiedSessionHead,
   type LiveSnapshot,
-  type SessionHead,
 } from "@codesesh/core";
 
 export interface SessionIndexAgent {
@@ -21,7 +21,7 @@ export interface SessionIndexAgent {
 
 export interface SessionIndexOutput {
   agents: SessionIndexAgent[];
-  sessions: SessionHead[];
+  sessions: IdentifiedSessionHead[];
 }
 
 export interface SessionIndexWindow {

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -35,6 +35,7 @@ describe("contract browser-safety", () => {
         "agentRoutePath",
         "applySessionChanges",
         "applySessionWindowChanges",
+        "assertIdentifiedSessionHead",
         "assertSessionIdentity",
         "buildSessionTree",
         "createSessionProjectionContext",

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -1,4 +1,5 @@
 export type * from "./session.js";
+export { assertIdentifiedSessionHead } from "./session.js";
 export * from "./message-part.js";
 export type * from "./agent.js";
 export * from "./agent-catalog.js";

--- a/packages/core/src/contract/session-index.ts
+++ b/packages/core/src/contract/session-index.ts
@@ -20,7 +20,7 @@ export function compareSessionActivityDesc(a: SessionHead, b: SessionHead): numb
   return (b.time_updated ?? b.time_created) - (a.time_updated ?? a.time_created);
 }
 
-export function sortSessionsByActivity(sessions: SessionHead[]): SessionHead[] {
+export function sortSessionsByActivity<T extends SessionHead>(sessions: T[]): T[] {
   for (let index = 1; index < sessions.length; index += 1) {
     if (compareSessionActivityDesc(sessions[index - 1]!, sessions[index]!) > 0) {
       return [...sessions].sort(compareSessionActivityDesc);
@@ -37,13 +37,13 @@ export function sortSessionsByActivity(sessions: SessionHead[]): SessionHead[] {
  * would produce, so the result is element-for-element identical to
  * `sortSessionsByActivity(shards.flat())` at O(n·k) instead of O(n log n).
  */
-export function mergeSortedSessions(shards: SessionHead[][]): SessionHead[] {
+export function mergeSortedSessions<T extends SessionHead>(shards: T[][]): T[] {
   const active = shards.filter((shard) => shard.length > 0);
   if (active.length === 0) return [];
   if (active.length === 1) return [...active[0]!];
 
   const total = active.reduce((sum, shard) => sum + shard.length, 0);
-  const merged: SessionHead[] = [];
+  const merged: T[] = [];
   const cursors = Array.from({ length: active.length }, () => 0);
 
   for (let position = 0; position < total; position += 1) {

--- a/packages/core/src/contract/session-tree.ts
+++ b/packages/core/src/contract/session-tree.ts
@@ -251,12 +251,12 @@ export function groupSessionsByCalendarDay(nodes: SessionTreeNode[]): SessionDay
  * mounted descendant of a match. The input order is preserved so callers keep
  * their existing sort behavior.
  */
-export function filterSessionTreeByActivityWindow(
-  sessions: SessionHead[],
+export function filterSessionTreeByActivityWindow<T extends SessionHead>(
+  sessions: T[],
   from?: number,
   to?: number,
   tree: SessionTree = buildSessionTree(sessions),
-): SessionHead[] {
+): T[] {
   if (from == null && to == null) return sessions;
 
   const pending = filterSessionTreeEntriesByActivityWindow(tree, from, to);

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -163,8 +163,12 @@ export interface SessionHead extends SessionIdentity {
   smart_tags_classifier_revision?: string;
 }
 
+export interface IdentifiedSessionHead extends SessionHead {
+  project_identity: ProjectIdentity;
+}
+
 export interface SessionListPage {
-  sessions: SessionHead[];
+  sessions: IdentifiedSessionHead[];
   nextCursor?: string;
 }
 
@@ -195,4 +199,17 @@ export interface SessionDetail extends SessionIdentity {
   smart_tags_source_updated_at?: number;
   smart_tags_classifier_revision?: string;
   file_activity?: SessionFileActivity[];
+}
+
+export interface IdentifiedSessionDetail extends SessionDetail {
+  project_identity: ProjectIdentity;
+}
+
+export function assertIdentifiedSessionHead(
+  session: SessionHead,
+): asserts session is IdentifiedSessionHead {
+  if (session.project_identity) return;
+  throw new Error(
+    `Session ${session.reference.agentName}/${session.reference.sessionId} is missing project_identity`,
+  );
 }

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { SessionHead, SessionDetail } from "../../types/index.js";
+import type { IdentifiedSessionHead, SessionDetail, SessionHead } from "../../types/index.js";
 import {
   BaseAgent,
   FileSystemSessionSource,
@@ -38,7 +38,7 @@ function makeSession(
   };
 }
 
-function withCurrentIdentity(session: SessionHead): SessionHead {
+function withCurrentIdentity(session: SessionHead): IdentifiedSessionHead {
   const projection = computeIdentityProjection(session.directory, realFs);
   return {
     ...session,
@@ -387,7 +387,7 @@ describe("finalizeAgentScan", () => {
   });
 
   it("persists an incremental diff and marks the result refreshed", async () => {
-    const cachedSessions = [makeSession("old")];
+    const cachedSessions = [withCurrentIdentity(makeSession("old"))];
     const updatedSessions = [makeSession("new")];
     const agent = createTestAgent({ name: "test", available: true, sessions: updatedSessions });
 
@@ -421,7 +421,7 @@ describe("finalizeAgentScan", () => {
   });
 
   it("serves fresh heads without advancing the durable timestamp when an incremental write fails", async () => {
-    const cachedSessions = [makeSession("old")];
+    const cachedSessions = [withCurrentIdentity(makeSession("old"))];
     const updatedSessions = [makeSession("new")];
     const agent = createTestAgent({ name: "test", available: true, sessions: updatedSessions });
     const events: Array<{ event: string; detail?: Record<string, unknown> }> = [];
@@ -456,7 +456,7 @@ describe("finalizeAgentScan", () => {
   });
 
   it("does not advance an incremental durable timestamp when cache writes are disabled", async () => {
-    const cachedSessions = [makeSession("old")];
+    const cachedSessions = [withCurrentIdentity(makeSession("old"))];
     const updatedSessions = [makeSession("new")];
     const agent = createTestAgent({ name: "test", available: true, sessions: updatedSessions });
 
@@ -499,7 +499,13 @@ describe("finalizeAgentScan", () => {
   });
 
   it("persists refreshed identity provenance for an otherwise unchanged cache", async () => {
-    const sessions = [makeSession("cached")];
+    const sessions = [
+      {
+        ...withCurrentIdentity(makeSession("cached")),
+        project_identity_resolver_revision: "outdated",
+        project_identity_input_signature: "outdated",
+      },
+    ];
     const agent = createTestAgent({ name: "test", available: true, sessions });
 
     await finalizeAgentScan(agent, sessions, {
@@ -531,7 +537,7 @@ describe("finalizeAgentScan", () => {
   });
 
   it("persists tag maintenance for an otherwise unchanged cache", async () => {
-    const sessions = [makeSession("cached")];
+    const sessions = [withCurrentIdentity(makeSession("cached"))];
     const agent = createTestAgent({ name: "test", available: true, sessions });
 
     const result = await finalizeAgentScan(agent, sessions, {
@@ -583,7 +589,7 @@ describe("scanSessions", () => {
 
   it("retains cached sessions when an agent is unavailable", async () => {
     mockedLoadCachedSessions.mockReturnValue({
-      sessions: [makeSession("cached")],
+      sessions: [withCurrentIdentity(makeSession("cached"))],
       meta: {},
       timestamp: 123,
     });
@@ -706,7 +712,7 @@ describe("scanSessions", () => {
   });
 
   it("retains a cached baseline when source enumeration fails", async () => {
-    const cached = makeSession("cached");
+    const cached = withCurrentIdentity(makeSession("cached"));
     mockedLoadCachedSessions.mockReturnValue({
       sessions: [cached],
       meta: { cached: { id: "cached", sourcePath: "/sessions/cached" } },
@@ -750,7 +756,7 @@ describe("scanSessions", () => {
   });
 
   it("retains the cached baseline when change detection fails", async () => {
-    const cached = makeSession("cached");
+    const cached = withCurrentIdentity(makeSession("cached"));
     mockedLoadCachedSessions.mockReturnValue({ sessions: [cached], meta: {}, timestamp: 123 });
     const agent = createTestAgent({
       name: "test",
@@ -804,7 +810,7 @@ describe("scanSessions", () => {
   });
 
   it("uses an explicitly declared enumerated source without relying on class identity", async () => {
-    const cached = makeSession("cached");
+    const cached = withCurrentIdentity(makeSession("cached"));
     const refreshed = makeSession("refreshed");
     mockedLoadCachedSessions.mockReturnValue({
       sessions: [cached],
@@ -845,7 +851,7 @@ describe("scanSessions", () => {
   });
 
   it("does not publish a false empty baseline when a forced scan fails", async () => {
-    const cached = makeSession("cached");
+    const cached = withCurrentIdentity(makeSession("cached"));
     mockedLoadCachedSessions.mockReturnValue({ sessions: [cached], meta: {}, timestamp: 123 });
     mockedCreateRegisteredAgents.mockReturnValue([
       createTestAgent({ name: "test", available: true, sessions: [], shouldThrow: true }),
@@ -949,7 +955,7 @@ describe("scanSessions", () => {
   });
 
   it("retains a cached head and writes a partial snapshot when full parsing fails", async () => {
-    const cached = makeSession("cached", undefined, "files");
+    const cached = withCurrentIdentity(makeSession("cached", undefined, "files"));
     const meta = {
       cached: {
         id: "cached",
@@ -1031,10 +1037,12 @@ describe("scanSessions", () => {
   });
 
   it("filters agent-specific stale sessions from cache-only results", async () => {
-    const empty = makeSession("empty", {
-      stats: { message_count: 0, total_input_tokens: 0, total_output_tokens: 0, total_cost: 0 },
-    });
-    const visible = makeSession("visible");
+    const empty = withCurrentIdentity(
+      makeSession("empty", {
+        stats: { message_count: 0, total_input_tokens: 0, total_output_tokens: 0, total_cost: 0 },
+      }),
+    );
+    const visible = withCurrentIdentity(makeSession("visible"));
     const cachedSessions = [empty, visible];
     mockedLoadCachedSessions.mockReturnValue({
       sessions: cachedSessions,
@@ -1060,7 +1068,7 @@ describe("scanSessions", () => {
 
   it("uses cached sessions even when last refresh is old", async () => {
     mockedLoadCachedSessions.mockReturnValue({
-      sessions: [makeSession("cached")],
+      sessions: [withCurrentIdentity(makeSession("cached"))],
       meta: {},
       timestamp: 0,
     });
@@ -1081,7 +1089,7 @@ describe("scanSessions", () => {
   });
 
   it("refreshes stale cache before returning results", async () => {
-    const cachedSessions = [makeSession("cached")];
+    const cachedSessions = [withCurrentIdentity(makeSession("cached"))];
     const refreshedSessions = [makeSession("fresh")];
     mockedLoadCachedSessions.mockReturnValue({
       sessions: cachedSessions,
@@ -1139,7 +1147,7 @@ describe("scanSessions", () => {
   });
 
   it("retains the durable baseline after a failed incremental cache write", async () => {
-    const cachedSessions = [makeSession("cached")];
+    const cachedSessions = [withCurrentIdentity(makeSession("cached"))];
     const refreshedSessions = [makeSession("fresh")];
     const checkForChanges = vi.fn(() => ({
       hasChanges: true,
@@ -1182,8 +1190,8 @@ describe("scanSessions", () => {
       displayName: "project",
     };
     const keep = withCurrentIdentity(makeSession("keep", { project_identity: projectIdentity }));
-    const changed = makeSession("changed");
-    const removed = makeSession("removed");
+    const changed = withCurrentIdentity(makeSession("changed"));
+    const removed = withCurrentIdentity(makeSession("removed"));
     const updatedChanged = makeSession("changed", { title: "Updated changed" });
     const added = makeSession("added");
 

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BaseAgent, type ChangeCheckResult, type SessionCacheMeta } from "../../agents/base.js";
-import type { SessionDetail, SessionHead } from "../../types/index.js";
+import type { IdentifiedSessionHead, SessionDetail, SessionHead } from "../../types/index.js";
 import { readCachedSessionCursor, saveCachedSessions } from "../cache/sessions.js";
 import { withCacheDb } from "../cache/schema.js";
 import { MESSAGE_CURSOR_VERSION } from "../cache/message-cursor.js";
@@ -79,7 +79,7 @@ class TestAgent extends BaseAgent {
   setSessionMetaMap(): void {}
 }
 
-function makeHead(overrides: Partial<SessionHead> = {}): SessionHead {
+function makeHead(overrides: Partial<IdentifiedSessionHead> = {}): IdentifiedSessionHead {
   return {
     reference: { agentName: "test", sessionId: "s1" },
     id: "s1",
@@ -136,7 +136,11 @@ function makeScanResult(agent: TestAgent, head = makeHead()): LiveSnapshot {
   };
 }
 
-function persistDetail(head: SessionHead, detail: SessionDetail, fingerprint: string): void {
+function persistDetail(
+  head: IdentifiedSessionHead,
+  detail: SessionDetail,
+  fingerprint: string,
+): void {
   saveCachedSessions("test", [head], { [head.id]: makeMeta(fingerprint) });
   syncSessionSearchIndex("test", [head], () => detail);
 }
@@ -305,28 +309,22 @@ describe("materializeSessionDetail", () => {
     ).toThrow("Session identity fields disagree");
   });
 
-  it("asks the caller to resolve identity instead of probing the filesystem", () => {
+  it("rejects an invalid snapshot instead of resolving identity during a detail request", () => {
     const detail = { ...makeDetail(), project_identity: undefined };
-    const head = { ...makeHead(), project_identity: undefined };
+    const head = {
+      ...makeHead(),
+      project_identity: undefined,
+    } as unknown as IdentifiedSessionHead;
     const agent = new TestAgent(detail, new Map([["s1", makeMeta("source")]]));
     const scanResult = makeScanResult(agent, head);
     const reference = { agentName: "test", sessionId: "s1" };
 
-    expect(materializeSessionDetail(scanResult, reference)).toEqual({
-      status: "needs-identity",
-      directory: "/workspace/project",
-    });
-    expect(materializeSessionDetailResponse(scanResult, reference, {})).toEqual({
-      status: "needs-identity",
-      directory: "/workspace/project",
-    });
-
-    const resolved = materializeSessionDetail(scanResult, reference, {
-      projectIdentityFallback: projectIdentity,
-    });
-    expect(resolved.status).toBe("found");
-    if (resolved.status !== "found") return;
-    expect(resolved.data.project_identity).toEqual(projectIdentity);
+    expect(() => materializeSessionDetail(scanResult, reference)).toThrow(
+      "Session test/s1 reached detail materialization without project_identity",
+    );
+    expect(() => materializeSessionDetailResponse(scanResult, reference, {})).toThrow(
+      "Session test/s1 reached detail materialization without project_identity",
+    );
   });
 
   it("derives the same file activity for cached and source details", () => {

--- a/packages/core/src/discovery/__tests__/smart-tag-worker-lifecycle.test.ts
+++ b/packages/core/src/discovery/__tests__/smart-tag-worker-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BaseAgent, SessionCacheMeta } from "../../agents/index.js";
-import type { SessionDetail, SessionHead } from "../../types/index.js";
+import type { IdentifiedSessionHead, SessionDetail } from "../../types/index.js";
 
 type WorkerBehavior = "clean-exit-without-message" | "empty-results" | "results";
 
@@ -61,13 +61,14 @@ vi.mock("node:worker_threads", () => ({ Worker: workers.FakeWorker }));
 
 import { finalizeAgentScan } from "../scanner.js";
 
-function makeSession(index: number): SessionHead {
+function makeSession(index: number): IdentifiedSessionHead {
   return {
     reference: { agentName: "test", sessionId: `session-${index}` },
     id: `session-${index}`,
     slug: `test/session-${index}`,
     title: `Session ${index}`,
     directory: "/workspace",
+    project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
     time_created: 1000,
     time_updated: 1000,
     stats: {
@@ -90,7 +91,7 @@ function makeAgent(): BaseAgent {
   } as unknown as BaseAgent;
 }
 
-async function runScan(agent: BaseAgent, sessions: SessionHead[]) {
+async function runScan(agent: BaseAgent, sessions: IdentifiedSessionHead[]) {
   return finalizeAgentScan(agent, sessions, {
     finalization: { kind: "unchanged", cached: { sessions, meta: {}, timestamp: 1 } },
     options: {

--- a/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
+++ b/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
@@ -1,7 +1,7 @@
 import { availableParallelism } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BaseAgent, SessionCacheMeta } from "../../agents/index.js";
-import type { SessionHead } from "../../types/index.js";
+import type { IdentifiedSessionHead } from "../../types/index.js";
 import { setCoreDiagnostics } from "../../utils/index.js";
 
 const workers = vi.hoisted(() => {
@@ -50,13 +50,14 @@ vi.mock("node:worker_threads", () => ({ Worker: workers.FakeWorker }));
 
 import { finalizeAgentScan } from "../scanner.js";
 
-function makeSession(index: number): SessionHead {
+function makeSession(index: number): IdentifiedSessionHead {
   return {
     reference: { agentName: "test", sessionId: `session-${index}` },
     id: `session-${index}`,
     slug: `test/session-${index}`,
     title: `Session ${index}`,
     directory: "/workspace",
+    project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
     time_created: 1000,
     time_updated: 1000,
     stats: {

--- a/packages/core/src/discovery/cache/__tests__/fixtures.ts
+++ b/packages/core/src/discovery/cache/__tests__/fixtures.ts
@@ -1,12 +1,12 @@
-import type { SessionDetail, SessionHead } from "../../../types/index.js";
+import type { IdentifiedSessionHead, SessionDetail } from "../../../types/index.js";
 import { createSessionIdentity } from "../../../contract/session-reference.js";
 
 export const TEST_NOW = 1_700_000_000_000;
 
 export function makeSessionHead(
   id: string,
-  overrides: Partial<SessionHead> = {},
-): SessionHead & Pick<SessionDetail, "reference"> {
+  overrides: Partial<IdentifiedSessionHead> = {},
+): IdentifiedSessionHead {
   const identity = createSessionIdentity(
     overrides.reference ?? { agentName: "codex", sessionId: id },
   );

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -21,7 +21,7 @@ import { setSchemaEnsuredPath } from "../db.js";
 import { MESSAGE_PARTS_FORMAT_VERSION } from "../messages.js";
 import { withCacheDb, withSearchDb } from "../schema.js";
 import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
-import type { SessionDetail, SessionHead } from "../../../types/index.js";
+import type { IdentifiedSessionHead, SessionDetail, SessionHead } from "../../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
 const SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS = 30_000;
@@ -49,10 +49,7 @@ function getCachePath(): string {
 // resolves to a "path" identity regardless of what manifests exist in /tmp.
 const FIXTURE_DIR = mkdtempSync(join(tmpdir(), "codesesh-identity-"));
 
-function makeAgentSession(
-  agentName: string,
-  id: string,
-): SessionHead & Pick<SessionDetail, "reference"> {
+function makeAgentSession(agentName: string, id: string): IdentifiedSessionHead {
   return {
     reference: { agentName, sessionId: id },
     id,

--- a/packages/core/src/discovery/cache/__tests__/search.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search.test.ts
@@ -81,10 +81,13 @@ describe("cache search", () => {
   it("maps database rows through the canonical session decoder", () => {
     expect(
       sessionHeadFromSearchRow({
+        agent_name: "codex",
         session_id: "s1",
-        slug: "codex/s1",
         title: "One",
         directory: "/tmp/project",
+        project_identity_kind: "path",
+        project_identity_key: "/tmp/project",
+        project_display_name: "project",
         time_created: 1,
         message_count: 2,
         total_input_tokens: 3,

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -252,6 +252,17 @@ describe("session identity persistence invariant", () => {
     expect(spawnSpy).not.toHaveBeenCalled();
     expect(existsSync(getCachePath())).toBe(false);
   });
+
+  it("rejects cached rows whose project identity is missing", () => {
+    saveCachedSessions("claudecode", [makeSession("corrupt-identity")]);
+    withCacheDb((db) => {
+      db.prepare(
+        "UPDATE sessions SET project_identity_key = '' WHERE agent_name = ? AND session_id = ?",
+      ).run("claudecode", "corrupt-identity");
+    });
+
+    expect(readCachedSessions("claudecode")).toEqual({ status: "failed" });
+  });
 });
 
 describe("withSearchIndexDb", () => {

--- a/packages/core/src/discovery/cache/db.ts
+++ b/packages/core/src/discovery/cache/db.ts
@@ -10,8 +10,8 @@ const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
 export const SEARCH_INDEX_BULK_SYNC_THRESHOLD = 100;
 
-export interface PersistedSessionHeadChange {
-  session: SessionHead;
+export interface PersistedSessionHeadChange<T extends SessionHead = SessionHead> {
+  session: T;
   sortIndex: number;
 }
 

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -3,7 +3,9 @@
  * binders, and message-text builders shared by sessions/search/file-activity.
  */
 import type { SessionCacheMeta } from "../../agents/base.js";
+import { assertIdentifiedSessionHead } from "../../contract/session.js";
 import type {
+  IdentifiedSessionHead,
   Message,
   MessagePart,
   ProjectIdentity,
@@ -161,10 +163,8 @@ export function requireSessionProjectIdentity(
   session: SessionHead,
 ): ProjectIdentity {
   assertSessionIdentity(session, agentName);
-  if (session.project_identity) return session.project_identity;
-  throw new Error(
-    `Session ${session.reference.agentName}/${session.reference.sessionId} is missing project_identity`,
-  );
+  assertIdentifiedSessionHead(session);
+  return session.project_identity;
 }
 
 export function assertSessionProjectIdentities(
@@ -397,7 +397,7 @@ export function writeFileActivityRows(
   }
 }
 
-export function sessionFromRow(row: SessionRow): SessionHead {
+export function sessionFromRow(row: SessionRow): IdentifiedSessionHead {
   const session: SessionHead = {
     ...createSessionIdentity({
       agentName: String(row.agent_name),
@@ -465,6 +465,7 @@ export function sessionFromRow(row: SessionRow): SessionHead {
     session.smart_tags_classifier_revision = String(row.smart_tags_classifier_revision);
   }
 
+  assertIdentifiedSessionHead(session);
   return session;
 }
 

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { SessionCacheMeta } from "../../agents/base.js";
-import type { SessionDetail, SessionHead } from "../../types/index.js";
+import type { IdentifiedSessionHead, SessionDetail } from "../../types/index.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { PersistedSessionHeadChange } from "./db.js";
 import { advanceAnalyticsRevision } from "./analytics-revision.js";
@@ -26,7 +26,7 @@ export type DurableSessionPublication =
   | {
       kind: "snapshot";
       agentName: string;
-      sessions: SessionHead[];
+      sessions: IdentifiedSessionHead[];
       meta: Record<string, SessionCacheMeta>;
       completeness: SessionSnapshotCompleteness;
       removedSessionIds: string[];
@@ -35,7 +35,7 @@ export type DurableSessionPublication =
   | {
       kind: "changes";
       agentName: string;
-      changes: PersistedSessionHeadChange[];
+      changes: PersistedSessionHeadChange<IdentifiedSessionHead>[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       publicationId?: string;

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -3,6 +3,7 @@
  */
 import type {
   FileActivityKind,
+  IdentifiedSessionHead,
   Message,
   ProjectIdentityKind,
   SessionHead,
@@ -96,7 +97,7 @@ export {
 } from "./search-index-writer.js";
 export { sessionDetailVersion } from "./detail-version.js";
 
-export function sessionHeadFromSearchRow(row: SearchResultRow): SessionHead {
+export function sessionHeadFromSearchRow(row: SearchResultRow): IdentifiedSessionHead {
   return sessionFromRow(row as SessionRow);
 }
 

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -5,7 +5,11 @@ import { existsSync, rmSync, unlinkSync } from "node:fs";
 import type { SessionCacheMeta } from "../../agents/base.js";
 import type { ReferencedSessionHead, SessionReference } from "../../contract/index.js";
 import { formatSessionReference, normalizeSessionReference } from "../../contract/index.js";
-import type { SessionDetail, SessionHead } from "../../types/index.js";
+import type {
+  IdentifiedSessionDetail,
+  IdentifiedSessionHead,
+  SessionHead,
+} from "../../types/index.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import { tableExists, type SQLiteDatabase } from "../../utils/sqlite.js";
 import {
@@ -69,18 +73,18 @@ const SESSION_HEAD_SELECT_COLUMNS = `
   s.meta_json
 `;
 export interface CachedResult {
-  sessions: SessionHead[];
+  sessions: IdentifiedSessionHead[];
   meta: Record<string, SessionCacheMeta>;
   timestamp: number;
 }
 
 export interface CachedSessionDataEntry {
-  data: SessionDetail;
+  data: IdentifiedSessionDetail;
   meta: SessionCacheMeta | null;
 }
 
 interface CachedSessionEntryBase {
-  data: Omit<SessionDetail, "messages">;
+  data: Omit<IdentifiedSessionDetail, "messages">;
   meta: SessionCacheMeta | null;
   detailVersion: string | null;
   pendingReindex: boolean;
@@ -159,7 +163,7 @@ export function readCachedSessions(agentName: string): CacheReadOutcome<CachedRe
       )
       .all(agentName) as SessionRow[];
 
-    const sessions: SessionHead[] = [];
+    const sessions: IdentifiedSessionHead[] = [];
     const meta: Record<string, SessionCacheMeta> = {};
 
     for (const row of rows) {
@@ -581,7 +585,10 @@ export function loadCachedSessionDataEntry(
   };
 }
 
-export function loadCachedSessionData(agentName: string, sessionId: string): SessionDetail | null {
+export function loadCachedSessionData(
+  agentName: string,
+  sessionId: string,
+): IdentifiedSessionDetail | null {
   return loadCachedSessionDataEntry(agentName, sessionId)?.data ?? null;
 }
 

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -8,8 +8,10 @@
  * plumbing that previously had to be kept in sync by hand.
  */
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
+import { assertIdentifiedSessionHead } from "../contract/index.js";
 import { sortSessionsByActivity } from "../contract/session-index.js";
 import type {
+  IdentifiedSessionHead,
   ProjectIdentity,
   SessionHead,
   SessionReference,
@@ -29,7 +31,7 @@ type ProjectIdentityResolver = (directory: string) => ProjectIdentityProjection;
 export function attachMissingProjectIdentities(
   sessions: SessionHead[],
   resolve: ProjectIdentityResolver = (directory) => computeIdentityProjection(directory, realFs),
-): SessionHead[] {
+): IdentifiedSessionHead[] {
   const projections = new Map<string, ProjectIdentityProjection>();
 
   return sessions.map((session) => {
@@ -48,6 +50,7 @@ export function attachMissingProjectIdentities(
       session.project_identity_resolver_revision === projection.resolverRevision &&
       session.project_identity_input_signature === projection.inputSignature
     ) {
+      assertIdentifiedSessionHead(session);
       return session;
     }
 
@@ -169,12 +172,12 @@ export function sessionSignature(session: SessionHead): string {
 }
 
 /** Sort sessions by activity time, newest first. */
-export function sortSessions(sessions: SessionHead[]): SessionHead[] {
+export function sortSessions<T extends SessionHead>(sessions: T[]): T[] {
   return sortSessionsByActivity(sessions);
 }
 
-export interface SessionDiffResult {
-  changes: PersistedSessionHeadChange[];
+export interface SessionDiffResult<T extends SessionHead = SessionHead> {
+  changes: PersistedSessionHeadChange<T>[];
   removedSessionIds: string[];
   counts: { new: number; updated: number; removed: number };
 }
@@ -198,19 +201,19 @@ export interface SessionDiffResult {
  * of the previous call's `updatedSessions`), a stale or mismatched hit will
  * silently suppress a real change.
  */
-export function computeSessionDiff(
+export function computeSessionDiff<T extends SessionHead>(
   cachedSessions: SessionHead[],
-  updatedSessions: SessionHead[],
+  updatedSessions: T[],
   changedIds: string[] = [],
   signature: (session: SessionHead) => string = sessionSignature,
   signatureCache?: Map<string, string>,
-): SessionDiffResult {
+): SessionDiffResult<T> {
   const cachedMap = new Map(
     cachedSessions.map((session) => [session.reference.sessionId, session]),
   );
   const updatedIds = new Set(updatedSessions.map((session) => session.reference.sessionId));
   const changedIdSet = new Set(changedIds);
-  const changes: PersistedSessionHeadChange[] = [];
+  const changes: PersistedSessionHeadChange<T>[] = [];
   const removedSessionIds: string[] = [];
   let newCount = 0;
   let updatedCount = 0;

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -1,6 +1,12 @@
 import { availableParallelism } from "node:os";
 import { Worker } from "node:worker_threads";
-import type { SessionDetail, SessionHead, SmartTag } from "../types/index.js";
+import type {
+  IdentifiedSessionHead,
+  SessionDetail,
+  SessionHead,
+  SmartTag,
+} from "../types/index.js";
+import { assertIdentifiedSessionHead } from "../contract/session.js";
 import { assertSessionIdentity } from "../contract/session-reference.js";
 import { filterSessionTreeByActivityWindow } from "../contract/session-tree.js";
 import type {
@@ -69,8 +75,8 @@ export interface ScanOptions {
 }
 
 export interface LiveSnapshot {
-  sessions: SessionHead[];
-  byAgent: Record<string, SessionHead[]>;
+  sessions: IdentifiedSessionHead[];
+  byAgent: Record<string, IdentifiedSessionHead[]>;
   agents: BaseAgent[];
   timings?: Record<string, AgentScanTiming>;
   cacheTimestamps?: Record<string, number>;
@@ -91,7 +97,7 @@ export interface ScanProgress {
   changedCount?: number;
 }
 
-export function filterSessions(sessions: SessionHead[], options: ScanOptions): SessionHead[] {
+export function filterSessions<T extends SessionHead>(sessions: T[], options: ScanOptions): T[] {
   let result = sessions;
 
   if (options.cwd) {
@@ -148,7 +154,7 @@ type CachePersistence = "persisted" | "failed" | "not-requested";
 interface SuccessfulAgentScanResult {
   status: "complete" | "partial";
   agent: BaseAgent;
-  heads: SessionHead[];
+  heads: IdentifiedSessionHead[];
   cachePersistence: CachePersistence;
   fromCache?: boolean;
   refreshed?: boolean;
@@ -160,12 +166,19 @@ interface FailedAgentScanResult {
   status: "failed";
   agent: BaseAgent;
   failure: AgentScanFailure;
-  retainedHeads?: SessionHead[];
+  retainedHeads?: IdentifiedSessionHead[];
   cacheTimestamp?: number;
   timing: AgentScanTiming;
 }
 
 type AgentScanResult = SuccessfulAgentScanResult | FailedAgentScanResult;
+
+function identifiedSessionHeads(sessions: SessionHead[]): IdentifiedSessionHead[] {
+  return sessions.map((session) => {
+    assertIdentifiedSessionHead(session);
+    return session;
+  });
+}
 
 function finalizeAgentScanFailure(
   agent: BaseAgent,
@@ -176,7 +189,7 @@ function finalizeAgentScanFailure(
   startedAt: number,
 ): FailedAgentScanResult {
   const retainedHeads = cached
-    ? filterSessions(agent.filterCachedSessions(cached.sessions), options)
+    ? identifiedSessionHeads(filterSessions(agent.filterCachedSessions(cached.sessions), options))
     : undefined;
   reportAgentScanFailure(failure, retainedHeads !== undefined);
   timing.total = performance.now() - startedAt;
@@ -476,7 +489,9 @@ export async function finalizeAgentScan(
 
   const identityStart = performance.now();
   const sessionsWithIdentity =
-    finalization.kind === "cache-only" ? sessions : attachMissingProjectIdentities(sessions);
+    finalization.kind === "cache-only"
+      ? identifiedSessionHeads(sessions)
+      : attachMissingProjectIdentities(sessions);
   const identityChanged = sessionsWithIdentity.some(
     (session, index) => session !== sessions[index],
   );
@@ -485,10 +500,11 @@ export async function finalizeAgentScan(
   let tagged = { sessions: sessionsWithIdentity, changed: false };
   if (finalization.kind !== "cache-only") {
     const tagsStart = performance.now();
-    tagged =
+    const tagResult =
       options.includeSmartTags === false
         ? tagged
         : await ensureSessionTags(agent, sessionsWithIdentity, options.smartTagWorkerUrl);
+    tagged = { ...tagResult, sessions: identifiedSessionHeads(tagResult.sessions) };
     timing.tags = performance.now() - tagsStart;
   }
 
@@ -806,10 +822,11 @@ async function scanAgentFull(
     timing.identity = performance.now() - t1;
 
     const t2 = performance.now();
-    const tagged =
+    const tagResult =
       options.includeSmartTags === false
         ? { sessions: headsWithIdentity, changed: false }
         : await ensureSessionTags(agent, headsWithIdentity, options.smartTagWorkerUrl);
+    const tagged = { ...tagResult, sessions: identifiedSessionHeads(tagResult.sessions) };
     timing.tags = performance.now() - t2;
 
     // 收集元数据
@@ -886,8 +903,8 @@ export async function scanSessions(
 ): Promise<LiveSnapshot> {
   const scanMarker = perf.start("scanSessions");
   const agents = createRegisteredAgents();
-  const byAgent: Record<string, SessionHead[]> = {};
-  const allSessions: SessionHead[] = [];
+  const byAgent: Record<string, IdentifiedSessionHead[]> = {};
+  const allSessions: IdentifiedSessionHead[] = [];
   const availableAgents: BaseAgent[] = [];
   const cacheTimestamps: Record<string, number> = {};
   const cacheFailures: Record<string, AgentCacheFailure> = {};

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -1,6 +1,11 @@
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
 import { assertSessionIdentity, type SessionReference } from "../contract/index.js";
-import type { ProjectIdentity, SessionDetail, SessionHead } from "../types/index.js";
+import type {
+  IdentifiedSessionDetail,
+  IdentifiedSessionHead,
+  ProjectIdentity,
+  SessionDetail,
+} from "../types/index.js";
 import {
   classifySessionTags,
   extractSessionFileActivity,
@@ -31,22 +36,15 @@ import {
 import type { LiveSnapshot } from "./scanner.js";
 
 export type SessionDetailResult =
-  | { status: "found"; data: SessionDetail }
+  | { status: "found"; data: IdentifiedSessionDetail }
   | { status: "unknown-agent" }
-  | { status: "not-ready" }
-  /**
-   * The session has no identity on its head or cached detail. Resolving one
-   * requires filesystem/git probing, which must not run on this synchronous
-   * path — the caller resolves `directory` asynchronously and retries with
-   * `projectIdentityFallback`.
-   */
-  | { status: "needs-identity"; directory: string };
+  | { status: "not-ready" };
 
 export type SessionDetailResponseResult =
   | SessionDetailResult
   | {
       status: "found-json";
-      data: Omit<SessionDetail, "messages">;
+      data: Omit<IdentifiedSessionDetail, "messages">;
       messages: Iterable<string>;
       messageCount: number;
       sentMessageCount: number;
@@ -54,21 +52,19 @@ export type SessionDetailResponseResult =
 
 export interface SessionDetailResponseOptions {
   messageCursor?: string;
-  /** Pre-resolved identity used when neither the head nor the cache has one. */
-  projectIdentityFallback?: ProjectIdentity;
 }
 
 interface SessionDetailLookup {
   agentsByName: Map<string, BaseAgent>;
-  headsByReference: Map<string, SessionHead>;
+  headsByReference: Map<string, IdentifiedSessionHead>;
 }
 
 interface SessionDetailContext {
   agent: BaseAgent;
-  head: SessionHead | undefined;
+  head: IdentifiedSessionHead | undefined;
 }
 
-const sessionDetailLookups = new WeakMap<SessionHead[], SessionDetailLookup>();
+const sessionDetailLookups = new WeakMap<IdentifiedSessionHead[], SessionDetailLookup>();
 const MAX_MESSAGE_CURSOR_LENGTH = 512;
 
 interface MessageCursorPayload {
@@ -163,7 +159,7 @@ function sessionReferenceKey(agentName: string, sessionId: string): string {
 }
 
 function assertSessionMatchesReference(
-  session: SessionHead | SessionDetail,
+  session: IdentifiedSessionHead | SessionDetail,
   reference: SessionReference,
 ): void {
   assertSessionIdentity(session, reference.agentName);
@@ -184,7 +180,7 @@ function getSessionDetailLookup(scanResult: LiveSnapshot): SessionDetailLookup {
   for (const agent of scanResult.agents) {
     if (!agentsByName.has(agent.name)) agentsByName.set(agent.name, agent);
   }
-  const headsByReference = new Map<string, SessionHead>();
+  const headsByReference = new Map<string, IdentifiedSessionHead>();
   for (const sessions of Object.values(scanResult.byAgent)) {
     for (const session of sessions) {
       const key = sessionReferenceKey(session.reference.agentName, session.reference.sessionId);
@@ -233,11 +229,14 @@ function cachedDetailState(
 }
 
 function getProjectIdentity(
-  data: Pick<SessionDetail, "directory" | "project_identity">,
-  head: SessionHead | undefined,
-  fallback: ProjectIdentity | undefined,
-): ProjectIdentity | null {
-  return head?.project_identity ?? data.project_identity ?? fallback ?? null;
+  data: Pick<SessionDetail, "reference" | "project_identity">,
+  head: IdentifiedSessionHead | undefined,
+): ProjectIdentity {
+  const identity = head?.project_identity ?? data.project_identity;
+  if (identity) return identity;
+  throw new Error(
+    `Session ${data.reference.agentName}/${data.reference.sessionId} reached detail materialization without project_identity`,
+  );
 }
 
 function getSmartTags(data: SessionDetail) {
@@ -254,7 +253,6 @@ function materializeStructuredSessionDetail(
   context: SessionDetailContext,
   reference: SessionReference,
   cachedEntry = loadCachedSessionRawEntry(reference.agentName, reference.sessionId),
-  identityFallback?: ProjectIdentity,
 ): SessionDetailResult {
   const { agent, head } = context;
   const currentMeta = head ? agent.getSessionMetaMap().get(reference.sessionId) : undefined;
@@ -302,8 +300,7 @@ function materializeStructuredSessionDetail(
   }
   assertSessionMatchesReference(data, reference);
 
-  const projectIdentity = getProjectIdentity(data, head, identityFallback);
-  if (!projectIdentity) return { status: "needs-identity", directory: data.directory };
+  const projectIdentity = getProjectIdentity(data, head);
   const fileActivity =
     data.file_activity ??
     (useCache
@@ -342,16 +339,10 @@ function* serializeCachedMessages(messageRows: CachedMessageRow[]): IterableIter
 export function materializeSessionDetail(
   scanResult: LiveSnapshot,
   reference: SessionReference,
-  options: Pick<SessionDetailResponseOptions, "projectIdentityFallback"> = {},
 ): SessionDetailResult {
   const context = getSessionDetailContext(scanResult, reference);
   if (!context) return { status: "unknown-agent" };
-  return materializeStructuredSessionDetail(
-    context,
-    reference,
-    undefined,
-    options.projectIdentityFallback,
-  );
+  return materializeStructuredSessionDetail(context, reference);
 }
 
 export function materializeSessionDetailResponse(
@@ -388,12 +379,7 @@ export function materializeSessionDetailResponse(
     cachedEntry.data.smart_tags == null ||
     cachedEntry.data.smart_tags_classifier_revision !== SMART_TAG_CLASSIFIER_REVISION
   ) {
-    const result = materializeStructuredSessionDetail(
-      context,
-      reference,
-      undefined,
-      options.projectIdentityFallback,
-    );
+    const result = materializeStructuredSessionDetail(context, reference, undefined);
     return result.status === "found"
       ? { ...result, data: { ...result.data, message_update: "reset" } }
       : result;
@@ -401,16 +387,10 @@ export function materializeSessionDetailResponse(
 
   const data = cachedEntry.data;
   assertSessionMatchesReference(data, reference);
-  const projectIdentity = getProjectIdentity(data, context.head, options.projectIdentityFallback);
-  if (!projectIdentity) return { status: "needs-identity", directory: data.directory };
+  const projectIdentity = getProjectIdentity(data, context.head);
   const stream = cursorRead?.stream;
   if (!stream) {
-    const result = materializeStructuredSessionDetail(
-      context,
-      reference,
-      undefined,
-      options.projectIdentityFallback,
-    );
+    const result = materializeStructuredSessionDetail(context, reference, undefined);
     return result.status === "found"
       ? { ...result, data: { ...result.data, message_update: "reset" } }
       : result;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,8 @@ import "./agents/register.js";
 
 export type {
   FileActivityKind,
+  IdentifiedSessionDetail,
+  IdentifiedSessionHead,
   ProjectIdentityRef,
   SessionDetail,
   SessionHead,

--- a/packages/core/src/projects/scope.ts
+++ b/packages/core/src/projects/scope.ts
@@ -35,11 +35,11 @@ export function matchesProjectScope(session: SessionHead, scope: ProjectScopeMat
   return session.directory ? isPathScopeMatch(scope.path, session.directory) : false;
 }
 
-export function filterSessionsByProjectScope(
-  sessions: SessionHead[],
+export function filterSessionsByProjectScope<T extends SessionHead>(
+  sessions: T[],
   queryPath: string,
   fs?: IdentityFs,
-): SessionHead[] {
+): T[] {
   const scope = createProjectScopeMatcher(queryPath, fs);
   return sessions.filter((session) => matchesProjectScope(session, scope));
 }

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -22,7 +22,9 @@ export type {
   MessagePart,
   Message,
   SessionHead,
+  IdentifiedSessionHead,
   SessionDetail,
+  IdentifiedSessionDetail,
 } from "../contract/session.js";
 export type { SessionReference } from "../contract/session-reference.js";
 


### PR DESCRIPTION
## Summary
- distinguish raw session heads from identity-complete published sessions
- reject incomplete cache rows and live/index publication payloads
- remove project identity resolution from session detail HTTP requests
- document the identity-completion lifecycle

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm test:migration`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm typecheck:e2e`
- `pnpm test:e2e`
- `pnpm perf:check`
- documentation, quality-task, and release preflight checks