### PR TITLE
refactor(discovery): unify refresh selection

### DIFF
--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -3,13 +3,13 @@ import {
   buildAgentCacheMeta,
   buildSessionPersistenceDiff,
   getAgentFullSyncCursor,
-  inspectAgentRefresh,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
   markAgentFullSyncCompleted,
   readCachedSessions,
   readAgentCacheInitialization,
   resolveSessionSnapshotCompleteness,
+  selectAgentRefresh,
   type BaseAgent,
   type AgentRefreshInspection,
   type CachedResult,
@@ -382,32 +382,28 @@ export class AgentSyncEngine {
       return { result: "unchanged", completion: { completeness: "complete" } };
     }
     const isInitialized = initialization.value;
-    const availabilityStartedAt = performance.now();
-    const isAvailable = agent.isAvailable();
-    const availabilityDuration = performance.now() - availabilityStartedAt;
+    const refresh = await selectAgentRefresh(agent, {
+      initialized: isInitialized,
+      sinceTimestamp: cacheTimestamp,
+      cachedSessions: refreshBaseline,
+    });
+    const availabilityDuration = refresh.availabilityDurationMs;
     let strategyResult: RefreshStrategyResult;
-    if (!isAvailable) {
+    if (refresh.kind === "unavailable") {
       strategyResult = this.refreshUnavailableAgent(agentName);
-    } else if (!isInitialized) {
+    } else if (refresh.kind === "initialize") {
       strategyResult = await this.initializeAgent(agent, previousSessions);
-    } else {
-      const refresh = await inspectAgentRefresh(
-        agent.sessionSourceAccess,
-        cacheTimestamp,
-        refreshBaseline,
+    } else if (refresh.kind === "synchronize") {
+      strategyResult = await this.syncAgentSources(
+        agent,
+        cached ?? {
+          sessions: refreshBaseline,
+          meta: durableMeta,
+        },
+        startedAt,
       );
-      if (refresh.kind === "synchronize") {
-        strategyResult = await this.syncAgentSources(
-          agent,
-          cached ?? {
-            sessions: refreshBaseline,
-            meta: durableMeta,
-          },
-          startedAt,
-        );
-      } else {
-        strategyResult = await this.refreshChangedAgent(agent, refresh, refreshBaseline, startedAt);
-      }
+    } else {
+      strategyResult = await this.refreshChangedAgent(agent, refresh, refreshBaseline, startedAt);
     }
     const stagedRun = strategyResult.workerRun;
     if (strategyResult.status === "unchanged") {

--- a/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
+++ b/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
@@ -4,6 +4,7 @@ import {
   inspectAgentRefresh,
   planAgentScan,
   resolveSessionSnapshotCompleteness,
+  selectAgentRefresh,
   type AgentScanIntent,
 } from "../agent-scan-plan.js";
 import type {
@@ -43,6 +44,7 @@ function agent(
 ): BaseAgent {
   return {
     sessionSourceAccess: source,
+    isAvailable: () => true,
     scan: vi.fn(() => sessions),
   } as unknown as BaseAgent;
 }
@@ -103,6 +105,49 @@ describe("planAgentScan", () => {
     if (plan.kind === "synchronize" || plan.kind === "check-for-changes") {
       expect(plan.source).toBe(source);
     }
+  });
+});
+
+describe("selectAgentRefresh", () => {
+  it("stops before change detection when the agent is unavailable", async () => {
+    const checkForChanges = vi.fn(aggregate.checkForChanges);
+    const target = agent({ ...aggregate, checkForChanges });
+    target.isAvailable = () => false;
+
+    const selection = await selectAgentRefresh(target, {
+      initialized: true,
+      sinceTimestamp: 10,
+      cachedSessions: [],
+    });
+
+    expect(selection).toMatchObject({ kind: "unavailable" });
+    expect(checkForChanges).not.toHaveBeenCalled();
+  });
+
+  it("selects initialization before change detection", async () => {
+    const checkForChanges = vi.fn(aggregate.checkForChanges);
+    const target = agent({ ...aggregate, checkForChanges });
+
+    const selection = await selectAgentRefresh(target, {
+      initialized: false,
+      sinceTimestamp: 10,
+      cachedSessions: [],
+    });
+
+    expect(selection).toMatchObject({ kind: "initialize" });
+    expect(checkForChanges).not.toHaveBeenCalled();
+  });
+
+  it("inspects an available initialized agent", async () => {
+    const target = agent(aggregate);
+
+    await expect(
+      selectAgentRefresh(target, {
+        initialized: true,
+        sinceTimestamp: 10,
+        cachedSessions: [],
+      }),
+    ).resolves.toMatchObject({ kind: "unchanged", availabilityDurationMs: expect.any(Number) });
   });
 });
 

--- a/packages/core/src/discovery/agent-scan-plan.ts
+++ b/packages/core/src/discovery/agent-scan-plan.ts
@@ -121,6 +121,11 @@ export type AgentRefreshInspection =
       checkDurationMs: number;
     };
 
+export type AgentRefreshSelection =
+  | { kind: "unavailable"; availabilityDurationMs: number }
+  | { kind: "initialize"; availabilityDurationMs: number }
+  | (AgentRefreshInspection & { availabilityDurationMs: number });
+
 export function planAgentScan(
   source: SessionSourceCapability,
   intent: "reload" | "backfill",
@@ -170,4 +175,28 @@ export async function inspectAgentRefresh(
   return check.hasChanges
     ? { kind: "scan", source: plan.source, check, checkDurationMs }
     : { kind: "unchanged", source: plan.source, check, checkDurationMs };
+}
+
+export async function selectAgentRefresh(
+  agent: Pick<BaseAgent, "isAvailable" | "sessionSourceAccess">,
+  options: {
+    initialized: boolean;
+    sinceTimestamp: number;
+    cachedSessions: SessionHead[];
+  },
+): Promise<AgentRefreshSelection> {
+  const availabilityStartedAt = performance.now();
+  const available = agent.isAvailable();
+  const availabilityDurationMs = performance.now() - availabilityStartedAt;
+  if (!available) return { kind: "unavailable", availabilityDurationMs };
+  if (!options.initialized) return { kind: "initialize", availabilityDurationMs };
+
+  return {
+    ...(await inspectAgentRefresh(
+      agent.sessionSourceAccess,
+      options.sinceTimestamp,
+      options.cachedSessions,
+    )),
+    availabilityDurationMs,
+  };
 }

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -13,9 +13,11 @@ export {
   inspectAgentRefresh,
   planAgentScan,
   resolveSessionSnapshotCompleteness,
+  selectAgentRefresh,
 } from "./agent-scan-plan.js";
 export type {
   AgentRefreshInspection,
+  AgentRefreshSelection,
   AgentScanIntent,
   AgentScanPlan,
   AgentScanPlanExecution,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -33,9 +33,9 @@ import {
 } from "./orchestrate.js";
 import {
   executeAgentScanPlan,
-  inspectAgentRefresh,
   planAgentScan,
   resolveSessionSnapshotCompleteness,
+  selectAgentRefresh,
 } from "./agent-scan-plan.js";
 import { ensureSessionTags } from "./session-tags.js";
 
@@ -449,8 +449,12 @@ async function scanAgentSmart(
         });
       }
 
-      const isAvail = agent.isAvailable();
-      if (!isAvail) {
+      const refresh = await selectAgentRefresh(agent, {
+        initialized: true,
+        sinceTimestamp: cached.timestamp,
+        cachedSessions: cached.sessions,
+      });
+      if (refresh.kind === "unavailable") {
         return finalizeAgentScanFailure(
           agent,
           {
@@ -465,6 +469,17 @@ async function scanAgentSmart(
           agentStart,
         );
       }
+      if (refresh.kind === "initialize") {
+        return scanAgentFull(
+          agent,
+          options,
+          cached,
+          cacheReadState,
+          onProgress,
+          timing,
+          agentStart,
+        );
+      }
 
       // 通知缓存已加载
       onProgress?.({
@@ -475,11 +490,6 @@ async function scanAgentSmart(
 
       onProgress?.({ agent: agent.name, phase: "checking" });
 
-      const refresh = await inspectAgentRefresh(
-        agent.sessionSourceAccess,
-        cached.timestamp,
-        cached.sessions,
-      );
       if (refresh.kind !== "synchronize") timing.checkChanges = refresh.checkDurationMs;
       if (refresh.kind === "synchronize") {
         return refreshCachedEnumeratedAgent(

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -63,6 +63,7 @@ export {
   listModelCostDistribution,
   planAgentScan,
   resolveSessionSnapshotCompleteness,
+  selectAgentRefresh,
   readCachedSessions,
   loadCachedSessionHeads,
   markAgentCacheInitialized,
@@ -88,6 +89,7 @@ export { PRICING_CAPTURE_EPOCH } from "../pricing/index.js";
 export { filterSessionTreeByActivityWindow, isSmartTag, SMART_TAGS } from "../contract/index.js";
 export type {
   AgentScanIntent,
+  AgentRefreshSelection,
   AgentScanPlan,
   AgentRefreshInspection,
   CachedResult,


### PR DESCRIPTION
## Summary

- centralize availability, initialization, and refresh-strategy selection
- reuse the same decision path for startup scans and live refreshes
- cover unavailable, initialization, and unchanged selections

## Validation

- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter @codesesh/core test -- agent-scan-plan`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core format:check`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter codesesh typecheck`
- `pnpm --filter codesesh test`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh format:check`