### PR TITLE
discovery: Centralize refresh commits

### DIFF
--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -1,8 +1,8 @@
 import {
   attachMissingProjectIdentities,
+  beginAgentRefresh,
   buildAgentCacheMeta,
   buildSessionPersistenceDiff,
-  commitAgentRefreshCheck,
   getAgentFullSyncCursor,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
@@ -10,7 +10,7 @@ import {
   readCachedSessions,
   readAgentCacheInitialization,
   resolveSessionSnapshotCompleteness,
-  selectAgentRefresh,
+  type AgentRefreshTransaction,
   type AgentRefreshSelection,
   type CachedResult,
   type IdentifiedSessionHead,
@@ -75,15 +75,10 @@ interface RefreshResult {
   completion: ScanCompletion;
 }
 
-type CommittableAgentRefresh = Extract<
-  AgentRefreshSelection,
-  { kind: "recompute-derived" | "full-scan" | "incremental-scan" }
->;
-
 interface PendingAgentState {
   meta: CachedSessions["meta"];
   refreshedAt?: number;
-  changeCheck?: CommittableAgentRefresh;
+  refreshTransaction?: AgentRefreshTransaction;
 }
 
 function countSessionUpdates(event: SessionsUpdatedEvent | null): {
@@ -333,7 +328,7 @@ export class AgentSyncEngine {
       return;
     }
     try {
-      if (state.changeCheck) commitAgentRefreshCheck(state.changeCheck);
+      state.refreshTransaction?.commit();
     } catch (error) {
       this.reportPostCommitError(operation, agent.name, error);
     }
@@ -428,11 +423,12 @@ export class AgentSyncEngine {
       return { result: "unchanged", completion: { completeness: "complete" } };
     }
     const isInitialized = initialization.value;
-    const refresh = await selectAgentRefresh(agent, {
+    const refreshTransaction = await beginAgentRefresh(agent, {
       initialized: isInitialized,
       sinceTimestamp: cacheTimestamp,
       cachedSessions: refreshBaseline,
     });
+    const refresh = refreshTransaction.selection;
     const availabilityDuration = refresh.availabilityDurationMs;
     let strategyResult: RefreshStrategyResult;
     try {
@@ -450,7 +446,13 @@ export class AgentSyncEngine {
           startedAt,
         );
       } else {
-        strategyResult = await this.refreshChangedAgent(agent, refresh, refreshBaseline, startedAt);
+        strategyResult = await this.refreshChangedAgent(
+          agent,
+          refresh,
+          refreshTransaction,
+          refreshBaseline,
+          startedAt,
+        );
       }
     } finally {
       agent.restoreSessionCacheMeta(durableMeta);
@@ -705,6 +707,7 @@ export class AgentSyncEngine {
   private async refreshChangedAgent(
     agent: BaseAgent,
     refresh: Exclude<AgentRefreshSelection, { kind: "unavailable" | "initialize" | "synchronize" }>,
+    refreshTransaction: AgentRefreshTransaction,
     baseline: IdentifiedSessionHead[],
     refreshStartedAt: number,
   ): Promise<RefreshStrategyResult> {
@@ -739,7 +742,7 @@ export class AgentSyncEngine {
         const pendingAgentState = {
           meta: result.meta,
           refreshedAt: checkResult.timestamp,
-          changeCheck: refresh,
+          refreshTransaction,
         };
         const persistenceDiff = buildSessionPersistenceDiff(baseline, sessions);
         if (
@@ -798,7 +801,7 @@ export class AgentSyncEngine {
             pendingAgentState: {
               meta: result.meta,
               refreshedAt: checkResult.timestamp,
-              changeCheck: refresh,
+              refreshTransaction,
             },
           }),
           status: "continue",
@@ -837,7 +840,7 @@ export class AgentSyncEngine {
         pendingAgentState: {
           meta: agent.snapshotSessionCacheMeta(),
           refreshedAt: checkResult.timestamp,
-          changeCheck: refresh,
+          refreshTransaction,
         },
       }),
       status: "continue",

--- a/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
+++ b/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  commitAgentRefreshCheck,
+  beginAgentRefresh,
   executeAgentScanPlan,
   inspectAgentRefresh,
   planAgentScan,
@@ -183,14 +183,15 @@ describe("selectAgentRefresh", () => {
       commitChangeCheck,
       checkForChanges: () => ({ hasChanges: false, timestamp: 11 }),
     };
-    const selection = await selectAgentRefresh(agent(source), {
+    const transaction = await beginAgentRefresh(agent(source), {
       initialized: true,
       sinceTimestamp: 10,
       cachedSessions: [],
     });
+    const selection = transaction.selection;
     if (selection.kind !== "recompute-derived") throw new Error("Expected derived refresh");
 
-    commitAgentRefreshCheck(selection);
+    transaction.commit();
 
     expect(commitChangeCheck).toHaveBeenCalledOnce();
   });

--- a/packages/core/src/discovery/agent-scan-plan.ts
+++ b/packages/core/src/discovery/agent-scan-plan.ts
@@ -156,6 +156,11 @@ type CommittableAgentRefresh = Extract<
   { kind: "recompute-derived" | "full-scan" | "incremental-scan" }
 >;
 
+export interface AgentRefreshTransaction {
+  selection: AgentRefreshSelection;
+  commit(): void;
+}
+
 export function planAgentScan(
   source: SessionSourceCapability,
   intent: "reload" | "backfill",
@@ -240,6 +245,29 @@ export async function selectAgentRefresh(
         };
   }
   return { ...inspection, availabilityDurationMs };
+}
+
+export async function beginAgentRefresh(
+  agent: Pick<BaseAgent, "isAvailable" | "sessionSourceAccess">,
+  options: {
+    initialized: boolean;
+    sinceTimestamp: number;
+    cachedSessions: SessionHead[];
+  },
+): Promise<AgentRefreshTransaction> {
+  const selection = await selectAgentRefresh(agent, options);
+  return {
+    selection,
+    commit: () => {
+      if (
+        selection.kind === "recompute-derived" ||
+        selection.kind === "full-scan" ||
+        selection.kind === "incremental-scan"
+      ) {
+        commitAgentRefreshCheck(selection);
+      }
+    },
+  };
 }
 
 export function commitAgentRefreshCheck(refresh: CommittableAgentRefresh): void {

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -9,6 +9,7 @@ export {
 export type { AgentCacheFailure, LiveSnapshot, ScanOptions } from "./scanner.js";
 export type { SessionTagTiming } from "./session-tags.js";
 export {
+  beginAgentRefresh,
   commitAgentRefreshCheck,
   executeAgentScanPlan,
   inspectAgentRefresh,
@@ -17,6 +18,7 @@ export {
   selectAgentRefresh,
 } from "./agent-scan-plan.js";
 export type {
+  AgentRefreshTransaction,
   AgentRefreshInspection,
   AgentRefreshSelection,
   AgentScanIntent,

--- a/packages/core/src/discovery/scanner.ts
+++ b/packages/core/src/discovery/scanner.ts
@@ -32,11 +32,10 @@ import {
   buildSessionPersistenceDiff,
 } from "./orchestrate.js";
 import {
+  beginAgentRefresh,
   executeAgentScanPlan,
-  commitAgentRefreshCheck,
   planAgentScan,
   resolveSessionSnapshotCompleteness,
-  selectAgentRefresh,
 } from "./agent-scan-plan.js";
 import { ensureSessionTags } from "./session-tags.js";
 
@@ -450,11 +449,12 @@ async function scanAgentSmart(
         });
       }
 
-      const refresh = await selectAgentRefresh(agent, {
+      const refreshTransaction = await beginAgentRefresh(agent, {
         initialized: true,
         sinceTimestamp: cached.timestamp,
         cachedSessions: cached.sessions,
       });
+      const refresh = refreshTransaction.selection;
       if (refresh.kind === "unavailable") {
         return finalizeAgentScanFailure(
           agent,
@@ -555,7 +555,7 @@ async function scanAgentSmart(
           ),
           onProgress,
         });
-        if (result.cachePersistence === "persisted") commitAgentRefreshCheck(refresh);
+        if (result.cachePersistence === "persisted") refreshTransaction.commit();
         return result;
       }
 
@@ -567,7 +567,7 @@ async function scanAgentSmart(
         completeness: "complete",
         onProgress,
       });
-      commitAgentRefreshCheck(refresh);
+      refreshTransaction.commit();
       return result;
     }
   }

--- a/packages/core/src/runtime/discovery.ts
+++ b/packages/core/src/runtime/discovery.ts
@@ -9,6 +9,7 @@ export type {
 } from "../types/index.js";
 export {
   attachMissingProjectIdentities,
+  beginAgentRefresh,
   buildAgentCacheMeta,
   buildSessionPersistenceDiff,
   clearCache,
@@ -57,6 +58,7 @@ export type {
   AgentCacheFailure,
   AgentRefreshInspection,
   AgentRefreshSelection,
+  AgentRefreshTransaction,
   AgentScanIntent,
   AgentScanPlan,
   CacheReadOutcome,


### PR DESCRIPTION
## Summary

- introduce a shared refresh transaction that owns change-check commits
- use the transaction in startup scans and live refreshes
- preserve each path's existing publication behavior

## Validation

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test