### PR TITLE
time-window: Align calendar range semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ npx codesesh --no-open
 ### Filter by Time
 
 ```bash
-# Only show sessions active in the last 3 days
+# Only show sessions active in the last 3 local calendar days
 npx codesesh --days 3
 
 # Show all sessions (no time limit)
 npx codesesh --days 0
 
-# Show sessions active after a specific date (overrides --days)
+# Show sessions active on or after a specific date (overrides --days)
 npx codesesh --from 2025-01-01
 
 # Show sessions within a date range
@@ -195,11 +195,11 @@ agent's own data directory.
 | `--tls-key` | — | — | Path to the private key matching `--tls-cert` |
 | `--trust-proxy` | — | `false` | A reverse proxy in front of CodeSesh terminates TLS |
 | `--public-url` | — | — | Public HTTPS origin used with `--trust-proxy` for startup links |
-| `--days` | `-d` | `7` | Only include sessions active in the last N days (`0` = all time) |
+| `--days` | `-d` | `7` | Only include sessions active in the last N local calendar days (`0` = all time) |
 | `--cwd` | — | — | Filter to sessions from a project directory (`.` = current dir) |
 | `--agent` | `-a` | all | Filter to specific agent(s), comma-separated |
-| `--from` | — | — | Sessions active after this date `YYYY-MM-DD` (overrides `--days`) |
-| `--to` | — | — | Sessions active before this date `YYYY-MM-DD` |
+| `--from` | — | — | Sessions active on or after this date `YYYY-MM-DD` (overrides `--days`) |
+| `--to` | — | — | Sessions active on or before this date `YYYY-MM-DD` |
 | `--session` | `-s` | — | Directly open a session (`agent://session-id`) |
 | `--json` | `-j` | `false` | Print the session index as JSON and exit (metadata only, no messages) |
 | `--no-open` | — | `false` | Don't auto-open the browser |

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -173,6 +173,20 @@ describe("fetchDashboard", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/dashboard?days=0");
   });
 
