### PR TITLE
fix(cache): Unify session row deletion

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -64,6 +64,19 @@ const CACHE_DATA_TABLES = [
   "project_sessions",
 ] as const;
 
+const SESSION_OWNED_DATA_TABLES = [
+  "cached_sessions",
+  "pending_reindex",
+  "session_documents",
+  "session_file_activity",
+  "message_tools",
+  "messages",
+  "session_model_cost",
+  "session_cost_summary",
+  "sessions",
+  "project_sessions",
+] as const;
+
 function getCacheDir(): string {
   return join(testHomeDir, ".cache", "codesesh");
 }
@@ -176,6 +189,58 @@ function emptyCacheDataTableCounts(): Record<(typeof CACHE_DATA_TABLES)[number],
     (typeof CACHE_DATA_TABLES)[number],
     number
   >;
+}
+
+function seedSessionOwnedRows(): void {
+  saveCachedSessions("claudecode", [makeSession("removed")]);
+  withCacheDb((db) => {
+    db.exec(`
+      INSERT INTO cached_sessions(agent_name, session_id, session_json)
+      VALUES ('claudecode', 'removed', '{}');
+      INSERT INTO pending_reindex(agent_name, session_id)
+      VALUES ('claudecode', 'removed');
+      INSERT INTO session_documents(
+        agent_name, session_id, title, content_text, content_hash,
+        indexed_message_count, detail_version, indexed_at
+      ) VALUES ('claudecode', 'removed', 'title', 'content', 'hash', 1, 'detail-v1', ${now});
+      INSERT INTO messages(
+        agent_name, session_id, message_index, message_id, role, time_created,
+        parts_json, content_text
+      ) VALUES ('claudecode', 'removed', 0, 'message-1', 'assistant', ${now}, '[]', 'content');
+      INSERT INTO message_tools(agent_name, session_id, message_index, tool_name)
+      VALUES ('claudecode', 'removed', 0, 'write');
+      INSERT INTO session_model_cost(
+        agent_name, session_id, model, cost, cost_recorded
+      ) VALUES ('claudecode', 'removed', 'test-model', 1, 1);
+      INSERT INTO session_cost_summary(
+        agent_name, session_id, message_cost, untimed_message_cost
+      ) VALUES ('claudecode', 'removed', 1, 0);
+      INSERT INTO session_file_activity(
+        agent_name, session_id, project_identity_key, path, kind, count, latest_time
+      ) VALUES ('claudecode', 'removed', '${FIXTURE_DIR}', 'src/index.ts', 'write', 1, ${now});
+      INSERT INTO project_sessions(
+        agent_name, session_id, identity_kind, identity_key, display_name,
+        directory, activity_time
+      ) VALUES (
+        'claudecode', 'removed', 'path', '${FIXTURE_DIR}', '${FIXTURE_DIR_NAME}',
+        '${FIXTURE_DIR}', ${now}
+      );
+    `);
+  });
+}
+
+function sessionOwnedDataTableCounts(): Record<(typeof SESSION_OWNED_DATA_TABLES)[number], number> {
+  return withCacheDb(
+    (db) =>
+      Object.fromEntries(
+        SESSION_OWNED_DATA_TABLES.map((table) => {
+          const row = db.prepare(`SELECT COUNT(*) AS value FROM ${table}`).get() as {
+            value?: number;
+          };
+          return [table, Number(row.value ?? 0)];
+        }),
+      ) as Record<(typeof SESSION_OWNED_DATA_TABLES)[number], number>,
+  )!;
 }
 
 beforeEach(() => {
@@ -675,6 +740,27 @@ describe("saveCachedSessions", () => {
 
     expect(loadCachedSessions("claudecode")).toBeNull();
     expect(getMigrationBackups()).toEqual([]);
+  });
+});
+
+describe("session removal", () => {
+  it.each([
+    {
+      name: "complete snapshot",
+      remove: () => saveCachedSessions("claudecode", []),
+    },
+    {
+      name: "incremental changes",
+      remove: () => saveCachedSessionChanges("claudecode", [], ["removed"]),
+    },
+  ])("removes every session-owned row through $name", ({ remove }) => {
+    seedSessionOwnedRows();
+
+    expect(remove()).toBe(true);
+
+    expect(sessionOwnedDataTableCounts()).toEqual(
+      Object.fromEntries(SESSION_OWNED_DATA_TABLES.map((table) => [table, 0])),
+    );
   });
 });
 

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -42,6 +42,18 @@ import { fileActivityFromRow, type FileActivityRow } from "./file-activity.js";
 export const CACHE_INITIALIZATION_VERSION = "session-cache-v2";
 const FULL_SYNC_CURSOR_PREFIX = "full_sync_cursor:";
 const SESSION_REFERENCE_QUERY_CHUNK_SIZE = 400;
