### PR TITLE
Copy sessions as Markdown from action menus

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -102,6 +102,8 @@ beforeEach(() => {
   responses["/api/agents"] = [];
   responses["/api/projects"] = workspaceProjectPage;
   responses["/api/sessions"] = { sessions: [] };
+  responses["/api/bookmarks"] = { bookmarks: [] };
+  delete responses["/api/sessions/claudecode/session-1"];
   vi.stubGlobal("__APP_VERSION__", "0.0.0-test");
   vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
     const url = String(input);
@@ -145,6 +147,45 @@ function dashboardRequests(): URLSearchParams[] {
 }
 
 describe("App session loading", () => {
+  it("loads and copies an available bookmarked session as Markdown", async () => {
+    const sessionDetail = {
+      ...SAMPLE_SESSION_HEAD,
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          time_created: 1,
+          parts: [{ type: "text", text: "Copy this conversation" }],
+        },
+      ],
+    };
+    responses["/api/agents"] = [{ name: "claudecode", displayName: "Claude Code", count: 1 }];
+    responses["/api/bookmarks"] = {
+      bookmarks: [
+        {
+          reference: SAMPLE_SESSION_HEAD.reference,
+          bookmarkedAt: 1,
+          availability: "available",
+          session: SAMPLE_SESSION_HEAD,
+        },
+      ],
+    };
+    responses["/api/sessions/claudecode/session-1"] = sessionDetail;
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    renderAppAt("/");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Session options" }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Copy as Markdown" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce());
+    expect(writeText.mock.calls[0]?.[0]).toContain("## User\n\nCopy this conversation");
+    expect(await screen.findByText("Session copied as Markdown.")).toBeTruthy();
+  });
+
   it("opens session details when dashboard loading fails and retries statistics independently", async () => {
     responses["/api/agents"] = [{ name: "claudecode", displayName: "Claude Code", count: 1 }];
     responses["/api/sessions"] = { sessions: [SAMPLE_SESSION_HEAD] };

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -38,6 +38,7 @@ import { formatSearchSubtitle } from "./lib/scan-format";
 import { findAgent } from "./lib/agents";
 import { getProjectIdentityKey } from "./lib/projects";
 import { buildSessionIndexes, getSessionAgentKey } from "./lib/session-indexes";
+import { useCopySessionAsMarkdown } from "./hooks/useCopySessionAsMarkdown";
 
 export default function App() {
   const navigate = useNavigate();
@@ -95,6 +96,7 @@ export default function App() {
   } = useUiPreferences();
   const resolvedTheme = useTheme(theme);
   const [aliasTarget, setAliasTarget] = useState<SessionAliasTarget | null>(null);
+  const { copySessionAsMarkdown, sessionCopyNotice } = useCopySessionAsMarkdown();
 
   const routeMatches = useMatches();
   const viewState = useMemo(
@@ -450,6 +452,7 @@ export default function App() {
               onMobileNavigationOpenChange: setMobileNavigationOpen,
               onToggleBookmark: toggleBookmark,
               onSelectFlatSidebarSession: handleSelectFlatSidebarSession,
+              onCopySessionAsMarkdown: (sessionHead) => void copySessionAsMarkdown(sessionHead),
               onToggleSidebarSessionBookmark: handleToggleSidebarSessionBookmark,
               onRenameSession: handleRenameSession,
               onRenameBookmarkedSession: handleRenameBookmarkedSession,
@@ -548,6 +551,11 @@ export default function App() {
                   ) : null}
                 </div>
                 <div aria-live="polite">
+                  {sessionCopyNotice ? (
+                    <p className="console-mono mt-2 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-text)]">
+                      {sessionCopyNotice}
+                    </p>
+                  ) : null}
                   {liveNotice ? (
                     <p className="console-mono mt-2 inline-flex rounded-sm border border-[var(--console-border)] bg-[var(--console-surface-muted)] px-2 py-1 text-[11px] text-[var(--console-text)]">
                       {liveNotice}

--- a/apps/web/src/components/SessionActionsMenu.test.tsx
+++ b/apps/web/src/components/SessionActionsMenu.test.tsx
@@ -55,6 +55,25 @@ describe("SessionActionsMenu", () => {
     await waitFor(() => expect(document.activeElement).toBe(trigger));
   });
 
+  it("offers Markdown copy when the session content is available", async () => {
+    const onCopyAsMarkdown = vi.fn();
+    render(
+      <SessionActionsMenu
+        bookmarked={false}
+        onCopyAsMarkdown={onCopyAsMarkdown}
+        onRename={vi.fn()}
+        onToggleBookmark={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Session options" }));
+    const copyItem = await screen.findByRole("menuitem", { name: "Copy as Markdown" });
+    expect(copyItem.querySelector("svg")).not.toBeNull();
+    fireEvent.click(copyItem);
+
+    expect(onCopyAsMarkdown).toHaveBeenCalledOnce();
+  });
+
   it("returns focus to the trigger when an outside pointer closes the menu", async () => {
     render(
       <>

--- a/apps/web/src/components/SessionActionsMenu.tsx
+++ b/apps/web/src/components/SessionActionsMenu.tsx
@@ -1,13 +1,15 @@
 import { Menu } from "@base-ui/react/menu";
-import { MoreHorizontal, Pencil, Star } from "./ui/icons";
+import { Copy, MoreHorizontal, Pencil, Star } from "./ui/icons";
 import { useRef } from "react";
 
 export function SessionActionMenuItems({
   bookmarked,
+  onCopyAsMarkdown,
   onRename,
   onToggleBookmark,
 }: {
   bookmarked: boolean;
+  onCopyAsMarkdown?: () => void;
   onRename: () => void;
   onToggleBookmark: () => void;
 }) {
@@ -20,6 +22,15 @@ export function SessionActionMenuItems({
         <Pencil className="size-3" aria-hidden="true" />
         Rename
       </Menu.Item>
+      {onCopyAsMarkdown ? (
+        <Menu.Item
+          onClick={onCopyAsMarkdown}
+          className="motion-hover motion-press flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
+        >
+          <Copy className="size-3" aria-hidden="true" />
+          Copy as Markdown
+        </Menu.Item>
+      ) : null}
       <Menu.Item
         onClick={onToggleBookmark}
         className="motion-hover motion-press flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs text-[var(--console-text)] hover:bg-[var(--console-surface-muted)] data-[highlighted]:bg-[var(--console-surface-muted)] focus-visible:outline-none"
@@ -33,10 +44,12 @@ export function SessionActionMenuItems({
 
 export function SessionActionsMenu({
   bookmarked,
+  onCopyAsMarkdown,
   onRename,
   onToggleBookmark,
 }: {
   bookmarked: boolean;
+  onCopyAsMarkdown?: () => void;
   onRename: () => void;
   onToggleBookmark: () => void;
 }) {
@@ -60,6 +73,7 @@ export function SessionActionsMenu({
           >
             <SessionActionMenuItems
               bookmarked={bookmarked}
+              onCopyAsMarkdown={onCopyAsMarkdown}
               onRename={onRename}
               onToggleBookmark={onToggleBookmark}
             />

--- a/apps/web/src/components/SessionTreeSidebar.test.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.test.tsx
@@ -276,6 +276,7 @@ function patchShadowEventRetargeting() {
 
 function renderSessionTreeSidebar(sessions = [makeSession({ sessionId: "s1" })]) {
   const session = sessions[0]!;
+  const onCopySessionAsMarkdown = vi.fn();
   const onToggleBookmark = vi.fn();
   const onRenameSession = vi.fn();
   render(
@@ -285,6 +286,7 @@ function renderSessionTreeSidebar(sessions = [makeSession({ sessionId: "s1" })])
       selectedSessionReference={getSessionReferenceKey(session)}
       onSelectSession={() => {}}
       bookmarkedSessionReferences={new Set()}
+      onCopySessionAsMarkdown={onCopySessionAsMarkdown}
       onToggleBookmark={onToggleBookmark}
       onRenameSession={onRenameSession}
     />,
@@ -292,7 +294,15 @@ function renderSessionTreeSidebar(sessions = [makeSession({ sessionId: "s1" })])
   const shadowRoot = document.querySelector("file-tree-container")!.shadowRoot!;
   const item = shadowRoot.querySelector<HTMLElement>('[data-item-type="file"]')!;
   const decoration = item.querySelector<HTMLElement>('[data-item-section="decoration"] > span')!;
-  return { session, onToggleBookmark, onRenameSession, shadowRoot, item, decoration };
+  return {
+    session,
+    onCopySessionAsMarkdown,
+    onToggleBookmark,
+    onRenameSession,
+    shadowRoot,
+    item,
+    decoration,
+  };
 }
 
 function dispatch(target: HTMLElement, type: string, init: EventInit & { key?: string } = {}) {
@@ -360,6 +370,7 @@ describe("SessionTreeSidebar selection state", () => {
         selectedSessionReference={selectedSessionReference}
         onSelectSession={onSelectSession}
         bookmarkedSessionReferences={new Set()}
+        onCopySessionAsMarkdown={() => {}}
         onToggleBookmark={() => {}}
         onRenameSession={() => {}}
         groupByProject={false}
@@ -409,6 +420,16 @@ describe("SessionTreeSidebar session options menu", () => {
     expect(onToggleBookmark).toHaveBeenCalledWith(session);
     await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
     await waitFor(() => expect((item.getRootNode() as ShadowRoot).activeElement).toBe(item));
+  });
+
+  it("copies the session selected by the context menu", async () => {
+    const { session, onCopySessionAsMarkdown, decoration } = renderSessionTreeSidebar();
+
+    dispatch(decoration, "click");
+    const copyItem = await screen.findByRole("menuitem", { name: "Copy as Markdown" });
+    dispatch(copyItem, "click");
+
+    expect(onCopySessionAsMarkdown).toHaveBeenCalledWith(session);
   });
 
   it("scrolls an overflowing title once while hovered", async () => {
@@ -529,10 +550,13 @@ describe("SessionTreeSidebar session options menu", () => {
     await waitFor(() => expect(screen.queryByRole("menu")).not.toBeNull());
 
     const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
+    const copyItem = screen.getByRole("menuitem", { name: "Copy as Markdown" });
     const bookmarkItem = screen.getByRole("menuitem", { name: "Add bookmark" });
     await waitFor(() => expect(document.activeElement).toBe(renameItem));
 
     dispatch(renameItem, "keydown", { key: "ArrowDown" });
+    await waitFor(() => expect(document.activeElement).toBe(copyItem));
+    dispatch(copyItem, "keydown", { key: "ArrowDown" });
     await waitFor(() => expect(document.activeElement).toBe(bookmarkItem));
 
     dispatch(bookmarkItem, "keydown", { key: "Enter" });

--- a/apps/web/src/components/SessionTreeSidebar.tsx
+++ b/apps/web/src/components/SessionTreeSidebar.tsx
@@ -31,6 +31,7 @@ interface SessionTreeSidebarProps {
   selectedSessionReference: string | null;
   onSelectSession: (session: SessionHead) => void;
   bookmarkedSessionReferences: Set<string>;
+  onCopySessionAsMarkdown: (session: SessionHead) => void;
   onToggleBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
   /** False when the listing already covers one project. */
@@ -309,6 +310,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   selectedSessionReference,
   onSelectSession,
   bookmarkedSessionReferences,
+  onCopySessionAsMarkdown,
   onToggleBookmark,
   onRenameSession,
   groupByProject = true,
@@ -328,6 +330,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   const groupCountByPathRef = useRef(modelData.groupCountByPath);
   const sessionByPathRef = useRef(modelData.sessionByPath);
   const onSelectSessionRef = useRef(onSelectSession);
+  const onCopySessionAsMarkdownRef = useRef(onCopySessionAsMarkdown);
   const onToggleBookmarkRef = useRef(onToggleBookmark);
   const onRenameSessionRef = useRef(onRenameSession);
   const syncingActiveSelectionRef = useRef(false);
@@ -381,6 +384,10 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
   useEffect(() => {
     onSelectSessionRef.current = onSelectSession;
   }, [onSelectSession]);
+
+  useEffect(() => {
+    onCopySessionAsMarkdownRef.current = onCopySessionAsMarkdown;
+  }, [onCopySessionAsMarkdown]);
 
   useEffect(() => {
     onToggleBookmarkRef.current = onToggleBookmark;
@@ -503,6 +510,7 @@ export const SessionTreeSidebar = memo(function SessionTreeSidebar({
                   // Read the prop directly: a ref read during render lags one
                   // update behind, leaving an open menu with a stale label.
                   bookmarked={bookmarkedSessionReferences.has(getSessionReferenceKey(menuSession))}
+                  onCopyAsMarkdown={() => onCopySessionAsMarkdownRef.current(menuSession)}
                   onRename={() => onRenameSessionRef.current(menuSession)}
                   onToggleBookmark={() => onToggleBookmarkRef.current(menuSession)}
                 />

--- a/apps/web/src/components/app/AppSidebar.test.tsx
+++ b/apps/web/src/components/app/AppSidebar.test.tsx
@@ -27,6 +27,7 @@ function createActions(overrides: Partial<AppSidebarActions> = {}): AppSidebarAc
     onMobileNavigationOpenChange: vi.fn(),
     onToggleBookmark: vi.fn(),
     onSelectFlatSidebarSession: vi.fn(),
+    onCopySessionAsMarkdown: vi.fn(),
     onToggleSidebarSessionBookmark: vi.fn(),
     onRenameSession: vi.fn(),
     onRenameBookmarkedSession: vi.fn(),

--- a/apps/web/src/components/app/AppSidebar.tsx
+++ b/apps/web/src/components/app/AppSidebar.tsx
@@ -110,6 +110,7 @@ export interface AppSidebarActions {
   onMobileNavigationOpenChange: (open: boolean) => void;
   onToggleBookmark: (session: BookmarkView) => void;
   onSelectFlatSidebarSession: (session: SessionHead) => void;
+  onCopySessionAsMarkdown: (session: SessionHead) => void;
   onToggleSidebarSessionBookmark: (session: SessionHead) => void;
   onRenameSession: (session: SessionHead) => void;
   onRenameBookmarkedSession: (session: BookmarkView) => void;
@@ -191,6 +192,7 @@ export function AppSidebar({
     onMobileNavigationOpenChange,
     onToggleBookmark,
     onSelectFlatSidebarSession,
+    onCopySessionAsMarkdown,
     onToggleSidebarSessionBookmark,
     onRenameSession,
     onRenameBookmarkedSession,
@@ -371,6 +373,9 @@ export function AppSidebar({
                       )}
                       <SessionActionsMenu
                         bookmarked
+                        onCopyAsMarkdown={
+                          available ? () => onCopySessionAsMarkdown(bookmark.session) : undefined
+                        }
                         onRename={() => onRenameBookmarkedSession(bookmark)}
                         onToggleBookmark={() => onToggleBookmark(bookmark)}
                       />
@@ -403,6 +408,7 @@ export function AppSidebar({
                   selectedSessionReference={selectedSessionReference}
                   onSelectSession={handleSelectSession}
                   bookmarkedSessionReferences={bookmarkedSidebarSessionReferences}
+                  onCopySessionAsMarkdown={onCopySessionAsMarkdown}
                   onToggleBookmark={onToggleSidebarSessionBookmark}
                   onRenameSession={onRenameSession}
                   groupByProject={false}

--- a/apps/web/src/hooks/useCopySessionAsMarkdown.test.tsx
+++ b/apps/web/src/hooks/useCopySessionAsMarkdown.test.tsx
@@ -1,0 +1,49 @@
+import { act, renderHook } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQueryClient } from "../lib/query-client";
+import { useCopySessionAsMarkdown } from "./useCopySessionAsMarkdown";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchSessionData: vi.fn(),
+  logClientEvent: vi.fn(),
+}));
+const clipboardMocks = vi.hoisted(() => ({ writeToClipboard: vi.fn() }));
+
+vi.mock("../lib/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api")>()),
+  fetchSessionData: apiMocks.fetchSessionData,
+  logClientEvent: apiMocks.logClientEvent,
+}));
+vi.mock("../lib/clipboard", () => clipboardMocks);
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={createQueryClient()}>{children}</QueryClientProvider>;
+}
+
+describe("useCopySessionAsMarkdown", () => {
+  it("reports and clears a clipboard failure", async () => {
+    vi.useFakeTimers();
+    apiMocks.fetchSessionData.mockResolvedValue({ ...SAMPLE_SESSION_HEAD, messages: [] });
+    clipboardMocks.writeToClipboard.mockResolvedValue(false);
+    const { result } = renderHook(() => useCopySessionAsMarkdown(), { wrapper: Wrapper });
+
+    await act(() => result.current.copySessionAsMarkdown(SAMPLE_SESSION_HEAD));
+
+    expect(result.current.sessionCopyNotice).toBe("Couldn’t copy session as Markdown.");
+    expect(apiMocks.logClientEvent).toHaveBeenCalledWith(
+      "session.markdown_copy.error",
+      expect.objectContaining({ error: "Clipboard write failed" }),
+    );
+
+    act(() => vi.advanceTimersByTime(2_500));
+    expect(result.current.sessionCopyNotice).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/useCopySessionAsMarkdown.ts
+++ b/apps/web/src/hooks/useCopySessionAsMarkdown.ts
@@ -1,0 +1,46 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
+import { fetchSessionData, logClientEvent, type SessionHead } from "../lib/api";
+import { writeToClipboard } from "../lib/clipboard";
+import { queryKeys } from "../lib/query-keys";
+import { formatSessionAsMarkdown } from "../lib/session-markdown";
+
+const COPY_NOTICE_DURATION_MS = 2_500;
+
+export function useCopySessionAsMarkdown() {
+  const queryClient = useQueryClient();
+  const [notice, setNotice] = useState<{ message: string } | null>(null);
+
+  useEffect(() => {
+    if (!notice) return;
+    const timer = window.setTimeout(() => setNotice(null), COPY_NOTICE_DURATION_MS);
+    return () => window.clearTimeout(timer);
+  }, [notice]);
+
+  const copySessionAsMarkdown = useCallback(
+    async (sessionHead: SessionHead) => {
+      const { agentName, sessionId } = sessionHead.reference;
+      try {
+        const detail = await queryClient.fetchQuery({
+          queryKey: queryKeys.sessionDetail(agentName, sessionId),
+          queryFn: ({ signal }) => fetchSessionData(agentName, sessionId, { signal }),
+          staleTime: Infinity,
+        });
+        const copied = await writeToClipboard(formatSessionAsMarkdown(detail));
+        if (!copied) throw new Error("Clipboard write failed");
+        setNotice({ message: "Session copied as Markdown." });
+        logClientEvent("session.markdown_copy.done", { agent: agentName, session: sessionId });
+      } catch (error) {
+        setNotice({ message: "Couldn’t copy session as Markdown." });
+        logClientEvent("session.markdown_copy.error", {
+          agent: agentName,
+          session: sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    [queryClient],
+  );
+
+  return { copySessionAsMarkdown, sessionCopyNotice: notice?.message ?? null };
+}

--- a/apps/web/src/lib/session-markdown.test.ts
+++ b/apps/web/src/lib/session-markdown.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import type { Message, SessionDetail } from "./api";
+import { formatSessionAsMarkdown } from "./session-markdown";
+
+function session(messages: Message[], overrides: Partial<SessionDetail> = {}): SessionDetail {
+  return {
+    reference: { agentName: "codex", sessionId: "session-1" },
+    title: "Raw title",
+    display_title: "Demo Session",
+    directory: "/repo/codesesh",
+    time_created: 1,
+    stats: {
+      message_count: messages.length,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost: 0,
+    },
+    messages,
+    ...overrides,
+  };
+}
+
+describe("formatSessionAsMarkdown", () => {
+  it("preserves message order and renders every normalized part type", () => {
+    const markdown = formatSessionAsMarkdown(
+      session([
+        {
+          id: "user-1",
+          role: "user",
+          time_created: 1,
+          parts: [{ type: "text", text: "Please inspect `README.md`." }],
+        },
+        {
+          id: "assistant-1",
+          role: "assistant",
+          time_created: 2,
+          parts: [
+            { type: "reasoning", text: "I should read it." },
+            { type: "plan", text: "1. Read\n2. Answer", approval_status: "success" },
+            {
+              type: "tool",
+              tool: "read",
+              title: "Tool: read",
+              state: {
+                status: "completed",
+                input: { path: "README.md" },
+                output: [{ type: "text", text: "# CodeSesh" }],
+                metadata: { duration_ms: 12 },
+              },
+            },
+            { type: "text", text: "Done." },
+            { type: "image", url: "https://example.com/shot.png" },
+          ],
+        },
+        {
+          id: "tool-1",
+          role: "tool",
+          time_created: 3,
+          parts: [
+            {
+              type: "tool",
+              tool: "bash",
+              state: {
+                status: "error",
+                input: '{"command":"exit 1"}',
+                error: "command failed",
+              },
+            },
+            { type: "plan", text: "Do not run it again", approval_status: "fail" },
+          ],
+        },
+      ]),
+    );
+
+    expect(markdown).toBe(`# Demo Session
+
+- Agent: \`codex\`
+- Session ID: \`session-1\`
+- Directory: \`/repo/codesesh\`
+
+## User
+
+Please inspect \`README.md\`.
+
+## Assistant
+
+### Reasoning
+
+I should read it.
+
+### Plan
+
+1. Read
+2. Answer
+
+### Tool: \`read\`
+
+Status: \`completed\`
+
+#### Input
+
+\`\`\`json
+{
+  "path": "README.md"
+}
+\`\`\`
+
+#### Output
+
+\`\`\`json
+[
+  {
+    "type": "text",
+    "text": "# CodeSesh"
+  }
+]
+\`\`\`
+
+#### Metadata
+
+\`\`\`json
+{
+  "duration_ms": 12
+}
+\`\`\`
+
+Done.
+
+![Image](<https://example.com/shot.png>)
+
+## Tool
+
+### Tool: \`bash\`
+
+Status: \`error\`
+
+#### Input
+
+\`\`\`json
+{
+  "command": "exit 1"
+}
+\`\`\`
+
+#### Error
+
+\`\`\`text
+command failed
+\`\`\`
+
+### Rejected plan
+
+Do not run it again
+`);
+  });
+
+  it("uses a longer fence when tool text contains fenced Markdown", () => {
+    const markdown = formatSessionAsMarkdown(
+      session([
+        {
+          id: "assistant-1",
+          role: "assistant",
+          time_created: 1,
+          parts: [
+            {
+              type: "tool",
+              tool: "write",
+              state: { status: "completed", output: "before\n```ts\nconst x = 1;\n```\nafter" },
+            },
+          ],
+        },
+      ]),
+    );
+
+    expect(markdown).toContain("````text\nbefore\n```ts\nconst x = 1;\n```\nafter\n````");
+  });
+
+  it("omits embedded image data and empty messages", () => {
+    const markdown = formatSessionAsMarkdown(
+      session([
+        { id: "empty", role: "assistant", time_created: 1, parts: [] },
+        {
+          id: "image",
+          role: "user",
+          time_created: 2,
+          parts: [{ type: "image", mime_type: "image/png", data: "very-large-base64" }],
+        },
+      ]),
+    );
+
+    expect(markdown).toContain("## User\n\n_Embedded image (image/png) omitted._");
+    expect(markdown).not.toContain("## Assistant");
+    expect(markdown).not.toContain("very-large-base64");
+  });
+
+  it("states when a session has no displayable messages", () => {
+    expect(formatSessionAsMarkdown(session([]))).toContain("_No displayable messages._");
+  });
+});

--- a/apps/web/src/lib/session-markdown.ts
+++ b/apps/web/src/lib/session-markdown.ts
@@ -1,0 +1,124 @@
+import type { ImagePart, Message, MessagePart, SessionDetail, ToolPart } from "./api";
+import { getSessionDisplayTitle } from "./session-title";
+
+const messageRoleLabels = {
+  user: "User",
+  assistant: "Assistant",
+  tool: "Tool",
+} satisfies Record<Message["role"], string>;
+
+function backtickDelimiter(text: string, minimumLength: number): string {
+  let length = minimumLength;
+  for (const match of text.matchAll(/`+/g)) {
+    length = Math.max(length, match[0].length + 1);
+  }
+  return "`".repeat(length);
+}
+
+function inlineCode(value: string): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  const delimiter = backtickDelimiter(text, 1);
+  const needsPadding = text.startsWith("`") || text.endsWith("`");
+  return `${delimiter}${needsPadding ? " " : ""}${text}${needsPadding ? " " : ""}${delimiter}`;
+}
+
+function markdownCodeBlock(content: string, language: "json" | "text"): string {
+  const delimiter = backtickDelimiter(content, 3);
+  const closingLineBreak = content.endsWith("\n") ? "" : "\n";
+  return `${delimiter}${language}\n${content}${closingLineBreak}${delimiter}`;
+}
+
+function formattedToolValue(value: unknown): { content: string; language: "json" | "text" } {
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (parsed !== null && typeof parsed === "object") {
+        return { content: JSON.stringify(parsed, null, 2), language: "json" };
+      }
+    } catch {}
+    return { content: value, language: "text" };
+  }
+
+  try {
+    const content = JSON.stringify(value, null, 2);
+    if (content !== undefined) return { content, language: "json" };
+  } catch {}
+  return { content: String(value), language: "text" };
+}
+
+function toolValueSection(label: string, value: unknown): string {
+  const { content, language } = formattedToolValue(value);
+  return `#### ${label}\n\n${markdownCodeBlock(content, language)}`;
+}
+
+function toolLabel(part: ToolPart): string {
+  return (part.title?.trim() || part.tool.trim() || "tool").replace(/^tool:\s*/i, "");
+}
+
+function formatToolPart(part: ToolPart): string {
+  const sections = [
+    `### Tool: ${inlineCode(toolLabel(part))}`,
+    `Status: ${inlineCode(part.state.status)}`,
+  ];
+  if (part.state.input !== undefined) {
+    sections.push(toolValueSection("Input", part.state.input));
+  }
+  if (part.state.output !== undefined && part.state.output !== null) {
+    sections.push(toolValueSection("Output", part.state.output));
+  }
+  if (part.state.error !== undefined && part.state.error !== null) {
+    sections.push(toolValueSection("Error", part.state.error));
+  }
+  if (part.state.metadata !== undefined && part.state.metadata !== null) {
+    sections.push(toolValueSection("Metadata", part.state.metadata));
+  }
+  return sections.join("\n\n");
+}
+
+function formatImagePart(part: ImagePart): string {
+  const url = part.url?.trim();
+  if (url && !url.toLowerCase().startsWith("data:")) {
+    const destination = url.replaceAll("<", "%3C").replaceAll(">", "%3E").replaceAll("\n", "%0A");
+    return `![Image](<${destination}>)`;
+  }
+  return `_Embedded image (${part.mime_type ?? "unknown type"}) omitted._`;
+}
+
+function formatMessagePart(part: MessagePart): string {
+  switch (part.type) {
+    case "text":
+      return part.text.trim();
+    case "reasoning": {
+      const text = part.text.trim();
+      return text ? `### Reasoning\n\n${text}` : "";
+    }
+    case "plan": {
+      const text = part.text.trim();
+      if (!text) return "";
+      const heading = part.approval_status === "fail" ? "Rejected plan" : "Plan";
+      return `### ${heading}\n\n${text}`;
+    }
+    case "tool":
+      return formatToolPart(part);
+    case "image":
+      return formatImagePart(part);
+  }
+}
+
+function formatMessage(message: Message): string {
+  const content = message.parts.map(formatMessagePart).filter(Boolean).join("\n\n");
+  if (!content) return "";
+  return `## ${messageRoleLabels[message.role]}\n\n${content}`;
+}
+
+export function formatSessionAsMarkdown(session: SessionDetail): string {
+  const title = getSessionDisplayTitle(session).replace(/\s+/g, " ").trim() || "Session";
+  const metadata = [
+    `- Agent: ${inlineCode(session.reference.agentName)}`,
+    `- Session ID: ${inlineCode(session.reference.sessionId)}`,
+  ];
+  if (session.directory.trim()) metadata.push(`- Directory: ${inlineCode(session.directory)}`);
+  const messages = session.messages.map(formatMessage).filter(Boolean);
+  const content = messages.length > 0 ? messages.join("\n\n") : "_No displayable messages._";
+  return [`# ${title}`, metadata.join("\n"), content].join("\n\n") + "\n";
+}


### PR DESCRIPTION
## Summary

- add a `Copy as Markdown` action for available sessions in bookmark and session-tree menus
- serialize user, assistant, tool, reasoning, plan, text, and image parts in transcript order
- render tool input, output, error, and metadata in collision-safe fenced code blocks
- reuse cached session details when available and report clipboard success or failure

## Testing

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm typecheck:e2e`
- `pnpm build`
- `pnpm test`
- `pnpm test:coverage`
- `pnpm perf:check`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm test:migration`
- repository quality, release, documentation path, and documentation fact checks