### PR TITLE
refactor(tags): centralize smart tag catalog

### DIFF
--- a/apps/web/src/components/InteractiveReceipt.tsx
+++ b/apps/web/src/components/InteractiveReceipt.tsx
@@ -8,7 +8,6 @@ import {
   type ReceiptLineItem,
   type ReceiptPayload,
 } from "./interactive-receipt-simulation";
-import { SMART_TAG_LABELS } from "./SmartTagChips";
 import type { SessionDetailToc } from "./session-detail/toc";
 
 interface InteractiveReceiptProps {
@@ -43,7 +42,7 @@ function buildReceiptItems(toc: SessionDetailToc): ReceiptLineItem[] {
 
 function formatReceiptSubtitle(tags?: SessionDetail["smart_tags"]) {
   if (!tags || tags.length === 0) return "SESSION ACTIVITY RECEIPT";
-  return tags.map((tag) => SMART_TAG_LABELS[tag]).join(" / ");
+  return tags.join(" / ");
 }
 
 function createReceiptPayload(session: SessionDetail, toc: SessionDetailToc): ReceiptPayload {

--- a/apps/web/src/components/SmartTagChips.tsx
+++ b/apps/web/src/components/SmartTagChips.tsx
@@ -1,17 +1,5 @@
 import type { CSSProperties } from "react";
-import type { SmartTag } from "../lib/api";
-
-export const SMART_TAG_LABELS: Record<SmartTag, string> = {
-  bugfix: "bugfix",
-  refactoring: "refactoring",
-  "feature-dev": "feature-dev",
-  testing: "testing",
-  docs: "docs",
-  "git-ops": "git-ops",
-  "build-deploy": "build-deploy",
-  exploration: "exploration",
-  planning: "planning",
-};
+import { SMART_TAGS, type SmartTag } from "../lib/api";
 
 // SmartTag values double as the --tag-{tone}-* CSS variable names in
 // index.css, which owns the actual color values.
@@ -19,7 +7,7 @@ export const SMART_TAG_TONES: Record<
   SmartTag,
   { text: string; border: string; background: string; bar: string }
 > = Object.fromEntries(
-  (Object.keys(SMART_TAG_LABELS) as SmartTag[]).map((tag) => [
+  SMART_TAGS.map((tag) => [
     tag,
     {
       text: `var(--tag-${tag}-text)`,
@@ -65,7 +53,7 @@ export function SmartTagChips({
           className="console-mono rounded-sm border px-1.5 py-0.5 text-[10px] font-medium"
           style={getSmartTagChipStyle(tag)}
         >
-          {SMART_TAG_LABELS[tag]}
+          {tag}
         </span>
       ))}
       {remaining > 0 ? (

--- a/apps/web/src/components/app/SearchFilterBar.tsx
+++ b/apps/web/src/components/app/SearchFilterBar.tsx
@@ -1,21 +1,8 @@
 import type { Dispatch, SetStateAction } from "react";
-import type { AgentInfo, FileActivityKind, SmartTag } from "../../lib/api";
+import { SMART_TAGS, type AgentInfo, type FileActivityKind } from "../../lib/api";
 import { getProjectIdentityKey } from "../../lib/projects";
-import { SMART_TAG_LABELS } from "../SmartTagChips";
 import { FilterChip } from "./FilterChip";
 import type { CostRangeId, SearchFilterState, SearchProjectOption } from "./types";
-
-export const SMART_TAG_OPTIONS: SmartTag[] = [
-  "bugfix",
-  "refactoring",
-  "feature-dev",
-  "testing",
-  "docs",
-  "git-ops",
-  "build-deploy",
-  "exploration",
-  "planning",
-];
 
 export const SEARCH_TOOL_OPTIONS = ["apply_patch", "bash", "read", "edit", "grep"] as const;
 
@@ -104,11 +91,11 @@ export function SearchFilterBar({
 
       <div className="mt-3 flex flex-wrap items-center gap-2">
         <span className="console-eyebrow">Tag</span>
-        {SMART_TAG_OPTIONS.map((tag) => (
+        {SMART_TAGS.map((tag) => (
           <FilterChip
             key={tag}
             active={filters.tag === tag}
-            label={SMART_TAG_LABELS[tag]}
+            label={tag}
             onClick={() => setFilter("tag", tag)}
           />
         ))}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -47,6 +47,8 @@ export type {
   BookmarkView,
 } from "@codesesh/core/contract";
 
+export { SMART_TAGS } from "@codesesh/core/contract";
+
 import { sessionRoutePath } from "@codesesh/core/contract";
 import type {
   AgentInfo,

--- a/packages/cli/src/api/__tests__/query-params.test.ts
+++ b/packages/cli/src/api/__tests__/query-params.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
+import { SMART_TAGS } from "@codesesh/core/contract";
 import {
   parseDateParam,
   parseDateWindow,
   parseSessionQuery,
+  parseSmartTags,
   SEARCH_LIMIT_POLICY,
 } from "../query-params.js";
 
@@ -87,5 +89,9 @@ describe("session query contract", () => {
     expect(
       parseSessionQuery(new URLSearchParams({ limit }), [], SEARCH_LIMIT_POLICY).limit,
     ).toEqual({ kind: "invalid", error: "limit must be a positive integer" });
+  });
+
+  it("accepts every public smart tag and rejects unknown values", () => {
+    expect(parseSmartTags([...SMART_TAGS, "BUGFIX", "unknown"])).toEqual(SMART_TAGS);
   });
 });

--- a/packages/cli/src/api/query-params.ts
+++ b/packages/cli/src/api/query-params.ts
@@ -8,6 +8,7 @@ import type { SessionHead, SmartTag } from "@codesesh/core/runtime";
 import {
   filterSessionTreeByActivityWindow,
   isProjectIdentityKind,
+  isSmartTag,
   type FileActivityKind,
   type ProjectIdentityRef,
   type SearchRequestOptions,
@@ -15,18 +16,6 @@ import {
 import type { TimeWindow } from "../time-window-resolution.js";
 
 export type SessionListDefaults = TimeWindow;
-
-const SMART_TAGS: readonly string[] = [
-  "bugfix",
-  "refactoring",
-  "feature-dev",
-  "testing",
-  "docs",
-  "git-ops",
-  "build-deploy",
-  "exploration",
-  "planning",
-];
 
 export interface LimitPolicy {
   defaultValue: number;
@@ -178,9 +167,7 @@ export function parseSessionQuery(
 }
 
 export function parseSmartTags(values: string[]): SmartTag[] | undefined {
-  const tags = values
-    .map((value) => value.toLowerCase())
-    .filter((value): value is SmartTag => SMART_TAGS.includes(value));
+  const tags = values.map((value) => value.toLowerCase()).filter(isSmartTag);
   return tags.length > 0 ? [...new Set(tags)] : undefined;
 }
 

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -30,6 +30,7 @@ describe("contract browser-safety", () => {
       [
         "AGENT_CATALOG",
         "PROJECT_IDENTITY_KINDS",
+        "SMART_TAGS",
         "UNKNOWN_AGENT_NAME",
         "addCalendarDays",
         "agentRoutePath",
@@ -57,6 +58,7 @@ describe("contract browser-safety", () => {
         "groupSessionsByCalendarDay",
         "getAgentCatalogEntry",
         "isProjectIdentityKind",
+        "isSmartTag",
         "matchesProjectIdentity",
         "mergeSessionsUpdatedEvents",
         "mergeSortedSessions",

--- a/packages/core/src/contract/__tests__/session.test.ts
+++ b/packages/core/src/contract/__tests__/session.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { IdentifiedSessionHead } from "../session.js";
-import { toPublicReferencedSessionHead, toPublicSessionHead } from "../session.js";
+import {
+  isSmartTag,
+  SMART_TAGS,
+  toPublicReferencedSessionHead,
+  toPublicSessionHead,
+} from "../session.js";
 
 const session: IdentifiedSessionHead = {
   reference: { agentName: "codex", sessionId: "session" },
@@ -50,5 +55,13 @@ describe("public session heads", () => {
       session: toPublicSessionHead(session),
       snippet: "match",
     });
+  });
+});
+
+describe("smart tags", () => {
+  it("derives runtime validation and ordering from the public catalog", () => {
+    expect(SMART_TAGS.every(isSmartTag)).toBe(true);
+    expect(isSmartTag("BUGFIX")).toBe(false);
+    expect(isSmartTag("unknown")).toBe(false);
   });
 });

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -1,6 +1,8 @@
 export type * from "./session.js";
 export {
   assertIdentifiedSessionHead,
+  isSmartTag,
+  SMART_TAGS,
   toPublicReferencedSessionHead,
   toPublicSessionHead,
 } from "./session.js";

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -14,16 +14,23 @@ export interface SessionStats {
 
 export type CostSource = "recorded" | "estimated";
 
-export type SmartTag =
-  | "bugfix"
-  | "refactoring"
-  | "feature-dev"
-  | "testing"
-  | "docs"
-  | "git-ops"
-  | "build-deploy"
-  | "exploration"
-  | "planning";
+export const SMART_TAGS = [
+  "bugfix",
+  "refactoring",
+  "feature-dev",
+  "testing",
+  "docs",
+  "git-ops",
+  "build-deploy",
+  "exploration",
+  "planning",
+] as const;
+
+export type SmartTag = (typeof SMART_TAGS)[number];
+
+export function isSmartTag(value: string): value is SmartTag {
+  return SMART_TAGS.some((tag) => tag === value);
+}
 
 export type FileActivityKind = "read" | "edit" | "write" | "delete";
 

--- a/packages/core/src/discovery/cache/search-query-parser.test.ts
+++ b/packages/core/src/discovery/cache/search-query-parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { SMART_TAGS } from "../../contract/index.js";
 import { parseSearchQuery } from "./search-query-parser.js";
 
 describe("parseSearchQuery", () => {
@@ -32,6 +33,16 @@ describe("parseSearchQuery", () => {
     expect(parseSearchQuery("cost:>1 cost:<5 cost:2").filters).toEqual({
       costMin: 2,
       costMax: 2,
+    });
+  });
+
+  it("recognizes every tag in the public catalog", () => {
+    const query = SMART_TAGS.map((tag) => `tag:${tag}`).join(" ");
+
+    expect(parseSearchQuery(query)).toEqual({
+      text: "",
+      filters: { tags: SMART_TAGS },
+      hasQualifiers: true,
     });
   });
 });

--- a/packages/core/src/discovery/cache/search-query-parser.ts
+++ b/packages/core/src/discovery/cache/search-query-parser.ts
@@ -1,4 +1,5 @@
-import type { FileActivityKind, ProjectIdentityKind, SmartTag } from "../../types/index.js";
+import { isSmartTag, type SmartTag } from "../../contract/index.js";
+import type { FileActivityKind, ProjectIdentityKind } from "../../types/index.js";
 import { isProjectIdentityKind } from "../../projects/index.js";
 
 export interface SearchQueryFilters {
@@ -102,20 +103,6 @@ function setCostMaximum(filters: SearchQueryFilters, value: number, exclusive: b
 function appendUnique<T>(values: T[] | undefined, value: T): T[] {
   if (values?.includes(value)) return values;
   return [...(values ?? []), value];
-}
-
-function isSmartTag(value: string): value is SmartTag {
-  return (
-    value === "bugfix" ||
-    value === "refactoring" ||
-    value === "feature-dev" ||
-    value === "testing" ||
-    value === "docs" ||
-    value === "git-ops" ||
-    value === "build-deploy" ||
-    value === "exploration" ||
-    value === "planning"
-  );
 }
 
 export function parseSearchQuery(input: string): ParsedSearchQuery {

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -83,7 +83,7 @@ export {
 } from "../discovery/index.js";
 export type { CacheReadOutcome } from "../discovery/index.js";
 export { PRICING_CAPTURE_EPOCH } from "../pricing/index.js";
-export { filterSessionTreeByActivityWindow } from "../contract/index.js";
+export { filterSessionTreeByActivityWindow, isSmartTag, SMART_TAGS } from "../contract/index.js";
 export type {
   AgentScanIntent,
   AgentScanPlan,

--- a/packages/core/src/utils/smart-tags.ts
+++ b/packages/core/src/utils/smart-tags.ts
@@ -1,18 +1,7 @@
 import type { MessagePart, SessionDetail, SmartTag, ToolPart } from "../types/index.js";
+import { SMART_TAGS } from "../contract/index.js";
 
 export const SMART_TAG_CLASSIFIER_REVISION = "smart-tags-v1";
-
-const TAG_ORDER: SmartTag[] = [
-  "bugfix",
-  "refactoring",
-  "feature-dev",
-  "testing",
-  "docs",
-  "git-ops",
-  "build-deploy",
-  "exploration",
-  "planning",
-];
 
 const USER_RULES: Array<[SmartTag, RegExp]> = [
   ["bugfix", /\b(fix|bug|error|crash|exception|fail(?:ed|ure)?)\b|修复|错误|报错|崩溃|异常/i],
@@ -73,7 +62,7 @@ export function classifySessionTags(session: Pick<SessionDetail, "messages">): S
     tags.add("exploration");
   }
 
-  return TAG_ORDER.filter((tag) => tags.has(tag));
+  return SMART_TAGS.filter((tag) => tags.has(tag));
 }
 
 function partText(part: MessagePart): string {


### PR DESCRIPTION
## Summary

- define the ordered smart tag catalog and runtime validator in the browser-safe contract
- reuse the catalog in classification, search parsing, HTTP query parsing, and web filters
- remove redundant identity label mappings and cover all catalog values in tests

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`