### PR TITLE
refactor(contract): unify session reference keys

### DIFF
--- a/apps/web/src/lib/bookmarks.test.ts
+++ b/apps/web/src/lib/bookmarks.test.ts
@@ -33,9 +33,7 @@ describe("bookmarks", () => {
   });
 
   it("uses normalized agent + opaque session id as bookmark key", () => {
-    expect(getSessionBookmarkKey({ agentName: " CoDeX ", sessionId: "a/b" })).toBe(
-      '["codex","a/b"]',
-    );
+    expect(getSessionBookmarkKey({ agentName: " CoDeX ", sessionId: "a/b" })).toBe("codex/a/b");
   });
 
   it("builds an optimistic available view from a live session", () => {

--- a/apps/web/src/lib/bookmarks.ts
+++ b/apps/web/src/lib/bookmarks.ts
@@ -1,6 +1,7 @@
 import type { BookmarkRecord, BookmarkView, SessionHead } from "./api";
 import {
   assertSessionIdentity,
+  getSessionReferenceKey,
   normalizeSessionReference,
   type SessionReference,
 } from "@codesesh/core/contract";
@@ -55,8 +56,7 @@ function parseLegacyBookmark(value: unknown): BookmarkRecord | null {
 }
 
 export function getSessionBookmarkKey(reference: SessionReference): string {
-  const normalized = normalizeSessionReference(reference);
-  return JSON.stringify([normalized.agentName, normalized.sessionId]);
+  return getSessionReferenceKey(reference);
 }
 
 export function toBookmarkView(session: SessionHead, agentKey: string): BookmarkView {

--- a/apps/web/src/lib/session-indexes.ts
+++ b/apps/web/src/lib/session-indexes.ts
@@ -4,6 +4,7 @@ import {
   createSessionIndex,
   getProjectAgentKey,
   getSessionAgentKey,
+  getSessionReferenceKey as referenceKey,
   getSessionRoutePath,
   getSessionRouteKey,
   sessionRoutePath,
@@ -48,7 +49,7 @@ export {
 };
 
 export function getSessionReferenceKey(session: Pick<SessionHead, "reference">): string {
-  return getSessionRouteKey(session.reference.agentName, session.reference.sessionId);
+  return referenceKey(session.reference);
 }
 
 function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {

--- a/packages/core/src/analytics/cost-attribution.ts
+++ b/packages/core/src/analytics/cost-attribution.ts
@@ -1,6 +1,9 @@
 import type { CostSource, SessionHead } from "../types/session.js";
-import type { SessionTree, SessionTreeNode } from "../contract/index.js";
-import { getSessionRouteKey } from "../contract/index.js";
+import {
+  getSessionReferenceKey,
+  type SessionTree,
+  type SessionTreeNode,
+} from "../contract/index.js";
 import type {
   DashboardCostFacts,
   MessageCostFact,
@@ -44,23 +47,16 @@ export interface AttributedUsage {
 
 export type UsageAttributionOptions = CostAttributionOptions;
 
-function costFactKey(agentName: string, sessionId: string): string {
-  return getSessionRouteKey(agentName, sessionId);
-}
-
 function indexFacts(facts: DashboardCostFacts | null | undefined): MetricFactIndex {
   const messagesBySession = new Map<string, MessageCostFact[]>();
   const summariesBySession = new Map<string, SessionCostSummary>();
   if (!facts) return { messagesBySession, summariesBySession };
 
   for (const summary of facts.sessions) {
-    summariesBySession.set(
-      costFactKey(summary.reference.agentName, summary.reference.sessionId),
-      summary,
-    );
+    summariesBySession.set(getSessionReferenceKey(summary.reference), summary);
   }
   for (const message of facts.messages) {
-    const key = costFactKey(message.reference.agentName, message.reference.sessionId);
+    const key = getSessionReferenceKey(message.reference);
     const messages = messagesBySession.get(key);
     if (messages) messages.push(message);
     else messagesBySession.set(key, [message]);
@@ -176,7 +172,7 @@ export function visitAttributedCosts(
       const session = node.session;
       const totalCost = Math.max(0, session.stats.total_cost);
       if (totalCost <= 0) continue;
-      const key = costFactKey(session.reference.agentName, session.reference.sessionId);
+      const key = getSessionReferenceKey(session.reference);
       const summary = factIndex.summariesBySession.get(key);
 
       if (factsAvailable && hasDetailedCost(session, summary)) {
@@ -232,7 +228,7 @@ export function visitAttributedUsage(
       for (const child of node.children) pending.push(child);
 
       const session = node.session;
-      const key = costFactKey(session.reference.agentName, session.reference.sessionId);
+      const key = getSessionReferenceKey(session.reference);
       const summary = factIndex.summariesBySession.get(key);
       const detailedMessages = factsAvailable && hasDetailedMessages(session, summary);
       const outputIncludesReasoning = factsAvailable

--- a/packages/core/src/bookmarks/materialize.ts
+++ b/packages/core/src/bookmarks/materialize.ts
@@ -7,7 +7,7 @@ import type {
 } from "../contract/index.js";
 import {
   assertSessionIdentity,
-  formatSessionReference,
+  getSessionReferenceKey,
   normalizeSessionReference,
 } from "../contract/index.js";
 
@@ -17,10 +17,6 @@ export interface BookmarkMaterializationOptions {
   resolveCachedSessions?: (
     references: readonly SessionReference[],
   ) => readonly ReferencedSessionHead[];
-}
-
-function referenceKey(reference: SessionReference): string {
-  return formatSessionReference(normalizeSessionReference(reference));
 }
 
 function canonicalSession(reference: SessionReference, session: SessionHead): SessionHead {
@@ -47,7 +43,7 @@ export function compareBookmarkViews(left: BookmarkView, right: BookmarkView): n
   return (
     compareDescending(getBookmarkViewTime(left), getBookmarkViewTime(right)) ||
     compareDescending(left.bookmarkedAt, right.bookmarkedAt) ||
-    referenceKey(left.reference).localeCompare(referenceKey(right.reference))
+    getSessionReferenceKey(left.reference).localeCompare(getSessionReferenceKey(right.reference))
   );
 }
 
@@ -61,7 +57,7 @@ export function materializeBookmarkViews(
     const reference = normalizeSessionReference(bookmark.reference);
     return {
       bookmark: { reference, bookmarkedAt: bookmark.bookmarkedAt },
-      key: referenceKey(reference),
+      key: getSessionReferenceKey(reference),
     };
   });
 
@@ -76,7 +72,7 @@ export function materializeBookmarkViews(
   if (missingByKey.size > 0 && options.resolveCachedSessions) {
     for (const cached of options.resolveCachedSessions([...missingByKey.values()])) {
       const reference = normalizeSessionReference(cached.reference);
-      const key = referenceKey(reference);
+      const key = getSessionReferenceKey(reference);
       if (missingByKey.has(key) && !cachedByKey.has(key)) {
         cachedByKey.set(key, canonicalSession(reference, cached.session));
       }

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -49,6 +49,7 @@ describe("contract browser-safety", () => {
         "getProjectAgentKey",
         "getProjectIdentityKey",
         "getSessionAgentKey",
+        "getSessionReferenceKey",
         "getSessionRouteKey",
         "getSessionRoutePath",
         "groupSessionsByCalendarDay",

--- a/packages/core/src/contract/__tests__/session-reference.test.ts
+++ b/packages/core/src/contract/__tests__/session-reference.test.ts
@@ -5,6 +5,7 @@ import {
   createSessionIdentity,
   formatSessionReference,
   getSessionAgentKey,
+  getSessionReferenceKey,
   getSessionRoutePath,
   normalizeSessionReference,
   parseSessionReference,
@@ -36,6 +37,9 @@ describe("session references", () => {
     expect(
       normalizeSessionReference({ agentName: " CoDeX ", sessionId: "nested/session" }),
     ).toEqual(reference);
+    expect(getSessionReferenceKey({ agentName: " CoDeX ", sessionId: "nested/session" })).toBe(
+      "codex/nested/session",
+    );
   });
 
   it.each(["", "codex", "/session", "codex/"])("rejects malformed value %j", (value) => {

--- a/packages/core/src/contract/session-index.ts
+++ b/packages/core/src/contract/session-index.ts
@@ -1,6 +1,6 @@
 import type { ReferencedSessionHead, SessionHead } from "./session.js";
 import { getProjectAgentKey, getProjectIdentityKey } from "./project-identity.js";
-import { formatSessionReference, type SessionReference } from "./session-reference.js";
+import { getSessionReferenceKey, type SessionReference } from "./session-reference.js";
 
 export type SessionHeadChange = ReferencedSessionHead;
 
@@ -65,8 +65,9 @@ export function mergeSortedSessions<T extends SessionHead>(shards: T[][]): T[] {
   return merged;
 }
 
+/** @deprecated Pass a SessionReference to getSessionReferenceKey instead. */
 export function getSessionRouteKey(agentName: string, sessionId: string): string {
-  return formatSessionReference({ agentName, sessionId });
+  return getSessionReferenceKey({ agentName, sessionId });
 }
 
 function pushMapValue<K, V>(map: Map<K, V[]>, key: K, value: V): void {
@@ -86,13 +87,12 @@ export function createSessionIndex(sourceSessions: SessionHead[]): CanonicalSess
   const byProjectAgentKey = new Map<string, SessionHead[]>();
 
   for (const session of sourceSessions) {
-    const { agentName, sessionId } = session.reference;
-    const routeKey = getSessionRouteKey(agentName, sessionId);
+    const routeKey = getSessionReferenceKey(session.reference);
     if (!byRouteKey.has(routeKey)) byRouteKey.set(routeKey, session);
     if (session.parent_reference) {
       pushMapValue(
         childrenByParentRouteKey,
-        getSessionRouteKey(session.parent_reference.agentName, session.parent_reference.sessionId),
+        getSessionReferenceKey(session.parent_reference),
         session,
       );
     }
@@ -129,20 +129,14 @@ export function applySessionChanges(
 ): SessionHead[] {
   const byRouteKey = new Map<string, SessionHead>();
   for (const session of sessions) {
-    byRouteKey.set(
-      getSessionRouteKey(session.reference.agentName, session.reference.sessionId),
-      session,
-    );
+    byRouteKey.set(getSessionReferenceKey(session.reference), session);
   }
 
   for (const removal of removals) {
-    byRouteKey.delete(getSessionRouteKey(removal.agentName, removal.sessionId));
+    byRouteKey.delete(getSessionReferenceKey(removal));
   }
   for (const change of changes) {
-    byRouteKey.set(
-      getSessionRouteKey(change.reference.agentName, change.reference.sessionId),
-      change.session,
-    );
+    byRouteKey.set(getSessionReferenceKey(change.reference), change.session);
   }
 
   return sortSessionsByActivity([...byRouteKey.values()]);

--- a/packages/core/src/contract/session-reference.ts
+++ b/packages/core/src/contract/session-reference.ts
@@ -38,6 +38,11 @@ export function formatSessionReference(reference: SessionReference): string {
   return `${normalized.agentName}/${normalized.sessionId}`;
 }
 
+/** Canonical key for maps and sets keyed by session identity. */
+export function getSessionReferenceKey(reference: SessionReference): string {
+  return formatSessionReference(reference);
+}
+
 export function createSessionIdentity(reference: SessionReference): SessionIdentity {
   const normalized = normalizeSessionReference(reference);
   return {

--- a/packages/core/src/contract/session-tree.ts
+++ b/packages/core/src/contract/session-tree.ts
@@ -8,11 +8,10 @@ import { startOfCalendarDay, toCalendarDayKey } from "./calendar-day.js";
 import {
   applySessionChanges,
   compareSessionActivityDesc,
-  getSessionRouteKey,
   type SessionHeadChange,
   type SessionHeadRemoval,
 } from "./session-index.js";
-import { formatSessionReference, type SessionReference } from "./session-reference.js";
+import { getSessionReferenceKey, type SessionReference } from "./session-reference.js";
 
 /**
  * Where a session sits relative to its parent, with orphans distinguished
@@ -64,11 +63,11 @@ export interface SessionDayGroup {
 }
 
 function sessionKey(session: SessionHead): string {
-  return getSessionRouteKey(session.reference.agentName, session.reference.sessionId);
+  return getSessionReferenceKey(session.reference);
 }
 
 function parentKey(session: SessionHead): string | null {
-  return session.parent_reference ? formatSessionReference(session.parent_reference) : null;
+  return session.parent_reference ? getSessionReferenceKey(session.parent_reference) : null;
 }
 
 function activityTime(session: SessionHead): number {
@@ -348,13 +347,9 @@ export function createSessionProjectionContext(
   removedSessionRefs: SessionReference[],
 ): SessionProjectionContext {
   const changedKeys = new Set(
-    changedSessionHeads.map(({ reference }) =>
-      getSessionRouteKey(reference.agentName, reference.sessionId),
-    ),
+    changedSessionHeads.map(({ reference }) => getSessionReferenceKey(reference)),
   );
-  const removedKeys = removedSessionRefs.map(({ agentName, sessionId }) =>
-    getSessionRouteKey(agentName, sessionId),
-  );
+  const removedKeys = removedSessionRefs.map(getSessionReferenceKey);
   const affectedKeys = new Set<string>();
   const previousGraph = createSessionHierarchyGraph(previousSessions);
   const nextGraph = createSessionHierarchyGraph(nextSessions);
@@ -408,16 +403,13 @@ export function applySessionWindowChanges(
     ...changes.changedSessionHeads,
   ];
   const upsertsByKey = new Map(
-    upserts.map((change) => [
-      getSessionRouteKey(change.reference.agentName, change.reference.sessionId),
-      change,
-    ]),
+    upserts.map((change) => [getSessionReferenceKey(change.reference), change]),
   );
   const sessionsByKey = new Map(sessions.map((session) => [sessionKey(session), session]));
   const orderedUpserts: SessionHeadChange[] = [];
   const reorderedRefs: SessionReference[] = [];
   for (const reference of changes.projectionSessionOrder ?? []) {
-    const key = getSessionRouteKey(reference.agentName, reference.sessionId);
+    const key = getSessionReferenceKey(reference);
     const change = upsertsByKey.get(key);
     const session = change?.session ?? sessionsByKey.get(key);
     if (!session) continue;

--- a/packages/core/src/discovery/cache/cost-facts.ts
+++ b/packages/core/src/discovery/cache/cost-facts.ts
@@ -3,7 +3,7 @@ import type {
   MessageCostFact,
   SessionCostSummary,
 } from "../../analytics/cost-facts.js";
-import type { CostSource } from "../../contract/index.js";
+import { getSessionReferenceKey, type CostSource } from "../../contract/index.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { hasCacheStorage } from "./db.js";
 import { withCacheDbReadOnly } from "./schema.js";
@@ -59,10 +59,6 @@ const EFFECTIVE_COST_TIME = `CASE
   WHEN m.time_completed > 0 THEN m.time_completed
   WHEN m.time_created > 0 THEN m.time_created
 END`;
-
-function sessionKey(agentName: string, sessionId: string): string {
-  return `${agentName}\u0000${sessionId}`;
-}
 
 function costSource(value: string | null | undefined): CostSource | undefined {
   return value === "recorded" || value === "estimated" ? value : undefined;
@@ -125,7 +121,7 @@ function readCostFacts(db: SQLiteDatabase, options: CostFactOptions): DashboardC
       untimedMessageCost: Number(row.untimed_message_cost ?? 0),
       modelCosts: [],
     };
-    bySession.set(sessionKey(agentName, sessionId), summary);
+    bySession.set(getSessionReferenceKey({ agentName, sessionId }), summary);
   }
 
   const modelRows =
@@ -151,7 +147,10 @@ function readCostFacts(db: SQLiteDatabase, options: CostFactOptions): DashboardC
           .all() as ModelCostRow[]);
   for (const row of modelRows) {
     const summary = bySession.get(
-      sessionKey(String(row.agent_name ?? ""), String(row.session_id ?? "")),
+      getSessionReferenceKey({
+        agentName: String(row.agent_name ?? ""),
+        sessionId: String(row.session_id ?? ""),
+      }),
     );
     if (!summary) continue;
     summary.modelCosts.push({

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -9,7 +9,12 @@ import type {
   SessionHead,
   SmartTag,
 } from "../../types/index.js";
-import type { SearchHighlightRange, SearchMatchType, SearchResult } from "../../contract/index.js";
+import {
+  getSessionReferenceKey,
+  type SearchHighlightRange,
+  type SearchMatchType,
+  type SearchResult,
+} from "../../contract/index.js";
 import { normalizeProjectScopePath, type ProjectScopeMatcher } from "../../projects/scope.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
@@ -449,7 +454,10 @@ function messageMatchType(row: MessageSearchRow): SearchMatchType {
 }
 
 function searchResultRowKey(row: Pick<SearchResultRow, "agent_name" | "session_id">): string {
-  return `${String(row.agent_name)}\u0000${String(row.session_id)}`;
+  return getSessionReferenceKey({
+    agentName: String(row.agent_name),
+    sessionId: String(row.session_id),
+  });
 }
 
 function fetchMessageSearchMatches(

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -1,5 +1,9 @@
 import type { BaseAgent, SessionCacheMeta } from "../agents/index.js";
-import { assertSessionIdentity, type SessionReference } from "../contract/index.js";
+import {
+  assertSessionIdentity,
+  getSessionReferenceKey,
+  type SessionReference,
+} from "../contract/index.js";
 import type {
   IdentifiedSessionDetail,
   IdentifiedSessionHead,
@@ -154,10 +158,6 @@ function loadCachedMessageStream(
   };
 }
 
-function sessionReferenceKey(agentName: string, sessionId: string): string {
-  return `${agentName}\0${sessionId}`;
-}
-
 function assertSessionMatchesReference(
   session: IdentifiedSessionHead | SessionDetail,
   reference: SessionReference,
@@ -183,7 +183,7 @@ function getSessionDetailLookup(scanResult: LiveSnapshot): SessionDetailLookup {
   const headsByReference = new Map<string, IdentifiedSessionHead>();
   for (const sessions of Object.values(scanResult.byAgent)) {
     for (const session of sessions) {
-      const key = sessionReferenceKey(session.reference.agentName, session.reference.sessionId);
+      const key = getSessionReferenceKey(session.reference);
       if (!headsByReference.has(key)) headsByReference.set(key, session);
     }
   }
@@ -202,9 +202,7 @@ function getSessionDetailContext(
   if (!agent) return null;
   return {
     agent,
-    head: lookup.headsByReference.get(
-      sessionReferenceKey(reference.agentName, reference.sessionId),
-    ),
+    head: lookup.headsByReference.get(getSessionReferenceKey(reference)),
   };
 }
 

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -7,7 +7,7 @@
 import type { SessionHead } from "../types/index.js";
 import {
   buildSessionTree,
-  getSessionRouteKey,
+  getSessionReferenceKey,
   type SearchResult,
   type SessionTree,
 } from "../contract/index.js";
@@ -115,10 +115,6 @@ export function matchesSessionSearchFilters(
   return matchesRecentSearchFilters(session, options, projectScope, inclusiveCost);
 }
 
-function sessionReferenceKey(agentName: string, sessionId: string): string {
-  return `${agentName}\u0000${sessionId}`;
-}
-
 export function filterSessionSearchCandidates(
   candidates: SearchResult[],
   options: SearchOptions,
@@ -151,9 +147,7 @@ export function filterSessionSearchCandidates(
     },
   );
   return headMatches.filter((candidate) =>
-    indexedMatches.has(
-      sessionReferenceKey(candidate.reference.agentName, candidate.reference.sessionId),
-    ),
+    indexedMatches.has(getSessionReferenceKey(candidate.reference)),
   );
 }
 
@@ -211,8 +205,8 @@ function inclusiveCostFor(
   lookup: ReturnType<typeof buildSessionTree>["byRouteKey"] | null,
 ): number {
   return (
-    lookup?.get(getSessionRouteKey(agentName, session.reference.sessionId))?.inclusiveStats.cost ??
-    session.stats.total_cost
+    lookup?.get(getSessionReferenceKey({ agentName, sessionId: session.reference.sessionId }))
+      ?.inclusiveStats.cost ?? session.stats.total_cost
   );
 }
 
@@ -235,7 +229,7 @@ function mergeSearchResultSources(results: SearchResult[], limit: number): Searc
   const merged: SearchResult[] = [];
 
   for (const result of results) {
-    const key = sessionReferenceKey(result.reference.agentName, result.reference.sessionId);
+    const key = getSessionReferenceKey(result.reference);
     if (seen.has(key)) continue;
     seen.add(key);
     merged.push(result);
@@ -262,17 +256,11 @@ function searchIndexedSessions(
     : searchSessions(query, options);
   const textMatchReferences =
     textQuery && options.file
-      ? new Set(
-          sessionResults.map((result) =>
-            sessionReferenceKey(result.reference.agentName, result.reference.sessionId),
-          ),
-        )
+      ? new Set(sessionResults.map((result) => getSessionReferenceKey(result.reference)))
       : null;
   const matchingFileResults = textMatchReferences
     ? fileResults.filter((result) =>
-        textMatchReferences.has(
-          sessionReferenceKey(result.reference.agentName, result.reference.sessionId),
-        ),
+        textMatchReferences.has(getSessionReferenceKey(result.reference)),
       )
     : fileResults;
 


### PR DESCRIPTION
## Summary
- add one canonical session-reference key projection to the browser-safe contract
- reuse it across indexes, trees, search, detail loading, cost attribution, and bookmarks
- retain the existing route-key helper as a deprecated compatibility wrapper

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`