+  it("sends exact bounds without a redundant days value", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(SAMPLE_DASHBOARD_DATA),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchDashboard({ from: 10, to: 20, days: 7 }, {});
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "/api/dashboard?from=1970-01-01T00%3A00%3A00.010Z&to=1970-01-01T00%3A00%3A00.020Z",
+    );
+  });
+
   it.each<[string, DashboardFilters, string]>([
     ["unfiltered", {}, "/api/dashboard?days=7"],
     [

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -292,8 +292,14 @@ export async function fetchDashboard(
   options?: FetchOptions,
 ): Promise<DashboardData> {
   const params = new URLSearchParams();
-  if (window?.days !== 0) appendTimeWindow(params, window);
-  if (window?.days != null) params.set("days", String(window.days));
+  if (window?.days === 0) {
+    params.set("days", "0");
+  } else if (window?.from != null) {
+    appendTimeWindow(params, window);
+  } else {
+    if (window?.to != null) params.set("to", String(window.to));
+    if (window?.days != null) params.set("days", String(window.days));
+  }
   if (filters.project) {
     params.set("projectKind", filters.project.kind);
     params.set("projectKey", filters.project.key);

--- a/apps/web/src/lib/time-window.test.ts
+++ b/apps/web/src/lib/time-window.test.ts
@@ -47,7 +47,15 @@ describe("time window URL state", () => {
   });
 
   it("re-resolves a preset fallback at the current local day", () => {
-    const result = resolveTimeWindow(new URLSearchParams(), { from: 10, to: 20, days: 7 }, now);
+    const result = resolveTimeWindow(
+      new URLSearchParams(),
+      {
+        from: new Date(2026, 6, 8).getTime(),
+        to: new Date(2026, 6, 15).getTime() - 1,
+        days: 7,
+      },
+      now,
+    );
 
     expect(result).toEqual({
       preset: "7d",
@@ -56,6 +64,21 @@ describe("time window URL state", () => {
         to: new Date(2026, 6, 15).getTime() - 1,
         days: 7,
       },
+    });
+  });
+
+  it("does not treat contradictory fallback bounds as a preset", () => {
+    const fallback = {
+      from: new Date(2026, 6, 1).getTime(),
+      to: new Date(2026, 6, 15).getTime() - 1,
+      days: 7,
+    };
+
+    expect(resolveTimeWindow(new URLSearchParams(), fallback, now)).toEqual({
+      preset: "custom",
+      window: fallback,
+      customFrom: "2026-07-01",
+      customTo: "2026-07-14",
     });
   });
 

--- a/apps/web/src/lib/time-window.ts
+++ b/apps/web/src/lib/time-window.ts
@@ -1,4 +1,10 @@
-import { addCalendarDays, startOfCalendarDay, toCalendarDayKey } from "@codesesh/core/contract";
+import {
+  addCalendarDays,
+  countCalendarDays,
+  parseCalendarDayBoundary,
+  startOfCalendarDay,
+  toCalendarDayKey,
+} from "@codesesh/core/contract";
 import type { AppConfig } from "./api";
 
 export type TimeWindow = AppConfig["window"];
@@ -22,27 +28,12 @@ function endOfLocalDay(timestamp: number): number {
   return addCalendarDays(timestamp, 1) - 1;
 }
 
-function parseLocalDate(value: string, endOfDay: boolean): number | null {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (!match) return null;
-  const year = Number(match[1]);
-  const month = Number(match[2]) - 1;
-  const day = Number(match[3]);
-  const date = endOfDay ? new Date(year, month, day + 1, 0, 0, 0, -1) : new Date(year, month, day);
-  const validation = new Date(year, month, day);
-  if (
-    validation.getFullYear() !== year ||
-    validation.getMonth() !== month ||
-    validation.getDate() !== day
-  ) {
-    return null;
-  }
-  return date.getTime();
-}
-
-function presetFromDefault(window: TimeWindow): TimeWindowPreset {
+function presetFromDefault(window: TimeWindow, now: number): TimeWindowPreset {
   if (window.days === 0 || window.from == null) return "all";
-  if (window.days === 7 || window.days === 14 || window.days === 30 || window.days === 90) {
+  if (
+    (window.days === 7 || window.days === 14 || window.days === 30 || window.days === 90) &&
+    countCalendarDays(window.from, window.to ?? now) === window.days
+  ) {
     return `${window.days}d`;
   }
   return "custom";
@@ -71,13 +62,13 @@ export function resolveTimeWindow(
   if (range === "custom") {
     const customFrom = params.get("from") ?? "";
     const customTo = params.get("to") ?? "";
-    const from = parseLocalDate(customFrom, false);
-    const to = parseLocalDate(customTo, true);
+    const from = parseCalendarDayBoundary(customFrom, "start");
+    const to = parseCalendarDayBoundary(customTo, "end");
     if (from != null && to != null && from <= to) {
       return { preset: range, window: { from, to }, customFrom, customTo };
     }
   }
-  const fallbackPreset = presetFromDefault(fallback);
+  const fallbackPreset = presetFromDefault(fallback, now);
   if (fallbackPreset !== "custom") {
     return { preset: fallbackPreset, window: presetWindow(fallbackPreset, now) };
   }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -67,7 +67,7 @@ npx codesesh
 # Choose a custom starting port
 npx codesesh --port 8080
 
-# Only show sessions active in the last 3 days
+# Only show sessions active in the last 3 local calendar days
 npx codesesh --days 3
 
 # Jump directly to a session
@@ -97,11 +97,11 @@ npx codesesh --trace
 | `--tls-key` | — | — | Path to the private key matching `--tls-cert`                          |
 | `--trust-proxy` | — | `false` | A reverse proxy in front of CodeSesh terminates TLS                    |
 | `--public-url` | — | — | Public HTTPS origin used with `--trust-proxy` for startup links       |
-| `--days`    | `-d`  | `7`     | Only include sessions active in the last N days (`0` = all time) |
+| `--days`    | `-d`  | `7`     | Only include sessions active in the last N local calendar days (`0` = all time) |
 | `--cwd`     | —     | —       | Filter to sessions from a project directory                 |
 | `--agent`   | `-a`  | all     | Filter to specific agent(s), comma-separated                |
-| `--from`    | —     | —       | Sessions active after this date `YYYY-MM-DD`                |
-| `--to`      | —     | —       | Sessions active before this date `YYYY-MM-DD`               |
+| `--from`    | —     | —       | Sessions active on or after this date `YYYY-MM-DD`          |
+| `--to`      | —     | —       | Sessions active on or before this date `YYYY-MM-DD`         |
 | `--session` | `-s`  | —       | Directly open a session (`agent://session-id`)              |
 | `--json`    | `-j`  | `false` | Print the session index as JSON and exit (metadata only)    |
 | `--no-open` | —     | `false` | Don't auto-open the browser                                 |

--- a/packages/cli/src/api/__tests__/handlers-state.test.ts
+++ b/packages/cli/src/api/__tests__/handlers-state.test.ts
@@ -811,6 +811,7 @@ describe("query boundary handlers", () => {
       query: {
         from: "2026-01-01T00:00:00.000Z",
         to: "2026-01-03T00:00:00.000Z",
+        days: "1",
       },
     });
     handleGetDashboard(custom as never, scanSource);

--- a/packages/cli/src/api/__tests__/handlers.test.ts
+++ b/packages/cli/src/api/__tests__/handlers.test.ts
@@ -1930,42 +1930,42 @@ describe("handleGetDashboard", () => {
     expect(todayBucket?.messages).toBe(7);
   });
 
-  it("uses the server default rolling window for dashboard totals", () => {
+  it("normalizes the server default to calendar-day dashboard totals", () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-05-02T12:00:00Z"));
+    vi.setSystemTime(new Date(2026, 4, 2, 12));
 
     const now = Date.now();
-    const yesterdayInRollingWindow = makeSession("yesterday-active", {
-      time_created: new Date("2026-05-01T18:00:00Z").getTime(),
-      time_updated: new Date("2026-05-01T18:00:00Z").getTime(),
+    const yesterdayActive = makeSession("yesterday-active", {
+      time_created: new Date(2026, 4, 1, 18).getTime(),
+      time_updated: new Date(2026, 4, 1, 18).getTime(),
     });
     const todayActive = makeSession("today-active", {
-      time_created: new Date("2026-05-02T08:00:00Z").getTime(),
-      time_updated: new Date("2026-05-02T08:00:00Z").getTime(),
+      time_created: new Date(2026, 4, 2, 8).getTime(),
+      time_updated: new Date(2026, 4, 2, 8).getTime(),
     });
     const stale = makeSession("stale", {
-      time_created: new Date("2026-05-01T08:00:00Z").getTime(),
-      time_updated: new Date("2026-05-01T08:00:00Z").getTime(),
+      time_created: new Date(2026, 4, 1, 8).getTime(),
+      time_updated: new Date(2026, 4, 1, 8).getTime(),
     });
 
     const c = makeMockContext();
     handleGetDashboard(
       c,
       makeScanSource({
-        sessions: [yesterdayInRollingWindow, todayActive, stale],
-        byAgent: { claudecode: [yesterdayInRollingWindow, todayActive, stale] },
+        sessions: [yesterdayActive, todayActive, stale],
+        byAgent: { claudecode: [yesterdayActive, todayActive, stale] },
       }),
       { from: now - 86400000, days: 1 },
     );
 
     const response = c.json.mock.calls[0]![0];
-    expect(response.totals.sessions).toBe(2);
+    expect(response.totals.sessions).toBe(1);
     expect(
       response.dailyActivity.reduce(
         (sum: number, bucket: { sessions: number }) => sum + bucket.sessions,
         0,
       ),
-    ).toBe(2);
+    ).toBe(1);
   });
 
   it("reports the preceding equal-length window as the compare baseline", () => {
@@ -2016,14 +2016,14 @@ describe("handleGetDashboard", () => {
     });
   });
 
-  it("keys the aggregate cache on the compare window", () => {
+  it("does not fragment the aggregate cache on redundant days", () => {
     const source = makeScanSource();
     const to = "2026-07-26T12:00:00.000Z";
 
     handleGetDashboard(makeMockContext({ query: { from: "2026-07-20", to } }), source);
     handleGetDashboard(makeMockContext({ query: { from: "2026-07-20", to, days: "3" } }), source);
 
-    expect(coreMocks.buildDashboard).toHaveBeenCalledTimes(2);
+    expect(coreMocks.buildDashboard).toHaveBeenCalledTimes(1);
   });
 
   it("reuses storage aggregations until the analytics revision changes", () => {

--- a/packages/cli/src/api/handlers.ts
+++ b/packages/cli/src/api/handlers.ts
@@ -6,7 +6,6 @@ import type {
 } from "@codesesh/core/runtime/discovery";
 import {
   addCalendarDays,
-  countCalendarDays,
   type SessionTree,
   type AppConfig,
   type SessionReference,
@@ -655,10 +654,7 @@ export function handleGetDashboard(
     projectKey: projectIdentity?.key,
   };
 
-  const compare =
-    from == null
-      ? undefined
-      : { from: addCalendarDays(from, -(days ?? countCalendarDays(from, to))), to: from - 1 };
+  const compare = from == null ? undefined : { from: addCalendarDays(from, -days), to: from - 1 };
 
   const fixedTo = dateWindow.to;
   const cacheTo = fixedTo ?? startOfCalendarDay(to);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -87,7 +87,7 @@ const main = defineCommand({
     days: {
       type: "string",
       alias: "d",
-      description: "Only include sessions active in the last N days (0 = all time)",
+      description: "Only include sessions active in the last N local calendar days (0 = all time)",
       default: "7",
     },
     cwd: {
@@ -96,11 +96,11 @@ const main = defineCommand({
     },
     from: {
       type: "string",
-      description: "Sessions active after this date, YYYY-MM-DD (overrides --days)",
+      description: "Sessions active on or after this date, YYYY-MM-DD (overrides --days)",
     },
     to: {
       type: "string",
-      description: "Sessions active before this date (YYYY-MM-DD)",
+      description: "Sessions active on or before this date (YYYY-MM-DD)",
     },
     session: {
       type: "string",

--- a/packages/cli/src/runtime-plan.test.ts
+++ b/packages/cli/src/runtime-plan.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { addCalendarDays, startOfCalendarDay } from "@codesesh/core/contract";
 import {
   buildCliRuntimePlan,
   parseSessionUri,
@@ -8,14 +9,14 @@ import {
 } from "./runtime-plan.js";
 
 const NOW = new Date("2026-07-17T08:00:00.000Z").getTime();
-const DAY_MS = 24 * 60 * 60 * 1000;
 const ENVIRONMENT = {
   currentWorkingDirectory: "/workspace/project",
   now: NOW,
 };
 
 describe("CLI runtime plan", () => {
-  it("builds the default rolling scan plan", () => {
+  it("builds the default calendar-day scan plan", () => {
+    const from = addCalendarDays(startOfCalendarDay(NOW), -6);
     expect(
       buildCliRuntimePlan(
         {
@@ -27,9 +28,9 @@ describe("CLI runtime plan", () => {
         ENVIRONMENT,
       ),
     ).toEqual({
-      listWindow: { from: NOW - 7 * DAY_MS, to: undefined, days: 7 },
+      listWindow: { from, to: undefined, days: 7 },
       scanOptions: { agents: undefined, cwd: undefined, useCache: true },
-      startupScanOptions: { from: NOW - 7 * DAY_MS, to: undefined },
+      startupScanOptions: { from, to: undefined },
     });
   });
 
@@ -83,8 +84,8 @@ describe("CLI runtime plan", () => {
     );
 
     expect(plan.listWindow).toEqual({
-      from: new Date("2026-07-01").getTime(),
-      to: new Date("2026-07-10").getTime(),
+      from: new Date(2026, 6, 1).getTime(),
+      to: new Date(2026, 6, 11).getTime() - 1,
     });
     expect(plan.startupScanOptions).toEqual({});
   });

--- a/packages/cli/src/time-window-resolution.test.ts
+++ b/packages/cli/src/time-window-resolution.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { addCalendarDays, startOfCalendarDay } from "@codesesh/core/contract";
 import { resolveTimeWindow } from "./time-window-resolution.js";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
 const NOW = new Date("2026-07-17T08:00:00.000Z").getTime();
 
 describe("resolveTimeWindow", () => {
@@ -15,9 +14,9 @@ describe("resolveTimeWindow", () => {
     });
   });
 
-  it("resolves positive CLI days as a rolling window", () => {
+  it("resolves positive CLI days as inclusive local calendar days", () => {
     expect(resolveTimeWindow({ mode: "cli", days: "7", now: NOW })).toEqual({
-      from: NOW - 7 * DAY_MS,
+      from: addCalendarDays(startOfCalendarDay(NOW), -6),
       to: undefined,
       days: 7,
     });
@@ -46,8 +45,8 @@ describe("resolveTimeWindow", () => {
     ).toEqual({ from, to, days: 4 });
   });
 
-  it("keeps the CLI default from value ahead of dashboard query days", () => {
-    const defaultFrom = NOW - 7 * DAY_MS;
+  it("lets dashboard query days override inherited CLI bounds", () => {
+    const defaultFrom = addCalendarDays(startOfCalendarDay(NOW), -6);
 
     expect(
       resolveTimeWindow({
@@ -57,14 +56,14 @@ describe("resolveTimeWindow", () => {
         defaultDays: 7,
         now: NOW,
       }),
-    ).toEqual({ from: defaultFrom, to: NOW, days: 3 });
+    ).toEqual({ from: addCalendarDays(startOfCalendarDay(NOW), -2), to: NOW, days: 3 });
   });
 
   it("supports explicit all-time dashboard windows", () => {
     expect(
       resolveTimeWindow({
         mode: "dashboard",
-        window: { from: NOW - 7 * DAY_MS, hasExplicitFrom: false },
+        window: { from: addCalendarDays(startOfCalendarDay(NOW), -6), hasExplicitFrom: false },
         days: "0",
         defaultDays: 7,
         now: NOW,
@@ -86,8 +85,8 @@ describe("resolveTimeWindow", () => {
     });
   });
 
-  it("uses validated dashboard defaults without parsing dates again", () => {
-    const defaultFrom = NOW - 5 * DAY_MS;
+  it("normalizes relative dashboard defaults to their calendar range", () => {
+    const defaultFrom = NOW - 5 * 24 * 60 * 60 * 1000;
 
     expect(
       resolveTimeWindow({
@@ -95,7 +94,18 @@ describe("resolveTimeWindow", () => {
         window: { from: defaultFrom, to: NOW, hasExplicitFrom: false },
         defaultDays: 5,
       }),
-    ).toEqual({ from: defaultFrom, to: NOW, days: 5 });
+    ).toEqual({ from: addCalendarDays(startOfCalendarDay(NOW), -4), to: NOW, days: 5 });
+  });
+
+  it("derives the day count from exact inherited bounds", () => {
+    const from = addCalendarDays(startOfCalendarDay(NOW), -4);
+
+    expect(
+      resolveTimeWindow({
+        mode: "dashboard",
+        window: { from, to: NOW, hasExplicitFrom: false },
+      }),
+    ).toEqual({ from, to: NOW, days: 5 });
   });
 });
 
@@ -124,6 +134,15 @@ describe("CS-133: dashboard windows are calendar ranges", () => {
 
     expect(resolved.from).toBe(webPresetFrom);
     expect(new Date(resolved.from!).getHours()).toBe(0);
+  });
+
+  it("treats CLI date-only bounds as inclusive local calendar dates", () => {
+    vi.stubEnv("TZ", "America/New_York");
+
+    expect(resolveTimeWindow({ mode: "cli", from: "2026-03-07", to: "2026-03-09" })).toEqual({
+      from: new Date(2026, 2, 7).getTime(),
+      to: new Date(2026, 2, 10).getTime() - 1,
+    });
   });
 
   it("reports elapsed days as calendar days across a transition", () => {

--- a/packages/cli/src/time-window-resolution.ts
+++ b/packages/cli/src/time-window-resolution.ts
@@ -1,7 +1,11 @@
-import { addCalendarDays, countCalendarDays, startOfCalendarDay } from "@codesesh/core/contract";
+import {
+  addCalendarDays,
+  countCalendarDays,
+  parseCalendarDayBoundary,
+  startOfCalendarDay,
+} from "@codesesh/core/contract";
 
-/** Rolling duration for CLI --days, which is a span of hours, not a calendar range. */
-const ROLLING_DAY_MS = 24 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_DASHBOARD_DAYS = 30;
 
 export interface TimeWindow {
@@ -36,6 +40,7 @@ interface DashboardTimeWindowRequest {
 
 interface DashboardTimeWindow extends TimeWindow {
   to: number;
+  days: number;
 }
 
 type TimeWindowRequest = CliTimeWindowRequest | DashboardTimeWindowRequest;
@@ -48,16 +53,19 @@ export function resolveTimeWindow(request: TimeWindowRequest): TimeWindow {
 
 function resolveCliWindow(request: CliTimeWindowRequest): TimeWindow {
   const now = request.now ?? Date.now();
-  const from = parseRequiredDate(request.from);
-  const to = parseRequiredDate(request.to);
+  const from = parseRequiredDate(request.from, "start");
+  const to = parseRequiredDate(request.to, "end");
+  if (from != null && to != null && from > to) {
+    throw new Error("Invalid time window: from must not be after to");
+  }
   if (from != null) return { from, to };
 
   const days = parseDays(request.days);
   if (days === 0) return { to, days };
   if (days == null || days < 0) return { to };
 
-  const rollingFrom = now - days * ROLLING_DAY_MS;
-  return Number.isFinite(rollingFrom) ? { from: rollingFrom, to, days } : { to };
+  const calendarFrom = addCalendarDays(startOfCalendarDay(to ?? now), -(days - 1));
+  return Number.isFinite(calendarFrom) ? { from: calendarFrom, to, days } : { to };
 }
 
 function resolveDashboardWindow(request: DashboardTimeWindowRequest): DashboardTimeWindow {
@@ -65,32 +73,43 @@ function resolveDashboardWindow(request: DashboardTimeWindowRequest): DashboardT
   const to = request.window.to ?? now;
   const hasQueryDays = Boolean(request.days?.trim());
   const parsedDays = hasQueryDays ? parseDays(request.days) : undefined;
-  let days = parsedDays != null && parsedDays > 0 ? parsedDays : request.defaultDays;
 
   if (request.window.hasExplicitFrom && request.window.from != null) {
-    days ??= countCalendarDays(request.window.from, to);
-    return { from: request.window.from, to, days };
+    return { from: request.window.from, to, days: countCalendarDays(request.window.from, to) };
   }
 
-  if (parsedDays === 0 || (!hasQueryDays && request.defaultDays === 0)) {
+  const days = parsedDays ?? request.defaultDays;
+  if (days === 0) {
     return { to, days: 0 };
   }
 
-  if (request.window.from != null) {
-    days ??= countCalendarDays(request.window.from, to);
-    return { from: request.window.from, to, days };
+  if (days != null && days > 0) {
+    return {
+      from: addCalendarDays(startOfCalendarDay(to), -(days - 1)),
+      to,
+      days,
+    };
   }
 
-  const resolvedDays = days != null && days > 0 ? days : DEFAULT_DASHBOARD_DAYS;
+  if (request.window.from != null) {
+    return { from: request.window.from, to, days: countCalendarDays(request.window.from, to) };
+  }
+
   return {
-    from: addCalendarDays(startOfCalendarDay(to), -(resolvedDays - 1)),
+    from: addCalendarDays(startOfCalendarDay(to), -(DEFAULT_DASHBOARD_DAYS - 1)),
     to,
-    days: resolvedDays,
+    days: DEFAULT_DASHBOARD_DAYS,
   };
 }
 
-function parseRequiredDate(value: string | undefined): number | undefined {
+function parseRequiredDate(
+  value: string | undefined,
+  boundary: "start" | "end",
+): number | undefined {
   if (!value) return undefined;
+  const calendarBoundary = parseCalendarDayBoundary(value, boundary);
+  if (calendarBoundary === null) throw new Error(`Invalid date: ${value}`);
+  if (calendarBoundary != null) return calendarBoundary;
   const timestamp = new Date(value).getTime();
   if (Number.isNaN(timestamp)) throw new Error(`Invalid date: ${value}`);
   return timestamp;
@@ -98,8 +117,8 @@ function parseRequiredDate(value: string | undefined): number | undefined {
 
 function parseDays(value: string | undefined): number | undefined {
   if (value == null) return undefined;
-  const days = Number.parseInt(value, 10);
-  return Number.isSafeInteger(days) && Number.isSafeInteger(days * ROLLING_DAY_MS)
-    ? days
-    : undefined;
+  const normalized = value.trim();
+  if (!/^-?\d+$/.test(normalized)) return undefined;
+  const days = Number(normalized);
+  return Number.isSafeInteger(days) && Number.isSafeInteger(days * DAY_MS) ? days : undefined;
 }

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -64,6 +64,7 @@ describe("contract browser-safety", () => {
         "mergeSortedSessions",
         "normalizeMessageParts",
         "normalizeSessionReference",
+        "parseCalendarDayBoundary",
         "parseSessionReference",
         "sessionRoutePath",
         "sortSessionsByActivity",

--- a/packages/core/src/contract/__tests__/calendar-day.test.ts
+++ b/packages/core/src/contract/__tests__/calendar-day.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   addCalendarDays,
   countCalendarDays,
+  parseCalendarDayBoundary,
   startOfCalendarDay,
   toCalendarDayKey,
 } from "../calendar-day.js";
@@ -95,5 +96,14 @@ describe("CS-133: calendar days across DST transitions", () => {
     const noon = new Date(2026, 2, 8, 12).getTime();
 
     expect(countCalendarDays(startOfCalendarDay(noon), noon)).toBe(1);
+  });
+
+  it("parses an inclusive date-only range across a DST transition", () => {
+    useTimeZone("America/New_York");
+
+    expect(parseCalendarDayBoundary("2026-03-07", "start")).toBe(new Date(2026, 2, 7).getTime());
+    expect(parseCalendarDayBoundary("2026-03-09", "end")).toBe(new Date(2026, 2, 10).getTime() - 1);
+    expect(parseCalendarDayBoundary("2026-02-31", "start")).toBeNull();
+    expect(parseCalendarDayBoundary("2026-03-07T12:00:00Z", "start")).toBeUndefined();
   });
 });

--- a/packages/core/src/contract/calendar-day.ts
+++ b/packages/core/src/contract/calendar-day.ts
@@ -18,6 +18,27 @@ export function addCalendarDays(timestamp: number, days: number): number {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days).getTime();
 }
 
+/**
+ * Parses a date-only value at its local calendar boundary. `undefined` means
+ * the input is not date-only; `null` means it has the right shape but is not a
+ * real calendar date.
+ */
+export function parseCalendarDayBoundary(
+  value: string,
+  boundary: "start" | "end",
+): number | null | undefined {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return undefined;
+  const year = Number(match[1]);
+  const month = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const start = new Date(year, month, day);
+  if (start.getFullYear() !== year || start.getMonth() !== month || start.getDate() !== day) {
+    return null;
+  }
+  return boundary === "start" ? start.getTime() : addCalendarDays(start.getTime(), 1) - 1;
+}
+
 /** Days since the epoch for a local calendar date, counted on a fixed-length UTC grid. */
 function toCalendarDayNumber(timestamp: number): number {
   const date = new Date(timestamp);


### PR DESCRIPTION
## Summary

- resolve CLI and dashboard day ranges as inclusive local calendar days
- keep exact bounds authoritative and prevent inherited defaults from contradicting requested day counts
- share date-only boundary parsing across the CLI and web app
- avoid sending redundant day counts with exact dashboard bounds

## Testing

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- node scripts/check-quality-task-coverage.mjs
- node scripts/check-docs-paths.mjs
- node scripts/check-docs-facts.mjs
- node scripts/release-preflight.mjs
- pnpm perf:check