### PR TITLE
refactor(cli): model worker run lifecycle

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -16,7 +16,7 @@ import type {
   SessionSourceFailure,
 } from "@codesesh/core/runtime";
 import type { ScanStatusEvent } from "@codesesh/core/contract";
-import type { WorkerResult, WorkerRunner } from "./worker-runner.js";
+import type { StagedWorkerRun, WorkerResult, WorkerRunner } from "./worker-runner.js";
 import { appLogger } from "./logging.js";
 import { AgentUnavailableDuringScanError } from "./scan-refresh-error.js";
 import type { ScanStatusModel } from "./scan-status-model.js";
@@ -189,11 +189,29 @@ class FakeSyncAgent extends FileSystemSessionSource {
   }
 }
 
+const workerLifecycle = {
+  commit: vi.fn(),
+  discard: vi.fn(),
+};
+
 function workerResult(
   result: Omit<WorkerResult, "completeness" | "explicitRemovedSessionIds">,
   completeness: WorkerResult["completeness"] = "complete",
-): WorkerResult {
-  return { ...result, completeness, explicitRemovedSessionIds: [] };
+): StagedWorkerRun {
+  let finalized = false;
+  return {
+    result: { ...result, completeness, explicitRemovedSessionIds: [] },
+    commit: () => {
+      if (finalized) return;
+      finalized = true;
+      workerLifecycle.commit();
+    },
+    discard: () => {
+      if (finalized) return;
+      finalized = true;
+      workerLifecycle.discard();
+    },
+  };
 }
 
 function makeWorkerRunner(): WorkerRunner {
@@ -208,8 +226,7 @@ function makeWorkerRunner(): WorkerRunner {
         payload.scanOptions.from == null && payload.scanOptions.to == null ? "complete" : "partial",
       ),
     ),
-    commit: vi.fn(),
-    discard: vi.fn(),
+    reset: vi.fn(),
     shutdown: vi.fn(async () => undefined),
   };
 }
@@ -289,6 +306,7 @@ describe("AgentSyncEngine", () => {
           changedIds: [],
         }),
       ),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(new FakeSyncAgent(), [session], workerRunner, { from: 1 });
@@ -365,6 +383,7 @@ describe("AgentSyncEngine", () => {
         }
         return workerResult({ sessions: [], meta: {} });
       }),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(new FakeSyncAgent(), [], workerRunner, { from: 1 });
@@ -438,6 +457,7 @@ describe("AgentSyncEngine", () => {
         payload.onProgress?.({ phase: "finalizing", total: 10_000, processed: 10_000 });
         return workerResult({ sessions: [], meta: {} });
       }),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     core.readAgentLastFullSyncAt.mockReturnValueOnce({ status: "success", value: null });
@@ -512,8 +532,7 @@ describe("AgentSyncEngine", () => {
         });
         return workerResult({ sessions: [next], meta: {} });
       }),
-      commit: vi.fn(),
-      discard: vi.fn(),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     core.readAgentLastFullSyncAt.mockReturnValueOnce({ status: "success", value: null });
@@ -565,8 +584,7 @@ describe("AgentSyncEngine", () => {
           "partial",
         );
       }),
-      commit: vi.fn(),
-      discard: vi.fn(),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     core.getAgentFullSyncCursor.mockReturnValueOnce("cursor-1");
@@ -588,8 +606,8 @@ describe("AgentSyncEngine", () => {
         },
       },
     });
