### PR TITLE
fix(core): preserve cache callback programming errors

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -31,11 +31,11 @@ function collectDiagnostics(
 }
 
 describe("withCacheDb diagnostics", () => {
-  it("reports cache.write_failed when the callback throws", () => {
+  it("reports cache.write_failed when a SQLite callback throws", () => {
     const events = collectDiagnostics();
 
     const result = withCacheDb(() => {
-      throw new Error("disk full");
+      throw Object.assign(new Error("disk full"), { code: "SQLITE_FULL" });
     });
 
     expect(result).toBeNull();
@@ -44,7 +44,7 @@ describe("withCacheDb diagnostics", () => {
         event: "cache.write_failed",
         detail: {
           message: "disk full",
-          code: undefined,
+          code: "SQLITE_FULL",
           error_class: "Error",
           stack: expect.any(String),
         },
@@ -73,10 +73,36 @@ describe("withCacheDb diagnostics", () => {
     ]);
   });
 
+  it("rethrows programming errors from read-only callbacks", () => {
+    withCacheDb(() => undefined);
+    const events = collectDiagnostics();
+
+    expect(() =>
+      withCacheDbReadOnly(() => {
+        throw new TypeError("invalid row projection");
+      }),
+    ).toThrow(new TypeError("invalid row projection"));
+    expect(events).toEqual([]);
+  });
+
+  it("rethrows programming errors without discarding the connection", () => {
+    const events = collectDiagnostics();
+    const connection = withCacheDb((db) => db);
+
+    expect(() =>
+      withCacheDb(() => {
+        throw new TypeError("invalid cache projection");
+      }),
+    ).toThrow(new TypeError("invalid cache projection"));
+
+    expect(events).toEqual([]);
+    expect(withCacheDb((db) => db)).toBe(connection);
+  });
+
   it("stays silent when no diagnostics sink is injected", () => {
     expect(() =>
       withCacheDb(() => {
-        throw new Error("boom");
+        throw Object.assign(new Error("boom"), { code: "SQLITE_IOERR" });
       }),
     ).not.toThrow();
   });

--- a/packages/core/src/discovery/cache/errors.ts
+++ b/packages/core/src/discovery/cache/errors.ts
@@ -1,0 +1,8 @@
+export class CacheDataIntegrityError extends Error {
+  readonly code = "CACHE_DATA_INTEGRITY";
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CacheDataIntegrityError";
+  }
+}

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -19,6 +19,7 @@ import { normalizeMessageParts } from "../../contract/message-part.js";
 import { assertSessionIdentity, createSessionIdentity } from "../../contract/session-reference.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import type { SQLiteStatement } from "./db.js";
+import { CacheDataIntegrityError } from "./errors.js";
 import type { MessageCursorContent } from "./message-cursor.js";
 
 export const MESSAGE_PARTS_FORMAT_VERSION = 1;
@@ -145,7 +146,12 @@ export function stringifyOptionalJson(value: unknown): string | null {
 }
 
 export function parseOptionalJson<T>(value: unknown): T | undefined {
-  return value == null ? undefined : (JSON.parse(String(value)) as T);
+  if (value == null) return undefined;
+  try {
+    return JSON.parse(String(value)) as T;
+  } catch (error) {
+    throw new CacheDataIntegrityError("Cached JSON field is malformed", { cause: error });
+  }
 }
 
 export function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string | null {
@@ -154,8 +160,12 @@ export function sourcePathFromMeta(meta: SessionCacheMeta | undefined): string |
 
 export function sourcePathFromMetaJson(metaJson: string | null | undefined): string | null {
   if (!metaJson) return null;
-  const meta = JSON.parse(metaJson) as SessionCacheMeta;
-  return sourcePathFromMeta(meta);
+  try {
+    const meta = JSON.parse(metaJson) as SessionCacheMeta;
+    return sourcePathFromMeta(meta);
+  } catch (error) {
+    throw new CacheDataIntegrityError("Cached session metadata is malformed", { cause: error });
+  }
 }
 
 export function requireSessionProjectIdentity(
@@ -465,7 +475,11 @@ export function sessionFromRow(row: SessionRow): IdentifiedSessionHead {
     session.smart_tags_classifier_revision = String(row.smart_tags_classifier_revision);
   }
 
-  assertIdentifiedSessionHead(session);
+  try {
+    assertIdentifiedSessionHead(session);
+  } catch (error) {
+    throw new CacheDataIntegrityError("Cached session identity is incomplete", { cause: error });
+  }
   return session;
 }
 

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -26,6 +26,7 @@ import {
   type CacheConnection,
   type CacheRow,
 } from "./db.js";
+import { CacheDataIntegrityError } from "./errors.js";
 import {
   messageFromBackfillRow,
   prepareInsertFileActivity,
@@ -145,6 +146,33 @@ function getLegacySessionDirectory(session: SessionHead): string | null {
   return typeof session.directory === "string" ? session.directory : null;
 }
 
+function isRecoverableCacheError(error: unknown): boolean {
+  if (error instanceof CacheDataIntegrityError) return true;
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    error.code.startsWith("SQLITE_")
+  );
+}
+
+function reportCacheFailure(
+  cachePath: string,
+  connection: CacheConnection,
+  event: "cache.write_failed" | "cache.read_failed",
+  error: unknown,
+): null {
+  getCoreDiagnostics()?.warn(event, {
+    message: error instanceof Error ? error.message : String(error),
+    code: (error as { code?: string })?.code,
+    error_class: error instanceof Error ? error.name : typeof error,
+    ...(event === "cache.write_failed" && error instanceof Error ? { stack: error.stack } : {}),
+  });
+  discardCacheConnection(cachePath, connection);
+  return null;
+}
+
 function withCacheConnection<T>(fn: (connection: CacheConnection) => T): T | null {
   const cachePath = getCachePath();
   const connection = getCacheConnection(cachePath);
@@ -155,16 +183,15 @@ function withCacheConnection<T>(fn: (connection: CacheConnection) => T): T | nul
       ensureSchema(connection.db, cachePath);
       setSchemaEnsuredPath(cachePath);
     }
+  } catch (error) {
+    return reportCacheFailure(cachePath, connection, "cache.write_failed", error);
+  }
+
+  try {
     return fn(connection);
   } catch (error) {
-    getCoreDiagnostics()?.warn("cache.write_failed", {
-      message: error instanceof Error ? error.message : String(error),
-      code: (error as { code?: string })?.code,
-      error_class: error instanceof Error ? error.name : typeof error,
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-    discardCacheConnection(cachePath, connection);
-    return null;
+    if (!isRecoverableCacheError(error)) throw error;
+    return reportCacheFailure(cachePath, connection, "cache.write_failed", error);
   }
 }
 
@@ -212,12 +239,8 @@ export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): CacheRead
   try {
     return { status: "success", value: fn(connection.db) };
   } catch (error) {
-    getCoreDiagnostics()?.warn("cache.read_failed", {
-      message: error instanceof Error ? error.message : String(error),
-      code: (error as { code?: string })?.code,
-      error_class: error instanceof Error ? error.name : typeof error,
-    });
-    discardCacheConnection(cachePath, connection);
+    if (!isRecoverableCacheError(error)) throw error;
+    reportCacheFailure(cachePath, connection, "cache.read_failed", error);
     return { status: "failed" };
   }
 }


### PR DESCRIPTION
## Summary
- only convert typed cache-integrity and `SQLITE_*` failures into best-effort cache outcomes
- rethrow ordinary callback errors without discarding the active connection
- classify malformed persisted JSON and incomplete cached identities as recoverable cache-integrity failures

## Validation
- `pnpm exec vitest run packages/core/src/discovery/cache/__tests__/diagnostics.test.ts packages/core/src/discovery/cache/__tests__/schema.test.ts packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core test`