### PR TITLE
Use query cache as the session data source

### DIFF
--- a/apps/web/src/hooks/session-store-load-state.test.ts
+++ b/apps/web/src/hooks/session-store-load-state.test.ts
@@ -1,58 +1,30 @@
-import { SAMPLE_DASHBOARD_DATA } from "@codesesh/core/test-fixtures";
 import { describe, expect, it } from "vitest";
-import type { SessionStoreSnapshot } from "./session-store-load-state";
 import {
   INITIAL_SESSION_STORE_LOAD_STATE,
   reduceSessionStoreLoad,
-  sessionStoreLoadSnapshot,
 } from "./session-store-load-state";
 
 const firstWindow = { from: 1, to: 2 };
 const secondWindow = { from: 3, to: 4 };
 
-function snapshot(window: { from: number; to: number }): SessionStoreSnapshot {
-  return {
-    window,
-    agents: [],
-    sessions: [],
-    dashboard: SAMPLE_DASHBOARD_DATA,
-  };
-}
-
 describe("session store load state", () => {
-  it("moves through loading, preview, and ready states", () => {
+  it("tracks the active request lifecycle without storing query data", () => {
     const loading = reduceSessionStoreLoad(INITIAL_SESSION_STORE_LOAD_STATE, {
       type: "begin",
       requestId: 1,
       window: firstWindow,
     });
-    const previewSnapshot = snapshot(firstWindow);
-    const preview = reduceSessionStoreLoad(loading, {
-      type: "publish-preview",
-      requestId: 1,
-      snapshot: previewSnapshot,
-    });
-    const readySnapshot = snapshot(firstWindow);
-    const ready = reduceSessionStoreLoad(preview, {
+    const ready = reduceSessionStoreLoad(loading, {
       type: "complete",
       requestId: 1,
-      snapshot: readySnapshot,
     });
 
     expect(loading).toEqual({ status: "loading", requestId: 1, window: firstWindow });
-    expect(preview).toEqual({
-      status: "preview",
-      requestId: 1,
-      window: firstWindow,
-      snapshot: previewSnapshot,
-    });
     expect(ready).toEqual({
       status: "ready",
       requestId: 1,
       window: firstWindow,
-      snapshot: readySnapshot,
     });
-    expect(sessionStoreLoadSnapshot(ready)).toBe(readySnapshot);
   });
 
   it("ignores late publications from an obsolete request", () => {
@@ -71,7 +43,6 @@ describe("session store load state", () => {
       reduceSessionStoreLoad(latestLoad, {
         type: "complete",
         requestId: 1,
-        snapshot: snapshot(firstWindow),
       }),
     ).toBe(latestLoad);
     expect(
@@ -102,12 +73,10 @@ describe("session store load state", () => {
       window: firstWindow,
       error,
     });
-    expect(sessionStoreLoadSnapshot(failed)).toBeNull();
     expect(
       reduceSessionStoreLoad(failed, {
-        type: "publish-preview",
+        type: "complete",
         requestId: 1,
-        snapshot: snapshot(firstWindow),
       }),
     ).toBe(failed);
   });

--- a/apps/web/src/hooks/session-store-load-state.ts
+++ b/apps/web/src/hooks/session-store-load-state.ts
@@ -1,11 +1,4 @@
-import type { AgentInfo, AppConfig, DashboardData, SessionHead } from "../lib/api";
-
-export interface SessionStoreSnapshot {
-  window: AppConfig["window"];
-  agents: AgentInfo[];
-  sessions: SessionHead[];
-  dashboard: DashboardData;
-}
+import type { AppConfig } from "../lib/api";
 
 interface ActiveSessionStoreLoad {
   requestId: number;
@@ -15,14 +8,12 @@ interface ActiveSessionStoreLoad {
 export type SessionStoreLoadState =
   | { status: "idle" }
   | (ActiveSessionStoreLoad & { status: "loading" })
-  | (ActiveSessionStoreLoad & { status: "preview"; snapshot: SessionStoreSnapshot })
-  | (ActiveSessionStoreLoad & { status: "ready"; snapshot: SessionStoreSnapshot })
+  | (ActiveSessionStoreLoad & { status: "ready" })
   | (ActiveSessionStoreLoad & { status: "failed"; error: unknown });
 
 export type SessionStoreLoadAction =
   | (ActiveSessionStoreLoad & { type: "begin" })
-  | { type: "publish-preview"; requestId: number; snapshot: SessionStoreSnapshot }
-  | { type: "complete"; requestId: number; snapshot: SessionStoreSnapshot }
+  | { type: "complete"; requestId: number }
   | { type: "fail"; requestId: number; error: unknown };
 
 export const INITIAL_SESSION_STORE_LOAD_STATE: SessionStoreLoadState = { status: "idle" };
@@ -39,20 +30,12 @@ export function reduceSessionStoreLoad(
     };
   }
   if (state.status === "idle" || action.requestId !== state.requestId) return state;
-  if (state.status !== "loading" && state.status !== "preview") return state;
+  if (state.status !== "loading") return state;
 
   switch (action.type) {
-    case "publish-preview":
-      return { ...state, status: "preview", snapshot: action.snapshot };
     case "complete":
-      return { ...state, status: "ready", snapshot: action.snapshot };
+      return { ...state, status: "ready" };
     case "fail":
       return { ...state, status: "failed", error: action.error };
   }
-}
-
-export function sessionStoreLoadSnapshot(
-  state: SessionStoreLoadState,
-): SessionStoreSnapshot | null {
-  return state.status === "preview" || state.status === "ready" ? state.snapshot : null;
 }

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -208,7 +208,7 @@ describe("useSessionStore", () => {
       progress?.onFirstPage?.([SAMPLE_SESSION_HEAD]);
       return completeSessions.promise;
     });
-    const { result } = await renderStore();
+    const { result, client } = await renderStore();
 
     let load!: ReturnType<typeof result.current.reload>;
     act(() => {
@@ -217,6 +217,9 @@ describe("useSessionStore", () => {
 
     await waitFor(() => expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]));
     expect(result.current.loading).toBe(false);
+    expect(
+      client.getQueryData<SessionProjection>(queryKeys.sessionProjection(config.window))?.sessions,
+    ).toEqual([SAMPLE_SESSION_HEAD]);
 
     completeSessions.resolve({ sessions: [SAMPLE_SESSION_HEAD, finalSession] });
     await act(() => load);

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -33,11 +33,14 @@ import {
 import {
   INITIAL_SESSION_STORE_LOAD_STATE,
   reduceSessionStoreLoad,
-  sessionStoreLoadSnapshot,
-  type SessionStoreSnapshot,
 } from "./session-store-load-state";
 
-export type { SessionStoreSnapshot } from "./session-store-load-state";
+export interface SessionStoreSnapshot {
+  window: AppConfig["window"];
+  agents: AgentInfo[];
+  sessions: SessionHead[];
+  dashboard: DashboardData;
+}
 
 export interface SessionProjection {
   window: AppConfig["window"];
@@ -278,31 +281,17 @@ export function useSessionStore() {
           }),
         ]);
         void queryClient.fetchQuery(projectsOptions(window)).catch(() => undefined);
-        let loadedAggregates: SnapshotAggregates | undefined;
-        let firstPage: SessionProjection | undefined;
-        const publishPreview = () => {
-          if (!loadedAggregates || !firstPage) return;
-          dispatchLoad({
-            type: "publish-preview",
-            requestId,
-            snapshot: createSnapshot(window, loadedAggregates, firstPage.sessions),
-          });
-        };
         const [aggregates, projection] = await Promise.all([
-          queryClient.fetchQuery(snapshotAggregatesOptions(window)).then((value) => {
-            loadedAggregates = value;
-            publishPreview();
-            return value;
-          }),
+          queryClient.fetchQuery(snapshotAggregatesOptions(window)),
           queryClient.fetchQuery(
             sessionProjectionOptions(window, (firstPageProjection) => {
-              firstPage = firstPageProjection;
-              publishPreview();
+              if (activeRequestRef.current?.requestId !== requestId) return;
+              queryClient.setQueryData(queryKeys.sessionProjection(window), firstPageProjection);
             }),
           ),
         ]);
         const snapshot = createSnapshot(window, aggregates, projection.sessions);
-        dispatchLoad({ type: "complete", requestId, snapshot });
+        dispatchLoad({ type: "complete", requestId });
         return snapshot;
       } catch (error) {
         if (isCancelledError(error)) return null;
@@ -411,10 +400,9 @@ export function useSessionStore() {
     }
   }, [configFailed, refetchConfig, reload]);
 
-  const currentSnapshot = sameWindow(querySnapshot?.window, requestedWindow) ? querySnapshot : null;
-  const loadSnapshot = sessionStoreLoadSnapshot(loadState);
-  const displayedSnapshot =
-    currentSnapshot ?? (sameWindow(loadSnapshot?.window, requestedWindow) ? loadSnapshot : null);
+  const displayedSnapshot = sameWindow(querySnapshot?.window, requestedWindow)
+    ? querySnapshot
+    : null;
   const agents = displayedSnapshot?.agents ?? EMPTY_AGGREGATES.agents;
   const projectPage = projectsQuery.data ?? EMPTY_PROJECT_PAGE;
   const projects = projectPage.projects;


### PR DESCRIPTION
## Summary
- keep only request lifecycle state in the session load reducer
- publish first-page session previews into the React Query cache
- derive displayed session data exclusively from query-backed projections and aggregates

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`