### PR TITLE
perf(core): index the search freshness probe columns

### DIFF
--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -72,6 +72,12 @@ TEMP 里让「进程被中断后留下孤儿暂存行」不可表达——连接
 系统，无需清理器兜底。TEMP 数据会溢写到数据库同目录的文件（`temp_store = FILE`、
 `SQLITE_TMPDIR` 指向缓存目录），因此暂存机制原本的内存上界仍然成立。
 
+`session_documents` 的 `content_text` 存的是整段会话正文，物理上排在 `content_hash` /
+`indexed_message_count` / `detail_version` 前面。每次扫描都要按会话核对索引是否过期，若从表行读
+这三列，SQLite 必须穿过每行的 overflow 链——核对一个没有变化的 Agent 也要读完整个已索引语料。
+`idx_session_documents_state` 覆盖这三列，`readSearchIndexState` 用 `INDEXED BY` 固定走它（没有
+统计信息时 SQLite 会优先选 `UNIQUE(agent_name, session_id)` 自动索引，从而退回读表行）。
+
 两个 FTS 表都由对应内容表的 insert/update/delete 触发器维护。批量变化达到阈值时，
 `runSearchIndexWrite()` 会在写事务中重建会话文档索引；文件路径索引仍由触发器增量维护。
 搜索先由会话文档索引召回和排序，再在候选会话的消息纯文本中定位首条命中消息，不再

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -1,3 +1,4 @@
+import Database from "better-sqlite3";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -10,6 +11,7 @@ import {
 } from "../cache/sessions.js";
 import { searchSessions, syncSessionSearchIndex } from "../cache/search.js";
 import { setSchemaEnsuredPath } from "../cache/db.js";
+import { searchIndexStateQuery } from "../cache/search-index-writer.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-smoke-test-"));
@@ -72,6 +74,23 @@ describe("session cache integration", () => {
       id: "smoke",
       messages: [{ id: "message" }],
     });
