### PR TITLE
perf(web): Batch detail query invalidation

### DIFF
--- a/apps/web/src/lib/session-query-consistency.test.ts
+++ b/apps/web/src/lib/session-query-consistency.test.ts
@@ -1,0 +1,76 @@
+import { SAMPLE_SESSIONS_UPDATED_EVENT } from "@codesesh/core/test-fixtures";
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionsUpdatedEvent } from "./api";
+import { queryKeys } from "./query-keys";
+import { invalidateLiveSessionDerivedQueries } from "./session-query-consistency";
+
+let client: QueryClient | null = null;
+
+afterEach(() => {
+  client?.clear();
+  client = null;
+});
+
+function makeClient(): QueryClient {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return client;
+}
+
+function changedHead(
+  agentName: string,
+  sessionId: string,
+): SessionsUpdatedEvent["changedSessionHeads"][number] {
+  const sample = SAMPLE_SESSIONS_UPDATED_EVENT.changedSessionHeads[0]!;
+  return {
+    reference: { agentName, sessionId },
+    session: sample.session,
+  };
+}
+
+describe("live session detail invalidation", () => {
+  it("invalidates every changed detail with one cache scan request", async () => {
+    const active = makeClient();
+    const changedKey = queryKeys.sessionDetail("codex", "changed");
+    const removedKey = queryKeys.sessionDetail("codex", "removed");
+    const unchangedKey = queryKeys.sessionDetail("codex", "unchanged");
+    const descendantKey = [...changedKey, "messages"] as const;
+    active.setQueryData(changedKey, { id: "changed" });
+    active.setQueryData(removedKey, { id: "removed" });
+    active.setQueryData(unchangedKey, { id: "unchanged" });
+    active.setQueryData(descendantKey, { id: "changed-messages" });
+    const invalidateQueries = vi.spyOn(active, "invalidateQueries");
+    const event = {
+      ...SAMPLE_SESSIONS_UPDATED_EVENT,
+      changedSessionHeads: [
+        changedHead("CodeX", "changed"),
+        ...Array.from({ length: 1_000 }, (_, index) => changedHead("CodeX", `absent-${index}`)),
+      ],
+      removedSessionRefs: [
+        { agentName: "CodeX", sessionId: "removed" },
+        { agentName: "CodeX", sessionId: "changed" },
+      ],
+    } satisfies SessionsUpdatedEvent;
+
+    await invalidateLiveSessionDerivedQueries(active, event);
+
+    expect(invalidateQueries).toHaveBeenCalledOnce();
+    expect(active.getQueryState(changedKey)?.isInvalidated).toBe(true);
+    expect(active.getQueryState(removedKey)?.isInvalidated).toBe(true);
+    expect(active.getQueryState(unchangedKey)?.isInvalidated).toBe(false);
+    expect(active.getQueryState(descendantKey)?.isInvalidated).toBe(false);
+  });
+
+  it("does not scan the cache when no detail changed", async () => {
+    const active = makeClient();
+    const invalidateQueries = vi.spyOn(active, "invalidateQueries");
+
+    await invalidateLiveSessionDerivedQueries(active, {
+      ...SAMPLE_SESSIONS_UPDATED_EVENT,
+      changedSessionHeads: [],
+      removedSessionRefs: [],
+    });
+
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/session-query-consistency.ts
+++ b/apps/web/src/lib/session-query-consistency.ts
@@ -28,24 +28,34 @@ export async function invalidateLiveSessionDerivedQueries(
   queryClient: QueryClient,
   event: SessionsUpdatedEvent,
 ): Promise<void> {
-  const changedDetailKeys = new Map<string, readonly unknown[]>();
+  const changedSessionsByAgent = new Map<string, Set<string>>();
+  const addChangedSession = (agentName: string, sessionId: string) => {
+    const normalizedAgent = agentName.toLowerCase();
+    const sessionIds = changedSessionsByAgent.get(normalizedAgent) ?? new Set<string>();
+    sessionIds.add(sessionId);
+    changedSessionsByAgent.set(normalizedAgent, sessionIds);
+  };
+
   for (const item of event.changedSessionHeads) {
     const { agentName, sessionId } = item.reference;
-    changedDetailKeys.set(
-      `${agentName.toLowerCase()}\0${sessionId}`,
-      queryKeys.sessionDetail(agentName.toLowerCase(), sessionId),
-    );
+    addChangedSession(agentName, sessionId);
   }
   for (const { agentName, sessionId } of event.removedSessionRefs) {
-    changedDetailKeys.set(
-      `${agentName.toLowerCase()}\0${sessionId}`,
-      queryKeys.sessionDetail(agentName.toLowerCase(), sessionId),
-    );
+    addChangedSession(agentName, sessionId);
   }
+  if (changedSessionsByAgent.size === 0) return;
 
-  await Promise.all(
-    Array.from(changedDetailKeys.values(), (queryKey) =>
-      queryClient.invalidateQueries({ queryKey, exact: true }),
-    ),
-  );
+  await queryClient.invalidateQueries({
+    predicate: ({ queryKey }) => {
+      if (
+        queryKey.length !== 3 ||
+        queryKey[0] !== queryKeys.sessionDetails[0] ||
+        typeof queryKey[1] !== "string" ||
+        typeof queryKey[2] !== "string"
+      ) {
+        return false;
+      }
+      return changedSessionsByAgent.get(queryKey[1])?.has(queryKey[2]) ?? false;
+    },
+  });
 }


### PR DESCRIPTION
## Summary

- batch live session detail invalidation into one query-cache traversal
- preserve exact detail-key matching and active-query refetch behavior
- add a regression test covering 1,000 changed sessions, removals, and unrelated queries

## Complexity

- before: O((changed + removed) * cached queries)
- after: O(changed + removed + cached queries)

## Testing

- pnpm perf:check
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test