### PR TITLE
refactor(cache): Split content migrations

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/content-migrations.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/content-migrations.test.ts
@@ -1,0 +1,74 @@
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import type { SQLiteDatabase } from "../../../utils/sqlite.js";
+import { runCacheContentMigrations } from "../content-migrations.js";
+
+type TestDatabase = Database.Database & SQLiteDatabase;
+
+function createDatabase(): TestDatabase {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE cache_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE sessions (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      PRIMARY KEY (agent_name, session_id)
+    );
+    CREATE TABLE pending_reindex (
+      agent_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      PRIMARY KEY (agent_name, session_id)
+    );
+    CREATE TABLE agent_cache (
+      agent_name TEXT PRIMARY KEY
+    );
+  `);
+  return db as unknown as TestDatabase;
+}
+
+function seedAgentCache(db: TestDatabase): void {
+  const insert = db.prepare("INSERT OR REPLACE INTO agent_cache(agent_name) VALUES (?)");
+  for (const agentName of ["codex", "opencode", "zcode", "cursor"]) insert.run(agentName);
+}
+
+describe("cache content migrations", () => {
+  it("invalidates affected content once without coupling it to the schema version", () => {
+    const db = createDatabase();
+    try {
+      db.exec(`
+        INSERT INTO sessions(agent_name, session_id) VALUES ('codex', 'codex-session');
+        INSERT INTO sessions(agent_name, session_id) VALUES ('cursor', 'cursor-session');
+      `);
+      seedAgentCache(db);
+
+      runCacheContentMigrations(db);
+
+      expect(db.prepare("SELECT * FROM pending_reindex").all()).toEqual([
+        { agent_name: "codex", session_id: "codex-session" },
+      ]);
+      expect(db.prepare("SELECT agent_name FROM agent_cache ORDER BY agent_name").all()).toEqual([
+        { agent_name: "cursor" },
+      ]);
+      expect(db.prepare("SELECT key, value FROM cache_meta ORDER BY key").all()).toEqual([
+        { key: "codex_exec_decode_migrated_v3", value: "1" },
+        { key: "opencode_subagent_fold_v1", value: "1" },
+        { key: "subagent_tree_v1", value: "1" },
+      ]);
+
+      seedAgentCache(db);
+      runCacheContentMigrations(db);
+
+      expect(db.prepare("SELECT agent_name FROM agent_cache ORDER BY agent_name").all()).toEqual([
+        { agent_name: "codex" },
+        { agent_name: "cursor" },
+        { agent_name: "opencode" },
+        { agent_name: "zcode" },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/packages/core/src/discovery/cache/content-migrations.ts
+++ b/packages/core/src/discovery/cache/content-migrations.ts
@@ -1,0 +1,51 @@
+import { tableExists, type SQLiteDatabase } from "../../utils/sqlite.js";
+
+interface CacheContentMigration {
+  readonly key: string;
+  readonly apply: (db: SQLiteDatabase) => void;
+}
+
+const CACHE_CONTENT_MIGRATIONS: readonly CacheContentMigration[] = [
+  {
+    key: "codex_exec_decode_migrated_v3",
+    apply(db) {
+      if (!tableExists(db, "sessions") || !tableExists(db, "pending_reindex")) return;
+      // Head hashes stay stable when only detail decoding changes, so queue targeted rebuilds.
+      db.exec(
+        "INSERT OR IGNORE INTO pending_reindex(agent_name, session_id) " +
+          "SELECT agent_name, session_id FROM sessions WHERE agent_name = 'codex'",
+      );
+    },
+  },
+  {
+    key: "opencode_subagent_fold_v1",
+    apply(db) {
+      if (!tableExists(db, "agent_cache")) return;
+      db.prepare("DELETE FROM agent_cache WHERE agent_name IN ('zcode', 'opencode')").run();
+    },
+  },
+  {
+    key: "subagent_tree_v1",
+    apply(db) {
+      if (!tableExists(db, "agent_cache")) return;
+      db.prepare(
+        "DELETE FROM agent_cache WHERE agent_name IN ('codex', 'zcode', 'opencode')",
+      ).run();
+    },
+  },
+];
+
+export function runCacheContentMigrations(db: SQLiteDatabase): void {
+  if (!tableExists(db, "cache_meta")) return;
+
+  const readMarker = db.prepare("SELECT value FROM cache_meta WHERE key = ?");
+  const writeMarker = db.prepare(
+    "INSERT INTO cache_meta(key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = '1'",
+  );
+
+  for (const migration of CACHE_CONTENT_MIGRATIONS) {
+    if (readMarker.get(migration.key)) continue;
+    migration.apply(db);
+    writeMarker.run(migration.key);
+  }
+}

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -13,6 +13,7 @@ import {
   type DatabaseRow,
   type SQLiteDatabase,
 } from "../../utils/sqlite.js";
+import { runCacheContentMigrations } from "./content-migrations.js";
 import { type CacheConnection, type CacheRow } from "./db.js";
 import {
   messageFromBackfillRow,
@@ -1405,73 +1406,6 @@ function addSessionParentReference(db: SQLiteDatabase): void {
   recreateProjectGroupsView(db);
 }
 
-const CODEX_EXEC_DECODE_MIGRATION_KEY = "codex_exec_decode_migrated_v3";
-
-/**
- * One-time: mark every cached Codex detail as pending re-index so code-mode
- * exec decoding takes effect on upgrade. The search content hash derives only
- * from head-level fields, none of which the decoder touches, so nothing would
- * otherwise trigger a refresh. Session rows carry huge content_text, so
- * rewriting them (or clearing a hash) is slow; instead we record just the
- * session ids in the lightweight pending_reindex table. loadCachedSessionData
- * treats a marked session as pending and re-parses its detail fresh on view;
- * the search index clears the marker as it repopulates each one. Gated by a
- * cache_meta flag; a fresh cache just records it.
- */
-function migrateCodexExecDecode(db: SQLiteDatabase): void {
-  if (!tableExists(db, "cache_meta")) return;
-  const done = db
-    .prepare("SELECT value FROM cache_meta WHERE key = ?")
-    .get(CODEX_EXEC_DECODE_MIGRATION_KEY);
-  if (done) return;
-
-  if (tableExists(db, "sessions") && tableExists(db, "pending_reindex")) {
-    db.exec(
-      "INSERT OR IGNORE INTO pending_reindex(agent_name, session_id) " +
-        "SELECT agent_name, session_id FROM sessions WHERE agent_name = 'codex'",
-    );
-  }
-  db.prepare(
-    "INSERT INTO cache_meta(key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = '1'",
-  ).run(CODEX_EXEC_DECODE_MIGRATION_KEY);
-}
-
-const OPENCODE_SUBAGENT_FOLD_KEY = "opencode_subagent_fold_v1";
-const SUBAGENT_TREE_KEY = "subagent_tree_v1";
-
-/**
- * One-time: invalidate cached OpenCode-family (zcode/opencode) heads after the
- * subagent relation format changed. The next scan rebuilds parent references
- * and folded token totals from the source database.
- */
-function migrateOpenCodeSubagentFold(db: SQLiteDatabase): void {
-  if (!tableExists(db, "cache_meta")) return;
-  const done = db
-    .prepare("SELECT value FROM cache_meta WHERE key = ?")
-    .get(OPENCODE_SUBAGENT_FOLD_KEY);
-  if (done) return;
-
-  if (tableExists(db, "agent_cache")) {
-    db.prepare("DELETE FROM agent_cache WHERE agent_name IN ('zcode', 'opencode')").run();
-  }
-  db.prepare(
-    "INSERT INTO cache_meta(key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = '1'",
-  ).run(OPENCODE_SUBAGENT_FOLD_KEY);
-}
-
-function migrateSubagentTree(db: SQLiteDatabase): void {
-  if (!tableExists(db, "cache_meta")) return;
-  const done = db.prepare("SELECT value FROM cache_meta WHERE key = ?").get(SUBAGENT_TREE_KEY);
-  if (done) return;
-
-  if (tableExists(db, "agent_cache")) {
-    db.prepare("DELETE FROM agent_cache WHERE agent_name IN ('codex', 'zcode', 'opencode')").run();
-  }
-  db.prepare(
-    "INSERT INTO cache_meta(key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = '1'",
-  ).run(SUBAGENT_TREE_KEY);
-}
-
 function rebuildSearchIndex(db: SQLiteDatabase): void {
   if (!tableExists(db, "session_documents_fts")) {
     return;
@@ -1623,9 +1557,7 @@ export function ensureCacheSchema(db: SQLiteDatabase, dbPath: string): void {
     createLatestCacheSchema(db);
     createSearchStateIndex(db);
     setCacheSchemaVersion(db);
-    migrateCodexExecDecode(db);
-    migrateOpenCodeSubagentFold(db);
-    migrateSubagentTree(db);
+    runCacheContentMigrations(db);
     return;
   }
 
@@ -1727,7 +1659,5 @@ export function ensureCacheSchema(db: SQLiteDatabase, dbPath: string): void {
     setCacheMetaVersion(db);
   }
 
-  migrateCodexExecDecode(db);
-  migrateOpenCodeSubagentFold(db);
-  migrateSubagentTree(db);
+  runCacheContentMigrations(db);
 }


### PR DESCRIPTION
## Summary

- move parser-driven cache invalidations out of the structural schema module
- run one-time content migrations through a shared marker lifecycle
- verify affected caches are invalidated once and remain untouched on later startups

## Validation

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm test:migration