### PR TITLE
refactor(agents): simplify file parse results

### DIFF
--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -8,8 +8,15 @@ import {
   diffSessionSources,
   FileSystemSessionSource,
   filteredSession,
+  SingleFileSessionSource,
 } from "../base.js";
-import type { AgentScanOptions, SessionCacheMeta, SessionSourceRef } from "../base.js";
+import type {
+  AgentScanOptions,
+  FileSessionMeta,
+  SessionCacheMeta,
+  SessionSourceFile,
+  SessionSourceRef,
+} from "../base.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { PRICING_CAPTURE_EPOCH } from "../../pricing/cost.js";
 import type { ModelPricing } from "../../pricing/fetcher.js";
@@ -97,6 +104,45 @@ class NormalizedNameSource extends FakeFileSystemSource {
   override readonly name = " FaKe ";
 }
 
+class ReentrantSingleFileSource extends SingleFileSessionSource {
+  readonly name = "reentrant";
+  readonly displayName = "Reentrant";
+  readonly source = {
+    sessionId: "filtered",
+    sourcePath: "/tmp/filtered.jsonl",
+    fingerprint: "fp-1",
+  };
+  nestedOutcomeStatus: string | undefined;
+  private parsing = false;
+
+  isAvailable(): boolean {
+    return true;
+  }
+
+  getSessionWatchPlan() {
+    return { status: "not-needed" as const, reason: "in-memory test source" };
+  }
+
+  getSessionData(_sessionId: string): SessionDetail {
+    return {} as SessionDetail;
+  }
+
+  listSessionSources(): SessionSourceRef[] {
+    return [this.source];
+  }
+
+  protected override parseFileSessionHeadResult() {
+    if (this.parsing) return filteredSession<SessionHead>("nested filter");
+    this.parsing = true;
+    this.nestedOutcomeStatus = this.scanSessionSourceOutcome(this.source).status;
+    return filteredSession<SessionHead>("outer filter");
+  }
+
+  protected createFileSessionMeta(head: SessionHead, source: SessionSourceFile): FileSessionMeta {
+    return this.buildFileSessionMeta({ head, source, fingerprint: "fp-1", extras: {} });
+  }
+}
+
 function makeSession(id: string): SessionHead {
   return {
     reference: { agentName: "fake", sessionId: id },
@@ -151,6 +197,15 @@ describe("BaseAgent", () => {
 });
 
 describe("FileSystemSessionSource.scan", () => {
+  it("keeps a rich parse result isolated during a nested scan of the same source", () => {
+    const agent = new ReentrantSingleFileSource();
+
+    const outcome = agent.scanSessionSourceOutcome(agent.source);
+
+    expect(agent.nestedOutcomeStatus).toBe("filtered");
+    expect(outcome).toMatchObject({ status: "filtered", reason: "outer filter" });
+  });
+
   it("ignores a session-file symlink outside the scan root", () => {
     const directory = mkdtempSync(join(tmpdir(), "codesesh-walk-symlink-"));
     const root = join(directory, "root");

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -507,12 +507,15 @@ describe("CodexAgent cache refresh", () => {
 
     const agent = new CodexAgent() as any;
     agent.basePath = tempDir;
-    // Drive the new primitives directly: listSessionSources enumerates the
-    // on-disk files, scanSessionSource parses each head.
-    agent.scanSessionSource = (file: string) => {
-      if (file === oldA) return makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa");
-      if (file === newC) return makeSession("019dcccc-cccc-7ccc-cccc-cccccccccccc");
-      return null;
+    // Replace the single-file parser while keeping the shared scan lifecycle intact.
+    agent.parseFileSessionHeadResult = (file: string) => {
+      if (file === oldA) {
+        return { status: "parsed", data: makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa") };
+      }
+      if (file === newC) {
+        return { status: "parsed", data: makeSession("019dcccc-cccc-7ccc-cccc-cccccccccccc") };
+      }
+      return { status: "skipped", reason: "unknown fixture" };
     };
 
     const sessions = agent.incrementalScan(
@@ -550,7 +553,7 @@ describe("CodexAgent cache refresh", () => {
     const agent = new CodexAgent() as any;
     agent.sessionIndexCache = new Map();
 
-    const head = agent.parseSessionHead(sessionFile);
+    const head = agent.scanSessionSource(sessionFile);
 
     expect(head?.time_created).toBe(new Date("2026-04-20T10:00:00Z").getTime());
     expect(head?.time_updated).toBe(new Date("2026-04-20T10:02:30Z").getTime());
@@ -574,7 +577,7 @@ describe("CodexAgent cache refresh", () => {
 
     const agent = new CodexAgent() as any;
     agent.sessionIndexCache = new Map();
-    const head = agent.parseSessionHead(sessionFile);
+    const head = agent.scanSessionSource(sessionFile);
 
     expect(head?.time_created).toBe(Date.parse("2026-04-20T10:00:00+08:00"));
     expect(head?.time_updated).toBe(Date.parse("2026-04-20T10:02:30+08:00"));
@@ -599,7 +602,7 @@ describe("CodexAgent cache refresh", () => {
     const agent = new CodexAgent() as any;
     agent.sessionIndexCache = new Map();
 
-    const head = agent.parseSessionHead(sessionFile);
+    const head = agent.scanSessionSource(sessionFile);
 
     expect(head?.stats.total_input_tokens).toBe(100);
     expect(head?.stats.total_output_tokens).toBe(25);
@@ -682,7 +685,7 @@ describe("CodexAgent cache refresh", () => {
     const agent = new CodexAgent() as any;
     agent.sessionIndexCache = new Map();
 
-    const head = agent.parseSessionHead(sessionFile);
+    const head = agent.scanSessionSource(sessionFile);
 
     expect(head?.stats.total_input_tokens).toBe(1000);
     expect(head?.stats.total_cache_read_tokens).toBe(800);
@@ -712,7 +715,7 @@ describe("CodexAgent cache refresh", () => {
     const agent = new CodexAgent() as any;
     agent.sessionIndexCache = new Map();
 
-    const head = agent.parseSessionHead(sessionFile);
+    const head = agent.scanSessionSource(sessionFile);
 
     expect(head?.model_usage).toEqual({ "gpt-5.5": 120, "gpt-5.4": 50 });
   });
@@ -736,7 +739,7 @@ describe("CodexAgent cache refresh", () => {
     const agent = new CodexAgent() as any;
     agent.sessionIndexCache = new Map();
 
-    const head = agent.parseSessionHead(sessionFile);
+    const head = agent.scanSessionSource(sessionFile);
 
     expect(head?.title).toBe("Untitled Session");
   });
@@ -1456,7 +1459,7 @@ describe("CodexAgent field shape mismatches", () => {
     const agent = new CodexAgent() as any;
     agent.sessionIndexCache = new Map();
 
-    const head = agent.parseSessionHead(sessionFile);
+    const head = agent.scanSessionSource(sessionFile);
 
     expect(head?.stats.total_input_tokens).toBe(0);
     expect(head?.stats.total_output_tokens).toBe(0);

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -562,53 +562,36 @@ export abstract class FileSystemSessionSource<
 export abstract class SingleFileSessionSource<
   TMeta extends FileSessionMeta = FileSessionMeta,
 > extends FileSystemSessionSource<TMeta> {
-  private readonly pendingParseResults = new Map<
-    string,
-    ParseSessionResult<SessionHead> | undefined
-  >();
-
-  protected abstract parseFileSessionHead(
+  protected abstract parseFileSessionHeadResult(
     sourcePath: string,
     options?: AgentScanOptions,
-  ): SessionHead | null;
-
-  protected parseFileSessionHeadResult(
-    sourcePath: string,
-    options?: AgentScanOptions,
-  ): ParseSessionResult<SessionHead> {
-    const head = this.parseFileSessionHead(sourcePath, options);
-    return head ? parsedSession(head) : skippedSession("source produced no session");
-  }
+  ): ParseSessionResult<SessionHead>;
 
   protected abstract createFileSessionMeta(head: SessionHead, source: SessionSourceFile): TMeta;
 
-  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
+  private parseSessionSource(
+    sourcePath: string,
+    options?: AgentScanOptions,
+  ): ParseSessionResult<SessionHead> {
     const result = this.parseFileSessionHeadResult(sourcePath, options);
-    if (this.pendingParseResults.has(sourcePath)) {
-      this.pendingParseResults.set(sourcePath, result);
-    }
     if (result.status === "parsed") {
       this.sessionMetaMap.set(
         result.data.reference.sessionId,
         this.createFileSessionMeta(result.data, this.sessionSourceFile(sourcePath)),
       );
     }
-    return getParsedSession(result);
+    return result;
+  }
+
+  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
+    return getParsedSession(this.parseSessionSource(sourcePath, options));
   }
 
   protected override scanSessionSourceResult(
     source: SessionSourceRef,
     options?: AgentScanOptions,
   ): ParseSessionResult<SessionHead> {
-    this.pendingParseResults.set(source.sourcePath, undefined);
-    try {
-      const head = this.scanSessionSource(source.sourcePath, options);
-      const result = this.pendingParseResults.get(source.sourcePath);
-      if (head) return result?.status === "parsed" ? result : parsedSession(head);
-      return result ?? skippedSession("source produced no session");
-    } finally {
-      this.pendingParseResults.delete(source.sourcePath);
-    }
+    return this.parseSessionSource(source.sourcePath, options);
   }
 
   protected buildFileSessionMeta<TExtra extends object>({

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -1,13 +1,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename, dirname } from "node:path";
 import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
-import {
-  SingleFileSessionSource,
-  filteredSession,
-  getParsedSession,
-  parsedSession,
-  skippedSession,
-} from "./base.js";
+import { SingleFileSessionSource, filteredSession, parsedSession, skippedSession } from "./base.js";
 import type { ParseSessionResult } from "./base.js";
 import type {
   SessionHead,
@@ -269,10 +263,6 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     this.childContextsBySource.clear();
     this.childSessionIdByToolUseId.clear();
     this.childIndexReady = false;
-  }
-
-  protected parseFileSessionHead(sourcePath: string): SessionHead | null {
-    return getParsedSession(this.parseFileSessionHeadResult(sourcePath));
   }
 
   protected override parseFileSessionHeadResult(

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1,13 +1,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, basename } from "node:path";
 import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
-import {
-  SingleFileSessionSource,
-  filteredSession,
-  getParsedSession,
-  parsedSession,
-  skippedSession,
-} from "./base.js";
+import { SingleFileSessionSource, filteredSession, parsedSession, skippedSession } from "./base.js";
 import type { ParseSessionResult } from "./base.js";
 import type { Message, SessionHead, SessionDetail, MessagePart } from "../types/index.js";
 import { firstExisting, resolveHomePath } from "../discovery/paths.js";
@@ -905,14 +899,6 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   }
 
   // ---- Session head parsing ----
-
-  protected parseFileSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {
-    return this.parseSessionHead(filePath, options);
-  }
-
-  private parseSessionHead(filePath: string, options?: AgentScanOptions): SessionHead | null {
-    return getParsedSession(this.parseFileSessionHeadResult(filePath, options));
-  }
 
   protected override parseFileSessionHeadResult(
     filePath: string,

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,12 +1,7 @@
 import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
 import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
-import {
-  SingleFileSessionSource,
-  filteredSession,
-  getParsedSession,
-  parsedSession,
-} from "./base.js";
+import { SingleFileSessionSource, filteredSession, parsedSession } from "./base.js";
 import type {
   AgentScanOptions,
   FileSessionMeta,
@@ -221,10 +216,6 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
   /** Fingerprint depends on an already-fetched stat to avoid re-statting the same file. */
   private sourceFingerprint(stat: { mtimeMs: number; size: number }): string {
     return JSON.stringify([HEAD_INDEX_VERSION, PARSER_VERSION, stat.mtimeMs, stat.size]);
-  }
-
-  protected parseFileSessionHead(filePath: string): SessionHead | null {
-    return getParsedSession(this.parseFileSessionHeadResult(filePath));
   }
 
   protected override parseFileSessionHeadResult(filePath: string): ParseSessionResult<SessionHead> {


### PR DESCRIPTION
## Summary

- make rich single-file parse results the canonical parser output
- remove the temporary path-keyed parse result map and redundant wrappers
- preserve filtered outcomes under nested scans and exercise Codex through the shared lifecycle

## Validation

- `pnpm --filter @codesesh/core test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @codesesh/core format:check`