### PR TITLE
refactor(core)!: Remove legacy session identity fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ npx codesesh -j
 ```
 
 The output is an index, not an archive: an `agents` summary and a `sessions` array of session
-metadata — reference, compatibility id/slug fields, title, directory, project identity,
+metadata — reference, title, directory, project identity,
 timestamps, token/cost stats and smart tags. It does **not** include messages, tool calls,
 reasoning or file activity, so it is not a backup of your history. Session content stays in each
 agent's own data directory.

--- a/apps/web/src/components/DetailLanding.test.tsx
+++ b/apps/web/src/components/DetailLanding.test.tsx
@@ -19,8 +19,6 @@ describe("DetailLanding", () => {
     const sessions: IndexedSession[] = [
       {
         reference: { agentName: "codex", sessionId: "session-1" },
-        id: "session-1",
-        slug: "codex/session-1",
         title: "Session",
         directory: "/repo",
         time_created: 1,

--- a/apps/web/src/components/InteractiveReceipt.test.tsx
+++ b/apps/web/src/components/InteractiveReceipt.test.tsx
@@ -36,8 +36,6 @@ function createDeferred<T>(): Deferred<T> {
 function createSession(title: string): SessionDetail {
   return {
     reference: { agentName: "codex", sessionId: "session-1" },
-    id: "session-1",
-    slug: "codex/session-1",
     title,
     directory: "/repo",
     time_created: 1,

--- a/apps/web/src/components/SessionDetail.test.tsx
+++ b/apps/web/src/components/SessionDetail.test.tsx
@@ -19,7 +19,7 @@ afterEach(() => {
 });
 
 describe("SessionDetail identity", () => {
-  it("uses the authoritative reference when slug is absent", () => {
+  it("uses the structured session reference", () => {
     displayModelMocks.build.mockReturnValue({
       messages: [],
       toc: { filterIds: [] },
@@ -29,8 +29,6 @@ describe("SessionDetail identity", () => {
     });
     const session: Api.SessionDetail = {
       reference: { agentName: "codex", sessionId: "s1" },
-      id: "s1",
-      slug: "codex/s1",
       title: "Session",
       directory: "/repo",
       time_created: 1,
@@ -63,8 +61,6 @@ describe("SessionDetail identity", () => {
     });
     const session: Api.SessionDetail = {
       reference: { agentName: "codex", sessionId: "parent" },
-      id: "parent",
-      slug: "codex/parent",
       title: "Parent",
       directory: "/repo",
       parent_reference: { agentName: "codex", sessionId: "root" },
@@ -79,8 +75,6 @@ describe("SessionDetail identity", () => {
     };
     const child: Api.SessionHead = {
       reference: { agentName: "codex", sessionId: "child" },
-      id: "child",
-      slug: "codex/child",
       title: "Child",
       directory: "/repo",
       time_created: 1,
@@ -129,8 +123,6 @@ describe("SessionDetail content filtering", () => {
     });
     const session: Api.SessionDetail = {
       reference: { agentName: "codex", sessionId: "s1" },
-      id: "s1",
-      slug: "codex/s1",
       title: "Session",
       directory: "/repo",
       time_created: 1,

--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -8,11 +8,13 @@ import {
   SessionTreeSidebar,
 } from "./SessionTreeSidebar";
 
-function makeSession(overrides: Partial<SessionHead> & { id: string }): SessionHead {
+function makeSession(
+  input: Partial<SessionHead> & { sessionId: string; agentName?: string },
+): SessionHead {
+  const { sessionId, agentName = "codex", ...overrides } = input;
   return {
-    reference: { agentName: "codex", sessionId: overrides.id },
-    slug: `codex/${overrides.id}`,
-    title: overrides.id,
+    reference: { agentName, sessionId },
+    title: sessionId,
     directory: "/repo/unused",
     time_created: 0,
     stats: {
@@ -39,7 +41,7 @@ describe("buildSessionTreeModel group sorting", () => {
     const depth = 12_000;
     const sessions = Array.from({ length: depth }, (_, index) =>
       makeSession({
-        id: `deep-${index}`,
+        sessionId: `deep-${index}`,
         title: "x",
         ...(index > 0
           ? { parent_reference: { agentName: "codex", sessionId: `deep-${index - 1}` } }
@@ -65,11 +67,11 @@ describe("buildSessionTreeModel group sorting", () => {
 
   it("renders every cycle member once under the Unmounted group", () => {
     const a = makeSession({
-      id: "a",
+      sessionId: "a",
       parent_reference: { agentName: "codex", sessionId: "b" },
     });
     const b = makeSession({
-      id: "b",
+      sessionId: "b",
       parent_reference: { agentName: "codex", sessionId: "a" },
     });
 
@@ -86,23 +88,23 @@ describe("buildSessionTreeModel group sorting", () => {
   it("orders groups by most recent session time, descending", () => {
     const sessions = [
       makeSession({
-        id: "old-1",
+        sessionId: "old-1",
         directory: "/repo/old",
         time_created: 100,
       }),
       makeSession({
-        id: "new-1",
+        sessionId: "new-1",
         directory: "/repo/new",
         time_created: 300,
       }),
       makeSession({
-        id: "mid-1",
+        sessionId: "mid-1",
         directory: "/repo/mid",
         time_created: 200,
       }),
       // A second, older session in the "new" group should not pull its maxTime down.
       makeSession({
-        id: "new-2",
+        sessionId: "new-2",
         directory: "/repo/new",
         time_created: 10,
       }),
@@ -115,8 +117,8 @@ describe("buildSessionTreeModel group sorting", () => {
 
   it("always places the unknown group last, regardless of session recency", () => {
     const sessions = [
-      makeSession({ id: "known-1", directory: "/repo/known", time_created: 10 }),
-      makeSession({ id: "unknown-1", directory: "", time_created: 9999 }),
+      makeSession({ sessionId: "known-1", directory: "/repo/known", time_created: 10 }),
+      makeSession({ sessionId: "unknown-1", directory: "", time_created: 9999 }),
     ];
 
     const { paths } = buildSessionTreeModel(sessions);
@@ -129,14 +131,14 @@ describe("buildSessionTreeModel group sorting", () => {
     // stack, so this only passes if the comparator avoids spreading.
     const bigGroup: SessionHead[] = Array.from({ length: 200_000 }, (_, index) =>
       makeSession({
-        id: `big-${index}`,
+        sessionId: `big-${index}`,
         directory: "/repo/big",
         time_created: index,
       }),
     );
     const sessions = [
       ...bigGroup,
-      makeSession({ id: "small-1", directory: "/repo/small", time_created: 999_999 }),
+      makeSession({ sessionId: "small-1", directory: "/repo/small", time_created: 999_999 }),
     ];
 
     const { paths } = buildSessionTreeModel(sessions);
@@ -146,8 +148,8 @@ describe("buildSessionTreeModel group sorting", () => {
   }, 30_000);
 
   it("keeps paths for equal session ids from different agents", () => {
-    const codex = makeSession({ id: "same", slug: "codex/same" });
-    const claude = makeSession({ id: "same", slug: "claude/same" });
+    const codex = makeSession({ sessionId: "same" });
+    const claude = makeSession({ sessionId: "same", agentName: "claude" });
 
     const model = buildSessionTreeModel([codex, claude]);
 
@@ -156,9 +158,9 @@ describe("buildSessionTreeModel group sorting", () => {
   });
 
   it("mounts child sessions below their parent path", () => {
-    const parent = makeSession({ id: "parent", title: "Main" });
+    const parent = makeSession({ sessionId: "parent", title: "Main" });
     const child = makeSession({
-      id: "child",
+      sessionId: "child",
       title: "Worker",
       parent_reference: { agentName: "codex", sessionId: "parent" },
     });
@@ -175,9 +177,9 @@ describe("buildSessionTreeModel group sorting", () => {
   });
 
   it("renders a child without its parent under the Unmounted group", () => {
-    const rooted = makeSession({ id: "rooted", directory: "/repo/known" });
+    const rooted = makeSession({ sessionId: "rooted", directory: "/repo/known" });
     const child = makeSession({
-      id: "orphan",
+      sessionId: "orphan",
       parent_reference: { agentName: "codex", sessionId: "missing" },
     });
 
@@ -192,11 +194,11 @@ describe("buildSessionTreeModel group sorting", () => {
 
   it("keeps a grandchild mounted under its orphaned parent", () => {
     const orphan = makeSession({
-      id: "orphan",
+      sessionId: "orphan",
       parent_reference: { agentName: "codex", sessionId: "missing" },
     });
     const grandchild = makeSession({
-      id: "grandchild",
+      sessionId: "grandchild",
       parent_reference: { agentName: "codex", sessionId: "orphan" },
     });
 
@@ -215,7 +217,7 @@ describe("buildSessionTreeModel path allocation", () => {
     // path. A restart-from-2 probe is O(N²) here and cannot finish in time.
     const sessions = Array.from({ length: 20_000 }, (_, index) =>
       makeSession({
-        id: `deadbeef-${index}`,
+        sessionId: `deadbeef-${index}`,
         title: "Same title",
         directory: "/repo/one",
       }),
@@ -233,9 +235,9 @@ describe("buildSessionTreeModel path allocation", () => {
 
   it("CS-145: keeps groups with the same label distinct", () => {
     const sessions = [
-      makeSession({ id: "a", directory: "/repo/one/shared" }),
-      makeSession({ id: "b", directory: "/repo/two/shared" }),
-      makeSession({ id: "c", directory: "/repo/three/shared" }),
+      makeSession({ sessionId: "a", directory: "/repo/one/shared" }),
+      makeSession({ sessionId: "b", directory: "/repo/two/shared" }),
+      makeSession({ sessionId: "c", directory: "/repo/three/shared" }),
     ];
 
     const { paths } = buildSessionTreeModel(sessions);
@@ -245,9 +247,9 @@ describe("buildSessionTreeModel path allocation", () => {
 
   it("CS-145: does not reuse a numbered label already taken by another title", () => {
     const sessions = [
-      makeSession({ id: "a", title: "Report (2)" }),
-      makeSession({ id: "b", title: "Report" }),
-      makeSession({ id: "c", title: "Report" }),
+      makeSession({ sessionId: "a", title: "Report (2)" }),
+      makeSession({ sessionId: "b", title: "Report" }),
+      makeSession({ sessionId: "c", title: "Report" }),
     ];
 
     const { paths } = buildSessionTreeModel(sessions);
@@ -272,7 +274,7 @@ function patchShadowEventRetargeting() {
   document.addEventListener("keydown", retarget, true);
 }
 
-function renderSessionTreeSidebar(sessions = [makeSession({ id: "s1" })]) {
+function renderSessionTreeSidebar(sessions = [makeSession({ sessionId: "s1" })]) {
   const session = sessions[0]!;
   const onToggleBookmark = vi.fn();
   const onRenameSession = vi.fn();
@@ -328,7 +330,7 @@ describe("CS-275: untrusted session titles stay inert", () => {
 
   it("renders HTML metacharacters in titles as text, not markup", async () => {
     const hostileTitle = '<img src=x onerror="globalThis.__cs275 = true"> <b>bold';
-    renderSessionTreeSidebar([makeSession({ id: "hostile", title: hostileTitle })]);
+    renderSessionTreeSidebar([makeSession({ sessionId: "hostile", title: hostileTitle })]);
 
     // The full title survives verbatim as escaped text (the visible label is
     // split by MiddleTruncate, so assert on the row's aria-label instead).
@@ -345,8 +347,8 @@ describe("SessionTreeSidebar selection state", () => {
   afterEach(cleanup);
 
   it("keeps one active row and hides its fill while keyboard focus is elsewhere", async () => {
-    const first = makeSession({ id: "first", title: "First session" });
-    const second = makeSession({ id: "second", title: "Second session" });
+    const first = makeSession({ sessionId: "first", title: "First session" });
+    const second = makeSession({ sessionId: "second", title: "Second session" });
     const sessions = [first, second];
     const firstReference = getSessionReferenceKey(first);
     const secondReference = getSessionReferenceKey(second);
@@ -411,7 +413,7 @@ describe("SessionTreeSidebar session options menu", () => {
 
   it("scrolls an overflowing title once while hovered", async () => {
     const title = "A deliberately long session title that needs a marquee";
-    const { shadowRoot } = renderSessionTreeSidebar([makeSession({ id: "long", title })]);
+    const { shadowRoot } = renderSessionTreeSidebar([makeSession({ sessionId: "long", title })]);
     const content = await waitFor(() => {
       const element = shadowRoot.querySelector<HTMLElement>(
         '[data-item-type="file"] [data-item-section="content"]',
@@ -492,9 +494,9 @@ describe("SessionTreeSidebar session options menu", () => {
   });
 
   it("shows and opens the parent row options when it has a child session", async () => {
-    const parent = makeSession({ id: "parent", title: "Main parent session with child" });
+    const parent = makeSession({ sessionId: "parent", title: "Main parent session with child" });
     const child = makeSession({
-      id: "child",
+      sessionId: "child",
       title: "Worker",
       parent_reference: { agentName: "codex", sessionId: "parent" },
     });

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -12,7 +12,7 @@ const sessionDetailRender = vi.hoisted(() => vi.fn());
 vi.mock("../SessionDetail", () => ({
   SessionDetail: (props: { session: SessionDetail; childSessions: SessionDetail[] }) => {
     sessionDetailRender(props);
-    return <div data-testid="session-detail">{props.session.id}</div>;
+    return <div data-testid="session-detail">{props.session.reference.sessionId}</div>;
   },
 }));
 
@@ -113,8 +113,6 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
 function makeSession(id: string): SessionDetail {
   return {
     reference: { agentName: "claudecode", sessionId: id },
-    id,
-    slug: `claudecode/${id}`,
     title: `Session ${id}`,
     directory: "/repo",
     time_created: 1,
@@ -131,8 +129,6 @@ function makeSession(id: string): SessionDetail {
 function makeLandingSession(agentKey: string, sessionId: string, title: string): IndexedSession {
   return {
     reference: { agentName: agentKey, sessionId },
-    id: sessionId,
-    slug: `${agentKey}/${sessionId}`,
     title,
     directory: "/repo",
     time_created: 1,
@@ -296,13 +292,12 @@ describe("AppRouteContent", () => {
     const parent = makeSession("parent");
     const child = {
       ...makeSession("child"),
-      slug: "claudecode/child",
       parent_reference: parent.reference,
     };
     props.viewState = {
       mode: "session",
       activeAgentKey: "claudecode",
-      activeSessionId: parent.id,
+      activeSessionId: parent.reference.sessionId,
     };
     props.sessionDetail.session = parent;
     props.childSessionsByParentRouteKey = new Map([

--- a/apps/web/src/components/app/SearchResultsPanel.test.tsx
+++ b/apps/web/src/components/app/SearchResultsPanel.test.tsx
@@ -9,8 +9,6 @@ afterEach(cleanup);
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: `Session ${id}`,
     directory: "/workspace",
     time_created: 1,

--- a/apps/web/src/components/project-timeline/ProjectTimeline.test.tsx
+++ b/apps/web/src/components/project-timeline/ProjectTimeline.test.tsx
@@ -23,12 +23,12 @@ function at(day: number, hour: number): number {
 function createSession(
   overrides: Partial<SessionHead> & { id: string; time_updated: number },
 ): SessionHead {
+  const { id, ...sessionOverrides } = overrides;
   return {
-    reference: { agentName: "codex", sessionId: overrides.id },
-    slug: `codex/${overrides.id}`,
-    title: overrides.id,
+    reference: { agentName: "codex", sessionId: id },
+    title: id,
     directory: "/workspace/a",
-    time_created: overrides.time_updated,
+    time_created: sessionOverrides.time_updated,
     stats: {
       message_count: 4,
       total_input_tokens: 100,
@@ -36,7 +36,7 @@ function createSession(
       total_tokens: 150,
       total_cost: 1,
     },
-    ...overrides,
+    ...sessionOverrides,
   };
 }
 
@@ -97,7 +97,7 @@ describe("ProjectTimeline", () => {
       createSession({
         id: `large-child-${index}`,
         time_updated: at(6, 9) + index,
-        parent_reference: { agentName: "codex", sessionId: parent.id },
+        parent_reference: { agentName: "codex", sessionId: parent.reference.sessionId },
       }),
     );
 

--- a/apps/web/src/components/project-timeline/timeline-session-row.test.tsx
+++ b/apps/web/src/components/project-timeline/timeline-session-row.test.tsx
@@ -35,8 +35,6 @@ function createRow(overrides: Partial<TimelineRow> = {}): TimelineRow {
 const CHILD = buildSessionTree([
   {
     reference: { agentName: "codex", sessionId: "child" },
-    id: "child",
-    slug: "codex/child",
     title: "Probe the cache",
     directory: "/workspace/a",
     time_created: new Date(2026, 7, 6, 9, 30).getTime(),

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -33,8 +33,6 @@ function fact(id: string, bookmarkedAt = 1): BookmarkRecord {
 function session(id: string, updated = 1): SessionHead {
   return {
     reference: { agentName: "cc", sessionId: id },
-    id,
-    slug: `cc/${id}`,
     title: id,
     directory: "/d",
     time_created: 1,
@@ -308,7 +306,7 @@ describe("useBookmarks", () => {
     expect(result.current.bookmarkedSessions[0]).toMatchObject({
       availability: "available",
       reference: { agentName: "cc", sessionId: "live" },
-      session: { id: "live", slug: "cc/live" },
+      session: { reference: { agentName: "cc", sessionId: "live" } },
     });
 
     request.resolve({ bookmark: fact("live") });

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
@@ -10,8 +10,6 @@ afterEach(cleanup);
 function makeSession(id: string): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: "/workspace",
     time_created: 1,
@@ -26,7 +24,7 @@ function makeSession(id: string): SessionHead {
 
 const sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
 const searchResults: SearchResult[] = sessions.slice(0, 2).map((session) => ({
-  reference: { agentName: "Codex", sessionId: session.id },
+  reference: { agentName: "Codex", sessionId: session.reference.sessionId },
   session,
   snippet: session.title,
   snippetHighlights: [],

--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -19,7 +19,19 @@ const sessionView: ViewState = {
   activeSessionId: "claudecode/abc",
 };
 
-const sample = { id: "abc", messages: [] } as unknown as SessionDetail;
+function makeSessionDetail(
+  agentName: string,
+  sessionId: string,
+  overrides: Record<string, unknown> = {},
+): SessionDetail {
+  return {
+    reference: { agentName, sessionId },
+    messages: [],
+    ...overrides,
+  } as unknown as SessionDetail;
+}
+
+const sample = makeSessionDetail("claudecode", "abc");
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -110,7 +122,7 @@ describe("useSessionDetail", () => {
     const { result } = renderSessionDetail();
     await waitFor(() => expect(result.current.session).toEqual(sample));
 
-    const updated = { id: "abc", messages: [1] } as unknown as SessionDetail;
+    const updated = makeSessionDetail("claudecode", "abc", { messages: [1] });
     vi.mocked(api.fetchSessionData).mockResolvedValue(updated);
     await act(async () => {
       await result.current.refresh();
@@ -149,18 +161,16 @@ describe("useSessionDetail", () => {
   it("requests and merges only messages appended by a live update", async () => {
     const firstMessage = { id: "m1" };
     const nextMessage = { id: "m2" };
-    const initial = {
-      id: "abc",
+    const initial = makeSessionDetail("claudecode", "abc", {
       messages: [firstMessage],
       message_cursor: "cursor-1",
       message_update: "reset",
-    } as unknown as SessionDetail;
-    const appended = {
-      id: "abc",
+    });
+    const appended = makeSessionDetail("claudecode", "abc", {
       messages: [nextMessage],
       message_cursor: "cursor-2",
       message_update: "append",
-    } as unknown as SessionDetail;
+    });
     vi.mocked(api.fetchSessionData).mockResolvedValueOnce(initial).mockResolvedValueOnce(appended);
     const { client, result } = renderSessionDetail();
     await waitFor(() => expect(result.current.session).toEqual(initial));
@@ -191,8 +201,8 @@ describe("useSessionDetail", () => {
       activeAgentKey: "codex",
       activeSessionId: "def",
     };
-    const sessionA = { id: "a", messages: [] } as unknown as SessionDetail;
-    const sessionB = { id: "b", messages: [] } as unknown as SessionDetail;
+    const sessionA = makeSessionDetail("claudecode", "a");
+    const sessionB = makeSessionDetail("codex", "b");
     vi.mocked(api.fetchSessionData).mockImplementation((_agent, sessionId) =>
       sessionId === viewA.activeSessionId ? requestA.promise : requestB.promise,
     );
@@ -206,7 +216,7 @@ describe("useSessionDetail", () => {
     await act(async () => requestA.resolve(sessionA));
 
     expect({
-      sessionId: result.current.session?.id,
+      sessionId: result.current.session?.reference.sessionId,
       lifecycle: vi
         .mocked(api.logClientEvent)
         .mock.calls.map(([event, fields]) => `${event}:${fields?.request_key}`),
@@ -227,7 +237,7 @@ describe("useSessionDetail", () => {
       activeAgentKey: "codex",
       activeSessionId: "def",
     };
-    const sessionB = { id: "b", messages: [] } as unknown as SessionDetail;
+    const sessionB = makeSessionDetail("codex", "b");
     vi.mocked(api.fetchSessionData).mockImplementation((agent, _sessionId, options) => {
       if (agent === "codex") return Promise.resolve(sessionB);
       return new Promise((_resolve, reject) => {
@@ -259,7 +269,7 @@ describe("useSessionDetail", () => {
       activeAgentKey: "codex",
       activeSessionId: "def",
     };
-    const sessionB = { id: "b", messages: [] } as unknown as SessionDetail;
+    const sessionB = makeSessionDetail("codex", "b");
     vi.mocked(api.fetchSessionData).mockImplementation((_agent, sessionId) =>
       sessionId === sessionView.activeSessionId ? requestA.promise : requestB.promise,
     );
@@ -300,8 +310,8 @@ describe("useSessionDetail", () => {
 
   it("does not let an old refresh overwrite a navigated session", async () => {
     const refreshRequest = deferred<SessionDetail>();
-    const refreshedA = { id: "a-refreshed", messages: [] } as unknown as SessionDetail;
-    const sessionB = { id: "b", messages: [] } as unknown as SessionDetail;
+    const refreshedA = makeSessionDetail("claudecode", "a-refreshed");
+    const sessionB = makeSessionDetail("codex", "b");
     const viewB: ViewState = {
       mode: "session",
       activeAgentKey: "codex",

--- a/apps/web/src/hooks/useSessionSearch.test.ts
+++ b/apps/web/src/hooks/useSessionSearch.test.ts
@@ -23,8 +23,6 @@ function makeSearchResult(id: string): SearchResult {
     reference: { agentName: "cc", sessionId: id },
     session: {
       reference: { agentName: "cc", sessionId: id },
-      id,
-      slug: `cc/${id}`,
       title: id,
       directory: "/workspace",
       time_created: 1,

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -286,7 +286,7 @@ describe("useSessionStore", () => {
         ...SAMPLE_SESSIONS_UPDATED_EVENT,
         changedSessionHeads: [
           {
-            reference: { agentName: "claudecode", sessionId: changedSession.id },
+            reference: { agentName: "claudecode", sessionId: changedSession.reference.sessionId },
             session: changedSession,
           },
         ],
@@ -313,7 +313,7 @@ describe("useSessionStore", () => {
         ...SAMPLE_SESSIONS_UPDATED_EVENT,
         changedSessionHeads: [
           {
-            reference: { agentName: "claudecode", sessionId: changedSession.id },
+            reference: { agentName: "claudecode", sessionId: changedSession.reference.sessionId },
             session: changedSession,
           },
         ],
@@ -378,11 +378,11 @@ describe("useSessionStore", () => {
         newSessions: historicalSessions.length,
         newSessionRefs: historicalSessions.map((session) => ({
           agentName: "claudecode",
-          sessionId: session.id,
+          sessionId: session.reference.sessionId,
         })),
         totalSessions: historicalSessions.length + 1,
         changedSessionHeads: historicalSessions.map((session) => ({
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           session,
         })),
       });
@@ -413,10 +413,10 @@ describe("useSessionStore", () => {
     await act(async () => {
       update = await result.current.applyLiveEvent({
         ...SAMPLE_SESSIONS_UPDATED_EVENT,
-        newSessionRefs: [{ agentName: "claudecode", sessionId: addedSession.id }],
+        newSessionRefs: [{ agentName: "claudecode", sessionId: addedSession.reference.sessionId }],
         changedSessionHeads: [
           {
-            reference: { agentName: "claudecode", sessionId: addedSession.id },
+            reference: { agentName: "claudecode", sessionId: addedSession.reference.sessionId },
             session: addedSession,
           },
         ],
@@ -453,10 +453,13 @@ describe("useSessionStore", () => {
   it("invalidates only session details changed by a live event", async () => {
     const { result, client } = await renderStore();
     await act(() => result.current.reload(config.window));
-    const changedDetailKey = queryKeys.sessionDetail("claudecode", SAMPLE_SESSION_HEAD.id);
+    const changedDetailKey = queryKeys.sessionDetail(
+      "claudecode",
+      SAMPLE_SESSION_HEAD.reference.sessionId,
+    );
     const unchangedDetailKey = queryKeys.sessionDetail("claudecode", "unchanged-session");
     const relatedDetailKey = queryKeys.sessionDetail("claudecode", "related-session");
-    client.setQueryData(changedDetailKey, { id: SAMPLE_SESSION_HEAD.id });
+    client.setQueryData(changedDetailKey, { id: SAMPLE_SESSION_HEAD.reference.sessionId });
     client.setQueryData(unchangedDetailKey, { id: "unchanged-session" });
     client.setQueryData(relatedDetailKey, { id: "related-session" });
 
@@ -624,7 +627,7 @@ describe("useSessionStore", () => {
         ...SAMPLE_SESSIONS_UPDATED_EVENT,
         changedSessionHeads: [
           {
-            reference: { agentName: "claudecode", sessionId: changedSession.id },
+            reference: { agentName: "claudecode", sessionId: changedSession.reference.sessionId },
             session: changedSession,
           },
         ],

--- a/apps/web/src/hooks/useSidebarModel.test.ts
+++ b/apps/web/src/hooks/useSidebarModel.test.ts
@@ -57,14 +57,14 @@ const projectView = {
 const sessionView = {
   mode: "session",
   activeAgentKey: "codex",
-  activeSessionId: codexSession.id,
+  activeSessionId: codexSession.reference.sessionId,
 } satisfies ViewState;
 
 afterEach(cleanup);
 
 function renderModel(initialViewState: ViewState = rootView, indexes = sessionIndexes) {
   const isSessionBookmarked = vi.fn((agentKey, sessionId) => {
-    return agentKey === "codex" && sessionId === codexSession.id;
+    return agentKey === "codex" && sessionId === codexSession.reference.sessionId;
   });
   return renderHook(
     ({ viewState, selectedProjectAgent }) =>

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -46,8 +46,6 @@ describe("fetchSessions", () => {
   it("collects cursor pages and publishes the first page", async () => {
     const nextSession = {
       ...SAMPLE_SESSION_HEAD,
-      id: "next-session",
-      slug: "claudecode/next-session",
     };
     const fetchMock = vi
       .fn()
@@ -75,8 +73,6 @@ describe("fetchSessions", () => {
   it("restarts pagination when the server snapshot changes", async () => {
     const latestSession = {
       ...SAMPLE_SESSION_HEAD,
-      id: "latest-session",
-      slug: "claudecode/latest-session",
     };
     const fetchMock = vi
       .fn()

--- a/apps/web/src/lib/bookmarks.test.ts
+++ b/apps/web/src/lib/bookmarks.test.ts
@@ -10,8 +10,6 @@ import {
 function createSession(overrides: Partial<SessionHead> = {}): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: "s1" },
-    id: "s1",
-    slug: "codex/s1",
     title: "Bookmark me",
     directory: "/tmp/project",
     time_created: 100,

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -99,7 +99,7 @@ describe("buildLocalRecentResults", () => {
       {
         reference: {
           agentName: "claudecode",
-          sessionId: sBugfixApp.id,
+          sessionId: sBugfixApp.reference.sessionId,
         },
         session: sBugfixApp,
         snippet: `Recent session · ${sBugfixApp.directory}`,
@@ -118,7 +118,7 @@ describe("buildLocalRecentResults", () => {
       undefined,
     );
 
-    expect(results.map((r) => r.session.id)).toEqual(["s-bugfix-other"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual(["s-bugfix-other"]);
   });
 
   it("filters by costMin (>= costMin, not strictly greater)", () => {
@@ -127,7 +127,7 @@ describe("buildLocalRecentResults", () => {
     // one_plus = costMin 1; sBugfixApp (0.5) is excluded, the other two (2, 5) pass.
     const results = buildLocalRecentResults(indexes, {}, 1);
 
-    expect(results.map((r) => r.session.id).sort()).toEqual(
+    expect(results.map((r) => r.session.reference.sessionId).sort()).toEqual(
       ["s-feature-app", "s-bugfix-other"].sort(),
     );
   });
@@ -135,7 +135,7 @@ describe("buildLocalRecentResults", () => {
   it("includes a parent when descendant cost reaches costMin", () => {
     const parent = makeSession("parent");
     const child = makeSession("child", {
-      parent_reference: { agentName: "claudecode", sessionId: parent.id },
+      parent_reference: { agentName: "claudecode", sessionId: parent.reference.sessionId },
       stats: {
         message_count: 1,
         total_input_tokens: 0,
@@ -145,7 +145,10 @@ describe("buildLocalRecentResults", () => {
     });
     const results = buildLocalRecentResults(buildIndexes([parent, child]), {}, 1);
 
-    expect(results.map((result) => result.session.id)).toEqual(["parent", "child"]);
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
+      "parent",
+      "child",
+    ]);
   });
 
   it("caps results at 50", () => {

--- a/apps/web/src/lib/session-detail-cache.test.ts
+++ b/apps/web/src/lib/session-detail-cache.test.ts
@@ -25,7 +25,10 @@ function makeClient() {
 
 /** Stand-in for a full transcript; only its identity matters here. */
 function transcript(id: string) {
-  return { id, messages: [{ id: `${id}-m1`, parts: [] }] };
+  return {
+    reference: { agentName: "codex", sessionId: id },
+    messages: [{ id: `${id}-m1`, parts: [] }],
+  };
 }
 
 async function openDetail(active: QueryClient, sessionId: string) {

--- a/apps/web/src/lib/session-indexes.test.ts
+++ b/apps/web/src/lib/session-indexes.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { formatSessionReference } from "@codesesh/core/contract";
 import type { AgentInfo, SessionHead } from "./api";
 import {
   buildSessionIndexes,
@@ -31,8 +30,6 @@ function createSession(
 ): SessionHead {
   return {
     reference: overrides.reference,
-    id: overrides.reference.sessionId,
-    slug: formatSessionReference(overrides.reference),
     title: overrides.title,
     directory: overrides.directory ?? "/workspace/a",
     project_identity: overrides.project_identity,
@@ -81,36 +78,36 @@ describe("session indexes", () => {
     const indexes = buildSessionIndexes([oldCodex, claude, newCodex, otherCodex], agents);
 
     expect(indexes.byRouteKey.get(getSessionRouteKey("CoDeX", "old"))).toBe(oldCodex);
-    expect(indexes.byAgent.get("codex")?.map((session) => session.id)).toEqual([
+    expect(indexes.byAgent.get("codex")?.map((session) => session.reference.sessionId)).toEqual([
       "other",
       "new",
       "old",
     ]);
     expect(
-      indexes.byProjectIdentityKey.get("path:/workspace/a")?.map((session) => session.id),
+      indexes.byProjectIdentityKey
+        .get("path:/workspace/a")
+        ?.map((session) => session.reference.sessionId),
     ).toEqual(["new", "claude", "old"]);
     expect(
       indexes.byProjectAgentKey
         .get(getProjectAgentKey("path:/workspace/a", "codex"))
-        ?.map((session) => session.id),
+        ?.map((session) => session.reference.sessionId),
     ).toEqual(["new", "old"]);
-    expect(indexes.sessionsByActivity.map((session) => session.id)).toEqual([
+    expect(indexes.sessionsByActivity.map((session) => session.reference.sessionId)).toEqual([
       "other",
       "new",
       "claude",
       "old",
     ]);
-    expect(indexes.landingSessions.map((session) => session.id)).toEqual([
+    expect(indexes.landingSessions.map((session) => session.reference.sessionId)).toEqual([
       "old",
       "claude",
       "new",
       "other",
     ]);
-    expect(indexes.byLandingAgent.get("codex")?.map((session) => session.id)).toEqual([
-      "old",
-      "new",
-      "other",
-    ]);
+    expect(
+      indexes.byLandingAgent.get("codex")?.map((session) => session.reference.sessionId),
+    ).toEqual(["old", "new", "other"]);
     expect(indexes.projectOptions).toEqual([
       {
         key: "path:/workspace/a",

--- a/apps/web/src/lib/session-timeline.test.ts
+++ b/apps/web/src/lib/session-timeline.test.ts
@@ -19,12 +19,12 @@ function at(day: number, hour: number, minute = 0): number {
 function createSession(
   overrides: Partial<SessionHead> & { id: string; time_updated: number },
 ): SessionHead {
+  const { id, ...sessionOverrides } = overrides;
   return {
-    reference: { agentName: "codex", sessionId: overrides.id },
-    slug: `codex/${overrides.id}`,
-    title: overrides.id,
+    reference: { agentName: "codex", sessionId: id },
+    title: id,
     directory: "/workspace/a",
-    time_created: overrides.time_updated,
+    time_created: sessionOverrides.time_updated,
     stats: {
       message_count: 1,
       total_input_tokens: 10,
@@ -32,7 +32,7 @@ function createSession(
       total_tokens: 15,
       total_cost: 0.5,
     },
-    ...overrides,
+    ...sessionOverrides,
   };
 }
 

--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -56,7 +56,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 `messages` 和 `session_file_activity` 通过复合外键关联 `sessions`，删除会话时级联清理。
 `sessions` 的 `(agent_name, session_id)` 复合主键是会话身份的持久化事实来源；领域对象的
-`reference` 由这两列恢复，`id` 与 `slug` 仅在序列化时作为兼容字段派生，不单独存储。
+`reference` 由这两列恢复，是会话模型中唯一的身份表示。
 
 ### 搜索索引
 

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -110,8 +110,6 @@ import { AgentSyncEngine } from "./agent-sync-engine.js";
 function makeSession(id: string, title = id): IdentifiedSessionHead {
   const session: SessionHead = {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title,
     directory: "/workspace",
     time_created: 1,
@@ -261,7 +259,7 @@ describe("AgentSyncEngine", () => {
       timestamp: Date.now(),
     });
     core.readPendingSearchIndexMaintenance
-      .mockReturnValueOnce({ sessionIds: [session.id], total: 1 })
+      .mockReturnValueOnce({ sessionIds: [session.reference.sessionId], total: 1 })
       .mockReturnValueOnce({ sessionIds: [], total: 0 });
     const { engine } = makeEngine(makeAgent(), [session]);
 
@@ -493,7 +491,7 @@ describe("AgentSyncEngine", () => {
           stage: "finalizing",
           changes: [{ session: next, sortIndex: 0 }],
           meta: {},
-          backfillCursor: next.id,
+          backfillCursor: next.reference.sessionId,
         });
         return workerResult({ sessions: [next], meta: {} });
       }),
@@ -510,7 +508,7 @@ describe("AgentSyncEngine", () => {
     await vi.waitFor(() => expect(statuses.at(-1)?.backfill.completedAgents).toEqual(["codex"]));
 
     expect(core.markAgentFullSyncProgress).toHaveBeenCalledOnce();
-    expect(core.markAgentFullSyncProgress).toHaveBeenCalledWith("codex", next.id);
+    expect(core.markAgentFullSyncProgress).toHaveBeenCalledWith("codex", next.reference.sessionId);
     expect(core.markAgentFullSyncCompleted).toHaveBeenCalledWith("codex");
   });
 
@@ -518,7 +516,7 @@ describe("AgentSyncEngine", () => {
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
     const failure: SessionSourceFailure = {
-      sessionId: previous.id,
+      sessionId: previous.reference.sessionId,
       sourcePath: "/session",
       stage: "parsing",
       errorClass: "SyntaxError",
@@ -544,7 +542,7 @@ describe("AgentSyncEngine", () => {
           {
             sessions: [updated],
             meta: {},
-            changedIds: [updated.id],
+            changedIds: [updated.reference.sessionId],
             sourceFailures: [failure],
           },
           "partial",
@@ -604,7 +602,11 @@ describe("AgentSyncEngine", () => {
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
     const agent = makeAgent({
-      checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
+      checkForChanges: () => ({
+        hasChanges: true,
+        changedIds: [updated.reference.sessionId],
+        timestamp: 2,
+      }),
       incrementalScan: () => [updated],
     });
     const { engine } = makeEngine(agent, [previous]);
@@ -656,7 +658,11 @@ describe("AgentSyncEngine", () => {
     const workerRunner = makeWorkerRunner();
     const incrementalScan = vi.fn(() => [updated]);
     const agent = makeAgent({
-      checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
+      checkForChanges: () => ({
+        hasChanges: true,
+        changedIds: [updated.reference.sessionId],
+        timestamp: 2,
+      }),
       incrementalScan,
     });
     const { engine } = makeEngine(agent, [previous], workerRunner, { from: 1, to: 2 });
@@ -671,17 +677,22 @@ describe("AgentSyncEngine", () => {
     expect(sessionChanges).toHaveBeenCalledWith(
       expect.objectContaining({
         agentName: "codex",
-        sessions: [expect.objectContaining({ id: updated.id, title: updated.title })],
+        sessions: [expect.objectContaining({ reference: updated.reference, title: updated.title })],
       }),
     );
     expect(statusChanges).toHaveBeenCalledWith(
       expect.objectContaining({ type: "scan-status", active: false }),
     );
     expect(workerRunner.discard).toHaveBeenCalledWith("codex");
-    expect(incrementalScan).toHaveBeenCalledWith([previous], [updated.id], undefined, {
-      from: 1,
-      to: 2,
-    });
+    expect(incrementalScan).toHaveBeenCalledWith(
+      [previous],
+      [updated.reference.sessionId],
+      undefined,
+      {
+        from: 1,
+        to: 2,
+      },
+    );
   });
 
   it("bounds progress broadcasts while preserving phase and completion", async () => {
@@ -815,7 +826,11 @@ describe("AgentSyncEngine", () => {
     const updated = makeSession("session", "after");
     const { engine } = makeEngine(
       makeAgent({
-        checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
+        checkForChanges: () => ({
+          hasChanges: true,
+          changedIds: [updated.reference.sessionId],
+          timestamp: 2,
+        }),
         incrementalScan: () => [updated],
       }),
       [previous],
@@ -982,7 +997,7 @@ describe("AgentSyncEngine", () => {
     expect(workerRunner.run).toHaveBeenCalledTimes(2);
     expect(currentMeta).toEqual(nextMeta);
     expect(engine.snapshot().sessions).toEqual([
-      expect.objectContaining({ id: head.id, title: head.title }),
+      expect.objectContaining({ reference: head.reference, title: head.title }),
     ]);
     expect(sessionChanges.mock.calls.filter(([change]) => change.event != null)).toHaveLength(1);
   });
@@ -1087,7 +1102,10 @@ describe("AgentSyncEngine", () => {
           agentName: "codex",
           changes: [
             expect.objectContaining({
-              session: expect.objectContaining({ id: "changed", title: "after" }),
+              session: expect.objectContaining({
+                reference: { agentName: "codex", sessionId: "changed" },
+                title: "after",
+              }),
             }),
           ],
           removedSessionIds: [],
@@ -1132,7 +1150,10 @@ describe("AgentSyncEngine", () => {
       }),
     );
     expect(engine.snapshot().sessions).toEqual([
-      expect.objectContaining({ id: "recent", title: "after" }),
+      expect.objectContaining({
+        reference: { agentName: "codex", sessionId: "recent" },
+        title: "after",
+      }),
     ]);
     expect(searchIndex.enqueue).toHaveBeenCalledWith(
       "scan.refresh",
@@ -1161,7 +1182,11 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async () =>
-        workerResult({ sessions: [steady], meta: repairedMeta, changedIds: [steady.id] }),
+        workerResult({
+          sessions: [steady],
+          meta: repairedMeta,
+          changedIds: [steady.reference.sessionId],
+        }),
       ),
       shutdown: vi.fn(async () => undefined),
     };
@@ -1183,7 +1208,11 @@ describe("AgentSyncEngine", () => {
           kind: "changes",
           agentName: "codex",
           changes: [
-            expect.objectContaining({ session: expect.objectContaining({ id: "steady" }) }),
+            expect.objectContaining({
+              session: expect.objectContaining({
+                reference: { agentName: "codex", sessionId: "steady" },
+              }),
+            }),
           ],
           meta: repairedMeta,
         }),
@@ -1197,7 +1226,7 @@ describe("AgentSyncEngine", () => {
     const updated = makeSession("changed", "after");
     const retained = makeSession("retained");
     const failure: SessionSourceFailure = {
-      sessionId: retained.id,
+      sessionId: retained.reference.sessionId,
       sourcePath: "/retained",
       stage: "parsing",
       errorClass: "SyntaxError",
@@ -1221,7 +1250,7 @@ describe("AgentSyncEngine", () => {
               changed: { id: "changed", sourcePath: "/changed", sourceFingerprint: "new" },
               retained: { id: "retained", sourcePath: "/retained", sourceFingerprint: "old" },
             },
-            changedIds: [changed.id],
+            changedIds: [changed.reference.sessionId],
             sourceFailures: [failure],
           },
           "partial",
@@ -1236,8 +1265,8 @@ describe("AgentSyncEngine", () => {
     await engine.refresh("codex");
 
     expect(engine.snapshot().sessions).toEqual([
-      expect.objectContaining({ id: updated.id, title: updated.title }),
-      expect.objectContaining({ id: retained.id, title: retained.title }),
+      expect.objectContaining({ reference: updated.reference, title: updated.title }),
+      expect.objectContaining({ reference: retained.reference, title: retained.title }),
     ]);
     expect(searchIndex.enqueue).toHaveBeenCalledWith(
       "scan.refresh",
@@ -1246,7 +1275,10 @@ describe("AgentSyncEngine", () => {
           kind: "changes",
           changes: [
             expect.objectContaining({
-              session: expect.objectContaining({ id: updated.id, title: updated.title }),
+              session: expect.objectContaining({
+                reference: updated.reference,
+                title: updated.title,
+              }),
             }),
           ],
           removedSessionIds: [],
@@ -1280,7 +1312,7 @@ describe("AgentSyncEngine", () => {
         workerResult({
           sessions: [updated],
           meta: { session: { id: "session", sourcePath: "/session", sourceFingerprint: "new" } },
-          changedIds: [updated.id],
+          changedIds: [updated.reference.sessionId],
         }),
       ),
       commit: vi.fn(),
@@ -1306,7 +1338,7 @@ describe("AgentSyncEngine", () => {
       await engine.refresh("codex");
 
       expect(engine.snapshot().byAgent.codex).toEqual([
-        expect.objectContaining({ id: updated.id, title: updated.title }),
+        expect.objectContaining({ reference: updated.reference, title: updated.title }),
       ]);
       expect(engine.status().agentStatuses.codex).toMatchObject({ status: "complete" });
       expect(workerRunner.commit).toHaveBeenCalledWith("codex");
@@ -1332,7 +1364,11 @@ describe("AgentSyncEngine", () => {
     const workerRunner = makeWorkerRunner();
     const { engine } = makeEngine(
       makeAgent({
-        checkForChanges: () => ({ hasChanges: true, changedIds: [updated.id], timestamp: 2 }),
+        checkForChanges: () => ({
+          hasChanges: true,
+          changedIds: [updated.reference.sessionId],
+          timestamp: 2,
+        }),
         incrementalScan: () => [updated],
       }),
       [previous],
@@ -1385,7 +1421,7 @@ describe("AgentSyncEngine", () => {
       .fn()
       .mockRejectedValueOnce(new AgentUnavailableDuringScanError("codex"))
       .mockResolvedValueOnce(
-        workerResult({ sessions: [updated], meta: {}, changedIds: [updated.id] }),
+        workerResult({ sessions: [updated], meta: {}, changedIds: [updated.reference.sessionId] }),
       );
     const warn = vi.spyOn(appLogger, "warn");
     const { engine } = makeEngine(
@@ -1466,7 +1502,7 @@ describe("AgentSyncEngine", () => {
     const agent = makeAgent({
       checkForChanges: () => ({
         hasChanges: true,
-        changedIds: [session.id],
+        changedIds: [session.reference.sessionId],
         timestamp: Date.now(),
       }),
       incrementalScan: () => [session],
@@ -1609,7 +1645,7 @@ describe("AgentSyncEngine", () => {
 
     expect(engine.snapshot().sessions).toEqual([
       expect.objectContaining({
-        id: newSession.id,
+        reference: newSession.reference,
         smart_tags_source_updated_at: newSession.smart_tags_source_updated_at,
       }),
     ]);

--- a/packages/cli/src/api/__tests__/contract.test.ts
+++ b/packages/cli/src/api/__tests__/contract.test.ts
@@ -56,7 +56,7 @@ describe("cli routes stay wire-compatible with @codesesh/core/contract", () => {
 
     expect(body.results).toEqual([
       {
-        reference: { agentName: "claudecode", sessionId: SAMPLE_SESSION_HEAD.id },
+        reference: { agentName: "claudecode", sessionId: SAMPLE_SESSION_HEAD.reference.sessionId },
         session: SAMPLE_SESSION_HEAD,
         snippet: `Recent session · ${SAMPLE_SESSION_HEAD.directory}`,
         snippetHighlights: [],

--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -113,8 +113,6 @@ const validReference = { agentName: "codex", sessionId: "s1" };
 
 const sessionHead: SessionHead = {
   reference: validReference,
-  id: "s1",
-  slug: "codex/s1",
   title: "Session one",
   directory: "/workspace",
   time_created: 1,

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -194,8 +194,6 @@ class MockAgent extends BaseAgent {
   getSessionData(_sessionId: string): SessionDetail {
     return {
       reference: { agentName: "claudecode", sessionId: "s1" },
-      id: "s1",
-      slug: "claudecode/s1",
       title: "Test Session",
       directory: "/home/user/project",
       time_created: 1000,
@@ -440,7 +438,7 @@ describe("handleGetSessions", () => {
     handleGetSessions(firstContext, source);
 
     const firstPage = firstContext.json.mock.calls[0]![0];
-    expect(firstPage.sessions.map((session: SessionHead) => session.id)).toEqual([
+    expect(firstPage.sessions.map((session: SessionHead) => session.reference.sessionId)).toEqual([
       "first",
       "second",
     ]);
@@ -554,7 +552,7 @@ describe("handleGetSessions", () => {
     handleGetSessions(c, makeScanSource());
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(1);
-    expect(response.sessions[0].id).toBe("s1");
+    expect(response.sessions[0].reference.sessionId).toBe("s1");
   });
 
   it("projects a persisted alias without changing the source title", () => {
@@ -576,12 +574,11 @@ describe("handleGetSessions", () => {
     });
   });
 
-  it("uses the authoritative reference when a legacy slug is malformed", () => {
+  it("uses the structured reference to resolve aliases", () => {
     const session = {
       ...makeSession("legacy", {
         reference: { agentName: "unknown", sessionId: "legacy" },
       }),
-      slug: "",
     };
     coreMocks.listSessionAliases.mockReturnValue([
       {
@@ -624,7 +621,7 @@ describe("handleGetSessions", () => {
       resolver,
     );
     const response = c.json.mock.calls[0]![0];
-    expect(response.sessions.map((session: SessionHead) => session.id)).toEqual([
+    expect(response.sessions.map((session: SessionHead) => session.reference.sessionId)).toEqual([
       "exact",
       "child",
       "parent",
@@ -698,7 +695,9 @@ describe("handleGetSessions", () => {
     });
     handleGetSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
     const response = c.json.mock.calls[0]![0];
-    expect(response.sessions.map((session: SessionHead) => session.id)).toEqual(["a"]);
+    expect(response.sessions.map((session: SessionHead) => session.reference.sessionId)).toEqual([
+      "a",
+    ]);
   });
 
   it("filters by from date", () => {
@@ -721,7 +720,7 @@ describe("handleGetSessions", () => {
     );
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(1);
-    expect(response.sessions[0].id).toBe("new");
+    expect(response.sessions[0].reference.sessionId).toBe("new");
   });
 
   it("uses activity time instead of creation time for session filters", () => {
@@ -745,7 +744,7 @@ describe("handleGetSessions", () => {
     );
     const response = c.json.mock.calls[0]![0];
     expect(response.sessions).toHaveLength(1);
-    expect(response.sessions[0].id).toBe("old-active");
+    expect(response.sessions[0].reference.sessionId).toBe("old-active");
   });
 
   it("rejects an invalid from date", () => {
@@ -832,12 +831,18 @@ describe("handleSearchSessions", () => {
     );
     coreMocks.executeSessionSearch.mockReturnValue(
       rankedSessions.map((session) => ({
-        reference: { agentName: "claudecode", sessionId: session.id },
+        reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
         session,
       })),
     );
     coreMocks.listSessionAliases.mockReturnValue(
-      aliasSessions.map((session) => makeAlias("claudecode", session.id, `Needle ${session.id}`)),
+      aliasSessions.map((session) =>
+        makeAlias(
+          "claudecode",
+          session.reference.sessionId,
+          `Needle ${session.reference.sessionId}`,
+        ),
+      ),
     );
     const sessions = [...rankedSessions, ...aliasSessions];
     const c = makeMockContext({ query: { q: "needle", limit: "3" } });
@@ -845,7 +850,9 @@ describe("handleSearchSessions", () => {
     handleSearchSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
 
     expect(
-      c.json.mock.calls[0]![0].results.map((result: SearchResult) => result.session.id),
+      c.json.mock.calls[0]![0].results.map(
+        (result: SearchResult) => result.session.reference.sessionId,
+      ),
     ).toEqual(["ranked-1", "ranked-2", "alias-1"]);
   });
 
@@ -859,7 +866,7 @@ describe("handleSearchSessions", () => {
     });
     coreMocks.executeSessionSearch.mockReturnValue(
       rankedSessions.map((session) => ({
-        reference: { agentName: "claudecode", sessionId: session.id },
+        reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
         session,
         snippet: "Ranked match",
         snippetHighlights: [],
@@ -876,7 +883,11 @@ describe("handleSearchSessions", () => {
     handleSearchSessions(c, makeScanSource({ sessions, byAgent: { claudecode: sessions } }));
 
     const results = c.json.mock.calls[0]![0].results as SearchResult[];
-    expect(results.map((result) => result.session.id)).toEqual(["ranked-1", "ranked-2", "alias-1"]);
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
+      "ranked-1",
+      "ranked-2",
+      "alias-1",
+    ]);
     expect(results[1]?.matchType).toBe("assistant_reply");
   });
 
@@ -988,7 +999,7 @@ describe("handleSearchSessions", () => {
       expect.objectContaining({ limit: 50 }),
       expect.anything(),
     );
-    expect(c.json.mock.calls[0]![0].results[0].session.id).toBe("s1000");
+    expect(c.json.mock.calls[0]![0].results[0].session.reference.sessionId).toBe("s1000");
   });
 
   it("excludes alias hits outside the requested time window", () => {
@@ -1360,7 +1371,7 @@ describe("handleGetProjects", () => {
     coreMocks.listDashboardCostFacts.mockReturnValue({
       sessions: [
         {
-          reference: { agentName: "agent", sessionId: session.id },
+          reference: { agentName: "agent", sessionId: session.reference.sessionId },
           messageCount: 1,
           untimedMessageCount: 0,
           inputTokens: 10,
@@ -1380,7 +1391,7 @@ describe("handleGetProjects", () => {
       ],
       messages: [
         {
-          reference: { agentName: "agent", sessionId: session.id },
+          reference: { agentName: "agent", sessionId: session.reference.sessionId },
           time: 150,
           inputTokens: 10,
           outputTokens: 5,
@@ -1640,7 +1651,9 @@ describe("handleGetDashboard", () => {
     expect(response.perAgent).toHaveLength(1);
     expect(response.perAgent[0]?.name).toBe("codex");
     expect(
-      response.recentSessions.map((item: { session: SessionHead }) => item.session.id),
+      response.recentSessions.map(
+        (item: { session: SessionHead }) => item.session.reference.sessionId,
+      ),
     ).toEqual(["app-codex"]);
   });
 
@@ -1692,8 +1705,10 @@ describe("handleGetDashboard", () => {
       },
     ]);
     expect(
-      response.recentSessions.map((item: { session: SessionHead }) => item.session.id),
-    ).toEqual(codexSessions.slice(0, 10).map((session) => session.id));
+      response.recentSessions.map(
+        (item: { session: SessionHead }) => item.session.reference.sessionId,
+      ),
+    ).toEqual(codexSessions.slice(0, 10).map((session) => session.reference.sessionId));
   });
 
   it("marks dashboard totals as estimated when any session uses estimated cost", () => {
@@ -1750,7 +1765,7 @@ describe("handleGetDashboard", () => {
 
     const response = c.json.mock.calls[0]![0];
     expect(response.totals.sessions).toBe(1);
-    expect(response.recentSessions[0]?.session.id).toBe("old");
+    expect(response.recentSessions[0]?.session.reference.sessionId).toBe("old");
     expect(response.dailyActivity).toEqual([
       {
         date: "2026-04-20",
@@ -1845,7 +1860,7 @@ describe("handleGetDashboard", () => {
     const response = c.json.mock.calls[0]![0];
     expect(response.totals.sessions).toBe(2);
     expect(response.totals.latestActivity).toBe(staleCreatedRecentlyUpdated.time_updated);
-    expect(response.recentSessions[0]?.session.id).toBe("old-active");
+    expect(response.recentSessions[0]?.session.reference.sessionId).toBe("old-active");
 
     const todayKey = toLocalDateKey(now);
     const todayBucket = response.dailyActivity.find(
@@ -2006,8 +2021,6 @@ describe("handleGetDashboard", () => {
 describe("handleGetSessionData", () => {
   const detail: SessionDetail = {
     reference: { agentName: "claudecode", sessionId: "s1" },
-    id: "s1",
-    slug: "claudecode/s1",
     title: "Test Session",
     directory: "/home/user/project",
     time_created: 1000,
@@ -2116,7 +2129,7 @@ describe("handleGetSessionData", () => {
     }
     json += decoder.decode();
     const payload = JSON.parse(json);
-    expect(payload.id).toBe("s1");
+    expect(payload.reference).toEqual({ agentName: "claudecode", sessionId: "s1" });
     expect(payload.display_title).toBe("Local Alias");
     expect(payload.messages[0].id).toBe("m0");
     expect(payload.messages).toHaveLength(200);

--- a/packages/cli/src/api/__tests__/search-transport.test.ts
+++ b/packages/cli/src/api/__tests__/search-transport.test.ts
@@ -44,8 +44,6 @@ function makeSessionHead(id: string, title: string, timeUpdated: number): Sessio
   const directory = `/fixtures/${id}`;
   return {
     reference: { agentName: "claudecode", sessionId: id },
-    id,
-    slug: `claudecode/${id}`,
     title,
     directory,
     project_identity: { kind: "path", key: directory, displayName: id },
@@ -75,7 +73,11 @@ function makeScanSource(): ScanResultSource {
 async function search(app: ReturnType<typeof createApiRoutes>, qs: string) {
   const res = await app.request(`/search${qs}`);
   const body = (await res.json()) as {
-    results?: Array<{ agentName: string; session: { id: string }; matchType: string }>;
+    results?: Array<{
+      agentName: string;
+      session: { reference: { agentName: string; sessionId: string } };
+      matchType: string;
+    }>;
     error?: string;
   };
   return { status: res.status, body };
@@ -86,8 +88,10 @@ beforeAll(() => {
   rmSync(getCacheDir(), { recursive: true, force: true });
   syncSessionSearchIndex("claudecode", [ftsTitle], () => ({
     ...ftsTitle,
-    reference: { agentName: "claudecode", sessionId: ftsTitle.id },
-    messages: [{ id: `${ftsTitle.id}-m1`, role: "assistant", time_created: now, parts: [] }],
+    reference: { agentName: "claudecode", sessionId: ftsTitle.reference.sessionId },
+    messages: [
+      { id: `${ftsTitle.reference.sessionId}-m1`, role: "assistant", time_created: now, parts: [] },
+    ],
   }));
 });
 
@@ -107,7 +111,10 @@ describe("search route: smoke wiring", () => {
   it("honors limit= on the recent-session path", async () => {
     const app = createApiRoutes(makeScanSource());
     const { body } = await search(app, "?limit=2");
-    expect(body.results!.map((r) => r.session.id)).toEqual(["recent-new", "recent-mid"]);
+    expect(body.results!.map((r) => r.session.reference.sessionId)).toEqual([
+      "recent-new",
+      "recent-mid",
+    ]);
   });
 
   it("normalizes a known agent and returns no results for an unknown agent", async () => {
@@ -134,7 +141,7 @@ describe("search route: smoke wiring", () => {
   it("routes a text q to the indexed FTS path and resolves matchType", async () => {
     const app = createApiRoutes(makeScanSource());
     const { body } = await search(app, "?q=uniquetitleneedle");
-    expect(body.results!.map((r) => r.session.id)).toEqual(["fts-title"]);
+    expect(body.results!.map((r) => r.session.reference.sessionId)).toEqual(["fts-title"]);
     expect(body.results![0]!.matchType).toBe("title");
   });
 });

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -18,7 +18,7 @@ import {
 import { appLogger } from "../logging.js";
 
 /** Anything the API returns that can carry a locally-renamed title. */
-type Titled = { id: string; title: string; display_title?: string };
+type Titled = { title: string; display_title?: string };
 
 export interface AliasView {
   readonly size: number;

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -131,7 +131,10 @@ const workerThreads = vi.hoisted(() => ({
         );
       };
       const sessionMap = new Map(
-        (data.previousSessions ?? []).map((session: SessionHead) => [session.id, session]),
+        (data.previousSessions ?? []).map((session: SessionHead) => [
+          session.reference.sessionId,
+          session,
+        ]),
       );
       const changedIds = new Set<string>();
       const sources = agent.listSessionSources();
@@ -149,14 +152,14 @@ const workerThreads = vi.hoisted(() => ({
         }
         const next = agent.scanSessionSource(source.sourcePath);
         changedIds.add(source.sessionId);
-        if (next) sessionMap.set(next.id, next);
+        if (next) sessionMap.set(next.reference.sessionId, next);
         else sessionMap.delete(source.sessionId);
       }
 
       for (const session of data.previousSessions ?? []) {
-        if (!currentIds.has(session.id)) {
-          sessionMap.delete(session.id);
-          changedIds.add(session.id);
+        if (!currentIds.has(session.reference.sessionId)) {
+          sessionMap.delete(session.reference.sessionId);
+          changedIds.add(session.reference.sessionId);
         }
       }
 
@@ -171,9 +174,12 @@ const workerThreads = vi.hoisted(() => ({
       meta: Record<string, SessionCacheMeta>,
     ) => {
       const previousById = new Map(
-        (data.previousSessions ?? []).map((session: SessionHead) => [session.id, session]),
+        (data.previousSessions ?? []).map((session: SessionHead) => [
+          session.reference.sessionId,
+          session,
+        ]),
       );
-      const updatedIds = new Set(sessions.map((session) => session.id));
+      const updatedIds = new Set(sessions.map((session) => session.reference.sessionId));
       const nextMeta = Object.fromEntries(
         Object.entries(meta).filter(([sessionId]) => updatedIds.has(sessionId)),
       ) as Record<string, SessionCacheMeta>;
@@ -191,16 +197,16 @@ const workerThreads = vi.hoisted(() => ({
         ...removedMetaIds,
       ]);
       const changes = sessions.flatMap((session, sortIndex) => {
-        const previous = previousById.get(session.id);
+        const previous = previousById.get(session.reference.sessionId);
         return !previous ||
-          changedIdSet.has(session.id) ||
+          changedIdSet.has(session.reference.sessionId) ||
           JSON.stringify(previous) !== JSON.stringify(session)
           ? [{ session, sortIndex }]
           : [];
       });
       const removedSessionIds = (data.previousSessions ?? [])
-        .filter((session: SessionHead) => !updatedIds.has(session.id))
-        .map((session: SessionHead) => session.id);
+        .filter((session: SessionHead) => !updatedIds.has(session.reference.sessionId))
+        .map((session: SessionHead) => session.reference.sessionId);
       return { changes, removedSessionIds, meta: changedMeta, removedMetaIds };
     };
     const dispatch = (data: any) => {
@@ -265,7 +271,7 @@ const workerThreads = vi.hoisted(() => ({
               }
               const serializedMeta = serializeMeta(agent);
               const delta = computeDelta(runData, sessions, changedIds, serializedMeta);
-              const sessionIds = new Set(sessions.map((session) => session.id));
+              const sessionIds = new Set(sessions.map((session) => session.reference.sessionId));
               stagedScanBaseline = {
                 requestId: runData.requestId,
                 sessions,
@@ -505,9 +511,7 @@ function makeAgent(name: string, overrides: Record<string, unknown> = {}) {
     isAvailable: vi.fn(() => true),
     getSessionData: vi.fn(() => ({
       reference: { agentName: name, sessionId: "session" },
-      id: "session",
       title: "session",
-      slug: `${name}/session`,
       directory: FIXTURE_DIR,
       time_created: 1000,
       time_updated: 1000,
@@ -670,9 +674,15 @@ describe("LiveScanStore", () => {
       }),
     );
     expect(snapshot.agents.map((agent) => agent.name)).toEqual(["codex", "kimi"]);
-    expect(snapshot.byAgent.codex!.map((session) => session.id)).toEqual(["newer", "older"]);
+    expect(snapshot.byAgent.codex!.map((session) => session.reference.sessionId)).toEqual([
+      "newer",
+      "older",
+    ]);
     expect(snapshot.byAgent.kimi).toEqual([]);
-    expect(snapshot.sessions.map((session) => session.id)).toEqual(["newer", "older"]);
+    expect(snapshot.sessions.map((session) => session.reference.sessionId)).toEqual([
+      "newer",
+      "older",
+    ]);
     expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
       expect.objectContaining({
         kind: "full",
@@ -742,7 +752,9 @@ describe("LiveScanStore", () => {
       }),
     );
     expect(workerThreads.workers).toHaveLength(0);
-    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["cached"]);
+    expect(store.getSnapshot().sessions.map((session) => session.reference.sessionId)).toEqual([
+      "cached",
+    ]);
 
     store.startBackgroundRefresh();
     expect(statusEvents.at(-1)).toEqual(
@@ -769,7 +781,9 @@ describe("LiveScanStore", () => {
         }),
       ],
     );
-    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["fresh"]);
+    expect(store.getSnapshot().sessions.map((session) => session.reference.sessionId)).toEqual([
+      "fresh",
+    ]);
     await vi.advanceTimersByTimeAsync(250);
     expect(events).toEqual([
       expect.objectContaining({
@@ -847,7 +861,9 @@ describe("LiveScanStore", () => {
     });
     expect(codex.scan).not.toHaveBeenCalled();
     expect(codex.incrementalScan).not.toHaveBeenCalled();
-    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent"]);
+    expect(store.getSnapshot().sessions.map((session) => session.reference.sessionId)).toEqual([
+      "recent",
+    ]);
     expect(workerThreads.workers).toHaveLength(1);
     expect(workerThreads.workers[0]?.workerData).toMatchObject({
       operation: { kind: "recompute-derived" },
@@ -905,7 +921,10 @@ describe("LiveScanStore", () => {
     );
     expect((codex.scan as ReturnType<typeof vi.fn>).mock.calls[1]?.[0]?.from).toBeUndefined();
     await vi.waitFor(() =>
-      expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent", "old"]),
+      expect(store.getSnapshot().sessions.map((session) => session.reference.sessionId)).toEqual([
+        "recent",
+        "old",
+      ]),
     );
     const backfillJob = workerThreads.workers.filter((worker) => worker.workerData.jobs).at(-1)
       ?.workerData.jobs;
@@ -1361,7 +1380,10 @@ describe("LiveScanStore", () => {
     expect(codex.incrementalScan).toHaveBeenCalledWith([old, recent], ["old"], undefined, {
       from: 3000,
     });
-    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["recent", "old"]);
+    expect(store.getSnapshot().sessions.map((session) => session.reference.sessionId)).toEqual([
+      "recent",
+      "old",
+    ]);
     expect(events).toEqual([]);
     expect(workerThreads.workers.at(-1)?.workerData.jobs).toEqual([
       {
@@ -1599,18 +1621,21 @@ describe("LiveScanStore", () => {
         totalSessions: 2,
         changedSessionHeads: [
           {
-            reference: { agentName: "codex", sessionId: updatedWithProject.id },
+            reference: { agentName: "codex", sessionId: updatedWithProject.reference.sessionId },
             session: updatedWithProject,
           },
           {
-            reference: { agentName: "codex", sessionId: addedWithProject.id },
+            reference: { agentName: "codex", sessionId: addedWithProject.reference.sessionId },
             session: addedWithProject,
           },
         ],
         removedSessionRefs: [],
       }),
     ]);
-    expect(store.getSnapshot().sessions.map((session) => session.id)).toEqual(["session", "added"]);
+    expect(store.getSnapshot().sessions.map((session) => session.reference.sessionId)).toEqual([
+      "session",
+      "added",
+    ]);
   });
 
   it("keeps the previous snapshot private until the refresh index commits", async () => {
@@ -1696,7 +1721,7 @@ describe("LiveScanStore", () => {
         removedSessions: 0,
         changedSessionHeads: [
           {
-            reference: { agentName: "codex", sessionId: previousWithProject.id },
+            reference: { agentName: "codex", sessionId: previousWithProject.reference.sessionId },
             session: previousWithProject,
           },
         ],
@@ -1984,11 +2009,15 @@ describe("LiveScanStore", () => {
         changedSessionHeads: [
           {
             reference: { agentName: "codex", sessionId: "codex-new" },
-            session: expect.objectContaining({ id: "codex-new" }),
+            session: expect.objectContaining({
+              reference: { agentName: "codex", sessionId: "codex-new" },
+            }),
           },
           {
             reference: { agentName: "kimi", sessionId: "kimi-new" },
-            session: expect.objectContaining({ id: "kimi-new" }),
+            session: expect.objectContaining({
+              reference: { agentName: "kimi", sessionId: "kimi-new" },
+            }),
           },
         ],
         removedSessionRefs: [],
@@ -2081,7 +2110,7 @@ describe("LiveScanStore", () => {
     const codex = makeAgent("codex", {
       checkForChanges: vi.fn(() => ({
         hasChanges: true,
-        changedIds: [codexAfter.id],
+        changedIds: [codexAfter.reference.sessionId],
         timestamp: 3000,
       })),
       incrementalScan: vi.fn(() => [codexAfter]),
@@ -2089,7 +2118,7 @@ describe("LiveScanStore", () => {
     const kimi = makeAgent("kimi", {
       checkForChanges: vi.fn(() => ({
         hasChanges: true,
-        changedIds: [kimiAfter.id],
+        changedIds: [kimiAfter.reference.sessionId],
         timestamp: 3000,
       })),
       incrementalScan: vi.fn(() => [kimiAfter]),
@@ -2183,7 +2212,10 @@ describe("LiveScanStore", () => {
         kind: "changes",
         changes: [
           expect.objectContaining({
-            session: expect.objectContaining({ id: "active", title: "version 3" }),
+            session: expect.objectContaining({
+              reference: { agentName: "codex", sessionId: "active" },
+              title: "version 3",
+            }),
           }),
         ],
       }),

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -17,8 +17,6 @@ function makeSession(
 ): IdentifiedSessionHead {
   return {
     reference: { agentName, sessionId: id },
-    id,
-    slug: `${agentName}/${id}`,
     title,
     directory: "/workspace",
     project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
@@ -59,18 +57,18 @@ describe("LiveSessionIndex", () => {
     );
   });
 
-  it("rejects conflicting session identities at snapshot boundaries", () => {
+  it("rejects another agent's session at snapshot boundaries", () => {
     const codex = makeAgent("codex");
-    const conflicting = { ...makeSession("session", 1), id: "other" };
+    const conflicting = makeSession("session", 1, "session", "cursor");
     const index = new LiveSessionIndex();
 
     expect(() => index.initialize(snapshot([codex], { codex: [conflicting] }))).toThrow(
-      "Session identity fields disagree",
+      'Session reference agent "cursor" does not match "codex"',
     );
 
     index.initialize(snapshot([codex], { codex: [] }));
     expect(() => index.commitAgentSessions("codex", [conflicting])).toThrow(
-      "Session identity fields disagree",
+      'Session reference agent "cursor" does not match "codex"',
     );
   });
 
@@ -154,7 +152,11 @@ describe("LiveSessionIndex", () => {
     const index = new LiveSessionIndex();
     index.initialize(snapshot([codex, kimi], { codex: [previous], kimi: [other] }));
 
-    const event = index.commitAgentSessions("codex", [added, updated], [updated.id]);
+    const event = index.commitAgentSessions(
+      "codex",
+      [added, updated],
+      [updated.reference.sessionId],
+    );
 
     expect(index.snapshot().byAgent.codex).toEqual([updated, added]);
     expect(index.snapshot().sessions).toEqual([updated, other, added]);
@@ -197,7 +199,11 @@ describe("LiveSessionIndex", () => {
     const index = new LiveSessionIndex();
     index.initialize(snapshot([codex], { codex: [root, child] }));
 
-    const event = index.commitAgentSessions("codex", [changedRoot, child], [changedRoot.id]);
+    const event = index.commitAgentSessions(
+      "codex",
+      [changedRoot, child],
+      [changedRoot.reference.sessionId],
+    );
 
     expect(event?.projectionRelatedSessionHeads).toEqual([
       {

--- a/packages/cli/src/pending-search-index-jobs.test.ts
+++ b/packages/cli/src/pending-search-index-jobs.test.ts
@@ -3,11 +3,9 @@ import type { IdentifiedSessionHead, SessionCacheMeta } from "@codesesh/core/run
 import { PendingSearchIndexJobs } from "./pending-search-index-jobs.js";
 import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 
-function makeSession(id: string, title: string): IdentifiedSessionHead {
+function makeSession(agentName: string, id: string, title: string): IdentifiedSessionHead {
   return {
-    reference: { agentName: "agent", sessionId: id },
-    id,
-    slug: `agent/${id}`,
+    reference: { agentName, sessionId: id },
     title,
     directory: "/tmp/project",
     project_identity: { kind: "path", key: "/tmp/project", displayName: "project" },
@@ -36,7 +34,7 @@ function changesJob(
     context: "scan.refresh",
     agentName,
     changes: changes.map(({ id, version }, sortIndex) => ({
-      session: makeSession(id, `version ${version}`),
+      session: makeSession(agentName, id, `version ${version}`),
       sortIndex,
     })),
     removedSessionIds,
@@ -46,13 +44,13 @@ function changesJob(
 }
 
 function fullJob(agentName: string, version: number): SearchIndexWorkerJob {
-  const session = makeSession("full", `version ${version}`);
+  const session = makeSession(agentName, "full", `version ${version}`);
   return {
     kind: "full",
     context: "scan.backfill",
     agentName,
     sessions: [session],
-    meta: { [session.id]: makeMeta(session.id, version) },
+    meta: { [session.reference.sessionId]: makeMeta(session.reference.sessionId, version) },
     completeness: "complete",
     removedSessionIds: [],
     saveCache: true,
@@ -140,7 +138,13 @@ describe("PendingSearchIndexJobs", () => {
       }),
       expect.objectContaining({
         kind: "changes",
-        changes: [expect.objectContaining({ session: expect.objectContaining({ id: "new" }) })],
+        changes: [
+          expect.objectContaining({
+            session: expect.objectContaining({
+              reference: { agentName: "codex", sessionId: "new" },
+            }),
+          }),
+        ],
       }),
     ]);
     pending.settle(batch);

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -109,8 +109,6 @@ vi.mock("@codesesh/core/runtime", async (importOriginal) => {
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: "/workspace",
     time_created: Date.now(),
@@ -616,22 +614,25 @@ describe("scan refresh worker entry", () => {
     const agent = makeAgent({
       scanSessionSource,
       listSessionSources: vi.fn(() => [
-        { sessionId: unchanged.id, sourcePath: "/unchanged", fingerprint: "same" },
-        { sessionId: changed.id, sourcePath: "/changed", fingerprint: "new" },
+        { sessionId: unchanged.reference.sessionId, sourcePath: "/unchanged", fingerprint: "same" },
+        { sessionId: changed.reference.sessionId, sourcePath: "/changed", fingerprint: "new" },
       ]),
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
       operation: { kind: "source-refresh", checkpoint: "durable" },
-      previousSessions: [unchanged, makeSession(changed.id, { time_created: 1, time_updated: 1 })],
+      previousSessions: [
+        unchanged,
+        makeSession(changed.reference.sessionId, { time_created: 1, time_updated: 1 }),
+      ],
       meta: {
         unchanged: currentPricingMeta({
-          id: unchanged.id,
+          id: unchanged.reference.sessionId,
           sourcePath: "/unchanged",
           sourceFingerprint: "same",
         }),
         changed: {
-          id: changed.id,
+          id: changed.reference.sessionId,
           sourcePath: "/changed",
           sourceFingerprint: "old",
         },
@@ -646,7 +647,7 @@ describe("scan refresh worker entry", () => {
       .find((message) => message?.type === "checkpoint" && message.checkpoint.stage === "scanned");
     expect(scannedCheckpoint?.checkpoint.sessions).toContainEqual(
       expect.objectContaining({
-        id: unchanged.id,
+        reference: unchanged.reference,
         smart_tags: ["bugfix"],
         smart_tags_source_updated_at: 1,
       }),
@@ -715,22 +716,22 @@ describe("scan refresh worker entry", () => {
     const agent = makeAgent({
       listSessionSources: vi.fn(() =>
         [newest, cursor, next].map((session) => ({
-          sessionId: session.id,
-          sourcePath: `/${session.id}`,
+          sessionId: session.reference.sessionId,
+          sourcePath: `/${session.reference.sessionId}`,
           fingerprint: "same",
         })),
       ),
     });
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     setWorkerData({
-      operation: { kind: "backfill", cursor: cursor.id, checkpoint: "durable" },
+      operation: { kind: "backfill", cursor: cursor.reference.sessionId, checkpoint: "durable" },
       previousSessions: [newest, cursor, next],
       meta: Object.fromEntries(
         [newest, cursor, next].map((session) => [
-          session.id,
+          session.reference.sessionId,
           {
-            id: session.id,
-            sourcePath: `/${session.id}`,
+            id: session.reference.sessionId,
+            sourcePath: `/${session.reference.sessionId}`,
             sourceFingerprint: "same",
           },
         ]),
@@ -749,7 +750,7 @@ describe("scan refresh worker entry", () => {
         type: "checkpoint",
         checkpoint: expect.objectContaining({
           stage: "finalizing",
-          backfillCursor: next.id,
+          backfillCursor: next.reference.sessionId,
         }),
       }),
     );

--- a/packages/cli/src/scan-refresh-worker.test.ts
+++ b/packages/cli/src/scan-refresh-worker.test.ts
@@ -12,8 +12,6 @@ const FIXTURE_DIR = mkdtempSync(join(tmpdir(), "codesesh-scan-refresh-worker-"))
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: FIXTURE_DIR,
     time_created: 1000,
@@ -114,10 +112,16 @@ describe("finalizeSessions", () => {
     const selected = makeSession("selected");
     const retained = makeSession("retained");
 
-    finalizeSessions(agent, [selected, retained], undefined, undefined, new Set([selected.id]));
+    finalizeSessions(
+      agent,
+      [selected, retained],
+      undefined,
+      undefined,
+      new Set([selected.reference.sessionId]),
+    );
 
     expect(getSessionData).toHaveBeenCalledTimes(1);
-    expect(getSessionData).toHaveBeenCalledWith(selected.id);
+    expect(getSessionData).toHaveBeenCalledWith(selected.reference.sessionId);
   });
 
   it("checkpoints settled sessions from newest to oldest", () => {
@@ -128,7 +132,7 @@ describe("finalizeSessions", () => {
 
     finalizeSessions(agent, [oldest, newest], undefined, (checkpoint) => {
       if (checkpoint.stage === "finalizing") {
-        checkpoints.push(checkpoint.changes.map(({ session }) => session.id));
+        checkpoints.push(checkpoint.changes.map(({ session }) => session.reference.sessionId));
       }
     });
 
@@ -162,7 +166,7 @@ describe("finalizeSessions", () => {
 
     expect(getSessionData).toHaveBeenCalledTimes(1);
     expect(getSessionData).toHaveBeenCalledWith("settled");
-    expect(result.map((session) => session.id)).toEqual(["hot", "settled"]);
+    expect(result.map((session) => session.reference.sessionId)).toEqual(["hot", "settled"]);
     expect(result[0]?.smart_tags).toBeUndefined();
   });
 });

--- a/packages/cli/src/search-index-maintenance-scheduler.test.ts
+++ b/packages/cli/src/search-index-maintenance-scheduler.test.ts
@@ -21,8 +21,6 @@ import { SearchIndexMaintenanceScheduler } from "./search-index-maintenance-sche
 function makeSession(id: string): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: "/workspace",
     time_created: 1,
@@ -48,7 +46,9 @@ beforeEach(() => {
   const sessions = [makeSession("one"), makeSession("two"), makeSession("three")];
   core.loadCachedSessions.mockReturnValue({
     sessions,
-    meta: Object.fromEntries(sessions.map((session) => [session.id, { id: session.id }])),
+    meta: Object.fromEntries(
+      sessions.map((session) => [session.reference.sessionId, { id: session.reference.sessionId }]),
+    ),
     timestamp: 1,
   });
 });

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -53,8 +53,14 @@ function makeAgent() {
   return {
     name: "codex",
     restoreSessionCacheMeta: vi.fn(),
-    getSessionData: vi.fn((id: string) => ({ id })),
+    getSessionData: vi.fn((sessionId: string) => ({
+      reference: { agentName: "codex", sessionId },
+    })),
   };
+}
+
+function makeSession(sessionId: string, agentName = "codex") {
+  return { reference: { agentName, sessionId } };
 }
 
 async function runWorker() {
@@ -117,14 +123,14 @@ describe("search index worker", () => {
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     mocks.syncSessionSearchIndex.mockImplementation(
       (_name: string, _sessions: unknown[], readSession: (id: string) => unknown) => {
-        expect(readSession("s1")).toEqual({ id: "s1" });
+        expect(readSession("s1")).toEqual(makeSession("s1"));
         return { indexed: 1, skipped: 0 };
       },
     );
     mocks.workerData = {
       context: "startup",
       agentNames: ["codex"],
-      sessionsByAgent: { codex: [{ id: "s1" }] },
+      sessionsByAgent: { codex: [makeSession("s1")] },
       metaByAgent: { codex: { s1: { id: "s1" } } },
     };
 
@@ -153,7 +159,7 @@ describe("search index worker", () => {
           kind: "full",
           context: "scan.refresh",
           agentName: "unknown",
-          sessions: [{ id: "s1" }],
+          sessions: [makeSession("s1", "unknown")],
           meta: {},
           completeness: "complete",
           removedSessionIds: [],
@@ -180,12 +186,12 @@ describe("search index worker", () => {
 
   it("saves a full cache and marks a completely indexed agent initialized", async () => {
     const agent = makeAgent();
-    const sessions = [{ id: "s1" }, { id: "s2" }];
+    const sessions = [makeSession("s1"), makeSession("s2")];
     const meta = { s1: { id: "s1" } };
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     mocks.commitDurableSessionPublication.mockImplementation(
       (_publication: unknown, readSession: (id: string) => unknown) => {
-        expect(readSession("s1")).toEqual({ id: "s1" });
+        expect(readSession("s1")).toEqual(makeSession("s1"));
         return {
           status: "committed",
           publicationId: "publication-full",
@@ -235,7 +241,7 @@ describe("search index worker", () => {
 
   it("passes partial scope and explicit removals to both durable indexes", async () => {
     const agent = makeAgent();
-    const sessions = [{ id: "recent" }];
+    const sessions = [makeSession("recent")];
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     mocks.commitDurableSessionPublication.mockReturnValue({
       status: "committed",
@@ -279,7 +285,7 @@ describe("search index worker", () => {
 
   it("CS-73 regression: still marks the agent initialized when a session couldn't be indexed, but warns", async () => {
     const agent = makeAgent();
-    const sessions = [{ id: "s1" }, { id: "broken" }];
+    const sessions = [makeSession("s1"), makeSession("broken")];
     const meta = { s1: { id: "s1" } };
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     // One session (e.g. its data failed to load) is left unindexed.
@@ -320,12 +326,12 @@ describe("search index worker", () => {
 
   it("applies incremental index changes and reports processed sessions", async () => {
     const agent = makeAgent();
-    const changes = [{ id: "updated", session: { id: "updated" } }];
+    const changes = [{ session: makeSession("updated"), sortIndex: 0 }];
     const removedSessionIds = ["removed"];
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     mocks.commitDurableSessionPublication.mockImplementation(
       (_publication: unknown, readSession: (id: string) => unknown) => {
-        expect(readSession("updated")).toEqual({ id: "updated" });
+        expect(readSession("updated")).toEqual(makeSession("updated"));
         return {
           status: "committed",
           publicationId: "publication-changes",
@@ -371,7 +377,7 @@ describe("search index worker", () => {
 
   it("updates maintenance rows without rewriting the session cache", async () => {
     const agent = makeAgent();
-    const changes = [{ session: { id: "legacy" }, sortIndex: 0 }];
+    const changes = [{ session: makeSession("legacy"), sortIndex: 0 }];
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     mocks.syncSessionSearchIndexChanges.mockReturnValue({ indexed: 1, skipped: 0 });
     mocks.workerData = {
@@ -425,7 +431,7 @@ describe("search index worker", () => {
           kind: "changes",
           context: "scan.refresh",
           agentName: "codex",
-          changes: [{ session: { id: "s1" }, sortIndex: 0 }],
+          changes: [{ session: makeSession("s1"), sortIndex: 0 }],
           removedSessionIds: [],
           meta: {},
         },
@@ -466,7 +472,7 @@ describe("search index worker", () => {
           kind: "full",
           context: "scan.refresh",
           agentName: "codex",
-          sessions: [{ id: "s1" }, { id: "s2" }],
+          sessions: [makeSession("s1"), makeSession("s2")],
           meta: {},
           completeness: "complete",
           removedSessionIds: [],
@@ -476,7 +482,7 @@ describe("search index worker", () => {
           kind: "full",
           context: "scan.refresh",
           agentName: "codex",
-          sessions: [{ id: "s3" }],
+          sessions: [makeSession("s3")],
           meta: {},
           completeness: "complete",
           removedSessionIds: [],
@@ -521,7 +527,7 @@ describe("search index worker", () => {
       kind: "full",
       context: "scan.initial",
       agentName,
-      sessions: [{ id: `${agentName}-s1` }],
+      sessions: [makeSession(`${agentName}-s1`, agentName)],
       meta: {},
       completeness: "complete",
       removedSessionIds: [],
@@ -560,7 +566,7 @@ describe("search index worker", () => {
           kind: "full",
           context: "scan.refresh",
           agentName: "codex",
-          sessions: [{ id: "s1" }],
+          sessions: [makeSession("s1")],
           meta: {},
           completeness: "complete",
           removedSessionIds: [],

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -136,8 +136,6 @@ function createStore() {
 function createLargeSessionsStore() {
   const sessions = Array.from({ length: 200 }, (_, index) => ({
     reference: { agentName: "codex", sessionId: `session-${index}` },
-    id: `session-${index}`,
-    slug: `codex/session-${index}`,
     title: `Session with a reasonably descriptive title ${index}`,
     directory: "/repo/some/nested/project/directory",
     project_identity: {

--- a/packages/cli/src/session-index-output.test.ts
+++ b/packages/cli/src/session-index-output.test.ts
@@ -9,8 +9,6 @@ import {
 function makeSession(id: string, activity: number): IdentifiedSessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: "/workspace",
     project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
@@ -34,10 +32,8 @@ function makeSnapshot(
 /** Fields the README promises; anything beyond this would make --json an archive. */
 const DOCUMENTED_SESSION_FIELDS = [
   "directory",
-  "id",
   "project_identity",
   "reference",
-  "slug",
   "stats",
   "time_created",
   "time_updated",
@@ -68,7 +64,7 @@ describe("CS-150: --json is a session index", () => {
       { from: 1_000 },
     );
 
-    expect(output.sessions.map((session) => session.id)).toEqual(["new"]);
+    expect(output.sessions.map((session) => session.reference.sessionId)).toEqual(["new"]);
   });
 
   it("filters by parent activity while retaining child sessions", () => {
@@ -80,7 +76,10 @@ describe("CS-150: --json is a session index", () => {
 
     const output = buildSessionIndexOutput(makeSnapshot([parent, child]), { from: 1_000 });
 
-    expect(output.sessions.map((session) => session.id)).toEqual(["parent", "child"]);
+    expect(output.sessions.map((session) => session.reference.sessionId)).toEqual([
+      "parent",
+      "child",
+    ]);
     expect(output.agents.find((agent) => agent.name === "codex")?.count).toBe(2);
   });
 

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -146,8 +146,6 @@ class ReentrantSingleFileSource extends SingleFileSessionSource {
 function makeSession(id: string): SessionHead {
   return {
     reference: { agentName: "fake", sessionId: id },
-    id,
-    slug: `fake/${id}`,
     title: id,
     directory: "/tmp",
     time_created: 1000,
@@ -186,12 +184,10 @@ describe("BaseAgent", () => {
     expect(agent.getUri("abc123")).toBe("fake://abc123");
   });
 
-  it("formats session slugs from its normalized registered identity", () => {
+  it("normalizes session references from its registered identity", () => {
     const agent = new NormalizedNameSource();
     expect(agent.sessionIdentityForTest("nested/session")).toEqual({
       reference: { agentName: "fake", sessionId: "nested/session" },
-      id: "nested/session",
-      slug: "fake/nested/session",
     });
   });
 });
@@ -251,7 +247,7 @@ describe("FileSystemSessionSource.scan", () => {
     };
     const sessions = agent.scan(options);
 
-    expect(sessions.map((session) => session.id)).toEqual(["a", "b"]);
+    expect(sessions.map((session) => session.reference.sessionId)).toEqual(["a", "b"]);
     expect(agent.lastScanOptions).toBe(options);
     expect(progress).toEqual([
       { total: 3, processed: 0, sessions: 0 },
@@ -274,7 +270,7 @@ describe("FileSystemSessionSource.scan", () => {
 
     try {
       const sessions = agent.scan();
-      expect(sessions.map((session) => session.id)).toEqual(["a"]);
+      expect(sessions.map((session) => session.reference.sessionId)).toEqual(["a"]);
       expect(events).toEqual([
         {
           event: "agent.session_source_outcome",
@@ -643,20 +639,20 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     ]);
 
     const updated = agent.incrementalScan([makeSession("a"), makeSession("b")], ["a"]);
-    expect(updated.map((s) => s.id).sort()).toEqual(["a", "b"]);
+    expect(updated.map((s) => s.reference.sessionId).sort()).toEqual(["a", "b"]);
     expect(agent.getSessionCacheMeta("a")?.sourceFingerprint).toBe("fp-1");
   });
 
   it("adds new sources when listed but missing from cache", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b")]);
     const updated = agent.incrementalScan([makeSession("a")], ["b"]);
-    expect(updated.map((s) => s.id).sort()).toEqual(["a", "b"]);
+    expect(updated.map((s) => s.reference.sessionId).sort()).toEqual(["a", "b"]);
   });
 
   it("retains the last-known-good session when a source no longer parses", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b", "fp-1", { head: null })]);
     const updated = agent.incrementalScan([makeSession("a"), makeSession("b")], ["b"]);
-    expect(updated.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(updated.map((s) => s.reference.sessionId)).toEqual(["a", "b"]);
     expect(agent.getSessionCacheMeta("b")).toBeUndefined();
   });
 
@@ -722,7 +718,9 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     const withRefs = agent.incrementalScan(cached, changedIds, refs);
 
     expect(listSpy).toHaveBeenCalledTimes(0);
-    expect(withRefs.map((s) => s.id).sort()).toEqual(fallback.map((s) => s.id).sort());
+    expect(withRefs.map((s) => s.reference.sessionId).sort()).toEqual(
+      fallback.map((s) => s.reference.sessionId).sort(),
+    );
   });
 });
 
@@ -892,7 +890,7 @@ describe("DatabaseSessionSource", () => {
     const sessions = agent.incrementalScan([makeSession("stale")], ["stale"], undefined, options);
     expect(agent.scanCount).toBe(1);
     expect(agent.lastScanOptions).toEqual(options);
-    expect(sessions.map((s) => s.id)).toEqual(["db-1"]);
+    expect(sessions.map((s) => s.reference.sessionId)).toEqual(["db-1"]);
   });
 
   it("rememberSession records meta keyed by db path", () => {

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -30,8 +30,6 @@ let tempDirs: string[] = [];
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
     reference: { agentName: "claudecode", sessionId: id },
-    id,
-    slug: `claudecode/${id}`,
     title: id,
     directory: "/tmp/project",
     time_created: 1000,
@@ -485,7 +483,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     );
 
     expect(head).toMatchObject({
-      id: sessionId,
+      reference: { agentName: "claudecode", sessionId },
       title: "Indexed summary",
       directory: "/tmp/project",
       stats: {
@@ -654,17 +652,19 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
 
     const heads = agent.scan();
-    const parent = heads.find((head: SessionHead) => head.id === parentId);
-    const child = heads.find((head: SessionHead) => head.id === childId);
+    const parent = heads.find((head: SessionHead) => head.reference.sessionId === parentId);
+    const child = heads.find((head: SessionHead) => head.reference.sessionId === childId);
 
-    expect(heads.map((head: SessionHead) => head.id).sort()).toEqual(
+    expect(heads.map((head: SessionHead) => head.reference.sessionId).sort()).toEqual(
       [parentId, childId, nestedChildId].sort(),
     );
     expect(child).toMatchObject({
       title: "repository-check",
       parent_reference: { agentName: "claudecode", sessionId: parentId },
     });
-    expect(heads.find((head: SessionHead) => head.id === nestedChildId)).toMatchObject({
+    expect(
+      heads.find((head: SessionHead) => head.reference.sessionId === nestedChildId),
+    ).toMatchObject({
       title: "Nested repository check",
       parent_reference: { agentName: "claudecode", sessionId: childId },
     });
@@ -676,7 +676,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     );
     expect(agentMessage?.subagent_id).toBe(childId);
     expect(agent.getSessionData(childId)).toMatchObject({
-      id: childId,
+      reference: { agentName: "claudecode", sessionId: childId },
       parent_reference: { agentName: "claudecode", sessionId: parentId },
       messages: [
         { role: "user" },
@@ -1035,7 +1035,7 @@ describe("ClaudeCodeAgent head parsing", () => {
 
     expect(agent.scan()).toMatchObject([
       {
-        id: childId,
+        reference: { agentName: "claudecode", sessionId: childId },
         title: "Orphan child",
         parent_reference: undefined,
       },

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -35,8 +35,6 @@ let tempDirs: string[] = [];
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: "/tmp/project",
     time_created: 1000,
@@ -513,7 +511,7 @@ describe("CodexAgent cache refresh", () => {
       ["019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb", "019dcccc-cccc-7ccc-cccc-cccccccccccc"],
     );
 
-    expect(sessions.map((session: SessionHead) => session.id).sort()).toEqual([
+    expect(sessions.map((session: SessionHead) => session.reference.sessionId).sort()).toEqual([
       "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
       "019dcccc-cccc-7ccc-cccc-cccccccccccc",
     ]);
@@ -1134,7 +1132,7 @@ describe("CodexAgent cache refresh", () => {
     );
 
     expect(head).toMatchObject({
-      id: sessionId,
+      reference: { agentName: "codex", sessionId },
       title: "Implement parser coverage",
       directory: "/tmp/project",
       stats: {
@@ -1560,7 +1558,7 @@ describe("CodexAgent subagent folding", () => {
     agent.sessionIndexCache = new Map();
 
     const heads = agent.scan({ from: 0 });
-    expect(heads.map((h: SessionHead) => h.id)).toEqual([PARENT_ID, CHILD_ID]);
+    expect(heads.map((h: SessionHead) => h.reference.sessionId)).toEqual([PARENT_ID, CHILD_ID]);
     expect(heads[0].stats.total_input_tokens).toBe(100);
     expect(heads[0].stats.total_output_tokens).toBe(20);
     expect(heads[1].parent_reference).toEqual({ agentName: "codex", sessionId: PARENT_ID });
@@ -1839,7 +1837,7 @@ describe("CodexAgent subagent folding", () => {
     agent.sessionIndexCache = new Map();
 
     const [head] = agent.scan({ from: 0 });
-    expect(head.id).toBe(PARENT_ID);
+    expect(head.reference.sessionId).toBe(PARENT_ID);
     expect(head.stats.total_input_tokens).toBe(100);
     expect(head.stats.total_output_tokens).toBe(20);
   });
@@ -1919,7 +1917,7 @@ describe("CodexAgent subagent folding", () => {
 
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
     expect(agent.scanSessionSource(childFile)).toMatchObject({
-      id: CHILD_ID,
+      reference: { agentName: "codex", sessionId: CHILD_ID },
       parent_reference: { agentName: "codex", sessionId: PARENT_ID },
     });
   });
@@ -1952,7 +1950,7 @@ describe("CodexAgent subagent folding", () => {
     agent.sessionIndexCache = new Map();
 
     const heads = agent.scan({ from: 0, fast: true });
-    expect(heads.find((head: SessionHead) => head.id === CHILD_ID)).toMatchObject({
+    expect(heads.find((head: SessionHead) => head.reference.sessionId === CHILD_ID)).toMatchObject({
       parent_reference: { agentName: "codex", sessionId: PARENT_ID },
     });
   });

--- a/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
@@ -67,8 +67,8 @@ describe("CS-142: Cursor scan shape", () => {
     const fastHeads = makeAgent(dbPath).scan({ from: 0, fast: true });
     const fullHeads = makeAgent(dbPath).scan({ from: 0 });
 
-    expect(fastHeads.map((head) => head.id)).toEqual(["c1"]);
-    expect(fullHeads.map((head) => head.id)).toEqual(["c1"]);
+    expect(fastHeads.map((head) => head.reference.sessionId)).toEqual(["c1"]);
+    expect(fullHeads.map((head) => head.reference.sessionId)).toEqual(["c1"]);
   });
 
   it("resolves legacy request ids to the canonical composer id", () => {
@@ -82,9 +82,8 @@ describe("CS-142: Cursor scan shape", () => {
 
     const detail = agent.getSessionData("legacy-request");
 
-    expect(detail.id).toBe("c1");
+    expect(detail.reference.sessionId).toBe("c1");
     expect(detail.reference).toEqual({ agentName: "cursor", sessionId: "c1" });
-    expect(detail.slug).toBe("cursor/c1");
   });
 
   it("migrates cached request-id metadata during a full scan", () => {
@@ -117,7 +116,10 @@ describe("CS-142: Cursor scan shape", () => {
 
     const heads = agent.scan({ from: 0 });
 
-    expect(textOf(agent, heads[0]!.id)).toEqual(["written first", "written second"]);
+    expect(textOf(agent, heads[0]!.reference.sessionId)).toEqual([
+      "written first",
+      "written second",
+    ]);
   });
 
   it("drops a composer whose bubbles are all malformed or internal", () => {
@@ -130,7 +132,7 @@ describe("CS-142: Cursor scan shape", () => {
 
     const heads = makeAgent(dbPath).scan({ from: 0 });
 
-    expect(heads.map((head) => head.id)).toEqual(["kept"]);
+    expect(heads.map((head) => head.reference.sessionId)).toEqual(["kept"]);
   });
 
   it("keeps a composer that only has subagents", () => {
@@ -138,7 +140,7 @@ describe("CS-142: Cursor scan shape", () => {
 
     const heads = makeAgent(dbPath).scan({ from: 0 });
 
-    expect(heads.map((head) => head.id)).toEqual(["sub"]);
+    expect(heads.map((head) => head.reference.sessionId)).toEqual(["sub"]);
   });
 
   it("applies the scan window to the composer's update time", () => {
@@ -151,7 +153,7 @@ describe("CS-142: Cursor scan shape", () => {
 
     const heads = makeAgent(dbPath).scan({ from: 1_000 });
 
-    expect(heads.map((head) => head.id)).toEqual(["new"]);
+    expect(heads.map((head) => head.reference.sessionId)).toEqual(["new"]);
   });
 
   it("releases composers excluded from the next scan", () => {
@@ -178,7 +180,7 @@ describe("CS-142: Cursor scan shape", () => {
     const agent = makeAgent(dbPath);
 
     const [head] = agent.scan({ from: 0 });
-    const detail = agent.getSessionData(head!.id);
+    const detail = agent.getSessionData(head!.reference.sessionId);
 
     expect(head?.time_updated).toBe(2_500);
     expect(detail.time_updated).toBe(head?.time_updated);

--- a/packages/core/src/agents/__tests__/dsh.test.ts
+++ b/packages/core/src/agents/__tests__/dsh.test.ts
@@ -502,7 +502,7 @@ describe("DSH storage records", () => {
     });
 
     const { agent, heads } = scanHeads();
-    const detail = agent.getSessionData(heads[0]!.id);
+    const detail = agent.getSessionData(heads[0]!.reference.sessionId);
     const assistant = detail.messages[1]!;
     expect(assistant.parts).toEqual([
       expect.objectContaining({ type: "reasoning", text: "thinking!" }),
@@ -624,7 +624,7 @@ describe("DSH transcript projection", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    const detail = agent.getSessionData(heads[0]!.id);
+    const detail = agent.getSessionData(heads[0]!.reference.sessionId);
     expect(detail.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
     expect(detail.messages[0]?.parts).toEqual([
       expect.objectContaining({ text: "what does this project do" }),
@@ -648,7 +648,7 @@ describe("DSH transcript projection", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    const detail = agent.getSessionData(heads[0]!.id);
+    const detail = agent.getSessionData(heads[0]!.reference.sessionId);
     expect(detail.messages).toHaveLength(2);
     expect(JSON.stringify(detail.messages)).not.toContain("compacted summary");
   });
@@ -683,7 +683,7 @@ describe("DSH transcript projection", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    const detail = agent.getSessionData(heads[0]!.id);
+    const detail = agent.getSessionData(heads[0]!.reference.sessionId);
     const parts = detail.messages[1]!.parts;
     expect(parts.filter((part) => part.type === "tool")).toHaveLength(2);
     expect(parts.map((part) => (part.type === "tool" ? part.state.status : part.type))).toEqual([
@@ -702,7 +702,7 @@ describe("DSH transcript projection", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    const tool = agent.getSessionData(heads[0]!.id).messages[1]!.parts[0];
+    const tool = agent.getSessionData(heads[0]!.reference.sessionId).messages[1]!.parts[0];
     expect(tool).toMatchObject({
       type: "tool",
       tool: "read",
@@ -751,7 +751,7 @@ describe("DSH transcript projection", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    const detail = agent.getSessionData(heads[0]!.id);
+    const detail = agent.getSessionData(heads[0]!.reference.sessionId);
     expect(detail.messages).toHaveLength(2);
     expect(detail.messages[1]?.parts).toEqual([
       expect.objectContaining({ type: "text", text: "settled answer" }),
@@ -773,7 +773,7 @@ describe("DSH transcript projection", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    const detail = agent.getSessionData(heads[0]!.id);
+    const detail = agent.getSessionData(heads[0]!.reference.sessionId);
     expect(detail.messages[1]).toMatchObject({
       role: "assistant",
       model: "deepseek-v4-flash",
@@ -794,7 +794,7 @@ describe("DSH transcript projection", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    expect(agent.getSessionData(heads[0]!.id).messages[1]?.parts).toEqual([
+    expect(agent.getSessionData(heads[0]!.reference.sessionId).messages[1]?.parts).toEqual([
       expect.objectContaining({ text: "assembled" }),
     ]);
   });
@@ -860,10 +860,9 @@ describe("DSH lineage", () => {
     });
     // The inherited title only applies when the child names nothing itself.
     expect(head.title).toBe("own question");
-    expect(agent.getSessionData(head.id).messages.map((message) => message.role)).toEqual([
-      "user",
-      "assistant",
-    ]);
+    expect(
+      agent.getSessionData(head.reference.sessionId).messages.map((message) => message.role),
+    ).toEqual(["user", "assistant"]);
   });
 
   it("uses an inherited title when the child has none of its own", () => {
@@ -913,7 +912,7 @@ describe("DSH token accounting", () => {
       total_cache_create_tokens: 500,
     });
     expect(heads[0]?.model_usage).toEqual({ "deepseek-v4-flash": 5_800 });
-    expect(agent.getSessionData(heads[0]!.id).messages[1]?.tokens).toEqual({
+    expect(agent.getSessionData(heads[0]!.reference.sessionId).messages[1]?.tokens).toEqual({
       input: 5_500,
       output: 200,
       reasoning: 100,
@@ -929,7 +928,7 @@ describe("DSH token accounting", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    expect(agent.getSessionData(heads[0]!.id).messages[1]?.tokens).toMatchObject({
+    expect(agent.getSessionData(heads[0]!.reference.sessionId).messages[1]?.tokens).toMatchObject({
       output: 0,
       reasoning: 5,
     });
@@ -983,7 +982,7 @@ describe("DSH image attachments", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    expect(agent.getSessionData(heads[0]!.id).messages[0]?.parts).toEqual([
+    expect(agent.getSessionData(heads[0]!.reference.sessionId).messages[0]?.parts).toEqual([
       expect.objectContaining({ type: "text", text: "look" }),
       expect.objectContaining({
         type: "image",
@@ -1009,7 +1008,7 @@ describe("DSH image attachments", () => {
     writeSession({ batches: [log.events] });
 
     const { agent, heads } = scanHeads();
-    const messages = agent.getSessionData(heads[0]!.id).messages;
+    const messages = agent.getSessionData(heads[0]!.reference.sessionId).messages;
     expect(messages[0]?.parts).toEqual([expect.objectContaining({ text: "look" })]);
     // An image-only message keeps its slot with a placeholder instead of vanishing.
     expect(messages[1]?.parts).toEqual([
@@ -1081,8 +1080,6 @@ describe("DSH source synchronization", () => {
       agent.filterCachedSessions([
         {
           reference: { agentName: "dsh", sessionId: "a" },
-          id: "a",
-          slug: "dsh/a",
           title: "a",
           directory: "/tmp",
           time_created: 1,
@@ -1090,8 +1087,6 @@ describe("DSH source synchronization", () => {
         },
         {
           reference: { agentName: "dsh", sessionId: "b" },
-          id: "b",
-          slug: "dsh/b",
           title: "b",
           directory: "/tmp",
           time_created: 1,

--- a/packages/core/src/agents/__tests__/grok.test.ts
+++ b/packages/core/src/agents/__tests__/grok.test.ts
@@ -215,8 +215,7 @@ describe("GrokAgent", () => {
 
     const [head] = agent.scan();
     expect(head).toMatchObject({
-      id: SESSION_ID,
-      slug: `grok/${SESSION_ID}`,
+      reference: { agentName: "grok", sessionId: SESSION_ID },
       title: "Grok session support",
       directory: "/tmp/grok-project",
       parent_reference: { agentName: "grok", sessionId: PARENT_SESSION_ID },

--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -171,7 +171,9 @@ describe("KimiCodeAgent", () => {
     const changes = agent.checkForChanges(0, heads);
     expect(changes.changedIds).toContain(SESSION_ID);
     const refreshed = agent.incrementalScan(heads, changes.changedIds ?? [], changes.refs);
-    expect(refreshed).toMatchObject([{ id: SESSION_ID, title: "Refresh me" }]);
+    expect(refreshed).toMatchObject([
+      { reference: { agentName: "kimi-code", sessionId: SESSION_ID }, title: "Refresh me" },
+    ]);
     expect(agent.getSessionCacheMeta(SESSION_ID)?.sourceFingerprint).toBe(
       changes.refs?.[0]?.fingerprint,
     );
@@ -288,8 +290,7 @@ describe("KimiCodeAgent", () => {
 
     const [head] = agent.scan();
     expect(head).toMatchObject({
-      id: SESSION_ID,
-      slug: `kimi-code/${SESSION_ID}`,
+      reference: { agentName: "kimi-code", sessionId: SESSION_ID },
       title: "Read package.json",
       directory: "/tmp/renamed-project",
       time_created: 1767225600000,
@@ -428,7 +429,10 @@ describe("KimiCodeAgent", () => {
 
     const refs = agent.listSessionSources();
     expect(agent.incrementalScan([], [emptyId], refs)).toMatchObject([
-      { id: emptyId, stats: { message_count: 1 } },
+      {
+        reference: { agentName: "kimi-code", sessionId: emptyId },
+        stats: { message_count: 1 },
+      },
     ]);
   });
 
@@ -442,8 +446,6 @@ describe("KimiCodeAgent", () => {
     const agent = createAgent(dataRoot);
     const stale = {
       reference: { agentName: "kimi-code", sessionId: SESSION_ID },
-      id: SESSION_ID,
-      slug: `kimi-code/${SESSION_ID}`,
       title: "New Session",
       directory: WORK_DIR,
       time_created: 1767225600000,

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -26,8 +26,6 @@ const KIMI_FIXTURE_ROOT = new URL("./fixtures/kimi/", import.meta.url);
 function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionHead {
   return {
     reference: { agentName: "kimi", sessionId: id },
-    id,
-    slug: `kimi/${id}`,
     title: id,
     directory: PROJECT_DIR,
     time_created: 1000,
@@ -111,7 +109,7 @@ describe("KimiAgent configuration", () => {
     const assistant = detail.messages.find((message) => message.role === "assistant");
 
     expect(head).toMatchObject({
-      id: "fixture-session",
+      reference: { agentName: "kimi", sessionId: "fixture-session" },
       directory: projectDir,
       stats: {
         total_input_tokens: 1_000,
@@ -157,12 +155,17 @@ describe("KimiAgent cache refresh", () => {
     const agent = createAgent(basePath);
     const sessions = agent.incrementalScan([makeSession("old-session")], ["new-session"]);
 
-    expect(sessions.map((session) => session.id).sort()).toEqual(["new-session", "old-session"]);
-    expect(sessions.find((session) => session.id === "new-session")).toMatchObject({
-      slug: "kimi/new-session",
-      title: "New",
-      directory: PROJECT_DIR,
-    });
+    expect(sessions.map((session) => session.reference.sessionId).sort()).toEqual([
+      "new-session",
+      "old-session",
+    ]);
+    expect(sessions.find((session) => session.reference.sessionId === "new-session")).toMatchObject(
+      {
+        reference: { agentName: "kimi", sessionId: "new-session" },
+        title: "New",
+        directory: PROJECT_DIR,
+      },
+    );
   });
 
   it("removes deleted sessions during incremental scan", () => {
@@ -176,7 +179,7 @@ describe("KimiAgent cache refresh", () => {
       ["deleted-session"],
     );
 
-    expect(sessions.map((session) => session.id)).toEqual(["old-session"]);
+    expect(sessions.map((session) => session.reference.sessionId)).toEqual(["old-session"]);
     expect(agent.getSessionCacheMeta("deleted-session")).toBeUndefined();
   });
 
@@ -237,7 +240,10 @@ describe("KimiAgent cache refresh", () => {
 
     const agent = createAgent(basePath);
     const cached = agent.scan();
-    expect(cached.map((session) => session.id).sort()).toEqual(["old-session", "recent-session"]);
+    expect(cached.map((session) => session.reference.sessionId).sort()).toEqual([
+      "old-session",
+      "recent-session",
+    ]);
 
     const window = { from: recent - 7 * 24 * 60 * 60 * 1000 };
     const refs = agent.listSessionSources(window);

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -262,8 +262,7 @@ describe("OpenCodeSqliteAgent", () => {
     expect(agent.isAvailable()).toBe(true);
     expect(agent.scan({ from: 0 })).toEqual([
       expect.objectContaining({
-        id: "s1",
-        slug: "test-agent/s1",
+        reference: { agentName: "test-agent", sessionId: "s1" },
         title: "Implement cache tests",
         stats: expect.objectContaining({
           message_count: 1,
@@ -469,7 +468,7 @@ describe("CS-206: database scans preserve the requested window", () => {
       to: 20_000,
     });
 
-    expect(heads.map((head) => head.id)).toEqual(["child-0", "root-0"]);
+    expect(heads.map((head) => head.reference.sessionId)).toEqual(["child-0", "root-0"]);
   });
 });
 
@@ -491,7 +490,7 @@ describe("CS-180: related session reads stay inside the selected roots", () => {
 
     const heads = agent.scan({ from: 15_000 });
 
-    expect(heads.map((head) => head.id)).toEqual([
+    expect(heads.map((head) => head.reference.sessionId)).toEqual([
       "recent-root",
       "child",
       "grandchild",
@@ -524,7 +523,7 @@ describe("CS-180: related session reads stay inside the selected roots", () => {
     agent.isAvailable();
 
     const heads = agent.scan({ from: 15_000 });
-    const ids = new Set(heads.map((head) => head.id));
+    const ids = new Set(heads.map((head) => head.reference.sessionId));
 
     expect(heads).toHaveLength(1_002);
     expect(ids.size).toBe(1_002);
@@ -556,7 +555,9 @@ describe("CS-180: related session reads stay inside the selected roots", () => {
     agent.isAvailable();
 
     expect(
-      agent.scan({ from: 15_000, includeRelatedSessions: false }).map((head) => head.id),
+      agent
+        .scan({ from: 15_000, includeRelatedSessions: false })
+        .map((head) => head.reference.sessionId),
     ).toEqual(["root-1", "root-0"]);
     expect(agent.scan({ from: 30_000 })).toEqual([]);
     expect(diagnostics).toEqual([]);
@@ -832,7 +833,7 @@ describe("subagent folding degrades when task_type/parent_id are absent", () => 
     const heads = agent.scan({ from: 0 });
     expect(heads).toHaveLength(1);
     expect(heads[0]).toMatchObject({
-      id: "s1",
+      reference: { agentName: "opencode", sessionId: "s1" },
       stats: expect.objectContaining({
         message_count: 1,
         total_input_tokens: 1_000,

--- a/packages/core/src/agents/__tests__/opencode.test.ts
+++ b/packages/core/src/agents/__tests__/opencode.test.ts
@@ -76,7 +76,7 @@ describe("OpenCodeAgent parsing", () => {
     const [head] = agent.scan({ from: 0 });
 
     expect(head).toMatchObject({
-      id: "legacy-session",
+      reference: { agentName: "opencode", sessionId: "legacy-session" },
       title: "Legacy session",
       stats: { message_count: 0 },
     });

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -147,8 +147,7 @@ describe("PiAgent", () => {
     const tool = data.messages[1]?.parts.find((part: MessagePart) => part.type === "tool");
 
     expect(head).toMatchObject({
-      id: sessionId,
-      slug: `pi/${sessionId}`,
+      reference: { agentName: "pi", sessionId },
       title: "Inspect package metadata",
       directory: "/tmp/project",
       stats: {
@@ -216,7 +215,7 @@ describe("PiAgent", () => {
       },
     ]);
 
-    expect(agent.listSessionSources()[0]?.sessionId).toBe(agent.scan()[0]?.id);
+    expect(agent.listSessionSources()[0]?.sessionId).toBe(agent.scan()[0]?.reference.sessionId);
   });
 
   it("stats each session file once during a scan", () => {
@@ -383,8 +382,7 @@ describe("PiAgent", () => {
     const tool = assistant?.parts.find((part: MessagePart) => part.type === "tool");
 
     expect(head).toMatchObject({
-      id: sessionId,
-      slug: `pi/${sessionId}`,
+      reference: { agentName: "pi", sessionId },
       title: "Package inspection",
       directory: "/tmp/project",
       stats: {
@@ -593,7 +591,7 @@ describe("PiAgent", () => {
 
     const [head] = agent.scan();
 
-    expect(head?.id).toBe(sessionId);
+    expect(head?.reference.sessionId).toBe(sessionId);
     expect(head?.directory).toBe("/tmp/first");
   });
 

--- a/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
+++ b/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
@@ -38,8 +38,6 @@ describe("failure normalization", () => {
 function session(id: string, title = id): SessionHead {
   return {
     reference: { agentName: "test", sessionId: id },
-    id,
-    slug: `test/${id}`,
     title,
     directory: "/workspace",
     time_created: 1,
@@ -109,7 +107,7 @@ class MemorySourceAdapter implements SessionSourceSynchronizationAdapter {
 
   filterCachedSessions(sessions: SessionHead[]): SessionHead[] {
     return this.visibleIds
-      ? sessions.filter((session) => this.visibleIds!.has(session.id))
+      ? sessions.filter((session) => this.visibleIds!.has(session.reference.sessionId))
       : sessions;
   }
 
@@ -175,8 +173,14 @@ describe("synchronizeSessionSources", () => {
 
     expect(adapter.scannedIds).toEqual(["changed", "parent"]);
     expect(adapter.listCalls).toBe(1);
-    expect(outcome.sessions.map(({ id }) => id)).toEqual(["unchanged", "changed", "parent"]);
-    expect(outcome.sessions.find(({ id }) => id === "changed")?.title).toBe("updated");
+    expect(outcome.sessions.map(({ reference: { sessionId: id } }) => id)).toEqual([
+      "unchanged",
+      "changed",
+      "parent",
+    ]);
+    expect(
+      outcome.sessions.find(({ reference: { sessionId: id } }) => id === "changed")?.title,
+    ).toBe("updated");
     expect(outcome.detectedSessionIds).toEqual(["changed", "removed"]);
     expect(outcome.changedSessionIds).toEqual(["removed", "changed", "parent"]);
     expect(outcome.explicitRemovedSessionIds).toEqual(["removed"]);
@@ -203,7 +207,10 @@ describe("synchronizeSessionSources", () => {
       { kind: "refresh", scanOptions: { from: 100 } },
     );
 
-    expect(outcome.sessions.map(({ id }) => id)).toEqual(["recent", "outside"]);
+    expect(outcome.sessions.map(({ reference: { sessionId: id } }) => id)).toEqual([
+      "recent",
+      "outside",
+    ]);
     expect(outcome.explicitRemovedSessionIds).toEqual([]);
     expect(outcome.finalizeSessionIds).toEqual(["recent"]);
     expect(outcome.completeness).toBe("partial");
@@ -267,7 +274,7 @@ describe("synchronizeSessionSources", () => {
       { kind: "refresh" },
     );
 
-    expect(outcome.sessions.map(({ id }) => id)).toEqual(["good"]);
+    expect(outcome.sessions.map(({ reference: { sessionId: id } }) => id)).toEqual(["good"]);
     expect(outcome.sourceFailures).toEqual([]);
     expect(outcome.completeness).toBe("complete");
     expect(outcome.sourceOutcomes).toContainEqual({ status: "failed", failure });

--- a/packages/core/src/agents/__tests__/zcode.test.ts
+++ b/packages/core/src/agents/__tests__/zcode.test.ts
@@ -188,8 +188,7 @@ describe("ZCodeAgent parsing", () => {
 
     expect(agent.getUri("sess_1")).toBe("zcode://sess_1");
     expect(head).toMatchObject({
-      id: "sess_1",
-      slug: "zcode/sess_1",
+      reference: { agentName: "zcode", sessionId: "sess_1" },
       title: "Build the ZCode adapter",
       directory: "/tmp/project",
       stats: {
@@ -201,8 +200,7 @@ describe("ZCodeAgent parsing", () => {
       },
     });
     expect(data).toMatchObject({
-      id: "sess_1",
-      slug: "zcode/sess_1",
+      reference: { agentName: "zcode", sessionId: "sess_1" },
       title: "Build the ZCode adapter",
       version: "0.14.8",
       summary_files: 3,
@@ -343,7 +341,7 @@ describe("ZCodeAgent subagent folding", () => {
     agent.dbPath = dbPath;
 
     const heads = agent.scan({ from: 0 });
-    expect(heads.map((h: any) => h.id)).toEqual(["parent", "child"]);
+    expect(heads.map((head: any) => head.reference.sessionId)).toEqual(["parent", "child"]);
     const [head] = heads;
     expect(head.stats).toMatchObject({
       message_count: 1,
@@ -552,7 +550,7 @@ describe("ZCodeAgent subagent folding", () => {
     agent.dbPath = dbPath;
 
     const [head] = agent.scan({ from: 0 });
-    expect(head.id).toBe("only");
+    expect(head.reference.sessionId).toBe("only");
     expect(head.stats).toMatchObject({ total_input_tokens: 10, total_output_tokens: 0 });
     expect(agent.getSessionData("only").stats.total_input_tokens).toBe(10);
   });

--- a/packages/core/src/analytics/__tests__/dashboard-tree-reuse.test.ts
+++ b/packages/core/src/analytics/__tests__/dashboard-tree-reuse.test.ts
@@ -14,8 +14,6 @@ import { buildDashboard } from "../dashboard.js";
 function makeSession(id: string, activity: number): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: "/project",
     time_created: activity,

--- a/packages/core/src/analytics/__tests__/dashboard.test.ts
+++ b/packages/core/src/analytics/__tests__/dashboard.test.ts
@@ -180,11 +180,11 @@ describe("buildDashboard", () => {
     const result = buildDashboard(
       [
         makeSession("a", {
-          slug: "claudecode/a",
+          reference: { agentName: "claudecode", sessionId: "a" },
           stats: { message_count: 2, total_input_tokens: 5, total_output_tokens: 5, total_cost: 0 },
         }),
         makeSession("b", {
-          slug: "claudecode/b",
+          reference: { agentName: "claudecode", sessionId: "b" },
           stats: { message_count: 1, total_input_tokens: 3, total_output_tokens: 2, total_cost: 0 },
         }),
       ],
@@ -251,7 +251,7 @@ describe("buildDashboard", () => {
       sessions: [
         {
           ...EMPTY_SESSION_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           messageCost: 6,
           untimedMessageCost: 0,
           modelCosts: [{ model: "sonnet", cost: 6, costRecorded: 0 }],
@@ -260,7 +260,7 @@ describe("buildDashboard", () => {
       messages: [
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day1 + 1_000,
           model: "sonnet",
           cost: 1,
@@ -268,7 +268,7 @@ describe("buildDashboard", () => {
         },
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day2 + 1_000,
           model: "sonnet",
           cost: 2,
@@ -276,7 +276,7 @@ describe("buildDashboard", () => {
         },
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day3 + 1_000,
           model: "sonnet",
           cost: 3,
@@ -325,7 +325,7 @@ describe("buildDashboard", () => {
       sessions: [
         {
           ...EMPTY_SESSION_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           messageCount: 2,
           inputTokens: 150,
           outputTokens: 30,
@@ -338,7 +338,7 @@ describe("buildDashboard", () => {
       messages: [
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day1 + 1_000,
           inputTokens: 100,
           outputTokens: 20,
@@ -348,7 +348,7 @@ describe("buildDashboard", () => {
         },
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day2 + 1_000,
           inputTokens: 50,
           outputTokens: 10,
@@ -396,7 +396,7 @@ describe("buildDashboard", () => {
       sessions: [
         {
           ...EMPTY_SESSION_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           messageCount: 2,
           untimedMessageCount: 1,
           inputTokens: 150,
@@ -411,7 +411,7 @@ describe("buildDashboard", () => {
       messages: [
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day1 + 1_000,
           inputTokens: 50,
           outputTokens: 10,
@@ -462,7 +462,7 @@ describe("buildDashboard", () => {
     });
     const summary = (session: SessionHead, outputTokens: number, reasoningTokens: number) => ({
       ...EMPTY_SESSION_USAGE,
-      reference: { agentName: "claudecode", sessionId: session.id },
+      reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
       messageCount: 1,
       inputTokens: 10,
       outputTokens,
@@ -473,7 +473,7 @@ describe("buildDashboard", () => {
     });
     const message = (session: SessionHead, outputTokens: number, reasoningTokens: number) => ({
       ...EMPTY_MESSAGE_USAGE,
-      reference: { agentName: "claudecode", sessionId: session.id },
+      reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
       time,
       inputTokens: 10,
       outputTokens,
@@ -515,7 +515,7 @@ describe("buildDashboard", () => {
       sessions: [
         {
           ...EMPTY_SESSION_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           messageCost: 6,
           untimedMessageCost: 3,
           modelCosts: [{ model: "sonnet", cost: 6, costRecorded: 0 }],
@@ -524,7 +524,7 @@ describe("buildDashboard", () => {
       messages: [
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day1 + 1_000,
           model: "sonnet",
           cost: 3,
@@ -859,7 +859,7 @@ describe("buildDashboard compare window", () => {
       sessions: [
         {
           ...EMPTY_SESSION_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           messageCost: 3,
           untimedMessageCost: 0,
           modelCosts: [],
@@ -868,14 +868,14 @@ describe("buildDashboard compare window", () => {
       messages: [
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: 150,
           cost: 1,
           costSource: "estimated",
         },
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: 250,
           cost: 2,
           costSource: "estimated",

--- a/packages/core/src/analytics/__tests__/projects.test.ts
+++ b/packages/core/src/analytics/__tests__/projects.test.ts
@@ -198,7 +198,7 @@ describe("attachProjectMetrics", () => {
       sessions: [
         {
           ...EMPTY_SESSION_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           messageCount: 1,
           inputTokens: 10,
           outputTokens: 5,
@@ -210,7 +210,7 @@ describe("attachProjectMetrics", () => {
       messages: [
         {
           ...EMPTY_MESSAGE_USAGE,
-          reference: { agentName: "claudecode", sessionId: session.id },
+          reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: 150,
           inputTokens: 10,
           outputTokens: 5,

--- a/packages/core/src/bookmarks/materialize.test.ts
+++ b/packages/core/src/bookmarks/materialize.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import type { BookmarkRecord, ReferencedSessionHead, SessionHead } from "../contract/index.js";
+import {
+  getSessionReferenceKey,
+  type BookmarkRecord,
+  type ReferencedSessionHead,
+  type SessionHead,
+} from "../contract/index.js";
 import { materializeBookmarkViews } from "./materialize.js";
 
 function makeBookmark(sessionId: string, agentName = "codex", bookmarkedAt = 1): BookmarkRecord {
@@ -9,8 +14,6 @@ function makeBookmark(sessionId: string, agentName = "codex", bookmarkedAt = 1):
 function makeSession(sessionId: string, agentName = "codex", timeUpdated = 1): SessionHead {
   return {
     reference: { agentName, sessionId },
-    id: sessionId,
-    slug: `${agentName}/${sessionId}`,
     title: `${sessionId} title`,
     directory: "/workspace",
     time_created: 1,
@@ -67,7 +70,10 @@ describe("materializeBookmarkViews", () => {
     expect(views[0]).toMatchObject({
       availability: "available",
       reference: { agentName: "codex", sessionId: "old" },
-      session: { id: "old", slug: "codex/old", title: "Cached title" },
+      session: {
+        reference: { agentName: "codex", sessionId: "old" },
+        title: "Cached title",
+      },
     });
   });
 
@@ -96,7 +102,7 @@ describe("materializeBookmarkViews", () => {
     const live = new Map(
       Array.from({ length: 10_000 }, (_, index) => {
         const session = makeSession(`unrelated-${index}`);
-        return [session.slug, session] as const;
+        return [getSessionReferenceKey(session.reference), session] as const;
       }),
     );
     live.set("codex/first", makeSession("first"));

--- a/packages/core/src/bookmarks/materialize.ts
+++ b/packages/core/src/bookmarks/materialize.ts
@@ -23,7 +23,7 @@ function canonicalSession(reference: SessionReference, session: SessionHead): Se
   const normalized = normalizeSessionReference(reference);
   assertSessionIdentity(session, normalized.agentName);
   if (session.reference.sessionId !== normalized.sessionId) {
-    throw new Error("Session identity fields disagree");
+    throw new Error("Session reference does not match expected session");
   }
   return session;
 }

--- a/packages/core/src/contract/__tests__/events.test.ts
+++ b/packages/core/src/contract/__tests__/events.test.ts
@@ -26,11 +26,11 @@ describe("mergeSessionsUpdatedEvents", () => {
     const reference = { agentName: "claudecode", sessionId: "session-1" };
     const first = {
       reference,
-      session: { id: "session-1", display_title: "Before" },
+      session: { display_title: "Before" },
     } as ReferencedSessionHead;
     const latest = {
       reference,
-      session: { id: "session-1", display_title: "After" },
+      session: { display_title: "After" },
     } as ReferencedSessionHead;
 
     const merged = mergeSessionsUpdatedEvents(event([first]), event([latest]));
@@ -40,7 +40,7 @@ describe("mergeSessionsUpdatedEvents", () => {
 
   it("lets the latest removal replace an earlier change", () => {
     const reference = { agentName: "claudecode", sessionId: "session-1" };
-    const changed = { reference, session: { id: "session-1" } } as ReferencedSessionHead;
+    const changed = { reference, session: {} } as ReferencedSessionHead;
 
     const merged = mergeSessionsUpdatedEvents(event([changed]), event([], [reference]));
 
@@ -53,11 +53,11 @@ describe("mergeSessionsUpdatedEvents", () => {
     const relatedReference = { agentName: "claudecode", sessionId: "related" };
     const changed = {
       reference: changedReference,
-      session: { id: "changed" },
+      session: {},
     } as ReferencedSessionHead;
     const related = {
       reference: relatedReference,
-      session: { id: "related" },
+      session: {},
     } as ReferencedSessionHead;
 
     const merged = mergeSessionsUpdatedEvents(event([], [], [related]), event([changed]));
@@ -68,10 +68,10 @@ describe("mergeSessionsUpdatedEvents", () => {
 
   it("lets a later change or removal replace a projection-related head", () => {
     const reference = { agentName: "claudecode", sessionId: "session-1" };
-    const related = { reference, session: { id: "session-1" } } as ReferencedSessionHead;
+    const related = { reference, session: {} } as ReferencedSessionHead;
     const changed = {
       reference,
-      session: { id: "session-1", display_title: "changed" },
+      session: { display_title: "changed" },
     } as ReferencedSessionHead;
 
     const changedMerge = mergeSessionsUpdatedEvents(event([], [], [related]), event([changed]));

--- a/packages/core/src/contract/__tests__/session-index.test.ts
+++ b/packages/core/src/contract/__tests__/session-index.test.ts
@@ -18,8 +18,6 @@ function createSession(
 ): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: "/workspace/app",
     time_created: activity,
@@ -35,7 +33,7 @@ function createSession(
 }
 
 function sessionIds(sessions: SessionHead[] | undefined): string[] {
-  return sessions?.map((session) => session.id) ?? [];
+  return sessions?.map((session) => session.reference.sessionId) ?? [];
 }
 
 describe("canonical session index", () => {
@@ -59,7 +57,7 @@ describe("canonical session index", () => {
       },
     });
     const path = createSession("path", 200, {
-      slug: "claude/path",
+      reference: { agentName: "claude", sessionId: "path" },
       project_identity: {
         kind: "path",
         key: "github.com/acme/app",
@@ -87,7 +85,7 @@ describe("canonical session index", () => {
       parent_reference: { agentName: "codex", sessionId: "shared-parent" },
     });
     const claudeChild = createSession("claude-child", 200, {
-      slug: "claude/claude-child",
+      reference: { agentName: "claude", sessionId: "claude-child" },
       parent_reference: { agentName: "claude", sessionId: "shared-parent" },
     });
 
@@ -101,30 +99,32 @@ describe("canonical session index", () => {
     ).toEqual([claudeChild]);
   });
 
-  it("indexes by the authoritative reference instead of the compatibility slug", () => {
-    const malformed = createSession("malformed", 100, { slug: "" });
+  it("indexes sessions by their structured reference", () => {
+    const session = createSession("session", 100);
 
-    const index = createSessionIndex([malformed]);
+    const index = createSessionIndex([session]);
 
-    expect(index.byAgent.get("codex")).toEqual([malformed]);
-    expect(index.byRouteKey.get(getSessionRouteKey("codex", "malformed"))).toBe(malformed);
+    expect(index.byAgent.get("codex")).toEqual([session]);
+    expect(index.byRouteKey.get(getSessionRouteKey("codex", "session"))).toBe(session);
   });
 
   it("applies route-keyed changes and removals with wire-event semantics", () => {
     const old = createSession("old", 100);
     const replaced = createSession("same", 200, { title: "Old title" });
     const replacement = createSession("same", 400, { title: "New title" });
-    const added = createSession("added", 300, { slug: "claude/added" });
+    const added = createSession("added", 300, {
+      reference: { agentName: "claude", sessionId: "added" },
+    });
 
     const sessions = applySessionChanges(
       [old, replaced],
       [
         {
-          reference: { agentName: "codex", sessionId: replacement.id },
+          reference: { agentName: "codex", sessionId: replacement.reference.sessionId },
           session: replacement,
         },
         {
-          reference: { agentName: "claude", sessionId: added.id },
+          reference: { agentName: "claude", sessionId: added.reference.sessionId },
           session: added,
         },
       ],
@@ -142,7 +142,10 @@ describe("canonical session index", () => {
     for (let batch = 0; batch < 20; batch += 1) {
       const changedId = `session-${(batch * 7) % 40}`;
       const added = createSession(`added-${batch}`, 1_000 + batch, {
-        slug: `${batch % 2 === 0 ? "codex" : "claude"}/added-${batch}`,
+        reference: {
+          agentName: batch % 2 === 0 ? "codex" : "claude",
+          sessionId: `added-${batch}`,
+        },
       });
       const changes = [
         {
@@ -150,7 +153,7 @@ describe("canonical session index", () => {
           session: createSession(changedId, 500 + batch),
         },
         {
-          reference: { agentName: getSessionAgentKey(added), sessionId: added.id },
+          reference: { agentName: getSessionAgentKey(added), sessionId: added.reference.sessionId },
           session: added,
         },
       ];
@@ -212,9 +215,9 @@ describe("mergeSortedSessions", () => {
       const sorted = sortSessionsByActivity(shards.flat());
 
       // Reference equality, so a tie resolved to a different shard fails here.
-      expect({ seed, ids: merged.map((session) => session.id) }).toEqual({
+      expect({ seed, ids: merged.map((session) => session.reference.sessionId) }).toEqual({
         seed,
-        ids: sorted.map((session) => session.id),
+        ids: sorted.map((session) => session.reference.sessionId),
       });
       expect(merged.every((session, index) => session === sorted[index])).toBe(true);
     }

--- a/packages/core/src/contract/__tests__/session-reference.test.ts
+++ b/packages/core/src/contract/__tests__/session-reference.test.ts
@@ -46,17 +46,19 @@ describe("session references", () => {
     expect(parseSessionReference(value)).toBeNull();
   });
 
-  it("derives compatibility fields from one canonical reference", () => {
+  it("normalizes and validates the canonical reference", () => {
     const identity = createSessionIdentity({ agentName: " CoDeX ", sessionId: "nested/session" });
 
     expect(identity).toEqual({
       reference: { agentName: "codex", sessionId: "nested/session" },
-      id: "nested/session",
-      slug: "codex/nested/session",
     });
     expect(getSessionAgentKey(identity)).toBe("codex");
-    expect(() => assertSessionIdentity({ ...identity, id: "different" }, "codex")).toThrow(
-      "Session identity fields disagree",
+    expect(() => assertSessionIdentity(identity, "codex")).not.toThrow();
+    expect(() =>
+      assertSessionIdentity({ reference: { ...identity.reference, agentName: " CoDeX " } }),
+    ).toThrow("Session reference is not normalized");
+    expect(() => assertSessionIdentity(identity, "claudecode")).toThrow(
+      'Session reference agent "codex" does not match "claudecode"',
     );
   });
 });

--- a/packages/core/src/contract/__tests__/session-tree.test.ts
+++ b/packages/core/src/contract/__tests__/session-tree.test.ts
@@ -23,8 +23,6 @@ interface SessionOverrides {
 function makeSession(id: string, time: number, overrides: SessionOverrides = {}): SessionHead {
   return {
     reference: { agentName: "codex", sessionId: id },
-    id,
-    slug: `codex/${id}`,
     title: id,
     directory: "/repo",
     time_created: time,
@@ -44,12 +42,12 @@ function makeSession(id: string, time: number, overrides: SessionOverrides = {})
 }
 
 function ids(nodes: { session: SessionHead }[]): string[] {
-  return nodes.map((node) => node.session.id);
+  return nodes.map((node) => node.session.reference.sessionId);
 }
 
 function referenced(session: SessionHead) {
   return {
-    reference: { agentName: "codex", sessionId: session.id },
+    reference: { agentName: "codex", sessionId: session.reference.sessionId },
     session,
   };
 }
@@ -90,11 +88,13 @@ describe("buildSessionTree", () => {
 
     while (pending.length > 0) {
       const node = pending.pop()!;
-      visible.push(node.session.id);
+      visible.push(node.session.reference.sessionId);
       pending.push(...node.children);
     }
 
-    expect([...visible].sort()).toEqual(sessions.map((session) => session.id).sort());
+    expect([...visible].sort()).toEqual(
+      sessions.map((session) => session.reference.sessionId).sort(),
+    );
     expect(new Set(visible).size).toBe(sessions.length);
   });
 
@@ -241,7 +241,9 @@ describe("session tree window filtering", () => {
     const sessions = [makeSession("a", 100, { parent: "b" }), makeSession("b", 1, { parent: "a" })];
 
     expect(
-      filterSessionTreeByActivityWindow(sessions, 90, 110).map((session) => session.id),
+      filterSessionTreeByActivityWindow(sessions, 90, 110).map(
+        (session) => session.reference.sessionId,
+      ),
     ).toEqual(["a"]);
   });
 
@@ -254,7 +256,9 @@ describe("session tree window filtering", () => {
     ];
 
     expect(
-      filterSessionTreeByActivityWindow(sessions, 90, 110).map((session) => session.id),
+      filterSessionTreeByActivityWindow(sessions, 90, 110).map(
+        (session) => session.reference.sessionId,
+      ),
     ).toEqual(["parent", "child-old", "child-new"]);
   });
 
@@ -266,7 +270,9 @@ describe("session tree window filtering", () => {
     ];
 
     expect(
-      filterSessionTreeByActivityWindow(sessions, 100, 100).map((session) => session.id),
+      filterSessionTreeByActivityWindow(sessions, 100, 100).map(
+        (session) => session.reference.sessionId,
+      ),
     ).toEqual(["grandchild", "child", "parent"]);
   });
 
@@ -277,7 +283,9 @@ describe("session tree window filtering", () => {
     ];
 
     expect(
-      filterSessionTreeByActivityWindow(sessions, 90, 110).map((session) => session.id),
+      filterSessionTreeByActivityWindow(sessions, 90, 110).map(
+        (session) => session.reference.sessionId,
+      ),
     ).toEqual(["orphan"]);
   });
 
@@ -289,7 +297,9 @@ describe("session tree window filtering", () => {
     ];
 
     expect(
-      filterSessionTreeByActivityWindow(sessions, 90, 110).map((session) => session.id),
+      filterSessionTreeByActivityWindow(sessions, 90, 110).map(
+        (session) => session.reference.sessionId,
+      ),
     ).toEqual(["orphan", "child", "grandchild"]);
   });
 
@@ -306,7 +316,7 @@ describe("session tree window filtering", () => {
         [recentRoot, child, grandchild, unrelated],
         [referenced(recentRoot)],
         [],
-      ).relatedSessionHeads.map(({ session }) => session.id),
+      ).relatedSessionHeads.map(({ session }) => session.reference.sessionId),
     ).toEqual(["child", "grandchild"]);
     expect(
       createSessionProjectionContext(
@@ -314,7 +324,7 @@ describe("session tree window filtering", () => {
         [child, grandchild],
         [],
         [{ agentName: "codex", sessionId: "root" }],
-      ).relatedSessionHeads.map(({ session }) => session.id),
+      ).relatedSessionHeads.map(({ session }) => session.reference.sessionId),
     ).toEqual(["child", "grandchild"]);
   });
 
@@ -331,7 +341,7 @@ describe("session tree window filtering", () => {
         [root, changedChild, grandchild, sibling],
         [referenced(changedChild)],
         [],
-      ).relatedSessionHeads.map(({ session }) => session.id),
+      ).relatedSessionHeads.map(({ session }) => session.reference.sessionId),
     ).toEqual(["root", "grandchild"]);
   });
 
@@ -383,7 +393,7 @@ describe("session tree window filtering", () => {
     const sortedNext = sortSessionsByActivity(next);
     const previousProjection = filterSessionTreeByActivityWindow(sortedPrevious, 90, 110);
     const changedSessionHeads = changedIds.map((id) =>
-      referenced(sortedNext.find((session) => session.id === id)!),
+      referenced(sortedNext.find((session) => session.reference.sessionId === id)!),
     );
     const removedSessionRefs = removedIds.map((sessionId) => ({
       agentName: "codex",
@@ -432,7 +442,7 @@ describe("session tree window filtering", () => {
       historical,
     ]);
     const afterHiddenRootRemoval = afterHiddenRootEnters.filter(
-      (session) => session.id !== "hidden-root",
+      (session) => session.reference.sessionId !== "hidden-root",
     );
     const transitions = [
       { next: afterBackfill, changedIds: ["historical"], removedIds: [] },
@@ -445,7 +455,7 @@ describe("session tree window filtering", () => {
 
     for (const transition of transitions) {
       const changedSessionHeads = transition.changedIds.map((id) =>
-        referenced(transition.next.find((session) => session.id === id)!),
+        referenced(transition.next.find((session) => session.reference.sessionId === id)!),
       );
       const removedSessionRefs = transition.removedIds.map((sessionId) => ({
         agentName: "codex",

--- a/packages/core/src/contract/session-reference.ts
+++ b/packages/core/src/contract/session-reference.ts
@@ -4,12 +4,7 @@ export interface SessionReference {
 }
 
 export interface SessionIdentity {
-  /** The only authoritative session identity. */
   readonly reference: SessionReference;
-  /** @deprecated Compatibility projection of `reference.sessionId`. */
-  readonly id: string;
-  /** @deprecated Compatibility projection serialized from `reference`. */
-  readonly slug: string;
 }
 
 export const UNKNOWN_AGENT_NAME = "unknown";
@@ -44,24 +39,21 @@ export function getSessionReferenceKey(reference: SessionReference): string {
 }
 
 export function createSessionIdentity(reference: SessionReference): SessionIdentity {
-  const normalized = normalizeSessionReference(reference);
   return {
-    reference: normalized,
-    id: normalized.sessionId,
-    slug: formatSessionReference(normalized),
+    reference: normalizeSessionReference(reference),
   };
 }
 
 export function assertSessionIdentity(identity: SessionIdentity, agentName?: string): void {
   const normalized = normalizeSessionReference(identity.reference);
   const expectedAgentName = agentName?.trim().toLowerCase();
-  if (
-    identity.reference.agentName !== normalized.agentName ||
-    identity.id !== normalized.sessionId ||
-    identity.slug !== formatSessionReference(normalized) ||
-    (expectedAgentName != null && normalized.agentName !== expectedAgentName)
-  ) {
-    throw new Error("Session identity fields disagree");
+  if (identity.reference.agentName !== normalized.agentName) {
+    throw new Error("Session reference is not normalized");
+  }
+  if (expectedAgentName != null && normalized.agentName !== expectedAgentName) {
+    throw new Error(
+      `Session reference agent "${normalized.agentName}" does not match "${expectedAgentName}"`,
+    );
   }
 }
 

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -31,8 +31,6 @@ describe("session cache integration", () => {
   it("persists, indexes, searches, and restores one session", () => {
     const session: SessionHead = {
       reference: { agentName: "codex", sessionId: "smoke" },
-      id: "smoke",
-      slug: "codex/smoke",
       title: "Cache smoke",
       directory: "/workspace/project",
       project_identity: {
@@ -50,7 +48,7 @@ describe("session cache integration", () => {
     };
     const data: SessionDetail = {
       ...session,
-      reference: { agentName: "codex", sessionId: session.id },
+      reference: { agentName: "codex", sessionId: session.reference.sessionId },
       messages: [
         {
           id: "message",
@@ -67,11 +65,13 @@ describe("session cache integration", () => {
     expect(searchSessions("needle")).toEqual([
       expect.objectContaining({
         reference: { agentName: "codex", sessionId: "smoke" },
-        session: expect.objectContaining({ id: "smoke" }),
+        session: expect.objectContaining({
+          reference: { agentName: "codex", sessionId: "smoke" },
+        }),
       }),
     ]);
     expect(loadCachedSessionData("codex", "smoke")).toMatchObject({
-      id: "smoke",
+      reference: { agentName: "codex", sessionId: "smoke" },
       messages: [{ id: "message" }],
     });
 
@@ -96,8 +96,6 @@ describe("session cache integration", () => {
   it("merges a partial snapshot without deleting data outside its window", () => {
     const old: SessionHead = {
       reference: { agentName: "codex", sessionId: "old" },
-      id: "old",
-      slug: "codex/old",
       title: "Old session",
       directory: "/workspace/project",
       project_identity: {
@@ -117,8 +115,6 @@ describe("session cache integration", () => {
     const recent: SessionHead = {
       ...old,
       reference: { agentName: "codex", sessionId: "recent" },
-      id: "recent",
-      slug: "codex/recent",
       title: "Recent session",
       time_created: 2,
       time_updated: 2,
@@ -165,14 +161,20 @@ describe("session cache integration", () => {
     saveCachedSessions("codex", [updatedRecent], {}, { completeness: "partial" });
 
     expect(loadCachedSessions("codex")).toMatchObject({
-      sessions: [{ id: "recent", title: "Updated recent" }, { id: "old" }],
+      sessions: [
+        {
+          reference: { agentName: "codex", sessionId: "recent" },
+          title: "Updated recent",
+        },
+        { reference: { agentName: "codex", sessionId: "old" } },
+      ],
       meta: { old: { sourcePath: "/sessions/old.jsonl" } },
     });
     expect(loadCachedSessionData("codex", "old")).toMatchObject({
       messages: [{ id: "old-user" }, { id: "old-tool" }],
       file_activity: [{ path: "src/legacy.ts" }],
     });
-    expect(searchSessions("historical-window-needle")[0]?.session.id).toBe("old");
+    expect(searchSessions("historical-window-needle")[0]?.session.reference.sessionId).toBe("old");
 
     saveCachedSessions("codex", [updatedRecent]);
 

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { formatSessionReference } from "../../contract/index.js";
 import type { SessionHead } from "../../types/index.js";
 
 export const EXPECTED_CACHE_SCHEMA_VERSION = 31;
@@ -499,14 +500,17 @@ function stampVersion(db: Database.Database, version: number): void {
 
 function seedSharedRows(db: Database.Database, version: number, seed: MigrationFixtureSeed): void {
   const sessionJson = JSON.stringify(seed.session);
-  const metaJson = JSON.stringify({ id: seed.session.id, sourcePath: seed.sourcePath });
+  const metaJson = JSON.stringify({
+    id: seed.session.reference.sessionId,
+    sourcePath: seed.sourcePath,
+  });
   db.prepare("INSERT INTO agent_cache(agent_name, timestamp) VALUES (?, ?)").run(
     seed.agentName,
     seed.now,
   );
   db.prepare(
     "INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json) VALUES (?, ?, ?, ?)",
-  ).run(seed.agentName, seed.session.id, sessionJson, metaJson);
+  ).run(seed.agentName, seed.session.reference.sessionId, sessionJson, metaJson);
 
   if (version >= 13) {
     db.prepare(
@@ -531,8 +535,8 @@ function seedLegacyRows(db: Database.Database, version: number, seed: MigrationF
       `,
     ).run(
       seed.agentName,
-      session.id,
-      session.slug,
+      session.reference.sessionId,
+      formatSessionReference(session.reference),
       session.title,
       session.directory,
       session.project_identity?.kind ?? "path",
@@ -558,8 +562,8 @@ function seedLegacyRows(db: Database.Database, version: number, seed: MigrationF
     `,
   ).run(
     seed.agentName,
-    session.id,
-    session.slug,
+    session.reference.sessionId,
+    formatSessionReference(session.reference),
     session.title,
     session.directory,
     session.time_created,
@@ -600,8 +604,8 @@ function seedNormalizedRows(
     `,
   ).run({
     agentName: seed.agentName,
-    sessionId: session.id,
-    slug: session.slug,
+    sessionId: session.reference.sessionId,
+    slug: formatSessionReference(session.reference),
     title: session.title,
     sourcePath: seed.sourcePath,
     directory: session.directory,
@@ -616,7 +620,7 @@ function seedNormalizedRows(
     outputTokens: session.stats.total_output_tokens,
     totalCost: session.stats.total_cost,
     totalTokens: session.stats.total_tokens ?? null,
-    metaJson: JSON.stringify({ id: session.id, sourcePath: seed.sourcePath }),
+    metaJson: JSON.stringify({ id: session.reference.sessionId, sourcePath: seed.sourcePath }),
   });
 
   const partsFormatColumn = version >= 17 ? "parts_format_version," : "";
@@ -630,8 +634,8 @@ function seedNormalizedRows(
     `,
   ).run(
     seed.agentName,
-    session.id,
-    `${session.id}-message`,
+    session.reference.sessionId,
+    `${session.reference.sessionId}-message`,
     session.time_created,
     JSON.stringify([{ type: "text", text: seed.messageText }]),
     seed.messageText,
@@ -644,7 +648,7 @@ function seedNormalizedRows(
         INSERT INTO message_tools(agent_name, session_id, message_index, tool_name)
         VALUES (?, ?, 0, 'read')
       `,
-    ).run(seed.agentName, session.id);
+    ).run(seed.agentName, session.reference.sessionId);
   }
 
   db.prepare(
@@ -655,7 +659,7 @@ function seedNormalizedRows(
     `,
   ).run(
     seed.agentName,
-    session.id,
+    session.reference.sessionId,
     session.project_identity?.key ?? session.directory,
     seed.filePath,
     seed.now,
@@ -679,7 +683,7 @@ function seedNormalizedSearchDocument(
           indexed_message_count, indexed_at
         ) VALUES (?, ?, ?, ?, 'normalized-content-hash', 1, ?)
       `,
-    ).run(seed.agentName, session.id, session.title, seed.searchContent, seed.now);
+    ).run(seed.agentName, session.reference.sessionId, session.title, seed.searchContent, seed.now);
     return;
   }
 
