### PR TITLE
refactor(web): Narrow session store results

### DIFF
--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionsUpdatedEvent } from "../lib/api";
 import * as api from "../lib/api";
 import { useLiveSync } from "./useLiveSync";
-import type { SessionStoreSnapshot } from "./useSessionStore";
 
 let sessionsCallback: ((event: SessionsUpdatedEvent) => void) | undefined;
 let reconnectCallback: (() => void) | undefined;
@@ -29,10 +28,9 @@ vi.mock("../lib/api", () => ({
 function makeDeps(visibleNewSessions = 0) {
   return {
     applyLiveEvent: vi.fn().mockResolvedValue({
-      snapshot: {} as SessionStoreSnapshot,
       visibleNewSessions,
     }),
-    resyncLiveState: vi.fn().mockResolvedValue({}),
+    resyncLiveState: vi.fn().mockResolvedValue(undefined),
     setScanStatus: vi.fn(),
   };
 }

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -5,11 +5,11 @@ import {
   type SessionsUpdatedEvent,
   subscribeSessionUpdates,
 } from "../lib/api";
-import type { LiveSessionApplyResult, SessionStoreSnapshot } from "./useSessionStore";
+import type { LiveSessionApplyResult } from "./useSessionStore";
 
 interface LiveSyncDeps {
   applyLiveEvent: (event: SessionsUpdatedEvent) => Promise<LiveSessionApplyResult | null>;
-  resyncLiveState: () => Promise<SessionStoreSnapshot | null>;
+  resyncLiveState: () => Promise<void>;
   setScanStatus: (event: ScanStatusEvent) => void;
 }
 

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -20,7 +20,7 @@ import {
   useSessionStore,
   type LiveSessionApplyResult,
   type SessionProjection,
-  type SessionStoreSnapshot,
+  type SessionReloadResult,
 } from "./useSessionStore";
 import { useDashboard } from "./useDashboard";
 
@@ -151,13 +151,13 @@ describe("useSessionStore", () => {
 
   it("ignores live events until a window has been selected", async () => {
     const { result } = await renderStore();
-    let snapshot: Awaited<ReturnType<typeof result.current.applyLiveEvent>> | undefined;
+    let update: Awaited<ReturnType<typeof result.current.applyLiveEvent>> | undefined;
 
     await act(async () => {
-      snapshot = await result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
+      update = await result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
     });
 
-    expect(snapshot).toBeNull();
+    expect(update).toBeNull();
     expect(api.fetchAgents).not.toHaveBeenCalled();
   });
 
@@ -170,13 +170,14 @@ describe("useSessionStore", () => {
       initialLoad = result.current.reload(config.window);
       liveUpdate = result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
     });
-    let snapshots!: [LiveSessionApplyResult | null, SessionStoreSnapshot | null];
+    let results!: [LiveSessionApplyResult | null, SessionReloadResult | null];
     await act(async () => {
-      snapshots = await Promise.all([liveUpdate, initialLoad]);
+      results = await Promise.all([liveUpdate, initialLoad]);
     });
-    const [liveSnapshot] = snapshots;
+    const [liveResult, reloadResult] = results;
 
-    expect(liveSnapshot?.snapshot.window).toEqual(config.window);
+    expect(liveResult).toEqual({ visibleNewSessions: 0 });
+    expect(reloadResult).toEqual({ agentCount: 2, sessionCount: 1 });
     await waitFor(() => expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]));
   });
 

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -31,7 +31,7 @@ import {
   invalidateSessionDerivedQueries,
 } from "../lib/session-query-consistency";
 
-export interface SessionStoreSnapshot {
+interface SessionStoreSnapshot {
   window: AppConfig["window"];
   agents: AgentInfo[];
   sessions: SessionHead[];
@@ -44,12 +44,15 @@ export interface SessionProjection {
 }
 
 export interface LiveSessionApplyResult {
-  snapshot: SessionStoreSnapshot;
   visibleNewSessions: number;
 }
 
+export interface SessionReloadResult {
+  agentCount: number;
+  sessionCount: number;
+}
+
 interface SnapshotAggregates {
-  window: AppConfig["window"];
   agents: AgentInfo[];
   dashboard: DashboardData;
 }
@@ -102,7 +105,7 @@ async function fetchSnapshotAggregates(
     queryClient.fetchQuery(agentCatalogOptions(window)),
     queryClient.fetchQuery(dashboardQueryOptions(window, {})),
   ]);
-  return { window, agents, dashboard };
+  return { agents, dashboard };
 }
 
 function sessionProjectionOptions(
@@ -250,13 +253,13 @@ export function useSessionStore() {
     sameWindow(projectionQuery.data.window, requestedWindow)
       ? createSnapshot(
           requestedWindow,
-          { window: requestedWindow, agents: agentsQuery.data, dashboard },
+          { agents: agentsQuery.data, dashboard },
           projectionQuery.data.sessions,
         )
       : null;
 
   const reload = useCallback(
-    async (window: AppConfig["window"]): Promise<SessionStoreSnapshot | null> => {
+    async (window: AppConfig["window"]): Promise<SessionReloadResult | null> => {
       const request = { window };
       activeRequestRef.current = request;
       liveAggregateWindowRef.current = null;
@@ -301,7 +304,10 @@ export function useSessionStore() {
             }),
           ),
         ]);
-        return createSnapshot(window, aggregates, projection.sessions);
+        return {
+          agentCount: aggregates.agents.length,
+          sessionCount: projection.sessions.length,
+        };
       } catch (error) {
         if (isCancelledError(error)) return null;
         if (activeRequestRef.current === request) setReloadFailed(true);
@@ -328,13 +334,8 @@ export function useSessionStore() {
           invalidateLiveSessionDerivedQueries(queryClient, event),
           invalidateLiveSessionCollections(queryClient),
         ]);
-        return refreshed ? { snapshot: refreshed, visibleNewSessions: 0 } : null;
+        return refreshed ? { visibleNewSessions: 0 } : null;
       }
