### PR TITLE
fix(core): unify Codex token usage accounting

### DIFF
--- a/packages/core/src/agents/__tests__/codex-token-usage.test.ts
+++ b/packages/core/src/agents/__tests__/codex-token-usage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { CodexTokenUsageAccumulator } from "../codex-token-usage.js";
+
+function tokenPayload(
+  lastUsage: Record<string, number> | undefined,
+  totalUsage?: Record<string, number>,
+): Record<string, unknown> {
+  return {
+    info: {
+      last_token_usage: lastUsage,
+      total_token_usage: totalUsage,
+    },
+  };
+}
+
+describe("CodexTokenUsageAccumulator", () => {
+  it("deduplicates events by their positive cumulative total", () => {
+    const accumulator = new CodexTokenUsageAccumulator();
+    const payload = tokenPayload(
+      { input_tokens: 100, output_tokens: 20 },
+      { input_tokens: 100, output_tokens: 20, total_tokens: 120 },
+    );
+
+    expect(accumulator.consume(payload, "gpt-5.5")).not.toBeNull();
+    expect(accumulator.consume(payload, "gpt-5.5")).toBeNull();
+    expect(accumulator.stats()).toMatchObject({
+      total_input_tokens: 100,
+      total_output_tokens: 20,
+    });
+    expect(accumulator.modelUsage()).toEqual({ "gpt-5.5": 120 });
+  });
+
+  it("counts last usage when a cumulative usage record is absent", () => {
+    const accumulator = new CodexTokenUsageAccumulator();
+
+    accumulator.consume(tokenPayload({ input_tokens: 40, output_tokens: 10 }), "gpt-5.5");
+    accumulator.consume(tokenPayload({ input_tokens: 20, output_tokens: 5 }), "gpt-5.5");
+
+    expect(accumulator.stats()).toMatchObject({
+      total_input_tokens: 60,
+      total_output_tokens: 15,
+    });
+    expect(accumulator.modelUsage()).toEqual({ "gpt-5.5": 75 });
+  });
+
+  it("keeps cumulative baselines current when records switch away from last usage", () => {
+    const accumulator = new CodexTokenUsageAccumulator();
+
+    accumulator.consume(
+      tokenPayload(
+        { input_tokens: 100, output_tokens: 20 },
+        { input_tokens: 100, output_tokens: 20, total_tokens: 120 },
+      ),
+      "gpt-5.5",
+    );
+    accumulator.consume(
+      tokenPayload(undefined, {
+        input_tokens: 140,
+        output_tokens: 30,
+        total_tokens: 170,
+      }),
+      "gpt-5.5",
+    );
+
+    expect(accumulator.stats()).toMatchObject({
+      total_input_tokens: 140,
+      total_output_tokens: 30,
+    });
+    expect(accumulator.modelUsage()).toEqual({ "gpt-5.5": 170 });
+  });
+
+  it("preserves cache-only usage deltas", () => {
+    const accumulator = new CodexTokenUsageAccumulator();
+
+    const delta = accumulator.consume(
+      tokenPayload({ input_tokens: 0, output_tokens: 0, cached_input_tokens: 10 }),
+      "gpt-5.5",
+    );
+
+    expect(delta?.tokens).toEqual({
+      input: 0,
+      output: 0,
+      reasoning: undefined,
+      cache_read: 10,
+    });
+    expect(accumulator.stats().total_cache_read_tokens).toBe(10);
+  });
+});

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -634,6 +634,35 @@ describe("CodexAgent cache refresh", () => {
     expect(detail.stats.total_cost).toBeGreaterThan(0);
   });
 