@@ -695,8 +699,8 @@ function seedNormalizedSearchDocument(
     `,
   ).run(
     seed.agentName,
-    session.id,
-    session.slug,
+    session.reference.sessionId,
+    formatSessionReference(session.reference),
     session.title,
     session.directory,
     session.time_created,
@@ -721,7 +725,7 @@ function seedProjectSession(db: Database.Database, seed: MigrationFixtureSeed): 
     `,
   ).run(
     seed.agentName,
-    session.id,
+    session.reference.sessionId,
     session.project_identity?.kind ?? "path",
     session.project_identity?.key ?? session.directory,
     session.project_identity?.displayName ?? session.directory,

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import Database from "better-sqlite3";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listBookmarks, type BookmarkRecord } from "../../state/bookmarks.js";
-import { createSessionIdentity } from "../../contract/index.js";
+import { createSessionIdentity, formatSessionReference } from "../../contract/index.js";
 import { setStateSchemaEnsuredPath } from "../../state/database.js";
 import type { SessionHead } from "../../types/index.js";
 import { setSchemaEnsuredPath } from "../cache/db.js";
@@ -159,8 +159,8 @@ function createLegacyStateFixture(version: 1 | 2): void {
       `,
     ).run(
       "claudecode",
-      session.id,
-      session.slug,
+      session.reference.sessionId,
+      formatSessionReference(session.reference),
       session.title,
       session.directory,
       session.time_created,
@@ -272,7 +272,7 @@ function expectMigratedBehavior(structured: boolean): void {
   const projects = listCachedProjectGroups();
   const results = searchSessions("needle");
 
-  expect(cached?.sessions.map((session) => session.id)).toEqual(["legacy-smoke"]);
+  expect(cached?.sessions.map((session) => session.reference.sessionId)).toEqual(["legacy-smoke"]);
   expect(cached?.sessions[0]?.reference).toEqual({
     agentName: "claudecode",
     sessionId: "legacy-smoke",
@@ -283,7 +283,7 @@ function expectMigratedBehavior(structured: boolean): void {
     total_output_tokens: 5,
     total_tokens: 15,
   });
-  expect(detail?.id).toBe("legacy-smoke");
+  expect(detail?.reference.sessionId).toBe("legacy-smoke");
   expect(detail?.messages).toEqual([]);
   expect(rawDetail?.pendingReindex).toBe(true);
   expect(rawDetail?.messageRows).toHaveLength(structured ? 1 : 0);
@@ -303,14 +303,18 @@ function expectMigratedBehavior(structured: boolean): void {
     },
   ]);
   expect(results).toHaveLength(1);
-  expect(results[0]?.session.id).toBe("legacy-smoke");
+  expect(results[0]?.session.reference.sessionId).toBe("legacy-smoke");
   expect(highlightedText(results[0])).toContain("needle");
 
   if (structured) {
     const toolResults = searchSessions("tool:read");
     const fileResults = searchFileActivitySessions("legacy.ts");
-    expect(toolResults.map((result) => result.session.id)).toEqual(["legacy-smoke"]);
-    expect(fileResults.map((result) => result.session.id)).toEqual(["legacy-smoke"]);
+    expect(toolResults.map((result) => result.session.reference.sessionId)).toEqual([
+      "legacy-smoke",
+    ]);
+    expect(fileResults.map((result) => result.session.reference.sessionId)).toEqual([
+      "legacy-smoke",
+    ]);
     expect(highlightedText(fileResults[0])).toContain("legacy.ts");
   }
 }
@@ -453,7 +457,12 @@ describe("sqlite migration release gate", () => {
         entries: {
           claudecode: {
             sessions: [session],
-            meta: { [session.id]: { id: session.id, sourcePath: "legacy.jsonl" } },
+            meta: {
+              [session.reference.sessionId]: {
+                id: session.reference.sessionId,
+                sourcePath: "legacy.jsonl",
+              },
+            },
             timestamp: now,
             version: 2,
           },
@@ -465,9 +474,9 @@ describe("sqlite migration release gate", () => {
     expect(loadCachedSessions("claudecode")).toBeNull();
     expect(saveCachedSessions("claudecode", [session])).toBe(true);
     expect(existsSync(getLegacyCachePath())).toBe(false);
-    expect(loadCachedSessions("claudecode")?.sessions.map(({ id }) => id)).toEqual([
-      "legacy-smoke",
-    ]);
+    expect(
+      loadCachedSessions("claudecode")?.sessions.map(({ reference: { sessionId: id } }) => id),
+    ).toEqual(["legacy-smoke"]);
     expect(getUserVersion(getCachePath())).toBe(EXPECTED_CACHE_SCHEMA_VERSION);
   });
 

--- a/packages/core/src/discovery/__tests__/orchestrate.test.ts
+++ b/packages/core/src/discovery/__tests__/orchestrate.test.ts
@@ -22,8 +22,6 @@ function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead 
   const timeCreated = overrides?.time_created ?? 1000;
   return {
     reference: { agentName: "agent", sessionId: id },
-    id,
-    slug: `agent/${id}`,
     title: `Session ${id}`,
     directory: "/home/user/project",
     time_created: timeCreated,
@@ -275,7 +273,6 @@ describe("sessionSignature", () => {
     expectSessionChange((session) => ({
       ...session,
       reference: { agentName: "changed", sessionId: session.reference.sessionId },
-      slug: `changed/${session.reference.sessionId}`,
     }));
   });
 
@@ -345,7 +342,7 @@ describe("sortSessions", () => {
       makeSession("mid", { time_updated: 3000 }),
     ];
     const sorted = sortSessions(sessions);
-    expect(sorted.map((s) => s.id)).toEqual(["new", "mid", "old"]);
+    expect(sorted.map((s) => s.reference.sessionId)).toEqual(["new", "mid", "old"]);
   });
 
   it("falls back to time_created when time_updated is missing", () => {
@@ -354,14 +351,16 @@ describe("sortSessions", () => {
       makeSession("b", { time_created: 1000, time_updated: undefined }),
     ];
     const sorted = sortSessions(sessions);
-    expect(sorted.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(sorted.map((s) => s.reference.sessionId)).toEqual(["a", "b"]);
   });
 
   it("does not mutate the input array", () => {
     const sessions = [makeSession("a", { time_updated: 1 }), makeSession("b", { time_updated: 2 })];
     const original = [...sessions];
     sortSessions(sessions);
-    expect(sessions.map((s) => s.id)).toEqual(original.map((s) => s.id));
+    expect(sessions.map((s) => s.reference.sessionId)).toEqual(
+      original.map((s) => s.reference.sessionId),
+    );
   });
 });
 
@@ -379,7 +378,7 @@ describe("computeSessionDiff", () => {
     const updated = [makeSession("a"), makeSession("b")];
     const diff = computeSessionDiff(cached, updated);
     expect(diff.counts).toEqual({ new: 1, updated: 0, removed: 0 });
-    expect(diff.changes.map((c) => c.session.id)).toEqual(["b"]);
+    expect(diff.changes.map((c) => c.session.reference.sessionId)).toEqual(["b"]);
     expect(diff.changes[0]!.sortIndex).toBe(1);
   });
 
@@ -403,16 +402,17 @@ describe("computeSessionDiff", () => {
     const updated = [makeSession("a")];
     const diff = computeSessionDiff(cached, updated, ["a"]);
     expect(diff.counts.updated).toBe(1);
-    expect(diff.changes.map((c) => c.session.id)).toEqual(["a"]);
+    expect(diff.changes.map((c) => c.session.reference.sessionId)).toEqual(["a"]);
   });
 
   it("accepts a custom signature function", () => {
     const cached = [makeSession("a", { title: "old" })];
     const updated = [makeSession("a", { title: "new" })];
     expect(computeSessionDiff(cached, updated).counts.updated).toBe(1);
-    expect(computeSessionDiff(cached, updated, [], (session) => session.slug).counts.updated).toBe(
-      0,
-    );
+    expect(
+      computeSessionDiff(cached, updated, [], (session) => session.reference.sessionId).counts
+        .updated,
+    ).toBe(0);
   });
 
   describe("signatureCache", () => {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -22,8 +22,6 @@ function makeSession(
   const timeCreated = overrides?.time_created ?? 1000;
   return {
     reference: { agentName, sessionId: id },
-    id,
-    slug: `${agentName}/${id}`,
     title: `Session ${id}`,
     directory: "/home/user/project",
     time_created: timeCreated,
@@ -160,7 +158,12 @@ describe("filterSessions", () => {
       makeSession("sibling", { directory: "/home/user/projectile" }),
     ];
     const result = filterSessions(sessions, { cwd: "/home/user/project" });
-    expect(result.map((s) => s.id)).toEqual(["exact", "child", "parent", "identity"]);
+    expect(result.map((s) => s.reference.sessionId)).toEqual([
+      "exact",
+      "child",
+      "parent",
+      "identity",
+    ]);
   });
 
   it("filters by cwd excluding non-matching directories", () => {
@@ -170,7 +173,7 @@ describe("filterSessions", () => {
     ];
     const result = filterSessions(sessions, { cwd: "/home/user/other" });
     expect(result).toHaveLength(1);
-    expect(result[0]!.id).toBe("b");
+    expect(result[0]!.reference.sessionId).toBe("b");
   });
 
   it("returns empty when cwd matches nothing", () => {
@@ -187,7 +190,7 @@ describe("filterSessions", () => {
     ];
     const result = filterSessions(sessions, { from: 200 });
     expect(result).toHaveLength(2);
-    expect(result.map((s) => s.id)).toEqual(["b", "c"]);
+    expect(result.map((s) => s.reference.sessionId)).toEqual(["b", "c"]);
   });
 
   it("filters by to timestamp", () => {
@@ -198,7 +201,7 @@ describe("filterSessions", () => {
     ];
     const result = filterSessions(sessions, { to: 200 });
     expect(result).toHaveLength(2);
-    expect(result.map((s) => s.id)).toEqual(["a", "b"]);
+    expect(result.map((s) => s.reference.sessionId)).toEqual(["a", "b"]);
   });
 
   it("filters by activity timestamp", () => {
@@ -207,7 +210,7 @@ describe("filterSessions", () => {
       makeSession("active", { time_created: 100, time_updated: 300 }),
     ];
     const result = filterSessions(sessions, { from: 200 });
-    expect(result.map((s) => s.id)).toEqual(["active"]);
+    expect(result.map((s) => s.reference.sessionId)).toEqual(["active"]);
   });
 
   it("combines cwd and time filters", () => {
@@ -218,7 +221,7 @@ describe("filterSessions", () => {
     ];
     const result = filterSessions(sessions, { cwd: "/home/user/project", from: 200 });
     expect(result).toHaveLength(1);
-    expect(result[0]!.id).toBe("b");
+    expect(result[0]!.reference.sessionId).toBe("b");
   });
 
   it("returns empty for null directory with cwd filter", () => {
@@ -384,7 +387,7 @@ describe("finalizeAgentScan", () => {
       onProgress,
     });
 
-    expect(result.heads.map((session) => session.id)).toEqual(["current"]);
+    expect(result.heads.map((session) => session.reference.sessionId)).toEqual(["current"]);
     expect(result.heads[0]?.project_identity).toBeDefined();
     expect(result.cachePersistence).toBe("not-requested");
     expect(result.cacheTimestamp).toBe(123);
@@ -422,7 +425,10 @@ describe("finalizeAgentScan", () => {
       "test",
       [
         {
-          session: expect.objectContaining({ id: "new", project_identity: expect.any(Object) }),
+          session: expect.objectContaining({
+            reference: { agentName: "test", sessionId: "new" },
+            project_identity: expect.any(Object),
+          }),
           sortIndex: 0,
         },
       ],
@@ -453,7 +459,7 @@ describe("finalizeAgentScan", () => {
         completeness: "complete",
       });
 
-      expect(result.heads.map((session) => session.id)).toEqual(["new"]);
+      expect(result.heads.map((session) => session.reference.sessionId)).toEqual(["new"]);
       expect(result.refreshed).toBe(true);
       expect(result.cachePersistence).toBe("failed");
       expect(result.cacheTimestamp).toBe(123);
@@ -535,7 +541,7 @@ describe("finalizeAgentScan", () => {
       [
         {
           session: expect.objectContaining({
-            id: "cached",
+            reference: { agentName: "test", sessionId: "cached" },
             project_identity_resolver_revision: expect.any(String),
             project_identity_input_signature: expect.any(String),
           }),
@@ -563,7 +569,7 @@ describe("finalizeAgentScan", () => {
     });
 
     expect(result.heads[0]).toMatchObject({
-      id: "cached",
+      reference: { agentName: "test", sessionId: "cached" },
       smart_tags: [],
       smart_tags_source_updated_at: 1000,
     });
@@ -571,7 +577,10 @@ describe("finalizeAgentScan", () => {
       "test",
       [
         {
-          session: expect.objectContaining({ id: "cached", smart_tags: [] }),
+          session: expect.objectContaining({
+            reference: { agentName: "test", sessionId: "cached" },
+            smart_tags: [],
+          }),
           sortIndex: 0,
         },
       ],
@@ -613,8 +622,10 @@ describe("scanSessions", () => {
     try {
       const result = await scanSessions({ useCache: true });
 
-      expect(result.sessions.map((session) => session.id)).toEqual(["cached"]);
-      expect(result.byAgent.test?.map((session) => session.id)).toEqual(["cached"]);
+      expect(result.sessions.map((session) => session.reference.sessionId)).toEqual(["cached"]);
+      expect(result.byAgent.test?.map((session) => session.reference.sessionId)).toEqual([
+        "cached",
+      ]);
       expect(result.cacheTimestamps).toEqual({ test: 123 });
       expect(result.scanFailures?.test).toEqual({
         agentName: "test",
@@ -652,8 +663,8 @@ describe("scanSessions", () => {
     expect(result.byAgent.test).toHaveLength(2);
   });
 
-  it("reports a scan failure when an adapter publishes a conflicting identity", async () => {
-    const conflicting = { ...makeSession("session"), id: "other" };
+  it("reports a scan failure when an adapter publishes another agent's session", async () => {
+    const conflicting = makeSession("session", undefined, "codex");
     mockedCreateRegisteredAgents.mockReturnValue([
       createTestAgent({ name: "test", available: true, sessions: [conflicting] }),
     ]);
@@ -664,7 +675,7 @@ describe("scanSessions", () => {
     expect(result.scanFailures?.test).toMatchObject({
       agentName: "test",
       stage: "scanning sessions",
-      message: "Session identity fields disagree",
+      message: 'Session reference agent "codex" does not match "test"',
     });
   });
 
@@ -716,7 +727,7 @@ describe("scanSessions", () => {
 
     const result = await scanSessions({});
 
-    expect(result.sessions.map((session) => session.id)).toEqual(["ok"]);
+    expect(result.sessions.map((session) => session.reference.sessionId)).toEqual(["ok"]);
     expect(result.byAgent.healthy).toHaveLength(1);
     expect(result.byAgent.failed).toBeUndefined();
     expect(result.scanFailures?.failed).toBeDefined();
@@ -743,8 +754,10 @@ describe("scanSessions", () => {
     try {
       const result = await scanSessions({ useCache: true });
 
-      expect(result.sessions.map((session) => session.id)).toEqual(["cached"]);
-      expect(result.byAgent.test?.map((session) => session.id)).toEqual(["cached"]);
+      expect(result.sessions.map((session) => session.reference.sessionId)).toEqual(["cached"]);
+      expect(result.byAgent.test?.map((session) => session.reference.sessionId)).toEqual([
+        "cached",
+      ]);
       expect(result.scanFailures?.test).toEqual({
         agentName: "test",
         stage: "enumerating session sources",
@@ -792,8 +805,10 @@ describe("scanSessions", () => {
     try {
       const result = await scanSessions({ useCache: true });
 
-      expect(result.sessions.map((session) => session.id)).toEqual(["cached"]);
-      expect(result.byAgent.test?.map((session) => session.id)).toEqual(["cached"]);
+      expect(result.sessions.map((session) => session.reference.sessionId)).toEqual(["cached"]);
+      expect(result.byAgent.test?.map((session) => session.reference.sessionId)).toEqual([
+        "cached",
+      ]);
       expect(result.cacheTimestamps).toEqual({ test: 123 });
       expect(result.scanFailures?.test).toEqual({
         agentName: "test",
@@ -892,7 +907,9 @@ describe("scanSessions", () => {
     expect(failed.scanFailures?.test?.stage).toBe("opening the database");
     expect(failed.byAgent.test).toBeUndefined();
     expect(recovered.scanFailures).toBeUndefined();
-    expect(recovered.byAgent.test?.map((session) => session.id)).toEqual(["recovered"]);
+    expect(recovered.byAgent.test?.map((session) => session.reference.sessionId)).toEqual([
+      "recovered",
+    ]);
   });
 
   it("calls onProgress for complete phase", async () => {
@@ -941,7 +958,7 @@ describe("scanSessions", () => {
     ]);
     const result = await scanSessions({ from: 200 });
     expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]!.id).toBe("new");
+    expect(result.sessions[0]!.reference.sessionId).toBe("new");
   });
 
   it("persists a windowed scan as a partial snapshot", async () => {
@@ -959,7 +976,7 @@ describe("scanSessions", () => {
 
     expect(mockedSaveCachedSessions).toHaveBeenCalledWith(
       "test",
-      [expect.objectContaining({ id: "recent" })],
+      [expect.objectContaining({ reference: { agentName: "test", sessionId: "recent" } })],
       {},
       { completeness: "partial" },
     );
@@ -984,10 +1001,12 @@ describe("scanSessions", () => {
 
     const result = await scanSessions({ useCache: false, includeSmartTags: false });
 
-    expect(result.sessions).toEqual([expect.objectContaining({ id: "cached" })]);
+    expect(result.sessions).toEqual([
+      expect.objectContaining({ reference: { agentName: "files", sessionId: "cached" } }),
+    ]);
     expect(mockedSaveCachedSessions).toHaveBeenCalledWith(
       "files",
-      [expect.objectContaining({ id: "cached" })],
+      [expect.objectContaining({ reference: { agentName: "files", sessionId: "cached" } })],
       meta,
       { completeness: "partial" },
     );
@@ -1010,7 +1029,7 @@ describe("scanSessions", () => {
     const result = await scanSessions({ useCache: true });
     // Should use cached sessions
     expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]!.id).toBe("cached");
+    expect(result.sessions[0]!.reference.sessionId).toBe("cached");
   });
 
   it("can return cached sessions without validating agent availability", async () => {
@@ -1037,7 +1056,7 @@ describe("scanSessions", () => {
     const result = await scanSessions({ useCache: true, cacheOnly: true });
 
     expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]!.id).toBe("cached");
+    expect(result.sessions[0]!.reference.sessionId).toBe("cached");
     expect(result.sessions[0]!.project_identity).toEqual({
       kind: "path",
       key: "/home/user/project",
@@ -1072,7 +1091,7 @@ describe("scanSessions", () => {
     const result = await scanSessions({ useCache: true, cacheOnly: true });
 
     expect(filterCachedSessions).toHaveBeenCalledWith(cachedSessions);
-    expect(result.sessions.map((session) => session.id)).toEqual(["visible"]);
+    expect(result.sessions.map((session) => session.reference.sessionId)).toEqual(["visible"]);
     expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
     expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
   });
@@ -1094,7 +1113,7 @@ describe("scanSessions", () => {
     const result = await scanSessions({ useCache: true, cacheOnly: true });
 
     expect(mockedLoadCachedSessions).toHaveBeenCalledWith("test");
-    expect(result.sessions.map((session) => session.id)).toEqual(["cached"]);
+    expect(result.sessions.map((session) => session.reference.sessionId)).toEqual(["cached"]);
     expect(mockedSaveCachedSessionChanges).not.toHaveBeenCalled();
     expect(mockedSaveCachedSessions).not.toHaveBeenCalled();
   });
@@ -1130,7 +1149,7 @@ describe("scanSessions", () => {
     });
 
     expect(result.sessions).toHaveLength(1);
-    expect(result.sessions[0]!.id).toBe("fresh");
+    expect(result.sessions[0]!.reference.sessionId).toBe("fresh");
     expect(incrementalScan).toHaveBeenCalledWith(cachedSessions, ["fresh"], undefined, {
       from: 500,
       to: 1_500,
@@ -1183,11 +1202,11 @@ describe("scanSessions", () => {
     const failed = await scanSessions({ useCache: true, includeSmartTags: false });
     const recovered = await scanSessions({ useCache: true, includeSmartTags: false });
 
-    expect(failed.sessions.map((session) => session.id)).toEqual(["fresh"]);
+    expect(failed.sessions.map((session) => session.reference.sessionId)).toEqual(["fresh"]);
     expect(failed.cacheTimestamps).toEqual({ test: 123 });
     expect(failed.cacheFailures).toEqual({ test: { agentName: "test" } });
     expect(failed.scanFailures).toBeUndefined();
-    expect(recovered.sessions.map((session) => session.id)).toEqual(["fresh"]);
+    expect(recovered.sessions.map((session) => session.reference.sessionId)).toEqual(["fresh"]);
     expect(recovered.cacheTimestamps).toEqual({ test: 456 });
     expect(recovered.cacheFailures).toBeUndefined();
     expect(checkForChanges).toHaveBeenNthCalledWith(1, 123, cachedSessions);
@@ -1233,7 +1252,7 @@ describe("scanSessions", () => {
       [
         {
           session: expect.objectContaining({
-            id: "changed",
+            reference: { agentName: "test", sessionId: "changed" },
             title: "Updated changed",
             project_identity: expect.objectContaining({ kind: "path", key: "/home/user/project" }),
           }),
@@ -1241,7 +1260,7 @@ describe("scanSessions", () => {
         },
         {
           session: expect.objectContaining({
-            id: "added",
+            reference: { agentName: "test", sessionId: "added" },
             project_identity: expect.objectContaining({ kind: "path", key: "/home/user/project" }),
           }),
           sortIndex: 2,

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -88,8 +88,6 @@ class TestAgent extends BaseAgent {
 function makeHead(overrides: Partial<IdentifiedSessionHead> = {}): IdentifiedSessionHead {
   return {
     reference: { agentName: "test", sessionId: "s1" },
-    id: "s1",
-    slug: "test/s1",
     title: "Cached Session",
     directory: "/workspace/project",
     project_identity: projectIdentity,
@@ -147,7 +145,7 @@ function persistDetail(
   detail: SessionDetail,
   fingerprint: string,
 ): void {
-  saveCachedSessions("test", [head], { [head.id]: makeMeta(fingerprint) });
+  saveCachedSessions("test", [head], { [head.reference.sessionId]: makeMeta(fingerprint) });
   syncSessionSearchIndex("test", [head], () => detail);
 }
 
@@ -312,7 +310,7 @@ describe("materializeSessionDetail", () => {
         agentName: "test",
         sessionId: "s1",
       }),
-    ).toThrow("Session identity fields disagree");
+    ).toThrow("Session reference does not match expected session");
   });
 
   it("rejects an invalid snapshot instead of resolving identity during a detail request", () => {
@@ -766,8 +764,6 @@ describe("materializeSessionDetail", () => {
       const sessionId = `s${index}`;
       return makeHead({
         reference: { agentName: "test", sessionId },
-        id: sessionId,
-        slug: `test/${sessionId}`,
       });
     });
     const target = heads.at(-1)!;
@@ -775,8 +771,6 @@ describe("materializeSessionDetail", () => {
       {
         ...makeDetail(),
         reference: target.reference,
-        id: target.id,
-        slug: target.slug,
       },
       new Map(),
     );
@@ -789,11 +783,11 @@ describe("materializeSessionDetail", () => {
 
     const first = materializeSessionDetail(scanResult, {
       agentName: "test",
-      sessionId: target.id,
+      sessionId: target.reference.sessionId,
     });
     const second = materializeSessionDetail(scanResult, {
       agentName: "test",
-      sessionId: target.id,
+      sessionId: target.reference.sessionId,
     });
 
     expect(first.status).toBe("found");

--- a/packages/core/src/discovery/__tests__/smart-tag-worker-lifecycle.test.ts
+++ b/packages/core/src/discovery/__tests__/smart-tag-worker-lifecycle.test.ts
@@ -64,8 +64,6 @@ import { finalizeAgentScan } from "../scanner.js";
 function makeSession(index: number): IdentifiedSessionHead {
   return {
     reference: { agentName: "test", sessionId: `session-${index}` },
-    id: `session-${index}`,
-    slug: `test/session-${index}`,
     title: `Session ${index}`,
     directory: "/workspace",
     project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },

--- a/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
+++ b/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
@@ -53,8 +53,6 @@ import { finalizeAgentScan } from "../scanner.js";
 function makeSession(index: number): IdentifiedSessionHead {
   return {
     reference: { agentName: "test", sessionId: `session-${index}` },
-    id: `session-${index}`,
-    slug: `test/session-${index}`,
     title: `Session ${index}`,
     directory: "/workspace",
     project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },

--- a/packages/core/src/discovery/cache/__tests__/analytics-revision.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/analytics-revision.test.ts
@@ -41,7 +41,7 @@ describe("analytics revision", () => {
   it("advances for durable session, message, activity, and deletion commits", () => {
     const session = makeSessionHead("one");
     const detail = {
-      ...makeSessionData(session.id),
+      ...makeSessionData(session.reference.sessionId),
       messages: [
         {
           id: "one-message",
@@ -69,7 +69,9 @@ describe("analytics revision", () => {
     });
     expect(getAnalyticsRevision()).toBe("2");
 
-    expect(syncSessionSearchIndexChanges("codex", [], [session.id], () => detail)).toMatchObject({
+    expect(
+      syncSessionSearchIndexChanges("codex", [], [session.reference.sessionId], () => detail),
+    ).toMatchObject({
       deleted: 1,
     });
     expect(getAnalyticsRevision()).toBe("3");
@@ -109,7 +111,7 @@ describe("analytics revision", () => {
           completeness: "complete",
           removedSessionIds: [],
         },
-        () => makeSessionData(session.id),
+        () => makeSessionData(session.reference.sessionId),
       ),
     ).toMatchObject({ status: "committed", searchIndex: { indexed: 1 } });
     expect(getAnalyticsRevision()).toBe("1");

--- a/packages/core/src/discovery/cache/__tests__/cost-facts.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/cost-facts.test.ts
@@ -79,7 +79,7 @@ describe("listDashboardCostFacts", () => {
     saveCachedSessions("codex", [session]);
     syncSessionSearchIndex("codex", [session], () => ({
       ...session,
-      reference: { agentName: "codex", sessionId: session.id },
+      reference: { agentName: "codex", sessionId: session.reference.sessionId },
       messages,
     }));
 

--- a/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
@@ -34,11 +34,13 @@ const OTHER_PROJECT = {
 
 function seedAgent(agent: string, seeds: Array<[SessionHead, SeedMessage[]]>): void {
   const sessions = seeds.map(([session]) => session);
-  const messagesById = new Map(seeds.map(([session, messages]) => [session.id, messages]));
+  const messagesById = new Map(
+    seeds.map(([session, messages]) => [session.reference.sessionId, messages]),
+  );
 
   saveCachedSessions(agent, sessions);
   syncSessionSearchIndex(agent, sessions, (sessionId) => {
-    const session = sessions.find((candidate) => candidate.id === sessionId)!;
+    const session = sessions.find((candidate) => candidate.reference.sessionId === sessionId)!;
     const messages: Message[] = (messagesById.get(sessionId) ?? []).map((seed, index) => ({
       id: `${sessionId}-m${index}`,
       role: "assistant",

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -126,8 +126,8 @@ describe("cache schema boundary", () => {
       );
 
       expect(restored?.reference).toEqual({ agentName: "codex", sessionId: "identity" });
-      expect(restored?.id).toBe("identity");
-      expect(restored?.slug).toBe("codex/identity");
+      expect(restored).not.toHaveProperty("id");
+      expect(restored).not.toHaveProperty("slug");
       expect(columns).not.toContain("slug");
       expect(warnings).toContainEqual({
         event: "sqlite.migration.session_identity.mismatch",
@@ -182,7 +182,7 @@ describe("cache schema boundary", () => {
   it("adds an empty hash chain column when upgrading schema 24", () => {
     const session = makeSessionHead("legacy-chain");
     saveCachedSessions("codex", [session]);
-    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
+    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.reference.sessionId));
 
     const legacyDb = new Database(getCachePath());
     try {
@@ -201,7 +201,7 @@ describe("cache schema boundary", () => {
       digest: (
         db
           .prepare("SELECT content_chain_digest FROM messages WHERE session_id = ?")
-          .get(session.id) as { content_chain_digest?: string | null }
+          .get(session.reference.sessionId) as { content_chain_digest?: string | null }
       ).content_chain_digest,
     }));
 
@@ -220,7 +220,7 @@ describe("cache schema boundary", () => {
     });
     saveCachedSessions("codex", [session]);
     syncSessionSearchIndex("codex", [session], () => ({
-      ...makeSessionData(session.id),
+      ...makeSessionData(session.reference.sessionId),
       ...session,
       messages: [
         {
@@ -285,7 +285,7 @@ describe("cache schema boundary", () => {
           FROM session_cost_summary
           WHERE agent_name = ? AND session_id = ?`,
         )
