### PR TITLE
refactor(scan): Centralize persistence decisions

### DIFF
--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -1,15 +1,14 @@
 import {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
+  buildSessionPersistenceDiff,
   getAgentFullSyncCursor,
-  computeSessionDiff,
   inspectAgentRefresh,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
   markAgentFullSyncCompleted,
   readCachedSessions,
   readAgentCacheInitialization,
-  sessionSignature,
   type BaseAgent,
   type AgentRefreshInspection,
   type CachedResult,
@@ -17,7 +16,7 @@ import {
   type ScanOptions,
   type LiveSnapshot,
   type SessionHead,
-  type PersistedSessionHeadChange,
+  type SessionPersistenceDiff,
   type SessionSourceFailure,
   type SessionSnapshotCompleteness,
 } from "@codesesh/core/runtime";
@@ -66,11 +65,6 @@ type SessionsChangedListener = (change: AgentSessionsChanged) => void;
 type StatusChangedListener = (event: ScanStatusEvent) => void;
 type CachedSessions = CachedResult;
 
-interface SessionPersistenceDiff {
-  changedSessions: PersistedSessionHeadChange<IdentifiedSessionHead>[];
-  removedSessionIds: string[];
-}
-
 interface RefreshResult {
   result: Exclude<AgentOperationResult, "failed">;
   completion: ScanCompletion;
@@ -88,7 +82,7 @@ interface RefreshStrategyBase {
 type RefreshPublication =
   | {
       kind: "changes";
-      diff: SessionPersistenceDiff;
+      diff: SessionPersistenceDiff<IdentifiedSessionHead>;
       candidateChangedIds: string[];
     }
   | {
@@ -107,30 +101,6 @@ const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 // SSE carries one compact summary; logs retain the complete failure list.
 const SOURCE_FAILURE_SUMMARY_MAX_LENGTH = 160;
 
-function buildPersistenceDiff(
-  previousSessions: SessionHead[],
-  nextSessions: IdentifiedSessionHead[],
-  candidateChangedIds: string[] = [],
-  completeness: SessionSnapshotCompleteness = "complete",
-  explicitRemovedSessionIds: readonly string[] = [],
-): SessionPersistenceDiff {
-  const { changes, removedSessionIds } = computeSessionDiff(
-    previousSessions,
-    nextSessions,
-    candidateChangedIds,
-    sessionSignature,
-  );
-  if (completeness === "complete") {
-    return { changedSessions: changes, removedSessionIds };
-  }
-  // A bounded or failed scan cannot prove that an omitted session disappeared.
-  const explicitRemovals = new Set(explicitRemovedSessionIds);
-  return {
-    changedSessions: changes,
-    removedSessionIds: removedSessionIds.filter((sessionId) => explicitRemovals.has(sessionId)),
-  };
-}
-
 function buildScanCompletion(
   completeness: SessionSnapshotCompleteness,
   sourceFailures: readonly SessionSourceFailure[],
@@ -146,10 +116,6 @@ function buildScanCompletion(
         ? `${summary.slice(0, SOURCE_FAILURE_SUMMARY_MAX_LENGTH - 1)}…`
         : summary,
   };
-}
-
-function restoreAgentCacheMeta(agent: BaseAgent, cached: CachedSessions): void {
-  agent.restoreSessionCacheMeta(cached.meta);
 }
 
 export class AgentSyncEngine {
@@ -398,7 +364,7 @@ export class AgentSyncEngine {
     const previousSessions = this.sessionIndex.snapshot().byAgent[agentName] ?? [];
     const refreshBaseline = cached?.sessions ?? previousSessions;
     const cacheTimestamp = cached?.timestamp ?? this.lastRefreshAtByAgent.get(agentName) ?? 0;
-    if (cached) restoreAgentCacheMeta(agent, cached);
+    if (cached) agent.restoreSessionCacheMeta(cached.meta);
     const durableMeta = agent.snapshotSessionCacheMeta();
     const durableLastRefreshAt = this.lastRefreshAtByAgent.get(agentName);
     const initialization = readAgentCacheInitialization(agentName);
@@ -640,7 +606,9 @@ export class AgentSyncEngine {
     agent.restoreSessionCacheMeta(result.meta);
     const sessions = attachMissingProjectIdentities(result.sessions);
     const preciseChangedIds = result.changedIds ?? [];
-    const persistenceDiff = buildPersistenceDiff(baseline.sessions, sessions, preciseChangedIds);
+    const persistenceDiff = buildSessionPersistenceDiff(baseline.sessions, sessions, {
+      candidateChangedIds: preciseChangedIds,
+    });
     this.lastRefreshAtByAgent.set(agent.name, Date.now());
     if (
       persistenceDiff.changedSessions.length === 0 &&
@@ -704,7 +672,7 @@ export class AgentSyncEngine {
       const sessions = attachMissingProjectIdentities(result.sessions);
       source.commitChangeCheck();
       this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
-      const persistenceDiff = buildPersistenceDiff(baseline, sessions);
+      const persistenceDiff = buildSessionPersistenceDiff(baseline, sessions);
       if (
         persistenceDiff.changedSessions.length === 0 &&
         persistenceDiff.removedSessionIds.length === 0
@@ -758,13 +726,11 @@ export class AgentSyncEngine {
           // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
           // signature intact; without the worker-reported ids they would never
           // persist and checkForChanges would rescan on every startup.
-          diff: buildPersistenceDiff(
-            baseline,
-            sessions,
-            result.changedIds ?? [],
-            result.completeness,
-            result.explicitRemovedSessionIds,
-          ),
+          diff: buildSessionPersistenceDiff(baseline, sessions, {
+            candidateChangedIds: result.changedIds ?? [],
+            completeness: result.completeness,
+            explicitRemovedSessionIds: result.explicitRemovedSessionIds,
+          }),
           candidateChangedIds: [],
         },
       };
@@ -791,13 +757,11 @@ export class AgentSyncEngine {
       status: "continue",
       publication: {
         kind: "changes",
-        diff: buildPersistenceDiff(
-          baseline,
-          sessions,
-          preciseChangedIds,
+        diff: buildSessionPersistenceDiff(baseline, sessions, {
+          candidateChangedIds: preciseChangedIds,
           completeness,
-          preciseChangedIds,
-        ),
+          explicitRemovedSessionIds: preciseChangedIds,
+        }),
         candidateChangedIds: preciseChangedIds,
       },
     };
@@ -905,7 +869,7 @@ export class AgentSyncEngine {
     const baseline = cached?.sessions ?? snapshot.byAgent[agentName] ?? [];
     const meta = cached?.meta ?? buildAgentCacheMeta(agent);
     const backfillCursor = getAgentFullSyncCursor(agentName);
-    if (cached) restoreAgentCacheMeta(agent, cached);
+    if (cached) agent.restoreSessionCacheMeta(cached.meta);
     let durableCommitted = false;
     try {
       if (!markAgentFullSyncStarted(agentName)) {

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -96,6 +96,7 @@ vi.mock("@codesesh/core/runtime", async (importOriginal) => {
     FileSystemSessionSource: mocks.FileSystemSessionSource,
     PRICING_CAPTURE_EPOCH: actual.PRICING_CAPTURE_EPOCH,
     buildAgentCacheMeta: actual.buildAgentCacheMeta,
+    buildSessionPersistenceDiff: actual.buildSessionPersistenceDiff,
     computeSessionDiff: actual.computeSessionDiff,
     planAgentScan: actual.planAgentScan,
     sessionSignature: actual.sessionSignature,

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -4,11 +4,10 @@ import { isDeepStrictEqual } from "node:util";
 import {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
-  computeSessionDiff,
+  buildSessionPersistenceDiff,
   createRegisteredAgents,
   ensureSessionTagsSync,
   planAgentScan,
-  sessionSignature,
   SMART_TAG_CLASSIFIER_REVISION,
   sortSessions,
   synchronizePricingGeneration,
@@ -574,12 +573,15 @@ async function run(
     new Set(sessions.map((session) => session.reference.sessionId)),
   );
   const metaDiff = computeCacheMetaDiff(previousMeta, nextMeta);
-  const diff = computeSessionDiff(
-    previousSessions,
-    sessions,
-    [...(changedIds ?? []), ...Object.keys(metaDiff.changes), ...metaDiff.removedIds],
-    sessionSignature,
-  );
+  const diff = buildSessionPersistenceDiff(previousSessions, sessions, {
+    candidateChangedIds: [
+      ...(changedIds ?? []),
+      ...Object.keys(metaDiff.changes),
+      ...metaDiff.removedIds,
+    ],
+    completeness,
+    explicitRemovedSessionIds,
+  });
 
   baseline.staged = {
     requestId: data.requestId,
@@ -592,7 +594,7 @@ async function run(
     type: "done",
     requestId: data.requestId,
     generation: baseline.generation,
-    changes: diff.changes,
+    changes: diff.changedSessions,
     removedSessionIds: diff.removedSessionIds,
     meta: metaDiff.changes,
     removedMetaIds: metaDiff.removedIds,

--- a/packages/core/src/discovery/__tests__/orchestrate.test.ts
+++ b/packages/core/src/discovery/__tests__/orchestrate.test.ts
@@ -6,6 +6,7 @@ import { clearIdentityCache } from "../../projects/index.js";
 import {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
+  buildSessionPersistenceDiff,
   computeSessionDiff,
   sessionSignature,
   sortSessions,
@@ -457,5 +458,36 @@ describe("computeSessionDiff", () => {
 
       expect(diff.counts.updated).toBe(1);
     });
+  });
+});
+
+describe("buildSessionPersistenceDiff", () => {
+  it("removes every missing session from a complete snapshot", () => {
+    const previous = [makeSession("retained"), makeSession("removed")];
+
+    expect(buildSessionPersistenceDiff(previous, [previous[0]!]).removedSessionIds).toEqual([
+      "removed",
+    ]);
+  });
+
+  it("only removes explicitly deleted sessions from a partial snapshot", () => {
+    const previous = [makeSession("retained"), makeSession("explicit"), makeSession("unknown")];
+
+    const diff = buildSessionPersistenceDiff(previous, [previous[0]!], {
+      completeness: "partial",
+      explicitRemovedSessionIds: ["explicit"],
+    });
+
+    expect(diff.removedSessionIds).toEqual(["explicit"]);
+  });
+
+  it("persists candidate changes even when their head signature is unchanged", () => {
+    const session = makeSession("changed");
+
+    const diff = buildSessionPersistenceDiff([session], [session], {
+      candidateChangedIds: [session.reference.sessionId],
+    });
+
+    expect(diff.changedSessions).toEqual([{ session, sortIndex: 0 }]);
   });
 });

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -13,10 +13,12 @@ export type { SessionReference } from "../contract/index.js";
 export {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
+  buildSessionPersistenceDiff,
   computeSessionDiff,
   sessionSignature,
   sortSessions,
 } from "./orchestrate.js";
+export type { SessionPersistenceDiff, SessionPersistenceDiffOptions } from "./orchestrate.js";
 export { mergeSortedSessions } from "../contract/session-index.js";
 export {
   clearCache,

--- a/packages/core/src/discovery/orchestrate.ts
+++ b/packages/core/src/discovery/orchestrate.ts
@@ -18,6 +18,7 @@ import type {
   SessionStats,
 } from "../types/index.js";
 import type { PersistedSessionHeadChange } from "./cache/db.js";
+import type { SessionSnapshotCompleteness } from "./cache/sessions.js";
 import {
   computeIdentityProjection,
   normalizeProjectDirectory,
@@ -195,7 +196,7 @@ export interface SessionDiffResult<T extends SessionHead = SessionHead> {
 export function computeSessionDiff<T extends SessionHead>(
   cachedSessions: SessionHead[],
   updatedSessions: T[],
-  changedIds: string[] = [],
+  changedIds: readonly string[] = [],
   signature: (session: SessionHead) => string = sessionSignature,
   signatureCache?: Map<string, string>,
 ): SessionDiffResult<T> {
@@ -238,5 +239,38 @@ export function computeSessionDiff<T extends SessionHead>(
     changes,
     removedSessionIds,
     counts: { new: newCount, updated: updatedCount, removed: removedSessionIds.length },
+  };
+}
+
+export interface SessionPersistenceDiff<T extends SessionHead> {
+  changedSessions: PersistedSessionHeadChange<T>[];
+  removedSessionIds: string[];
+}
+
+export interface SessionPersistenceDiffOptions {
+  candidateChangedIds?: readonly string[];
+  completeness?: SessionSnapshotCompleteness;
+  explicitRemovedSessionIds?: readonly string[];
+}
+
+export function buildSessionPersistenceDiff<T extends SessionHead>(
+  previousSessions: SessionHead[],
+  nextSessions: T[],
+  options: SessionPersistenceDiffOptions = {},
+): SessionPersistenceDiff<T> {
+  const { changes, removedSessionIds } = computeSessionDiff(
+    previousSessions,
+    nextSessions,
+    options.candidateChangedIds,
+    sessionSignature,
+  );
+  if ((options.completeness ?? "complete") === "complete") {
+    return { changedSessions: changes, removedSessionIds };
+  }
+
+  const explicitRemovals = new Set(options.explicitRemovedSessionIds);
+  return {
+    changedSessions: changes,
+    removedSessionIds: removedSessionIds.filter((sessionId) => explicitRemovals.has(sessionId)),
   };
 }

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -45,8 +45,7 @@ import {
 import {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
-  computeSessionDiff,
-  sessionSignature,
+  buildSessionPersistenceDiff,
 } from "./orchestrate.js";
 import { inspectAgentRefresh, planAgentScan } from "./agent-scan-plan.js";
 
@@ -243,10 +242,6 @@ interface SmartTagWorkerResult {
   error?: string;
 }
 
-function restoreAgentCacheMeta(agent: BaseAgent, cached: CachedResult): void {
-  agent.restoreSessionCacheMeta(cached.meta);
-}
-
 function saveCachedSessionDiff(
   agent: BaseAgent,
   cachedSessions: SessionHead[],
@@ -255,23 +250,22 @@ function saveCachedSessionDiff(
   completeness: "complete" | "partial" = "complete",
   explicitRemovedSessionIds: readonly string[] = [],
 ): boolean {
-  const diff = computeSessionDiff(cachedSessions, updatedSessions, changedIds, sessionSignature);
-  const explicitRemovals = new Set(explicitRemovedSessionIds);
-  const removedSessionIds =
-    completeness === "complete"
-      ? diff.removedSessionIds
-      : diff.removedSessionIds.filter((sessionId) => explicitRemovals.has(sessionId));
+  const diff = buildSessionPersistenceDiff(cachedSessions, updatedSessions, {
+    candidateChangedIds: changedIds,
+    completeness,
+    explicitRemovedSessionIds,
+  });
   const persisted = saveCachedSessionChanges(
     agent.name,
-    diff.changes,
-    removedSessionIds,
+    diff.changedSessions,
+    diff.removedSessionIds,
     buildAgentCacheMeta(agent),
   );
   if (persisted === false) {
     getCoreDiagnostics()?.warn("cache.save_failed", {
       agent: agent.name,
-      changed_sessions: diff.changes.length,
-      removed_sessions: removedSessionIds.length,
+      changed_sessions: diff.changedSessions.length,
+      removed_sessions: diff.removedSessionIds.length,
     });
   }
   return persisted;
@@ -658,7 +652,7 @@ async function scanAgentSmart(
 
     if (cached !== null) {
       // 恢复元数据
-      restoreAgentCacheMeta(agent, cached);
+      agent.restoreSessionCacheMeta(cached.meta);
 
       if (options.cacheOnly) {
         const visibleSessions = agent.filterCachedSessions(cached.sessions);
@@ -934,7 +928,7 @@ async function scanAgentOutcome(
         cached = outcome.value;
       }
     }
-    if (cached) restoreAgentCacheMeta(agent, cached);
+    if (cached) agent.restoreSessionCacheMeta(cached.meta);
     const failure = createAgentScanFailure(agent.name, "scanning sessions", error);
     return {
       agentName: agent.name,

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -42,6 +42,7 @@ export type {
 export {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
+  buildSessionPersistenceDiff,
   clearCache,
   closeCacheStorage,
   commitDurableSessionPublication,
@@ -101,6 +102,8 @@ export type {
   SearchOptions,
   SearchRequestOptions,
   PersistedSessionHeadChange,
+  SessionPersistenceDiff,
+  SessionPersistenceDiffOptions,
   SessionTagTiming,
 } from "../discovery/index.js";
 export {


### PR DESCRIPTION
## Summary

- centralize changed-session and removal decisions in the core scan orchestration layer
- make one-shot scans, live refreshes, and refresh workers share partial-snapshot deletion rules
- remove duplicate cache restoration wrappers and add focused decision tests

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`