### PR TITLE
refactor(agents): inject session source roots

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -85,8 +85,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     );
     writeFileSync(indexFile, JSON.stringify({ entries: [{ sessionId: "session-1" }] }));
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     // Seed baseline: a full scan populates metaMap with the source fingerprint.
     agent.scan();
@@ -127,8 +126,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     utimesSync(oldFile, oldTime, oldTime);
     utimesSync(newFile, newTime, newTime);
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     expect(
       agent
@@ -164,8 +162,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     utimesSync(parentFile, parentTime, parentTime);
     utimesSync(childFile, childTime, childTime);
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     expect(
       agent
@@ -204,8 +201,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       writeFileSync(metaPath, JSON.stringify({ name: childId }));
     }
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
     const readSpy = vi.mocked(readFileSync);
     const statSpy = vi.mocked(statSync);
 
@@ -258,8 +254,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       JSON.stringify({ agentId: childId, toolUseId: "tool-child" }),
     );
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
     agent.scan();
     const restoredMeta = agent.snapshotSessionCacheMeta();
     const walkSpy = vi.spyOn(agent, "walkFiles");
@@ -281,8 +276,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     mkdirSync(projectDir, { recursive: true });
     writeMinimalClaudeSession(join(projectDir, parentId + ".jsonl"));
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
     agent.scan();
 
     mkdirSync(childDir, { recursive: true });
@@ -291,8 +285,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       join(childDir, "agent-" + childId + ".meta.json"),
       JSON.stringify({ agentId: childId, toolUseId: "tool-added-child" }),
     );
-    const refreshedAgent = new ClaudeCodeAgent() as any;
-    refreshedAgent.basePath = basePath;
+    const refreshedAgent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
     refreshedAgent.scan();
     const walkSpy = vi.spyOn(agent, "walkFiles");
 
@@ -323,8 +316,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     utimesSync(parentFile, parentTime, parentTime);
     utimesSync(childFile, childTime, childTime);
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     expect(
       agent
@@ -356,8 +348,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const indexFile = join(projectDir, "sessions-index.json");
     writeFileSync(indexFile, JSON.stringify({ entries: [] }));
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     const statSpy = vi.mocked(statSync);
     statSpy.mockClear();
@@ -384,8 +375,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     utimesSync(sessionFile, sessionTime, sessionTime);
     utimesSync(indexFile, indexTime, indexTime);
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     expect(agent.listSessionSources()).toEqual([
       {
@@ -485,8 +475,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -662,8 +651,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     const heads = agent.scan();
     const parent = heads.find((head: SessionHead) => head.id === parentId);
@@ -758,8 +746,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -800,8 +787,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     expect(agent.scan()).toEqual([]);
   });
@@ -845,8 +831,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -900,8 +885,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     expect(agent.scan()).toEqual([]);
   });
@@ -949,8 +933,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
     setCoreDiagnostics(sink);
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     const [head] = agent.scan();
 
@@ -994,8 +977,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
     setCoreDiagnostics(sink);
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     // No visible messages were extracted, so the session is filtered out entirely.
     expect(agent.scan()).toEqual([]);
