### PR TITLE
Propagate project reload failures

### DIFF
--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -480,9 +480,17 @@ describe("useSessionStore", () => {
     const error = new Error("projects unavailable");
     vi.mocked(api.fetchProjects).mockRejectedValue(error);
     const { result } = await renderStore();
+    let reloadFailure: unknown;
 
-    await act(() => result.current.reload());
+    await act(async () => {
+      try {
+        await result.current.reload();
+      } catch (caught) {
+        reloadFailure = caught;
+      }
+    });
 
+    expect(reloadFailure).toBe(error);
     await waitFor(() => expect(result.current.projectsError).toBe("projects unavailable"));
     expect(result.current.projects).toEqual([]);
     expect(result.current.error).toBeNull();

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -240,13 +240,14 @@ export function useSessionStore(window: AppConfig["window"] | null) {
 
   const reload = useCallback(async (): Promise<void> => {
     if (!window) return;
-    const [agentsResult, projectionResult, dashboardResult] = await Promise.all([
+    const [agentsResult, projectionResult, dashboardResult, projectsResult] = await Promise.all([
       refetchAgents({ cancelRefetch: true }),
       refetchProjection({ cancelRefetch: true }),
       refetchDashboard({ cancelRefetch: true }),
       refetchProjects({ cancelRefetch: true }),
     ]);
-    const failure = agentsResult.error ?? projectionResult.error ?? dashboardResult.error;
+    const failure =
+      agentsResult.error ?? projectionResult.error ?? dashboardResult.error ?? projectsResult.error;
     if (failure) throw failure;
   }, [refetchAgents, refetchDashboard, refetchProjection, refetchProjects, window]);
 


### PR DESCRIPTION
## Summary

- include the projects query result in the full reload failure contract
- preserve independently loaded sessions and dashboard data when projects fail
- cover project reload rejection while retaining the project-specific error state

## Testing

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- node scripts/check-quality-task-coverage.mjs
- node scripts/check-docs-paths.mjs
- node scripts/check-docs-facts.mjs
- node scripts/release-preflight.mjs
- pnpm perf:check