### PR TITLE
fix(core): make database scans self-contained

### DIFF
--- a/packages/core/src/agents/__tests__/cursor-opencode.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-opencode.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import Database from "better-sqlite3";
@@ -20,7 +20,9 @@ describe("SQLite-backed agent parse contracts", () => {
   it("cleans Cursor messages and resolves title/tool names consistently", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-cursor-test-"));
     tempDirs.push(tempDir);
-    const dbPath = join(tempDir, "state.vscdb");
+    const databaseDir = join(tempDir, "globalStorage");
+    mkdirSync(databaseDir, { recursive: true });
+    const dbPath = join(databaseDir, "state.vscdb");
     const db = new Database(dbPath);
     try {
       db.exec("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)");
@@ -56,8 +58,7 @@ describe("SQLite-backed agent parse contracts", () => {
       db.close();
     }
 
-    const agent = new CursorAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
     agent.buildWorkspacePathMap = () => new Map([["composer-1", "/tmp/project"]]);
 
     const [head] = agent.scan({ from: 0 });
@@ -171,8 +172,7 @@ describe("SQLite-backed agent parse contracts", () => {
       db.close();
     }
 
-    const agent = new OpenCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new OpenCodeAgent({ sourceRoot: tempDir });
 
     const [head] = agent.scan({ from: 0 });
     const data = agent.getSessionData("session-1");

--- a/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -19,7 +19,9 @@ interface BubbleSpec {
 function createDb(entries: Array<[string, unknown]>): string {
   const dir = mkdtempSync(join(tmpdir(), "codesesh-cursor-shape-"));
   tempDirs.push(dir);
-  const dbPath = join(dir, "state.vscdb");
+  const databaseDir = join(dir, "globalStorage");
+  mkdirSync(databaseDir, { recursive: true });
+  const dbPath = join(databaseDir, "state.vscdb");
   const db = new Database(dbPath);
   db.exec("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
   const insert = db.prepare("INSERT INTO cursorDiskKV (key, value) VALUES (?, ?)");
@@ -43,9 +45,7 @@ function bubbles(composerId: string, specs: BubbleSpec[]): Array<[string, unknow
 }
 
 function makeAgent(dbPath: string) {
-  const agent = new CursorAgent();
-  (agent as unknown as { dbPath: string }).dbPath = dbPath;
-  return agent;
+  return new CursorAgent({ sourceRoot: dirname(dirname(dbPath)) });
 }
 
 function textOf(agent: CursorAgent, sessionId: string): string[] {

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -19,7 +19,9 @@ let tempDirs: string[] = [];
 const CURSOR_FIXTURE_ROOT = new URL("./fixtures/cursor/", import.meta.url);
 
 function createCursorDb(tempDir: string): string {
-  const dbPath = join(tempDir, "state.vscdb");
+  const databaseDir = join(tempDir, "globalStorage");
+  mkdirSync(databaseDir, { recursive: true });
+  const dbPath = join(databaseDir, "state.vscdb");
   const db = new Database(dbPath);
   db.exec("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
   db.close();
@@ -91,8 +93,7 @@ describe("CursorAgent parsing", () => {
       },
     });
 
-    const agent = new CursorAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
     agent.composerCache.set("composer-1", {
       id: "composer-1",
       text: "Fallback title",
@@ -135,8 +136,7 @@ describe("CursorAgent parsing", () => {
       },
     });
 
-    const agent = new CursorAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
     agent.composerCache.set("composer-1", { id: "composer-1", createdAt: 1_000 });
 
     const tool = agent
@@ -162,8 +162,7 @@ describe("CursorAgent parsing", () => {
     );
     insertKv(dbPath, "bubble:sub-1", fixture);
 
-    const agent = new CursorAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
     agent.composerCache.set("composer-1", {
       id: "composer-1",
       createdAt: 1_000,
@@ -201,8 +200,7 @@ describe("CursorAgent parsing", () => {
       createdAt: 1_000,
     });
 
-    const agent = new CursorAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
     agent.composerCache.set("composer-1", {
       id: "composer-1",
       createdAt: 1_000,
@@ -232,8 +230,7 @@ describe("CursorAgent parsing", () => {
     setCoreDiagnostics(sink);
 
     try {
-      const agent = new CursorAgent() as any;
-      agent.dbPath = dbPath;
+      const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
       agent.composerCache.set("composer-1", {
         id: "composer-1",
         createdAt: 1_000,
@@ -271,8 +268,7 @@ describe("CursorAgent parsing", () => {
     setCoreDiagnostics(sink);
 
     try {
-      const agent = new CursorAgent() as any;
-      agent.dbPath = dbPath;
+      const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
       agent.composerCache.set("composer-1", {
         id: "composer-1",
         createdAt: 1_000,
@@ -296,9 +292,7 @@ describe("CursorAgent parsing", () => {
 
 describe("CursorAgent scan outcomes", () => {
   function makeScanningAgent(dbPath: string): CursorAgent {
-    const agent = new CursorAgent();
-    Object.assign(agent, { dbPath });
-    return agent;
+    return new CursorAgent({ sourceRoot: dirname(dirname(dbPath)) });
   }
 
   it("reports a corrupt database as a failure", () => {

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -250,7 +250,7 @@ afterEach(() => {
 });
 
 describe("OpenCodeSqliteAgent", () => {
-  it("builds matching heads and details through the shared SQLite adapter", () => {
+  it("scans without a prior availability check", () => {
     const dbPath = createDatabase();
     const agent = new OpenCodeSqliteAgent({
       name: "test-agent",
@@ -259,7 +259,6 @@ describe("OpenCodeSqliteAgent", () => {
       getSessionWatchPlan: () => ({ status: "not-needed", reason: "test adapter" }),
     });
 
-    expect(agent.isAvailable()).toBe(true);
     expect(agent.scan({ from: 0 })).toEqual([
       expect.objectContaining({
         reference: { agentName: "test-agent", sessionId: "s1" },

--- a/packages/core/src/agents/__tests__/opencode.test.ts
+++ b/packages/core/src/agents/__tests__/opencode.test.ts
@@ -70,8 +70,7 @@ describe("OpenCodeAgent parsing", () => {
     ).run("legacy-session", "Legacy session", 1_000, 2_000, "/tmp/project");
     db.close();
 
-    const agent = new OpenCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new OpenCodeAgent({ sourceRoot: tempDir });
 
     const [head] = agent.scan({ from: 0 });
 
@@ -140,8 +139,7 @@ describe("OpenCodeAgent parsing", () => {
     );
     db.close();
 
-    const agent = new OpenCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new OpenCodeAgent({ sourceRoot: tempDir });
 
     const data = agent.getSessionData("session-1");
 
@@ -186,8 +184,7 @@ describe("OpenCodeAgent parsing", () => {
     const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
     setCoreDiagnostics(sink);
 
-    const agent = new OpenCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new OpenCodeAgent({ sourceRoot: tempDir });
 
     const data = agent.getSessionData("session-drift");
 

--- a/packages/core/src/agents/__tests__/zcode.test.ts
+++ b/packages/core/src/agents/__tests__/zcode.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import Database from "better-sqlite3";
@@ -10,7 +10,9 @@ import { buildSessionTree } from "../../contract/session-tree.js";
 let tempDirs: string[] = [];
 
 function createZCodeDb(tempDir: string): string {
-  const dbPath = join(tempDir, "db.sqlite");
+  const databaseDir = join(tempDir, "cli", "db");
+  mkdirSync(databaseDir, { recursive: true });
+  const dbPath = join(databaseDir, "db.sqlite");
   const db = new Database(dbPath);
   db.exec(`
     CREATE TABLE session (
@@ -53,7 +55,9 @@ afterEach(() => {
 });
 
 function createZCodeDbWithSubagent(tempDir: string): string {
-  const dbPath = join(tempDir, "db.sqlite");
+  const databaseDir = join(tempDir, "cli", "db");
+  mkdirSync(databaseDir, { recursive: true });
+  const dbPath = join(databaseDir, "db.sqlite");
   const db = new Database(dbPath);
   db.exec(`
     CREATE TABLE session (
@@ -180,8 +184,7 @@ describe("ZCodeAgent parsing", () => {
     );
     db.close();
 
-    const agent = new ZCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new ZCodeAgent({ sourceRoot: tempDir });
 
     const [head] = agent.scan({ from: 0 });
     const data = agent.getSessionData("sess_1");
@@ -246,8 +249,7 @@ describe("ZCodeAgent parsing", () => {
     const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
     setCoreDiagnostics(sink);
 
-    const agent = new ZCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new ZCodeAgent({ sourceRoot: tempDir });
 
     const data = agent.getSessionData("sess_drift");
 
@@ -337,20 +339,19 @@ describe("ZCodeAgent subagent folding", () => {
       info: (event, detail) => diagnostics.push({ event, detail }),
       warn: () => {},
     });
-    const agent = new ZCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new ZCodeAgent({ sourceRoot: tempDir });
 
     const heads = agent.scan({ from: 0 });
     expect(heads.map((head: any) => head.reference.sessionId)).toEqual(["parent", "child"]);
-    const [head] = heads;
+    const head = heads[0]!;
     expect(head.stats).toMatchObject({
       message_count: 1,
       total_input_tokens: 10,
       total_output_tokens: 0,
     });
     expect(head.parent_reference).toBeUndefined();
-    expect(heads[1].parent_reference).toEqual({ agentName: "zcode", sessionId: "parent" });
-    expect(heads[1].stats).toMatchObject({ message_count: 1, total_input_tokens: 40 });
+    expect(heads[1]!.parent_reference).toEqual({ agentName: "zcode", sessionId: "parent" });
+    expect(heads[1]!.stats).toMatchObject({ message_count: 1, total_input_tokens: 40 });
     expect(buildSessionTree(heads).roots[0]?.inclusiveStats).toMatchObject({
       inputTokens: 50,
       outputTokens: 60,
@@ -419,8 +420,7 @@ describe("ZCodeAgent subagent folding", () => {
     insertTextPart(db, "part_child", "msg_child", "child", "working", 1_200);
     db.close();
 
-    const agent = new ZCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new ZCodeAgent({ sourceRoot: tempDir });
 
     const data = agent.getSessionData("parent");
     expect(data.stats).toMatchObject({
@@ -429,7 +429,7 @@ describe("ZCodeAgent subagent folding", () => {
       total_output_tokens: 60,
     });
     expect(data.messages).toHaveLength(1);
-    expect(data.messages[0].id).toBe("msg_parent");
+    expect(data.messages[0]!.id).toBe("msg_parent");
 
     const child = agent.getSessionData("child");
     expect(child.parent_reference).toEqual({ agentName: "zcode", sessionId: "parent" });
@@ -511,10 +511,9 @@ describe("ZCodeAgent subagent folding", () => {
     insertTextPart(db, "part_b", "msg_b", "child_b", "b", 2_100);
     db.close();
 
-    const agent = new ZCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new ZCodeAgent({ sourceRoot: tempDir });
 
-    const [head] = agent.scan({ from: 0 });
+    const head = agent.scan({ from: 0 })[0]!;
     expect(head.stats).toMatchObject({
       message_count: 1,
       total_input_tokens: 5,
@@ -546,10 +545,9 @@ describe("ZCodeAgent subagent folding", () => {
     insertTextPart(db, "part_only", "msg_only", "only", "hi", 1_000);
     db.close();
 
-    const agent = new ZCodeAgent() as any;
-    agent.dbPath = dbPath;
+    const agent = new ZCodeAgent({ sourceRoot: tempDir });
 
-    const [head] = agent.scan({ from: 0 });
+    const head = agent.scan({ from: 0 })[0]!;
     expect(head.reference.sessionId).toBe("only");
     expect(head.stats).toMatchObject({ total_input_tokens: 10, total_output_tokens: 0 });
     expect(agent.getSessionData("only").stats.total_input_tokens).toBe(10);

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -10,7 +10,7 @@ import {
   parsedSession,
   SessionScanError,
 } from "./base.js";
-import type { AgentScanOptions } from "./base.js";
+import type { AgentScanOptions, AgentSourceOptions } from "./base.js";
 import type {
   SessionHead,
   SessionDetail,
@@ -85,6 +85,14 @@ export class CursorAgent extends DatabaseSessionSource {
   private composerCache = new Map<string, ComposerData>();
   private directoryCache = new Map<string, string>();
 
+  constructor(private readonly options: AgentSourceOptions = {}) {
+    super();
+  }
+
+  private getDataRoot(): string | null {
+    return this.options.sourceRoot ?? resolveCursorDataRoot();
+  }
+
   protected getDatabasePath(): string | null {
     if (!this.dbPath) {
       this.dbPath = this.findDbPath();
@@ -94,13 +102,13 @@ export class CursorAgent extends DatabaseSessionSource {
 
   private findDbPath(): string | null {
     if (!isSqliteAvailable()) return null;
-    const dataPath = resolveCursorDataRoot();
+    const dataPath = this.getDataRoot();
     if (!dataPath) return null;
     return join(dataPath, "globalStorage", "state.vscdb");
   }
 
   getSessionWatchPlan() {
-    const dataPath = resolveCursorDataRoot();
+    const dataPath = this.getDataRoot();
     return {
       status: "supported" as const,
       targets: dataPath
@@ -121,7 +129,7 @@ export class CursorAgent extends DatabaseSessionSource {
    */
   private buildWorkspacePathMap(): Map<string, string> {
     const map = new Map<string, string>();
-    const dataPath = resolveCursorDataRoot();
+    const dataPath = this.getDataRoot();
     if (!dataPath) return map;
 
     const wsStoragePath = join(dataPath, "workspaceStorage");
@@ -200,7 +208,7 @@ export class CursorAgent extends DatabaseSessionSource {
   scan(options?: AgentScanOptions): SessionHead[] {
     this.composerCache.clear();
     this.directoryCache.clear();
-    if (!this.dbPath) return [];
+    if (!this.getDatabasePath()) return [];
 
     const scanMarker = perf.start("cursor:scan");
 

--- a/packages/core/src/agents/opencode-sqlite.ts
+++ b/packages/core/src/agents/opencode-sqlite.ts
@@ -149,9 +149,10 @@ export class OpenCodeSqliteAgent extends DatabaseSessionSource {
   }
 
   scan(options?: AgentScanOptions): SessionHead[] {
-    if (!this.dbPath) return [];
+    const dbPath = this.getDatabasePath();
+    if (!dbPath) return [];
 
-    const db = openDbReadOnly(this.dbPath);
+    const db = openDbReadOnly(dbPath);
     if (!db) throw new SessionScanError(this.name, "opening the database");
 
     try {

--- a/packages/core/src/agents/opencode.ts
+++ b/packages/core/src/agents/opencode.ts
@@ -3,6 +3,7 @@ import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import { firstExisting, resolveDataHome } from "../discovery/paths.js";
 import { isSqliteAvailable } from "../utils/sqlite.js";
 import { OpenCodeSqliteAgent } from "./opencode-sqlite.js";
+import type { AgentSourceOptions } from "./base.js";
 
 const AGENT_METADATA = getAgentCatalogEntry("opencode");
 
@@ -10,29 +11,32 @@ export function resolveOpenCodeDataRoot(): string {
   return join(resolveDataHome(), "opencode");
 }
 
-function findOpenCodeDbPath(): string | null {
+function findOpenCodeDbPath(sourceRoot?: string): string | null {
   if (!isSqliteAvailable()) return null;
+  if (sourceRoot) return firstExisting(join(sourceRoot, "opencode.db"));
   return firstExisting(join(resolveOpenCodeDataRoot(), "opencode.db"), "data/opencode/opencode.db");
 }
 
-function getOpenCodeSessionWatchPlan() {
-  const dataRoot = resolveOpenCodeDataRoot();
+function getOpenCodeSessionWatchPlan(sourceRoot?: string) {
+  const dataRoot = sourceRoot ?? resolveOpenCodeDataRoot();
   return {
     status: "supported" as const,
-    targets: [
-      { root: dataRoot, path: join(dataRoot, "opencode.db") },
-      { root: "data/opencode", path: "data/opencode/opencode.db" },
-    ],
+    targets: sourceRoot
+      ? [{ root: dataRoot, path: join(dataRoot, "opencode.db") }]
+      : [
+          { root: dataRoot, path: join(dataRoot, "opencode.db") },
+          { root: "data/opencode", path: "data/opencode/opencode.db" },
+        ],
   };
 }
 
 export class OpenCodeAgent extends OpenCodeSqliteAgent {
-  constructor() {
+  constructor(options: AgentSourceOptions = {}) {
     super({
       name: AGENT_METADATA.name,
       displayName: AGENT_METADATA.displayName,
-      findDbPath: findOpenCodeDbPath,
-      getSessionWatchPlan: getOpenCodeSessionWatchPlan,
+      findDbPath: () => findOpenCodeDbPath(options.sourceRoot),
+      getSessionWatchPlan: () => getOpenCodeSessionWatchPlan(options.sourceRoot),
     });
   }
 }

--- a/packages/core/src/agents/zcode.ts
+++ b/packages/core/src/agents/zcode.ts
@@ -4,6 +4,7 @@ import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import { firstExisting } from "../discovery/paths.js";
 import { isSqliteAvailable } from "../utils/sqlite.js";
 import { OpenCodeSqliteAgent } from "./opencode-sqlite.js";
+import type { AgentSourceOptions } from "./base.js";
 
 const AGENT_METADATA = getAgentCatalogEntry("zcode");
 
@@ -13,15 +14,15 @@ export function resolveZCodeDataRoot(): string | null {
   return join(homedir(), ".zcode");
 }
 
-function findZCodeDbPath(): string | null {
+function findZCodeDbPath(sourceRoot?: string): string | null {
   if (!isSqliteAvailable()) return null;
-  const dataRoot = resolveZCodeDataRoot();
+  const dataRoot = sourceRoot ?? resolveZCodeDataRoot();
   if (!dataRoot) return null;
   return firstExisting(join(dataRoot, "cli", "db", "db.sqlite"));
 }
 
-function getZCodeSessionWatchPlan() {
-  const dataRoot = resolveZCodeDataRoot();
+function getZCodeSessionWatchPlan(sourceRoot?: string) {
+  const dataRoot = sourceRoot ?? resolveZCodeDataRoot();
   return {
     status: "supported" as const,
     targets: dataRoot ? [{ root: dataRoot, path: join(dataRoot, "cli", "db", "db.sqlite") }] : [],
@@ -29,12 +30,12 @@ function getZCodeSessionWatchPlan() {
 }
 
 export class ZCodeAgent extends OpenCodeSqliteAgent {
-  constructor() {
+  constructor(options: AgentSourceOptions = {}) {
     super({
       name: AGENT_METADATA.name,
       displayName: AGENT_METADATA.displayName,
-      findDbPath: findZCodeDbPath,
-      getSessionWatchPlan: getZCodeSessionWatchPlan,
+      findDbPath: () => findZCodeDbPath(options.sourceRoot),
+      getSessionWatchPlan: () => getZCodeSessionWatchPlan(options.sourceRoot),
     });
   }
 }


### PR DESCRIPTION
## Summary

- resolve SQLite database paths inside every scan instead of relying on an earlier availability probe
- allow OpenCode, ZCode, and Cursor agents to receive an explicit source root
- update database-agent tests to use supported construction instead of mutating private path state

## Verification

- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`
- 57 focused database-agent tests
- regression test covering scan without a prior availability check