-    expect(workerRunner.commit).toHaveBeenCalledWith("codex");
-    expect(workerRunner.discard).not.toHaveBeenCalled();
+    expect(workerLifecycle.commit).toHaveBeenCalledTimes(2);
+    expect(workerLifecycle.discard).not.toHaveBeenCalled();
     expect(workerRunner.run).toHaveBeenCalledWith(
       "codex",
       expect.objectContaining({
@@ -700,7 +718,7 @@ describe("AgentSyncEngine", () => {
     expect(statusChanges).toHaveBeenCalledWith(
       expect.objectContaining({ type: "scan-status", active: false }),
     );
-    expect(workerRunner.discard).toHaveBeenCalledWith("codex");
+    expect(workerRunner.reset).toHaveBeenCalledWith("codex");
     expect(incrementalScan).toHaveBeenCalledWith(
       [previous],
       [updated.reference.sessionId],
@@ -722,6 +740,7 @@ describe("AgentSyncEngine", () => {
         payload.onProgress?.({ phase: "finalizing", total: 10_000, processed: 10_000 });
         return workerResult({ sessions: [], meta: {} });
       }),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(makeAgent(), [], workerRunner);
@@ -768,6 +787,7 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async () => workerResult({ sessions: [updated], meta: {} })),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(
@@ -901,6 +921,7 @@ describe("AgentSyncEngine", () => {
         expect(payload.onCheckpoint).toBeUndefined();
         return workerResult({ sessions: [tagged], meta });
       }),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(makeAgent(), [], workerRunner);
@@ -941,6 +962,7 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async () => workerResult({ sessions: [recent], meta: {} }, "partial")),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const state: LiveSnapshot = {
@@ -987,6 +1009,7 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async () => workerResult({ sessions: [head], meta: nextMeta })),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const agent = makeAgent({
@@ -1090,6 +1113,7 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: runWorker,
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(
@@ -1147,6 +1171,7 @@ describe("AgentSyncEngine", () => {
           "partial",
         ),
       ),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const agent = makeAgent({
@@ -1205,6 +1230,7 @@ describe("AgentSyncEngine", () => {
           changedIds: [steady.reference.sessionId],
         }),
       ),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const agent = makeAgent({
@@ -1273,8 +1299,7 @@ describe("AgentSyncEngine", () => {
           "partial",
         ),
       ),
-      commit: vi.fn(),
-      discard: vi.fn(),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(new FakeSyncAgent(), [changed, retained], workerRunner);
@@ -1311,8 +1336,8 @@ describe("AgentSyncEngine", () => {
         sourceFailureSummary: "SyntaxError: Unexpected end of JSON input",
       }),
     );
-    expect(workerRunner.commit).toHaveBeenCalledWith("codex");
-    expect(workerRunner.discard).not.toHaveBeenCalled();
+    expect(workerLifecycle.commit).toHaveBeenCalledOnce();
+    expect(workerLifecycle.discard).not.toHaveBeenCalled();
   });
 
   it("keeps a committed refresh complete when post-commit notifications throw", async () => {
@@ -1332,8 +1357,7 @@ describe("AgentSyncEngine", () => {
           changedIds: [updated.reference.sessionId],
         }),
       ),
-      commit: vi.fn(),
-      discard: vi.fn(),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(new FakeSyncAgent(), [previous], workerRunner);
@@ -1358,8 +1382,8 @@ describe("AgentSyncEngine", () => {
         expect.objectContaining({ reference: updated.reference, title: updated.title }),
       ]);
       expect(engine.status().agentStatuses.codex).toMatchObject({ status: "complete" });
-      expect(workerRunner.commit).toHaveBeenCalledWith("codex");
-      expect(workerRunner.discard).not.toHaveBeenCalled();
+      expect(workerLifecycle.commit).toHaveBeenCalledOnce();
+      expect(workerLifecycle.discard).not.toHaveBeenCalled();
       expect(finishAgent).toHaveBeenCalledTimes(2);
       expect(logError).toHaveBeenCalledWith(
         "scan.refresh.post_commit_error",
@@ -1402,8 +1426,9 @@ describe("AgentSyncEngine", () => {
       "[codex] Session refresh failed:",
       expect.objectContaining({ message: "index failed" }),
     );
-    expect(workerRunner.commit).not.toHaveBeenCalled();
-    expect(workerRunner.discard).toHaveBeenCalledWith("codex");
+    expect(workerLifecycle.commit).not.toHaveBeenCalled();
+    expect(workerLifecycle.discard).not.toHaveBeenCalled();
+    expect(workerRunner.reset).toHaveBeenCalledWith("codex");
     expect(engine.status().agentStatuses.codex).toMatchObject({ status: "failed" });
   });
 
@@ -1457,8 +1482,8 @@ describe("AgentSyncEngine", () => {
     expect(refreshState.lastRefreshAtByAgent.get("codex")).toBe(baselineTimestamp);
     expect(sessionChanges).not.toHaveBeenCalled();
     expect(searchIndex.enqueue).not.toHaveBeenCalled();
-    expect(workerRunner.commit).not.toHaveBeenCalled();
-    expect(workerRunner.discard).toHaveBeenCalledWith("codex");
+    expect(workerLifecycle.commit).not.toHaveBeenCalled();
+    expect(workerLifecycle.discard).not.toHaveBeenCalled();
     expect(engine.status().agentStatuses.codex).toMatchObject({ status: "failed" });
     expect(warn).toHaveBeenCalledWith("scan.refresh.worker_agent_unavailable", {
       agent: "codex",
@@ -1593,6 +1618,7 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async () => workerResult({ sessions: [session], meta: {}, changedIds: [] })),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const { engine } = makeEngine(agent, [session], workerRunner);
@@ -1629,6 +1655,7 @@ describe("AgentSyncEngine", () => {
       // changed — mirrors an out-of-band reclassification the file-fingerprint
       // check can't see.
       run: vi.fn(async () => workerResult({ sessions: [newSession], meta: {}, changedIds: [] })),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const state: LiveSnapshot = {
@@ -1667,8 +1694,7 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async () => workerResult({ sessions: [newSession], meta: {}, changedIds: [] })),
-      commit: vi.fn(),
-      discard: vi.fn(),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const engine = new AgentSyncEngine({ workerRunner });
@@ -1689,8 +1715,8 @@ describe("AgentSyncEngine", () => {
 
     expect(engine.snapshot().sessions).toEqual([oldSession]);
     expect(sessionChanges).not.toHaveBeenCalled();
-    expect(workerRunner.commit).not.toHaveBeenCalled();
-    expect(workerRunner.discard).toHaveBeenCalledTimes(1);
+    expect(workerLifecycle.commit).not.toHaveBeenCalled();
+    expect(workerLifecycle.discard).toHaveBeenCalledTimes(1);
 
     await engine.refresh("codex");
 
@@ -1705,7 +1731,7 @@ describe("AgentSyncEngine", () => {
         event: expect.objectContaining({ updatedSessions: 1 }),
       }),
     );
-    expect(workerRunner.commit).toHaveBeenCalledTimes(1);
+    expect(workerLifecycle.commit).toHaveBeenCalledTimes(1);
   });
 
   it("CS-73 regression: a windowed startup scan with one unindexed session still switches to the incremental refresh path", async () => {
@@ -1732,6 +1758,7 @@ describe("AgentSyncEngine", () => {
     const workerRunner: WorkerRunner = {
       activeCount: 0,
       run: vi.fn(async () => workerResult({ sessions: scanResult, meta: {} }, "partial")),
+      reset: vi.fn(),
       shutdown: vi.fn(async () => undefined),
     };
     const state: LiveSnapshot = { agents: [agent], byAgent: { codex: [] }, sessions: [] };

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -46,7 +46,7 @@ import type {
 } from "./scan-refresh-operation.js";
 import type { ScanRefreshWorkerCheckpoint } from "./scan-refresh-worker.js";
 import { AgentUnavailableDuringScanError } from "./scan-refresh-error.js";
-import type { WorkerRunner } from "./worker-runner.js";
+import type { StagedWorkerRun, WorkerRunner } from "./worker-runner.js";
 import { toError } from "./errors.js";
 
 export type { AgentOperationResult } from "./agent-operation-scheduler.js";
@@ -77,6 +77,7 @@ interface RefreshStrategyBase {
   sourceFailures: SessionSourceFailure[];
   completeness: SessionSnapshotCompleteness;
   scope: Pick<ScanOptions, "from" | "to">;
+  workerRun?: StagedWorkerRun;
 }
 
 type RefreshPublication =
@@ -295,14 +296,23 @@ export class AgentSyncEngine {
     let cached: CachedSessions | null = null;
     let result: AgentOperationResult = "failed";
     let completion: ScanCompletion = { completeness: "complete" };
+    let stagedRun: StagedWorkerRun | undefined;
     try {
       if (this.findAgent(agentName))
         cached = this.readCachedSessionsOrWarn("scan.refresh", agentName);
-      const refresh = await this.runRefresh(agentName, cached, startedAt, (committedCompletion) => {
-        durableCommitted = true;
-        completion = committedCompletion;
-        result = "committed";
-      });
+      const refresh = await this.runRefresh(
+        agentName,
+        cached,
+        startedAt,
+        (committedCompletion) => {
+          durableCommitted = true;
+          completion = committedCompletion;
+          result = "committed";
+        },
+        (run) => {
+          stagedRun = run;
+        },
+      );
       result = refresh.result;
       completion = refresh.completion;
     } catch (error) {
@@ -310,7 +320,7 @@ export class AgentSyncEngine {
         this.reportPostCommitError("scan.refresh", agentName, error);
         result = "committed";
       } else {
-        this.options.workerRunner.discard?.(agentName);
+        stagedRun?.discard();
         failed = true;
         const failure = toError(error);
         if (failure instanceof AgentUnavailableDuringScanError) {
@@ -354,6 +364,7 @@ export class AgentSyncEngine {
     cached: CachedSessions | null,
     startedAt: number,
     onDurableCommit: (completion: ScanCompletion) => void,
+    onWorkerRun: (run: StagedWorkerRun | undefined) => void,
   ): Promise<RefreshResult> {
     const pendingPathCount = this.scheduler.takePendingSignalCount(agentName);
     const agent = this.findAgent(agentName);
@@ -403,8 +414,10 @@ export class AgentSyncEngine {
         strategyResult = await this.refreshChangedAgent(agent, refresh, refreshBaseline, startedAt);
       }
     }
+    const stagedRun = strategyResult.workerRun;
+    onWorkerRun(stagedRun);
     if (strategyResult.status === "unchanged") {
-      this.options.workerRunner.commit?.(agentName);
+      stagedRun?.commit();
       return {
         result: "unchanged",
         completion: buildScanCompletion(strategyResult.completeness, strategyResult.sourceFailures),
@@ -489,6 +502,7 @@ export class AgentSyncEngine {
         indexJob: persistentJob,
         onPublishing: () => this.statusReporter.beginAgentPublishing(agentName),
         onCommitted: () => {
+          stagedRun?.commit();
           publicationCommitted = true;
           onDurableCommit(completion);
         },
@@ -501,7 +515,6 @@ export class AgentSyncEngine {
       }
       throw error;
     }
-    this.options.workerRunner.commit?.(agentName);
     const persistDuration = performance.now() - persistStartedAt;
     logSearchIndexSync("scan.refresh", null, { pending_paths: pendingPathCount });
 
@@ -568,22 +581,29 @@ export class AgentSyncEngine {
     this.statusReporter.setScanPhase("initializing");
     const scanStartedAt = performance.now();
     const scope = this.startupScanOptions();
-    const result = await this.runWorker(agent, previousSessions, { kind: "full-scan" }, scope);
-    agent.restoreSessionCacheMeta(result.meta);
-    const sessions = attachMissingProjectIdentities(result.sessions);
-    this.lastRefreshAtByAgent.set(agent.name, Date.now());
-    return {
-      ...this.refreshStrategyBase(sessions, result.completeness, scope, {
-        scanDuration: performance.now() - scanStartedAt,
-        sourceFailures: result.sourceFailures ?? [],
-      }),
-      status: "continue",
-      publication: {
-        kind: "full",
-        sessions,
-        explicitRemovedSessionIds: result.explicitRemovedSessionIds,
-      },
-    };
+    const workerRun = await this.runWorker(agent, previousSessions, { kind: "full-scan" }, scope);
+    try {
+      const { result } = workerRun;
+      agent.restoreSessionCacheMeta(result.meta);
+      const sessions = attachMissingProjectIdentities(result.sessions);
+      this.lastRefreshAtByAgent.set(agent.name, Date.now());
+      return {
+        ...this.refreshStrategyBase(sessions, result.completeness, scope, {
+          scanDuration: performance.now() - scanStartedAt,
+          sourceFailures: result.sourceFailures ?? [],
+          workerRun,
+        }),
+        status: "continue",
+        publication: {
+          kind: "full",
+          sessions,
+          explicitRemovedSessionIds: result.explicitRemovedSessionIds,
+        },
+      };
+    } catch (error) {
+      workerRun.discard();
+      throw error;
+    }
   }
 
   private async syncAgentSources(
@@ -593,7 +613,7 @@ export class AgentSyncEngine {
   ): Promise<RefreshStrategyResult> {
     const scanStartedAt = performance.now();
     const scope = this.startupScanOptions();
-    const result = await this.runWorker(
+    const workerRun = await this.runWorker(
       agent,
       baseline.sessions,
       { kind: "source-refresh" },
@@ -602,38 +622,46 @@ export class AgentSyncEngine {
         meta: baseline.meta,
       },
     );
-    agent.restoreSessionCacheMeta(result.meta);
-    const sessions = attachMissingProjectIdentities(result.sessions);
-    const preciseChangedIds = result.changedIds ?? [];
-    const persistenceDiff = buildSessionPersistenceDiff(baseline.sessions, sessions, {
-      candidateChangedIds: preciseChangedIds,
-    });
-    this.lastRefreshAtByAgent.set(agent.name, Date.now());
-    if (
-      persistenceDiff.changedSessions.length === 0 &&
-      persistenceDiff.removedSessionIds.length === 0 &&
-      (result.sourceFailures?.length ?? 0) === 0
-    ) {
-      this.logUnchangedRefresh(agent.name, refreshStartedAt);
+    try {
+      const { result } = workerRun;
+      agent.restoreSessionCacheMeta(result.meta);
+      const sessions = attachMissingProjectIdentities(result.sessions);
+      const preciseChangedIds = result.changedIds ?? [];
+      const persistenceDiff = buildSessionPersistenceDiff(baseline.sessions, sessions, {
+        candidateChangedIds: preciseChangedIds,
+      });
+      this.lastRefreshAtByAgent.set(agent.name, Date.now());
+      if (
+        persistenceDiff.changedSessions.length === 0 &&
+        persistenceDiff.removedSessionIds.length === 0 &&
+        (result.sourceFailures?.length ?? 0) === 0
+      ) {
+        this.logUnchangedRefresh(agent.name, refreshStartedAt);
+        return {
+          ...this.refreshStrategyBase(sessions, result.completeness, scope, {
+            scanDuration: performance.now() - scanStartedAt,
+            workerRun,
+          }),
+          status: "unchanged",
+        };
+      }
       return {
         ...this.refreshStrategyBase(sessions, result.completeness, scope, {
           scanDuration: performance.now() - scanStartedAt,
+          sourceFailures: result.sourceFailures ?? [],
+          workerRun,
         }),
-        status: "unchanged",
+        status: "continue",
+        publication: {
+          kind: "changes",
+          diff: persistenceDiff,
+          candidateChangedIds: preciseChangedIds,
+        },
       };
+    } catch (error) {
+      workerRun.discard();
+      throw error;
     }
-    return {
-      ...this.refreshStrategyBase(sessions, result.completeness, scope, {
-        scanDuration: performance.now() - scanStartedAt,
-        sourceFailures: result.sourceFailures ?? [],
-      }),
-      status: "continue",
-      publication: {
-        kind: "changes",
-        diff: persistenceDiff,
-        candidateChangedIds: preciseChangedIds,
-      },
-    };
   }
 
   private async refreshChangedAgent(
@@ -666,17 +694,33 @@ export class AgentSyncEngine {
     const checkDuration = refresh.checkDurationMs;
     if (refresh.kind === "unchanged") {
       const scanStartedAt = performance.now();
-      const result = await this.runWorker(agent, baseline, { kind: "recompute-derived" }, {});
-      agent.restoreSessionCacheMeta(result.meta);
-      const sessions = attachMissingProjectIdentities(result.sessions);
-      source.commitChangeCheck();
-      this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
-      const persistenceDiff = buildSessionPersistenceDiff(baseline, sessions);
-      if (
-        persistenceDiff.changedSessions.length === 0 &&
-        persistenceDiff.removedSessionIds.length === 0
-      ) {
-        this.logUnchangedRefresh(agent.name, refreshStartedAt);
+      const workerRun = await this.runWorker(agent, baseline, { kind: "recompute-derived" }, {});
+      try {
+        const { result } = workerRun;
+        agent.restoreSessionCacheMeta(result.meta);
+        const sessions = attachMissingProjectIdentities(result.sessions);
+        source.commitChangeCheck();
+        this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
+        const persistenceDiff = buildSessionPersistenceDiff(baseline, sessions);
+        if (
+          persistenceDiff.changedSessions.length === 0 &&
+          persistenceDiff.removedSessionIds.length === 0
+        ) {
+          this.logUnchangedRefresh(agent.name, refreshStartedAt);
+          return {
+            ...this.refreshStrategyBase(
+              sessions,
+              result.completeness,
+              {},
+              {
+                checkDuration,
+                scanDuration: performance.now() - scanStartedAt,
+                workerRun,
+              },
+            ),
+            status: "unchanged",
+          };
+        }
         return {
           ...this.refreshStrategyBase(
             sessions,
@@ -685,56 +729,55 @@ export class AgentSyncEngine {
             {
               checkDuration,
               scanDuration: performance.now() - scanStartedAt,
+              sourceFailures: result.sourceFailures ?? [],
+              workerRun,
             },
           ),
-          status: "unchanged",
+          status: "continue",
+          publication: { kind: "changes", diff: persistenceDiff, candidateChangedIds: [] },
         };
+      } catch (error) {
+        workerRun.discard();
+        throw error;
       }
-      return {
-        ...this.refreshStrategyBase(
-          sessions,
-          result.completeness,
-          {},
-          {
-            checkDuration,
-            scanDuration: performance.now() - scanStartedAt,
-            sourceFailures: result.sourceFailures ?? [],
-          },
-        ),
-        status: "continue",
-        publication: { kind: "changes", diff: persistenceDiff, candidateChangedIds: [] },
-      };
     }
     const preciseChangedIds = checkResult.changedIds ?? null;
     const scanStartedAt = performance.now();
     if (preciseChangedIds === null) {
-      const result = await this.runWorker(agent, baseline, { kind: "full-scan" }, scope);
-      agent.restoreSessionCacheMeta(result.meta);
-      const sessions = attachMissingProjectIdentities(result.sessions);
-      source.commitChangeCheck();
-      this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
-      return {
-        ...this.refreshStrategyBase(sessions, result.completeness, scope, {
-          checkDuration,
-          scanDuration: performance.now() - scanStartedAt,
-          sourceFailures: result.sourceFailures ?? [],
-        }),
-        status: "continue",
-        publication: {
-          kind: "changes",
-          // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
-          // signature intact; without the worker-reported ids they would never
-          // persist and checkForChanges would rescan on every startup.
-          diff: buildSessionPersistenceDiff(baseline, sessions, {
-            candidateChangedIds: result.changedIds ?? [],
-            completeness: result.completeness,
-            explicitRemovedSessionIds: result.explicitRemovedSessionIds,
+      const workerRun = await this.runWorker(agent, baseline, { kind: "full-scan" }, scope);
+      try {
+        const { result } = workerRun;
+        agent.restoreSessionCacheMeta(result.meta);
+        const sessions = attachMissingProjectIdentities(result.sessions);
+        source.commitChangeCheck();
+        this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
+        return {
+          ...this.refreshStrategyBase(sessions, result.completeness, scope, {
+            checkDuration,
+            scanDuration: performance.now() - scanStartedAt,
+            sourceFailures: result.sourceFailures ?? [],
+            workerRun,
           }),
-          candidateChangedIds: [],
-        },
-      };
+          status: "continue",
+          publication: {
+            kind: "changes",
+            // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
+            // signature intact; without the worker-reported ids they would never
+            // persist and checkForChanges would rescan on every startup.
+            diff: buildSessionPersistenceDiff(baseline, sessions, {
+              candidateChangedIds: result.changedIds ?? [],
+              completeness: result.completeness,
+              explicitRemovedSessionIds: result.explicitRemovedSessionIds,
+            }),
+            candidateChangedIds: [],
+          },
+        };
+      } catch (error) {
+        workerRun.discard();
+        throw error;
+      }
     }
-    this.options.workerRunner.discard?.(agent.name);
+    this.options.workerRunner.reset(agent.name);
     const sessions = attachMissingProjectIdentities(
       await Promise.resolve(
         source.incrementalScan(baseline, preciseChangedIds, checkResult.refs, scope),
@@ -862,6 +905,7 @@ export class AgentSyncEngine {
     const backfillCursor = getAgentFullSyncCursor(agentName);
     if (cached) agent.restoreSessionCacheMeta(cached.meta);
     let durableCommitted = false;
+    let workerRun: StagedWorkerRun | undefined;
     try {
       if (!markAgentFullSyncStarted(agentName)) {
         appLogger.warn("scan.backfill.cache_state_unavailable", {
@@ -879,7 +923,7 @@ export class AgentSyncEngine {
         cursor: backfillCursor ?? undefined,
         durable_checkpoints: operation.checkpoint === "durable",
       });
-      const result = await this.runWorker(
+      workerRun = await this.runWorker(
         agent,
         baseline,
         operation,
@@ -890,6 +934,7 @@ export class AgentSyncEngine {
           onCheckpoint: (checkpoint) => this.handleBackfillCheckpoint(agentName, checkpoint),
         },
       );
+      const { result } = workerRun;
       agent.restoreSessionCacheMeta(result.meta);
       const fullSessions = attachMissingProjectIdentities(result.sessions);
       const completion = buildScanCompletion(result.completeness, result.sourceFailures ?? []);
@@ -928,6 +973,7 @@ export class AgentSyncEngine {
           if (stage === "search_staged") updatePublicationPhase("committing");
         },
         onCommitted: () => {
+          workerRun?.commit();
           durableCommitted = true;
           if (completion.completeness === "partial") {
             this.backfills.recordCompletion(attempt, completion);
@@ -935,7 +981,7 @@ export class AgentSyncEngine {
         },
       });
       durableCommitted = publication.durableCommitted;
-      this.options.workerRunner.commit?.(agentName);
+      workerRun.commit();
       if (completion.completeness === "complete" && !markAgentFullSyncCompleted(agentName)) {
         appLogger.warn("scan.backfill.completion_not_durable", { agent: agentName });
       }
@@ -958,11 +1004,12 @@ export class AgentSyncEngine {
       return "committed";
     } catch (error) {
       if (durableCommitted) {
+        workerRun?.commit();
         this.reportPostCommitError("scan.backfill", agentName, error);
         return "committed";
       }
       agent.restoreSessionCacheMeta(meta);
-      this.options.workerRunner.discard?.(agentName);
+      workerRun?.discard();
       appLogger.error("scan.backfill.error", { agent: agentName, error });
       console.error(`[${agentName}] Backfill failed:`, error);
       return "failed";

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -928,14 +928,13 @@ describe("LiveScanStore", () => {
     });
 
     workerThreads.deferScanRefreshWorkers = false;
-    await expect(
-      runner.run(agent.name, {
-        previousSessions: [],
-        operation: { kind: "full-scan" },
-        scanOptions: {},
-        meta: {},
-      }),
-    ).resolves.toEqual({
+    const retry = await runner.run(agent.name, {
+      previousSessions: [],
+      operation: { kind: "full-scan" },
+      scanOptions: {},
+      meta: {},
+    });
+    expect(retry.result).toEqual({
       sessions: [],
       meta: {},
       changedIds: [],
@@ -943,6 +942,7 @@ describe("LiveScanStore", () => {
       completeness: "complete",
       explicitRemovedSessionIds: [],
     });
+    retry.commit();
   });
 
   it("rehydrates an unavailable-agent error from the scan worker", async () => {
@@ -1008,7 +1008,8 @@ describe("LiveScanStore", () => {
       durationMs: 0,
     });
 
-    await expect(refresh).resolves.toEqual({
+    const run = await refresh;
+    expect(run.result).toEqual({
       sessions: [],
       meta: {},
       changedIds: [],
@@ -1016,7 +1017,7 @@ describe("LiveScanStore", () => {
       completeness: "complete",
       explicitRemovedSessionIds: [],
     });
-    runner.commit("codex");
+    run.commit();
     await runner.shutdown();
   });
 
@@ -1070,7 +1071,7 @@ describe("LiveScanStore", () => {
     core.createRegisteredAgents.mockReturnValue([agent]);
     const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
 
-    const result = await runner.run("codex", {
+    const run = await runner.run("codex", {
       previousSessions: [removed, retained],
       operation: { kind: "full-scan" },
       scanOptions: {},
@@ -1080,7 +1081,7 @@ describe("LiveScanStore", () => {
       },
     });
 
-    expect(result).toEqual({
+    expect(run.result).toEqual({
       sessions: [added, retained],
       meta: {
         added: { id: "added", sourcePath: "/added" },
@@ -1092,7 +1093,7 @@ describe("LiveScanStore", () => {
       explicitRemovedSessionIds: [],
     });
     expect(runner.activeCount).toBe(1);
-    runner.commit("codex");
+    run.commit();
     expect(runner.activeCount).toBe(0);
     await runner.shutdown();
   });
@@ -1111,20 +1112,20 @@ describe("LiveScanStore", () => {
     });
     await expect(
       runner.run("codex", {
-        previousSessions: first.sessions,
+        previousSessions: first.result.sessions,
         operation: { kind: "recompute-derived" },
         scanOptions: {},
-        meta: first.meta,
+        meta: first.result.meta,
       }),
     ).rejects.toThrow("Scan refresh worker for codex is busy");
-    runner.commit("codex");
+    first.commit();
     const worker = workerThreads.workers.at(-1)!;
 
     const second = await runner.run("codex", {
-      previousSessions: first.sessions,
+      previousSessions: first.result.sessions,
       operation: { kind: "recompute-derived" },
       scanOptions: {},
-      meta: first.meta,
+      meta: first.result.meta,
     });
     const runRequest = worker.postMessage.mock.calls
       .map(([request]) => request)
@@ -1138,21 +1139,21 @@ describe("LiveScanStore", () => {
     });
     expect(runRequest).not.toHaveProperty("previousSessions");
     expect(runRequest).not.toHaveProperty("meta");
-    expect(second.sessions).toEqual([session]);
+    expect(second.result.sessions).toEqual([session]);
     expect(core.createRegisteredAgents).toHaveBeenCalledTimes(1);
 
-    runner.commit("codex");
+    second.commit();
     worker.emitExit(1);
-    await runner.run("codex", {
-      previousSessions: second.sessions,
+    const replacement = await runner.run("codex", {
+      previousSessions: second.result.sessions,
       operation: { kind: "full-scan" },
       scanOptions: {},
-      meta: second.meta,
+      meta: second.result.meta,
     });
     const replacementWorker = workerThreads.workers.at(-1)!;
     expect(replacementWorker).not.toBe(worker);
-    expect(replacementWorker.workerData.previousSessions).toEqual(second.sessions);
-    runner.commit("codex");
+    expect(replacementWorker.workerData.previousSessions).toEqual(second.result.sessions);
+    replacement.commit();
     await runner.shutdown();
   });
 
@@ -1163,17 +1164,17 @@ describe("LiveScanStore", () => {
     core.createRegisteredAgents.mockReturnValue([agent]);
     const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
 
-    await runner.run("codex", {
+    const candidateRun = await runner.run("codex", {
       previousSessions: [lastKnownGood],
       operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {},
     });
     const discardedWorker = workerThreads.workers.at(-1)!;
-    runner.discard("codex");
+    candidateRun.discard();
 
     expect(discardedWorker.terminate).toHaveBeenCalledTimes(1);
-    await runner.run("codex", {
+    const replacementRun = await runner.run("codex", {
       previousSessions: [lastKnownGood],
       operation: { kind: "full-scan" },
       scanOptions: {},
@@ -1184,7 +1185,7 @@ describe("LiveScanStore", () => {
     expect(replacementWorker.workerData.previousSessions).toEqual([lastKnownGood]);
     expect(replacementWorker.workerData.generation).toBe(0);
 
-    runner.commit("codex");
+    replacementRun.commit();
     await runner.shutdown();
   });
 
@@ -1219,14 +1220,14 @@ describe("LiveScanStore", () => {
     expect(staleWorker.terminate).toHaveBeenCalledTimes(1);
 
     workerThreads.deferScanRefreshWorkers = false;
-    await runner.run("codex", {
+    const replacementRun = await runner.run("codex", {
       previousSessions: [],
       operation: { kind: "full-scan" },
       scanOptions: {},
       meta: {},
     });
     expect(workerThreads.workers.at(-1)).not.toBe(staleWorker);
-    runner.commit("codex");
+    replacementRun.commit();
     await runner.shutdown();
   });
 

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -41,16 +41,21 @@ export interface WorkerResult {
   explicitRemovedSessionIds: string[];
 }
 
+export interface StagedWorkerRun {
+  readonly result: WorkerResult;
+  commit(): void;
+  discard(): void;
+}
+
 export interface WorkerRunner {
   readonly activeCount: number;
-  run(agentName: string, payload: WorkerPayload): Promise<WorkerResult>;
-  commit?(agentName: string): void;
-  discard?(agentName: string): void;
+  run(agentName: string, payload: WorkerPayload): Promise<StagedWorkerRun>;
+  reset(agentName: string): void;
   shutdown(): Promise<void>;
 }
 
 interface PendingRequest {
-  resolve: (result: WorkerResult) => void;
+  resolve: (run: StagedWorkerRun) => void;
   reject: (error: Error) => void;
   payload: WorkerPayload;
   generation: number;
@@ -128,7 +133,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
     return count;
   }
 
-  run(agentName: string, payload: WorkerPayload): Promise<WorkerResult> {
+  run(agentName: string, payload: WorkerPayload): Promise<StagedWorkerRun> {
     if (this.isShuttingDown) return Promise.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
 
     const existingSlot = this.workers.get(agentName);
@@ -180,25 +185,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
     });
   }
 
-  commit(agentName: string): void {
-    const slot = this.workers.get(agentName);
-    const awaiting = slot?.awaitingCommit;
-    if (!slot || !awaiting) return;
-    const request: ScanRefreshWorkerCommitRequest = {
-      type: "commit",
-      requestId: awaiting.requestId,
-      generation: awaiting.generation,
-    };
-    try {
-      slot.worker.postMessage(request);
-      slot.awaitingCommit = null;
-      slot.generation += 1;
-    } catch {
-      this.invalidateWorker(agentName, slot);
-    }
-  }
-
-  discard(agentName: string): void {
+  reset(agentName: string): void {
     const slot = this.workers.get(agentName);
     if (slot) this.invalidateWorker(agentName, slot);
   }
@@ -302,9 +289,65 @@ export class ThreadWorkerRunner implements WorkerRunner {
         requestId: message.requestId,
         generation: message.generation,
       };
-      pending.resolve(result);
+      pending.resolve(this.createStagedRun(slot, message.requestId, message.generation, result));
     } catch (error) {
       pending.reject(toError(error));
+      this.invalidateWorker(slot.agentName, slot);
+    }
+  }
+
+  private createStagedRun(
+    slot: WorkerSlot,
+    requestId: number,
+    generation: number,
+    result: WorkerResult,
+  ): StagedWorkerRun {
+    let finalized = false;
+    return {
+      result,
+      commit: () => {
+        if (finalized) return;
+        finalized = true;
+        this.commitStagedRun(slot, requestId, generation);
+      },
+      discard: () => {
+        if (finalized) return;
+        finalized = true;
+        this.discardStagedRun(slot, requestId, generation);
+      },
+    };
+  }
+
+  private commitStagedRun(slot: WorkerSlot, requestId: number, generation: number): void {
+    const awaiting = slot.awaitingCommit;
+    if (
+      this.workers.get(slot.agentName) !== slot ||
+      awaiting?.requestId !== requestId ||
+      awaiting.generation !== generation
+    ) {
+      return;
+    }
+    const request: ScanRefreshWorkerCommitRequest = {
+      type: "commit",
+      requestId,
+      generation,
+    };
+    try {
+      slot.worker.postMessage(request);
+      slot.awaitingCommit = null;
+      slot.generation += 1;
+    } catch {
+      this.invalidateWorker(slot.agentName, slot);
+    }
+  }
+
+  private discardStagedRun(slot: WorkerSlot, requestId: number, generation: number): void {
+    const awaiting = slot.awaitingCommit;
+    if (
+      this.workers.get(slot.agentName) === slot &&
+      awaiting?.requestId === requestId &&
+      awaiting.generation === generation
+    ) {
       this.invalidateWorker(slot.agentName, slot);
     }
   }


### PR DESCRIPTION
## Summary

- return request-bound staged results from scan refresh workers
- require each staged result to be committed or discarded by its consumer
- separate external baseline reset from staged result finalization
- finalize worker state at durable refresh and backfill publication boundaries

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`