### PR TITLE
fix(cli): shut down the store on the --json path

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -251,18 +251,23 @@ const main = defineCommand({
       await pricingRefresh.cancel();
       const scanFailureDiagnostics = formatScanFailureDiagnostics(result);
       if (scanFailureDiagnostics.length > 0) {
-        await store.shutdown();
         for (const diagnostic of scanFailureDiagnostics) console.error(diagnostic);
         process.exitCode = 1;
-        return;
+      } else {
+        for (const diagnostic of formatCacheFailureDiagnostics(result)) console.error(diagnostic);
+        const output = buildSessionIndexOutput(result, {
+          from: listDefaultFrom,
+          to: listDefaultTo,
+        });
+        appLogger.info("cli.json_output", {
+          sessions: output.sessions.length,
+          duration_ms: Math.round(performance.now() - startedAt),
+        });
+        console.log(JSON.stringify(output, null, 2));
       }
-      for (const diagnostic of formatCacheFailureDiagnostics(result)) console.error(diagnostic);
-      const output = buildSessionIndexOutput(result, { from: listDefaultFrom, to: listDefaultTo });
-      appLogger.info("cli.json_output", {
-        sessions: output.sessions.length,
-        duration_ms: Math.round(performance.now() - startedAt),
-      });
-      console.log(JSON.stringify(output, null, 2));
+      // Worker threads and the SQLite connections hold the event loop open;
+      // without this the one-shot process prints its output and never exits.
+      await store.shutdown();
       return;
     }
 

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -81,7 +81,6 @@ const workerThreads = vi.hoisted(() => ({
     on: ReturnType<typeof vi.fn>;
     once: ReturnType<typeof vi.fn>;
     postMessage: ReturnType<typeof vi.fn>;
-    unref: ReturnType<typeof vi.fn>;
     terminate: ReturnType<typeof vi.fn>;
     emitMessage: (message: unknown) => void;
     emitDone: () => void;
@@ -340,7 +339,6 @@ const workerThreads = vi.hoisted(() => ({
       postMessage: vi.fn((data: unknown) => {
         if (!workerThreads.deferScanRefreshWorkers) dispatch(data);
       }),
-      unref: vi.fn(),
       terminate: vi.fn(async () => {
         for (const handler of exitHandlers) handler(0);
       }),

--- a/packages/cli/src/project-identity-resolver.test.ts
+++ b/packages/cli/src/project-identity-resolver.test.ts
@@ -17,8 +17,6 @@ const workerMocks = vi.hoisted(() => {
       return this;
     }
 
-    unref(): void {}
-
     postMessage(message: unknown): void {
       this.postedMessages.push(message);
     }

--- a/packages/cli/src/project-identity-resolver.ts
+++ b/packages/cli/src/project-identity-resolver.ts
@@ -251,7 +251,6 @@ export class ThreadProjectIdentityResolver implements ProjectIdentityResolver {
       retirement: null,
     };
     this.workers.add(slot);
-    worker.unref();
     worker.on("message", (message: unknown) => {
       if (appLogger.consumeWorkerMessage(message)) return;
       this.handleWorkerMessage(slot, message);

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -18,8 +18,6 @@ const workerMocks = vi.hoisted(() => {
       return this;
     }
 
-    unref(): void {}
-
     postMessage(message: unknown): void {
       this.postedMessages.push(message);
     }

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -154,7 +154,6 @@ export class SearchIndexJobRunner {
       this.startNextBatch();
       return;
     }
-    worker.unref();
     this.worker = worker;
     this.activeBatch = batch;
 

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -226,7 +226,6 @@ export class ThreadWorkerRunner implements WorkerRunner {
       awaitingCommit: null,
       closed: false,
     };
-    worker.unref();
     this.workers.set(agentName, slot);
     worker.on("message", (message: unknown) => {
       if (appLogger.consumeWorkerMessage(message)) return;

--- a/tests/e2e/json-index-exit.spec.ts
+++ b/tests/e2e/json-index-exit.spec.ts
@@ -1,0 +1,59 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "playwright/test";
+
+const CLI_ENTRY = fileURLToPath(new URL("../../packages/cli/dist/index.js", import.meta.url));
+const EXIT_TIMEOUT_MS = 60_000;
+
+/**
+ * `--json` is one-shot: it prints the session index and must hand the shell
+ * back. Nothing else in the suite would notice a process that finishes its
+ * work and then keeps the event loop alive on its worker threads and SQLite
+ * handles, so the exit itself is the assertion. An isolated empty HOME keeps
+ * this hermetic — the hang reproduces with zero sessions to scan.
+ */
+test("exits after printing the session index as JSON", async () => {
+  test.setTimeout(EXIT_TIMEOUT_MS * 2);
+  const home = mkdtempSync(join(tmpdir(), "codesesh-json-exit-"));
+  try {
+    const child = spawn(process.execPath, [CLI_ENTRY, "--json", "--days", "7"], {
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        XDG_DATA_HOME: join(home, ".local", "share"),
+        XDG_CONFIG_HOME: join(home, ".config"),
+        APPDATA: join(home, "AppData", "Roaming"),
+        LOCALAPPDATA: join(home, "AppData", "Local"),
+        CODESESH_LOG_DIR: join(home, "logs"),
+        CODESESH_STATE_STORE: "memory",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: EXIT_TIMEOUT_MS,
+    });
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    const [code, signal] = (await once(child, "exit")) as [number | null, NodeJS.Signals | null];
+    expect(
+      signal,
+      `--json never exited on its own; it had to be killed. stderr: ${stderr}`,
+    ).toBeNull();
+    expect(code, `--json exited non-zero. stderr: ${stderr}`).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({ sessions: expect.any(Array) });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What was wrong

`codesesh --json` never exited. It printed a complete session index and then hung forever.

The `jsonOnly` success path in `packages/cli/src/index.ts` returned without calling `store.shutdown()`; only the scan-failure branch did. `LiveScanStore.performShutdown()` is the sole thing that terminates the worker runners and calls `closeCacheStorage()`, so the worker threads and their SQLite connections kept the libuv loop alive indefinitely.

The `worker.unref()` calls that looked like a safety net were dead code. All three are immediately followed by `worker.on("message", ...)`, and attaching the first `message` listener re-refs the worker's public `MessagePort`, undoing the `unref` one statement later.

### The reported symptom was a red herring

This started as an investigation into `Cache persistence failed; serving in-memory results without advancing the durable baseline`. That message is **not** a defect: it is `SQLITE_BUSY` from cross-process write contention, and the code already handles it correctly — it logs, reports via `cacheFailures`, serves in-memory results, and deliberately does not advance the durable baseline.

What manufactured the contention was this bug. Every benchmark invocation left a live process holding SQLite connections, and those zombies were the "concurrent writers". A clean single-process run produces empty stderr and zero cache failures.

The 904MB WAL had the same cause: a zombie always held a connection open, so SQLite's last-connection checkpoint never ran.

## What changed

- `packages/cli/src/index.ts`: hoist `await store.shutdown()` so both `--json` exits share it.
- Remove the three no-op `worker.unref()` calls in `search-index-job-runner.ts`, `worker-runner.ts` and `project-identity-resolver.ts`, plus the now-unused `unref` stubs in the worker fakes.

Moving the `unref` after the listener is deliberately **not** the fix. A genuinely unref'd worker can let the process exit before `syncInitialIndex()` resolves, i.e. `--json` could print nothing. Lifecycle stays owned explicitly by shutdown rather than by handle-ref accounting.

- `tests/e2e/json-index-exit.spec.ts`: new regression test. It spawns the built CLI with an isolated empty `HOME` and asserts the process exits on its own with parseable JSON. Nothing in the suite previously exercised the one-shot `--json` process.

## How it was verified

Measured on a real 10GB dataset (3113 sessions, 194819 messages):

| | before | after |
|---|---|---|
| `--json -d 7` exit code | 124 (killed at 90s, never exits) | 0 |
| wall time | never returns | 24s cold, 2s warm |
| leftover processes | 1 per invocation | none |
| stderr | — | empty |
| `codesesh.db-wal` / `-shm` after run | 904MB, retained | removed by last-connection checkpoint |

Three back-to-back `--json` runs: 6s, 2s, 2s, all exit 0, zero `cache.save_failed` / `cache.write_failed` entries across all three logs. The warm 2s runs also confirm the durable baseline advances normally, so the "full rescan every start" theory was false.

The new spec was confirmed to fail against the unfixed build (process had to be killed) and pass with the fix (615ms).

Local gate, all green: `pnpm lint`, `format:check`, `typecheck`, `typecheck:e2e`, `check-quality-task-coverage`, `check-docs-paths`, `check-docs-facts`, `release-preflight`, `perf:check`, `build`, `test` (557 CLI / 818 web), `test:e2e` (29 passed), `test:coverage`.

## Out of scope

Recorded from the same investigation, deliberately not bundled:

- `commitDurableSessionPublication` holds the single SQLite write lock for one monolithic transaction (24s warm) against a 5s `busy_timeout`. Now that zombie processes are gone the scenario can be measured honestly before deciding whether to chunk the publication or raise the timeout.
- `packages/core/src/discovery/scanner.ts:738` calls `commitChangeCheck()` before persistence succeeds, contradicting the intent documented at `packages/core/src/agents/base.ts:768`. Harmless in the scanner, potentially stale-until-restart in the long-lived `AgentSyncEngine`.