### PR TITLE
Split session timeline responsibilities

### DIFF
--- a/apps/web/src/components/session-detail/session-message-timeline-tooltip.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline-tooltip.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useLayoutEffect, useRef, useState, type RefObject } from "react";
+import { createPortal } from "react-dom";
+import type { SessionTimelineEntry } from "./timeline";
+
+const TIMELINE_TOOLTIP_VIEWPORT_PADDING = 8;
+
+export interface TimelineTooltip {
+  entryId: string;
+  id: string;
+  text: string;
+  anchorX: number;
+  top: number;
+  source: "focus" | "pointer";
+}
+
+export function useSessionMessageTimelineTooltip() {
+  const tooltipRef = useRef<HTMLSpanElement | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+  const [tooltip, setTooltip] = useState<TimelineTooltip | null>(null);
+
+  useLayoutEffect(() => {
+    const element = tooltipRef.current;
+    if (!element || !tooltip) return;
+    const halfWidth = element.offsetWidth / 2;
+    const left = Math.min(
+      window.innerWidth - TIMELINE_TOOLTIP_VIEWPORT_PADDING - halfWidth,
+      Math.max(TIMELINE_TOOLTIP_VIEWPORT_PADDING + halfWidth, tooltip.anchorX),
+    );
+    element.style.left = `${left}px`;
+  }, [tooltip]);
+
+  const show = useCallback(
+    (entry: SessionTimelineEntry, trigger: HTMLElement, source: TimelineTooltip["source"]) => {
+      const rect = trigger.getBoundingClientRect();
+      triggerRef.current = trigger;
+      setTooltip({
+        entryId: entry.id,
+        id: `timeline-tooltip-${entry.id}`,
+        text: entry.tooltip,
+        anchorX: rect.left + rect.width / 2,
+        top: rect.bottom + 8,
+        source,
+      });
+    },
+    [],
+  );
+
+  const hide = useCallback((entryId: string) => {
+    setTooltip((current) => {
+      if (current?.entryId !== entryId) return current;
+      triggerRef.current = null;
+      return null;
+    });
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    setTooltip((current) => {
+      const trigger = triggerRef.current;
+      if (
+        !current ||
+        current.source !== "focus" ||
+        !trigger ||
+        trigger !== document.activeElement
+      ) {
+        triggerRef.current = null;
+        return null;
+      }
+
+      const rect = trigger.getBoundingClientRect();
+      return {
+        ...current,
+        anchorX: rect.left + rect.width / 2,
+        top: rect.bottom + 8,
+      };
+    });
+  }, []);
+
+  return { tooltip, tooltipRef, show, hide, handleScroll };
+}
+
+export function SessionMessageTimelineTooltip({
+  tooltip,
+  tooltipRef,
+}: {
+  tooltip: TimelineTooltip | null;
+  tooltipRef: RefObject<HTMLSpanElement | null>;
+}) {
+  if (!tooltip) return null;
+  return createPortal(
+    <span
+      ref={tooltipRef}
+      id={tooltip.id}
+      role="tooltip"
+      className="t-tt session-timeline-floating-tooltip console-mono text-[11px]"
+      style={{ left: tooltip.anchorX, top: tooltip.top }}
+    >
+      {tooltip.text}
+    </span>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/session-detail/session-message-timeline.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.tsx
@@ -1,36 +1,22 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent,
-} from "react";
-import { createPortal } from "react-dom";
+import { memo, useCallback, useMemo, useRef } from "react";
 import { ChevronLeft, ChevronRight } from "../ui/icons";
-import {
-  findTimelineIndexAtPointer,
-  type SessionTimelineEntry,
-  type SessionTimelineEntryKind,
-} from "./timeline";
-import { getActivationScrollBehavior, type SessionAnchorScrollBehavior } from "./scroll-behavior";
+import type { SessionAnchorScrollBehavior } from "./scroll-behavior";
+import type { SessionTimelineEntry, SessionTimelineEntryKind } from "./timeline";
 import type { TimelineAnchorRegistry } from "./timeline-anchor-registry";
 import {
-  getInitialTimelineRenderRange,
-  getTimelineRenderRange,
   getTrackLayout,
   getVirtualizedSegmentStyle,
-  scrollTimelineIndexIntoView,
   TIMELINE_SEGMENT_MIN_WIDTH,
-  VIRTUALIZED_TIMELINE_THRESHOLD,
 } from "./session-message-timeline-layout";
+import { SessionMessageTimelineMinimap } from "./session-message-timeline-minimap";
 import {
-  SessionMessageTimelineMinimap,
-  type MinimapWindow,
-} from "./session-message-timeline-minimap";
+  SessionMessageTimelineTooltip,
+  type TimelineTooltip,
+  useSessionMessageTimelineTooltip,
+} from "./session-message-timeline-tooltip";
 import { useActiveTimelineIndex } from "./use-active-timeline-index";
