### PR TITLE
refactor(agents)!: Remove legacy refresh paths

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -6,7 +6,6 @@ import {
   attachMissingProjectIdentities,
   FileSystemSessionSource,
   type AgentScanOptions,
-  type ChangeCheckResult,
   type IdentifiedSessionHead,
   type AgentRoots,
   type ScanOptions,
@@ -476,8 +475,6 @@ function makeFileSystemAgent(
     snapshotSessionCacheMeta?: () => Record<string, SessionCacheMeta>;
     restoreSessionCacheMeta?: (meta: Readonly<Record<string, SessionCacheMeta>>) => void;
     removeSessionCacheMeta?: (sessionIds: Iterable<string>) => void;
-    checkForChanges?: (sinceTimestamp: number, cachedSessions: SessionHead[]) => ChangeCheckResult;
-    incrementalScan?: (cachedSessions: SessionHead[], changedIds: string[]) => SessionHead[];
   } = {},
 ) {
   const agent = Object.create(FileSystemSessionSource.prototype) as InstanceType<
@@ -496,10 +493,6 @@ function makeFileSystemAgent(
   agent.snapshotSessionCacheMeta = overrides.snapshotSessionCacheMeta ?? vi.fn(() => ({}));
   agent.restoreSessionCacheMeta = overrides.restoreSessionCacheMeta ?? vi.fn();
   agent.removeSessionCacheMeta = overrides.removeSessionCacheMeta ?? vi.fn();
-  agent.checkForChanges =
-    overrides.checkForChanges ??
-    vi.fn(() => ({ hasChanges: false, changedIds: [], timestamp: Date.now() }));
-  agent.incrementalScan = overrides.incrementalScan ?? vi.fn((cached: SessionHead[]) => cached);
   Object.defineProperty(agent, "sessionSourceAccess", {
     value: {
       kind: "enumerated",
@@ -1325,10 +1318,6 @@ describe("LiveScanStore", () => {
       sourcePath === "/tmp/s" ? updated : added,
     );
     const codex = makeFileSystemAgent("codex", {
-      checkForChanges: vi.fn(() => {
-        throw new Error("checkForChanges should not run for source-backed agents");
-      }),
-      incrementalScan: vi.fn(),
       listSessionSources: vi.fn(() => [
         { sessionId: "session", sourcePath: "/tmp/s", fingerprint: "next" },
         { sessionId: "added", sourcePath: "/tmp/added", fingerprint: "new" },
@@ -1364,8 +1353,6 @@ describe("LiveScanStore", () => {
     await vi.waitFor(() => expect(store.getSnapshot().sessions).toHaveLength(2));
     await vi.advanceTimersByTimeAsync(250);
 
-    expect(codex.checkForChanges).not.toHaveBeenCalled();
-    expect(codex.incrementalScan).not.toHaveBeenCalled();
     expect(scanSessionSource).toHaveBeenCalledTimes(2);
     expect(scanSessionSource).toHaveBeenCalledWith("/tmp/s", expect.any(Object));
     expect(scanSessionSource).toHaveBeenCalledWith("/tmp/added", expect.any(Object));

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -16,6 +16,7 @@ import type {
   SessionCacheMeta,
   SessionSourceFile,
   SessionSourceRef,
+  SessionSourceSynchronizationRequest,
 } from "../base.js";
 import type { SessionDetail, SessionHead } from "../../types/index.js";
 import { PRICING_CAPTURE_EPOCH } from "../../pricing/cost.js";
@@ -102,6 +103,17 @@ class FakeFileSystemSource extends FileSystemSessionSource {
 
 class NormalizedNameSource extends FakeFileSystemSource {
   override readonly name = " FaKe ";
+}
+
+function synchronizeFileSource(
+  agent: FakeFileSystemSource,
+  sessions: SessionHead[],
+  request: SessionSourceSynchronizationRequest,
+) {
+  return agent.sessionSourceAccess.synchronize(
+    { sessions, meta: agent.snapshotSessionCacheMeta() },
+    request,
+  );
 }
 
 class ReentrantSingleFileSource extends SingleFileSessionSource {
@@ -539,7 +551,7 @@ describe("diffSessionSources", () => {
   });
 });
 
-describe("FileSystemSessionSource.checkForChanges", () => {
+describe("FileSystemSessionSource source inspection", () => {
   it("reports no changes when fingerprints and paths match", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b")]);
     // Seed metaMap as if a prior scan populated it.
@@ -554,9 +566,10 @@ describe("FileSystemSessionSource.checkForChanges", () => {
       fingerprint: "fp-1",
     });
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("a"), makeSession("b")]);
-    expect(result.hasChanges).toBe(false);
-    expect(result.changedIds).toEqual([]);
+    const result = synchronizeFileSource(agent, [makeSession("a"), makeSession("b")], {
+      kind: "inspect",
+    });
+    expect(result.detectedSessionIds).toEqual([]);
   });
 
   it("detects added sources", () => {
@@ -567,9 +580,8 @@ describe("FileSystemSessionSource.checkForChanges", () => {
       fingerprint: "fp-1",
     });
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toEqual(["b"]);
+    const result = synchronizeFileSource(agent, [makeSession("a")], { kind: "inspect" });
+    expect(result.detectedSessionIds).toEqual(["b"]);
   });
 
   it("detects removed sources", () => {
@@ -584,9 +596,10 @@ describe("FileSystemSessionSource.checkForChanges", () => {
       ghost: { id: "ghost", sourcePath: "/tmp/ghost-does-not-exist.jsonl" },
     });
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("a"), makeSession("ghost")]);
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toEqual(["ghost"]);
+    const result = synchronizeFileSource(agent, [makeSession("a"), makeSession("ghost")], {
+      kind: "inspect",
+    });
+    expect(result.detectedSessionIds).toEqual(["ghost"]);
   });
 
   it("detects changed fingerprints", () => {
@@ -596,9 +609,8 @@ describe("FileSystemSessionSource.checkForChanges", () => {
       a: { id: "a", sourcePath: "/tmp/a.jsonl", sourceFingerprint: "fp-1" },
     });
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toEqual(["a"]);
+    const result = synchronizeFileSource(agent, [makeSession("a")], { kind: "inspect" });
+    expect(result.detectedSessionIds).toEqual(["a"]);
   });
 
   it("detects changed source paths even with identical fingerprints", () => {
@@ -607,18 +619,16 @@ describe("FileSystemSessionSource.checkForChanges", () => {
       a: { id: "a", sourcePath: "/tmp/old-a.jsonl", sourceFingerprint: "fp-1" },
     });
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toEqual(["a"]);
+    const result = synchronizeFileSource(agent, [makeSession("a")], { kind: "inspect" });
+    expect(result.detectedSessionIds).toEqual(["a"]);
   });
 
   it("treats missing fingerprint as changed", () => {
     const agent = new FakeFileSystemSource([source("a")]);
     agent.restoreSessionCacheMeta({ a: { id: "a", sourcePath: "/tmp/a.jsonl" } });
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("a")]);
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toEqual(["a"]);
+    const result = synchronizeFileSource(agent, [makeSession("a")], { kind: "inspect" });
+    expect(result.detectedSessionIds).toEqual(["a"]);
   });
 
   it("returns refs matching the listSessionSources enumeration", () => {
@@ -626,12 +636,14 @@ describe("FileSystemSessionSource.checkForChanges", () => {
     agent.scanSessionSource("/tmp/a.jsonl");
     agent.scanSessionSource("/tmp/b.jsonl");
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("a"), makeSession("b")]);
-    expect(result.refs).toEqual(agent.listSessionSources());
+    const result = synchronizeFileSource(agent, [makeSession("a"), makeSession("b")], {
+      kind: "inspect",
+    });
+    expect(result.sources).toEqual(agent.listSessionSources());
   });
 });
 
-describe("FileSystemSessionSource.incrementalScan", () => {
+describe("FileSystemSessionSource source synchronization", () => {
   it("reports source enumeration, change, and processing workload", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b")]);
 
@@ -654,20 +666,29 @@ describe("FileSystemSessionSource.incrementalScan", () => {
       source("b", "fp-1", { head: makeSession("b") }),
     ]);
 
-    const updated = agent.incrementalScan([makeSession("a"), makeSession("b")], ["a"]);
+    const updated = synchronizeFileSource(agent, [makeSession("a"), makeSession("b")], {
+      kind: "known-changes",
+      changedIds: ["a"],
+    }).sessions;
     expect(updated.map((s) => s.reference.sessionId).sort()).toEqual(["a", "b"]);
     expect(agent.getSessionCacheMeta("a")?.sourceFingerprint).toBe("fp-1");
   });
 
   it("adds new sources when listed but missing from cache", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b")]);
-    const updated = agent.incrementalScan([makeSession("a")], ["b"]);
+    const updated = synchronizeFileSource(agent, [makeSession("a")], {
+      kind: "known-changes",
+      changedIds: ["b"],
+    }).sessions;
     expect(updated.map((s) => s.reference.sessionId).sort()).toEqual(["a", "b"]);
   });
 
   it("retains the last-known-good session when a source no longer parses", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b", "fp-1", { head: null })]);
-    const updated = agent.incrementalScan([makeSession("a"), makeSession("b")], ["b"]);
+    const updated = synchronizeFileSource(agent, [makeSession("a"), makeSession("b")], {
+      kind: "known-changes",
+      changedIds: ["b"],
+    }).sessions;
     expect(updated.map((s) => s.reference.sessionId)).toEqual(["a", "b"]);
     expect(agent.getSessionCacheMeta("b")).toBeUndefined();
   });
@@ -681,7 +702,10 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     agent.scanSessionSource("/tmp/a.jsonl");
     agent.setSources([source("a", "fp-new", { head: null, error })]);
 
-    const retained = agent.incrementalScan([before], ["a"]);
+    const retained = synchronizeFileSource(agent, [before], {
+      kind: "known-changes",
+      changedIds: ["a"],
+    }).sessions;
 
     expect(retained).toEqual([before]);
     expect(agent.getSessionCacheMeta("a")?.sourceFingerprint).toBe("fp-old");
@@ -690,7 +714,12 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     recovered.title = "recovered";
     agent.setSources([source("a", "fp-new", { head: recovered })]);
 
-    expect(agent.incrementalScan(retained, ["a"])[0]?.title).toBe("recovered");
+    expect(
+      synchronizeFileSource(agent, retained, {
+        kind: "known-changes",
+        changedIds: ["a"],
+      }).sessions[0]?.title,
+    ).toBe("recovered");
     expect(agent.getSessionCacheMeta("a")?.sourceFingerprint).toBe("fp-new");
   });
 
@@ -700,7 +729,10 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     agent.scanSessionSource("/tmp/a.jsonl");
     agent.setSources([source("a", "fp-new", { head: null, filtered: true })]);
 
-    const updated = agent.incrementalScan([before], ["a"]);
+    const updated = synchronizeFileSource(agent, [before], {
+      kind: "known-changes",
+      changedIds: ["a"],
+    }).sessions;
 
     expect(updated).toEqual([]);
     expect(agent.getSessionCacheMeta("a")).toBeUndefined();
@@ -713,7 +745,10 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     const missingError = Object.assign(new Error("source disappeared"), { code: "ENOENT" });
     agent.setSources([source("a", "fp-new", { head: null, error: missingError })]);
 
-    const updated = agent.incrementalScan([before], ["a"]);
+    const updated = synchronizeFileSource(agent, [before], {
+      kind: "known-changes",
+      changedIds: ["a"],
+    }).sessions;
 
     expect(updated).toEqual([]);
     expect(agent.getSessionCacheMeta("a")).toBeUndefined();
@@ -728,10 +763,17 @@ describe("FileSystemSessionSource.incrementalScan", () => {
     const changedIds = ["a", "b"];
     const refs = agent.listSessionSources();
 
-    const fallback = agent.incrementalScan(cached, changedIds);
+    const fallback = synchronizeFileSource(agent, cached, {
+      kind: "known-changes",
+      changedIds,
+    }).sessions;
 
     const listSpy = vi.spyOn(agent, "listSessionSources");
-    const withRefs = agent.incrementalScan(cached, changedIds, refs);
+    const withRefs = synchronizeFileSource(agent, cached, {
+      kind: "known-changes",
+      changedIds,
+      refs,
+    }).sessions;
 
     expect(listSpy).toHaveBeenCalledTimes(0);
     expect(withRefs.map((s) => s.reference.sessionId).sort()).toEqual(

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -44,6 +44,13 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
   };
 }
 
+function refresh(agent: ClaudeCodeAgent, sessions: SessionHead[]) {
+  return agent.sessionSourceAccess.synchronize(
+    { sessions, meta: agent.snapshotSessionCacheMeta() },
+    { kind: "refresh" },
+  );
+}
+
 function writeMinimalClaudeSession(filePath: string): void {
   writeFileSync(
     filePath,
@@ -91,8 +98,8 @@ describe("ClaudeCodeAgent cache refresh", () => {
     expect(baselineFingerprint).toBeDefined();
 
     // No changes yet.
-    const unchanged = agent.checkForChanges(Date.now(), [makeSession("session-1")]);
-    expect(unchanged.hasChanges).toBe(false);
+    const unchanged = refresh(agent, [makeSession("session-1")]);
+    expect(unchanged.detectedSessionIds).toEqual([]);
 
     // Rewrite the index file (bumps its mtime → fingerprint changes).
     const later = new Date(Date.now() + 2000);
@@ -101,9 +108,8 @@ describe("ClaudeCodeAgent cache refresh", () => {
     });
     utimesSync(indexFile, later, later);
 
-    const changed = agent.checkForChanges(Date.now(), [makeSession("session-1")]);
-    expect(changed.hasChanges).toBe(true);
-    expect(changed.changedIds).toContain("session-1");
+    const changed = refresh(agent, [makeSession("session-1")]);
+    expect(changed.detectedSessionIds).toContain("session-1");
     // The fingerprint now reflects the new index mtime.
     expect(agent.listSessionSources()[0]?.fingerprint).not.toBe(baselineFingerprint);
   });

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -49,6 +49,13 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
   };
 }
 
+function refresh(agent: CodexAgent, sessions: SessionHead[]) {
+  return agent.sessionSourceAccess.synchronize(
+    { sessions, meta: agent.snapshotSessionCacheMeta() },
+    { kind: "refresh" },
+  );
+}
+
 describe("CodexAgent cache refresh", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -92,13 +99,12 @@ describe("CodexAgent cache refresh", () => {
       { file: newC, stat: statSync(newC) },
     ];
 
-    const result = agent.checkForChanges(Date.now(), [
+    const result = refresh(agent, [
       makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
       makeSession("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb"),
     ]);
 
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toContain("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb");
+    expect(result.detectedSessionIds).toContain("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb");
   });
 
   it("re-prices a cached head after missing model pricing arrives", () => {
@@ -134,16 +140,16 @@ describe("CodexAgent cache refresh", () => {
     const cached = agent.scan({ from: 0 }) as SessionHead[];
     expect(cached[0]?.stats.total_cost).toBe(0);
     expect(agent.getSessionCacheMeta(sessionId)?.unpricedModels).toEqual([model]);
-    expect(agent.checkForChanges(Date.now(), cached).hasChanges).toBe(false);
+    expect(refresh(agent, cached).detectedSessionIds).toEqual([]);
 
     pricingAvailable = true;
-    const changed = agent.checkForChanges(Date.now(), cached);
-    expect(changed.changedIds).toEqual([sessionId]);
+    const result = refresh(agent, cached);
+    expect(result.detectedSessionIds).toEqual([sessionId]);
 
-    const refreshed = agent.incrementalScan(cached, changed.changedIds ?? [], changed.refs);
+    const refreshed = result.sessions;
     expect(refreshed[0]?.stats.total_cost).toBeGreaterThan(0);
     expect(agent.getSessionCacheMeta(sessionId)?.unpricedModels).toBeUndefined();
-    expect(agent.checkForChanges(Date.now(), refreshed).hasChanges).toBe(false);
+    expect(refresh(agent, refreshed).detectedSessionIds).toEqual([]);
   });
 
   it("ignores unrelated session index changes during cache validation", () => {
@@ -181,12 +187,9 @@ describe("CodexAgent cache refresh", () => {
     );
     utimesSync(indexFile, later, later);
 
-    const result = agent.checkForChanges(Date.now(), [
-      makeSession(sessionId, { title: "Old title" }),
-    ]);
+    const result = refresh(agent, [makeSession(sessionId, { title: "Old title" })]);
 
-    expect(result.hasChanges).toBe(false);
-    expect(result.changedIds).toEqual([]);
+    expect(result.detectedSessionIds).toEqual([]);
     expect(agent.listSessionSources()[0]?.fingerprint).toBe(baselineFingerprint);
   });
 
@@ -540,12 +543,9 @@ describe("CodexAgent cache refresh", () => {
     ]);
     agent.listRolloutFiles = () => [{ file: sessionFile, stat: statSync(sessionFile) }];
 
-    const result = agent.checkForChanges(Date.now(), [
-      makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
-    ]);
+    const result = refresh(agent, [makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa")]);
 
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toContain("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa");
+    expect(result.detectedSessionIds).toContain("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa");
   });
 
   it("removes deleted sessions and adds new sessions during incremental scan", () => {
@@ -575,13 +575,10 @@ describe("CodexAgent cache refresh", () => {
       return { status: "skipped", reason: "unknown fixture" };
     };
 
-    const sessions = agent.incrementalScan(
-      [
-        makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
-        makeSession("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb"),
-      ],
-      ["019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb", "019dcccc-cccc-7ccc-cccc-cccccccccccc"],
-    );
+    const sessions = refresh(agent, [
+      makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa"),
+      makeSession("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb"),
+    ]).sessions;
 
     expect(sessions.map((session: SessionHead) => session.reference.sessionId).sort()).toEqual([
       "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",

--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -22,6 +22,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { KimiCodeAgent } from "../kimi-code.js";
 import { TranscriptBuilder } from "../transcript-builder.js";
+import type { SessionHead } from "../../types/index.js";
 
 const SESSION_ID = "ses_test-kimi-code";
 const WORK_DIR = "/tmp/kimi-code-project";
@@ -31,6 +32,13 @@ const mockedReadFileSync = vi.mocked(readFileSync);
 
 function createAgent(dataRoot: string): KimiCodeAgent {
   return new KimiCodeAgent({ sourceRoot: join(dataRoot, "sessions") });
+}
+
+function refresh(agent: KimiCodeAgent, sessions: SessionHead[]) {
+  return agent.sessionSourceAccess.synchronize(
+    { sessions, meta: agent.snapshotSessionCacheMeta() },
+    { kind: "refresh" },
+  );
 }
 
 function createSession(
@@ -193,14 +201,13 @@ describe("KimiCodeAgent", () => {
       },
     });
 
-    const changes = agent.checkForChanges(0, heads);
-    expect(changes.changedIds).toContain(SESSION_ID);
-    const refreshed = agent.incrementalScan(heads, changes.changedIds ?? [], changes.refs);
-    expect(refreshed).toMatchObject([
+    const result = refresh(agent, heads);
+    expect(result.detectedSessionIds).toContain(SESSION_ID);
+    expect(result.sessions).toMatchObject([
       { reference: { agentName: "kimi-code", sessionId: SESSION_ID }, title: "Refresh me" },
     ]);
     expect(agent.getSessionCacheMeta(SESSION_ID)?.sourceFingerprint).toBe(
-      changes.refs?.[0]?.fingerprint,
+      result.sources[0]?.fingerprint,
     );
     expect(agent.getSessionData(SESSION_ID).messages[0]).toMatchObject({
       role: "user",
@@ -452,8 +459,7 @@ describe("KimiCodeAgent", () => {
       })}\n`,
     );
 
-    const refs = agent.listSessionSources();
-    expect(agent.incrementalScan([], [emptyId], refs)).toMatchObject([
+    expect(refresh(agent, []).sessions).toMatchObject([
       {
         reference: { agentName: "kimi-code", sessionId: emptyId },
         stats: { message_count: 1 },
@@ -483,10 +489,9 @@ describe("KimiCodeAgent", () => {
     expect(agent.filterCachedSessions([stale])).toEqual([]);
     expect(agent.getSessionCacheMeta(SESSION_ID)).toBeUndefined();
 
-    const changes = agent.checkForChanges(0, [stale]);
-    expect(changes.hasChanges).toBe(true);
-    expect(changes.changedIds).toContain(SESSION_ID);
-    expect(agent.incrementalScan([stale], changes.changedIds ?? [], changes.refs)).toEqual([]);
+    const result = refresh(agent, [stale]);
+    expect(result.detectedSessionIds).toContain(SESSION_ID);
+    expect(result.sessions).toEqual([]);
   });
 
   it("keeps a missing record timestamp unavailable", () => {

--- a/packages/core/src/agents/__tests__/kimi.test.ts
+++ b/packages/core/src/agents/__tests__/kimi.test.ts
@@ -47,6 +47,13 @@ function createAgent(basePath: string): KimiAgent {
   });
 }
 
+function refresh(agent: KimiAgent, sessions: SessionHead[]) {
+  return agent.sessionSourceAccess.synchronize(
+    { sessions, meta: agent.snapshotSessionCacheMeta() },
+    { kind: "refresh" },
+  );
+}
+
 function createSessionDir(
   basePath: string,
   id: string,
@@ -140,20 +147,19 @@ describe("KimiAgent cache refresh", () => {
     // A new session appears on disk after the baseline scan.
     createSessionDir(basePath, "new-session", "New", 1_000);
 
-    const result = agent.checkForChanges(Date.now(), [makeSession("old-session")]);
+    const result = refresh(agent, [makeSession("old-session")]);
 
-    expect(result.hasChanges).toBe(true);
-    expect(result.changedIds).toEqual(["new-session"]);
+    expect(result.detectedSessionIds).toEqual(["new-session"]);
   });
 
   it("adds changed session directories during incremental scan", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-kimi-test-"));
     tempDirs.push(basePath);
     createSessionDir(basePath, "old-session", "Old", 1_000);
-    createSessionDir(basePath, "new-session", "New", 1_000);
-
     const agent = createAgent(basePath);
-    const sessions = agent.incrementalScan([makeSession("old-session")], ["new-session"]);
+    const baseline = agent.scan();
+    createSessionDir(basePath, "new-session", "New", 1_000);
+    const sessions = refresh(agent, baseline).sessions;
 
     expect(sessions.map((session) => session.reference.sessionId).sort()).toEqual([
       "new-session",
@@ -174,10 +180,11 @@ describe("KimiAgent cache refresh", () => {
     createSessionDir(basePath, "old-session", "Old", 1_000);
 
     const agent = createAgent(basePath);
-    const sessions = agent.incrementalScan(
-      [makeSession("old-session"), makeSession("deleted-session")],
-      ["deleted-session"],
-    );
+    agent.scan();
+    const sessions = refresh(agent, [
+      makeSession("old-session"),
+      makeSession("deleted-session"),
+    ]).sessions;
 
     expect(sessions.map((session) => session.reference.sessionId)).toEqual(["old-session"]);
     expect(agent.getSessionCacheMeta("deleted-session")).toBeUndefined();

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -308,9 +308,9 @@ export abstract class BaseAgent<TMeta extends SessionCacheMeta = SessionCacheMet
  * 的会话或 null 转成 parsed/skipped 结果；需要保留 filtered 等结果时可覆写，
  * 例如 KimiAgent。
  *
- * 变更检测 / 增量扫描 / metaMap 管理由本基类统一提供：
- *   checkForChanges 用 listSessionSources 的指纹与缓存 metaMap 比对，
- *   incrementalScan 对变更集合调用 scanSessionSource 重解析。
+ * 源同步与 metaMap 管理由本基类统一提供：
+ *   synchronizeSessionSources 用 listSessionSources 的指纹与缓存 metaMap 比对，
+ *   并对变更集合调用 scanSessionSource 重解析。
  * 两原语在各子类中复用同一个 sourceFingerprint 计算，故指纹精确比对即等价于变更检测。
  */
 export abstract class FileSystemSessionSource<
@@ -486,33 +486,6 @@ export abstract class FileSystemSessionSource<
     } catch {
       return null;
     }
-  }
-
-  checkForChanges(_sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    const outcome = this.synchronizeSessionSources(
-      { sessions: cachedSessions, meta: this.snapshotSessionCacheMeta() },
-      { kind: "inspect" },
-    );
-
-    return {
-      hasChanges: outcome.detectedSessionIds.length > 0 || outcome.sourceFailures.length > 0,
-      changedIds: outcome.detectedSessionIds,
-      timestamp: Date.now(),
-      refs: outcome.sources,
-      sourceFailures: outcome.sourceFailures,
-    };
-  }
-
-  incrementalScan(
-    cachedSessions: SessionHead[],
-    changedIds: string[],
-    refs?: SessionSourceRef[],
-    _scanOptions?: AgentScanOptions,
-  ): SessionHead[] {
-    return this.synchronizeSessionSources(
-      { sessions: cachedSessions, meta: this.snapshotSessionCacheMeta() },
-      { kind: "known-changes", changedIds, refs },
-    ).sessions;
   }
 }
 

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -11,7 +11,6 @@ import {
 } from "./base.js";
 import type {
   AgentScanOptions,
-  ChangeCheckResult,
   ParseSessionResult,
   SessionCacheMeta,
   SessionSourceRef,
@@ -493,33 +492,8 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     return refs;
   }
 
-  checkForChanges(sinceTimestamp: number, cachedSessions: SessionHead[]): ChangeCheckResult {
-    const result = super.checkForChanges(sinceTimestamp, cachedSessions);
-    if (result.status === "failed") return result;
-    const emptySessionIds = cachedSessions
-      .filter((session) => !this.hasMessages(session))
-      .map((session) => session.reference.sessionId);
-    if (emptySessionIds.length === 0) return result;
-
-    return {
-      ...result,
-      hasChanges: true,
-      changedIds: [...new Set([...(result.changedIds ?? []), ...emptySessionIds])],
-    };
-  }
-
   filterCachedSessions(sessions: SessionHead[]): SessionHead[] {
     return this.removeEmptyCachedSessions(sessions);
-  }
-
-  incrementalScan(
-    cachedSessions: SessionHead[],
-    changedIds: string[],
-    refs?: SessionSourceRef[],
-    scanOptions?: AgentScanOptions,
-  ): SessionHead[] {
-    const visibleSessions = this.removeEmptyCachedSessions(cachedSessions);
-    return super.incrementalScan(visibleSessions, changedIds, refs, scanOptions);
   }
 
   private hasMessages(session: SessionHead): boolean {


### PR DESCRIPTION
## Summary

- remove legacy file-backed Agent refresh methods that production never calls
- route file-backed refresh tests through sessionSourceAccess.synchronize
- keep aggregate database refresh behavior unchanged

## Breaking change

FileSystemSessionSource no longer exposes checkForChanges or incrementalScan. Callers must use sessionSourceAccess.synchronize.

## Testing

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test