+  it("keeps head and detail token stats aligned without cumulative usage", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const sessionId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaab";
+    const sessionFile = join(tempDir, `rollout-2026-04-20T10-00-00-${sessionId}.jsonl`);
+
+    writeFileSync(
+      sessionFile,
+      [
+        '{"timestamp":"2026-04-20T10:00:00Z","type":"session_meta","payload":{"cwd":"/tmp/project","model":"gpt-5.5"}}',
+        '{"timestamp":"2026-04-20T10:01:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}}',
+        '{"timestamp":"2026-04-20T10:02:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":20}}}}',
+        "",
+      ].join("\n"),
+    );
+
+    const agent = new CodexAgent() as any;
+    agent.basePath = tempDir;
+    const [head] = agent.scan();
+    const detail = agent.getSessionData(sessionId);
+
+    expect(detail.stats).toMatchObject({
+      total_input_tokens: head?.stats.total_input_tokens,
+      total_output_tokens: head?.stats.total_output_tokens,
+      total_cache_read_tokens: head?.stats.total_cache_read_tokens,
+      total_cost: head?.stats.total_cost,
+    });
+  });
+
   it("prices Codex cached input with cache read rates", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
     const sessionFile = join(

--- a/packages/core/src/agents/codex-token-usage.ts
+++ b/packages/core/src/agents/codex-token-usage.ts
@@ -1,0 +1,122 @@
+import type { MessageTokens, SessionStats } from "../types/index.js";
+import { estimateTokenCost } from "../utils/cost.js";
+import { asRecord, narrowField } from "../utils/narrow.js";
+
+export interface CodexTokenUsageDelta {
+  tokens: MessageTokens;
+  model: string | null;
+  cost: number | null;
+}
+
+function usageRecord(value: unknown, field: string): Record<string, unknown> | undefined {
+  return narrowField("codex", field, value, asRecord);
+}
+
+function tokenCount(value: unknown): number {
+  const count = Number(value ?? 0);
+  return Number.isFinite(count) ? count : 0;
+}
+
+function cachedInputTokens(usage: Record<string, unknown> | undefined): number {
+  if (!usage) return 0;
+  return tokenCount(usage["cached_input_tokens"] ?? usage["cache_read_input_tokens"]);
+}
+
+export class CodexTokenUsageAccumulator {
+  private previousCumulativeTotal = 0;
+  private previousInput = 0;
+  private previousOutput = 0;
+  private previousReasoning = 0;
+  private previousCachedInput = 0;
+  private totalInput = 0;
+  private totalOutput = 0;
+  private totalCacheRead = 0;
+  private totalCost = 0;
+  private readonly tokensByModel: Record<string, number> = {};
+
+  consume(payload: Record<string, unknown>, model: string | null): CodexTokenUsageDelta | null {
+    const info = usageRecord(payload["info"], "token_count.info");
+    const totalUsage = info
+      ? usageRecord(info["total_token_usage"], "token_count.total_token_usage")
+      : undefined;
+    const lastUsage = info
+      ? usageRecord(info["last_token_usage"], "token_count.last_token_usage")
+      : undefined;
+    const cumulativeTotal = tokenCount(totalUsage?.["total_tokens"]);
+    const hasCumulativeTotal = cumulativeTotal > 0;
+
+    if (hasCumulativeTotal && cumulativeTotal === this.previousCumulativeTotal) return null;
+
+    let input = 0;
+    let output = 0;
+    let reasoning = 0;
+    let cacheRead = 0;
+    if (lastUsage) {
+      input = tokenCount(lastUsage["input_tokens"]);
+      output = tokenCount(lastUsage["output_tokens"]);
+      reasoning = tokenCount(lastUsage["reasoning_output_tokens"]);
+      cacheRead = cachedInputTokens(lastUsage);
+    } else if (totalUsage && hasCumulativeTotal) {
+      input = tokenCount(totalUsage["input_tokens"]) - this.previousInput;
+      output = tokenCount(totalUsage["output_tokens"]) - this.previousOutput;
+      reasoning = tokenCount(totalUsage["reasoning_output_tokens"]) - this.previousReasoning;
+      cacheRead = cachedInputTokens(totalUsage) - this.previousCachedInput;
+    } else {
+      return null;
+    }
+
+    if (totalUsage) {
+      this.previousInput = tokenCount(totalUsage["input_tokens"]);
+      this.previousOutput = tokenCount(totalUsage["output_tokens"]);
+      this.previousReasoning = tokenCount(totalUsage["reasoning_output_tokens"]);
+      this.previousCachedInput = cachedInputTokens(totalUsage);
+    }
+    if (hasCumulativeTotal) this.previousCumulativeTotal = cumulativeTotal;
+
+    const normalizedInput = Math.max(0, input);
+    const normalizedOutput = Math.max(0, output);
+    const normalizedReasoning = Math.max(0, reasoning);
+    const normalizedCacheRead = Math.max(0, cacheRead);
+    if (
+      normalizedInput === 0 &&
+      normalizedOutput === 0 &&
+      normalizedReasoning === 0 &&
+      normalizedCacheRead === 0
+    ) {
+      return null;
+    }
+
+    const tokens: MessageTokens = {
+      input: normalizedInput,
+      output: normalizedOutput,
+      reasoning: normalizedReasoning || undefined,
+      cache_read: normalizedCacheRead || undefined,
+    };
+    const cost = estimateTokenCost(model, tokens);
+    const modelTokens = normalizedInput + normalizedOutput + normalizedReasoning;
+    if (model && modelTokens > 0) {
+      this.tokensByModel[model] = (this.tokensByModel[model] ?? 0) + modelTokens;
+    }
+    this.totalInput += normalizedInput;
+    this.totalOutput += normalizedOutput + normalizedReasoning;
+    this.totalCacheRead += normalizedCacheRead;
+    this.totalCost += cost ?? 0;
+
+    return { tokens, model, cost };
+  }
+
+  stats(messageCount = 0): SessionStats {
+    return {
+      message_count: messageCount,
+      total_input_tokens: this.totalInput,
+      total_output_tokens: this.totalOutput,
+      total_cache_read_tokens: this.totalCacheRead || undefined,
+      total_cost: this.totalCost,
+      cost_source: this.totalCost > 0 ? "estimated" : undefined,
+    };
+  }
+
+  modelUsage(): Record<string, number> | undefined {
+    return Object.keys(this.tokensByModel).length > 0 ? { ...this.tokensByModel } : undefined;
+  }
+}

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -14,7 +14,6 @@ import { firstExisting, resolveHomePath } from "../discovery/paths.js";
 import { parseJsonlLines, readJsonlFile, readJsonlFileLines } from "../utils/jsonl.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
 import { cleanInternalText, isInternalEventType } from "../utils/session-normalization.js";
-import { estimateTokenCost } from "../utils/cost.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import { parseAgentTimestamp } from "../utils/timestamp.js";
 import { asRecord, asString, narrowField } from "../utils/narrow.js";
@@ -28,6 +27,7 @@ import {
   splitExecToolName,
   stripExecOutputEnvelope,
 } from "./codex-exec-decode.js";
+import { CodexTokenUsageAccumulator } from "./codex-token-usage.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -95,11 +95,6 @@ function extractModelName(raw: unknown): string | null {
   return typeof raw === "string" && raw.trim() ? raw.trim() : null;
 }
 
-function extractCachedInputTokens(usage: Record<string, unknown> | undefined): number {
-  if (!usage) return 0;
-  return Number(usage["cached_input_tokens"] ?? usage["cache_read_input_tokens"] ?? 0);
-}
-
 function narrowRecordField(value: unknown, field: string): Record<string, unknown> | undefined {
   return narrowField("codex", field, value, asRecord);
 }
@@ -135,21 +130,6 @@ function readLeadingJsonlLines(filePath: string, limit: number): string[] {
     if (lines.length === limit) break;
   }
   return lines;
-}
-
-function extractTokenUsage(payload: Record<string, unknown>): {
-  totalUsage: Record<string, unknown> | undefined;
-  lastUsage: Record<string, unknown> | undefined;
-} {
-  const info = narrowRecordField(payload["info"], "token_count.info");
-  return {
-    totalUsage: info
-      ? narrowRecordField(info["total_token_usage"], "token_count.total_token_usage")
-      : undefined,
-    lastUsage: info
-      ? narrowRecordField(info["last_token_usage"], "token_count.last_token_usage")
-      : undefined,
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -529,17 +509,8 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   }
 
   private parseTokenStats(filePath: string): SessionHead["stats"] {
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheReadTokens = 0;
-    let totalCost = 0;
+    const usage = new CodexTokenUsageAccumulator();
     let activeModel: string | null = null;
-
-    let prevCumulativeTotal = 0;
-    let prevInput = 0;
-    let prevOutput = 0;
-    let prevReasoning = 0;
-    let prevCachedInput = 0;
 
     for (const line of readJsonlFileLines(filePath)) {
       try {
@@ -554,58 +525,14 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
         }
 
         if (recordType === "event_msg" && String(payload["type"] ?? "") === "token_count") {
-          const { totalUsage, lastUsage } = extractTokenUsage(payload);
-          const cumulativeTotal = Number(totalUsage?.["total_tokens"] ?? 0);
-          if (cumulativeTotal <= 0 || cumulativeTotal === prevCumulativeTotal) continue;
-          prevCumulativeTotal = cumulativeTotal;
-
-          let inputTokens = 0;
-          let outputTokens = 0;
-          let reasoningTokens = 0;
-          let cacheReadTokens = 0;
-
-          if (lastUsage) {
-            inputTokens = Number(lastUsage["input_tokens"] ?? 0);
-            outputTokens = Number(lastUsage["output_tokens"] ?? 0);
-            reasoningTokens = Number(lastUsage["reasoning_output_tokens"] ?? 0);
-            cacheReadTokens = extractCachedInputTokens(lastUsage);
-          } else if (totalUsage) {
-            inputTokens = Number(totalUsage["input_tokens"] ?? 0) - prevInput;
-            outputTokens = Number(totalUsage["output_tokens"] ?? 0) - prevOutput;
-            reasoningTokens = Number(totalUsage["reasoning_output_tokens"] ?? 0) - prevReasoning;
-            cacheReadTokens = extractCachedInputTokens(totalUsage) - prevCachedInput;
-            prevInput = Number(totalUsage["input_tokens"] ?? 0);
-            prevOutput = Number(totalUsage["output_tokens"] ?? 0);
-            prevReasoning = Number(totalUsage["reasoning_output_tokens"] ?? 0);
-            prevCachedInput = extractCachedInputTokens(totalUsage);
-          }
-
-          const totalInput = Math.max(0, inputTokens);
-          const totalCacheRead = Math.max(0, cacheReadTokens);
-          totalInputTokens += totalInput;
-          totalOutputTokens += outputTokens + reasoningTokens;
-          totalCacheReadTokens += totalCacheRead;
-          totalCost +=
-            estimateTokenCost(activeModel, {
-              input: totalInput,
-              output: outputTokens,
-              reasoning: reasoningTokens || undefined,
-              cache_read: totalCacheRead || undefined,
-            }) ?? 0;
+          usage.consume(payload, activeModel);
         }
       } catch {
         // skip malformed records
       }
     }
 
-    return {
-      message_count: 0,
-      total_input_tokens: totalInputTokens,
-      total_output_tokens: totalOutputTokens,
-      total_cache_read_tokens: totalCacheReadTokens || undefined,
-      total_cost: totalCost,
-      cost_source: totalCost > 0 ? "estimated" : undefined,
-    };
+    return usage.stats();
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -615,21 +542,10 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     this.basePath ??= this.findBasePath();
 
     const transcript = new TranscriptBuilder();
-
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheReadTokens = 0;
-    let totalCost = 0;
+    const usage = new CodexTokenUsageAccumulator();
 
     let pendingPlan: MessagePart | null = null;
     let activeModel: string | null = null;
-
-    // Token-count dedup state (matches codeburn strategy)
-    let prevCumulativeTotal = 0;
-    let prevInput = 0;
-    let prevOutput = 0;
-    let prevReasoning = 0;
-    let prevCachedInput = 0;
 
     for (const record of readJsonlFile(meta.sourcePath)) {
       try {
@@ -645,58 +561,13 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
         if (recordType === "event_msg") {
           const payload = extractPayload(record);
           if (String(payload["type"] ?? "") === "token_count") {
-            const { totalUsage, lastUsage } = extractTokenUsage(payload);
-            const cumulativeTotal = Number(totalUsage?.["total_tokens"] ?? 0);
-
-            if (cumulativeTotal > 0 && cumulativeTotal === prevCumulativeTotal) {
-              // duplicate event
-            } else {
-              prevCumulativeTotal = cumulativeTotal;
-
-              let inputTokens = 0;
-              let outputTokens = 0;
-              let reasoningTokens = 0;
-              let cacheReadTokens = 0;
-
-              if (lastUsage) {
-                inputTokens = Number(lastUsage["input_tokens"] ?? 0);
-                outputTokens = Number(lastUsage["output_tokens"] ?? 0);
-                reasoningTokens = Number(lastUsage["reasoning_output_tokens"] ?? 0);
-                cacheReadTokens = extractCachedInputTokens(lastUsage);
-              } else if (cumulativeTotal > 0 && totalUsage) {
-                inputTokens = Number(totalUsage["input_tokens"] ?? 0) - prevInput;
-                outputTokens = Number(totalUsage["output_tokens"] ?? 0) - prevOutput;
-                reasoningTokens =
-                  Number(totalUsage["reasoning_output_tokens"] ?? 0) - prevReasoning;
-                cacheReadTokens = extractCachedInputTokens(totalUsage) - prevCachedInput;
-
-                prevInput = Number(totalUsage["input_tokens"] ?? 0);
-                prevOutput = Number(totalUsage["output_tokens"] ?? 0);
-                prevReasoning = Number(totalUsage["reasoning_output_tokens"] ?? 0);
-                prevCachedInput = extractCachedInputTokens(totalUsage);
-              }
-
-              const totalInput = Math.max(0, inputTokens);
-              const totalCacheRead = Math.max(0, cacheReadTokens);
-              if (totalInput || outputTokens || reasoningTokens) {
-                totalInputTokens += totalInput;
-                totalOutputTokens += outputTokens + reasoningTokens;
-                totalCacheReadTokens += totalCacheRead;
-
-                const tokens = {
-                  input: totalInput,
-                  output: outputTokens,
-                  reasoning: reasoningTokens || undefined,
-                  cache_read: totalCacheRead || undefined,
-                };
-                const cost = estimateTokenCost(activeModel, tokens);
-                transcript.attachUsageToLatestAssistant(tokens, {
-                  model: activeModel,
-                  cost: cost ?? undefined,
-                  costSource: cost === null ? undefined : "estimated",
-                });
-                totalCost += cost ?? 0;
-              }
+            const delta = usage.consume(payload, activeModel);
+            if (delta) {
+              transcript.attachUsageToLatestAssistant(delta.tokens, {
+                model: delta.model,
+                cost: delta.cost ?? undefined,
+                costSource: delta.cost === null ? undefined : "estimated",
+              });
             }
           }
         }
@@ -706,14 +577,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     }
 
     if (pendingPlan) transcript.appendToCurrentAssistant(pendingPlan);
-    const result = transcript.finish({
-      message_count: 0,
-      total_input_tokens: totalInputTokens,
-      total_output_tokens: totalOutputTokens,
-      total_cache_read_tokens: totalCacheReadTokens || undefined,
-      total_cost: totalCost,
-      cost_source: totalCost > 0 ? "estimated" : undefined,
-    });
+    const result = transcript.finish(usage.stats());
 
     this.applyChildStats(result.stats, meta.id);
 
@@ -1072,17 +936,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     let updatedAt = 0;
     let messageCount = 0;
     let activeModel: string | null = null;
-    const modelUsageMap: Record<string, number> = {};
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
-    let totalCacheReadTokens = 0;
-    let totalCost = 0;
-
-    let scanPrevCumulativeTotal = 0;
-    let scanPrevInput = 0;
-    let scanPrevOutput = 0;
-    let scanPrevReasoning = 0;
-    let scanPrevCachedInput = 0;
+    const usage = new CodexTokenUsageAccumulator();
 
     const COUNTED_TYPES = new Set(["message", "function_call", "function_call_output"]);
 
@@ -1148,52 +1002,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
 
         if (recordType === "event_msg") {
           if (String(payload["type"] ?? "") === "token_count") {
-            const { totalUsage, lastUsage } = extractTokenUsage(payload);
-            const cumulativeTotal = Number(totalUsage?.["total_tokens"] ?? 0);
-
-            if (cumulativeTotal > 0 && cumulativeTotal !== scanPrevCumulativeTotal) {
-              scanPrevCumulativeTotal = cumulativeTotal;
-
-              let inputTokens = 0;
-              let outputTokens = 0;
-              let reasoningTokens = 0;
-              let cacheReadTokens = 0;
-
-              if (lastUsage) {
-                inputTokens = Number(lastUsage["input_tokens"] ?? 0);
-                outputTokens = Number(lastUsage["output_tokens"] ?? 0);
-                reasoningTokens = Number(lastUsage["reasoning_output_tokens"] ?? 0);
-                cacheReadTokens = extractCachedInputTokens(lastUsage);
-              } else if (cumulativeTotal > 0 && totalUsage) {
-                inputTokens = Number(totalUsage["input_tokens"] ?? 0) - scanPrevInput;
-                outputTokens = Number(totalUsage["output_tokens"] ?? 0) - scanPrevOutput;
-                reasoningTokens =
-                  Number(totalUsage["reasoning_output_tokens"] ?? 0) - scanPrevReasoning;
-                cacheReadTokens = extractCachedInputTokens(totalUsage) - scanPrevCachedInput;
-
-                scanPrevInput = Number(totalUsage["input_tokens"] ?? 0);
-                scanPrevOutput = Number(totalUsage["output_tokens"] ?? 0);
-                scanPrevReasoning = Number(totalUsage["reasoning_output_tokens"] ?? 0);
-                scanPrevCachedInput = extractCachedInputTokens(totalUsage);
-              }
-
-              const totalInput = Math.max(0, inputTokens);
-              const totalCacheRead = Math.max(0, cacheReadTokens);
-              totalInputTokens += totalInput;
-              totalOutputTokens += outputTokens + reasoningTokens;
-              totalCacheReadTokens += totalCacheRead;
-              const totalForModel = totalInput + outputTokens + reasoningTokens;
-              if (activeModel && totalForModel > 0) {
-                modelUsageMap[activeModel] = (modelUsageMap[activeModel] ?? 0) + totalForModel;
-              }
-              const cost = estimateTokenCost(activeModel, {
-                input: totalInput,
-                output: outputTokens,
-                reasoning: reasoningTokens || undefined,
-                cache_read: totalCacheRead || undefined,
-              });
-              if (cost !== null) totalCost += cost;
-            }
+            usage.consume(payload, activeModel);
           }
         }
       } catch {
@@ -1216,15 +1025,8 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
         parentThreadId == null ? undefined : { agentName: this.name, sessionId: parentThreadId },
       time_created: createdAt,
       time_updated: updatedAt,
-      stats: {
-        message_count: messageCount,
-        total_input_tokens: totalInputTokens,
-        total_output_tokens: totalOutputTokens,
-        total_cache_read_tokens: totalCacheReadTokens || undefined,
-        total_cost: totalCost,
-        cost_source: totalCost > 0 ? "estimated" : undefined,
-      },
-      model_usage: Object.keys(modelUsageMap).length > 0 ? modelUsageMap : undefined,
+      stats: usage.stats(messageCount),
+      model_usage: usage.modelUsage(),
     });
   }
 


### PR DESCRIPTION
## Summary
- replace three Codex token accounting implementations with one accumulator
- keep cumulative baselines aligned across mixed usage payload shapes
- add parity coverage for head/detail stats, deduplication, missing cumulative usage, and cache-only usage

## Validation
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core test`