@@ -1015,9 +997,7 @@ describe("ClaudeCodeAgent head parsing", () => {
     const sessionFile = join(projectDir, "session-1.jsonl");
     writeFileSync(sessionFile, lines.join("\n"));
 
-    const agent = new ClaudeCodeAgent() as never as { basePath: string };
-    agent.basePath = basePath;
-    return { agent: agent as never as ClaudeCodeAgent, sessionFile };
+    return { agent: new ClaudeCodeAgent({ sourceRoot: basePath }), sessionFile };
   }
 
   function userLine(text: string, timestamp = "2026-04-20T10:00:00Z"): string {
@@ -1051,8 +1031,7 @@ describe("ClaudeCodeAgent head parsing", () => {
       }),
     );
 
-    const agent = new ClaudeCodeAgent() as any;
-    agent.basePath = basePath;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     expect(agent.scan()).toMatchObject([
       {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -75,8 +75,7 @@ describe("CodexAgent cache refresh", () => {
     writeFileSync(oldA, '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n');
     writeFileSync(newC, '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:05:00Z"}}\n');
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionMetaMap = new Map([
       [
         "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
@@ -132,8 +131,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
     const cached = agent.scan({ from: 0 }) as SessionHead[];
     expect(cached[0]?.stats.total_cost).toBe(0);
@@ -167,8 +165,7 @@ describe("CodexAgent cache refresh", () => {
     );
     writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"Old title"}\n`);
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = sessionsDir;
+    const agent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
     // Seed baseline meta with the live fingerprint.
     agent.scan();
     const baselineFingerprint = agent.listSessionSources()[0]?.fingerprint;
@@ -220,8 +217,7 @@ describe("CodexAgent cache refresh", () => {
     utimesSync(oldFile, oldTime, oldTime);
     utimesSync(newFile, newTime, newTime);
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
 
     expect(
       agent
@@ -266,8 +262,7 @@ describe("CodexAgent cache refresh", () => {
       );
     }
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
 
     const statSpy = vi.mocked(statSync);
     statSpy.mockClear();
@@ -299,8 +294,7 @@ describe("CodexAgent cache refresh", () => {
       meta({ id: childId, thread_source: "subagent", parent_thread_id: parentId }),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     const window = { from: Date.now() - 24 * 60 * 60 * 1000 };
     const openSpy = vi.mocked(openSync);
 
@@ -348,8 +342,7 @@ describe("CodexAgent cache refresh", () => {
     const sessionTime = new Date(1_700_000_000_000);
     utimesSync(sessionFile, sessionTime, sessionTime);
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = sessionsDir;
+    const agent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
 
     expect(agent.listSessionSources()).toEqual([
       {
@@ -387,8 +380,7 @@ describe("CodexAgent cache refresh", () => {
       );
     }
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = sessionsDir;
+    const agent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
     const readSpy = vi.mocked(readFileSync);
     const statSpy = vi.mocked(statSync);
     readSpy.mockClear();
@@ -426,8 +418,7 @@ describe("CodexAgent cache refresh", () => {
     );
     writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"Old title"}\n`);
 
-    const firstAgent = new CodexAgent() as any;
-    firstAgent.basePath = sessionsDir;
+    const firstAgent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
     const firstFingerprint = firstAgent.listSessionSources()[0]?.fingerprint;
 
     writeFileSync(
@@ -438,13 +429,11 @@ describe("CodexAgent cache refresh", () => {
         "",
       ].join("\n"),
     );
-    const unrelatedAgent = new CodexAgent() as any;
-    unrelatedAgent.basePath = sessionsDir;
+    const unrelatedAgent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
     const unrelatedFingerprint = unrelatedAgent.listSessionSources()[0]?.fingerprint;
 
     writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"New title"}\n`);
-    const renamedAgent = new CodexAgent() as any;
-    renamedAgent.basePath = sessionsDir;
+    const renamedAgent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
     const renamedFingerprint = renamedAgent.listSessionSources()[0]?.fingerprint;
 
     expect(unrelatedFingerprint).toBe(firstFingerprint);
@@ -464,8 +453,7 @@ describe("CodexAgent cache refresh", () => {
       '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionMetaMap = new Map([
       [
         "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
@@ -505,8 +493,7 @@ describe("CodexAgent cache refresh", () => {
     writeFileSync(oldA, "");
     writeFileSync(newC, "");
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     // Replace the single-file parser while keeping the shared scan lifecycle intact.
     agent.parseFileSessionHeadResult = (file: string) => {
       if (file === oldA) {
@@ -627,8 +614,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     const [head] = agent.scan();
     const detail = agent.getSessionData(sessionId);
 
@@ -653,8 +639,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     const [head] = agent.scan();
     const detail = agent.getSessionData(sessionId);
 
@@ -760,8 +745,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
 
     expect(agent.scan()).toEqual([]);
   });
@@ -838,8 +822,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -909,8 +892,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
 
     agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -959,8 +941,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
 
     agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -1138,8 +1119,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -1242,8 +1222,7 @@ describe("CodexAgent code-mode exec decoding", () => {
     ];
     writeFileSync(sessionFile, lines.join("\n"));
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.scan();
     return { agent, sessionId };
   }
@@ -1487,8 +1466,7 @@ describe("CodexAgent field shape mismatches", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.scan();
 
     const data = agent.getSessionData(sessionId);
@@ -1578,8 +1556,7 @@ describe("CodexAgent subagent folding", () => {
       extra: [tokenCountLine(40, 60, 100)],
     });
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
 
     const heads = agent.scan({ from: 0 });
@@ -1611,8 +1588,7 @@ describe("CodexAgent subagent folding", () => {
       extra: [tokenCountLine(40, 60, 100)],
     });
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
     agent.scan({ from: 0 });
 
@@ -1642,8 +1618,7 @@ describe("CodexAgent subagent folding", () => {
       ],
     });
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
     agent.scan({ from: 0 });
 
@@ -1738,8 +1713,7 @@ describe("CodexAgent subagent folding", () => {
     });
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
     agent.scan({ from: 0 });
     agent.getSessionData(PARENT_ID);
@@ -1783,8 +1757,7 @@ describe("CodexAgent subagent folding", () => {
     });
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
     agent.scan({ from: 0 });
     expect(agent.getSessionData(PARENT_ID).messages).toEqual([]);
@@ -1807,8 +1780,7 @@ describe("CodexAgent subagent folding", () => {
     });
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
     agent.scan({ from: 0 });
     agent.getSessionData(PARENT_ID);
@@ -1834,8 +1806,7 @@ describe("CodexAgent subagent folding", () => {
       ],
     });
 
-    const scanned = new CodexAgent() as any;
-    scanned.basePath = tempDir;
+    const scanned = new CodexAgent({ sourceRoot: tempDir }) as any;
     scanned.sessionIndexCache = new Map();
     scanned.scan({ from: 0 });
 
@@ -1864,8 +1835,7 @@ describe("CodexAgent subagent folding", () => {
       ],
     });
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
 
     const [head] = agent.scan({ from: 0 });
@@ -1884,8 +1854,7 @@ describe("CodexAgent subagent folding", () => {
       parentThreadId: PARENT_ID,
     });
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
 
     const refs = [
@@ -1920,8 +1889,7 @@ describe("CodexAgent subagent folding", () => {
       extra: [tokenCountLine(40, 60, 100)],
     });
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
     const [parentHead] = agent.scan({ from: 0 });
     expect(parentHead.stats.total_input_tokens).toBe(100);
@@ -1946,8 +1914,7 @@ describe("CodexAgent subagent folding", () => {
       extra: [tokenCountLine(40, 60, 100)],
     });
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
 
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
@@ -1981,8 +1948,7 @@ describe("CodexAgent subagent folding", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.basePath = tempDir;
+    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
 
     const heads = agent.scan({ from: 0, fast: true });

--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -29,9 +29,7 @@ let tempDirs: string[] = [];
 const mockedReadFileSync = vi.mocked(readFileSync);
 
 function createAgent(dataRoot: string): KimiCodeAgent {
-  const agent = new KimiCodeAgent() as never as { basePath: string };
-  agent.basePath = join(dataRoot, "sessions");
-  return agent as never as KimiCodeAgent;
+  return new KimiCodeAgent({ sourceRoot: join(dataRoot, "sessions") });
 }
 
 function createSession(

--- a/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
@@ -35,13 +35,10 @@ const mockedOpenSync = vi.mocked(openSync);
 let tempDirs: string[] = [];
 
 function createAgent(basePath: string): KimiAgent {
-  const agent = new KimiAgent() as never as {
-    basePath: string;
-    projectMap: Map<string, string>;
-  };
-  agent.basePath = basePath;
-  agent.projectMap = new Map([[PROJECT_HASH, PROJECT_DIR]]);
-  return agent as never as KimiAgent;
+  return new KimiAgent({
+    sourceRoot: basePath,
+    projectDirectories: new Map([[PROJECT_HASH, PROJECT_DIR]]),
+  });
 }
 
 function createSessionDir(basePath: string, id: string, customTitle: string): string {
@@ -249,8 +246,11 @@ describe("KimiAgent stats extraction", () => {
       ].join("\n"),
     );
 
-    const agent = createAgent(basePath);
-    (agent as unknown as { defaultModel: string | null }).defaultModel = "kimi-for-coding";
+    const agent = new KimiAgent({
+      sourceRoot: basePath,
+      projectDirectories: new Map([[PROJECT_HASH, PROJECT_DIR]]),
+      defaultModel: "kimi-for-coding",
+    });
     const [head] = agent.scan();
     const marks = markReads();
     const detail = agent.getSessionData("detail-reads");

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -43,10 +43,10 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
 }
 
 function createAgent(basePath: string): KimiAgent {
-  const agent = new KimiAgent() as any;
-  agent.basePath = basePath;
-  agent.projectMap = new Map([[PROJECT_HASH, PROJECT_DIR]]);
-  return agent as KimiAgent;
+  return new KimiAgent({
+    sourceRoot: basePath,
+    projectDirectories: new Map([[PROJECT_HASH, PROJECT_DIR]]),
+  });
 }
 
 function createSessionDir(

--- a/packages/core/src/agents/__tests__/watch-plan.test.ts
+++ b/packages/core/src/agents/__tests__/watch-plan.test.ts
@@ -1,13 +1,54 @@
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "../register.js";
 import { createRegisteredAgents, resolveAgentRoots } from "../registry.js";
+import { ClaudeCodeAgent } from "../claudecode.js";
+import { CodexAgent } from "../codex.js";
+import { DshAgent } from "../dsh.js";
+import { GrokAgent } from "../grok.js";
+import { KimiAgent } from "../kimi.js";
+import { KimiCodeAgent } from "../kimi-code.js";
+import { PiAgent } from "../pi.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
 });
 
 describe("registered agent session watch plans", () => {
+  it("watches explicitly configured source roots", () => {
+    const root = "/tmp/custom-agent-root";
+    const sourceRoot = join(root, "sessions");
+    const watchRoot = dirname(sourceRoot);
+
+    expect(new CodexAgent({ sourceRoot }).getSessionWatchPlan()).toEqual({
+      status: "supported",
+      targets: [
+        { root: watchRoot, path: sourceRoot },
+        { root: watchRoot, path: join(watchRoot, "session_index.jsonl") },
+      ],
+    });
+    expect(new KimiCodeAgent({ sourceRoot }).getSessionWatchPlan()).toEqual({
+      status: "supported",
+      targets: [
+        { root: watchRoot, path: sourceRoot },
+        { root: watchRoot, path: join(watchRoot, "session_index.jsonl") },
+      ],
+    });
+
+    for (const agent of [
+      new ClaudeCodeAgent({ sourceRoot }),
+      new DshAgent({ sourceRoot }),
+      new GrokAgent({ sourceRoot }),
+      new KimiAgent({ sourceRoot }),
+      new PiAgent({ sourceRoot }),
+    ]) {
+      expect(agent.getSessionWatchPlan()).toEqual({
+        status: "supported",
+        targets: [{ root: watchRoot, path: sourceRoot }],
+      });
+    }
+  });
+
   it("requires every adapter to declare a closed watch capability state", () => {
     const agents = createRegisteredAgents();
 

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -78,6 +78,10 @@ export interface AgentScanProgress {
   sessions?: number;
 }
 
+export interface AgentSourceOptions {
+  readonly sourceRoot?: string;
+}
+
 export interface FileWalkOptions {
   recursive?: boolean;
   scanWindow?: Pick<AgentScanOptions, "from" | "to">;
@@ -342,6 +346,13 @@ export abstract class BaseAgent {
 export abstract class FileSystemSessionSource<
   TMeta extends SessionCacheMeta = SessionCacheMeta,
 > extends BaseAgent {
+  protected readonly configuredSourceRoot: string | null;
+
+  constructor(options: AgentSourceOptions = {}) {
+    super();
+    this.configuredSourceRoot = options.sourceRoot ?? null;
+  }
+
   readonly sessionSourceAccess: EnumeratedSessionSourceCapability = {
     kind: "enumerated",
     synchronize: (baseline, request) => this.synchronizeSessionSources(baseline, request),

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -116,7 +116,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   readonly name = AGENT_METADATA.name;
   readonly displayName = AGENT_METADATA.displayName;
 
-  private basePath: string | null = null;
+  private basePath: string | null = this.configuredSourceRoot;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private sessionsIndexCache: Record<string, any> = {};
   private sessionsIndexMtime: Record<string, number | null> = {};
@@ -126,10 +126,19 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   private childIndexReady = false;
 
   private findBasePath(): string | null {
-    return firstExisting(join(resolveClaudeCodeDataRoot(), "projects"), "data/claudecode");
+    return (
+      this.configuredSourceRoot ??
+      firstExisting(join(resolveClaudeCodeDataRoot(), "projects"), "data/claudecode")
+    );
   }
 
   getSessionWatchPlan() {
+    if (this.configuredSourceRoot) {
+      return {
+        status: "supported" as const,
+        targets: [{ root: dirname(this.configuredSourceRoot), path: this.configuredSourceRoot }],
+      };
+    }
     const dataRoot = resolveClaudeCodeDataRoot();
     return {
       status: "supported" as const,

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { join, basename } from "node:path";
+import { join, basename, dirname } from "node:path";
 import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import { SingleFileSessionSource, filteredSession, parsedSession, skippedSession } from "./base.js";
 import type { ParseSessionResult } from "./base.js";
@@ -403,7 +403,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   readonly name = AGENT_METADATA.name;
   readonly displayName = AGENT_METADATA.displayName;
 
-  private basePath: string | null = null;
+  private basePath: string | null = this.configuredSourceRoot;
   private sessionIndexCache = new Map<string, string>();
   private sessionIndexMtime: number | null | undefined;
   private sessionIndexPath: string | undefined;
@@ -420,10 +420,20 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   // ---- BaseAgent implementation ----
 
   private findBasePath(): string | null {
-    return firstExisting(join(resolveCodexDataRoot(), "sessions"));
+    return this.configuredSourceRoot ?? firstExisting(join(resolveCodexDataRoot(), "sessions"));
   }
 
   getSessionWatchPlan() {
+    if (this.configuredSourceRoot) {
+      const root = dirname(this.configuredSourceRoot);
+      return {
+        status: "supported" as const,
+        targets: [
+          { root, path: this.configuredSourceRoot },
+          { root, path: join(root, "session_index.jsonl") },
+        ],
+      };
+    }
     const dataRoot = resolveCodexDataRoot();
     return {
       status: "supported" as const,

--- a/packages/core/src/agents/dsh.ts
+++ b/packages/core/src/agents/dsh.ts
@@ -8,7 +8,7 @@
  * those fields say it does.
  */
 import { existsSync, readdirSync, realpathSync, statSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   FileSystemSessionSource,
@@ -95,10 +95,10 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
   readonly displayName = AGENT_METADATA.displayName;
 
   getSessionWatchPlan(): SessionWatchPlan {
-    const dataRoot = resolveDshDataRoot();
+    const dataRoot = this.dataRoot();
     return {
       status: "supported",
-      targets: [{ root: dataRoot, path: dshSessionsRoot(dataRoot) }],
+      targets: [{ root: dataRoot, path: this.sessionsRoot() }],
     };
   }
 
@@ -113,7 +113,7 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
   }
 
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[] {
-    const sessionsRoot = dshSessionsRoot(resolveDshDataRoot());
+    const sessionsRoot = this.sessionsRoot();
     const refs: SessionSourceRef[] = [];
     const seenIds = new Map<string, string>();
 
@@ -233,7 +233,7 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
   }
 
   private parseSession(sourcePath: string, encoding: DshEncoding): ParsedDshSession {
-    const dataRoot = resolveDshDataRoot();
+    const dataRoot = this.dataRoot();
     const { header, events } = readDshSessionLog(sourcePath, encoding);
     return {
       header,
@@ -256,7 +256,7 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
    * holding both physical encodings (which one is current is unknowable).
    */
   private listArtifacts(): DshArtifact[] {
-    const sessionsRoot = dshSessionsRoot(resolveDshDataRoot());
+    const sessionsRoot = this.sessionsRoot();
     const artifacts: DshArtifact[] = [];
     let rootEncoding: DshEncoding | null = null;
 
@@ -286,6 +286,14 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
     }
 
     return artifacts;
+  }
+
+  private dataRoot(): string {
+    return this.configuredSourceRoot ? dirname(this.configuredSourceRoot) : resolveDshDataRoot();
+  }
+
+  private sessionsRoot(): string {
+    return this.configuredSourceRoot ?? dshSessionsRoot(this.dataRoot());
   }
 
   private listDirectories(directory: string, tolerateMissing: boolean): string[] {

--- a/packages/core/src/agents/grok.ts
+++ b/packages/core/src/agents/grok.ts
@@ -824,10 +824,13 @@ export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
   readonly name = AGENT_METADATA.name;
   readonly displayName = AGENT_METADATA.displayName;
 
-  private basePath: string | null = null;
+  private basePath: string | null = this.configuredSourceRoot;
 
   private findBasePath(): string | null {
-    return firstExisting(join(resolveGrokDataRoot(), "sessions"), "data/grok");
+    return (
+      this.configuredSourceRoot ??
+      firstExisting(join(resolveGrokDataRoot(), "sessions"), "data/grok")
+    );
   }
 
   isAvailable(): boolean {
@@ -836,6 +839,12 @@ export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
   }
 
   getSessionWatchPlan() {
+    if (this.configuredSourceRoot) {
+      return {
+        status: "supported" as const,
+        targets: [{ root: dirname(this.configuredSourceRoot), path: this.configuredSourceRoot }],
+      };
+    }
     const dataRoot = resolveGrokDataRoot();
     return {
       status: "supported" as const,

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -343,15 +343,26 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
   readonly name = AGENT_METADATA.name;
   readonly displayName = AGENT_METADATA.displayName;
 
-  private basePath: string | null = null;
+  private basePath: string | null = this.configuredSourceRoot;
   private workDirBySessionPath = new Map<string, string>();
 
   private findBasePath(): string | null {
+    if (this.configuredSourceRoot) return this.configuredSourceRoot;
     const sessionsPath = join(resolveKimiCodeDataRoot(), "sessions");
     return existsSync(sessionsPath) ? sessionsPath : null;
   }
 
   getSessionWatchPlan() {
+    if (this.configuredSourceRoot) {
+      const root = dirname(this.configuredSourceRoot);
+      return {
+        status: "supported" as const,
+        targets: [
+          { root, path: this.configuredSourceRoot },
+          { root, path: join(root, "session_index.jsonl") },
+        ],
+      };
+    }
     const dataRoot = resolveKimiCodeDataRoot();
     return {
       status: "supported" as const,

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -11,6 +11,7 @@ import {
 } from "./base.js";
 import type {
   AgentScanOptions,
+  AgentSourceOptions,
   ParseSessionResult,
   SessionCacheMeta,
   SessionSourceRef,
@@ -221,19 +222,40 @@ function extractFirstUserTitle(contextFile: string | null, wireFile: string | nu
 
 const AGENT_METADATA = getAgentCatalogEntry("kimi");
 
+export interface KimiAgentOptions extends AgentSourceOptions {
+  projectDirectories?: ReadonlyMap<string, string>;
+  defaultModel?: string | null;
+}
+
 export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
   readonly name = AGENT_METADATA.name;
   readonly displayName = AGENT_METADATA.displayName;
 
-  private basePath: string | null = null;
-  private projectMap = new Map<string, string>();
-  private defaultModel: string | null = null;
+  private basePath: string | null;
+  private projectMap: Map<string, string>;
+  private defaultModel: string | null;
+
+  constructor(options: KimiAgentOptions = {}) {
+    super(options);
+    this.basePath = this.configuredSourceRoot;
+    this.projectMap = new Map(options.projectDirectories);
+    this.defaultModel = options.defaultModel ?? null;
+  }
 
   private findBasePath(): string | null {
-    return firstExisting(join(resolveKimiDataRoot(), "sessions"), "data/kimi");
+    return (
+      this.configuredSourceRoot ??
+      firstExisting(join(resolveKimiDataRoot(), "sessions"), "data/kimi")
+    );
   }
 
   getSessionWatchPlan() {
+    if (this.configuredSourceRoot) {
+      return {
+        status: "supported" as const,
+        targets: [{ root: dirname(this.configuredSourceRoot), path: this.configuredSourceRoot }],
+      };
+    }
     const dataRoot = resolveKimiDataRoot();
     return {
       status: "supported" as const,

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import { SingleFileSessionSource, filteredSession, parsedSession } from "./base.js";
 import type {
@@ -133,13 +133,22 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
   readonly name = AGENT_METADATA.name;
   readonly displayName = AGENT_METADATA.displayName;
 
-  private basePath: string | null = null;
+  private basePath: string | null = this.configuredSourceRoot;
 
   private findBasePath(): string | null {
-    return firstExisting(join(resolvePiDataRoot(), "agent", "sessions"), "data/pi");
+    return (
+      this.configuredSourceRoot ??
+      firstExisting(join(resolvePiDataRoot(), "agent", "sessions"), "data/pi")
+    );
   }
 
   getSessionWatchPlan() {
+    if (this.configuredSourceRoot) {
+      return {
+        status: "supported" as const,
+        targets: [{ root: dirname(this.configuredSourceRoot), path: this.configuredSourceRoot }],
+      };
+    }
     const dataRoot = resolvePiDataRoot();
     return {
       status: "supported" as const,


### PR DESCRIPTION
## Summary

- add one immutable source-root option for filesystem session adapters
- use configured roots consistently for discovery, scanning, attachments, and watch plans
- replace direct private root/config mutations across Codex, Claude, and Kimi tests

## Validation

- `pnpm --filter @codesesh/core test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @codesesh/core format:check`