### PR TITLE
fix(core): stage publication payloads in temp schema

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 30`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 31`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`
@@ -22,7 +22,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 | `cache/schema.ts` | 建表、迁移、事务边界、FTS 完整性检查 |
 | `cache/sessions.ts` | 会话列表和详情快照的读取、写入与清理 |
 | `cache/messages.ts` | `sessions` / `messages` 行与领域对象之间的转换 |
-| `cache/publication-staging.ts` | 大批量详情发布的影子载荷与中断回收 |
+| `cache/publication-staging.ts` | 大批量详情发布的连接级影子载荷与 v21 遗留中断回收 |
 | `cache/search-index-writer.ts` | 详情、工具、文件活动与全文索引的同步写入 |
 | `cache/search.ts` | 搜索查询与结构化过滤 |
 | `cache/search-query-parser.ts` | 搜索语法解析 |
@@ -32,7 +32,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 ## Schema 清单
 
-当前 schema 创建 16 张表（其中 2 张是 FTS5 虚表）和 1 个视图。
+当前 schema 创建 15 张表（其中 2 张是 FTS5 虚表）和 1 个视图。
 
 ### 生命周期与同步状态
 
@@ -65,16 +65,22 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 | `session_file_activity_path_fts` | trigram FTS5 虚表 | 文件路径匹配 |
 | `session_documents` | 普通表 | 会话标题、聚合文本、内容签名与已索引消息数 |
 | `session_documents_fts` | FTS5 虚表 | 会话级标题和聚合文本搜索 |
-| `search_index_publication_entries` | 普通表 | 大批量发布提交前暂存序列化详情；提交或回滚后清空 |
+
+大批量发布提交前暂存的序列化详情（`search_index_publication_entries`）建在连接的 TEMP schema
+上，不属于持久 schema。它的有效生命周期只有一次进程内发布，没有任何路径会跨进程续期；放在
+TEMP 里让「进程被中断后留下孤儿暂存行」不可表达——连接一断，SQLite 直接把这些字节还给操作
+系统，无需清理器兜底。TEMP 数据会溢写到数据库同目录的文件（`temp_store = FILE`、
+`SQLITE_TMPDIR` 指向缓存目录），因此暂存机制原本的内存上界仍然成立。
 
 两个 FTS 表都由对应内容表的 insert/update/delete 触发器维护。批量变化达到阈值时，
 `runSearchIndexWrite()` 会在写事务中重建会话文档索引；文件路径索引仍由触发器增量维护。
 搜索先由会话文档索引召回和排序，再在候选会话的消息纯文本中定位首条命中消息，不再
 为同一批内容维护第二套消息级倒排索引。
 
-Schema 24 删除旧消息索引后，SQLite 会把对应页计入 freelist，后续写入可以直接复用；
-数据库文件的字节大小不会因此立即下降。物理压缩需要重写整个数据库，因此不在启动迁移
-中自动执行，避免把一次性磁盘回收变成阻塞式维护。
+Schema 24 删除旧消息索引、schema 31 删除持久暂存表后，SQLite 会把对应页计入 freelist，
+后续写入可以直接复用；数据库文件的字节大小不会因此立即下降。物理压缩需要重写整个数据库，
+因此不在启动迁移中自动执行，避免把一次性磁盘回收变成阻塞式维护。需要真正缩小文件时手动执行
+`sqlite3 ~/.cache/codesesh/codesesh.db 'VACUUM'`。
 
 ### 项目聚合
 

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 30;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 31;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -25,13 +25,9 @@ function readPublicationCounts(db: SQLiteDatabase) {
   const documents = db
     .prepare("SELECT COUNT(*) AS value FROM session_documents WHERE agent_name = ?")
     .get("codex") as { value?: number };
-  const payloads = db
-    .prepare("SELECT COUNT(*) AS value FROM search_index_publication_entries")
-    .get() as { value?: number };
   return {
     sessions: Number(sessions.value ?? 0),
     documents: Number(documents.value ?? 0),
-    payloads: Number(payloads.value ?? 0),
   };
 }
 
@@ -76,11 +72,11 @@ describe("cache schema boundary", () => {
       "session_documents",
       "session_file_activity",
       "project_groups_v",
-      "search_index_publication_entries",
     ]) {
       expect(state?.names.has(name)).toBe(true);
     }
     expect(state?.names.has("messages_fts")).toBe(false);
+    expect(state?.names.has("search_index_publication_entries")).toBe(false);
     expect(state?.documentColumns).toEqual([
       "id",
       "agent_name",
@@ -102,7 +98,7 @@ describe("cache schema boundary", () => {
         "publication_id",
       ]),
     );
-    expect(state?.version).toBe(30);
+    expect(state?.version).toBe(31);
   });
 
   it("derives session identity from the composite key when upgrading schema 29", () => {
@@ -178,7 +174,7 @@ describe("cache schema boundary", () => {
       ),
     }));
 
-    expect(migrated).toEqual({ objects: [], version: 30 });
+    expect(migrated).toEqual({ objects: [], version: 31 });
   });
 
   it("adds an empty hash chain column when upgrading schema 24", () => {
@@ -207,7 +203,7 @@ describe("cache schema boundary", () => {
       ).content_chain_digest,
     }));
 
-    expect(migrated).toEqual({ version: 30, digest: null });
+    expect(migrated).toEqual({ version: 31, digest: null });
   });
 
   it("backfills session usage summaries when upgrading schema 28", () => {
@@ -295,7 +291,7 @@ describe("cache schema boundary", () => {
     }));
 
     expect(migrated).toEqual({
-      version: 30,
+      version: 31,
       summary: {
         message_count: 2,
         untimed_message_count: 1,
@@ -340,7 +336,7 @@ describe("cache schema boundary", () => {
     expect(secondProbeCount).toBe(firstProbeCount);
   });
 
-  it("defers orphaned publication cleanup until the first search-index write", () => {
+  it("defers orphaned v21 publication cleanup until the first search-index write", () => {
     const session = makeSessionHead("orphaned-publication");
     saveCachedSessions("codex", [session]);
     syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
@@ -351,16 +347,6 @@ describe("cache schema boundary", () => {
         "orphaned",
         session.id,
       );
-      db.prepare(
-        `
-          INSERT INTO search_index_publication_entries(
-            publication_id,
-            agent_name,
-            session_id,
-            payload_json
-          ) VALUES (?, ?, ?, ?)
-        `,
-      ).run("orphaned", "codex", session.id, "{}");
     } finally {
       db.close();
     }
@@ -368,11 +354,11 @@ describe("cache schema boundary", () => {
 
     const beforeCleanup = schema.withCacheDb(readPublicationCounts);
 
-    expect(beforeCleanup).toEqual({ sessions: 1, documents: 1, payloads: 1 });
+    expect(beforeCleanup).toEqual({ sessions: 1, documents: 1 });
 
     const afterCleanup = schema.withSearchIndexDb(readPublicationCounts);
 
-    expect(afterCleanup).toEqual({ sessions: 0, documents: 0, payloads: 0 });
+    expect(afterCleanup).toEqual({ sessions: 0, documents: 0 });
   });
 
   it("skips cleanup scans after an empty staging probe", () => {
@@ -381,7 +367,7 @@ describe("cache schema boundary", () => {
 
     schema.withSearchIndexDb(() => undefined);
     const firstProbeCount = prepare.mock.calls.filter(([sql]) =>
-      String(sql).includes("SELECT 1 FROM search_index_publication_entries LIMIT 1"),
+      String(sql).includes("SELECT 1 FROM sessions WHERE publication_id IS NOT NULL LIMIT 1"),
     ).length;
     const cleanupStatementCount = prepare.mock.calls.filter(([sql]) =>
       String(sql).includes("DELETE FROM"),
@@ -389,7 +375,7 @@ describe("cache schema boundary", () => {
 
     schema.withSearchIndexDb(() => undefined);
     const secondProbeCount = prepare.mock.calls.filter(([sql]) =>
-      String(sql).includes("SELECT 1 FROM search_index_publication_entries LIMIT 1"),
+      String(sql).includes("SELECT 1 FROM sessions WHERE publication_id IS NOT NULL LIMIT 1"),
     ).length;
     prepare.mockRestore();
 
@@ -475,7 +461,7 @@ describe("cache schema boundary", () => {
           .get("codex", session.id) != null,
     }));
 
-    expect(migrated).toEqual({ version: 30, detailVersion: "", pending: true });
+    expect(migrated).toEqual({ version: 31, detailVersion: "", pending: true });
   });
 
   it("marks legacy project identities stale by leaving added provenance empty", () => {
@@ -514,7 +500,7 @@ describe("cache schema boundary", () => {
     });
 
     expect(migrated).toEqual({
-      version: 30,
+      version: 31,
       resolverRevision: null,
       inputSignature: null,
       classifierRevision: null,
@@ -584,7 +570,7 @@ describe("cache schema boundary", () => {
       });
 
       expect(migrated).toEqual({
-        version: 30,
+        version: 31,
         partsJson: legacyPartsJson,
         partsFormatVersion: 0,
       });

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -19,7 +19,8 @@ import {
 } from "../search.js";
 import { setSchemaEnsuredPath } from "../db.js";
 import { MESSAGE_PARTS_FORMAT_VERSION } from "../messages.js";
-import { withCacheDb, withSearchDb } from "../schema.js";
+import { prepareSessionSnapshotSearchIndex } from "../search-index-writer.js";
+import { withCacheDb, withSearchDb, withSearchIndexDb } from "../schema.js";
 import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
 import type { IdentifiedSessionHead, SessionDetail, SessionHead } from "../../../types/index.js";
 
@@ -418,7 +419,7 @@ describe("durable publication", () => {
       expect(searchSessions("bulk-42 bulk needle")).toHaveLength(1);
       expect(
         withCacheDb((db) =>
-          db.prepare("SELECT COUNT(*) AS value FROM search_index_publication_entries").get(),
+          db.prepare("SELECT COUNT(*) AS value FROM temp.search_index_publication_entries").get(),
         ),
       ).toEqual({ value: 0 });
 
@@ -443,6 +444,56 @@ describe("durable publication", () => {
         indexed: 0,
       });
       expect(loadAgain).not.toHaveBeenCalled();
+    },
+    SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "leaves nothing durable when a pre-staged publication never commits",
+    () => {
+      const sessions = Array.from({ length: 70 }, (_, index) => makeSession(`abandoned-${index}`));
+      const payloadText = `abandoned needle ${"filler ".repeat(300)}`;
+      const durablePageCount = () => {
+        const db = new Database(getCachePath(), { readonly: true });
+        try {
+          return Number(db.pragma("page_count", { simple: true }));
+        } finally {
+          db.close();
+        }
+      };
+
+      withCacheDb(() => undefined);
+      const pagesBeforeStaging = durablePageCount();
+
+      withSearchIndexDb((db) =>
+        prepareSessionSnapshotSearchIndex(
+          db,
+          "codex",
+          sessions,
+          (sessionId) => makeSessionData(sessionId, `${sessionId} ${payloadText}`),
+          { publicationId: "abandoned" },
+        ),
+      );
+      // Dropping the prepared publication and closing every connection is what a
+      // SIGINT or worker.terminate() between staging and commit leaves behind.
+      setSchemaEnsuredPath(null);
+
+      expect(durablePageCount()).toBe(pagesBeforeStaging);
+
+      const reopened = new Database(getCachePath(), { readonly: true });
+      try {
+        expect(
+          reopened
+            .prepare(
+              `SELECT COUNT(*) AS value FROM sqlite_master
+               WHERE type = 'table' AND name = 'search_index_publication_entries'`,
+            )
+            .get(),
+        ).toEqual({ value: 0 });
+      } finally {
+        reopened.close();
+      }
+      expect(searchSessions("abandoned-42 abandoned needle")).toHaveLength(0);
     },
     SEARCH_INDEX_BATCH_TEST_TIMEOUT_MS,
   );
@@ -513,11 +564,13 @@ describe("durable publication", () => {
             .get("codex"),
         ).toEqual({ value: 1 });
         expect(
-          verifyDb
-            .prepare(
-              "SELECT COUNT(*) AS value FROM search_index_publication_entries WHERE publication_id = ?",
-            )
-            .get(result.publicationId),
+          withCacheDb((db) =>
+            db
+              .prepare(
+                "SELECT COUNT(*) AS value FROM temp.search_index_publication_entries WHERE publication_id = ?",
+              )
+              .get(result.publicationId),
+          ),
         ).toEqual({ value: 0 });
       } finally {
         verifyDb.close();
@@ -1365,7 +1418,7 @@ describe("searchSessions", () => {
     } finally {
       migratedDb.close();
     }
-    expect(getUserVersion(getCachePath())).toBe(30);
+    expect(getUserVersion(getCachePath())).toBe(31);
   });
 
   it("keeps small incremental updates searchable immediately", () => {
@@ -2158,7 +2211,7 @@ describe("searchSessions", () => {
     expect(listFileActivity({ path: "migrated/App", limit: 10 }).map((item) => item.path)).toEqual([
       "src/migrated/App.tsx",
     ]);
-    expect(getUserVersion(getCachePath())).toBe(30);
+    expect(getUserVersion(getCachePath())).toBe(31);
   });
 
   it("refreshes cached project identities when migrating to schema version 12", () => {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -56,7 +56,6 @@ const CACHE_DATA_TABLES = [
   "cache_initialization",
   "cached_sessions",
   "pending_reindex",
-  "search_index_publication_entries",
   "session_documents",
   "session_file_activity",
   "message_tools",
@@ -279,7 +278,7 @@ describe("withCacheDb schema memo", () => {
   it("runs ensureSchema on the first open but skips it on later opens for the same path", () => {
     withCacheDb(() => undefined);
     expect(getSchemaEnsuredPath()).toBe(getCachePath());
-    expect(getUserVersion(getCachePath())).toBe(30);
+    expect(getUserVersion(getCachePath())).toBe(31);
 
     const db = new Database(getCachePath());
     db.pragma("user_version = 14");
@@ -290,7 +289,7 @@ describe("withCacheDb schema memo", () => {
 
     setSchemaEnsuredPath(null);
     withCacheDb(() => undefined);
-    expect(getUserVersion(getCachePath())).toBe(30);
+    expect(getUserVersion(getCachePath())).toBe(31);
   });
 });
 
@@ -298,7 +297,7 @@ describe("saveCachedSessions", () => {
   it("creates sqlite cache db", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     expect(readFileSync(getCachePath()).byteLength).toBeGreaterThan(0);
-    expect(getUserVersion(getCachePath())).toBe(30);
+    expect(getUserVersion(getCachePath())).toBe(31);
   });
 
   it("writes structured session rows for cache restores", () => {
@@ -571,7 +570,7 @@ describe("saveCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
 
     expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
-    expect(getUserVersion(getCachePath())).toBe(30);
+    expect(getUserVersion(getCachePath())).toBe(31);
     expect(listCachedProjectGroups()).toEqual([
       {
         identityKind: "path",
@@ -631,7 +630,7 @@ describe("saveCachedSessions", () => {
 
     try {
       expect(loadCachedSessions("claudecode")?.sessions).toEqual([]);
-      expect(getUserVersion(getCachePath())).toBe(30);
+      expect(getUserVersion(getCachePath())).toBe(31);
       expect(warnings).toContainEqual({
         event: "sqlite.migration.identity_precompute.missing_directory",
         detail: { agent_name: "claudecode", session_id: "legacy-null-directory" },
@@ -758,8 +757,6 @@ describe("clearCache", () => {
         INSERT INTO cache_initialization(agent_name, initialized_at, index_version, last_sync_at)
         VALUES ('codex', ${now}, 'index-v1', ${now});
         INSERT INTO pending_reindex(agent_name, session_id) VALUES ('orphan', 'clear-me');
-        INSERT INTO search_index_publication_entries(publication_id, agent_name, session_id, payload_json)
-        VALUES ('staged-publication', 'codex', 'clear-me', '{}');
         INSERT INTO session_documents(
           agent_name, session_id, title, content_text, content_hash,
           indexed_message_count, detail_version, indexed_at

--- a/packages/core/src/discovery/cache/publication-staging.ts
+++ b/packages/core/src/discovery/cache/publication-staging.ts
@@ -6,15 +6,22 @@ interface StagedPublicationRow extends DatabaseRow {
 }
 
 const PUBLICATION_READ_BATCH_SIZE = 64;
+const STAGING_TABLE = "temp.search_index_publication_entries";
 
 export interface PublicationPayload {
   sessionId: string;
   json: string;
 }
 
-export function createPublicationStagingTable(db: SQLiteDatabase): void {
+/**
+ * Staged payloads are scratch for one in-process publication — nothing resumes
+ * one across processes. Holding them in the connection's TEMP schema makes an
+ * orphan unrepresentable: an abrupt exit returns the bytes to the OS instead of
+ * leaving a corpus-sized copy inside the durable cache for a sweeper to find.
+ */
+function ensureStagingTable(db: SQLiteDatabase): void {
   db.exec(`
