### PR TITLE
fix(cache): skip legacy table backup

### DIFF
--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -32,7 +32,7 @@ export function hasStructuredMessages(fixture: ReleaseCacheFixture): boolean {
 }
 
 export function expectedBackupCount(fixture: ReleaseCacheFixture): number {
-  return [6, 15, 30, 32].filter((version) => version > fixture.version).length;
+  return [6, 15, 30].filter((version) => version > fixture.version).length;
 }
 
 export function createReleaseCacheFixture(

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -691,6 +691,46 @@ describe("saveCachedSessions", () => {
     }
   });
 
+  it("drops redundant version 31 cache tables without backing up canonical data", () => {
+    saveCachedSessions("claudecode", [makeSession("canonical")]);
+    setSchemaEnsuredPath(null);
+
+    const db = new Database(getCachePath());
+    try {
+      db.exec(`
+        CREATE TABLE cached_sessions (
+          agent_name TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          session_json TEXT NOT NULL,
+          meta_json TEXT,
+          PRIMARY KEY (agent_name, session_id)
+        );
+        PRAGMA user_version = 31;
+        UPDATE cache_meta SET value = '31' WHERE key = 'version';
+      `);
+    } finally {
+      db.close();
+    }
+
+    expect(
+      readCachedValue("claudecode")?.sessions.map((session) => session.reference.sessionId),
+    ).toEqual(["canonical"]);
+    expect(getMigrationBackups()).toEqual([]);
+
+    const migrated = new Database(getCachePath(), { readonly: true });
+    try {
+      const legacyTableCount = migrated
+        .prepare(
+          "SELECT COUNT(*) AS value FROM sqlite_master WHERE type = 'table' AND name = 'cached_sessions'",
+        )
+        .get() as { value?: number };
+      expect(Number(legacyTableCount.value ?? 0)).toBe(0);
+      expect(Number(migrated.pragma("user_version", { simple: true }))).toBe(CACHE_SCHEMA_VERSION);
+    } finally {
+      migrated.close();
+    }
+  });
+
   it("skips destructive migration backup when cache tables are empty", () => {
     mkdirSync(getCacheDir(), { recursive: true });
     const db = new Database(getCachePath());

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -901,7 +901,7 @@ export function ensureCacheSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 29, migrate: addSessionUsageSummary },
       { version: 30, destructive: true, migrate: dropDerivedSessionSlug },
       { version: 31, migrate: dropDurablePublicationStaging },
-      { version: 32, destructive: true, migrate: dropLegacyCacheTables },
+      { version: 32, migrate: dropLegacyCacheTables },
     ],
   });
 


### PR DESCRIPTION
## Summary

- skip the full-database backup when schema v32 drops redundant legacy cache tables
- preserve canonical session data while removing the legacy tables
- update migration backup expectations and add a v31 upgrade regression test

## Root cause

Schema v32 marked the legacy table drop as destructive. The generic migration runner therefore executed `VACUUM INTO` before startup could continue. For multi-gigabyte cache databases this blocked server startup and browser launch for tens of seconds, while interrupted attempts left large backup files behind.

The removed tables contain derived cache data that has already been replaced by canonical normalized tables, so a full database backup is unnecessary for this migration. Backups remain enabled for migrations that need recovery.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- targeted v31 migration and cache lifecycle tests