### PR TITLE
refactor(web): unify session scroll ownership

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -31,6 +31,10 @@ import {
   resolveReducedMotionScrollBehavior,
   type SessionAnchorScrollBehavior,
 } from "./session-detail/scroll-behavior";
+import {
+  createTimelineAnchorRegistry,
+  type TimelineAnchorRegistry,
+} from "./session-detail/timeline-anchor-registry";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -50,11 +54,13 @@ interface SessionDetailProps {
 function scrollToSessionAnchor({
   anchorId,
   behavior,
+  anchorRegistry,
   prepareAnchor,
   isCurrent,
 }: {
   anchorId: string;
   behavior: SessionAnchorScrollBehavior;
+  anchorRegistry: TimelineAnchorRegistry;
   prepareAnchor?: () => void;
   isCurrent: () => boolean;
 }) {
@@ -63,13 +69,13 @@ function scrollToSessionAnchor({
     behavior,
     window.matchMedia("(prefers-reduced-motion: reduce)").matches,
   );
-  let element = document.getElementById(anchorId);
+  let element = anchorRegistry.get(anchorId);
   if (!element && prepareAnchor) {
     prepareAnchor();
     let attempts = 0;
     const retryScroll = () => {
       if (!isCurrent()) return;
-      element = document.getElementById(anchorId);
+      element = anchorRegistry.get(anchorId);
       if (element) {
         element.scrollIntoView({ behavior: scrollBehavior, block: "center" });
         return;
@@ -126,10 +132,8 @@ export function SessionDetail({
     [session.file_activity, session.messages, sessionAgentKey],
   );
   const { messages: messageModels, toc, fileChangeSummary } = displayModel;
-  const { state: filterState, actions: filterActions } = useSessionFilters(
-    toc,
-    formatSessionReference(session.reference),
-  );
+  const sessionReference = formatSessionReference(session.reference);
+  const { state: filterState, actions: filterActions } = useSessionFilters(toc, sessionReference);
   const [openAuxPanel, setOpenAuxPanel] = useState<"toc" | "files" | null>(null);
   const selection = useMemo(
     () =>
@@ -143,6 +147,7 @@ export function SessionDetail({
     () => new Map(childSessions.map((child) => [child.reference.sessionId, child])),
     [childSessions],
   );
+  const anchorRegistry = useMemo(createTimelineAnchorRegistry, [sessionReference]);
   const virtualListRef = useRef<MessageListHandle | null>(null);
   const scrollRequestRef = useRef(0);
   const handleJumpToMessageAnchor = useCallback(
@@ -153,12 +158,13 @@ export function SessionDetail({
       scrollToSessionAnchor({
         anchorId,
         behavior,
+        anchorRegistry,
         prepareAnchor:
           listIndex == null ? undefined : () => virtualListRef.current?.scrollToIndex(listIndex),
         isCurrent: () => scrollRequestRef.current === requestId,
       });
     },
-    [selection],
+    [anchorRegistry, selection],
   );
   const handleJumpToAnchor = useCallback(
     (anchorId: string, behavior: SessionAnchorScrollBehavior) => {
@@ -222,6 +228,7 @@ export function SessionDetail({
             <>
               <SessionMessageTimeline
                 entries={timelineEntries}
+                anchorRegistry={anchorRegistry}
                 onNavigate={(entry, behavior) =>
                   handleJumpToMessageAnchor(entry.anchorId, entry.messageIndex, behavior)
                 }
@@ -234,7 +241,7 @@ export function SessionDetail({
                 }}
               >
                 <MessageList
-                  key={formatSessionReference(session.reference)}
+                  key={sessionReference}
                   messages={filteredMessages}
                   sessionAgentKey={sessionAgentKey}
                   agent={sessionAgent}
@@ -242,6 +249,7 @@ export function SessionDetail({
                   highlightQuery={highlightQuery}
                   childSessionById={childSessionById}
                   apiRef={virtualListRef}
+                  anchorRegistry={anchorRegistry}
                 />
               </RenderProfiler>
             </>

--- a/apps/web/src/components/session-detail/message-list.test.tsx
+++ b/apps/web/src/components/session-detail/message-list.test.tsx
@@ -3,6 +3,9 @@ import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FilteredSessionMessage } from "./toc";
 import { MessageList, type MessageListHandle, VIRTUALIZED_MESSAGE_THRESHOLD } from "./message-list";
+import { createTimelineAnchorRegistry } from "./timeline-anchor-registry";
+
+const anchorRegistry = createTimelineAnchorRegistry();
 
 vi.mock("./message-rendering", () => ({
   MessageItem: ({ messageIndex }: { messageIndex: number }) => (
@@ -62,6 +65,7 @@ describe("MessageList virtualization", () => {
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={apiRef}
+        anchorRegistry={anchorRegistry}
       />,
     );
 
@@ -78,6 +82,7 @@ describe("MessageList virtualization", () => {
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}
+        anchorRegistry={anchorRegistry}
       />,
     );
 
@@ -94,6 +99,7 @@ describe("MessageList virtualization", () => {
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={apiRef}
+        anchorRegistry={anchorRegistry}
       />,
     );
     await waitFor(() => expect(apiRef.current).not.toBeNull());
@@ -127,6 +133,7 @@ describe("MessageList virtualization", () => {
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={apiRef}
+        anchorRegistry={anchorRegistry}
       />,
       { container: scrollContainer },
     );
@@ -149,6 +156,7 @@ describe("MessageList virtualization", () => {
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}
+        anchorRegistry={anchorRegistry}
       />,
     );
 
@@ -178,6 +186,7 @@ describe("MessageList virtualization", () => {
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}
+        anchorRegistry={anchorRegistry}
       />,
       { container: scrollContainer },
     );
@@ -203,6 +212,7 @@ describe("MessageList virtualization", () => {
         sessionAgentKey="claudecode"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}
+        anchorRegistry={anchorRegistry}
       />,
     );
     const list = view.container.firstElementChild as HTMLElement;
@@ -233,6 +243,7 @@ describe("MessageList virtualization", () => {
           sessionAgentKey="claudecode"
           baseDirectory="/tmp/project"
           apiRef={{ current: null }}
+          anchorRegistry={anchorRegistry}
         />
       </Profiler>,
     );

--- a/apps/web/src/components/session-detail/message-list.tsx
+++ b/apps/web/src/components/session-detail/message-list.tsx
@@ -12,6 +12,19 @@ import { formatTokens } from "../../lib/format";
 import type { FilteredSessionMessage } from "./toc";
 import { MessageItem } from "./message-rendering";
 import { HeightIndex } from "./height-index";
+import {
+  findScrollParent,
+  getElementTop,
+  getScrollTop,
+  getViewportHeight,
+  isWindowScrollParent,
+  scrollParentTo,
+  type ScrollParent,
+} from "./scroll-behavior";
+import {
+  TimelineAnchorRegistryProvider,
+  type TimelineAnchorRegistry,
+} from "./timeline-anchor-registry";
 
 const MESSAGE_LIST_GAP_PX = 32;
 export const VIRTUALIZED_MESSAGE_THRESHOLD = 80;
@@ -30,49 +43,7 @@ interface MessageListProps {
   highlightQuery?: string;
   childSessionById?: ReadonlyMap<string, SessionHead>;
   apiRef: { current: MessageListHandle | null };
-}
-
-type ScrollParent = HTMLElement | Window;
-
-function isWindowScrollParent(parent: ScrollParent): parent is Window {
-  return parent === window;
-}
-
-function findScrollParent(node: HTMLElement): ScrollParent {
-  let parent = node.parentElement;
-
-  while (parent) {
-    const { overflowY } = window.getComputedStyle(parent);
-    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") return parent;
-    parent = parent.parentElement;
-  }
-
-  return window;
-}
-
-function getScrollTop(parent: ScrollParent) {
-  return isWindowScrollParent(parent) ? window.scrollY : parent.scrollTop;
-}
-
-function getViewportHeight(parent: ScrollParent) {
-  return isWindowScrollParent(parent) ? window.innerHeight || 900 : parent.clientHeight;
-}
-
-function getListTop(node: HTMLElement, parent: ScrollParent) {
-  if (isWindowScrollParent(parent)) return node.getBoundingClientRect().top + window.scrollY;
-
-  const parentRect = parent.getBoundingClientRect();
-  const nodeRect = node.getBoundingClientRect();
-  return parent.scrollTop + nodeRect.top - parentRect.top;
-}
-
-function scrollParentTo(parent: ScrollParent, top: number) {
-  if (isWindowScrollParent(parent)) {
-    window.scrollTo({ top, behavior: "auto" });
-    return;
-  }
-
-  parent.scrollTo({ top, behavior: "auto" });
+  anchorRegistry: TimelineAnchorRegistry;
 }
 
 export function MessageList({
@@ -83,6 +54,7 @@ export function MessageList({
   highlightQuery,
   childSessionById,
   apiRef,
+  anchorRegistry,
 }: MessageListProps) {
   const shouldVirtualize = messages.length > VIRTUALIZED_MESSAGE_THRESHOLD;
 
@@ -100,27 +72,30 @@ export function MessageList({
         highlightQuery={highlightQuery}
         childSessionById={childSessionById}
         apiRef={apiRef}
+        anchorRegistry={anchorRegistry}
       />
     );
   }
 
   return (
-    <div className="flex min-w-0 flex-col gap-8">
-      {messages.map(({ msg, blocks, index }) => (
-        <MessageItem
-          key={`${msg.id}:${index}`}
-          messageIndex={index}
-          msg={msg}
-          blocks={blocks}
-          formatTokens={formatTokens}
-          sessionAgentKey={sessionAgentKey}
-          agent={agent}
-          baseDirectory={baseDirectory}
-          highlightQuery={highlightQuery}
-          childSessionById={childSessionById}
-        />
-      ))}
-    </div>
+    <TimelineAnchorRegistryProvider registry={anchorRegistry}>
+      <div className="flex min-w-0 flex-col gap-8">
+        {messages.map(({ msg, blocks, index }) => (
+          <MessageItem
+            key={`${msg.id}:${index}`}
+            messageIndex={index}
+            msg={msg}
+            blocks={blocks}
+            formatTokens={formatTokens}
+            sessionAgentKey={sessionAgentKey}
+            agent={agent}
+            baseDirectory={baseDirectory}
+            highlightQuery={highlightQuery}
+            childSessionById={childSessionById}
+          />
+        ))}
+      </div>
+    </TimelineAnchorRegistryProvider>
   );
 }
 
@@ -132,6 +107,7 @@ function VirtualizedMessageList({
   highlightQuery,
   childSessionById,
   apiRef,
+  anchorRegistry,
 }: MessageListProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const scrollParentRef = useRef<ScrollParent | null>(null);
@@ -158,7 +134,7 @@ function VirtualizedMessageList({
     const node = containerRef.current;
     const scrollParent = node ? findScrollParent(node) : window;
     scrollParentRef.current = scrollParent;
-    const listTop = node ? getListTop(node, scrollParent) : 0;
+    const listTop = node ? getElementTop(scrollParent, node) : 0;
     const next = {
       scrollTop: getScrollTop(scrollParent),
       height: getViewportHeight(scrollParent),
@@ -315,7 +291,7 @@ function VirtualizedMessageList({
       const node = containerRef.current;
       const scrollParent = node ? findScrollParent(node) : (scrollParentRef.current ?? window);
       scrollParentRef.current = scrollParent;
-      const listTop = node ? getListTop(node, scrollParent) : 0;
+      const listTop = node ? getElementTop(scrollParent, node) : 0;
       const nextTop = Math.max(0, listTop + heightIndex.startAt(index) - 24);
       scrollParentTo(scrollParent, nextTop);
       const nextViewport = {
@@ -337,37 +313,39 @@ function VirtualizedMessageList({
   }, [apiRef, scrollToIndex]);
 
   return (
-    <div
-      ref={containerRef}
-      className="relative min-w-0"
-      style={{ height: Math.max(1, heightIndex.totalSize) }}
-    >
-      {virtualItems.map(({ index, start }) => {
-        const item = messages[index];
-        if (!item) return null;
+    <TimelineAnchorRegistryProvider registry={anchorRegistry}>
+      <div
+        ref={containerRef}
+        className="relative min-w-0"
+        style={{ height: Math.max(1, heightIndex.totalSize) }}
+      >
+        {virtualItems.map(({ index, start }) => {
+          const item = messages[index];
+          if (!item) return null;
 
-        return (
-          <VirtualizedMessageRow
-            key={`${item.msg.id}:${item.index}`}
-            index={index}
-            top={start}
-            onMeasure={measureItem}
-          >
-            <MessageItem
-              messageIndex={item.index}
-              msg={item.msg}
-              blocks={item.blocks}
-              formatTokens={formatTokens}
-              sessionAgentKey={sessionAgentKey}
-              agent={agent}
-              baseDirectory={baseDirectory}
-              highlightQuery={highlightQuery}
-              childSessionById={childSessionById}
-            />
-          </VirtualizedMessageRow>
-        );
-      })}
-    </div>
+          return (
+            <VirtualizedMessageRow
+              key={`${item.msg.id}:${item.index}`}
+              index={index}
+              top={start}
+              onMeasure={measureItem}
+            >
+              <MessageItem
+                messageIndex={item.index}
+                msg={item.msg}
+                blocks={item.blocks}
+                formatTokens={formatTokens}
+                sessionAgentKey={sessionAgentKey}
+                agent={agent}
+                baseDirectory={baseDirectory}
+                highlightQuery={highlightQuery}
+                childSessionById={childSessionById}
+              />
+            </VirtualizedMessageRow>
+          );
+        })}
+      </div>
+    </TimelineAnchorRegistryProvider>
   );
 }
 

--- a/apps/web/src/components/session-detail/message-markdown-memo.test.tsx
+++ b/apps/web/src/components/session-detail/message-markdown-memo.test.tsx
@@ -2,7 +2,10 @@ import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MarkdownContent } from "../MarkdownContent";
 import { MessageList, VIRTUALIZED_MESSAGE_THRESHOLD } from "./message-list";
+import { createTimelineAnchorRegistry } from "./timeline-anchor-registry";
 import type { FilteredSessionMessage } from "./toc";
+
+const anchorRegistry = createTimelineAnchorRegistry();
 
 const { markdownRender } = vi.hoisted(() => ({
   markdownRender: vi.fn(),
@@ -84,6 +87,7 @@ describe("message markdown memoization", () => {
         sessionAgentKey="codex"
         baseDirectory="/tmp/project"
         apiRef={{ current: null }}
+        anchorRegistry={anchorRegistry}
       />,
       { container: scrollContainer },
     );
@@ -104,6 +108,7 @@ describe("message markdown memoization", () => {
         baseDirectory="/tmp/project"
         highlightQuery="Message"
         apiRef={{ current: null }}
+        anchorRegistry={anchorRegistry}
       />,
     );
     expect(markdownRender.mock.calls.length).toBeGreaterThan(initialRenderCount);

--- a/apps/web/src/components/session-detail/message-rendering.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.tsx
@@ -26,6 +26,7 @@ import { isCodexTurnAbortedMessage } from "./codex-abort";
 import { buildCodexPlanDisplay } from "./codex-plan";
 import { getDisplayTextWithRelativePaths } from "./path-extract";
 import { buildBlockTimelineAnchorId, buildMessageTimelineAnchorId } from "./timeline";
+import { useTimelineAnchorRef } from "./timeline-anchor-registry";
 import { INITIAL_CONTENT_RENDER_BUDGETS } from "../../lib/content-render-budget";
 import {
   type ToolStatus,
@@ -99,6 +100,8 @@ export const MessageItem = memo(function MessageItem({
 }) {
   const isUser = msg.role === "user";
   const isAbortMessage = isCodexTurnAbortedMessage(msg, sessionAgentKey);
+  const messageAnchorId = isUser ? buildMessageTimelineAnchorId(messageIndex) : undefined;
+  const messageAnchorRef = useTimelineAnchorRef(messageAnchorId);
 
   const getAgentAvatar = () => {
     const agentName = agent?.displayName ?? sessionAgentKey;
@@ -127,8 +130,8 @@ export const MessageItem = memo(function MessageItem({
 
   return (
     <article
-      id={isUser ? buildMessageTimelineAnchorId(messageIndex) : undefined}
-      data-session-timeline-anchor={isUser ? buildMessageTimelineAnchorId(messageIndex) : undefined}
+      ref={messageAnchorRef}
+      id={messageAnchorId}
       className="w-full scroll-mt-20 border-l-2 border-[var(--console-thread)] pl-4 pr-3 md:pr-5"
     >
       <div className="flex gap-4">
@@ -207,22 +210,12 @@ export const MessageItem = memo(function MessageItem({
                 );
               }
               return (
-                <div
+                <MessageTextSection
                   key={index}
-                  id={timelineAnchorId}
-                  data-session-timeline-anchor={timelineAnchorId}
-                  className="scroll-mt-20 rounded-lg border border-[var(--console-border)] bg-[var(--console-surface)] p-4 shadow-[var(--shadow-raised)]"
-                >
-                  <div className="console-markdown text-sm leading-relaxed text-[var(--console-text)]">
-                    {block.parts.map((part, partIndex) => (
-                      <MessageMarkdown
-                        key={partIndex}
-                        text={part.text}
-                        highlightQuery={highlightQuery}
-                      />
-                    ))}
-                  </div>
-                </div>
+                  anchorId={timelineAnchorId}
+                  parts={block.parts}
+                  highlightQuery={highlightQuery}
+                />
               );
             })
           )}
@@ -257,6 +250,32 @@ export const MessageItem = memo(function MessageItem({
   );
 });
 
+const MessageTextSection = memo(function MessageTextSection({
+  anchorId,
+  parts,
+  highlightQuery,
+}: {
+  anchorId: string;
+  parts: Array<{ text: string }>;
+  highlightQuery?: string;
+}) {
+  const anchorRef = useTimelineAnchorRef(anchorId);
+
+  return (
+    <div
+      ref={anchorRef}
+      id={anchorId}
+      className="scroll-mt-20 rounded-lg border border-[var(--console-border)] bg-[var(--console-surface)] p-4 shadow-[var(--shadow-raised)]"
+    >
+      <div className="console-markdown text-sm leading-relaxed text-[var(--console-text)]">
+        {parts.map((part, index) => (
+          <MessageMarkdown key={index} text={part.text} highlightQuery={highlightQuery} />
+        ))}
+      </div>
+    </div>
+  );
+});
+
 function AbortToolItem() {
   return (
     <div className="space-y-2">
@@ -286,6 +305,7 @@ const ReasoningSection = memo(function ReasoningSection({
   highlightQuery?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const anchorRef = useTimelineAnchorRef(anchorId);
   const fullText = useMemo(
     () =>
       parts
@@ -297,8 +317,8 @@ const ReasoningSection = memo(function ReasoningSection({
 
   return (
     <div
+      ref={anchorRef}
       id={anchorId}
-      data-session-timeline-anchor={anchorId}
       className="scroll-mt-20 overflow-hidden rounded-lg border border-[var(--console-thinking-border)] bg-[var(--console-thinking-bg)]"
     >
       <button
@@ -372,8 +392,10 @@ const PlansSection = memo(function PlansSection({
   parts: PlanPart[];
   highlightQuery?: string;
 }) {
+  const anchorRef = useTimelineAnchorRef(anchorId);
+
   return (
-    <div id={anchorId} data-session-timeline-anchor={anchorId} className="scroll-mt-20 space-y-2">
+    <div ref={anchorRef} id={anchorId} className="scroll-mt-20 space-y-2">
       {parts.map((plan, i) => (
         <PlanItem key={i} part={plan} highlightQuery={highlightQuery} />
       ))}
@@ -475,6 +497,7 @@ const ToolItem = memo(function ToolItem({
   highlightQuery?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const anchorRef = useTimelineAnchorRef(anchorId);
   const state = useMemo(() => normalizeToolState(tool), [tool]);
   const strategy = useMemo(
     () => getToolDisplayStrategy(sessionAgentKey, tool, state, baseDirectory),
@@ -489,7 +512,7 @@ const ToolItem = memo(function ToolItem({
   const ToolIcon = strategy.Icon;
 
   return (
-    <div id={anchorId} data-session-timeline-anchor={anchorId} className="scroll-mt-20">
+    <div ref={anchorRef} id={anchorId} className="scroll-mt-20">
       <div className="flex flex-wrap items-start gap-2">
         <div
           className={`w-full max-w-[720px] rounded-lg border border-[var(--console-border-strong)] bg-[var(--console-surface)] px-3 py-2.5 text-left shadow-[var(--shadow-raised)] ${

--- a/apps/web/src/components/session-detail/scroll-behavior.ts
+++ b/apps/web/src/components/session-detail/scroll-behavior.ts
@@ -1,5 +1,7 @@
 export type SessionAnchorScrollBehavior = "auto" | "smooth";
 
+export type ScrollParent = HTMLElement | Window;
+
 export type SessionAnchorScrollHandler = (
   anchorId: string,
   behavior: SessionAnchorScrollBehavior,
@@ -14,4 +16,53 @@ export function resolveReducedMotionScrollBehavior(
   prefersReducedMotion: boolean,
 ): SessionAnchorScrollBehavior {
   return behavior === "smooth" && prefersReducedMotion ? "auto" : behavior;
+}
+
+export function findScrollParent(node: HTMLElement): ScrollParent {
+  let parent = node.parentElement;
+
+  while (parent) {
+    const { overflowY } = window.getComputedStyle(parent);
+    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") return parent;
+    parent = parent.parentElement;
+  }
+
+  return window;
+}
+
+export function isWindowScrollParent(parent: ScrollParent): parent is Window {
+  return parent === window;
+}
+
+export function getScrollTop(parent: ScrollParent) {
+  if (!isWindowScrollParent(parent)) return parent.scrollTop;
+  return window.scrollY || (document.scrollingElement ?? document.documentElement).scrollTop;
+}
+
+export function getViewportHeight(parent: ScrollParent) {
+  return isWindowScrollParent(parent) ? window.innerHeight || 900 : parent.clientHeight;
+}
+
+export function getScrollHeight(parent: ScrollParent) {
+  return isWindowScrollParent(parent)
+    ? (document.scrollingElement ?? document.documentElement).scrollHeight
+    : parent.scrollHeight;
+}
+
+export function getElementTop(parent: ScrollParent, element: HTMLElement) {
+  if (isWindowScrollParent(parent))
+    return element.getBoundingClientRect().top + getScrollTop(parent);
+
+  const parentRect = parent.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+  return parent.scrollTop + elementRect.top - parentRect.top;
+}
+
+export function scrollParentTo(parent: ScrollParent, top: number) {
+  if (isWindowScrollParent(parent)) {
+    window.scrollTo({ top, behavior: "auto" });
+    return;
+  }
+
+  parent.scrollTo({ top, behavior: "auto" });
 }

--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionMessageTimeline, VIRTUALIZED_TIMELINE_THRESHOLD } from "./session-message-timeline";
 import type { SessionTimelineEntry } from "./timeline";
+import { createTimelineAnchorRegistry } from "./timeline-anchor-registry";
 
 // Mirrors the ResizeObserverMock pattern used in message-list.test.tsx: a controllable
 // stand-in so tests can drive which anchors are "visible" without a real layout engine.
@@ -65,7 +66,13 @@ afterEach(() => {
 
 function renderTimeline(timelineEntries = entries) {
   const onNavigate = vi.fn();
-  const view = render(<SessionMessageTimeline entries={timelineEntries} onNavigate={onNavigate} />);
+  const view = render(
+    <SessionMessageTimeline
+      entries={timelineEntries}
+      anchorRegistry={createTimelineAnchorRegistry()}
+      onNavigate={onNavigate}
+    />,
+  );
   const timeline = view.getByRole("navigation", { name: "Session message timeline" });
   const track = view.getByTestId("session-timeline-track");
   Object.defineProperties(track, {
@@ -372,15 +379,22 @@ describe("SessionMessageTimeline", () => {
     const anchorElements = new Map(
       entries.map((entry) => {
         const anchor = document.createElement("div");
-        anchor.dataset.sessionTimelineAnchor = entry.anchorId;
+        anchor.id = entry.anchorId;
         detail.appendChild(anchor);
         return [entry.anchorId, anchor] as const;
       }),
     );
 
-    render(<SessionMessageTimeline entries={entries} onNavigate={vi.fn()} />, {
-      container: detail,
-    });
+    const anchorRegistry = createTimelineAnchorRegistry();
+    anchorElements.forEach((anchor, anchorId) => anchorRegistry.register(anchorId, anchor));
+    render(
+      <SessionMessageTimeline
+        entries={entries}
+        anchorRegistry={anchorRegistry}
+        onNavigate={vi.fn()}
+      />,
+      { container: detail },
+    );
 
     const observer = IntersectionObserverMock.instances[0]!;
     const agentAnchor = anchorElements.get("agent-1")!;
@@ -419,6 +433,27 @@ describe("SessionMessageTimeline", () => {
     detail.remove();
   });
 
+  it("tracks anchors mounted and unmounted by the virtual message list", () => {
+    IntersectionObserverMock.instances = [];
+    vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
+    const anchorRegistry = createTimelineAnchorRegistry();
+    render(
+      <SessionMessageTimeline
+        entries={entries}
+        anchorRegistry={anchorRegistry}
+        onNavigate={vi.fn()}
+      />,
+    );
+    const observer = IntersectionObserverMock.instances[0]!;
+    const anchor = document.createElement("div");
+
+    act(() => anchorRegistry.register("agent-1", anchor));
+    expect(observer.targets.has(anchor)).toBe(true);
+
+    act(() => anchorRegistry.register("agent-1", null));
+    expect(observer.targets.has(anchor)).toBe(false);
+  });
+
   it("reveals an active entry outside the virtualized render range", async () => {
     IntersectionObserverMock.instances = [];
     vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
@@ -436,14 +471,21 @@ describe("SessionMessageTimeline", () => {
     const detail = document.createElement("div");
     detail.setAttribute("data-testid", "session-detail");
     const anchor = document.createElement("div");
-    anchor.dataset.sessionTimelineAnchor = "entry-1500";
+    anchor.id = "entry-1500";
     anchor.getBoundingClientRect = () => ({ top: 100 }) as DOMRect;
     detail.appendChild(anchor);
     document.body.appendChild(detail);
 
-    const view = render(<SessionMessageTimeline entries={longEntries} onNavigate={vi.fn()} />, {
-      container: detail,
-    });
+    const anchorRegistry = createTimelineAnchorRegistry();
+    anchorRegistry.register("entry-1500", anchor);
+    const view = render(
+      <SessionMessageTimeline
+        entries={longEntries}
+        anchorRegistry={anchorRegistry}
+        onNavigate={vi.fn()}
+      />,
+      { container: detail },
+    );
     const timeline = view.getByRole("navigation", { name: "Session message timeline" });
     const track = view.getByTestId("session-timeline-track");
     Object.defineProperties(timeline, {

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -18,12 +18,20 @@ import {
   type SessionTimelineEntry,
   type SessionTimelineEntryKind,
 } from "./timeline";
-import { getActivationScrollBehavior, type SessionAnchorScrollBehavior } from "./scroll-behavior";
-
-type ScrollParent = HTMLElement | Window;
+import {
+  findScrollParent,
+  getScrollHeight,
+  getScrollTop,
+  getViewportHeight,
+  isWindowScrollParent,
+  getActivationScrollBehavior,
+  type SessionAnchorScrollBehavior,
+} from "./scroll-behavior";
+import type { TimelineAnchorRegistry } from "./timeline-anchor-registry";
 
 interface SessionMessageTimelineProps {
   entries: SessionTimelineEntry[];
+  anchorRegistry: TimelineAnchorRegistry;
   onNavigate: (entry: SessionTimelineEntry, behavior: SessionAnchorScrollBehavior) => void;
 }
 
@@ -168,40 +176,15 @@ const TimelineSegment = memo(function TimelineSegment({
   );
 });
 
-function findScrollParent(node: HTMLElement): ScrollParent {
-  let parent = node.parentElement;
-
-  while (parent) {
-    const { overflowY } = window.getComputedStyle(parent);
-    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") return parent;
-    parent = parent.parentElement;
-  }
-
-  return window;
-}
-
-function isWindowScrollParent(parent: ScrollParent): parent is Window {
-  return parent === window;
-}
-
-function getScrollViewport(parent: ScrollParent) {
-  if (isWindowScrollParent(parent)) {
-    const viewportHeight = window.innerHeight || 900;
-    const scrollingElement = document.scrollingElement ?? document.documentElement;
-    return {
-      center: viewportHeight / 2,
-      scrollTop: window.scrollY || scrollingElement.scrollTop,
-      viewportHeight,
-      scrollHeight: scrollingElement.scrollHeight,
-    };
-  }
-
-  const rect = parent.getBoundingClientRect();
+function getScrollViewport(parent: HTMLElement | Window) {
+  const viewportHeight = getViewportHeight(parent);
   return {
-    center: rect.top + parent.clientHeight / 2,
-    scrollTop: parent.scrollTop,
-    viewportHeight: parent.clientHeight,
-    scrollHeight: parent.scrollHeight,
+    center: isWindowScrollParent(parent)
+      ? viewportHeight / 2
+      : parent.getBoundingClientRect().top + viewportHeight / 2,
+    scrollTop: getScrollTop(parent),
+    viewportHeight,
+    scrollHeight: getScrollHeight(parent),
   };
 }
 
@@ -250,7 +233,11 @@ function scrollTimelineIndexIntoView(
   }
 }
 
-export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTimelineProps) {
+export function SessionMessageTimeline({
+  entries,
+  anchorRegistry,
+  onNavigate,
+}: SessionMessageTimelineProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const trackRef = useRef<HTMLDivElement | null>(null);
@@ -349,28 +336,25 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
     const root = rootRef.current;
     if (!root || entries.length === 0) return;
 
-    const detail = root.closest<HTMLElement>('[data-testid="session-detail"]');
     const scrollParent = findScrollParent(root);
     let frame = 0;
 
-    // jsdom (test env) has no IntersectionObserver; fall back to the pre-CS-80 full-scan
-    // path so existing tests keep exercising real layout without a polyfill.
-    const anchorSelector = "[data-session-timeline-anchor]";
-    const readAnchorPosition = (anchor: HTMLElement) => {
-      const anchorId = anchor.dataset.sessionTimelineAnchor;
-      const index = anchorId ? entryIndexes.get(anchorId) : undefined;
+    const readAnchorPosition = (anchorId: string, anchor: HTMLElement) => {
+      const index = entryIndexes.get(anchorId);
       return index == null ? null : { index, top: anchor.getBoundingClientRect().top };
     };
     const scanAllAnchors = () =>
-      Array.from(detail?.querySelectorAll<HTMLElement>(anchorSelector) ?? []).flatMap(
-        (anchor) => readAnchorPosition(anchor) ?? [],
+      Array.from(anchorRegistry.entries()).flatMap(
+        ([anchorId, anchor]) => readAnchorPosition(anchorId, anchor) ?? [],
       );
 
     // Only intersecting anchors are re-measured per frame; IO keeps this set updated
     // so scroll frames read O(visible) rects instead of O(total anchors).
     const visibleAnchors = new Map<string, HTMLElement>();
     const scanVisibleAnchors = () =>
-      Array.from(visibleAnchors.values()).flatMap((anchor) => readAnchorPosition(anchor) ?? []);
+      Array.from(visibleAnchors).flatMap(
+        ([anchorId, anchor]) => readAnchorPosition(anchorId, anchor) ?? [],
+      );
 
     const updateActiveEntry = () => {
       const viewport = getScrollViewport(scrollParent);
@@ -394,6 +378,9 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
       });
     };
 
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleUpdate);
+    const observedAnchorIds = new WeakMap<HTMLElement, string>();
     const intersectionObserver =
       typeof IntersectionObserver === "undefined"
         ? null
@@ -401,7 +388,7 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
             (ioEntries) => {
               for (const entry of ioEntries) {
                 const anchor = entry.target as HTMLElement;
-                const anchorId = anchor.dataset.sessionTimelineAnchor;
+                const anchorId = observedAnchorIds.get(anchor);
                 if (!anchorId) continue;
                 if (entry.isIntersecting) visibleAnchors.set(anchorId, anchor);
                 else visibleAnchors.delete(anchorId);
@@ -411,57 +398,42 @@ export function SessionMessageTimeline({ entries, onNavigate }: SessionMessageTi
             { root: isWindowScrollParent(scrollParent) ? null : scrollParent, threshold: 0 },
           );
 
-    const observeAnchor = (anchor: HTMLElement) => intersectionObserver?.observe(anchor);
-    const unobserveAnchor = (anchor: HTMLElement) => {
+    const observeAnchor = (anchorId: string, anchor: HTMLElement) => {
+      observedAnchorIds.set(anchor, anchorId);
+      intersectionObserver?.observe(anchor);
+      resizeObserver?.observe(anchor);
+    };
+    const unobserveAnchor = (anchorId: string, anchor: HTMLElement) => {
       intersectionObserver?.unobserve(anchor);
-      const anchorId = anchor.dataset.sessionTimelineAnchor;
-      if (anchorId) visibleAnchors.delete(anchorId);
+      resizeObserver?.unobserve(anchor);
+      observedAnchorIds.delete(anchor);
+      visibleAnchors.delete(anchorId);
     };
-    const forEachAnchorIn = (node: Node, visit: (anchor: HTMLElement) => void) => {
-      if (!(node instanceof HTMLElement)) return;
-      if (node.matches(anchorSelector)) visit(node);
-      node.querySelectorAll<HTMLElement>(anchorSelector).forEach(visit);
-    };
-
-    if (intersectionObserver && detail) {
-      detail.querySelectorAll<HTMLElement>(anchorSelector).forEach(observeAnchor);
+    if (intersectionObserver) {
+      Array.from(anchorRegistry.entries()).forEach(([anchorId, anchor]) =>
+        observeAnchor(anchorId, anchor),
+      );
     }
 
     scheduleUpdate();
     scrollParent.addEventListener("scroll", scheduleUpdate, { passive: true });
     window.addEventListener("resize", scheduleUpdate);
 
-    const resizeObserver =
-      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleUpdate);
-    if (detail) resizeObserver?.observe(detail);
-
-    // Converged to registration bookkeeping only: mutations register/unregister IO targets
-    // for added/removed anchors instead of forcing a full-scan recompute on every DOM change.
-    const mutationObserver =
-      typeof MutationObserver === "undefined"
-        ? null
-        : new MutationObserver((records) => {
-            if (!intersectionObserver) {
-              scheduleUpdate();
-              return;
-            }
-            for (const record of records) {
-              record.addedNodes.forEach((node) => forEachAnchorIn(node, observeAnchor));
-              record.removedNodes.forEach((node) => forEachAnchorIn(node, unobserveAnchor));
-            }
-            scheduleUpdate();
-          });
-    if (detail) mutationObserver?.observe(detail, { childList: true, subtree: true });
+    const unsubscribe = anchorRegistry.subscribe((anchorId, element, previous) => {
+      if (previous && previous !== element) unobserveAnchor(anchorId, previous);
+      if (element) observeAnchor(anchorId, element);
+      scheduleUpdate();
+    });
 
     return () => {
       if (frame) cancelAnimationFrame(frame);
       intersectionObserver?.disconnect();
       resizeObserver?.disconnect();
-      mutationObserver?.disconnect();
+      unsubscribe();
       scrollParent.removeEventListener("scroll", scheduleUpdate);
       window.removeEventListener("resize", scheduleUpdate);
     };
-  }, [entries.length, entryIndexes]);
+  }, [anchorRegistry, entries.length, entryIndexes]);
 
   useEffect(() => {
     const scrollViewport = scrollRef.current;

--- a/apps/web/src/components/session-detail/timeline-anchor-registry.test.tsx
+++ b/apps/web/src/components/session-detail/timeline-anchor-registry.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createTimelineAnchorRegistry,
+  TimelineAnchorRegistryProvider,
+  useTimelineAnchorRef,
+} from "./timeline-anchor-registry";
+
+afterEach(cleanup);
+
+function Anchor({ anchorId }: { anchorId: string }) {
+  return <div ref={useTimelineAnchorRef(anchorId)} />;
+}
+
+describe("TimelineAnchorRegistry", () => {
+  it("owns anchor registration for the rendered message tree", () => {
+    const registry = createTimelineAnchorRegistry();
+    const view = render(
+      <TimelineAnchorRegistryProvider registry={registry}>
+        <Anchor anchorId="message-1" />
+      </TimelineAnchorRegistryProvider>,
+    );
+
+    expect(registry.get("message-1")).toBe(view.container.firstElementChild);
+
+    view.unmount();
+    expect(registry.get("message-1")).toBeUndefined();
+  });
+
+  it("publishes dynamic mount and unmount changes", () => {
+    const registry = createTimelineAnchorRegistry();
+    const listener = vi.fn();
+    registry.subscribe(listener);
+    const element = document.createElement("div");
+
+    registry.register("tool-1", element);
+    registry.register("tool-1", null);
+
+    expect(listener).toHaveBeenNthCalledWith(1, "tool-1", element, undefined);
+    expect(listener).toHaveBeenNthCalledWith(2, "tool-1", null, element);
+  });
+});

--- a/apps/web/src/components/session-detail/timeline-anchor-registry.tsx
+++ b/apps/web/src/components/session-detail/timeline-anchor-registry.tsx
@@ -1,0 +1,61 @@
+import { createContext, useCallback, useContext, type ReactNode, type RefCallback } from "react";
+
+type AnchorListener = (
+  anchorId: string,
+  element: HTMLElement | null,
+  previous: HTMLElement | undefined,
+) => void;
+
+export interface TimelineAnchorRegistry {
+  get: (anchorId: string) => HTMLElement | undefined;
+  entries: () => IterableIterator<[string, HTMLElement]>;
+  register: (anchorId: string, element: HTMLElement | null) => void;
+  subscribe: (listener: AnchorListener) => () => void;
+}
+
+export function createTimelineAnchorRegistry(): TimelineAnchorRegistry {
+  const anchors = new Map<string, HTMLElement>();
+  const listeners = new Set<AnchorListener>();
+
+  return {
+    get: (anchorId) => anchors.get(anchorId),
+    entries: () => anchors.entries(),
+    register: (anchorId, element) => {
+      const previous = anchors.get(anchorId);
+      if (previous === element || (!previous && !element)) return;
+      if (element) anchors.set(anchorId, element);
+      else anchors.delete(anchorId);
+      listeners.forEach((listener) => listener(anchorId, element, previous));
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+const TimelineAnchorRegistryContext = createContext<TimelineAnchorRegistry | null>(null);
+
+export function TimelineAnchorRegistryProvider({
+  registry,
+  children,
+}: {
+  registry: TimelineAnchorRegistry;
+  children: ReactNode;
+}) {
+  return (
+    <TimelineAnchorRegistryContext.Provider value={registry}>
+      {children}
+    </TimelineAnchorRegistryContext.Provider>
+  );
+}
+
+export function useTimelineAnchorRef(anchorId?: string): RefCallback<HTMLElement> {
+  const registry = useContext(TimelineAnchorRegistryContext);
+  return useCallback(
+    (element) => {
+      if (anchorId) registry?.register(anchorId, element);
+    },
+    [anchorId, registry],
+  );
+}


### PR DESCRIPTION
## Summary

- centralize scroll-parent geometry shared by the message virtualizer and timeline
- replace document queries and DOM mutation scanning with an explicit timeline anchor registry
- track virtualized anchor mount, resize, and unmount events directly

## Verification

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm perf:check`