### PR TITLE
www: Add Umami landing page analytics

### DIFF
--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -319,6 +319,17 @@ const jsonLd = {
       set:html={JSON.stringify(jsonLd)}
     />
     {
+      import.meta.env.PROD && (
+        <script
+          is:inline
+          defer
+          src="https://umami.xingkaixin.me/script.js"
+          data-website-id="ef9537a4-c9aa-4f4c-b228-78efa155a203"
+          data-domains={analyticsHost}
+        />
+      )
+    }
+    {
       analyticsEnabled && (
         <script
           is:inline

--- a/tests/e2e/www.spec.ts
+++ b/tests/e2e/www.spec.ts
@@ -28,6 +28,7 @@ test("keeps production analytics out of development", async ({ page }) => {
   await page.goto("/");
 
   await expect(page.locator('script[src*="cloudflareinsights.com"]')).toHaveCount(0);
+  await expect(page.locator('script[src="https://umami.xingkaixin.me/script.js"]')).toHaveCount(0);
 });
 
 for (const locale of locales) {


### PR DESCRIPTION
## Summary

- Add self-hosted Umami tracking to the shared landing page layout for English, Chinese, and Japanese pages.
- Load the deferred script only in production builds and restrict tracking to `codesesh.xingkaixin.me`.
- Preserve existing Cloudflare analytics and leave the local application unchanged.
- Extend the existing development analytics test to cover Umami.

## Verification

- `pnpm --filter @codesesh/www lint`
- `pnpm --filter @codesesh/www format:check`
- `pnpm exec oxfmt --check tests/e2e/www.spec.ts`
- `pnpm test:e2e --project=www-chromium` — 11 tests passed; includes the workspace build.
- Checked generated HTML for all three locales: each contains exactly one deferred Umami script with the supplied website ID and production domain restriction.

## Rollout

Tracking becomes active after the product site is deployed. No additional environment variables are required. Live event delivery has not been verified.
