### PR TITLE
refactor(cache): split search index responsibilities

### DIFF
--- a/packages/core/src/discovery/cache/search-index-state.ts
+++ b/packages/core/src/discovery/cache/search-index-state.ts
@@ -1,0 +1,356 @@
+import type { SessionCacheMeta } from "../../agents/session-source-types.js";
+import type { SessionHead } from "../../types/index.js";
+import type { SQLiteDatabase } from "../../utils/sqlite.js";
+import { withCacheDbReadOnly } from "./connection.js";
+import { sessionDetailVersion } from "./detail-version.js";
+import type { SessionSnapshotCompleteness } from "./snapshot-types.js";
+
+export interface SearchIndexSyncOptions {
+  isBulk?: boolean;
+  bulkThreshold?: number;
+  includePendingReindex?: boolean;
+  detailVersions?: Readonly<Record<string, string>>;
+  completeness?: SessionSnapshotCompleteness;
+  removedSessionIds?: readonly string[];
+  publicationId?: string;
+}
+
+export interface PendingSearchIndexMaintenance {
+  sessionIds: string[];
+  total: number;
+}
+
+export interface SearchIndexState {
+  contentHashBySessionId: Map<string, string>;
+  publishedContentHashBySessionId: Map<string, string>;
+  indexedMessageCountBySessionId: Map<string, number>;
+  messageCountBySessionId: Map<string, number>;
+  detailVersionBySessionId: Map<string, string>;
+  targetDetailVersionBySessionId: Map<string, string>;
+  pendingReindexSessionIds: Set<string>;
+}
+
+interface IndexedSearchRow {
+  session_id?: string;
+  content_hash?: string;
+  indexed_message_count?: number;
+  detail_version?: string;
+  meta_json?: string | null;
+}
+
+interface PublishedSessionRow {
+  session_title?: string | null;
+  session_directory?: string | null;
+  session_time_created?: number | null;
+  session_time_updated?: number | null;
+  session_message_count?: number | null;
+  session_total_input_tokens?: number | null;
+  session_total_output_tokens?: number | null;
+  session_total_cache_read_tokens?: number | null;
+  session_total_cache_create_tokens?: number | null;
+  session_total_cost?: number | null;
+  session_cost_source?: string | null;
+  session_total_tokens?: number | null;
+  session_project_identity_kind?: string | null;
+  session_project_identity_key?: string | null;
+  session_project_display_name?: string | null;
+  session_project_identity_resolver_revision?: string | null;
+  session_project_identity_input_signature?: string | null;
+}
+
+interface MessageCountRow {
+  session_id?: string;
+  value?: number;
+}
+
+type SearchIndexStateRow = IndexedSearchRow & MessageCountRow & PublishedSessionRow;
+
+interface SearchIndexSessionFacts {
+  title: string;
+  directory: string;
+  timeCreated: number;
+  timeUpdated: number;
+  messageCount: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheReadTokens: number;
+  totalCacheCreateTokens: number;
+  totalCost: number;
+  costSource: string;
+  totalTokens: number;
+  projectIdentityKind: string;
+  projectIdentityKey: string;
+  projectDisplayName: string;
+  projectIdentityResolverRevision: string;
+  projectIdentityInputSignature: string;
+}
+
+const SEARCH_INDEX_STATE_BATCH_SIZE = 900;
+
+function readPendingReindexIds(db: SQLiteDatabase, agentName: string): Set<string> {
+  const rows = db
+    .prepare("SELECT session_id FROM pending_reindex WHERE agent_name = ?")
+    .all(agentName) as Array<{ session_id?: string }>;
+  return new Set(rows.map((row) => String(row.session_id)));
+}
+
+function searchIndexSessionFacts(session: SessionHead): SearchIndexSessionFacts {
+  return {
+    title: session.title,
+    directory: session.directory,
+    timeCreated: session.time_created,
+    timeUpdated: session.time_updated ?? session.time_created,
+    messageCount: session.stats.message_count,
+    totalInputTokens: session.stats.total_input_tokens,
+    totalOutputTokens: session.stats.total_output_tokens,
+    totalCacheReadTokens: session.stats.total_cache_read_tokens ?? 0,
+    totalCacheCreateTokens: session.stats.total_cache_create_tokens ?? 0,
+    totalCost: session.stats.total_cost,
+    costSource: session.stats.cost_source ?? "",
+    totalTokens: session.stats.total_tokens ?? 0,
+    projectIdentityKind: session.project_identity?.kind ?? "",
+    projectIdentityKey: session.project_identity?.key ?? "",
+    projectDisplayName: session.project_identity?.displayName ?? "",
+    projectIdentityResolverRevision: session.project_identity_resolver_revision ?? "",
+    projectIdentityInputSignature: session.project_identity_input_signature ?? "",
+  };
+}
+
+function hashSearchIndexSessionFacts(facts: SearchIndexSessionFacts): string {
+  return JSON.stringify(facts);
+}
+
+export function sessionContentHash(session: SessionHead): string {
+  return hashSearchIndexSessionFacts(searchIndexSessionFacts(session));
+}
+
+function publishedSessionContentHash(row: PublishedSessionRow): string | null {
+  if (row.session_title == null) return null;
+  return hashSearchIndexSessionFacts({
+    title: row.session_title,
+    directory: row.session_directory ?? "",
+    timeCreated: Number(row.session_time_created ?? 0),
+    timeUpdated: Number(row.session_time_updated ?? row.session_time_created ?? 0),
+    messageCount: Number(row.session_message_count ?? 0),
+    totalInputTokens: Number(row.session_total_input_tokens ?? 0),
+    totalOutputTokens: Number(row.session_total_output_tokens ?? 0),
+    totalCacheReadTokens: Number(row.session_total_cache_read_tokens ?? 0),
+    totalCacheCreateTokens: Number(row.session_total_cache_create_tokens ?? 0),
+    totalCost: Number(row.session_total_cost ?? 0),
+    costSource: row.session_cost_source ?? "",
+    totalTokens: Number(row.session_total_tokens ?? 0),
+    projectIdentityKind: row.session_project_identity_kind ?? "",
+    projectIdentityKey: row.session_project_identity_key ?? "",
+    projectDisplayName: row.session_project_display_name ?? "",
+    projectIdentityResolverRevision: row.session_project_identity_resolver_revision ?? "",
+    projectIdentityInputSignature: row.session_project_identity_input_signature ?? "",
+  });
+}
+
+export function detailVersionFromMetaJson(value: string | null | undefined): string {
+  if (!value) return sessionDetailVersion(null);
+  try {
+    return sessionDetailVersion(JSON.parse(value) as SessionCacheMeta);
+  } catch {
+    return sessionDetailVersion(null);
+  }
+}
+
+function searchIndexStateFromRows(
+  indexedRows: SearchIndexStateRow[],
+  messageCountRows: MessageCountRow[],
+  pendingReindexSessionIds: Set<string> = new Set(),
+): SearchIndexState {
+  return {
+    contentHashBySessionId: new Map(
+      indexedRows.map((row) => [String(row.session_id), String(row.content_hash ?? "")]),
+    ),
+    publishedContentHashBySessionId: new Map(
+      indexedRows.flatMap((row) => {
+        const contentHash = publishedSessionContentHash(row);
+        return contentHash == null ? [] : [[String(row.session_id), contentHash]];
+      }),
+    ),
+    indexedMessageCountBySessionId: new Map(
+      indexedRows.map((row) => [String(row.session_id), Number(row.indexed_message_count ?? 0)]),
+    ),
+    messageCountBySessionId: new Map(
+      messageCountRows.map((row) => [String(row.session_id), Number(row.value ?? 0)]),
+    ),
+    detailVersionBySessionId: new Map(
+      indexedRows.map((row) => [String(row.session_id), String(row.detail_version ?? "")]),
+    ),
+    targetDetailVersionBySessionId: new Map(
+      indexedRows.map((row) => [String(row.session_id), detailVersionFromMetaJson(row.meta_json)]),
+    ),
+    pendingReindexSessionIds,
+  };
+}
+
+/**
+ * Freshness probe for a batch of sessions: is each one's indexed document still
+ * in step with its cached head?
+ *
+ * INDEXED BY is not a micro-optimisation. Without stats SQLite prefers the
+ * UNIQUE(agent_name, session_id) auto-index, and reaching content_hash then
+ * means reading each row past content_text through its overflow chain — proving
+ * an unchanged agent is up to date would cost the size of the indexed corpus.
+ * Pinning the covering index keeps the probe proportional to the session count.
+ */
+export function searchIndexStateQuery(sessionIdCount: number): string {
+  const requestedRows = Array.from({ length: sessionIdCount }, () => "(?)").join(", ");
+  return `
+    WITH requested_session_ids(session_id) AS (VALUES ${requestedRows})
+    SELECT
+      requested.session_id,
+      documents.content_hash,
+      documents.indexed_message_count,
+      documents.detail_version,
+      sessions.meta_json,
+      sessions.title AS session_title,
+      sessions.directory AS session_directory,
+      sessions.time_created AS session_time_created,
+      sessions.time_updated AS session_time_updated,
+      sessions.message_count AS session_message_count,
+      sessions.total_input_tokens AS session_total_input_tokens,
+      sessions.total_output_tokens AS session_total_output_tokens,
+      sessions.total_cache_read_tokens AS session_total_cache_read_tokens,
+      sessions.total_cache_create_tokens AS session_total_cache_create_tokens,
+      sessions.total_cost AS session_total_cost,
+      sessions.cost_source AS session_cost_source,
+      sessions.total_tokens AS session_total_tokens,
+      sessions.project_identity_kind AS session_project_identity_kind,
+      sessions.project_identity_key AS session_project_identity_key,
+      sessions.project_display_name AS session_project_display_name,
+      sessions.project_identity_resolver_revision AS session_project_identity_resolver_revision,
+      sessions.project_identity_input_signature AS session_project_identity_input_signature,
+      COUNT(messages.message_index) AS value
+    FROM requested_session_ids AS requested
+    LEFT JOIN session_documents AS documents
+      INDEXED BY idx_session_documents_state
+      ON documents.agent_name = ? AND documents.session_id = requested.session_id
+    LEFT JOIN messages
+      ON messages.agent_name = ? AND messages.session_id = requested.session_id
+    LEFT JOIN sessions
+      ON sessions.agent_name = ? AND sessions.session_id = requested.session_id
+    GROUP BY
+      requested.session_id,
+      documents.content_hash,
+      documents.indexed_message_count,
+      documents.detail_version,
+      sessions.meta_json,
+      sessions.title,
+      sessions.directory,
+      sessions.time_created,
+      sessions.time_updated,
+      sessions.message_count,
+      sessions.total_input_tokens,
+      sessions.total_output_tokens,
+      sessions.total_cache_read_tokens,
+      sessions.total_cache_create_tokens,
+      sessions.total_cost,
+      sessions.cost_source,
+      sessions.total_tokens,
+      sessions.project_identity_kind,
+      sessions.project_identity_key,
+      sessions.project_display_name,
+      sessions.project_identity_resolver_revision,
+      sessions.project_identity_input_signature
+  `;
+}
+
+export function readSearchIndexState(
+  db: SQLiteDatabase,
+  agentName: string,
+  sessionIds: string[],
+): SearchIndexState {
+  const rows: SearchIndexStateRow[] = [];
+  const uniqueSessionIds = [...new Set(sessionIds)];
+
+  for (let offset = 0; offset < uniqueSessionIds.length; offset += SEARCH_INDEX_STATE_BATCH_SIZE) {
+    const batch = uniqueSessionIds.slice(offset, offset + SEARCH_INDEX_STATE_BATCH_SIZE);
+    const batchRows = db
+      .prepare(searchIndexStateQuery(batch.length))
+      .all(...batch, agentName, agentName, agentName) as SearchIndexStateRow[];
+    rows.push(...batchRows);
+  }
+
+  return searchIndexStateFromRows(rows, rows, readPendingReindexIds(db, agentName));
+}
+
+export function targetDetailVersion(
+  state: SearchIndexState,
+  sessionId: string,
+  options: SearchIndexSyncOptions,
+): string {
+  return (
+    options.detailVersions?.[sessionId] ??
+    state.targetDetailVersionBySessionId.get(sessionId) ??
+    sessionDetailVersion(null)
+  );
+}
+
+export function searchIndexEntryNeedsUpdate(
+  state: SearchIndexState,
+  session: SessionHead,
+  options: SearchIndexSyncOptions,
+): boolean {
+  const sessionId = session.reference.sessionId;
+  const pendingMaintenance = state.pendingReindexSessionIds.has(sessionId);
+  const targetVersion = targetDetailVersion(state, sessionId, options);
+  if (pendingMaintenance && options.includePendingReindex === false) {
+    return (
+      state.publishedContentHashBySessionId.get(sessionId) !== sessionContentHash(session) ||
+      state.targetDetailVersionBySessionId.get(sessionId) !== targetVersion
+    );
+  }
+  return (
+    pendingMaintenance ||
+    state.detailVersionBySessionId.get(sessionId) !== targetVersion ||
+    state.contentHashBySessionId.get(sessionId) !== sessionContentHash(session) ||
+    state.indexedMessageCountBySessionId.get(sessionId) !==
+      (state.messageCountBySessionId.get(sessionId) ?? 0)
+  );
+}
+
+export function readPendingSearchIndexMaintenance(
+  agentName: string,
+  limit: number,
+): PendingSearchIndexMaintenance | null {
+  const boundedLimit = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0;
+  const outcome = withCacheDbReadOnly((db) => {
+    const totalRow = db
+      .prepare(
+        `
+          SELECT COUNT(*) AS value
+          FROM pending_reindex AS pending
+          INNER JOIN sessions
+            ON sessions.agent_name = pending.agent_name
+            AND sessions.session_id = pending.session_id
+          WHERE pending.agent_name = ?
+            AND sessions.publication_id IS NULL
+        `,
+      )
+      .get(agentName) as { value?: number } | undefined;
+    const rows = db
+      .prepare(
+        `
+          SELECT pending.session_id
+          FROM pending_reindex AS pending
+          INNER JOIN sessions
+            ON sessions.agent_name = pending.agent_name
+            AND sessions.session_id = pending.session_id
+          WHERE pending.agent_name = ?
+            AND sessions.publication_id IS NULL
+          ORDER BY sessions.sort_index, pending.session_id
+          LIMIT ?
+        `,
+      )
+      .all(agentName, boundedLimit) as Array<{ session_id?: string }>;
+    return {
+      sessionIds: rows.map((row) => String(row.session_id)),
+      total: Number(totalRow?.value ?? 0),
+    };
+  });
+  return outcome.status === "success" ? outcome.value : null;
+}

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -1,5 +1,4 @@
-import type { SessionCacheMeta } from "../../agents/session-source-types.js";
-import type { SessionDetail, SessionFileActivity, SessionHead } from "../../types/index.js";
+import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
@@ -7,39 +6,39 @@ import { SEARCH_INDEX_BULK_SYNC_THRESHOLD, type PersistedSessionHeadChange } fro
 import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import {
   buildSessionContentFromMessages,
-  messageCursorContentFromStructuredRecord,
-  MESSAGE_PARTS_FORMAT_VERSION,
   normalizeMessages,
-  prepareInsertFileActivity,
-  prepareInsertMessageTool,
-  prepareUpsertSession,
   assertSessionProjectIdentities,
   requireSessionProjectIdentity,
-  upsertSessionRow,
-  writeFileActivityRows,
-  type StructuredMessageRecord,
 } from "./messages.js";
