### PR TITLE
fix(web): Reuse dashboard query cache

### DIFF
--- a/apps/web/src/hooks/useDashboard.test.ts
+++ b/apps/web/src/hooks/useDashboard.test.ts
@@ -75,6 +75,9 @@ describe("useDashboard", () => {
       JSON.stringify(queryKeys.dashboard(window, scope)),
     );
     expect(new Set(keys).size).toBe(keys.length);
+    expect(queryKeys.dashboard(window, globalScope)).toEqual(
+      queryKeys.dashboard(window, { project: undefined, agent: undefined }),
+    );
   });
 
   it("ignores an earlier response after the dashboard scope changes", async () => {

--- a/apps/web/src/hooks/useDashboard.ts
+++ b/apps/web/src/hooks/useDashboard.ts
@@ -1,12 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
-import {
-  type AppConfig,
-  type DashboardData,
-  type DashboardFilters,
-  fetchDashboard,
-} from "../lib/api";
-import { queryKeys } from "../lib/query-keys";
+import { type AppConfig, type DashboardData, type DashboardFilters } from "../lib/api";
+import { dashboardQueryOptions } from "../lib/dashboard-query";
 
 export type { DashboardFilters };
 
@@ -22,17 +17,8 @@ export function useDashboard(
   const isEnabled = window !== null;
 
   const query = useQuery({
-    queryKey: queryKeys.dashboard(window ?? {}, filters),
+    ...dashboardQueryOptions(window ?? {}, filters),
     enabled: isEnabled,
-    queryFn: async ({ signal }) => {
-      if (!window) throw new Error("Dashboard window is required");
-      try {
-        return await fetchDashboard(window, filters, { signal });
-      } catch (error) {
-        if (!signal.aborted) console.error("Failed to load dashboard:", error);
-        throw error;
-      }
-    },
   });
   const refetch = query.refetch;
   const retry = useCallback(async () => {

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -22,6 +22,7 @@ import {
   type SessionProjection,
   type SessionStoreSnapshot,
 } from "./useSessionStore";
+import { useDashboard } from "./useDashboard";
 
 vi.mock("../lib/api", () => ({
   fetchAgents: vi.fn(),
@@ -196,6 +197,21 @@ describe("useSessionStore", () => {
     expect(result.current.validAgentKeys.has("codex")).toBe(false);
     expect(result.current.agentNameMap.get("claudecode")).toBe("Claude Code");
     expect(result.current.version).toBeGreaterThan(0);
+  });
+
+  it("shares the global dashboard query with dashboard consumers", async () => {
+    const { Wrapper } = createQueryWrapper();
+    const store = renderHook(() => useSessionStore(), { wrapper: Wrapper });
+    await waitFor(() => expect(store.result.current.config).toEqual(config));
+    await act(() => store.result.current.reload(config.window));
+
+    const dashboard = renderHook(
+      () => useDashboard(config.window, { project: undefined, agent: undefined }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(dashboard.result.current.dashboard).toEqual(SAMPLE_DASHBOARD_DATA));
+    expect(api.fetchDashboard).toHaveBeenCalledOnce();
   });
 
   it("renders the first session page while the complete window keeps loading", async () => {
@@ -419,13 +435,10 @@ describe("useSessionStore", () => {
       project: { kind: "path", key: "p1" },
     });
     const searchKey = queryKeys.search("needle", {});
-    const inactiveAggregateKey = queryKeys.sessionAggregate({ from: 10, to: 20 });
+    const inactiveAgentCatalogKey = queryKeys.agentCatalog({ from: 10, to: 20 });
     client.setQueryData(projectDashboardKey, SAMPLE_DASHBOARD_DATA);
     client.setQueryData(searchKey, []);
-    client.setQueryData(inactiveAggregateKey, {
-      agents,
-      dashboard: SAMPLE_DASHBOARD_DATA,
-    });
+    client.setQueryData(inactiveAgentCatalogKey, agents);
     now += 2_001;
 
     await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
@@ -434,7 +447,7 @@ describe("useSessionStore", () => {
       expect(client.getQueryState(projectDashboardKey)?.isInvalidated).toBe(true),
     );
     await waitFor(() => expect(client.getQueryState(searchKey)?.isInvalidated).toBe(true));
-    expect(client.getQueryState(inactiveAggregateKey)?.isInvalidated).toBe(false);
+    expect(client.getQueryState(inactiveAgentCatalogKey)?.isInvalidated).toBe(false);
   });
 
   it("invalidates only session details changed by a live event", async () => {
@@ -578,6 +591,7 @@ describe("useSessionStore", () => {
 
   it("keeps the projection available when a live aggregate refresh fails", async () => {
     const error = new Error("dashboard unavailable");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
     let now = Date.now();
     vi.spyOn(Date, "now").mockImplementation(() => now);
     const { result } = await renderStore();

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -19,11 +19,11 @@ import {
   type SessionsUpdatedEvent,
   fetchAgents,
   fetchConfig,
-  fetchDashboard,
   fetchProjects,
   fetchSessions,
 } from "../lib/api";
 import { createAgentCatalog } from "../lib/agents";
+import { DASHBOARD_STALE_TIME_MS, dashboardQueryOptions } from "../lib/dashboard-query";
 import { queryKeys } from "../lib/query-keys";
 import {
   invalidateLiveSessionCollections,
@@ -63,7 +63,7 @@ interface ActiveLoadRequest {
   window: AppConfig["window"];
 }
 
-const LIVE_AGGREGATE_REFRESH_INTERVAL_MS = 2_000;
+const LIVE_AGGREGATE_REFRESH_INTERVAL_MS = DASHBOARD_STALE_TIME_MS;
 const EMPTY_PROJECTS: ApiProjectGroup[] = [];
 const EMPTY_PROJECT_PAGE: ApiProjectPage = {
   projects: EMPTY_PROJECTS,
@@ -91,23 +91,23 @@ function projectsOptions(window: AppConfig["window"]) {
   });
 }
 
-async function fetchSnapshotAggregates(
-  window: AppConfig["window"],
-  signal: AbortSignal,
-): Promise<SnapshotAggregates> {
-  const [agents, dashboard] = await Promise.all([
-    fetchAgents(window, { signal }),
-    fetchDashboard(window, {}, { signal }),
-  ]);
-  return { window, agents, dashboard };
-}
-
-function snapshotAggregatesOptions(window: AppConfig["window"]) {
+function agentCatalogOptions(window: AppConfig["window"]) {
   return queryOptions({
-    queryKey: queryKeys.sessionAggregate(window),
-    queryFn: ({ signal }) => fetchSnapshotAggregates(window, signal),
+    queryKey: queryKeys.agentCatalog(window),
+    queryFn: ({ signal }) => fetchAgents(window, { signal }),
     staleTime: LIVE_AGGREGATE_REFRESH_INTERVAL_MS,
   });
+}
+
+async function fetchSnapshotAggregates(
+  queryClient: QueryClient,
+  window: AppConfig["window"],
+): Promise<SnapshotAggregates> {
+  const [agents, dashboard] = await Promise.all([
+    queryClient.fetchQuery(agentCatalogOptions(window)),
+    queryClient.fetchQuery(dashboardQueryOptions(window, {})),
+  ]);
+  return { window, agents, dashboard };
 }
 
 function sessionProjectionOptions(
@@ -156,26 +156,31 @@ async function fetchLiveSnapshotAggregates(
   window: AppConfig["window"],
   forceRefresh: boolean,
 ): Promise<SnapshotAggregates> {
-  const options = snapshotAggregatesOptions(window);
-  const state = queryClient.getQueryState(options.queryKey);
+  const agentOptions = agentCatalogOptions(window);
+  const dashboardOptions = dashboardQueryOptions(window, {});
+  const agentState = queryClient.getQueryState(agentOptions.queryKey);
+  const dashboardState = queryClient.getQueryState(dashboardOptions.queryKey);
   const needsRefresh =
     forceRefresh ||
-    !state ||
-    state.data === undefined ||
-    state.isInvalidated ||
-    Date.now() - state.dataUpdatedAt >= LIVE_AGGREGATE_REFRESH_INTERVAL_MS;
-  if (forceRefresh) {
-    await queryClient.invalidateQueries({
-      queryKey: options.queryKey,
-      exact: true,
-      refetchType: "none",
-    });
+    !agentState ||
+    agentState.data === undefined ||
+    agentState.isInvalidated ||
+    Date.now() - agentState.dataUpdatedAt >= LIVE_AGGREGATE_REFRESH_INTERVAL_MS ||
+    !dashboardState ||
+    dashboardState.data === undefined ||
+    dashboardState.isInvalidated ||
+    Date.now() - dashboardState.dataUpdatedAt >= LIVE_AGGREGATE_REFRESH_INTERVAL_MS;
+  if (needsRefresh) {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: agentOptions.queryKey,
+        exact: true,
+        refetchType: "none",
+      }),
+      invalidateLiveSessionCollections(queryClient),
+    ]);
   }
-  const [aggregates] = await Promise.all([
-    queryClient.fetchQuery(options),
-    needsRefresh ? invalidateLiveSessionCollections(queryClient) : Promise.resolve(),
-  ]);
-  return aggregates;
+  return fetchSnapshotAggregates(queryClient, window);
 }
 
 function refreshLiveProjects(queryClient: QueryClient, window: AppConfig["window"]): void {
@@ -230,8 +235,12 @@ export function useSessionStore() {
     ...sessionProjectionOptions(requestedWindow ?? {}),
     enabled: false,
   });
-  const aggregatesQuery = useQuery({
-    ...snapshotAggregatesOptions(requestedWindow ?? {}),
+  const agentsQuery = useQuery({
+    ...agentCatalogOptions(requestedWindow ?? {}),
+    enabled: false,
+  });
+  const dashboardQuery = useQuery({
+    ...dashboardQueryOptions(requestedWindow ?? {}, {}),
     enabled: false,
   });
   const projectsQuery = useQuery({
@@ -241,13 +250,18 @@ export function useSessionStore() {
   });
   const configFailed = configQuery.isError;
   const refetchConfig = configQuery.refetch;
+  const dashboard = dashboardQuery.data;
   const querySnapshot =
     requestedWindow !== null &&
     projectionQuery.data &&
-    aggregatesQuery.data &&
-    sameWindow(projectionQuery.data.window, requestedWindow) &&
-    sameWindow(aggregatesQuery.data.window, requestedWindow)
-      ? createSnapshot(requestedWindow, aggregatesQuery.data, projectionQuery.data.sessions)
+    agentsQuery.data !== undefined &&
+    dashboard !== undefined &&
+    sameWindow(projectionQuery.data.window, requestedWindow)
+      ? createSnapshot(
+          requestedWindow,
+          { window: requestedWindow, agents: agentsQuery.data, dashboard },
+          projectionQuery.data.sessions,
+        )
       : null;
 
   const reload = useCallback(
@@ -259,7 +273,7 @@ export function useSessionStore() {
       try {
         await Promise.all([
           queryClient.cancelQueries({ queryKey: queryKeys.sessionProjections }),
-          queryClient.cancelQueries({ queryKey: queryKeys.sessionAggregates }),
+          queryClient.cancelQueries({ queryKey: queryKeys.agentCatalogs }),
           queryClient.cancelQueries({ queryKey: queryKeys.projects }),
         ]);
         removeOtherSessionProjections(queryClient, window);
@@ -270,7 +284,12 @@ export function useSessionStore() {
             refetchType: "none",
           }),
           queryClient.invalidateQueries({
-            queryKey: queryKeys.sessionAggregate(window),
+            queryKey: queryKeys.agentCatalog(window),
+            exact: true,
+            refetchType: "none",
+          }),
+          queryClient.invalidateQueries({
+            queryKey: queryKeys.dashboard(window, {}),
             exact: true,
             refetchType: "none",
           }),
@@ -282,7 +301,7 @@ export function useSessionStore() {
         ]);
         void queryClient.fetchQuery(projectsOptions(window)).catch(() => undefined);
         const [aggregates, projection] = await Promise.all([
-          queryClient.fetchQuery(snapshotAggregatesOptions(window)),
+          fetchSnapshotAggregates(queryClient, window),
           queryClient.fetchQuery(
             sessionProjectionOptions(window, (firstPageProjection) => {
               if (activeRequestRef.current?.requestId !== requestId) return;
@@ -308,10 +327,12 @@ export function useSessionStore() {
       if (!activeRequest) return null;
       const { window: activeWindow } = activeRequest;
       const projectionKey = queryKeys.sessionProjection(activeWindow);
-      const aggregateKey = queryKeys.sessionAggregate(activeWindow);
+      const agentCatalogKey = queryKeys.agentCatalog(activeWindow);
+      const dashboardKey = queryKeys.dashboard(activeWindow, {});
       const currentProjection = queryClient.getQueryData<SessionProjection>(projectionKey);
-      const currentAggregates = queryClient.getQueryData<SnapshotAggregates>(aggregateKey);
-      if (!currentProjection || !currentAggregates) {
+      const currentAgents = queryClient.getQueryData<AgentInfo[]>(agentCatalogKey);
+      const currentDashboard = queryClient.getQueryData<DashboardData>(dashboardKey);
+      if (!currentProjection || currentAgents === undefined || currentDashboard === undefined) {
         const refreshed = await reload(activeWindow);
         await Promise.all([
           invalidateLiveSessionDerivedQueries(queryClient, event),
@@ -319,6 +340,11 @@ export function useSessionStore() {
         ]);
         return refreshed ? { snapshot: refreshed, visibleNewSessions: 0 } : null;
       }
+      const currentAggregates = {
+        window: activeWindow,
+        agents: currentAgents,
+        dashboard: currentDashboard,
+      };
 
       const projection = applySessionWindowChanges(currentProjection.sessions, {
         changedSessionHeads: event.changedSessionHeads,

--- a/apps/web/src/lib/dashboard-query.ts
+++ b/apps/web/src/lib/dashboard-query.ts
@@ -1,0 +1,20 @@
+import { queryOptions } from "@tanstack/react-query";
+import { type AppConfig, type DashboardFilters, fetchDashboard } from "./api";
+import { queryKeys } from "./query-keys";
+
+export const DASHBOARD_STALE_TIME_MS = 2_000;
+
+export function dashboardQueryOptions(window: AppConfig["window"], filters: DashboardFilters) {
+  return queryOptions({
+    queryKey: queryKeys.dashboard(window, filters),
+    staleTime: DASHBOARD_STALE_TIME_MS,
+    queryFn: async ({ signal }) => {
+      try {
+        return await fetchDashboard(window, filters, { signal });
+      } catch (error) {
+        if (!signal.aborted) console.error("Failed to load dashboard:", error);
+        throw error;
+      }
+    },
+  });
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -10,12 +10,21 @@ function normalizeWindow(window: TimeWindow) {
   };
 }
 
+function normalizeDashboardFilters(filters: DashboardFilters): DashboardFilters {
+  return {
+    ...(filters.project ? { project: filters.project } : {}),
+    ...(filters.agent ? { agent: filters.agent } : {}),
+  };
+}
+
 export const queryKeys = {
   bookmarks: ["bookmarks"] as const,
   config: ["config"] as const,
   dashboards: ["dashboard"] as const,
   dashboard: (window: TimeWindow, filters: DashboardFilters) =>
-    ["dashboard", normalizeWindow(window), filters] as const,
+    ["dashboard", normalizeWindow(window), normalizeDashboardFilters(filters)] as const,
+  agentCatalogs: ["agent-catalog"] as const,
+  agentCatalog: (window: TimeWindow) => ["agent-catalog", normalizeWindow(window)] as const,
   projects: ["projects"] as const,
   projectPage: (window: TimeWindow, cursor?: string) =>
     ["projects", "page", normalizeWindow(window), cursor ?? null] as const,
@@ -29,7 +38,4 @@ export const queryKeys = {
   sessionProjections: ["session-projection"] as const,
   sessionProjection: (window: TimeWindow) =>
     ["session-projection", normalizeWindow(window)] as const,
-  sessionAggregates: ["session-aggregates"] as const,
-  sessionAggregate: (window: TimeWindow) =>
-    ["session-aggregates", normalizeWindow(window)] as const,
 } as const;

--- a/apps/web/src/lib/session-query-consistency.ts
+++ b/apps/web/src/lib/session-query-consistency.ts
@@ -4,7 +4,7 @@ import { queryKeys } from "./query-keys";
 
 function invalidateSessionCollections(queryClient: QueryClient) {
   return [
-    queryClient.invalidateQueries({ queryKey: queryKeys.sessionAggregates }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.agentCatalogs }),
     queryClient.invalidateQueries({ queryKey: queryKeys.dashboards }),
     queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
   ];


### PR DESCRIPTION
## Summary

- give dashboard requests one canonical query option and cache key
- cache window-specific agent data independently instead of duplicating dashboard data in a combined query
- normalize empty dashboard filters and verify the session store and dashboard consumers share one request

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`