### PR TITLE
fix(contract): sanitize public session heads

### DIFF
--- a/packages/cli/src/api/__tests__/contract.test.ts
+++ b/packages/cli/src/api/__tests__/contract.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { SAMPLE_SCAN_STATUS_EVENT, SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
+import { toPublicSessionHead } from "@codesesh/core/contract";
 import type { LiveSnapshot } from "@codesesh/core/runtime";
 import { createApiRoutes } from "../routes.js";
 import type { ScanResultSource } from "../handlers.js";
@@ -57,7 +58,7 @@ describe("cli routes stay wire-compatible with @codesesh/core/contract", () => {
     expect(body.results).toEqual([
       {
         reference: { agentName: "claudecode", sessionId: SAMPLE_SESSION_HEAD.reference.sessionId },
-        session: SAMPLE_SESSION_HEAD,
+        session: toPublicSessionHead(SAMPLE_SESSION_HEAD),
         snippet: `Recent session · ${SAMPLE_SESSION_HEAD.directory}`,
         snippetHighlights: [],
         matchType: "recent",

--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -265,6 +265,38 @@ describe("bookmark handlers", () => {
     expect(coreMocks.importBookmarks).not.toHaveBeenCalled();
   });
 
+  it("omits internal metadata from available sessions", () => {
+    const internalSession = {
+      ...sessionHead,
+      model_usage: { "gpt-5.5": 5 },
+      project_identity_resolver_revision: "resolver-v2",
+      project_identity_input_signature: "signature",
+      smart_tags_source_updated_at: 2,
+      smart_tags_classifier_revision: "classifier-v2",
+    };
+    const source: ScanResultSource = {
+      getSnapshot: () =>
+        ({
+          sessions: [internalSession],
+          byAgent: { codex: [internalSession] },
+          agents: [],
+        }) as LiveSnapshot,
+    };
+    coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
+    const c = makeContext();
+
+    handleGetBookmarks(c as never, source);
+
+    const bookmark = getResponsePayload<{ bookmarks: BookmarkView[] }>(c).bookmarks[0];
+    const responseSession = bookmark?.availability === "available" ? bookmark.session : undefined;
+    expect(responseSession).not.toHaveProperty("model_usage");
+    expect(responseSession).not.toHaveProperty("project_identity_resolver_revision");
+    expect(responseSession).not.toHaveProperty("project_identity_input_signature");
+    expect(responseSession).not.toHaveProperty("smart_tags_source_updated_at");
+    expect(responseSession).not.toHaveProperty("smart_tags_classifier_revision");
+    expect(internalSession.model_usage).toEqual({ "gpt-5.5": 5 });
+  });
+
   it("tolerates unavailable alias storage and logs unexpected alias failures", () => {
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
     coreMocks.listSessionAliases.mockImplementationOnce(() => {

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1187,6 +1187,8 @@ describe("handleGetFileActivity", () => {
   it("projects aliases onto nested sessions", () => {
     const session = makeSession("s1", {
       reference: { agentName: "claudecode", sessionId: "s1" },
+      model_usage: { "gpt-5.5": 5 },
+      smart_tags_source_updated_at: 2,
     });
     coreMocks.listSessionAliases.mockReturnValue([makeAlias("claudecode", "s1", "Activity alias")]);
     coreMocks.listFileActivity.mockReturnValue([
@@ -1204,7 +1206,10 @@ describe("handleGetFileActivity", () => {
 
     handleGetFileActivity(c);
 
-    expect(c.json.mock.calls[0]![0].activity[0].session.display_title).toBe("Activity alias");
+    const responseSession = c.json.mock.calls[0]![0].activity[0].session;
+    expect(responseSession.display_title).toBe("Activity alias");
+    expect(responseSession).not.toHaveProperty("model_usage");
+    expect(responseSession).not.toHaveProperty("smart_tags_source_updated_at");
   });
 });
 
@@ -1541,6 +1546,30 @@ describe("handleGetDashboard", () => {
     expect(c.json.mock.calls[0]![0].recentFileActivities[0].session.display_title).toBe(
       "Activity alias",
     );
+  });
+
+  it("omits internal metadata from recent sessions", () => {
+    const session = makeSession("private", {
+      model_usage: { "gpt-5.5": 5 },
+      project_identity_resolver_revision: "resolver-v2",
+      project_identity_input_signature: "signature",
+      smart_tags_source_updated_at: 2,
+      smart_tags_classifier_revision: "classifier-v2",
+    });
+    const c = makeMockContext();
+
+    handleGetDashboard(
+      c,
+      makeScanSource({ sessions: [session], byAgent: { claudecode: [session] } }),
+    );
+
+    const responseSession = c.json.mock.calls[0]![0].recentSessions[0].session;
+    expect(responseSession).not.toHaveProperty("model_usage");
+    expect(responseSession).not.toHaveProperty("project_identity_resolver_revision");
+    expect(responseSession).not.toHaveProperty("project_identity_input_signature");
+    expect(responseSession).not.toHaveProperty("smart_tags_source_updated_at");
+    expect(responseSession).not.toHaveProperty("smart_tags_classifier_revision");
+    expect(session.model_usage).toEqual({ "gpt-5.5": 5 });
   });
 
   it("aggregates totals across all sessions", () => {

--- a/packages/cli/src/api/bookmark-handlers.ts
+++ b/packages/cli/src/api/bookmark-handlers.ts
@@ -1,6 +1,6 @@
 import type { Context } from "hono";
 import type { BookmarkRecord, BookmarkView } from "@codesesh/core/runtime";
-import { createSessionIndex } from "@codesesh/core/contract";
+import { createSessionIndex, toPublicSessionHead } from "@codesesh/core/contract";
 import {
   SessionAliasValidationError,
   StateStorageUnavailableError,
@@ -58,7 +58,12 @@ function materializeStoredBookmarks(
     liveSessionsByReference: sessionIndex.byRouteKey,
     knownAgentNames: KNOWN_AGENT_NAME_SET,
     resolveCachedSessions: loadCachedSessionHeads,
-  }).map((bookmark) => decorateBookmark(bookmark, aliases));
+  }).map((bookmark) => {
+    const decorated = decorateBookmark(bookmark, aliases);
+    return decorated.availability === "available"
+      ? { ...decorated, session: toPublicSessionHead(decorated.session) }
+      : decorated;
+  });
 }
 
 export function handleGetBookmarks(c: Context, scanSource: ScanResultSource) {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -7,6 +7,8 @@ import {
   type AppConfig,
   type SessionReference,
   startOfCalendarDay,
+  toPublicReferencedSessionHead,
+  toPublicSessionHead,
 } from "@codesesh/core/contract";
 import {
   attachProjectMetricsFromTree,
@@ -141,18 +143,6 @@ function parseDateWindowRequest(c: Context, endpoint: string, defaults: SessionL
 interface ClientLogPayload {
   event?: unknown;
   data?: unknown;
-}
-
-function toSessionListItem(session: IdentifiedSessionHead): IdentifiedSessionHead {
-  const {
-    model_usage: _modelUsage,
-    project_identity_resolver_revision: _resolverRevision,
-    project_identity_input_signature: _identityInputSignature,
-    smart_tags_source_updated_at: _smartTagsSourceUpdatedAt,
-    smart_tags_classifier_revision: _smartTagsClassifierRevision,
-    ...item
-  } = session;
-  return item;
 }
 
 function getSessionHeadReference(session: SessionHead): SessionReference {
@@ -384,7 +374,7 @@ export async function handleGetSessions(
     }
     return c.json({
       sessions: page.items.map((session) =>
-        toSessionListItem(aliases.decorate(session, getSessionHeadReference(session))),
+        toPublicSessionHead(aliases.decorate(session, getSessionHeadReference(session))),
       ),
       ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
     });
@@ -392,7 +382,7 @@ export async function handleGetSessions(
 
   return c.json({
     sessions: sessions.map((session) =>
-      toSessionListItem(aliases.decorate(session, getSessionHeadReference(session))),
+      toPublicSessionHead(aliases.decorate(session, getSessionHeadReference(session))),
     ),
   });
 }
@@ -477,7 +467,9 @@ export async function handleSearchSessions(
     resolvedSearchOptions.limit ?? 50,
   );
   return c.json({
-    results: withParentContext(mergedResults, getSessionTree, aliases),
+    results: withParentContext(mergedResults, getSessionTree, aliases).map(
+      toPublicReferencedSessionHead,
+    ),
   });
 }
 
@@ -533,7 +525,7 @@ export async function handleGetFileActivity(
       from: window.from,
       to: window.to,
       limit: sessionQuery.limit.value,
-    }).map((activity) => decorateFileActivity(activity, aliases)),
+    }).map((activity) => toPublicReferencedSessionHead(decorateFileActivity(activity, aliases))),
   });
 }
 
@@ -711,12 +703,14 @@ export function handleGetDashboard(
   const aliases = loadAliasView();
   return c.json({
     ...data,
-    recentSessions: data.recentSessions.map((item) => ({
-      ...item,
-      session: aliases.decorate(item.session, item.reference),
-    })),
+    recentSessions: data.recentSessions.map((item) =>
+      toPublicReferencedSessionHead({
+        ...item,
+        session: aliases.decorate(item.session, item.reference),
+      }),
+    ),
     recentFileActivities: data.recentFileActivities.map((activity) =>
-      decorateFileActivity(activity, aliases),
+      toPublicReferencedSessionHead(decorateFileActivity(activity, aliases)),
     ),
   });
 }

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -15,7 +15,7 @@ import {
   type SessionHead,
   type SessionSourceRef,
 } from "@codesesh/core/runtime";
-import { createSessionIdentity } from "@codesesh/core/contract";
+import { createSessionIdentity, toPublicSessionHead } from "@codesesh/core/contract";
 import { AgentUnavailableDuringScanError } from "./scan-refresh-error.js";
 import { buildScanRefreshDelta } from "./scan-refresh-delta.js";
 
@@ -1560,11 +1560,11 @@ describe("LiveScanStore", () => {
         changedSessionHeads: [
           {
             reference: { agentName: "codex", sessionId: updatedWithProject.reference.sessionId },
-            session: updatedWithProject,
+            session: toPublicSessionHead(updatedWithProject),
           },
           {
             reference: { agentName: "codex", sessionId: addedWithProject.reference.sessionId },
-            session: addedWithProject,
+            session: toPublicSessionHead(addedWithProject),
           },
         ],
         removedSessionRefs: [],
@@ -1660,7 +1660,7 @@ describe("LiveScanStore", () => {
         changedSessionHeads: [
           {
             reference: { agentName: "codex", sessionId: previousWithProject.reference.sessionId },
-            session: previousWithProject,
+            session: toPublicSessionHead(previousWithProject),
           },
         ],
         removedSessionRefs: [],

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -190,6 +190,25 @@ describe("LiveSessionIndex", () => {
     });
   });
 
+  it("omits internal metadata from published session heads", () => {
+    const codex = makeAgent("codex");
+    const session = {
+      ...makeSession("session", 1),
+      model_usage: { "gpt-5.5": 5 },
+      project_identity_resolver_revision: "resolver-v2",
+      project_identity_input_signature: "signature",
+      smart_tags_source_updated_at: 2,
+      smart_tags_classifier_revision: "classifier-v2",
+    };
+    const index = new LiveSessionIndex();
+    index.initialize(snapshot([codex], { codex: [] }));
+
+    const event = index.commitAgentSessions("codex", [session]);
+
+    expect(event?.changedSessionHeads[0]?.session).toEqual(makeSession("session", 1));
+    expect(index.snapshot().sessions[0]).toBe(session);
+  });
+
   it("publishes unchanged hierarchy members needed to project a changed root", () => {
     const codex = makeAgent("codex");
     const root = makeSession("root", 1, "before");

--- a/packages/cli/src/live-session-index.ts
+++ b/packages/cli/src/live-session-index.ts
@@ -13,6 +13,7 @@ import {
   assertIdentifiedSessionHead,
   assertSessionIdentity,
   createSessionProjectionContext,
+  toPublicReferencedSessionHead,
   type SessionsUpdatedEvent,
 } from "@codesesh/core/contract";
 
@@ -125,8 +126,10 @@ export class LiveSessionIndex {
       removedSessions: counts.removed,
       totalSessions: this.sessions.length,
       timestamp: Date.now(),
-      changedSessionHeads,
-      projectionRelatedSessionHeads: projectionContext.relatedSessionHeads,
+      changedSessionHeads: changedSessionHeads.map(toPublicReferencedSessionHead),
+      projectionRelatedSessionHeads: projectionContext.relatedSessionHeads.map(
+        toPublicReferencedSessionHead,
+      ),
       projectionSessionOrder: projectionContext.sessionOrder,
       removedSessionRefs,
     };

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -67,6 +67,8 @@ describe("contract browser-safety", () => {
         "sortSessionsByActivity",
         "startOfCalendarDay",
         "toCalendarDayKey",
+        "toPublicReferencedSessionHead",
+        "toPublicSessionHead",
         "updateSessionIndex",
       ].sort(),
     );

--- a/packages/core/src/contract/__tests__/session.test.ts
+++ b/packages/core/src/contract/__tests__/session.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { IdentifiedSessionHead } from "../session.js";
+import { toPublicReferencedSessionHead, toPublicSessionHead } from "../session.js";
+
+const session: IdentifiedSessionHead = {
+  reference: { agentName: "codex", sessionId: "session" },
+  title: "Session",
+  directory: "/workspace",
+  project_identity: { kind: "path", key: "/workspace", displayName: "workspace" },
+  project_identity_resolver_revision: "resolver-v2",
+  project_identity_input_signature: "signature",
+  time_created: 1,
+  stats: {
+    message_count: 1,
+    total_input_tokens: 2,
+    total_output_tokens: 3,
+    total_cost: 0,
+  },
+  model_usage: { "gpt-5.5": 5 },
+  smart_tags: ["testing"],
+  smart_tags_source_updated_at: 2,
+  smart_tags_classifier_revision: "classifier-v2",
+};
+
+describe("public session heads", () => {
+  it("removes internal metadata without mutating the source", () => {
+    const result = toPublicSessionHead(session);
+
+    expect(result).toEqual({
+      reference: session.reference,
+      title: "Session",
+      directory: "/workspace",
+      project_identity: session.project_identity,
+      time_created: 1,
+      stats: session.stats,
+      smart_tags: ["testing"],
+    });
+    expect(session.model_usage).toEqual({ "gpt-5.5": 5 });
+  });
+
+  it("preserves surrounding transport fields", () => {
+    expect(
+      toPublicReferencedSessionHead({
+        reference: session.reference,
+        session,
+        snippet: "match",
+      }),
+    ).toEqual({
+      reference: session.reference,
+      session: toPublicSessionHead(session),
+      snippet: "match",
+    });
+  });
+});

--- a/packages/core/src/contract/bookmarks.ts
+++ b/packages/core/src/contract/bookmarks.ts
@@ -1,4 +1,4 @@
-import type { SessionHead } from "./session.js";
+import type { PublicSessionHead } from "./session.js";
 import type { SessionReference } from "./session-reference.js";
 
 export interface BookmarkRecord {
@@ -8,7 +8,7 @@ export interface BookmarkRecord {
 
 export interface AvailableBookmarkView extends BookmarkRecord {
   availability: "available";
-  session: SessionHead;
+  session: PublicSessionHead;
 }
 
 export interface UnavailableBookmarkView extends BookmarkRecord {

--- a/packages/core/src/contract/dashboard.ts
+++ b/packages/core/src/contract/dashboard.ts
@@ -1,7 +1,7 @@
 import type { FileActivityResult } from "./file-activity.js";
 import type { ModelCostEntry } from "./model-cost.js";
 import type { ProjectIdentityKind } from "./project-identity.js";
-import type { CostSource, ReferencedSessionHead } from "./session.js";
+import type { CostSource, PublicReferencedSessionHead } from "./session.js";
 
 export interface DashboardAgentStat {
   name: string;
@@ -62,7 +62,7 @@ export interface DashboardPreviousTotals {
   cost: number;
 }
 
-export type DashboardRecentSession = ReferencedSessionHead;
+export type DashboardRecentSession = PublicReferencedSessionHead;
 
 export interface DashboardTotals {
   sessions: number;

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -1,4 +1,4 @@
-import type { ReferencedSessionHead } from "./session.js";
+import type { PublicReferencedSessionHead } from "./session.js";
 import type { SessionReference } from "./session-reference.js";
 
 export interface SessionsUpdatedEvent {
@@ -11,9 +11,9 @@ export interface SessionsUpdatedEvent {
   removedSessions: number;
   totalSessions: number;
   timestamp: number;
-  changedSessionHeads: ReferencedSessionHead[];
+  changedSessionHeads: PublicReferencedSessionHead[];
   /** Unchanged hierarchy context; it must not count as an update or invalidate session detail. */
-  projectionRelatedSessionHeads?: ReferencedSessionHead[];
+  projectionRelatedSessionHeads?: PublicReferencedSessionHead[];
   /** Canonical global order for affected activity-time ties. */
   projectionSessionOrder?: SessionReference[];
   removedSessionRefs: SessionReference[];
@@ -23,19 +23,19 @@ export function mergeSessionsUpdatedEvents(
   previous: SessionsUpdatedEvent,
   next: SessionsUpdatedEvent,
 ): SessionsUpdatedEvent {
-  const changedSessionHeads = new Map<string, ReferencedSessionHead>();
-  const projectionRelatedSessionHeads = new Map<string, ReferencedSessionHead>();
+  const changedSessionHeads = new Map<string, PublicReferencedSessionHead>();
+  const projectionRelatedSessionHeads = new Map<string, PublicReferencedSessionHead>();
   const projectionSessionOrder = new Map<string, SessionReference>();
   const newSessionRefs = new Map<string, SessionReference>();
   const removedSessionRefs = new Map<string, SessionReference>();
   const sessionKey = (agentName: string, sessionId: string) => `${agentName}\0${sessionId}`;
-  const addChanged = (item: ReferencedSessionHead) => {
+  const addChanged = (item: PublicReferencedSessionHead) => {
     const key = sessionKey(item.reference.agentName, item.reference.sessionId);
     removedSessionRefs.delete(key);
     projectionRelatedSessionHeads.delete(key);
     changedSessionHeads.set(key, item);
   };
-  const addProjectionRelated = (item: ReferencedSessionHead) => {
+  const addProjectionRelated = (item: PublicReferencedSessionHead) => {
     const key = sessionKey(item.reference.agentName, item.reference.sessionId);
     if (changedSessionHeads.has(key) || removedSessionRefs.has(key)) return;
     projectionRelatedSessionHeads.set(key, item);

--- a/packages/core/src/contract/file-activity.ts
+++ b/packages/core/src/contract/file-activity.ts
@@ -1,11 +1,11 @@
 import type {
   FileActivityKind,
-  ReferencedSessionHead,
+  PublicReferencedSessionHead,
   SessionFileActivity,
   ToolPart,
 } from "./session.js";
 
-export type FileActivityResult = SessionFileActivity & ReferencedSessionHead;
+export type FileActivityResult = SessionFileActivity & PublicReferencedSessionHead;
 
 export interface FileToolOperation {
   kind: FileActivityKind;

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -1,5 +1,9 @@
 export type * from "./session.js";
-export { assertIdentifiedSessionHead } from "./session.js";
+export {
+  assertIdentifiedSessionHead,
+  toPublicReferencedSessionHead,
+  toPublicSessionHead,
+} from "./session.js";
 export * from "./message-part.js";
 export type * from "./agent.js";
 export * from "./agent-catalog.js";

--- a/packages/core/src/contract/search.ts
+++ b/packages/core/src/contract/search.ts
@@ -1,5 +1,5 @@
 import type { SessionReference } from "./session-reference.js";
-import type { ReferencedSessionHead } from "./session.js";
+import type { PublicReferencedSessionHead } from "./session.js";
 
 export type SearchMatchType =
   | "recent"
@@ -19,7 +19,7 @@ export interface SearchHighlightRange {
   end: number;
 }
 
-export interface SearchResult extends ReferencedSessionHead {
+export interface SearchResult extends PublicReferencedSessionHead {
   snippet: string;
   snippetHighlights: SearchHighlightRange[];
   matchType: SearchMatchType;

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -167,14 +167,30 @@ export interface IdentifiedSessionHead extends SessionHead {
   project_identity: ProjectIdentity;
 }
 
+type InternalSessionHeadField =
+  | "model_usage"
+  | "project_identity_resolver_revision"
+  | "project_identity_input_signature"
+  | "smart_tags_source_updated_at"
+  | "smart_tags_classifier_revision";
+
+export type PublicSessionHead = Omit<SessionHead, InternalSessionHeadField>;
+
+export type PublicIdentifiedSessionHead = Omit<IdentifiedSessionHead, InternalSessionHeadField>;
+
 export interface SessionListPage {
-  sessions: IdentifiedSessionHead[];
+  sessions: PublicIdentifiedSessionHead[];
   nextCursor?: string;
 }
 
 export interface ReferencedSessionHead {
   reference: SessionReference;
   session: SessionHead;
+}
+
+export interface PublicReferencedSessionHead {
+  reference: SessionReference;
+  session: PublicSessionHead;
 }
 
 /** Complete normalized content for replaying a Session */
@@ -212,4 +228,24 @@ export function assertIdentifiedSessionHead(
   throw new Error(
     `Session ${session.reference.agentName}/${session.reference.sessionId} is missing project_identity`,
   );
+}
+
+export function toPublicSessionHead<T extends SessionHead>(
+  session: T,
+): Omit<T, InternalSessionHeadField> {
+  const {
+    model_usage: _modelUsage,
+    project_identity_resolver_revision: _resolverRevision,
+    project_identity_input_signature: _identityInputSignature,
+    smart_tags_source_updated_at: _smartTagsSourceUpdatedAt,
+    smart_tags_classifier_revision: _classifierRevision,
+    ...publicSession
+  } = session;
+  return publicSession;
+}
+
+export function toPublicReferencedSessionHead<T extends ReferencedSessionHead>(
+  item: T,
+): Omit<T, "session"> & { session: PublicSessionHead } {
+  return { ...item, session: toPublicSessionHead(item.session) };
 }

--- a/packages/core/src/test-fixtures.ts
+++ b/packages/core/src/test-fixtures.ts
@@ -1,6 +1,7 @@
 import type { DashboardData } from "./contract/dashboard.js";
 import type { AgentScanStatus, ScanStatusEvent, SessionsUpdatedEvent } from "./contract/events.js";
 import type { SessionHead } from "./contract/session.js";
+import { toPublicSessionHead } from "./contract/session.js";
 import { createSessionIdentity } from "./contract/session-reference.js";
 
 export const SAMPLE_SESSION_HEAD = {
@@ -78,7 +79,7 @@ export const SAMPLE_SESSIONS_UPDATED_EVENT = {
   changedSessionHeads: [
     {
       reference: SAMPLE_SESSION_HEAD.reference,
-      session: SAMPLE_SESSION_HEAD,
+      session: toPublicSessionHead(SAMPLE_SESSION_HEAD),
     },
   ],
   projectionRelatedSessionHeads: [],
@@ -143,7 +144,7 @@ export const SAMPLE_DASHBOARD_DATA = {
   recentSessions: [
     {
       reference: SAMPLE_SESSION_HEAD.reference,
-      session: SAMPLE_SESSION_HEAD,
+      session: toPublicSessionHead(SAMPLE_SESSION_HEAD),
     },
   ],
   recentFileActivities: [],


### PR DESCRIPTION
## Summary
- define explicit public session-head contract types
- remove internal metadata through one browser-safe converter across HTTP and live events
- add regression coverage for lists, search, dashboard, file activity, bookmarks, and SSE publication

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test