### PR TITLE
agents: Unify session source parsing

### DIFF
--- a/packages/cli/src/agent-backfill-scheduler.test.ts
+++ b/packages/cli/src/agent-backfill-scheduler.test.ts
@@ -36,8 +36,8 @@ class FakeSyncAgent extends FileSystemSessionSource {
     return [];
   }
 
-  scanSessionSource() {
-    return null;
+  protected scanSessionSourceResult() {
+    return { status: "skipped" as const, reason: "empty test source" };
   }
 
   getSessionData() {

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -180,8 +180,8 @@ class FakeSyncAgent extends FileSystemSessionSource {
     return [];
   }
 
-  scanSessionSource() {
-    return null;
+  protected scanSessionSourceResult() {
+    return { status: "skipped" as const, reason: "empty test source" };
   }
 
   getSessionData() {

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -472,13 +472,14 @@ function makeFileSystemAgent(
   name: string,
   overrides: {
     listSessionSources?: (options?: AgentScanOptions) => SessionSourceRef[];
-    scanSessionSource?: (sourcePath: string) => SessionHead | null;
+    scanSessionSource?: (sourcePath: string, options?: AgentScanOptions) => SessionHead | null;
     getSessionCacheMeta?: (sessionId: string) => SessionCacheMeta | undefined;
     snapshotSessionCacheMeta?: () => Record<string, SessionCacheMeta>;
     restoreSessionCacheMeta?: (meta: Readonly<Record<string, SessionCacheMeta>>) => void;
     removeSessionCacheMeta?: (sessionIds: Iterable<string>) => void;
   } = {},
 ) {
+  const parseSource = overrides.scanSessionSource ?? vi.fn(() => null);
   const agent = Reflect.construct(FileSystemSessionSource, []) as InstanceType<
     typeof FileSystemSessionSource
   >;
@@ -489,7 +490,14 @@ function makeFileSystemAgent(
   agent.getSessionData = vi.fn(() => ({}) as SessionDetail);
   agent.getSessionWatchPlan = vi.fn(() => watchPlanFor(name));
   agent.listSessionSources = overrides.listSessionSources ?? vi.fn(() => []);
-  agent.scanSessionSource = overrides.scanSessionSource ?? vi.fn(() => null);
+  Object.defineProperty(agent, "scanSessionSourceResult", {
+    value: (source: SessionSourceRef, options?: AgentScanOptions) => {
+      const session = parseSource(source.sourcePath, options);
+      return session
+        ? { status: "parsed" as const, data: session }
+        : { status: "skipped" as const, reason: "empty test source" };
+    },
+  });
   agent.getSessionCacheMeta = overrides.getSessionCacheMeta ?? vi.fn();
   agent.snapshotSessionCacheMeta = overrides.snapshotSessionCacheMeta ?? vi.fn(() => ({}));
   agent.restoreSessionCacheMeta = overrides.restoreSessionCacheMeta ?? vi.fn();

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -1,5 +1,6 @@
 import { PRICING_CAPTURE_EPOCH } from "@codesesh/core/runtime/pricing";
 import {
+  type AgentScanOptions,
   type BaseAgent,
   type SessionCacheMeta,
   type SessionSourceRef,
@@ -110,13 +111,17 @@ function currentPricingMeta(meta: SessionCacheMeta): SessionCacheMeta {
 
 function makeAgent(overrides: Record<string, unknown> = {}) {
   let sessionMeta: Record<string, SessionCacheMeta> = {};
+  const parseSource =
+    (overrides.scanSessionSource as
+      | ((sourcePath: string, options?: AgentScanOptions) => SessionHead | null)
+      | undefined) ?? vi.fn(() => null);
+  const { scanSessionSource: _scanSessionSource, ...agentOverrides } = overrides;
   const agent = Object.assign(new mocks.FileSystemSessionSource(), {
     name: "codex",
     isAvailable: vi.fn(() => true),
     scan: vi.fn(() => []),
     incrementalScan: vi.fn(() => []),
     listSessionSources: vi.fn(() => []),
-    scanSessionSource: vi.fn(() => null),
     expandChangedSessionIds: vi.fn((changedIds: string[]) => changedIds),
     filterCachedSessions: vi.fn((sessions: SessionHead[]) => sessions),
     getSessionData: vi.fn(),
@@ -128,7 +133,15 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
     removeSessionCacheMeta: vi.fn((sessionIds: Iterable<string>) => {
       for (const sessionId of sessionIds) delete sessionMeta[sessionId];
     }),
-    ...overrides,
+    ...agentOverrides,
+  });
+  Object.defineProperty(agent, "scanSessionSourceResult", {
+    value: (source: SessionSourceRef, options?: AgentScanOptions) => {
+      const session = parseSource(source.sourcePath, options);
+      return session
+        ? { status: "parsed" as const, data: session }
+        : { status: "skipped" as const, reason: "empty test source" };
+    },
   });
   return agent;
 }

--- a/packages/core/src/agents/__tests__/base.test.ts
+++ b/packages/core/src/agents/__tests__/base.test.ts
@@ -8,7 +8,9 @@ import {
   diffSessionSources,
   FileSystemSessionSource,
   filteredSession,
+  parsedSession,
   SingleFileSessionSource,
+  skippedSession,
 } from "../base.js";
 import type {
   AgentScanOptions,
@@ -80,24 +82,19 @@ class FakeFileSystemSource extends FileSystemSessionSource {
     }));
   }
 
-  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
+  protected override scanSessionSourceResult(ref: SessionSourceRef, options?: AgentScanOptions) {
     this.lastScanOptions = options;
-    const found = this.sources.find((s) => s.sourcePath === sourcePath);
+    const found = this.sources.find((s) => s.sourcePath === ref.sourcePath);
     if (found?.error) throw found.error;
     if (found?.throws) throw new Error("parse failed");
-    if (!found || !found.head) return null;
+    if (found?.filtered) return filteredSession<SessionHead>("no visible messages");
+    if (!found || !found.head) return skippedSession<SessionHead>("source produced no session");
     this.sessionMetaMap.set(found.sessionId, {
       id: found.sessionId,
       sourcePath: found.sourcePath,
       sourceFingerprint: found.fingerprint,
     });
-    return found.head;
-  }
-
-  protected override scanSessionSourceResult(ref: SessionSourceRef, options?: AgentScanOptions) {
-    const found = this.sources.find((item) => item.sourcePath === ref.sourcePath);
-    if (found?.filtered) return filteredSession<SessionHead>("no visible messages");
-    return super.scanSessionSourceResult(ref, options);
+    return parsedSession(found.head);
   }
 }
 
@@ -305,9 +302,9 @@ describe("FileSystemSessionSource.scan", () => {
 
 describe("FileSystemSessionSource pricing miss capture", () => {
   class UnpricedModelSource extends FakeFileSystemSource {
-    override scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
+    protected override scanSessionSourceResult(ref: SessionSourceRef, options?: AgentScanOptions) {
       estimateTokenCost("vendor/nonexistent-model", { input: 10, output: 10 });
-      return super.scanSessionSource(sourcePath, options);
+      return super.scanSessionSourceResult(ref, options);
     }
   }
 

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -300,11 +300,9 @@ export abstract class BaseAgent<TMeta extends SessionCacheMeta = SessionCacheMet
  *
  * 子类只需实现两个必需的文件级原语：
  *   - listSessionSources(): 枚举所有源 + 计算指纹
- *   - scanSessionSource(): 解析单个源（同时写入 metaMap）
+ *   - scanSessionSourceResult(): 解析单个源（同时写入 metaMap）
  *
- * scanSessionSourceResult() 是可选的富结果扩展点：默认将 scanSessionSource()
- * 的会话或 null 转成 parsed/skipped 结果；需要保留 filtered 等结果时可覆写，
- * 例如 KimiAgent。
+ * scanSessionSource() 是兼容旧调用方的公开入口，由富结果统一派生。
  *
  * 源同步与 metaMap 管理由本基类统一提供：
  *   同步流程用 listSessionSources 的指纹与缓存 metaMap 比对，
@@ -333,15 +331,16 @@ export abstract class FileSystemSessionSource<
   abstract listSessionSources(options?: AgentScanOptions): SessionSourceRef[];
 
   /** 解析单个源并写入 metaMap，返回会话 head（解析失败/不可见返回 null）。 */
-  abstract scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null;
+  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
+    return getParsedSession(
+      this.scanSessionSourceResult({ sessionId: "", sourcePath, fingerprint: "" }, options),
+    );
+  }
 
-  protected scanSessionSourceResult(
+  protected abstract scanSessionSourceResult(
     source: SessionSourceRef,
     options?: AgentScanOptions,
-  ): ParseSessionResult<SessionHead> {
-    const session = this.scanSessionSource(source.sourcePath, options);
-    return session ? parsedSession(session) : skippedSession("source produced no session");
-  }
+  ): ParseSessionResult<SessionHead>;
 
   scanSessionSourceOutcome(
     source: SessionSourceRef,
@@ -503,10 +502,6 @@ export abstract class SingleFileSessionSource<
       );
     }
     return result;
-  }
-
-  scanSessionSource(sourcePath: string, options?: AgentScanOptions): SessionHead | null {
-    return getParsedSession(this.parseSessionSource(sourcePath, options));
   }
 
   protected override scanSessionSourceResult(

--- a/packages/core/src/agents/dsh.ts
+++ b/packages/core/src/agents/dsh.ts
@@ -14,7 +14,6 @@ import {
   FileSystemSessionSource,
   SessionScanError,
   filteredSession,
-  getParsedSession,
   matchesScanWindow,
   parsedSession,
 } from "./base.js";
@@ -153,12 +152,6 @@ export class DshAgent extends FileSystemSessionSource<DshSessionMeta> {
   }
 
   /** The scan window is applied during enumeration, so parsing needs no options. */
-  scanSessionSource(sourcePath: string): SessionHead | null {
-    return getParsedSession(
-      this.scanSessionSourceResult({ sessionId: "", sourcePath, fingerprint: "" }),
-    );
-  }
-
   protected override scanSessionSourceResult(
     source: SessionSourceRef,
   ): ParseSessionResult<SessionHead> {

--- a/packages/core/src/agents/grok.ts
+++ b/packages/core/src/agents/grok.ts
@@ -4,7 +4,6 @@ import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import {
   FileSystemSessionSource,
   filteredSession,
-  getParsedSession,
   matchesScanWindow,
   parsedSession,
   skippedSession,
@@ -876,10 +875,6 @@ export class GrokAgent extends FileSystemSessionSource<GrokSessionMeta> {
         },
       ];
     });
-  }
-
-  scanSessionSource(sourcePath: string): SessionHead | null {
-    return getParsedSession(this.parseSessionHeadResult(sourcePath));
   }
 
   protected override scanSessionSourceResult(

--- a/packages/core/src/agents/kimi-code.ts
+++ b/packages/core/src/agents/kimi-code.ts
@@ -508,10 +508,6 @@ export class KimiCodeAgent extends FileSystemSessionSource<SessionMeta> {
     });
   }
 
-  scanSessionSource(sourcePath: string): SessionHead | null {
-    return getParsedSession(this.parseSessionHeadResult(sourcePath));
-  }
-
   protected override scanSessionSourceResult(
     source: SessionSourceRef,
   ): ParseSessionResult<SessionHead> {

--- a/packages/core/src/agents/kimi.ts
+++ b/packages/core/src/agents/kimi.ts
@@ -419,10 +419,6 @@ export class KimiAgent extends FileSystemSessionSource<SessionMeta> {
     return refs;
   }
 
-  scanSessionSource(sourcePath: string): SessionHead | null {
-    return getParsedSession(this.parseSessionHeadResult(sourcePath));
-  }
-
   protected override scanSessionSourceResult(
     source: SessionSourceRef,
   ): ParseSessionResult<SessionHead> {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -123,7 +123,7 @@ class FailingFileAgent extends FileSystemSessionSource {
     return [{ sessionId: "cached", sourcePath: "/cached.jsonl", fingerprint: "new" }];
   }
 
-  scanSessionSource(): SessionHead | null {
+  protected scanSessionSourceResult(): never {
     throw new SyntaxError("Unexpected end of JSON input");
   }
 


### PR DESCRIPTION
## Summary
- make rich parse outcomes the only adapter extension point
- derive the nullable public parser from the canonical outcome
- update adapter and integration test doubles to follow the same contract

## Validation
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test