### PR TITLE
refactor: remove production import cycles

### DIFF
--- a/apps/web/src/components/session-detail/display-model-types.ts
+++ b/apps/web/src/components/session-detail/display-model-types.ts
@@ -1,0 +1,14 @@
+import type { Message } from "../../lib/api";
+import type { MessageBlock } from "./blocks";
+
+export interface MessageDisplayModel {
+  msg: Message;
+  blocks: MessageBlock[];
+  index: number;
+}
+
+export interface FilteredSessionMessage {
+  msg: Message;
+  blocks: MessageBlock[];
+  index: number;
+}

--- a/apps/web/src/components/session-detail/display-model.ts
+++ b/apps/web/src/components/session-detail/display-model.ts
@@ -7,19 +7,11 @@ import {
   type FileChangeSummary,
 } from "./file-change";
 import { buildSessionTimelineEntries, type SessionTimelineEntry } from "./timeline";
-import {
-  buildSessionDetailToc,
-  filterSessionMessages,
-  type FilteredSessionMessage,
-  type SessionDetailToc,
-} from "./toc";
+import { buildSessionDetailToc, filterSessionMessages, type SessionDetailToc } from "./toc";
 import { normalizeMessagesForDisplay } from "./tool-strategy";
+import type { FilteredSessionMessage, MessageDisplayModel } from "./display-model-types";
 
