### PR TITLE
fix(cache): validate schema migration plans

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -10,6 +10,9 @@ import { readCachedSessions, saveCachedSessions } from "../sessions.js";
 import { syncSessionSearchIndex } from "../search-index-writer.js";
 import { makeSessionData, makeSessionHead } from "./fixtures.js";
 import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
+import { ensureCacheSchema } from "../schema.js";
+import { CACHE_SCHEMA_VERSION } from "../version.js";
+import { UnsupportedCacheSchemaVersionError } from "../errors.js";
 
 const schema = connection;
 
@@ -107,6 +110,30 @@ describe("cache schema boundary", () => {
       ]),
     );
     expect(state?.version).toBe(31);
+  });
+
+  it("refuses a newer cache schema without mutating it", () => {
+    schema.withCacheDb(() => undefined);
+    setSchemaEnsuredPath(null);
+    const db = new Database(getCachePath());
+    const newerVersion = CACHE_SCHEMA_VERSION + 1;
+    try {
+      db.exec(`
+        CREATE TABLE newer_schema_marker(value TEXT NOT NULL);
+        INSERT INTO newer_schema_marker(value) VALUES ('preserve-me');
+        PRAGMA user_version = ${newerVersion};
+      `);
+
+      expect(() => ensureCacheSchema(db as unknown as SQLiteDatabase, getCachePath())).toThrow(
+        new UnsupportedCacheSchemaVersionError(newerVersion, CACHE_SCHEMA_VERSION),
+      );
+      expect(Number(db.pragma("user_version", { simple: true }))).toBe(newerVersion);
+      expect(db.prepare("SELECT value FROM newer_schema_marker").all()).toEqual([
+        { value: "preserve-me" },
+      ]);
+    } finally {
+      db.close();
+    }
   });
 
   it("derives session identity from the composite key when upgrading schema 29", () => {

--- a/packages/core/src/discovery/cache/errors.ts
+++ b/packages/core/src/discovery/cache/errors.ts
@@ -6,3 +6,15 @@ export class CacheDataIntegrityError extends Error {
     this.name = "CacheDataIntegrityError";
   }
 }
+
+export class UnsupportedCacheSchemaVersionError extends Error {
+  constructor(
+    readonly currentVersion: number,
+    readonly supportedVersion: number,
+  ) {
+    super(
+      `Cache schema version ${currentVersion} is newer than supported version ${supportedVersion}`,
+    );
+    this.name = "UnsupportedCacheSchemaVersionError";
+  }
+}

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -56,6 +56,7 @@ import {
   type ProjectBackfillSessionRow,
 } from "./schema-version.js";
 import { CACHE_SCHEMA_VERSION } from "./version.js";
+import { UnsupportedCacheSchemaVersionError } from "./errors.js";
 
 export { runSearchIndexWrite, runWithFtsRecovery } from "./schema-fts.js";
 
@@ -800,6 +801,9 @@ function setCacheSchemaVersion(db: SQLiteDatabase): void {
 
 export function ensureCacheSchema(db: SQLiteDatabase, dbPath: string): void {
   const currentVersion = getCurrentCacheSchemaVersion(db);
+  if (currentVersion > CACHE_SCHEMA_VERSION) {
+    throw new UnsupportedCacheSchemaVersionError(currentVersion, CACHE_SCHEMA_VERSION);
+  }
   if (currentVersion === 0 && !hasAnyCacheSchema(db)) {
     createLatestCacheSchema(db);
     createSearchStateIndex(db);

--- a/packages/core/src/state/database.ts
+++ b/packages/core/src/state/database.ts
@@ -146,6 +146,7 @@ function setStateSchemaVersion(db: SQLiteDatabase): void {
 
 function ensureSchema(db: SQLiteDatabase, dbPath: string): void {
   const currentVersion = getCurrentStateSchemaVersion(db);
+  if (currentVersion > STATE_SCHEMA_VERSION) return;
   if (currentVersion === 0 && !hasAnyStateSchema(db)) {
     setStateSchemaVersion(db);
     return;

--- a/packages/core/src/utils/__tests__/sqlite.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite.test.ts
@@ -9,6 +9,7 @@ import {
   openDb,
   openDbReadOnly,
   runSchemaMigrations,
+  SchemaMigrationPlanError,
   type SQLiteDatabase,
 } from "../sqlite.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
@@ -88,6 +89,57 @@ describe("sqlite migration helpers", () => {
           }),
         },
       ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects an incomplete plan before applying migrations", () => {
+    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    let migrationRan = false;
+    try {
+      expect(() =>
+        runSchemaMigrations(db, {
+          dbPath: ":memory:",
+          currentVersion: 0,
+          targetVersion: 2,
+          migrations: [
+            {
+              version: 1,
+              migrate: () => {
+                migrationRan = true;
+              },
+            },
+          ],
+          backupTables: [],
+          backupLabel: "incomplete",
+        }),
+      ).toThrow(new SchemaMigrationPlanError("incomplete has no migration for target version 2"));
+
+      expect(migrationRan).toBe(false);
+      expect(getUserVersion(db)).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects unordered migration plans", () => {
+    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    try {
+      expect(() =>
+        runSchemaMigrations(db, {
+          dbPath: ":memory:",
+          currentVersion: 0,
+          targetVersion: 2,
+          migrations: [
+            { version: 2, migrate: () => {} },
+            { version: 1, migrate: () => {} },
+          ],
+          backupTables: [],
+          backupLabel: "unordered",
+        }),
+      ).toThrow("unordered migrations must be ordered by strictly increasing version");
+      expect(getUserVersion(db)).toBe(0);
     } finally {
       db.close();
     }

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -102,6 +102,44 @@ export interface RunSchemaMigrationsOptions {
   backupLabel: string;
 }
 
+export class SchemaMigrationPlanError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SchemaMigrationPlanError";
+  }
+}
+
+function validateSchemaVersion(value: number, label: string): void {
+  if (Number.isSafeInteger(value) && value >= 0) return;
+  throw new SchemaMigrationPlanError(`${label} must be a non-negative safe integer`);
+}
+
+function validateMigrationPlan(options: RunSchemaMigrationsOptions): void {
+  let previousVersion = -1;
+  let reachesTarget = false;
+
+  for (const migration of options.migrations) {
+    if (!Number.isSafeInteger(migration.version) || migration.version < 0) {
+      throw new SchemaMigrationPlanError(
+        `${options.backupLabel} migration version must be a non-negative safe integer`,
+      );
+    }
+    if (migration.version <= previousVersion) {
+      throw new SchemaMigrationPlanError(
+        `${options.backupLabel} migrations must be ordered by strictly increasing version`,
+      );
+    }
+    previousVersion = migration.version;
+    reachesTarget ||= migration.version === options.targetVersion;
+  }
+
+  if (!reachesTarget) {
+    throw new SchemaMigrationPlanError(
+      `${options.backupLabel} has no migration for target version ${options.targetVersion}`,
+    );
+  }
+}
+
 function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
 }
@@ -194,6 +232,10 @@ export function runSchemaMigrations(
 ): string[] {
   const backups: string[] = [];
   let currentVersion = options.currentVersion;
+  validateSchemaVersion(currentVersion, `${options.backupLabel} current version`);
+  validateSchemaVersion(options.targetVersion, `${options.backupLabel} target version`);
+  if (currentVersion >= options.targetVersion) return backups;
+  validateMigrationPlan(options);
 
   for (const migration of options.migrations) {
     if (migration.version <= currentVersion) {
@@ -254,8 +296,10 @@ export function runSchemaMigrations(
     }
   }
 
-  if (currentVersion < options.targetVersion) {
-    setUserVersion(db, options.targetVersion);
+  if (currentVersion !== options.targetVersion) {
+    throw new SchemaMigrationPlanError(
+      `${options.backupLabel} stopped at version ${currentVersion}, expected ${options.targetVersion}`,
+    );
   }
 
   return backups;


### PR DESCRIPTION
## Summary
- validate migration ordering and target coverage before applying any schema changes
- stop stamping a target version that no migration reached
- reject newer cache schemas without mutating them while preserving the state-store compatibility policy

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test