-import { advanceMessageCursorDigest, initialMessageCursorDigest } from "./message-cursor.js";
-import { withCacheDbReadOnly, withSearchIndexDb } from "./connection.js";
+import { withSearchIndexDb } from "./connection.js";
 import { runSearchIndexWrite } from "./schema.js";
 import { sessionDetailVersion } from "./detail-version.js";
-import type { SessionSnapshotCompleteness } from "./snapshot-types.js";
 import {
   deletePublicationPayloads,
   discardPublicationStaging,
   readPublicationPayloads,
   stagePublicationPayloads,
 } from "./publication-staging.js";
+import {
+  prepareSessionMaterializationWriter,
+  type SessionMaterializationEntry,
+} from "./session-materialization-writer.js";
+import {
+  detailVersionFromMetaJson,
+  readSearchIndexState,
+  searchIndexEntryNeedsUpdate,
+  sessionContentHash,
+  targetDetailVersion,
+  type SearchIndexState,
+  type SearchIndexSyncOptions,
+} from "./search-index-state.js";
 
-export interface SearchIndexSyncOptions {
-  isBulk?: boolean;
-  bulkThreshold?: number;
-  includePendingReindex?: boolean;
-  detailVersions?: Readonly<Record<string, string>>;
-  completeness?: SessionSnapshotCompleteness;
-  removedSessionIds?: readonly string[];
-  publicationId?: string;
-}
+export {
+  readPendingSearchIndexMaintenance,
+  searchIndexStateQuery,
+  type PendingSearchIndexMaintenance,
+  type SearchIndexSyncOptions,
+} from "./search-index-state.js";
 
 export interface SearchIndexSyncFailure {
   sessionId: string;
@@ -60,73 +59,11 @@ export interface SearchIndexSyncResult {
   rebuildDurationMs?: number;
 }
 
-export interface PendingSearchIndexMaintenance {
-  sessionIds: string[];
-  total: number;
-}
-
-interface SearchIndexState {
-  contentHashBySessionId: Map<string, string>;
-  publishedContentHashBySessionId: Map<string, string>;
-  indexedMessageCountBySessionId: Map<string, number>;
-  messageCountBySessionId: Map<string, number>;
-  detailVersionBySessionId: Map<string, string>;
-  targetDetailVersionBySessionId: Map<string, string>;
-  pendingReindexSessionIds: Set<string>;
-}
-
-interface IndexedSearchRow {
-  session_id?: string;
-  content_hash?: string;
-  indexed_message_count?: number;
-  detail_version?: string;
-  meta_json?: string | null;
-}
-
-interface PublishedSessionRow {
-  session_title?: string | null;
-  session_directory?: string | null;
-  session_time_created?: number | null;
-  session_time_updated?: number | null;
-  session_message_count?: number | null;
-  session_total_input_tokens?: number | null;
-  session_total_output_tokens?: number | null;
-  session_total_cache_read_tokens?: number | null;
-  session_total_cache_create_tokens?: number | null;
-  session_total_cost?: number | null;
-  session_cost_source?: string | null;
-  session_total_tokens?: number | null;
-  session_project_identity_kind?: string | null;
-  session_project_identity_key?: string | null;
-  session_project_display_name?: string | null;
-  session_project_identity_resolver_revision?: string | null;
-  session_project_identity_input_signature?: string | null;
-}
-
-interface MessageCountRow {
-  session_id?: string;
-  value?: number;
-}
-
-function readPendingReindexIds(db: SQLiteDatabase, agentName: string): Set<string> {
-  const rows = db
-    .prepare("SELECT session_id FROM pending_reindex WHERE agent_name = ?")
-    .all(agentName) as Array<{ session_id?: string }>;
-  return new Set(rows.map((row) => String(row.session_id)));
-}
-
-type SearchIndexStateRow = IndexedSearchRow & MessageCountRow & PublishedSessionRow;
-
-const SEARCH_INDEX_STATE_BATCH_SIZE = 900;
 const SEARCH_INDEX_COMMIT_CHUNK_SIZE = 64;
 
-interface LoadedSearchIndexEntry {
-  session: SessionHead;
-  messages: StructuredMessageRecord[];
+interface LoadedSearchIndexEntry extends SessionMaterializationEntry {
   contentText: string;
   contentHash: string;
-  fileActivity: SessionFileActivity[];
-  sortIndex: number;
   detailVersion: string;
 }
 
@@ -188,287 +125,6 @@ function shouldBulkSyncSearchIndex(options: SearchIndexSyncOptions, changedCount
 
   const threshold = options.bulkThreshold ?? SEARCH_INDEX_BULK_SYNC_THRESHOLD;
   return threshold > 0 && changedCount >= threshold;
-}
-
-interface SearchIndexSessionFacts {
-  title: string;
-  directory: string;
-  timeCreated: number;
-  timeUpdated: number;
-  messageCount: number;
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  totalCacheReadTokens: number;
-  totalCacheCreateTokens: number;
-  totalCost: number;
-  costSource: string;
-  totalTokens: number;
-  projectIdentityKind: string;
-  projectIdentityKey: string;
-  projectDisplayName: string;
-  projectIdentityResolverRevision: string;
-  projectIdentityInputSignature: string;
-}
-
-function searchIndexSessionFacts(session: SessionHead): SearchIndexSessionFacts {
-  return {
-    title: session.title,
-    directory: session.directory,
-    timeCreated: session.time_created,
-    timeUpdated: session.time_updated ?? session.time_created,
-    messageCount: session.stats.message_count,
-    totalInputTokens: session.stats.total_input_tokens,
-    totalOutputTokens: session.stats.total_output_tokens,
-    totalCacheReadTokens: session.stats.total_cache_read_tokens ?? 0,
-    totalCacheCreateTokens: session.stats.total_cache_create_tokens ?? 0,
-    totalCost: session.stats.total_cost,
-    costSource: session.stats.cost_source ?? "",
-    totalTokens: session.stats.total_tokens ?? 0,
-    projectIdentityKind: session.project_identity?.kind ?? "",
-    projectIdentityKey: session.project_identity?.key ?? "",
-    projectDisplayName: session.project_identity?.displayName ?? "",
-    projectIdentityResolverRevision: session.project_identity_resolver_revision ?? "",
-    projectIdentityInputSignature: session.project_identity_input_signature ?? "",
-  };
-}
-
-function hashSearchIndexSessionFacts(facts: SearchIndexSessionFacts): string {
-  return JSON.stringify(facts);
-}
-
-function sessionContentHash(session: SessionHead): string {
-  return hashSearchIndexSessionFacts(searchIndexSessionFacts(session));
-}
-
-function publishedSessionContentHash(row: PublishedSessionRow): string | null {
-  if (row.session_title == null) return null;
-  return hashSearchIndexSessionFacts({
-    title: row.session_title,
-    directory: row.session_directory ?? "",
-    timeCreated: Number(row.session_time_created ?? 0),
-    timeUpdated: Number(row.session_time_updated ?? row.session_time_created ?? 0),
-    messageCount: Number(row.session_message_count ?? 0),
-    totalInputTokens: Number(row.session_total_input_tokens ?? 0),
-    totalOutputTokens: Number(row.session_total_output_tokens ?? 0),
-    totalCacheReadTokens: Number(row.session_total_cache_read_tokens ?? 0),
-    totalCacheCreateTokens: Number(row.session_total_cache_create_tokens ?? 0),
-    totalCost: Number(row.session_total_cost ?? 0),
-    costSource: row.session_cost_source ?? "",
-    totalTokens: Number(row.session_total_tokens ?? 0),
-    projectIdentityKind: row.session_project_identity_kind ?? "",
-    projectIdentityKey: row.session_project_identity_key ?? "",
-    projectDisplayName: row.session_project_display_name ?? "",
-    projectIdentityResolverRevision: row.session_project_identity_resolver_revision ?? "",
-    projectIdentityInputSignature: row.session_project_identity_input_signature ?? "",
-  });
-}
-
-function detailVersionFromMetaJson(value: string | null | undefined): string {
-  if (!value) return sessionDetailVersion(null);
-  try {
-    return sessionDetailVersion(JSON.parse(value) as SessionCacheMeta);
-  } catch {
-    return sessionDetailVersion(null);
-  }
-}
-
-function searchIndexStateFromRows(
-  indexedRows: SearchIndexStateRow[],
-  messageCountRows: MessageCountRow[],
-  pendingReindexSessionIds: Set<string> = new Set(),
-): SearchIndexState {
-  return {
-    contentHashBySessionId: new Map(
-      indexedRows.map((row) => [String(row.session_id), String(row.content_hash ?? "")]),
-    ),
-    publishedContentHashBySessionId: new Map(
-      indexedRows.flatMap((row) => {
-        const contentHash = publishedSessionContentHash(row);
-        return contentHash == null ? [] : [[String(row.session_id), contentHash]];
-      }),
-    ),
-    indexedMessageCountBySessionId: new Map(
-      indexedRows.map((row) => [String(row.session_id), Number(row.indexed_message_count ?? 0)]),
-    ),
-    messageCountBySessionId: new Map(
-      messageCountRows.map((row) => [String(row.session_id), Number(row.value ?? 0)]),
-    ),
-    detailVersionBySessionId: new Map(
-      indexedRows.map((row) => [String(row.session_id), String(row.detail_version ?? "")]),
-    ),
-    targetDetailVersionBySessionId: new Map(
-      indexedRows.map((row) => [String(row.session_id), detailVersionFromMetaJson(row.meta_json)]),
-    ),
-    pendingReindexSessionIds,
-  };
-}
-
-/**
- * Freshness probe for a batch of sessions: is each one's indexed document still
- * in step with its cached head?
- *
- * INDEXED BY is not a micro-optimisation. Without stats SQLite prefers the
- * UNIQUE(agent_name, session_id) auto-index, and reaching content_hash then
- * means reading each row past content_text through its overflow chain — proving
- * an unchanged agent is up to date would cost the size of the indexed corpus.
- * Pinning the covering index keeps the probe proportional to the session count.
- */
-export function searchIndexStateQuery(sessionIdCount: number): string {
-  const requestedRows = Array.from({ length: sessionIdCount }, () => "(?)").join(", ");
-  return `
-    WITH requested_session_ids(session_id) AS (VALUES ${requestedRows})
-    SELECT
-      requested.session_id,
-      documents.content_hash,
-      documents.indexed_message_count,
-      documents.detail_version,
-      sessions.meta_json,
-      sessions.title AS session_title,
-      sessions.directory AS session_directory,
-      sessions.time_created AS session_time_created,
-      sessions.time_updated AS session_time_updated,
-      sessions.message_count AS session_message_count,
-      sessions.total_input_tokens AS session_total_input_tokens,
-      sessions.total_output_tokens AS session_total_output_tokens,
-      sessions.total_cache_read_tokens AS session_total_cache_read_tokens,
-      sessions.total_cache_create_tokens AS session_total_cache_create_tokens,
-      sessions.total_cost AS session_total_cost,
-      sessions.cost_source AS session_cost_source,
-      sessions.total_tokens AS session_total_tokens,
-      sessions.project_identity_kind AS session_project_identity_kind,
-      sessions.project_identity_key AS session_project_identity_key,
-      sessions.project_display_name AS session_project_display_name,
-      sessions.project_identity_resolver_revision AS session_project_identity_resolver_revision,
-      sessions.project_identity_input_signature AS session_project_identity_input_signature,
-      COUNT(messages.message_index) AS value
-    FROM requested_session_ids AS requested
-    LEFT JOIN session_documents AS documents
-      INDEXED BY idx_session_documents_state
-      ON documents.agent_name = ? AND documents.session_id = requested.session_id
-    LEFT JOIN messages
-      ON messages.agent_name = ? AND messages.session_id = requested.session_id
-    LEFT JOIN sessions
-      ON sessions.agent_name = ? AND sessions.session_id = requested.session_id
-    GROUP BY
-      requested.session_id,
-      documents.content_hash,
-      documents.indexed_message_count,
-      documents.detail_version,
-      sessions.meta_json,
-      sessions.title,
-      sessions.directory,
-      sessions.time_created,
-      sessions.time_updated,
-      sessions.message_count,
-      sessions.total_input_tokens,
-      sessions.total_output_tokens,
-      sessions.total_cache_read_tokens,
-      sessions.total_cache_create_tokens,
-      sessions.total_cost,
-      sessions.cost_source,
-      sessions.total_tokens,
-      sessions.project_identity_kind,
-      sessions.project_identity_key,
-      sessions.project_display_name,
-      sessions.project_identity_resolver_revision,
-      sessions.project_identity_input_signature
-  `;
-}
-
-function readSearchIndexState(
-  db: SQLiteDatabase,
-  agentName: string,
-  sessionIds: string[],
-): SearchIndexState {
-  const rows: SearchIndexStateRow[] = [];
-  const uniqueSessionIds = [...new Set(sessionIds)];
-
-  for (let offset = 0; offset < uniqueSessionIds.length; offset += SEARCH_INDEX_STATE_BATCH_SIZE) {
-    const batch = uniqueSessionIds.slice(offset, offset + SEARCH_INDEX_STATE_BATCH_SIZE);
-    const batchRows = db
-      .prepare(searchIndexStateQuery(batch.length))
-      .all(...batch, agentName, agentName, agentName) as SearchIndexStateRow[];
-    rows.push(...batchRows);
-  }
-
-  return searchIndexStateFromRows(rows, rows, readPendingReindexIds(db, agentName));
-}
-
-function targetDetailVersion(
-  state: SearchIndexState,
-  sessionId: string,
-  options: SearchIndexSyncOptions,
-): string {
-  return (
-    options.detailVersions?.[sessionId] ??
-    state.targetDetailVersionBySessionId.get(sessionId) ??
-    sessionDetailVersion(null)
-  );
-}
-
-function searchIndexEntryNeedsUpdate(
-  state: SearchIndexState,
-  session: SessionHead,
-  options: SearchIndexSyncOptions,
-): boolean {
-  const sessionId = session.reference.sessionId;
-  const pendingMaintenance = state.pendingReindexSessionIds.has(sessionId);
-  const targetVersion = targetDetailVersion(state, sessionId, options);
-  if (pendingMaintenance && options.includePendingReindex === false) {
-    return (
-      state.publishedContentHashBySessionId.get(sessionId) !== sessionContentHash(session) ||
-      state.targetDetailVersionBySessionId.get(sessionId) !== targetVersion
-    );
-  }
-  return (
-    pendingMaintenance ||
-    state.detailVersionBySessionId.get(sessionId) !== targetVersion ||
-    state.contentHashBySessionId.get(sessionId) !== sessionContentHash(session) ||
-    state.indexedMessageCountBySessionId.get(sessionId) !==
-      (state.messageCountBySessionId.get(sessionId) ?? 0)
-  );
-}
-
-export function readPendingSearchIndexMaintenance(
-  agentName: string,
-  limit: number,
-): PendingSearchIndexMaintenance | null {
-  const boundedLimit = Number.isFinite(limit) ? Math.max(0, Math.floor(limit)) : 0;
-  const outcome = withCacheDbReadOnly((db) => {
-    const totalRow = db
-      .prepare(
-        `
-          SELECT COUNT(*) AS value
-          FROM pending_reindex AS pending
-          INNER JOIN sessions
-            ON sessions.agent_name = pending.agent_name
-            AND sessions.session_id = pending.session_id
-          WHERE pending.agent_name = ?
-            AND sessions.publication_id IS NULL
-        `,
-      )
-      .get(agentName) as { value?: number } | undefined;
-    const rows = db
-      .prepare(
-        `
-          SELECT pending.session_id
-          FROM pending_reindex AS pending
-          INNER JOIN sessions
-            ON sessions.agent_name = pending.agent_name
-            AND sessions.session_id = pending.session_id
-          WHERE pending.agent_name = ?
-            AND sessions.publication_id IS NULL
-          ORDER BY sessions.sort_index, pending.session_id
-          LIMIT ?
-        `,
-      )
-      .all(agentName, boundedLimit) as Array<{ session_id?: string }>;
-    return {
-      sessionIds: rows.map((row) => String(row.session_id)),
-      total: Number(totalRow?.value ?? 0),
-    };
-  });
-  return outcome.status === "success" ? outcome.value : null;
 }
 
 function loadSearchIndexEntry(
@@ -536,135 +192,7 @@ function writeSearchIndexRows(
   const deleteRow = db.prepare(
     "DELETE FROM session_documents WHERE agent_name = ? AND session_id = ?",
   );
-  const deleteMessages = db.prepare(
-    "DELETE FROM messages WHERE agent_name = ? AND session_id = ? AND message_index >= ?",
-  );
-  const deleteMessageTools = db.prepare(
-    "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ? AND message_index >= ?",
-  );
-  const deleteFileActivity = db.prepare(
-    "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteModelCost = db.prepare(
-    "DELETE FROM session_model_cost WHERE agent_name = ? AND session_id = ?",
-  );
-  const deleteCostSummary = db.prepare(
-    "DELETE FROM session_cost_summary WHERE agent_name = ? AND session_id = ?",
-  );
-  // Derived from the message rows just written, in the same transaction, so
-  // the rollup can never drift from its source (CS-270).
-  const rebuildModelCost = db.prepare(`
-    INSERT INTO session_model_cost(agent_name, session_id, model, cost, cost_recorded)
-    SELECT
-      agent_name,
-      session_id,
-      model,
-      SUM(COALESCE(cost, 0)),
-      SUM(CASE WHEN cost_source = 'recorded' THEN COALESCE(cost, 0) ELSE 0 END)
-    FROM messages
-    WHERE agent_name = ? AND session_id = ? AND model IS NOT NULL AND model <> ''
-    GROUP BY agent_name, session_id, model
-  `);
-  const rebuildCostSummary = db.prepare(`
-    WITH normalized AS (
-      SELECT
-        agent_name,
-        session_id,
-        COALESCE(time_completed, 0) <= 0 AND COALESCE(time_created, 0) <= 0 AS untimed,
-        MAX(CAST(COALESCE(json_extract(tokens_json, '$.input'), 0) AS INTEGER), 0) AS input_tokens,
-        MAX(CAST(COALESCE(json_extract(tokens_json, '$.output'), 0) AS INTEGER), 0) AS output_tokens,
-        MAX(CAST(COALESCE(json_extract(tokens_json, '$.reasoning'), 0) AS INTEGER), 0) AS reasoning_tokens,
-        MAX(CAST(COALESCE(json_extract(tokens_json, '$.cache_read'), 0) AS INTEGER), 0) AS cache_read_tokens,
-        MAX(CAST(COALESCE(json_extract(tokens_json, '$.cache_create'), 0) AS INTEGER), 0) AS cache_create_tokens,
-        CASE WHEN cost > 0 THEN cost ELSE 0 END AS normalized_cost
-      FROM messages
-      WHERE agent_name = ? AND session_id = ?
-    )
-    INSERT INTO session_cost_summary(
-      agent_name,
-      session_id,
-      message_count,
-      untimed_message_count,
-      input_tokens,
-      output_tokens,
-      reasoning_tokens,
-      cache_read_tokens,
-      cache_create_tokens,
-      untimed_input_tokens,
-      untimed_output_tokens,
-      untimed_reasoning_tokens,
-      untimed_cache_read_tokens,
-      untimed_cache_create_tokens,
-      message_cost,
-      untimed_message_cost
-    )
-    SELECT
-      agent_name,
-      session_id,
-      COUNT(*),
-      SUM(CASE WHEN untimed THEN 1 ELSE 0 END),
-      SUM(input_tokens),
-      SUM(output_tokens),
-      SUM(reasoning_tokens),
-      SUM(cache_read_tokens),
-      SUM(cache_create_tokens),
-      SUM(CASE WHEN untimed THEN input_tokens ELSE 0 END),
-      SUM(CASE WHEN untimed THEN output_tokens ELSE 0 END),
-      SUM(CASE WHEN untimed THEN reasoning_tokens ELSE 0 END),
-      SUM(CASE WHEN untimed THEN cache_read_tokens ELSE 0 END),
-      SUM(CASE WHEN untimed THEN cache_create_tokens ELSE 0 END),
-      SUM(normalized_cost),
-      SUM(CASE WHEN untimed THEN normalized_cost ELSE 0 END)
-    FROM normalized
-    GROUP BY agent_name, session_id
-  `);
-  const writeMaterializedSession = prepareUpsertSession(db, "materialization");
-  const insertFileActivity = prepareInsertFileActivity(db);
-  const insertMessageTool = prepareInsertMessageTool(db);
-  const upsertMessage = db.prepare(`
-    INSERT INTO messages(
-      agent_name,
-      session_id,
-      message_index,
-      message_id,
-      role,
-      time_created,
-      time_completed,
-      agent,
-      mode,
-      model,
-      provider,
-      tokens_json,
-      cost,
-      cost_source,
-      parts_json,
-      parts_format_version,
-      content_chain_digest,
-      subagent_id,
-      nickname,
-      content_text,
-      tool_metadata_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ON CONFLICT(agent_name, session_id, message_index) DO UPDATE SET
-      message_id = excluded.message_id,
-      role = excluded.role,
-      time_created = excluded.time_created,
-      time_completed = excluded.time_completed,
-      agent = excluded.agent,
-      mode = excluded.mode,
-      model = excluded.model,
-      provider = excluded.provider,
-      tokens_json = excluded.tokens_json,
-      cost = excluded.cost,
-      cost_source = excluded.cost_source,
-      parts_json = excluded.parts_json,
-      parts_format_version = excluded.parts_format_version,
-      content_chain_digest = excluded.content_chain_digest,
-      subagent_id = excluded.subagent_id,
-      nickname = excluded.nickname,
-      content_text = excluded.content_text,
-      tool_metadata_json = excluded.tool_metadata_json
-  `);
+  const materialization = prepareSessionMaterializationWriter(db, agentName);
   const upsertRow = db.prepare(`
     INSERT INTO session_documents(
       agent_name,
@@ -695,11 +223,7 @@ function writeSearchIndexRows(
 
   for (const sessionId of new Set(removedSessionIds)) {
     deleteRow.run(agentName, sessionId);
-    deleteFileActivity.run(agentName, sessionId);
-    deleteMessageTools.run(agentName, sessionId, 0);
-    deleteMessages.run(agentName, sessionId, 0);
-    deleteModelCost.run(agentName, sessionId);
-    deleteCostSummary.run(agentName, sessionId);
+    materialization.deleteSession(sessionId);
     clearPendingReindex.run(agentName, sessionId);
   }
 
@@ -715,59 +239,8 @@ function writeSearchIndexRows(
         continue;
       }
     }
-    upsertSessionRow(
-      writeMaterializedSession,
-      agentName,
-      entry.session,
-      null,
-      entry.sortIndex,
-      null,
-    );
-    deleteFileActivity.run(agentName, sessionId);
-    deleteMessageTools.run(agentName, sessionId, 0);
     clearPendingReindex.run(agentName, sessionId);
-    writeFileActivityRows(insertFileActivity, entry.fileActivity);
-    let contentChainDigest = initialMessageCursorDigest({
-      agentName,
-      sessionId,
-    });
-    for (const message of entry.messages) {
-      contentChainDigest = advanceMessageCursorDigest(
-        contentChainDigest,
-        messageCursorContentFromStructuredRecord(message),
-      );
-      upsertMessage.run(
-        agentName,
-        sessionId,
-        message.index,
-        message.id,
-        message.role,
-        message.timeCreated,
-        message.timeCompleted ?? null,
-        message.agent ?? null,
-        message.mode ?? null,
-        message.model ?? null,
-        message.provider ?? null,
-        message.tokensJson ?? null,
-        message.cost ?? null,
-        message.costSource ?? null,
-        message.partsJson,
-        MESSAGE_PARTS_FORMAT_VERSION,
-        contentChainDigest,
-        message.subagentId ?? null,
-        message.nickname ?? null,
-        message.contentText,
-        message.toolMetadataJson ?? null,
-      );
-      for (const toolName of message.toolNames) {
-        insertMessageTool.run(agentName, sessionId, message.index, toolName);
-      }
-    }
-    deleteMessages.run(agentName, sessionId, entry.messages.length);
-    deleteModelCost.run(agentName, sessionId);
-    deleteCostSummary.run(agentName, sessionId);
-    rebuildModelCost.run(agentName, sessionId);
-    rebuildCostSummary.run(agentName, sessionId);
+    materialization.writeSession(entry);
     upsertRow.run(
       agentName,
       sessionId,
@@ -861,7 +334,7 @@ function readSearchIndexPlanInput(
   if (request.kind === "snapshot") {
     const existingRows = db
       .prepare("SELECT session_id FROM session_documents WHERE agent_name = ? ORDER BY id")
-      .all(agentName) as IndexedSearchRow[];
+      .all(agentName) as Array<{ session_id?: string }>;
     const includedSessionIds = new Set(
       request.sessions.map((session) => session.reference.sessionId),
     );

--- a/packages/core/src/discovery/cache/session-materialization-writer.ts
+++ b/packages/core/src/discovery/cache/session-materialization-writer.ts
@@ -1,0 +1,222 @@
+import type { SessionFileActivity, SessionHead } from "../../types/index.js";
+import type { SQLiteDatabase } from "../../utils/sqlite.js";
+import {
+  messageCursorContentFromStructuredRecord,
+  MESSAGE_PARTS_FORMAT_VERSION,
+  prepareInsertFileActivity,
+  prepareInsertMessageTool,
+  prepareUpsertSession,
+  upsertSessionRow,
+  writeFileActivityRows,
+  type StructuredMessageRecord,
+} from "./messages.js";
+import { advanceMessageCursorDigest, initialMessageCursorDigest } from "./message-cursor.js";
+
+export interface SessionMaterializationEntry {
+  session: SessionHead;
+  messages: StructuredMessageRecord[];
+  fileActivity: SessionFileActivity[];
+  sortIndex: number;
+}
+
+export interface SessionMaterializationWriter {
+  deleteSession(sessionId: string): void;
+  writeSession(entry: SessionMaterializationEntry): void;
+}
+
+export function prepareSessionMaterializationWriter(
+  db: SQLiteDatabase,
+  agentName: string,
+): SessionMaterializationWriter {
+  const deleteMessages = db.prepare(
+    "DELETE FROM messages WHERE agent_name = ? AND session_id = ? AND message_index >= ?",
+  );
+  const deleteMessageTools = db.prepare(
+    "DELETE FROM message_tools WHERE agent_name = ? AND session_id = ? AND message_index >= ?",
+  );
+  const deleteFileActivity = db.prepare(
+    "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
+  );
+  const deleteModelCost = db.prepare(
+    "DELETE FROM session_model_cost WHERE agent_name = ? AND session_id = ?",
+  );
+  const deleteCostSummary = db.prepare(
+    "DELETE FROM session_cost_summary WHERE agent_name = ? AND session_id = ?",
+  );
+  // Rebuild both rollups from the message rows in the same transaction so
+  // derived cost facts cannot drift from their source.
+  const rebuildModelCost = db.prepare(`
+    INSERT INTO session_model_cost(agent_name, session_id, model, cost, cost_recorded)
+    SELECT
+      agent_name,
+      session_id,
+      model,
+      SUM(COALESCE(cost, 0)),
+      SUM(CASE WHEN cost_source = 'recorded' THEN COALESCE(cost, 0) ELSE 0 END)
+    FROM messages
+    WHERE agent_name = ? AND session_id = ? AND model IS NOT NULL AND model <> ''
+    GROUP BY agent_name, session_id, model
+  `);
+  const rebuildCostSummary = db.prepare(`
+    WITH normalized AS (
+      SELECT
+        agent_name,
+        session_id,
+        COALESCE(time_completed, 0) <= 0 AND COALESCE(time_created, 0) <= 0 AS untimed,
+        MAX(CAST(COALESCE(json_extract(tokens_json, '$.input'), 0) AS INTEGER), 0) AS input_tokens,
+        MAX(CAST(COALESCE(json_extract(tokens_json, '$.output'), 0) AS INTEGER), 0) AS output_tokens,
+        MAX(CAST(COALESCE(json_extract(tokens_json, '$.reasoning'), 0) AS INTEGER), 0) AS reasoning_tokens,
+        MAX(CAST(COALESCE(json_extract(tokens_json, '$.cache_read'), 0) AS INTEGER), 0) AS cache_read_tokens,
+        MAX(CAST(COALESCE(json_extract(tokens_json, '$.cache_create'), 0) AS INTEGER), 0) AS cache_create_tokens,
+        CASE WHEN cost > 0 THEN cost ELSE 0 END AS normalized_cost
+      FROM messages
+      WHERE agent_name = ? AND session_id = ?
+    )
+    INSERT INTO session_cost_summary(
+      agent_name,
+      session_id,
+      message_count,
+      untimed_message_count,
+      input_tokens,
+      output_tokens,
+      reasoning_tokens,
+      cache_read_tokens,
+      cache_create_tokens,
+      untimed_input_tokens,
+      untimed_output_tokens,
+      untimed_reasoning_tokens,
+      untimed_cache_read_tokens,
+      untimed_cache_create_tokens,
+      message_cost,
+      untimed_message_cost
+    )
+    SELECT
+      agent_name,
+      session_id,
+      COUNT(*),
+      SUM(CASE WHEN untimed THEN 1 ELSE 0 END),
+      SUM(input_tokens),
+      SUM(output_tokens),
+      SUM(reasoning_tokens),
+      SUM(cache_read_tokens),
+      SUM(cache_create_tokens),
+      SUM(CASE WHEN untimed THEN input_tokens ELSE 0 END),
+      SUM(CASE WHEN untimed THEN output_tokens ELSE 0 END),
+      SUM(CASE WHEN untimed THEN reasoning_tokens ELSE 0 END),
+      SUM(CASE WHEN untimed THEN cache_read_tokens ELSE 0 END),
+      SUM(CASE WHEN untimed THEN cache_create_tokens ELSE 0 END),
+      SUM(normalized_cost),
+      SUM(CASE WHEN untimed THEN normalized_cost ELSE 0 END)
+    FROM normalized
+    GROUP BY agent_name, session_id
+  `);
+  const writeMaterializedSession = prepareUpsertSession(db, "materialization");
+  const insertFileActivity = prepareInsertFileActivity(db);
+  const insertMessageTool = prepareInsertMessageTool(db);
+  const upsertMessage = db.prepare(`
+    INSERT INTO messages(
+      agent_name,
+      session_id,
+      message_index,
+      message_id,
+      role,
+      time_created,
+      time_completed,
+      agent,
+      mode,
+      model,
+      provider,
+      tokens_json,
+      cost,
+      cost_source,
+      parts_json,
+      parts_format_version,
+      content_chain_digest,
+      subagent_id,
+      nickname,
+      content_text,
+      tool_metadata_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(agent_name, session_id, message_index) DO UPDATE SET
+      message_id = excluded.message_id,
+      role = excluded.role,
+      time_created = excluded.time_created,
+      time_completed = excluded.time_completed,
+      agent = excluded.agent,
+      mode = excluded.mode,
+      model = excluded.model,
+      provider = excluded.provider,
+      tokens_json = excluded.tokens_json,
+      cost = excluded.cost,
+      cost_source = excluded.cost_source,
+      parts_json = excluded.parts_json,
+      parts_format_version = excluded.parts_format_version,
+      content_chain_digest = excluded.content_chain_digest,
+      subagent_id = excluded.subagent_id,
+      nickname = excluded.nickname,
+      content_text = excluded.content_text,
+      tool_metadata_json = excluded.tool_metadata_json
+  `);
+
+  return {
+    deleteSession(sessionId) {
+      deleteFileActivity.run(agentName, sessionId);
+      deleteMessageTools.run(agentName, sessionId, 0);
+      deleteMessages.run(agentName, sessionId, 0);
+      deleteModelCost.run(agentName, sessionId);
+      deleteCostSummary.run(agentName, sessionId);
+    },
+    writeSession(entry) {
+      const sessionId = entry.session.reference.sessionId;
+      upsertSessionRow(
+        writeMaterializedSession,
+        agentName,
+        entry.session,
+        null,
+        entry.sortIndex,
+        null,
+      );
+      deleteFileActivity.run(agentName, sessionId);
+      deleteMessageTools.run(agentName, sessionId, 0);
+      writeFileActivityRows(insertFileActivity, entry.fileActivity);
+      let contentChainDigest = initialMessageCursorDigest({ agentName, sessionId });
+      for (const message of entry.messages) {
+        contentChainDigest = advanceMessageCursorDigest(
+          contentChainDigest,
+          messageCursorContentFromStructuredRecord(message),
+        );
+        upsertMessage.run(
+          agentName,
+          sessionId,
+          message.index,
+          message.id,
+          message.role,
+          message.timeCreated,
+          message.timeCompleted ?? null,
+          message.agent ?? null,
+          message.mode ?? null,
+          message.model ?? null,
+          message.provider ?? null,
+          message.tokensJson ?? null,
+          message.cost ?? null,
+          message.costSource ?? null,
+          message.partsJson,
+          MESSAGE_PARTS_FORMAT_VERSION,
+          contentChainDigest,
+          message.subagentId ?? null,
+          message.nickname ?? null,
+          message.contentText,
+          message.toolMetadataJson ?? null,
+        );
+        for (const toolName of message.toolNames) {
+          insertMessageTool.run(agentName, sessionId, message.index, toolName);
+        }
+      }
+      deleteMessages.run(agentName, sessionId, entry.messages.length);
+      deleteModelCost.run(agentName, sessionId);
+      deleteCostSummary.run(agentName, sessionId);
+      rebuildModelCost.run(agentName, sessionId);
+      rebuildCostSummary.run(agentName, sessionId);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- isolate search index freshness state and maintenance reads
- move session detail table writes into a dedicated materialization writer
- keep cache, detail, and search document publication in the existing atomic transaction
- reduce `search-index-writer.ts` from 1,194 lines to 667 lines

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- CI repository checks, release preflight, performance checks, and bundle budget