### PR TITLE
search: Reuse maintenance session lookups

### DIFF
--- a/packages/cli/src/search-index-maintenance-scheduler.test.ts
+++ b/packages/cli/src/search-index-maintenance-scheduler.test.ts
@@ -60,6 +60,43 @@ beforeEach(() => {
 });
 
 describe("SearchIndexMaintenanceScheduler", () => {
+  it.each([1_000, 2_000])("indexes %i sessions with linear lookup work", async (size) => {
+    let referenceReads = 0;
+    const sessionIds = Array.from({ length: size }, (_, index) => `session-${index}`);
+    const sessions = sessionIds.map((id) => {
+      const session = makeSession(id);
+      const reference = session.reference;
+      Object.defineProperty(session, "reference", {
+        get() {
+          referenceReads += 1;
+          return reference;
+        },
+      });
+      return session;
+    });
+    core.readCachedSessions.mockReturnValue({
+      status: "success",
+      value: { sessions, meta: {}, timestamp: 1 },
+    });
+    let processed = 0;
+    core.readPendingSearchIndexMaintenance.mockImplementation((_agent, limit: number) => ({
+      sessionIds: sessionIds.slice(processed, processed + limit),
+      total: size - processed,
+    }));
+    const runner = makeRunner();
+    runner.enqueueMaintenance.mockImplementation(async (_context, jobs) => {
+      const job = jobs[0];
+      if (job?.kind === "maintenance") processed += job.changes.length;
+    });
+    const scheduler = new SearchIndexMaintenanceScheduler(runner as never, () => undefined);
+
+    scheduler.enqueue("codex");
+    await scheduler.waitForIdle();
+
+    expect(processed).toBe(size);
+    expect(referenceReads).toBeLessThanOrEqual(size * 3);
+  });
+
   it("commits bounded resumable batches until no maintenance remains", async () => {
     core.readPendingSearchIndexMaintenance
       .mockReturnValueOnce({ sessionIds: ["one", "two"], total: 3 })
@@ -87,12 +124,56 @@ describe("SearchIndexMaintenanceScheduler", () => {
     expect(jobs.map((job) => (job?.kind === "maintenance" ? job.changes.length : 0))).toEqual([
       2, 1,
     ]);
+    expect(
+      jobs.flatMap((job) =>
+        job?.kind === "maintenance"
+          ? job.changes.map(({ session, sortIndex }) => [session.reference.sessionId, sortIndex])
+          : [],
+      ),
+    ).toEqual([
+      ["one", 0],
+      ["two", 1],
+      ["three", 2],
+    ]);
     expect(statuses.at(-1)).toEqual({
       active: false,
       pendingAgents: [],
       completedAgents: ["codex"],
       failedAgents: [],
     });
+  });
+
+  it("rebuilds the lookup when a new cache snapshot is enqueued during a batch", async () => {
+    core.readPendingSearchIndexMaintenance
+      .mockReturnValueOnce({ sessionIds: ["one", "two"], total: 3 })
+      .mockReturnValueOnce({ sessionIds: ["three"], total: 1 })
+      .mockReturnValueOnce({ sessionIds: ["three"], total: 1 })
+      .mockReturnValueOnce({ sessionIds: [], total: 0 });
+    let finishBatch!: () => void;
+    const firstBatch = new Promise<void>((resolve) => {
+      finishBatch = resolve;
+    });
+    const runner = makeRunner();
+    runner.enqueueMaintenance.mockReturnValueOnce(firstBatch);
+    const scheduler = new SearchIndexMaintenanceScheduler(runner as never, () => undefined);
+
+    scheduler.enqueue("codex");
+    const updated = { ...makeSession("three"), title: "Updated session" };
+    core.readCachedSessions.mockReturnValue({
+      status: "success",
+      value: { sessions: [updated], meta: { three: { id: "three" } }, timestamp: 2 },
+    });
+    scheduler.enqueue("codex");
+    finishBatch();
+    await scheduler.waitForIdle();
+
+    expect(core.readCachedSessions).toHaveBeenCalledTimes(2);
+    expect(runner.enqueueMaintenance.mock.calls[1]?.[1]).toEqual([
+      expect.objectContaining({
+        changes: [{ session: updated, sortIndex: 0 }],
+        meta: { three: { id: "three" } },
+      }),
+    ]);
   });
 
   it("stops retrying a batch that cannot clear any durable marker", async () => {

--- a/packages/cli/src/search-index-maintenance-scheduler.ts
+++ b/packages/cli/src/search-index-maintenance-scheduler.ts
@@ -15,11 +15,16 @@ const MAINTENANCE_BATCH_SIZE = 4;
 
 type StatusListener = (status: SearchIndexMaintenanceStatus) => void;
 
+interface IndexedSessionCache {
+  sessionsById: Map<string, PersistedSessionHeadChange<IdentifiedSessionHead>>;
+  meta: CachedResult["meta"];
+}
+
 export class SearchIndexMaintenanceScheduler {
   private readonly pendingAgents = new Set<string>();
   private readonly completedAgents = new Set<string>();
   private readonly failedAgents = new Set<string>();
-  private readonly cachedSessionsByAgent = new Map<string, CachedResult>();
+  private readonly cachedSessionsByAgent = new Map<string, IndexedSessionCache>();
   private currentAgent: string | undefined;
   private remaining: number | undefined;
   private pumpPromise: Promise<void> | null = null;
@@ -98,19 +103,21 @@ export class SearchIndexMaintenanceScheduler {
       if (outcome.status === "failed") {
         throw new Error(`Session cache read failed for ${agentName}`);
       }
-      cached = outcome.value ?? undefined;
+      if (!outcome.value) throw new Error(`Session cache is unavailable for ${agentName}`);
+      cached = {
+        sessionsById: new Map(
+          outcome.value.sessions.map((session, sortIndex) => [
+            session.reference.sessionId,
+            { session, sortIndex },
+          ]),
+        ),
+        meta: outcome.value.meta,
+      };
+      this.cachedSessionsByAgent.set(agentName, cached);
     }
-    if (!cached) throw new Error(`Session cache is unavailable for ${agentName}`);
-    this.cachedSessionsByAgent.set(agentName, cached);
-    const sessionsById = new Map(
-      cached.sessions.map((session, sortIndex) => [
-        session.reference.sessionId,
-        { session, sortIndex },
-      ]),
-    );
     const changes = pending.sessionIds.flatMap(
       (sessionId): PersistedSessionHeadChange<IdentifiedSessionHead>[] => {
-        const change = sessionsById.get(sessionId);
+        const change = cached.sessionsById.get(sessionId);
         return change ? [change] : [];
       },
     );


### PR DESCRIPTION
## Summary
- Build the session-ID lookup once per cached maintenance snapshot and reuse it across bounded batches.
- Retain the existing invalidation on enqueue, completion, failure, and stop, including a new snapshot arriving while a batch is running.
- Preserve the original session ordering and per-session metadata.

## Verification
- Measured reference accesses for a full maintenance pass: 1,000 sessions decreased from 251,000 to 2,000; 2,000 sessions decreased from 1,002,000 to 4,000.
- Added deterministic linear-work regressions for both sizes, and a regression for replacing the cache during an in-flight batch.
- Extended existing batch tests to verify sort indices. All six scheduler tests passed.
- Passed `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm format:check`, and `pnpm perf:check`.

## Risk
- Lookup work becomes O(n) across the maintenance pass with O(n) retained memory. Batch size, job payloads, and durable progress behavior are unchanged.
