### PR TITLE
refactor(cache): Unify session head upserts

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -116,6 +116,43 @@ describe("search index writer", () => {
     expect(listFileActivity({ projectKind: "path", projectKey: "/workspace/project" })).toEqual([]);
   });
 
+  it("keeps cache-owned fields when materializing an indexed head", () => {
+    const other = makeSessionHead("other");
+    const session = makeSessionHead("materialized");
+    const meta = {
+      id: session.reference.sessionId,
+      sourcePath: "/cached/materialized.jsonl",
+      sourceFingerprint: "cached-version",
+    };
+    saveCachedSessions("codex", [other, session], { [session.reference.sessionId]: meta });
+
+    const updated = { ...session, title: "Materialized title" };
+    syncSessionSearchIndexChanges("codex", [{ session: updated, sortIndex: 0 }], [], () => ({
+      ...makeSessionData(session.reference.sessionId),
+      ...updated,
+    }));
+
+    const row = withCacheDb(
+      (db) =>
+        db
+          .prepare(
+            "SELECT sort_index, title, source_path, meta_json FROM sessions WHERE agent_name = ? AND session_id = ?",
+          )
+          .get("codex", session.reference.sessionId) as {
+          sort_index: number;
+          title: string;
+          source_path: string;
+          meta_json: string;
+        },
+    );
+    expect(row).toEqual({
+      sort_index: 1,
+      title: updated.title,
+      source_path: meta.sourcePath,
+      meta_json: JSON.stringify(meta),
+    });
+  });
+
   it("recomputes the message hash chain when an indexed prefix changes", () => {
     const session = {
       ...makeSessionHead("chain"),

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -184,7 +184,19 @@ export function assertSessionProjectIdentities(
   for (const session of sessions) requireSessionProjectIdentity(agentName, session);
 }
 
-export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
+export function prepareUpsertSession(
+  db: SQLiteDatabase,
+  mode: "cache" | "materialization" = "cache",
+): SQLiteStatement {
+  const cacheAssignments =
+    mode === "cache"
+      ? `sort_index = excluded.sort_index,
+      source_path = CASE
+        WHEN excluded.meta_json IS NULL THEN sessions.source_path
+        ELSE excluded.source_path
+      END,
+      meta_json = COALESCE(excluded.meta_json, sessions.meta_json),`
+      : "";
   return db.prepare(`
     INSERT INTO sessions(
       agent_name,
@@ -219,12 +231,8 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
       publication_id
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id) DO UPDATE SET
-      sort_index = excluded.sort_index,
+      ${cacheAssignments}
       title = excluded.title,
-      source_path = CASE
-        WHEN excluded.meta_json IS NULL THEN sessions.source_path
-        ELSE excluded.source_path
-      END,
       directory = excluded.directory,
       parent_agent_name = excluded.parent_agent_name,
       parent_session_id = excluded.parent_session_id,
@@ -248,77 +256,8 @@ export function prepareUpsertSession(db: SQLiteDatabase): SQLiteStatement {
       smart_tags_json = excluded.smart_tags_json,
       smart_tags_source_updated_at = excluded.smart_tags_source_updated_at,
       smart_tags_classifier_revision = excluded.smart_tags_classifier_revision,
-      meta_json = COALESCE(excluded.meta_json, sessions.meta_json),
       publication_id = excluded.publication_id
   `);
-}
-
-function prepareIndexedSession(db: SQLiteDatabase): SQLiteStatement {
-  const onConflict = `DO UPDATE SET
-          title = excluded.title,
-          directory = excluded.directory,
-          parent_agent_name = excluded.parent_agent_name,
-          parent_session_id = excluded.parent_session_id,
-          project_identity_kind = excluded.project_identity_kind,
-          project_identity_key = excluded.project_identity_key,
-          project_display_name = excluded.project_display_name,
-          project_identity_resolver_revision = excluded.project_identity_resolver_revision,
-          project_identity_input_signature = excluded.project_identity_input_signature,
-          time_created = excluded.time_created,
-          time_updated = excluded.time_updated,
-          activity_time = excluded.activity_time,
-          message_count = excluded.message_count,
-          total_input_tokens = excluded.total_input_tokens,
-          total_output_tokens = excluded.total_output_tokens,
-          total_cache_read_tokens = excluded.total_cache_read_tokens,
-          total_cache_create_tokens = excluded.total_cache_create_tokens,
-          total_cost = excluded.total_cost,
-          cost_source = excluded.cost_source,
-          total_tokens = excluded.total_tokens,
-          model_usage_json = excluded.model_usage_json,
-          smart_tags_json = excluded.smart_tags_json,
-          smart_tags_source_updated_at = excluded.smart_tags_source_updated_at,
-          smart_tags_classifier_revision = excluded.smart_tags_classifier_revision,
-          publication_id = excluded.publication_id`;
-  return db.prepare(`
-    INSERT INTO sessions(
-      agent_name,
-      session_id,
-      sort_index,
-      title,
-      source_path,
-      directory,
-      parent_agent_name,
-      parent_session_id,
-      project_identity_kind,
-      project_identity_key,
-      project_display_name,
-      project_identity_resolver_revision,
-      project_identity_input_signature,
-      time_created,
-      time_updated,
-      activity_time,
-      message_count,
-      total_input_tokens,
-      total_output_tokens,
-      total_cache_read_tokens,
-      total_cache_create_tokens,
-      total_cost,
-      cost_source,
-      total_tokens,
-      model_usage_json,
-      smart_tags_json,
-      smart_tags_source_updated_at,
-      smart_tags_classifier_revision,
-      meta_json,
-      publication_id
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(agent_name, session_id) ${onConflict}
-  `);
-}
-
-export function prepareUpsertIndexedSession(db: SQLiteDatabase): SQLiteStatement {
-  return prepareIndexedSession(db);
 }
 
 export function upsertSessionRow(

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -12,7 +12,7 @@ import {
   normalizeMessages,
   prepareInsertFileActivity,
   prepareInsertMessageTool,
-  prepareUpsertIndexedSession,
+  prepareUpsertSession,
   assertSessionProjectIdentities,
   requireSessionProjectIdentity,
   upsertSessionRow,
@@ -618,7 +618,7 @@ function writeSearchIndexRows(
     FROM normalized
     GROUP BY agent_name, session_id
   `);
-  const writeIndexedSession = prepareUpsertIndexedSession(db);
+  const writeMaterializedSession = prepareUpsertSession(db, "materialization");
   const insertFileActivity = prepareInsertFileActivity(db);
   const insertMessageTool = prepareInsertMessageTool(db);
   const upsertMessage = db.prepare(`
@@ -715,7 +715,14 @@ function writeSearchIndexRows(
         continue;
       }
     }
-    upsertSessionRow(writeIndexedSession, agentName, entry.session, null, entry.sortIndex, null);
+    upsertSessionRow(
+      writeMaterializedSession,
+      agentName,
+      entry.session,
+      null,
+      entry.sortIndex,
+      null,
+    );
     deleteFileActivity.run(agentName, sessionId);
     deleteMessageTools.run(agentName, sessionId, 0);
     clearPendingReindex.run(agentName, sessionId);


### PR DESCRIPTION
## Summary

- consolidate cache and search materialization session upserts into one statement builder
- preserve cache-owned sort, source, and metadata fields during detail materialization
- add regression coverage for field ownership

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`