### PR TITLE
ci: verify CLI on Node 22.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Verify documented repository facts
         run: node scripts/check-docs-facts.mjs
 
-      - name: Smoke test CLI on minimum Node version
+      - name: Smoke test CLI on Node 22 toolchain
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == 22
         run: node packages/cli/dist/index.js --version
 
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 24]
+        node-version: ["22.0.0", 24]
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ More agents coming soon. See the [extension checklist](#extending).
 
 <!-- repo-fact:node-version:start -->
 
-- Node.js 22+ for the published CLI and building from source
+- Node.js 22+ for the published CLI; use the Node 24 toolchain pinned in `mise.toml` when
+  building from source
 
 <!-- repo-fact:node-version:end -->
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,7 +73,7 @@ CodeSesh 认为，你的会话历史属于**你** —— 你应该在一个地�
 
 <!-- repo-fact:node-version:start -->
 
-- 发布后的 CLI 和源码构建均需要 Node.js 22+
+- 发布后的 CLI 支持 Node.js 22+；源码构建请使用 `mise.toml` 固定的 Node 24 工具链
 
 <!-- repo-fact:node-version:end -->
 

--- a/apps/www/public/llms-full.txt
+++ b/apps/www/public/llms-full.txt
@@ -98,10 +98,10 @@ The command starts a local server and opens the Web UI at:
 http://localhost:4521
 ```
 
-Published CLI and source build requirement:
+Published CLI runtime and source build toolchain:
 
 <!-- repo-fact:node-version:start -->
-- Node.js 22+
+- Node.js 22+ for the published CLI; use the Node 24 toolchain pinned in mise.toml for source builds
 <!-- repo-fact:node-version:end -->
 
 Source build package manager:
@@ -129,7 +129,7 @@ CodeSesh runs on the user's machine and uses a local SQLite index with a local W
 The fastest way to start CodeSesh is running `npx codesesh` in a terminal. CodeSesh scans supported local AI coding sessions and opens the Web UI at `http://localhost:4521`; if that default port is busy, it automatically tries the next available port.
 
 <!-- repo-fact:node-version:start -->
-The published CLI and source development require Node.js 22+.
+The published CLI supports Node.js 22+. Source development uses the Node 24 toolchain pinned in mise.toml.
 <!-- repo-fact:node-version:end -->
 
 <!-- repo-fact:pnpm-version:start -->


### PR DESCRIPTION
## Summary

- run the packaged CLI smoke suite on exact Node 22.0.0
- keep repository builds on the supported Node 22 toolchain
- distinguish the published runtime floor from the pinned source-build toolchain

## Verification

- pnpm lint
- pnpm typecheck
- pnpm build
- node scripts/check-docs-facts.mjs
- packaged CLI smoke on Node 22.0.0