### PR TITLE
web/routes: Scope models by route

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,7 +23,7 @@ import { buildRouteHeaderModel } from "./lib/build-route-header-model";
 import { AppSidebar } from "./components/app/AppSidebar";
 import type { SearchControlsHandle } from "./components/app/SearchControls";
 import { ShortcutHelpDialog } from "./components/app/ShortcutHelpDialog";
-import { AppRouteContent } from "./components/app/AppRouteContent";
+import { AppRouteContent, type AppRouteModel } from "./components/app/AppRouteContent";
 import { AppToolbar } from "./components/app/AppToolbar";
 import { AppPageHeader } from "./components/app/AppPageHeader";
 import { AppMainContent } from "./components/app/AppMainContent";
@@ -255,50 +255,107 @@ export default function App() {
     selectedProject: selectedProjectNavigation?.project ?? null,
   });
 
+  const overview = {
+    window: loadedWindow,
+    rangePreset: timeWindowController.preset ?? "all",
+    onRangeChange: timeWindowController.selectPreset,
+    onSelectCustom: timeWindowController.selectCustom,
+  };
+  const bookmarkActions = {
+    isBookmarked: bookmarks.isSessionBookmarked,
+    toggleSessionBookmark: bookmarks.toggleSessionBookmark,
+  };
+  let routeContent: AppRouteModel;
+  switch (viewState.mode) {
+    case "root":
+      routeContent = {
+        ...viewState,
+        agentCatalog,
+        projectCount: projectPage.summary.projects,
+        overview,
+      };
+      break;
+    case "projects":
+      routeContent = {
+        ...viewState,
+        agentCatalog,
+        projectPage,
+        projectsLoad: {
+          loading: projectsLoading,
+          error: projectsError,
+          retry: () => void retryProjects(),
+        },
+        window: loadedWindow,
+      };
+      break;
+    case "project":
+      routeContent = {
+        ...viewState,
+        agentCatalog,
+        project: activeProject?.project ?? null,
+        projectLoad: {
+          loading: projectLookup.loading,
+          error: projectLookup.error,
+          retry: () => void projectLookup.retry(),
+        },
+        sessions: activeProjectSessions,
+        agentFilter: {
+          selectedAgent: selectedProjectAgent,
+          onChangeAgent: selectProjectAgent,
+        },
+        overview,
+      };
+      break;
+    case "agent":
+      routeContent = {
+        ...viewState,
+        agents: activeAgents,
+        agentCatalog,
+        sessions: sessionIndexes.byLandingAgent.get(viewState.activeAgentKey) ?? [],
+        bookmarks: bookmarkActions,
+      };
+      break;
+    case "session":
+      routeContent = {
+        ...viewState,
+        agents: activeAgents,
+        agentCatalog,
+        sessions: sessionIndexes.byLandingAgent.get(viewState.activeAgentKey) ?? [],
+        bookmarks: bookmarkActions,
+        detail: {
+          session: sessionDetail.session,
+          loading: sessionDetail.sessionLoading,
+          error: sessionDetail.sessionError,
+          retry: () => void sessionDetail.refresh(),
+        },
+        detailHighlightQuery,
+        childSessionsByParentRouteKey: sessionIndexes.childrenByParentRouteKey,
+      };
+      break;
+    case "missingAgent":
+      routeContent = {
+        ...viewState,
+        agents: activeAgents,
+        agentCatalog,
+        sessions: sessionIndexes.landingSessions,
+        bookmarks: bookmarkActions,
+      };
+      break;
+    case "invalidRoute":
+      routeContent = viewState;
+      break;
+  }
+
   const content = (
     <AppRouteContent
-      loading={loading}
-      error={error}
-      onRetry={() => void retryLoad()}
-      viewState={viewState}
-      detailHighlightQuery={detailHighlightQuery}
-      agents={activeAgents}
-      agentCatalog={agentCatalog}
-      agentNameMap={agentNameMap}
-      projectPage={projectPage}
-      projectsError={projectsError}
-      projectsLoading={projectsLoading}
-      onRetryProjects={() => void retryProjects()}
-      landingSessions={sessionIndexes.landingSessions}
-      childSessionsByParentRouteKey={sessionIndexes.childrenByParentRouteKey}
-      sessionsByAgent={sessionIndexes.byLandingAgent}
-      activeProject={activeProject?.project ?? null}
-      activeProjectLoading={projectLookup.loading}
-      activeProjectError={projectLookup.error}
-      onRetryActiveProject={() => void projectLookup.retry()}
-      activeProjectSessions={activeProjectSessions}
-      overview={{
-        window: loadedWindow,
-        // `preset` is null only until the config resolves, and until then the
-        // shell renders its loading skeleton instead of the overview.
-        rangePreset: timeWindowController.preset ?? "all",
-        onRangeChange: timeWindowController.selectPreset,
-        onSelectCustom: timeWindowController.selectCustom,
-      }}
-      sessionDetail={{
-        session: sessionDetail.session,
-        loading: sessionDetail.sessionLoading,
-        error: sessionDetail.sessionError,
-        retry: () => void sessionDetail.refresh(),
-      }}
-      projectAgentFilter={{
-        selectedAgent: selectedProjectAgent,
-        onChangeAgent: selectProjectAgent,
-      }}
+      load={{ loading, error, retry: () => void retryLoad() }}
+      route={routeContent}
       search={{
         active: search.searchMode,
         query: search.activeSearchQuery,
         state: search.searchState,
+        agentNameMap,
+        agents: activeAgents,
         projectOptions: search.projectOptions,
         filters: search.searchFilters,
         onChangeFilters: search.setSearchFilters,
@@ -306,10 +363,6 @@ export default function App() {
         onRetry: search.retrySearch,
         selectedIndex: search.selectedSearchIndex,
         registerResultRef: search.registerResultRef,
-      }}
-      bookmarks={{
-        isBookmarked: bookmarks.isSessionBookmarked,
-        toggleSessionBookmark: bookmarks.toggleSessionBookmark,
       }}
     />
   );

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -5,7 +5,7 @@ import type { AgentInfo, ApiProjectGroup, SessionDetail } from "../../lib/api";
 import { createAgentCatalog } from "../../lib/agents";
 import { getSessionRouteKey, type IndexedSession } from "../../lib/session-indexes";
 import { createQueryWrapper } from "../../test/query-wrapper";
-import { AppRouteContent } from "./AppRouteContent";
+import { AppRouteContent, type AppRouteModel } from "./AppRouteContent";
 
 const sessionDetailRender = vi.hoisted(() => vi.fn());
 
@@ -47,54 +47,23 @@ const routeAgents = [
 ] satisfies AgentInfo[];
 
 function makeProps(): Parameters<typeof AppRouteContent>[0] {
+  const agentCatalog = createAgentCatalog([]);
   return {
-    loading: false,
-    error: null,
-    onRetry: vi.fn(),
-    viewState: {
+    load: { loading: false, error: null, retry: vi.fn() },
+    route: {
       mode: "root",
       activeAgentKey: null,
       activeSessionId: null,
+      agentCatalog,
+      projectCount: 1,
+      overview: makeOverview(),
     },
-    detailHighlightQuery: "",
-    agents: [],
-    agentCatalog: createAgentCatalog([]),
-    agentNameMap: new Map(),
-    projectPage: {
-      projects: [project],
-      summary: {
-        projects: 1,
-        sessions: 0,
-        tokens: 0,
-        cost: 0,
-        latestActivity: null,
-      },
-    },
-    projectsError: null,
-    projectsLoading: false,
-    onRetryProjects: vi.fn(),
-    landingSessions: [],
-    childSessionsByParentRouteKey: new Map(),
-    sessionsByAgent: new Map(),
-    activeProject: null,
-    activeProjectLoading: false,
-    activeProjectError: null,
-    onRetryActiveProject: vi.fn(),
-    activeProjectSessions: [],
-    // A null window keeps the overview's dashboard query idle, so these
-    // assertions never depend on the network.
-    overview: {
-      window: null,
-      rangePreset: "30d",
-      onRangeChange: vi.fn(),
-      onSelectCustom: vi.fn(),
-    },
-    sessionDetail: { session: null, loading: false, error: null, retry: vi.fn() },
-    projectAgentFilter: { onChangeAgent: vi.fn() },
     search: {
       active: false,
       query: "",
       state: { status: "idle" },
+      agentNameMap: agentCatalog.displayNameByKey,
+      agents: [],
       projectOptions: [],
       filters: {},
       onChangeFilters: vi.fn(),
@@ -103,10 +72,54 @@ function makeProps(): Parameters<typeof AppRouteContent>[0] {
       selectedIndex: 0,
       registerResultRef: vi.fn(),
     },
-    bookmarks: {
-      isBookmarked: vi.fn(() => false),
-      toggleSessionBookmark: vi.fn(),
+  };
+}
+
+function makeOverview() {
+  return {
+    window: null,
+    rangePreset: "30d" as const,
+    onRangeChange: vi.fn(),
+    onSelectCustom: vi.fn(),
+  };
+}
+
+function makeProjectPage(projects = [project]) {
+  return {
+    projects,
+    summary: {
+      projects: projects.length,
+      sessions: 0,
+      tokens: 0,
+      cost: 0,
+      latestActivity: null,
     },
+  };
+}
+
+function makeBookmarks() {
+  return {
+    isBookmarked: vi.fn(() => false),
+    toggleSessionBookmark: vi.fn(),
+  };
+}
+
+function makeSessionRoute(
+  activeSessionId: string,
+  detail: Extract<AppRouteModel, { mode: "session" }>["detail"],
+  sessions: IndexedSession[] = [],
+): Extract<AppRouteModel, { mode: "session" }> {
+  return {
+    mode: "session",
+    activeAgentKey: "claudecode",
+    activeSessionId,
+    agents: routeAgents,
+    agentCatalog: createAgentCatalog(routeAgents),
+    sessions,
+    bookmarks: makeBookmarks(),
+    detail,
+    detailHighlightQuery: "",
+    childSessionsByParentRouteKey: new Map(),
   };
 }
 
@@ -142,12 +155,6 @@ function makeLandingSession(agentKey: string, sessionId: string, title: string):
   };
 }
 
-function addRouteAgents(props: ReturnType<typeof makeProps>): void {
-  props.agents = routeAgents;
-  props.agentCatalog = createAgentCatalog(routeAgents);
-  props.agentNameMap = props.agentCatalog.displayNameByKey;
-}
-
 afterEach(() => {
   cleanup();
   sessionDetailRender.mockClear();
@@ -167,13 +174,13 @@ function renderContent(props: Parameters<typeof AppRouteContent>[0]) {
 describe("AppRouteContent", () => {
   it("offers a retry action when the initial load fails", () => {
     const props = makeProps();
-    props.error = "Failed to load configuration.";
+    props.load.error = "Failed to load configuration.";
 
     renderContent(props);
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
 
-    expect(screen.getByRole("alert").textContent).toContain(props.error);
-    expect(props.onRetry).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("alert").textContent).toContain(props.load.error);
+    expect(props.load.retry).toHaveBeenCalledTimes(1);
   });
 
   it("renders the overview on the root route", async () => {
@@ -187,18 +194,20 @@ describe("AppRouteContent", () => {
 
   it("shows a retryable project failure instead of an empty state", async () => {
     const props = makeProps();
-    props.viewState = { mode: "projects", activeAgentKey: null, activeSessionId: null };
-    props.projectPage = {
-      projects: [],
-      summary: {
-        projects: 0,
-        sessions: 0,
-        tokens: 0,
-        cost: 0,
-        latestActivity: null,
+    const retry = vi.fn();
+    props.route = {
+      mode: "projects",
+      activeAgentKey: null,
+      activeSessionId: null,
+      agentCatalog: createAgentCatalog([]),
+      projectPage: makeProjectPage([]),
+      projectsLoad: {
+        loading: false,
+        error: "projects unavailable",
+        retry,
       },
+      window: null,
     };
-    props.projectsError = "projects unavailable";
     renderContent(props);
 
     const alert = await screen.findByRole("alert", {}, { timeout: LAZY_SURFACE_TIMEOUT_MS });
@@ -206,7 +215,7 @@ describe("AppRouteContent", () => {
     expect(alert.textContent).toContain("projects unavailable");
     expect(screen.queryByText("No projects found")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-    expect(props.onRetryProjects).toHaveBeenCalledOnce();
+    expect(retry).toHaveBeenCalledOnce();
   });
 
   // The route surfaces load on demand, so these assertions wait for the chunk.
@@ -217,14 +226,19 @@ describe("AppRouteContent", () => {
       ...project,
       agentStats: [{ name: "claudecode", sessions: 1, messages: 2, tokens: 3, cost: 0.1 }],
     } satisfies ApiProjectGroup;
-    props.viewState = {
+    props.route = {
       mode: "project",
       activeAgentKey: null,
       activeSessionId: null,
       activeProjectKind: "git_remote",
       activeProjectKey: project.identityKey,
+      agentCatalog: createAgentCatalog([]),
+      project: activeProject,
+      projectLoad: { loading: false, error: null, retry: vi.fn() },
+      sessions: [],
+      agentFilter: { onChangeAgent: vi.fn() },
+      overview: makeOverview(),
     };
-    props.activeProject = activeProject;
 
     renderContent(props);
 
@@ -255,12 +269,12 @@ describe("AppRouteContent", () => {
 
   it("remounts session-scoped UI when the route changes to another session", async () => {
     const props = makeProps();
-    props.viewState = {
-      mode: "session",
-      activeAgentKey: "claudecode",
-      activeSessionId: "session-a",
-    };
-    props.sessionDetail.session = makeSession("session-a");
+    props.route = makeSessionRoute("session-a", {
+      session: makeSession("session-a"),
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    });
     const view = render(
       <MemoryRouter>
         <AppRouteContent {...props} />
@@ -272,12 +286,12 @@ describe("AppRouteContent", () => {
       { timeout: LAZY_SURFACE_TIMEOUT_MS },
     );
 
-    props.viewState = {
-      mode: "session",
-      activeAgentKey: "claudecode",
-      activeSessionId: "session-b",
-    };
-    props.sessionDetail.session = makeSession("session-b");
+    props.route = makeSessionRoute("session-b", {
+      session: makeSession("session-b"),
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    });
     view.rerender(
       <MemoryRouter>
         <AppRouteContent {...props} />
@@ -294,15 +308,16 @@ describe("AppRouteContent", () => {
       ...makeSession("child"),
       parent_reference: parent.reference,
     };
-    props.viewState = {
-      mode: "session",
-      activeAgentKey: "claudecode",
-      activeSessionId: parent.reference.sessionId,
-    };
-    props.sessionDetail.session = parent;
-    props.childSessionsByParentRouteKey = new Map([
+    const route = makeSessionRoute(parent.reference.sessionId, {
+      session: parent,
+      loading: false,
+      error: null,
+      retry: vi.fn(),
+    });
+    route.childSessionsByParentRouteKey = new Map([
       [getSessionRouteKey("claudecode", "parent"), [child]],
     ]);
+    props.route = route;
     const view = render(
       <MemoryRouter>
         <AppRouteContent {...props} />
@@ -311,7 +326,7 @@ describe("AppRouteContent", () => {
     await screen.findByTestId("session-detail", {}, { timeout: LAZY_SURFACE_TIMEOUT_MS });
     const firstChildren = sessionDetailRender.mock.calls.at(-1)?.[0].childSessions;
 
-    props.detailHighlightQuery = "unrelated";
+    route.detailHighlightQuery = "unrelated";
     view.rerender(
       <MemoryRouter>
         <AppRouteContent {...props} />
@@ -323,19 +338,18 @@ describe("AppRouteContent", () => {
 
   it("renders an agent landing with encoded session links and full-reference bookmark actions", () => {
     const props = makeProps();
-    addRouteAgents(props);
+    const bookmarks = makeBookmarks();
     const sessionId = "shared/id?x#y%";
     const claudeSession = makeLandingSession("claudecode", sessionId, "Claude opaque session");
-    const codexSession = makeLandingSession("codex", sessionId, "Codex twin session");
-    props.viewState = {
+    props.route = {
       mode: "agent",
       activeAgentKey: "claudecode",
       activeSessionId: null,
+      agents: routeAgents,
+      agentCatalog: createAgentCatalog(routeAgents),
+      sessions: [claudeSession],
+      bookmarks,
     };
-    props.sessionsByAgent = new Map([
-      ["claudecode", [claudeSession]],
-      ["codex", [codexSession]],
-    ]);
 
     renderContent(props);
 
@@ -343,15 +357,14 @@ describe("AppRouteContent", () => {
     const sessionLink = screen.getByRole("link", { name: /Claude opaque session/ });
     expect(sessionLink.getAttribute("href")).toBe("/claudecode/shared%2Fid%3Fx%23y%25");
     expect(screen.queryByText("Codex twin session")).toBeNull();
-    expect(props.bookmarks.isBookmarked).toHaveBeenCalledWith("claudecode", sessionId);
+    expect(bookmarks.isBookmarked).toHaveBeenCalledWith("claudecode", sessionId);
 
     fireEvent.click(screen.getByRole("button", { name: "Add bookmark" }));
-    expect(props.bookmarks.toggleSessionBookmark).toHaveBeenCalledWith(claudeSession, "claudecode");
+    expect(bookmarks.toggleSessionBookmark).toHaveBeenCalledWith(claudeSession, "claudecode");
   });
 
   it("renders a missing session with agent-scoped recovery links", () => {
     const props = makeProps();
-    addRouteAgents(props);
     const attemptedSessionId = "missing/id?#%";
     const recoverySessionId = "recovery/id?#%";
     const claudeSession = makeLandingSession(
@@ -359,22 +372,14 @@ describe("AppRouteContent", () => {
       recoverySessionId,
       "Claude recovery session",
     );
-    const codexSession = makeLandingSession("codex", recoverySessionId, "Codex recovery session");
-    props.viewState = {
-      mode: "session",
-      activeAgentKey: "claudecode",
-      activeSessionId: attemptedSessionId,
-    };
-    props.sessionDetail = {
+    const route = makeSessionRoute(attemptedSessionId, {
       session: null,
       loading: false,
       error: { kind: "missing" },
       retry: vi.fn(),
-    };
-    props.sessionsByAgent = new Map([
-      ["claudecode", [claudeSession]],
-      ["codex", [codexSession]],
-    ]);
+    });
+    route.sessions = [claudeSession];
+    props.route = route;
 
     renderContent(props);
 
@@ -383,27 +388,21 @@ describe("AppRouteContent", () => {
     const recoveryLink = screen.getByRole("link", { name: /Claude recovery session/ });
     expect(recoveryLink.getAttribute("href")).toBe("/claudecode/recovery%2Fid%3F%23%25");
     expect(screen.queryByText("Codex recovery session")).toBeNull();
-    expect(props.bookmarks.isBookmarked).toHaveBeenCalledWith("claudecode", recoverySessionId);
+    expect(route.bookmarks.isBookmarked).toHaveBeenCalledWith("claudecode", recoverySessionId);
 
     fireEvent.click(screen.getByRole("button", { name: "Add bookmark" }));
-    expect(props.bookmarks.toggleSessionBookmark).toHaveBeenCalledWith(claudeSession, "claudecode");
+    expect(route.bookmarks.toggleSessionBookmark).toHaveBeenCalledWith(claudeSession, "claudecode");
   });
 
   it("renders a retryable load failure instead of a missing session", () => {
     const props = makeProps();
-    addRouteAgents(props);
     const retry = vi.fn();
-    props.viewState = {
-      mode: "session",
-      activeAgentKey: "claudecode",
-      activeSessionId: "unavailable-session",
-    };
-    props.sessionDetail = {
+    props.route = makeSessionRoute("unavailable-session", {
       session: null,
       loading: false,
       error: { kind: "load-failed", message: "server unavailable" },
       retry,
-    };
+    });
 
     renderContent(props);
 
@@ -416,12 +415,15 @@ describe("AppRouteContent", () => {
 
   it("renders a missing agent with diagnostics and canonical recovery links", () => {
     const props = makeProps();
-    addRouteAgents(props);
-    props.viewState = {
+    props.route = {
       mode: "missingAgent",
       activeAgentKey: null,
       activeSessionId: null,
       attemptedKey: "ghost-agent",
+      agents: routeAgents,
+      agentCatalog: createAgentCatalog(routeAgents),
+      sessions: [],
+      bookmarks: makeBookmarks(),
     };
 
     renderContent(props);

--- a/apps/web/src/components/app/AppRouteContent.tsx
+++ b/apps/web/src/components/app/AppRouteContent.tsx
@@ -8,30 +8,41 @@ import {
   type SetStateAction,
 } from "react";
 import { Link, useLocation } from "react-router-dom";
+import type { SessionDetailError } from "../../hooks/useSessionDetail";
+import type { AgentCatalog } from "../../lib/agents";
+import type {
+  AgentInfo,
+  AppConfig,
+  ApiProjectGroup,
+  ApiProjectPage,
+  SessionDetail,
+  SessionHead,
+} from "../../lib/api";
+import { getSessionRouteKey, type IndexedSession } from "../../lib/session-indexes";
+import type { TimeWindowPreset } from "../../lib/time-window";
+import type { ViewState } from "../../lib/view-state";
 import { DetailLanding, type LandingAgentItem } from "../DetailLanding";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { RenderProfiler } from "../RenderProfiler";
 import { SessionDetailSkeleton } from "../SessionDetailSkeleton";
+import type { SearchFilterState, SearchLoadState, SearchProjectOption } from "./types";
 
-// Each surface owns its heavy dependencies — markdown, syntax highlighting and
-// the receipt reach the browser when their route does, not on first paint.
 const OverviewScreen = lazy(() =>
-  import("../overview/OverviewScreen").then((m) => ({ default: m.OverviewScreen })),
+  import("../overview/OverviewScreen").then((module) => ({ default: module.OverviewScreen })),
 );
 const ProjectsOverview = lazy(() =>
-  import("../Projects").then((m) => ({ default: m.ProjectsOverview })),
+  import("../Projects").then((module) => ({ default: module.ProjectsOverview })),
 );
 const ProjectDashboardView = lazy(() =>
-  import("../Projects").then((m) => ({ default: m.ProjectDashboardView })),
+  import("../Projects").then((module) => ({ default: module.ProjectDashboardView })),
 );
-const SessionDetail = lazy(() =>
-  import("../SessionDetail").then((m) => ({ default: m.SessionDetail })),
+const SessionDetailView = lazy(() =>
+  import("../SessionDetail").then((module) => ({ default: module.SessionDetail })),
 );
 const SearchResultsPanel = lazy(() =>
-  import("./SearchResultsPanel").then((m) => ({ default: m.SearchResultsPanel })),
+  import("./SearchResultsPanel").then((module) => ({ default: module.SearchResultsPanel })),
 );
 
-/** Keeps a failed chunk load contained to the surface that needed it. */
 function LazySurface({ children }: { children: ReactNode }) {
   const location = useLocation();
   return (
@@ -40,30 +51,20 @@ function LazySurface({ children }: { children: ReactNode }) {
     </ErrorBoundary>
   );
 }
-import type {
-  AgentInfo,
-  AppConfig,
-  ApiProjectGroup,
-  ApiProjectPage,
-  SessionHead,
-} from "../../lib/api";
-import type * as Api from "../../lib/api";
-import type { SessionDetailError } from "../../hooks/useSessionDetail";
-import type { AgentCatalog } from "../../lib/agents";
-import type { TimeWindowPreset } from "../../lib/time-window";
-import type { ViewState } from "../../lib/view-state";
-import type { SearchFilterState, SearchLoadState, SearchProjectOption } from "./types";
-import { getSessionRouteKey, type IndexedSession } from "../../lib/session-indexes";
+
+interface LoadModel {
+  loading: boolean;
+  error: string | null;
+  retry: () => void;
+}
 
 interface SessionDetailModel {
-  session: Api.SessionDetail | null;
+  session: SessionDetail | null;
   loading: boolean;
   error: SessionDetailError | null;
   retry: () => void;
 }
 
-/** The overview owns its scope and its own request; the shell only lends it the
- *  loaded window and the app-wide time-window presets. */
 interface OverviewModel {
   window: AppConfig["window"] | null;
   rangePreset: TimeWindowPreset;
@@ -80,6 +81,8 @@ interface SearchContentModel {
   active: boolean;
   query: string;
   state: SearchLoadState;
+  agentNameMap: ReadonlyMap<string, string>;
+  agents: AgentInfo[];
   projectOptions: SearchProjectOption[];
   filters: SearchFilterState;
   onChangeFilters: Dispatch<SetStateAction<SearchFilterState>>;
@@ -94,257 +97,276 @@ interface BookmarkContentModel {
   toggleSessionBookmark: (session: SessionHead, agentKey: string) => void;
 }
 
-interface AppRouteContentProps {
-  loading: boolean;
-  error: string | null;
-  onRetry: () => void;
-  viewState: ViewState;
-  detailHighlightQuery: string;
+interface LandingRouteModel {
   agents: AgentInfo[];
   agentCatalog: AgentCatalog;
-  agentNameMap: ReadonlyMap<string, string>;
-  projectPage: ApiProjectPage;
-  projectsError: string | null;
-  projectsLoading: boolean;
-  onRetryProjects: () => void;
-  landingSessions: IndexedSession[];
-  childSessionsByParentRouteKey: ReadonlyMap<string, SessionHead[]>;
-  sessionsByAgent: Map<string, IndexedSession[]>;
-  activeProject: ApiProjectGroup | null;
-  activeProjectLoading: boolean;
-  activeProjectError: string | null;
-  onRetryActiveProject: () => void;
-  activeProjectSessions: IndexedSession[];
-  overview: OverviewModel;
-  sessionDetail: SessionDetailModel;
-  projectAgentFilter: ProjectAgentFilterModel;
-  search: SearchContentModel;
+  sessions: IndexedSession[];
   bookmarks: BookmarkContentModel;
 }
 
-export function AppRouteContent({
-  loading,
-  error,
-  onRetry,
-  viewState,
-  detailHighlightQuery,
-  agents,
-  agentCatalog,
-  agentNameMap,
-  projectPage,
-  projectsError,
-  projectsLoading,
-  onRetryProjects,
-  landingSessions,
-  childSessionsByParentRouteKey,
-  sessionsByAgent,
-  activeProject,
-  activeProjectLoading,
-  activeProjectError,
-  onRetryActiveProject,
-  activeProjectSessions,
-  overview,
-  sessionDetail,
-  projectAgentFilter,
-  search,
-  bookmarks,
-}: AppRouteContentProps) {
-  const landingAgentItems = useMemo<LandingAgentItem[]>(
-    () =>
-      agents.map((agent) => ({
-        key: agent.name.toLowerCase(),
-        name: agent.displayName,
-        icon: agent.icon,
-        iconColored: agent.iconColored,
-        count: agent.count,
-      })),
-    [agents],
+type RootRouteModel = Extract<ViewState, { mode: "root" }> & {
+  agentCatalog: AgentCatalog;
+  projectCount: number;
+  overview: OverviewModel;
+};
+
+type ProjectsRouteModel = Extract<ViewState, { mode: "projects" }> & {
+  agentCatalog: AgentCatalog;
+  projectPage: ApiProjectPage;
+  projectsLoad: LoadModel;
+  window: AppConfig["window"] | null;
+};
+
+type ProjectRouteModel = Extract<ViewState, { mode: "project" }> & {
+  agentCatalog: AgentCatalog;
+  project: ApiProjectGroup | null;
+  projectLoad: LoadModel;
+  sessions: IndexedSession[];
+  agentFilter: ProjectAgentFilterModel;
+  overview: OverviewModel;
+};
+
+type AgentRouteModel = Extract<ViewState, { mode: "agent" }> & LandingRouteModel;
+
+type SessionRouteModel = Extract<ViewState, { mode: "session" }> &
+  LandingRouteModel & {
+    detail: SessionDetailModel;
+    detailHighlightQuery: string;
+    childSessionsByParentRouteKey: ReadonlyMap<string, SessionHead[]>;
+  };
+
+type MissingAgentRouteModel = Extract<ViewState, { mode: "missingAgent" }> & LandingRouteModel;
+
+export type AppRouteModel =
+  | RootRouteModel
+  | ProjectsRouteModel
+  | ProjectRouteModel
+  | AgentRouteModel
+  | SessionRouteModel
+  | MissingAgentRouteModel
+  | Extract<ViewState, { mode: "invalidRoute" }>;
+
+interface AppRouteContentProps {
+  load: LoadModel;
+  search: SearchContentModel;
+  route: AppRouteModel;
+}
+
+function landingAgentItems(agents: AgentInfo[]): LandingAgentItem[] {
+  return agents.map((agent) => ({
+    key: agent.name.toLowerCase(),
+    name: agent.displayName,
+    icon: agent.icon,
+    iconColored: agent.iconColored,
+    count: agent.count,
+  }));
+}
+
+function SearchRouteContent({ search }: { search: SearchContentModel }) {
+  const resultCount = search.state.status === "loaded" ? search.state.results.length : 0;
+  return (
+    <RenderProfiler
+      id="SearchResultsPanel"
+      detail={{ results: resultCount, loading: search.state.status === "loading" }}
+    >
+      <LazySurface>
+        <SearchResultsPanel
+          query={search.query}
+          state={search.state}
+          agentNameMap={search.agentNameMap}
+          agents={search.agents}
+          projects={search.projectOptions}
+          filters={search.filters}
+          onChangeFilters={search.onChangeFilters}
+          onOpenResult={search.onClose}
+          onRetry={search.onRetry}
+          selectedIndex={search.selectedIndex}
+          registerResultRef={search.registerResultRef}
+        />
+      </LazySurface>
+    </RenderProfiler>
   );
-  const currentSession = viewState.mode === "session" ? sessionDetail.session : null;
+}
+
+function LoadError({ load }: { load: LoadModel }) {
+  return (
+    <div
+      role="alert"
+      className="mx-auto max-w-4xl rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6 text-sm text-[var(--console-error)]"
+    >
+      <p>{load.error}</p>
+      <button
+        type="button"
+        onClick={load.retry}
+        className="console-mono mt-4 rounded-sm border border-[var(--console-error-border)] px-3 py-1.5 text-xs motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function RootRouteContent({ route }: { route: RootRouteModel }) {
+  return (
+    <RenderProfiler id="OverviewScreen" detail={{ projects: route.projectCount }}>
+      <LazySurface>
+        <OverviewScreen
+          window={route.overview.window}
+          agentCatalog={route.agentCatalog}
+          rangePreset={route.overview.rangePreset}
+          onRangeChange={route.overview.onRangeChange}
+          onSelectCustom={route.overview.onSelectCustom}
+        />
+      </LazySurface>
+    </RenderProfiler>
+  );
+}
+
+function ProjectsRouteContent({ route }: { route: ProjectsRouteModel }) {
+  return (
+    <LazySurface>
+      <ProjectsOverview
+        initialPage={route.projectPage}
+        window={route.window}
+        agentCatalog={route.agentCatalog}
+        loading={route.projectsLoad.loading}
+        error={route.projectsLoad.error}
+        onRetry={route.projectsLoad.retry}
+      />
+    </LazySurface>
+  );
+}
+
+function ProjectRouteContent({ route }: { route: ProjectRouteModel }) {
+  return (
+    <LazySurface>
+      <ProjectDashboardView
+        project={route.project}
+        loading={route.projectLoad.loading}
+        error={route.projectLoad.error}
+        onRetry={route.projectLoad.retry}
+        agentCatalog={route.agentCatalog}
+        projectKey={route.activeProjectKey}
+        sessions={route.sessions}
+        activeAgent={route.agentFilter.selectedAgent}
+        onChangeAgent={route.agentFilter.onChangeAgent}
+        timeWindow={route.overview.window}
+        rangePreset={route.overview.rangePreset}
+        onRangeChange={route.overview.onRangeChange}
+        onSelectCustom={route.overview.onSelectCustom}
+      />
+    </LazySurface>
+  );
+}
+
+function AgentRouteContent({ route }: { route: AgentRouteModel }) {
+  const agentItems = useMemo(() => landingAgentItems(route.agents), [route.agents]);
+  const toggleSessionBookmark = route.bookmarks.toggleSessionBookmark;
+  const toggleBookmark = useCallback(
+    (session: IndexedSession) => toggleSessionBookmark(session, session.reference.agentName),
+    [toggleSessionBookmark],
+  );
+  return (
+    <DetailLanding
+      type="agent"
+      agentCatalog={route.agentCatalog}
+      sessions={route.sessions}
+      agentItems={agentItems}
+      activeAgentKey={route.activeAgentKey}
+      isBookmarked={route.bookmarks.isBookmarked}
+      onToggleBookmark={toggleBookmark}
+    />
+  );
+}
+
+function SessionRouteContent({ route }: { route: SessionRouteModel }) {
+  const agentItems = useMemo(() => landingAgentItems(route.agents), [route.agents]);
+  const currentSession = route.detail.session;
   const currentSessionAgentName = currentSession?.reference.agentName;
   const currentSessionId = currentSession?.reference.sessionId;
   const childSessions = useMemo(() => {
     if (!currentSessionAgentName || !currentSessionId) return [];
-    const parentRouteKey = getSessionRouteKey(currentSessionAgentName, currentSessionId);
-    return childSessionsByParentRouteKey.get(parentRouteKey) ?? [];
-  }, [childSessionsByParentRouteKey, currentSessionAgentName, currentSessionId]);
-  const toggleSessionBookmark = bookmarks.toggleSessionBookmark;
-  const toggleLandingBookmark = useCallback(
+    return (
+      route.childSessionsByParentRouteKey.get(
+        getSessionRouteKey(currentSessionAgentName, currentSessionId),
+      ) ?? []
+    );
+  }, [route.childSessionsByParentRouteKey, currentSessionAgentName, currentSessionId]);
+  const toggleSessionBookmark = route.bookmarks.toggleSessionBookmark;
+  const toggleBookmark = useCallback(
     (session: IndexedSession) => toggleSessionBookmark(session, session.reference.agentName),
     [toggleSessionBookmark],
   );
-  if (loading) return <SessionDetailSkeleton />;
-  if (search.active) {
-    const resultCount = search.state.status === "loaded" ? search.state.results.length : 0;
-    return (
-      <RenderProfiler
-        id="SearchResultsPanel"
-        detail={{ results: resultCount, loading: search.state.status === "loading" }}
-      >
-        <LazySurface>
-          <SearchResultsPanel
-            query={search.query}
-            state={search.state}
-            agentNameMap={agentNameMap}
-            agents={agents}
-            projects={search.projectOptions}
-            filters={search.filters}
-            onChangeFilters={search.onChangeFilters}
-            onOpenResult={search.onClose}
-            onRetry={search.onRetry}
-            selectedIndex={search.selectedIndex}
-            registerResultRef={search.registerResultRef}
-          />
-        </LazySurface>
-      </RenderProfiler>
-    );
-  }
-  if (error) {
-    return (
-      <div
-        role="alert"
-        className="mx-auto max-w-4xl rounded-sm border border-[var(--console-error-border)] bg-[var(--console-error-bg)] p-6 text-sm text-[var(--console-error)]"
-      >
-        <p>{error}</p>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="console-mono mt-4 rounded-sm border border-[var(--console-error-border)] px-3 py-1.5 text-xs motion-hover hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--brand)] focus-visible:outline-none"
-        >
-          Retry
-        </button>
-      </div>
-    );
-  }
-  if (viewState.mode === "root") {
-    return (
-      <RenderProfiler id="OverviewScreen" detail={{ projects: projectPage.summary.projects }}>
-        <LazySurface>
-          <OverviewScreen
-            window={overview.window}
-            agentCatalog={agentCatalog}
-            rangePreset={overview.rangePreset}
-            onRangeChange={overview.onRangeChange}
-            onSelectCustom={overview.onSelectCustom}
-          />
-        </LazySurface>
-      </RenderProfiler>
-    );
-  }
-  if (viewState.mode === "projects") {
-    return (
-      <LazySurface>
-        <ProjectsOverview
-          initialPage={projectPage}
-          window={overview.window}
-          agentCatalog={agentCatalog}
-          loading={projectsLoading}
-          error={projectsError}
-          onRetry={onRetryProjects}
-        />
-      </LazySurface>
-    );
-  }
-  if (viewState.mode === "project") {
-    return (
-      <LazySurface>
-        <ProjectDashboardView
-          project={activeProject}
-          loading={activeProjectLoading}
-          error={activeProjectError}
-          onRetry={onRetryActiveProject}
-          agentCatalog={agentCatalog}
-          projectKey={viewState.activeProjectKey}
-          sessions={activeProjectSessions}
-          activeAgent={projectAgentFilter.selectedAgent}
-          onChangeAgent={projectAgentFilter.onChangeAgent}
-          timeWindow={overview.window}
-          rangePreset={overview.rangePreset}
-          onRangeChange={overview.onRangeChange}
-          onSelectCustom={overview.onSelectCustom}
-        />
-      </LazySurface>
-    );
-  }
-  if (viewState.mode === "agent") {
+
+  if (route.detail.loading) return <SessionDetailSkeleton />;
+  if (route.detail.error?.kind === "missing") {
     return (
       <DetailLanding
-        type="agent"
-        agentCatalog={agentCatalog}
-        sessions={sessionsByAgent.get(viewState.activeAgentKey) ?? []}
-        agentItems={landingAgentItems}
-        activeAgentKey={viewState.activeAgentKey}
-        isBookmarked={bookmarks.isBookmarked}
-        onToggleBookmark={toggleLandingBookmark}
+        type="missing-session"
+        agentCatalog={route.agentCatalog}
+        sessions={route.sessions}
+        agentItems={agentItems}
+        activeAgentKey={route.activeAgentKey}
+        attemptedSessionId={route.activeSessionId}
+        isBookmarked={route.bookmarks.isBookmarked}
+        onToggleBookmark={toggleBookmark}
       />
     );
   }
-  if (viewState.mode === "session") {
-    if (sessionDetail.loading) return <SessionDetailSkeleton />;
-    if (sessionDetail.error?.kind === "missing") {
-      return (
-        <DetailLanding
-          type="missing-session"
-          agentCatalog={agentCatalog}
-          sessions={sessionsByAgent.get(viewState.activeAgentKey) ?? []}
-          agentItems={landingAgentItems}
-          activeAgentKey={viewState.activeAgentKey}
-          attemptedSessionId={viewState.activeSessionId}
-          isBookmarked={bookmarks.isBookmarked}
-          onToggleBookmark={toggleLandingBookmark}
-        />
-      );
-    }
-    if (sessionDetail.error?.kind === "load-failed") {
-      return (
-        <DetailLanding
-          type="load-failed"
-          agentCatalog={agentCatalog}
-          sessions={sessionsByAgent.get(viewState.activeAgentKey) ?? []}
-          agentItems={landingAgentItems}
-          loadFailureMessage={sessionDetail.error.message}
-          isBookmarked={bookmarks.isBookmarked}
-          onToggleBookmark={toggleLandingBookmark}
-          onRetry={sessionDetail.retry}
-        />
-      );
-    }
-    if (!currentSession) return <SessionDetailSkeleton />;
-    return (
-      <RenderProfiler
-        id="SessionDetail"
-        detail={{
-          messages: currentSession.messages.length,
-          session: currentSession.reference.sessionId,
-        }}
-      >
-        <LazySurface>
-          <SessionDetail
-            key={`${currentSession.reference.agentName}/${currentSession.reference.sessionId}`}
-            session={currentSession}
-            agentCatalog={agentCatalog}
-            highlightQuery={detailHighlightQuery}
-            childSessions={childSessions}
-          />
-        </LazySurface>
-      </RenderProfiler>
-    );
-  }
-  if (viewState.mode === "missingAgent") {
+  if (route.detail.error?.kind === "load-failed") {
     return (
       <DetailLanding
-        type="missing-agent"
-        agentCatalog={agentCatalog}
-        sessions={landingSessions}
-        agentItems={landingAgentItems}
-        attemptedAgentKey={viewState.attemptedKey}
-        isBookmarked={bookmarks.isBookmarked}
-        onToggleBookmark={(session) =>
-          bookmarks.toggleSessionBookmark(session, session.reference.agentName)
-        }
+        type="load-failed"
+        agentCatalog={route.agentCatalog}
+        sessions={route.sessions}
+        agentItems={agentItems}
+        loadFailureMessage={route.detail.error.message}
+        isBookmarked={route.bookmarks.isBookmarked}
+        onToggleBookmark={toggleBookmark}
+        onRetry={route.detail.retry}
       />
     );
   }
+  if (!currentSession) return <SessionDetailSkeleton />;
+  return (
+    <RenderProfiler
+      id="SessionDetail"
+      detail={{
+        messages: currentSession.messages.length,
+        session: currentSession.reference.sessionId,
+      }}
+    >
+      <LazySurface>
+        <SessionDetailView
+          key={`${currentSession.reference.agentName}/${currentSession.reference.sessionId}`}
+          session={currentSession}
+          agentCatalog={route.agentCatalog}
+          highlightQuery={route.detailHighlightQuery}
+          childSessions={childSessions}
+        />
+      </LazySurface>
+    </RenderProfiler>
+  );
+}
+
+function MissingAgentRouteContent({ route }: { route: MissingAgentRouteModel }) {
+  const agentItems = useMemo(() => landingAgentItems(route.agents), [route.agents]);
+  return (
+    <DetailLanding
+      type="missing-agent"
+      agentCatalog={route.agentCatalog}
+      sessions={route.sessions}
+      agentItems={agentItems}
+      attemptedAgentKey={route.attemptedKey}
+      isBookmarked={route.bookmarks.isBookmarked}
+      onToggleBookmark={(session) =>
+        route.bookmarks.toggleSessionBookmark(session, session.reference.agentName)
+      }
+    />
+  );
+}
+
+function InvalidRouteContent() {
   return (
     <div
       role="alert"
@@ -364,4 +386,30 @@ export function AppRouteContent({
       </Link>
     </div>
   );
+}
+
+function RouteContent({ route }: { route: AppRouteModel }) {
+  switch (route.mode) {
+    case "root":
+      return <RootRouteContent route={route} />;
+    case "projects":
+      return <ProjectsRouteContent route={route} />;
+    case "project":
+      return <ProjectRouteContent route={route} />;
+    case "agent":
+      return <AgentRouteContent route={route} />;
+    case "session":
+      return <SessionRouteContent route={route} />;
+    case "missingAgent":
+      return <MissingAgentRouteContent route={route} />;
+    case "invalidRoute":
+      return <InvalidRouteContent />;
+  }
+}
+
+export function AppRouteContent({ load, search, route }: AppRouteContentProps) {
+  if (load.loading) return <SessionDetailSkeleton />;
+  if (search.active) return <SearchRouteContent search={search} />;
+  if (load.error) return <LoadError load={load} />;
+  return <RouteContent route={route} />;
 }


### PR DESCRIPTION
## Summary

- replace the cross-route prop bag with a discriminated route model
- give each route component only the data and actions it consumes
- keep search and application loading as explicit shared layers

## Validation

- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test