### PR TITLE
refactor(web): remove unused load error state

### DIFF
--- a/apps/web/src/hooks/session-store-load-state.test.ts
+++ b/apps/web/src/hooks/session-store-load-state.test.ts
@@ -49,13 +49,11 @@ describe("session store load state", () => {
       reduceSessionStoreLoad(latestLoad, {
         type: "fail",
         requestId: 1,
-        error: new Error("late failure"),
       }),
     ).toBe(latestLoad);
   });
 
-  it("records only a failure for the active in-flight request", () => {
-    const error = new Error("unavailable");
+  it("records a failure only for the active in-flight request", () => {
     const loading = reduceSessionStoreLoad(INITIAL_SESSION_STORE_LOAD_STATE, {
       type: "begin",
       requestId: 1,
@@ -64,14 +62,12 @@ describe("session store load state", () => {
     const failed = reduceSessionStoreLoad(loading, {
       type: "fail",
       requestId: 1,
-      error,
     });
 
     expect(failed).toEqual({
       status: "failed",
       requestId: 1,
       window: firstWindow,
-      error,
     });
     expect(
       reduceSessionStoreLoad(failed, {

--- a/apps/web/src/hooks/session-store-load-state.ts
+++ b/apps/web/src/hooks/session-store-load-state.ts
@@ -9,12 +9,12 @@ export type SessionStoreLoadState =
   | { status: "idle" }
   | (ActiveSessionStoreLoad & { status: "loading" })
   | (ActiveSessionStoreLoad & { status: "ready" })
-  | (ActiveSessionStoreLoad & { status: "failed"; error: unknown });
+  | (ActiveSessionStoreLoad & { status: "failed" });
 
 export type SessionStoreLoadAction =
   | (ActiveSessionStoreLoad & { type: "begin" })
   | { type: "complete"; requestId: number }
-  | { type: "fail"; requestId: number; error: unknown };
+  | { type: "fail"; requestId: number };
 
 export const INITIAL_SESSION_STORE_LOAD_STATE: SessionStoreLoadState = { status: "idle" };
 
@@ -36,6 +36,6 @@ export function reduceSessionStoreLoad(
     case "complete":
       return { ...state, status: "ready" };
     case "fail":
-      return { ...state, status: "failed", error: action.error };
+      return { ...state, status: "failed" };
   }
 }

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -295,7 +295,7 @@ export function useSessionStore() {
         return snapshot;
       } catch (error) {
         if (isCancelledError(error)) return null;
-        dispatchLoad({ type: "fail", requestId, error });
+        dispatchLoad({ type: "fail", requestId });
         throw error;
       }
     },


### PR DESCRIPTION
## Summary

- keep only lifecycle facts consumed by the session store
- avoid duplicating query failures in reducer state
- preserve original errors through the existing rejected promise

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`