### PR TITLE
Centralize agent scan execution planning

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -892,6 +892,24 @@ describe("AgentSyncEngine", () => {
     );
   });
 
+  it("checks an initialized empty aggregate baseline instead of forcing a reload", async () => {
+    const checkForChanges = vi.fn(() => ({ hasChanges: false, timestamp: 2 }));
+    const workerRunner = makeWorkerRunner();
+    const { engine } = makeEngine(makeAgent({ checkForChanges }), [], workerRunner);
+
+    await engine.refresh("codex");
+
+    expect(checkForChanges).toHaveBeenCalledWith(expect.any(Number), []);
+    expect(workerRunner.run).toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ operation: { kind: "recompute-derived" } }),
+    );
+    expect(workerRunner.run).not.toHaveBeenCalledWith(
+      "codex",
+      expect.objectContaining({ operation: { kind: "full-scan" } }),
+    );
+  });
+
   it("distinguishes queued and active publication before committing the refresh", async () => {
     let startIndex!: () => void;
     let commitIndex!: () => void;

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -7,6 +7,7 @@ import {
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
   markAgentFullSyncCompleted,
+  planAgentScan,
   readCachedSessions,
   readAgentCacheInitialization,
   sessionSignature,
@@ -417,25 +418,26 @@ export class AgentSyncEngine {
       strategyResult = this.refreshUnavailableAgent(agentName);
     } else if (!isInitialized) {
       strategyResult = await this.initializeAgent(agent, previousSessions);
-    } else if (agent.sessionSourceAccess.kind === "enumerated") {
-      strategyResult = await this.syncAgentSources(
-        agent,
-        cached ?? {
-          sessions: refreshBaseline,
-          meta: durableMeta,
-        },
-        startedAt,
-      );
-    } else if (refreshBaseline.length > 0) {
-      strategyResult = await this.refreshChangedAgent(
-        agent,
-        agent.sessionSourceAccess,
-        refreshBaseline,
-        cacheTimestamp,
-        startedAt,
-      );
     } else {
-      strategyResult = await this.scanAgentFully(agent, previousSessions);
+      const scanPlan = planAgentScan(agent.sessionSourceAccess, "refresh");
+      if (scanPlan.kind === "synchronize") {
+        strategyResult = await this.syncAgentSources(
+          agent,
+          cached ?? {
+            sessions: refreshBaseline,
+            meta: durableMeta,
+          },
+          startedAt,
+        );
+      } else {
+        strategyResult = await this.refreshChangedAgent(
+          agent,
+          scanPlan.source,
+          refreshBaseline,
+          cacheTimestamp,
+          startedAt,
+        );
+      }
     }
     if (strategyResult.status === "unchanged") {
       this.options.workerRunner.commit?.(agentName);
@@ -794,30 +796,6 @@ export class AgentSyncEngine {
           preciseChangedIds,
         ),
         candidateChangedIds: preciseChangedIds,
-      },
-    };
-  }
-
-  private async scanAgentFully(
-    agent: BaseAgent,
-    previousSessions: IdentifiedSessionHead[],
-  ): Promise<RefreshStrategyResult> {
-    const scanStartedAt = performance.now();
-    const scope = this.startupScanOptions();
-    const result = await this.runWorker(agent, previousSessions, { kind: "full-scan" }, scope);
-    agent.restoreSessionCacheMeta(result.meta);
-    const sessions = attachMissingProjectIdentities(result.sessions);
-    this.lastRefreshAtByAgent.set(agent.name, Date.now());
-    return {
-      ...this.refreshStrategyBase(sessions, result.completeness, scope, {
-        scanDuration: performance.now() - scanStartedAt,
-        sourceFailures: result.sourceFailures ?? [],
-      }),
-      status: "continue",
-      publication: {
-        kind: "full",
-        sessions,
-        explicitRemovedSessionIds: result.explicitRemovedSessionIds,
       },
     };
   }

--- a/packages/cli/src/scan-refresh-operation.test.ts
+++ b/packages/cli/src/scan-refresh-operation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isBackfillOperation,
+  scanIntentForOperation,
   usesDurableCheckpoints,
   type ScanRefreshOperation,
 } from "./scan-refresh-operation.js";
