### PR TITLE
build: centralize shared dependency versions

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,10 +18,10 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",
-    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
-    "@fontsource-variable/jetbrains-mono": "^5.3.0",
-    "@fontsource-variable/space-grotesk": "^5.3.0",
-    "@hugeicons/core-free-icons": "^4.2.3",
+    "@fontsource-variable/ibm-plex-sans": "catalog:",
+    "@fontsource-variable/jetbrains-mono": "catalog:",
+    "@fontsource-variable/space-grotesk": "catalog:",
+    "@hugeicons/core-free-icons": "catalog:",
     "@hugeicons/react": "^1.1.9",
     "@pierre/trees": "1.0.0-beta.6",
     "@tanstack/react-query": "^5.101.4",
@@ -39,18 +39,18 @@
   "devDependencies": {
     "@codesesh/core": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
-    "@tailwindcss/vite": "^4.3.3",
+    "@tailwindcss/vite": "catalog:",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
-    "@types/node": "22.20.1",
+    "@types/node": "catalog:",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
-    "@typescript/native": "npm:typescript@^7.0.2",
+    "@typescript/native": "catalog:",
     "@vitejs/plugin-react": "^6.0.5",
     "happy-dom": "^20.11.2",
     "postcss": "^8.5.26",
-    "tailwindcss": "^4.3.3",
-    "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "vite": "^8.2.1"
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -16,25 +16,25 @@
     "deploy:cf": "pnpm build && wrangler pages deploy dist --project-name codesesh"
   },
   "dependencies": {
-    "@fontsource-variable/ibm-plex-sans": "^5.3.0",
-    "@fontsource-variable/jetbrains-mono": "^5.3.0",
-    "@fontsource-variable/space-grotesk": "^5.3.0",
+    "@fontsource-variable/ibm-plex-sans": "catalog:",
+    "@fontsource-variable/jetbrains-mono": "catalog:",
+    "@fontsource-variable/space-grotesk": "catalog:",
     "astro": "^7.2.2"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",
     "@codesesh/core": "workspace:*",
-    "@hugeicons/core-free-icons": "^4.2.3",
-    "@tailwindcss/vite": "^4.3.3",
-    "@types/node": "22.20.1",
+    "@hugeicons/core-free-icons": "catalog:",
+    "@tailwindcss/vite": "catalog:",
+    "@types/node": "catalog:",
     "eslint": "10.8.1",
     "eslint-plugin-astro": "3.1.0",
     "eslint-plugin-jsx-a11y": "6.10.2",
     "prettier": "3.9.6",
     "prettier-plugin-astro": "0.14.1",
-    "tailwindcss": "^4.3.3",
-    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
     "typescript-eslint": "8.67.0",
-    "vite": "^8.2.1"
+    "vite": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
   },
   "devDependencies": {
     "@codesesh/core": "workspace:*",
-    "@types/node": "22.20.1",
-    "@typescript/native": "npm:typescript@^7.0.2",
+    "@types/node": "catalog:",
+    "@typescript/native": "catalog:",
     "@vitest/coverage-v8": "^4.1.10",
     "oxfmt": "^0.63.0",
     "oxlint": "^1.78.0",
     "playwright": "^1.62.1",
     "turbo": "^2.10.10",
-    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "typescript": "catalog:",
     "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@11.20.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@codesesh/core": "workspace:*",
     "@hono/node-server": "^2.1.1",
-    "better-sqlite3": "^13.0.3",
+    "better-sqlite3": "catalog:",
     "citty": "^0.2.2",
     "consola": "^3.4.2",
     "hono": "^4.13.2",
@@ -60,10 +60,10 @@
   },
   "devDependencies": {
     "@codesesh/web": "workspace:*",
-    "@types/node": "22.20.1",
-    "@typescript/native": "npm:typescript@^7.0.2",
-    "tsup": "^8.5.1",
-    "typescript": "npm:@typescript/typescript6@^6.0.2"
+    "@types/node": "catalog:",
+    "@typescript/native": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,13 +43,13 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^9.6.0",
-    "@types/node": "22.20.1",
-    "@typescript/native": "npm:typescript@^7.0.2",
+    "@types/node": "catalog:",
+    "@typescript/native": "catalog:",
     "node-gyp": "^13.0.1",
-    "tsup": "^8.5.1",
-    "typescript": "npm:@typescript/typescript6@^6.0.2"
+    "tsup": "catalog:",
+    "typescript": "catalog:"
   },
   "dependencies": {
-    "better-sqlite3": "^13.0.3"
+    "better-sqlite3": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,45 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@fontsource-variable/ibm-plex-sans':
+      specifier: ^5.3.0
+      version: 5.3.0
+    '@fontsource-variable/jetbrains-mono':
+      specifier: ^5.3.0
+      version: 5.3.0
+    '@fontsource-variable/space-grotesk':
+      specifier: ^5.3.0
+      version: 5.3.0
+    '@hugeicons/core-free-icons':
+      specifier: ^4.2.3
+      version: 4.2.3
+    '@tailwindcss/vite':
+      specifier: ^4.3.3
+      version: 4.3.3
+    '@types/node':
+      specifier: 22.20.1
+      version: 22.20.1
+    '@typescript/native':
+      specifier: npm:typescript@^7.0.2
+      version: 7.0.2
+    better-sqlite3:
+      specifier: ^13.0.3
+      version: 13.0.3
+    tailwindcss:
+      specifier: ^4.3.3
+      version: 4.3.3
+    tsup:
+      specifier: ^8.5.1
+      version: 8.5.1
+    typescript:
+      specifier: npm:@typescript/typescript6@^6.0.2
+      version: 6.0.2
+    vite:
+      specifier: ^8.2.1
+      version: 8.2.1
+
 overrides:
   esbuild@>=0.27.3 <0.28.1: 0.28.2
   nanoid@<3.3.18: ^3.3.18
@@ -16,10 +55,10 @@ importers:
         specifier: workspace:*
         version: link:packages/core
       '@types/node':
-        specifier: 22.20.1
+        specifier: 'catalog:'
         version: 22.20.1
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: 'catalog:'
         version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: ^4.1.10
@@ -37,7 +76,7 @@ importers:
         specifier: ^2.10.10
         version: 2.10.10
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
+        specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: ^4.1.10
@@ -49,16 +88,16 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(@types/react@19.2.18)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource-variable/ibm-plex-sans':
-        specifier: ^5.3.0
+        specifier: 'catalog:'
         version: 5.3.0
       '@fontsource-variable/jetbrains-mono':
-        specifier: ^5.3.0
+        specifier: 'catalog:'
         version: 5.3.0
       '@fontsource-variable/space-grotesk':
-        specifier: ^5.3.0
+        specifier: 'catalog:'
         version: 5.3.0
       '@hugeicons/core-free-icons':
-        specifier: ^4.2.3
+        specifier: 'catalog:'
         version: 4.2.3
       '@hugeicons/react':
         specifier: ^1.1.9
@@ -107,7 +146,7 @@ importers:
         specifier: ^4.3.3
         version: 4.3.3
       '@tailwindcss/vite':
-        specifier: ^4.3.3
+        specifier: 'catalog:'
         version: 4.3.3(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       '@testing-library/dom':
         specifier: ^10.4.1
@@ -116,7 +155,7 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
-        specifier: 22.20.1
+        specifier: 'catalog:'
         version: 22.20.1
       '@types/react':
         specifier: ^19.2.18
@@ -125,7 +164,7 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: 'catalog:'
         version: typescript@7.0.2
       '@vitejs/plugin-react':
         specifier: ^6.0.5
@@ -137,25 +176,25 @@ importers:
         specifier: ^8.5.26
         version: 8.5.26
       tailwindcss:
-        specifier: ^4.3.3
+        specifier: 'catalog:'
         version: 4.3.3
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
+        specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
 
   apps/www:
     dependencies:
       '@fontsource-variable/ibm-plex-sans':
-        specifier: ^5.3.0
+        specifier: 'catalog:'
         version: 5.3.0
       '@fontsource-variable/jetbrains-mono':
-        specifier: ^5.3.0
+        specifier: 'catalog:'
         version: 5.3.0
       '@fontsource-variable/space-grotesk':
-        specifier: ^5.3.0
+        specifier: 'catalog:'
         version: 5.3.0
       astro:
         specifier: ^7.2.2
@@ -168,13 +207,13 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@hugeicons/core-free-icons':
-        specifier: ^4.2.3
+        specifier: 'catalog:'
         version: 4.2.3
       '@tailwindcss/vite':
-        specifier: ^4.3.3
+        specifier: 'catalog:'
         version: 4.3.3(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       '@types/node':
-        specifier: 22.20.1
+        specifier: 'catalog:'
         version: 22.20.1
       eslint:
         specifier: 10.8.1
@@ -192,16 +231,16 @@ importers:
         specifier: 0.14.1
         version: 0.14.1
       tailwindcss:
-        specifier: ^4.3.3
+        specifier: 'catalog:'
         version: 4.3.3
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
+        specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
       typescript-eslint:
         specifier: 8.67.0
         version: 8.67.0(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
       vite:
-        specifier: ^8.2.1
+        specifier: 'catalog:'
         version: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
 
   packages/cli:
@@ -213,7 +252,7 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(hono@4.13.2)
       better-sqlite3:
-        specifier: ^13.0.3
+        specifier: 'catalog:'
         version: 13.0.3
       citty:
         specifier: ^0.2.2
@@ -232,41 +271,41 @@ importers:
         specifier: workspace:*
         version: link:../../apps/web
       '@types/node':
-        specifier: 22.20.1
+        specifier: 'catalog:'
         version: 22.20.1
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: 'catalog:'
         version: typescript@7.0.2
       tsup:
-        specifier: ^8.5.1
+        specifier: 'catalog:'
         version: 8.5.1(@typescript/typescript6@6.0.2)(jiti@2.7.0)(postcss@8.5.26)(supports-color@7.2.0)(yaml@2.9.0)
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
+        specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
   packages/core:
     dependencies:
       better-sqlite3:
-        specifier: ^13.0.3
+        specifier: 'catalog:'
         version: 13.0.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^9.6.0
         version: 9.6.0
       '@types/node':
-        specifier: 22.20.1
+        specifier: 'catalog:'
         version: 22.20.1
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: 'catalog:'
         version: typescript@7.0.2
       node-gyp:
         specifier: ^13.0.1
         version: 13.0.1
       tsup:
-        specifier: ^8.5.1
+        specifier: 'catalog:'
         version: 8.5.1(@typescript/typescript6@6.0.2)(jiti@2.7.0)(postcss@8.5.26)(supports-color@7.2.0)(yaml@2.9.0)
       typescript:
-        specifier: npm:@typescript/typescript6@^6.0.2
+        specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,20 @@ packages:
   - "packages/*"
   - "apps/*"
 
+catalog:
+  "@fontsource-variable/ibm-plex-sans": ^5.3.0
+  "@fontsource-variable/jetbrains-mono": ^5.3.0
+  "@fontsource-variable/space-grotesk": ^5.3.0
+  "@hugeicons/core-free-icons": ^4.2.3
+  "@tailwindcss/vite": ^4.3.3
+  "@types/node": 22.20.1
+  "@typescript/native": npm:typescript@^7.0.2
+  better-sqlite3: ^13.0.3
+  tailwindcss: ^4.3.3
+  tsup: ^8.5.1
+  typescript: npm:@typescript/typescript6@^6.0.2
+  vite: ^8.2.1
+
 allowBuilds:
   better-sqlite3: true
   esbuild: true

--- a/scripts/package-artifact-checks.mjs
+++ b/scripts/package-artifact-checks.mjs
@@ -4,7 +4,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
-  assertNoWorkspaceReferences,
+  assertNoLocalDependencyReferences,
   createPublishManifest,
   validatePackedFiles,
 } from "./package-artifact.mjs";
@@ -14,6 +14,9 @@ const sourceManifest = JSON.parse(
   readFileSync(resolve(scriptDir, "../packages/cli/package.json"), "utf8"),
 );
 const publishedReadme = readFileSync(resolve(scriptDir, "../packages/cli/README.md"), "utf8");
+const catalog = {
+  "better-sqlite3": "^13.0.3",
+};
 const validFiles = [
   "README.md",
   "package.json",
@@ -28,12 +31,17 @@ const validFiles = [
 
 test("creates an installable publish manifest without mutating the source", () => {
   const source = structuredClone(sourceManifest);
-  const publish = createPublishManifest(source);
+  const publish = createPublishManifest(source, catalog);
 
   assert.equal(publish.dependencies["@codesesh/core"], undefined);
-  assert.equal(publish.devDependencies["@codesesh/web"], undefined);
-  assertNoWorkspaceReferences(publish);
+  assert.equal(publish.dependencies["better-sqlite3"], catalog["better-sqlite3"]);
+  assert.equal(publish.devDependencies, undefined);
+  assertNoLocalDependencyReferences(publish);
   assert.deepEqual(source, sourceManifest);
+});
+
+test("rejects unresolved catalog dependencies", () => {
+  assert.throws(() => createPublishManifest(sourceManifest, {}), /better-sqlite3/);
 });
 
 test("accepts the complete npm artifact allowlist", () => {

--- a/scripts/package-artifact.mjs
+++ b/scripts/package-artifact.mjs
@@ -47,18 +47,29 @@ function run(executable, args, options = {}) {
   });
 }
 
-function isWorkspaceReference(value) {
-  return typeof value === "string" && value.startsWith("workspace:");
+function isLocalDependencyReference(value) {
+  return (
+    typeof value === "string" && (value.startsWith("workspace:") || value.startsWith("catalog:"))
+  );
 }
 
-export function createPublishManifest(source) {
+export function createPublishManifest(source, catalog) {
   const manifest = structuredClone(source);
+  delete manifest.devDependencies;
   for (const field of dependencyFields) {
     const dependencies = manifest[field];
     if (!dependencies || typeof dependencies !== "object") continue;
     for (const [name, value] of Object.entries(dependencies)) {
-      if (!isWorkspaceReference(value)) continue;
-      if (field === "devDependencies" || name === "@codesesh/core") {
+      if (typeof value === "string" && value.startsWith("catalog:")) {
+        const catalogValue = catalog[name];
+        if (value !== "catalog:" || typeof catalogValue !== "string") {
+          throw new Error(`Cannot resolve catalog dependency ${name} from ${field}`);
+        }
+        dependencies[name] = catalogValue;
+        continue;
+      }
+      if (typeof value !== "string" || !value.startsWith("workspace:")) continue;
+      if (name === "@codesesh/core") {
         delete dependencies[name];
         continue;
       }
@@ -68,11 +79,11 @@ export function createPublishManifest(source) {
   return manifest;
 }
 
-export function assertNoWorkspaceReferences(manifest) {
+export function assertNoLocalDependencyReferences(manifest) {
   for (const field of dependencyFields) {
     for (const [name, value] of Object.entries(manifest[field] ?? {})) {
-      if (isWorkspaceReference(value)) {
-        throw new Error(`Packed manifest contains workspace dependency ${field}.${name}`);
+      if (isLocalDependencyReference(value)) {
+        throw new Error(`Packed manifest contains local dependency reference ${field}.${name}`);
       }
     }
   }
@@ -133,8 +144,14 @@ function packPackage() {
     cpSync(join(cliDir, "dist"), join(stageDir, "dist"), { recursive: true });
     cpSync(join(cliDir, "README.md"), join(stageDir, "README.md"));
     const sourceManifest = JSON.parse(readFileSync(join(cliDir, "package.json"), "utf8"));
-    const publishManifest = createPublishManifest(sourceManifest);
-    assertNoWorkspaceReferences(publishManifest);
+    const catalog = JSON.parse(
+      execFileSync(command("pnpm"), ["config", "get", "catalog"], {
+        cwd: rootDir,
+        encoding: "utf8",
+      }),
+    );
+    const publishManifest = createPublishManifest(sourceManifest, catalog);
+    assertNoLocalDependencyReferences(publishManifest);
     writeFileSync(join(stageDir, "package.json"), `${JSON.stringify(publishManifest, null, 2)}\n`);
 
     if (relative(rootDir, artifactDir) !== "artifacts/npm") {

--- a/scripts/smoke-package-artifact.mjs
+++ b/scripts/smoke-package-artifact.mjs
@@ -104,8 +104,9 @@ function assertInstalledManifest(manifest) {
   ]) {
     for (const [name, value] of Object.entries(manifest[field] ?? {})) {
       assert(
-        typeof value !== "string" || !value.startsWith("workspace:"),
-        `Installed manifest leaked ${field}.${name}`,
+        typeof value !== "string" ||
+          (!value.startsWith("workspace:") && !value.startsWith("catalog:")),
+        `Installed manifest leaked local dependency reference ${field}.${name}`,
       );
     }
   }


### PR DESCRIPTION
## Summary

- define one pnpm catalog for dependencies shared across workspace packages
- replace repeated manifest versions with catalog references
- preserve every resolved dependency version in the lockfile

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- repository quality, documentation, release, and performance checks