-export interface MessageDisplayModel {
-  msg: Message;
-  blocks: MessageBlock[];
-  index: number;
-}
+export type { MessageDisplayModel } from "./display-model-types";
 
 export interface SessionDetailSelection {
   messages: FilteredSessionMessage[];

--- a/apps/web/src/components/session-detail/file-change.ts
+++ b/apps/web/src/components/session-detail/file-change.ts
@@ -4,7 +4,7 @@
  * per-path summaries (with anchor ids for click-to-scroll).
  */
 import type { Message, SessionFileActivity, ToolPart } from "../../lib/api";
-import type { MessageDisplayModel } from "./display-model";
+import type { MessageDisplayModel } from "./display-model-types";
 import { getCodexPatchEntries } from "./codex-patch";
 import { normalizeToolLabel, normalizeToolName } from "./tool-normalize";
 import { extractPathsFromToolInput, getToolInputValue } from "./path-extract";

--- a/apps/web/src/components/session-detail/timeline.ts
+++ b/apps/web/src/components/session-detail/timeline.ts
@@ -1,7 +1,7 @@
 import type { MessagePart, ToolPart } from "../../lib/api";
 import { classifyToolOperation } from "./file-change";
 import { normalizeToolLabel } from "./tool-normalize";
-import type { FilteredSessionMessage } from "./toc";
+import type { FilteredSessionMessage } from "./display-model-types";
 
 const TIMELINE_SUMMARY_LENGTH = 48;
 const TIMELINE_SCROLL_EDGE_TOLERANCE = 1;

--- a/apps/web/src/components/session-detail/toc.ts
+++ b/apps/web/src/components/session-detail/toc.ts
@@ -1,5 +1,5 @@
 import type { ToolPart } from "../../lib/api";
-import type { MessageDisplayModel } from "./display-model";
+import type { FilteredSessionMessage, MessageDisplayModel } from "./display-model-types";
 import type { MessageBlock } from "./blocks";
 import { classifyToolOperation, type ToolOperationKind } from "./file-change";
 
@@ -34,11 +34,7 @@ export interface SessionDetailToc {
   totalUnitCount: number;
 }
 
-export interface FilteredSessionMessage {
-  msg: MessageDisplayModel["msg"];
-  blocks: MessageBlock[];
-  index: number;
-}
+export type { FilteredSessionMessage } from "./display-model-types";
 
 type ToolMessageBlock = Extract<MessageBlock, { type: "tool" }>;
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "serve": "node --watch packages/cli/dist/index.js",
     "clean": "turbo run clean",
     "lint": "pnpm lint:root && turbo run lint",
-    "lint:root": "oxlint scripts tests playwright.config.ts vitest.config.ts",
+    "lint:root": "node scripts/check-import-cycles.mjs && oxlint scripts tests playwright.config.ts vitest.config.ts",
     "lint:fix": "pnpm lint:fix:root && turbo run lint:fix",
     "lint:fix:root": "oxlint scripts tests playwright.config.ts vitest.config.ts --fix",
     "format": "pnpm format:root && turbo run format",

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -20,6 +20,15 @@ import type {
   SessionSourceSynchronizationOutcome,
   SessionSourceSynchronizationRequest,
 } from "./session-source-synchronization.js";
+import type {
+  AgentScanOptions,
+  SessionCacheMeta,
+  SessionCacheMetaSnapshot,
+  SessionSourceFailure,
+  SessionSourceOutcome,
+  SessionSourceRef,
+  SessionSourceScanBatch,
+} from "./session-source-types.js";
 
 export {
   createSessionSourceFailure,
@@ -36,6 +45,18 @@ export type {
 } from "./session-source-synchronization.js";
 
 export type { ParseSessionResult };
+export type {
+  AgentScanOptions,
+  AgentScanProgress,
+  SessionCacheMeta,
+  SessionCacheMetaSnapshot,
+  SessionSourceAbsenceOutcome,
+  SessionSourceDiff,
+  SessionSourceFailure,
+  SessionSourceOutcome,
+  SessionSourceRef,
+  SessionSourceScanBatch,
+} from "./session-source-types.js";
 
 export function parsedSession<T>(session: T): ParseSessionResult<T> {
   return { status: "parsed", data: session };
@@ -51,31 +72,6 @@ export function filteredSession<T>(reason: string): ParseSessionResult<T> {
 
 export function getParsedSession<T>(result: ParseSessionResult<T>): T | null {
   return result.status === "parsed" ? result.data : null;
-}
-
-export interface SessionCacheMeta {
-  id: string;
-  sourcePath: string;
-  /** Models the head parse could not price; their arrival invalidates the cache. */
-  unpricedModels?: string[];
-  /** Pricing-miss capture semantics used when this head was parsed. */
-  pricingCaptureEpoch?: string;
-  [key: string]: unknown;
-}
-
-export interface AgentScanOptions {
-  from?: number;
-  to?: number;
-  fast?: boolean;
-  includeRelatedSessions?: boolean;
-  onProgress?: (progress: AgentScanProgress) => void;
-}
-
-export interface AgentScanProgress {
-  phase?: "scanning" | "finalizing";
-  total?: number;
-  processed?: number;
-  sessions?: number;
 }
 
 export interface AgentSourceOptions {
@@ -120,43 +116,12 @@ interface FailedChangeCheck {
 /** 变更检测结果 */
 export type ChangeCheckResult = SuccessfulChangeCheck | FailedChangeCheck;
 
-export interface SessionSourceRef {
-  sessionId: string;
-  sourcePath: string;
-  fingerprint: string;
-}
-
-export interface SessionSourceFailure {
-  sessionId: string;
-  sourcePath: string;
-  stage: "enumeration" | "parsing";
-  errorClass: string;
-  message: string;
-}
-
 export interface AgentScanFailure {
   agentName: string;
   stage: string;
   sourcePath?: string;
   errorClass: string;
   message: string;
-}
-
-export type SessionSourceOutcome =
-  | { status: "parsed"; session: SessionHead; source: SessionSourceRef }
-  | { status: "filtered"; reason: string; source: SessionSourceRef }
-  | { status: "missing"; source: SessionSourceRef }
-  | { status: "failed"; failure: SessionSourceFailure };
-
-export type SessionSourceAbsenceOutcome = Extract<
-  SessionSourceOutcome,
-  { status: "missing" | "failed" }
->;
-
-export interface SessionSourceScanBatch {
-  sources: SessionSourceRef[];
-  outcomes: SessionSourceOutcome[];
-  sessions: SessionHead[];
 }
 
 export interface SessionSourceFile {
@@ -190,16 +155,6 @@ export type SessionWatchPlan =
   | { status: "not-needed"; reason: string };
 
 /** What a source enumeration says needs re-parsing and what disappeared. */
-export interface SessionSourceDiff {
-  changedIds: string[];
-  removedIds: string[];
-  failedIds: string[];
-  sourceOutcomes: SessionSourceAbsenceOutcome[];
-}
-
-/** Cache metadata crosses process and persistence boundaries as an isolated plain object. */
-export type SessionCacheMetaSnapshot = Readonly<Record<string, SessionCacheMeta>>;
-
 function cloneSessionCacheMeta(meta: SessionCacheMeta): SessionCacheMeta {
   return structuredClone(meta);
 }

--- a/packages/core/src/agents/register.ts
+++ b/packages/core/src/agents/register.ts
@@ -1,5 +1,9 @@
-import { AGENT_CATALOG, type AgentName } from "../contract/agent-catalog.js";
-import type { AgentRegistration } from "./registry.js";
+import {
+  AGENT_CATALOG,
+  type AgentCatalogEntry,
+  type AgentName,
+} from "../contract/agent-catalog.js";
+import type { BaseAgent } from "./base.js";
 import { ClaudeCodeAgent, resolveClaudeCodeDataRoot } from "./claudecode.js";
 import { OpenCodeAgent, resolveOpenCodeDataRoot } from "./opencode.js";
 import { KimiAgent, resolveKimiDataRoot } from "./kimi.js";
@@ -10,6 +14,11 @@ import { PiAgent, resolvePiDataRoot } from "./pi.js";
 import { ZCodeAgent, resolveZCodeDataRoot } from "./zcode.js";
 import { GrokAgent, resolveGrokDataRoot } from "./grok.js";
 import { DshAgent, resolveDshDataRoot } from "./dsh.js";
+
+export interface AgentRegistration extends AgentCatalogEntry {
+  create: () => BaseAgent;
+  resolveDataRoot: () => string | null;
+}
 
 type AgentRuntimeRegistration = Pick<AgentRegistration, "create" | "resolveDataRoot">;
 

--- a/packages/core/src/agents/registry.ts
+++ b/packages/core/src/agents/registry.ts
@@ -1,14 +1,10 @@
 import type { BaseAgent } from "./base.js";
 import type { AgentInfo } from "../types/index.js";
-import type { AgentCatalogEntry } from "../contract/agent-catalog.js";
-import { AGENT_REGISTRATIONS } from "./register.js";
+import { AGENT_REGISTRATIONS, type AgentRegistration } from "./register.js";
 
 export type { AgentToolStrategy } from "../contract/agent-catalog.js";
 
-export interface AgentRegistration extends AgentCatalogEntry {
-  create: () => BaseAgent;
-  resolveDataRoot: () => string | null;
-}
+export type { AgentRegistration } from "./register.js";
 
 export type AgentRoots = Readonly<Record<string, string | null>>;
 

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -1,5 +1,5 @@
 import { statSync } from "node:fs";
-import type { SessionSnapshotCompleteness } from "../discovery/cache/sessions.js";
+import type { SessionSnapshotCompleteness } from "../discovery/cache/snapshot-types.js";
 import { PRICING_CAPTURE_EPOCH, pricingBecameAvailable } from "../pricing/cost.js";
 import type { SessionHead } from "../types/index.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
@@ -12,7 +12,7 @@ import type {
   SessionSourceFailure,
   SessionSourceOutcome,
   SessionSourceRef,
-} from "./base.js";
+} from "./session-source-types.js";
 
 export interface SessionSourceSynchronizationAdapter {
   readonly name: string;

--- a/packages/core/src/agents/session-source-types.ts
+++ b/packages/core/src/agents/session-source-types.ts
@@ -1,0 +1,64 @@
+import type { SessionHead } from "../types/index.js";
+
+export interface SessionCacheMeta {
+  id: string;
+  sourcePath: string;
+  unpricedModels?: string[];
+  pricingCaptureEpoch?: string;
+  [key: string]: unknown;
+}
+
+export interface AgentScanOptions {
+  from?: number;
+  to?: number;
+  fast?: boolean;
+  includeRelatedSessions?: boolean;
+  onProgress?: (progress: AgentScanProgress) => void;
+}
+
+export interface AgentScanProgress {
+  phase?: "scanning" | "finalizing";
+  total?: number;
+  processed?: number;
+  sessions?: number;
+}
+
+export interface SessionSourceRef {
+  sessionId: string;
+  sourcePath: string;
+  fingerprint: string;
+}
+
+export interface SessionSourceFailure {
+  sessionId: string;
+  sourcePath: string;
+  stage: "enumeration" | "parsing";
+  errorClass: string;
+  message: string;
+}
+
+export type SessionSourceOutcome =
+  | { status: "parsed"; session: SessionHead; source: SessionSourceRef }
+  | { status: "filtered"; reason: string; source: SessionSourceRef }
+  | { status: "missing"; source: SessionSourceRef }
+  | { status: "failed"; failure: SessionSourceFailure };
+
+export type SessionSourceAbsenceOutcome = Extract<
+  SessionSourceOutcome,
+  { status: "missing" | "failed" }
+>;
+
+export interface SessionSourceScanBatch {
+  sources: SessionSourceRef[];
+  outcomes: SessionSourceOutcome[];
+  sessions: SessionHead[];
+}
+
+export interface SessionSourceDiff {
+  changedIds: string[];
+  removedIds: string[];
+  failedIds: string[];
+  sourceOutcomes: SessionSourceAbsenceOutcome[];
+}
+
+export type SessionCacheMetaSnapshot = Readonly<Record<string, SessionCacheMeta>>;

--- a/packages/core/src/discovery/cache/detail-version.ts
+++ b/packages/core/src/discovery/cache/detail-version.ts
@@ -1,4 +1,4 @@
-import type { SessionCacheMeta } from "../../agents/base.js";
+import type { SessionCacheMeta } from "../../agents/session-source-types.js";
 
 const DETAIL_PROJECTION_VERSION = "session-detail-v1";
 

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -2,7 +2,7 @@
  * Structured message storage: row ↔ domain mapping, prepared-statement
  * binders, and message-text builders shared by sessions/search/file-activity.
  */
-import type { SessionCacheMeta } from "../../agents/base.js";
+import type { SessionCacheMeta } from "../../agents/session-source-types.js";
 import { assertIdentifiedSessionHead } from "../../contract/session.js";
 import type {
   IdentifiedSessionHead,

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { SessionCacheMeta } from "../../agents/base.js";
+import type { SessionCacheMeta } from "../../agents/session-source-types.js";
 import type { IdentifiedSessionHead, SessionDetail } from "../../types/index.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { PersistedSessionHeadChange } from "./db.js";
@@ -19,8 +19,8 @@ import {
   deleteLegacyCacheFile,
   writeCachedSessionChanges,
   writeCachedSessionSnapshot,
-  type SessionSnapshotCompleteness,
 } from "./sessions.js";
+import type { SessionSnapshotCompleteness } from "./snapshot-types.js";
 
 export type DurableSessionPublication =
   | {

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -1,4 +1,4 @@
-import type { SessionCacheMeta } from "../../agents/base.js";
+import type { SessionCacheMeta } from "../../agents/session-source-types.js";
 import type { SessionDetail, SessionFileActivity, SessionHead } from "../../types/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
@@ -23,7 +23,7 @@ import { advanceMessageCursorDigest, initialMessageCursorDigest } from "./messag
 import { withCacheDbReadOnly, withSearchIndexDb } from "./connection.js";
 import { runSearchIndexWrite } from "./schema.js";
 import { sessionDetailVersion } from "./detail-version.js";
-import type { SessionSnapshotCompleteness } from "./sessions.js";
+import type { SessionSnapshotCompleteness } from "./snapshot-types.js";
 import {
   deletePublicationPayloads,
   discardPublicationStaging,

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -2,7 +2,7 @@
  * Cache persistence: load / save / clear / info / initialization tracking.
  */
 import { existsSync, rmSync, unlinkSync } from "node:fs";
-import type { SessionCacheMeta } from "../../agents/base.js";
+import type { SessionCacheMeta } from "../../agents/session-source-types.js";
 import type { ReferencedSessionHead, SessionReference } from "../../contract/index.js";
 import { formatSessionReference, normalizeSessionReference } from "../../contract/index.js";
 import type {
@@ -116,7 +116,8 @@ export interface CachedSessionCursorReader {
   messageRows(startIndex: number): CachedMessageRow[];
 }
 
-export type SessionSnapshotCompleteness = "complete" | "partial";
+export type { SessionSnapshotCompleteness } from "./snapshot-types.js";
+import type { SessionSnapshotCompleteness } from "./snapshot-types.js";
 
 export interface SaveCachedSessionsOptions {
   completeness?: SessionSnapshotCompleteness;

--- a/packages/core/src/discovery/cache/snapshot-types.ts
+++ b/packages/core/src/discovery/cache/snapshot-types.ts
@@ -1,0 +1,1 @@
+export type SessionSnapshotCompleteness = "complete" | "partial";

--- a/packages/core/src/projects/fs.ts
+++ b/packages/core/src/projects/fs.ts
@@ -1,6 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
-import type { IdentityFs } from "./identity.js";
+
+export interface IdentityFs {
+  exists(path: string): boolean;
+  readText(path: string): string | null;
+  spawn(cmd: string, args: string[], opts: { cwd: string }): { stdout: string; exitCode: number };
+}
 
 export const realFs: IdentityFs = {
   exists(path) {

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -3,13 +3,9 @@ import * as path from "node:path";
 import { createHash } from "node:crypto";
 import type { ProjectIdentity, ProjectIdentityKind } from "../types/index.js";
 import { fallbackDisplayName } from "./display-name.js";
-import { realFs } from "./fs.js";
+import { realFs, type IdentityFs } from "./fs.js";
 
-export interface IdentityFs {
-  exists(path: string): boolean;
-  readText(path: string): string | null;
-  spawn(cmd: string, args: string[], opts: { cwd: string }): { stdout: string; exitCode: number };
-}
+export type { IdentityFs } from "./fs.js";
 
 export const PROJECT_IDENTITY_RESOLVER_REVISION = "project-identity-v2";
 

--- a/scripts/check-import-cycles.mjs
+++ b/scripts/check-import-cycles.mjs
@@ -1,0 +1,119 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const SOURCE_ROOTS = ["packages/core/src", "packages/cli/src", "apps/web/src", "apps/www/src"];
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"];
+
+function isProductionSource(path) {
+  return (
+    SOURCE_EXTENSIONS.some((extension) => path.endsWith(extension)) &&
+    !path.endsWith(".d.ts") &&
+    !path.includes("/__tests__/") &&
+    !/\.(?:test|spec)\.[cm]?tsx?$/.test(path)
+  );
+}
+
+function listSourceFiles(root) {
+  const files = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...listSourceFiles(path));
+    else if (isProductionSource(path)) files.push(resolve(path));
+  }
+  return files;
+}
+
+function resolveLocalModule(sourcePath, specifier, sourceFiles) {
+  const withoutJsExtension = specifier.replace(/\.[cm]?js$/, "");
+  const base = resolve(dirname(sourcePath), withoutJsExtension);
+  const candidates = [
+    ...SOURCE_EXTENSIONS.map((extension) => `${base}${extension}`),
+    ...SOURCE_EXTENSIONS.map((extension) => join(base, `index${extension}`)),
+  ];
+  return candidates.find((candidate) => sourceFiles.has(candidate));
+}
+
+function localDependencies(sourcePath, sourceFiles) {
+  const source = ts.createSourceFile(
+    sourcePath,
+    readFileSync(sourcePath, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const dependencies = [];
+  ts.forEachChild(source, (node) => {
+    if (!ts.isImportDeclaration(node) && !ts.isExportDeclaration(node)) return;
+    const specifier = node.moduleSpecifier;
+    if (!specifier || !ts.isStringLiteral(specifier) || !specifier.text.startsWith(".")) return;
+    const dependency = resolveLocalModule(sourcePath, specifier.text, sourceFiles);
+    if (dependency) dependencies.push(dependency);
+  });
+  return dependencies;
+}
+
+function findCycles(graph) {
+  let nextIndex = 0;
+  const stack = [];
+  const onStack = new Set();
+  const indexes = new Map();
+  const lowLinks = new Map();
+  const cycles = [];
+
+  function visit(source) {
+    indexes.set(source, nextIndex);
+    lowLinks.set(source, nextIndex);
+    nextIndex += 1;
+    stack.push(source);
+    onStack.add(source);
+
+    for (const dependency of graph.get(source) ?? []) {
+      if (!indexes.has(dependency)) {
+        visit(dependency);
+        lowLinks.set(source, Math.min(lowLinks.get(source), lowLinks.get(dependency)));
+      } else if (onStack.has(dependency)) {
+        lowLinks.set(source, Math.min(lowLinks.get(source), indexes.get(dependency)));
+      }
+    }
+
+    if (lowLinks.get(source) !== indexes.get(source)) return;
+    const component = [];
+    let member;
+    do {
+      member = stack.pop();
+      onStack.delete(member);
+      component.push(member);
+    } while (member !== source);
+
+    const selfCycle =
+      component.length === 1 && (graph.get(component[0]) ?? []).includes(component[0]);
+    if (component.length > 1 || selfCycle) cycles.push(component);
+  }
+
+  for (const source of graph.keys()) {
+    if (!indexes.has(source)) visit(source);
+  }
+  return cycles;
+}
+
+function main() {
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const files = SOURCE_ROOTS.flatMap((root) => listSourceFiles(join(repoRoot, root)));
+  const sourceFiles = new Set(files);
+  const graph = new Map(files.map((source) => [source, localDependencies(source, sourceFiles)]));
+  const cycles = findCycles(graph);
+
+  if (cycles.length > 0) {
+    console.error("Production import cycles found:");
+    for (const cycle of cycles) {
+      console.error(`  - ${cycle.map((path) => relative(repoRoot, path)).join(" -> ")}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Production import graph is acyclic across ${files.length} TypeScript files`);
+}
+
+main();

--- a/scripts/check-quality-task-coverage.mjs
+++ b/scripts/check-quality-task-coverage.mjs
@@ -26,7 +26,14 @@ export const SCRIPT_PACKAGE_TASK_REQUIREMENTS = {
 };
 export const ROOT_TASK_REQUIREMENTS = {
   lint: ["pnpm lint:root", "turbo run lint"],
-  "lint:root": ["oxlint", "scripts", "tests", "playwright.config.ts", "vitest.config.ts"],
+  "lint:root": [
+    "node scripts/check-import-cycles.mjs",
+    "oxlint",
+    "scripts",
+    "tests",
+    "playwright.config.ts",
+    "vitest.config.ts",
+  ],
   "lint:fix": ["pnpm lint:fix:root", "turbo run lint:fix"],
   "lint:fix:root": [
     "oxlint",

--- a/scripts/check-quality-task-coverage.test.mjs
+++ b/scripts/check-quality-task-coverage.test.mjs
@@ -89,7 +89,8 @@ describe("CS-173: quality task coverage", () => {
   it("keeps root sources in every repository quality command", () => {
     const scripts = {
       lint: "pnpm lint:root && turbo run lint",
-      "lint:root": "oxlint scripts tests playwright.config.ts vitest.config.ts",
+      "lint:root":
+        "node scripts/check-import-cycles.mjs && oxlint scripts tests playwright.config.ts vitest.config.ts",
       "lint:fix": "pnpm lint:fix:root && turbo run lint:fix",
       "lint:fix:root": "oxlint scripts tests playwright.config.ts vitest.config.ts --fix",
       format: "pnpm format:root && turbo run format",
@@ -105,7 +106,11 @@ describe("CS-173: quality task coverage", () => {
     );
     expect(
       findCommandCoverageGaps(
-        { ...scripts, "lint:root": "oxlint scripts playwright.config.ts vitest.config.ts" },
+        {
+          ...scripts,
+          "lint:root":
+            "node scripts/check-import-cycles.mjs && oxlint scripts playwright.config.ts vitest.config.ts",
+        },
         ROOT_TASK_REQUIREMENTS,
         "codesesh-monorepo",
       ),


### PR DESCRIPTION
## Summary

- relocate shared source synchronization, snapshot, project filesystem, registry, and display model types to their owning modules
- preserve existing public type export paths through re-exports
- add a TypeScript AST import-cycle check to the root lint task
- keep the production TypeScript graph acyclic across core, CLI, web, and www

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm --filter @codesesh/web test:bundle`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`