+import { useSessionMessageTimelineNavigation } from "./use-session-message-timeline-navigation";
+import { useSessionMessageTimelineViewport } from "./use-session-message-timeline-viewport";
 
 export { VIRTUALIZED_TIMELINE_THRESHOLD } from "./session-message-timeline-layout";
 
@@ -39,18 +25,6 @@ interface SessionMessageTimelineProps {
   anchorRegistry: TimelineAnchorRegistry;
   onNavigate: (entry: SessionTimelineEntry, behavior: SessionAnchorScrollBehavior) => void;
 }
-
-interface TimelineTooltip {
-  entryId: string;
-  id: string;
-  text: string;
-  anchorX: number;
-  top: number;
-  source: "focus" | "pointer";
-}
-
-const TIMELINE_SCROLL_EDGE_TOLERANCE = 1;
-const TIMELINE_TOOLTIP_VIEWPORT_PADDING = 8;
 
 const KIND_CLASS: Record<SessionTimelineEntryKind, string> = {
   user: "bg-[var(--timeline-user)]",
@@ -116,26 +90,44 @@ export function SessionMessageTimeline({
   onNavigate,
 }: SessionMessageTimelineProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const trackRef = useRef<HTMLDivElement | null>(null);
-  const tooltipRef = useRef<HTMLSpanElement | null>(null);
-  const tooltipTriggerRef = useRef<HTMLElement | null>(null);
-  const dragRef = useRef({ active: false, moved: false, startX: 0, lastIndex: -1 });
-  const suppressClickRef = useRef(false);
-  const pendingFocusIndexRef = useRef<number | null>(null);
-  const [tooltip, setTooltip] = useState<TimelineTooltip | null>(null);
-  const [scrollAvailability, setScrollAvailability] = useState({ left: false, right: false });
-  const [minimapWindow, setMinimapWindow] = useState<MinimapWindow | null>(null);
-  const [renderRange, setRenderRange] = useState(() =>
-    getInitialTimelineRenderRange(entries.length),
-  );
   const activeIndex = useActiveTimelineIndex({ rootRef, entries, anchorRegistry });
   const trackLayout = getTrackLayout(entries.length);
-  const virtualized = entries.length > VIRTUALIZED_TIMELINE_THRESHOLD;
-  const renderStart = virtualized ? Math.min(renderRange.start, entries.length) : 0;
-  const renderEnd = virtualized
-    ? Math.max(renderStart, Math.min(renderRange.end, entries.length))
-    : entries.length;
+  const {
+    scrollRef,
+    trackRef,
+    virtualized,
+    renderStart,
+    renderEnd,
+    scrollAvailability,
+    minimapWindow,
+    update: updateViewport,
+    scrollByPage,
+    focusIndex,
+  } = useSessionMessageTimelineViewport({
+    activeIndex,
+    entryCount: entries.length,
+    gapWidth: trackLayout.gapWidth,
+  });
+  const {
+    tooltip,
+    tooltipRef,
+    show: showTooltip,
+    hide: hideTooltip,
+    handleScroll: handleTooltipScroll,
+  } = useSessionMessageTimelineTooltip();
+  const {
+    handleKeyDown,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handlePointerCancel,
+    handleClick,
+  } = useSessionMessageTimelineNavigation({
+    entries,
+    trackRef,
+    focusIndex,
+    onNavigate,
+  });
   const renderedEntries = useMemo(
     () =>
       entries
@@ -144,196 +136,10 @@ export function SessionMessageTimeline({
     [entries, renderEnd, renderStart],
   );
 
-  const updateScrollAvailability = useCallback(() => {
-    const viewport = scrollRef.current;
-    if (!viewport) return;
-    const nextRenderRange = getTimelineRenderRange(
-      entries.length,
-      viewport.scrollLeft,
-      viewport.clientWidth,
-      viewport.scrollWidth,
-    );
-    setRenderRange((current) =>
-      current.start === nextRenderRange.start && current.end === nextRenderRange.end
-        ? current
-        : nextRenderRange,
-    );
-    const maxScrollLeft = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
-    const next = {
-      left: viewport.scrollLeft > TIMELINE_SCROLL_EDGE_TOLERANCE,
-      right: viewport.scrollLeft < maxScrollLeft - TIMELINE_SCROLL_EDGE_TOLERANCE,
-    };
-    setScrollAvailability((current) =>
-      current.left === next.left && current.right === next.right ? current : next,
-    );
-    if (maxScrollLeft <= 0) {
-      setMinimapWindow(null);
-      return;
-    }
-    const window = {
-      start: viewport.scrollLeft / viewport.scrollWidth,
-      size: viewport.clientWidth / viewport.scrollWidth,
-    };
-    setMinimapWindow((current) =>
-      current?.start === window.start && current.size === window.size ? current : window,
-    );
-  }, [entries.length]);
-
-  useLayoutEffect(() => {
-    const element = tooltipRef.current;
-    if (!element || !tooltip) return;
-    const halfWidth = element.offsetWidth / 2;
-    const left = Math.min(
-      window.innerWidth - TIMELINE_TOOLTIP_VIEWPORT_PADDING - halfWidth,
-      Math.max(TIMELINE_TOOLTIP_VIEWPORT_PADDING + halfWidth, tooltip.anchorX),
-    );
-    element.style.left = `${left}px`;
-  }, [tooltip]);
-
-  useLayoutEffect(() => {
-    updateScrollAvailability();
-    const viewport = scrollRef.current;
-    const track = trackRef.current;
-    if (!viewport || !track || typeof ResizeObserver === "undefined") return;
-
-    const observer = new ResizeObserver(updateScrollAvailability);
-    observer.observe(viewport);
-    observer.observe(track);
-    return () => observer.disconnect();
-  }, [entries.length, updateScrollAvailability]);
-
-  useEffect(() => {
-    const scrollViewport = scrollRef.current;
-    const track = trackRef.current;
-    if (!scrollViewport || !track) return;
-
-    scrollTimelineIndexIntoView(
-      scrollViewport,
-      track,
-      activeIndex,
-      entries.length,
-      trackLayout.gapWidth,
-    );
-    updateScrollAvailability();
-  }, [activeIndex, entries.length, trackLayout.gapWidth, updateScrollAvailability]);
-
-  useLayoutEffect(() => {
-    const pendingIndex = pendingFocusIndexRef.current;
-    if (pendingIndex == null) return;
-    const segment = trackRef.current?.querySelector<HTMLButtonElement>(
-      `[data-timeline-index="${pendingIndex}"]`,
-    );
-    if (!segment) return;
-    pendingFocusIndexRef.current = null;
-    segment.focus();
-  }, [renderEnd, renderStart]);
-
-  const showTooltip = useCallback(
-    (entry: SessionTimelineEntry, trigger: HTMLElement, source: TimelineTooltip["source"]) => {
-      const rect = trigger.getBoundingClientRect();
-      tooltipTriggerRef.current = trigger;
-      setTooltip({
-        entryId: entry.id,
-        id: `timeline-tooltip-${entry.id}`,
-        text: entry.tooltip,
-        anchorX: rect.left + rect.width / 2,
-        top: rect.bottom + 8,
-        source,
-      });
-    },
-    [],
-  );
-
-  const hideTooltip = useCallback((entryId: string) => {
-    setTooltip((current) => {
-      if (current?.entryId !== entryId) return current;
-      tooltipTriggerRef.current = null;
-      return null;
-    });
-  }, []);
-
   const handleTimelineScroll = useCallback(() => {
-    updateScrollAvailability();
-    setTooltip((current) => {
-      const trigger = tooltipTriggerRef.current;
-      if (
-        !current ||
-        current.source !== "focus" ||
-        !trigger ||
-        trigger !== document.activeElement
-      ) {
-        tooltipTriggerRef.current = null;
-        return null;
-      }
-
-      const rect = trigger.getBoundingClientRect();
-      return {
-        ...current,
-        anchorX: rect.left + rect.width / 2,
-        top: rect.bottom + 8,
-      };
-    });
-  }, [updateScrollAvailability]);
-
-  const scrollTimeline = useCallback((direction: -1 | 1) => {
-    const viewport = scrollRef.current;
-    if (!viewport) return;
-    viewport.scrollLeft += direction * Math.max(120, viewport.clientWidth * 0.75);
-  }, []);
-
-  const navigateFromPointer = useCallback(
-    (clientX: number, behavior: SessionAnchorScrollBehavior) => {
-      const track = trackRef.current;
-      if (!track) return;
-      const rect = track.getBoundingClientRect();
-      const index = findTimelineIndexAtPointer(clientX, rect.left, rect.width, entries.length);
-      if (index == null || index === dragRef.current.lastIndex) return;
-      const entry = entries[index];
-      if (!entry) return;
-      dragRef.current.lastIndex = index;
-      onNavigate(entry, behavior);
-    },
-    [entries, onNavigate],
-  );
-
-  const focusTimelineIndex = useCallback(
-    (index: number) => {
-      const viewport = scrollRef.current;
-      const track = trackRef.current;
-      if (!viewport || !track) return;
-      const segment = track.querySelector<HTMLButtonElement>(`[data-timeline-index="${index}"]`);
-      if (segment) {
-        segment.focus();
-        return;
-      }
-
-      pendingFocusIndexRef.current = index;
-      scrollTimelineIndexIntoView(viewport, track, index, entries.length, trackLayout.gapWidth);
-      updateScrollAvailability();
-    },
-    [entries.length, trackLayout.gapWidth, updateScrollAvailability],
-  );
-
-  const handleTimelineKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
-      const indexValue = (event.target as HTMLElement).closest<HTMLButtonElement>(
-        "[data-timeline-index]",
-      )?.dataset.timelineIndex;
-      const index = indexValue == null ? null : Number(indexValue);
-      if (index == null || !Number.isInteger(index)) return;
-
-      let nextIndex: number | null = null;
-      if (event.key === "ArrowLeft") nextIndex = Math.max(0, index - 1);
-      if (event.key === "ArrowRight") nextIndex = Math.min(entries.length - 1, index + 1);
-      if (event.key === "Home") nextIndex = 0;
-      if (event.key === "End") nextIndex = entries.length - 1;
-      if (nextIndex == null || nextIndex === index) return;
-
-      event.preventDefault();
-      focusTimelineIndex(nextIndex);
-    },
-    [entries.length, focusTimelineIndex],
-  );
+    updateViewport();
+    handleTooltipScroll();
+  }, [handleTooltipScroll, updateViewport]);
 
   return (
     <div className="sticky top-0 z-20 -mx-2 bg-[var(--console-bg)] px-2 py-3">
@@ -363,56 +169,12 @@ export function SessionMessageTimeline({
                       minWidth: `${trackLayout.minWidth}px`,
                     }
               }
-              onKeyDown={handleTimelineKeyDown}
-              onPointerDown={(event) => {
-                if (event.button !== 0) return;
-                dragRef.current = {
-                  active: true,
-                  moved: false,
-                  startX: event.clientX,
-                  lastIndex: -1,
-                };
-              }}
-              onPointerMove={(event) => {
-                const drag = dragRef.current;
-                if (!drag.active) return;
-                if (!drag.moved) {
-                  if (Math.abs(event.clientX - drag.startX) < 3) return;
-                  drag.moved = true;
-                  event.currentTarget.setPointerCapture(event.pointerId);
-                }
-                suppressClickRef.current = true;
-                navigateFromPointer(event.clientX, "auto");
-              }}
-              onPointerUp={(event) => {
-                dragRef.current.active = false;
-                if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-                  event.currentTarget.releasePointerCapture(event.pointerId);
-                }
-                window.setTimeout(() => {
-                  suppressClickRef.current = false;
-                }, 0);
-              }}
-              onPointerCancel={() => {
-                dragRef.current.active = false;
-                suppressClickRef.current = false;
-              }}
-              onClick={(event) => {
-                if (suppressClickRef.current) return;
-                const behavior = getActivationScrollBehavior(event.detail);
-
-                const indexValue = (event.target as HTMLElement).closest<HTMLButtonElement>(
-                  "[data-timeline-index]",
-                )?.dataset.timelineIndex;
-                const index = indexValue == null ? null : Number(indexValue);
-                const entry =
-                  index == null || !Number.isInteger(index) ? undefined : entries[index];
-                if (entry) {
-                  onNavigate(entry, behavior);
-                  return;
-                }
-                navigateFromPointer(event.clientX, behavior);
-              }}
+              onKeyDown={handleKeyDown}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerCancel}
+              onClick={handleClick}
             >
               {renderedEntries.map(({ entry, index }) => (
                 <TimelineSegment
@@ -435,7 +197,7 @@ export function SessionMessageTimeline({
               type="button"
               aria-label="Scroll timeline left"
               className="absolute inset-y-0 left-0 z-10 flex w-8 items-center justify-start bg-[linear-gradient(to_right,var(--console-surface)_55%,transparent)] pl-0.5 text-[var(--console-muted)] hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--brand)]"
-              onClick={() => scrollTimeline(-1)}
+              onClick={() => scrollByPage(-1)}
             >
               <ChevronLeft size={14} aria-hidden="true" />
             </button>
@@ -445,7 +207,7 @@ export function SessionMessageTimeline({
               type="button"
               aria-label="Scroll timeline right"
               className="absolute inset-y-0 right-0 z-10 flex w-8 items-center justify-end bg-[linear-gradient(to_left,var(--console-surface)_55%,transparent)] pr-0.5 text-[var(--console-muted)] hover:text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--brand)]"
-              onClick={() => scrollTimeline(1)}
+              onClick={() => scrollByPage(1)}
             >
               <ChevronRight size={14} aria-hidden="true" />
             </button>
@@ -458,19 +220,7 @@ export function SessionMessageTimeline({
             visibleWindow={minimapWindow}
           />
         )}
-        {tooltip &&
-          createPortal(
-            <span
-              ref={tooltipRef}
-              id={tooltip.id}
-              role="tooltip"
-              className="t-tt session-timeline-floating-tooltip console-mono text-[11px]"
-              style={{ left: tooltip.anchorX, top: tooltip.top }}
-            >
-              {tooltip.text}
-            </span>,
-            document.body,
-          )}
+        <SessionMessageTimelineTooltip tooltip={tooltip} tooltipRef={tooltipRef} />
       </div>
     </div>
   );

--- a/apps/web/src/components/session-detail/use-session-message-timeline-navigation.ts
+++ b/apps/web/src/components/session-detail/use-session-message-timeline-navigation.ts
@@ -1,0 +1,125 @@
+import {
+  useCallback,
+  useRef,
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent,
+  type RefObject,
+} from "react";
+import { getActivationScrollBehavior, type SessionAnchorScrollBehavior } from "./scroll-behavior";
+import { findTimelineIndexAtPointer, type SessionTimelineEntry } from "./timeline";
+
+interface TimelineNavigationOptions {
+  entries: SessionTimelineEntry[];
+  trackRef: RefObject<HTMLDivElement | null>;
+  focusIndex: (index: number) => void;
+  onNavigate: (entry: SessionTimelineEntry, behavior: SessionAnchorScrollBehavior) => void;
+}
+
+export function useSessionMessageTimelineNavigation({
+  entries,
+  trackRef,
+  focusIndex,
+  onNavigate,
+}: TimelineNavigationOptions) {
+  const dragRef = useRef({ active: false, moved: false, startX: 0, lastIndex: -1 });
+  const suppressClickRef = useRef(false);
+
+  const navigateFromPointer = useCallback(
+    (clientX: number, behavior: SessionAnchorScrollBehavior) => {
+      const track = trackRef.current;
+      if (!track) return;
+      const rect = track.getBoundingClientRect();
+      const index = findTimelineIndexAtPointer(clientX, rect.left, rect.width, entries.length);
+      if (index == null || index === dragRef.current.lastIndex) return;
+      const entry = entries[index];
+      if (!entry) return;
+      dragRef.current.lastIndex = index;
+      onNavigate(entry, behavior);
+    },
+    [entries, onNavigate, trackRef],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const indexValue = (event.target as HTMLElement).closest<HTMLButtonElement>(
+        "[data-timeline-index]",
+      )?.dataset.timelineIndex;
+      const index = indexValue == null ? null : Number(indexValue);
+      if (index == null || !Number.isInteger(index)) return;
+
+      let nextIndex: number | null = null;
+      if (event.key === "ArrowLeft") nextIndex = Math.max(0, index - 1);
+      if (event.key === "ArrowRight") nextIndex = Math.min(entries.length - 1, index + 1);
+      if (event.key === "Home") nextIndex = 0;
+      if (event.key === "End") nextIndex = entries.length - 1;
+      if (nextIndex == null || nextIndex === index) return;
+
+      event.preventDefault();
+      focusIndex(nextIndex);
+    },
+    [entries.length, focusIndex],
+  );
+
+  const handlePointerDown = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    dragRef.current = { active: true, moved: false, startX: event.clientX, lastIndex: -1 };
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const drag = dragRef.current;
+      if (!drag.active) return;
+      if (!drag.moved) {
+        if (Math.abs(event.clientX - drag.startX) < 3) return;
+        drag.moved = true;
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }
+      suppressClickRef.current = true;
+      navigateFromPointer(event.clientX, "auto");
+    },
+    [navigateFromPointer],
+  );
+
+  const handlePointerUp = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    dragRef.current.active = false;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    window.setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 0);
+  }, []);
+
+  const handlePointerCancel = useCallback(() => {
+    dragRef.current.active = false;
+    suppressClickRef.current = false;
+  }, []);
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (suppressClickRef.current) return;
+      const behavior = getActivationScrollBehavior(event.detail);
+      const indexValue = (event.target as HTMLElement).closest<HTMLButtonElement>(
+        "[data-timeline-index]",
+      )?.dataset.timelineIndex;
+      const index = indexValue == null ? null : Number(indexValue);
+      const entry = index == null || !Number.isInteger(index) ? undefined : entries[index];
+      if (entry) {
+        onNavigate(entry, behavior);
+        return;
+      }
+      navigateFromPointer(event.clientX, behavior);
+    },
+    [entries, navigateFromPointer, onNavigate],
+  );
+
+  return {
+    handleKeyDown,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handlePointerCancel,
+    handleClick,
+  };
+}

