### PR TITLE
refactor(contract)!: Remove duplicate event counts

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -161,7 +161,6 @@ describe("App live updates", () => {
       liveSubscription.onUpdate?.({
         ...SAMPLE_SESSIONS_UPDATED_EVENT,
         changedAgents: ["claudecode"],
-        newSessions: 0,
         newSessionRefs: [],
         totalSessions: 1,
         changedSessionHeads: [

--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -71,7 +71,7 @@ describe("useLiveSync", () => {
     const { result } = renderHook(() => useLiveSync(makeDeps(3)));
 
     await act(async () => {
-      sessionsCallback?.({ ...SAMPLE_SESSIONS_UPDATED_EVENT, newSessions: 3 });
+      sessionsCallback?.(SAMPLE_SESSIONS_UPDATED_EVENT);
       await vi.advanceTimersByTimeAsync(500);
     });
 
@@ -83,7 +83,7 @@ describe("useLiveSync", () => {
     const { result } = renderHook(() => useLiveSync(makeDeps()));
 
     await act(async () => {
-      sessionsCallback?.({ ...SAMPLE_SESSIONS_UPDATED_EVENT, newSessions: 3 });
+      sessionsCallback?.(SAMPLE_SESSIONS_UPDATED_EVENT);
       await vi.advanceTimersByTimeAsync(500);
     });
 
@@ -94,12 +94,20 @@ describe("useLiveSync", () => {
     vi.useFakeTimers();
     const deps = makeDeps();
     renderHook(() => useLiveSync(deps));
+    const first = { agentName: "claudecode", sessionId: "first" };
+    const second = { agentName: "claudecode", sessionId: "second" };
+    const third = { agentName: "claudecode", sessionId: "third" };
 
     await act(async () => {
-      sessionsCallback?.({ ...SAMPLE_SESSIONS_UPDATED_EVENT, newSessions: 1 });
       sessionsCallback?.({
         ...SAMPLE_SESSIONS_UPDATED_EVENT,
-        newSessions: 2,
+        newSessionRefs: [first],
+        changedSessionHeads: [],
+      });
+      sessionsCallback?.({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        newSessionRefs: [second, third],
+        changedSessionHeads: [],
         timestamp: SAMPLE_SESSIONS_UPDATED_EVENT.timestamp + 1,
       });
       await vi.advanceTimersByTimeAsync(500);
@@ -108,7 +116,7 @@ describe("useLiveSync", () => {
     expect(deps.applyLiveEvent).toHaveBeenCalledOnce();
     expect(deps.applyLiveEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        newSessions: 3,
+        newSessionRefs: [first, second, third],
         timestamp: SAMPLE_SESSIONS_UPDATED_EVENT.timestamp + 1,
       }),
     );

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -375,7 +375,6 @@ describe("useSessionStore", () => {
     await act(async () => {
       update = await result.current.applyLiveEvent({
         ...SAMPLE_SESSIONS_UPDATED_EVENT,
-        newSessions: historicalSessions.length,
         newSessionRefs: historicalSessions.map((session) => ({
           agentName: "claudecode",
           sessionId: session.reference.sessionId,

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -350,7 +350,7 @@ export function useSessionStore() {
       const previousSessionKeys = new Set(
         currentProjection.sessions.map((session) => formatSessionReference(session.reference)),
       );
-      const visibleNewSessions = (event.newSessionRefs ?? []).filter((reference) => {
+      const visibleNewSessions = event.newSessionRefs.filter((reference) => {
         const key = formatSessionReference(reference);
         return !previousSessionKeys.has(key) && visibleSessionKeys.has(key);
       }).length;

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SAMPLE_DASHBOARD_DATA, SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
+import {
+  SAMPLE_DASHBOARD_DATA,
+  SAMPLE_SESSIONS_UPDATED_EVENT,
+  SAMPLE_SESSION_HEAD,
+} from "@codesesh/core/test-fixtures";
 import type { DashboardFilters } from "./api";
 import {
   ApiRequestError,
@@ -348,10 +352,10 @@ describe("subscribeSessionUpdates", () => {
     const onScanStatus = vi.fn();
     subscribeSessionUpdates(onUpdate, onScanStatus);
 
-    latest().emit("sessions-updated", { type: "sessions-updated", newSessions: 1 });
+    latest().emit("sessions-updated", SAMPLE_SESSIONS_UPDATED_EVENT);
     latest().emit("scan-status", { type: "scan-status", active: true });
 
-    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({ newSessions: 1 }));
+    expect(onUpdate).toHaveBeenCalledWith(SAMPLE_SESSIONS_UPDATED_EVENT);
     expect(onScanStatus).toHaveBeenCalledWith(expect.objectContaining({ active: true }));
   });
 

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -824,7 +824,12 @@ describe("AgentSyncEngine", () => {
       expect.any(Function),
     );
     expect(sessionChanges).toHaveBeenCalledWith(
-      expect.objectContaining({ event: expect.objectContaining({ updatedSessions: 1 }) }),
+      expect.objectContaining({
+        event: expect.objectContaining({
+          newSessionRefs: [],
+          changedSessionHeads: [expect.objectContaining({ reference: updated.reference })],
+        }),
+      }),
     );
   });
 
@@ -1680,7 +1685,10 @@ describe("AgentSyncEngine", () => {
     expect(sessionChanges).toHaveBeenCalledWith(
       expect.objectContaining({
         agentName: "codex",
-        event: expect.objectContaining({ updatedSessions: 1 }),
+        event: expect.objectContaining({
+          newSessionRefs: [],
+          changedSessionHeads: [expect.objectContaining({ reference: oldSession.reference })],
+        }),
       }),
     );
   });
@@ -1728,7 +1736,10 @@ describe("AgentSyncEngine", () => {
     ]);
     expect(sessionChanges).toHaveBeenCalledWith(
       expect.objectContaining({
-        event: expect.objectContaining({ updatedSessions: 1 }),
+        event: expect.objectContaining({
+          newSessionRefs: [],
+          changedSessionHeads: [expect.objectContaining({ reference: newSession.reference })],
+        }),
       }),
     );
     expect(workerLifecycle.commit).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -20,7 +20,11 @@ import {
   type SessionSourceFailure,
   type SessionSnapshotCompleteness,
 } from "@codesesh/core/runtime";
-import type { ScanCompletion, ScanStatusEvent } from "@codesesh/core/contract";
+import type {
+  ScanCompletion,
+  ScanStatusEvent,
+  SessionsUpdatedEvent,
+} from "@codesesh/core/contract";
 import { AgentBackfillScheduler } from "./agent-backfill-scheduler.js";
 import { AgentOperationScheduler, type AgentOperationResult } from "./agent-operation-scheduler.js";
 import {
@@ -68,6 +72,19 @@ type CachedSessions = CachedResult;
 interface RefreshResult {
   result: Exclude<AgentOperationResult, "failed">;
   completion: ScanCompletion;
+}
+
+function countSessionUpdates(event: SessionsUpdatedEvent | null): {
+  newSessions: number;
+  updatedSessions: number;
+  removedSessions: number;
+} {
+  if (!event) return { newSessions: 0, updatedSessions: 0, removedSessions: 0 };
+  return {
+    newSessions: event.newSessionRefs.length,
+    updatedSessions: event.changedSessionHeads.length - event.newSessionRefs.length,
+    removedSessions: event.removedSessionRefs.length,
+  };
 }
 
 interface RefreshStrategyBase {
@@ -520,15 +537,16 @@ export class AgentSyncEngine {
 
     const totalDurationMs = performance.now() - startedAt;
     this.scheduler.recordRefreshDuration(agentName, totalDurationMs);
+    const sessionUpdateCounts = countSessionUpdates(publication.event);
     appLogger.info(
       strategyResult.sourceFailures.length > 0 ? "scan.refresh.partial" : "scan.refresh.done",
       {
         agent: agentName,
         duration_ms: Math.round(totalDurationMs),
         sessions: nextSessions.length,
-        new_sessions: publication.event?.newSessions ?? 0,
-        updated_sessions: publication.event?.updatedSessions ?? 0,
-        removed_sessions: publication.event?.removedSessions ?? 0,
+        new_sessions: sessionUpdateCounts.newSessions,
+        updated_sessions: sessionUpdateCounts.updatedSessions,
+        removed_sessions: sessionUpdateCounts.removedSessions,
         pending_paths: pendingPathCount,
         availability_ms: Math.round(availabilityDuration),
         check_ms: Math.round(strategyResult.checkDuration),

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -696,8 +696,8 @@ describe("LiveScanStore", () => {
       expect.objectContaining({
         type: "sessions-updated",
         changedAgents: ["codex"],
-        newSessions: 1,
-        removedSessions: 1,
+        newSessionRefs: [{ agentName: "codex", sessionId: "fresh" }],
+        removedSessionRefs: [{ agentName: "codex", sessionId: "cached" }],
         totalSessions: 1,
       }),
     ]);
@@ -1375,9 +1375,8 @@ describe("LiveScanStore", () => {
     ]);
     expect(events).toEqual([
       expect.objectContaining({
-        newSessions: 1,
-        updatedSessions: 1,
-        removedSessions: 0,
+        newSessionRefs: [{ agentName: "codex", sessionId: "added" }],
+        removedSessionRefs: [],
       }),
     ]);
   });
@@ -1540,9 +1539,7 @@ describe("LiveScanStore", () => {
       expect.objectContaining({
         type: "sessions-updated",
         changedAgents: ["codex"],
-        newSessions: 1,
-        updatedSessions: 1,
-        removedSessions: 0,
+        newSessionRefs: [{ agentName: "codex", sessionId: "added" }],
         totalSessions: 2,
         changedSessionHeads: [
           {
@@ -1607,7 +1604,15 @@ describe("LiveScanStore", () => {
 
     expect(store.getSnapshot().sessions[0]?.title).toBe("new");
     expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "sessions-updated", updatedSessions: 1 }),
+      expect.objectContaining({
+        type: "sessions-updated",
+        newSessionRefs: [],
+        changedSessionHeads: [
+          expect.objectContaining({
+            reference: { agentName: "codex", sessionId: "session" },
+          }),
+        ],
+      }),
     );
   });
 
@@ -1641,9 +1646,7 @@ describe("LiveScanStore", () => {
       expect.objectContaining({
         type: "sessions-updated",
         changedAgents: ["codex"],
-        newSessions: 0,
-        updatedSessions: 1,
-        removedSessions: 0,
+        newSessionRefs: [],
         changedSessionHeads: [
           {
             reference: { agentName: "codex", sessionId: previousWithProject.reference.sessionId },
@@ -1751,7 +1754,7 @@ describe("LiveScanStore", () => {
     expect(events).toEqual([
       expect.objectContaining({
         changedAgents: ["codex"],
-        newSessions: 1,
+        newSessionRefs: [{ agentName: "codex", sessionId: "new" }],
       }),
     ]);
 
@@ -1927,9 +1930,10 @@ describe("LiveScanStore", () => {
     expect(events).toEqual([
       expect.objectContaining({
         changedAgents: ["codex", "kimi"],
-        newSessions: 2,
-        updatedSessions: 0,
-        removedSessions: 0,
+        newSessionRefs: [
+          { agentName: "codex", sessionId: "codex-new" },
+          { agentName: "kimi", sessionId: "kimi-new" },
+        ],
         totalSessions: 4,
         changedSessionHeads: [
           {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -189,7 +189,7 @@ export class LiveScanStore {
 
   private emit(event: SessionsUpdatedEvent): void {
     if (this.shuttingDown) return;
-    if (this.pendingEvent || event.newSessions > 0) {
+    if (this.pendingEvent || event.newSessionRefs.length > 0) {
       this.queueEvent(event);
       return;
     }

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -165,10 +165,7 @@ describe("LiveSessionIndex", () => {
     expect(event).toEqual({
       type: "sessions-updated",
       changedAgents: ["codex"],
-      newSessions: 1,
       newSessionRefs: [{ agentName: "codex", sessionId: "added" }],
-      updatedSessions: 1,
-      removedSessions: 0,
       totalSessions: 3,
       timestamp: expect.any(Number),
       changedSessionHeads: [
@@ -291,9 +288,7 @@ describe("LiveSessionIndex", () => {
     expect(index.snapshot().sessions).toEqual([]);
     expect(event).toEqual(
       expect.objectContaining({
-        newSessions: 0,
-        updatedSessions: 0,
-        removedSessions: 1,
+        newSessionRefs: [],
         totalSessions: 0,
         changedSessionHeads: [],
         removedSessionRefs: [{ agentName: "codex", sessionId: "removed" }],

--- a/packages/cli/src/live-session-index.ts
+++ b/packages/cli/src/live-session-index.ts
@@ -120,10 +120,7 @@ export class LiveSessionIndex {
     return {
       type: "sessions-updated",
       changedAgents: [agentName],
-      newSessions: counts.new,
       newSessionRefs,
-      updatedSessions: counts.updated,
-      removedSessions: counts.removed,
       totalSessions: this.sessions.length,
       timestamp: Date.now(),
       changedSessionHeads: changedSessionHeads.map(toPublicReferencedSessionHead),

--- a/packages/core/src/contract/__tests__/events.test.ts
+++ b/packages/core/src/contract/__tests__/events.test.ts
@@ -6,13 +6,12 @@ function event(
   changedSessionHeads: ReferencedSessionHead[],
   removedSessionRefs: SessionsUpdatedEvent["removedSessionRefs"] = [],
   projectionRelatedSessionHeads: ReferencedSessionHead[] = [],
+  newSessionRefs: SessionsUpdatedEvent["newSessionRefs"] = [],
 ): SessionsUpdatedEvent {
   return {
     type: "sessions-updated",
     changedAgents: ["claudecode"],
-    newSessions: 0,
-    updatedSessions: changedSessionHeads.length,
-    removedSessions: removedSessionRefs.length,
+    newSessionRefs,
     totalSessions: 2,
     timestamp: 1,
     changedSessionHeads,
@@ -89,9 +88,7 @@ describe("mergeSessionsUpdatedEvents", () => {
   it("removes a coalesced new-session reference when that session is removed", () => {
     const reference = { agentName: "claudecode", sessionId: "session-1" };
     const added = {
-      ...event([]),
-      newSessions: 1,
-      newSessionRefs: [reference],
+      ...event([], [], [], [reference]),
       projectionSessionOrder: [reference],
     };
 
@@ -99,6 +96,41 @@ describe("mergeSessionsUpdatedEvents", () => {
 
     expect(merged.newSessionRefs).toEqual([]);
     expect(merged.projectionSessionOrder).toEqual([]);
+  });
+
+  it("keeps a coalesced addition classified as new after a later update", () => {
+    const reference = { agentName: "claudecode", sessionId: "session-1" };
+    const added = { reference, session: { display_title: "Added" } } as ReferencedSessionHead;
+    const updated = {
+      reference,
+      session: { display_title: "Updated" },
+    } as ReferencedSessionHead;
+
+    const merged = mergeSessionsUpdatedEvents(
+      event([added], [], [], [reference]),
+      event([updated]),
+    );
+
+    expect(merged.newSessionRefs).toEqual([reference]);
+    expect(merged.changedSessionHeads).toEqual([updated]);
+    expect(merged.removedSessionRefs).toEqual([]);
+  });
+
+  it("treats a re-created removed session as the latest change", () => {
+    const reference = { agentName: "claudecode", sessionId: "session-1" };
+    const recreated = {
+      reference,
+      session: { display_title: "Re-created" },
+    } as ReferencedSessionHead;
+
+    const merged = mergeSessionsUpdatedEvents(
+      event([], [reference]),
+      event([recreated], [], [], [reference]),
+    );
+
+    expect(merged.newSessionRefs).toEqual([reference]);
+    expect(merged.changedSessionHeads).toEqual([recreated]);
+    expect(merged.removedSessionRefs).toEqual([]);
   });
 
   it("uses the latest canonical order for an affected activity tie", () => {

--- a/packages/core/src/contract/events.ts
+++ b/packages/core/src/contract/events.ts
@@ -4,11 +4,8 @@ import type { SessionReference } from "./session-reference.js";
 export interface SessionsUpdatedEvent {
   type: "sessions-updated";
   changedAgents: string[];
-  newSessions: number;
   /** Exact new-session subset for consumers that project the global event into a local view. */
-  newSessionRefs?: SessionReference[];
-  updatedSessions: number;
-  removedSessions: number;
+  newSessionRefs: SessionReference[];
   totalSessions: number;
   timestamp: number;
   changedSessionHeads: PublicReferencedSessionHead[];
@@ -59,12 +56,12 @@ export function mergeSessionsUpdatedEvents(
     removedSessionRefs.set(key, item);
   };
 
-  for (const item of previous.newSessionRefs ?? []) addNew(item);
+  for (const item of previous.newSessionRefs) addNew(item);
   for (const item of previous.projectionRelatedSessionHeads ?? []) addProjectionRelated(item);
   for (const item of previous.projectionSessionOrder ?? []) addProjectionOrder(item);
   for (const item of previous.changedSessionHeads) addChanged(item);
   for (const item of previous.removedSessionRefs) addRemoved(item);
-  for (const item of next.newSessionRefs ?? []) addNew(item);
+  for (const item of next.newSessionRefs) addNew(item);
   for (const item of next.projectionRelatedSessionHeads ?? []) addProjectionRelated(item);
   for (const item of next.projectionSessionOrder ?? []) addProjectionOrder(item);
   for (const item of next.changedSessionHeads) addChanged(item);
@@ -73,10 +70,7 @@ export function mergeSessionsUpdatedEvents(
   return {
     type: "sessions-updated",
     changedAgents: Array.from(new Set([...previous.changedAgents, ...next.changedAgents])),
-    newSessions: previous.newSessions + next.newSessions,
     newSessionRefs: [...newSessionRefs.values()],
-    updatedSessions: previous.updatedSessions + next.updatedSessions,
-    removedSessions: previous.removedSessions + next.removedSessions,
     totalSessions: next.totalSessions,
     timestamp: next.timestamp,
     changedSessionHeads: [...changedSessionHeads.values()],

--- a/packages/core/src/test-fixtures.ts
+++ b/packages/core/src/test-fixtures.ts
@@ -70,10 +70,7 @@ export const SAMPLE_SCAN_STATUS_EVENT = {
 export const SAMPLE_SESSIONS_UPDATED_EVENT = {
   type: "sessions-updated",
   changedAgents: ["claudecode"],
-  newSessions: 1,
   newSessionRefs: [SAMPLE_SESSION_HEAD.reference],
-  updatedSessions: 0,
-  removedSessions: 0,
   totalSessions: 43,
   timestamp: 1_700_000_020_000,
   changedSessionHeads: [


### PR DESCRIPTION
## Summary
- make session reference arrays the canonical live-update delta
- remove serialized counts that became inconsistent after event coalescing
- derive diagnostic counts at the logging boundary
- cover add/update/remove/re-create event sequences

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- pnpm perf:check

BREAKING CHANGE: SessionsUpdatedEvent now requires newSessionRefs and no longer exposes newSessions, updatedSessions, or removedSessions.