### PR TITLE
web: Decouple session readiness from statistics

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -278,7 +278,9 @@ describe("App dashboard scope wiring", () => {
 
     renderAppAt("/projects/path/%2Foutside-first-page");
 
-    expect(await screen.findByRole("heading", { name: "outside-first-page" })).toBeTruthy();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "outside-first-page" }),
+    ).toBeTruthy();
     expect(requestedUrls.some((url) => url.includes("projectKey=%2Foutside-first-page"))).toBe(
       true,
     );

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -10,6 +10,8 @@ import { appRouteChildren } from "./lib/app-routes";
 import { createQueryClient } from "./lib/query-client";
 import { ScanStatusProvider } from "./hooks/useScanStatus";
 
+const LAZY_SURFACE_TIMEOUT_MS = 5_000;
+
 const liveSubscription = vi.hoisted(() => ({
   onUpdate: undefined as ((event: SessionsUpdatedEvent) => void) | undefined,
 }));
@@ -143,6 +145,41 @@ function dashboardRequests(): URLSearchParams[] {
 }
 
 describe("App session loading", () => {
+  it("opens session details when dashboard loading fails and retries statistics independently", async () => {
+    responses["/api/agents"] = [{ name: "claudecode", displayName: "Claude Code", count: 1 }];
+    responses["/api/sessions"] = { sessions: [SAMPLE_SESSION_HEAD] };
+    let dashboardAvailable = false;
+    const defaultFetch = globalThis.fetch;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/dashboard" && !dashboardAvailable) {
+        return new Response("statistics unavailable", { status: 503 });
+      }
+      if (url.pathname === "/api/sessions/claudecode/session-1") {
+        return Response.json({ ...SAMPLE_SESSION_HEAD, messages: [] });
+      }
+      return defaultFetch(input);
+    });
+    const { router } = renderAppAt("/claudecode/session-1");
+
+    await screen.findByTestId("session-detail", {}, { timeout: LAZY_SURFACE_TIMEOUT_MS });
+    expect(
+      screen.queryByText("Failed to load session data for the selected time window."),
+    ).toBeNull();
+
+    await act(() => router.navigate("/"));
+    await screen.findByText(
+      "Couldn't load the dashboard.",
+      {},
+      { timeout: LAZY_SURFACE_TIMEOUT_MS },
+    );
+    dashboardAvailable = true;
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.queryByText("Couldn't load the dashboard.")).toBeNull());
+    expect(screen.getByTestId("dashboard")).toBeTruthy();
+  });
+
   it("shows pagination progress and lets the user retry a failed later page", async () => {
     responses["/api/agents"] = [{ name: "claudecode", displayName: "Claude Code", count: 2 }];
     const finalSession = {

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentInfo,
   AppConfig,
+  DashboardData,
   ApiProjectGroup,
   ApiProjectPage,
   SessionHead,
@@ -83,6 +84,58 @@ async function renderStore(window: AppConfig["window"] = config.window) {
 }
 
 describe("useSessionStore", () => {
+  it("makes sessions ready before the initial dashboard request completes", async () => {
+    const dashboard = deferred<DashboardData>();
+    vi.mocked(api.fetchDashboard).mockReturnValueOnce(dashboard.promise);
+    const { result } = await renderStore();
+
+    expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]);
+    expect(result.current.window).toEqual(config.window);
+    expect(result.current.loadPending).toBe(false);
+    expect(result.current.dashboard).toBeNull();
+
+    const changed = { ...SAMPLE_SESSION_HEAD, title: "Live session before stats" };
+    await act(() =>
+      result.current.applyLiveEvent({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        changedSessionHeads: [{ reference: changed.reference, session: changed }],
+      }),
+    );
+    await waitFor(() => expect(result.current.sessions).toEqual([changed]));
+    await act(async () => {
+      dashboard.resolve(SAMPLE_DASHBOARD_DATA);
+    });
+
+    await waitFor(() => expect(result.current.dashboard).toEqual(SAMPLE_DASHBOARD_DATA));
+    expect(result.current.sessions).toEqual([changed]);
+    expect(api.fetchSessions).toHaveBeenCalledOnce();
+  });
+
+  it("keeps session data available when the initial dashboard request fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(api.fetchDashboard).mockRejectedValue(new Error("dashboard unavailable"));
+    const { result, client } = await renderStore();
+    await waitFor(() =>
+      expect(client.getQueryState(queryKeys.dashboard(config.window, {}))?.status).toBe("error"),
+    );
+
+    expect(result.current.sessions).toEqual([SAMPLE_SESSION_HEAD]);
+    expect(result.current.agents).toEqual(agents);
+    expect(result.current.error).toBeNull();
+    expect(result.current.loadPending).toBe(false);
+    expect(result.current.dashboard).toBeNull();
+
+    const changed = { ...SAMPLE_SESSION_HEAD, title: "Live session without stats" };
+    await act(() =>
+      result.current.applyLiveEvent({
+        ...SAMPLE_SESSIONS_UPDATED_EVENT,
+        changedSessionHeads: [{ reference: changed.reference, session: changed }],
+      }),
+    );
+    await waitFor(() => expect(result.current.sessions).toEqual([changed]));
+    expect(api.fetchSessions).toHaveBeenCalledOnce();
+  });
+
   it("exposes a later page failure without hiding already loaded sessions", async () => {
     vi.mocked(api.fetchSessions).mockImplementationOnce(
       async (_options, _fetchOptions, progress) => {

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -15,7 +15,6 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   type AgentInfo,
   type AppConfig,
-  type DashboardData,
   type ApiProjectGroup,
   type ApiProjectPage,
   type SessionHead,
@@ -33,13 +32,6 @@ import {
   invalidateSessionDerivedQueries,
 } from "../lib/session-query-consistency";
 
-interface SessionStoreSnapshot {
-  window: AppConfig["window"];
-  agents: AgentInfo[];
-  sessions: SessionHead[];
-  dashboard: DashboardData;
-}
-
 export interface SessionProjection {
   sessions: SessionHead[];
   complete: boolean;
@@ -47,11 +39,6 @@ export interface SessionProjection {
 
 export interface LiveSessionApplyResult {
   visibleNewSessions: number;
-}
-
-interface SnapshotAggregates {
-  agents: AgentInfo[];
-  dashboard: DashboardData;
 }
 
 const LIVE_AGGREGATE_REFRESH_INTERVAL_MS = DASHBOARD_STALE_TIME_MS;
@@ -67,10 +54,7 @@ const EMPTY_PROJECT_PAGE: ApiProjectPage = {
   },
 };
 
-const EMPTY_AGGREGATES = {
-  agents: [] satisfies AgentInfo[],
-  dashboard: null,
-};
+const EMPTY_AGENTS: AgentInfo[] = [];
 const EMPTY_SESSIONS: SessionHead[] = [];
 
 function projectsOptions(window: AppConfig["window"]) {
@@ -147,14 +131,6 @@ function removeOtherSessionProjections(
     queryKey: queryKeys.sessionProjections,
     predicate: (query) => query.queryHash !== activeProjectionHash,
   });
-}
-
-function createSnapshot(
-  window: AppConfig["window"],
-  aggregates: SnapshotAggregates,
-  sessions: SessionHead[],
-): SessionStoreSnapshot {
-  return { window, agents: aggregates.agents, dashboard: aggregates.dashboard, sessions };
 }
 
 async function refreshLiveSnapshotAggregates(
@@ -248,18 +224,8 @@ export function useSessionStore(window: AppConfig["window"] | null) {
   const refetchAgents = agentsQuery.refetch;
   const refetchDashboard = dashboardQuery.refetch;
   const refetchProjects = projectsQuery.refetch;
-  const dashboard = dashboardQuery.data;
-  const querySnapshot =
-    window !== null &&
-    projectionQuery.data &&
-    agentsQuery.data !== undefined &&
-    dashboard !== undefined
-      ? createSnapshot(
-          window,
-          { agents: agentsQuery.data, dashboard },
-          projectionQuery.data.sessions,
-        )
-      : null;
+  const hasSessionData =
+    window !== null && projectionQuery.data !== undefined && agentsQuery.data !== undefined;
 
   useEffect(() => {
     if (window) removeOtherSessionProjections(queryClient, window);
@@ -300,11 +266,9 @@ export function useSessionStore(window: AppConfig["window"] | null) {
       }
       const projectionKey = queryKeys.sessionProjection(activeWindow);
       const agentCatalogKey = queryKeys.agentCatalog(activeWindow);
-      const dashboardKey = queryKeys.dashboard(activeWindow, {});
       const currentProjection = queryClient.getQueryData<SessionProjection>(projectionKey);
       const currentAgents = queryClient.getQueryData<AgentInfo[]>(agentCatalogKey);
-      const currentDashboard = queryClient.getQueryData<DashboardData>(dashboardKey);
-      if (!currentProjection || currentAgents === undefined || currentDashboard === undefined) {
+      if (!currentProjection || currentAgents === undefined) {
         await reload();
         await Promise.all([
           invalidateLiveSessionDerivedQueries(queryClient, event),
@@ -386,8 +350,7 @@ export function useSessionStore(window: AppConfig["window"] | null) {
     await refetchProjection({ cancelRefetch: true });
   }, [refetchProjection, window]);
 
-  const displayedSnapshot = querySnapshot;
-  const agents = displayedSnapshot?.agents ?? EMPTY_AGGREGATES.agents;
+  const agents = hasSessionData ? agentsQuery.data : EMPTY_AGENTS;
   const projectPage = projectsQuery.data ?? EMPTY_PROJECT_PAGE;
   const projects = projectPage.projects;
   const projectsLoading = window === null || projectsQuery.isPending;
@@ -408,14 +371,13 @@ export function useSessionStore(window: AppConfig["window"] | null) {
   );
   const loadFailed =
     (projectionQuery.isError && projectionQuery.data === undefined) ||
-    (agentsQuery.isError && agentsQuery.data === undefined) ||
-    (dashboardQuery.isError && dashboardQuery.data === undefined);
+    (agentsQuery.isError && agentsQuery.data === undefined);
   const error = loadFailed ? "Failed to load session data for the selected time window." : null;
 
   return {
-    window: displayedSnapshot?.window ?? null,
+    window: hasSessionData ? window : null,
     agents,
-    sessions: displayedSnapshot?.sessions ?? EMPTY_SESSIONS,
+    sessions: hasSessionData ? projectionQuery.data.sessions : EMPTY_SESSIONS,
     sessionsLoading: projectionQuery.isFetching,
     sessionsError:
       projectionQuery.data !== undefined &&
@@ -426,13 +388,9 @@ export function useSessionStore(window: AppConfig["window"] | null) {
     projectPage,
     projectsError,
     projectsLoading,
-    dashboard: displayedSnapshot?.dashboard ?? EMPTY_AGGREGATES.dashboard,
-    loading: window === null || (!loadFailed && displayedSnapshot === null),
-    loadPending:
-      window === null ||
-      projectionQuery.isFetching ||
-      agentsQuery.isFetching ||
-      dashboardQuery.isFetching,
+    dashboard: window !== null ? (dashboardQuery.data ?? null) : null,
+    loading: window === null || (!loadFailed && !hasSessionData),
+    loadPending: window === null || projectionQuery.isFetching || agentsQuery.isFetching,
     error,
     version: projectionQuery.dataUpdatedAt,
     activeAgents: agentCatalog.active,


### PR DESCRIPTION
## Summary
- Make session readiness depend on the session projection and agent catalog, independently of dashboard loading or failure.
- Keep live session updates incremental when statistics are unavailable, and exclude dashboard requests from session-load telemetry readiness.
- Remove the redundant combined snapshot types and factory. Dashboard errors and retries remain owned by the existing statistics screen.

## Verification
- Reproduced a dashboard failure leaving one session in the cache but zero visible sessions and a global load error.
- Added hook regressions for slow and failed initial dashboard requests, including live updates while statistics are unavailable.
- Added an App regression proving session details remain accessible after a dashboard 503 and statistics can be retried independently.
- Used the existing lazy-surface test timeout budget for the new full-component integration test.
- Made the project lookup assertion target the page heading explicitly; earlier session readiness can render both page and section headings before the assertion runs.
- Passed `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm format:check`, `pnpm test:coverage`, the initial bundle budget test, and all 31 end-to-end tests.

## Risk
- No API or persisted data changes. Explicit full reload behavior is unchanged; initial session readiness no longer waits for optional statistics.