--- a/apps/web/src/components/session-detail/use-session-message-timeline-viewport.ts
+++ b/apps/web/src/components/session-detail/use-session-message-timeline-viewport.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  getInitialTimelineRenderRange,
+  getTimelineRenderRange,
+  scrollTimelineIndexIntoView,
+  VIRTUALIZED_TIMELINE_THRESHOLD,
+} from "./session-message-timeline-layout";
+import type { MinimapWindow } from "./session-message-timeline-minimap";
+
+const TIMELINE_SCROLL_EDGE_TOLERANCE = 1;
+
+interface TimelineViewportOptions {
+  activeIndex: number;
+  entryCount: number;
+  gapWidth: number;
+}
+
+export function useSessionMessageTimelineViewport({
+  activeIndex,
+  entryCount,
+  gapWidth,
+}: TimelineViewportOptions) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const pendingFocusIndexRef = useRef<number | null>(null);
+  const [scrollAvailability, setScrollAvailability] = useState({ left: false, right: false });
+  const [minimapWindow, setMinimapWindow] = useState<MinimapWindow | null>(null);
+  const [renderRange, setRenderRange] = useState(() => getInitialTimelineRenderRange(entryCount));
+  const virtualized = entryCount > VIRTUALIZED_TIMELINE_THRESHOLD;
+  const renderStart = virtualized ? Math.min(renderRange.start, entryCount) : 0;
+  const renderEnd = virtualized
+    ? Math.max(renderStart, Math.min(renderRange.end, entryCount))
+    : entryCount;
+
+  const update = useCallback(() => {
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+    const nextRenderRange = getTimelineRenderRange(
+      entryCount,
+      viewport.scrollLeft,
+      viewport.clientWidth,
+      viewport.scrollWidth,
+    );
+    setRenderRange((current) =>
+      current.start === nextRenderRange.start && current.end === nextRenderRange.end
+        ? current
+        : nextRenderRange,
+    );
+    const maxScrollLeft = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
+    const nextAvailability = {
+      left: viewport.scrollLeft > TIMELINE_SCROLL_EDGE_TOLERANCE,
+      right: viewport.scrollLeft < maxScrollLeft - TIMELINE_SCROLL_EDGE_TOLERANCE,
+    };
+    setScrollAvailability((current) =>
+      current.left === nextAvailability.left && current.right === nextAvailability.right
+        ? current
+        : nextAvailability,
+    );
+    if (maxScrollLeft <= 0) {
+      setMinimapWindow(null);
+      return;
+    }
+    const nextWindow = {
+      start: viewport.scrollLeft / viewport.scrollWidth,
+      size: viewport.clientWidth / viewport.scrollWidth,
+    };
+    setMinimapWindow((current) =>
+      current?.start === nextWindow.start && current.size === nextWindow.size
+        ? current
+        : nextWindow,
+    );
+  }, [entryCount]);
+
+  useLayoutEffect(() => {
+    update();
+    const viewport = scrollRef.current;
+    const track = trackRef.current;
+    if (!viewport || !track || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(update);
+    observer.observe(viewport);
+    observer.observe(track);
+    return () => observer.disconnect();
+  }, [entryCount, update]);
+
+  useEffect(() => {
+    const viewport = scrollRef.current;
+    const track = trackRef.current;
+    if (!viewport || !track) return;
+
+    scrollTimelineIndexIntoView(viewport, track, activeIndex, entryCount, gapWidth);
+    update();
+  }, [activeIndex, entryCount, gapWidth, update]);
+
+  useLayoutEffect(() => {
+    const pendingIndex = pendingFocusIndexRef.current;
+    if (pendingIndex == null) return;
+    const segment = trackRef.current?.querySelector<HTMLButtonElement>(
+      `[data-timeline-index="${pendingIndex}"]`,
+    );
+    if (!segment) return;
+    pendingFocusIndexRef.current = null;
+    segment.focus();
+  }, [renderEnd, renderStart]);
+
+  const scrollByPage = useCallback((direction: -1 | 1) => {
+    const viewport = scrollRef.current;
+    if (!viewport) return;
+    viewport.scrollLeft += direction * Math.max(120, viewport.clientWidth * 0.75);
+  }, []);
+
+  const focusIndex = useCallback(
+    (index: number) => {
+      const viewport = scrollRef.current;
+      const track = trackRef.current;
+      if (!viewport || !track) return;
+      const segment = track.querySelector<HTMLButtonElement>(`[data-timeline-index="${index}"]`);
+      if (segment) {
+        segment.focus();
+        return;
+      }
+
+      pendingFocusIndexRef.current = index;
+      scrollTimelineIndexIntoView(viewport, track, index, entryCount, gapWidth);
+      update();
+    },
+    [entryCount, gapWidth, update],
+  );
+
+  return {
+    scrollRef,
+    trackRef,
+    virtualized,
+    renderStart,
+    renderEnd,
+    scrollAvailability,
+    minimapWindow,
+    update,
+    scrollByPage,
+    focusIndex,
+  };
+}


### PR DESCRIPTION
## Summary

- move viewport windowing, scroll availability, and focus management into a dedicated hook
- move pointer and keyboard navigation into a focused interaction hook
- isolate tooltip state, positioning, and portal rendering from the timeline composition
- preserve the existing component API and user-visible behavior

## Testing

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- node scripts/check-quality-task-coverage.mjs
- node scripts/check-docs-paths.mjs
- node scripts/check-docs-facts.mjs
- node scripts/release-preflight.mjs
- pnpm perf:check