### PR TITLE
web: Surface incomplete session loads

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -141,6 +141,47 @@ function dashboardRequests(): URLSearchParams[] {
     .filter((url) => url.startsWith("/api/dashboard"))
     .map((url) => new URLSearchParams(url.split("?")[1] ?? ""));
 }
+
+describe("App session loading", () => {
+  it("shows pagination progress and lets the user retry a failed later page", async () => {
+    responses["/api/agents"] = [{ name: "claudecode", displayName: "Claude Code", count: 2 }];
+    const finalSession = {
+      ...SAMPLE_SESSION_HEAD,
+      ...createSessionIdentity({ agentName: "claudecode", sessionId: "last-page-session" }),
+      title: "Session from the last page",
+    };
+    let failPage!: (response: Response) => void;
+    const secondPage = new Promise<Response>((resolve) => {
+      failPage = resolve;
+    });
+    let retry = false;
+    const defaultFetch = globalThis.fetch;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname !== "/api/sessions") return defaultFetch(input);
+      if (url.searchParams.has("cursor")) return secondPage;
+      return Response.json({
+        sessions: retry ? [SAMPLE_SESSION_HEAD, finalSession] : [SAMPLE_SESSION_HEAD],
+        nextCursor: retry ? undefined : "second-page",
+      });
+    });
+    renderAppAt("/claudecode");
+
+    await screen.findByText("Loading sessions… Results are not yet complete.");
+    await act(async () => {
+      failPage(new Response("second page unavailable", { status: 503 }));
+    });
+    await screen.findByText(/Displayed sessions may be incomplete/);
+    expect(screen.getAllByText(SAMPLE_SESSION_HEAD.title).length).toBeGreaterThan(0);
+
+    retry = true;
+    fireEvent.click(screen.getByRole("button", { name: "Retry session load" }));
+
+    await screen.findByText(finalSession.title);
+    expect(screen.queryByText(/Displayed sessions may be incomplete/)).toBeNull();
+    expect(screen.queryByText("Loading sessions… Results are not yet complete.")).toBeNull();
+  });
+});
 
 describe("App live updates", () => {
   it("preserves keyboard selection when a live update replaces the session list", async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -49,6 +49,8 @@ export default function App() {
     activeAgents,
     agentCatalog,
     sessions,
+    sessionsLoading,
+    sessionsError,
     projects,
     projectPage,
     projectsError,
@@ -61,6 +63,7 @@ export default function App() {
     applyLiveEvent,
     resyncLiveState,
     retryProjects,
+    retrySessions,
   } = sessionStore;
   const loading = appConfig.loading || (!appConfig.error && sessionStore.loading);
   const error = appConfig.error ?? sessionStore.error;
@@ -68,7 +71,7 @@ export default function App() {
   useWindowLoadTelemetry({
     window: timeWindow,
     pending: appConfig.loading || (!appConfig.error && sessionStore.loadPending),
-    error,
+    error: error ?? sessionsError,
     agentCount: sessionStore.agents.length,
     sessionCount: sessionStore.sessions.length,
   });
@@ -552,6 +555,26 @@ export default function App() {
                   ) : null}
                 </div>
                 <ScanStatusNotice visible={viewState.mode === "root"} />
+                {!loading && !error && (sessionsLoading || sessionsError) ? (
+                  <div
+                    role={sessionsError ? "alert" : "status"}
+                    className="console-mono mt-2 flex flex-wrap items-center gap-2 rounded-sm border border-[var(--console-warning-border)] bg-[var(--console-warning-bg)] px-2 py-1 text-[11px] text-[var(--console-warning)]"
+                  >
+                    <span>
+                      {sessionsError ?? "Loading sessions… Results are not yet complete."}
+                    </span>
+                    {sessionsError ? (
+                      <button
+                        type="button"
+                        disabled={sessionsLoading}
+                        onClick={() => void retrySessions()}
+                        className="rounded-sm border border-current px-2 py-1 focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none disabled:opacity-50"
+                      >
+                        Retry session load
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
             </section>
 

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -83,6 +83,59 @@ async function renderStore(window: AppConfig["window"] = config.window) {
 }
 
 describe("useSessionStore", () => {
+  it("exposes a later page failure without hiding already loaded sessions", async () => {
+    vi.mocked(api.fetchSessions).mockImplementationOnce(
+      async (_options, _fetchOptions, progress) => {
+        progress?.onFirstPage?.([SAMPLE_SESSION_HEAD]);
+        throw new Error("second page unavailable");
+      },
+    );
+    const { result, client } = await renderStore();
+    await waitFor(() =>
+      expect(client.getQueryState(queryKeys.sessionProjection(config.window))?.status).toBe(
+        "error",
+      ),
+    );
+    expect(result.current.sessionsError).toContain("incomplete");
+    expect(result.current.error).toBeNull();
+    expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]);
+
+    await act(() => result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
+    await waitFor(() =>
+      expect(result.current.sessions).toEqual(
+        SAMPLE_SESSIONS_UPDATED_EVENT.changedSessionHeads.map(({ session }) => session),
+      ),
+    );
+    await waitFor(() => expect(result.current.sessionsError).toContain("incomplete"));
+
+    await act(() => result.current.retrySessions());
+
+    await waitFor(() => expect(result.current.sessionsError).toBeNull());
+    expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]);
+  });
+
+  it("retains a complete projection when a refresh fails after its first page", async () => {
+    const secondSession = {
+      ...SAMPLE_SESSION_HEAD,
+      ...createSessionIdentity({ agentName: "claudecode", sessionId: "second-session" }),
+    };
+    const completeSessions = [SAMPLE_SESSION_HEAD, secondSession];
+    vi.mocked(api.fetchSessions).mockResolvedValueOnce({ sessions: completeSessions });
+    const { result } = await renderStore();
+    vi.mocked(api.fetchSessions).mockImplementationOnce(
+      async (_options, _fetchOptions, progress) => {
+        progress?.onFirstPage?.([SAMPLE_SESSION_HEAD]);
+        throw new Error("second page unavailable");
+      },
+    );
+
+    await act(() => result.current.retrySessions());
+
+    await waitFor(() => expect(result.current.sessionsError).not.toBeNull());
+    expect(result.current.sessions).toEqual(completeSessions);
+    expect(result.current.error).toBeNull();
+  });
+
   it("preserves live additions received while the first page is still loading", async () => {
     const response = deferred<{ sessions: SessionHead[] }>();
     let firstPage!: (sessions: SessionHead[]) => void;
@@ -276,6 +329,7 @@ describe("useSessionStore", () => {
 
     await waitFor(() => expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]));
     expect(result.current.loading).toBe(false);
+    expect(result.current.sessionsLoading).toBe(true);
     expect(
       client.getQueryData<SessionProjection>(queryKeys.sessionProjection(config.window))?.sessions,
     ).toEqual([SAMPLE_SESSION_HEAD]);
@@ -286,6 +340,7 @@ describe("useSessionStore", () => {
     await waitFor(() =>
       expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD, finalSession]),
     );
+    expect(result.current.sessionsLoading).toBe(false);
   });
 
   it("keeps the latest snapshot when an earlier request finishes late", async () => {

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -42,6 +42,7 @@ interface SessionStoreSnapshot {
 
 export interface SessionProjection {
   sessions: SessionHead[];
+  complete: boolean;
 }
 
 export interface LiveSessionApplyResult {
@@ -126,8 +127,9 @@ async function fetchSessionProjection(
   load: SessionProjectionLoad,
 ): Promise<SessionProjection> {
   const { window } = load;
-  const project = (sessions: SessionHead[]): SessionProjection => ({
+  const project = (sessions: SessionHead[], complete: boolean): SessionProjection => ({
     sessions: load.event ? applyProjectionEvent(sessions, load.event, window).sessions : sessions,
+    complete,
   });
   const result = await fetchSessions(
     { from: window.from, to: window.to },
@@ -135,13 +137,16 @@ async function fetchSessionProjection(
     {
       onFirstPage(sessions) {
         if (!signal.aborted) {
-          queryClient.setQueryData(queryKeys.sessionProjection(window), project(sessions));
+          queryClient.setQueryData<SessionProjection>(
+            queryKeys.sessionProjection(window),
+            (previous) => previous ?? project(sessions, false),
+          );
         }
       },
     },
   );
   signal.throwIfAborted();
-  return project(result.sessions);
+  return project(result.sessions, true);
 }
 
 function removeOtherSessionProjections(
@@ -389,6 +394,11 @@ export function useSessionStore(window: AppConfig["window"] | null) {
     }
   }, [reload, window]);
 
+  const retrySessions = useCallback(async (): Promise<void> => {
+    if (!window) return;
+    await refetchProjection({ cancelRefetch: true });
+  }, [refetchProjection, window]);
+
   const displayedSnapshot = querySnapshot;
   const agents = displayedSnapshot?.agents ?? EMPTY_AGGREGATES.agents;
   const projectPage = projectsQuery.data ?? EMPTY_PROJECT_PAGE;
@@ -419,6 +429,12 @@ export function useSessionStore(window: AppConfig["window"] | null) {
     window: displayedSnapshot?.window ?? null,
     agents,
     sessions: displayedSnapshot?.sessions ?? EMPTY_SESSIONS,
+    sessionsLoading: projectionQuery.isFetching,
+    sessionsError:
+      projectionQuery.data !== undefined &&
+      (projectionQuery.isError || (!projectionQuery.data.complete && !projectionQuery.isFetching))
+        ? "Session loading failed. Displayed sessions may be incomplete or out of date."
+        : null,
     projects,
     projectPage,
     projectsError,
@@ -440,6 +456,7 @@ export function useSessionStore(window: AppConfig["window"] | null) {
     applyLiveEvent,
     resyncLiveState,
     retryLoad,
+    retrySessions,
     retryProjects,
   };
 }


### PR DESCRIPTION
## Summary
- Distinguish a first-page projection from a fully loaded session list, and retain the complete cached list during refreshes.
- Show nonblocking pagination progress and failure notices, with a dedicated session retry action. Include partial failures in load telemetry.
- Preserve incomplete-load warnings across live cache updates, which otherwise reset the query status to success.

## Verification
- Reproduced a failed second page leaving one session visible with no error or pending indication.
- Reproduced SSE cache updates clearing the query error despite the list still being incomplete.
- Added hook regressions for partial failure, live updates after failure, retry recovery, and retaining a complete list during a failed refresh.
- Added an App test covering paginated HTTP failure, the visible warning, and the retry button.
- Passed `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm format:check`, and the initial bundle budget test.

## Risk
- No server or persisted data changes. Available sessions remain usable while loading or retrying.
