### PR TITLE
Fix refresh check commit ordering

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -1410,6 +1410,7 @@ describe("AgentSyncEngine", () => {
     searchIndex.enqueue.mockRejectedValueOnce(new Error("index failed"));
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
+    const commitChangeCheck = vi.fn();
     const workerRunner = makeWorkerRunner();
     const { engine } = makeEngine(
       makeAgent({
@@ -1418,6 +1419,7 @@ describe("AgentSyncEngine", () => {
           changedIds: [updated.reference.sessionId],
           timestamp: 2,
         }),
+        commitChangeCheck,
         incrementalScan: () => [updated],
       }),
       [previous],
@@ -1437,6 +1439,7 @@ describe("AgentSyncEngine", () => {
     expect(workerLifecycle.commit).not.toHaveBeenCalled();
     expect(workerLifecycle.discard).not.toHaveBeenCalled();
     expect(workerRunner.reset).toHaveBeenCalledWith("codex");
+    expect(commitChangeCheck).not.toHaveBeenCalled();
     expect(engine.status().agentStatuses.codex).toMatchObject({ status: "failed" });
   });
 

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -2,6 +2,7 @@ import {
   attachMissingProjectIdentities,
   buildAgentCacheMeta,
   buildSessionPersistenceDiff,
+  commitAgentRefreshCheck,
   getAgentFullSyncCursor,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
@@ -11,7 +12,7 @@ import {
   resolveSessionSnapshotCompleteness,
   selectAgentRefresh,
   type BaseAgent,
-  type AgentRefreshInspection,
+  type AgentRefreshSelection,
   type CachedResult,
   type IdentifiedSessionHead,
   type ScanOptions,
@@ -96,6 +97,7 @@ interface RefreshStrategyBase {
   completeness: SessionSnapshotCompleteness;
   scope: Pick<ScanOptions, "from" | "to">;
   workerRun?: StagedWorkerRun;
+  commitChangeCheck?: () => void;
 }
 
 type RefreshPublication =
@@ -292,6 +294,14 @@ export class AgentSyncEngine {
     appLogger.error(`${operation}.post_commit_error`, { agent: agentName, error });
   }
 
+  private commitRefreshChangeCheck(agentName: string, commit?: () => void): void {
+    try {
+      commit?.();
+    } catch (error) {
+      this.reportPostCommitError("scan.refresh", agentName, error);
+    }
+  }
+
   private finishCommittedAgentScan(agentName: string, completion: ScanCompletion): void {
     try {
       this.statusReporter.finishAgentScan(agentName, completion);
@@ -408,6 +418,7 @@ export class AgentSyncEngine {
     const stagedRun = strategyResult.workerRun;
     if (strategyResult.status === "unchanged") {
       stagedRun?.commit();
+      this.commitRefreshChangeCheck(agentName, strategyResult.commitChangeCheck);
       return {
         result: "unchanged",
         completion: buildScanCompletion(strategyResult.completeness, strategyResult.sourceFailures),
@@ -499,6 +510,7 @@ export class AgentSyncEngine {
       else this.lastRefreshAtByAgent.set(agentName, durableLastRefreshAt);
       throw error;
     }
+    this.commitRefreshChangeCheck(agentName, strategyResult.commitChangeCheck);
     const persistDuration = performance.now() - persistStartedAt;
     const totalDurationMs = performance.now() - startedAt;
     try {
@@ -654,7 +666,7 @@ export class AgentSyncEngine {
 
   private async refreshChangedAgent(
     agent: BaseAgent,
-    refresh: Exclude<AgentRefreshInspection, { kind: "synchronize" }>,
+    refresh: Exclude<AgentRefreshSelection, { kind: "unavailable" | "initialize" | "synchronize" }>,
     baseline: IdentifiedSessionHead[],
     refreshStartedAt: number,
   ): Promise<RefreshStrategyResult> {
@@ -680,14 +692,13 @@ export class AgentSyncEngine {
     }
     const { check: checkResult, source } = refresh;
     const checkDuration = refresh.checkDurationMs;
-    if (refresh.kind === "unchanged") {
+    if (refresh.kind === "recompute-derived") {
       const scanStartedAt = performance.now();
       const workerRun = await this.runWorker(agent, baseline, { kind: "recompute-derived" }, {});
       try {
         const { result } = workerRun;
         agent.restoreSessionCacheMeta(result.meta);
         const sessions = attachMissingProjectIdentities(result.sessions);
-        source.commitChangeCheck();
         this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
         const persistenceDiff = buildSessionPersistenceDiff(baseline, sessions);
         if (
@@ -704,6 +715,7 @@ export class AgentSyncEngine {
                 checkDuration,
                 scanDuration: performance.now() - scanStartedAt,
                 workerRun,
+                commitChangeCheck: () => commitAgentRefreshCheck(refresh),
               },
             ),
             status: "unchanged",
@@ -719,6 +731,7 @@ export class AgentSyncEngine {
               scanDuration: performance.now() - scanStartedAt,
               sourceFailures: result.sourceFailures ?? [],
               workerRun,
+              commitChangeCheck: () => commitAgentRefreshCheck(refresh),
             },
           ),
           status: "continue",
@@ -729,15 +742,13 @@ export class AgentSyncEngine {
         throw error;
       }
     }
-    const preciseChangedIds = checkResult.changedIds ?? null;
     const scanStartedAt = performance.now();
-    if (preciseChangedIds === null) {
+    if (refresh.kind === "full-scan") {
       const workerRun = await this.runWorker(agent, baseline, { kind: "full-scan" }, scope);
       try {
         const { result } = workerRun;
         agent.restoreSessionCacheMeta(result.meta);
         const sessions = attachMissingProjectIdentities(result.sessions);
-        source.commitChangeCheck();
         this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
         return {
           ...this.refreshStrategyBase(sessions, result.completeness, scope, {
@@ -745,6 +756,7 @@ export class AgentSyncEngine {
             scanDuration: performance.now() - scanStartedAt,
             sourceFailures: result.sourceFailures ?? [],
             workerRun,
+            commitChangeCheck: () => commitAgentRefreshCheck(refresh),
           }),
           status: "continue",
           publication: {
@@ -765,13 +777,13 @@ export class AgentSyncEngine {
         throw error;
       }
     }
+    const preciseChangedIds = refresh.check.changedIds;
     this.options.workerRunner.reset(agent.name);
     const sessions = attachMissingProjectIdentities(
       await Promise.resolve(
         source.incrementalScan(baseline, preciseChangedIds, checkResult.refs, scope),
       ),
     );
-    source.commitChangeCheck();
     this.lastRefreshAtByAgent.set(agent.name, checkResult.timestamp);
     const sourceFailures = checkResult.sourceFailures ?? [];
     const completeness = resolveSessionSnapshotCompleteness(scope, sourceFailures);
@@ -780,6 +792,7 @@ export class AgentSyncEngine {
         checkDuration,
         scanDuration: performance.now() - scanStartedAt,
         sourceFailures,
+        commitChangeCheck: () => commitAgentRefreshCheck(refresh),
       }),
       status: "continue",
       publication: {

--- a/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
+++ b/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  commitAgentRefreshCheck,
   executeAgentScanPlan,
   inspectAgentRefresh,
   planAgentScan,
@@ -147,7 +148,51 @@ describe("selectAgentRefresh", () => {
         sinceTimestamp: 10,
         cachedSessions: [],
       }),
-    ).resolves.toMatchObject({ kind: "unchanged", availabilityDurationMs: expect.any(Number) });
+    ).resolves.toMatchObject({
+      kind: "recompute-derived",
+      availabilityDurationMs: expect.any(Number),
+    });
+  });
+
+  it.each([
+    { changedIds: undefined, expectedKind: "full-scan" },
+    { changedIds: [], expectedKind: "incremental-scan" },
+    { changedIds: ["changed"], expectedKind: "incremental-scan" },
+  ])(
+    "selects $expectedKind when changed ids are $changedIds",
+    async ({ changedIds, expectedKind }) => {
+      const source: AggregateSessionSourceCapability = {
+        ...aggregate,
+        checkForChanges: () => ({ hasChanges: true, changedIds, timestamp: 11 }),
+      };
+
+      await expect(
+        selectAgentRefresh(agent(source), {
+          initialized: true,
+          sinceTimestamp: 10,
+          cachedSessions: [],
+        }),
+      ).resolves.toMatchObject({ kind: expectedKind });
+    },
+  );
+
+  it("commits a successful aggregate refresh through the policy owner", async () => {
+    const commitChangeCheck = vi.fn();
+    const source: AggregateSessionSourceCapability = {
+      ...aggregate,
+      commitChangeCheck,
+      checkForChanges: () => ({ hasChanges: false, timestamp: 11 }),
+    };
+    const selection = await selectAgentRefresh(agent(source), {
+      initialized: true,
+      sinceTimestamp: 10,
+      cachedSessions: [],
+    });
+    if (selection.kind !== "recompute-derived") throw new Error("Expected derived refresh");
+
+    commitAgentRefreshCheck(selection);
+
+    expect(commitChangeCheck).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -1205,6 +1205,7 @@ describe("scanSessions", () => {
       incrementalScanResult: refreshedSessions,
     });
     agent.checkForChanges = checkForChanges;
+    const commitChangeCheck = vi.spyOn(agent, "commitChangeCheck");
     mockCachedSessions({
       sessions: cachedSessions,
       meta: {},
@@ -1227,6 +1228,7 @@ describe("scanSessions", () => {
     expect(recovered.cacheFailures).toBeUndefined();
     expect(checkForChanges).toHaveBeenNthCalledWith(1, 123, cachedSessions);
     expect(checkForChanges).toHaveBeenNthCalledWith(2, 123, cachedSessions);
+    expect(commitChangeCheck).toHaveBeenCalledOnce();
   });
 
   it("reports a failed cache read separately from an empty cache", async () => {

--- a/packages/core/src/discovery/agent-scan-plan.ts
+++ b/packages/core/src/discovery/agent-scan-plan.ts
@@ -124,7 +124,37 @@ export type AgentRefreshInspection =
 export type AgentRefreshSelection =
   | { kind: "unavailable"; availabilityDurationMs: number }
   | { kind: "initialize"; availabilityDurationMs: number }
-  | (AgentRefreshInspection & { availabilityDurationMs: number });
+  | ({ kind: "synchronize"; source: EnumeratedSessionSourceCapability } & {
+      availabilityDurationMs: number;
+    })
+  | ({
+      kind: "failed";
+      failure: Extract<ChangeCheckResult, { status: "failed" }>["failure"];
+      checkDurationMs: number;
+    } & { availabilityDurationMs: number })
+  | ({
+      kind: "recompute-derived";
+      source: AggregateSessionSourceCapability;
+      check: SuccessfulChangeCheck;
+      checkDurationMs: number;
+    } & { availabilityDurationMs: number })
+  | ({
+      kind: "full-scan";
+      source: AggregateSessionSourceCapability;
+      check: SuccessfulChangeCheck;
+      checkDurationMs: number;
+    } & { availabilityDurationMs: number })
+  | ({
+      kind: "incremental-scan";
+      source: AggregateSessionSourceCapability;
+      check: SuccessfulChangeCheck & { changedIds: string[] };
+      checkDurationMs: number;
+    } & { availabilityDurationMs: number });
+
+type CommittableAgentRefresh = Extract<
+  AgentRefreshSelection,
+  { kind: "recompute-derived" | "full-scan" | "incremental-scan" }
+>;
 
 export function planAgentScan(
   source: SessionSourceCapability,
@@ -191,12 +221,27 @@ export async function selectAgentRefresh(
   if (!available) return { kind: "unavailable", availabilityDurationMs };
   if (!options.initialized) return { kind: "initialize", availabilityDurationMs };
 
-  return {
-    ...(await inspectAgentRefresh(
-      agent.sessionSourceAccess,
-      options.sinceTimestamp,
-      options.cachedSessions,
-    )),
-    availabilityDurationMs,
-  };
+  const inspection = await inspectAgentRefresh(
+    agent.sessionSourceAccess,
+    options.sinceTimestamp,
+    options.cachedSessions,
+  );
+  if (inspection.kind === "unchanged") {
+    return { ...inspection, kind: "recompute-derived", availabilityDurationMs };
+  }
+  if (inspection.kind === "scan") {
+    return inspection.check.changedIds === undefined
+      ? { ...inspection, kind: "full-scan", availabilityDurationMs }
+      : {
+          ...inspection,
+          kind: "incremental-scan",
+          check: { ...inspection.check, changedIds: inspection.check.changedIds },
+          availabilityDurationMs,
+        };
+  }
+  return { ...inspection, availabilityDurationMs };
+}
+
+export function commitAgentRefreshCheck(refresh: CommittableAgentRefresh): void {
+  refresh.source.commitChangeCheck();
 }

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -9,6 +9,7 @@ export {
 export type { AgentCacheFailure, LiveSnapshot, ScanOptions } from "./scanner.js";
 export type { SessionTagTiming } from "./session-tags.js";
 export {
+  commitAgentRefreshCheck,
   executeAgentScanPlan,
   inspectAgentRefresh,
   planAgentScan,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -33,6 +33,7 @@ import {
 } from "./orchestrate.js";
 import {
   executeAgentScanPlan,
+  commitAgentRefreshCheck,
   planAgentScan,
   resolveSessionSnapshotCompleteness,
   selectAgentRefresh,
@@ -519,7 +520,7 @@ async function scanAgentSmart(
         );
       }
 
-      if (refresh.kind === "scan") {
+      if (refresh.kind === "full-scan" || refresh.kind === "incremental-scan") {
         const checkResult = refresh.check;
         onProgress?.({
           agent: agent.name,
@@ -532,15 +533,13 @@ async function scanAgentSmart(
         const updatedSessions = await Promise.resolve(
           refresh.source.incrementalScan(
             cached.sessions,
-            checkResult.changedIds || [],
+            checkResult.changedIds ?? [],
             checkResult.refs,
             scanOptions,
           ),
         );
         timing.scan = performance.now() - t2;
-        refresh.source.commitChangeCheck();
-
-        return finalizeAgentScan(agent, updatedSessions, {
+        const result = await finalizeAgentScan(agent, updatedSessions, {
           finalization: {
             kind: "incremental",
             cached,
@@ -556,10 +555,11 @@ async function scanAgentSmart(
           ),
           onProgress,
         });
+        if (result.cachePersistence === "persisted") commitAgentRefreshCheck(refresh);
+        return result;
       }
 
-      refresh.source.commitChangeCheck();
-      return finalizeAgentScan(agent, cached.sessions, {
+      const result = await finalizeAgentScan(agent, cached.sessions, {
         finalization: { kind: "unchanged", cached },
         options,
         timing,
@@ -567,6 +567,8 @@ async function scanAgentSmart(
         completeness: "complete",
         onProgress,
       });
+      commitAgentRefreshCheck(refresh);
+      return result;
     }
   }
 

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -44,6 +44,7 @@ export {
   buildSessionPersistenceDiff,
   clearCache,
   closeCacheStorage,
+  commitAgentRefreshCheck,
   commitDurableSessionPublication,
   computeSessionDiff,
   executeAgentScanPlan,


### PR DESCRIPTION
## Summary

- centralize refresh strategy selection for full, incremental, and derived recomputation paths
- commit aggregate source checks only after durable publication succeeds
- preserve the previous source baseline when indexing or cache persistence fails

## Testing

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- node scripts/check-quality-task-coverage.mjs
- node scripts/check-docs-paths.mjs
- node scripts/check-docs-facts.mjs
- node scripts/release-preflight.mjs
- pnpm perf:check