-        .get("codex", session.id),
+        .get("codex", session.reference.sessionId),
       hasIndex:
         db
           .prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?")
@@ -341,13 +341,13 @@ describe("cache schema boundary", () => {
   it("defers orphaned v21 publication cleanup until the first search-index write", () => {
     const session = makeSessionHead("orphaned-publication");
     saveCachedSessions("codex", [session]);
-    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
+    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.reference.sessionId));
 
     const db = new Database(getCachePath());
     try {
       db.prepare("UPDATE sessions SET publication_id = ? WHERE session_id = ?").run(
         "orphaned",
-        session.id,
+        session.reference.sessionId,
       );
     } finally {
       db.close();
@@ -389,13 +389,13 @@ describe("cache schema boundary", () => {
   it("invalidates v21 detail rows so inconsistent publications rebuild", () => {
     const session = makeSessionHead("publication-rebuild");
     saveCachedSessions("codex", [session]);
-    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
+    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.reference.sessionId));
 
     const db = new Database(getCachePath());
     try {
       db.prepare("UPDATE session_documents SET content_hash = ? WHERE session_id = ?").run(
         "stale-but-matching",
-        session.id,
+        session.reference.sessionId,
       );
       db.pragma("user_version = 21");
       db.prepare("UPDATE cache_meta SET value = '21' WHERE key = 'version'").run();
@@ -409,13 +409,13 @@ describe("cache schema boundary", () => {
         (
           ready
             .prepare("SELECT content_hash FROM session_documents WHERE session_id = ?")
-            .get(session.id) as { content_hash?: string }
+            .get(session.reference.sessionId) as { content_hash?: string }
         ).content_hash ?? "missing",
       ),
       pending:
         ready
           .prepare("SELECT 1 FROM pending_reindex WHERE agent_name = ? AND session_id = ?")
-          .get("codex", session.id) != null,
+          .get("codex", session.reference.sessionId) != null,
     }));
 
     expect(migrated).toEqual({ contentHash: "", pending: true });
@@ -434,9 +434,13 @@ describe("cache schema boundary", () => {
   it("marks existing details for validation when adding projection versions", () => {
     const session = makeSessionHead("legacy-detail");
     saveCachedSessions("codex", [session], {
-      [session.id]: { id: session.id, sourcePath: "/legacy", sourceFingerprint: "legacy" },
+      [session.reference.sessionId]: {
+        id: session.reference.sessionId,
+        sourcePath: "/legacy",
+        sourceFingerprint: "legacy",
+      },
     });
-    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.id));
+    syncSessionSearchIndex("codex", [session], () => makeSessionData(session.reference.sessionId));
 
     const legacyDb = new Database(getCachePath());
     // A real v18 database predates both the projection version and the index over it.
@@ -456,12 +460,12 @@ describe("cache schema boundary", () => {
           .prepare(
             "SELECT detail_version FROM session_documents WHERE agent_name = ? AND session_id = ?",
           )
-          .get("codex", session.id) as { detail_version?: string }
+          .get("codex", session.reference.sessionId) as { detail_version?: string }
       ).detail_version,
       pending:
         db
           .prepare("SELECT 1 FROM pending_reindex WHERE agent_name = ? AND session_id = ?")
-          .get("codex", session.id) != null,
+          .get("codex", session.reference.sessionId) != null,
     }));
 
     expect(migrated).toEqual({ version: 31, detailVersion: "", pending: true });
@@ -487,7 +491,7 @@ describe("cache schema boundary", () => {
                   smart_tags_classifier_revision
            FROM sessions WHERE session_id = ?`,
         )
-        .get(session.id) as {
+        .get(session.reference.sessionId) as {
         project_identity_resolver_revision?: string | null;
         project_identity_input_signature?: string | null;
         smart_tags_classifier_revision?: string | null;

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -45,7 +45,9 @@ describe("search index writer", () => {
     expect(searchSessions("needle")).toEqual([
       expect.objectContaining({
         reference: { agentName: "codex", sessionId: "one" },
-        session: expect.objectContaining({ id: "one" }),
+        session: expect.objectContaining({
+          reference: { agentName: "codex", sessionId: "one" },
+        }),
       }),
     ]);
     expect(syncSessionSearchIndex("codex", [session], loadSession)).toMatchObject({
@@ -57,7 +59,7 @@ describe("search index writer", () => {
   it("reindexes file activity when only the project identity changes", () => {
     const initial = makeSessionHead("identity-change");
     const detail = (session: typeof initial) => ({
-      ...makeSessionData(session.id),
+      ...makeSessionData(session.reference.sessionId),
       ...session,
       messages: [
         {
@@ -119,10 +121,14 @@ describe("search index writer", () => {
       ...makeSessionHead("chain"),
       stats: { ...makeSessionHead("chain").stats, message_count: 2 },
     };
-    const firstMeta = { id: session.id, sourcePath: "/chain", sourceFingerprint: "first" };
+    const firstMeta = {
+      id: session.reference.sessionId,
+      sourcePath: "/chain",
+      sourceFingerprint: "first",
+    };
     const nextMeta = { ...firstMeta, sourceFingerprint: "next" };
     const detail = (firstText: string, secondText: string) => ({
-      ...makeSessionData(session.id),
+      ...makeSessionData(session.reference.sessionId),
       ...session,
       messages: [
         {
@@ -146,14 +152,16 @@ describe("search index writer", () => {
             .prepare(
               "SELECT content_chain_digest FROM messages WHERE agent_name = ? AND session_id = ? ORDER BY message_index",
             )
-            .all("codex", session.id) as Array<{ content_chain_digest?: string | null }>,
+            .all("codex", session.reference.sessionId) as Array<{
+            content_chain_digest?: string | null;
+          }>,
       )?.map((row) => row.content_chain_digest);
 
-    saveCachedSessions("codex", [session], { [session.id]: firstMeta });
+    saveCachedSessions("codex", [session], { [session.reference.sessionId]: firstMeta });
     syncSessionSearchIndex("codex", [session], () => detail("first", "second"));
     const firstDigests = readDigests();
 
-    saveCachedSessions("codex", [session], { [session.id]: nextMeta });
+    saveCachedSessions("codex", [session], { [session.reference.sessionId]: nextMeta });
     syncSessionSearchIndex("codex", [session], () => detail("rewritten", "second"));
     const nextDigests = readDigests();
 
@@ -168,10 +176,14 @@ describe("search index writer", () => {
       ...makeSessionHead("rollback"),
       stats: { ...makeSessionHead("rollback").stats, message_count: 2 },
     };
-    const firstMeta = { id: session.id, sourcePath: "/rollback", sourceFingerprint: "first" };
+    const firstMeta = {
+      id: session.reference.sessionId,
+      sourcePath: "/rollback",
+      sourceFingerprint: "first",
+    };
     const nextMeta = { ...firstMeta, sourceFingerprint: "next" };
     const detail = (firstText: string, secondText: string) => ({
-      ...makeSessionData(session.id),
+      ...makeSessionData(session.reference.sessionId),
       ...session,
       messages: [
         {
@@ -189,12 +201,14 @@ describe("search index writer", () => {
       ],
     });
 
-    saveCachedSessions("codex", [session], { [session.id]: firstMeta });
+    saveCachedSessions("codex", [session], { [session.reference.sessionId]: firstMeta });
     syncSessionSearchIndex("codex", [session], () => detail("first", "second"));
-    const before = loadCachedSessionRawEntry("codex", session.id)?.messageRows.map((row) => ({
-      partsJson: row.parts_json,
-      digest: row.content_chain_digest,
-    }));
+    const before = loadCachedSessionRawEntry("codex", session.reference.sessionId)?.messageRows.map(
+      (row) => ({
+        partsJson: row.parts_json,
+        digest: row.content_chain_digest,
+      }),
+    );
     withCacheDb((db) => {
       db.exec(`
         CREATE TRIGGER reject_message_chain_update
@@ -205,15 +219,17 @@ describe("search index writer", () => {
         END;
       `);
     });
-    saveCachedSessions("codex", [session], { [session.id]: nextMeta });
+    saveCachedSessions("codex", [session], { [session.reference.sessionId]: nextMeta });
 
     expect(
       syncSessionSearchIndex("codex", [session], () => detail("rewritten", "second")),
     ).toBeNull();
-    const after = loadCachedSessionRawEntry("codex", session.id)?.messageRows.map((row) => ({
-      partsJson: row.parts_json,
-      digest: row.content_chain_digest,
-    }));
+    const after = loadCachedSessionRawEntry("codex", session.reference.sessionId)?.messageRows.map(
+      (row) => ({
+        partsJson: row.parts_json,
+        digest: row.content_chain_digest,
+      }),
+    );
 
     expect(after).toEqual(before);
   });
@@ -226,16 +242,16 @@ describe("search index writer", () => {
     withCacheDb((db) => {
       db.prepare("INSERT INTO pending_reindex(agent_name, session_id) VALUES (?, ?)").run(
         "codex",
-        session.id,
+        session.reference.sessionId,
       );
       db.prepare(
         "UPDATE session_documents SET content_hash = '' WHERE agent_name = ? AND session_id = ?",
-      ).run("codex", session.id);
+      ).run("codex", session.reference.sessionId);
     });
     loadSession.mockClear();
 
     expect(readPendingSearchIndexMaintenance("codex", 16)).toEqual({
-      sessionIds: [session.id],
+      sessionIds: [session.reference.sessionId],
       total: 1,
     });
     const foregroundPublication = commitDurableSessionPublication(
@@ -273,11 +289,11 @@ describe("search index writer", () => {
     withCacheDb((db) => {
       db.prepare("INSERT INTO pending_reindex(agent_name, session_id) VALUES (?, ?)").run(
         "codex",
-        session.id,
+        session.reference.sessionId,
       );
       db.prepare(
         "UPDATE session_documents SET content_hash = '' WHERE agent_name = ? AND session_id = ?",
-      ).run("codex", session.id);
+      ).run("codex", session.reference.sessionId);
     });
     const updated = { ...session, title: "Updated head" };
     const loadSession = vi.fn(() => ({ ...makeSessionData("one", "new detail"), ...updated }));
@@ -318,16 +334,17 @@ describe("search index writer", () => {
       ["updated", "removed"].map((id) => ({
         ...makeSessionHead(id),
         reference: { agentName, sessionId: id },
-        slug: `${agentName}/${id}`,
       }));
     const detailFor = (session: ReturnType<typeof makeSessionHead>, text: string) => ({
-      ...makeSessionData(session.id, text),
+      ...makeSessionData(session.reference.sessionId, text),
       ...session,
     });
 
     for (const agentName of [directAgent, durableAgent]) {
       const initial = initialFor(agentName);
-      const sessionsById = new Map(initial.map((session) => [session.id, session]));
+      const sessionsById = new Map(
+        initial.map((session) => [session.reference.sessionId, session]),
+      );
       saveCachedSessions(agentName, initial);
       syncSessionSearchIndex(agentName, initial, (sessionId) =>
         detailFor(sessionsById.get(sessionId)!, `${agentName} initial ${sessionId}`),

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -53,8 +53,6 @@ const FIXTURE_DIR = mkdtempSync(join(tmpdir(), "codesesh-identity-"));
 function makeAgentSession(agentName: string, id: string): IdentifiedSessionHead {
   return {
     reference: { agentName, sessionId: id },
-    id,
-    slug: `${agentName}/${id}`,
     title: `Session ${id}`,
     directory: FIXTURE_DIR,
     project_identity: {
@@ -218,7 +216,7 @@ describe("durable publication", () => {
     const original = makeSession("head-failure");
     saveCachedSessions("codex", [original]);
     syncSessionSearchIndex("codex", [original], () =>
-      makeSessionData(original.id, "head old content"),
+      makeSessionData(original.reference.sessionId, "head old content"),
     );
 
     const db = new Database(getCachePath());
@@ -244,7 +242,7 @@ describe("durable publication", () => {
         completeness: "complete",
         removedSessionIds: [],
       },
-      () => makeSessionData(original.id, "head updated content"),
+      () => makeSessionData(original.reference.sessionId, "head updated content"),
     );
 
     expect(result).toMatchObject({ status: "rolled-back", stage: "cache" });
@@ -343,7 +341,7 @@ describe("durable publication", () => {
     const original = makeSession("commit-failure");
     saveCachedSessions("codex", [original]);
     syncSessionSearchIndex("codex", [original], () =>
-      makeSessionData(original.id, "commit old content"),
+      makeSessionData(original.reference.sessionId, "commit old content"),
     );
 
     const db = new Database(getCachePath());
@@ -375,7 +373,7 @@ describe("durable publication", () => {
         completeness: "complete",
         removedSessionIds: [],
       },
-      () => makeSessionData(original.id, "commit updated content"),
+      () => makeSessionData(original.reference.sessionId, "commit updated content"),
     );
 
     expect(result).toMatchObject({ status: "rolled-back", stage: "commit" });
@@ -503,15 +501,18 @@ describe("durable publication", () => {
     () => {
       const historical = makeSession("historical");
       saveCachedSessions("codex", [historical], {
-        historical: { id: historical.id, sourcePath: "/historical" },
+        historical: { id: historical.reference.sessionId, sourcePath: "/historical" },
       });
       syncSessionSearchIndex("codex", [historical], () =>
-        makeSessionData(historical.id, "historical content"),
+        makeSessionData(historical.reference.sessionId, "historical content"),
       );
 
       const sessions = Array.from({ length: 70 }, (_, index) => makeSession(`rollback-${index}`));
       const meta = Object.fromEntries(
-        sessions.map((session) => [session.id, { id: session.id, sourcePath: `/${session.id}` }]),
+        sessions.map((session) => [
+          session.reference.sessionId,
+          { id: session.reference.sessionId, sourcePath: `/${session.reference.sessionId}` },
+        ]),
       );
       const db = new Database(getCachePath());
       try {
@@ -540,7 +541,9 @@ describe("durable publication", () => {
       );
 
       expect(result).toMatchObject({ status: "rolled-back", stage: "cache" });
-      expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).toEqual([historical.id]);
+      expect(
+        loadCachedSessions("codex")?.sessions.map(({ reference: { sessionId: id } }) => id),
+      ).toEqual([historical.reference.sessionId]);
       expect(searchSessions("rollback-42 rollback content")).toHaveLength(0);
       const verifyDb = new Database(getCachePath(), { readonly: true });
       try {
@@ -590,7 +593,7 @@ describe("durable publication", () => {
 
       const updated = originals.map((session) => ({
         ...session,
-        title: `Updated ${session.id}`,
+        title: `Updated ${session.reference.sessionId}`,
       }));
       const db = new Database(getCachePath());
       try {
@@ -730,16 +733,18 @@ describe("durable publication", () => {
         sessions: [updatedRecent],
         meta: {},
         completeness: "partial",
-        removedSessionIds: [removed.id],
+        removedSessionIds: [removed.reference.sessionId],
       },
-      () => makeSessionData(recent.id, "recent partial content"),
+      () => makeSessionData(recent.reference.sessionId, "recent partial content"),
     );
 
     expect(partial.status).toBe("committed");
-    expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).toEqual(
-      expect.arrayContaining([recent.id, historical.id]),
-    );
-    expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).not.toContain(removed.id);
+    expect(
+      loadCachedSessions("codex")?.sessions.map(({ reference: { sessionId: id } }) => id),
+    ).toEqual(expect.arrayContaining([recent.reference.sessionId, historical.reference.sessionId]));
+    expect(
+      loadCachedSessions("codex")?.sessions.map(({ reference: { sessionId: id } }) => id),
+    ).not.toContain(removed.reference.sessionId);
     expect(searchSessions("historical publication")).toHaveLength(1);
     expect(searchSessions("removed publication")).toHaveLength(0);
 
@@ -749,14 +754,16 @@ describe("durable publication", () => {
         kind: "changes",
         agentName: "codex",
         changes: [{ session: updatedHistorical, sortIndex: 0 }],
-        removedSessionIds: [recent.id],
+        removedSessionIds: [recent.reference.sessionId],
         meta: {},
       },
-      () => makeSessionData(historical.id, "historical incremental content"),
+      () => makeSessionData(historical.reference.sessionId, "historical incremental content"),
     );
 
     expect(incremental.status).toBe("committed");
-    expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).toEqual([historical.id]);
+    expect(
+      loadCachedSessions("codex")?.sessions.map(({ reference: { sessionId: id } }) => id),
+    ).toEqual([historical.reference.sessionId]);
     expect(searchSessions("historical incremental")).toHaveLength(1);
     expect(searchSessions("recent partial")).toHaveLength(0);
   });
@@ -786,13 +793,17 @@ describe("searchSessions", () => {
 
     saveCachedSessions("codex", [below, boundary, above]);
 
-    expect(searchSessions("cost:>1").map((result) => result.session.id)).toEqual(["above"]);
-    expect(searchSessions("cost:<1").map((result) => result.session.id)).toEqual(["below"]);
-    expect(searchSessions("cost:>=1").map((result) => result.session.id)).toEqual([
+    expect(searchSessions("cost:>1").map((result) => result.session.reference.sessionId)).toEqual([
+      "above",
+    ]);
+    expect(searchSessions("cost:<1").map((result) => result.session.reference.sessionId)).toEqual([
+      "below",
+    ]);
+    expect(searchSessions("cost:>=1").map((result) => result.session.reference.sessionId)).toEqual([
       "above",
       "boundary",
     ]);
-    expect(searchSessions("cost:<=1").map((result) => result.session.id)).toEqual([
+    expect(searchSessions("cost:<=1").map((result) => result.session.reference.sessionId)).toEqual([
       "boundary",
       "below",
     ]);
@@ -810,7 +821,7 @@ describe("searchSessions", () => {
     };
     const details = new Map<string, SessionDetail>([
       [
-        parent.id,
+        parent.reference.sessionId,
         {
           ...parent,
           messages: [
@@ -824,7 +835,7 @@ describe("searchSessions", () => {
         },
       ],
       [
-        child.id,
+        child.reference.sessionId,
         {
           ...child,
           messages: [],
@@ -834,7 +845,9 @@ describe("searchSessions", () => {
     syncSessionSearchIndex("codex", [parent, child], (sessionId) => details.get(sessionId)!);
 
     expect(
-      searchSessions("inclusivecostneedle cost:>1").map((result) => result.session.id),
+      searchSessions("inclusivecostneedle cost:>1").map(
+        (result) => result.session.reference.sessionId,
+      ),
     ).toEqual(["inclusive-parent"]);
   });
 
@@ -882,7 +895,7 @@ describe("searchSessions", () => {
     const data = loadCachedSessionData("codex", "cached-detail");
 
     expect(data).toMatchObject({
-      id: "cached-detail",
+      reference: { agentName: "codex", sessionId: "cached-detail" },
       title: "Session cached-detail",
       stats: {
         message_count: 1,
@@ -922,7 +935,7 @@ describe("searchSessions", () => {
     const results = searchSessions("sqlite");
     expect(results).toHaveLength(1);
     expect(results[0]?.reference.agentName).toBe("claudecode");
-    expect(results[0]?.session.id).toBe("s1");
+    expect(results[0]?.session.reference.sessionId).toBe("s1");
     expect(results[0]?.session.stats).toMatchObject({
       message_count: 1,
       total_input_tokens: 11,
@@ -965,7 +978,7 @@ describe("searchSessions", () => {
     const sessions = [remote, path];
     saveCachedSessions("claudecode", sessions);
     syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
-      ...sessions.find((session) => session.id === sessionId)!,
+      ...sessions.find((session) => session.reference.sessionId === sessionId)!,
       messages: makeSessionData(sessionId, "identity collision needle").messages,
     }));
 
@@ -973,7 +986,7 @@ describe("searchSessions", () => {
       searchSessions("collision", {
         projectKind: "git_remote",
         projectKey: "github.com/acme/app",
-      }).map((result) => result.session.id),
+      }).map((result) => result.session.reference.sessionId),
     ).toEqual(["remote"]);
     expect(searchSessions("collision", { projectKey: "github.com/acme/app" })).toEqual([]);
   });
@@ -1126,11 +1139,11 @@ describe("searchSessions", () => {
     expect(highlightedText(searchSessions('"quoted phrase"')[0])).toContain("quoted phrase");
 
     const allTermResults = searchSessions("assistantneedle reply");
-    expect(allTermResults[0]?.session.id).toBe("assistant");
+    expect(allTermResults[0]?.session.reference.sessionId).toBe("assistant");
     expect(allTermResults[0]?.matchType).toBe("assistant_reply");
 
     const orResults = searchSessions("alphaneedle OR betaneedle");
-    expect(orResults[0]?.session.id).toBe("or-first");
+    expect(orResults[0]?.session.reference.sessionId).toBe("or-first");
     expect(orResults[0]?.matchType).toBe("assistant_reply");
     expect(highlightedText(orResults[0])).toContain("betaneedle");
 
@@ -1147,7 +1160,7 @@ describe("searchSessions", () => {
 
     saveCachedSessions("claudecode", sessions);
     syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
-      ...sessions.find((session) => session.id === sessionId)!,
+      ...sessions.find((session) => session.reference.sessionId === sessionId)!,
       messages: Array.from({ length: 30 }, (_, messageIndex) => ({
         id: `${sessionId}-m${messageIndex}`,
         role: "user" as const,
@@ -1231,7 +1244,7 @@ describe("searchSessions", () => {
       }
       return session;
     });
-    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+    const sessionMap = new Map(sessions.map((session) => [session.reference.sessionId, session]));
 
     saveCachedSessions("claudecode", sessions);
     const result = syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
@@ -1275,7 +1288,7 @@ describe("searchSessions", () => {
       },
     });
     expect(filteredResults).toHaveLength(1);
-    expect(filteredResults[0]?.session.id).toBe("bulk-42");
+    expect(filteredResults[0]?.session.reference.sessionId).toBe("bulk-42");
     expect(highlightedText(filteredResults[0])).toContain("needle");
   });
 
@@ -1310,7 +1323,7 @@ describe("searchSessions", () => {
         },
       },
     ];
-    const sessionById = new Map(sessions.map((session) => [session.id, session]));
+    const sessionById = new Map(sessions.map((session) => [session.reference.sessionId, session]));
 
     saveCachedSessions("claudecode", sessions);
     syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
@@ -1332,7 +1345,7 @@ describe("searchSessions", () => {
           path: `${scopeRoot}/child`,
         },
       })
-        .map(({ session }) => session.id)
+        .map(({ session }) => session.reference.sessionId)
         .sort(),
     ).toEqual(["scope-ancestor", "scope-descendant"]);
   });
@@ -1379,7 +1392,8 @@ describe("searchSessions", () => {
     };
     const loadSession = vi.fn(() => ({
       ...session,
-      messages: makeAgentSessionData("codex", session.id, "normalized content").messages,
+      messages: makeAgentSessionData("codex", session.reference.sessionId, "normalized content")
+        .messages,
     }));
 
     syncSessionSearchIndex("codex", [session], loadSession);
@@ -1394,7 +1408,7 @@ describe("searchSessions", () => {
   it("backfills normalized message counts when migrating existing search documents", () => {
     const session = makeAgentSession("codex", "normalized-count-migration");
     syncSessionSearchIndex("codex", [session], () =>
-      makeAgentSessionData("codex", session.id, "normalized migration content"),
+      makeAgentSessionData("codex", session.reference.sessionId, "normalized migration content"),
     );
 
     const db = new Database(getCachePath());
@@ -1476,19 +1490,19 @@ describe("searchSessions", () => {
       stats: { ...makeSession("removed").stats, message_count: 2 },
     };
     const sessions = [keep, changed, removed];
-    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+    const sessionMap = new Map(sessions.map((session) => [session.reference.sessionId, session]));
     const makeIndexedData = (session: SessionHead, text: string, path: string): SessionDetail => ({
       ...session,
-      reference: { agentName: "claudecode", sessionId: session.id },
+      reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
       messages: [
         {
-          id: `${session.id}-m1`,
+          id: `${session.reference.sessionId}-m1`,
           role: "user",
           time_created: now,
           parts: [{ type: "text", text }],
         },
         {
-          id: `${session.id}-m2`,
+          id: `${session.reference.sessionId}-m2`,
           role: "assistant",
           time_created: now + 1,
           parts: [
@@ -1534,10 +1548,14 @@ describe("searchSessions", () => {
       deleted: 1,
       indexed: 1,
     });
-    expect(searchSessions("updatedtoken").map((item) => item.session.id)).toEqual(["changed"]);
+    expect(searchSessions("updatedtoken").map((item) => item.session.reference.sessionId)).toEqual([
+      "changed",
+    ]);
     expect(searchSessions("changedtoken")).toHaveLength(0);
     expect(searchSessions("removedtoken")).toHaveLength(0);
-    expect(searchSessions("keeptoken").map((item) => item.session.id)).toEqual(["keep"]);
+    expect(searchSessions("keeptoken").map((item) => item.session.reference.sessionId)).toEqual([
+      "keep",
+    ]);
     expect(
       listFileActivity({ agent: "claudecode" })
         .map((item) => item.path)
@@ -1552,11 +1570,11 @@ describe("searchSessions", () => {
       const sessions = Array.from({ length: multiBatchSessionCount }, (_, index) =>
         makeSession(`batch-${index}`),
       );
-      const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+      const sessionMap = new Map(sessions.map((session) => [session.reference.sessionId, session]));
 
       saveCachedSessions("claudecode", sessions);
       syncSessionSearchIndex("claudecode", sessions, (sessionId) =>
-        makeSessionData(sessionMap.get(sessionId)!.id, `content ${sessionId}`),
+        makeSessionData(sessionMap.get(sessionId)!.reference.sessionId, `content ${sessionId}`),
       );
 
       let stateQueryExecutions = 0;
@@ -1620,23 +1638,26 @@ describe("searchSessions", () => {
       stats: { ...makeSession("zero-messages").stats, message_count: 0 },
     };
     const sessions = [missingDocument, missingMessages, zeroMessages];
-    const sessionMap = new Map(sessions.map((session) => [session.id, session]));
+    const sessionMap = new Map(sessions.map((session) => [session.reference.sessionId, session]));
 
     saveCachedSessions("claudecode", sessions);
     syncSessionSearchIndex("claudecode", sessions, (sessionId) => ({
       ...sessionMap.get(sessionId)!,
-      messages: sessionId === zeroMessages.id ? [] : makeSessionData(sessionId, sessionId).messages,
+      messages:
+        sessionId === zeroMessages.reference.sessionId
+          ? []
+          : makeSessionData(sessionId, sessionId).messages,
     }));
 
     const db = new Database(getCachePath());
     try {
       db.prepare("DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?").run(
         "claudecode",
-        missingDocument.id,
+        missingDocument.reference.sessionId,
       );
       db.prepare("DELETE FROM messages WHERE agent_name = ? AND session_id = ?").run(
         "claudecode",
-        missingMessages.id,
+        missingMessages.reference.sessionId,
       );
     } finally {
       db.close();
@@ -1664,9 +1685,9 @@ describe("searchSessions", () => {
       skipped: 0,
     });
     expect(loadSession.mock.calls.map(([sessionId]) => sessionId)).toEqual([
-      missingDocument.id,
-      missingMessages.id,
-      missingMessages.id,
+      missingDocument.reference.sessionId,
+      missingMessages.reference.sessionId,
+      missingMessages.reference.sessionId,
     ]);
   });
 
@@ -1816,7 +1837,7 @@ describe("searchSessions", () => {
 
     saveCachedSessions("claudecode", [target, other]);
     syncSessionSearchIndex("claudecode", [target, other], (sessionId) => ({
-      ...(sessionId === target.id ? target : other),
+      ...(sessionId === target.reference.sessionId ? target : other),
       messages: [
         {
           id: `${sessionId}-tool`,
@@ -1825,7 +1846,7 @@ describe("searchSessions", () => {
           parts: [
             {
               type: "tool",
-              tool: sessionId === target.id ? "apply_patch" : "grep",
+              tool: sessionId === target.reference.sessionId ? "apply_patch" : "grep",
               state: { status: "completed" },
             },
           ],
@@ -1833,9 +1854,9 @@ describe("searchSessions", () => {
       ],
     }));
 
-    expect(searchSessions("tool:apply_patch").map((result) => result.session.id)).toEqual([
-      "tool-target",
-    ]);
+    expect(
+      searchSessions("tool:apply_patch").map((result) => result.session.reference.sessionId),
+    ).toEqual(["tool-target"]);
 
     const db = new Database(getCachePath(), { readonly: true });
     try {
@@ -1955,7 +1976,7 @@ describe("searchSessions", () => {
 
     const searchResults = searchFileActivitySessions("src/new.ts");
     expect(searchResults).toHaveLength(1);
-    expect(searchResults[0]?.session.id).toBe("files");
+    expect(searchResults[0]?.session.reference.sessionId).toBe("files");
     expect(highlightedText(searchResults[0])).toContain("src/new.ts");
 
     const directWriteResults = searchFileActivitySessions("src/direct.ts");
@@ -1989,7 +2010,7 @@ describe("searchSessions", () => {
       "claudecode",
       sessions.map(({ session }) => session),
       (sessionId) => {
-        const entry = sessions.find(({ session }) => session.id === sessionId)!;
+        const entry = sessions.find(({ session }) => session.reference.sessionId === sessionId)!;
         return {
           ...entry.session,
           messages: [
@@ -2008,7 +2029,10 @@ describe("searchSessions", () => {
     // limit would spend the whole budget there and never reach "sparse".
     const results = searchFileActivitySessions("src/shared/module", { limit: 2 });
 
-    expect(results.map((result) => result.session.id)).toEqual(["dense", "sparse"]);
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
+      "dense",
+      "sparse",
+    ]);
   });
 
   it("CS-134: keeps same-id sessions from different agents apart", () => {
@@ -2323,7 +2347,7 @@ describe("searchSessions", () => {
     );
 
     expect(results).toHaveLength(1);
-    expect(results[0]?.session.id).toBe("structured");
+    expect(results[0]?.session.reference.sessionId).toBe("structured");
     expect(results[0]?.matchType).toBe("user_message");
     expect(results[0]?.session.smart_tags).toEqual(["feature-dev"]);
   });
@@ -2348,7 +2372,7 @@ describe("searchSessions", () => {
     const results = searchSessions("agent:codex tag:testing");
 
     expect(results).toHaveLength(1);
-    expect(results[0]?.session.id).toBe("recent");
+    expect(results[0]?.session.reference.sessionId).toBe("recent");
     expect(results[0]?.matchType).toBe("recent");
   });
 
@@ -2359,13 +2383,13 @@ describe("searchSessions", () => {
     const sessions = [old, recent, removed];
     const meta = Object.fromEntries(
       sessions.map((session) => [
-        session.id,
-        { id: session.id, sourcePath: `/${session.id}.jsonl` },
+        session.reference.sessionId,
+        { id: session.reference.sessionId, sourcePath: `/${session.reference.sessionId}.jsonl` },
       ]),
     );
     saveCachedSessions("codex", sessions, meta);
     syncSessionSearchIndex("codex", sessions, (sessionId) => {
-      const session = sessions.find(({ id }) => id === sessionId)!;
+      const session = sessions.find(({ reference: { sessionId: id } }) => id === sessionId)!;
       const text =
         sessionId === "old"
           ? "historicalscope"
@@ -2404,22 +2428,26 @@ describe("searchSessions", () => {
       "codex",
       [updatedRecent],
       { recent: meta.recent! },
-      { completeness: "partial", removedSessionIds: [removed.id] },
+      { completeness: "partial", removedSessionIds: [removed.reference.sessionId] },
     );
     syncSessionSearchIndex(
       "codex",
       [updatedRecent],
       () => makeAgentSessionData("codex", "recent", "recentscope updated"),
-      { completeness: "partial", removedSessionIds: [removed.id] },
+      { completeness: "partial", removedSessionIds: [removed.reference.sessionId] },
     );
 
-    expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).toEqual(
-      expect.arrayContaining(["old", "recent"]),
-    );
-    expect(loadCachedSessions("codex")?.sessions.map(({ id }) => id)).not.toContain("removed");
+    expect(
+      loadCachedSessions("codex")?.sessions.map(({ reference: { sessionId: id } }) => id),
+    ).toEqual(expect.arrayContaining(["old", "recent"]));
+    expect(
+      loadCachedSessions("codex")?.sessions.map(({ reference: { sessionId: id } }) => id),
+    ).not.toContain("removed");
     expect(loadCachedSessions("codex")?.meta.old).toEqual(meta.old);
     expect(loadCachedSessionData("codex", "old")?.messages).toHaveLength(1);
-    expect(searchSessions("historicalscope").map(({ session }) => session.id)).toEqual(["old"]);
+    expect(
+      searchSessions("historicalscope").map(({ session }) => session.reference.sessionId),
+    ).toEqual(["old"]);
     expect(searchSessions("deletedscope")).toEqual([]);
     expect(
       listFileActivity({ agent: "codex", sessionId: "old", limit: 10 }).map(({ path }) => path),
@@ -2447,7 +2475,7 @@ describe("searchSessions", () => {
 
     const results = searchSessions("windowed");
     expect(results).toHaveLength(1);
-    expect(results[0]?.session.id).toBe("windowed");
+    expect(results[0]?.session.reference.sessionId).toBe("windowed");
 
     const db = new Database(getCachePath(), { readonly: true });
     try {
@@ -2551,7 +2579,7 @@ describe("searchSessions", () => {
     const results = searchSessions("orphan");
 
     expect(results).toHaveLength(1);
-    expect(results[0]?.session.id).toBe("fts-empty");
+    expect(results[0]?.session.reference.sessionId).toBe("fts-empty");
     expect(highlightedText(results[0])).toContain("orphan");
   });
 
@@ -2567,7 +2595,7 @@ describe("searchSessions", () => {
       db.exec("DROP TRIGGER session_documents_au");
       db.prepare(
         "UPDATE session_documents SET content_text = ? WHERE agent_name = ? AND session_id = ?",
-      ).run("documentrepairneedle", "claudecode", session.id);
+      ).run("documentrepairneedle", "claudecode", session.reference.sessionId);
     } finally {
       db.close();
     }
@@ -2600,7 +2628,9 @@ describe("searchSessions", () => {
     }
     setSchemaEnsuredPath(null);
 
-    expect(searchSessions("tablerepairneedle")[0]?.session.id).toBe(session.id);
+    expect(searchSessions("tablerepairneedle")[0]?.session.reference.sessionId).toBe(
+      session.reference.sessionId,
+    );
   });
 
   it("validates and rebuilds FTS indexes after SQLite reports corruption", () => {
@@ -2641,6 +2671,8 @@ describe("searchSessions", () => {
     });
 
     expect(result).toBe("recovered");
-    expect(searchSessions("recoverytoken42")[0]?.session.id).toBe(session.id);
+    expect(searchSessions("recoverytoken42")[0]?.session.reference.sessionId).toBe(
+      session.reference.sessionId,
+    );
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/search.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search.test.ts
@@ -94,6 +94,9 @@ describe("cache search", () => {
         total_output_tokens: 4,
         total_cost: 0.5,
       }),
-    ).toMatchObject({ id: "s1", stats: { message_count: 2, total_cost: 0.5 } });
+    ).toMatchObject({
+      reference: { agentName: "codex", sessionId: "s1" },
+      stats: { message_count: 2, total_cost: 0.5 },
+    });
   });
 });

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -97,8 +97,6 @@ const FIXTURE_DIR_NAME = FIXTURE_DIR.split(/[\\/]/).pop()!;
 function makeSession(id: string, agentName = "claudecode"): SessionHead {
   return {
     reference: { agentName, sessionId: id },
-    id,
-    slug: `${agentName}/${id}`,
     title: `Session ${id}`,
     directory: FIXTURE_DIR,
     project_identity: {
@@ -154,7 +152,7 @@ function createLegacyCachedSessionDb(version: number, session = makeSession("leg
         INSERT INTO cached_sessions(agent_name, session_id, session_json, meta_json)
         VALUES (?, ?, ?, ?)
       `,
-    ).run("claudecode", session.id, JSON.stringify(session), null);
+    ).run("claudecode", session.reference.sessionId, JSON.stringify(session), null);
   } finally {
     db.close();
   }
@@ -267,7 +265,9 @@ describe("loadCachedSessions", () => {
   it("returns cached sessions even when last refresh is old", () => {
     saveCachedSessions("claudecode", [makeSession("s1")]);
     dateNowSpy.mockReturnValue(now + 8 * 24 * 60 * 60 * 1000);
-    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual(["s1"]);
+    expect(
+      loadCachedSessions("claudecode")?.sessions.map((session) => session.reference.sessionId),
+    ).toEqual(["s1"]);
   });
 
   it("returns cached sessions and meta when valid", () => {
@@ -280,7 +280,7 @@ describe("loadCachedSessions", () => {
     const result = loadCachedSessions("claudecode");
     expect(result).not.toBeNull();
     expect(result?.sessions).toHaveLength(1);
-    expect(result?.sessions[0]?.id).toBe("s1");
+    expect(result?.sessions[0]?.reference.sessionId).toBe("s1");
     expect(result?.meta.s1?.sourcePath).toBe("/path/to/source");
     expect(result?.timestamp).toBe(now);
   });
@@ -297,11 +297,11 @@ describe("loadCachedSessions", () => {
 });
 
 describe("session identity persistence invariant", () => {
-  it("rejects conflicting session identities before opening the cache", () => {
-    const session = { ...makeSession("session"), slug: "codex/other" };
+  it("rejects a session owned by another agent before opening the cache", () => {
+    const session = makeSession("session", "codex");
 
     expect(() => saveCachedSessions("claudecode", [session])).toThrow(
-      "Session identity fields disagree",
+      'Session reference agent "codex" does not match "claudecode"',
     );
     expect(existsSync(getCachePath())).toBe(false);
   });
@@ -463,7 +463,7 @@ describe("saveCachedSessions", () => {
     }
 
     const result = loadCachedSessions("claudecode");
-    expect(result?.sessions.map((session) => session.id)).toEqual(["s1"]);
+    expect(result?.sessions.map((session) => session.reference.sessionId)).toEqual(["s1"]);
   });
 
   it("overwrites cached rows for the same agent", () => {
@@ -471,7 +471,7 @@ describe("saveCachedSessions", () => {
     saveCachedSessions("claudecode", [makeSession("new")]);
 
     const result = loadCachedSessions("claudecode");
-    expect(result?.sessions.map((session) => session.id)).toEqual(["new"]);
+    expect(result?.sessions.map((session) => session.reference.sessionId)).toEqual(["new"]);
   });
 
   it("preserves cached rows for an empty partial snapshot", () => {
@@ -479,9 +479,9 @@ describe("saveCachedSessions", () => {
 
     saveCachedSessions("claudecode", [], {}, { completeness: "partial" });
 
-    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
-      "existing",
-    ]);
+    expect(
+      loadCachedSessions("claudecode")?.sessions.map((session) => session.reference.sessionId),
+    ).toEqual(["existing"]);
   });
 
   it("derives restored order from session activity", () => {
@@ -490,10 +490,9 @@ describe("saveCachedSessions", () => {
 
     saveCachedSessions("claudecode", [older, newer]);
 
-    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
-      "newer",
-      "older",
-    ]);
+    expect(
+      loadCachedSessions("claudecode")?.sessions.map((session) => session.reference.sessionId),
+    ).toEqual(["newer", "older"]);
   });
 
   it("does not rewrite retained sort indexes for a partial snapshot", () => {
@@ -552,12 +551,12 @@ describe("saveCachedSessions", () => {
     saveCachedSessions("cursor", [makeSession("cursor-1", "cursor")]);
     saveCachedSessions("claudecode", [makeSession("claude-1")]);
 
-    expect(loadCachedSessions("cursor")?.sessions.map((session) => session.id)).toEqual([
-      "cursor-1",
-    ]);
-    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
-      "claude-1",
-    ]);
+    expect(
+      loadCachedSessions("cursor")?.sessions.map((session) => session.reference.sessionId),
+    ).toEqual(["cursor-1"]);
+    expect(
+      loadCachedSessions("claudecode")?.sessions.map((session) => session.reference.sessionId),
+    ).toEqual(["claude-1"]);
   });
 
   it("removes legacy json cache file after sqlite write", () => {
@@ -634,7 +633,7 @@ describe("saveCachedSessions", () => {
 
     const result = loadCachedSessions("claudecode");
 
-    expect(result?.sessions.map((session) => session.id)).toEqual(["legacy"]);
+    expect(result?.sessions.map((session) => session.reference.sessionId)).toEqual(["legacy"]);
     expect(getUserVersion(getCachePath())).toBe(31);
     expect(listCachedProjectGroups()).toEqual([
       {
@@ -668,9 +667,9 @@ describe("saveCachedSessions", () => {
     });
 
     try {
-      expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
-        "legacy-without-identity",
-      ]);
+      expect(
+        loadCachedSessions("claudecode")?.sessions.map((session) => session.reference.sessionId),
+      ).toEqual(["legacy-without-identity"]);
       expect(events.indexOf("identity")).toBeGreaterThanOrEqual(0);
       expect(events.indexOf("identity")).toBeLessThan(events.indexOf("migration"));
     } finally {
@@ -708,9 +707,9 @@ describe("saveCachedSessions", () => {
   it("backs up populated cache before destructive migration", () => {
     createLegacyCachedSessionDb(2);
 
-    expect(loadCachedSessions("claudecode")?.sessions.map((session) => session.id)).toEqual([
-      "legacy",
-    ]);
+    expect(
+      loadCachedSessions("claudecode")?.sessions.map((session) => session.reference.sessionId),
+    ).toEqual(["legacy"]);
 
     const backups = getMigrationBackups();
     expect(backups).toHaveLength(1);
@@ -796,7 +795,10 @@ describe("saveCachedSessionChanges", () => {
     });
 
     const cached = loadCachedSessions("claudecode");
-    expect(cached?.sessions.map((session) => session.id)).toEqual(["changed", "unchanged"]);
+    expect(cached?.sessions.map((session) => session.reference.sessionId)).toEqual([
+      "changed",
+      "unchanged",
+    ]);
     expect(cached?.sessions[0]?.title).toBe("Changed updated");
     expect(cached?.meta.changed?.sourcePath).toBe("/tmp/changed-new");
     expect(cached?.meta.unchanged?.sourcePath).toBe("/tmp/unchanged");

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -35,7 +35,7 @@ describe("cached sessions", () => {
     });
 
     expect(loadCachedSessions("codex")).toMatchObject({
-      sessions: [{ id: "one" }],
+      sessions: [{ reference: { agentName: "codex", sessionId: "one" } }],
       meta: { one: { sourcePath: "/transcripts/one.jsonl" } },
     });
     expect(getCacheInfo().size).toBe(1);
@@ -48,7 +48,10 @@ describe("cached sessions", () => {
     saveCachedSessionChanges("codex", [{ session: changed, sortIndex: 0 }], ["remove"]);
 
     expect(loadCachedSessions("codex")?.sessions).toEqual([
-      expect.objectContaining({ id: "keep", title: "Updated" }),
+      expect.objectContaining({
+        reference: { agentName: "codex", sessionId: "keep" },
+        title: "Updated",
+      }),
     ]);
   });
 
@@ -96,7 +99,7 @@ describe("cached sessions", () => {
     saveCachedSessions("codex", [makeSessionHead("parent"), child]);
 
     const restoredChild = loadCachedSessions("codex")?.sessions.find(
-      (session) => session.id === "child",
+      (session) => session.reference.sessionId === "child",
     );
     expect(restoredChild?.parent_reference).toEqual({
       agentName: "codex",

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -128,6 +128,13 @@ function getLegacySessionDirectory(session: SessionHead): string | null {
   return typeof session.directory === "string" ? session.directory : null;
 }
 
+function removeLegacySessionIdentityFields(session: SessionHead): SessionHead {
+  const normalized = { ...session } as SessionHead & { id?: unknown; slug?: unknown };
+  delete normalized.id;
+  delete normalized.slug;
+  return normalized;
+}
+
 interface SearchIndexWriteResult<T> {
   value: T;
   rebuildDurationMs?: number;
@@ -942,7 +949,7 @@ function backfillStructuredSessions(
         const directory = getLegacySessionDirectory(parsed);
         if (directory == null) continue;
         const session = {
-          ...parsed,
+          ...removeLegacySessionIdentityFields(parsed),
           ...createSessionIdentity({
             agentName: String(row.agent_name),
             sessionId: String(row.session_id),

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -123,8 +123,8 @@ const SESSION_STATS_SIGNATURE_SPEC = {
   total_cache_create_tokens: (stats) => stats.total_cache_create_tokens ?? 0,
 } satisfies ObjectSignatureSpec<SessionStats>;
 
-/** Compatibility projections are derived from `reference`; `display_title` is API decoration. */
-type SessionHeadSignatureExcludedField = "id" | "slug" | "display_title";
+/** `display_title` is local API decoration, not a source-session fact. */
+type SessionHeadSignatureExcludedField = "display_title";
 
 type SessionHeadSignatureField = Exclude<keyof SessionHead, SessionHeadSignatureExcludedField>;
 

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -164,7 +164,7 @@ function assertSessionMatchesReference(
 ): void {
   assertSessionIdentity(session, reference.agentName);
   if (session.reference.sessionId !== reference.sessionId) {
-    throw new Error("Session identity fields disagree");
+    throw new Error("Session reference does not match expected session");
   }
 }
 

--- a/packages/core/src/projects/groups.test.ts
+++ b/packages/core/src/projects/groups.test.ts
@@ -5,8 +5,6 @@ import { buildProjectGroups } from "./groups.js";
 function makeSession(id: string, agent: string, time: number): SessionHead {
   return {
     reference: { agentName: agent, sessionId: id },
-    id,
-    slug: `${agent}/${id}`,
     title: id,
     directory: "/repo",
     project_identity: {

--- a/packages/core/src/projects/scope.test.ts
+++ b/packages/core/src/projects/scope.test.ts
@@ -6,8 +6,6 @@ import { createProjectScopeMatcherFromIdentity, filterSessionsByProjectScope } f
 function makeSession(id: string, overrides?: Partial<SessionHead>): SessionHead {
   return {
     reference: { agentName: "agent", sessionId: id },
-    id,
-    slug: `agent/${id}`,
     title: `Session ${id}`,
     directory: "/repo",
     time_created: 1000,
@@ -57,7 +55,7 @@ describe("filterSessionsByProjectScope", () => {
 
     const result = filterSessionsByProjectScope(sessions, "/home/user/project");
 
-    expect(result.map((session) => session.id)).toEqual([
+    expect(result.map((session) => session.reference.sessionId)).toEqual([
       "exact",
       "child",
       "parent",

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -111,8 +111,6 @@ function makeSessionHead(spec: FixtureSpec): SessionHead {
   const directory = spec.project ? `/projects/${spec.project.key}` : `/fixtures/${spec.id}`;
   return {
     reference: { agentName: spec.agent, sessionId: spec.id },
-    id: spec.id,
-    slug: `${spec.agent}/${spec.id}`,
     title: spec.title ?? "plain",
     directory,
     project_identity: spec.project ?? { kind: "path", key: directory, displayName: spec.id },
@@ -399,7 +397,7 @@ function legacyRecentResultKeys(snapshot: SessionSearchSnapshot, options: Search
     )
     .sort((left, right) => compareSessionActivityDesc(left.session, right.session))
     .slice(0, limit)
-    .map(({ agentName, session }) => `${agentName}/${session.id}`);
+    .map(({ agentName, session }) => `${agentName}/${session.reference.sessionId}`);
 }
 
 function makeRandomSnapshot(seed: number): SessionSearchSnapshot {
@@ -416,8 +414,6 @@ function makeRandomSnapshot(seed: number): SessionSearchSnapshot {
       const sessionId = `${agentName}-${index}`;
       return {
         reference: { agentName, sessionId },
-        id: sessionId,
-        slug: `${agentName}/${sessionId}`,
         title: `${agentName}-${index}`,
         directory: `/fixtures/${agentName}`,
         time_created: activity,
@@ -475,13 +471,13 @@ describe("search characterization: source selection", () => {
 
   it("routes a text query to the indexed FTS path", () => {
     const results = search("uniquetitleneedle", { limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["fts-title"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual(["fts-title"]);
     expect(results[0]!.matchType).toBe("title");
   });
 
   it("routes a file= filter (no text) to the indexed file-activity path", () => {
     const results = search("", { file: "app.tsx", limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["file-only"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual(["file-only"]);
     expect(results[0]!.matchType).toBe("file_path");
   });
 
@@ -492,7 +488,10 @@ describe("search characterization: source selection", () => {
     // just like the recent path -- except results now come from the SQLite
     // index instead of the snapshot.
     const results = search("", { tools: ["bash"], limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["fts-tool", "file-qualifier-match"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual([
+      "fts-tool",
+      "file-qualifier-match",
+    ]);
     expect(results[0]!.matchType).toBe("recent");
   });
 
@@ -502,7 +501,7 @@ describe("search characterization: source selection", () => {
     // treated identically to an empty query as far as source selection goes.
     const results = search("tag:bugfix", { limit: 50 });
     expect(results.every((r) => r.matchType === "recent")).toBe(true);
-    expect(results.map((r) => r.session.id).sort()).toEqual(
+    expect(results.map((r) => r.session.reference.sessionId).sort()).toEqual(
       ["lagging-session", "recent-mid"].sort(),
     );
   });
@@ -511,17 +510,20 @@ describe("search characterization: source selection", () => {
 describe("search characterization: recent (empty-query) path", () => {
   it("orders by activity time descending and applies limit", () => {
     const results = search("", { limit: 2 });
-    expect(results.map((r) => r.session.id)).toEqual(["recent-new", "lagging-session"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual([
+      "recent-new",
+      "lagging-session",
+    ]);
   });
 
   it("applies the from/to activity window", () => {
     const results = search("", { from: now - 15_000, limit: 50 });
-    expect(results.map((r) => r.session.id)).not.toContain("recent-old");
+    expect(results.map((r) => r.session.reference.sessionId)).not.toContain("recent-old");
   });
 
   it("filters by agent", () => {
     const results = search("", { agent: "codex", limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["codex-session"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual(["codex-session"]);
   });
 
   it("filters by projectKind+projectKey pair", () => {
@@ -530,19 +532,19 @@ describe("search characterization: recent (empty-query) path", () => {
       projectKey: PROJ_OTHER.key,
       limit: 50,
     });
-    expect(results.map((r) => r.session.id).sort()).toEqual(
+    expect(results.map((r) => r.session.reference.sessionId).sort()).toEqual(
       ["recent-mid", "lagging-session", "file-qualifier-mismatch"].sort(),
     );
   });
 
   it("filters by tag", () => {
     const results = search("", { tags: ["testing"], limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["codex-session"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual(["codex-session"]);
   });
 
   it("filters by costMin", () => {
     const results = search("", { costMin: 1, limit: 50 });
-    expect(results.map((r) => r.session.id).sort()).toEqual(
+    expect(results.map((r) => r.session.reference.sessionId).sort()).toEqual(
       ["recent-mid", "lagging-session", "file-qualifier-match"].sort(),
     );
   });
@@ -570,7 +572,10 @@ describe("search characterization: recent (empty-query) path", () => {
 
     const results = executeSessionSearch("", { costMin: 1 }, snapshot);
 
-    expect(results.map((result) => result.session.id)).toEqual(["cost-parent", "cost-child"]);
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
+      "cost-parent",
+      "cost-child",
+    ]);
   });
 
   it("reads the global ordered snapshot only until the result limit", () => {
@@ -598,7 +603,7 @@ describe("search characterization: recent (empty-query) path", () => {
       { sessions: tracked.sessions, byAgent: inaccessibleShards },
     );
 
-    expect(results.map((result) => result.session.id)).toEqual([
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
       "bounded-0",
       "bounded-1",
       "bounded-2",
@@ -628,7 +633,7 @@ describe("search characterization: recent (empty-query) path", () => {
       { sessions: inaccessibleGlobal, byAgent: { codex: tracked.sessions } },
     );
 
-    expect(results.map((result) => result.session.id)).toEqual([
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
       "agent-bounded-0",
       "agent-bounded-1",
     ]);
@@ -670,26 +675,29 @@ describe("search characterization: recent (empty-query) path", () => {
 describe("search characterization: FTS path", () => {
   it("resolves matchType per hit location: title / user_message / assistant_reply / tool_output", () => {
     expect(search("uniquetitleneedle", { limit: 50 })[0]).toMatchObject({
-      session: { id: "fts-title" },
+      session: { reference: { agentName: "claudecode", sessionId: "fts-title" } },
       matchType: "title",
     });
     expect(search("uniqueusermessageneedle", { limit: 50 })[0]).toMatchObject({
-      session: { id: "fts-user" },
+      session: { reference: { agentName: "claudecode", sessionId: "fts-user" } },
       matchType: "user_message",
     });
     expect(search("uniqueassistantneedle", { limit: 50 })[0]).toMatchObject({
-      session: { id: "fts-assistant" },
+      session: { reference: { agentName: "claudecode", sessionId: "fts-assistant" } },
       matchType: "assistant_reply",
     });
     expect(search("uniquetoolneedle", { limit: 50 })[0]).toMatchObject({
-      session: { id: "fts-tool" },
+      session: { reference: { agentName: "claudecode", sessionId: "fts-tool" } },
       matchType: "tool_output",
     });
   });
 
   it("supports OR queries across sessions, breaking bm25 ties by activity time", () => {
     const results = search("alphaonlyneedle OR betaonlyneedle", { limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["or-session-a", "or-session-b"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual([
+      "or-session-a",
+      "or-session-b",
+    ]);
   });
 
   it("merges a tag: qualifier from q with a tags option using AND (intersection), not override", () => {
@@ -698,25 +706,25 @@ describe("search characterization: FTS path", () => {
     // AND's every tag in the merged list. So combining a qualifier tag with an
     // options tag requires sessions to have BOTH tags, not either.
     const results = search("tagneedle tag:refactoring", { tags: ["feature-dev"], limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["tagmerge-both"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual(["tagmerge-both"]);
   });
 
   it("keeps an explicit inclusive cost bound independent from a strict qualifier", () => {
     const results = search("needle cost:>0.1", { costMin: 3.5, limit: 50 });
-    expect(results.map((r) => r.session.id)).toContain("recent-mid");
+    expect(results.map((r) => r.session.reference.sessionId)).toContain("recent-mid");
   });
 });
 
 describe("search characterization: file activity path", () => {
   it("returns file_path matches for a file option", () => {
     const results = search("", { file: "app.tsx", limit: 50 });
-    expect(results.map((r) => r.session.id)).toEqual(["file-only"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual(["file-only"]);
     expect(results[0]!.matchType).toBe("file_path");
   });
 
   it("dedupes a session hit by both file and FTS search, keeping the file_path match first", () => {
     const results = search("sharedneedle", { file: "shared.ts", limit: 50 });
-    const matches = results.filter((r) => r.session.id === "file-and-text");
+    const matches = results.filter((r) => r.session.reference.sessionId === "file-and-text");
     expect(matches).toHaveLength(1);
     expect(matches[0]!.matchType).toBe("file_path");
   });
@@ -775,9 +783,9 @@ describe("search characterization: file activity path", () => {
       ["file-qualifier-match"],
     ],
   ])("applies complete search semantics for %s", (_label, options, expectedIds) => {
-    expect(search("", { ...options, limit: 50 }).map((result) => result.session.id)).toEqual(
-      expectedIds,
-    );
+    expect(
+      search("", { ...options, limit: 50 }).map((result) => result.session.reference.sessionId),
+    ).toEqual(expectedIds);
   });
 
   it("requires both text and an explicit file qualifier to match", () => {
@@ -785,7 +793,9 @@ describe("search characterization: file activity path", () => {
       file: "qualifier-matrix.ts",
       limit: 50,
     });
-    expect(results.map((result) => result.session.id)).toEqual(["file-qualifier-match"]);
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
+      "file-qualifier-match",
+    ]);
   });
 });
 
@@ -794,7 +804,9 @@ describe("search candidate filtering", () => {
     const snapshot = makeSnapshot();
     const candidates = [fileQualifierMatch, fileQualifierMismatch].map((spec) => ({
       reference: { agentName: spec.agent, sessionId: spec.id },
-      session: snapshot.byAgent[spec.agent]!.find((session) => session.id === spec.id)!,
+      session: snapshot.byAgent[spec.agent]!.find(
+        (session) => session.reference.sessionId === spec.id,
+      )!,
       snippet: "Alias",
       snippetHighlights: [],
       matchType: "title" as const,
@@ -805,7 +817,9 @@ describe("search candidate filtering", () => {
       tools: ["bash"],
     });
 
-    expect(results.map((result) => result.session.id)).toEqual(["file-qualifier-match"]);
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
+      "file-qualifier-match",
+    ]);
   });
 
   it("uses the full snapshot for alias-style inclusive cost filters", () => {
@@ -822,11 +836,11 @@ describe("search candidate filtering", () => {
         cost: 2,
         messages: [],
       }),
-      parent_reference: { agentName: "codex", sessionId: parent.id },
+      parent_reference: { agentName: "codex", sessionId: parent.reference.sessionId },
     };
     const candidates: SearchResult[] = [
       {
-        reference: { agentName: "codex", sessionId: parent.id },
+        reference: { agentName: "codex", sessionId: parent.reference.sessionId },
         session: parent,
         snippet: "Alias",
         snippetHighlights: [],
@@ -842,7 +856,9 @@ describe("search candidate filtering", () => {
       },
     );
 
-    expect(results.map((result) => result.session.id)).toEqual([parent.id]);
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
+      parent.reference.sessionId,
+    ]);
   });
 
   it("uses a supplied session tree for inclusive cost filters", () => {
@@ -859,18 +875,20 @@ describe("search candidate filtering", () => {
         cost: 0,
         messages: [],
       }),
-      parent_reference: { agentName: "codex", sessionId: parent.id },
+      parent_reference: { agentName: "codex", sessionId: parent.reference.sessionId },
     };
     const snapshot = {
       sessions: [parent, child],
       byAgent: { codex: [parent, child] },
     };
     const sessionTree = buildSessionTree([parent, child]);
-    sessionTree.byRouteKey.get(`codex/${parent.id}`)!.inclusiveStats.cost = 1;
+    sessionTree.byRouteKey.get(`codex/${parent.reference.sessionId}`)!.inclusiveStats.cost = 1;
 
     const results = executeSessionSearch("", { costMin: 1 }, snapshot, { sessionTree });
 
-    expect(results.map((result) => result.session.id)).toEqual([parent.id]);
+    expect(results.map((result) => result.session.reference.sessionId)).toEqual([
+      parent.reference.sessionId,
+    ]);
   });
 });
 
@@ -878,7 +896,11 @@ describe("search characterization: limit", () => {
   it("truncates FTS results to the requested limit, preserving order", () => {
     const results = search("docneedle", { limit: 3 });
     expect(results).toHaveLength(3);
-    expect(results.map((r) => r.session.id)).toEqual(["limit-1", "limit-2", "limit-3"]);
+    expect(results.map((r) => r.session.reference.sessionId)).toEqual([
+      "limit-1",
+      "limit-2",
+      "limit-3",
+    ]);
   });
 });
 
@@ -907,14 +929,14 @@ describe("search characterization: recent vs SQLite-indexed equivalence (tag fil
     // only sees the one it indexed. Current behavior: NOT equivalent -- the
     // recent path's result set is a strict superset of the indexed path's.
     const indexedIds = searchSessions("", { tags: ["bugfix"] })
-      .map((r) => r.session.id)
+      .map((r) => r.session.reference.sessionId)
       .sort();
     expect(indexedIds).toEqual(["recent-mid"]);
   });
 
   it("recent-path result set for the same tag filter includes the un-synced session too", () => {
     const results = search("", { tags: ["bugfix"], limit: 50 });
-    expect(results.map((r) => r.session.id).sort()).toEqual(
+    expect(results.map((r) => r.session.reference.sessionId).sort()).toEqual(
       ["recent-mid", "lagging-session"].sort(),
     );
   });
@@ -952,7 +974,7 @@ describe("search characterization: skip redundant sessions query for file-only s
     const { result, sql } = withPreparedSqlCapture(() =>
       search("", { file: "app.tsx", limit: 50 }),
     );
-    expect(result.map((r) => r.session.id)).toEqual(["file-only"]);
+    expect(result.map((r) => r.session.reference.sessionId)).toEqual(["file-only"]);
     expect(ranSearchSessions(sql)).toBe(false);
   });
 
@@ -960,7 +982,7 @@ describe("search characterization: skip redundant sessions query for file-only s
     const { result, sql } = withPreparedSqlCapture(() =>
       search("", { fileKind: "edit", limit: 50 }),
     );
-    expect(result.map((r) => r.session.id)).toContain("file-only");
+    expect(result.map((r) => r.session.reference.sessionId)).toContain("file-only");
     expect(ranSearchSessions(sql)).toBe(true);
   });
 
@@ -968,7 +990,7 @@ describe("search characterization: skip redundant sessions query for file-only s
     const { result, sql } = withPreparedSqlCapture(() =>
       search("", { file: "tagcheck.ts", tags: ["docs"], limit: 50 }),
     );
-    expect(result.map((r) => r.session.id)).toEqual(["file-tag-docs"]);
+    expect(result.map((r) => r.session.reference.sessionId)).toEqual(["file-tag-docs"]);
     expect(result[0]?.session.smart_tags).toEqual(["docs"]);
     expect(ranSearchSessions(sql)).toBe(false);
   });

--- a/packages/core/src/utils/__tests__/smart-tags.test.ts
+++ b/packages/core/src/utils/__tests__/smart-tags.test.ts
@@ -5,8 +5,6 @@ import type { SessionDetail } from "../../types/index.js";
 function makeSession(messages: SessionDetail["messages"]): SessionDetail {
   return {
     reference: { agentName: "test", sessionId: "s1" },
-    id: "s1",
-    slug: "test/s1",
     title: "Session",
     directory: "/repo",
     time_created: 1,

--- a/tests/e2e/aggregation.spec.ts
+++ b/tests/e2e/aggregation.spec.ts
@@ -43,9 +43,11 @@ test("searches and opens the aggregated Codex session", async ({ page }) => {
     .poll(async () => {
       const response = await page.request.get("/api/search?q=codex-shared-needle");
       const body = (await response.json()) as {
-        results?: Array<{ session?: { id?: string } }>;
+        results?: Array<{ session?: { reference?: { sessionId?: string } } }>;
       };
-      return body.results?.some((result) => result.session?.id === CODEX_SESSION_ID);
+      return body.results?.some(
+        (result) => result.session?.reference?.sessionId === CODEX_SESSION_ID,
+      );
     })
     .toBe(true);
 

--- a/tests/e2e/live-refresh.spec.ts
+++ b/tests/e2e/live-refresh.spec.ts
@@ -41,8 +41,10 @@ test("refreshes an open session when its source file changes", async ({ page }, 
   const searchResponse = await page.request.get(`/api/search?q=${searchNeedle}`);
   expect(searchResponse.ok()).toBe(true);
   const searchBody = (await searchResponse.json()) as {
-    results?: Array<{ session?: { id?: string } }>;
+    results?: Array<{ session?: { reference?: { sessionId?: string } } }>;
   };
-  expect(searchBody.results?.some((result) => result.session?.id === "e2e-dashboard")).toBe(true);
+  expect(
+    searchBody.results?.some((result) => result.session?.reference?.sessionId === "e2e-dashboard"),
+  ).toBe(true);
   expect(mainFrameNavigations).toBe(0);
 });


### PR DESCRIPTION
## Summary

- make structured references the only session identity representation
- strip legacy id and slug properties while upgrading cached session JSON
- update API, UI, documentation, and fixtures to consume canonical references

## Validation

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm test:migration

## Breaking change

Session heads and details no longer expose the deprecated id and slug properties. Consumers must use reference.sessionId and format the reference when a string key is required.