### PR TITLE
web/sessions: Preserve live updates during reload

### DIFF
--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -239,6 +239,7 @@ describe("useSessionStore", () => {
     act(() => {
       reload = result.current.reload();
     });
+    await waitFor(() => expect(api.fetchSessions).toHaveBeenCalledTimes(2));
     const changed = { ...SAMPLE_SESSION_HEAD, title: "Live title" };
     await act(() =>
       result.current.applyLiveEvent({
@@ -257,6 +258,7 @@ describe("useSessionStore", () => {
     act(() => {
       reload = result.current.reload();
     });
+    await waitFor(() => expect(api.fetchSessions).toHaveBeenCalledTimes(3));
     await act(() =>
       result.current.applyLiveEvent({
         ...SAMPLE_SESSIONS_UPDATED_EVENT,

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -1,12 +1,9 @@
-import {
-  applySessionWindowChanges,
-  formatSessionReference,
-  mergeSessionsUpdatedEvents,
-} from "@codesesh/core/contract";
+import { applySessionWindowChanges, formatSessionReference } from "@codesesh/core/contract";
 import {
   hashKey,
   keepPreviousData,
   queryOptions,
+  replaceEqualDeep,
   useQuery,
   useQueryClient,
   type QueryClient,
@@ -30,6 +27,7 @@ import {
   invalidateLiveSessionCollections,
   invalidateLiveSessionDerivedQueries,
   invalidateSessionDerivedQueries,
+  PendingSessionProjectionLoads,
 } from "../lib/session-query-consistency";
 
 export interface SessionProjection {
@@ -74,9 +72,9 @@ function agentCatalogOptions(window: AppConfig["window"]) {
   });
 }
 
-interface SessionProjectionLoad {
+interface LoadedSessionProjection extends SessionProjection {
+  loadId: number;
   window: AppConfig["window"];
-  event: SessionsUpdatedEvent | null;
 }
 
 function applyProjectionEvent(
@@ -97,29 +95,59 @@ function applyProjectionEvent(
 async function fetchSessionProjection(
   queryClient: QueryClient,
   signal: AbortSignal,
-  load: SessionProjectionLoad,
-): Promise<SessionProjection> {
-  const { window } = load;
-  const project = (sessions: SessionHead[], complete: boolean): SessionProjection => ({
-    sessions: load.event ? applyProjectionEvent(sessions, load.event, window).sessions : sessions,
-    complete,
-  });
-  const result = await fetchSessions(
-    { from: window.from, to: window.to },
-    { signal },
-    {
-      onFirstPage(sessions) {
-        if (!signal.aborted) {
-          queryClient.setQueryData<SessionProjection>(
-            queryKeys.sessionProjection(window),
-            (previous) => previous ?? project(sessions, false),
-          );
-        }
+  window: AppConfig["window"],
+  pendingLoads: PendingSessionProjectionLoads,
+): Promise<LoadedSessionProjection> {
+  const loadId = pendingLoads.begin();
+  let readyToCommit = false;
+  const project = (sessions: SessionHead[], complete: boolean): SessionProjection => {
+    const event = pendingLoads.read(loadId);
+    return {
+      sessions: event ? applyProjectionEvent(sessions, event, window).sessions : sessions,
+      complete,
+    };
+  };
+  try {
+    const result = await fetchSessions(
+      { from: window.from, to: window.to },
+      { signal },
+      {
+        onFirstPage(sessions) {
+          if (!signal.aborted) {
+            queryClient.setQueryData<SessionProjection>(
+              queryKeys.sessionProjection(window),
+              (previous) => previous ?? project(sessions, false),
+            );
+          }
+        },
       },
-    },
-  );
-  signal.throwIfAborted();
-  return project(result.sessions, true);
+    );
+    signal.throwIfAborted();
+    readyToCommit = true;
+    return {
+      sessions: result.sessions,
+      complete: true,
+      loadId,
+      window,
+    };
+  } finally {
+    if (!readyToCommit) pendingLoads.cancel(loadId);
+  }
+}
+
+function commitSessionProjection(
+  projection: SessionProjection,
+  pendingLoads: PendingSessionProjectionLoads,
+): SessionProjection {
+  if (!("loadId" in projection) || !("window" in projection)) return projection;
+  const loaded = projection as LoadedSessionProjection;
+  const event = pendingLoads.complete(loaded.loadId);
+  return {
+    sessions: event
+      ? applyProjectionEvent(loaded.sessions, event, loaded.window).sessions
+      : loaded.sessions,
+    complete: loaded.complete,
+  };
 }
 
 function removeOtherSessionProjections(
@@ -190,21 +218,19 @@ function sameWindow(
 
 export function useSessionStore(window: AppConfig["window"] | null) {
   const queryClient = useQueryClient();
-  const pendingProjectionLoad = useRef<SessionProjectionLoad | null>(null);
+  const pendingProjectionLoads = useRef(new PendingSessionProjectionLoads()).current;
   const liveAggregateWindowRef = useRef<AppConfig["window"] | null>(null);
   const liveAggregateRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const projectionQuery = useQuery({
+  const projectionQuery = useQuery<SessionProjection>({
     queryKey: queryKeys.sessionProjection(window ?? {}),
     staleTime: Infinity,
-    queryFn: async ({ signal }): Promise<SessionProjection> => {
-      const load: SessionProjectionLoad = { window: window ?? {}, event: null };
-      pendingProjectionLoad.current = load;
-      try {
-        return await fetchSessionProjection(queryClient, signal, load);
-      } finally {
-        if (pendingProjectionLoad.current === load) pendingProjectionLoad.current = null;
-      }
-    },
+    structuralSharing: (_previous, next) =>
+      replaceEqualDeep(
+        _previous,
+        commitSessionProjection(next as SessionProjection, pendingProjectionLoads),
+      ),
+    queryFn: ({ signal }): Promise<SessionProjection> =>
+      fetchSessionProjection(queryClient, signal, window ?? {}, pendingProjectionLoads),
     enabled: window !== null,
   });
   const agentsQuery = useQuery({
@@ -258,12 +284,7 @@ export function useSessionStore(window: AppConfig["window"] | null) {
     async (event: SessionsUpdatedEvent): Promise<LiveSessionApplyResult | null> => {
       if (!window) return null;
       const activeWindow = window;
-      const pendingLoad = pendingProjectionLoad.current;
-      if (pendingLoad && sameWindow(pendingLoad.window, activeWindow)) {
-        pendingLoad.event = pendingLoad.event
-          ? mergeSessionsUpdatedEvents(pendingLoad.event, event)
-          : event;
-      }
+      pendingProjectionLoads.record(event);
       const projectionKey = queryKeys.sessionProjection(activeWindow);
       const agentCatalogKey = queryKeys.agentCatalog(activeWindow);
       const currentProjection = queryClient.getQueryData<SessionProjection>(projectionKey);
@@ -326,7 +347,7 @@ export function useSessionStore(window: AppConfig["window"] | null) {
       }
       return { visibleNewSessions };
     },
-    [queryClient, reload, window],
+    [pendingProjectionLoads, queryClient, reload, window],
   );
 
   const resyncLiveState = useCallback(async (): Promise<void> => {

--- a/apps/web/src/lib/session-query-consistency.test.ts
+++ b/apps/web/src/lib/session-query-consistency.test.ts
@@ -3,7 +3,10 @@ import { QueryClient } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionsUpdatedEvent } from "./api";
 import { queryKeys } from "./query-keys";
-import { invalidateLiveSessionDerivedQueries } from "./session-query-consistency";
+import {
+  invalidateLiveSessionDerivedQueries,
+  PendingSessionProjectionLoads,
+} from "./session-query-consistency";
 
 let client: QueryClient | null = null;
 
@@ -72,5 +75,50 @@ describe("live session detail invalidation", () => {
     });
 
     expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+});
+
+describe("pending session projection loads", () => {
+  it("keeps every live event until each older load commits", () => {
+    const loads = new PendingSessionProjectionLoads();
+    const firstLoad = loads.begin();
+    const secondLoad = loads.begin();
+    const changed = changedHead("Codex", "changed");
+    const removed = { agentName: "Codex", sessionId: "removed" };
+
+    loads.record({
+      ...SAMPLE_SESSIONS_UPDATED_EVENT,
+      changedSessionHeads: [changed],
+      removedSessionRefs: [],
+    });
+    loads.record({
+      ...SAMPLE_SESSIONS_UPDATED_EVENT,
+      changedSessionHeads: [],
+      removedSessionRefs: [removed],
+    });
+
+    expect(loads.complete(firstLoad)).toMatchObject({
+      changedSessionHeads: [changed],
+      removedSessionRefs: [removed],
+    });
+    expect(loads.read(secondLoad)).toMatchObject({
+      changedSessionHeads: [changed],
+      removedSessionRefs: [removed],
+    });
+    expect(loads.complete(secondLoad)).toMatchObject({
+      changedSessionHeads: [changed],
+      removedSessionRefs: [removed],
+    });
+    expect(loads.read(secondLoad)).toBeNull();
+  });
+
+  it("drops events owned by a cancelled load", () => {
+    const loads = new PendingSessionProjectionLoads();
+    const load = loads.begin();
+    loads.record(SAMPLE_SESSIONS_UPDATED_EVENT);
+
+    loads.cancel(load);
+
+    expect(loads.complete(load)).toBeNull();
   });
 });

--- a/apps/web/src/lib/session-query-consistency.ts
+++ b/apps/web/src/lib/session-query-consistency.ts
@@ -1,6 +1,38 @@
+import { mergeSessionsUpdatedEvents } from "@codesesh/core/contract";
 import type { QueryClient } from "@tanstack/react-query";
 import type { SessionsUpdatedEvent } from "./api";
 import { queryKeys } from "./query-keys";
+
+export class PendingSessionProjectionLoads {
+  private nextId = 0;
+  private readonly events = new Map<number, SessionsUpdatedEvent | null>();
+
+  begin(): number {
+    const id = this.nextId++;
+    this.events.set(id, null);
+    return id;
+  }
+
+  record(event: SessionsUpdatedEvent): void {
+    for (const [id, current] of this.events) {
+      this.events.set(id, current ? mergeSessionsUpdatedEvents(current, event) : event);
+    }
+  }
+
+  read(id: number): SessionsUpdatedEvent | null {
+    return this.events.get(id) ?? null;
+  }
+
+  complete(id: number): SessionsUpdatedEvent | null {
+    const event = this.read(id);
+    this.events.delete(id);
+    return event;
+  }
+
+  cancel(id: number): void {
+    this.events.delete(id);
+  }
+}
 
 function invalidateSessionCollections(queryClient: QueryClient) {
   return [


### PR DESCRIPTION
## Summary

- track live events independently for every in-flight session projection request
- reconcile those events when React Query commits the full response
- make the stale-response regression test deterministic and cover concurrent and cancelled loads

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`
- repeated the stale full-response regression test 20 times