### PR TITLE
refactor(scan): unify refresh inspection

### DIFF
--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -4,15 +4,15 @@ import {
   getAgentFullSyncCursor,
   computeSessionDiff,
   loadCachedSessions,
+  inspectAgentRefresh,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
   markAgentFullSyncCompleted,
-  planAgentScan,
   readCachedSessions,
   readAgentCacheInitialization,
   sessionSignature,
   type BaseAgent,
-  type AggregateSessionSourceCapability,
+  type AgentRefreshInspection,
   type IdentifiedSessionHead,
   type ScanOptions,
   type LiveSnapshot,
@@ -419,8 +419,12 @@ export class AgentSyncEngine {
     } else if (!isInitialized) {
       strategyResult = await this.initializeAgent(agent, previousSessions);
     } else {
-      const scanPlan = planAgentScan(agent.sessionSourceAccess, "refresh");
-      if (scanPlan.kind === "synchronize") {
+      const refresh = await inspectAgentRefresh(
+        agent.sessionSourceAccess,
+        cacheTimestamp,
+        refreshBaseline,
+      );
+      if (refresh.kind === "synchronize") {
         strategyResult = await this.syncAgentSources(
           agent,
           cached ?? {
@@ -430,13 +434,7 @@ export class AgentSyncEngine {
           startedAt,
         );
       } else {
-        strategyResult = await this.refreshChangedAgent(
-          agent,
-          scanPlan.source,
-          refreshBaseline,
-          cacheTimestamp,
-          startedAt,
-        );
+        strategyResult = await this.refreshChangedAgent(agent, refresh, refreshBaseline, startedAt);
       }
     }
     if (strategyResult.status === "unchanged") {
@@ -673,28 +671,33 @@ export class AgentSyncEngine {
 
   private async refreshChangedAgent(
     agent: BaseAgent,
-    source: AggregateSessionSourceCapability,
+    refresh: Exclude<AgentRefreshInspection, { kind: "synchronize" }>,
     baseline: IdentifiedSessionHead[],
-    cacheTimestamp: number,
     refreshStartedAt: number,
   ): Promise<RefreshStrategyResult> {
     const scope = this.startupScanOptions();
-    const checkStartedAt = performance.now();
-    const checkResult = await Promise.resolve(source.checkForChanges(cacheTimestamp, baseline));
-    const checkDuration = performance.now() - checkStartedAt;
-    if (checkResult.status === "failed") {
+    if (refresh.kind === "failed") {
       appLogger.warn("scan.refresh.change_check_failed", {
         agent: agent.name,
-        source_path: checkResult.failure.sourcePath,
-        error_class: checkResult.failure.errorClass,
-        message: checkResult.failure.message,
+        source_path: refresh.failure.sourcePath,
+        error_class: refresh.failure.errorClass,
+        message: refresh.failure.message,
       });
       return {
-        ...this.refreshStrategyBase(baseline, "partial", {}, { checkDuration }),
+        ...this.refreshStrategyBase(
+          baseline,
+          "partial",
+          {},
+          {
+            checkDuration: refresh.checkDurationMs,
+          },
+        ),
         status: "unchanged",
       };
     }
-    if (!checkResult.hasChanges) {
+    const { check: checkResult, source } = refresh;
+    const checkDuration = refresh.checkDurationMs;
+    if (refresh.kind === "unchanged") {
       const scanStartedAt = performance.now();
       const result = await this.runWorker(agent, baseline, { kind: "recompute-derived" }, {});
       agent.restoreSessionCacheMeta(result.meta);

--- a/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
+++ b/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { planAgentScan, type AgentScanIntent } from "../agent-scan-plan.js";
+import { inspectAgentRefresh, planAgentScan, type AgentScanIntent } from "../agent-scan-plan.js";
 import type {
   AggregateSessionSourceCapability,
+  ChangeCheckResult,
   EnumeratedSessionSourceCapability,
 } from "../../agents/index.js";
 
@@ -74,5 +75,55 @@ describe("planAgentScan", () => {
     if (plan.kind === "synchronize" || plan.kind === "check-for-changes") {
       expect(plan.source).toBe(source);
     }
+  });
+});
+
+describe("inspectAgentRefresh", () => {
+  it("returns enumerated sources without running an aggregate change check", async () => {
+    await expect(inspectAgentRefresh(enumerated, 10, [])).resolves.toEqual({
+      kind: "synchronize",
+      source: enumerated,
+    });
+  });
+
+  it.each<{ result: ChangeCheckResult; expectedKind: "unchanged" | "scan" }>([
+    {
+      result: { hasChanges: false, timestamp: 11 },
+      expectedKind: "unchanged",
+    },
+    {
+      result: { hasChanges: true, changedIds: ["changed"], timestamp: 11 },
+      expectedKind: "scan",
+    },
+  ])("classifies a successful check as $expectedKind", async ({ result, expectedKind }) => {
+    const source: AggregateSessionSourceCapability = {
+      ...aggregate,
+      checkForChanges: () => result,
+    };
+
+    const inspection = await inspectAgentRefresh(source, 10, []);
+
+    expect(inspection).toMatchObject({ kind: expectedKind, source, check: result });
+  });
+
+  it("preserves a failed change check as a distinct recovery class", async () => {
+    const failure = {
+      sourcePath: "/sessions.db",
+      errorClass: "SqliteError",
+      message: "database is locked",
+    };
+    const source: AggregateSessionSourceCapability = {
+      ...aggregate,
+      checkForChanges: () => ({
+        status: "failed",
+        hasChanges: false,
+        timestamp: 10,
+        failure,
+      }),
+    };
+
+    const inspection = await inspectAgentRefresh(source, 10, []);
+
+    expect(inspection).toMatchObject({ kind: "failed", failure });
   });
 });

--- a/packages/core/src/discovery/agent-scan-plan.ts
+++ b/packages/core/src/discovery/agent-scan-plan.ts
@@ -1,8 +1,10 @@
 import type {
   AggregateSessionSourceCapability,
+  ChangeCheckResult,
   EnumeratedSessionSourceCapability,
   SessionSourceCapability,
 } from "../agents/index.js";
+import type { SessionHead } from "../types/index.js";
 
 export type AgentScanIntent = "reload" | "refresh" | "backfill" | "recompute-derived";
 
@@ -19,6 +21,31 @@ export type AgentScanPlan =
 type SourceScanPlan = Extract<AgentScanPlan, { kind: "scan" | "synchronize" }>;
 type RefreshScanPlan = Extract<AgentScanPlan, { kind: "synchronize" | "check-for-changes" }>;
 type RecomputeScanPlan = Extract<AgentScanPlan, { kind: "reuse-baseline" }>;
+
+type SuccessfulChangeCheck = Exclude<ChangeCheckResult, { status: "failed" }>;
+
+export type AgentRefreshInspection =
+  | {
+      kind: "synchronize";
+      source: EnumeratedSessionSourceCapability;
+    }
+  | {
+      kind: "failed";
+      failure: Extract<ChangeCheckResult, { status: "failed" }>["failure"];
+      checkDurationMs: number;
+    }
+  | {
+      kind: "unchanged";
+      source: AggregateSessionSourceCapability;
+      check: SuccessfulChangeCheck;
+      checkDurationMs: number;
+    }
+  | {
+      kind: "scan";
+      source: AggregateSessionSourceCapability;
+      check: SuccessfulChangeCheck;
+      checkDurationMs: number;
+    };
 
 export function planAgentScan(
   source: SessionSourceCapability,
@@ -48,4 +75,25 @@ export function planAgentScan(
   }
 
   return intent === "refresh" ? { kind: "check-for-changes", source } : { kind: "scan" };
+}
+
+export async function inspectAgentRefresh(
+  source: SessionSourceCapability,
+  sinceTimestamp: number,
+  cachedSessions: SessionHead[],
+): Promise<AgentRefreshInspection> {
+  const plan = planAgentScan(source, "refresh");
+  if (plan.kind === "synchronize") {
+    return { kind: "synchronize", source: plan.source };
+  }
+
+  const startedAt = performance.now();
+  const check = await Promise.resolve(plan.source.checkForChanges(sinceTimestamp, cachedSessions));
+  const checkDurationMs = performance.now() - startedAt;
+  if (check.status === "failed") {
+    return { kind: "failed", failure: check.failure, checkDurationMs };
+  }
+  return check.hasChanges
+    ? { kind: "scan", source: plan.source, check, checkDurationMs }
+    : { kind: "unchanged", source: plan.source, check, checkDurationMs };
 }

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -1,8 +1,8 @@
 export { firstExisting, readEnvPath, resolveDataHome, resolveHomePath } from "./paths.js";
 export { ensureSessionTagsSync, filterSessions, scanSessions } from "./scanner.js";
 export type { AgentCacheFailure, LiveSnapshot, ScanOptions, SessionTagTiming } from "./scanner.js";
-export { planAgentScan } from "./agent-scan-plan.js";
-export type { AgentScanIntent, AgentScanPlan } from "./agent-scan-plan.js";
+export { inspectAgentRefresh, planAgentScan } from "./agent-scan-plan.js";
+export type { AgentRefreshInspection, AgentScanIntent, AgentScanPlan } from "./agent-scan-plan.js";
 export {
   materializeSessionDetail,
   materializeSessionDetailResponse,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -48,7 +48,7 @@ import {
   computeSessionDiff,
   sessionSignature,
 } from "./orchestrate.js";
-import { planAgentScan } from "./agent-scan-plan.js";
+import { inspectAgentRefresh, planAgentScan } from "./agent-scan-plan.js";
 
 export interface ScanOptions {
   /** Filter to specific agent name(s) */
@@ -683,11 +683,16 @@ async function scanAgentSmart(
 
       onProgress?.({ agent: agent.name, phase: "checking" });
 
-      const scanPlan = planAgentScan(agent.sessionSourceAccess, "refresh");
-      if (scanPlan.kind === "synchronize") {
+      const refresh = await inspectAgentRefresh(
+        agent.sessionSourceAccess,
+        cached.timestamp,
+        cached.sessions,
+      );
+      if (refresh.kind !== "synchronize") timing.checkChanges = refresh.checkDurationMs;
+      if (refresh.kind === "synchronize") {
         return refreshCachedEnumeratedAgent(
           agent,
-          scanPlan.source,
+          refresh.source,
           cached,
           options,
           timing,
@@ -695,21 +700,15 @@ async function scanAgentSmart(
           onProgress,
         );
       }
-      const t1 = performance.now();
-      const checkResult = await Promise.resolve(
-        scanPlan.source.checkForChanges(cached.timestamp, cached.sessions),
-      );
-      timing.checkChanges = performance.now() - t1;
-
-      if (checkResult.status === "failed") {
+      if (refresh.kind === "failed") {
         return finalizeAgentScanFailure(
           agent,
           {
             agentName: agent.name,
             stage: "checking for changes",
-            sourcePath: checkResult.failure.sourcePath,
-            errorClass: checkResult.failure.errorClass,
-            message: checkResult.failure.message,
+            sourcePath: refresh.failure.sourcePath,
+            errorClass: refresh.failure.errorClass,
+            message: refresh.failure.message,
           },
           options,
           cached,
@@ -718,7 +717,8 @@ async function scanAgentSmart(
         );
       }
 
-      if (checkResult.hasChanges) {
+      if (refresh.kind === "scan") {
+        const checkResult = refresh.check;
         onProgress?.({
           agent: agent.name,
           phase: "incremental",
@@ -728,7 +728,7 @@ async function scanAgentSmart(
         const t2 = performance.now();
         const scanOptions = buildAgentScanOptions(agent, options, onProgress);
         const updatedSessions = await Promise.resolve(
-          scanPlan.source.incrementalScan(
+          refresh.source.incrementalScan(
             cached.sessions,
             checkResult.changedIds || [],
             checkResult.refs,
@@ -736,7 +736,7 @@ async function scanAgentSmart(
           ),
         );
         timing.scan = performance.now() - t2;
-        scanPlan.source.commitChangeCheck();
+        refresh.source.commitChangeCheck();
 
         return finalizeAgentScan(agent, updatedSessions, {
           finalization: {
@@ -758,7 +758,7 @@ async function scanAgentSmart(
         });
       }
 
-      scanPlan.source.commitChangeCheck();
+      refresh.source.commitChangeCheck();
       return finalizeAgentScan(agent, cached.sessions, {
         finalization: { kind: "unchanged", cached },
         options,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,7 @@ export {
   markAgentFullSyncCompleted,
   materializeSessionDetailResponse,
   mergeSearchQueryOptions,
+  inspectAgentRefresh,
   readPendingSearchIndexMaintenance,
   mergeSortedSessions,
   saveCachedSessionChanges,
@@ -83,6 +84,7 @@ export { filterSessionTreeByActivityWindow } from "./contract/index.js";
 export type {
   AgentScanIntent,
   AgentScanPlan,
+  AgentRefreshInspection,
   FileActivityResult,
   AgentCacheFailure,
   LiveSnapshot,


### PR DESCRIPTION
## Summary
- centralize refresh capability planning and aggregate change-check classification
- reuse the same inspection result in startup and live refresh paths
- preserve scan timing and existing recovery behavior

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`
- `pnpm format:check`