### PR TITLE
fix(api): unify dashboard date parsing

### DIFF
--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1489,6 +1489,15 @@ describe("handleGetProjects", () => {
 });
 
 describe("handleGetDashboard", () => {
+  it("rejects invalid dates instead of silently using defaults", () => {
+    const c = makeMockContext({ query: { from: "invalid", to: "invalid" } });
+
+    handleGetDashboard(c, makeScanSource(), { from: 1, to: 2, days: 5 });
+
+    expect(c.json).toHaveBeenCalledWith({ error: "from must be a valid date" }, 400);
+    expect(coreMocks.buildDashboard).not.toHaveBeenCalled();
+  });
+
   it("reuses matching snapshot aggregates and invalidates them with the sessions array", () => {
     let snapshot = makeScanResult();
     const source: ScanResultSource = { getSnapshot: () => snapshot };

--- a/packages/cli/src/api/__tests__/query-params.test.ts
+++ b/packages/cli/src/api/__tests__/query-params.test.ts
@@ -41,6 +41,21 @@ describe("session query contract", () => {
     });
   });
 
+  it("records whether the start came from the query", () => {
+    expect(parseDateWindow(new URLSearchParams(), { from: 1000, to: 2000 })).toEqual({
+      kind: "valid",
+      from: 1000,
+      to: 2000,
+      hasExplicitFrom: false,
+    });
+    expect(parseDateWindow(new URLSearchParams("from=1970-01-01T00:00:01.500Z"), {})).toEqual({
+      kind: "valid",
+      from: 1500,
+      to: undefined,
+      hasExplicitFrom: true,
+    });
+  });
+
   it("distinguishes an absent agent from known and unknown values", () => {
     expect(parseSessionQuery(new URLSearchParams(), ["claudecode"]).agent).toEqual({
       kind: "all",

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -627,12 +627,9 @@ export function handleGetDashboard(
   if (dateWindow.kind === "rejected") return dateWindow.response;
   const { from, to, days } = resolveTimeWindow({
     mode: "dashboard",
-    query: {
-      days: c.req.query("days"),
-      from: c.req.query("from"),
-      to: c.req.query("to"),
-    },
-    defaults,
+    window: dateWindow,
+    days: c.req.query("days"),
+    defaultDays: defaults.days,
   });
   const scope: DashboardScope = {
     agent: optionalQueryValue(c.req.query("agent"))?.toLowerCase(),

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -54,7 +54,12 @@ export type DateParamOutcome =
   | { kind: "invalid"; error: string };
 
 export type DateWindowOutcome =
-  | { kind: "valid"; from: number | undefined; to: number | undefined }
+  | {
+      kind: "valid";
+      from: number | undefined;
+      to: number | undefined;
+      hasExplicitFrom: boolean;
+    }
   | { kind: "invalid"; parameter: "from" | "to"; error: string };
 
 export interface SessionQuery {
@@ -111,7 +116,12 @@ export function parseDateWindow(
     return { kind: "invalid", parameter: "from", error: "must not be after to" };
   }
 
-  return { kind: "valid", from: from.value, to: to.value };
+  return {
+    kind: "valid",
+    from: from.value,
+    to: to.value,
+    hasExplicitFrom: from.kind === "valid",
+  };
 }
 
 export function parseNumberParam(value: string | undefined): number | undefined {

--- a/packages/cli/src/time-window-resolution.test.ts
+++ b/packages/cli/src/time-window-resolution.test.ts
@@ -41,10 +41,7 @@ describe("resolveTimeWindow", () => {
     expect(
       resolveTimeWindow({
         mode: "dashboard",
-        query: {
-          from: "2026-07-10T00:00:00.000Z",
-          to: "2026-07-13T00:00:00.000Z",
-        },
+        window: { from, to, hasExplicitFrom: true },
       }),
     ).toEqual({ from, to, days: 4 });
   });
@@ -55,8 +52,9 @@ describe("resolveTimeWindow", () => {
     expect(
       resolveTimeWindow({
         mode: "dashboard",
-        query: { days: "3" },
-        defaults: { from: defaultFrom, days: 7 },
+        window: { from: defaultFrom, hasExplicitFrom: false },
+        days: "3",
+        defaultDays: 7,
         now: NOW,
       }),
     ).toEqual({ from: defaultFrom, to: NOW, days: 3 });
@@ -66,29 +64,36 @@ describe("resolveTimeWindow", () => {
     expect(
       resolveTimeWindow({
         mode: "dashboard",
-        query: { days: "0" },
-        defaults: { from: NOW - 7 * DAY_MS, days: 7 },
+        window: { from: NOW - 7 * DAY_MS, hasExplicitFrom: false },
+        days: "0",
+        defaultDays: 7,
         now: NOW,
       }),
     ).toEqual({ to: NOW, days: 0 });
   });
 
   it("uses the 30-day dashboard fallback from the local day boundary", () => {
-    expect(resolveTimeWindow({ mode: "dashboard", query: {}, now: NOW })).toEqual({
+    expect(
+      resolveTimeWindow({
+        mode: "dashboard",
+        window: { hasExplicitFrom: false },
+        now: NOW,
+      }),
+    ).toEqual({
       from: addCalendarDays(startOfCalendarDay(NOW), -29),
       to: NOW,
       days: 30,
     });
   });
 
-  it("falls back from invalid dashboard query dates", () => {
+  it("uses validated dashboard defaults without parsing dates again", () => {
     const defaultFrom = NOW - 5 * DAY_MS;
 
     expect(
       resolveTimeWindow({
         mode: "dashboard",
-        query: { from: "invalid", to: "invalid" },
-        defaults: { from: defaultFrom, to: NOW, days: 5 },
+        window: { from: defaultFrom, to: NOW, hasExplicitFrom: false },
+        defaultDays: 5,
       }),
     ).toEqual({ from: defaultFrom, to: NOW, days: 5 });
   });
@@ -112,7 +117,8 @@ describe("CS-133: dashboard windows are calendar ranges", () => {
 
     const resolved = resolveTimeWindow({
       mode: "dashboard",
-      query: { days: String(days) },
+      window: { hasExplicitFrom: false },
+      days: String(days),
       now: nowMs,
     });
 
@@ -128,7 +134,7 @@ describe("CS-133: dashboard windows are calendar ranges", () => {
     expect(
       resolveTimeWindow({
         mode: "dashboard",
-        query: { from: new Date(from).toISOString() },
+        window: { from, hasExplicitFrom: true },
         now: to,
       }).days,
     ).toBe(3);

--- a/packages/cli/src/time-window-resolution.ts
+++ b/packages/cli/src/time-window-resolution.ts
@@ -11,21 +11,26 @@ export interface TimeWindow {
   days?: number;
 }
 
-interface RawTimeWindow {
+interface RawCliTimeWindow {
   from?: string;
   to?: string;
   days?: string;
 }
 
-interface CliTimeWindowRequest extends RawTimeWindow {
+interface CliTimeWindowRequest extends RawCliTimeWindow {
   mode: "cli";
   now?: number;
 }
 
 interface DashboardTimeWindowRequest {
   mode: "dashboard";
-  query: RawTimeWindow;
-  defaults?: TimeWindow;
+  window: {
+    from?: number;
+    to?: number;
+    hasExplicitFrom: boolean;
+  };
+  days?: string;
+  defaultDays?: number;
   now?: number;
 }
 
@@ -57,25 +62,23 @@ function resolveCliWindow(request: CliTimeWindowRequest): TimeWindow {
 
 function resolveDashboardWindow(request: DashboardTimeWindowRequest): DashboardTimeWindow {
   const now = request.now ?? Date.now();
-  const defaults = request.defaults ?? {};
-  const to = parseOptionalDate(request.query.to) ?? defaults.to ?? now;
-  const hasQueryDays = Boolean(request.query.days?.trim());
-  const parsedDays = hasQueryDays ? parseDays(request.query.days) : undefined;
-  let days = parsedDays != null && parsedDays > 0 ? parsedDays : defaults.days;
+  const to = request.window.to ?? now;
+  const hasQueryDays = Boolean(request.days?.trim());
+  const parsedDays = hasQueryDays ? parseDays(request.days) : undefined;
+  let days = parsedDays != null && parsedDays > 0 ? parsedDays : request.defaultDays;
 
-  const queryFrom = parseOptionalDate(request.query.from);
-  if (queryFrom != null) {
-    days ??= countCalendarDays(queryFrom, to);
-    return { from: queryFrom, to, days };
+  if (request.window.hasExplicitFrom && request.window.from != null) {
+    days ??= countCalendarDays(request.window.from, to);
+    return { from: request.window.from, to, days };
   }
 
-  if (parsedDays === 0 || (!hasQueryDays && defaults.days === 0)) {
+  if (parsedDays === 0 || (!hasQueryDays && request.defaultDays === 0)) {
     return { to, days: 0 };
   }
 
-  if (defaults.from != null) {
-    days ??= countCalendarDays(defaults.from, to);
-    return { from: defaults.from, to, days };
+  if (request.window.from != null) {
+    days ??= countCalendarDays(request.window.from, to);
+    return { from: request.window.from, to, days };
   }
 
   const resolvedDays = days != null && days > 0 ? days : DEFAULT_DASHBOARD_DAYS;
@@ -91,12 +94,6 @@ function parseRequiredDate(value: string | undefined): number | undefined {
   const timestamp = new Date(value).getTime();
   if (Number.isNaN(timestamp)) throw new Error(`Invalid date: ${value}`);
   return timestamp;
-}
-
-function parseOptionalDate(value: string | undefined): number | undefined {
-  if (value == null) return undefined;
-  const timestamp = new Date(value).getTime();
-  return Number.isNaN(timestamp) ? undefined : timestamp;
 }
 
 function parseDays(value: string | undefined): number | undefined {


### PR DESCRIPTION
## Summary
- parse and validate dashboard date parameters once at the HTTP boundary
- pass validated timestamps into calendar-window resolution
- keep invalid dates aligned with the API’s 400 response policy

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test