-      const currentAggregates = {
-        window: activeWindow,
-        agents: currentAgents,
-        dashboard: currentDashboard,
-      };
 
       const projection = applySessionWindowChanges(currentProjection.sessions, {
         changedSessionHeads: event.changedSessionHeads,
@@ -381,20 +382,16 @@ export function useSessionStore() {
           }
         })
         .catch(() => undefined);
-      return {
-        snapshot: createSnapshot(activeWindow, currentAggregates, projection.sessions),
-        visibleNewSessions,
-      };
+      return { visibleNewSessions };
     },
     [queryClient, reload],
   );
 
-  const resyncLiveState = useCallback(async (): Promise<SessionStoreSnapshot | null> => {
+  const resyncLiveState = useCallback(async (): Promise<void> => {
     const activeRequest = activeRequestRef.current;
-    if (!activeRequest) return null;
-    const refreshed = await reload(activeRequest.window);
+    if (!activeRequest) return;
+    await reload(activeRequest.window);
     await invalidateSessionDerivedQueries(queryClient);
-    return refreshed;
   }, [queryClient, reload]);
 
   const retryLoad = useCallback(async (): Promise<void> => {

--- a/apps/web/src/hooks/useWindowedDataLoad.test.ts
+++ b/apps/web/src/hooks/useWindowedDataLoad.test.ts
@@ -1,20 +1,13 @@
-import { SAMPLE_DASHBOARD_DATA } from "@codesesh/core/test-fixtures";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AppConfig } from "../lib/api";
 import * as api from "../lib/api";
-import type { SessionStoreSnapshot } from "./useSessionStore";
 import { useWindowedDataLoad } from "./useWindowedDataLoad";
 
 vi.mock("../lib/api", () => ({ logClientEvent: vi.fn() }));
 
 const window = { from: 1, to: 2 } as AppConfig["window"];
-const snapshot = {
-  window,
-  agents: [],
-  sessions: [],
-  dashboard: SAMPLE_DASHBOARD_DATA,
-} satisfies SessionStoreSnapshot;
+const result = { agentCount: 0, sessionCount: 0 };
 
 afterEach(() => {
   cleanup();
@@ -29,7 +22,7 @@ describe("useWindowedDataLoad", () => {
   });
 
   it("reloads the store and records the snapshot counts", async () => {
-    const reload = vi.fn().mockResolvedValue(snapshot);
+    const reload = vi.fn().mockResolvedValue(result);
     renderHook(() => useWindowedDataLoad({ window, reload }));
 
     await waitFor(() => expect(reload).toHaveBeenCalledWith(window));
@@ -43,7 +36,7 @@ describe("useWindowedDataLoad", () => {
   });
 
   it("reloads once for each selected window", async () => {
-    const reload = vi.fn().mockResolvedValue(snapshot);
+    const reload = vi.fn().mockResolvedValue(result);
     const { rerender } = renderHook(
       ({ selectedWindow }) => useWindowedDataLoad({ window: selectedWindow, reload }),
       { initialProps: { selectedWindow: window } },

--- a/apps/web/src/hooks/useWindowedDataLoad.ts
+++ b/apps/web/src/hooks/useWindowedDataLoad.ts
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 import { type AppConfig, logClientEvent } from "../lib/api";
-import type { SessionStoreSnapshot } from "./useSessionStore";
+import type { SessionReloadResult } from "./useSessionStore";
 
 interface WindowedDataLoadDeps {
   window: AppConfig["window"] | null;
-  reload: (window: AppConfig["window"]) => Promise<SessionStoreSnapshot | null>;
+  reload: (window: AppConfig["window"]) => Promise<SessionReloadResult | null>;
 }
 
 export function useWindowedDataLoad({ window, reload }: WindowedDataLoadDeps) {
@@ -15,12 +15,12 @@ export function useWindowedDataLoad({ window, reload }: WindowedDataLoadDeps) {
     logClientEvent("app.load.start", { path: globalThis.window.location.pathname });
 
     void reload(window)
-      .then((snapshot) => {
-        if (!current || !snapshot) return;
+      .then((result) => {
+        if (!current || !result) return;
         logClientEvent("app.load.done", {
           duration_ms: Math.round(performance.now() - startedAt),
-          agents: snapshot.agents.length,
-          sessions: snapshot.sessions.length,
+          agents: result.agentCount,
+          sessions: result.sessionCount,
         });
       })
       .catch((error) => {


### PR DESCRIPTION
## Summary
- return only load counts from session store reloads
- return only the visible-new-session count from live updates
- make reconnect resynchronization a result-free command
- keep the full store snapshot private to the hook

## Testing
- pnpm lint
- pnpm perf:check
- pnpm typecheck
- pnpm build
- pnpm test