-    CREATE TABLE IF NOT EXISTS search_index_publication_entries (
+    CREATE TEMP TABLE IF NOT EXISTS search_index_publication_entries (
       publication_id TEXT NOT NULL,
       agent_name TEXT NOT NULL,
       session_id TEXT NOT NULL,
@@ -30,8 +37,9 @@ export function stagePublicationPayloads(
   agentName: string,
   payloads: Iterable<PublicationPayload>,
 ): number {
+  ensureStagingTable(db);
   const upsert = db.prepare(`
-    INSERT INTO search_index_publication_entries(
+    INSERT INTO ${STAGING_TABLE}(
       publication_id,
       agent_name,
       session_id,
@@ -48,6 +56,11 @@ export function stagePublicationPayloads(
   return staged;
 }
 
+/**
+ * Deliberately does not create the table: staging and commit must share one
+ * connection, so a missing temp schema means that invariant broke and must fail
+ * loudly instead of silently indexing nothing.
+ */
 export function* readPublicationPayloads(
   db: SQLiteDatabase,
   publicationId: string,
@@ -55,7 +68,7 @@ export function* readPublicationPayloads(
 ): Generator<string> {
   const readBatch = db.prepare(`
         SELECT session_id, payload_json
-        FROM search_index_publication_entries
+        FROM ${STAGING_TABLE}
         WHERE publication_id = ? AND agent_name = ? AND session_id > ?
         ORDER BY session_id
         LIMIT ?
@@ -74,13 +87,19 @@ export function* readPublicationPayloads(
   }
 }
 
-export function deletePublicationPayloads(db: SQLiteDatabase, publicationId: string): void {
-  db.prepare("DELETE FROM search_index_publication_entries WHERE publication_id = ?").run(
+export function deletePublicationPayloads(
+  db: SQLiteDatabase,
+  publicationId: string,
+  agentName: string,
+): void {
+  ensureStagingTable(db);
+  db.prepare(`DELETE FROM ${STAGING_TABLE} WHERE publication_id = ? AND agent_name = ?`).run(
     publicationId,
+    agentName,
   );
 }
 
-function hasLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string): boolean {
+export function hasLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string): boolean {
   const predicate = publicationId ? "publication_id = ?" : "publication_id IS NOT NULL";
   const params = publicationId ? [publicationId] : [];
   return (
@@ -88,12 +107,7 @@ function hasLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string): b
   );
 }
 
-export function hasPublicationStaging(db: SQLiteDatabase): boolean {
-  const payload = db.prepare("SELECT 1 FROM search_index_publication_entries LIMIT 1").get();
-  return payload !== undefined || hasLegacyPublicationRows(db);
-}
-
-function deleteLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string): void {
+export function deleteLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string): void {
   // Schema v21 could leave staged heads and their live detail rows after an interruption.
   const predicate = publicationId
     ? "staged.publication_id = ?"
@@ -124,13 +138,13 @@ function deleteLegacyPublicationRows(db: SQLiteDatabase, publicationId?: string)
   ).run(...params);
 }
 
-export function discardPublicationStaging(db: SQLiteDatabase, publicationId?: string): void {
+export function discardPublicationStaging(
+  db: SQLiteDatabase,
+  publicationId: string,
+  agentName: string,
+): void {
   if (hasLegacyPublicationRows(db, publicationId)) {
     deleteLegacyPublicationRows(db, publicationId);
   }
-  if (publicationId) {
-    deletePublicationPayloads(db, publicationId);
-  } else {
-    db.prepare("DELETE FROM search_index_publication_entries").run();
-  }
+  deletePublicationPayloads(db, publicationId, agentName);
 }

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -167,7 +167,7 @@ export function commitDurableSessionPublication(
   });
 
   if (!searchIndex) {
-    discardPreparedSessionSearchIndex(publicationId);
+    discardPreparedSessionSearchIndex(publicationId, publication.agentName);
     diagnostics?.warn("search_index.publication_stage", {
       ...detail,
       stage: "rolled_back",

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -40,11 +40,7 @@ import {
   type SessionRow,
 } from "./messages.js";
 import { CACHE_SCHEMA_VERSION } from "./version.js";
-import {
-  createPublicationStagingTable,
-  discardPublicationStaging,
-  hasPublicationStaging,
-} from "./publication-staging.js";
+import { deleteLegacyPublicationRows, hasLegacyPublicationRows } from "./publication-staging.js";
 
 interface MessageToolBackfillRow extends DatabaseRow {
   agent_name?: string;
@@ -199,9 +195,9 @@ function cleanPublicationStaging(connection: CacheConnection): void {
   if (connection.publicationStagingCleaned) return;
 
   const startedAt = performance.now();
-  const reclaimed = hasPublicationStaging(connection.db);
+  const reclaimed = hasLegacyPublicationRows(connection.db);
   if (reclaimed) {
-    connection.db.transaction(() => discardPublicationStaging(connection.db)).immediate();
+    connection.db.transaction(() => deleteLegacyPublicationRows(connection.db)).immediate();
   }
   connection.publicationStagingCleaned = true;
   getCoreDiagnostics()?.info?.("sqlite.publication_staging_cleanup.completed", {
@@ -779,7 +775,6 @@ function createLatestCacheSchema(db: SQLiteDatabase): void {
   createSessionTables(db);
   createFileActivityTables(db);
   createProjectTables(db);
-  createPublicationStagingTable(db);
   ensureFtsReady(db);
 }
 
@@ -1236,7 +1231,6 @@ function invalidateSearchContentHashes(db: SQLiteDatabase): void {
 }
 
 function addAtomicPublicationStaging(db: SQLiteDatabase): void {
-  createPublicationStagingTable(db);
   invalidateSearchContentHashes(db);
   if (tableExists(db, "sessions") && tableExists(db, "pending_reindex")) {
     db.exec(`
@@ -1246,6 +1240,10 @@ function addAtomicPublicationStaging(db: SQLiteDatabase): void {
       WHERE publication_id IS NULL
     `);
   }
+}
+
+function dropDurablePublicationStaging(db: SQLiteDatabase): void {
+  db.exec("DROP TABLE IF EXISTS search_index_publication_entries");
 }
 
 function replaceSessionActivityIndex(db: SQLiteDatabase): void {
@@ -1802,6 +1800,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 28, migrate: addSessionCostSummary },
       { version: 29, migrate: addSessionUsageSummary },
       { version: 30, destructive: true, migrate: dropDerivedSessionSlug },
+      { version: 31, migrate: dropDurablePublicationStaging },
     ],
   });
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -968,7 +968,7 @@ export function writePreparedSessionSearchIndex(
         publication.failures,
       );
       if (publication.publicationId) {
-        deletePublicationPayloads(db, publication.publicationId);
+        deletePublicationPayloads(db, publication.publicationId, publication.agentName);
       }
     },
     "caller",
@@ -988,9 +988,9 @@ export function writePreparedSessionSearchIndex(
   };
 }
 
-export function discardPreparedSessionSearchIndex(publicationId: string): void {
+export function discardPreparedSessionSearchIndex(publicationId: string, agentName: string): void {
   withSearchIndexDb((db) =>
-    db.transaction(() => discardPublicationStaging(db, publicationId)).immediate(),
+    db.transaction(() => discardPublicationStaging(db, publicationId, agentName)).immediate(),
   );
 }
 

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -790,7 +790,6 @@ export function clearCache(): void {
         DELETE FROM cache_initialization;
         DELETE FROM cached_sessions;
         DELETE FROM pending_reindex;
-        DELETE FROM search_index_publication_entries;
         DELETE FROM session_documents;
         DELETE FROM session_file_activity;
         DELETE FROM message_tools;

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 30;
+export const CACHE_SCHEMA_VERSION = 31;

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -295,6 +295,10 @@ export function openDb(dbPath: string): SQLiteDatabase | null {
   }
   try {
     ensurePrivateDirectory(dirname(dbPath));
+    // TEMP tables can hold a full corpus of staged publication payloads, so they
+    // must spill to disk next to the database rather than to a $TMPDIR that may
+    // be RAM-backed.
+    if (!isInMemoryPath(dbPath)) process.env.SQLITE_TMPDIR ||= dirname(dbPath);
     const db = DatabaseConstructor(dbPath);
     // The sidecars only exist once the connection is established.
     restrictPrivateDatabase(dbPath);
@@ -305,6 +309,7 @@ export function openDb(dbPath: string): SQLiteDatabase | null {
       db.pragma("journal_mode = WAL");
       db.pragma("synchronous = NORMAL");
       db.pragma("foreign_keys = ON");
+      db.pragma("temp_store = FILE");
     } catch {
       // The database remains usable when SQLite rejects connection-level tuning.
     }


### PR DESCRIPTION
## What was wrong

`search_index_publication_entries` was created as a **permanent table in the primary cache DB**, yet its data's only valid lifetime is a single in-process `commitDurableSessionPublication` call. Nothing ever resumes a staged publication across processes: the id is a fresh `randomUUID()` per call, and the startup handler unconditionally deletes everything it finds.

`loadOrPreStageEntries` durably commits each 64-session chunk on its own, but the only deletes live in the final commit transaction, the rollback path, or the *next* process's first search-index write. So **any termination between the first staged chunk and the final commit leaves a full-corpus JSON copy of every changed session inside `codesesh.db`**. `SearchIndexJobRunner.shutdown()` calls `worker.terminate()` with no chance for the worker to discard, so a plain Ctrl-C during a scan orphans it. That is the ordinary case, not an edge case.

The premise that "cleanup is not running" turned out to be wrong — the cleanup runs, works, and is tested. The defect is that scratch data was living in durable storage at all.

### Measured on a 3113-session / 194819-message cache

- `page_count`=2671187 x `page_size`=4096 -> **10.94 GB file**, of which `freelist_count`=944159 -> **3.87 GB is dead free pages**. `auto_vacuum`=0 (NONE).
- `SELECT COUNT(*) FROM search_index_publication_entries` -> 0, and the table holds 0 pages in `dbstat` *now* — the 4026 MB seen earlier was swept between measurements and turned into freelist, not into free disk.
- Runtime logs contain 6 distinct `sqlite.publication_staging_cleanup.completed {reclaimed:true}` events, the worst one a **15532 ms blocking startup stall**.
- 15 log files have exactly one more publication `"stage":"started"` than `"committed"`, each ending in a shutdown. Zero `rolled_back` events — termination, not rollback, is the leak source.
- Staging really is corpus-sized: `search_index.pre_staged {agent:"codex",changed:2222,staged:2222}`.

## What changed

**Staging rows are now connection-scoped instead of database-scoped, so an orphan in the primary DB is unrepresentable rather than swept.**

- `publication-staging.ts`: the table is created lazily as `CREATE TEMP TABLE IF NOT EXISTS` and every statement is qualified as `temp.search_index_publication_entries`, so it can never bind to a leftover main-schema table. SQLite unlinks its temp file at creation, so `SIGKILL` / `worker.terminate()` returns the bytes to the OS immediately — no sweeper, no orphan, no growth of `codesesh.db`. Creation is lazy rather than at `ensureSchema` time because `ensureSchema` is skipped after a reconnect, which would otherwise leave the next publication without a table.
- `readPublicationPayloads` deliberately does *not* create the table. Prepare and commit must share one connection (they do — `publication.ts` threads a single `db` through both); if a future refactor breaks that, the read now fails loudly instead of silently indexing zero sessions.
- The startup sweep keeps only the legacy v21 `sessions.publication_id` path and becomes ~free, so the 15.5 s stall disappears. This also removes an existing hazard: `cleanPublicationStaging` used to do an unscoped `DELETE FROM search_index_publication_entries` per fresh connection, and each thread has its own connection — a second thread starting mid-publication could wipe another thread's in-flight staging.
- Migration **v31** drops the durable table (non-destructive, so it does not mint another multi-GB `.bak`); `CACHE_SCHEMA_VERSION` 30 -> 31.
- `deletePublicationPayloads` is now scoped by `agent_name` too, matching the read predicate. `syncInitialIndex` stamps one shared publicationId onto every agent's job; jobs run sequentially today so it never misfired, but the asymmetry was a trap.
- `openDb` pins `temp_store = FILE` and points `SQLITE_TMPDIR` at the database directory. Verified `SQLITE_TEMP_STORE=1` / `PRAGMA temp_store`=0, i.e. temp tables are already file-backed here, so the memory bound that motivated staging is preserved; the pragma and env var stop a RAM-backed `/tmp` on other hosts from turning a disk-growth bug into an OOM.

## Deliberately not included: automatic VACUUM

Freed pages go to the freelist and are reused, so **the file stops growing**, but it does not shrink on its own. A one-shot `VACUUM` gated on the v31 migration was considered and rejected: on an 11 GB database it means minutes of blocking startup and ~11 GB of scratch space, which is a worse defect than the disk usage it reclaims. `docs/sqlite-storage.md` now documents `sqlite3 ~/.cache/codesesh/codesesh.db 'VACUUM'` for manual reclaim, alongside the existing note about schema 24.

## How it was verified

New regression test `leaves nothing durable when a pre-staged publication never commits` publishes 70 sessions (past the 64-row pre-staging threshold), drops the prepared publication and closes every connection — exactly what a SIGINT between staging and commit leaves behind — then reopens the database and asserts `page_count` is unchanged and no `search_index_publication_entries` table exists in the main schema.

**Confirmed it catches the defect**: reverting only `publication-staging.ts` + `schema.ts` makes it fail with `expected 196 to be 56` — 140 orphaned pages from a single interrupted publication.

Existing coverage adapted: the "defers orphaned publication cleanup" test now covers only the legacy v21 sweep, and the staging-count assertions moved to the temp schema. The rollback test at `search-integration.test.ts` passes unchanged in behaviour.

Full local gate green: `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, `check-quality-task-coverage`, `check-docs-paths`, `release-preflight`, `pnpm perf:check`, `pnpm build`, `check-docs-facts`, `pnpm test` (1004 core + 818 web + CLI, all passing), plus `pnpm test:migration` for the schema bump.

## Separate follow-up (not addressed here)

`~/.cache/codesesh/codesesh.db.2026-08-19T135147-575Z.cache-migration.bak` is 11 GB. It was produced by `backupDatabase`'s `VACUUM INTO` during the v29->v30 migration, which copied the live DB *including* the orphaned 4 GB staging, 78 seconds before the sweeper deleted it. Nothing ever prunes old `.bak` files — a retention policy is worth its own change. No user data is deleted by this PR.