### PR TITLE
web: Refresh active dashboard scopes on live events

### DIFF
--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -560,6 +560,32 @@ describe("useSessionStore", () => {
     expect(client.getQueryState(inactiveAgentCatalogKey)?.isInvalidated).toBe(false);
   });
 
+  it("refreshes the visible scoped dashboard after a live event", async () => {
+    const filters = { project: { kind: "path" as const, key: "p1" }, agent: "claudecode" };
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(
+      () => ({
+        store: useSessionStore(config.window),
+        scoped: useDashboard(config.window, filters),
+      }),
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => expect(result.current.store.loading).toBe(false));
+    await waitFor(() => expect(result.current.scoped.dashboard).toEqual(SAMPLE_DASHBOARD_DATA));
+    const liveDashboard = {
+      ...SAMPLE_DASHBOARD_DATA,
+      totals: { ...SAMPLE_DASHBOARD_DATA.totals, sessions: 50 },
+    };
+    vi.mocked(api.fetchDashboard).mockImplementation(async (_window, scope) =>
+      scope?.project ? liveDashboard : SAMPLE_DASHBOARD_DATA,
+    );
+
+    await act(() => result.current.store.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT));
+
+    await waitFor(() => expect(result.current.scoped.dashboard).toEqual(liveDashboard));
+    expect(api.fetchDashboard).toHaveBeenCalledTimes(4);
+  });
+
   it("invalidates only session details changed by a live event", async () => {
     const { result, client } = await renderStore();
     await act(() => result.current.reload());
@@ -612,7 +638,10 @@ describe("useSessionStore", () => {
     await act(() => result.current.reload());
     vi.mocked(api.fetchSessions).mockClear();
     const firstAgents = deferred<AgentInfo[]>();
-    vi.mocked(api.fetchAgents).mockReturnValueOnce(firstAgents.promise).mockResolvedValue(agents);
+    vi.mocked(api.fetchAgents)
+      .mockClear()
+      .mockReturnValueOnce(firstAgents.promise)
+      .mockResolvedValue(agents);
 
     let firstUpdate!: ReturnType<typeof result.current.applyLiveEvent>;
     let secondUpdate!: ReturnType<typeof result.current.applyLiveEvent>;
@@ -620,8 +649,10 @@ describe("useSessionStore", () => {
       firstUpdate = result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
       secondUpdate = result.current.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
     });
-    firstAgents.resolve(agents);
     await act(() => Promise.all([firstUpdate, secondUpdate]));
+    expect(api.fetchAgents).toHaveBeenCalledOnce();
+    firstAgents.resolve(agents);
+    await act(async () => firstAgents.promise);
 
     expect(api.fetchSessions).not.toHaveBeenCalled();
     expect(result.current.version).toBeGreaterThan(0);

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -90,17 +90,6 @@ function agentCatalogOptions(window: AppConfig["window"]) {
   });
 }
 
-async function fetchSnapshotAggregates(
-  queryClient: QueryClient,
-  window: AppConfig["window"],
-): Promise<SnapshotAggregates> {
-  const [agents, dashboard] = await Promise.all([
-    queryClient.fetchQuery(agentCatalogOptions(window)),
-    queryClient.fetchQuery(dashboardQueryOptions(window, {})),
-  ]);
-  return { agents, dashboard };
-}
-
 interface SessionProjectionLoad {
   window: AppConfig["window"];
   event: SessionsUpdatedEvent | null;
@@ -171,21 +160,19 @@ function createSnapshot(
 async function refreshLiveSnapshotAggregates(
   queryClient: QueryClient,
   window: AppConfig["window"],
-): Promise<SnapshotAggregates> {
+): Promise<void> {
   const agentOptions = agentCatalogOptions(window);
   await Promise.all([
-    queryClient.invalidateQueries({
-      queryKey: agentOptions.queryKey,
-      exact: true,
-      refetchType: "none",
-    }),
-    queryClient.invalidateQueries({
-      queryKey: queryKeys.dashboards,
-      refetchType: "none",
-    }),
+    queryClient.invalidateQueries(
+      { queryKey: agentOptions.queryKey, exact: true, refetchType: "active" },
+      { throwOnError: true, cancelRefetch: false },
+    ),
+    queryClient.invalidateQueries(
+      { queryKey: queryKeys.dashboards, refetchType: "active" },
+      { throwOnError: true, cancelRefetch: false },
+    ),
     queryClient.invalidateQueries({ queryKey: queryKeys.searches }),
   ]);
-  return fetchSnapshotAggregates(queryClient, window);
 }
 
 async function refreshLiveProjects(


### PR DESCRIPTION
## Summary
- Refresh active project/agent dashboard queries when session events invalidate aggregate data.
- Use one refresh path for both global and scoped statistics, removing the redundant explicit aggregate fetch.
- Keep inactive dashboards invalidated without fetching them, and reuse in-flight requests when live events overlap.

## Verification
- Reproduced an active scoped dashboard remaining invalidated with only its initial request after an SSE event.
- Added a regression verifying scoped totals update after the event.
- Extended the overlapping-event test to verify an in-flight aggregate request is reused.
- Existing tests cover aggregate throttling, trailing refreshes, inactive queries, and failure handling.
- Passed `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm format:check`, `pnpm test:coverage`, and the initial bundle budget test.

## Risk
- No API changes. The existing aggregate refresh interval is preserved; only active dashboard scopes issue requests.
