### PR TITLE
feat(www): add Japanese landing page

### DIFF
--- a/apps/www/public/llms.txt
+++ b/apps/www/public/llms.txt
@@ -6,6 +6,7 @@
 
 - [English landing page](https://codesesh.xingkaixin.me/)
 - [Chinese landing page](https://codesesh.xingkaixin.me/zh/)
+- [Japanese landing page](https://codesesh.xingkaixin.me/ja/)
 - [Markdown landing page](https://codesesh.xingkaixin.me/index.md)
 - [Full product knowledge](https://codesesh.xingkaixin.me/llms-full.txt)
 - [GitHub repository](https://github.com/xingkaixin/codesesh)

--- a/apps/www/public/sitemap.xml
+++ b/apps/www/public/sitemap.xml
@@ -2,13 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://codesesh.xingkaixin.me/</loc>
-    <lastmod>2026-08-07</lastmod>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://codesesh.xingkaixin.me/zh/</loc>
-    <lastmod>2026-08-07</lastmod>
+    <lastmod>2026-08-21</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://codesesh.xingkaixin.me/ja/</loc>
+    <lastmod>2026-08-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/apps/www/src/components/Footer.astro
+++ b/apps/www/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { copy, type Locale } from "../data/landing";
+import { copy, localeConfig, type Locale } from "../data/landing";
 
 interface Props {
   locale: Locale;
@@ -14,7 +14,7 @@ const t = copy[locale].footer;
     class="mx-auto flex max-w-[1180px] flex-col gap-5 border-t border-[var(--console-border)] pt-6 sm:flex-row sm:items-center"
   >
     <a
-      href={locale === "zh" ? "/zh/" : "/"}
+      href={localeConfig[locale].route}
       class="flex items-center gap-2.5 rounded-sm text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
     >
       <img
@@ -31,7 +31,10 @@ const t = copy[locale].footer;
     <span class="console-mono text-[10px] leading-5 text-[var(--console-muted)]"
       >{t.note}</span
     >
-    <nav class="flex gap-5 sm:ml-auto" aria-label="Footer navigation">
+    <nav
+      class="flex gap-5 sm:ml-auto"
+      aria-label={localeConfig[locale].footerNavigationLabel}
+    >
       <a class="footer-link" href="https://github.com/xingkaixin/codesesh"
         >GitHub</a
       >

--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -28,7 +28,7 @@ const themes = [
     >
       <img src="/logo.svg?v=3" alt="CodeSesh" class="size-6 rounded-sm" />
       <span
-        class="console-display hidden text-sm font-bold tracking-[0.06em] min-[360px]:inline"
+        class="console-display hidden text-sm font-bold tracking-[0.06em] sm:inline"
       >
         CODESESH
       </span>

--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-import { copy, localeRoutes, type Locale } from "../data/landing";
+import { copy, localeConfig, locales, type Locale } from "../data/landing";
 import Icon from "./Icon.astro";
 
 interface Props {
@@ -23,7 +23,7 @@ const themes = [
     class="mx-auto flex h-[60px] max-w-[1180px] items-center px-4 sm:px-6 lg:px-7"
   >
     <a
-      href={localeRoutes[locale]}
+      href={localeConfig[locale].route}
       class="motion-hover flex shrink-0 items-center gap-2.5 rounded-sm text-[var(--console-text)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
     >
       <img src="/logo.svg?v=3" alt="CodeSesh" class="size-6 rounded-sm" />
@@ -36,7 +36,7 @@ const themes = [
 
     <nav
       class="ml-8 hidden items-center gap-6 md:flex"
-      aria-label={locale === "zh" ? "主导航" : "Primary navigation"}
+      aria-label={localeConfig[locale].primaryNavigationLabel}
     >
       <a class="landing-nav-link" href="#tour">{t.tour}</a>
       <a class="landing-nav-link" href="#capabilities">{t.capabilities}</a>
@@ -46,7 +46,7 @@ const themes = [
 
     <nav
       class="ml-auto flex items-center gap-1.5 sm:gap-2"
-      aria-label={locale === "zh" ? "站点控制" : "Site controls"}
+      aria-label={localeConfig[locale].siteControlsLabel}
     >
       <div
         class="flex min-h-9 items-center rounded-sm border border-[var(--console-border)] bg-[var(--console-surface)] p-0.5"
@@ -54,9 +54,9 @@ const themes = [
         aria-label={t.languageLabel}
       >
         {
-          (["zh", "en"] as const).map((item) => (
+          locales.map((item) => (
             <a
-              href={localeRoutes[item]}
+              href={localeConfig[item].route}
               class:list={[
                 "motion-hover console-mono inline-flex min-h-8 items-center rounded-sm px-2 text-[10px] font-medium focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none",
                 locale === item
@@ -65,7 +65,7 @@ const themes = [
               ]}
               aria-current={locale === item ? "page" : undefined}
             >
-              {item === "zh" ? "中文" : "EN"}
+              {localeConfig[item].switchLabel}
             </a>
           ))
         }

--- a/apps/www/src/components/ProductDemo.astro
+++ b/apps/www/src/components/ProductDemo.astro
@@ -31,27 +31,6 @@ interface RangeDatum {
 const { locale, id, scene } = Astro.props;
 const t = copy[locale].tour;
 
-const labels =
-  locale === "zh"
-    ? {
-        search: "搜索示例会话",
-        range: "示例数据时间范围",
-        overview: "概览示例界面",
-        projects: "项目树示例界面",
-        replay: "会话回放示例界面",
-        filters: "切换消息类型的显示与隐藏",
-        visibleStatus: "当前显示 {count} 条消息",
-      }
-    : {
-        search: "Search sample sessions",
-        range: "Sample data time range",
-        overview: "Overview demo interface",
-        projects: "Project tree demo interface",
-        replay: "Session replay demo interface",
-        filters: "Toggle message types on or off",
-        visibleStatus: "Showing {count} messages",
-      };
-
 const overviewRanges = {
   "7d": {
     chip: "Last 7d / Apr 16-23, 2026",
@@ -224,26 +203,28 @@ const defaultBarMax = Math.max(...defaultRange.bars.map((bar) => bar.value));
 const rangePayload = JSON.stringify(overviewRanges).replaceAll("<", "\\u003c");
 const previewLabel =
   scene === "overview"
-    ? labels.overview
+    ? t.overview
     : scene === "projects"
-      ? labels.projects
-      : labels.replay;
+      ? t.projects
+      : t.replay;
 const sampleLabel = `${t.sampleLabel} / DEMO`;
 
 const replayFilters = [
-  { key: "user", label: locale === "zh" ? "用户消息" : "User", count: 4 },
-  {
-    key: "agent",
-    label: locale === "zh" ? "Agent 回复" : "Agent responses",
-    count: 15,
-  },
-  { key: "tools", label: locale === "zh" ? "工具调用" : "Tools", count: 22 },
+  { key: "user", label: t.userMessages, count: 4 },
+  { key: "agent", label: t.agentResponses, count: 15 },
+  { key: "tools", label: t.toolCalls, count: 22 },
   { key: "bash", label: "bash", count: 8 },
   { key: "edit-file", label: "edit_file", count: 6 },
 ] as const;
 ---
 
-<div id={id} class="product-demo" data-product-demo={scene} data-scene={scene}>
+<div
+  id={id}
+  class="product-demo"
+  data-product-demo={scene}
+  data-scene={scene}
+  data-sample-sessions-template={t.sampleSessions}
+>
   <div
     class="demo-viewport"
     role="region"
@@ -260,11 +241,11 @@ const replayFilters = [
                 <strong>CODESESH</strong>
               </div>
               <label class="demo-search">
-                <span class="sr-only">{labels.search}</span>
+                <span class="sr-only">{t.search}</span>
                 <input
                   type="search"
                   placeholder="Search sessions"
-                  aria-label={labels.search}
+                  aria-label={t.search}
                 />
                 <kbd>/</kbd>
               </label>
@@ -276,7 +257,7 @@ const replayFilters = [
             </header>
 
             <div class="demo-frame">
-              <aside class="demo-sidebar" aria-label="Sample projects">
+              <aside class="demo-sidebar" aria-label={t.sampleProjects}>
                 <nav>
                   <ul class="demo-nav-list">
                     <li aria-current="page" class="is-active">
@@ -332,7 +313,7 @@ const replayFilters = [
                   <div
                     class="demo-range-tabs"
                     role="group"
-                    aria-label={labels.range}
+                    aria-label={t.range}
                   >
                     <button
                       type="button"
@@ -383,7 +364,9 @@ const replayFilters = [
                     {defaultRange.bars.map((bar, index) => (
                       <li
                         data-demo-bar={index}
-                        aria-label={`${bar.label}: ${bar.value} sample sessions`}
+                        aria-label={t.sampleSessions
+                          .replace("{label}", bar.label)
+                          .replace("{count}", String(bar.value))}
                       >
                         <span class="demo-bar-track" aria-hidden="true">
                           <span
@@ -464,7 +447,7 @@ const replayFilters = [
             </header>
 
             <div class="demo-frame demo-project-frame">
-              <aside class="demo-sidebar" aria-label="Sample projects">
+              <aside class="demo-sidebar" aria-label={t.sampleProjects}>
                 <nav>
                   <ul class="demo-nav-list">
                     <li>
@@ -646,7 +629,7 @@ const replayFilters = [
               <aside class="demo-replay-sidebar">
                 <fieldset class="demo-toc">
                   <legend>Session TOC</legend>
-                  <div role="group" aria-label={labels.filters}>
+                  <div role="group" aria-label={t.filters}>
                     {replayFilters.map((filter) => (
                       <label>
                         <input
@@ -691,9 +674,9 @@ const replayFilters = [
                   class="sr-only"
                   aria-live="polite"
                   data-replay-status
-                  data-status-template={labels.visibleStatus}
+                  data-status-template={t.visibleStatus}
                 >
-                  {labels.visibleStatus.replace("{count}", "3")}
+                  {t.visibleStatus.replace("{count}", "3")}
                 </span>
                 <ol id={`${id}-messages`} class="demo-message-list">
                   <li data-replay-item="user" data-replay-message>
@@ -869,6 +852,8 @@ const replayFilters = [
   function initializeOverviewDemo(root: HTMLElement) {
     const source = root.querySelector<HTMLScriptElement>("[data-demo-ranges]");
     if (!source?.textContent) return;
+    const sampleSessionsTemplate =
+      root.dataset.sampleSessionsTemplate ?? "{label}: {count} sample sessions";
 
     let ranges: Record<string, DemoRange>;
     try {
@@ -919,7 +904,9 @@ const replayFilters = [
         if (label) label.textContent = bar.label;
         item.setAttribute(
           "aria-label",
-          `${bar.label}: ${bar.value} sample sessions`,
+          sampleSessionsTemplate
+            .replace("{label}", bar.label)
+            .replace("{count}", String(bar.value)),
         );
       });
 

--- a/apps/www/src/components/ProductShowcase.astro
+++ b/apps/www/src/components/ProductShowcase.astro
@@ -7,56 +7,26 @@ interface Props {
 }
 
 const { locale } = Astro.props;
-const metadata = {
-  zh: [
-    {
-      number: "01 / Overview",
-      path: "apps/web / dashboard",
-      hint: "切换时间范围，观察整块面板同步重算",
-    },
-    {
-      number: "02 / Project tree",
-      path: "apps/web / project timeline",
-      hint: "展开带有 sub 标记的会话，查看子 Agent 记录",
-    },
-    {
-      number: "03 / Replay",
-      path: "apps/web / session detail",
-      hint: "展开工具调用查看输出，也可以从 TOC 隐藏消息类型",
-    },
-  ],
-  en: [
-    {
-      number: "01 / Overview",
-      path: "apps/web / dashboard",
-      hint: "Switch the time range and watch the whole panel recompute",
-    },
-    {
-      number: "02 / Project tree",
-      path: "apps/web / project timeline",
-      hint: "Expand a session marked sub to inspect its child agent work",
-    },
-    {
-      number: "03 / Replay",
-      path: "apps/web / session detail",
-      hint: "Expand tool calls for output, or use the TOC to hide message types",
-    },
-  ],
-} as const;
-
-const sceneTypes = ["overview", "projects", "replay"] as const;
-const sceneCopy = copy[locale].scenes;
-const sceneMetadata = metadata[locale];
-const scenes = [
-  { scene: sceneTypes[0], copy: sceneCopy[0], meta: sceneMetadata[0] },
-  { scene: sceneTypes[1], copy: sceneCopy[1], meta: sceneMetadata[1] },
-  { scene: sceneTypes[2], copy: sceneCopy[2], meta: sceneMetadata[2] },
+const sceneMetadata = [
+  { scene: "overview", number: "01 / Overview", path: "apps/web / dashboard" },
+  {
+    scene: "projects",
+    number: "02 / Project tree",
+    path: "apps/web / project timeline",
+  },
+  { scene: "replay", number: "03 / Replay", path: "apps/web / session detail" },
 ] as const;
+const sceneCopy = copy[locale].scenes;
+const scenes = sceneMetadata.map((meta, index) => ({
+  copy: sceneCopy[index],
+  meta,
+}));
 ---
 
 <div class="product-showcase">
   {
-    scenes.map(({ scene, copy: sceneCopy, meta }, index) => {
+    scenes.map(({ copy: sceneCopy, meta }, index) => {
+      const { scene } = meta;
       const sectionId = index === 0 ? "tour" : `tour-${scene}`;
       const headingId = `${sectionId}-heading`;
       const descriptionId = `${sectionId}-description`;
@@ -80,7 +50,7 @@ const scenes = [
                 <p id={descriptionId}>{sceneCopy?.description}</p>
                 <p class="showcase-hint">
                   <span aria-hidden="true">↓</span>
-                  {meta.hint}
+                  {sceneCopy?.hint}
                 </p>
               </div>
 

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -1,6 +1,6 @@
 import { AGENT_CATALOG } from "@codesesh/core/contract";
 
-export const locales = ["en", "zh"] as const;
+export const locales = ["en", "zh", "ja"] as const;
 
 export type Locale = (typeof locales)[number];
 
@@ -147,12 +147,22 @@ export const localeConfig = {
     siteControlsLabel: "站点控制",
     footerNavigationLabel: "页脚导航",
   },
+  ja: {
+    route: "/ja/",
+    language: "ja",
+    ogLocale: "ja_JP",
+    switchLabel: "日本語",
+    primaryNavigationLabel: "メインナビゲーション",
+    siteControlsLabel: "サイト設定",
+    footerNavigationLabel: "フッターナビゲーション",
+  },
 } satisfies Record<Locale, LocaleConfig>;
 
 const agentDisplayNames = AGENT_CATALOG.map(({ displayName }) => displayName);
 const agentCount = agentDisplayNames.length;
 const agentNamesEn = `${agentDisplayNames.slice(0, -1).join(", ")}, and ${agentDisplayNames.at(-1)}`;
 const agentNamesZh = `${agentDisplayNames.slice(0, -1).join("、")}和${agentDisplayNames.at(-1)}`;
+const agentNamesJa = agentDisplayNames.join("、");
 
 export const agents = AGENT_CATALOG.map((entry) => ({
   name: entry.displayName,
@@ -555,6 +565,216 @@ export const copy = {
       note: "MIT licensed, with session data and indexes kept local",
       docs: "Docs",
       issues: "Issues",
+    },
+  },
+  ja: {
+    meta: {
+      title: "CodeSesh：ローカルのAIコーディング履歴を検索・再生",
+      description: `CodeSeshは、${agentCount}種類のAIコーディングエージェントのローカルセッションをプロジェクト別に整理し、構造化検索、完全な再生、ローカルSQLiteインデックスを提供します。`,
+    },
+    header: {
+      tour: "製品ツアー",
+      capabilities: "機能",
+      agents: "対応エージェント",
+      faq: "FAQ",
+      github: "GitHub",
+      languageLabel: "言語",
+      themeLabel: "テーマ",
+      themeLight: "ライト",
+      themeDark: "ダーク",
+      themeSystem: "システム",
+      themeSwitchTo: "。クリックして{next}に切り替えます。",
+    },
+    hero: {
+      eyebrow: `ローカル実行 / 設定不要 / ${agentCount}エージェント`,
+      title: ["AIとの開発履歴を、", "すべてここに。"],
+      body: `CodeSeshは${agentCount}種類のAIコーディングエージェントのローカル履歴をスキャンし、1つのインデックスに集約します。プロジェクト別に整理し、構造化検索とメッセージ単位の再生を可能にします。`,
+      privacy:
+        "セッション内容とインデックスはローカルに保持されます。アカウント、クラウド同期、セッションのテレメトリは不要です。",
+      command: "npx codesesh",
+      endpoint: "http://localhost:4521",
+      agentsLabel: "セッションの読み取り元",
+      copied: "コピーしました",
+      copyFailed: "コピーできませんでした。コマンドを手動でコピーしてください。",
+      copyCommand: "コピー",
+    },
+    tour: {
+      previewLabel: "CodeSeshのインタラクティブ製品デモ",
+      sampleLabel: "サンプルデータ",
+      search: "サンプルセッションを検索",
+      range: "サンプルデータの期間",
+      overview: "概要のデモ画面",
+      projects: "プロジェクトツリーのデモ画面",
+      replay: "セッション再生のデモ画面",
+      filters: "メッセージ種別の表示と非表示を切り替える",
+      visibleStatus: "{count}件のメッセージを表示中",
+      userMessages: "ユーザーメッセージ",
+      agentResponses: "エージェントの応答",
+      toolCalls: "ツール呼び出し",
+      sampleProjects: "サンプルプロジェクト",
+      sampleSessions: "{label}：サンプルセッション{count}件",
+    },
+    scenes: [
+      {
+        title: "今週、何に時間を使ったかがひと目でわかる",
+        description:
+          "セッション、メッセージ、トークン、コスト、最近のアクティビティを1つのローカルインデックスから表示。期間を変えると、概要全体が再集計されます。",
+        hint: "期間を切り替えて、パネル全体が再集計される様子を確認",
+      },
+      {
+        title: "セッションを、本来のプロジェクトへ",
+        description:
+          "リポジトリとプロジェクト単位で履歴をまとめ、サブエージェントのセッションを親セッションの下に保持。メッセージ、トークン、コストを階層ごとに集計します。",
+        hint: "subラベルの付いたセッションを展開し、子エージェントの作業を確認",
+      },
+      {
+        title: "タスクの全工程を時系列で再現",
+        description:
+          "メッセージ、ツール呼び出し、ファイル変更を発生順に表示。種別フィルターとファイル追跡で、必要なコンテキストをすばやく見つけられます。",
+        hint: "ツール呼び出しの出力を展開し、TOCでメッセージ種別を切り替え",
+      },
+    ],
+    features: {
+      title: [
+        "取り込む、整理する、見つける、振り返る。",
+        "4つがそろって、履歴は使える資産になる。",
+      ],
+      body: "CodeSeshは、AIと進める実際の開発サイクルに沿って機能を構成しています。",
+      groups: [
+        {
+          title: "取り込む",
+          description: "異なるエージェントのローカルセッションを1つのインデックスに集約します。",
+          items: [
+            {
+              icon: "settings",
+              title: "設定不要",
+              description:
+                "コマンドを1つ実行するだけで、ファイルシステム上の対応エージェントのセッションを自動検出します。",
+            },
+            {
+              icon: "eye",
+              title: "統合タイムライン",
+              description: `${agentCount}種類のAIコーディングエージェントの履歴を1つの画面で確認できます。`,
+            },
+            {
+              icon: "timer",
+              title: "リアルタイム更新",
+              description:
+                "ローカルセッションの変更を自動的にインデックスへ反映し、画面を再起動せずに更新します。",
+            },
+          ],
+        },
+        {
+          title: "整理する",
+          description: "セッションをプロジェクト、タスク、開発コンテキストに結び付けます。",
+          items: [
+            {
+              icon: "list-tree",
+              title: "プロジェクトとセッションツリー",
+              description:
+                "リポジトリ別にグループ化し、サブエージェントのセッションを親セッションの下に保持します。",
+            },
+            {
+              icon: "tags",
+              title: "スマートタグ",
+              description:
+                "修正、リファクタリング、機能、テスト、ドキュメント、計画などの作業を自動で分類します。",
+            },
+            {
+              icon: "bookmark",
+              title: "セッションの別名",
+              description:
+                "重要なセッションに覚えやすい名前を付け、検索やブックマークでも同じ名前を使えます。",
+            },
+          ],
+        },
+        {
+          title: "見つける",
+          description: "過去の判断、手順、コンテキストを現在のタスクに呼び戻します。",
+          items: [
+            {
+              icon: "search",
+              title: "構造化グローバル検索",
+              description:
+                "タイトル、メッセージ、ツール出力、ファイルパスを検索し、プロジェクト、タグ、ツールで絞り込めます。",
+            },
+            {
+              icon: "list-tree",
+              title: "ファイルアクティビティ索引",
+              description:
+                "ファイルを起点に、そのファイルを読み取りまたは変更したセッションを探せます。",
+            },
+            {
+              icon: "keyboard",
+              title: "キーボード操作",
+              description:
+                "表示の切り替え、検索へのフォーカス、グループ間の移動をキーボードだけで行えます。",
+            },
+          ],
+        },
+        {
+          title: "振り返る",
+          description: "問題の発見から結果に至るまで、タスクの全工程を再現します。",
+          items: [
+            {
+              icon: "terminal",
+              title: "会話全体の再生",
+              description: "メッセージ、ツール呼び出し、推論ステップを発生順に確認できます。",
+            },
+            {
+              icon: "bar-chart-3",
+              title: "コストとトークンの可視化",
+              description:
+                "トークン、キャッシュヒット、記録済みコスト、モデル別の推定値を並べて確認できます。",
+            },
+            {
+              icon: "database",
+              title: "ローカルSQLiteインデックス",
+              description:
+                "1つのローカルデータベースで、高速な復元、検索、スキーマ移行を支えます。",
+            },
+          ],
+        },
+      ],
+    },
+    agents: {
+      title: ["ローカルのAIコーディング環境を", "まとめてカバー"],
+      body: "各エージェントはコアアダプターを通じて接続され、セッション、プロジェクト、検索、ファイルアクティビティを1つのインデックスに集約します。",
+    },
+    faq: {
+      title: "よくある質問",
+      body: "CodeSeshの用途、インストール方法、データの取り扱い、大規模な履歴について説明します。",
+      items: [
+        {
+          question: "CodeSeshとは何ですか？",
+          answer: `CodeSeshは、AIコーディングのセッション履歴を検出、集約、検索、再生するためのローカル開発者ツールです。${agentNamesJa}のローカル記録を、プロジェクトに結び付いた開発履歴として整理します。`,
+        },
+        {
+          question: "CodeSeshはローカルのAIセッションデータをアップロードしますか？",
+          answer:
+            "いいえ。CodeSeshはローカルSQLiteインデックスとlocalhostで動作するWeb UIを使用します。セッション内容、ファイルパス、トークン統計、記録済みコストは端末内に保持されます。アカウント、クラウド同期、セッションのテレメトリは必要ありません。",
+        },
+        {
+          question: "CodeSeshをインストールして起動するには？",
+          answer:
+            "ターミナルでnpx codeseshを実行してください。対応するローカルAIコーディングセッションをスキャンし、http://localhost:4521 でWeb UIを開きます。既定のポートが使用中の場合は、次に利用可能なポートを試します。公開版CLIにはNode.js 22以降が必要です。",
+        },
+        {
+          question: "大量の履歴があっても快適に動作しますか？",
+          answer:
+            "初回スキャンではバックフィルの進捗を保存し、中断後も再開できます。次回以降はローカルSQLiteキャッシュから復元し、ファイル監視によって変更されたセッションだけを増分更新します。長い会話は、すべてのメッセージを一度に描画せず、表示領域に合わせて仮想化されます。",
+        },
+      ],
+    },
+    cta: {
+      title: "コーディング履歴を、今すぐ取り戻そう",
+      body: "オープンソースで無料。セッションデータはローカルに保持されます。コマンド1つで、AIとの開発履歴を検索できるようになります。",
+      github: "GitHubで見る",
+    },
+    footer: {
+      note: "MITライセンス。セッションデータとインデックスはローカルに保持",
+      docs: "ドキュメント",
+      issues: "問題を報告",
     },
   },
 } satisfies Record<Locale, LandingCopy>;

--- a/apps/www/src/data/landing.ts
+++ b/apps/www/src/data/landing.ts
@@ -1,6 +1,8 @@
 import { AGENT_CATALOG } from "@codesesh/core/contract";
 
-export type Locale = "en" | "zh";
+export const locales = ["en", "zh"] as const;
+
+export type Locale = (typeof locales)[number];
 
 export type HeadingCopy = string | string[];
 
@@ -21,6 +23,7 @@ export type IconName =
 export interface ProductScene {
   title: string;
   description: string;
+  hint: string;
 }
 
 export interface FeatureItem {
@@ -73,6 +76,18 @@ interface LandingCopy {
   tour: {
     previewLabel: string;
     sampleLabel: string;
+    search: string;
+    range: string;
+    overview: string;
+    projects: string;
+    replay: string;
+    filters: string;
+    visibleStatus: string;
+    userMessages: string;
+    agentResponses: string;
+    toolCalls: string;
+    sampleProjects: string;
+    sampleSessions: string;
   };
   scenes: ProductScene[];
   features: {
@@ -103,10 +118,36 @@ interface LandingCopy {
 
 export const siteUrl = "https://codesesh.xingkaixin.me";
 
-export const localeRoutes = {
-  en: "/",
-  zh: "/zh/",
-} satisfies Record<Locale, string>;
+interface LocaleConfig {
+  route: string;
+  language: string;
+  ogLocale: string;
+  switchLabel: string;
+  primaryNavigationLabel: string;
+  siteControlsLabel: string;
+  footerNavigationLabel: string;
+}
+
+export const localeConfig = {
+  en: {
+    route: "/",
+    language: "en",
+    ogLocale: "en_US",
+    switchLabel: "EN",
+    primaryNavigationLabel: "Primary navigation",
+    siteControlsLabel: "Site controls",
+    footerNavigationLabel: "Footer navigation",
+  },
+  zh: {
+    route: "/zh/",
+    language: "zh-CN",
+    ogLocale: "zh_CN",
+    switchLabel: "中文",
+    primaryNavigationLabel: "主导航",
+    siteControlsLabel: "站点控制",
+    footerNavigationLabel: "页脚导航",
+  },
+} satisfies Record<Locale, LocaleConfig>;
 
 const agentDisplayNames = AGENT_CATALOG.map(({ displayName }) => displayName);
 const agentCount = agentDisplayNames.length;
@@ -153,22 +194,37 @@ export const copy = {
     tour: {
       previewLabel: "CodeSesh 交互式产品示例",
       sampleLabel: "示例数据",
+      search: "搜索示例会话",
+      range: "示例数据时间范围",
+      overview: "概览示例界面",
+      projects: "项目树示例界面",
+      replay: "会话回放示例界面",
+      filters: "切换消息类型的显示与隐藏",
+      visibleStatus: "当前显示 {count} 条消息",
+      userMessages: "用户消息",
+      agentResponses: "Agent 回复",
+      toolCalls: "工具调用",
+      sampleProjects: "示例项目",
+      sampleSessions: "{label}：{count} 个示例会话",
     },
     scenes: [
       {
         title: "打开就知道这周花在哪儿了",
         description:
           "会话、消息、Token、成本与最近活跃都来自同一个本地索引。切换时间窗口，概览同步重算。",
+        hint: "切换时间范围，观察整块面板同步重算",
       },
       {
         title: "会话回到它该在的项目里",
         description:
           "按仓库和项目身份归组，子 Agent 会话保留在父会话下，消息、Token 与成本按层级汇总。",
+        hint: "展开带有 sub 标记的会话，查看子 Agent 记录",
       },
       {
         title: "一次任务的完整路径逐条还原",
         description:
           "消息、工具调用和文件变更按发生顺序呈现，类型过滤与文件追踪帮助你快速定位关键上下文。",
+        hint: "展开工具调用查看输出，也可以从 TOC 隐藏消息类型",
       },
     ],
     features: {
@@ -335,22 +391,37 @@ export const copy = {
     tour: {
       previewLabel: "Interactive CodeSesh product sample",
       sampleLabel: "Sample data",
+      search: "Search sample sessions",
+      range: "Sample data time range",
+      overview: "Overview demo interface",
+      projects: "Project tree demo interface",
+      replay: "Session replay demo interface",
+      filters: "Toggle message types on or off",
+      visibleStatus: "Showing {count} messages",
+      userMessages: "User",
+      agentResponses: "Agent responses",
+      toolCalls: "Tools",
+      sampleProjects: "Sample projects",
+      sampleSessions: "{label}: {count} sample sessions",
     },
     scenes: [
       {
         title: "Open it and see where the week went",
         description:
           "Sessions, messages, tokens, cost, and recent activity come from one local index. Change the time window and the overview recomputes.",
+        hint: "Switch the time range and watch the whole panel recompute",
       },
       {
         title: "Sessions go back where they belong",
         description:
           "Group history by repository and project, keep subagent sessions under their parent, and aggregate messages, tokens, and cost by hierarchy.",
+        hint: "Expand a session marked sub to inspect its child agent work",
       },
       {
         title: "Replay the complete path of a task",
         description:
           "Read messages, tool calls, and file changes in sequence, then use type filters and file tracking to find the context that matters.",
+        hint: "Expand tool calls for output, or use the TOC to hide message types",
       },
     ],
     features: {

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -2,7 +2,13 @@
 import "@fontsource-variable/ibm-plex-sans";
 import "@fontsource-variable/jetbrains-mono";
 import "@fontsource-variable/space-grotesk";
-import { copy, localeRoutes, siteUrl, type Locale } from "../data/landing";
+import {
+  copy,
+  localeConfig,
+  locales,
+  siteUrl,
+  type Locale,
+} from "../data/landing";
 import analyticsLoader from "../scripts/analytics-loader.js?raw";
 import "../styles/global.css";
 
@@ -12,12 +18,15 @@ interface Props {
 
 const { locale } = Astro.props;
 const t = copy[locale];
-const canonicalUrl = new URL(localeRoutes[locale], siteUrl).toString();
-const englishUrl = new URL(localeRoutes.en, siteUrl).toString();
-const chineseUrl = new URL(localeRoutes.zh, siteUrl).toString();
-const language = locale === "zh" ? "zh-CN" : "en";
-const ogLocale = locale === "zh" ? "zh_CN" : "en_US";
-const ogLocaleAlternate = locale === "zh" ? "en_US" : "zh_CN";
+const currentLocale = localeConfig[locale];
+const canonicalUrl = new URL(currentLocale.route, siteUrl).toString();
+const alternateLocales = locales.map((key) => ({
+  ...localeConfig[key],
+  url: new URL(localeConfig[key].route, siteUrl).toString(),
+}));
+const ogLocaleAlternates = alternateLocales.filter(
+  (alternate) => alternate.ogLocale !== currentLocale.ogLocale,
+);
 // The token is a public-by-design client-side site ID, but it belongs in
 // deploy configuration, not source: rotating or re-pointing analytics must
 // not require a code change. A missing token disables analytics.
@@ -55,7 +64,7 @@ const jsonLd = {
       publisher: {
         "@id": `${siteUrl}/#organization`,
       },
-      inLanguage: ["en", "zh-CN"],
+      inLanguage: alternateLocales.map(({ language }) => language),
     },
     {
       "@type": "ImageObject",
@@ -72,7 +81,7 @@ const jsonLd = {
       url: canonicalUrl,
       name: t.meta.title,
       description: t.meta.description,
-      inLanguage: language,
+      inLanguage: currentLocale.language,
       isPartOf: {
         "@id": websiteId,
       },
@@ -130,7 +139,7 @@ const jsonLd = {
 ---
 
 <!doctype html>
-<html lang={language}>
+<html lang={currentLocale.language}>
   <head>
     <meta charset="UTF-8" />
     <script is:inline>
@@ -243,9 +252,22 @@ const jsonLd = {
       content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
     />
     <link rel="canonical" href={canonicalUrl} />
-    <link rel="alternate" hreflang="en" href={englishUrl} />
-    <link rel="alternate" hreflang="zh-CN" href={chineseUrl} />
-    <link rel="alternate" hreflang="x-default" href={englishUrl} />
+    <Fragment>
+      {
+        alternateLocales.map((alternate) => (
+          <link
+            rel="alternate"
+            hreflang={alternate.language}
+            href={alternate.url}
+          />
+        ))
+      }
+    </Fragment>
+    <link
+      rel="alternate"
+      hreflang="x-default"
+      href={new URL(localeConfig.en.route, siteUrl).toString()}
+    />
     <link rel="alternate" type="text/markdown" href="/index.md" />
     <link
       rel="alternate"
@@ -271,8 +293,14 @@ const jsonLd = {
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content={t.meta.title} />
     <meta property="og:site_name" content="CodeSesh" />
-    <meta property="og:locale" content={ogLocale} />
-    <meta property="og:locale:alternate" content={ogLocaleAlternate} />
+    <meta property="og:locale" content={currentLocale.ogLocale} />
+    <Fragment>
+      {
+        ogLocaleAlternates.map((alternate) => (
+          <meta property="og:locale:alternate" content={alternate.ogLocale} />
+        ))
+      }
+    </Fragment>
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={t.meta.title} />

--- a/apps/www/src/pages/ja/index.astro
+++ b/apps/www/src/pages/ja/index.astro
@@ -1,0 +1,8 @@
+---
+import LandingPage from "../../components/LandingPage.astro";
+import LandingLayout from "../../layouts/LandingLayout.astro";
+---
+
+<LandingLayout locale="ja">
+  <LandingPage locale="ja" />
+</LandingLayout>

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -127,9 +127,31 @@
     font-family: var(--font-sans);
   }
 
+  :lang(ja) .console-ui {
+    font-family:
+      "Hiragino Sans",
+      "Yu Gothic UI",
+      "Yu Gothic",
+      Meiryo,
+      "Noto Sans JP",
+      -apple-system,
+      sans-serif;
+  }
+
   .console-display {
     font-family: var(--font-display);
     letter-spacing: var(--tracking-display);
+  }
+
+  :lang(ja) .console-display {
+    font-family:
+      "Hiragino Sans",
+      "Yu Gothic UI",
+      "Yu Gothic",
+      Meiryo,
+      "Noto Sans JP",
+      -apple-system,
+      sans-serif;
   }
 
   .console-mono {
@@ -150,6 +172,11 @@
     text-wrap: balance;
     word-break: keep-all;
     overflow-wrap: normal;
+  }
+
+  :lang(ja) .landing-heading {
+    word-break: normal;
+    overflow-wrap: anywhere;
   }
 
   .landing-nav-link,

--- a/tests/e2e/www.spec.ts
+++ b/tests/e2e/www.spec.ts
@@ -7,6 +7,7 @@ const supportedAgents = AGENT_CATALOG.map(({ displayName }) => displayName);
 const locales = [
   { route: "/", language: "en", canonical: `${siteUrl}/` },
   { route: "/zh/", language: "zh-CN", canonical: `${siteUrl}/zh/` },
+  { route: "/ja/", language: "ja", canonical: `${siteUrl}/ja/` },
 ] as const;
 
 interface JsonLdNode {
@@ -44,6 +45,10 @@ for (const locale of locales) {
       "href",
       `${siteUrl}/zh/`,
     );
+    await expect(page.locator('link[rel="alternate"][hreflang="ja"]')).toHaveAttribute(
+      "href",
+      `${siteUrl}/ja/`,
+    );
     await expect(page.locator('link[rel="alternate"][hreflang="x-default"]')).toHaveAttribute(
       "href",
       `${siteUrl}/`,
@@ -55,6 +60,12 @@ for (const locale of locales) {
     await expect(page.locator('meta[name="twitter:image:alt"]')).toHaveAttribute(
       "content",
       await page.title(),
+    );
+    await expect(page.locator('meta[property="og:locale:alternate"]')).toHaveCount(2);
+    await expect(page.locator("header [role=group] a")).toHaveCount(3);
+    await expect(page.locator('header [role=group] a[aria-current="page"]')).toHaveAttribute(
+      "href",
+      locale.route,
     );
 
     const faqItems = page.locator("#faq details");
@@ -190,21 +201,23 @@ test("explores each interactive product preview", async ({ page }) => {
   await expect(tool).toContainText("buildClauses(filters)");
 });
 
-test("keeps the landing page within a 390px mobile viewport", async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto("/");
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-  });
+for (const route of ["/", "/ja/"]) {
+  test(`keeps ${route} within a 390px mobile viewport`, async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(route);
+    await page.evaluate(async () => {
+      await document.fonts.ready;
+    });
 
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
-      ),
-    )
-    .toBe(true);
-});
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+        ),
+      )
+      .toBe(true);
+  });
+}
 
 test("removes landing and product preview motion when reduced motion is requested", async ({
   page,


### PR DESCRIPTION
## Summary

- add a complete Japanese landing page at `/ja/`
- centralize locale routes, language metadata, navigation labels, and product-demo accessibility copy
- publish Japanese canonical, hreflang, Open Graph, structured data, sitemap, and `llms.txt` entries
- use Japanese system font fallbacks and keep the three-language header within mobile viewports
- extend landing-page E2E coverage to Japanese metadata, language switching, and mobile overflow

The simulated product UI remains in English to match the current CodeSesh application language; its surrounding guidance and accessibility text are localized.

## Testing

- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`
- `pnpm exec playwright test tests/e2e/www.spec.ts`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`
- visual inspection at 1440px and 390px