### PR TITLE
Improve agent session pipeline performance

### DIFF
--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -117,6 +117,23 @@ describe("formatScanStatusLabel", () => {
     );
   });
 
+  it("does not warn when a completed refresh is partial only because it is windowed", () => {
+    expect(
+      formatScanStatusLabel({
+        active: false,
+        backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
+        agentStatuses: {
+          claudecode: {
+            agentName: "claudecode",
+            status: "complete",
+            completeness: "partial",
+            updatedAt: 1,
+          },
+        },
+      } as unknown as ScanStatusEvent),
+    ).toBeNull();
+  });
+
   it("shows a completed partial full-history refresh", () => {
     expect(
       formatScanStatusLabel({

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -208,7 +208,25 @@ describe("formatScanStatusLabel", () => {
           failedAgents: [],
         },
       } as unknown as ScanStatusEvent),
-    ).toBe("Publishing full-history sessions · zcode");
+    ).toBe("Preparing full-history publication · zcode");
+  });
+
+  it("distinguishes writing and committing a full-history index", () => {
+    const status = {
+      active: false,
+      backfill: {
+        active: true,
+        currentAgent: "codex",
+        pendingAgents: [],
+        progress: { phase: "indexing" },
+        completedAgents: [],
+        failedAgents: [],
+      },
+    } as unknown as ScanStatusEvent;
+
+    expect(formatScanStatusLabel(status)).toBe("Writing full-history search index · codex");
+    status.backfill.progress = { phase: "committing" };
+    expect(formatScanStatusLabel(status)).toBe("Committing full-history publication · codex");
   });
 
   it("does not describe a queued full-history publication as active", () => {

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -60,11 +60,15 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
     const stageLabel =
       progress?.phase === "publish-queued"
         ? "Full-history publication queued"
-        : progress?.phase === "publishing" || progress?.phase === "indexing"
-          ? "Publishing full-history sessions"
-          : progress?.phase === "finalizing"
-            ? "Finalizing full-history metadata"
-            : "Scanning full session history";
+        : progress?.phase === "committing"
+          ? "Committing full-history publication"
+          : progress?.phase === "indexing"
+            ? "Writing full-history search index"
+            : progress?.phase === "publishing"
+              ? "Preparing full-history publication"
+              : progress?.phase === "finalizing"
+                ? "Finalizing full-history metadata"
+                : "Scanning full session history";
     return current
       ? `${stageLabel} · ${current}${progressLabel}${pending > 0 ? ` · ${pending} history scan queued` : ""}`
       : `${stageLabel}${progressLabel}`;

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -15,6 +15,15 @@ function formatPartialCompletion(
   return [countLabel, completion.sourceFailureSummary].filter((value) => value != null).join(" · ");
 }
 
+function hasSourceFailures(
+  completion: Pick<
+    NonNullable<ScanStatusEvent["agentStatuses"][string]>,
+    "sourceFailureCount" | "sourceFailureSummary"
+  >,
+): boolean {
+  return (completion.sourceFailureCount ?? 0) > 0 || completion.sourceFailureSummary != null;
+}
+
 export function formatIsoDate(ts: number): string {
   const d = new Date(ts);
   const y = d.getFullYear();
@@ -112,7 +121,7 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
   }
 
   const partialBackfill = Object.entries(status.backfill?.partialAgents ?? {}).find(
-    ([, completion]) => completion.completeness === "partial",
+    ([, completion]) => completion.completeness === "partial" && hasSourceFailures(completion),
   );
   if (partialBackfill) {
     const [agentName, completion] = partialBackfill;
@@ -120,7 +129,10 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
     return `Full-history refresh completed with partial data · ${agentName}${detail ? ` · ${detail}` : ""}`;
   }
   const partialAgent = Object.values(status.agentStatuses ?? {}).find(
-    (agentStatus) => agentStatus.status === "complete" && agentStatus.completeness === "partial",
+    (agentStatus) =>
+      agentStatus.status === "complete" &&
+      agentStatus.completeness === "partial" &&
+      hasSourceFailures(agentStatus),
   );
   if (partialAgent) {
     const detail = formatPartialCompletion(partialAgent);

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -13,6 +13,7 @@
 | 一次 Session Detail 只发一条 part 查询 | `packages/core/src/agents/__tests__/opencode-sqlite.test.ts` |
 | 文件活动搜索的 limit 作用于 Session | `packages/core/src/discovery/cache/__tests__/search-integration.test.ts` |
 | 关键查询走预期索引（`EXPLAIN QUERY PLAN`） | 同上两处 |
+| 仅会话头元数据变化时复用已物化消息 | `packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts` |
 | 首屏 JS gzip 预算与延迟依赖 | `apps/web/tests/initial-bundle.test.ts` |
 | Session Detail 缓存基数上界 | `apps/web/src/lib/session-detail-cache.test.ts` |
 | 一帧测量只产生一次 commit | `apps/web/src/components/session-detail/message-list.test.tsx` |

--- a/packages/cli/src/agent-backfill-scheduler.test.ts
+++ b/packages/cli/src/agent-backfill-scheduler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { FileSystemSessionSource, type CachedResult } from "@codesesh/core/runtime";
+import { FileSystemSessionSource } from "@codesesh/core/runtime";
 import type { ScanStatusEvent } from "@codesesh/core/contract";
 import {
   BackfillLifecycle,
@@ -10,7 +10,6 @@ import { AgentBackfillScheduler } from "./agent-backfill-scheduler.js";
 import { appLogger } from "./logging.js";
 import { ScanStatusReporter } from "./scan-status-reporter.js";
 
-type CacheReadResult = { status: "success"; value: CachedResult | null } | { status: "failed" };
 type LastFullSyncReadResult = { status: "success"; value: number | null } | { status: "failed" };
 
 const core = vi.hoisted(() => ({
@@ -18,16 +17,11 @@ const core = vi.hoisted(() => ({
     status: "success",
     value: Date.now(),
   })),
-  readCachedSessions: vi.fn<() => CacheReadResult>(() => ({
-    status: "success",
-    value: null,
-  })),
 }));
 
 vi.mock("@codesesh/core/runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime")>()),
   readAgentLastFullSyncAt: core.readAgentLastFullSyncAt,
-  readCachedSessions: core.readCachedSessions,
 }));
 
 class FakeSyncAgent extends FileSystemSessionSource {
@@ -76,46 +70,37 @@ afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   core.readAgentLastFullSyncAt.mockReturnValue({ status: "success", value: Date.now() });
-  core.readCachedSessions.mockReturnValue({ status: "success", value: null });
 });
 
 describe("AgentBackfillScheduler", () => {
-  it("caches source-integrity checks until the full-sync interval expires", () => {
+  it("caches a recent full-sync marker until its interval expires", () => {
     vi.useFakeTimers();
     const now = new Date("2026-08-12T00:00:00.000Z").getTime();
     vi.setSystemTime(now);
     core.readAgentLastFullSyncAt.mockReturnValue({ status: "success", value: now });
     const agent = new FakeSyncAgent();
     const isAvailable = vi.spyOn(agent, "isAvailable");
-    const listSessionSources = vi.spyOn(agent, "listSessionSources");
     const { scheduler } = makeScheduler();
-    const cached = { sessions: [], meta: {}, timestamp: now };
 
-    expect(scheduler.needsBackfill(agent, cached)).toBe(false);
-    expect(scheduler.needsBackfill(agent, cached)).toBe(false);
-    expect(isAvailable).toHaveBeenCalledOnce();
-    expect(listSessionSources).toHaveBeenCalledOnce();
+    expect(scheduler.needsBackfill(agent)).toBe(false);
+    expect(scheduler.needsBackfill(agent)).toBe(false);
+    expect(isAvailable).not.toHaveBeenCalled();
     expect(core.readAgentLastFullSyncAt).toHaveBeenCalledOnce();
-    expect(core.readCachedSessions).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
 
-    expect(scheduler.needsBackfill(agent, cached)).toBe(true);
-    expect(isAvailable).toHaveBeenCalledTimes(2);
-    expect(listSessionSources).toHaveBeenCalledOnce();
+    expect(scheduler.needsBackfill(agent)).toBe(true);
+    expect(isAvailable).toHaveBeenCalledOnce();
     expect(core.readAgentLastFullSyncAt).toHaveBeenCalledTimes(2);
   });
 
-  it("skips backfill when cached sessions cannot be read", () => {
-    core.readCachedSessions.mockReturnValueOnce({ status: "failed" });
-    const warn = vi.spyOn(appLogger, "warn");
+  it("does not enumerate raw sources after a recent full sync", () => {
+    const agent = new FakeSyncAgent();
+    const listSessionSources = vi.spyOn(agent, "listSessionSources");
     const { scheduler } = makeScheduler();
 
-    expect(scheduler.needsBackfill(new FakeSyncAgent())).toBe(false);
-    expect(warn).toHaveBeenCalledWith("scan.backfill.cache_state_unavailable", {
-      agent: "codex",
-      state: "cached_sessions",
-    });
+    expect(scheduler.needsBackfill(agent)).toBe(false);
+    expect(listSessionSources).not.toHaveBeenCalled();
   });
 
   it("skips backfill when the full-sync timestamp cannot be read", () => {

--- a/packages/cli/src/agent-backfill-scheduler.ts
+++ b/packages/cli/src/agent-backfill-scheduler.ts
@@ -1,10 +1,4 @@
-import {
-  readAgentLastFullSyncAt,
-  readCachedSessions,
-  type BaseAgent,
-  type CachedResult,
-  type ScanOptions,
-} from "@codesesh/core/runtime";
+import { readAgentLastFullSyncAt, type BaseAgent, type ScanOptions } from "@codesesh/core/runtime";
 import type {
   BackfillAttemptRef,
   BackfillLifecycle,
@@ -12,8 +6,6 @@ import type {
 } from "./backfill-lifecycle.js";
 import { appLogger } from "./logging.js";
 import type { ScanStatusReporter } from "./scan-status-reporter.js";
-
-type CachedSessions = CachedResult;
 
 export interface AgentBackfillSchedulerOptions {
   lifecycle: BackfillLifecycle;
@@ -25,10 +17,9 @@ export interface AgentBackfillSchedulerOptions {
 
 const BACKFILL_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const PARTIAL_BACKFILL_RETRY_DELAY_MS = 5 * 60 * 1000;
-const CACHE_TRUNCATION_COVERAGE = 0.5;
 
 /**
- * Owns backfill eligibility, queue progression, retries, and cache-integrity
+ * Owns backfill eligibility, queue progression, retries, and full-sync
  * validity windows. The sync engine supplies only the actual scan operation.
  */
 export class AgentBackfillScheduler {
@@ -37,7 +28,7 @@ export class AgentBackfillScheduler {
 
   constructor(private readonly options: AgentBackfillSchedulerOptions) {}
 
-  needsBackfill(agent: BaseAgent, cached?: CachedSessions | null, reloadCached = false): boolean {
+  needsBackfill(agent: BaseAgent): boolean {
     const { from, to } = this.options.startupScanOptions;
     if (from == null && to == null) return false;
     const now = Date.now();
@@ -54,33 +45,7 @@ export class AgentBackfillScheduler {
     if (lastSyncAt == null || now - lastSyncAt > BACKFILL_INTERVAL_MS) {
       return agent.isAvailable();
     }
-    if (agent.sessionSourceAccess.kind !== "enumerated") return false;
-    if (!agent.isAvailable()) return false;
-
-    let cachedSessions = cached;
-    if (reloadCached || cached === undefined) {
-      const outcome = readCachedSessions(agent.name);
-      if (outcome.status === "failed") {
-        appLogger.warn("scan.backfill.cache_state_unavailable", {
-          agent: agent.name,
-          state: "cached_sessions",
-        });
-        return false;
-      }
-      cachedSessions = outcome.value;
-    }
-    const sourceCount = agent.sessionSourceAccess.count();
-    const cachedCount = cachedSessions?.sessions.length ?? 0;
     this.cacheIntegrityValidUntilByAgent.set(agent.name, lastSyncAt + BACKFILL_INTERVAL_MS);
-    if (sourceCount > 0 && cachedCount / sourceCount < CACHE_TRUNCATION_COVERAGE) {
-      appLogger.warn("scan.backfill.cache_truncated", {
-        agent: agent.name,
-        cached_sessions: cachedCount,
-        source_files: sourceCount,
-        last_sync_at: lastSyncAt,
-      });
-      return true;
-    }
     return false;
   }
 

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -412,6 +412,16 @@ describe("AgentSyncEngine", () => {
   });
 
   it("bounds backfill progress and publishes its terminal immediately", async () => {
+    searchIndex.enqueue.mockImplementationOnce(async (...args: unknown[]) => {
+      const onStarted = args[2];
+      const onProgress = args[3];
+      if (typeof onStarted === "function") onStarted();
+      if (typeof onProgress === "function") {
+        onProgress({ agentName: "codex", stage: "prepared" });
+        onProgress({ agentName: "codex", stage: "search_staged" });
+      }
+      return undefined;
+    });
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async (_agentName, payload) => {
@@ -441,11 +451,13 @@ describe("AgentSyncEngine", () => {
     const progress = statuses.flatMap((status) =>
       status.backfill.progress ? [status.backfill.progress] : [],
     );
-    expect(progress).toHaveLength(5);
+    expect(progress).toHaveLength(7);
     expect(progress.map((item) => item.processed)).toEqual([
       1,
       10_000,
       10_000,
+      undefined,
+      undefined,
       undefined,
       undefined,
     ]);
@@ -455,6 +467,8 @@ describe("AgentSyncEngine", () => {
       "finalizing",
       "publish-queued",
       "publishing",
+      "indexing",
+      "committing",
     ]);
     expect(statuses.at(-1)?.backfill).toEqual({
       active: false,

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -442,7 +442,13 @@ describe("AgentSyncEngine", () => {
       status.backfill.progress ? [status.backfill.progress] : [],
     );
     expect(progress).toHaveLength(5);
-    expect(progress.map((item) => item.processed)).toEqual([1, 10_000, 10_000, 10_000, 10_000]);
+    expect(progress.map((item) => item.processed)).toEqual([
+      1,
+      10_000,
+      10_000,
+      undefined,
+      undefined,
+    ]);
     expect(progress.map((item) => item.phase)).toEqual([
       "scanning",
       "scanning",

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -895,7 +895,9 @@ export class AgentSyncEngine {
       const fullSessions = attachMissingProjectIdentities(result.sessions);
       const completion = buildScanCompletion(result.completeness, result.sourceFailures ?? []);
       this.statusReporter.flushProgressStatus(`backfill:${agentName}`);
-      const updatePublicationPhase = (phase: "publish-queued" | "publishing") => {
+      const updatePublicationPhase = (
+        phase: "publish-queued" | "publishing" | "indexing" | "committing",
+      ) => {
         if (
           this.backfills.updateProgress(attempt, {
             phase,
@@ -922,6 +924,10 @@ export class AgentSyncEngine {
           saveCache: true,
         },
         onPublishing: () => updatePublicationPhase("publishing"),
+        onPublicationProgress: ({ stage }) => {
+          if (stage === "prepared") updatePublicationPhase("indexing");
+          if (stage === "search_staged") updatePublicationPhase("committing");
+        },
         onCommitted: () => {
           durableCommitted = true;
           if (completion.completeness === "partial") {

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -334,12 +334,12 @@ export class AgentSyncEngine {
       if (!durableCommitted) throw error;
       this.reportPostCommitError("scan.refresh", agentName, error);
     }
-    // The backfill probe touches the agent's filesystem (isAvailable /
-    // listSessionSources) and may throw on transient errors; that must not
+    // The backfill probe touches cache state and may check agent availability;
+    // either operation can throw on transient errors, but that must not
     // fail — let alone reject — an otherwise finished refresh.
     try {
       const agent = this.findAgent(agentName);
-      if (agent && this.needsBackfill(agent, cached, failed || result === "committed")) {
+      if (agent && this.backfillScheduler.needsBackfill(agent)) {
         this.enqueueBackfill(agentName);
       }
       if (agent) this.searchIndexMaintenance.enqueue(agentName);
@@ -841,14 +841,6 @@ export class AgentSyncEngine {
       return null;
     }
     return outcome.value;
-  }
-
-  private needsBackfill(
-    agent: BaseAgent,
-    cached?: CachedSessions | null,
-    reloadCached = false,
-  ): boolean {
-    return this.backfillScheduler.needsBackfill(agent, cached, reloadCached);
   }
 
   private enqueueBackfill(agentName: string): void {

--- a/packages/cli/src/backfill-lifecycle.test.ts
+++ b/packages/cli/src/backfill-lifecycle.test.ts
@@ -26,7 +26,6 @@ describe("BackfillLifecycle", () => {
       expect(lifecycle.updateProgress(attempt, { phase: "publishing", sessions: 3 })).toBe(true);
       expect(lifecycle.status().progress).toEqual({
         phase: "publishing",
-        processed: 2,
         sessions: 3,
       });
       expect(lifecycle.complete(attempt, terminal)).toBe(true);

--- a/packages/cli/src/backfill-lifecycle.ts
+++ b/packages/cli/src/backfill-lifecycle.ts
@@ -52,9 +52,10 @@ export class BackfillLifecycle {
   updateProgress(attempt: BackfillAttemptRef, progress: BackfillProgress): boolean {
     const current = this.matchingRunningAttempt(attempt);
     if (!current) return false;
+    const phaseChanged = progress.phase != null && progress.phase !== current.progress?.phase;
     this.attempts.set(attempt.agentName, {
       ...current,
-      progress: { ...current.progress, ...progress },
+      progress: phaseChanged ? { ...progress } : { ...current.progress, ...progress },
     });
     return true;
   }

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -953,7 +953,7 @@ describe("LiveScanStore", () => {
     expect(core.markAgentFullSyncStarted).toHaveBeenCalledWith("codex");
   });
 
-  it("queues a backfill when a recent full-sync marker has a truncated file cache", async () => {
+  it("does not infer cache truncation from raw source and session counts", async () => {
     const cached = makeSession("cached");
     const codex = makeFileSystemAgent("codex", {
       listSessionSources: vi.fn(() =>
@@ -986,7 +986,8 @@ describe("LiveScanStore", () => {
 
     store.startBackgroundRefresh();
 
-    await vi.waitFor(() => expect(core.markAgentFullSyncStarted).toHaveBeenCalledWith("codex"));
+    await vi.waitFor(() => expect(store.getScanStatus().active).toBe(false));
+    expect(core.markAgentFullSyncStarted).not.toHaveBeenCalled();
   });
 
   it("rejects a scan worker that exits successfully before sending done", async () => {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -124,6 +124,17 @@ export class LiveScanStore {
                 scan_ms: timing.scan != null ? Math.round(timing.scan) : undefined,
                 identity_ms: timing.identity != null ? Math.round(timing.identity) : undefined,
                 tags_ms: timing.tags != null ? Math.round(timing.tags) : undefined,
+                source_enumeration_ms:
+                  timing.sourceEnumeration != null
+                    ? Math.round(timing.sourceEnumeration)
+                    : undefined,
+                source_diff_ms:
+                  timing.sourceDiff != null ? Math.round(timing.sourceDiff) : undefined,
+                source_parse_ms:
+                  timing.sourceParse != null ? Math.round(timing.sourceParse) : undefined,
+                enumerated_sources: timing.enumeratedSources,
+                changed_sources: timing.changedSources,
+                processed_sources: timing.processedSources,
               },
             ]),
           )

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -249,11 +249,9 @@ export function logSearchIndexSync(
       failures: result.failures,
     });
   }
-  if (!result || result.mode !== "bulk" || result.rebuildDurationMs == null) {
-    return;
-  }
+  if (!result) return;
 
-  appLogger.info("search_index.sync", {
+  const detail = {
     context,
     agent: result.agentName,
     mode: result.mode,
@@ -263,7 +261,14 @@ export function logSearchIndexSync(
     indexed: result.indexed,
     skipped: result.skipped,
     duration_ms: Math.round(result.durationMs),
-    rebuild_duration_ms: Math.round(result.rebuildDurationMs),
+    planning_ms: Math.round(result.planningDurationMs),
+    get_session_data_calls: result.getSessionDataCalls,
+    get_session_data_ms: Math.round(result.getSessionDataDurationMs),
+    materialization_ms: Math.round(result.materializationDurationMs),
+    rebuild_duration_ms:
+      result.rebuildDurationMs != null ? Math.round(result.rebuildDurationMs) : undefined,
     ...data,
-  });
+  };
+  if (result.mode === "bulk") appLogger.info("search_index.sync", detail);
+  else appLogger.debug("search_index.sync", detail);
 }

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -263,6 +263,7 @@ export function logSearchIndexSync(
     duration_ms: Math.round(result.durationMs),
     planning_ms: Math.round(result.planningDurationMs),
     get_session_data_calls: result.getSessionDataCalls,
+    reused_materializations: result.reusedMaterializations,
     get_session_data_ms: Math.round(result.getSessionDataDurationMs),
     materialization_ms: Math.round(result.materializationDurationMs),
     rebuild_duration_ms:

--- a/packages/cli/src/pending-search-index-jobs.test.ts
+++ b/packages/cli/src/pending-search-index-jobs.test.ts
@@ -167,6 +167,36 @@ describe("PendingSearchIndexJobs", () => {
     await Promise.all(waiters);
   });
 
+  it("sends publication progress only to waiters for the matching agent", async () => {
+    const pending = new PendingSearchIndexJobs();
+    const codexProgress: string[] = [];
+    const kimiProgress: string[] = [];
+    const waiters = [
+      pending.enqueue(
+        1,
+        "codex",
+        [changesJob("codex", [{ id: "one", version: 1 }])],
+        undefined,
+        ({ stage }) => codexProgress.push(stage),
+      ),
+      pending.enqueue(
+        2,
+        "kimi",
+        [changesJob("kimi", [{ id: "two", version: 1 }])],
+        undefined,
+        ({ stage }) => kimiProgress.push(stage),
+      ),
+    ];
+
+    const batch = pending.take()!;
+    batch.progress({ agentName: "codex", stage: "prepared" }, () => undefined);
+
+    expect(codexProgress).toEqual(["prepared"]);
+    expect(kimiProgress).toEqual([]);
+    pending.settle(batch);
+    await Promise.all(waiters);
+  });
+
   it("bounds queued work by unique session count", async () => {
     const pending = new PendingSearchIndexJobs();
     const waiters = Array.from({ length: 1_000 }, (_, index) =>

--- a/packages/cli/src/pending-search-index-jobs.ts
+++ b/packages/cli/src/pending-search-index-jobs.ts
@@ -1,10 +1,13 @@
 import type {
   IdentifiedSessionHead,
   PersistedSessionHeadChange,
-  SearchIndexSyncOptions,
   SessionCacheMeta,
 } from "@codesesh/core/runtime";
-import type { SearchIndexWorkerJob } from "./search-index-worker.js";
+import type {
+  SearchIndexPublicationProgress,
+  SearchIndexWorkerJob,
+  SearchIndexWorkerOptions,
+} from "./search-index-worker.js";
 
 type FullSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "full" }>;
 type ChangesSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "changes" }>;
@@ -15,6 +18,8 @@ interface JobWaiter {
   resolve: () => void;
   reject: (error: Error) => void;
   onStarted?: () => void;
+  onProgress?: (progress: SearchIndexPublicationProgress) => void;
+  agentNames: Set<string>;
 }
 
 interface PendingChanges {
@@ -25,7 +30,7 @@ interface PendingChanges {
   changesBySessionId: Map<string, PersistedSessionHeadChange<IdentifiedSessionHead>>;
   removedSessionIds: Set<string>;
   meta: Record<string, SessionCacheMeta>;
-  searchIndexOptions?: SearchIndexSyncOptions;
+  searchIndexOptions?: SearchIndexWorkerOptions;
 }
 
 interface PendingAgentJobs {
@@ -38,6 +43,7 @@ export interface SearchIndexJobBatch {
   readonly context: string;
   readonly jobs: SearchIndexWorkerJob[];
   start(onError: (error: unknown) => void): void;
+  progress(progress: SearchIndexPublicationProgress, onError: (error: unknown) => void): void;
 }
 
 class PendingSearchIndexJobBatch implements SearchIndexJobBatch {
@@ -81,6 +87,17 @@ class PendingSearchIndexJobBatch implements SearchIndexJobBatch {
     for (const waiter of this.waiters) {
       try {
         waiter.onStarted?.();
+      } catch (error) {
+        onError(error);
+      }
+    }
+  }
+
+  progress(progress: SearchIndexPublicationProgress, onError: (error: unknown) => void): void {
+    for (const waiter of this.waiters) {
+      if (!waiter.agentNames.has(progress.agentName)) continue;
+      try {
+        waiter.onProgress?.(progress);
       } catch (error) {
         onError(error);
       }
@@ -140,11 +157,18 @@ export class PendingSearchIndexJobs {
     context: string,
     jobs: SearchIndexWorkerJob[],
     onStarted?: () => void,
+    onProgress?: (progress: SearchIndexPublicationProgress) => void,
   ): Promise<void> {
     if (jobs.length === 0) return Promise.resolve();
 
     return new Promise((resolve, reject) => {
-      const waiter = { resolve, reject, onStarted };
+      const waiter = {
+        resolve,
+        reject,
+        onStarted,
+        onProgress,
+        agentNames: new Set(jobs.map((job) => job.agentName)),
+      };
       if (this.pendingBatch) {
         this.pendingBatch.merge(context, jobs, waiter);
       } else {
@@ -216,9 +240,9 @@ function mergeChanges(pending: PendingChanges, job: IncrementalSearchIndexJob): 
 }
 
 function mergeSearchIndexOptions(
-  current: SearchIndexSyncOptions | undefined,
-  incoming: SearchIndexSyncOptions | undefined,
-): SearchIndexSyncOptions | undefined {
+  current: SearchIndexWorkerOptions | undefined,
+  incoming: SearchIndexWorkerOptions | undefined,
+): SearchIndexWorkerOptions | undefined {
   if (!current) return incoming;
   if (!incoming) return current;
   return { ...current, ...incoming };

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -369,6 +369,11 @@ async function run(
     | {
         sourceCount: number;
         removedCount: number;
+        enumerationMs: number;
+        diffMs: number;
+        parseMs: number;
+        changedCount: number;
+        processedCount: number;
       }
     | undefined;
 
@@ -388,6 +393,11 @@ async function run(
     sourceSynchronizationDetails = {
       sourceCount: result.sourceCount,
       removedCount: result.removedSourceCount,
+      enumerationMs: result.timing.enumerationMs,
+      diffMs: result.timing.diffMs,
+      parseMs: result.timing.parseMs,
+      changedCount: result.timing.changedSourceCount,
+      processedCount: result.timing.processedSourceCount,
     };
     sourceFailures = result.sourceFailures;
     explicitRemovedSessionIds = result.explicitRemovedSessionIds;
@@ -446,6 +456,11 @@ async function run(
     changed_ids: changedIds?.length ?? 0,
     source_count: sourceSynchronizationDetails?.sourceCount,
     removed_count: sourceSynchronizationDetails?.removedCount,
+    source_enumeration_ms: roundMilliseconds(sourceSynchronizationDetails?.enumerationMs ?? 0),
+    source_diff_ms: roundMilliseconds(sourceSynchronizationDetails?.diffMs ?? 0),
+    source_parse_ms: roundMilliseconds(sourceSynchronizationDetails?.parseMs ?? 0),
+    changed_sources: sourceSynchronizationDetails?.changedCount,
+    processed_sources: sourceSynchronizationDetails?.processedCount,
     failed_sources: sourceFailures.length,
     duration_ms: Math.round(scanDuration),
   });

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -41,7 +41,9 @@ const workerMocks = vi.hoisted(() => {
 
 vi.mock("node:worker_threads", () => ({ Worker: workerMocks.FakeWorker }));
 vi.mock("node:fs", () => ({ existsSync: () => workerMocks.workerExists }));
-vi.mock("@codesesh/core/runtime", () => ({ getPricingGeneration: () => ({ id: 17 }) }));
+vi.mock("@codesesh/core/runtime", () => ({
+  getPricingGeneration: () => ({ id: 17 }),
+}));
 vi.mock("./logging.js", () => ({
   appLogger: {
     debug: vi.fn(),
@@ -109,6 +111,24 @@ describe("SearchIndexJobRunner", () => {
 
     expect(workerMocks.consumeWorkerMessage).toHaveBeenNthCalledWith(1, logMessage);
     await expect(completion).resolves.toBeUndefined();
+  });
+
+  it("reports durable publication stages from the worker", async () => {
+    const runner = new SearchIndexJobRunner();
+    const progress = vi.fn();
+    const completion = runner.enqueue("scan.backfill", [makeJob()], undefined, progress);
+    const worker = startedWorker();
+    worker.post({ type: "publication-progress", agentName: "codex", stage: "prepared" });
+
+    expect(progress).toHaveBeenCalledWith({ agentName: "codex", stage: "prepared" });
+    worker.post({
+      type: "done",
+      context: "scan.backfill",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
+    await completion;
   });
 
   it("pins each worker batch to the current pricing generation", async () => {

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -8,6 +8,7 @@ import { PendingSearchIndexJobs, type SearchIndexJobBatch } from "./pending-sear
 import type {
   SearchIndexWorkerJob,
   SearchIndexWorkerMessage,
+  SearchIndexPublicationProgress,
   SearchIndexWorkerRunRequest,
 } from "./search-index-worker.js";
 
@@ -30,8 +31,13 @@ export class SearchIndexJobRunner {
   private pendingMaintenanceJobs = new PendingSearchIndexJobs();
   private isShuttingDown = false;
 
-  enqueue(context: string, jobs: SearchIndexWorkerJob[], onStarted?: () => void): Promise<void> {
-    return this.enqueueIn(this.pendingJobs, context, jobs, onStarted);
+  enqueue(
+    context: string,
+    jobs: SearchIndexWorkerJob[],
+    onStarted?: () => void,
+    onProgress?: (progress: SearchIndexPublicationProgress) => void,
+  ): Promise<void> {
+    return this.enqueueIn(this.pendingJobs, context, jobs, onStarted, onProgress);
   }
 
   enqueueMaintenance(context: string, jobs: SearchIndexWorkerJob[]): Promise<void> {
@@ -43,12 +49,13 @@ export class SearchIndexJobRunner {
     context: string,
     jobs: SearchIndexWorkerJob[],
     onStarted?: () => void,
+    onProgress?: (progress: SearchIndexPublicationProgress) => void,
   ): Promise<void> {
     if (jobs.length === 0) return Promise.resolve();
     if (this.isShuttingDown) return Promise.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
 
     const batchId = this.nextBatchId++;
-    const completion = queue.enqueue(batchId, context, jobs, onStarted);
+    const completion = queue.enqueue(batchId, context, jobs, onStarted, onProgress);
     if (this.activeBatch) {
       const snapshot = this.snapshot();
       appLogger.debug("search_index.worker_queued", {
@@ -162,6 +169,17 @@ export class SearchIndexJobRunner {
       if (this.worker !== worker) return;
       const activeBatch = this.activeBatch;
       if (!activeBatch) return;
+      if (message.type === "publication-progress") {
+        const { agentName, stage } = message;
+        activeBatch.progress({ agentName, stage }, (error) => {
+          appLogger.error("search_index.worker_progress_listener_failed", {
+            batch_id: activeBatch.id,
+            context: activeBatch.context,
+            error: toError(error),
+          });
+        });
+        return;
+      }
       if (message.type === "sync-result") {
         logSearchIndexSync(message.context, message.result);
         return;

--- a/packages/cli/src/search-index-publisher.ts
+++ b/packages/cli/src/search-index-publisher.ts
@@ -1,7 +1,10 @@
 import { buildAgentCacheMeta, type CachedResult, type LiveSnapshot } from "@codesesh/core/runtime";
 import { appLogger } from "./logging.js";
 import type { SearchIndexJobRunner } from "./search-index-job-runner.js";
-import type { SearchIndexWorkerJob } from "./search-index-worker.js";
+import type {
+  SearchIndexPublicationProgress,
+  SearchIndexWorkerJob,
+} from "./search-index-worker.js";
 
 export interface SearchIndexPublisherOptions {
   jobs: SearchIndexJobRunner;
@@ -62,6 +65,7 @@ export class SearchIndexPublisher {
       agent?: string;
       agents?: string[];
       onStarted?: () => void;
+      onProgress?: (progress: SearchIndexPublicationProgress) => void;
     },
   ): Promise<void> {
     appLogger.info("session.publication.prepared", {
@@ -76,9 +80,11 @@ export class SearchIndexPublisher {
         ...job,
         publicationId: details.publicationId,
       }));
-      await (details.onStarted
-        ? this.options.jobs.enqueue(context, publicationJobs, details.onStarted)
-        : this.options.jobs.enqueue(context, publicationJobs));
+      await (details.onProgress
+        ? this.options.jobs.enqueue(context, publicationJobs, details.onStarted, details.onProgress)
+        : details.onStarted
+          ? this.options.jobs.enqueue(context, publicationJobs, details.onStarted)
+          : this.options.jobs.enqueue(context, publicationJobs));
     } catch (error) {
       appLogger.error("session.publication.failed", {
         publication_id: details.publicationId,

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -190,8 +190,13 @@ describe("search index worker", () => {
     const meta = { s1: { id: "s1" } };
     mocks.createRegisteredAgents.mockReturnValue([agent]);
     mocks.commitDurableSessionPublication.mockImplementation(
-      (_publication: unknown, readSession: (id: string) => unknown) => {
+      (
+        _publication: unknown,
+        readSession: (id: string) => unknown,
+        options: { onPublicationStage?: (stage: string) => void },
+      ) => {
         expect(readSession("s1")).toEqual(makeSession("s1"));
+        options.onPublicationStage?.("prepared");
         return {
           status: "committed",
           publicationId: "publication-full",
@@ -233,8 +238,16 @@ describe("search index worker", () => {
         publicationId: "scan.refresh:codex:1",
       },
       expect.any(Function),
-      { force: true },
+      expect.objectContaining({
+        force: true,
+        onPublicationStage: expect.any(Function),
+      }),
     );
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      type: "publication-progress",
+      agentName: "codex",
+      stage: "prepared",
+    });
     expect(mocks.markAgentCacheInitialized).toHaveBeenCalledWith("codex");
     expect(mocks.appLoggerWarn).not.toHaveBeenCalled();
   });
@@ -279,7 +292,7 @@ describe("search index worker", () => {
         removedSessionIds: ["removed"],
       },
       expect.any(Function),
-      undefined,
+      { onPublicationStage: expect.any(Function) },
     );
   });
 
@@ -368,7 +381,10 @@ describe("search index worker", () => {
         meta: {},
       },
       expect.any(Function),
-      { force: true },
+      expect.objectContaining({
+        force: true,
+        onPublicationStage: expect.any(Function),
+      }),
     );
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: "done", sessions: 1 }),

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -12,6 +12,7 @@ import {
   type IdentifiedSessionHead,
   type SearchIndexSyncResult,
   type SearchIndexSyncOptions,
+  type SearchIndexPublicationStage,
   type SessionCacheMeta,
   type PersistedSessionHeadChange,
   type SessionSnapshotCompleteness,
@@ -20,6 +21,13 @@ import {
 import { appLogger } from "./logging.js";
 
 export type SearchIndexPersistStage = DurableSessionPublicationFailureStage;
+
+export interface SearchIndexPublicationProgress {
+  agentName: string;
+  stage: SearchIndexPublicationStage;
+}
+
+export type SearchIndexWorkerOptions = Omit<SearchIndexSyncOptions, "onPublicationStage">;
 
 export type SearchIndexWorkerMessage =
   | {
@@ -37,6 +45,7 @@ export type SearchIndexWorkerMessage =
       /** True when the job carries a durable publication whose staged state must be rolled back. */
       fatal: boolean;
     }
+  | ({ type: "publication-progress" } & SearchIndexPublicationProgress)
   | {
       type: "done";
       context: string;
@@ -56,7 +65,7 @@ export type SearchIndexWorkerJob =
       removedSessionIds: string[];
       publicationId?: string;
       saveCache?: boolean;
-      searchIndexOptions?: SearchIndexSyncOptions;
+      searchIndexOptions?: SearchIndexWorkerOptions;
     }
   | {
       kind: "changes";
@@ -66,7 +75,7 @@ export type SearchIndexWorkerJob =
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
       publicationId?: string;
-      searchIndexOptions?: SearchIndexSyncOptions;
+      searchIndexOptions?: SearchIndexWorkerOptions;
     }
   | {
       kind: "maintenance";
@@ -75,7 +84,7 @@ export type SearchIndexWorkerJob =
       changes: PersistedSessionHeadChange<IdentifiedSessionHead>[];
       removedSessionIds: string[];
       meta: Record<string, SessionCacheMeta>;
-      searchIndexOptions?: SearchIndexSyncOptions;
+      searchIndexOptions?: SearchIndexWorkerOptions;
     };
 
 export interface SearchIndexWorkerRunRequest {
@@ -162,7 +171,7 @@ function runJob(
         ...(job.publicationId ? { publicationId: job.publicationId } : {}),
       },
       (sessionId) => agent.getSessionData(sessionId),
-      job.searchIndexOptions,
+      publicationSearchIndexOptions(job),
     );
     if (publication.status === "rolled-back") return publication;
     postSyncResult(job.context, publication.searchIndex);
@@ -181,7 +190,7 @@ function runJob(
         ...(job.publicationId ? { publicationId: job.publicationId } : {}),
       },
       (sessionId) => agent.getSessionData(sessionId),
-      job.searchIndexOptions,
+      publicationSearchIndexOptions(job),
     );
     if (publication.status === "rolled-back") return publication;
     const result = publication.searchIndex;
@@ -208,6 +217,19 @@ function runJob(
   if (!result) return { stage: "search_index", publicationId };
   postSyncResult(job.context, result);
   return null;
+}
+
+function publicationSearchIndexOptions(job: SearchIndexWorkerJob): SearchIndexSyncOptions {
+  return {
+    ...job.searchIndexOptions,
+    onPublicationStage: (stage) => {
+      parentPort?.postMessage({
+        type: "publication-progress",
+        agentName: job.agentName,
+        stage,
+      } satisfies SearchIndexWorkerMessage);
+    },
+  };
 }
 
 function postSyncResult(context: string, result: SearchIndexSyncResult): void {

--- a/packages/cli/src/session-publication.ts
+++ b/packages/cli/src/session-publication.ts
@@ -3,7 +3,10 @@ import type { SessionsUpdatedEvent } from "@codesesh/core/contract";
 import type { LiveSessionIndex } from "./live-session-index.js";
 import { appLogger } from "./logging.js";
 import type { SearchIndexPublisher } from "./search-index-publisher.js";
-import type { SearchIndexWorkerJob } from "./search-index-worker.js";
+import type {
+  SearchIndexPublicationProgress,
+  SearchIndexWorkerJob,
+} from "./search-index-worker.js";
 
 export interface AgentSessionsChanged {
   agentName: string;
@@ -18,6 +21,7 @@ export interface SessionPublication {
   candidateChangedIds: string[];
   indexJob: SearchIndexWorkerJob;
   onPublishing?: () => void;
+  onPublicationProgress?: (progress: SearchIndexPublicationProgress) => void;
   onCommitted?: (result: SessionPublicationResult) => void;
 }
 
@@ -60,6 +64,9 @@ export class SessionPublicationCoordinator {
       publicationId,
       agent: publication.agentName,
       ...(publication.onPublishing ? { onStarted: publication.onPublishing } : {}),
+      ...(publication.onPublicationProgress
+        ? { onProgress: publication.onPublicationProgress }
+        : {}),
     });
     const diffStartedAt = performance.now();
     const event = this.sessionIndex.commitAgentSessions(

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -632,6 +632,22 @@ describe("FileSystemSessionSource.checkForChanges", () => {
 });
 
 describe("FileSystemSessionSource.incrementalScan", () => {
+  it("reports source enumeration, change, and processing workload", () => {
+    const agent = new FakeFileSystemSource([source("a"), source("b")]);
+
+    const result = agent.synchronizeSessionSources({ sessions: [], meta: {} }, { kind: "reload" });
+
+    expect(result.timing).toMatchObject({
+      totalMs: expect.any(Number),
+      enumerationMs: expect.any(Number),
+      diffMs: expect.any(Number),
+      parseMs: expect.any(Number),
+      enumeratedSourceCount: 2,
+      changedSourceCount: 2,
+      processedSourceCount: 2,
+    });
+  });
+
   it("re-parses changed sources and merges into cached sessions", () => {
     const agent = new FakeFileSystemSource([
       source("a", "fp-1", { head: makeSession("a") }),

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -1778,6 +1778,7 @@ describe("CodexAgent subagent folding", () => {
       threadSource: "subagent",
       parentThreadId: PARENT_ID,
       extra: [
+        tokenCountLine(40, 60, 100),
         '{"timestamp":"2026-04-20T10:03:00Z","type":"response_item","phase":"final_answer","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first child result"}]}}',
       ],
     });
@@ -1786,14 +1787,17 @@ describe("CodexAgent subagent folding", () => {
     const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
     agent.sessionIndexCache = new Map();
     agent.scan({ from: 0 });
-    agent.getSessionData(PARENT_ID);
-
     const openSpy = vi.mocked(openSync);
+    openSpy.mockClear();
+    const initial = agent.getSessionData(PARENT_ID);
+    expect(childOpenCount(childFile)).toBe(1);
+    expect(initial.stats.total_input_tokens).toBe(40);
+
     openSpy.mockClear();
     agent.getSessionData(PARENT_ID);
     expect(childOpenCount(childFile)).toBe(0);
 
-    const cacheEntry = agent.childFinalMessagesByParent.get(PARENT_ID)?.get(childFile);
+    const cacheEntry = agent.childSessionSummariesByParent.get(PARENT_ID)?.get(childFile);
     expect(cacheEntry).toBeDefined();
     cacheEntry.parserVersion = "codex-parser-old";
     openSpy.mockClear();
@@ -1804,12 +1808,14 @@ describe("CodexAgent subagent folding", () => {
       threadSource: "subagent",
       parentThreadId: PARENT_ID,
       extra: [
+        tokenCountLine(50, 70, 120),
         '{"timestamp":"2026-04-20T10:03:00Z","type":"response_item","phase":"final_answer","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"updated child result"}]}}',
       ],
     });
     openSpy.mockClear();
     const refreshed = agent.getSessionData(PARENT_ID);
     expect(childOpenCount(childFile)).toBeGreaterThan(0);
+    expect(refreshed.stats.total_input_tokens).toBe(50);
     expect(refreshed.messages).toContainEqual(
       expect.objectContaining({
         parts: [expect.objectContaining({ type: "text", text: "updated child result" })],
@@ -1854,12 +1860,12 @@ describe("CodexAgent subagent folding", () => {
     agent.sessionIndexCache = new Map();
     agent.scan({ from: 0 });
     agent.getSessionData(PARENT_ID);
-    expect(agent.childFinalMessagesByParent.get(PARENT_ID)?.has(childFile)).toBe(true);
+    expect(agent.childSessionSummariesByParent.get(PARENT_ID)?.has(childFile)).toBe(true);
 
     rmSync(childFile);
     agent.subagentIndex = null;
     agent.getSessionData(PARENT_ID);
-    expect(agent.childFinalMessagesByParent.has(PARENT_ID)).toBe(false);
+    expect(agent.childSessionSummariesByParent.has(PARENT_ID)).toBe(false);
   });
 
   it("finds child rollouts when detail parsing starts from cached metadata", () => {

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -322,6 +322,78 @@ describe("CodexAgent cache refresh", () => {
     expect(agent.ensureSubagentIndex().childFilesByParent.get(otherParentId)).toEqual([childFile]);
   });
 
+  it("rebuilds the subagent index from persisted session metadata", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const parentId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const childId = "019dcccc-cccc-7ccc-cccc-cccccccccccc";
+    const parentFile = join(tempDir, `rollout-2026-04-20T10-00-00-${parentId}.jsonl`);
+    const childFile = join(tempDir, `rollout-2026-04-20T10-05-00-${childId}.jsonl`);
+    writeFileSync(
+      parentFile,
+      `${JSON.stringify({ type: "session_meta", payload: { id: parentId } })}\n`,
+    );
+    writeFileSync(
+      childFile,
+      `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: childId, thread_source: "subagent", parent_thread_id: parentId },
+      })}\n`,
+    );
+
+    const firstAgent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    firstAgent.scan();
+    const cachedMeta = firstAgent.snapshotSessionCacheMeta();
+    expect(cachedMeta[childId]).toMatchObject({ isSubagent: true, parentThreadId: parentId });
+
+    const restoredAgent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    restoredAgent.restoreSessionCacheMeta(cachedMeta);
+    const openSpy = vi.mocked(openSync);
+    openSpy.mockClear();
+    const readDirectorySpy = vi.spyOn(restoredAgent, "readSessionSourceDirectory");
+
+    const sources = restoredAgent.listScanSources({ from: 0 });
+
+    expect(sources.map((source: { file: string }) => source.file).sort()).toEqual(
+      [parentFile, childFile].sort(),
+    );
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(readDirectorySpy).toHaveBeenCalledOnce();
+    expect(restoredAgent.ensureSubagentIndex().childFilesByParent.get(parentId)).toEqual([
+      childFile,
+    ]);
+  });
+
+  it("upgrades legacy session metadata while rebuilding the subagent index", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-test-"));
+    tempDirs.push(tempDir);
+    const parentId = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const childId = "019dcccc-cccc-7ccc-cccc-cccccccccccc";
+    const childFile = join(tempDir, `rollout-2026-04-20T10-05-00-${childId}.jsonl`);
+    writeFileSync(
+      childFile,
+      `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: childId, thread_source: "subagent", parent_thread_id: parentId },
+      })}\n`,
+    );
+
+    const firstAgent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    firstAgent.scan();
+    const cachedMeta = firstAgent.snapshotSessionCacheMeta();
+    delete cachedMeta[childId].isSubagent;
+    delete cachedMeta[childId].parentThreadId;
+
+    const restoredAgent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    restoredAgent.restoreSessionCacheMeta(cachedMeta);
+    restoredAgent.listScanSources({ from: 0 });
+
+    expect(restoredAgent.snapshotSessionCacheMeta()[childId]).toMatchObject({
+      isSubagent: true,
+      parentThreadId: parentId,
+    });
+  });
+
   it("keeps source references and fingerprints byte-for-byte stable", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-codex-fingerprint-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -42,6 +42,7 @@ export type {
   SessionSourceSynchronizationBaseline,
   SessionSourceSynchronizationOutcome,
   SessionSourceSynchronizationRequest,
+  SessionSourceSynchronizationTiming,
 } from "./session-source-synchronization.js";
 
 export type { ParseSessionResult };

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -114,10 +114,14 @@ interface SessionMeta extends FileSessionMeta {
   parentThreadId: string | null;
 }
 
-interface ChildFinalMessageCacheEntry {
+interface ChildSessionSummary {
+  stats: SessionHead["stats"];
+  message: Message | null;
+}
+
+interface ChildSessionSummaryCacheEntry extends ChildSessionSummary {
   sourceFingerprint: string;
   parserVersion: string;
-  message: Message | null;
 }
 
 class ChildMessageVisibilityIndex {
@@ -198,8 +202,10 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     string,
     { fingerprint: string; meta: ThreadMeta | null }
   >();
-  private subagentStatsByParent = new Map<string, SessionHead["stats"][]>();
-  private childFinalMessagesByParent = new Map<string, Map<string, ChildFinalMessageCacheEntry>>();
+  private childSessionSummariesByParent = new Map<
+    string,
+    Map<string, ChildSessionSummaryCacheEntry>
+  >();
 
   // ---- BaseAgent implementation ----
 
@@ -247,8 +253,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   restoreSessionCacheMeta(meta: Readonly<Record<string, SessionCacheMeta>>): void {
     super.restoreSessionCacheMeta(meta);
     this.subagentIndex = null;
-    this.subagentStatsByParent.clear();
-    this.childFinalMessagesByParent.clear();
+    this.childSessionSummariesByParent.clear();
   }
 
   /**
@@ -271,8 +276,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       if (!parentId) continue;
       expanded.add(parentId);
       this.subagentIndex = null;
-      this.subagentStatsByParent.delete(parentId);
-      this.childFinalMessagesByParent.delete(parentId);
+      this.childSessionSummariesByParent.delete(parentId);
     }
     return [...expanded];
   }
@@ -297,33 +301,6 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       });
       return null;
     }
-  }
-
-  private parseTokenStats(filePath: string): SessionHead["stats"] {
-    const usage = new CodexTokenUsageAccumulator();
-    let activeModel: string | null = null;
-
-    for (const line of readJsonlFileLines(filePath)) {
-      try {
-        const data = JSON.parse(line);
-        const recordType = String(data["type"] ?? "");
-        const payload = extractCodexPayload(data);
-
-        if (recordType === "session_meta" || recordType === "turn_context") {
-          const nextModel = extractModelName(payload["model"]);
-          if (nextModel) activeModel = nextModel;
-          continue;
-        }
-
-        if (recordType === "event_msg" && String(payload["type"] ?? "") === "token_count") {
-          usage.consume(payload, activeModel);
-        }
-      } catch {
-        // skip malformed records
-      }
-    }
-
-    return usage.stats();
   }
 
   getSessionData(sessionId: string): SessionDetail {
@@ -375,9 +352,12 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     if (pendingPlan) transcript.appendToCurrentAssistant(pendingPlan);
     const result = transcript.finish(usage.stats());
 
-    this.applyChildStats(result.stats, meta.id);
+    const childSummaries = this.collectChildSummaries(meta.id);
+    this.applyChildStats(result.stats, childSummaries);
 
-    const childMessages = this.collectChildMessages(meta.id);
+    const childMessages = childSummaries
+      .flatMap(({ message }) => (message ? [message] : []))
+      .sort((left, right) => left.time_created - right.time_created);
     this.mergeChildMessages(result.messages, childMessages);
     result.stats.message_count = result.messages.length;
 
@@ -446,8 +426,8 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     return index;
   }
 
-  private applyChildStats(target: SessionHead["stats"], sessionId: string): void {
-    for (const stats of this.collectChildStats(sessionId)) {
+  private applyChildStats(target: SessionHead["stats"], summaries: ChildSessionSummary[]): void {
+    for (const { stats } of summaries) {
       target.total_input_tokens += stats.total_input_tokens ?? 0;
       target.total_output_tokens += stats.total_output_tokens ?? 0;
       target.total_cost += stats.total_cost ?? 0;
@@ -456,17 +436,6 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
           (target.total_cache_read_tokens ?? 0) + stats.total_cache_read_tokens;
       }
     }
-  }
-
-  private collectChildStats(parentSessionId: string): SessionHead["stats"][] {
-    const files = this.collectChildFiles(parentSessionId);
-    if (files.length === 0) return [];
-    const cached = this.subagentStatsByParent.get(parentSessionId);
-    if (cached) return cached;
-
-    const stats = files.map((file) => this.parseTokenStats(file));
-    this.subagentStatsByParent.set(parentSessionId, stats);
-    return stats;
   }
 
   private collectChildFiles(parentSessionId: string): string[] {
@@ -482,23 +451,19 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     }
   }
 
-  private collectChildMessages(parentSessionId: string): Message[] {
+  private collectChildSummaries(parentSessionId: string): ChildSessionSummary[] {
     const childFiles = this.collectChildFiles(parentSessionId);
-    this.reconcileChildFinalMessageCache(parentSessionId, childFiles);
-    return childFiles
-      .flatMap((file) => {
-        const message = this.getChildFinalMessage(parentSessionId, file);
-        return message ? [message] : [];
-      })
-      .sort((left, right) => left.time_created - right.time_created);
+    this.reconcileChildSummaryCache(parentSessionId, childFiles);
+    return childFiles.map((file) => this.getChildSummary(parentSessionId, file));
   }
 
-  private getChildFinalMessage(parentSessionId: string, filePath: string): Message | null {
-    const sourceFingerprint = this.childFinalMessageFingerprint(filePath);
-    let cache = this.childFinalMessagesByParent.get(parentSessionId);
+  private getChildSummary(parentSessionId: string, filePath: string): ChildSessionSummary {
+    const { mtimeMs, size } = statSync(filePath);
+    const sourceFingerprint = JSON.stringify([mtimeMs, size]);
+    let cache = this.childSessionSummariesByParent.get(parentSessionId);
     if (!cache) {
       cache = new Map();
-      this.childFinalMessagesByParent.set(parentSessionId, cache);
+      this.childSessionSummariesByParent.set(parentSessionId, cache);
     }
 
     const cached = cache.get(filePath);
@@ -506,43 +471,51 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       cached?.sourceFingerprint === sourceFingerprint &&
       cached.parserVersion === PARSER_VERSION
     ) {
-      return cached.message;
+      return cached;
     }
 
-    const message = this.readChildFinalMessage(filePath);
-    cache.set(filePath, { sourceFingerprint, parserVersion: PARSER_VERSION, message });
-    return message;
+    const summary = this.readChildSummary(filePath, mtimeMs, size);
+    cache.set(filePath, { sourceFingerprint, parserVersion: PARSER_VERSION, ...summary });
+    return summary;
   }
 
-  private reconcileChildFinalMessageCache(parentSessionId: string, childFiles: string[]): void {
-    const cache = this.childFinalMessagesByParent.get(parentSessionId);
+  private reconcileChildSummaryCache(parentSessionId: string, childFiles: string[]): void {
+    const cache = this.childSessionSummariesByParent.get(parentSessionId);
     if (!cache) return;
 
     const activeFiles = new Set(childFiles);
     for (const filePath of cache.keys()) {
       if (!activeFiles.has(filePath)) cache.delete(filePath);
     }
-    if (cache.size === 0) this.childFinalMessagesByParent.delete(parentSessionId);
+    if (cache.size === 0) this.childSessionSummariesByParent.delete(parentSessionId);
   }
 
-  private childFinalMessageFingerprint(filePath: string): string {
-    const { mtimeMs, size } = statSync(filePath);
-    return JSON.stringify([mtimeMs, size]);
-  }
-
-  private readChildFinalMessage(filePath: string): Message | null {
+  private readChildSummary(
+    filePath: string,
+    fallbackMtimeMs: number,
+    size: number,
+  ): ChildSessionSummary {
     const sessionId = extractSessionId(filePath);
-    const threadMeta = this.readThreadMeta(filePath);
+    const threadMeta = this.readThreadMeta(filePath, { mtimeMs: fallbackMtimeMs, size });
+    const usage = new CodexTokenUsageAccumulator();
+    let activeModel: string | null = null;
     type ChildOutput = { id: string; text: string; timestampMs: number; isFinal: boolean };
     let latestOutput: ChildOutput | null = null;
     let finalOutput: ChildOutput | null = null;
-    let fallbackMtimeMs: number | null = null;
 
     for (const record of readJsonlFile(filePath)) {
       try {
         const recordType = String(record["type"] ?? "");
-        if (recordType !== "response_item") continue;
         const payload = extractCodexPayload(record);
+        if (recordType === "session_meta" || recordType === "turn_context") {
+          activeModel = extractModelName(payload["model"]) ?? activeModel;
+          continue;
+        }
+        if (recordType === "event_msg" && String(payload["type"] ?? "") === "token_count") {
+          usage.consume(payload, activeModel);
+          continue;
+        }
+        if (recordType !== "response_item") continue;
         if (String(payload["type"] ?? "") !== "message") continue;
         if (String(payload["role"] ?? "") !== "assistant") continue;
 
@@ -553,9 +526,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
           id: asString(payload["id"]) ?? `codex-subagent-${sessionId}`,
           text,
           timestampMs:
-            parseCodexTimestampMs(record) ||
-            parseCodexTimestampMs(payload) ||
-            (fallbackMtimeMs ??= statSync(filePath).mtimeMs),
+            parseCodexTimestampMs(record) || parseCodexTimestampMs(payload) || fallbackMtimeMs,
           isFinal:
             String(record["phase"] ?? "") === "final_answer" ||
             String(payload["phase"] ?? "") === "final_answer",
@@ -568,20 +539,23 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     }
 
     const selected = finalOutput ?? latestOutput;
-    if (!selected) return null;
-
     return {
-      id: selected.id,
-      role: "assistant",
-      agent: "codex",
-      time_created: selected.timestampMs,
-      mode: null,
-      model: null,
-      provider: null,
-      cost: 0,
-      subagent_id: sessionId,
-      nickname: threadMeta?.agentNickname ?? undefined,
-      parts: [{ type: "text", text: selected.text, time_created: selected.timestampMs }],
+      stats: usage.stats(),
+      message: selected
+        ? {
+            id: selected.id,
+            role: "assistant",
+            agent: "codex",
+            time_created: selected.timestampMs,
+            mode: null,
+            model: null,
+            provider: null,
+            cost: 0,
+            subagent_id: sessionId,
+            nickname: threadMeta?.agentNickname ?? undefined,
+            parts: [{ type: "text", text: selected.text, time_created: selected.timestampMs }],
+          }
+        : null,
     };
   }
 

--- a/packages/core/src/agents/codex.ts
+++ b/packages/core/src/agents/codex.ts
@@ -110,6 +110,7 @@ interface SessionMeta extends FileSessionMeta {
   indexMtimeMs: number | null;
   headIndexVersion: string;
   parserVersion: string;
+  isSubagent: boolean;
   parentThreadId: string | null;
 }
 
@@ -276,9 +277,12 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     return [...expanded];
   }
 
-  private readThreadMeta(filePath: string): ThreadMeta | null {
+  private readThreadMeta(
+    filePath: string,
+    sourceStat?: { mtimeMs: number; size: number },
+  ): ThreadMeta | null {
     try {
-      const { mtimeMs, size } = statSync(filePath);
+      const { mtimeMs, size } = sourceStat ?? statSync(filePath);
       const fingerprint = `${mtimeMs}:${size}`;
       const cached = this.threadMetaByPath.get(filePath);
       if (cached && cached.fingerprint === fingerprint) return cached.meta;
@@ -397,21 +401,42 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
    * afterwards means "no children", so per-session directory rescans (the old
    * O(N²) finalization hotspot) never happen.
    */
-  private ensureSubagentIndex(): SubagentIndex {
+  private ensureSubagentIndex(currentSources?: readonly SessionSourceFile[]): SubagentIndex {
     if (this.subagentIndex) return this.subagentIndex;
     this.basePath ??= this.findBasePath();
     const index: SubagentIndex = { childFilesByParent: new Map(), subagentFiles: new Set() };
-    const paths = this.listRolloutFilePaths();
-    for (const file of paths) {
-      const threadMeta = this.readThreadMeta(file);
-      if (threadMeta?.threadSource !== "subagent") continue;
+    const sourceByPath = new Map(currentSources?.map((source) => [source.file, source]));
+    const paths = currentSources?.map((source) => source.file) ?? this.listRolloutFilePaths();
+    const activePaths = currentSources ? null : new Set(paths);
+    const addSubagent = (file: string, parentThreadId: string | null): void => {
       index.subagentFiles.add(file);
-      if (!threadMeta.parentThreadId) continue;
-      const files = index.childFilesByParent.get(threadMeta.parentThreadId);
-      if (files) files.push(file);
-      else index.childFilesByParent.set(threadMeta.parentThreadId, [file]);
+      if (!parentThreadId) return;
+      const files = index.childFilesByParent.get(parentThreadId);
+      if (!files) index.childFilesByParent.set(parentThreadId, [file]);
+      else if (!files.includes(file)) files.push(file);
+    };
+    for (const meta of this.sessionMetaMap.values()) {
+      if (activePaths && !activePaths.has(meta.sourcePath)) continue;
+      const isKnownSubagent =
+        meta.isSubagent === true ||
+        (typeof meta.isSubagent !== "boolean" && meta.parentThreadId != null);
+      if (isKnownSubagent) addSubagent(meta.sourcePath, meta.parentThreadId);
     }
-    if (this.threadMetaByPath.size > paths.length) {
+    for (const file of paths) {
+      const cached = this.sessionMetaMap.get(extractSessionId(file));
+      const hasCachedThreadMeta =
+        cached?.sourcePath === file && typeof cached.isSubagent === "boolean";
+      if (hasCachedThreadMeta) continue;
+      const threadMeta = this.readThreadMeta(file, sourceByPath.get(file)?.stat);
+      const isSubagent = threadMeta?.threadSource === "subagent";
+      if (cached?.sourcePath === file && threadMeta) {
+        cached.isSubagent = isSubagent;
+        cached.parentThreadId = isSubagent ? threadMeta.parentThreadId : null;
+      }
+      if (!isSubagent) continue;
+      addSubagent(file, threadMeta?.parentThreadId ?? null);
+    }
+    if (!currentSources && this.threadMetaByPath.size > paths.length) {
       const active = new Set(paths);
       for (const path of this.threadMetaByPath.keys()) {
         if (!active.has(path)) this.threadMetaByPath.delete(path);
@@ -593,7 +618,7 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
     const windowed = this.listRolloutFiles(options).sort(compareSourceActivityDesc);
     if (options?.from == null && options?.to == null) return windowed;
 
-    const { childFilesByParent, subagentFiles } = this.ensureSubagentIndex();
+    const { childFilesByParent, subagentFiles } = this.ensureSubagentIndex(windowed);
     const rootFiles = windowed.filter((source) => !subagentFiles.has(source.file));
     const rootIds = new Set(rootFiles.map(({ file }) => extractSessionId(file)));
     if (rootIds.size === 0) return rootFiles;
@@ -605,11 +630,15 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
       const parentId = pending.pop()!;
       if (seenParents.has(parentId)) continue;
       seenParents.add(parentId);
-      for (const file of childFilesByParent.get(parentId) ?? []) {
+      const childFiles = childFilesByParent.get(parentId) ?? [];
+      for (let childIndex = childFiles.length - 1; childIndex >= 0; childIndex -= 1) {
+        const file = childFiles[childIndex]!;
         if (selected.has(file)) continue;
         try {
           selected.set(file, this.sessionSourceFile(file));
         } catch {
+          childFiles.splice(childIndex, 1);
+          subagentFiles.delete(file);
           continue;
         }
         pending.push(extractSessionId(file));
@@ -621,6 +650,8 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
   protected createFileSessionMeta(head: SessionHead, source: SessionSourceFile): SessionMeta {
     const indexPath = this.getSessionIndexPath();
     const indexMtime = this.sessionIndexMtime ?? null;
+    const threadMeta = this.readThreadMeta(source.file, source.stat);
+    const isSubagent = threadMeta?.threadSource === "subagent";
     return this.buildFileSessionMeta({
       head,
       source,
@@ -630,7 +661,8 @@ export class CodexAgent extends SingleFileSessionSource<SessionMeta> {
         indexMtimeMs: indexMtime,
         headIndexVersion: HEAD_INDEX_VERSION,
         parserVersion: PARSER_VERSION,
-        parentThreadId: head.parent_reference?.sessionId ?? null,
+        isSubagent,
+        parentThreadId: isSubagent ? threadMeta.parentThreadId : null,
       },
     });
   }

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -42,6 +42,7 @@ export type {
   SessionSourceSynchronizationBaseline,
   SessionSourceSynchronizationOutcome,
   SessionSourceSynchronizationRequest,
+  SessionSourceSynchronizationTiming,
   SessionWatchPlan,
   SessionWatchTarget,
 } from "./base.js";

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -58,6 +58,17 @@ export interface SessionSourceSynchronizationOutcome {
   completeness: SessionSnapshotCompleteness;
   sourceCount: number;
   removedSourceCount: number;
+  timing: SessionSourceSynchronizationTiming;
+}
+
+export interface SessionSourceSynchronizationTiming {
+  totalMs: number;
+  enumerationMs: number;
+  diffMs: number;
+  parseMs: number;
+  enumeratedSourceCount: number;
+  changedSourceCount: number;
+  processedSourceCount: number;
 }
 
 /** Parser/index revisions live inside the fingerprint, so comparison must be exact. */
@@ -252,6 +263,7 @@ export function synchronizeSessionSources(
   baseline: SessionSourceSynchronizationBaseline,
   request: SessionSourceSynchronizationRequest,
 ): SessionSourceSynchronizationOutcome {
+  const startedAt = performance.now();
   adapter.restoreSessionCacheMeta(baseline.meta);
   const baselineMeta = adapter.snapshotSessionCacheMeta();
   const baselineSessions = adapter.filterCachedSessions(baseline.sessions);
@@ -268,11 +280,12 @@ export function synchronizeSessionSources(
   }));
   adapter.removeSessionCacheMeta(filteredBaselineIds);
   const scanOptions = request.scanOptions;
-  const sources =
-    request.kind === "known-changes" && request.refs
-      ? request.refs
-      : adapter.listSessionSources(scanOptions);
+  const suppliedSources = request.kind === "known-changes" ? request.refs : undefined;
+  const enumerationStartedAt = performance.now();
+  const sources = suppliedSources ?? adapter.listSessionSources(scanOptions);
+  const enumerationMs = suppliedSources ? 0 : performance.now() - enumerationStartedAt;
   const sourceById = new Map(sources.map((source) => [source.sessionId, source]));
+  const diffStartedAt = performance.now();
   const diff =
     request.kind === "known-changes"
       ? { changedIds: request.changedIds, removedIds: [], failedIds: [], sourceOutcomes: [] }
@@ -282,6 +295,7 @@ export function synchronizeSessionSources(
           adapter.snapshotSessionCacheMeta(),
           scanOptions,
         );
+  const diffMs = performance.now() - diffStartedAt;
   const detectedSessionIds = unique([
     ...filteredBaselineIds,
     ...diff.changedIds,
@@ -310,6 +324,15 @@ export function synchronizeSessionSources(
       completeness: isWindowed(scanOptions) || sourceFailures.length > 0 ? "partial" : "complete",
       sourceCount: sources.length,
       removedSourceCount: diff.removedIds.length,
+      timing: {
+        totalMs: performance.now() - startedAt,
+        enumerationMs,
+        diffMs,
+        parseMs: 0,
+        enumeratedSourceCount: sources.length,
+        changedSourceCount: diff.changedIds.length,
+        processedSourceCount: 0,
+      },
     };
   }
 
@@ -341,6 +364,7 @@ export function synchronizeSessionSources(
     });
   }
 
+  const parseStartedAt = performance.now();
   synchronizationIds.forEach((sessionId, index) => {
     const source = sourceById.get(sessionId);
     if (!source) {
@@ -388,6 +412,7 @@ export function synchronizeSessionSources(
       sessions: sessionsById.size,
     });
   });
+  const parseMs = performance.now() - parseStartedAt;
 
   const failedIds = new Set(sourceFailures.map((failure) => failure.sessionId));
   const finalizeSessionIds = (
@@ -410,5 +435,14 @@ export function synchronizeSessionSources(
     completeness: isWindowed(scanOptions) || sourceFailures.length > 0 ? "partial" : "complete",
     sourceCount: sources.length,
     removedSourceCount: diff.removedIds.length,
+    timing: {
+      totalMs: performance.now() - startedAt,
+      enumerationMs,
+      diffMs,
+      parseMs,
+      enumeratedSourceCount: sources.length,
+      changedSourceCount: diff.changedIds.length,
+      processedSourceCount: synchronizationIds.length,
+    },
   };
 }

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -122,7 +122,7 @@ export interface ScanCompletion {
  * (capped at one agent at a time) periodically re-checks the rest of history.
  */
 export interface BackfillProgress {
-  phase?: "scanning" | "finalizing" | "publish-queued" | "publishing" | "indexing";
+  phase?: "scanning" | "finalizing" | "publish-queued" | "publishing" | "indexing" | "committing";
   total?: number;
   processed?: number;
   sessions?: number;

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -95,6 +95,9 @@ describe("session cache integration", () => {
       expect(plan.map(({ detail }) => detail)).toContainEqual(
         expect.stringContaining("COVERING INDEX idx_session_documents_state"),
       );
+      expect(plan.map(({ detail }) => detail)).toContainEqual(
+        expect.stringMatching(/COVERING INDEX .*messages/),
+      );
     } finally {
       db.close();
     }

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -863,6 +863,15 @@ describe("scanSessions", () => {
       completeness: "complete" as const,
       sourceCount: 1,
       removedSourceCount: 1,
+      timing: {
+        totalMs: 1,
+        enumerationMs: 0.2,
+        diffMs: 0.1,
+        parseMs: 0.5,
+        enumeratedSourceCount: 1,
+        changedSourceCount: 1,
+        processedSourceCount: 1,
+      },
     }));
     Object.assign(agent, {
       sessionSourceAccess: {

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -63,6 +63,11 @@ describe("search index writer", () => {
 
   it("reindexes file activity when only the project identity changes", () => {
     const initial = makeSessionHead("identity-change");
+    const meta = {
+      id: initial.reference.sessionId,
+      sourcePath: "/identity-change",
+      sourceFingerprint: "stable-source",
+    };
     const detail = (session: typeof initial) => ({
       ...makeSessionData(session.reference.sessionId),
       ...session,
@@ -81,7 +86,7 @@ describe("search index writer", () => {
         },
       ],
     });
-    saveCachedSessions("codex", [initial]);
+    saveCachedSessions("codex", [initial], { [initial.reference.sessionId]: meta });
     syncSessionSearchIndex("codex", [initial], () => detail(initial));
 
     const updated = {
@@ -102,16 +107,21 @@ describe("search index writer", () => {
         agentName: "codex",
         changes: [{ session: updated, sortIndex: 0 }],
         removedSessionIds: [],
-        meta: {},
+        meta: { [initial.reference.sessionId]: meta },
       },
       loadSession,
     );
 
     expect(publication).toMatchObject({
       status: "committed",
-      searchIndex: { changed: 1, indexed: 1 },
+      searchIndex: {
+        changed: 1,
+        indexed: 1,
+        getSessionDataCalls: 0,
+        reusedMaterializations: 1,
+      },
     });
-    expect(loadSession).toHaveBeenCalledOnce();
+    expect(loadSession).not.toHaveBeenCalled();
     expect(
       listFileActivity({
         projectKind: "git_remote",
@@ -119,6 +129,50 @@ describe("search index writer", () => {
       }),
     ).toHaveLength(1);
     expect(listFileActivity({ projectKind: "path", projectKey: "/workspace/project" })).toEqual([]);
+  });
+
+  it("reuses materialized messages when only indexed head metadata changes", () => {
+    const initial = makeSessionHead("head-only");
+    const meta = {
+      id: initial.reference.sessionId,
+      sourcePath: "/head-only",
+      sourceFingerprint: "stable-source",
+    };
+    saveCachedSessions("codex", [initial], { [initial.reference.sessionId]: meta });
+    syncSessionSearchIndex("codex", [initial], () =>
+      makeSessionData(initial.reference.sessionId, "preserved message body"),
+    );
+
+    const updated = { ...initial, title: "Renamed without reparsing" };
+    const loadSession = vi.fn(() => {
+      throw new Error("source detail should not be loaded");
+    });
+    const publication = commitDurableSessionPublication(
+      {
+        kind: "changes",
+        agentName: "codex",
+        changes: [{ session: updated, sortIndex: 0 }],
+        removedSessionIds: [],
+        meta: { [initial.reference.sessionId]: meta },
+      },
+      loadSession,
+    );
+
+    expect(publication).toMatchObject({
+      status: "committed",
+      searchIndex: {
+        changed: 1,
+        indexed: 1,
+        getSessionDataCalls: 0,
+        reusedMaterializations: 1,
+      },
+    });
+    expect(loadSession).not.toHaveBeenCalled();
+    expect(searchSessions("Renamed without reparsing")).toHaveLength(1);
+    expect(searchSessions("preserved message body")).toHaveLength(1);
+    expect(loadCachedSessionRawEntry("codex", initial.reference.sessionId)?.data.title).toBe(
+      updated.title,
+    );
   });
 
   it("keeps cache-owned fields when materializing an indexed head", () => {

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -41,6 +41,10 @@ describe("search index writer", () => {
       mode: "incremental",
       changed: 1,
       indexed: 1,
+      planningDurationMs: expect.any(Number),
+      getSessionDataCalls: 1,
+      getSessionDataDurationMs: expect.any(Number),
+      materializationDurationMs: expect.any(Number),
     });
     expect(searchSessions("needle")).toEqual([
       expect.objectContaining({
@@ -53,6 +57,7 @@ describe("search index writer", () => {
     expect(syncSessionSearchIndex("codex", [session], loadSession)).toMatchObject({
       changed: 0,
       indexed: 0,
+      getSessionDataCalls: 0,
     });
   });
 

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -175,6 +175,50 @@ describe("search index writer", () => {
     );
   });
 
+  it("reuses normalized Codex messages when raw head counts differ", () => {
+    const base = makeSessionHead("normalized-head-only");
+    const initial = {
+      ...base,
+      stats: { ...base.stats, message_count: 5 },
+    };
+    const meta = {
+      id: initial.reference.sessionId,
+      sourcePath: "/normalized-head-only",
+      sourceFingerprint: "stable-source",
+    };
+    saveCachedSessions("codex", [initial], { [initial.reference.sessionId]: meta });
+    syncSessionSearchIndex("codex", [initial], () =>
+      makeSessionData(initial.reference.sessionId, "normalized message body"),
+    );
+
+    const updated = { ...initial, title: "Renamed normalized session" };
+    const loadSession = vi.fn(() => {
+      throw new Error("source detail should not be loaded");
+    });
+    const publication = commitDurableSessionPublication(
+      {
+        kind: "changes",
+        agentName: "codex",
+        changes: [{ session: updated, sortIndex: 0 }],
+        removedSessionIds: [],
+        meta: { [initial.reference.sessionId]: meta },
+      },
+      loadSession,
+    );
+
+    expect(publication).toMatchObject({
+      status: "committed",
+      searchIndex: {
+        changed: 1,
+        indexed: 1,
+        getSessionDataCalls: 0,
+        reusedMaterializations: 1,
+      },
+    });
+    expect(loadSession).not.toHaveBeenCalled();
+    expect(searchSessions("normalized message body")).toHaveLength(1);
+  });
+
   it("keeps cache-owned fields when materializing an indexed head", () => {
     const other = makeSessionHead("other");
     const session = makeSessionHead("materialized");

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -326,6 +326,7 @@ describe("durable publication", () => {
     } finally {
       retryDb.close();
     }
+    const publicationStages: string[] = [];
     const retried = commitDurableSessionPublication(
       {
         kind: "snapshot",
@@ -336,9 +337,17 @@ describe("durable publication", () => {
         removedSessionIds: [],
       },
       () => makeSessionData("atomic", "updated content"),
+      { onPublicationStage: (stage) => publicationStages.push(stage) },
     );
 
     expect(retried.status).toBe("committed");
+    expect(publicationStages).toEqual([
+      "started",
+      "prepared",
+      "cache_staged",
+      "search_staged",
+      "committed",
+    ]);
     expect(readCachedValue("codex")?.sessions[0]?.title).toBe(updated.title);
     expect(readCachedValue("codex")?.meta.atomic?.sourcePath).toBe("/updated");
     expect(searchSessions("updated content")).toHaveLength(1);

--- a/packages/core/src/discovery/cache/publication.ts
+++ b/packages/core/src/discovery/cache/publication.ts
@@ -21,6 +21,7 @@ import {
   writeCachedSessionSnapshot,
 } from "./sessions.js";
 import type { SessionSnapshotCompleteness } from "./snapshot-types.js";
+import type { SearchIndexPublicationStage } from "./search-index-state.js";
 
 export type DurableSessionPublication =
   | {
@@ -57,6 +58,17 @@ export type DurableSessionPublicationCommitResult =
 
 function publicationSessionCount(publication: DurableSessionPublication): number {
   return publication.kind === "snapshot" ? publication.sessions.length : publication.changes.length;
+}
+
+function reportPublicationStage(
+  detail: Record<string, unknown>,
+  stage: SearchIndexPublicationStage,
+  options: SearchIndexSyncOptions,
+): void {
+  getCoreDiagnostics()?.info?.("search_index.publication_stage", { ...detail, stage });
+  try {
+    options.onPublicationStage?.(stage);
+  } catch {}
 }
 
 function publicationSearchOptions(
@@ -96,13 +108,12 @@ export function commitDurableSessionPublication(
   );
   const publicationId = publication.publicationId ?? randomUUID();
   let failureStage: DurableSessionPublicationFailureStage = "prepare";
-  const diagnostics = getCoreDiagnostics();
   const detail = {
     agent: publication.agentName,
     publication_id: publicationId,
     sessions: publicationSessionCount(publication),
   };
-  diagnostics?.info?.("search_index.publication_stage", { ...detail, stage: "started" });
+  reportPublicationStage(detail, "started", searchOptions);
 
   const searchIndex = withSearchIndexDb((db) => {
     const options = publicationSearchOptions(publication, searchOptions, publicationId);
@@ -123,7 +134,7 @@ export function commitDurableSessionPublication(
             loadSessionData,
             options,
           );
-    diagnostics?.info?.("search_index.publication_stage", { ...detail, stage: "prepared" });
+    reportPublicationStage(detail, "prepared", options);
 
     return db
       .transaction(() => {
@@ -148,17 +159,11 @@ export function commitDurableSessionPublication(
             publication.meta,
           );
         }
-        diagnostics?.info?.("search_index.publication_stage", {
-          ...detail,
-          stage: "cache_staged",
-        });
+        reportPublicationStage(detail, "cache_staged", options);
 
         failureStage = "search_index";
         const result = writePreparedSessionSearchIndex(db, prepared);
-        diagnostics?.info?.("search_index.publication_stage", {
-          ...detail,
-          stage: "search_staged",
-        });
+        reportPublicationStage(detail, "search_staged", options);
         advanceAnalyticsRevision(db);
         failureStage = "commit";
         return result;
@@ -168,7 +173,7 @@ export function commitDurableSessionPublication(
 
   if (!searchIndex) {
     discardPreparedSessionSearchIndex(publicationId, publication.agentName);
-    diagnostics?.warn("search_index.publication_stage", {
+    getCoreDiagnostics()?.warn("search_index.publication_stage", {
       ...detail,
       stage: "rolled_back",
       failure_stage: failureStage,
@@ -177,6 +182,6 @@ export function commitDurableSessionPublication(
   }
 
   deleteLegacyCacheFile();
-  diagnostics?.info?.("search_index.publication_stage", { ...detail, stage: "committed" });
+  reportPublicationStage(detail, "committed", searchOptions);
   return { status: "committed", publicationId, searchIndex };
 }

--- a/packages/core/src/discovery/cache/search-index-state.ts
+++ b/packages/core/src/discovery/cache/search-index-state.ts
@@ -224,38 +224,18 @@ export function searchIndexStateQuery(sessionIdCount: number): string {
       sessions.project_display_name AS session_project_display_name,
       sessions.project_identity_resolver_revision AS session_project_identity_resolver_revision,
       sessions.project_identity_input_signature AS session_project_identity_input_signature,
-      COUNT(messages.message_index) AS value
+      (
+        SELECT COUNT(*)
+        FROM messages
+        WHERE messages.agent_name = ?
+          AND messages.session_id = requested.session_id
+      ) AS value
     FROM requested_session_ids AS requested
     LEFT JOIN session_documents AS documents
       INDEXED BY idx_session_documents_state
       ON documents.agent_name = ? AND documents.session_id = requested.session_id
-    LEFT JOIN messages
-      ON messages.agent_name = ? AND messages.session_id = requested.session_id
     LEFT JOIN sessions
       ON sessions.agent_name = ? AND sessions.session_id = requested.session_id
-    GROUP BY
-      requested.session_id,
-      documents.content_hash,
-      documents.indexed_message_count,
-      documents.detail_version,
-      sessions.meta_json,
-      sessions.title,
-      sessions.directory,
-      sessions.time_created,
-      sessions.time_updated,
-      sessions.message_count,
-      sessions.total_input_tokens,
-      sessions.total_output_tokens,
-      sessions.total_cache_read_tokens,
-      sessions.total_cache_create_tokens,
-      sessions.total_cost,
-      sessions.cost_source,
-      sessions.total_tokens,
-      sessions.project_identity_kind,
-      sessions.project_identity_key,
-      sessions.project_display_name,
-      sessions.project_identity_resolver_revision,
-      sessions.project_identity_input_signature
   `;
 }
 

--- a/packages/core/src/discovery/cache/search-index-state.ts
+++ b/packages/core/src/discovery/cache/search-index-state.ts
@@ -5,6 +5,13 @@ import { withCacheDbReadOnly } from "./connection.js";
 import { sessionDetailVersion } from "./detail-version.js";
 import type { SessionSnapshotCompleteness } from "./snapshot-types.js";
 
+export type SearchIndexPublicationStage =
+  | "started"
+  | "prepared"
+  | "cache_staged"
+  | "search_staged"
+  | "committed";
+
 export interface SearchIndexSyncOptions {
   isBulk?: boolean;
   bulkThreshold?: number;
@@ -13,6 +20,7 @@ export interface SearchIndexSyncOptions {
   completeness?: SessionSnapshotCompleteness;
   removedSessionIds?: readonly string[];
   publicationId?: string;
+  onPublicationStage?: (stage: SearchIndexPublicationStage) => void;
 }
 
 export interface PendingSearchIndexMaintenance {

--- a/packages/core/src/discovery/cache/search-index-state.ts
+++ b/packages/core/src/discovery/cache/search-index-state.ts
@@ -23,6 +23,7 @@ export interface PendingSearchIndexMaintenance {
 export interface SearchIndexState {
   contentHashBySessionId: Map<string, string>;
   publishedContentHashBySessionId: Map<string, string>;
+  publishedDetailFactsHashBySessionId: Map<string, string>;
   indexedMessageCountBySessionId: Map<string, number>;
   messageCountBySessionId: Map<string, number>;
   detailVersionBySessionId: Map<string, string>;
@@ -85,6 +86,20 @@ interface SearchIndexSessionFacts {
   projectIdentityInputSignature: string;
 }
 
+type SearchIndexDetailFacts = Pick<
+  SearchIndexSessionFacts,
+  | "timeCreated"
+  | "timeUpdated"
+  | "messageCount"
+  | "totalInputTokens"
+  | "totalOutputTokens"
+  | "totalCacheReadTokens"
+  | "totalCacheCreateTokens"
+  | "totalCost"
+  | "costSource"
+  | "totalTokens"
+>;
+
 const SEARCH_INDEX_STATE_BATCH_SIZE = 900;
 
 function readPendingReindexIds(db: SQLiteDatabase, agentName: string): Set<string> {
@@ -120,14 +135,42 @@ function hashSearchIndexSessionFacts(facts: SearchIndexSessionFacts): string {
   return JSON.stringify(facts);
 }
 
+function searchIndexDetailFacts(facts: SearchIndexSessionFacts): SearchIndexDetailFacts {
+  return {
+    timeCreated: facts.timeCreated,
+    timeUpdated: facts.timeUpdated,
+    messageCount: facts.messageCount,
+    totalInputTokens: facts.totalInputTokens,
+    totalOutputTokens: facts.totalOutputTokens,
+    totalCacheReadTokens: facts.totalCacheReadTokens,
+    totalCacheCreateTokens: facts.totalCacheCreateTokens,
+    totalCost: facts.totalCost,
+    costSource: facts.costSource,
+    totalTokens: facts.totalTokens,
+  };
+}
+
+function hashSearchIndexDetailFacts(facts: SearchIndexSessionFacts): string {
+  return JSON.stringify(searchIndexDetailFacts(facts));
+}
+
 export function sessionContentHash(session: SessionHead): string {
   return hashSearchIndexSessionFacts(searchIndexSessionFacts(session));
 }
 
 function publishedSessionContentHash(row: PublishedSessionRow): string | null {
   if (row.session_title == null) return null;
-  return hashSearchIndexSessionFacts({
-    title: row.session_title,
+  return hashSearchIndexSessionFacts(searchIndexSessionFactsFromRow(row));
+}
+
+function publishedSessionDetailFactsHash(row: PublishedSessionRow): string | null {
+  if (row.session_title == null) return null;
+  return hashSearchIndexDetailFacts(searchIndexSessionFactsFromRow(row));
+}
+
+function searchIndexSessionFactsFromRow(row: PublishedSessionRow): SearchIndexSessionFacts {
+  return {
+    title: String(row.session_title),
     directory: row.session_directory ?? "",
     timeCreated: Number(row.session_time_created ?? 0),
     timeUpdated: Number(row.session_time_updated ?? row.session_time_created ?? 0),
@@ -144,7 +187,11 @@ function publishedSessionContentHash(row: PublishedSessionRow): string | null {
     projectDisplayName: row.session_project_display_name ?? "",
     projectIdentityResolverRevision: row.session_project_identity_resolver_revision ?? "",
     projectIdentityInputSignature: row.session_project_identity_input_signature ?? "",
-  });
+  };
+}
+
+export function sessionDetailFactsHash(session: SessionHead): string {
+  return hashSearchIndexDetailFacts(searchIndexSessionFacts(session));
 }
 
 export function detailVersionFromMetaJson(value: string | null | undefined): string {
@@ -169,6 +216,12 @@ function searchIndexStateFromRows(
       indexedRows.flatMap((row) => {
         const contentHash = publishedSessionContentHash(row);
         return contentHash == null ? [] : [[String(row.session_id), contentHash]];
+      }),
+    ),
+    publishedDetailFactsHashBySessionId: new Map(
+      indexedRows.flatMap((row) => {
+        const detailFactsHash = publishedSessionDetailFactsHash(row);
+        return detailFactsHash == null ? [] : [[String(row.session_id), detailFactsHash]];
       }),
     ),
     indexedMessageCountBySessionId: new Map(

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -2,9 +2,14 @@ import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { extractSessionFileActivity } from "../../utils/file-activity.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
-import { SEARCH_INDEX_BULK_SYNC_THRESHOLD, type PersistedSessionHeadChange } from "./db.js";
+import {
+  SEARCH_INDEX_BULK_SYNC_THRESHOLD,
+  type PersistedSessionHeadChange,
+  type SQLiteStatement,
+} from "./db.js";
 import { advanceAnalyticsRevision } from "./analytics-revision.js";
 import {
+  appendPlainText,
   buildSessionContentFromMessages,
   normalizeMessages,
   assertSessionProjectIdentities,
@@ -28,6 +33,7 @@ import {
   readSearchIndexState,
   searchIndexEntryNeedsUpdate,
   sessionContentHash,
+  sessionDetailFactsHash,
   targetDetailVersion,
   type SearchIndexState,
   type SearchIndexSyncOptions,
@@ -59,17 +65,31 @@ export interface SearchIndexSyncResult {
   rebuildDurationMs?: number;
   planningDurationMs: number;
   getSessionDataCalls: number;
+  reusedMaterializations: number;
   getSessionDataDurationMs: number;
   materializationDurationMs: number;
 }
 
 const SEARCH_INDEX_COMMIT_CHUNK_SIZE = 64;
 
-interface LoadedSearchIndexEntry extends SessionMaterializationEntry {
+interface LoadedSearchIndexEntryBase {
+  session: SessionHead;
   contentText: string;
   contentHash: string;
   detailVersion: string;
+  sortIndex: number;
+  messageCount: number;
 }
+
+interface ParsedSearchIndexEntry extends LoadedSearchIndexEntryBase, SessionMaterializationEntry {
+  materialization: "replace";
+}
+
+interface ReusedSearchIndexEntry extends LoadedSearchIndexEntryBase {
+  materialization: "reuse";
+}
+
+type LoadedSearchIndexEntry = ParsedSearchIndexEntry | ReusedSearchIndexEntry;
 
 interface SearchIndexRowWriteOptions {
   verifySupersession?: boolean;
@@ -77,6 +97,7 @@ interface SearchIndexRowWriteOptions {
 
 interface SearchIndexLoadTiming {
   calls: number;
+  reused: number;
   getSessionDataMs: number;
   materializationMs: number;
 }
@@ -96,6 +117,7 @@ interface SearchIndexPlan {
   changes: PersistedSessionHeadChange[];
   removedSessionIds: string[];
   detailVersionBySessionId: Map<string, string>;
+  reusableSessionIds: Set<string>;
   needsRebuild: boolean;
   startedAt: number;
 }
@@ -131,7 +153,7 @@ interface PreparedSearchIndexPublication {
 }
 
 function createSearchIndexLoadTiming(): SearchIndexLoadTiming {
-  return { calls: 0, getSessionDataMs: 0, materializationMs: 0 };
+  return { calls: 0, reused: 0, getSessionDataMs: 0, materializationMs: 0 };
 }
 
 function shouldBulkSyncSearchIndex(options: SearchIndexSyncOptions, changedCount: number): boolean {
@@ -167,11 +189,13 @@ function loadSearchIndexEntry(
       const identity = requireSessionProjectIdentity(agentName, change.session);
       return {
         session: change.session,
+        materialization: "replace",
         messages,
         contentText: buildSessionContentFromMessages(data.title ?? change.session.title, messages),
         contentHash: sessionContentHash(change.session),
         fileActivity: extractSessionFileActivity(agentName, sessionId, identity.key, data.messages),
         sortIndex: change.sortIndex,
+        messageCount: messages.length,
         detailVersion,
       };
     } finally {
@@ -189,21 +213,73 @@ function loadSearchIndexEntry(
   }
 }
 
+function loadReusedSearchIndexEntry(
+  readCachedContent: SQLiteStatement,
+  agentName: string,
+  change: PersistedSessionHeadChange,
+  detailVersion: string,
+  timing: SearchIndexLoadTiming,
+): ReusedSearchIndexEntry | null {
+  const sessionId = change.session.reference.sessionId;
+  const startedAt = performance.now();
+  try {
+    const rows = readCachedContent.all(agentName, sessionId) as Array<{
+      content_text?: string | null;
+    }>;
+    if (rows.length !== change.session.stats.message_count) return null;
+
+    const chunks: string[] = [];
+    appendPlainText(change.session.title, chunks);
+    for (const row of rows) appendPlainText(row.content_text, chunks);
+    timing.reused += 1;
+    return {
+      session: change.session,
+      materialization: "reuse",
+      contentText: chunks.join("\n"),
+      contentHash: sessionContentHash(change.session),
+      detailVersion,
+      sortIndex: change.sortIndex,
+      messageCount: rows.length,
+    };
+  } finally {
+    timing.materializationMs += performance.now() - startedAt;
+  }
+}
+
 function* loadSearchIndexEntries(
+  db: SQLiteDatabase,
   agentName: string,
   changes: Iterable<PersistedSessionHeadChange>,
   loadSessionData: (sessionId: string) => SessionDetail,
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
   timing: SearchIndexLoadTiming,
+  reusableSessionIds: ReadonlySet<string>,
 ): Generator<LoadedSearchIndexEntry> {
+  const readCachedContent = db.prepare(
+    "SELECT content_text FROM messages WHERE agent_name = ? AND session_id = ? ORDER BY message_index",
+  );
   for (const change of changes) {
     const sessionId = change.session.reference.sessionId;
+    const detailVersion = detailVersionFor(sessionId);
+    if (reusableSessionIds.has(sessionId)) {
+      const reused = loadReusedSearchIndexEntry(
+        readCachedContent,
+        agentName,
+        change,
+        detailVersion,
+        timing,
+      );
+      if (reused) {
+        yield reused;
+        continue;
+      }
+    }
     const entry = loadSearchIndexEntry(
       agentName,
       change,
       loadSessionData,
-      detailVersionFor(sessionId),
+      detailVersion,
       failures,
       timing,
     );
@@ -271,14 +347,18 @@ function writeSearchIndexRows(
       }
     }
     clearPendingReindex.run(agentName, sessionId);
-    materialization.writeSession(entry);
+    if (entry.materialization === "reuse") {
+      materialization.reuseSessionHead(entry.session, entry.sortIndex);
+    } else {
+      materialization.writeSession(entry);
+    }
     upsertRow.run(
       agentName,
       sessionId,
       entry.session.title,
       entry.contentText,
       entry.contentHash,
-      entry.messages.length,
+      entry.messageCount,
       entry.detailVersion,
       Date.now(),
     );
@@ -303,18 +383,21 @@ function loadOrPreStageEntries(
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
   timing: SearchIndexLoadTiming,
+  reusableSessionIds: ReadonlySet<string>,
   publicationId?: string,
 ): { entries: LoadedSearchIndexEntry[]; preStaged: number } {
   if (changes.length <= SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
     return {
       entries: [
         ...loadSearchIndexEntries(
+          db,
           agentName,
           changes,
           loadSessionData,
           detailVersionFor,
           failures,
           timing,
+          reusableSessionIds,
         ),
       ],
       preStaged: 0,
@@ -330,12 +413,14 @@ function loadOrPreStageEntries(
     const chunk = changes.slice(offset, offset + SEARCH_INDEX_COMMIT_CHUNK_SIZE);
     runSearchIndexWrite(db, false, () => {
       const entries = loadSearchIndexEntries(
+        db,
         agentName,
         chunk,
         loadSessionData,
         detailVersionFor,
         failures,
         timing,
+        reusableSessionIds,
       );
       preStaged += stagePublicationPayloads(
         db,
@@ -428,6 +513,26 @@ function createSearchIndexPlan(input: SearchIndexPlanInput): SearchIndexPlan {
       return [sessionId, targetDetailVersion(input.state, sessionId, input.options)];
     }),
   );
+  const unversionedDetail = sessionDetailVersion(null);
+  // Reuse is safe only when a source-backed version and every message-derived
+  // head fact still match; title, directory, and project identity can then change independently.
+  const reusableSessionIds = new Set(
+    changes.flatMap(({ session }) => {
+      const sessionId = session.reference.sessionId;
+      const targetVersion = detailVersionBySessionId.get(sessionId);
+      const storedMessageCount = input.state.messageCountBySessionId.get(sessionId);
+      const canReuse =
+        typeof targetVersion === "string" &&
+        targetVersion !== unversionedDetail &&
+        input.state.detailVersionBySessionId.get(sessionId) === targetVersion &&
+        input.state.indexedMessageCountBySessionId.get(sessionId) === storedMessageCount &&
+        storedMessageCount === session.stats.message_count &&
+        input.state.publishedDetailFactsHashBySessionId.get(sessionId) ===
+          sessionDetailFactsHash(session) &&
+        !input.state.pendingReindexSessionIds.has(sessionId);
+      return canReuse ? [sessionId] : [];
+    }),
+  );
   const changedCount = input.removedSessionIds.length + changes.length;
   const isBulk = shouldBulkSyncSearchIndex(input.options, changedCount);
 
@@ -438,6 +543,7 @@ function createSearchIndexPlan(input: SearchIndexPlanInput): SearchIndexPlan {
     changes,
     removedSessionIds: input.removedSessionIds,
     detailVersionBySessionId,
+    reusableSessionIds,
     needsRebuild: isBulk && changedCount > 0,
     startedAt: input.startedAt,
   };
@@ -481,6 +587,7 @@ function prepareSearchIndexPublication(
     (sessionId) => detailVersionForPlan(plan, sessionId),
     failures,
     loadTiming,
+    plan.reusableSessionIds,
     publicationId,
   );
 
@@ -579,6 +686,7 @@ export function writePreparedSessionSearchIndex(
     rebuildDurationMs,
     planningDurationMs: publication.planningDurationMs,
     getSessionDataCalls: publication.loadTiming.calls,
+    reusedMaterializations: publication.loadTiming.reused,
     getSessionDataDurationMs: publication.loadTiming.getSessionDataMs,
     materializationDurationMs: publication.loadTiming.materializationMs,
   };
@@ -612,6 +720,7 @@ function searchIndexSyncResult(
     rebuildDurationMs,
     planningDurationMs,
     getSessionDataCalls: loadTiming.calls,
+    reusedMaterializations: loadTiming.reused,
     getSessionDataDurationMs: loadTiming.getSessionDataMs,
     materializationDurationMs: loadTiming.materializationMs,
   };
@@ -629,12 +738,14 @@ function executeSearchIndexPlan(
   const loadTiming = createSearchIndexLoadTiming();
   const loadEntries = (changes: PersistedSessionHeadChange[]) =>
     loadSearchIndexEntries(
+      db,
       plan.agentName,
       changes,
       loadSessionData,
       (sessionId) => detailVersionForPlan(plan, sessionId),
       failures,
       loadTiming,
+      plan.reusableSessionIds,
     );
 
   if (largeBacklogStrategy === "chunked" && plan.changes.length > SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
@@ -723,6 +834,7 @@ export function syncSessionSearchIndexChanges(
       durationMs: 0,
       planningDurationMs: 0,
       getSessionDataCalls: 0,
+      reusedMaterializations: 0,
       getSessionDataDurationMs: 0,
       materializationDurationMs: 0,
     };

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -43,6 +43,7 @@ export {
   readPendingSearchIndexMaintenance,
   searchIndexStateQuery,
   type PendingSearchIndexMaintenance,
+  type SearchIndexPublicationStage,
   type SearchIndexSyncOptions,
 } from "./search-index-state.js";
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -117,7 +117,7 @@ interface SearchIndexPlan {
   changes: PersistedSessionHeadChange[];
   removedSessionIds: string[];
   detailVersionBySessionId: Map<string, string>;
-  reusableSessionIds: Set<string>;
+  reusableMessageCountBySessionId: Map<string, number>;
   needsRebuild: boolean;
   startedAt: number;
 }
@@ -218,6 +218,7 @@ function loadReusedSearchIndexEntry(
   agentName: string,
   change: PersistedSessionHeadChange,
   detailVersion: string,
+  expectedMessageCount: number,
   timing: SearchIndexLoadTiming,
 ): ReusedSearchIndexEntry | null {
   const sessionId = change.session.reference.sessionId;
@@ -226,7 +227,7 @@ function loadReusedSearchIndexEntry(
     const rows = readCachedContent.all(agentName, sessionId) as Array<{
       content_text?: string | null;
     }>;
-    if (rows.length !== change.session.stats.message_count) return null;
+    if (rows.length !== expectedMessageCount) return null;
 
     const chunks: string[] = [];
     appendPlainText(change.session.title, chunks);
@@ -254,7 +255,7 @@ function* loadSearchIndexEntries(
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
   timing: SearchIndexLoadTiming,
-  reusableSessionIds: ReadonlySet<string>,
+  reusableMessageCountBySessionId: ReadonlyMap<string, number>,
 ): Generator<LoadedSearchIndexEntry> {
   const readCachedContent = db.prepare(
     "SELECT content_text FROM messages WHERE agent_name = ? AND session_id = ? ORDER BY message_index",
@@ -262,12 +263,14 @@ function* loadSearchIndexEntries(
   for (const change of changes) {
     const sessionId = change.session.reference.sessionId;
     const detailVersion = detailVersionFor(sessionId);
-    if (reusableSessionIds.has(sessionId)) {
+    const reusableMessageCount = reusableMessageCountBySessionId.get(sessionId);
+    if (reusableMessageCount !== undefined) {
       const reused = loadReusedSearchIndexEntry(
         readCachedContent,
         agentName,
         change,
         detailVersion,
+        reusableMessageCount,
         timing,
       );
       if (reused) {
@@ -383,7 +386,7 @@ function loadOrPreStageEntries(
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
   timing: SearchIndexLoadTiming,
-  reusableSessionIds: ReadonlySet<string>,
+  reusableMessageCountBySessionId: ReadonlyMap<string, number>,
   publicationId?: string,
 ): { entries: LoadedSearchIndexEntry[]; preStaged: number } {
   if (changes.length <= SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
@@ -397,7 +400,7 @@ function loadOrPreStageEntries(
           detailVersionFor,
           failures,
           timing,
-          reusableSessionIds,
+          reusableMessageCountBySessionId,
         ),
       ],
       preStaged: 0,
@@ -420,7 +423,7 @@ function loadOrPreStageEntries(
         detailVersionFor,
         failures,
         timing,
-        reusableSessionIds,
+        reusableMessageCountBySessionId,
       );
       preStaged += stagePublicationPayloads(
         db,
@@ -514,9 +517,9 @@ function createSearchIndexPlan(input: SearchIndexPlanInput): SearchIndexPlan {
     }),
   );
   const unversionedDetail = sessionDetailVersion(null);
-  // Reuse is safe only when a source-backed version and every message-derived
-  // head fact still match; title, directory, and project identity can then change independently.
-  const reusableSessionIds = new Set(
+  // Reuse is safe only when the source-backed detail version, normalized message rows,
+  // and every message-derived head fact still match.
+  const reusableMessageCountBySessionId = new Map(
     changes.flatMap(({ session }) => {
       const sessionId = session.reference.sessionId;
       const targetVersion = detailVersionBySessionId.get(sessionId);
@@ -524,13 +527,13 @@ function createSearchIndexPlan(input: SearchIndexPlanInput): SearchIndexPlan {
       const canReuse =
         typeof targetVersion === "string" &&
         targetVersion !== unversionedDetail &&
+        typeof storedMessageCount === "number" &&
         input.state.detailVersionBySessionId.get(sessionId) === targetVersion &&
         input.state.indexedMessageCountBySessionId.get(sessionId) === storedMessageCount &&
-        storedMessageCount === session.stats.message_count &&
         input.state.publishedDetailFactsHashBySessionId.get(sessionId) ===
           sessionDetailFactsHash(session) &&
         !input.state.pendingReindexSessionIds.has(sessionId);
-      return canReuse ? [sessionId] : [];
+      return canReuse ? ([[sessionId, storedMessageCount]] as const) : [];
     }),
   );
   const changedCount = input.removedSessionIds.length + changes.length;
@@ -543,7 +546,7 @@ function createSearchIndexPlan(input: SearchIndexPlanInput): SearchIndexPlan {
     changes,
     removedSessionIds: input.removedSessionIds,
     detailVersionBySessionId,
-    reusableSessionIds,
+    reusableMessageCountBySessionId,
     needsRebuild: isBulk && changedCount > 0,
     startedAt: input.startedAt,
   };
@@ -587,7 +590,7 @@ function prepareSearchIndexPublication(
     (sessionId) => detailVersionForPlan(plan, sessionId),
     failures,
     loadTiming,
-    plan.reusableSessionIds,
+    plan.reusableMessageCountBySessionId,
     publicationId,
   );
 
@@ -745,7 +748,7 @@ function executeSearchIndexPlan(
       (sessionId) => detailVersionForPlan(plan, sessionId),
       failures,
       loadTiming,
-      plan.reusableSessionIds,
+      plan.reusableMessageCountBySessionId,
     );
 
   if (largeBacklogStrategy === "chunked" && plan.changes.length > SEARCH_INDEX_COMMIT_CHUNK_SIZE) {

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -57,6 +57,10 @@ export interface SearchIndexSyncResult {
   failures?: SearchIndexSyncFailure[];
   durationMs: number;
   rebuildDurationMs?: number;
+  planningDurationMs: number;
+  getSessionDataCalls: number;
+  getSessionDataDurationMs: number;
+  materializationDurationMs: number;
 }
 
 const SEARCH_INDEX_COMMIT_CHUNK_SIZE = 64;
@@ -69,6 +73,12 @@ interface LoadedSearchIndexEntry extends SessionMaterializationEntry {
 
 interface SearchIndexRowWriteOptions {
   verifySupersession?: boolean;
+}
+
+interface SearchIndexLoadTiming {
+  calls: number;
+  getSessionDataMs: number;
+  materializationMs: number;
 }
 
 type SearchIndexPlanRequest =
@@ -116,6 +126,12 @@ interface PreparedSearchIndexPublication {
   failures: SearchIndexSyncFailure[];
   needsRebuild: boolean;
   startedAt: number;
+  planningDurationMs: number;
+  loadTiming: SearchIndexLoadTiming;
+}
+
+function createSearchIndexLoadTiming(): SearchIndexLoadTiming {
+  return { calls: 0, getSessionDataMs: 0, materializationMs: 0 };
 }
 
 function shouldBulkSyncSearchIndex(options: SearchIndexSyncOptions, changedCount: number): boolean {
@@ -133,21 +149,34 @@ function loadSearchIndexEntry(
   loadSessionData: (sessionId: string) => SessionDetail,
   detailVersion: string,
   failures: SearchIndexSyncFailure[],
+  timing: SearchIndexLoadTiming,
 ): LoadedSearchIndexEntry | null {
   const sessionId = change.session.reference.sessionId;
   try {
-    const data = loadSessionData(sessionId);
-    const messages = normalizeMessages(data);
-    const identity = requireSessionProjectIdentity(agentName, change.session);
-    return {
-      session: change.session,
-      messages,
-      contentText: buildSessionContentFromMessages(data.title ?? change.session.title, messages),
-      contentHash: sessionContentHash(change.session),
-      fileActivity: extractSessionFileActivity(agentName, sessionId, identity.key, data.messages),
-      sortIndex: change.sortIndex,
-      detailVersion,
-    };
+    timing.calls += 1;
+    const loadStartedAt = performance.now();
+    let data: SessionDetail;
+    try {
+      data = loadSessionData(sessionId);
+    } finally {
+      timing.getSessionDataMs += performance.now() - loadStartedAt;
+    }
+    const materializationStartedAt = performance.now();
+    try {
+      const messages = normalizeMessages(data);
+      const identity = requireSessionProjectIdentity(agentName, change.session);
+      return {
+        session: change.session,
+        messages,
+        contentText: buildSessionContentFromMessages(data.title ?? change.session.title, messages),
+        contentHash: sessionContentHash(change.session),
+        fileActivity: extractSessionFileActivity(agentName, sessionId, identity.key, data.messages),
+        sortIndex: change.sortIndex,
+        detailVersion,
+      };
+    } finally {
+      timing.materializationMs += performance.now() - materializationStartedAt;
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     failures.push({ sessionId, reason: "parse-failed", message });
@@ -166,6 +195,7 @@ function* loadSearchIndexEntries(
   loadSessionData: (sessionId: string) => SessionDetail,
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
+  timing: SearchIndexLoadTiming,
 ): Generator<LoadedSearchIndexEntry> {
   for (const change of changes) {
     const sessionId = change.session.reference.sessionId;
@@ -175,6 +205,7 @@ function* loadSearchIndexEntries(
       loadSessionData,
       detailVersionFor(sessionId),
       failures,
+      timing,
     );
     if (entry) yield entry;
   }
@@ -271,12 +302,20 @@ function loadOrPreStageEntries(
   loadSessionData: (sessionId: string) => SessionDetail,
   detailVersionFor: (sessionId: string) => string,
   failures: SearchIndexSyncFailure[],
+  timing: SearchIndexLoadTiming,
   publicationId?: string,
 ): { entries: LoadedSearchIndexEntry[]; preStaged: number } {
   if (changes.length <= SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
     return {
       entries: [
-        ...loadSearchIndexEntries(agentName, changes, loadSessionData, detailVersionFor, failures),
+        ...loadSearchIndexEntries(
+          agentName,
+          changes,
+          loadSessionData,
+          detailVersionFor,
+          failures,
+          timing,
+        ),
       ],
       preStaged: 0,
     };
@@ -296,6 +335,7 @@ function loadOrPreStageEntries(
         loadSessionData,
         detailVersionFor,
         failures,
+        timing,
       );
       preStaged += stagePublicationPayloads(
         db,
@@ -431,6 +471,8 @@ function prepareSearchIndexPublication(
     planning_ms: Math.round(performance.now() - plan.startedAt),
   });
   const failures: SearchIndexSyncFailure[] = [];
+  const planningDurationMs = performance.now() - plan.startedAt;
+  const loadTiming = createSearchIndexLoadTiming();
   const { entries, preStaged } = loadOrPreStageEntries(
     db,
     plan.agentName,
@@ -438,6 +480,7 @@ function prepareSearchIndexPublication(
     loadSessionData,
     (sessionId) => detailVersionForPlan(plan, sessionId),
     failures,
+    loadTiming,
     publicationId,
   );
 
@@ -453,6 +496,8 @@ function prepareSearchIndexPublication(
     failures,
     needsRebuild: plan.needsRebuild,
     startedAt: plan.startedAt,
+    planningDurationMs,
+    loadTiming,
   };
 }
 
@@ -532,6 +577,10 @@ export function writePreparedSessionSearchIndex(
     failures: publication.failures.length > 0 ? publication.failures : undefined,
     durationMs: performance.now() - publication.startedAt,
     rebuildDurationMs,
+    planningDurationMs: publication.planningDurationMs,
+    getSessionDataCalls: publication.loadTiming.calls,
+    getSessionDataDurationMs: publication.loadTiming.getSessionDataMs,
+    materializationDurationMs: publication.loadTiming.materializationMs,
   };
 }
 
@@ -545,6 +594,8 @@ function searchIndexSyncResult(
   plan: SearchIndexPlan,
   indexed: number,
   failures: SearchIndexSyncFailure[],
+  planningDurationMs: number,
+  loadTiming: SearchIndexLoadTiming,
   rebuildDurationMs?: number,
   mode = plan.mode,
 ): SearchIndexSyncResult {
@@ -559,6 +610,10 @@ function searchIndexSyncResult(
     failures: failures.length > 0 ? failures : undefined,
     durationMs: performance.now() - plan.startedAt,
     rebuildDurationMs,
+    planningDurationMs,
+    getSessionDataCalls: loadTiming.calls,
+    getSessionDataDurationMs: loadTiming.getSessionDataMs,
+    materializationDurationMs: loadTiming.materializationMs,
   };
 }
 
@@ -570,6 +625,8 @@ function executeSearchIndexPlan(
 ): SearchIndexSyncResult {
   let indexed = 0;
   const failures: SearchIndexSyncFailure[] = [];
+  const planningDurationMs = performance.now() - plan.startedAt;
+  const loadTiming = createSearchIndexLoadTiming();
   const loadEntries = (changes: PersistedSessionHeadChange[]) =>
     loadSearchIndexEntries(
       plan.agentName,
@@ -577,6 +634,7 @@ function executeSearchIndexPlan(
       loadSessionData,
       (sessionId) => detailVersionForPlan(plan, sessionId),
       failures,
+      loadTiming,
     );
 
   if (largeBacklogStrategy === "chunked" && plan.changes.length > SEARCH_INDEX_COMMIT_CHUNK_SIZE) {
@@ -598,7 +656,15 @@ function executeSearchIndexPlan(
         if (chunkIndexed > 0) advanceAnalyticsRevision(db);
       });
     }
-    return searchIndexSyncResult(plan, indexed, failures, undefined, "incremental");
+    return searchIndexSyncResult(
+      plan,
+      indexed,
+      failures,
+      planningDurationMs,
+      loadTiming,
+      undefined,
+      "incremental",
+    );
   }
 
   const { rebuildDurationMs } = runSearchIndexWrite(db, plan.needsRebuild, () => {
@@ -611,7 +677,14 @@ function executeSearchIndexPlan(
     );
     if (indexed > 0 || plan.removedSessionIds.length > 0) advanceAnalyticsRevision(db);
   });
-  return searchIndexSyncResult(plan, indexed, failures, rebuildDurationMs);
+  return searchIndexSyncResult(
+    plan,
+    indexed,
+    failures,
+    planningDurationMs,
+    loadTiming,
+    rebuildDurationMs,
+  );
 }
 
 export function syncSessionSearchIndex(
@@ -648,6 +721,10 @@ export function syncSessionSearchIndexChanges(
       indexed: 0,
       skipped: 0,
       durationMs: 0,
+      planningDurationMs: 0,
+      getSessionDataCalls: 0,
+      getSessionDataDurationMs: 0,
+      materializationDurationMs: 0,
     };
   }
 

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -96,6 +96,7 @@ export {
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,
   type PendingSearchIndexMaintenance,
+  type SearchIndexPublicationStage,
   type SearchIndexSyncOptions,
   type SearchIndexSyncFailure,
   type SearchIndexSyncResult,

--- a/packages/core/src/discovery/cache/session-materialization-writer.ts
+++ b/packages/core/src/discovery/cache/session-materialization-writer.ts
@@ -6,6 +6,7 @@ import {
   prepareInsertFileActivity,
   prepareInsertMessageTool,
   prepareUpsertSession,
+  requireSessionProjectIdentity,
   upsertSessionRow,
   writeFileActivityRows,
   type StructuredMessageRecord,
@@ -21,6 +22,7 @@ export interface SessionMaterializationEntry {
 
 export interface SessionMaterializationWriter {
   deleteSession(sessionId: string): void;
+  reuseSessionHead(session: SessionHead, sortIndex: number): void;
   writeSession(entry: SessionMaterializationEntry): void;
 }
 
@@ -36,6 +38,9 @@ export function prepareSessionMaterializationWriter(
   );
   const deleteFileActivity = db.prepare(
     "DELETE FROM session_file_activity WHERE agent_name = ? AND session_id = ?",
+  );
+  const updateFileActivityIdentity = db.prepare(
+    "UPDATE session_file_activity SET project_identity_key = ? WHERE agent_name = ? AND session_id = ?",
   );
   const deleteModelCost = db.prepare(
     "DELETE FROM session_model_cost WHERE agent_name = ? AND session_id = ?",
@@ -158,6 +163,10 @@ export function prepareSessionMaterializationWriter(
       tool_metadata_json = excluded.tool_metadata_json
   `);
 
+  const writeSessionHead = (session: SessionHead, sortIndex: number): void => {
+    upsertSessionRow(writeMaterializedSession, agentName, session, null, sortIndex, null);
+  };
+
   return {
     deleteSession(sessionId) {
       deleteFileActivity.run(agentName, sessionId);
@@ -166,16 +175,17 @@ export function prepareSessionMaterializationWriter(
       deleteModelCost.run(agentName, sessionId);
       deleteCostSummary.run(agentName, sessionId);
     },
+    reuseSessionHead(session, sortIndex) {
+      writeSessionHead(session, sortIndex);
+      updateFileActivityIdentity.run(
+        requireSessionProjectIdentity(agentName, session).key,
+        agentName,
+        session.reference.sessionId,
+      );
+    },
     writeSession(entry) {
       const sessionId = entry.session.reference.sessionId;
-      upsertSessionRow(
-        writeMaterializedSession,
-        agentName,
-        entry.session,
-        null,
-        entry.sortIndex,
-        null,
-      );
+      writeSessionHead(entry.session, entry.sortIndex);
       deleteFileActivity.run(agentName, sessionId);
       deleteMessageTools.run(agentName, sessionId, 0);
       writeFileActivityRows(insertFileActivity, entry.fileActivity);

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -85,6 +85,7 @@ export {
 } from "./cache/search.js";
 export type {
   ParsedSearchQuery,
+  SearchIndexPublicationStage,
   SearchIndexSyncOptions,
   PendingSearchIndexMaintenance,
   SearchIndexSyncFailure,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -8,6 +8,7 @@ import type {
   BaseAgent,
   EnumeratedSessionSourceCapability,
   SessionSourceFailure,
+  SessionSourceSynchronizationTiming,
 } from "../agents/index.js";
 import {
   createAgentScanFailure,
@@ -97,7 +98,25 @@ export interface AgentScanTiming {
   scan?: number;
   identity?: number;
   tags?: number;
+  sourceEnumeration?: number;
+  sourceDiff?: number;
+  sourceParse?: number;
+  enumeratedSources?: number;
+  changedSources?: number;
+  processedSources?: number;
   total: number;
+}
+
+function applySessionSourceTiming(
+  target: AgentScanTiming,
+  source: SessionSourceSynchronizationTiming,
+): void {
+  target.sourceEnumeration = source.enumerationMs;
+  target.sourceDiff = source.diffMs;
+  target.sourceParse = source.parseMs;
+  target.enumeratedSources = source.enumeratedSourceCount;
+  target.changedSources = source.changedSourceCount;
+  target.processedSources = source.processedSourceCount;
 }
 
 function buildAgentScanOptions(
@@ -341,6 +360,7 @@ async function refreshCachedEnumeratedAgent(
     },
   );
   timing.scan = performance.now() - scanStartedAt;
+  applySessionSourceTiming(timing, synchronization.timing);
   const hasSourceChanges =
     synchronization.detectedSessionIds.length > 0 || synchronization.sourceFailures.length > 0;
 
@@ -591,6 +611,7 @@ async function scanAgentFull(
       );
       heads = synchronization.sessions;
       sourceFailures = synchronization.sourceFailures;
+      applySessionSourceTiming(timing, synchronization.timing);
     } else {
       heads = agent.scan(agentScanOptions);
     }

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -37,6 +37,7 @@ export type {
   SessionSourceSynchronizationBaseline,
   SessionSourceSynchronizationOutcome,
   SessionSourceSynchronizationRequest,
+  SessionSourceSynchronizationTiming,
   SessionWatchPlan,
 } from "../agents/index.js";
 export {

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -99,6 +99,7 @@ export type {
   DurableSessionPublicationCommitResult,
   DurableSessionPublicationFailureStage,
   PendingSearchIndexMaintenance,
+  SearchIndexPublicationStage,
   SearchIndexSyncOptions,
   SearchIndexSyncFailure,
   SearchIndexSyncResult,

--- a/scripts/benchmark-performance.mjs
+++ b/scripts/benchmark-performance.mjs
@@ -247,20 +247,48 @@ async function findFreePort() {
   return typeof address === "object" && address ? address.port : 4521;
 }
 
-async function waitForServer(url, child, timeoutMs) {
+export function findStartupUrl(output, expectedOrigin) {
+  for (const match of output.matchAll(/https?:\/\/\S+/g)) {
+    try {
+      const candidate = new URL(match[0]);
+      if (candidate.origin === expectedOrigin && candidate.searchParams.has("access_token")) {
+        return candidate;
+      }
+    } catch {}
+  }
+  return null;
+}
+
+export function authenticatedApiUrl(startupUrl, pathname) {
+  const requestUrl = new URL(pathname, startupUrl);
+  const accessToken = startupUrl.searchParams.get("access_token");
+  if (accessToken) requestUrl.searchParams.set("access_token", accessToken);
+  return requestUrl;
+}
+
+export function benchmarkSessionPath(session) {
+  const { agentName, sessionId } = session.reference;
+  return `/${encodeURIComponent(agentName.trim().toLowerCase())}/${encodeURIComponent(sessionId)}`;
+}
+
+async function waitForServer(url, cli, timeoutMs) {
   const startedAt = performance.now();
   let lastError = null;
 
   while (performance.now() - startedAt < timeoutMs) {
-    if (child.exitCode !== null) {
-      throw new Error(`CLI exited early with code ${child.exitCode}`);
+    if (cli.child.exitCode !== null) {
+      throw new Error(`CLI exited early with code ${cli.child.exitCode}`);
     }
 
-    try {
-      const response = await fetch(`${url}/api/config`);
-      if (response.ok) return;
-    } catch (error) {
-      lastError = error;
+    const startupUrl = findStartupUrl(cli.getOutput(), url);
+    if (startupUrl) {
+      try {
+        const response = await fetch(authenticatedApiUrl(startupUrl, "/api/config"));
+        if (response.ok) return startupUrl;
+        lastError = new Error(`health check returned ${response.status}`);
+      } catch (error) {
+        lastError = error;
+      }
     }
 
     await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
@@ -375,20 +403,20 @@ async function launchBrowser(headless) {
   }
 }
 
-async function getWindowedSessions(url) {
-  const response = await fetch(`${url}/api/sessions`);
+async function getWindowedSessions(startupUrl) {
+  const response = await fetch(authenticatedApiUrl(startupUrl, "/api/sessions"));
   if (!response.ok) {
     throw new Error(`Failed to fetch sessions: ${response.status}`);
   }
   return response.json();
 }
 
-async function waitForWindowedSessions(url, timeoutMs) {
+async function waitForWindowedSessions(startupUrl, timeoutMs) {
   const startedAt = performance.now();
   let lastResult = { sessions: [] };
 
   while (performance.now() - startedAt < timeoutMs) {
-    lastResult = await getWindowedSessions(url);
+    lastResult = await getWindowedSessions(startupUrl);
     if (Array.isArray(lastResult.sessions) && lastResult.sessions.length > 0) {
       return lastResult;
     }
@@ -425,8 +453,7 @@ function createFixtureData(sessionCount) {
   const sessions = Array.from({ length: sessionCount }, (_, index) => {
     const id = `benchmark-${String(index).padStart(4, "0")}`;
     return {
-      id,
-      slug: `codex/${id}`,
+      reference: { agentName: "codex", sessionId: id },
       title: `Benchmark session ${index}`,
       directory: "/benchmark/project",
       project_identity: {
@@ -490,12 +517,12 @@ function createFixtureData(sessionCount) {
 }
 
 function createFixtureSessionDetail(session) {
+  const sessionId = session.reference.sessionId;
   return {
     ...session,
-    reference: { agentName: "codex", sessionId: session.id },
     messages: [
       {
-        id: `${session.id}-message`,
+        id: `${sessionId}-message`,
         role: "user",
         time_created: session.time_created,
         parts: [{ type: "text", text: session.title }],
@@ -536,7 +563,9 @@ async function installFixtureRoutes(context, fixture) {
     if (pathname === "/api/sessions") return json({ sessions: fixture.sessions });
     if (pathname.startsWith("/api/sessions/")) {
       const sessionId = decodeURIComponent(pathname.split("/").at(-1) ?? "");
-      const session = fixture.sessions.find((candidate) => candidate.id === sessionId);
+      const session = fixture.sessions.find(
+        (candidate) => candidate.reference.sessionId === sessionId,
+      );
       return session
         ? json(createFixtureSessionDetail(session))
         : route.fulfill({ status: 404, contentType: "application/json", body: "{}" });
@@ -665,8 +694,8 @@ async function openSidebarProject(page, timeoutMs) {
 }
 
 function createLiveEvent(session, index, totalSessions) {
-  const [agentName] = String(session.slug).split("/");
-  const reference = { agentName, sessionId: session.id };
+  const reference = session.reference;
+  const { agentName } = reference;
   return {
     type: "sessions-updated",
     changedAgents: [agentName],
@@ -793,7 +822,7 @@ async function runIteration(iteration, options) {
     const startedAt = performance.now();
     cli = spawnCli(port, options.days, options.coldStart);
 
-    await waitForServer(url, cli.child, options.timeoutMs);
+    const startupUrl = await waitForServer(url, cli, options.timeoutMs);
     const serverReadyMs = performance.now() - startedAt;
     console.log(`#${iteration} server ready in ${formatMs(serverReadyMs)}`);
 
@@ -808,7 +837,10 @@ async function runIteration(iteration, options) {
     }
     const page = await context.newPage();
 
-    await page.goto(url, { waitUntil: "domcontentloaded", timeout: options.timeoutMs });
+    await page.goto(startupUrl.href, {
+      waitUntil: "domcontentloaded",
+      timeout: options.timeoutMs,
+    });
     await page.locator('[data-testid="dashboard"]').waitFor({
       state: "visible",
       timeout: options.timeoutMs,
@@ -816,7 +848,7 @@ async function runIteration(iteration, options) {
     const dashboardReadyMs = performance.now() - startedAt;
     console.log(`#${iteration} dashboard visible in ${formatMs(dashboardReadyMs)}`);
 
-    const { sessions } = fixture ?? (await waitForWindowedSessions(url, options.timeoutMs));
+    const { sessions } = fixture ?? (await waitForWindowedSessions(startupUrl, options.timeoutMs));
     if (!Array.isArray(sessions) || sessions.length === 0) {
       const windowLabel = options.days === 0 ? "all time" : `the last ${options.days} days`;
       const retryHint =
@@ -831,9 +863,9 @@ async function runIteration(iteration, options) {
       options.profileScenarios.length > 0 ? await runProfileScenarios(page, sessions, options) : [];
 
     const target = selectBenchmarkTarget(sessions, options.target);
-    const [agentKey, sessionId] = String(target.slug).split("/");
-    const targetPath = `/${target.slug}`;
-    const sessionApiPath = `/api/sessions/${agentKey}/${sessionId}`;
+    const { agentName: agentKey, sessionId } = target.reference;
+    const targetPath = benchmarkSessionPath(target);
+    const sessionApiPath = `/api/sessions/${encodeURIComponent(agentKey)}/${encodeURIComponent(sessionId)}`;
     console.log(
       `#${iteration} opening ${targetPath} (${getSessionMessageCount(target)} messages, ${formatSessionTokenCount(target)} tokens, target=${options.target}, navigation=${options.navigation})`,
     );
@@ -847,6 +879,7 @@ async function runIteration(iteration, options) {
         },
         { timeout: options.timeoutMs },
       );
+      void responsePromise.catch(() => undefined);
 
       const clicked = await clickSessionLink(page, targetPath);
       console.log(`#${iteration} click dispatched`);
@@ -863,8 +896,9 @@ async function runIteration(iteration, options) {
         },
         { timeout: options.timeoutMs },
       );
+      void responsePromise.catch(() => undefined);
 
-      await page.goto(`${url}${targetPath}`, {
+      await page.goto(authenticatedApiUrl(startupUrl, targetPath).href, {
         waitUntil: "domcontentloaded",
         timeout: options.timeoutMs,
       });
@@ -897,7 +931,7 @@ async function runIteration(iteration, options) {
     return {
       iteration,
       sessions: sessions.length,
-      target: target.slug,
+      target: `${agentKey}/${sessionId}`,
       serverReadyMs,
       dashboardReadyMs,
       sessionClickMs,
@@ -961,7 +995,9 @@ async function main() {
   console.log(JSON.stringify({ options, results }, null, 2));
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+if (process.argv[1]?.endsWith("benchmark-performance.mjs")) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/benchmark-performance.test.mjs
+++ b/scripts/benchmark-performance.test.mjs
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  authenticatedApiUrl,
+  benchmarkSessionPath,
+  findStartupUrl,
+} from "./benchmark-performance.mjs";
+
+describe("performance benchmark authentication", () => {
+  it("extracts the authenticated startup URL for the expected server", () => {
+    const output = [
+      "http://localhost:4000/?access_token=wrong-server",
+      "  http://localhost:4521/?access_token=benchmark-secret",
+    ].join("\n");
+
+    expect(findStartupUrl(output, "http://localhost:4521")?.href).toBe(
+      "http://localhost:4521/?access_token=benchmark-secret",
+    );
+  });
+
+  it("carries the startup token into API probes", () => {
+    const startupUrl = new URL("http://localhost:4521/?access_token=benchmark-secret");
+
+    expect(authenticatedApiUrl(startupUrl, "/api/config").href).toBe(
+      "http://localhost:4521/api/config?access_token=benchmark-secret",
+    );
+  });
+
+  it("builds detail paths from canonical session references", () => {
+    expect(
+      benchmarkSessionPath({
+        reference: { agentName: "Codex", sessionId: "opaque/id?#" },
+      }),
+    ).toBe("/codex/opaque%2Fid%3F%23");
+  });
+});


### PR DESCRIPTION
## Summary

- fix authenticated end-to-end performance probes and canonical session routing
- expose source discovery, parsing, and search-index maintenance timings
- reuse persisted Codex subagent metadata to avoid full-history prefix reads and duplicate directory traversal during windowed scans
- replace wide message joins with indexed per-session freshness counts
- parse Codex child token stats and final output in one streaming pass
- reuse cached normalized messages for head-only index updates while retaining source-version, stored-row, statistics, migration, and supersession checks
- reset backfill progress snapshots when phases change so scan counters do not appear as publication progress
- suppress misleading partial-data warnings for successful windowed refreshes while preserving real source-failure warnings
- trust the durable recent full-sync marker instead of comparing filtered sessions with raw source-file counts
- report preparation, index writing, and transaction commit stages during full-history publication

## Performance

Measured on the same local cache:

- Codex source enumeration for a seven-day, 179-source window decreased from 1056.46 ms to 74.53 ms (92.9%)
- unchanged search-index planning for 530 Claude Code sessions decreased from about 290 ms to 14 ms (95.2%)
- each Codex child rollout now requires one full read per parent detail parse instead of two
- rebuilding index input for a 441 MB Codex session from cached messages took 63.67 ms instead of 3719.8 ms for source parsing, reducing preparation time by 98.3% (about 58x)
- the normalized-message fix let all 2,253 migrated Codex documents reuse materialized data with zero source-detail reads
- recent full-sync checks no longer enumerate every raw source file, removing an O(source files) startup probe and preventing filtered Claude Code files from scheduling redundant backfills
- the observed one-time Codex migration spent about 16 seconds preparing, 49 seconds writing the index, and 9 seconds committing; these stages are now visible instead of appearing stalled

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm format:check`
- `pnpm perf:check`
- documentation path, fact, quality-task coverage, and release preflight checks
- authenticated real-browser benchmark
- fixture benchmark with live update profiling
- regression coverage for window-only partial status, recent full-sync scheduling, publication progress routing, and differing Codex raw and normalized message counts