@@ -10,32 +11,38 @@ describe("ScanRefreshOperation", () => {
     operation: ScanRefreshOperation;
     backfill: boolean;
     durableCheckpoints: boolean;
+    intent: "reload" | "refresh" | "recompute-derived" | "backfill";
   }>([
     {
       operation: { kind: "full-scan" },
       backfill: false,
       durableCheckpoints: false,
+      intent: "reload",
     },
     {
       operation: { kind: "source-refresh", checkpoint: "durable" },
       backfill: false,
       durableCheckpoints: true,
+      intent: "refresh",
     },
     {
       operation: { kind: "recompute-derived" },
       backfill: false,
       durableCheckpoints: false,
+      intent: "recompute-derived",
     },
     {
       operation: { kind: "backfill", cursor: "cursor", checkpoint: "durable" },
       backfill: true,
       durableCheckpoints: true,
+      intent: "backfill",
     },
   ])(
     "classifies $operation.kind without boolean mode inference",
-    ({ operation, backfill, durableCheckpoints }) => {
+    ({ operation, backfill, durableCheckpoints, intent }) => {
       expect(isBackfillOperation(operation)).toBe(backfill);
       expect(usesDurableCheckpoints(operation)).toBe(durableCheckpoints);
+      expect(scanIntentForOperation(operation)).toBe(intent);
     },
   );
 });

--- a/packages/cli/src/scan-refresh-operation.ts
+++ b/packages/cli/src/scan-refresh-operation.ts
@@ -1,3 +1,5 @@
+import type { AgentScanIntent } from "@codesesh/core";
+
 type DurableCheckpoint = { checkpoint?: "durable" };
 
 export type ScanRefreshOperation =
