### PR TITLE
web: Preserve live changes during session loads

### DIFF
--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -83,6 +83,90 @@ async function renderStore(window: AppConfig["window"] = config.window) {
 }
 
 describe("useSessionStore", () => {
+  it("preserves live additions received while the first page is still loading", async () => {
+    const response = deferred<{ sessions: SessionHead[] }>();
+    let firstPage!: (sessions: SessionHead[]) => void;
+    vi.mocked(api.fetchSessions).mockImplementationOnce((_options, _fetchOptions, progress) => {
+      firstPage = progress!.onFirstPage!;
+      return response.promise;
+    });
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useSessionStore(config.window), { wrapper: Wrapper });
+    await waitFor(() => expect(api.fetchSessions).toHaveBeenCalled());
+    const added = {
+      ...SAMPLE_SESSION_HEAD,
+      ...createSessionIdentity({ agentName: "claudecode", sessionId: "live-added" }),
+    };
+    let applied!: ReturnType<typeof result.current.applyLiveEvent>;
+    act(() => {
+      applied = result.current.applyLiveEvent({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        newSessionRefs: [added.reference],
+        changedSessionHeads: [{ reference: added.reference, session: added }],
+        projectionSessionOrder: [SAMPLE_SESSION_HEAD.reference, added.reference],
+      });
+    });
+    act(() => firstPage([SAMPLE_SESSION_HEAD]));
+    await waitFor(() => expect(result.current.sessions).toContainEqual(added));
+    const changed = { ...added, title: "Updated while loading" };
+    await act(() =>
+      result.current.applyLiveEvent({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        newSessionRefs: [],
+        changedSessionHeads: [{ reference: changed.reference, session: changed }],
+        projectionSessionOrder: [SAMPLE_SESSION_HEAD.reference, changed.reference],
+      }),
+    );
+    await act(async () => {
+      response.resolve({ sessions: [SAMPLE_SESSION_HEAD] });
+      await applied;
+    });
+    await waitFor(() => expect(result.current.sessions).toHaveLength(2));
+    expect(result.current.sessions).toContainEqual(changed);
+  });
+
+  it("preserves live changes and removals when an older full response finishes", async () => {
+    const { result } = await renderStore();
+    const response = deferred<{ sessions: SessionHead[] }>();
+    vi.mocked(api.fetchSessions).mockReturnValueOnce(response.promise);
+    let reload!: Promise<void>;
+    act(() => {
+      reload = result.current.reload();
+    });
+    const changed = { ...SAMPLE_SESSION_HEAD, title: "Live title" };
+    await act(() =>
+      result.current.applyLiveEvent({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        changedSessionHeads: [{ reference: changed.reference, session: changed }],
+      }),
+    );
+    await act(async () => {
+      response.resolve({ sessions: [SAMPLE_SESSION_HEAD] });
+      await reload;
+    });
+    expect(result.current.sessions[0]?.title).toBe("Live title");
+
+    const removedResponse = deferred<{ sessions: SessionHead[] }>();
+    vi.mocked(api.fetchSessions).mockReturnValueOnce(removedResponse.promise);
+    act(() => {
+      reload = result.current.reload();
+    });
+    await act(() =>
+      result.current.applyLiveEvent({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        changedSessionHeads: [],
+        newSessionRefs: [],
+        projectionSessionOrder: [],
+        removedSessionRefs: [changed.reference],
+      }),
+    );
+    await act(async () => {
+      removedResponse.resolve({ sessions: [changed] });
+      await reload;
+    });
+    await waitFor(() => expect(result.current.sessions).toEqual([]));
+  });
+
   it("stays idle until a window is selected", () => {
     const { Wrapper } = createQueryWrapper();
     const { result } = renderHook(() => useSessionStore(null), { wrapper: Wrapper });
@@ -137,7 +221,11 @@ describe("useSessionStore", () => {
     });
 
     expect(liveResult).toEqual({ visibleNewSessions: 0 });
-    await waitFor(() => expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]));
+    await waitFor(() =>
+      expect(result.current.sessions).toEqual(
+        SAMPLE_SESSIONS_UPDATED_EVENT.changedSessionHeads.map(({ session }) => session),
+      ),
+    );
   });
 
   it("keeps projects available alongside the session snapshot", async () => {

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -1,4 +1,8 @@
-import { applySessionWindowChanges, formatSessionReference } from "@codesesh/core/contract";
+import {
+  applySessionWindowChanges,
+  formatSessionReference,
+  mergeSessionsUpdatedEvents,
+} from "@codesesh/core/contract";
 import {
   hashKey,
   keepPreviousData,
@@ -96,25 +100,48 @@ async function fetchSnapshotAggregates(
   return { agents, dashboard };
 }
 
-function sessionProjectionOptions(queryClient: QueryClient, window: AppConfig["window"]) {
-  return queryOptions({
-    queryKey: queryKeys.sessionProjection(window),
-    staleTime: Infinity,
-    queryFn: async ({ signal }): Promise<SessionProjection> => {
-      const sessionResult = await fetchSessions(
-        { from: window.from, to: window.to },
-        { signal },
-        {
-          onFirstPage(sessions) {
-            if (!signal.aborted) {
-              queryClient.setQueryData(queryKeys.sessionProjection(window), { sessions });
-            }
-          },
-        },
-      );
-      return { sessions: sessionResult.sessions };
-    },
+interface SessionProjectionLoad {
+  window: AppConfig["window"];
+  event: SessionsUpdatedEvent | null;
+}
+
+function applyProjectionEvent(
+  sessions: SessionHead[],
+  event: SessionsUpdatedEvent,
+  window: AppConfig["window"],
+) {
+  return applySessionWindowChanges(sessions, {
+    changedSessionHeads: event.changedSessionHeads,
+    projectionRelatedSessionHeads: event.projectionRelatedSessionHeads,
+    projectionSessionOrder: event.projectionSessionOrder,
+    removedSessionRefs: event.removedSessionRefs,
+    from: window.from,
+    to: window.to,
   });
+}
+
+async function fetchSessionProjection(
+  queryClient: QueryClient,
+  signal: AbortSignal,
+  load: SessionProjectionLoad,
+): Promise<SessionProjection> {
+  const { window } = load;
+  const project = (sessions: SessionHead[]): SessionProjection => ({
+    sessions: load.event ? applyProjectionEvent(sessions, load.event, window).sessions : sessions,
+  });
+  const result = await fetchSessions(
+    { from: window.from, to: window.to },
+    { signal },
+    {
+      onFirstPage(sessions) {
+        if (!signal.aborted) {
+          queryClient.setQueryData(queryKeys.sessionProjection(window), project(sessions));
+        }
+      },
+    },
+  );
+  signal.throwIfAborted();
+  return project(result.sessions);
 }
 
 function removeOtherSessionProjections(
@@ -195,10 +222,21 @@ function sameWindow(
 
 export function useSessionStore(window: AppConfig["window"] | null) {
   const queryClient = useQueryClient();
+  const pendingProjectionLoad = useRef<SessionProjectionLoad | null>(null);
   const liveAggregateWindowRef = useRef<AppConfig["window"] | null>(null);
   const liveAggregateRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const projectionQuery = useQuery({
-    ...sessionProjectionOptions(queryClient, window ?? {}),
+    queryKey: queryKeys.sessionProjection(window ?? {}),
+    staleTime: Infinity,
+    queryFn: async ({ signal }): Promise<SessionProjection> => {
+      const load: SessionProjectionLoad = { window: window ?? {}, event: null };
+      pendingProjectionLoad.current = load;
+      try {
+        return await fetchSessionProjection(queryClient, signal, load);
+      } finally {
+        if (pendingProjectionLoad.current === load) pendingProjectionLoad.current = null;
+      }
+    },
     enabled: window !== null,
   });
   const agentsQuery = useQuery({
@@ -262,6 +300,12 @@ export function useSessionStore(window: AppConfig["window"] | null) {
     async (event: SessionsUpdatedEvent): Promise<LiveSessionApplyResult | null> => {
       if (!window) return null;
       const activeWindow = window;
+      const pendingLoad = pendingProjectionLoad.current;
+      if (pendingLoad && sameWindow(pendingLoad.window, activeWindow)) {
+        pendingLoad.event = pendingLoad.event
+          ? mergeSessionsUpdatedEvents(pendingLoad.event, event)
+          : event;
+      }
       const projectionKey = queryKeys.sessionProjection(activeWindow);
       const agentCatalogKey = queryKeys.agentCatalog(activeWindow);
       const dashboardKey = queryKeys.dashboard(activeWindow, {});
@@ -277,14 +321,7 @@ export function useSessionStore(window: AppConfig["window"] | null) {
         return { visibleNewSessions: 0 };
       }
 
-      const projection = applySessionWindowChanges(currentProjection.sessions, {
-        changedSessionHeads: event.changedSessionHeads,
-        projectionRelatedSessionHeads: event.projectionRelatedSessionHeads,
-        projectionSessionOrder: event.projectionSessionOrder,
-        removedSessionRefs: event.removedSessionRefs,
-        from: activeWindow.from,
-        to: activeWindow.to,
-      });
+      const projection = applyProjectionEvent(currentProjection.sessions, event, activeWindow);
       const visibleSessionKeys = new Set(
         projection.sessions.map((session) => formatSessionReference(session.reference)),
       );


### PR DESCRIPTION
## Summary
- Preserve session additions, edits, and removals received over SSE while a full session request is in flight.
- Coalesce pending events with the existing contract merger and apply them to both the first page and the final response before updating the query cache.
- Keep pending events scoped to the active request and time window, and reject aborted results.

## Verification
- Reproduced a live title being overwritten by a delayed full response before the fix.
- Added hook regressions for events before the first page, multiple events during pagination, and removals during reload.
- Passed `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm format:check`, and the initial bundle budget test.

## Risk
- No API or persisted data changes. The existing event projection rules also handle replayed updates.
