### PR TITLE
fix(core): slim Kimi Code head scans

### DIFF
--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -21,6 +21,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { KimiCodeAgent } from "../kimi-code.js";
+import { TranscriptBuilder } from "../transcript-builder.js";
 
 const SESSION_ID = "ses_test-kimi-code";
 const WORK_DIR = "/tmp/kimi-code-project";
@@ -65,6 +66,30 @@ afterEach(() => {
 });
 
 describe("KimiCodeAgent", () => {
+  it("does not retain transcript payloads while scanning heads", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
+    tempDirs.push(dataRoot);
+    const payload = "head-scan-payload-that-must-not-be-retained";
+    createSession(dataRoot, [
+      {
+        type: "context.append_message",
+        message: { role: "user", content: payload },
+      },
+    ]);
+    const finish = vi.spyOn(TranscriptBuilder.prototype, "finish");
+
+    const agent = createAgent(dataRoot);
+    expect(agent.scan()[0]?.stats.message_count).toBe(1);
+    const headTranscript = finish.mock.results[0]?.value;
+    expect(JSON.stringify(headTranscript)).not.toContain(payload);
+    expect(JSON.stringify(headTranscript)).toContain("[content]");
+    finish.mockRestore();
+
+    expect(agent.getSessionData(SESSION_ID).messages[0]?.parts).toEqual([
+      expect.objectContaining({ type: "text", text: payload }),
+    ]);
+  });
+
   it("surfaces state read failures instead of treating them as malformed sessions", () => {
     const dataRoot = mkdtempSync(join(tmpdir(), "codesesh-kimi-code-test-"));
     tempDirs.push(dataRoot);

--- a/packages/core/src/agents/__tests__/transcript-builder.test.ts
+++ b/packages/core/src/agents/__tests__/transcript-builder.test.ts
@@ -2,6 +2,37 @@ import { describe, expect, it } from "vitest";
 import { TranscriptBuilder } from "../transcript-builder.js";
 
 describe("TranscriptBuilder", () => {
+  it("retains message structure without transcript content", () => {
+    const builder = new TranscriptBuilder({ contentRetention: "structure" });
+    builder.appendMessage({
+      id: "m1",
+      role: "assistant",
+      timestampMs: 1,
+      parts: [
+        { type: "text", text: "large response" },
+        {
+          type: "tool",
+          tool: "read",
+          callID: "call-1",
+          state: { status: "running", input: { path: "secret.ts" } },
+        },
+      ],
+    });
+    builder.resolveToolCall("call-1", { output: "large output", status: "completed" });
+
+    expect(builder.finish().messages).toEqual([
+      expect.objectContaining({
+        parts: [
+          expect.objectContaining({ type: "text", text: "[content]" }),
+          expect.objectContaining({
+            type: "tool",
+            state: { status: "completed" },
+          }),
+        ],
+      }),
+    ]);
+  });
+
   it("groups streaming assistant parts until a tool closes the text message", () => {
     const builder = new TranscriptBuilder();
     const meta = { id: "assistant", timestampMs: 10, agent: "codex" };

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -550,7 +550,7 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     if (result.status !== "parsed") return result;
     const source = result.data;
 
-    const parsed = this.parseWire(source);
+    const parsed = this.parseWire(source, "head");
     const transcript = parsed.builder.finish(parsed.stats);
     if (transcript.messages.length === 0) {
       this.sessionMetaMap.delete(source.id);
@@ -598,8 +598,13 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     };
   }
 
-  private parseWire(source: Pick<SessionSource, "wireFile">): ParsedWire {
-    const builder = new TranscriptBuilder();
+  private parseWire(
+    source: Pick<SessionSource, "wireFile">,
+    projection: "head" | "detail" = "detail",
+  ): ParsedWire {
+    const builder = new TranscriptBuilder({
+      contentRetention: projection === "head" ? "structure" : "full",
+    });
     const totals = buildUsageTotals();
     const ignoredToolCallIds = new Set<string>();
     let activeModel: string | null = null;

--- a/packages/core/src/agents/transcript-builder.ts
+++ b/packages/core/src/agents/transcript-builder.ts
@@ -37,6 +37,13 @@ export interface TranscriptResult {
   stats: SessionStats;
 }
 
+interface TranscriptBuilderOptions {
+  messageDefaults?: "nullable" | "sparse";
+  contentRetention?: "full" | "structure";
+}
+
+const RETAINED_CONTENT = "[content]";
+
 function mergeTokens(base: Message["tokens"], extra: Message["tokens"]): Message["tokens"] {
   if (!base) return extra;
   if (!extra) return base;
@@ -62,7 +69,7 @@ export class TranscriptBuilder {
   private currentAssistant: Message | null = null;
   private latestTextAssistant: Message | null = null;
 
-  constructor(private readonly options: { messageDefaults?: "nullable" | "sparse" } = {}) {}
+  constructor(private readonly options: TranscriptBuilderOptions = {}) {}
 
   beginTurn(): void {
     this.currentAssistant = null;
@@ -149,10 +156,10 @@ export class TranscriptBuilder {
         });
 
     if (target) {
-      this.pushPart(message, part);
+      const retainedPart = this.pushPart(message, part);
       this.applyMissingMetadata(message, input);
       if (options.markModeAsTool) message.mode = "tool";
-      this.registerToolCall(part);
+      this.registerToolCall(retainedPart);
     }
 
     this.currentAssistant = message;
@@ -175,12 +182,16 @@ export class TranscriptBuilder {
   resolveToolCall(callId: string, resolution: ToolResolution): boolean {
     return this.updateToolCall(callId, (part) => {
       const state = part.state;
-      if (resolution.output !== undefined) state.output = resolution.output;
+      if (resolution.output !== undefined && this.options.contentRetention !== "structure") {
+        state.output = resolution.output;
+      }
       if (resolution.status !== undefined) state.status = resolution.status;
       else if (resolution.output !== undefined && state.status === "running") {
         state.status = "completed";
       }
-      if (resolution.metadata !== undefined) state.metadata = resolution.metadata;
+      if (resolution.metadata !== undefined && this.options.contentRetention !== "structure") {
+        state.metadata = resolution.metadata;
+      }
       if (resolution.consume) this.pendingToolCalls.delete(callId);
     });
   }
@@ -245,7 +256,7 @@ export class TranscriptBuilder {
       tokens: input.tokens,
       cost: sparse ? input.cost : (input.cost ?? 0),
       cost_source: input.costSource,
-      parts: input.parts ?? [],
+      parts: (input.parts ?? []).map((part) => this.retainPart(part)),
       subagent_id: input.subagentId,
       nickname: input.nickname,
     };
@@ -265,9 +276,30 @@ export class TranscriptBuilder {
     this.pushPart(message, part);
   }
 
-  private pushPart(message: Message, part: MessagePart): void {
-    message.parts.push(part);
-    this.notePart(message, part);
+  private pushPart(message: Message, part: MessagePart): MessagePart {
+    const retainedPart = this.retainPart(part);
+    message.parts.push(retainedPart);
+    this.notePart(message, retainedPart);
+    return retainedPart;
+  }
+
+  private retainPart(part: MessagePart): MessagePart {
+    if (this.options.contentRetention !== "structure") return part;
+    if (part.type === "text" || part.type === "reasoning") {
+      return { ...part, text: RETAINED_CONTENT };
+    }
+    if (part.type === "plan") return { ...part, text: RETAINED_CONTENT };
+    if (part.type === "image") {
+      return { type: "image", url: RETAINED_CONTENT, time_created: part.time_created };
+    }
+    return {
+      type: "tool",
+      tool: part.tool,
+      title: part.title,
+      callID: part.callID,
+      state: { status: part.state.status },
+      time_created: part.time_created,
+    };
   }
 
   private notePart(message: Message, part: MessagePart): void {


### PR DESCRIPTION
## Summary

- add a structure-only transcript retention mode for metadata projections
- use it during Kimi Code head scans so message payloads are not retained
- keep full transcript content available for session details

## Validation

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test