@@ -16,4 +18,17 @@ export function isBackfillOperation(
 
 export function usesDurableCheckpoints(operation: ScanRefreshOperation): boolean {
   return "checkpoint" in operation && operation.checkpoint === "durable";
+}
+
+export function scanIntentForOperation(operation: ScanRefreshOperation): AgentScanIntent {
+  switch (operation.kind) {
+    case "full-scan":
+      return "reload";
+    case "source-refresh":
+      return "refresh";
+    case "recompute-derived":
+      return "recompute-derived";
+    case "backfill":
+      return "backfill";
+  }
 }

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -97,6 +97,7 @@ vi.mock("@codesesh/core", async (importOriginal) => {
     PRICING_CAPTURE_EPOCH: actual.PRICING_CAPTURE_EPOCH,
     buildAgentCacheMeta: actual.buildAgentCacheMeta,
     computeSessionDiff: actual.computeSessionDiff,
+    planAgentScan: actual.planAgentScan,
     sessionSignature: actual.sessionSignature,
     SMART_TAG_CLASSIFIER_REVISION: "smart-tags-v1",
     sortSessions: actual.sortSessions,

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -7,6 +7,7 @@ import {
   computeSessionDiff,
   createRegisteredAgents,
   ensureSessionTagsSync,
+  planAgentScan,
   sessionSignature,
   SMART_TAG_CLASSIFIER_REVISION,
   sortSessions,
@@ -29,6 +30,7 @@ import {
 } from "./scan-refresh-error.js";
 import {
   isBackfillOperation,
+  scanIntentForOperation,
   usesDurableCheckpoints,
   type ScanRefreshOperation,
 } from "./scan-refresh-operation.js";
@@ -365,9 +367,7 @@ async function run(
   const previousMeta = baseline.meta;
   const operation = data.operation;
   const backfill = isBackfillOperation(operation);
-  const sourceSynchronization =
-    operation.kind === "source-refresh" ||
-    (backfill && agent.sessionSourceAccess.kind === "enumerated");
+  const scanPlan = planAgentScan(agent.sessionSourceAccess, scanIntentForOperation(operation));
   const durableCheckpoints = usesDurableCheckpoints(operation);
   const backfillCursor = backfill ? operation.cursor : undefined;
 
@@ -404,16 +404,13 @@ async function run(
       }
     | undefined;
 
-  if (operation.kind === "recompute-derived") {
+  if (scanPlan.kind === "reuse-baseline") {
     sessions = previousSessions;
-  } else if (sourceSynchronization) {
-    if (agent.sessionSourceAccess.kind !== "enumerated") {
-      throw new Error(`Agent ${agent.name} does not support Session Source synchronization`);
-    }
-    const result = agent.sessionSourceAccess.synchronize(
+  } else if (scanPlan.kind === "synchronize") {
+    const result = scanPlan.source.synchronize(
       { sessions: previousSessions, meta: previousMeta },
       {
-        kind: "refresh",
+        kind: scanPlan.requestKind,
         scanOptions: { ...data.scanOptions, onProgress: reportProgress },
       },
     );
@@ -426,19 +423,7 @@ async function run(
     };
     sourceFailures = result.sourceFailures;
     explicitRemovedSessionIds = result.explicitRemovedSessionIds;
-  } else if (agent.sessionSourceAccess.kind === "enumerated") {
-    const result = agent.sessionSourceAccess.synchronize(
-      { sessions: previousSessions, meta: previousMeta },
-      {
-        kind: "reload",
-        scanOptions: { ...data.scanOptions, onProgress: reportProgress },
-      },
-    );
-    sessions = result.sessions;
-    finalizeSessionIds = new Set(result.finalizeSessionIds);
-    sourceFailures = result.sourceFailures;
-    explicitRemovedSessionIds = result.explicitRemovedSessionIds;
-  } else {
+  } else if (scanPlan.kind === "scan") {
     sessions = inheritSmartTags(
       await Promise.resolve(
         agent.scan({
@@ -448,6 +433,8 @@ async function run(
       ),
       previousSessions,
     );
+  } else {
+    throw new Error(`Change checks must run before dispatching Agent ${agent.name} to the worker`);
   }
 
   sessions = attachMissingProjectIdentities(sessions);

--- a/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
+++ b/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { planAgentScan, type AgentScanIntent } from "../agent-scan-plan.js";
+import type {
+  AggregateSessionSourceCapability,
+  EnumeratedSessionSourceCapability,
+} from "../../agents/index.js";
+
+const enumerated: EnumeratedSessionSourceCapability = {
+  kind: "enumerated",
+  synchronize: () => ({}) as never,
+  count: () => 0,
+};
+
+const aggregate: AggregateSessionSourceCapability = {
+  kind: "aggregate",
+  checkForChanges: () => ({ hasChanges: false, timestamp: 0 }),
+  commitChangeCheck: () => undefined,
+  incrementalScan: (sessions) => sessions,
+};
+
+describe("planAgentScan", () => {
+  it.each<{
+    sourceKind: "enumerated" | "aggregate";
+    intent: AgentScanIntent;
+    expected: { kind: string; requestKind?: "reload" | "refresh" };
+  }>([
+    {
+      sourceKind: "enumerated",
+      intent: "reload",
+      expected: { kind: "synchronize", requestKind: "reload" },
+    },
+    {
+      sourceKind: "enumerated",
+      intent: "refresh",
+      expected: { kind: "synchronize", requestKind: "refresh" },
+    },
+    {
+      sourceKind: "enumerated",
+      intent: "backfill",
+      expected: { kind: "synchronize", requestKind: "refresh" },
+    },
+    {
+      sourceKind: "aggregate",
+      intent: "reload",
+      expected: { kind: "scan" },
+    },
+    {
+      sourceKind: "aggregate",
+      intent: "refresh",
+      expected: { kind: "check-for-changes" },
+    },
+    {
+      sourceKind: "aggregate",
+      intent: "backfill",
+      expected: { kind: "scan" },
+    },
+    {
+      sourceKind: "enumerated",
+      intent: "recompute-derived",
+      expected: { kind: "reuse-baseline" },
+    },
+    {
+      sourceKind: "aggregate",
+      intent: "recompute-derived",
+      expected: { kind: "reuse-baseline" },
+    },
+  ])("plans $sourceKind $intent as $expected.kind", ({ sourceKind, intent, expected }) => {
+    const source = sourceKind === "enumerated" ? enumerated : aggregate;
+    const plan = planAgentScan(source, intent);
+    expect({
+      kind: plan.kind,
+      ...(plan.kind === "synchronize" ? { requestKind: plan.requestKind } : {}),
+    }).toEqual(expected);
+    if (plan.kind === "synchronize" || plan.kind === "check-for-changes") {
+      expect(plan.source).toBe(source);
+    }
+  });
+});

--- a/packages/core/src/discovery/agent-scan-plan.ts
+++ b/packages/core/src/discovery/agent-scan-plan.ts
@@ -1,0 +1,51 @@
+import type {
+  AggregateSessionSourceCapability,
+  EnumeratedSessionSourceCapability,
+  SessionSourceCapability,
+} from "../agents/index.js";
+
+export type AgentScanIntent = "reload" | "refresh" | "backfill" | "recompute-derived";
+
+export type AgentScanPlan =
+  | { kind: "scan" }
+  | {
+      kind: "synchronize";
+      requestKind: "reload" | "refresh";
+      source: EnumeratedSessionSourceCapability;
+    }
+  | { kind: "check-for-changes"; source: AggregateSessionSourceCapability }
+  | { kind: "reuse-baseline" };
+
+type SourceScanPlan = Extract<AgentScanPlan, { kind: "scan" | "synchronize" }>;
+type RefreshScanPlan = Extract<AgentScanPlan, { kind: "synchronize" | "check-for-changes" }>;
+type RecomputeScanPlan = Extract<AgentScanPlan, { kind: "reuse-baseline" }>;
+
+export function planAgentScan(
+  source: SessionSourceCapability,
+  intent: "reload" | "backfill",
+): SourceScanPlan;
+export function planAgentScan(source: SessionSourceCapability, intent: "refresh"): RefreshScanPlan;
+export function planAgentScan(
+  source: SessionSourceCapability,
+  intent: "recompute-derived",
+): RecomputeScanPlan;
+export function planAgentScan(
+  source: SessionSourceCapability,
+  intent: AgentScanIntent,
+): AgentScanPlan;
+export function planAgentScan(
+  source: SessionSourceCapability,
+  intent: AgentScanIntent,
+): AgentScanPlan {
+  if (intent === "recompute-derived") return { kind: "reuse-baseline" };
+
+  if (source.kind === "enumerated") {
+    return {
+      kind: "synchronize",
+      requestKind: intent === "reload" ? "reload" : "refresh",
+      source,
+    };
+  }
+
+  return intent === "refresh" ? { kind: "check-for-changes", source } : { kind: "scan" };
+}

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -1,6 +1,8 @@
 export { firstExisting, readEnvPath, resolveDataHome, resolveHomePath } from "./paths.js";
 export { ensureSessionTagsSync, filterSessions, scanSessions } from "./scanner.js";
 export type { AgentCacheFailure, LiveSnapshot, ScanOptions, SessionTagTiming } from "./scanner.js";
+export { planAgentScan } from "./agent-scan-plan.js";
+export type { AgentScanIntent, AgentScanPlan } from "./agent-scan-plan.js";
 export {
   materializeSessionDetail,
   materializeSessionDetailResponse,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -48,6 +48,7 @@ import {
   computeSessionDiff,
   sessionSignature,
 } from "./orchestrate.js";
+import { planAgentScan } from "./agent-scan-plan.js";
 
 export interface ScanOptions {
   /** Filter to specific agent name(s) */
@@ -682,10 +683,11 @@ async function scanAgentSmart(
 
       onProgress?.({ agent: agent.name, phase: "checking" });
 
-      if (agent.sessionSourceAccess.kind === "enumerated") {
+      const scanPlan = planAgentScan(agent.sessionSourceAccess, "refresh");
+      if (scanPlan.kind === "synchronize") {
         return refreshCachedEnumeratedAgent(
           agent,
-          agent.sessionSourceAccess,
+          scanPlan.source,
           cached,
           options,
           timing,
@@ -693,10 +695,9 @@ async function scanAgentSmart(
           onProgress,
         );
       }
-
       const t1 = performance.now();
       const checkResult = await Promise.resolve(
-        agent.sessionSourceAccess.checkForChanges(cached.timestamp, cached.sessions),
+        scanPlan.source.checkForChanges(cached.timestamp, cached.sessions),
       );
       timing.checkChanges = performance.now() - t1;
 
@@ -727,7 +728,7 @@ async function scanAgentSmart(
         const t2 = performance.now();
         const scanOptions = buildAgentScanOptions(agent, options, onProgress);
         const updatedSessions = await Promise.resolve(
-          agent.sessionSourceAccess.incrementalScan(
+          scanPlan.source.incrementalScan(
             cached.sessions,
             checkResult.changedIds || [],
             checkResult.refs,
@@ -735,7 +736,7 @@ async function scanAgentSmart(
           ),
         );
         timing.scan = performance.now() - t2;
-        agent.sessionSourceAccess.commitChangeCheck();
+        scanPlan.source.commitChangeCheck();
 
         return finalizeAgentScan(agent, updatedSessions, {
           finalization: {
@@ -757,7 +758,7 @@ async function scanAgentSmart(
         });
       }
 
-      agent.sessionSourceAccess.commitChangeCheck();
+      scanPlan.source.commitChangeCheck();
       return finalizeAgentScan(agent, cached.sessions, {
         finalization: { kind: "unchanged", cached },
         options,
@@ -802,11 +803,12 @@ async function scanAgentFull(
     const agentScanOptions = buildAgentScanOptions(agent, options, onProgress);
     let heads: SessionHead[];
     let sourceFailures: SessionSourceFailure[] = [];
-    if (agent.sessionSourceAccess.kind === "enumerated") {
+    const scanPlan = planAgentScan(agent.sessionSourceAccess, "reload");
+    if (scanPlan.kind === "synchronize") {
       const cached = loadCachedSessions(agent.name);
-      const synchronization = agent.sessionSourceAccess.synchronize(
+      const synchronization = scanPlan.source.synchronize(
         { sessions: cached?.sessions ?? [], meta: cached?.meta ?? {} },
-        { kind: "reload", scanOptions: agentScanOptions },
+        { kind: scanPlan.requestKind, scanOptions: agentScanOptions },
       );
       heads = synchronization.sessions;
       sourceFailures = synchronization.sourceFailures;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export {
   listFileActivity,
   listModelCostDistribution,
   loadCachedSessions,
+  planAgentScan,
   readCachedSessions,
   loadCachedSessionHeads,
   markAgentCacheInitialized,
@@ -80,6 +81,8 @@ export type { CacheReadOutcome } from "./discovery/index.js";
 export { PRICING_CAPTURE_EPOCH } from "./pricing/index.js";
 export { filterSessionTreeByActivityWindow } from "./contract/index.js";
 export type {
+  AgentScanIntent,
+  AgentScanPlan,
   FileActivityResult,
   AgentCacheFailure,
   LiveSnapshot,


### PR DESCRIPTION
## Summary
- centralize capability and intent routing in a pure core planner
- use the same execution plan in one-shot scanning, live refresh, and refresh workers
- treat initialized empty aggregate snapshots as valid refresh baselines

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`