### PR TITLE
refactor(cache): split connection from schema

### DIFF
--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BaseAgent, type ChangeCheckResult, type SessionCacheMeta } from "../../agents/base.js";
 import type { IdentifiedSessionHead, SessionDetail, SessionHead } from "../../types/index.js";
 import { readCachedSessionCursor, saveCachedSessions } from "../cache/sessions.js";
-import { withCacheDb } from "../cache/schema.js";
+import { withCacheDb } from "../cache/connection.js";
 import { MESSAGE_CURSOR_VERSION } from "../cache/message-cursor.js";
 import { syncSessionSearchIndex } from "../cache/search.js";
 import { materializeSessionDetail, materializeSessionDetailResponse } from "../session-detail.js";

--- a/packages/core/src/discovery/cache/__tests__/analytics-revision.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/analytics-revision.test.ts
@@ -16,7 +16,7 @@ import {
   readAnalyticsRevision,
 } from "../analytics-revision.js";
 import { getCachePath, setSchemaEnsuredPath } from "../db.js";
-import { withCacheDb } from "../schema.js";
+import { withCacheDb } from "../connection.js";
 import { commitDurableSessionPublication } from "../publication.js";
 import { clearCache, saveCachedSessionChanges, saveCachedSessions } from "../sessions.js";
 import { syncSessionSearchIndex, syncSessionSearchIndexChanges } from "../search.js";

--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -10,7 +10,7 @@ import {
   withCacheDbReadOnly,
   withSearchDb,
   withSearchIndexDb,
-} from "../schema.js";
+} from "../connection.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-diag-test-"));
 

--- a/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
@@ -15,14 +15,14 @@ vi.mock("node:os", async (importOriginal) => {
 
 // Wrap (not replace) withCacheDb so the writable-fallback path is still
 // exercised for real, while letting the test assert whether it ran.
-vi.mock("../schema.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../schema.js")>();
+vi.mock("../connection.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../connection.js")>();
   return { ...actual, withCacheDb: vi.fn(actual.withCacheDb) };
 });
 
 import { listCachedProjectGroups } from "../project-groups.js";
 import { saveCachedSessions } from "../sessions.js";
-import { withCacheDb } from "../schema.js";
+import { withCacheDb } from "../connection.js";
 import { setSchemaEnsuredPath } from "../db.js";
 import { makeSessionHead, TEST_NOW } from "./fixtures.js";
 

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -5,11 +5,13 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SQLiteDatabase } from "../../../utils/sqlite.js";
 import { getCachePath, setSchemaEnsuredPath } from "../db.js";
-import * as schema from "../schema.js";
+import * as connection from "../connection.js";
 import { loadCachedSessions, saveCachedSessions } from "../sessions.js";
 import { syncSessionSearchIndex } from "../search-index-writer.js";
 import { makeSessionData, makeSessionHead } from "./fixtures.js";
 import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
+
+const schema = connection;
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-schema-test-"));
 
@@ -419,9 +421,8 @@ describe("cache schema boundary", () => {
     expect(migrated).toEqual({ contentHash: "", pending: true });
   });
 
