### PR TITLE
refactor(core): narrow source sync API

### DIFF
--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -477,10 +477,9 @@ function makeFileSystemAgent(
     removeSessionCacheMeta?: (sessionIds: Iterable<string>) => void;
   } = {},
 ) {
-  const agent = Object.create(FileSystemSessionSource.prototype) as InstanceType<
+  const agent = Reflect.construct(FileSystemSessionSource, []) as InstanceType<
     typeof FileSystemSessionSource
   >;
-  Object.defineProperty(agent, "sessionMetaMap", { value: new Map(), writable: true });
   Object.defineProperty(agent, "name", { value: name, configurable: true });
   Object.defineProperty(agent, "displayName", { value: name, configurable: true });
   agent.isAvailable = vi.fn(() => true);
@@ -493,15 +492,6 @@ function makeFileSystemAgent(
   agent.snapshotSessionCacheMeta = overrides.snapshotSessionCacheMeta ?? vi.fn(() => ({}));
   agent.restoreSessionCacheMeta = overrides.restoreSessionCacheMeta ?? vi.fn();
   agent.removeSessionCacheMeta = overrides.removeSessionCacheMeta ?? vi.fn();
-  Object.defineProperty(agent, "sessionSourceAccess", {
-    value: {
-      kind: "enumerated",
-      synchronize: (...args: Parameters<typeof agent.synchronizeSessionSources>) =>
-        agent.synchronizeSessionSources(...args),
-      count: (options?: AgentScanOptions) => agent.listSessionSources(options).length,
-    },
-    configurable: true,
-  });
   return agent;
 }
 

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -1,6 +1,5 @@
 import {
   PRICING_CAPTURE_EPOCH,
-  synchronizeSessionSources,
   type BaseAgent,
   type SessionCacheMeta,
   type SessionHead,
@@ -8,41 +7,11 @@ import {
 } from "@codesesh/core/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => {
-  class FileSystemSessionSource {
-    scanSessionSourceOutcome(source: SessionSourceRef) {
-      try {
-        const session = (
-          this as unknown as { scanSessionSource(path: string): SessionHead | null }
-        ).scanSessionSource(source.sourcePath);
-        if (session) return { status: "parsed" as const, source, session };
-        return {
-          status: "failed" as const,
-          source,
-          failure: {
-            sessionId: source.sessionId,
-            sourcePath: source.sourcePath,
-            stage: "parsing" as const,
-            errorClass: "Error",
-            message: "source produced no session",
-          },
-        };
-      } catch (error) {
-        return {
-          status: "failed" as const,
-          source,
-          failure: {
-            sessionId: source.sessionId,
-            sourcePath: source.sourcePath,
-            stage: "parsing" as const,
-            errorClass: error instanceof Error ? error.name : typeof error,
-            message: error instanceof Error ? error.message : String(error),
-          },
-        };
-      }
-    }
-  }
+type FileSystemSourceConstructor = new () => InstanceType<
+  typeof import("@codesesh/core/runtime").FileSystemSessionSource
+>;
 
+const mocks = vi.hoisted(() => {
   return {
     workerData: {} as Record<string, unknown>,
     workerMessageHandler: undefined as ((message: unknown) => void) | undefined,
@@ -60,7 +29,7 @@ const mocks = vi.hoisted(() => {
         return { sessions };
       },
     ),
-    FileSystemSessionSource,
+    FileSystemSessionSource: undefined as unknown as FileSystemSourceConstructor,
     appLogger: {
       debug: vi.fn(),
       info: vi.fn(),
@@ -88,6 +57,7 @@ vi.mock("./logging.js", () => ({ appLogger: mocks.appLogger }));
 
 vi.mock("@codesesh/core/runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime")>();
+  mocks.FileSystemSessionSource = actual.FileSystemSessionSource as FileSystemSourceConstructor;
   return {
     attachMissingProjectIdentities: mocks.attachMissingProjectIdentities,
     createRegisteredAgents: mocks.createRegisteredAgents,
@@ -96,7 +66,7 @@ vi.mock("@codesesh/core/runtime", async (importOriginal) => {
     executeAgentScanPlan: actual.executeAgentScanPlan,
     hasStaleSessionTags: actual.hasStaleSessionTags,
     inheritSessionTags: actual.inheritSessionTags,
-    FileSystemSessionSource: mocks.FileSystemSessionSource,
+    FileSystemSessionSource: actual.FileSystemSessionSource,
     PRICING_CAPTURE_EPOCH: actual.PRICING_CAPTURE_EPOCH,
     buildAgentCacheMeta: actual.buildAgentCacheMeta,
     buildSessionPersistenceDiff: actual.buildSessionPersistenceDiff,
@@ -104,7 +74,6 @@ vi.mock("@codesesh/core/runtime", async (importOriginal) => {
     planAgentScan: actual.planAgentScan,
     sessionSignature: actual.sessionSignature,
     sortSessions: actual.sortSessions,
-    synchronizeSessionSources: actual.synchronizeSessionSources,
     setCoreDiagnostics: actual.setCoreDiagnostics,
   };
 });
@@ -152,16 +121,7 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
     }),
     ...overrides,
   });
-  return Object.assign(agent, {
-    sessionSourceAccess: {
-      kind: "enumerated" as const,
-      synchronize: (
-        baseline: Parameters<typeof synchronizeSessionSources>[1],
-        request: Parameters<typeof synchronizeSessionSources>[2],
-      ) => synchronizeSessionSources(agent as never, baseline, request),
-      count: () => agent.listSessionSources().length,
-    },
-  });
+  return agent;
 }
 
 function makeGenericAgent(overrides: Record<string, unknown> = {}) {
@@ -596,7 +556,7 @@ describe("scan refresh worker entry", () => {
     await runWorker();
 
     expect(agent.scan).not.toHaveBeenCalled();
-    expect(scanSessionSource).toHaveBeenCalledWith("/changed");
+    expect(scanSessionSource).toHaveBeenCalledWith("/changed", expect.any(Object));
     expect(mocks.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "progress",
@@ -696,8 +656,8 @@ describe("scan refresh worker entry", () => {
       ["child"],
       expect.arrayContaining([expect.objectContaining({ sessionId: "parent" })]),
     );
-    expect(scanSessionSource).toHaveBeenCalledWith("/child");
-    expect(scanSessionSource).toHaveBeenCalledWith("/parent");
+    expect(scanSessionSource).toHaveBeenCalledWith("/child", expect.any(Object));
+    expect(scanSessionSource).toHaveBeenCalledWith("/parent", expect.any(Object));
   });
 
   it("resumes backfill finalization after the durable cursor", async () => {
@@ -792,7 +752,7 @@ describe("scan refresh worker entry", () => {
 
     await runWorker();
 
-    expect(scanSessionSource).toHaveBeenCalledWith("/recent");
+    expect(scanSessionSource).toHaveBeenCalledWith("/recent", expect.any(Object));
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: "done",
@@ -975,9 +935,9 @@ describe("scan refresh worker entry", () => {
     await runWorker();
 
     expect(scanSessionSource).toHaveBeenCalledTimes(3);
-    expect(scanSessionSource).toHaveBeenCalledWith("/changed");
-    expect(scanSessionSource).toHaveBeenCalledWith("/moved-to");
-    expect(scanSessionSource).toHaveBeenCalledWith("/missing");
+    expect(scanSessionSource).toHaveBeenCalledWith("/changed", expect.any(Object));
+    expect(scanSessionSource).toHaveBeenCalledWith("/moved-to", expect.any(Object));
+    expect(scanSessionSource).toHaveBeenCalledWith("/missing", expect.any(Object));
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: "done",
@@ -1029,7 +989,7 @@ describe("scan refresh worker entry", () => {
 
     await runWorker();
 
-    expect(scanSessionSource).toHaveBeenCalledWith("/legacy");
+    expect(scanSessionSource).toHaveBeenCalledWith("/legacy", expect.any(Object));
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: "done",

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -647,7 +647,10 @@ describe("FileSystemSessionSource source synchronization", () => {
   it("reports source enumeration, change, and processing workload", () => {
     const agent = new FakeFileSystemSource([source("a"), source("b")]);
 
-    const result = agent.synchronizeSessionSources({ sessions: [], meta: {} }, { kind: "reload" });
+    const result = agent.sessionSourceAccess.synchronize(
+      { sessions: [], meta: {} },
+      { kind: "reload" },
+    );
 
     expect(result.timing).toMatchObject({
       totalMs: expect.any(Number),

--- a/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
+++ b/packages/core/src/agents/__tests__/session-source-synchronization.test.ts
@@ -6,12 +6,13 @@ import type { SessionHead } from "../../types/index.js";
 import {
   createAgentScanFailure,
   createSessionSourceFailure,
-  synchronizeSessionSources,
   type SessionCacheMeta,
   type SessionSourceOutcome,
   type SessionSourceRef,
-  type SessionSourceSynchronizationAdapter,
 } from "../base.js";
+import { synchronizeSessionSources } from "../session-source-synchronization.js";
+
+type SessionSourceSynchronizationAdapter = Parameters<typeof synchronizeSessionSources>[0];
 
 describe("failure normalization", () => {
   it("describes agent and source failures with the same bounded fields", () => {

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -35,10 +35,8 @@ export {
   diffSessionSources,
   matchesScanWindow,
   reportSessionSourceOutcome,
-  synchronizeSessionSources,
 } from "./session-source-synchronization.js";
 export type {
-  SessionSourceSynchronizationAdapter,
   SessionSourceSynchronizationBaseline,
   SessionSourceSynchronizationOutcome,
   SessionSourceSynchronizationRequest,
@@ -309,7 +307,7 @@ export abstract class BaseAgent<TMeta extends SessionCacheMeta = SessionCacheMet
  * 例如 KimiAgent。
  *
  * 源同步与 metaMap 管理由本基类统一提供：
- *   synchronizeSessionSources 用 listSessionSources 的指纹与缓存 metaMap 比对，
+ *   同步流程用 listSessionSources 的指纹与缓存 metaMap 比对，
  *   并对变更集合调用 scanSessionSource 重解析。
  * 两原语在各子类中复用同一个 sourceFingerprint 计算，故指纹精确比对即等价于变更检测。
  */
@@ -325,7 +323,7 @@ export abstract class FileSystemSessionSource<
 
   readonly sessionSourceAccess: EnumeratedSessionSourceCapability = {
     kind: "enumerated",
-    synchronize: (baseline, request) => this.synchronizeSessionSources(baseline, request),
+    synchronize: (baseline, request) => runSessionSourceSynchronization(this, baseline, request),
     count: (options) => this.listSessionSources(options).length,
   };
 
@@ -398,19 +396,12 @@ export abstract class FileSystemSessionSource<
     return changedIds;
   }
 
-  synchronizeSessionSources(
-    baseline: SessionSourceSynchronizationBaseline,
-    request: SessionSourceSynchronizationRequest,
-  ): SessionSourceSynchronizationOutcome {
-    return runSessionSourceSynchronization(this, baseline, request);
-  }
-
   scan(options?: AgentScanOptions): SessionHead[] {
     return this.scanSessionSources(options).sessions;
   }
 
   scanSessionSources(options?: AgentScanOptions): SessionSourceScanBatch {
-    const outcome = this.synchronizeSessionSources(
+    const outcome = this.sessionSourceAccess.synchronize(
       { sessions: [], meta: this.snapshotSessionCacheMeta() },
       { kind: "reload", scanOptions: options },
     );

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -16,7 +16,6 @@ export {
   reportAgentScanFailure,
   reportSessionSourceOutcome,
   skippedSession,
-  synchronizeSessionSources,
 } from "./base.js";
 export type {
   AgentScanFailure,
@@ -38,7 +37,6 @@ export type {
   SessionSourceScanBatch,
   SessionSourceCapability,
   SessionSourceRef,
-  SessionSourceSynchronizationAdapter,
   SessionSourceSynchronizationBaseline,
   SessionSourceSynchronizationOutcome,
   SessionSourceSynchronizationRequest,

--- a/packages/core/src/agents/session-source-synchronization.ts
+++ b/packages/core/src/agents/session-source-synchronization.ts
@@ -14,7 +14,7 @@ import type {
   SessionSourceRef,
 } from "./session-source-types.js";
 
-export interface SessionSourceSynchronizationAdapter {
+interface SessionSourceSynchronizationAdapter {
   readonly name: string;
   listSessionSources(options?: AgentScanOptions): SessionSourceRef[];
   scanSessionSourceOutcome(

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -15,7 +15,6 @@ export {
   getAgentInfoMap,
   getRegisteredAgents,
   reportSessionSourceOutcome,
-  synchronizeSessionSources,
 } from "../agents/index.js";
 export type {
   AgentScanFailure,
@@ -33,7 +32,6 @@ export type {
   SessionSourceScanBatch,
   SessionSourceCapability,
   SessionSourceRef,
-  SessionSourceSynchronizationAdapter,
   SessionSourceSynchronizationBaseline,
   SessionSourceSynchronizationOutcome,
   SessionSourceSynchronizationRequest,


### PR DESCRIPTION
## Summary

- remove the internal source-synchronization adapter and runner from public runtime exports
- route file-source scans through the declared `sessionSourceAccess.synchronize` capability
- update integration fixtures to exercise the real capability instead of bypassing it
- keep the synchronization algorithm and public capability contracts unchanged

## Validation

- `pnpm --filter @codesesh/core format`
- `pnpm --filter @codesesh/core lint`
- `pnpm --filter @codesesh/core typecheck`
- `pnpm --filter @codesesh/core test`
- `pnpm --filter @codesesh/core build`
- `pnpm --filter codesesh format`
- `pnpm --filter codesesh lint`
- `pnpm --filter codesesh typecheck`
- `pnpm --filter codesesh test`