### PR TITLE
fix(agents): surface Kimi I/O failures

### DIFF
--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -1,7 +1,18 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(actual.readFileSync),
+  };
+});
+
 import {
   appendFileSync,
   mkdtempSync,
   mkdirSync,
+  readFileSync,
   rmSync,
   statSync,
   utimesSync,
@@ -9,13 +20,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
 import { KimiCodeAgent } from "../kimi-code.js";
 
 const SESSION_ID = "ses_test-kimi-code";
 const WORK_DIR = "/tmp/kimi-code-project";
 
 let tempDirs: string[] = [];
+const mockedReadFileSync = vi.mocked(readFileSync);
 
 function createAgent(dataRoot: string): KimiCodeAgent {
   const agent = new KimiCodeAgent() as never as { basePath: string };
@@ -52,9 +63,40 @@ function createSession(
 afterEach(() => {
   for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
   tempDirs = [];
+  mockedReadFileSync.mockClear();
 });
 
 describe("KimiCodeAgent", () => {
+  it("surfaces state read failures instead of treating them as malformed sessions", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    const sessionDir = createSession(dataRoot, []);
+    const statePath = join(sessionDir, "state.json");
+    const error = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    mockedReadFileSync.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() => createAgent(dataRoot).listSessionSources()).toThrowError(
+      expect.objectContaining({
+        name: "SessionScanError",
+        agentName: "kimi-code",
+        stage: "reading session state",
+        sourcePath: statePath,
+        cause: error,
+      }),
+    );
+  });
+
+  it("skips readable state files with malformed JSON", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    const sessionDir = createSession(dataRoot, []);
+    writeFileSync(join(sessionDir, "state.json"), "not-json");
+
+    expect(createAgent(dataRoot).listSessionSources()).toEqual([]);
+  });
+
   it("enumerates an old session by recent wire activity", () => {
     const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
     tempDirs.push(dataRoot);

--- a/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
@@ -83,6 +83,36 @@ afterEach(() => {
 });
 
 describe("KimiAgent source enumeration", () => {
+  it("surfaces state read failures instead of treating them as malformed metadata", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
+    tempDirs.push(basePath);
+    const sessionDir = createSessionDir(basePath, "unreadable", "Unreadable");
+    const statePath = join(sessionDir, "state.json");
+    const error = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    mockedReadFileSync.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() => createAgent(basePath).listSessionSources()).toThrowError(
+      expect.objectContaining({
+        name: "SessionScanError",
+        agentName: "kimi",
+        stage: "reading session metadata",
+        sourcePath: statePath,
+        cause: error,
+      }),
+    );
+  });
+
+  it("skips readable state files with malformed JSON", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
+    tempDirs.push(basePath);
+    const sessionDir = createSessionDir(basePath, "malformed", "Malformed");
+    writeFileSync(join(sessionDir, "state.json"), "not-json");
+
+    expect(createAgent(basePath).listSessionSources()).toEqual([]);
+  });
+
   it("does not read transcripts while enumerating sources", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-enum-"));
     tempDirs.push(basePath);

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -329,9 +329,9 @@ function applyUsage(
   });
 }
 
-function readState(stateFile: string): Record<string, unknown> | null {
+function parseState(content: string): Record<string, unknown> | null {
   try {
-    return asRecord(JSON.parse(readFileSync(stateFile, "utf-8"))) ?? null;
+    return asRecord(JSON.parse(content)) ?? null;
   } catch {
     return null;
   }
@@ -405,47 +405,49 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
   }
 
   private resolveSessionSourceResult(sessionDir: string): ParseSessionResult<SessionSource> {
-    try {
-      const stateFile = join(sessionDir, "state.json");
-      const wireFile = join(sessionDir, "agents", "main", "wire.jsonl");
-      if (!existsSync(stateFile) || !existsSync(wireFile)) return skippedSession("missing wire");
+    const stateFile = join(sessionDir, "state.json");
+    const wireFile = join(sessionDir, "agents", "main", "wire.jsonl");
+    if (!existsSync(stateFile) || !existsSync(wireFile)) return skippedSession("missing wire");
 
-      const state = readState(stateFile);
-      if (!state) return skippedSession("malformed state");
+    const content = this.scanStep("reading session state", stateFile, () =>
+      readFileSync(stateFile, "utf-8"),
+    );
+    const state = parseState(content);
+    if (!state) return skippedSession("malformed state");
 
-      const stateStat = statSync(stateFile);
-      const wireStat = statSync(wireFile);
-      const createdAt =
-        parseTimestamp(state.createdAt) ?? parseTimestamp(state.created_at) ?? stateStat.mtimeMs;
-      const activityAt = Math.max(
-        parseTimestamp(state.updatedAt) ?? parseTimestamp(state.updated_at) ?? createdAt,
-        wireStat.mtimeMs,
-      );
-      const custom = asRecord(state.custom);
-      const workDir =
-        asString(state.workDir) ??
-        asString(custom?.cwd) ??
-        this.workDirBySessionPath.get(resolve(sessionDir)) ??
-        "";
-      const explicitTitle = asString(state.title) ?? asString(state.customTitle) ?? "";
+    const [stateStat, wireStat] = this.scanStep(
+      "reading session source metadata",
+      sessionDir,
+      () => [statSync(stateFile), statSync(wireFile)] as const,
+    );
+    const createdAt =
+      parseTimestamp(state.createdAt) ?? parseTimestamp(state.created_at) ?? stateStat.mtimeMs;
+    const activityAt = Math.max(
+      parseTimestamp(state.updatedAt) ?? parseTimestamp(state.updated_at) ?? createdAt,
+      wireStat.mtimeMs,
+    );
+    const custom = asRecord(state.custom);
+    const workDir =
+      asString(state.workDir) ??
+      asString(custom?.cwd) ??
+      this.workDirBySessionPath.get(resolve(sessionDir)) ??
+      "";
+    const explicitTitle = asString(state.title) ?? asString(state.customTitle) ?? "";
 
-      return parsedSession({
-        id: basename(sessionDir),
-        sourcePath: sessionDir,
-        stateFile,
-        wireFile,
-        workDir,
-        createdAt,
-        activityAt,
-        stateMtimeMs: stateStat.mtimeMs,
-        stateSize: stateStat.size,
-        wireMtimeMs: wireStat.mtimeMs,
-        wireSize: wireStat.size,
-        explicitTitle,
-      });
-    } catch {
-      return skippedSession("malformed session");
-    }
+    return parsedSession({
+      id: basename(sessionDir),
+      sourcePath: sessionDir,
+      stateFile,
+      wireFile,
+      workDir,
+      createdAt,
+      activityAt,
+      stateMtimeMs: stateStat.mtimeMs,
+      stateSize: stateStat.size,
+      wireMtimeMs: wireStat.mtimeMs,
+      wireSize: wireStat.size,
+      explicitTitle,
+    });
   }
 
   private sourceFingerprint(source: SessionSource): string {

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -299,64 +299,71 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
    * 只读小 JSON 文件与 statSync，不触碰 transcript——枚举路径依赖这一点。
    */
   private resolveSessionSourceResult(sessionDir: string): ParseSessionResult<SessionSource> {
-    try {
-      const sessionId = basename(sessionDir);
-      const projectHash = basename(dirname(sessionDir));
-      const contextFile = join(sessionDir, "context.jsonl");
-      const wireFile = join(sessionDir, "wire.jsonl");
+    const sessionId = basename(sessionDir);
+    const projectHash = basename(dirname(sessionDir));
+    const contextFile = join(sessionDir, "context.jsonl");
+    const wireFile = join(sessionDir, "wire.jsonl");
 
-      const existingContextFile = existsSync(contextFile) ? contextFile : null;
-      const existingWireFile = existsSync(wireFile) ? wireFile : null;
-      if (!existingContextFile && !existingWireFile) {
-        return skippedSession("missing transcript");
-      }
-
-      const statePath = join(sessionDir, "state.json");
-      const metaPath = join(sessionDir, "metadata.json");
-
-      let explicitTitle = "";
-      let wireMtime: number | null = null;
-      let metaFile = "";
-      let metadata: Record<string, unknown> = {};
-
-      if (existsSync(statePath)) {
-        metadata = asRecord(JSON.parse(readFileSync(statePath, "utf-8"))) ?? {};
-        explicitTitle = String(metadata.custom_title ?? "");
-        wireMtime = readWireMtime(metadata);
-        metaFile = statePath;
-      } else if (existsSync(metaPath)) {
-        metadata = asRecord(JSON.parse(readFileSync(metaPath, "utf-8"))) ?? {};
-        explicitTitle = String(metadata.title ?? "");
-        wireMtime = readWireMtime(metadata);
-        metaFile = metaPath;
-      }
-
-      const sessionStat = statSync(sessionDir);
-      const createdAt =
-        parseTimestamp(metadata.createdAt) ??
-        parseTimestamp(metadata.created_at) ??
-        (sessionStat.birthtimeMs > 0 ? sessionStat.birthtimeMs : sessionStat.ctimeMs);
-      const activityAt = Math.max(
-        createdAt,
-        wireMtime === null ? 0 : wireMtime * 1000,
-        existingContextFile ? statSync(existingContextFile).mtimeMs : 0,
-        existingWireFile ? statSync(existingWireFile).mtimeMs : 0,
-      );
-
-      return parsedSession({
-        id: sessionId,
-        sourcePath: sessionDir,
-        cwd: this.projectMap.get(projectHash) || "",
-        contextFile: existingContextFile,
-        wireFile: existingWireFile,
-        createdAt,
-        activityAt,
-        metaFile,
-        explicitTitle,
-      });
-    } catch {
-      return skippedSession("malformed metadata");
+    const existingContextFile = existsSync(contextFile) ? contextFile : null;
+    const existingWireFile = existsSync(wireFile) ? wireFile : null;
+    if (!existingContextFile && !existingWireFile) {
+      return skippedSession("missing transcript");
     }
+
+    const statePath = join(sessionDir, "state.json");
+    const metaPath = join(sessionDir, "metadata.json");
+    const metaFile = existsSync(statePath) ? statePath : existsSync(metaPath) ? metaPath : "";
+    let metadata: Record<string, unknown> = {};
+
+    if (metaFile) {
+      const content = this.scanStep("reading session metadata", metaFile, () =>
+        readFileSync(metaFile, "utf-8"),
+      );
+      try {
+        metadata = asRecord(JSON.parse(content)) ?? {};
+      } catch {
+        return skippedSession("malformed metadata");
+      }
+    }
+
+    const explicitTitle = String(
+      metaFile === statePath ? (metadata.custom_title ?? "") : (metadata.title ?? ""),
+    );
+    const wireMtime = readWireMtime(metadata);
+    const [sessionStat, contextMtimeMs, wireMtimeMs] = this.scanStep(
+      "reading session source metadata",
+      sessionDir,
+      () => {
+        const sessionStat = statSync(sessionDir);
+        return [
+          sessionStat,
+          existingContextFile ? statSync(existingContextFile).mtimeMs : 0,
+          existingWireFile ? statSync(existingWireFile).mtimeMs : 0,
+        ] as const;
+      },
+    );
+    const createdAt =
+      parseTimestamp(metadata.createdAt) ??
+      parseTimestamp(metadata.created_at) ??
+      (sessionStat.birthtimeMs > 0 ? sessionStat.birthtimeMs : sessionStat.ctimeMs);
+    const activityAt = Math.max(
+      createdAt,
+      wireMtime === null ? 0 : wireMtime * 1000,
+      contextMtimeMs,
+      wireMtimeMs,
+    );
+
+    return parsedSession({
+      id: sessionId,
+      sourcePath: sessionDir,
+      cwd: this.projectMap.get(projectHash) || "",
+      contextFile: existingContextFile,
+      wireFile: existingWireFile,
+      createdAt,
+      activityAt,
+      metaFile,
+      explicitTitle,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

- distinguish unreadable Kimi session files from readable malformed JSON
- wrap state reads and source stat operations with contextual scan failures
- cover both Kimi adapters with I/O and malformed-data regression tests

## Validation

- `pnpm --filter @codesesh/core test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @codesesh/core format:check`