-  it("exposes capabilities instead of migration steps", () => {
+  it("exposes connection capabilities instead of schema internals", () => {
     expect(Object.keys(schema).sort()).toEqual([
-      "runSearchIndexWrite",
       "withCacheDb",
       "withCacheDbOutcome",
       "withCacheDbReadOnly",

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../search-index-writer.js";
 import { setSchemaEnsuredPath } from "../db.js";
 import { commitDurableSessionPublication } from "../publication.js";
-import { withCacheDb } from "../schema.js";
+import { withCacheDb } from "../connection.js";
 import {
   loadCachedSessionRawEntry,
   saveCachedSessionChanges,

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -20,7 +20,7 @@ import {
 import { setSchemaEnsuredPath } from "../db.js";
 import { MESSAGE_PARTS_FORMAT_VERSION } from "../messages.js";
 import { prepareSessionSnapshotSearchIndex } from "../search-index-writer.js";
-import { withCacheDb, withSearchDb, withSearchIndexDb } from "../schema.js";
+import { withCacheDb, withSearchDb, withSearchIndexDb } from "../connection.js";
 import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
 import type { IdentifiedSessionHead, SessionDetail, SessionHead } from "../../../types/index.js";
 

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -33,7 +33,7 @@ import type { SessionCacheMeta } from "../../../agents/base.js";
 import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
 import { clearIdentityCache } from "../../../projects/identity.js";
 import { realFs } from "../../../projects/fs.js";
-import { withCacheDb, withSearchIndexDb } from "../schema.js";
+import { withCacheDb, withSearchIndexDb } from "../connection.js";
 import { getSchemaEnsuredPath, setSchemaEnsuredPath } from "../db.js";
 import { CACHE_SCHEMA_VERSION } from "../version.js";
 import type { SessionHead } from "../../../types/index.js";

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -12,7 +12,7 @@ import {
   saveCachedSessions,
 } from "../sessions.js";
 import { setSchemaEnsuredPath } from "../db.js";
-import { withCacheDb } from "../schema.js";
+import { withCacheDb } from "../connection.js";
 import { makeSessionHead } from "./fixtures.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-sessions-test-"));

--- a/packages/core/src/discovery/cache/analytics-revision.ts
+++ b/packages/core/src/discovery/cache/analytics-revision.ts
@@ -1,6 +1,6 @@
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { hasCacheStorage } from "./db.js";
-import { withCacheDbReadOnly } from "./schema.js";
+import { withCacheDbReadOnly } from "./connection.js";
 
 const ANALYTICS_REVISION_KEY = "analytics_revision";
 

--- a/packages/core/src/discovery/cache/connection.ts
+++ b/packages/core/src/discovery/cache/connection.ts
@@ -1,0 +1,130 @@
+/**
+ * Cache connection boundary. It owns connection recovery and exposes ready
+ * database capabilities while schema creation and FTS repair remain in schema.
+ */
+import { getCoreDiagnostics } from "../../utils/diagnostics.js";
+import type { SQLiteDatabase } from "../../utils/sqlite.js";
+import {
+  discardCacheConnection,
+  getCacheConnection,
+  getCachePath,
+  getSchemaEnsuredPath,
+  hasCacheStorage,
+  setSchemaEnsuredPath,
+  type CacheConnection,
+} from "./db.js";
+import { CacheDataIntegrityError } from "./errors.js";
+import { deleteLegacyPublicationRows, hasLegacyPublicationRows } from "./publication-staging.js";
+import { ensureCacheSchema, runWithFtsRecovery } from "./schema.js";
+
+type CacheFailureEvent = "cache.write_failed" | "cache.read_failed";
+
+function isRecoverableCacheError(error: unknown): boolean {
+  if (error instanceof CacheDataIntegrityError) return true;
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string" &&
+    error.code.startsWith("SQLITE_")
+  );
+}
+
+function reportCacheFailure(
+  cachePath: string,
+  connection: CacheConnection,
+  event: CacheFailureEvent,
+  error: unknown,
+): null {
+  getCoreDiagnostics()?.warn(event, {
+    message: error instanceof Error ? error.message : String(error),
+    code: (error as { code?: string })?.code,
+    error_class: error instanceof Error ? error.name : typeof error,
+    ...(event === "cache.write_failed" && error instanceof Error ? { stack: error.stack } : {}),
+  });
+  discardCacheConnection(cachePath, connection);
+  return null;
+}
+
+function withCacheConnection<T>(
+  callbackFailureEvent: CacheFailureEvent,
+  fn: (connection: CacheConnection) => T,
+): T | null {
+  const cachePath = getCachePath();
+  const connection = getCacheConnection(cachePath);
+  if (!connection) return null;
+
+  try {
+    if (getSchemaEnsuredPath() !== cachePath) {
+      ensureCacheSchema(connection.db, cachePath);
+      setSchemaEnsuredPath(cachePath);
+    }
+  } catch (error) {
+    return reportCacheFailure(cachePath, connection, "cache.write_failed", error);
+  }
+
+  try {
+    return fn(connection);
+  } catch (error) {
+    if (!isRecoverableCacheError(error)) throw error;
+    return reportCacheFailure(cachePath, connection, callbackFailureEvent, error);
+  }
+}
+
+function cleanPublicationStaging(connection: CacheConnection): void {
+  if (connection.publicationStagingCleaned) return;
+
+  const startedAt = performance.now();
+  const reclaimed = hasLegacyPublicationRows(connection.db);
+  if (reclaimed) {
+    connection.db.transaction(() => deleteLegacyPublicationRows(connection.db)).immediate();
+  }
+  connection.publicationStagingCleaned = true;
+  getCoreDiagnostics()?.info?.("sqlite.publication_staging_cleanup.completed", {
+    duration_ms: Math.round(performance.now() - startedAt),
+    reclaimed,
+  });
+}
+
+export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
+  return withCacheConnection("cache.write_failed", ({ db }) => fn(db));
+}
+
+export type CacheReadOutcome<T> = { status: "success"; value: T } | { status: "failed" };
+
+/** Preserves the difference between a failed read and a successful nullish payload. */
+export function withCacheDbOutcome<T>(fn: (db: SQLiteDatabase) => T): CacheReadOutcome<T> {
+  let outcome: CacheReadOutcome<T> = { status: "failed" };
+  withCacheConnection("cache.read_failed", ({ db }) => {
+    outcome = { status: "success", value: fn(db) };
+  });
+  return outcome;
+}
+
+export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): CacheReadOutcome<T> {
+  const cachePath = getCachePath();
+  if (!hasCacheStorage()) return { status: "failed" };
+
+  const connection = getCacheConnection(cachePath);
+  if (!connection) return { status: "failed" };
+  try {
+    return { status: "success", value: fn(connection.db) };
+  } catch (error) {
+    if (!isRecoverableCacheError(error)) throw error;
+    reportCacheFailure(cachePath, connection, "cache.read_failed", error);
+    return { status: "failed" };
+  }
+}
+
+export function withSearchDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
+  return withCacheConnection("cache.read_failed", (connection) =>
+    runWithFtsRecovery(connection, fn),
+  );
+}
+
+export function withSearchIndexDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
+  return withCacheConnection("cache.write_failed", (connection) => {
+    cleanPublicationStaging(connection);
+    return runWithFtsRecovery(connection, fn);
+  });
+}

--- a/packages/core/src/discovery/cache/cost-facts.ts
+++ b/packages/core/src/discovery/cache/cost-facts.ts
@@ -6,7 +6,7 @@ import type {
 import { getSessionReferenceKey, type CostSource } from "../../contract/index.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { hasCacheStorage } from "./db.js";
-import { withCacheDbReadOnly } from "./schema.js";
+import { withCacheDbReadOnly } from "./connection.js";
 
 export interface CostFactOptions {
   from?: number;

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -11,7 +11,7 @@ import type { FileActivityResult, SearchHighlightRange } from "../../contract/in
 import { normalizeProjectScopePath, type ProjectScopeMatcher } from "../../projects/scope.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { filePathFtsQuery, hasCacheStorage, likePattern, normalizeFilePathSearch } from "./db.js";
-import { withCacheDb, withCacheDbReadOnly } from "./schema.js";
+import { withCacheDb, withCacheDbReadOnly } from "./connection.js";
 import {
   buildSessionSearchFilters,
   mergeSearchQueryOptions,

--- a/packages/core/src/discovery/cache/model-cost.ts
+++ b/packages/core/src/discovery/cache/model-cost.ts
@@ -6,7 +6,7 @@ import type { ModelCostEntry } from "../../contract/index.js";
 import type { ProjectIdentityKind } from "../../types/index.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { hasCacheStorage } from "./db.js";
-import { withCacheDbReadOnly } from "./schema.js";
+import { withCacheDbReadOnly } from "./connection.js";
 
 export type { ModelCostEntry };
 

--- a/packages/core/src/discovery/cache/project-groups.ts
+++ b/packages/core/src/discovery/cache/project-groups.ts
@@ -6,7 +6,7 @@ import type { ProjectGroup, ProjectIdentityKind, SessionHead } from "../../types
 import { buildProjectGroups } from "../../projects/index.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { hasCacheStorage } from "./db.js";
-import { withCacheDb, withCacheDbReadOnly } from "./schema.js";
+import { withCacheDb, withCacheDbReadOnly } from "./connection.js";
 
 export interface ProjectGroupRow extends DatabaseRow {
   identity_kind?: ProjectIdentityKind;

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -14,7 +14,7 @@ import {
   type SearchIndexSyncOptions,
   type SearchIndexSyncResult,
 } from "./search-index-writer.js";
-import { withSearchIndexDb } from "./schema.js";
+import { withSearchIndexDb } from "./connection.js";
 import {
   deleteLegacyCacheFile,
   writeCachedSessionChanges,

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -1,7 +1,4 @@
-/**
- * Cache storage boundary. Callers request a ready database capability while
- * schema creation, migrations, and search-index maintenance stay internal.
- */
+/** Cache schema creation, migration, and search-index repair. */
 import type { ProjectIdentity, ProjectIdentityKind, SessionHead } from "../../types/index.js";
 import { createSessionIdentity } from "../../contract/index.js";
 import { computeIdentity, realFs } from "../../projects/index.js";
@@ -16,17 +13,7 @@ import {
   type DatabaseRow,
   type SQLiteDatabase,
 } from "../../utils/sqlite.js";
-import {
-  discardCacheConnection,
-  getCacheConnection,
-  getCachePath,
-  getSchemaEnsuredPath,
-  hasCacheStorage,
-  setSchemaEnsuredPath,
-  type CacheConnection,
-  type CacheRow,
-} from "./db.js";
-import { CacheDataIntegrityError } from "./errors.js";
+import { type CacheConnection, type CacheRow } from "./db.js";
 import {
   messageFromBackfillRow,
   prepareInsertFileActivity,
@@ -40,7 +27,6 @@ import {
   type SessionRow,
 } from "./messages.js";
 import { CACHE_SCHEMA_VERSION } from "./version.js";
-import { deleteLegacyPublicationRows, hasLegacyPublicationRows } from "./publication-staging.js";
 
 interface MessageToolBackfillRow extends DatabaseRow {
   agent_name?: string;
@@ -140,123 +126,6 @@ function prepareLegacyProjectIdentityResolver(
 
 function getLegacySessionDirectory(session: SessionHead): string | null {
   return typeof session.directory === "string" ? session.directory : null;
-}
-
-function isRecoverableCacheError(error: unknown): boolean {
-  if (error instanceof CacheDataIntegrityError) return true;
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    typeof error.code === "string" &&
-    error.code.startsWith("SQLITE_")
-  );
-}
-
-function reportCacheFailure(
-  cachePath: string,
-  connection: CacheConnection,
-  event: CacheFailureEvent,
-  error: unknown,
-): null {
-  getCoreDiagnostics()?.warn(event, {
-    message: error instanceof Error ? error.message : String(error),
-    code: (error as { code?: string })?.code,
-    error_class: error instanceof Error ? error.name : typeof error,
-    ...(event === "cache.write_failed" && error instanceof Error ? { stack: error.stack } : {}),
-  });
-  discardCacheConnection(cachePath, connection);
-  return null;
-}
-
-type CacheFailureEvent = "cache.write_failed" | "cache.read_failed";
-
-function withCacheConnection<T>(
-  callbackFailureEvent: CacheFailureEvent,
-  fn: (connection: CacheConnection) => T,
-): T | null {
-  const cachePath = getCachePath();
-  const connection = getCacheConnection(cachePath);
-  if (!connection) return null;
-
-  try {
-    if (getSchemaEnsuredPath() !== cachePath) {
-      ensureSchema(connection.db, cachePath);
-      setSchemaEnsuredPath(cachePath);
-    }
-  } catch (error) {
-    return reportCacheFailure(cachePath, connection, "cache.write_failed", error);
-  }
-
-  try {
-    return fn(connection);
-  } catch (error) {
-    if (!isRecoverableCacheError(error)) throw error;
-    return reportCacheFailure(cachePath, connection, callbackFailureEvent, error);
-  }
-}
-
-function cleanPublicationStaging(connection: CacheConnection): void {
-  if (connection.publicationStagingCleaned) return;
-
-  const startedAt = performance.now();
-  const reclaimed = hasLegacyPublicationRows(connection.db);
-  if (reclaimed) {
-    connection.db.transaction(() => deleteLegacyPublicationRows(connection.db)).immediate();
-  }
-  connection.publicationStagingCleaned = true;
-  getCoreDiagnostics()?.info?.("sqlite.publication_staging_cleanup.completed", {
-    duration_ms: Math.round(performance.now() - startedAt),
-    reclaimed,
-  });
-}
-
-export function withCacheDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
-  return withCacheConnection("cache.write_failed", ({ db }) => fn(db));
-}
-
-export type CacheReadOutcome<T> = { status: "success"; value: T } | { status: "failed" };
-
-/**
- * Like withCacheDb (schema-ensuring, so it can be the first cache touch at
- * startup and still run migrations) but with an explicit failure outcome
- * instead of a null that shadows legitimate empty results.
- */
-export function withCacheDbOutcome<T>(fn: (db: SQLiteDatabase) => T): CacheReadOutcome<T> {
-  let result: CacheReadOutcome<T> = { status: "failed" };
-  withCacheConnection("cache.read_failed", ({ db }) => {
-    result = { status: "success", value: fn(db) };
-  });
-  return result;
-}
-
-export function withCacheDbReadOnly<T>(fn: (db: SQLiteDatabase) => T): CacheReadOutcome<T> {
-  const cachePath = getCachePath();
-  if (!hasCacheStorage()) return { status: "failed" };
-
-  const connection = getCacheConnection(cachePath);
-  if (!connection) return { status: "failed" };
-
-  try {
-    return { status: "success", value: fn(connection.db) };
-  } catch (error) {
-    if (!isRecoverableCacheError(error)) throw error;
-    reportCacheFailure(cachePath, connection, "cache.read_failed", error);
-    return { status: "failed" };
-  }
-}
-
-export function withSearchDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
-  return withCacheConnection("cache.read_failed", (connection) =>
-    runWithFtsRecovery(connection, fn),
-  );
-}
-
-export function withSearchIndexDb<T>(fn: (db: SQLiteDatabase) => T): T | null {
-  return withCacheConnection("cache.write_failed", (connection) => {
-    cleanPublicationStaging(connection);
-    return runWithFtsRecovery(connection, fn);
-  });
 }
 
 interface SearchIndexWriteResult<T> {
@@ -1678,7 +1547,10 @@ function isFtsCorruptionError(error: unknown): boolean {
   );
 }
 
-function runWithFtsRecovery<T>(connection: CacheConnection, fn: (db: SQLiteDatabase) => T): T {
+export function runWithFtsRecovery<T>(
+  connection: CacheConnection,
+  fn: (db: SQLiteDatabase) => T,
+): T {
   const { db } = connection;
   if (!connection.ftsReady) {
     ensureFtsReady(db);
@@ -1738,7 +1610,7 @@ function setCacheSchemaVersion(db: SQLiteDatabase): void {
   setCacheMetaVersion(db);
 }
 
-function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
+export function ensureCacheSchema(db: SQLiteDatabase, dbPath: string): void {
   const currentVersion = getCurrentCacheSchemaVersion(db);
   if (currentVersion === 0 && !hasAnyCacheSchema(db)) {
     createLatestCacheSchema(db);

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -20,7 +20,8 @@ import {
   type StructuredMessageRecord,
 } from "./messages.js";
 import { advanceMessageCursorDigest, initialMessageCursorDigest } from "./message-cursor.js";
-import { runSearchIndexWrite, withCacheDbReadOnly, withSearchIndexDb } from "./schema.js";
+import { withCacheDbReadOnly, withSearchIndexDb } from "./connection.js";
+import { runSearchIndexWrite } from "./schema.js";
 import { sessionDetailVersion } from "./detail-version.js";
 import type { SessionSnapshotCompleteness } from "./sessions.js";
 import {

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -20,7 +20,7 @@ import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { escapeRegExp, filePathFtsQuery, hasCacheStorage, likePattern } from "./db.js";
 import { normalizeToolName, sessionFromRow, type SessionRow } from "./messages.js";
-import { withSearchDb } from "./schema.js";
+import { withSearchDb } from "./connection.js";
 import {
   parseSearchQuery,
   splitSearchTokens,

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -26,7 +26,7 @@ import {
   withCacheDbOutcome,
   withCacheDbReadOnly,
   type CacheReadOutcome,
-} from "./schema.js";
+} from "./connection.js";
 import {
   assertSessionProjectIdentities,
   messageFromCachedRow,

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -43,7 +43,7 @@ export type {
   SaveCachedSessionsOptions,
   SessionSnapshotCompleteness,
 } from "./cache/sessions.js";
-export type { CacheReadOutcome } from "./cache/schema.js";
+export type { CacheReadOutcome } from "./cache/connection.js";
 export { closeCacheStorage, getCachePath } from "./cache/db.js";
 export type { PersistedSessionHeadChange } from "./cache/db.js";
 export { getAnalyticsRevision } from "./cache/analytics-revision.js";


### PR DESCRIPTION
## Summary
- move connection acquisition, recovery, and publication cleanup into a dedicated cache boundary
- keep schema creation, migrations, FTS repair, and index rebuild logic in the schema module
- update internal consumers and tests without changing the schema version or storage behavior

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`