### PR TITLE
fix(cli): preserve unavailable refresh baseline

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -1485,6 +1485,40 @@ describe("AgentSyncEngine", () => {
     expect(searchIndex.enqueue).not.toHaveBeenCalled();
   });
 
+  it("detects database changes after an unavailable agent recovers", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    let available = false;
+    const previous = makeSession("session", "before");
+    const updated = makeSession("session", "after");
+    const checkForChanges = vi.fn((sinceTimestamp: number) => ({
+      hasChanges: sinceTimestamp < 1_500,
+      timestamp: Date.now(),
+    }));
+    const agent = makeAgent({
+      isAvailable: () => available,
+      checkForChanges,
+    });
+    const workerRunner = makeWorkerRunner();
+    vi.mocked(workerRunner.run).mockImplementation(async (_agentName, payload) =>
+      workerResult({
+        sessions: payload.operation.kind === "full-scan" ? [updated] : payload.previousSessions,
+        meta: payload.meta,
+        changedIds: payload.operation.kind === "full-scan" ? [updated.reference.sessionId] : [],
+      }),
+    );
+    const { engine } = makeEngine(agent, [previous], workerRunner);
+
+    vi.setSystemTime(2_000);
+    await engine.refresh("codex");
+    available = true;
+    await engine.refresh("codex");
+
+    expect(checkForChanges).toHaveBeenCalledOnce();
+    expect(checkForChanges).toHaveBeenCalledWith(1_000, [previous]);
+    expect(engine.snapshot().byAgent.codex).toEqual([updated]);
+  });
+
   it("CS-138: still publishes a genuinely empty scan as removals", async () => {
     const workerRunner = makeWorkerRunner();
     const previous = makeSession("session", "before");

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -543,7 +543,6 @@ export class AgentSyncEngine {
    * empty database.
    */
   private refreshUnavailableAgent(agentName: string): RefreshStrategyResult {
-    this.lastRefreshAtByAgent.set(agentName, Date.now());
     const previousSessions = this.sessionIndex.snapshot().byAgent[agentName] ?? [];
     if (previousSessions.length > 0) {
       appLogger.warn("scan.refresh.agent_unavailable", {


### PR DESCRIPTION
## Summary

- keep the last confirmed refresh baseline when an agent source is unavailable
- detect database changes correctly when the source later recovers
- cover the unavailable-to-recovered lifecycle with a regression test

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`