### PR TITLE
Refactor agent registry as immutable data

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,7 @@ CLI Entry (packages/cli/src/index.ts --json)
 | `packages/core/src/contract/agent-catalog.ts` | Agent 公开身份与存储类型声明 |
 | `packages/core/src/agents/base.ts` | Agent 原语与显式 Session Source Access 能力 |
 | `packages/core/src/agents/register.ts` | Agent 工厂与数据根目录注册 |
-| `packages/core/src/agents/registry.ts` | 注册表存储与 Catalog/运行时能力一致性校验 |
+| `packages/core/src/agents/registry.ts` | 从不可变注册声明派生 Agent 实例、公开信息与数据根目录 |
 | `packages/cli/src/live-scan.ts` | 运行中快照、订阅和生命周期入口 |
 | `packages/cli/src/agent-sync-engine.ts` | 持续 refresh、backfill、持久化后发布 |
 | `packages/cli/src/session-watcher.ts` | 文件事件监听、稳定性等待与归并 |

--- a/packages/cli/src/session-watcher.test.ts
+++ b/packages/cli/src/session-watcher.test.ts
@@ -2,12 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createRegisteredAgents,
-  registerAgent,
-  type BaseAgent,
-  type SessionWatchPlan,
-} from "@codesesh/core";
+import { type BaseAgent, type SessionWatchPlan } from "@codesesh/core";
 
 const fsWatch = vi.hoisted(() => ({
   watchers: [] as Array<{
@@ -244,7 +239,7 @@ describe("SessionWatcher", () => {
     });
   });
 
-  it("consumes a newly registered adapter without watcher name changes", async () => {
+  it("consumes a provided adapter without watcher name changes", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "watcher-registered-adapter-"));
     try {
       const adapter = Object.assign(
@@ -260,21 +255,9 @@ describe("SessionWatcher", () => {
           },
         },
       ) as unknown as BaseAgent;
-      registerAgent({
-        name: "registered-test-agent",
-        displayName: "Registered Test Agent",
-        icon: "/test-agent.svg",
-        resolveDataRoot: () => tempDir,
-        resumeCommandPrefix: null,
-        sourceKind: "filesystem",
-        toolStrategy: "default",
-        create: () => adapter,
-      });
       const watcher = new SessionWatcher();
 
-      watcher.start(
-        createRegisteredAgents().filter((agent) => agent.name === "registered-test-agent"),
-      );
+      watcher.start([adapter]);
 
       expect(fsWatch.watchers).toEqual([
         expect.objectContaining({

--- a/packages/core/src/agents/__tests__/registry.test.ts
+++ b/packages/core/src/agents/__tests__/registry.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { AGENT_CATALOG } from "../../contract/agent-catalog.js";
-import "../register.js";
 import { getAgentInfoMap, getRegisteredAgents } from "../registry.js";
 
 describe("agent registry", () => {
+  it("exposes an immutable registration list", () => {
+    expect(Object.isFrozen(getRegisteredAgents())).toBe(true);
+    expect(getRegisteredAgents().every((registration) => Object.isFrozen(registration))).toBe(true);
+  });
+
   it("projects public metadata from the catalog", () => {
     const counts: Record<string, number> = { claudecode: 2, codex: 1 };
 

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -47,7 +47,6 @@ export type {
 } from "./base.js";
 export type { ParseSessionResult } from "../types/index.js";
 export {
-  registerAgent,
   createRegisteredAgents,
   getRegisteredAgents,
   getAgentInfoMap,

--- a/packages/core/src/agents/register.ts
+++ b/packages/core/src/agents/register.ts
@@ -1,5 +1,5 @@
 import { AGENT_CATALOG, type AgentName } from "../contract/agent-catalog.js";
-import { registerAgent, type AgentRegistration } from "./registry.js";
+import type { AgentRegistration } from "./registry.js";
 import { ClaudeCodeAgent, resolveClaudeCodeDataRoot } from "./claudecode.js";
 import { OpenCodeAgent, resolveOpenCodeDataRoot } from "./opencode.js";
 import { KimiAgent, resolveKimiDataRoot } from "./kimi.js";
@@ -56,6 +56,23 @@ const RUNTIME_REGISTRATIONS = {
   },
 } satisfies Record<AgentName, AgentRuntimeRegistration>;
 
-for (const catalogEntry of AGENT_CATALOG) {
-  registerAgent({ ...catalogEntry, ...RUNTIME_REGISTRATIONS[catalogEntry.name] });
-}
+export const AGENT_REGISTRATIONS: readonly AgentRegistration[] = Object.freeze(
+  AGENT_CATALOG.map((catalogEntry) => {
+    const runtime = RUNTIME_REGISTRATIONS[catalogEntry.name];
+    return Object.freeze({
+      ...catalogEntry,
+      ...runtime,
+      create: () => {
+        const agent = runtime.create();
+        const expectedSource =
+          catalogEntry.sourceKind === "filesystem" ? "enumerated" : "aggregate";
+        if (agent.sessionSourceAccess.kind !== expectedSource) {
+          throw new Error(
+            `Agent ${catalogEntry.name} declares ${catalogEntry.sourceKind} storage but provides ${agent.sessionSourceAccess.kind} source access`,
+          );
+        }
+        return agent;
+      },
+    });
+  }),
+);

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -1,6 +1,7 @@
 import type { BaseAgent } from "./base.js";
 import type { AgentInfo } from "../types/index.js";
 import type { AgentCatalogEntry } from "../contract/agent-catalog.js";
+import { AGENT_REGISTRATIONS } from "./register.js";
 
 export type { AgentToolStrategy } from "../contract/agent-catalog.js";
 
@@ -11,41 +12,22 @@ export interface AgentRegistration extends AgentCatalogEntry {
 
 export type AgentRoots = Readonly<Record<string, string | null>>;
 
-let registrations: AgentRegistration[] = [];
-
-export function registerAgent(reg: AgentRegistration): void {
-  const create = reg.create;
-  registrations.push({
-    ...reg,
-    create: () => {
-      const agent = create();
-      const expectedSource = reg.sourceKind === "filesystem" ? "enumerated" : "aggregate";
-      if (agent.sessionSourceAccess.kind !== expectedSource) {
-        throw new Error(
-          `Agent ${reg.name} declares ${reg.sourceKind} storage but provides ${agent.sessionSourceAccess.kind} source access`,
-        );
-      }
-      return agent;
-    },
-  });
-}
-
 export function createRegisteredAgents(): BaseAgent[] {
-  return registrations.map((r) => r.create());
+  return AGENT_REGISTRATIONS.map((registration) => registration.create());
 }
 
 export function getRegisteredAgents(): readonly AgentRegistration[] {
-  return registrations;
+  return AGENT_REGISTRATIONS;
 }
 
 export function resolveAgentRoots(): AgentRoots {
   return Object.fromEntries(
-    registrations.map((registration) => [registration.name, registration.resolveDataRoot()]),
+    AGENT_REGISTRATIONS.map((registration) => [registration.name, registration.resolveDataRoot()]),
   );
 }
 
 export function getAgentInfoMap(sessionsByAgent: Record<string, number>): AgentInfo[] {
-  return registrations.map((registration) => ({
+  return AGENT_REGISTRATIONS.map((registration) => ({
     name: registration.name,
     displayName: registration.displayName,
     icon: registration.icon,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,3 @@
-// Register all agent adapters (side effect import)
-import "./agents/register.js";
-
 export type {
   FileActivityKind,
   IdentifiedSessionDetail,
@@ -17,7 +14,6 @@ export {
   FileSystemSessionSource,
   getAgentInfoMap,
   getRegisteredAgents,
-  registerAgent,
   reportSessionSourceOutcome,
   synchronizeSessionSources,
 } from "./agents/index.js";


### PR DESCRIPTION
## Summary

- derive runtime agent registrations from the closed agent catalog
- freeze registration data and remove global registration mutation
- test SessionWatcher through its explicit agent input

## Testing

- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter @codesesh/core test`
- `pnpm --filter codesesh typecheck`
- `pnpm --filter codesesh test`
- `pnpm --filter @codesesh/web typecheck`
- `pnpm --filter @codesesh/web test`
- `node scripts/check-docs-facts.mjs`
- `node scripts/check-docs-paths.mjs`