+const SESSION_ROW_DELETE_ORDER = [
+  "pending_reindex",
+  "session_documents",
+  "message_tools",
+  "messages",
+  "session_model_cost",
+  "session_cost_summary",
+  "session_file_activity",
+  "cached_sessions",
+  "project_sessions",
+  "sessions",
+] as const;
 const SESSION_HEAD_SELECT_COLUMNS = `
   s.agent_name,
   s.session_id,
@@ -623,23 +635,6 @@ export function writeCachedSessionSnapshot(
   options: SaveCachedSessionsOptions = {},
 ): void {
   const completeness = options.completeness ?? "complete";
-  const deleteSession = db.prepare("DELETE FROM sessions WHERE agent_name = ? AND session_id = ?");
-  const deleteSearchDocument = db.prepare(
-    "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteMessages = db.prepare("DELETE FROM messages WHERE agent_name = ? AND session_id = ?");
-  const deleteModelCost = db.prepare(
-    "DELETE FROM session_model_cost WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteCostSummary = db.prepare(
-    "DELETE FROM session_cost_summary WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteMessageTools = db.prepare(
-    "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteFileActivity = db.prepare(
-    "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
-  );
   const upsertAgent = db.prepare(`
     INSERT INTO agent_cache(agent_name, timestamp)
     VALUES (?, ?)
@@ -660,15 +655,7 @@ export function writeCachedSessionSnapshot(
       if (!sessionIds.has(sessionId)) sessionIdsToDelete.add(sessionId);
     }
   }
-  for (const sessionId of sessionIdsToDelete) {
-    deleteSearchDocument.run(agentName, sessionId);
-    deleteMessageTools.run(agentName, sessionId);
-    deleteMessages.run(agentName, sessionId);
-    deleteModelCost.run(agentName, sessionId);
-    deleteCostSummary.run(agentName, sessionId);
-    deleteFileActivity.run(agentName, sessionId);
-    deleteSession.run(agentName, sessionId);
-  }
+  deleteCachedSessionRows(db, agentName, sessionIdsToDelete);
 
   sessions.forEach((session, index) => {
     const sessionMeta = meta[session.reference.sessionId];
@@ -719,23 +706,6 @@ export function writeCachedSessionChanges(
   removedSessionIds: string[],
   meta: Record<string, SessionCacheMeta> = {},
 ): void {
-  const deleteSession = db.prepare("DELETE FROM sessions WHERE agent_name = ? AND session_id = ?");
-  const deleteSearchDocument = db.prepare(
-    "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteMessages = db.prepare("DELETE FROM messages WHERE agent_name = ? AND session_id = ?");
-  const deleteModelCost = db.prepare(
-    "DELETE FROM session_model_cost WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteCostSummary = db.prepare(
-    "DELETE FROM session_cost_summary WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteMessageTools = db.prepare(
-    "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteFileActivity = db.prepare(
-    "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
-  );
   const upsertAgent = db.prepare(`
     INSERT INTO agent_cache(agent_name, timestamp)
     VALUES (?, ?)
@@ -745,15 +715,7 @@ export function writeCachedSessionChanges(
 
   upsertAgent.run(agentName, Date.now());
 
-  for (const sessionId of new Set(removedSessionIds)) {
-    deleteSearchDocument.run(agentName, sessionId);
-    deleteMessageTools.run(agentName, sessionId);
-    deleteMessages.run(agentName, sessionId);
-    deleteModelCost.run(agentName, sessionId);
-    deleteCostSummary.run(agentName, sessionId);
-    deleteFileActivity.run(agentName, sessionId);
-    deleteSession.run(agentName, sessionId);
-  }
+  deleteCachedSessionRows(db, agentName, removedSessionIds);
 
   for (const { session, sortIndex } of changes) {
     const sessionId = session.reference.sessionId;
@@ -773,6 +735,19 @@ export function writeCachedSessionChanges(
       sortIndex,
       sourcePathFromMeta(sessionMeta),
     );
+  }
+}
+
+function deleteCachedSessionRows(
+  db: SQLiteDatabase,
+  agentName: string,
+  sessionIds: Iterable<string>,
+): void {
+  const deleteStatements = SESSION_ROW_DELETE_ORDER.map((table) =>
+    db.prepare(`DELETE FROM ${table} WHERE agent_name = ? AND session_id = ?`),
+  );
+  for (const sessionId of new Set(sessionIds)) {
+    for (const statement of deleteStatements) statement.run(agentName, sessionId);
   }
 }
 


### PR DESCRIPTION
## Summary

- route full-snapshot and incremental session removals through one ordered deletion path
- remove pending reindex markers and legacy session projections with their owning session
- verify every session-owned cache table is cleared through both write paths

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`