+
+    // Every scan re-probes each cached session for index drift. content_text
+    // holds the whole session body, so a plan that reaches the document rows
+    // makes that probe cost the corpus size rather than the session count.
+    const db = new Database(join(testHomeDir, ".cache", "codesesh", "codesesh.db"), {
+      readonly: true,
+    });
+    try {
+      const plan = db
+        .prepare(`EXPLAIN QUERY PLAN ${searchIndexStateQuery(1)}`)
+        .all("smoke", "codex", "codex", "codex") as Array<{ detail: string }>;
+      expect(plan.map(({ detail }) => detail)).toContainEqual(
+        expect.stringContaining("COVERING INDEX idx_session_documents_state"),
+      );
+    } finally {
+      db.close();
+    }
   });
 
   it("merges a partial snapshot without deleting data outside its window", () => {

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -251,6 +251,11 @@ function readMigratedFacts(): Record<string, unknown> {
       )
         .map((row) => row.name)
         .sort(),
+      documentStateIndexColumns: (
+        db.prepare("PRAGMA index_info(idx_session_documents_state)").all() as Array<{
+          name: string;
+        }>
+      ).map((row) => row.name),
       sessionColumns: (db.prepare("PRAGMA table_info(sessions)").all() as Array<{ name: string }>)
         .map((row) => row.name)
         .sort(),
@@ -377,6 +382,13 @@ describe("sqlite migration release gate", () => {
           "indexed_message_count",
           "session_id",
           "title",
+        ],
+        documentStateIndexColumns: [
+          "agent_name",
+          "session_id",
+          "content_hash",
+          "indexed_message_count",
+          "detail_version",
         ],
         sessionColumns: [
           "activity_time",

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -438,6 +438,8 @@ describe("cache schema boundary", () => {
     syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
 
     const legacyDb = new Database(getCachePath());
+    // A real v18 database predates both the projection version and the index over it.
+    legacyDb.exec("DROP INDEX idx_session_documents_state");
     legacyDb.exec("ALTER TABLE session_documents DROP COLUMN detail_version");
     legacyDb.pragma("user_version = 18");
     legacyDb.prepare("UPDATE cache_meta SET value = '18' WHERE key = 'version'").run();

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -599,6 +599,26 @@ function createSearchTables(db: SQLiteDatabase): void {
   createSearchTriggers(db);
 }
 
+/**
+ * Covers the search-index freshness probe (see readSearchIndexState) so it never
+ * has to read past content_text in the document rows.
+ *
+ * Created only once the schema has reached the target version: createSearchTables
+ * doubles as the v4 migration and still sees the legacy column set there.
+ */
+function createSearchStateIndex(db: SQLiteDatabase): void {
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_session_documents_state
+      ON session_documents(
+        agent_name,
+        session_id,
+        content_hash,
+        indexed_message_count,
+        detail_version
+      )
+  `);
+}
+
 function createSearchTriggers(db: SQLiteDatabase): void {
   db.exec(`
     CREATE TRIGGER IF NOT EXISTS session_documents_ai AFTER INSERT ON session_documents BEGIN
@@ -1715,6 +1735,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   const currentVersion = getCurrentCacheSchemaVersion(db);
   if (currentVersion === 0 && !hasAnyCacheSchema(db)) {
     createLatestCacheSchema(db);
+    createSearchStateIndex(db);
     setCacheSchemaVersion(db);
     migrateCodexExecDecode(db);
     migrateOpenCodeSubagentFold(db);
@@ -1805,6 +1826,7 @@ function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   });
 
   createLatestCacheSchema(db);
+  createSearchStateIndex(db);
 
   // Only stamp when behind: every thread's first connection runs ensureSchema,
   // and an unconditional PRAGMA user_version write would contend for the write

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -259,6 +259,68 @@ function searchIndexStateFromRows(
   };
 }
 
+/**
+ * Freshness probe for a batch of sessions: is each one's indexed document still
+ * in step with its cached head?
+ *
+ * INDEXED BY is not a micro-optimisation. Without stats SQLite prefers the
+ * UNIQUE(agent_name, session_id) auto-index, and reaching content_hash then
+ * means reading each row past content_text through its overflow chain — proving
+ * an unchanged agent is up to date would cost the size of the indexed corpus.
+ * Pinning the covering index keeps the probe proportional to the session count.
+ */
+export function searchIndexStateQuery(sessionIdCount: number): string {
+  const requestedRows = Array.from({ length: sessionIdCount }, () => "(?)").join(", ");
+  return `
+    WITH requested_session_ids(session_id) AS (VALUES ${requestedRows})
+    SELECT
+      requested.session_id,
+      documents.content_hash,
+      documents.indexed_message_count,
+      documents.detail_version,
+      sessions.meta_json,
+      sessions.title AS session_title,
+      sessions.directory AS session_directory,
+      sessions.time_created AS session_time_created,
+      sessions.time_updated AS session_time_updated,
+      sessions.message_count AS session_message_count,
+      sessions.total_input_tokens AS session_total_input_tokens,
+      sessions.total_output_tokens AS session_total_output_tokens,
+      sessions.total_cache_read_tokens AS session_total_cache_read_tokens,
+      sessions.total_cache_create_tokens AS session_total_cache_create_tokens,
+      sessions.total_cost AS session_total_cost,
+      sessions.cost_source AS session_cost_source,
+      sessions.total_tokens AS session_total_tokens,
+      COUNT(messages.message_index) AS value
+    FROM requested_session_ids AS requested
+    LEFT JOIN session_documents AS documents
+      INDEXED BY idx_session_documents_state
+      ON documents.agent_name = ? AND documents.session_id = requested.session_id
+    LEFT JOIN messages
+      ON messages.agent_name = ? AND messages.session_id = requested.session_id
+    LEFT JOIN sessions
+      ON sessions.agent_name = ? AND sessions.session_id = requested.session_id
+    GROUP BY
+      requested.session_id,
+      documents.content_hash,
+      documents.indexed_message_count,
+      documents.detail_version,
+      sessions.meta_json,
+      sessions.title,
+      sessions.directory,
+      sessions.time_created,
+      sessions.time_updated,
+      sessions.message_count,
+      sessions.total_input_tokens,
+      sessions.total_output_tokens,
+      sessions.total_cache_read_tokens,
+      sessions.total_cache_create_tokens,
+      sessions.total_cost,
+      sessions.cost_source,
+      sessions.total_tokens
+  `;
+}
+
 function readSearchIndexState(
   db: SQLiteDatabase,
   agentName: string,
@@ -269,57 +331,8 @@ function readSearchIndexState(
 
   for (let offset = 0; offset < uniqueSessionIds.length; offset += SEARCH_INDEX_STATE_BATCH_SIZE) {
     const batch = uniqueSessionIds.slice(offset, offset + SEARCH_INDEX_STATE_BATCH_SIZE);
-    const requestedRows = batch.map(() => "(?)").join(", ");
     const batchRows = db
-      .prepare(
-        `
-          WITH requested_session_ids(session_id) AS (VALUES ${requestedRows})
-          SELECT
-            requested.session_id,
-            documents.content_hash,
-            documents.indexed_message_count,
-            documents.detail_version,
-            sessions.meta_json,
-            sessions.title AS session_title,
-            sessions.directory AS session_directory,
-            sessions.time_created AS session_time_created,
-            sessions.time_updated AS session_time_updated,
-            sessions.message_count AS session_message_count,
-            sessions.total_input_tokens AS session_total_input_tokens,
-            sessions.total_output_tokens AS session_total_output_tokens,
-            sessions.total_cache_read_tokens AS session_total_cache_read_tokens,
-            sessions.total_cache_create_tokens AS session_total_cache_create_tokens,
-            sessions.total_cost AS session_total_cost,
-            sessions.cost_source AS session_cost_source,
-            sessions.total_tokens AS session_total_tokens,
-            COUNT(messages.message_index) AS value
-          FROM requested_session_ids AS requested
-          LEFT JOIN session_documents AS documents
-            ON documents.agent_name = ? AND documents.session_id = requested.session_id
-          LEFT JOIN messages
-            ON messages.agent_name = ? AND messages.session_id = requested.session_id
-          LEFT JOIN sessions
-            ON sessions.agent_name = ? AND sessions.session_id = requested.session_id
-          GROUP BY
-            requested.session_id,
-            documents.content_hash,
-            documents.indexed_message_count,
-            documents.detail_version,
-            sessions.meta_json,
-            sessions.title,
-            sessions.directory,
-            sessions.time_created,
-            sessions.time_updated,
-            sessions.message_count,
-            sessions.total_input_tokens,
-            sessions.total_output_tokens,
-            sessions.total_cache_read_tokens,
-            sessions.total_cache_create_tokens,
-            sessions.total_cost,
-            sessions.cost_source,
-            sessions.total_tokens
-        `,
-      )
+      .prepare(searchIndexStateQuery(batch.length))
       .all(...batch, agentName, agentName, agentName) as SearchIndexStateRow[];
     rows.push(...batchRows);
   }


### PR DESCRIPTION
## What was wrong

`codesesh --json` spent almost all of its wall clock proving the search index was
already up to date.

The ticket blamed `BaseAgent.scan()` being synchronous, so `await Promise.all(scanPromises)`
in `scanSessions()` is fake parallelism. That part of the ticket is factually true, but it
is not what costs the time. Measured on a 3113-session / 194 819-message cache (11 GB DB):

| phase | warm | cold |
|---|---|---|
| whole `--json -d 7` run | 5.2 s | 26.5 s |
| of which: scan (all agents, serial) | 2.3 s | 3.8 s |
| of which: initial search-index sync | **2.9 s** | **22.7 s** |

Perfect cross-agent scan parallelism is bounded by the slowest agent (codex, 0.93 s), so the
entire theoretical win from the proposed change is ~1 s warm. The index phase is the real cost.

The index phase does almost no work — it re-indexed **1** session out of 3113. The time goes
into deciding that. `readSearchIndexState` probes each cached session for drift by reading
`content_hash`, `indexed_message_count` and `detail_version` from `session_documents`. Those
three small columns are declared *after* `content_text`, which holds the entire session body:
`session_documents` is 1.9 GB across 3113 rows, ~600 KB per row. SQLite cannot reach a column
behind a large one without walking that row's overflow chain, so answering "is this document
current?" for an agent that has not changed at all reads the whole indexed corpus.

Per-agent breakdown of one warm run (`plan` = the drift probe, `exec` = real indexing work):

```
codex       plan 867ms  exec 1510ms  changes 1
claudecode  plan 241ms  exec    1ms  changes 0
(7 more)    plan ~140ms exec    0ms  changes 0
```

## What changed

`idx_session_documents_state` covers `(agent_name, session_id, content_hash,
indexed_message_count, detail_version)` — 1.2 MB against 1.9 GB of document rows — and
`readSearchIndexState` pins it with `INDEXED BY`. The hint is load-bearing: without stats
SQLite prefers the `UNIQUE(agent_name, session_id)` auto-index and goes back to reading the
rows, which is exactly the defect.

The index is created after migrations finish rather than inside `createSearchTables`, because
that function doubles as the v4 migration and runs there against the legacy column set.

No semantics change. The drift decision, the publication protocol, cache completeness and the
`--json` payload are all untouched; only the access path to three columns changes. Every scan
publication on the server path uses the same probe, so it gets the same reduction.

## How it was verified

Real cache, 3113 sessions / 194 819 messages, from `scan.initial.done`:

| | before | after |
|---|---|---|
| `--json -d 7` total (warm, steady state) | 5197 / 5218 / 5305 ms | **1641 / 1643 ms** |
| initial index phase | 2862 / 2874 / 2904 ms | **830 / 837 ms** |
| `--json -d 7` total (cold page cache) | 26 267 ms (index 22 721 ms) | — |

3.2× on wall clock, 3.5× on the phase that was the problem.

One-time upgrade cost: the first run against an existing cache builds the index inside
`ensureSchema`. On the 11 GB database that showed up as `claudecode.cache_load_ms 19454`
(total run 25.6 s); every run after it reports `cache_load_ms 7`.

Output equivalence: `--json -d 7` before and after returns the same 216 sessions, the same
per-agent counts and byte-identical session objects except for 2 sessions that were genuinely
written to disk between the two runs. Two consecutive post-change runs are byte-identical.

Search still resolves against the migrated 11 GB cache (`/api/search?q=codesesh&days=90` →
39 results, `q=scanner` → 50), and a fresh cache still indexes on first `--json`
(`session_documents` 1, `messages` 3).

Regression tests: the probe's query plan must resolve entirely from the covering index, so a
probed column that leaves the index fails the test instead of silently reverting to a scan of
every indexed document; the migration gate asserts upgraded caches gain the index with the
exact column order.

Gate: `pnpm lint`, `format:check`, `typecheck`, `check-quality-task-coverage`,
`check-docs-paths`, `release-preflight`, `perf:check`, `build`, `check-docs-facts`, `test`,
`test:migration`, `test:coverage`, `test:e2e` (29 passed) all green locally.

## What was deliberately not done

Making `BaseAgent.scan()` async or fanning agents out to workers. It is a real serialisation
but a ~1 s ceiling warm, against a worker fan-out overhead of 100–450 ms, in the highest-risk
part of the scan path. Sharding within codex — the only agent with real headroom — is blocked
by its cross-file parent/child aggregation (`ensureSubagentIndex`, `applyChildStats`), which
reads other sessions' files while parsing one head.

Skipping the initial index sync on `--json` was also rejected: it is load-bearing. `--json`
writes the session cache and marks the agent initialised, so a later server run finds nothing
changed, publishes no index job, and the sessions stay unsearchable forever. Reproduced on an
isolated HOME — after `--json` with the sync removed plus a full server run, the session was
still at `session_documents 0 / messages 0 / pending_reindex 0`.
