### PR TITLE
logging: Protect and correlate local diagnostics

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -15,6 +15,9 @@ const LAZY_SURFACE_TIMEOUT_MS = 5_000;
 const liveSubscription = vi.hoisted(() => ({
   onUpdate: undefined as ((event: SessionsUpdatedEvent) => void) | undefined,
 }));
+const clientTelemetry = vi.hoisted(() => ({
+  logClientEvent: vi.fn<(event: string, data?: Record<string, unknown>) => void>(),
+}));
 
 vi.mock("./lib/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./lib/api")>()),
@@ -22,7 +25,7 @@ vi.mock("./lib/api", async (importOriginal) => ({
     liveSubscription.onUpdate = onUpdate;
     return () => undefined;
   },
-  logClientEvent: () => undefined,
+  logClientEvent: clientTelemetry.logClientEvent,
 }));
 
 const emptyDashboard: DashboardData = {
@@ -99,6 +102,7 @@ beforeEach(() => {
   requestedUrls = [];
   projectDetailResponse = null;
   liveSubscription.onUpdate = undefined;
+  clientTelemetry.logClientEvent.mockClear();
   responses["/api/agents"] = [];
   responses["/api/projects"] = workspaceProjectPage;
   responses["/api/sessions"] = { sessions: [] };
@@ -144,6 +148,10 @@ function dashboardRequests(): URLSearchParams[] {
   return requestedUrls
     .filter((url) => url.startsWith("/api/dashboard"))
     .map((url) => new URLSearchParams(url.split("?")[1] ?? ""));
+}
+
+function routeChangeCalls() {
+  return clientTelemetry.logClientEvent.mock.calls.filter(([event]) => event === "route.change");
 }
 
 describe("App session loading", () => {
@@ -345,5 +353,24 @@ describe("App dashboard scope wiring", () => {
 
     await waitFor(() => expect(dashboardRequests().length).toBeGreaterThan(0));
     expect(dashboardRequests().every((params) => params.get("projectKey") === null)).toBe(true);
+  });
+});
+
+describe("App route telemetry", () => {
+  it("records concrete route changes within the same view without exposing route identity", async () => {
+    const { router } = renderAppAt("/projects/path/%2Fworkspace");
+
+    await waitFor(() => expect(routeChangeCalls()).toHaveLength(1));
+    await act(async () => {
+      await router.navigate("/projects/path/%2Fanother-workspace");
+    });
+    await waitFor(() => expect(routeChangeCalls()).toHaveLength(2));
+
+    const [event, payload] = routeChangeCalls()[1] ?? [];
+    expect(event).toBe("route.change");
+    expect(payload).toMatchObject({ mode: "project" });
+    expect(payload).not.toHaveProperty("path");
+    expect(payload).not.toHaveProperty("project");
+    expect(payload).not.toHaveProperty("projectKey");
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -102,7 +102,6 @@ export default function App() {
 
   useEffect(() => {
     logClientEvent("route.change", {
-      path: location.pathname,
       mode: viewState.mode,
       agent: viewState.activeAgentKey,
       session: viewState.activeSessionId,

--- a/apps/web/src/components/RenderProfiler.tsx
+++ b/apps/web/src/components/RenderProfiler.tsx
@@ -116,7 +116,15 @@ export function RenderProfiler({
     pushProfileEntry(entry);
 
     if (entry.actualDuration >= PROFILER_SLOW_COMMIT_MS && shouldLogRenderProfilerEntries()) {
-      logClientEvent("react.profiler.commit", { ...entry });
+      logClientEvent("react.profiler.commit", {
+        profiler_id: entry.id,
+        source: entry.source,
+        phase: entry.phase,
+        actual_duration_ms: entry.actualDuration,
+        base_duration_ms: entry.baseDuration,
+        start_time_ms: entry.startTime,
+        commit_time_ms: entry.commitTime,
+      });
     }
   };
 

--- a/apps/web/src/hooks/useCopySessionAsMarkdown.test.tsx
+++ b/apps/web/src/hooks/useCopySessionAsMarkdown.test.tsx
@@ -40,8 +40,12 @@ describe("useCopySessionAsMarkdown", () => {
     expect(result.current.sessionCopyNotice).toBe("Couldn’t copy session as Markdown.");
     expect(apiMocks.logClientEvent).toHaveBeenCalledWith(
       "session.markdown_copy.error",
-      expect.objectContaining({ error: "Clipboard write failed" }),
+      expect.objectContaining({ error_name: "Error" }),
     );
+    const errorData = apiMocks.logClientEvent.mock.calls.find(
+      ([event]) => event === "session.markdown_copy.error",
+    )?.[1];
+    expect(JSON.stringify(errorData)).not.toContain("Clipboard write failed");
 
     act(() => vi.advanceTimersByTime(2_500));
     expect(result.current.sessionCopyNotice).toBeNull();

--- a/apps/web/src/hooks/useCopySessionAsMarkdown.ts
+++ b/apps/web/src/hooks/useCopySessionAsMarkdown.ts
@@ -35,7 +35,7 @@ export function useCopySessionAsMarkdown() {
         logClientEvent("session.markdown_copy.error", {
           agent: agentName,
           session: sessionId,
-          error: error instanceof Error ? error.message : String(error),
+          error_name: error instanceof Error ? error.name : "UnknownError",
         });
       }
     },

--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -57,6 +57,7 @@ function renderSessionDetail(view: ViewState = sessionView) {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("useSessionDetail", () => {
@@ -71,6 +72,35 @@ describe("useSessionDetail", () => {
       "claudecode/abc",
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
+  });
+
+  it("creates a compatible operation identifier without randomUUID", async () => {
+    vi.stubGlobal("crypto", {});
+    vi.mocked(api.fetchSessionData).mockResolvedValue(sample);
+    renderSessionDetail();
+
+    await waitFor(() => expect(api.fetchSessionData).toHaveBeenCalledOnce());
+    expect(vi.mocked(api.fetchSessionData).mock.calls[0]?.[2]?.operationId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("does not include a failed session URL in client telemetry", async () => {
+    vi.mocked(api.fetchSessionData).mockRejectedValue(
+      new api.ApiRequestError("GET /api/sessions/codex/private-session failed", 500),
+    );
+    renderSessionDetail();
+
+    await waitFor(() =>
+      expect(api.logClientEvent).toHaveBeenCalledWith(
+        "session.open.error",
+        expect.objectContaining({ error_name: "Error", error_status: 500 }),
+      ),
+    );
+    const errorCall = vi
+      .mocked(api.logClientEvent)
+      .mock.calls.find(([event]) => event === "session.open.error");
+    expect(JSON.stringify(errorCall?.[1])).not.toContain("private-session");
   });
 
   it("classifies a confirmed 404 as a missing session", async () => {

--- a/apps/web/src/hooks/useSessionDetail.ts
+++ b/apps/web/src/hooks/useSessionDetail.ts
@@ -4,8 +4,6 @@ import { ApiRequestError, fetchSessionData, logClientEvent, type SessionDetail }
 import { queryKeys } from "../lib/query-keys";
 import type { ViewState } from "../lib/view-state";
 
-let nextSessionRequestId = 1;
-
 export type SessionDetailError = { kind: "missing" } | { kind: "load-failed"; message: string };
 
 function getSessionDetailError(error: unknown): SessionDetailError {
@@ -32,6 +30,15 @@ function sessionRoute(viewState: ViewState) {
   };
 }
 
+function createOperationId(): string {
+  const generated = globalThis.crypto?.randomUUID?.();
+  if (generated) return generated;
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (token) => {
+    const value = Math.floor(Math.random() * 16);
+    return (token === "x" ? value : (value & 0x3) | 0x8).toString(16);
+  });
+}
+
 export function useSessionDetail(viewState: ViewState) {
   const queryClient = useQueryClient();
   const route = sessionRoute(viewState);
@@ -42,7 +49,7 @@ export function useSessionDetail(viewState: ViewState) {
     staleTime: Infinity,
     queryFn: async ({ signal }) => {
       if (!route) throw new Error("Session route is required");
-      const requestId = nextSessionRequestId++;
+      const operationId = createOperationId();
       const requestKey = `${route.agent}/${route.sessionId}`;
       const startedAt = performance.now();
       let didLogCancellation = false;
@@ -50,14 +57,14 @@ export function useSessionDetail(viewState: ViewState) {
         if (didLogCancellation) return;
         didLogCancellation = true;
         logClientEvent("session.open.cancel", {
-          request_id: requestId,
+          operation_id: operationId,
           request_key: requestKey,
           reason: "query-cancelled",
         });
       };
       signal.addEventListener("abort", logCancellation, { once: true });
       logClientEvent("session.open.start", {
-        request_id: requestId,
+        operation_id: operationId,
         request_key: requestKey,
         trigger: "route",
         agent: route.agent,
@@ -69,11 +76,12 @@ export function useSessionDetail(viewState: ViewState) {
         const response = await fetchSessionData(route.agent, route.sessionId, {
           signal,
           messageCursor: previous?.message_cursor,
+          operationId,
         });
         const data = mergeSessionDetailUpdate(previous, response);
         if (signal.aborted) throw new DOMException("Aborted", "AbortError");
         logClientEvent("session.open.done", {
-          request_id: requestId,
+          operation_id: operationId,
           request_key: requestKey,
           trigger: "route",
           agent: route.agent,
@@ -88,13 +96,14 @@ export function useSessionDetail(viewState: ViewState) {
           throw error;
         }
         logClientEvent("session.open.error", {
-          request_id: requestId,
+          operation_id: operationId,
           request_key: requestKey,
           trigger: "route",
           agent: route.agent,
           session: route.sessionId,
           duration_ms: Math.round(performance.now() - startedAt),
-          error: error instanceof Error ? error.message : String(error),
+          error_name: error instanceof Error ? error.name : "UnknownError",
+          error_status: error instanceof ApiRequestError ? error.status : undefined,
         });
         throw error;
       } finally {

--- a/apps/web/src/hooks/useSessionSearch.test.ts
+++ b/apps/web/src/hooks/useSessionSearch.test.ts
@@ -91,9 +91,13 @@ describe("useSessionSearch", () => {
     await waitFor(() =>
       expect(api.logClientEvent).toHaveBeenCalledWith(
         "search.error",
-        expect.objectContaining({ error: "Search unavailable" }),
+        expect.objectContaining({ error_name: "Error" }),
       ),
     );
+    const errorData = vi
+      .mocked(api.logClientEvent)
+      .mock.calls.find(([event]) => event === "search.error")?.[1];
+    expect(JSON.stringify(errorData)).not.toContain("Search unavailable");
     expect(result.current.searchState).toEqual({
       status: "failed",
       error: "Search unavailable",

--- a/apps/web/src/hooks/useSessionSearch.ts
+++ b/apps/web/src/hooks/useSessionSearch.ts
@@ -81,7 +81,7 @@ export function useSessionSearch(
           console.error("Failed to load search results:", error);
           logClientEvent("search.error", {
             duration_ms: Math.round(performance.now() - startedAt),
-            error: error instanceof Error ? error.message : String(error),
+            error_name: error instanceof Error ? error.name : "UnknownError",
           });
         }
         throw error;

--- a/apps/web/src/hooks/useWindowLoadTelemetry.test.ts
+++ b/apps/web/src/hooks/useWindowLoadTelemetry.test.ts
@@ -42,6 +42,7 @@ describe("useWindowLoadTelemetry", () => {
 
     rerender({ window, pending: false, error: null, agentCount: 2, sessionCount: 10 });
 
+    expect(api.logClientEvent).toHaveBeenCalledWith("app.load.start");
     await waitFor(() =>
       expect(api.logClientEvent).toHaveBeenCalledWith("app.load.done", {
         duration_ms: expect.any(Number),
@@ -68,9 +69,12 @@ describe("useWindowLoadTelemetry", () => {
     await waitFor(() =>
       expect(api.logClientEvent).toHaveBeenCalledWith("app.load.error", {
         duration_ms: expect.any(Number),
-        error: "reload failed",
       }),
     );
+    const errorData = vi
+      .mocked(api.logClientEvent)
+      .mock.calls.find(([event]) => event === "app.load.error")?.[1];
+    expect(JSON.stringify(errorData)).not.toContain("reload failed");
     expect(console.error).toHaveBeenCalledWith("Failed to load data:", "reload failed");
   });
 });

--- a/apps/web/src/hooks/useWindowLoadTelemetry.ts
+++ b/apps/web/src/hooks/useWindowLoadTelemetry.ts
@@ -20,7 +20,7 @@ export function useWindowLoadTelemetry({
 
   useEffect(() => {
     startedAtRef.current = window ? performance.now() : null;
-    if (window) logClientEvent("app.load.start", { path: globalThis.window.location.pathname });
+    if (window) logClientEvent("app.load.start");
   }, [window]);
 
   useEffect(() => {
@@ -30,7 +30,7 @@ export function useWindowLoadTelemetry({
     startedAtRef.current = null;
     if (error) {
       console.error("Failed to load data:", error);
-      logClientEvent("app.load.error", { duration_ms, error });
+      logClientEvent("app.load.error", { duration_ms });
       return;
     }
     logClientEvent("app.load.done", {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,4 +1,4 @@
-import { sessionRoutePath } from "@codesesh/core/contract";
+import { CODESESH_OPERATION_ID_HEADER, sessionRoutePath } from "@codesesh/core/contract";
 import type {
   AgentInfo,
   ApiProjectGroup,
@@ -151,7 +151,14 @@ export function createApiClient(access: RemoteAccess) {
     options?: SessionDetailFetchOptions,
   ): Promise<SessionDetail> {
     const path = `/api/sessions${sessionRoutePath({ agentName: agent, sessionId })}`;
-    const fetchOptions: FetchOptions | undefined = options ? { signal: options.signal } : undefined;
+    const fetchOptions: RequestInit | undefined = options
+      ? {
+          signal: options.signal,
+          ...(options.operationId
+            ? { headers: { [CODESESH_OPERATION_ID_HEADER]: options.operationId } }
+            : {}),
+        }
+      : undefined;
     if (!options?.messageCursor) return fetchJson(path, fetchOptions);
 
     const params = new URLSearchParams({ messageCursor: options.messageCursor });

--- a/apps/web/src/lib/api-contract.ts
+++ b/apps/web/src/lib/api-contract.ts
@@ -76,6 +76,7 @@ export interface FetchOptions {
 
 export interface SessionDetailFetchOptions extends FetchOptions {
   messageCursor?: string;
+  operationId?: string;
 }
 
 export interface ProjectPageOptions extends FetchOptions {

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -289,6 +289,21 @@ describe("fetchSessionData", () => {
     );
   });
 
+  it("sends the session-detail operation identifier as a request header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ messages: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchSessionData("codex", "session", { operationId: "detail-operation" });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/sessions/codex/session", {
+      signal: undefined,
+      headers: { "X-CodeSesh-Operation-ID": "detail-operation" },
+    });
+  });
+
   it("exposes failed response status through ApiRequestError", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,

--- a/apps/web/src/lib/client-telemetry.ts
+++ b/apps/web/src/lib/client-telemetry.ts
@@ -1,26 +1,49 @@
 import type { RemoteAccess } from "./remote-access";
 
+interface ClientTelemetryData {
+  actual_duration_ms?: number;
+  agent?: string | null;
+  agents?: number;
+  base_duration_ms?: number;
+  commit_time_ms?: number;
+  duration_ms?: number;
+  error_name?: string;
+  error_status?: number;
+  messages?: number;
+  mode?: string;
+  operation_id?: string;
+  phase?: string;
+  profiler_id?: string;
+  query_length?: number;
+  reason?: string;
+  request_key?: string;
+  results?: number;
+  session?: string | null;
+  sessions?: number;
+  source?: string;
+  start_time_ms?: number;
+  trigger?: string;
+}
+
 export function createClientTelemetry(access: RemoteAccess) {
   return Object.freeze({
-    logClientEvent(event: string, data: Record<string, unknown> = {}): void {
-      const body = JSON.stringify({ event, data });
-
+    logClientEvent(event: string, data: ClientTelemetryData = {}): void {
       try {
+        const body = JSON.stringify({ event, data });
         if (!access.hasCredentials && typeof navigator !== "undefined" && navigator.sendBeacon) {
           const blob = new Blob([body], { type: "application/json" });
           if (navigator.sendBeacon("/api/logs", blob)) return;
         }
+        void fetch(
+          "/api/logs",
+          access.authorize({
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body,
+            keepalive: true,
+          }),
+        ).catch(() => {});
       } catch {}
-
-      void fetch(
-        "/api/logs",
-        access.authorize({
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body,
-          keepalive: true,
-        }),
-      ).catch(() => {});
     },
   });
 }

--- a/packages/cli/src/agent-operation-scheduler.ts
+++ b/packages/cli/src/agent-operation-scheduler.ts
@@ -16,6 +16,7 @@ interface AgentOperationLifecycle {
   agentName: string;
   kind: AgentOperationKind;
   generation: number;
+  operationId: string;
   startedAt: number;
 }
 
@@ -99,14 +100,17 @@ export class AgentOperationScheduler {
     const run = previous.then(async () => {
       if (this.isStopped) return "skipped";
       const lifecycle = this.beginOperation(agentName, kind);
-      try {
-        const result = await operation();
-        this.completeOperation(lifecycle, result);
-        return result;
-      } catch (error) {
-        this.completeOperation(lifecycle, "failed");
-        throw error;
-      }
+      return appLogger.runWithContext({ operation_id: lifecycle.operationId }, async () => {
+        this.logOperationStarted(lifecycle);
+        try {
+          const result = await operation();
+          this.completeOperation(lifecycle, result);
+          return result;
+        } catch (error) {
+          this.completeOperation(lifecycle, "failed");
+          throw error;
+        }
+      });
     });
     const tail = run.then(
       () => undefined,
@@ -171,13 +175,22 @@ export class AgentOperationScheduler {
     const generation = (this.operationGenerations.get(agentName) ?? 0) + 1;
     const startedAt = Date.now();
     this.operationGenerations.set(agentName, generation);
-    appLogger.info("scan.agent_operation.started", {
-      agent: agentName,
-      operation: kind,
+    return {
+      agentName,
+      kind,
       generation,
-      started_at: startedAt,
+      operationId: `${agentName}:${generation}`,
+      startedAt,
+    };
+  }
+
+  private logOperationStarted(lifecycle: AgentOperationLifecycle): void {
+    appLogger.info("scan.agent_operation.started", {
+      agent: lifecycle.agentName,
+      operation: lifecycle.kind,
+      generation: lifecycle.generation,
+      started_at: lifecycle.startedAt,
     });
-    return { agentName, kind, generation, startedAt };
   }
 
   private completeOperation(

--- a/packages/cli/src/api/__tests__/client-log-handler.test.ts
+++ b/packages/cli/src/api/__tests__/client-log-handler.test.ts
@@ -4,7 +4,7 @@ import { loggerMocks, makeContext } from "./state-handler-test-fixtures.js";
 const { handlePostClientLog } = await import("../client-log-handler.js");
 
 describe("client logging handler", () => {
-  it("rejects malformed and blank log events", async () => {
+  it("rejects malformed, blank, and unknown log events", async () => {
     const malformed = makeContext({ rejectBody: true });
     await handlePostClientLog(malformed as never);
     expect(malformed.json).toHaveBeenCalledWith({ ok: false }, 400);
@@ -12,43 +12,73 @@ describe("client logging handler", () => {
     const blank = makeContext({ body: { event: "   " } });
     await handlePostClientLog(blank as never);
     expect(blank.json).toHaveBeenCalledWith({ ok: false }, 400);
+
+    const unknown = makeContext({ body: { event: "private arbitrary text" } });
+    await handlePostClientLog(unknown as never);
+    expect(unknown.json).toHaveBeenCalledWith({ ok: false }, 400);
     expect(loggerMocks.info).not.toHaveBeenCalled();
   });
 
-  it("sanitizes event names and bounds structured log data", async () => {
+  it("keeps only known low-risk scalar log data", async () => {
     const data = {
-      text: "x".repeat(400),
-      count: 2,
-      enabled: true,
-      empty: null,
+      agent: "codex",
+      session: null,
+      duration_ms: 42,
+      error_name: "TypeError",
+      error_status: 500,
+      operation_id: "123e4567-e89b-42d3-a456-426614174000",
+      request_key: "x".repeat(400),
+      error: "/Users/private/session.jsonl",
+      path: "/Users/private",
+      detail: { prompt: "private prompt" },
       nested: { value: 1 },
-      ...Object.fromEntries(Array.from({ length: 30 }, (_, index) => [`extra${index}`, index])),
+      enabled: true,
     };
     const c = makeContext({
-      body: { event: ` feature launch!?${"z".repeat(140)}`, data },
+      body: { event: " session.open.error ", data },
     });
 
     await handlePostClientLog(c as never);
 
     const [event, loggedData] = loggerMocks.info.mock.calls[0]!;
-    expect(event).toMatch(/^client\.feature_launch__/);
-    expect(event).toHaveLength(127);
-    expect(loggedData).toMatchObject({
-      text: "x".repeat(300),
-      count: 2,
-      enabled: true,
-      empty: null,
-      nested: "[object Object]",
+    expect(event).toBe("client.session.open.error");
+    expect(loggedData).toEqual({
+      agent: "codex",
+      session: null,
+      duration_ms: 42,
+      error_name: "TypeError",
+      error_status: 500,
+      operation_id: "123e4567-e89b-42d3-a456-426614174000",
+      request_key: "x".repeat(300),
     });
-    expect(Object.keys(loggedData)).toHaveLength(30);
+    expect(JSON.stringify(loggedData)).not.toContain("private");
     expect(c.json).toHaveBeenCalledWith({ ok: true });
   });
 
-  it("drops non-record log data", async () => {
-    const c = makeContext({ body: { event: "ready", data: "not-an-object" } });
+  it("drops invalid values for allowed fields", async () => {
+    const c = makeContext({
+      body: {
+        event: "app.load.done",
+        data: {
+          agent: { name: "codex" },
+          duration_ms: Number.POSITIVE_INFINITY,
+          messages: -1,
+          error_status: "500",
+          operation_id: "123e4567-e89b-02d3-7456-426614174000",
+        },
+      },
+    });
 
     await handlePostClientLog(c as never);
 
-    expect(loggerMocks.info).toHaveBeenCalledWith("client.ready", {});
+    expect(loggerMocks.info).toHaveBeenCalledWith("client.app.load.done", {});
+  });
+
+  it("drops non-record log data", async () => {
+    const c = makeContext({ body: { event: "app.load.start", data: "not-an-object" } });
+
+    await handlePostClientLog(c as never);
+
+    expect(loggerMocks.info).toHaveBeenCalledWith("client.app.load.start", {});
   });
 });

--- a/packages/cli/src/api/__tests__/routes.test.ts
+++ b/packages/cli/src/api/__tests__/routes.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 
-const loggerMocks = vi.hoisted(() => ({ warn: vi.fn() }));
+const loggerMocks = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn() }));
 
 vi.mock("../../logging.js", () => ({ appLogger: loggerMocks }));
 import {
@@ -16,7 +16,53 @@ import type { ScanEventSource } from "../../scan-source.js";
 
 describe("createApiRoutes", () => {
   beforeEach(() => {
+    loggerMocks.info.mockClear();
     loggerMocks.warn.mockClear();
+  });
+
+  function infoLogs(event: string): Record<string, unknown>[] {
+    return loggerMocks.info.mock.calls
+      .filter(([loggedEvent]) => loggedEvent === event)
+      .map(([, data]) => data as Record<string, unknown>);
+  }
+
+  it("logs bounded connection lifecycle data with elapsed time", async () => {
+    const eventSource: ScanEventSource = {
+      getScanStatus: () => SAMPLE_SCAN_STATUS_EVENT,
+      subscribe: () => () => {},
+      subscribeScanStatus: () => () => {},
+    };
+    const now = vi.spyOn(performance, "now").mockReturnValue(1_000);
+    const app = createApiRoutes(
+      { getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }) },
+      eventSource,
+    );
+
+    try {
+      const response = await app.request("/events");
+      const opened = infoLogs("api.sse.connection.opened");
+      expect(opened).toEqual([
+        {
+          connection_id: expect.any(String),
+          active_connections: 1,
+          connection_limit: MAX_ACTIVE_SSE_CONNECTIONS,
+        },
+      ]);
+
+      now.mockReturnValue(1_375);
+      await response.body?.cancel();
+
+      expect(infoLogs("api.sse.connection.closed")).toEqual([
+        {
+          connection_id: opened[0]!.connection_id,
+          close_reason: "client_cancelled",
+          duration_ms: 375,
+          active_connections: 0,
+        },
+      ]);
+    } finally {
+      now.mockRestore();
+    }
   });
 
   it("bounds active SSE clients and restores capacity after cancellation", async () => {
@@ -44,6 +90,11 @@ describe("createApiRoutes", () => {
     expect(eventSource.subscribe).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS);
     expect(eventSource.subscribeScanStatus).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS);
     expect(loggerMocks.warn).toHaveBeenCalledWith("api.sse.connection_limit_reached", {
+      active_connections: MAX_ACTIVE_SSE_CONNECTIONS,
+      connection_limit: MAX_ACTIVE_SSE_CONNECTIONS,
+    });
+    expect(infoLogs("api.sse.connection.opened").at(-1)).toEqual({
+      connection_id: expect.any(String),
       active_connections: MAX_ACTIVE_SSE_CONNECTIONS,
       connection_limit: MAX_ACTIVE_SSE_CONNECTIONS,
     });
@@ -86,6 +137,18 @@ describe("createApiRoutes", () => {
 
     expect(unsubscribeSessions).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS);
     expect(unsubscribeScanStatus).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS);
+    expect(infoLogs("api.sse.connection.closed")).toHaveLength(MAX_ACTIVE_SSE_CONNECTIONS);
+    expect(
+      infoLogs("api.sse.connection.closed").every(
+        (data) => data.close_reason === "server_shutdown",
+      ),
+    ).toBe(true);
+    expect(infoLogs("api.sse.connection.closed").at(-1)).toEqual({
+      connection_id: expect.any(String),
+      close_reason: "server_shutdown",
+      duration_ms: expect.any(Number),
+      active_connections: 0,
+    });
     const afterShutdown = await app.request("/events");
     expect(afterShutdown.status).toBe(200);
     const reader = afterShutdown.body!.getReader();
@@ -121,6 +184,12 @@ describe("createApiRoutes", () => {
 
     expect(eventSource.subscribe).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS + 1);
     expect(unsubscribeSessions).toHaveBeenCalledTimes(MAX_ACTIVE_SSE_CONNECTIONS + 1);
+    expect(infoLogs("api.sse.connection.closed")).toHaveLength(MAX_ACTIVE_SSE_CONNECTIONS + 1);
+    expect(
+      infoLogs("api.sse.connection.closed").every(
+        (data) => data.close_reason === "setup_failed" && data.active_connections === 0,
+      ),
+    ).toBe(true);
   });
 
   it("returns a Hono instance with route handlers", () => {
@@ -168,6 +237,9 @@ describe("createApiRoutes", () => {
 
     expect(unsubscribeSessions).toHaveBeenCalledOnce();
     expect(unsubscribeScanStatus).toHaveBeenCalledOnce();
+    expect(infoLogs("api.sse.connection.closed")).toEqual([
+      expect.objectContaining({ close_reason: "client_cancelled", active_connections: 0 }),
+    ]);
     expect(() => emitSession?.({ type: "sessions-updated" })).not.toThrow();
     expect(() => emitScanStatus?.({ type: "scan-status" })).not.toThrow();
   });
@@ -194,6 +266,9 @@ describe("createApiRoutes", () => {
 
     expect(unsubscribeSessions).toHaveBeenCalledOnce();
     expect(unsubscribeScanStatus).toHaveBeenCalledOnce();
+    expect(infoLogs("api.sse.connection.closed")).toEqual([
+      expect.objectContaining({ close_reason: "client_disconnected", active_connections: 0 }),
+    ]);
   });
 
   it("keeps only the latest numeric status for a slow SSE client", async () => {
@@ -289,6 +364,9 @@ describe("createApiRoutes", () => {
 
     expect(unsubscribeSessions).toHaveBeenCalledOnce();
     expect(unsubscribeScanStatus).toHaveBeenCalledOnce();
+    expect(infoLogs("api.sse.connection.closed")).toEqual([
+      expect.objectContaining({ close_reason: "client_too_slow", active_connections: 0 }),
+    ]);
     await expect(response.body!.getReader().read()).rejects.toThrow("SSE client fell behind");
   });
 });

--- a/packages/cli/src/api/__tests__/search-transport.test.ts
+++ b/packages/cli/src/api/__tests__/search-transport.test.ts
@@ -33,6 +33,7 @@ vi.mock("node:os", async (importOriginal) => {
 // throws (accessing testHomeDir before its own initialization).
 const { closeCacheStorage, syncSessionSearchIndex } =
   await import("@codesesh/core/runtime/discovery");
+const { appLogger } = await import("../../logging.js");
 const { createApiRoutes } = await import("../routes.js");
 
 function getCacheDir(): string {
@@ -96,7 +97,8 @@ beforeAll(() => {
   }));
 });
 
-afterAll(() => {
+afterAll(async () => {
+  await appLogger.flush();
   closeCacheStorage();
   rmSync(getCacheDir(), { recursive: true, force: true });
 });

--- a/packages/cli/src/api/client-log-handler.ts
+++ b/packages/cli/src/api/client-log-handler.ts
@@ -7,18 +7,36 @@ interface ClientLogPayload {
   data?: unknown;
 }
 
+const CLIENT_LOG_EVENTS = new Set<string>([
+  "app.load.done",
+  "app.load.error",
+  "app.load.start",
+  "bookmark.add",
+  "bookmark.delete",
+  "react.profiler.commit",
+  "route.change",
+  "search.done",
+  "search.error",
+  "search.start",
+  "session.markdown_copy.done",
+  "session.markdown_copy.error",
+  "session.open.cancel",
+  "session.open.done",
+  "session.open.error",
+  "session.open.start",
+]);
+
 export async function handlePostClientLog(c: Context) {
   const payload = (await c.req.json().catch(() => null)) as ClientLogPayload | null;
   const rawEvent = payload?.event;
 
-  if (typeof rawEvent !== "string" || !rawEvent.trim()) {
+  if (typeof rawEvent !== "string") {
     return c.json({ ok: false }, 400);
   }
 
-  const event = rawEvent
-    .trim()
-    .replace(/[^a-zA-Z0-9_.:-]/g, "_")
-    .slice(0, 120);
+  const event = rawEvent.trim();
+  if (!CLIENT_LOG_EVENTS.has(event)) return c.json({ ok: false }, 400);
+
   appLogger.info(`client.${event}`, sanitizeClientLogData(payload?.data));
   return c.json({ ok: true });
 }

--- a/packages/cli/src/api/request-payloads.ts
+++ b/packages/cli/src/api/request-payloads.ts
@@ -59,15 +59,54 @@ export function parseBookmarkImport(value: unknown): BookmarkRecord | null {
 export function sanitizeClientLogData(value: unknown): Record<string, unknown> {
   if (!isRecord(value)) return {};
 
-  return Object.fromEntries(
-    Object.entries(value)
-      .slice(0, 30)
-      .map(([key, item]) => {
-        if (typeof item === "string") return [key, item.slice(0, 300)];
-        if (typeof item === "number" || typeof item === "boolean" || item == null) {
-          return [key, item];
-        }
-        return [key, String(item).slice(0, 300)];
-      }),
-  );
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    if (CLIENT_LOG_STRING_FIELDS.has(key) && typeof item === "string") {
+      if (key === "operation_id" && !UUID_PATTERN.test(item)) continue;
+      sanitized[key] = item.slice(0, 300);
+      continue;
+    }
+    if (
+      CLIENT_LOG_NUMBER_FIELDS.has(key) &&
+      typeof item === "number" &&
+      Number.isFinite(item) &&
+      item >= 0
+    ) {
+      sanitized[key] = item;
+      continue;
+    }
+    if (CLIENT_LOG_NULLABLE_FIELDS.has(key) && item === null) sanitized[key] = null;
+  }
+  return sanitized;
 }
+
+const CLIENT_LOG_STRING_FIELDS = new Set([
+  "agent",
+  "error_name",
+  "mode",
+  "operation_id",
+  "phase",
+  "profiler_id",
+  "reason",
+  "request_key",
+  "session",
+  "source",
+  "trigger",
+]);
+
+const CLIENT_LOG_NUMBER_FIELDS = new Set([
+  "actual_duration_ms",
+  "agents",
+  "base_duration_ms",
+  "commit_time_ms",
+  "duration_ms",
+  "error_status",
+  "messages",
+  "query_length",
+  "results",
+  "sessions",
+  "start_time_ms",
+]);
+
+const CLIENT_LOG_NULLABLE_FIELDS = new Set(["agent", "session"]);
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { randomUUID } from "node:crypto";
 import {
   handleGetAgents,
   handleGetConfig,
@@ -26,6 +27,13 @@ import type { SessionDetailLoader } from "../session-detail-loader.js";
 import { SseEventBuffer } from "./sse-event-buffer.js";
 
 export const MAX_ACTIVE_SSE_CONNECTIONS = 32;
+
+type SseConnectionCloseReason =
+  | "client_cancelled"
+  | "client_disconnected"
+  | "client_too_slow"
+  | "server_shutdown"
+  | "setup_failed";
 
 export interface ApiRouteOptions {
   defaultSessionFrom?: number;
@@ -62,8 +70,9 @@ function createSseConnectionBudget(maxConnections: number): SseConnectionBudget 
 
 function createSseResponse(
   eventSource: ScanEventSource,
-  signal: AbortSignal,
-  releaseConnection: () => void,
+  requestSignal: AbortSignal,
+  shutdownSignal: AbortSignal | undefined,
+  closeConnection: (reason: SseConnectionCloseReason) => void,
 ): Response {
   let cancelStream = () => {};
   let drainStream = () => {};
@@ -74,26 +83,31 @@ function createSseResponse(
         let isClosed = false;
         let unsubscribeSessions = () => {};
         let unsubscribeScanStatus = () => {};
-        let abortStream = () => {};
+        let disconnectStream = () => {};
+        let shutdownStream = () => {};
         let heartbeat: ReturnType<typeof setInterval> | undefined;
         let buffer: SseEventBuffer | undefined;
 
-        const cleanup = () => {
+        const cleanup = (reason: SseConnectionCloseReason) => {
           if (isClosed) return false;
           isClosed = true;
           buffer?.close();
           if (heartbeat) clearInterval(heartbeat);
           unsubscribeSessions();
           unsubscribeScanStatus();
-          signal.removeEventListener("abort", abortStream);
-          releaseConnection();
+          requestSignal.removeEventListener("abort", disconnectStream);
+          shutdownSignal?.removeEventListener("abort", shutdownStream);
+          closeConnection(reason);
           return true;
         };
-        abortStream = () => {
-          if (cleanup()) controller.close();
+        disconnectStream = () => {
+          if (cleanup("client_disconnected")) controller.close();
+        };
+        shutdownStream = () => {
+          if (cleanup("server_shutdown")) controller.close();
         };
         buffer = new SseEventBuffer(controller, () => {
-          if (cleanup()) controller.error(new Error("SSE client fell behind"));
+          if (cleanup("client_too_slow")) controller.error(new Error("SSE client fell behind"));
         });
         drainStream = () => buffer.drain();
 
@@ -110,13 +124,17 @@ function createSseResponse(
 
           heartbeat = setInterval(() => buffer?.enqueueHeartbeat(), 15000);
           cancelStream = () => {
-            cleanup();
+            cleanup("client_cancelled");
           };
 
-          if (signal.aborted) abortStream();
-          else signal.addEventListener("abort", abortStream, { once: true });
+          if (shutdownSignal?.aborted) shutdownStream();
+          else if (requestSignal.aborted) disconnectStream();
+          else {
+            requestSignal.addEventListener("abort", disconnectStream, { once: true });
+            shutdownSignal?.addEventListener("abort", shutdownStream, { once: true });
+          }
         } catch (error) {
-          cleanup();
+          cleanup("setup_failed");
           throw error;
         }
       },
@@ -187,13 +205,34 @@ export function createApiRoutes(
         c.header("Retry-After", "1");
         return c.json({ error: "Too many active event streams" }, 429);
       }
-      const signal = options.shutdownSignal
-        ? AbortSignal.any([c.req.raw.signal, options.shutdownSignal])
-        : c.req.raw.signal;
-      try {
-        return createSseResponse(eventSource, signal, releaseConnection);
-      } catch (error) {
+      const connectionId = randomUUID();
+      const connectedAt = performance.now();
+      let isClosed = false;
+      appLogger.info("api.sse.connection.opened", {
+        connection_id: connectionId,
+        active_connections: sseConnections.activeCount(),
+        connection_limit: MAX_ACTIVE_SSE_CONNECTIONS,
+      });
+      const closeConnection = (reason: SseConnectionCloseReason) => {
+        if (isClosed) return;
+        isClosed = true;
         releaseConnection();
+        appLogger.info("api.sse.connection.closed", {
+          connection_id: connectionId,
+          close_reason: reason,
+          duration_ms: Math.max(0, Math.round(performance.now() - connectedAt)),
+          active_connections: sseConnections.activeCount(),
+        });
+      };
+      try {
+        return createSseResponse(
+          eventSource,
+          c.req.raw.signal,
+          options.shutdownSignal,
+          closeConnection,
+        );
+      } catch (error) {
+        closeConnection("setup_failed");
         throw error;
       }
     });

--- a/packages/cli/src/cli-exit.test.ts
+++ b/packages/cli/src/cli-exit.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { closeLoggerBeforeTermination } from "./cli-exit.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("CLI log close watchdog", () => {
+  it("forces the requested exit code when logger close exceeds the deadline", async () => {
+    vi.useFakeTimers();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as typeof process.exit);
+
+    const closing = closeLoggerBeforeTermination(() => new Promise<void>(() => undefined), 7);
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(stderr).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await closing;
+
+    expect(stderr).toHaveBeenCalledOnce();
+    expect(stderr).toHaveBeenCalledWith(
+      "[codesesh] Timed out closing application log; forcing exit\n",
+    );
+    expect(exit).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(7);
+  });
+
+  it("does not force exit after logger close completes", async () => {
+    vi.useFakeTimers();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const exit = vi
+      .spyOn(process, "exit")
+      .mockImplementation((() => undefined) as typeof process.exit);
+
+    await closeLoggerBeforeTermination(async () => undefined, 0);
+    await vi.runAllTimersAsync();
+
+    expect(stderr).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/cli-exit.ts
+++ b/packages/cli/src/cli-exit.ts
@@ -1,0 +1,24 @@
+const LOG_CLOSE_TIMEOUT_MS = 2_000;
+const LOG_CLOSE_TIMEOUT_MESSAGE = "[codesesh] Timed out closing application log; forcing exit\n";
+
+export async function closeLoggerBeforeTermination(
+  closeLogger: () => Promise<void>,
+  exitCode: string | number,
+): Promise<void> {
+  let watchdog: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<false>((resolve) => {
+    watchdog = setTimeout(() => resolve(false), LOG_CLOSE_TIMEOUT_MS);
+  });
+
+  try {
+    const closed = await Promise.race([closeLogger().then(() => true as const), timedOut]);
+    if (closed) return;
+    try {
+      process.stderr.write(LOG_CLOSE_TIMEOUT_MESSAGE);
+    } finally {
+      process.exit(exitCode);
+    }
+  } finally {
+    if (watchdog) clearTimeout(watchdog);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import "./diagnostics-bridge.js";
 import { defineCommand, runMain } from "citty";
+import { closeLoggerBeforeTermination } from "./cli-exit.js";
 import { createServer, getServerStartupErrorMessage } from "./server.js";
 import { LiveScanStore } from "./live-scan.js";
 import { printScanResults } from "./output.js";
@@ -36,8 +37,26 @@ import { startPricingRefresh } from "./pricing-refresh.js";
 // touching the app log; record it first, then let the crash proceed.
 process.on("unhandledRejection", (reason) => {
   appLogger.error("process.unhandled_rejection", { error: reason });
+  appLogger.flushSync();
   throw reason;
 });
+process.on("uncaughtExceptionMonitor", (error, origin) => {
+  appLogger.error("process.uncaught_exception", { error, exception_origin: origin });
+  appLogger.flushSync();
+});
+
+const closeApplicationLog = (exitCode: string | number) =>
+  closeLoggerBeforeTermination(() => appLogger.close(), exitCode);
+
+let shutdownOnSignal: (signal: NodeJS.Signals) => void = (signal) => {
+  appLogger.info("cli.shutdown", { signal, phase: "startup" });
+  appLogger.flushSync();
+  process.exit(0);
+};
+const dispatchSignal = (signal: NodeJS.Signals) => shutdownOnSignal(signal);
+process.once("SIGINT", dispatchSignal);
+process.once("SIGTERM", dispatchSignal);
+process.once("SIGHUP", dispatchSignal);
 
 const main = defineCommand({
   meta: {
@@ -206,6 +225,7 @@ const main = defineCommand({
       targetSession = parseSessionUri(args.session as string);
       if (!targetSession) {
         console.error(`Invalid session format: ${args.session}. Expected: agent://session-id`);
+        await closeApplicationLog(1);
         process.exit(1);
       }
     }
@@ -269,6 +289,7 @@ const main = defineCommand({
       // Worker threads and the SQLite connections hold the event loop open;
       // without this the one-shot process prints its output and never exits.
       await store.shutdown();
+      await closeApplicationLog(process.exitCode ?? 0);
       return;
     }
 
@@ -291,6 +312,7 @@ const main = defineCommand({
       });
     } catch (error) {
       console.error(getServerStartupErrorMessage(error, port));
+      await closeApplicationLog(1);
       process.exit(1);
     }
 
@@ -307,18 +329,18 @@ const main = defineCommand({
       appLogger.info("cli.shutdown", { signal });
       await pricingRefresh.cancel();
       await app.shutdown();
+      await closeApplicationLog(0);
       process.exit(0);
     };
     // If shutdown rejects, process.exit(0) inside it never runs; log and
     // exit non-zero instead of leaving an unhandled rejection behind.
-    const shutdownOnSignal = (signal: NodeJS.Signals) => {
-      shutdown(signal).catch((error) => {
+    shutdownOnSignal = (signal: NodeJS.Signals) => {
+      shutdown(signal).catch(async (error) => {
         appLogger.error("cli.shutdown_failed", { signal, error });
+        await closeApplicationLog(1);
         process.exit(1);
       });
     };
-    process.once("SIGINT", shutdownOnSignal);
-    process.once("SIGTERM", shutdownOnSignal);
 
     console.log(`  ${url}`);
     console.log("");
@@ -336,6 +358,18 @@ const main = defineCommand({
     }
   },
 });
+
+const runCliCommand = main.run;
+if (!runCliCommand) throw new Error("CLI command is missing its runner");
+main.run = async (context) => {
+  try {
+    return await runCliCommand(context);
+  } catch (error) {
+    appLogger.error("cli.fatal", { error });
+    await closeApplicationLog(1);
+    throw error;
+  }
+};
 
 if (process.argv.slice(2).includes("-v")) {
   console.log(VERSION);

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -328,7 +328,8 @@ vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   };
 });
 
-vi.mock("node:worker_threads", () => ({
+vi.mock("node:worker_threads", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:worker_threads")>()),
   Worker: workerThreads.Worker,
 }));
 

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -75,6 +75,7 @@ const core = vi.hoisted(() => {
 });
 
 const workerThreads = vi.hoisted(() => ({
+  acknowledgeLogDrain: true,
   deferSearchIndexWorkers: false,
   deferScanRefreshWorkers: false,
   workers: [] as Array<{
@@ -82,6 +83,7 @@ const workerThreads = vi.hoisted(() => ({
     workerData: any;
     on: ReturnType<typeof vi.fn>;
     once: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
     postMessage: ReturnType<typeof vi.fn>;
     terminate: ReturnType<typeof vi.fn>;
     emitMessage: (message: unknown) => void;
@@ -255,9 +257,35 @@ const workerThreads = vi.hoisted(() => ({
             queueMicrotask(() => handler(0));
           }
         }
+        if (event === "error") errorHandlers.push(handler as (error: Error) => void);
+        return worker;
+      }),
+      off: vi.fn((event: string, handler: (message: unknown) => void) => {
+        const handlers =
+          event === "message" ? messageHandlers : event === "exit" ? exitHandlers : errorHandlers;
+        const index = handlers.indexOf(handler as never);
+        if (index >= 0) handlers.splice(index, 1);
         return worker;
       }),
       postMessage: vi.fn((data: unknown) => {
+        if (
+          data != null &&
+          typeof data === "object" &&
+          "type" in data &&
+          data.type === "codesesh.worker-log-drain" &&
+          "requestId" in data
+        ) {
+          if (!workerThreads.acknowledgeLogDrain) return;
+          queueMicrotask(() => {
+            for (const handler of messageHandlers.slice()) {
+              handler({
+                type: "codesesh.worker-log-drained",
+                requestId: data.requestId,
+              });
+            }
+          });
+          return;
+        }
         if (!workerThreads.deferScanRefreshWorkers) dispatch(data);
       }),
       terminate: vi.fn(async () => {
@@ -511,6 +539,7 @@ describe("LiveScanStore", () => {
     vi.clearAllMocks();
     fsWatch.watchers.length = 0;
     workerThreads.workers.length = 0;
+    workerThreads.acknowledgeLogDrain = true;
     workerThreads.deferSearchIndexWorkers = false;
     workerThreads.deferScanRefreshWorkers = false;
     fsWatch.watch.mockImplementation(
@@ -939,6 +968,34 @@ describe("LiveScanStore", () => {
     retry.commit();
   });
 
+  it("waits for an errored scan worker to exit during shutdown", async () => {
+    workerThreads.deferScanRefreshWorkers = true;
+    workerThreads.acknowledgeLogDrain = false;
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+    const refresh = runner
+      .run("codex", {
+        previousSessions: [],
+        operation: { kind: "full-scan" },
+        scanOptions: {},
+        meta: {},
+      })
+      .catch((error: Error) => error);
+    const worker = workerThreads.workers.at(-1)!;
+    worker.emitError(new Error("scan failed"));
+    let shutdownCompleted = false;
+    const shutdown = runner.shutdown().then(() => {
+      shutdownCompleted = true;
+    });
+
+    await Promise.resolve();
+    expect(shutdownCompleted).toBe(false);
+    worker.emitExit(1);
+    await shutdown;
+
+    expect(await refresh).toEqual(new Error("scan failed"));
+    expect(worker.terminate).not.toHaveBeenCalled();
+  });
+
   it("rehydrates an unavailable-agent error from the scan worker", async () => {
     workerThreads.deferScanRefreshWorkers = true;
     const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
@@ -1013,6 +1070,45 @@ describe("LiveScanStore", () => {
     });
     run.commit();
     await runner.shutdown();
+  });
+
+  it("keeps the originating operation context when a staged result commits later", async () => {
+    workerThreads.deferScanRefreshWorkers = true;
+    const runner = new ThreadWorkerRunner(new URL("./scan-refresh-worker.js", import.meta.url));
+    const refresh = appLogger.runWithContext({ operation_id: "scan-operation" }, () =>
+      runner.run("codex", {
+        previousSessions: [],
+        operation: { kind: "full-scan" },
+        scanOptions: {},
+        meta: {},
+      }),
+    );
+    const worker = workerThreads.workers.at(-1)!;
+    worker.emitMessage({
+      type: "done",
+      requestId: worker.workerData.requestId,
+      generation: worker.workerData.generation,
+      changes: [],
+      removedSessionIds: [],
+      meta: {},
+      removedMetaIds: [],
+      sourceFailures: [],
+      completeness: "complete",
+      explicitRemovedSessionIds: [],
+      durationMs: 0,
+    });
+    const staged = await refresh;
+
+    appLogger.runWithContext({ operation_id: "unrelated-operation" }, () => staged.commit());
+
+    expect(worker.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "commit",
+        logContext: { operation_id: "scan-operation" },
+      }),
+    );
+    await runner.shutdown();
+    workerThreads.deferScanRefreshWorkers = false;
   });
 
   it("rejects a scan worker request when its checkpoint cannot commit", async () => {
@@ -1166,6 +1262,8 @@ describe("LiveScanStore", () => {
     });
     const discardedWorker = workerThreads.workers.at(-1)!;
     candidateRun.discard();
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(discardedWorker.terminate).toHaveBeenCalledTimes(1);
     const replacementRun = await runner.run("codex", {
@@ -2022,6 +2120,9 @@ describe("LiveScanStore", () => {
       scan_workers: 1,
     });
     expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(worker.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "codesesh.worker-log-drain" }),
+    );
     expect(store.getSnapshot().sessions).toEqual([existing]);
     expect(listener).not.toHaveBeenCalled();
   });
@@ -2185,6 +2286,9 @@ describe("LiveScanStore", () => {
     await Promise.all([runner.shutdown(), runner.shutdown()]);
 
     expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(worker.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "codesesh.worker-log-drain" }),
+    );
     expect(await outcome).toBeInstanceOf(Error);
     await expect(runner.enqueue("scan.refresh", [job])).rejects.toThrow(
       "Live scan store shut down",

--- a/packages/cli/src/log-file-writer.ts
+++ b/packages/cli/src/log-file-writer.ts
@@ -1,0 +1,511 @@
+import { appendFileSync, chmodSync, mkdirSync } from "node:fs";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  rename,
+  unlink,
+  type FileHandle,
+} from "node:fs/promises";
+import { join } from "node:path";
+import {
+  PRIVATE_DIR_MODE,
+  PRIVATE_FILE_MODE,
+  type WorkerLogLevel,
+} from "@codesesh/core/runtime/diagnostics";
+import type { EncodedLogLine } from "./log-record.js";
+
+const MAX_BATCH_BYTES = 64 * 1024;
+const UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+const CURRENT_LOG_PATTERN = new RegExp(`^codesesh-(\\d+)-${UUID_PATTERN}-active\\.log$`);
+const EMERGENCY_LOG_PATTERN = new RegExp(`^codesesh-(\\d+)-${UUID_PATTERN}-emergency\\.log$`);
+const RUN_LOG_PATTERN = new RegExp(`^codesesh-\\d+-${UUID_PATTERN}-\\d+\\.log$`);
+const LEGACY_ACTIVE_LOG_PATTERN = /^codesesh-(\d+)\.log$/;
+const LEGACY_ROTATED_LOG_PATTERN =
+  /^codesesh-\d+-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-\d+\.log$/;
+const ORIGINAL_ROTATED_LOG_PATTERN =
+  /^codesesh-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z-\d+-\d+\.log$/;
+const ORIGINAL_ACTIVE_LOG_PATTERN = /^codesesh\.log$/;
+const LOG_LEVEL_PRIORITY: Record<WorkerLogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+export interface DroppedLogCounts {
+  debug: number;
+  info: number;
+  warn: number;
+  error: number;
+}
+
+interface LogFileWriterOptions {
+  logDir: string;
+  runId: string;
+  maxFileBytes: number;
+  maxFiles: number;
+  maxDirectoryBytes: number;
+  maxAgeMs: number;
+  maxQueueBytes: number;
+  createDropSummary(counts: DroppedLogCounts): EncodedLogLine;
+}
+
+interface PendingLine extends EncodedLogLine {
+  internal?: boolean;
+}
+
+interface ManagedLogFile {
+  name: string;
+  path: string;
+  bytes: number;
+  mtimeMs: number;
+  isProtected: boolean;
+}
+
+function emptyDropCounts(): DroppedLogCounts {
+  return { debug: 0, info: 0, warn: 0, error: 0 };
+}
+
+function droppedCount(counts: DroppedLogCounts): number {
+  return counts.debug + counts.info + counts.warn + counts.error;
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String(error.code)
+    : undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) !== "ESRCH";
+  }
+}
+
+function activeLogPid(name: string): number | null {
+  const match =
+    CURRENT_LOG_PATTERN.exec(name) ??
+    EMERGENCY_LOG_PATTERN.exec(name) ??
+    LEGACY_ACTIVE_LOG_PATTERN.exec(name);
+  if (!match) return null;
+  const pid = Number(match[1]);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+}
+
+function isManagedLog(name: string): boolean {
+  return (
+    CURRENT_LOG_PATTERN.test(name) ||
+    EMERGENCY_LOG_PATTERN.test(name) ||
+    RUN_LOG_PATTERN.test(name) ||
+    LEGACY_ACTIVE_LOG_PATTERN.test(name) ||
+    LEGACY_ROTATED_LOG_PATTERN.test(name) ||
+    ORIGINAL_ROTATED_LOG_PATTERN.test(name) ||
+    ORIGINAL_ACTIVE_LOG_PATTERN.test(name)
+  );
+}
+
+export class AsyncLogFileWriter {
+  private readonly logDir: string;
+  private readonly prefix: string;
+  private readonly currentPath: string;
+  private readonly emergencyPath: string;
+  private readonly maxFileBytes: number;
+  private readonly maxFiles: number;
+  private readonly maxDirectoryBytes: number;
+  private readonly maxAgeMs: number;
+  private readonly maxQueueBytes: number;
+  private readonly createDropSummary: (counts: DroppedLogCounts) => EncodedLogLine;
+  private queue: PendingLine[] = [];
+  private inFlight: PendingLine[] = [];
+  private dropped = emptyDropCounts();
+  private queuedBytes = 0;
+  private currentBytes = 0;
+  private rotationIndex = 0;
+  private handle: FileHandle | null = null;
+  private drainPromise: Promise<void> | null = null;
+  private closePromise: Promise<void> | null = null;
+  private storagePrepared = false;
+  private currentFileCreated = false;
+  private needsRecoverySeparator = false;
+  private writeFailureReported = false;
+  private overflowReported = false;
+  private closedWriteReported = false;
+
+  constructor(options: LogFileWriterOptions) {
+    this.logDir = options.logDir;
+    this.prefix = `codesesh-${process.pid}-${options.runId}`;
+    this.currentPath = join(this.logDir, `${this.prefix}-active.log`);
+    this.emergencyPath = join(this.logDir, `${this.prefix}-emergency.log`);
+    this.maxFileBytes = options.maxFileBytes;
+    this.maxFiles = options.maxFiles;
+    this.maxDirectoryBytes = options.maxDirectoryBytes;
+    this.maxAgeMs = options.maxAgeMs;
+    this.maxQueueBytes = options.maxQueueBytes;
+    this.createDropSummary = options.createDropSummary;
+  }
+
+  get path(): string {
+    return this.currentPath;
+  }
+
+  enqueue(entry: EncodedLogLine): void {
+    if (this.closePromise) {
+      if (!this.closedWriteReported) {
+        this.closedWriteReported = true;
+        this.writeStderr("Log entry dropped after logger close");
+      }
+      return;
+    }
+    if (!this.makeRoom(entry)) {
+      this.recordDrop(entry.level);
+      this.scheduleDrain();
+      return;
+    }
+    this.queue.push(entry);
+    this.queuedBytes += entry.bytes;
+    this.scheduleDrain();
+  }
+
+  async flush(): Promise<void> {
+    while (this.queue.length > 0 || droppedCount(this.dropped) > 0 || this.drainPromise) {
+      this.scheduleDrain();
+      const drain = this.drainPromise;
+      if (!drain) break;
+      await drain;
+    }
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closePromise = this.finishClose();
+    return this.closePromise;
+  }
+
+  flushSync(): void {
+    const pending = this.queue.splice(0);
+    const pendingBytes = pending.reduce((total, entry) => total + entry.bytes, 0);
+    this.queuedBytes = Math.max(0, this.queuedBytes - pendingBytes);
+    const dropped = droppedCount(this.dropped);
+    const emergency = [...this.inFlight, ...pending];
+    if (dropped > 0) {
+      emergency.push(this.createDropSummary({ ...this.dropped }));
+      this.dropped = emptyDropCounts();
+    }
+    if (emergency.length === 0) return;
+    try {
+      mkdirSync(this.logDir, { recursive: true, mode: PRIVATE_DIR_MODE });
+      if (process.platform !== "win32") chmodSync(this.logDir, PRIVATE_DIR_MODE);
+      appendFileSync(this.emergencyPath, emergency.map((entry) => entry.line).join(""), {
+        encoding: "utf8",
+        mode: PRIVATE_FILE_MODE,
+      });
+      if (process.platform !== "win32") chmodSync(this.emergencyPath, PRIVATE_FILE_MODE);
+    } catch (error) {
+      this.reportWriteFailure(error);
+    }
+  }
+
+  private makeRoom(entry: EncodedLogLine): boolean {
+    if (entry.bytes > this.maxQueueBytes) return false;
+    if (entry.bytes <= this.maxQueueBytes - this.queuedBytes) return true;
+    if (entry.level === "debug" || entry.level === "info") return false;
+
+    const requiredBytes = entry.bytes - (this.maxQueueBytes - this.queuedBytes);
+    const candidates = this.queue
+      .map((candidate, index) => ({ candidate, index }))
+      .filter(
+        ({ candidate }) =>
+          !candidate.internal &&
+          LOG_LEVEL_PRIORITY[candidate.level] < LOG_LEVEL_PRIORITY[entry.level],
+      )
+      .toSorted((left, right) => {
+        return (
+          LOG_LEVEL_PRIORITY[left.candidate.level] - LOG_LEVEL_PRIORITY[right.candidate.level] ||
+          left.index - right.index
+        );
+      });
+    const removedIndexes = new Set<number>();
+    let removedBytes = 0;
+    for (const { candidate, index } of candidates) {
+      removedIndexes.add(index);
+      removedBytes += candidate.bytes;
+      if (removedBytes >= requiredBytes) break;
+    }
+    if (removedBytes < requiredBytes) return false;
+
+    this.queue = this.queue.filter((candidate, index) => {
+      if (!removedIndexes.has(index)) return true;
+      this.queuedBytes -= candidate.bytes;
+      this.recordDrop(candidate.level);
+      return false;
+    });
+    return true;
+  }
+
+  private recordDrop(level: WorkerLogLevel): void {
+    this.dropped[level] += 1;
+    if (this.overflowReported) return;
+    this.overflowReported = true;
+    this.writeStderr("Log queue full; entries were dropped");
+  }
+
+  private scheduleDrain(): void {
+    if (this.drainPromise) return;
+    const drain = Promise.resolve()
+      .then(() => this.drain())
+      .catch((error) => {
+        this.discardPending();
+        this.reportWriteFailure(error);
+      });
+    this.drainPromise = drain;
+    void drain.then(() => {
+      if (this.drainPromise === drain) this.drainPromise = null;
+      if (this.queue.length > 0 || droppedCount(this.dropped) > 0) this.scheduleDrain();
+    });
+  }
+
+  private async drain(): Promise<void> {
+    while (this.queue.length > 0 || droppedCount(this.dropped) > 0) {
+      try {
+        await this.openCurrentFile();
+      } catch (error) {
+        this.discardPending();
+        this.reportWriteFailure(error);
+        return;
+      }
+      this.enqueueDropSummaryIfPossible();
+      if (this.queue.length === 0) return;
+      if (this.shouldRotate(this.queue[0]!.bytes)) await this.rotate();
+      const batch = this.takeBatch();
+      await this.appendBatch(batch);
+    }
+  }
+
+  private enqueueDropSummaryIfPossible(): void {
+    if (droppedCount(this.dropped) === 0) return;
+    const summary = this.createDropSummary({ ...this.dropped });
+    if (summary.bytes > this.maxQueueBytes - this.queuedBytes) {
+      if (this.queue.length === 0) this.dropped = emptyDropCounts();
+      return;
+    }
+    this.dropped = emptyDropCounts();
+    this.queue.push({ ...summary, internal: true });
+    this.queuedBytes += summary.bytes;
+  }
+
+  private takeBatch(): PendingLine[] {
+    const first = this.queue[0]!;
+    const remainingFileBytes = Math.max(0, this.maxFileBytes - this.currentBytes);
+    const batchLimit =
+      this.currentBytes === 0 && first.bytes > this.maxFileBytes
+        ? first.bytes
+        : Math.min(MAX_BATCH_BYTES, remainingFileBytes);
+    let count = 0;
+    let bytes = 0;
+    for (const next of this.queue) {
+      if (count > 0 && next.bytes > batchLimit - bytes) break;
+      count += 1;
+      if (count === 1 && next.bytes > batchLimit) {
+        break;
+      }
+      bytes += next.bytes;
+    }
+    return this.queue.splice(0, count);
+  }
+
+  private async appendBatch(batch: PendingLine[]): Promise<void> {
+    const bytes = batch.reduce((total, entry) => total + entry.bytes, 0);
+    this.inFlight = batch;
+    try {
+      if (!this.handle) throw new Error("Log file is not open");
+      if (this.needsRecoverySeparator && this.currentBytes > 0) {
+        await this.handle.writeFile("\n", "utf8");
+        this.currentBytes += 1;
+      }
+      this.needsRecoverySeparator = false;
+      await this.handle.writeFile(batch.map((entry) => entry.line).join(""), "utf8");
+      this.currentBytes += bytes;
+      this.writeFailureReported = false;
+      this.overflowReported = false;
+    } catch (error) {
+      this.needsRecoverySeparator = true;
+      for (const entry of batch) {
+        if (!entry.internal) this.recordDrop(entry.level);
+      }
+      await this.closeHandle();
+      this.reportWriteFailure(error);
+    } finally {
+      if (this.inFlight === batch) this.inFlight = [];
+      this.queuedBytes = Math.max(0, this.queuedBytes - bytes);
+    }
+  }
+
+  private shouldRotate(nextBytes: number): boolean {
+    return this.currentBytes > 0 && nextBytes > this.maxFileBytes - this.currentBytes;
+  }
+
+  private async rotate(): Promise<void> {
+    await this.closeHandle();
+    this.rotationIndex += 1;
+    const rotatedPath = join(this.logDir, `${this.prefix}-${this.rotationIndex}.log`);
+    await rename(this.currentPath, rotatedPath);
+    this.currentFileCreated = false;
+    this.currentBytes = 0;
+    await this.openCurrentFile();
+  }
+
+  private async openCurrentFile(): Promise<void> {
+    if (this.handle) return;
+    await this.prepareStorage();
+    const handle = await open(
+      this.currentPath,
+      this.currentFileCreated ? "a" : "ax",
+      PRIVATE_FILE_MODE,
+    );
+    this.currentFileCreated = true;
+    try {
+      const stats = await handle.stat();
+      this.currentBytes = stats.size;
+      if (process.platform !== "win32") await chmod(this.currentPath, PRIVATE_FILE_MODE);
+    } catch (error) {
+      await handle.close().catch(() => undefined);
+      throw error;
+    }
+    this.handle = handle;
+    await this.pruneLogs();
+  }
+
+  private async prepareStorage(): Promise<void> {
+    if (this.storagePrepared) return;
+    await mkdir(this.logDir, { recursive: true, mode: PRIVATE_DIR_MODE });
+    if (process.platform !== "win32") await chmod(this.logDir, PRIVATE_DIR_MODE);
+    await this.restrictExistingLogs();
+    this.storagePrepared = true;
+  }
+
+  private async restrictExistingLogs(): Promise<void> {
+    if (process.platform === "win32") return;
+    const entries = await readdir(this.logDir, { withFileTypes: true });
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isFile() && isManagedLog(entry.name))
+        .map((entry) =>
+          chmod(join(this.logDir, entry.name), PRIVATE_FILE_MODE).catch((error) => {
+            this.reportWriteFailure(error);
+          }),
+        ),
+    );
+  }
+
+  private async pruneLogs(): Promise<void> {
+    let files: ManagedLogFile[];
+    try {
+      files = await this.managedLogs();
+    } catch (error) {
+      this.reportWriteFailure(error);
+      return;
+    }
+
+    const now = Date.now();
+    for (const file of files) {
+      if (!file.isProtected && now - file.mtimeMs > this.maxAgeMs) {
+        if (await this.removeLog(file)) files = files.filter((item) => item.path !== file.path);
+      }
+    }
+
+    let totalBytes = files.reduce((total, file) => total + file.bytes, 0);
+    let totalFiles = files.length;
+    const candidates = files
+      .filter((file) => !file.isProtected)
+      .toSorted(
+        (left, right) => left.mtimeMs - right.mtimeMs || left.name.localeCompare(right.name),
+      );
+    for (const file of candidates) {
+      if (totalFiles <= this.maxFiles && totalBytes <= this.maxDirectoryBytes) break;
+      if (!(await this.removeLog(file))) continue;
+      totalFiles -= 1;
+      totalBytes = Math.max(0, totalBytes - file.bytes);
+    }
+  }
+
+  private async managedLogs(): Promise<ManagedLogFile[]> {
+    const entries = await readdir(this.logDir, { withFileTypes: true });
+    const files: ManagedLogFile[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !isManagedLog(entry.name)) continue;
+      const path = join(this.logDir, entry.name);
+      try {
+        const stats = await lstat(path);
+        if (!stats.isFile()) continue;
+        const pid = activeLogPid(entry.name);
+        files.push({
+          name: entry.name,
+          path,
+          bytes: stats.size,
+          mtimeMs: stats.mtimeMs,
+          isProtected:
+            path === this.currentPath ||
+            ORIGINAL_ACTIVE_LOG_PATTERN.test(entry.name) ||
+            (pid != null && isProcessAlive(pid)),
+        });
+      } catch (error) {
+        if (errorCode(error) !== "ENOENT") this.reportWriteFailure(error);
+      }
+    }
+    return files;
+  }
+
+  private async removeLog(file: ManagedLogFile): Promise<boolean> {
+    try {
+      await unlink(file.path);
+      return true;
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") return true;
+      this.reportWriteFailure(error);
+      return false;
+    }
+  }
+
+  private async finishClose(): Promise<void> {
+    await this.flush();
+    await this.closeHandle();
+    if (this.storagePrepared) await this.pruneLogs();
+  }
+
+  private async closeHandle(): Promise<void> {
+    const handle = this.handle;
+    this.handle = null;
+    if (!handle) return;
+    try {
+      await handle.close();
+    } catch (error) {
+      this.reportWriteFailure(error);
+    }
+  }
+
+  private reportWriteFailure(error: unknown): void {
+    if (this.writeFailureReported) return;
+    this.writeFailureReported = true;
+    const message = error instanceof Error ? error.message : String(error);
+    this.writeStderr(`Failed to write log ${this.currentPath}: ${message}`);
+  }
+
+  private discardPending(): void {
+    this.queue.splice(0);
+    this.queuedBytes = 0;
+    this.dropped = emptyDropCounts();
+  }
+
+  private writeStderr(message: string): void {
+    try {
+      process.stderr.write(`[codesesh] ${message}\n`);
+    } catch {}
+  }
+}

--- a/packages/cli/src/log-record.test.ts
+++ b/packages/cli/src/log-record.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import { LogRecordEncoder } from "./log-record.js";
+
+const UUID = "123e4567-e89b-42d3-a456-426614174000";
+
+function createEncoder(): LogRecordEncoder {
+  return new LogRecordEncoder({
+    fingerprintKey: Buffer.alloc(32, 1),
+    maxRecordBytes: 64 * 1_024,
+  });
+}
+
+function encode(data: Record<string, unknown>, event = "test.event"): Record<string, unknown> {
+  return JSON.parse(
+    createEncoder().encode({
+      timestamp: "2026-08-30T00:00:00.000Z",
+      level: "info",
+      event,
+      runId: UUID,
+      sequence: 1,
+      pid: 1,
+      data,
+    }).line,
+  ) as Record<string, unknown>;
+}
+
+describe("LogRecordEncoder", () => {
+  it("fingerprints unapproved strings and identifiers while preserving audited values", () => {
+    const record = encode({
+      detail: "private detail",
+      unsafe: {
+        source: "private-source",
+        trigger: "private-trigger",
+        reason: "private-reason",
+      },
+      profiler_id: "private-profiler",
+      error_name: "PrivateError",
+      userId: "12345",
+      count: 12,
+      enabled: true,
+      empty: null,
+      agent: "codex",
+      method: "POST",
+      browser: {
+        mode: "session",
+        phase: "mount",
+        profiler_id: "App",
+        source: "react-profiler",
+        trigger: "route",
+        reason: "query-cancelled",
+      },
+      sync: { mode: "bulk", failed_agents: ["codex", "private-agent"] },
+      exception_origin: "uncaughtException",
+      context: "scan.refresh",
+      route: "/api/sessions/:agent/:id",
+      status: "committed",
+    });
+
+    expect(record.detail).toMatch(/^string:[a-f0-9]{16}$/);
+    expect(record.unsafe).toMatchObject({
+      source: expect.stringMatching(/^string:[a-f0-9]{16}$/),
+      trigger: expect.stringMatching(/^string:[a-f0-9]{16}$/),
+      reason: expect.stringMatching(/^string:[a-f0-9]{16}$/),
+    });
+    expect(record.profiler_id).toMatch(/^identifier:[a-f0-9]{16}$/);
+    expect(record.error_name).toMatch(/^string:[a-f0-9]{16}$/);
+    expect(record.userId).toMatch(/^identifier:[a-f0-9]{16}$/);
+    expect(record).toMatchObject({
+      count: 12,
+      enabled: true,
+      empty: null,
+      agent: "codex",
+      method: "POST",
+      browser: {
+        mode: "session",
+        phase: "mount",
+        profiler_id: "App",
+        source: "react-profiler",
+        trigger: "route",
+        reason: "query-cancelled",
+      },
+      sync: {
+        mode: "bulk",
+        failed_agents: ["codex", expect.stringMatching(/^string:[a-f0-9]{16}$/)],
+      },
+      exception_origin: "uncaughtException",
+      context: "scan.refresh",
+      route: "/api/sessions/:agent/:id",
+      status: "committed",
+    });
+  });
+
+  it("only preserves browser correlation identifiers when they are UUIDs", () => {
+    const record = encode(
+      {
+        valid_operation_id: UUID,
+        operation_id: UUID,
+        request_id: "private-request",
+        connection_id: "private-connection",
+        context: "private-context",
+        status: "private-status",
+      },
+      "client.session.open",
+    );
+
+    expect(record.valid_operation_id).toMatch(/^identifier:[a-f0-9]{16}$/);
+    expect(record.operation_id).toBe(UUID);
+    expect(record.request_id).toMatch(/^identifier:[a-f0-9]{16}$/);
+    expect(record.connection_id).toMatch(/^identifier:[a-f0-9]{16}$/);
+    expect(record.context).toMatch(/^string:[a-f0-9]{16}$/);
+    expect(record.status).toMatch(/^string:[a-f0-9]{16}$/);
+
+    expect(
+      encode({ request_id: "internal-request", operation_id: "internal-operation" }),
+    ).toMatchObject({ request_id: "internal-request", operation_id: "internal-operation" });
+  });
+
+  it("keeps sanitized stack frames through a second pass", () => {
+    const encoder = createEncoder();
+    const error = new Error("private failure");
+    Object.defineProperty(error, "stack", {
+      value: "Error: private failure\n    at first (first.ts:1:1)\n    at second (second.ts:2:2)",
+    });
+    const transported = encoder.sanitizeForTransport({ error }, "worker.failed");
+    const record = JSON.parse(
+      encoder.encode({
+        timestamp: "2026-08-30T00:00:00.000Z",
+        level: "error",
+        event: "worker.failed",
+        runId: UUID,
+        sequence: 1,
+        pid: 1,
+        data: transported,
+      }).line,
+    ) as { error: { stack: string } };
+
+    expect(record.error.stack).toContain("at first");
+    expect(record.error.stack).toContain("at second");
+    expect(record.error.stack).not.toContain("private failure");
+    expect(encode({ stack: "    at only (single.ts:1:1)" }).stack).toContain("at only");
+  });
+
+  it("rejects proxies without invoking their traps", () => {
+    let ownKeysCalls = 0;
+    const value = new Proxy(
+      {},
+      {
+        ownKeys() {
+          ownKeysCalls += 1;
+          throw new Error("must not run");
+        },
+      },
+    );
+
+    expect(encode({ value }).value).toBe("[unserializable]");
+    expect(ownKeysCalls).toBe(0);
+
+    let conversionCalls = 0;
+    const callable = new Proxy(() => undefined, {
+      get() {
+        conversionCalls += 1;
+        throw new Error("must not run");
+      },
+    });
+    expect(encode({ callable }).callable).toBe("[unserializable]");
+    expect(conversionCalls).toBe(0);
+
+    let prototypeCalls = 0;
+    const prototype = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          prototypeCalls += 1;
+          throw new Error("must not run");
+        },
+      },
+    );
+    expect(encode({ inherited: Object.create(prototype) }).inherited).toEqual({});
+    expect(prototypeCalls).toBe(0);
+  });
+
+  it("reads errors and arrays without invoking accessors and detects error cycles", () => {
+    let accessorCalls = 0;
+    const error = new Error();
+    Object.defineProperty(error, "message", {
+      get() {
+        accessorCalls += 1;
+        return "private message";
+      },
+    });
+    Object.defineProperty(error, "cause", { value: error });
+    const unsafeString = {
+      toString() {
+        accessorCalls += 1;
+        return "private value";
+      },
+    };
+    Object.defineProperty(error, "name", { value: unsafeString });
+    Object.defineProperty(error, "stack", { value: unsafeString });
+    const values: unknown[] = [];
+    Object.defineProperty(values, "0", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        accessorCalls += 1;
+        return "private value";
+      },
+    });
+    values.length = 1;
+
+    const record = encode({ error, values }) as {
+      error: { cause: string };
+      values: unknown[];
+    };
+    expect(record.error.cause).toBe("[circular]");
+    expect(record.values).toEqual(["[accessor]"]);
+    expect(accessorCalls).toBe(0);
+  });
+
+  it("uses built-in container methods and omits binary views", () => {
+    let overriddenCalls = 0;
+    const map = new Map([["key", "value"]]);
+    const set = new Set(["value"]);
+    const date = new Date("2026-08-30T00:00:00.000Z");
+    const url = new URL("https://example.com/private?token=secret");
+    const binary = new Uint8Array([1, 2, 3]);
+    for (const [target, key] of [
+      [map, "entries"],
+      [set, "values"],
+      [date, "toISOString"],
+      [date, "getTime"],
+      [url, "toString"],
+      [binary, "private"],
+    ] as const) {
+      Object.defineProperty(target, key, {
+        configurable: true,
+        get() {
+          overriddenCalls += 1;
+          throw new Error("must not run");
+        },
+      });
+    }
+
+    const record = encode({ map, set, date, url, binary });
+    expect(record.map).toHaveLength(1);
+    expect(record.set).toHaveLength(1);
+    expect(record.date).toBe("2026-08-30T00:00:00.000Z");
+    expect(record.url).toBe("https://example.com/");
+    expect(record.binary).toBe("[omitted]");
+    expect(overriddenCalls).toBe(0);
+  });
+});

--- a/packages/cli/src/log-record.ts
+++ b/packages/cli/src/log-record.ts
@@ -1,0 +1,785 @@
+import { createHmac, type BinaryLike } from "node:crypto";
+import { homedir } from "node:os";
+import { types } from "node:util";
+import { AGENT_CATALOG } from "@codesesh/core/contract";
+import type { WorkerLogContext, WorkerLogLevel } from "@codesesh/core/runtime/diagnostics";
+
+export const LOG_SCHEMA_VERSION = 1;
+export const MIN_LOG_RECORD_BYTES = 512;
+
+const MAX_ARRAY_ITEMS = 50;
+const MAX_OBJECT_FIELDS = 100;
+const MAX_DEPTH = 5;
+const MAX_STRING_LENGTH = 4_000;
+const MAX_SANITIZED_VALUES = 1_000;
+const REDACTED_VALUE = "[redacted]";
+const OMITTED_VALUE = "[omitted]";
+const TRUNCATED_VALUE = "[truncated]";
+const UNSERIALIZABLE_VALUE = "[unserializable]";
+const ACCESSOR_VALUE = "[accessor]";
+const CIRCULAR_VALUE = "[circular]";
+const SAFE_SENTINELS = new Set([
+  ACCESSOR_VALUE,
+  CIRCULAR_VALUE,
+  OMITTED_VALUE,
+  REDACTED_VALUE,
+  TRUNCATED_VALUE,
+  UNSERIALIZABLE_VALUE,
+]);
+const LOG_CONTEXT_KEYS = new Set<keyof WorkerLogContext>([
+  "request_id",
+  "operation_id",
+  "publication_id",
+]);
+const CORRELATION_ID_KEYS = new Set([...LOG_CONTEXT_KEYS, "connection_id"]);
+
+const SENSITIVE_KEYS = new Set([
+  "access_token",
+  "api_key",
+  "apikey",
+  "authorization",
+  "client_secret",
+  "cookie",
+  "credential",
+  "credentials",
+  "id_token",
+  "passphrase",
+  "passwd",
+  "password",
+  "private_key",
+  "refresh_token",
+  "secret",
+  "set_cookie",
+  "token",
+]);
+
+const OMITTED_KEYS = new Set([
+  "argv",
+  "body",
+  "command_args",
+  "content",
+  "env",
+  "environment",
+  "headers",
+  "http_body",
+  "message",
+  "messages",
+  "prompt",
+  "prompts",
+  "request_body",
+  "response_body",
+  "stderr",
+  "stdout",
+  "tool_output",
+  "tool_outputs",
+  "transcript",
+  "transcripts",
+]);
+
+const IDENTIFIER_KEYS = new Set([
+  "cursor",
+  "message_cursor",
+  "request_key",
+  "session",
+  "session_id",
+]);
+const ERROR_TEXT_KEYS = new Set(["cause", "error"]);
+const KNOWN_AGENT_NAMES = new Set<string>(AGENT_CATALOG.map(({ name }) => name));
+const HTTP_METHODS = new Set(["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]);
+const AUDITED_STRING_VALUES = new Map<string, ReadonlySet<string>>([
+  [
+    "mode",
+    new Set([
+      "agent",
+      "bulk",
+      "incremental",
+      "invalidRoute",
+      "missingAgent",
+      "project",
+      "projects",
+      "root",
+      "session",
+    ]),
+  ],
+  ["phase", new Set(["measure", "mount", "nested-update", "update"])],
+  [
+    "profiler_id",
+    new Set([
+      "App",
+      "InteractiveReceipt",
+      "MainContent",
+      "MessageList",
+      "OverviewScreen",
+      "SearchControls",
+      "SearchResultsPanel",
+      "SessionDetail",
+      "SessionTreeSidebar",
+    ]),
+  ],
+  ["source", new Set(["commit-latency", "custom-timing", "react-profiler"])],
+  ["trigger", new Set(["route"])],
+  ["reason", new Set(["query-cancelled"])],
+  ["exception_origin", new Set(["uncaughtException", "unhandledRejection"])],
+]);
+const INTERNAL_PLAINTEXT_KEYS = new Set([
+  "authentication",
+  "bind_category",
+  "cache",
+  "close_reason",
+  "context",
+  "encoding",
+  "endpoint",
+  "event",
+  "exception_origin",
+  "failure_stage",
+  "field",
+  "indexes",
+  "label",
+  "loopback_authority",
+  "message_update",
+  "operation",
+  "outcome",
+  "parameter",
+  "persistent_index_worker_job",
+  "publication_completeness",
+  "query_keys",
+  "request_type",
+  "result",
+  "route",
+  "signal",
+  "stage",
+  "state",
+  "status",
+  "transport",
+  "update",
+  "validation_outcome",
+  "version",
+  "worker_level",
+]);
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const FINGERPRINT_TOKEN_PATTERN =
+  /^(?:error_message|field|identifier|path|string|url):[a-f0-9]{16}$/;
+
+const PATH_KEY_PATTERN = /(?:^|_)(?:cwd|directory|file|path|root)$/;
+const URL_KEY_PATTERN = /(?:^|_)(?:origin|url)$/;
+const SENSITIVE_KEY_SUFFIX_PATTERN =
+  /(?:^|_)(?:api_key|authorization|cookie|credential|credentials|passphrase|passwd|password|private_key|secret|token)$/;
+const BEARER_PATTERN = /\bBearer\s+[^\s,;]+/gi;
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g;
+const SECRET_QUERY_PATTERN =
+  /([?&](?:access_token|api_key|apikey|password|secret|token)=)[^&#\s]*/gi;
+const PRIVATE_KEY_PATTERN =
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g;
+const INCOMPLETE_PRIVATE_KEY_PATTERN = /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*$/g;
+const INCOMPLETE_JWT_PATTERN = /\beyJ[A-Za-z0-9_-]*(?:\.[A-Za-z0-9_-]*){0,2}$/g;
+const LINE_BREAK_PATTERN = /\r\n|[\n\r]/;
+
+interface SanitizationBudget {
+  remainingValues: number;
+  remainingCharacters: number;
+}
+
+interface PersonalPrefixReplacement {
+  prefix: string;
+  replacement: string;
+  pattern?: RegExp;
+}
+
+export interface EncodedLogLine {
+  line: string;
+  bytes: number;
+  level: WorkerLogLevel;
+}
+
+export interface LogRecordInput {
+  timestamp: string;
+  level: WorkerLogLevel;
+  event: string;
+  runId: string;
+  sequence: number;
+  pid: number;
+  threadId?: number;
+  context?: WorkerLogContext;
+  data: Record<string, unknown>;
+}
+
+interface LogRecordEncoderOptions {
+  fingerprintKey: BinaryLike;
+  maxRecordBytes: number;
+  currentWorkingDirectory?: string;
+  homeDirectory?: string;
+}
+
+function normalizedKey(key: string): string {
+  return key
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .toLowerCase();
+}
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS.has(key) || SENSITIVE_KEY_SUFFIX_PATTERN.test(key);
+}
+
+function isIdentifierKey(key: string): boolean {
+  return (
+    !CORRELATION_ID_KEYS.has(key) &&
+    (IDENTIFIER_KEYS.has(key) || /(?:^|_)(?:cursor|id|request_key|session_id)$/.test(key))
+  );
+}
+
+function isAuditedString(key: string, value: string): boolean {
+  if (
+    (key === "agent" || key === "agent_name" || key === "agents" || key === "failed_agents") &&
+    KNOWN_AGENT_NAMES.has(value)
+  ) {
+    return true;
+  }
+  if (key === "method" && HTTP_METHODS.has(value)) return true;
+  return AUDITED_STRING_VALUES.get(key)?.has(value) === true;
+}
+
+function windowsPathPattern(value: string): RegExp | undefined {
+  if (!/^(?:[a-z]:[\\/]|\\\\)/i.test(value)) return undefined;
+  const pattern = value
+    .split(/[\\/]+/)
+    .map((segment) => segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join("[\\\\/]+");
+  return new RegExp(pattern, "gi");
+}
+
+export class LogRecordEncoder {
+  private readonly fingerprintKey: BinaryLike;
+  private readonly maxRecordBytes: number;
+  private readonly personalPrefixes: PersonalPrefixReplacement[];
+
+  constructor(options: LogRecordEncoderOptions) {
+    this.fingerprintKey = options.fingerprintKey;
+    this.maxRecordBytes = Math.max(
+      MIN_LOG_RECORD_BYTES,
+      Number.isFinite(options.maxRecordBytes) ? Math.floor(options.maxRecordBytes) : 0,
+    );
+    const personalPrefixes: Array<[string, string]> = [
+      [options.currentWorkingDirectory ?? process.cwd(), "<cwd>"],
+      [options.homeDirectory ?? homedir(), "~"],
+    ];
+    this.personalPrefixes = personalPrefixes
+      .toSorted(([left], [right]) => right.length - left.length)
+      .map(([prefix, replacement]) => ({
+        prefix,
+        replacement,
+        pattern: windowsPathPattern(prefix),
+      }));
+  }
+
+  encode(input: LogRecordInput): EncodedLogLine {
+    const budget = this.createSanitizationBudget();
+    const trustedCorrelationIds = !input.event.startsWith("client.");
+    const fixed = {
+      schema_version: LOG_SCHEMA_VERSION,
+      ts: input.timestamp,
+      level: input.level,
+      event: this.sanitizeEvent(input.event, budget),
+      run_id: input.runId,
+      seq: input.sequence,
+      pid: input.pid,
+      ...(input.threadId == null ? {} : { thread_id: input.threadId }),
+    };
+    const context = this.sanitizeContext(input.context, trustedCorrelationIds, budget);
+    const data = this.sanitizeFields(input.data, trustedCorrelationIds, budget);
+    const line = `${JSON.stringify({ ...data, ...context, ...fixed })}\n`;
+    const bytes = Buffer.byteLength(line);
+    if (bytes <= this.maxRecordBytes) return { line, bytes, level: input.level };
+
+    const truncatedLine = `${JSON.stringify({
+      ...context,
+      ...fixed,
+      record_truncated: true,
+      original_bytes: bytes,
+    })}\n`;
+    const truncatedBytes = Buffer.byteLength(truncatedLine);
+    if (truncatedBytes <= this.maxRecordBytes) {
+      return { line: truncatedLine, bytes: truncatedBytes, level: input.level };
+    }
+
+    const minimalLine = `${JSON.stringify({
+      schema_version: LOG_SCHEMA_VERSION,
+      ts: input.timestamp.slice(0, 40).replace(/[^0-9TZ:.-]/g, "_"),
+      level: input.level,
+      event: fixed.event.slice(0, 64),
+      record_truncated: true,
+      original_bytes: bytes,
+    })}\n`;
+    return {
+      line: minimalLine,
+      bytes: Buffer.byteLength(minimalLine),
+      level: input.level,
+    };
+  }
+
+  sanitizeForTransport(data: Record<string, unknown>, event = ""): Record<string, unknown> {
+    const sanitized = this.sanitizeFields(
+      data,
+      !event.startsWith("client."),
+      this.createSanitizationBudget(),
+    );
+    const bytes = Buffer.byteLength(JSON.stringify(sanitized));
+    return bytes <= this.maxRecordBytes
+      ? sanitized
+      : { transport_truncated: true, original_bytes: bytes };
+  }
+
+  private sanitizeFields(
+    data: Record<string, unknown>,
+    trustedCorrelationIds: boolean,
+    budget: SanitizationBudget,
+  ): Record<string, unknown> {
+    const normalized = this.sanitizeValue(
+      data,
+      "",
+      0,
+      new WeakSet(),
+      trustedCorrelationIds,
+      budget,
+    );
+    return normalized && typeof normalized === "object" && !Array.isArray(normalized)
+      ? (normalized as Record<string, unknown>)
+      : { diagnostic_data: normalized };
+  }
+
+  private sanitizeValue(
+    value: unknown,
+    key: string,
+    depth: number,
+    ancestors: WeakSet<object>,
+    trustedCorrelationIds: boolean,
+    budget: SanitizationBudget,
+  ): unknown {
+    if (budget.remainingValues <= 0 || budget.remainingCharacters <= 0) return TRUNCATED_VALUE;
+    budget.remainingValues -= 1;
+
+    const normalized = normalizedKey(this.takeKeyInput(key, budget));
+    if (isSensitiveKey(normalized)) return REDACTED_VALUE;
+    if (ERROR_TEXT_KEYS.has(normalized) && typeof value === "string") {
+      return this.fingerprint("error_message", value, budget);
+    }
+    if (
+      OMITTED_KEYS.has(normalized) &&
+      value != null &&
+      typeof value !== "number" &&
+      typeof value !== "boolean"
+    ) {
+      return OMITTED_VALUE;
+    }
+    const valueType = typeof value;
+    if (
+      (valueType === "function" || (valueType === "object" && value !== null)) &&
+      types.isProxy(value)
+    ) {
+      return UNSERIALIZABLE_VALUE;
+    }
+    if (value == null || typeof value === "boolean") return value;
+    if (typeof value === "number") {
+      if (Number.isFinite(value)) return value;
+      return value === Number.POSITIVE_INFINITY
+        ? "Infinity"
+        : value === Number.NEGATIVE_INFINITY
+          ? "-Infinity"
+          : "NaN";
+    }
+    if (typeof value === "bigint") {
+      return this.sanitizeString(value.toString(), normalized, budget, trustedCorrelationIds);
+    }
+    if (typeof value === "string") {
+      if (normalized === "stack") return this.sanitizeStack(value, budget);
+      return this.sanitizeString(value, normalized, budget, trustedCorrelationIds);
+    }
+    if (typeof value !== "object") return OMITTED_VALUE;
+    if (depth >= MAX_DEPTH) return TRUNCATED_VALUE;
+    if (ArrayBuffer.isView(value) || types.isAnyArrayBuffer(value)) {
+      return OMITTED_VALUE;
+    }
+    if (ancestors.has(value)) return CIRCULAR_VALUE;
+
+    ancestors.add(value);
+    try {
+      if (types.isDate(value)) {
+        const timestamp = Date.prototype.getTime.call(value);
+        return Number.isNaN(timestamp)
+          ? this.takeLiteral("Invalid Date", budget)
+          : this.takeLiteral(Date.prototype.toISOString.call(value), budget);
+      }
+      const url = this.urlString(value);
+      if (url != null) {
+        return this.sanitizeString(url, "url", budget, trustedCorrelationIds);
+      }
+      if (types.isNativeError(value)) {
+        return this.sanitizeError(value, depth, ancestors, trustedCorrelationIds, budget);
+      }
+      if (Array.isArray(value)) {
+        return this.sanitizeArray(value, key, depth, ancestors, trustedCorrelationIds, budget);
+      }
+      if (types.isMap(value)) {
+        const result: unknown[] = [];
+        for (const [mapKey, item] of Map.prototype.entries.call(value)) {
+          result.push([
+            this.sanitizeValue(mapKey, "key", depth + 1, ancestors, trustedCorrelationIds, budget),
+            this.sanitizeValue(item, key, depth + 1, ancestors, trustedCorrelationIds, budget),
+          ]);
+          if (
+            result.length >= MAX_ARRAY_ITEMS ||
+            budget.remainingValues <= 0 ||
+            budget.remainingCharacters <= 0
+          ) {
+            break;
+          }
+        }
+        return result;
+      }
+      if (types.isSet(value)) {
+        const result: unknown[] = [];
+        for (const item of Set.prototype.values.call(value)) {
+          result.push(
+            this.sanitizeValue(item, key, depth + 1, ancestors, trustedCorrelationIds, budget),
+          );
+          if (
+            result.length >= MAX_ARRAY_ITEMS ||
+            budget.remainingValues <= 0 ||
+            budget.remainingCharacters <= 0
+          ) {
+            break;
+          }
+        }
+        return result;
+      }
+      return this.sanitizeObject(value, depth, ancestors, trustedCorrelationIds, budget);
+    } catch {
+      return UNSERIALIZABLE_VALUE;
+    } finally {
+      ancestors.delete(value);
+    }
+  }
+
+  private sanitizeObject(
+    value: object,
+    depth: number,
+    ancestors: WeakSet<object>,
+    trustedCorrelationIds: boolean,
+    budget: SanitizationBudget,
+  ): Record<string, unknown> | string {
+    let keys: string[];
+    try {
+      keys = Object.getOwnPropertyNames(value).slice(0, MAX_OBJECT_FIELDS);
+    } catch {
+      return UNSERIALIZABLE_VALUE;
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const key of keys) {
+      let descriptor: PropertyDescriptor | undefined;
+      try {
+        descriptor = Object.getOwnPropertyDescriptor(value, key);
+      } catch {
+        result[this.boundedFieldName(key, budget)] = UNSERIALIZABLE_VALUE;
+        if (budget.remainingCharacters <= 0) break;
+        continue;
+      }
+      if (!descriptor) continue;
+
+      result[this.boundedFieldName(key, budget)] =
+        "value" in descriptor
+          ? this.sanitizeValue(
+              descriptor.value,
+              key,
+              depth + 1,
+              ancestors,
+              trustedCorrelationIds,
+              budget,
+            )
+          : ACCESSOR_VALUE;
+      if (budget.remainingValues <= 0 || budget.remainingCharacters <= 0) break;
+    }
+    return result;
+  }
+
+  private sanitizeArray(
+    value: unknown[],
+    key: string,
+    depth: number,
+    ancestors: WeakSet<object>,
+    trustedCorrelationIds: boolean,
+    budget: SanitizationBudget,
+  ): unknown[] {
+    const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
+    const length =
+      lengthDescriptor && "value" in lengthDescriptor && typeof lengthDescriptor.value === "number"
+        ? Math.min(lengthDescriptor.value, MAX_ARRAY_ITEMS)
+        : 0;
+    const result: unknown[] = [];
+    for (let index = 0; index < length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      result.push(
+        !descriptor
+          ? null
+          : "value" in descriptor
+            ? this.sanitizeValue(
+                descriptor.value,
+                key,
+                depth + 1,
+                ancestors,
+                trustedCorrelationIds,
+                budget,
+              )
+            : ACCESSOR_VALUE,
+      );
+      if (budget.remainingValues <= 0 || budget.remainingCharacters <= 0) break;
+    }
+    return result;
+  }
+
+  private sanitizeError(
+    error: Error,
+    depth: number,
+    ancestors: WeakSet<object>,
+    trustedCorrelationIds: boolean,
+    budget: SanitizationBudget,
+  ): Record<string, unknown> {
+    const code = this.errorProperty(error, "code");
+    const cause = this.errorProperty(error, "cause");
+    const message = this.errorStringProperty(error, "message", "");
+    const stack = this.errorStringProperty(error, "stack", "");
+    return {
+      name: this.sanitizeString(
+        this.errorStringProperty(error, "name", "Error"),
+        "name",
+        budget,
+        trustedCorrelationIds,
+      ),
+      message_fingerprint: this.fingerprint("error_message", message, budget),
+      stack: this.sanitizeStack(stack, budget),
+      ...(code == null
+        ? {}
+        : {
+            code: this.sanitizeValue(
+              code,
+              "code",
+              depth + 1,
+              ancestors,
+              trustedCorrelationIds,
+              budget,
+            ),
+          }),
+      ...(cause == null
+        ? {}
+        : {
+            cause: this.sanitizeValue(
+              cause,
+              "cause",
+              depth + 1,
+              ancestors,
+              trustedCorrelationIds,
+              budget,
+            ),
+          }),
+    };
+  }
+
+  private errorProperty(error: Error, key: string): unknown {
+    try {
+      const descriptor = Object.getOwnPropertyDescriptor(error, key);
+      if (!descriptor) return undefined;
+      return "value" in descriptor ? descriptor.value : ACCESSOR_VALUE;
+    } catch {
+      return UNSERIALIZABLE_VALUE;
+    }
+  }
+
+  private errorStringProperty(error: Error, key: string, fallback: string): string {
+    const value = this.errorProperty(error, key);
+    return value == null ? fallback : typeof value === "string" ? value : UNSERIALIZABLE_VALUE;
+  }
+
+  private urlString(value: object): string | undefined {
+    try {
+      return URL.prototype.toString.call(value);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private createSanitizationBudget(): SanitizationBudget {
+    return {
+      remainingValues: MAX_SANITIZED_VALUES,
+      remainingCharacters: Math.max(0, Math.floor(this.maxRecordBytes)),
+    };
+  }
+
+  private sanitizeContext(
+    context: WorkerLogContext | undefined,
+    trustedCorrelationIds: boolean,
+    budget: SanitizationBudget,
+  ): WorkerLogContext {
+    if (!context) return {};
+    return Object.fromEntries(
+      Object.entries(context).flatMap(([key, value]) =>
+        LOG_CONTEXT_KEYS.has(key as keyof WorkerLogContext) &&
+        typeof value === "string" &&
+        value.length > 0
+          ? [
+              [
+                key,
+                this.sanitizeString(value, normalizedKey(key), budget, trustedCorrelationIds).slice(
+                  0,
+                  160,
+                ),
+              ],
+            ]
+          : [],
+      ),
+    );
+  }
+
+  private sanitizeEvent(event: string, budget: SanitizationBudget): string {
+    return this.takePrefix(event, budget)
+      .trim()
+      .replace(/[^a-zA-Z0-9_.:-]/g, "_")
+      .slice(0, 160);
+  }
+
+  private sanitizeString(
+    value: string,
+    key: string,
+    budget: SanitizationBudget,
+    trustedCorrelationIds = false,
+  ): string {
+    if (FINGERPRINT_TOKEN_PATTERN.test(value) || SAFE_SENTINELS.has(value)) {
+      return this.takeLiteral(value, budget);
+    }
+    if (CORRELATION_ID_KEYS.has(key)) {
+      return trustedCorrelationIds || UUID_PATTERN.test(value)
+        ? this.takeLiteral(value, budget)
+        : this.fingerprint("identifier", value, budget);
+    }
+    if (isAuditedString(key, value)) return this.takeLiteral(value, budget);
+    if (isIdentifierKey(key)) return this.fingerprint("identifier", value, budget);
+    if (trustedCorrelationIds && INTERNAL_PLAINTEXT_KEYS.has(key)) {
+      const bounded = this.takePrefix(value, budget);
+      return this.sanitizeBoundedString(bounded, key, bounded.length < value.length);
+    }
+    if (PATH_KEY_PATTERN.test(key)) return this.fingerprint("path", value, budget);
+    if (
+      URL_KEY_PATTERN.test(key) &&
+      value.length > Math.min(MAX_STRING_LENGTH, budget.remainingCharacters)
+    ) {
+      return this.fingerprint("url", value, budget);
+    }
+    if (URL_KEY_PATTERN.test(key)) {
+      const bounded = this.takePrefix(value, budget);
+      return this.sanitizeBoundedString(bounded, key, bounded.length < value.length);
+    }
+    return this.fingerprint("string", value, budget);
+  }
+
+  private takeLiteral(value: string, budget: SanitizationBudget): string {
+    if (value.length > budget.remainingCharacters) return TRUNCATED_VALUE;
+    budget.remainingCharacters -= value.length;
+    return value;
+  }
+
+  private sanitizeStack(value: string, budget: SanitizationBudget): string {
+    const bounded = this.takePrefix(value, budget);
+    const inputTruncated = bounded.length < value.length;
+    const startsWithFrame = /^\s*at(?:\s|$)/.test(bounded);
+    const lineBreak = LINE_BREAK_PATTERN.exec(bounded);
+    if (!startsWithFrame && !lineBreak) return inputTruncated ? TRUNCATED_VALUE : "";
+
+    const stackBody = startsWithFrame
+      ? bounded
+      : bounded.slice(lineBreak!.index + lineBreak![0].length);
+    const sanitized = this.sanitizeBoundedString(stackBody, "stack", inputTruncated);
+    return inputTruncated && !sanitized.endsWith(TRUNCATED_VALUE)
+      ? `${sanitized}[truncated]`
+      : sanitized;
+  }
+
+  private sanitizeBoundedString(value: string, key: string, inputTruncated: boolean): string {
+    let sanitized = value
+      .replace(PRIVATE_KEY_PATTERN, REDACTED_VALUE)
+      .replace(BEARER_PATTERN, `Bearer ${REDACTED_VALUE}`)
+      .replace(JWT_PATTERN, REDACTED_VALUE)
+      .replace(SECRET_QUERY_PATTERN, `$1${REDACTED_VALUE}`);
+    if (inputTruncated) {
+      sanitized = sanitized
+        .replace(INCOMPLETE_PRIVATE_KEY_PATTERN, REDACTED_VALUE)
+        .replace(INCOMPLETE_JWT_PATTERN, REDACTED_VALUE);
+    }
+    if (URL_KEY_PATTERN.test(key)) sanitized = this.sanitizeUrl(sanitized);
+    sanitized = this.replacePersonalPrefixes(sanitized);
+    return !inputTruncated && sanitized.length <= MAX_STRING_LENGTH
+      ? sanitized
+      : `${sanitized.slice(0, MAX_STRING_LENGTH)}[truncated]`;
+  }
+
+  private takePrefix(value: string, budget: SanitizationBudget): string {
+    const length = Math.min(value.length, MAX_STRING_LENGTH, budget.remainingCharacters);
+    budget.remainingCharacters -= length;
+    return value.slice(0, length);
+  }
+
+  private takeKeyInput(key: string, budget: SanitizationBudget): string {
+    const length = Math.min(key.length, MAX_STRING_LENGTH, budget.remainingCharacters);
+    budget.remainingCharacters -= length;
+    if (length >= key.length) return key;
+    if (length === 0) return "";
+    if (length < 3) return key.slice(-length);
+
+    const contentLength = length - 1;
+    const prefixLength = Math.ceil(contentLength / 2);
+    return `${key.slice(0, prefixLength)}_${key.slice(-(contentLength - prefixLength))}`;
+  }
+
+  private boundedFieldName(key: string, budget: SanitizationBudget): string {
+    if (key.length <= MAX_STRING_LENGTH && key.length <= budget.remainingCharacters) {
+      budget.remainingCharacters -= key.length;
+      return key;
+    }
+    return this.fingerprint("field", key, budget);
+  }
+
+  private sanitizeUrl(value: string): string {
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      return OMITTED_VALUE;
+    }
+    return url.origin === "null" ? OMITTED_VALUE : `${url.origin}/`;
+  }
+
+  private replacePersonalPrefixes(value: string): string {
+    return this.personalPrefixes.reduce(
+      (text, { prefix, replacement, pattern }) =>
+        pattern ? text.replace(pattern, replacement) : text.split(prefix).join(replacement),
+      value,
+    );
+  }
+
+  private fingerprint(kind: string, value: string, budget: SanitizationBudget): string {
+    if (FINGERPRINT_TOKEN_PATTERN.test(value)) return this.takeLiteral(value, budget);
+    const suffix = `\0${value.length}`;
+    const contentLength = MAX_STRING_LENGTH - suffix.length;
+    const prefixLength = Math.ceil(contentLength / 2);
+    const bounded =
+      value.length <= MAX_STRING_LENGTH
+        ? value
+        : `${value.slice(0, prefixLength)}${value.slice(-(contentLength - prefixLength))}${suffix}`;
+    if (bounded.length > budget.remainingCharacters) return TRUNCATED_VALUE;
+    budget.remainingCharacters -= bounded.length;
+    const digest = createHmac("sha256", this.fingerprintKey)
+      .update(bounded)
+      .digest("hex")
+      .slice(0, 16);
+    return `${kind}:${digest}`;
+  }
+}

--- a/packages/cli/src/logging.test.ts
+++ b/packages/cli/src/logging.test.ts
@@ -126,7 +126,7 @@ describe("AppLogger", () => {
     const record = JSON.parse(readFileSync(logger.getLogPath(), "utf8")) as { stack: string };
     expect(record.stack).not.toContain(privateMessage);
     expect(record.stack).not.toContain(homedir());
-    expect(record.stack).toContain("~/private/reader.ts");
+    expect(record.stack).toContain(join("~", "private", "reader.ts"));
   });
 
   it("omits relative and unparseable URL values", async () => {
@@ -263,6 +263,7 @@ describe("AppLogger", () => {
     const ownerLogDir = createTempDir();
     const owner = createLogger({ logDir: ownerLogDir, maxBytes: 1_000, maxFiles: 200 });
     const messages: unknown[] = [];
+    const entriesPerWorker = 5;
     const workers = Array.from({ length: 4 }, (_, threadId) => {
       const logger = createLogger({ logDir: createTempDir() });
       logger.forwardToParent({ postMessage: (message) => messages.push(message) }, threadId + 1);
@@ -270,26 +271,27 @@ describe("AppLogger", () => {
     });
 
     for (const [worker, logger] of workers.entries()) {
-      for (let index = 0; index < 30; index += 1) {
+      for (let index = 0; index < entriesPerWorker; index += 1) {
         logger.info("worker.rotation", { worker, index });
       }
     }
     for (const message of messages) owner.consumeWorkerMessage(message);
     await owner.flush();
 
-    const records = readdirSync(ownerLogDir)
-      .filter((name) => name.endsWith(".log"))
-      .flatMap((name) =>
-        readFileSync(join(ownerLogDir, name), "utf8")
-          .trim()
-          .split("\n")
-          .filter(Boolean)
-          .map((line) => JSON.parse(line) as { worker: number; index: number }),
-      );
+    const logFiles = readdirSync(ownerLogDir).filter((name) => name.endsWith(".log"));
+    const records = logFiles.flatMap((name) =>
+      readFileSync(join(ownerLogDir, name), "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as { worker: number; index: number }),
+    );
     const uniqueEntries = new Set(records.map(({ worker, index }) => `${worker}:${index}`));
+    const expectedEntries = workers.length * entriesPerWorker;
 
-    expect(records).toHaveLength(120);
-    expect(uniqueEntries.size).toBe(120);
+    expect(logFiles.length).toBeGreaterThan(1);
+    expect(records).toHaveLength(expectedEntries);
+    expect(uniqueEntries.size).toBe(expectedEntries);
   });
 
   it("bounds worker transport payloads before structured cloning", () => {

--- a/packages/cli/src/logging.test.ts
+++ b/packages/cli/src/logging.test.ts
@@ -6,22 +6,17 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { basename, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AppLogger } from "./logging.js";
-
-const coreMocks = vi.hoisted(() => ({ restrictPrivateFile: vi.fn() }));
-
-vi.mock("@codesesh/core/runtime/diagnostics", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@codesesh/core/runtime/diagnostics")>();
-  coreMocks.restrictPrivateFile.mockImplementation(actual.restrictPrivateFile);
-  return { ...actual, restrictPrivateFile: coreMocks.restrictPrivateFile };
-});
+import { LogRecordEncoder, MIN_LOG_RECORD_BYTES } from "./log-record.js";
+import { AppLogger, type LoggerOptions } from "./logging.js";
 
 const tempDirs: string[] = [];
+const loggers: AppLogger[] = [];
 
 function createTempDir() {
   const dir = mkdtempSync(join(tmpdir(), "codesesh-logs-"));
@@ -29,70 +24,247 @@ function createTempDir() {
   return dir;
 }
 
+function createLogger(options: LoggerOptions): AppLogger {
+  const logger = new AppLogger(options);
+  loggers.push(logger);
+  return logger;
+}
+
 describe("AppLogger", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    await Promise.all(loggers.splice(0).map((logger) => logger.close()));
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
     vi.restoreAllMocks();
   });
 
-  it("writes structured log lines", () => {
+  it("writes structured log lines", async () => {
     const logDir = createTempDir();
-    const logger = new AppLogger({ logDir, maxBytes: 10_000 });
+    const logger = createLogger({ logDir, maxBytes: 10_000 });
 
     logger.info("test.event", { duration_ms: 12, ok: true });
+    await logger.flush();
 
     const line = readFileSync(logger.getLogPath(), "utf8").trim();
     expect(JSON.parse(line)).toMatchObject({
+      schema_version: 1,
       level: "info",
       event: "test.event",
       duration_ms: 12,
       ok: true,
+      seq: 1,
+    });
+    expect(JSON.parse(line).run_id).toEqual(expect.any(String));
+  });
+
+  it("never lets unsafe diagnostic data escape into product control flow", async () => {
+    const logger = createLogger({ logDir: createTempDir() });
+    const data: Record<string, unknown> = {};
+    Object.defineProperty(data, "broken", {
+      enumerable: true,
+      get() {
+        throw new Error("getter exploded");
+      },
+    });
+
+    expect(() => logger.info("test.unsafe_data", data)).not.toThrow();
+    await logger.flush();
+  });
+
+  it("redacts credentials and personal path prefixes before persistence", async () => {
+    const logger = createLogger({ logDir: createTempDir() });
+    const privatePath = join(homedir(), "project", "session.jsonl");
+    const privateUrl =
+      "https://user:private-password@example.com/sessions/private-session-id?token=private-query#private-fragment";
+
+    logger.info("test.redaction", {
+      authorization: "Bearer private-token",
+      accessToken: "camel-case-token",
+      nested: { password: "private-password" },
+      path: privatePath,
+      file: privatePath,
+      prompt: "private prompt body",
+      message: "private diagnostic message",
+      error: "private source error",
+      target: { url: privateUrl },
+      sessionId: "camel-case-session-id",
+      session_id: "private-session-id",
+    });
+    await logger.flush();
+
+    const persisted = readFileSync(logger.getLogPath(), "utf8");
+    const record = JSON.parse(persisted) as Record<string, unknown>;
+    expect(record.authorization).toBe("[redacted]");
+    expect(record.nested).toEqual({ password: "[redacted]" });
+    expect(record.message).toBe("[omitted]");
+    expect(record.error).toMatch(/^error_message:[a-f0-9]{16}$/);
+    expect(record.path).toMatch(/^path:[a-f0-9]{16}$/);
+    expect(record.file).toBe(record.path);
+    expect(persisted).not.toContain("session.jsonl");
+    expect(record.session_id).not.toBe("private-session-id");
+    expect(persisted).not.toContain("camel-case-token");
+    expect(persisted).not.toContain("camel-case-session-id");
+    expect(persisted).not.toContain("private prompt body");
+    expect(persisted).not.toContain("private source error");
+    expect(persisted).not.toContain("private-password");
+    expect(persisted).not.toContain("private-session-id");
+    expect(persisted).not.toContain("private-query");
+    expect(persisted).not.toContain("private-fragment");
+    expect(record.target).toEqual({ url: "https://example.com/" });
+  });
+
+  it("removes message text and personal paths from plain stack fields", async () => {
+    const logger = createLogger({ logDir: createTempDir() });
+    const privateMessage = "failed while reading a private session";
+
+    logger.error("test.plain_stack", {
+      stack: `Error: ${privateMessage}\n    at ${join(homedir(), "private", "reader.ts")}:1:1`,
+    });
+    await logger.flush();
+
+    const record = JSON.parse(readFileSync(logger.getLogPath(), "utf8")) as { stack: string };
+    expect(record.stack).not.toContain(privateMessage);
+    expect(record.stack).not.toContain(homedir());
+    expect(record.stack).toContain("~/private/reader.ts");
+  });
+
+  it("omits relative and unparseable URL values", async () => {
+    const logger = createLogger({ logDir: createTempDir() });
+
+    logger.info("test.unsafe_urls", {
+      relativeUrl: "/sessions/private-session?token=private-token",
+      malformedUrl: "http://[private-host",
+    });
+    await logger.flush();
+
+    const persisted = readFileSync(logger.getLogPath(), "utf8");
+    const record = JSON.parse(persisted) as Record<string, unknown>;
+    expect(record.relativeUrl).toBe("[omitted]");
+    expect(record.malformedUrl).toBe("[omitted]");
+    expect(persisted).not.toContain("private-session");
+    expect(persisted).not.toContain("private-host");
+  });
+
+  it("isolates correlation context across concurrent operations", async () => {
+    const logger = createLogger({ logDir: createTempDir() });
+
+    await Promise.all([
+      logger.runWithContext({ request_id: "request-a", operation_id: "operation-a" }, async () => {
+        await Promise.resolve();
+        logger.info("context.a");
+      }),
+      logger.runWithContext({ request_id: "request-b", operation_id: "operation-b" }, async () => {
+        logger.info("context.b");
+        await Promise.resolve();
+      }),
+    ]);
+    await logger.flush();
+
+    const records = readFileSync(logger.getLogPath(), "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records.find((record) => record.event === "context.a")).toMatchObject({
+      request_id: "request-a",
+      operation_id: "operation-a",
+    });
+    expect(records.find((record) => record.event === "context.b")).toMatchObject({
+      request_id: "request-b",
+      operation_id: "operation-b",
     });
   });
 
-  it("rotates logs and keeps the configured file count", () => {
+  it("inherits request context when an operation adds its identifier", async () => {
+    const logger = createLogger({ logDir: createTempDir() });
+
+    logger.runWithContext({ request_id: "request" }, () => {
+      logger.runWithContext({ operation_id: "operation" }, () => logger.info("context.nested"));
+    });
+    await logger.flush();
+
+    expect(JSON.parse(readFileSync(logger.getLogPath(), "utf8"))).toMatchObject({
+      request_id: "request",
+      operation_id: "operation",
+    });
+  });
+
+  it("rotates logs and keeps the configured file count", async () => {
     const logDir = createTempDir();
-    const logger = new AppLogger({ logDir, maxBytes: 120, maxFiles: 2 });
+    const logger = createLogger({ logDir, maxBytes: 120, maxFiles: 2 });
 
     for (let index = 0; index < 8; index += 1) {
       logger.info("test.rotate", { index, text: "x".repeat(80) });
     }
+    await logger.flush();
 
     const files = readdirSync(logDir).filter((name) => name.endsWith(".log"));
     expect(files.length).toBeLessThanOrEqual(2);
-    expect(files).toContain(`codesesh-${process.pid}.log`);
+    expect(files).toContain(basename(logger.getLogPath()));
   });
 
-  it("forwards worker entries to a single file owner", () => {
+  it("forwards worker entries to a single file owner", async () => {
     const workerLogDir = createTempDir();
     const ownerLogDir = createTempDir();
     const messages: unknown[] = [];
-    const workerLogger = new AppLogger({ logDir: workerLogDir });
-    const ownerLogger = new AppLogger({ logDir: ownerLogDir });
+    const workerLogger = createLogger({ logDir: workerLogDir });
+    const ownerLogger = createLogger({ logDir: ownerLogDir });
     workerLogger.forwardToParent({ postMessage: (message) => messages.push(message) }, 7);
 
-    workerLogger.warn("worker.warning", { session: "one" });
+    workerLogger.runWithContext({ operation_id: "worker-operation" }, () => {
+      workerLogger.warn("worker.warning", { session: "one" });
+    });
 
     expect(existsSync(workerLogger.getLogPath())).toBe(false);
     expect(messages).toHaveLength(1);
     expect(ownerLogger.consumeWorkerMessage(messages[0])).toBe(true);
     expect(ownerLogger.consumeWorkerMessage({ type: "done" })).toBe(false);
-    expect(JSON.parse(readFileSync(ownerLogger.getLogPath(), "utf8"))).toMatchObject({
+    await ownerLogger.flush();
+    const record = JSON.parse(readFileSync(ownerLogger.getLogPath(), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(record).toMatchObject({
       level: "warn",
       event: "worker.warning",
-      session: "one",
       thread_id: 7,
+      operation_id: "worker-operation",
     });
+    expect(record.session).not.toBe("one");
   });
 
-  it("preserves all worker entries across owner rotations", () => {
+  it("shares stable fingerprints across loggers and transport passes", async () => {
+    const messages: unknown[] = [];
+    const firstWorker = createLogger({ logDir: createTempDir() });
+    const secondWorker = createLogger({ logDir: createTempDir() });
+    const owner = createLogger({ logDir: createTempDir() });
+    firstWorker.forwardToParent({ postMessage: (message) => messages.push(message) }, 1);
+    secondWorker.forwardToParent({ postMessage: (message) => messages.push(message) }, 2);
+
+    firstWorker.info("worker.private", { detail: "same private value", sessionId: "12345" });
+    secondWorker.info("worker.private", { detail: "same private value", sessionId: "12345" });
+
+    const transported = messages.map(
+      (message) => (message as { data: { detail: string; sessionId: string } }).data,
+    );
+    expect(transported[1]).toEqual(transported[0]);
+    for (const message of messages) owner.consumeWorkerMessage(message);
+    await owner.flush();
+
+    const records = readFileSync(owner.getLogPath(), "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { detail: string; sessionId: string });
+    expect(records[0]).toMatchObject(transported[0]!);
+    expect(records[1]).toMatchObject(transported[0]!);
+  });
+
+  it("preserves all worker entries across owner rotations", async () => {
     const ownerLogDir = createTempDir();
-    const owner = new AppLogger({ logDir: ownerLogDir, maxBytes: 300, maxFiles: 200 });
+    const owner = createLogger({ logDir: ownerLogDir, maxBytes: 1_000, maxFiles: 200 });
     const messages: unknown[] = [];
     const workers = Array.from({ length: 4 }, (_, threadId) => {
-      const logger = new AppLogger({ logDir: createTempDir() });
+      const logger = createLogger({ logDir: createTempDir() });
       logger.forwardToParent({ postMessage: (message) => messages.push(message) }, threadId + 1);
       return logger;
     });
@@ -103,6 +275,7 @@ describe("AppLogger", () => {
       }
     }
     for (const message of messages) owner.consumeWorkerMessage(message);
+    await owner.flush();
 
     const records = readdirSync(ownerLogDir)
       .filter((name) => name.endsWith(".log"))
@@ -119,41 +292,293 @@ describe("AppLogger", () => {
     expect(uniqueEntries.size).toBe(120);
   });
 
-  it("does not remove another process's rotated logs", () => {
-    const logDir = createTempDir();
-    const foreignActiveLog = join(logDir, `codesesh-${process.pid + 1}.log`);
-    const foreignLog = join(logDir, `codesesh-${process.pid + 1}-foreign-1.log`);
-    writeFileSync(foreignActiveLog, "foreign active\n");
-    writeFileSync(foreignLog, "foreign\n");
-    const logger = new AppLogger({ logDir, maxBytes: 120, maxFiles: 1 });
+  it("bounds worker transport payloads before structured cloning", () => {
+    const messages: unknown[] = [];
+    const worker = createLogger({ logDir: createTempDir() });
+    worker.forwardToParent({ postMessage: (message) => messages.push(message) }, 1);
 
-    for (let index = 0; index < 4; index += 1) {
-      logger.info("test.rotate", { index, text: "x".repeat(80) });
-    }
+    worker.info("worker.large", {
+      payload: Array.from({ length: 50 }, () =>
+        Array.from({ length: 50 }, () => "x".repeat(4_000)),
+      ),
+    });
 
-    expect(existsSync(foreignActiveLog)).toBe(true);
-    expect(existsSync(foreignLog)).toBe(true);
+    expect(Buffer.byteLength(JSON.stringify(messages[0]))).toBeLessThanOrEqual(70_000);
   });
 
-  it("restricts the active file only when it is created", () => {
-    coreMocks.restrictPrivateFile.mockClear();
-    const logger = new AppLogger({ logDir: createTempDir(), maxBytes: 10_000 });
+  it("bounds string sanitization before applying redaction patterns", () => {
+    const maxRecordBytes = 8_192;
+    const messages: unknown[] = [];
+    const worker = createLogger({ logDir: createTempDir(), maxRecordBytes });
+    worker.forwardToParent({ postMessage: (message) => messages.push(message) }, 1);
+    const replace = vi.spyOn(String.prototype, "replace");
+
+    worker.info("worker.large_string", {
+      detail: `Bearer ${"private-token".repeat(100_000)}`,
+      keyMaterial: `-----BEGIN PRIVATE KEY-----\n${"private-key-data".repeat(100_000)}\n-----END PRIVATE KEY-----`,
+      payload: Array.from({ length: 50 }, () => "x".repeat(4_000)),
+    });
+
+    const replacedCharacters = replace.mock.contexts.reduce<number>(
+      (total, value) => total + String(value).length,
+      0,
+    );
+    expect(replace.mock.contexts.every((value) => String(value).length <= 4_000)).toBe(true);
+    expect(replacedCharacters).toBeLessThanOrEqual(maxRecordBytes * 8);
+    expect(JSON.stringify(messages[0])).not.toContain("private-token");
+    expect(JSON.stringify(messages[0])).not.toContain("private-key-data");
+  });
+
+  it("bounds aggregate traversal across repeated containers", () => {
+    const messages: unknown[] = [];
+    const worker = createLogger({ logDir: createTempDir() });
+    worker.forwardToParent({ postMessage: (message) => messages.push(message) }, 1);
+    const entries = new Map(Array.from({ length: 50 }, (_, index) => [index, { value: index }]));
+    const originalEntries = entries.entries.bind(entries);
+    let entriesRead = 0;
+    vi.spyOn(entries, "entries").mockImplementation(function* () {
+      for (const entry of originalEntries()) {
+        entriesRead += 1;
+        yield entry;
+      }
+      return undefined;
+    });
+
+    worker.info("worker.repeated_containers", {
+      payload: Array.from({ length: 50 }, () => entries),
+    });
+
+    expect(entriesRead).toBeLessThan(500);
+    expect(messages).toHaveLength(1);
+  });
+
+  it("fingerprints worker errors and removes the message-bearing stack line", async () => {
+    const messages: unknown[] = [];
+    const worker = createLogger({ logDir: createTempDir() });
+    const owner = createLogger({ logDir: createTempDir() });
+    worker.forwardToParent({ postMessage: (message) => messages.push(message) }, 1);
+    const error = new Error("parse failed with private input");
+    error.stack = `Error: parse failed with private input\n    at ${join(homedir(), "private", "reader.ts")}:1:1`;
+
+    worker.error("worker.failed", { error });
+    worker.error("worker.failed_again", { error });
+    expect(JSON.stringify(messages)).not.toContain("parse failed with private input");
+    for (const message of messages) owner.consumeWorkerMessage(message);
+    await owner.flush();
+
+    const records = readFileSync(owner.getLogPath(), "utf8")
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            error: { message_fingerprint: string; message?: string; stack: string };
+          },
+      );
+    expect(records[0]?.error.message_fingerprint).toMatch(/^error_message:[a-f0-9]{16}$/);
+    expect(records[1]?.error.message_fingerprint).toBe(records[0]?.error.message_fingerprint);
+    expect(records[0]?.error.message).toBeUndefined();
+    expect(records[0]?.error.stack).not.toContain("parse failed with private input");
+    expect(records[0]?.error.stack).not.toContain(homedir());
+  });
+
+  it("redacts Windows path prefixes across case and separator variants", () => {
+    const encoder = new LogRecordEncoder({
+      fingerprintKey: Buffer.alloc(32, 1),
+      maxRecordBytes: 64 * 1_024,
+      currentWorkingDirectory: "C:\\Users\\Kevin\\Project",
+      homeDirectory: "C:\\Users\\Kevin",
+    });
+    const error = new Error("private failure");
+    Object.defineProperty(error, "stack", {
+      value: "Error: private failure\n    at c:/USERS/kevin/project\\src/reader.ts:1:1",
+    });
+
+    const record = JSON.parse(
+      encoder.encode({
+        timestamp: "2026-08-29T00:00:00.000Z",
+        level: "error",
+        event: "test.windows_paths",
+        runId: "00000000-0000-4000-8000-000000000000",
+        sequence: 1,
+        pid: 1,
+        data: {
+          detail: "read c:/USERS/kevin/project\\session.jsonl and C:\\users\\KEVIN\\notes.txt",
+          error,
+        },
+      }).line,
+    ) as { detail: string; error: { stack: string } };
+
+    expect(record.detail).toMatch(/^string:[a-f0-9]{16}$/);
+    expect(record.error.stack).toContain("<cwd>");
+    expect(`${record.detail}\n${record.error.stack}`.toLowerCase()).not.toContain("c:/users/kevin");
+    expect(`${record.detail}\n${record.error.stack}`.toLowerCase()).not.toContain(
+      "c:\\users\\kevin",
+    );
+  });
+
+  it("removes stale logs left by previous processes", async () => {
+    const logDir = createTempDir();
+    for (let index = 0; index < 4; index += 1) {
+      writeFileSync(join(logDir, `codesesh-${900_000_000 + index}.log`), `stale ${index}\n`);
+    }
+    const logger = createLogger({ logDir, maxBytes: 10_000, maxFiles: 2 });
+
+    logger.info("test.retention");
+    await logger.flush();
+
+    const files = readdirSync(logDir).filter((name) => name.endsWith(".log"));
+    expect(files).toHaveLength(2);
+    expect(files).toContain(basename(logger.getLogPath()));
+  });
+
+  it("applies age retention only to managed inactive logs", async () => {
+    const logDir = createTempDir();
+    const stale = join(logDir, "codesesh-900000000.log");
+    const originalRotated = join(logDir, "codesesh-2026-01-01T00-00-00-000Z-900000000-1.log");
+    const unrelated = join(logDir, "codesesh-notes.log");
+    writeFileSync(stale, "stale\n");
+    writeFileSync(originalRotated, "stale\n");
+    writeFileSync(unrelated, "keep\n");
+    const old = new Date(Date.now() - 10_000);
+    utimesSync(stale, old, old);
+    utimesSync(originalRotated, old, old);
+    utimesSync(unrelated, old, old);
+    const logger = createLogger({ logDir, maxAgeMs: 1_000 });
+
+    logger.info("test.retention_age");
+    await logger.flush();
+
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(originalRotated)).toBe(false);
+    expect(existsSync(unrelated)).toBe(true);
+  });
+
+  it("preserves emergency logs owned by a live process during retention", async () => {
+    const logDir = createTempDir();
+    const firstLogger = createLogger({ logDir });
+
+    firstLogger.error("test.emergency");
+    firstLogger.flushSync();
+    const emergencyFile = readdirSync(logDir).find((name) => name.endsWith("-emergency.log"));
+    expect(emergencyFile).toBeDefined();
+
+    const secondLogger = createLogger({ logDir, maxFiles: 1, maxDirectoryBytes: 1 });
+    secondLogger.info("test.retention");
+    await secondLogger.flush();
+
+    expect(existsSync(join(logDir, emergencyFile!))).toBe(true);
+  });
+
+  it("reports bounded-queue loss and preserves a queued warning", async () => {
+    const logDir = createTempDir();
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const logger = createLogger({ logDir, maxQueueBytes: 1_000 });
+
+    for (let index = 0; index < 100; index += 1) {
+      logger.info("queue.info", { index, detail: "x".repeat(100) });
+    }
+    logger.warn("queue.warning", { outcome: "preserved" });
+    await logger.flush();
+
+    const records = readdirSync(logDir)
+      .filter((name) => name.endsWith(".log"))
+      .flatMap((name) =>
+        readFileSync(join(logDir, name), "utf8")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line) as Record<string, unknown>),
+      );
+    expect(records).toContainEqual(expect.objectContaining({ event: "queue.warning" }));
+    expect(records).toContainEqual(
+      expect.objectContaining({ event: "logger.records_dropped", info: expect.any(Number) }),
+    );
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("Log queue full"));
+  });
+
+  it("never evicts an error to accept a lower-priority warning", async () => {
+    const logDir = createTempDir();
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const logger = createLogger({ logDir, maxQueueBytes: 300 });
+
+    logger.error("queue.error", { detail: "x".repeat(80) });
+    logger.warn("queue.warning", { detail: "x".repeat(80) });
+    await logger.flush();
+
+    const persisted = readdirSync(logDir)
+      .filter((name) => name.endsWith(".log"))
+      .map((name) => readFileSync(join(logDir, name), "utf8"))
+      .join("");
+    expect(persisted).toContain('"event":"queue.error"');
+    expect(persisted).not.toContain('"event":"queue.warning"');
+  });
+
+  it("settles flush when the queue cannot hold a drop summary", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const logger = createLogger({ logDir: createTempDir(), maxQueueBytes: 1 });
+
+    logger.info("queue.too_small");
+    await logger.flush();
+
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("Log queue full"));
+  });
+
+  it("replaces an oversized record with bounded metadata", async () => {
+    const logger = createLogger({ logDir: createTempDir(), maxRecordBytes: 512 });
+
+    logger.info("record.large", {
+      detail: "private-large-value".repeat(1_000),
+      ...Object.fromEntries(Array.from({ length: 100 }, (_, index) => [`metric_${index}`, index])),
+    });
+    await logger.flush();
+
+    const persisted = readFileSync(logger.getLogPath(), "utf8");
+    expect(Buffer.byteLength(persisted)).toBeLessThanOrEqual(MIN_LOG_RECORD_BYTES);
+    expect(JSON.parse(persisted)).toMatchObject({ record_truncated: true });
+    expect(persisted).not.toContain("private-large-value");
+  });
+
+  it("enforces the minimum record limit for tiny configurations", async () => {
+    const logger = createLogger({ logDir: createTempDir(), maxRecordBytes: 1 });
+    const privateContext = "\0".repeat(160);
+
+    logger.runWithContext(
+      {
+        request_id: privateContext,
+        operation_id: privateContext,
+        publication_id: privateContext,
+      },
+      () => logger.info("record.tiny_limit", { detail: "private-value".repeat(1_000) }),
+    );
+    await logger.flush();
+
+    const persisted = readFileSync(logger.getLogPath(), "utf8");
+    expect(Buffer.byteLength(persisted)).toBeLessThanOrEqual(MIN_LOG_RECORD_BYTES);
+    expect(JSON.parse(persisted)).toMatchObject({ record_truncated: true });
+    expect(persisted).not.toContain("private-value");
+  });
+
+  it("defers file access until after the logging call returns", async () => {
+    const logger = createLogger({ logDir: createTempDir(), maxBytes: 10_000 });
 
     logger.info("test.first");
-    logger.info("test.second");
 
-    expect(coreMocks.restrictPrivateFile).toHaveBeenCalledExactlyOnceWith(logger.getLogPath());
+    expect(existsSync(logger.getLogPath())).toBe(false);
+    await logger.flush();
+    expect(existsSync(logger.getLogPath())).toBe(true);
   });
 
-  it("reports a file write failure once instead of dropping it silently", () => {
+  it("reports a file write failure once instead of dropping it silently", async () => {
     const root = createTempDir();
     const blocker = join(root, "not-a-directory");
     writeFileSync(blocker, "x");
     const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    const logger = new AppLogger({ logDir: blocker });
+    const logger = createLogger({ logDir: blocker });
 
     logger.info("test.failure");
     logger.info("test.failure-again");
+    await logger.flush();
 
     expect(stderr).toHaveBeenCalledOnce();
     expect(stderr).toHaveBeenCalledWith(expect.stringContaining("Failed to write log"));
@@ -163,30 +588,40 @@ describe("AppLogger", () => {
 describe("CS-141: log permissions", () => {
   const isPosix = process.platform !== "win32";
 
-  it.runIf(isPosix)("tightens logs a previous run left readable", () => {
+  it.runIf(isPosix)("tightens logs a previous run left readable", async () => {
     const dir = mkdtempSync(join(tmpdir(), "codesesh-log-existing-"));
     try {
-      const stale = join(dir, "codesesh-2026-01-01T000000-000Z-1-1.log");
-      writeFileSync(stale, "old entry");
-      chmodSync(stale, 0o644);
+      const staleLogs = [
+        join(dir, "codesesh-12345-2026-01-01T00-00-00-000Z-1.log"),
+        join(dir, "codesesh-2026-01-01T00-00-00-000Z-12345-1.log"),
+        join(dir, "codesesh.log"),
+      ];
+      for (const stale of staleLogs) {
+        writeFileSync(stale, "old entry");
+        chmodSync(stale, 0o644);
+      }
 
-      new AppLogger({ logDir: dir }).info("permissions.check", { ok: true });
+      const logger = new AppLogger({ logDir: dir });
+      logger.info("permissions.check", { ok: true });
+      await logger.close();
 
-      expect(statSync(stale).mode & 0o777).toBe(0o600);
+      for (const stale of staleLogs) expect(statSync(stale).mode & 0o777).toBe(0o600);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it.runIf(isPosix)("keeps the log directory and file owner-only", () => {
+  it.runIf(isPosix)("keeps the log directory and file owner-only", async () => {
     const dir = mkdtempSync(join(tmpdir(), "codesesh-log-perms-"));
     try {
       const logger = new AppLogger({ logDir: dir });
       logger.info("permissions.check", { ok: true });
+      await logger.flush();
       const logPath = logger.getLogPath();
 
       expect(statSync(dir).mode & 0o777).toBe(0o700);
       expect(statSync(logPath!).mode & 0o777).toBe(0o600);
+      await logger.close();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -1,22 +1,38 @@
-import { appendFileSync, existsSync, readdirSync, renameSync, statSync, unlinkSync } from "node:fs";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomBytes, randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { getEnvironmentData, setEnvironmentData } from "node:worker_threads";
 import {
-  ensurePrivateDirectory,
   isWorkerLogMessage,
-  restrictExistingPrivateFiles,
-  restrictPrivateFile,
   WORKER_LOG_MESSAGE_TYPE,
+  type WorkerLogContext,
   type WorkerLogLevel,
   type WorkerLogMessage,
 } from "@codesesh/core/runtime/diagnostics";
 import type { SearchIndexSyncResult } from "@codesesh/core/runtime/discovery";
+import { AsyncLogFileWriter, type DroppedLogCounts } from "./log-file-writer.js";
+import { LogRecordEncoder, type EncodedLogLine } from "./log-record.js";
 
+export type LogContext = WorkerLogContext;
 type LogLevel = WorkerLogLevel;
 
 interface WorkerLogPort {
   postMessage(message: WorkerLogMessage): void;
 }
+
+const DEFAULT_MAX_FILE_BYTES = 5_000_000;
+const DEFAULT_MAX_FILES = 10;
+const DEFAULT_MAX_DIRECTORY_BYTES = 50_000_000;
+const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+const DEFAULT_MAX_QUEUE_BYTES = 1_000_000;
+const DEFAULT_MAX_RECORD_BYTES = 64 * 1_024;
+const FINGERPRINT_KEY_ENVIRONMENT_DATA = "codesesh.logging.fingerprint-key.v1";
+const LOG_CONTEXT_KEYS = new Set<keyof LogContext>([
+  "request_id",
+  "operation_id",
+  "publication_id",
+]);
 
 const LEVEL_WEIGHT: Record<LogLevel, number> = {
   debug: 10,
@@ -30,6 +46,10 @@ export interface LoggerOptions {
   level?: LogLevel;
   maxBytes?: number;
   maxFiles?: number;
+  maxDirectoryBytes?: number;
+  maxAgeMs?: number;
+  maxQueueBytes?: number;
+  maxRecordBytes?: number;
 }
 
 function parseLevel(value: string | undefined): LogLevel {
@@ -39,9 +59,19 @@ function parseLevel(value: string | undefined): LogLevel {
   return "info";
 }
 
-function parsePositiveInt(value: string | undefined, fallback: number): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+function positiveInteger(value: number | undefined, fallback: number): number {
+  const parsed = Math.floor(value ?? Number.NaN);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  return positiveInteger(value == null ? undefined : Number(value), fallback);
+}
+
+function parseMaxAge(value: string | undefined): number {
+  const days = parsePositiveInteger(value, DEFAULT_MAX_AGE_MS / (24 * 60 * 60 * 1_000));
+  const milliseconds = days * 24 * 60 * 60 * 1_000;
+  return Number.isSafeInteger(milliseconds) ? milliseconds : DEFAULT_MAX_AGE_MS;
 }
 
 function getDefaultLogDir(): string {
@@ -49,56 +79,90 @@ function getDefaultLogDir(): string {
   return join(base, "codesesh", "logs");
 }
 
-function toLogValue(value: unknown, depth = 0): unknown {
-  if (value == null || typeof value === "string" || typeof value === "number") return value;
-  if (typeof value === "boolean") return value;
-  if (typeof value === "bigint") return value.toString();
-  if (value instanceof Error) {
-    return {
-      name: value.name,
-      message: value.message,
-      stack: value.stack,
-    };
-  }
-  if (depth >= 4) return "[truncated]";
-  if (Array.isArray(value)) return value.slice(0, 50).map((item) => toLogValue(item, depth + 1));
-  if (typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value as Record<string, unknown>).map(([key, item]) => [
-        key,
-        toLogValue(item, depth + 1),
-      ]),
-    );
-  }
-  return String(value);
+function sharedFingerprintKey(): string {
+  const existing = getEnvironmentData(FINGERPRINT_KEY_ENVIRONMENT_DATA) as unknown;
+  if (typeof existing === "string" && /^[a-f0-9]{64}$/.test(existing)) return existing;
+
+  const generated = randomBytes(32).toString("hex");
+  setEnvironmentData(FINGERPRINT_KEY_ENVIRONMENT_DATA, generated);
+  return generated;
 }
 
-function timestampForFile(date = new Date()): string {
-  return date.toISOString().replace(/[:.]/g, "-");
+const LOG_FINGERPRINT_KEY = sharedFingerprintKey();
+
+function normalizedContext(context: LogContext): LogContext {
+  return Object.fromEntries(
+    Object.entries(context).flatMap(([key, value]) =>
+      LOG_CONTEXT_KEYS.has(key as keyof LogContext) && typeof value === "string" && value.length > 0
+        ? [[key, value.slice(0, 160)]]
+        : [],
+    ),
+  );
 }
 
 export class AppLogger {
-  private readonly logDir: string;
   private readonly level: LogLevel;
-  private readonly maxBytes: number;
-  private readonly maxFiles: number;
-  private readonly currentPath: string;
-  private rotationIndex = 0;
-  private restrictedExistingLogs = false;
+  private readonly runId: string;
+  private readonly context = new AsyncLocalStorage<LogContext>();
+  private readonly encoder: LogRecordEncoder;
+  private readonly writer: AsyncLogFileWriter;
   private workerTarget: { port: WorkerLogPort; threadId: number } | null = null;
-  private writeFailureReported = false;
+  private sequence = 0;
+  private transportFailureReported = false;
 
   constructor(options: LoggerOptions = {}) {
-    this.logDir = options.logDir ?? process.env.CODESESH_LOG_DIR ?? getDefaultLogDir();
+    const logDir = options.logDir ?? process.env.CODESESH_LOG_DIR ?? getDefaultLogDir();
     this.level = options.level ?? parseLevel(process.env.CODESESH_LOG_LEVEL);
-    this.maxBytes =
-      options.maxBytes ?? parsePositiveInt(process.env.CODESESH_LOG_MAX_BYTES, 5_000_000);
-    this.maxFiles = options.maxFiles ?? parsePositiveInt(process.env.CODESESH_LOG_MAX_FILES, 5);
-    this.currentPath = join(this.logDir, `codesesh-${process.pid}.log`);
+    this.runId = randomUUID();
+    const maxRecordBytes = positiveInteger(
+      options.maxRecordBytes,
+      parsePositiveInteger(process.env.CODESESH_LOG_MAX_RECORD_BYTES, DEFAULT_MAX_RECORD_BYTES),
+    );
+    this.encoder = new LogRecordEncoder({
+      fingerprintKey: LOG_FINGERPRINT_KEY,
+      maxRecordBytes,
+    });
+    this.writer = new AsyncLogFileWriter({
+      logDir,
+      runId: this.runId,
+      maxFileBytes: positiveInteger(
+        options.maxBytes,
+        parsePositiveInteger(process.env.CODESESH_LOG_MAX_BYTES, DEFAULT_MAX_FILE_BYTES),
+      ),
+      maxFiles: positiveInteger(
+        options.maxFiles,
+        parsePositiveInteger(process.env.CODESESH_LOG_MAX_FILES, DEFAULT_MAX_FILES),
+      ),
+      maxDirectoryBytes: positiveInteger(
+        options.maxDirectoryBytes,
+        parsePositiveInteger(process.env.CODESESH_LOG_MAX_TOTAL_BYTES, DEFAULT_MAX_DIRECTORY_BYTES),
+      ),
+      maxAgeMs: positiveInteger(
+        options.maxAgeMs,
+        parseMaxAge(process.env.CODESESH_LOG_MAX_AGE_DAYS),
+      ),
+      maxQueueBytes: positiveInteger(
+        options.maxQueueBytes,
+        parsePositiveInteger(process.env.CODESESH_LOG_MAX_QUEUE_BYTES, DEFAULT_MAX_QUEUE_BYTES),
+      ),
+      createDropSummary: (counts) => this.encodeDropSummary(counts),
+    });
   }
 
   getLogPath(): string {
-    return this.currentPath;
+    return this.writer.path;
+  }
+
+  runWithContext<Result>(context: LogContext, operation: () => Result): Result {
+    return this.context.run({ ...this.captureContext(), ...normalizedContext(context) }, operation);
+  }
+
+  restoreContext<Result>(context: LogContext, operation: () => Result): Result {
+    return this.context.run(normalizedContext(context), operation);
+  }
+
+  captureContext(): LogContext {
+    return { ...this.context.getStore() };
   }
 
   forwardToParent(port: WorkerLogPort, threadId: number): void {
@@ -108,14 +172,22 @@ export class AppLogger {
   consumeWorkerMessage(message: unknown): boolean {
     if (!isWorkerLogMessage(message)) return false;
     if (LEVEL_WEIGHT[message.level] < LEVEL_WEIGHT[this.level]) return true;
-    this.appendRecord({
-      ...message.data,
-      ts: message.ts,
-      level: message.level,
-      event: message.event,
-      pid: message.pid,
-      thread_id: message.threadId,
-    });
+    try {
+      this.writer.enqueue(
+        this.encode({
+          timestamp: message.ts,
+          level: message.level,
+          event: message.event,
+          pid: message.pid,
+          threadId: message.threadId,
+          context: message.context,
+          data: message.data,
+        }),
+      );
+      this.transportFailureReported = false;
+    } catch (error) {
+      this.reportTransportFailure(error);
+    }
     return true;
   }
 
@@ -135,103 +207,81 @@ export class AppLogger {
     this.write("error", event, data);
   }
 
+  flush(): Promise<void> {
+    return this.writer.flush();
+  }
+
+  close(): Promise<void> {
+    return this.writer.close();
+  }
+
+  flushSync(): void {
+    this.writer.flushSync();
+  }
+
   private write(level: LogLevel, event: string, data: Record<string, unknown>): void {
     if (LEVEL_WEIGHT[level] < LEVEL_WEIGHT[this.level]) return;
-
-    const ts = new Date().toISOString();
-    const normalizedData = toLogValue(data) as Record<string, unknown>;
-    if (this.workerTarget) {
-      try {
+    try {
+      const timestamp = new Date().toISOString();
+      const context = this.captureContext();
+      if (this.workerTarget) {
         this.workerTarget.port.postMessage({
           type: WORKER_LOG_MESSAGE_TYPE,
-          ts,
+          ts: timestamp,
           level,
           event,
           pid: process.pid,
           threadId: this.workerTarget.threadId,
-          data: normalizedData,
+          context,
+          data: this.encoder.sanitizeForTransport(data, event),
         });
-      } catch (error) {
-        this.reportWriteFailure(error);
+        this.transportFailureReported = false;
+        return;
       }
-      return;
-    }
 
-    this.appendRecord({
-      ...normalizedData,
-      ts,
-      level,
-      event,
-      pid: process.pid,
+      this.writer.enqueue(
+        this.encode({
+          timestamp,
+          level,
+          event,
+          pid: process.pid,
+          context,
+          data,
+        }),
+      );
+    } catch (error) {
+      this.reportTransportFailure(error);
+    }
+  }
+
+  private encode(
+    input: Omit<Parameters<LogRecordEncoder["encode"]>[0], "runId" | "sequence">,
+  ): EncodedLogLine {
+    this.sequence += 1;
+    return this.encoder.encode({
+      ...input,
+      runId: this.runId,
+      sequence: this.sequence,
     });
   }
 
-  private appendRecord(record: Record<string, unknown>): void {
-    try {
-      ensurePrivateDirectory(this.logDir);
-      this.restrictExistingLogs();
-      const line = `${JSON.stringify(record)}\n`;
-      const restrictCurrentFile = this.rotateIfNeeded(Buffer.byteLength(line));
-      appendFileSync(this.currentPath, line, "utf8");
-      if (restrictCurrentFile) restrictPrivateFile(this.currentPath);
-      this.writeFailureReported = false;
-    } catch (error) {
-      this.reportWriteFailure(error);
-    }
+  private encodeDropSummary(counts: DroppedLogCounts): EncodedLogLine {
+    return this.encode({
+      timestamp: new Date().toISOString(),
+      level: "warn",
+      event: "logger.records_dropped",
+      pid: process.pid,
+      data: { ...counts },
+    });
   }
 
-  private reportWriteFailure(error: unknown): void {
-    if (this.writeFailureReported) return;
-    this.writeFailureReported = true;
+  private reportTransportFailure(error: unknown): void {
+    if (this.transportFailureReported) return;
+    this.transportFailureReported = true;
     const message = error instanceof Error ? error.message : String(error);
     try {
-      process.stderr.write(`[codesesh] Failed to write log ${this.currentPath}: ${message}\n`);
+      process.stderr.write(`[codesesh] Failed to prepare log entry: ${message}\n`);
     } catch {}
-  }
-
-  /** Logs rotated by an earlier run predate the owner-only policy. */
-  private restrictExistingLogs(): void {
-    if (this.restrictedExistingLogs) return;
-    this.restrictedExistingLogs = true;
-    restrictExistingPrivateFiles(
-      this.logDir,
-      (name) => name.startsWith("codesesh") && name.endsWith(".log"),
-    );
-  }
-
-  private rotateIfNeeded(nextBytes: number): boolean {
-    if (!existsSync(this.currentPath)) {
-      this.removeExpiredLogs();
-      return true;
-    }
-
-    const currentSize = statSync(this.currentPath).size;
-    if (currentSize + nextBytes <= this.maxBytes) return false;
-
-    this.rotationIndex += 1;
-    const rotatedPath = join(
-      this.logDir,
-      `codesesh-${process.pid}-${timestampForFile()}-${this.rotationIndex}.log`,
-    );
-    renameSync(this.currentPath, rotatedPath);
-    restrictPrivateFile(rotatedPath);
-    this.removeExpiredLogs();
-    return true;
-  }
-
-  private removeExpiredLogs(): void {
-    const ownedPrefix = `codesesh-${process.pid}-`;
-    const rotated = readdirSync(this.logDir)
-      .filter((name) => name.startsWith(ownedPrefix) && name.endsWith(".log"))
-      .map((name) => {
-        const path = join(this.logDir, name);
-        return { path, mtimeMs: statSync(path).mtimeMs };
-      })
-      .toSorted((a, b) => b.mtimeMs - a.mtimeMs);
-
-    for (const item of rotated.slice(Math.max(0, this.maxFiles - 1))) {
-      unlinkSync(item.path);
-    }
   }
 }
 

--- a/packages/cli/src/loopback-write-guard.ts
+++ b/packages/cli/src/loopback-write-guard.ts
@@ -57,7 +57,6 @@ export function loopbackWriteGuard(): MiddlewareHandler {
     if (!decision.allowed) {
       appLogger.warn("http.loopback_request.rejected", {
         method: c.req.method,
-        path: url.pathname,
         reason: decision.reason,
       });
       const error =

--- a/packages/cli/src/pending-search-index-jobs.ts
+++ b/packages/cli/src/pending-search-index-jobs.ts
@@ -8,11 +8,22 @@ import type {
   SearchIndexWorkerJob,
   SearchIndexWorkerOptions,
 } from "./search-index-worker.js";
+import type { LogContext } from "./logging.js";
 
 type FullSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "full" }>;
 type ChangesSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "changes" }>;
 type MaintenanceSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "maintenance" }>;
 type IncrementalSearchIndexJob = ChangesSearchIndexJob | MaintenanceSearchIndexJob;
+
+const LOG_CONTEXT_KEYS = ["request_id", "operation_id", "publication_id"] as const;
+
+function commonLogContext(left: LogContext, right: LogContext): LogContext {
+  const common: LogContext = {};
+  for (const key of LOG_CONTEXT_KEYS) {
+    if (left[key] !== undefined && left[key] === right[key]) common[key] = left[key];
+  }
+  return common;
+}
 
 interface JobWaiter {
   resolve: () => void;
@@ -41,6 +52,7 @@ interface PendingAgentJobs {
 export interface SearchIndexJobBatch {
   readonly id: number;
   readonly context: string;
+  readonly logContext: LogContext;
   readonly jobs: SearchIndexWorkerJob[];
   start(onError: (error: unknown) => void): void;
   progress(progress: SearchIndexPublicationProgress, onError: (error: unknown) => void): void;
@@ -48,6 +60,7 @@ export interface SearchIndexJobBatch {
 
 class PendingSearchIndexJobBatch implements SearchIndexJobBatch {
   context: string;
+  logContext: LogContext;
   private readonly jobsByAgent = new Map<string, PendingAgentJobs>();
   private readonly waiters: JobWaiter[] = [];
   private settled = false;
@@ -58,9 +71,11 @@ class PendingSearchIndexJobBatch implements SearchIndexJobBatch {
     context: string,
     jobs: SearchIndexWorkerJob[],
     waiter: JobWaiter,
+    logContext: LogContext,
   ) {
     this.context = context;
-    this.merge(context, jobs, waiter);
+    this.logContext = logContext;
+    this.merge(context, jobs, waiter, logContext);
   }
 
   get jobs(): SearchIndexWorkerJob[] {
@@ -104,8 +119,14 @@ class PendingSearchIndexJobBatch implements SearchIndexJobBatch {
     }
   }
 
-  merge(context: string, jobs: SearchIndexWorkerJob[], waiter: JobWaiter): void {
+  merge(
+    context: string,
+    jobs: SearchIndexWorkerJob[],
+    waiter: JobWaiter,
+    logContext: LogContext,
+  ): void {
     this.context = context;
+    this.logContext = commonLogContext(this.logContext, logContext);
     this.waiters.push(waiter);
     for (const job of jobs) this.mergeJob(job);
   }
@@ -158,6 +179,7 @@ export class PendingSearchIndexJobs {
     jobs: SearchIndexWorkerJob[],
     onStarted?: () => void,
     onProgress?: (progress: SearchIndexPublicationProgress) => void,
+    logContext: LogContext = {},
   ): Promise<void> {
     if (jobs.length === 0) return Promise.resolve();
 
@@ -170,9 +192,9 @@ export class PendingSearchIndexJobs {
         agentNames: new Set(jobs.map((job) => job.agentName)),
       };
       if (this.pendingBatch) {
-        this.pendingBatch.merge(context, jobs, waiter);
+        this.pendingBatch.merge(context, jobs, waiter, logContext);
       } else {
-        this.pendingBatch = new PendingSearchIndexJobBatch(id, context, jobs, waiter);
+        this.pendingBatch = new PendingSearchIndexJobBatch(id, context, jobs, waiter, logContext);
         this.batches.add(this.pendingBatch);
       }
     });

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -37,6 +37,8 @@ const mocks = vi.hoisted(() => {
       warn: vi.fn(),
       error: vi.fn(),
       forwardToParent: vi.fn(),
+      restoreContext: vi.fn((_context, operation) => operation()),
+      captureContext: vi.fn(() => ({})),
     },
   };
 });
@@ -203,6 +205,47 @@ describe("scan refresh worker entry", () => {
     expect(mocks.synchronizePricingGeneration.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.createRegisteredAgents.mock.invocationCallOrder[0]!,
     );
+  });
+
+  it("acknowledges log drain after requests already queued in the worker", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([makeAgent()]);
+    await runWorker();
+    mocks.postMessage.mockClear();
+
+    mocks.workerMessageHandler?.({
+      type: "commit",
+      requestId: 1,
+      generation: 0,
+    });
+    mocks.workerMessageHandler?.({
+      type: "run",
+      requestId: 2,
+      agentName: "codex",
+      generation: 1,
+      pricingGenerationId: 17,
+      operation: { kind: "full-scan" },
+      scanOptions: { fast: true },
+    });
+    mocks.workerMessageHandler?.({
+      type: "codesesh.worker-log-drain",
+      requestId: "drain-1",
+    });
+
+    await vi.waitFor(() =>
+      expect(mocks.postMessage).toHaveBeenCalledWith({
+        type: "codesesh.worker-log-drained",
+        requestId: "drain-1",
+      }),
+    );
+    const messages = mocks.postMessage.mock.calls.map(([message]) => message);
+    const doneIndex = messages.findIndex(
+      (message) => message.type === "done" && message.requestId === 2,
+    );
+    const drainIndex = messages.findIndex(
+      (message) => message.type === "codesesh.worker-log-drained",
+    );
+    expect(doneIndex).toBeGreaterThanOrEqual(0);
+    expect(drainIndex).toBeGreaterThan(doneIndex);
   });
 
   it("reports an unknown agent as an error", async () => {

--- a/packages/cli/src/scan-refresh-worker.ts
+++ b/packages/cli/src/scan-refresh-worker.ts
@@ -22,7 +22,8 @@ import {
   type SessionSourceFailure,
 } from "@codesesh/core/runtime/agents";
 import { synchronizePricingGeneration } from "@codesesh/core/runtime/pricing";
-import { appLogger } from "./logging.js";
+import { appLogger, type LogContext } from "./logging.js";
+import { acknowledgeWorkerLogDrain } from "./worker-log-drain.js";
 import { MonotonicValueSampler } from "./monotonic-value-sampler.js";
 import { buildScanRefreshDelta } from "./scan-refresh-delta.js";
 import {
@@ -95,12 +96,14 @@ export interface ScanRefreshWorkerRunRequest {
   operation: ScanRefreshOperation;
   scanOptions: Pick<ScanOptions, "from" | "to" | "fast">;
   meta?: Record<string, SessionCacheMeta>;
+  logContext?: LogContext;
 }
 
 export interface ScanRefreshWorkerCommitRequest {
   type: "commit";
   requestId: number;
   generation: number;
+  logContext?: LogContext;
 }
 
 export type ScanRefreshWorkerRequest = ScanRefreshWorkerRunRequest | ScanRefreshWorkerCommitRequest;
@@ -601,7 +604,11 @@ function handleCommit(data: ScanRefreshWorkerCommitRequest): void {
 
 function enqueueRequest(data: ScanRefreshWorkerRequest): void {
   requestTail = requestTail
-    .then(() => (data.type === "commit" ? handleCommit(data) : handleRequest(data)))
+    .then(() =>
+      appLogger.restoreContext(data.logContext ?? {}, () =>
+        data.type === "commit" ? handleCommit(data) : handleRequest(data),
+      ),
+    )
     .catch((error) => {
       appLogger.error("scan.refresh_worker.request_error", {
         request_id: data.requestId,
@@ -624,6 +631,8 @@ if (
   enqueueRequest(initialRequest as ScanRefreshWorkerRunRequest);
 }
 
-parentPort?.on("message", (message: ScanRefreshWorkerRequest) => {
-  enqueueRequest(message);
+const workerPort = parentPort;
+workerPort?.on("message", (message: unknown) => {
+  if (acknowledgeWorkerLogDrain(workerPort, message, requestTail)) return;
+  enqueueRequest(message as ScanRefreshWorkerRequest);
 });

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SearchIndexWorkerJob } from "./search-index-worker.js";
 
 const workerMocks = vi.hoisted(() => {
-  type Handler = (arg: never) => void;
+  type Handler = (arg: unknown) => void;
   class FakeWorker {
-    private handlers = new Map<string, Handler>();
+    private handlers = new Map<string, Handler[]>();
     readonly workerData: Record<string, unknown>;
     readonly postedMessages: unknown[] = [];
 
@@ -14,20 +14,65 @@ const workerMocks = vi.hoisted(() => {
     }
 
     on(event: string, handler: Handler): this {
-      this.handlers.set(event, handler);
+      const handlers = this.handlers.get(event) ?? [];
+      handlers.push(handler);
+      this.handlers.set(event, handlers);
+      return this;
+    }
+
+    once(event: string, handler: Handler): this {
+      const wrapped = (arg: unknown) => {
+        this.off(event, wrapped);
+        handler(arg);
+      };
+      return this.on(event, wrapped);
+    }
+
+    off(event: string, handler: Handler): this {
+      const handlers = this.handlers.get(event);
+      if (handlers)
+        this.handlers.set(
+          event,
+          handlers.filter((item) => item !== handler),
+        );
       return this;
     }
 
     postMessage(message: unknown): void {
       this.postedMessages.push(message);
+      if (
+        message != null &&
+        typeof message === "object" &&
+        "type" in message &&
+        message.type === "codesesh.worker-log-drain" &&
+        "requestId" in message
+      ) {
+        queueMicrotask(() => {
+          this.post({
+            type: "codesesh.worker-log-drained",
+            requestId: message.requestId,
+          });
+        });
+      }
     }
 
     async terminate(): Promise<number> {
+      this.emit("exit", 0);
       return 0;
     }
 
     post(message: unknown): void {
-      (this.handlers.get("message") as ((arg: unknown) => void) | undefined)?.(message);
+      this.emit("message", message);
+    }
+
+    exit(code: number): void {
+      this.emit("exit", code);
+    }
+
+    private emit(event: string, arg: unknown): void {
+      const handlers = this.handlers.get(event);
+      if (!handlers) return;
+      for (const handler of handlers.slice()) handler(arg);
     }
   }
   const workers: FakeWorker[] = [];
@@ -35,7 +80,9 @@ const workerMocks = vi.hoisted(() => {
     workers,
     FakeWorker,
     workerExists: true,
+    context: {} as Record<string, string>,
     consumeWorkerMessage: vi.fn((_message: unknown) => false),
+    restoreContext: vi.fn((_context: unknown, operation: () => unknown) => operation()),
   };
 });
 
@@ -51,6 +98,8 @@ vi.mock("./logging.js", () => ({
     warn: vi.fn(),
     error: vi.fn(),
     consumeWorkerMessage: workerMocks.consumeWorkerMessage,
+    captureContext: vi.fn(() => ({ ...workerMocks.context })),
+    restoreContext: workerMocks.restoreContext,
   },
   logSearchIndexSync: vi.fn(),
 }));
@@ -88,6 +137,7 @@ function startedWorker() {
 beforeEach(() => {
   workerMocks.workers.length = 0;
   workerMocks.workerExists = true;
+  workerMocks.context = {};
   vi.clearAllMocks();
   workerMocks.consumeWorkerMessage.mockReturnValue(false);
 });
@@ -164,8 +214,10 @@ describe("SearchIndexJobRunner", () => {
 
   it("reuses one worker for consecutive batches", async () => {
     const runner = new SearchIndexJobRunner();
+    workerMocks.context = { operation_id: "first-operation" };
     const first = runner.enqueue("scan.refresh", [makeJob()]);
     const worker = startedWorker();
+    expect(worker.workerData.logContext).toEqual({ operation_id: "first-operation" });
     worker.post({
       type: "done",
       context: "scan.refresh",
@@ -175,11 +227,16 @@ describe("SearchIndexJobRunner", () => {
     });
     await first;
 
+    workerMocks.context = { operation_id: "second-operation" };
     const second = runner.enqueue("scan.refresh", [makeJob()]);
 
     expect(workerMocks.workers).toEqual([worker]);
     expect(worker.postedMessages).toEqual([
-      expect.objectContaining({ context: "scan.refresh", pricingGenerationId: 17 }),
+      expect.objectContaining({
+        context: "scan.refresh",
+        pricingGenerationId: 17,
+        logContext: { operation_id: "second-operation" },
+      }),
     ]);
     worker.post({
       type: "done",
@@ -189,6 +246,26 @@ describe("SearchIndexJobRunner", () => {
       failedAgents: [],
     });
     await second;
+  });
+
+  it("does not attribute an idle worker exit to its first operation", async () => {
+    const runner = new SearchIndexJobRunner();
+    workerMocks.context = { operation_id: "finished-operation" };
+    const completion = runner.enqueue("scan.refresh", [makeJob()]);
+    const worker = startedWorker();
+    worker.post({
+      type: "done",
+      context: "scan.refresh",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
+    await completion;
+    workerMocks.restoreContext.mockClear();
+
+    worker.exit(0);
+
+    expect(workerMocks.restoreContext).toHaveBeenCalledWith({}, expect.any(Function));
   });
 
   it("dispatches a queued batch after the active batch completes", async () => {
@@ -221,6 +298,38 @@ describe("SearchIndexJobRunner", () => {
       failedAgents: [],
     });
     await second;
+  });
+
+  it("does not attribute a merged batch to only its last operation", async () => {
+    const runner = new SearchIndexJobRunner();
+    workerMocks.context = { operation_id: "active-operation" };
+    const active = runner.enqueue("active", [makeJob()]);
+    const worker = startedWorker();
+
+    workerMocks.context = { operation_id: "queued-operation-a" };
+    const queuedA = runner.enqueue("queued-a", [makeJob()]);
+    workerMocks.context = { operation_id: "queued-operation-b" };
+    const queuedB = runner.enqueue("queued-b", [makeJob()]);
+    worker.post({
+      type: "done",
+      context: "active",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
+    await active;
+
+    expect(worker.postedMessages.at(-1)).toEqual(
+      expect.objectContaining({ context: "queued-b", logContext: {} }),
+    );
+    worker.post({
+      type: "done",
+      context: "queued-b",
+      durationMs: 1,
+      sessions: 1,
+      failedAgents: [],
+    });
+    await Promise.all([queuedA, queuedB]);
   });
 
   it("runs foreground publications before the next maintenance batch", async () => {

--- a/packages/cli/src/search-index-job-runner.ts
+++ b/packages/cli/src/search-index-job-runner.ts
@@ -11,6 +11,7 @@ import type {
   SearchIndexPublicationProgress,
   SearchIndexWorkerRunRequest,
 } from "./search-index-worker.js";
+import { terminateWorkerAfterLogDrain } from "./worker-log-drain.js";
 
 const SHUTDOWN_ERROR_MESSAGE = "Live scan store shut down";
 
@@ -30,6 +31,7 @@ export class SearchIndexJobRunner {
   private pendingJobs = new PendingSearchIndexJobs();
   private pendingMaintenanceJobs = new PendingSearchIndexJobs();
   private isShuttingDown = false;
+  private retirements = new Set<Promise<number>>();
 
   enqueue(
     context: string,
@@ -55,7 +57,14 @@ export class SearchIndexJobRunner {
     if (this.isShuttingDown) return Promise.reject(new Error(SHUTDOWN_ERROR_MESSAGE));
 
     const batchId = this.nextBatchId++;
-    const completion = queue.enqueue(batchId, context, jobs, onStarted, onProgress);
+    const completion = queue.enqueue(
+      batchId,
+      context,
+      jobs,
+      onStarted,
+      onProgress,
+      appLogger.captureContext(),
+    );
     if (this.activeBatch) {
       const snapshot = this.snapshot();
       appLogger.debug("search_index.worker_queued", {
@@ -94,7 +103,13 @@ export class SearchIndexJobRunner {
     if (activeBatch) this.settle(activeBatch, shutdownError);
     this.pendingJobs.rejectAll(shutdownError);
     this.pendingMaintenanceJobs.rejectAll(shutdownError);
-    if (worker) await worker.terminate();
+    const activeRetirement = worker ? this.retireWorker(worker) : null;
+    const retirements = [...this.retirements];
+    try {
+      if (activeRetirement) await activeRetirement;
+    } finally {
+      await Promise.allSettled(retirements);
+    }
   }
 
   private startNextBatch(): void {
@@ -102,19 +117,21 @@ export class SearchIndexJobRunner {
     const batch = this.pendingJobs.take() ?? this.pendingMaintenanceJobs.take();
     if (!batch) return;
 
-    appLogger.info("search_index.worker_dequeued", {
-      batch_id: batch.id,
-      context: batch.context,
-      pending_batches: this.pendingJobs.batchCount,
-    });
-    batch.start((error) => {
-      appLogger.error("search_index.worker_start_listener_failed", {
+    appLogger.restoreContext(batch.logContext, () => {
+      appLogger.info("search_index.worker_dequeued", {
         batch_id: batch.id,
         context: batch.context,
-        error: toError(error),
+        pending_batches: this.pendingJobs.batchCount,
       });
+      batch.start((error) => {
+        appLogger.error("search_index.worker_start_listener_failed", {
+          batch_id: batch.id,
+          context: batch.context,
+          error: toError(error),
+        });
+      });
+      this.startBatch(batch);
     });
-    this.startBatch(batch);
   }
 
   private startBatch(batch: SearchIndexJobBatch): void {
@@ -127,6 +144,7 @@ export class SearchIndexJobRunner {
       type: "run",
       pricingGenerationId: getPricingGeneration().id,
       context: batch.context,
+      logContext: batch.logContext,
       jobs: batch.jobs,
     };
     const existingWorker = this.worker;
@@ -169,65 +187,82 @@ export class SearchIndexJobRunner {
       if (this.worker !== worker) return;
       const activeBatch = this.activeBatch;
       if (!activeBatch) return;
-      if (message.type === "publication-progress") {
-        const { agentName, stage } = message;
-        activeBatch.progress({ agentName, stage }, (error) => {
-          appLogger.error("search_index.worker_progress_listener_failed", {
-            batch_id: activeBatch.id,
-            context: activeBatch.context,
-            error: toError(error),
-          });
-        });
-        return;
-      }
-      if (message.type === "sync-result") {
-        logSearchIndexSync(message.context, message.result);
-        return;
-      }
-      if (message.type === "persist-failed") {
-        appLogger.error("search_index.persist_failed", {
-          batch_id: activeBatch.id,
-          context: message.context,
-          stage: message.stage,
-          publication_id: message.publicationId,
-          agent: message.agentName,
-          sessions: message.sessions,
-        });
-        // Non-fatal failures keep the batch running: the worker continues
-        // with the remaining agents and reports them in the done message.
-        if (message.fatal) {
-          this.finishBatch(
-            activeBatch,
-            new Error(
-              `Search index worker failed to persist ${message.stage} for ${message.agentName}`,
-            ),
-          );
-        }
-        return;
-      }
-      if (message.type !== "done") return;
-
-      if (message.failedAgents.length > 0) {
-        appLogger.warn("search_index.batch_partial", {
-          batch_id: activeBatch.id,
-          context: message.context,
-          failed_agents: message.failedAgents,
-        });
-      }
-      appLogger.info(`${message.context}.done`, {
-        duration_ms: Math.round(message.durationMs),
-        sessions: message.sessions,
+      appLogger.restoreContext(activeBatch.logContext, () => {
+        this.handleWorkerMessage(activeBatch, message);
       });
-      this.finishBatch(activeBatch);
     });
     worker.on("error", (error) => {
-      appLogger.error("search_index.worker_error", {
-        context: this.activeBatch?.context ?? batch.context,
-        error,
+      const activeBatch = this.worker === worker ? this.activeBatch : null;
+      appLogger.restoreContext(activeBatch?.logContext ?? {}, () => {
+        appLogger.error("search_index.worker_error", {
+          context: activeBatch?.context,
+          error,
+        });
+        this.invalidateWorker(worker, toError(error));
       });
-      this.invalidateWorker(worker, toError(error));
     });
-    worker.on("exit", (code) => this.finishWorker(worker, code));
+    worker.on("exit", (code) => {
+      const activeBatch = this.worker === worker ? this.activeBatch : null;
+      appLogger.restoreContext(activeBatch?.logContext ?? {}, () =>
+        this.finishWorker(worker, code),
+      );
+    });
+  }
+
+  private handleWorkerMessage(
+    activeBatch: SearchIndexJobBatch,
+    message: SearchIndexWorkerMessage,
+  ): void {
+    if (message.type === "publication-progress") {
+      const { agentName, stage } = message;
+      activeBatch.progress({ agentName, stage }, (error) => {
+        appLogger.error("search_index.worker_progress_listener_failed", {
+          batch_id: activeBatch.id,
+          context: activeBatch.context,
+          error: toError(error),
+        });
+      });
+      return;
+    }
+    if (message.type === "sync-result") {
+      logSearchIndexSync(message.context, message.result);
+      return;
+    }
+    if (message.type === "persist-failed") {
+      appLogger.error("search_index.persist_failed", {
+        batch_id: activeBatch.id,
+        context: message.context,
+        stage: message.stage,
+        publication_id: message.publicationId,
+        agent: message.agentName,
+        sessions: message.sessions,
+      });
+      // Non-fatal failures keep the batch running: the worker continues
+      // with the remaining agents and reports them in the done message.
+      if (message.fatal) {
+        this.finishBatch(
+          activeBatch,
+          new Error(
+            `Search index worker failed to persist ${message.stage} for ${message.agentName}`,
+          ),
+        );
+      }
+      return;
+    }
+    if (message.type !== "done") return;
+
+    if (message.failedAgents.length > 0) {
+      appLogger.warn("search_index.batch_partial", {
+        batch_id: activeBatch.id,
+        context: message.context,
+        failed_agents: message.failedAgents,
+      });
+    }
+    appLogger.info(`${message.context}.done`, {
+      duration_ms: Math.round(message.durationMs),
+      sessions: message.sessions,
+    });
+    this.finishBatch(activeBatch);
   }
 
   private finishBatch(batch: SearchIndexJobBatch, error?: Error): void {
@@ -243,7 +278,7 @@ export class SearchIndexJobRunner {
     const batch = this.activeBatch;
     this.activeBatch = null;
     if (batch) this.settle(batch, error);
-    void worker.terminate();
+    void this.retireWorker(worker);
     this.startNextBatch();
   }
 
@@ -273,17 +308,26 @@ export class SearchIndexJobRunner {
   }
 
   private settle(batch: SearchIndexJobBatch, error?: Error): void {
-    if (
-      !this.pendingJobs.settle(batch, error) &&
-      !this.pendingMaintenanceJobs.settle(batch, error)
-    ) {
-      return;
-    }
-    appLogger.info("search_index.worker_settled", {
-      batch_id: batch.id,
-      context: batch.context,
-      result: error ? "rejected" : "resolved",
+    appLogger.restoreContext(batch.logContext, () => {
+      if (
+        !this.pendingJobs.settle(batch, error) &&
+        !this.pendingMaintenanceJobs.settle(batch, error)
+      ) {
+        return;
+      }
+      appLogger.info("search_index.worker_settled", {
+        batch_id: batch.id,
+        context: batch.context,
+        result: error ? "rejected" : "resolved",
+      });
     });
+  }
+
+  private retireWorker(worker: Worker): Promise<number> {
+    const retirement = terminateWorkerAfterLogDrain(worker);
+    this.retirements.add(retirement);
+    void retirement.finally(() => this.retirements.delete(retirement)).catch(() => undefined);
+    return retirement;
   }
 
   private workerUrl(): URL | null {

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   appLoggerInfo: vi.fn(),
   appLoggerWarn: vi.fn(),
   appLoggerError: vi.fn(),
+  restoreContext: vi.fn((_context: unknown, operation: () => unknown) => operation()),
   messageHandler: undefined as ((message: Record<string, unknown>) => void) | undefined,
 }));
 
@@ -54,6 +55,7 @@ vi.mock("./logging.js", () => ({
     info: mocks.appLoggerInfo,
     warn: mocks.appLoggerWarn,
     error: mocks.appLoggerError,
+    restoreContext: mocks.restoreContext,
   },
 }));
 
@@ -105,14 +107,35 @@ describe("search index worker", () => {
     );
   });
 
+  it("acknowledges log drain without starting another batch", async () => {
+    mocks.createRegisteredAgents.mockReturnValue([]);
+    await runWorker();
+    mocks.createRegisteredAgents.mockClear();
+    mocks.postMessage.mockClear();
+
+    mocks.messageHandler?.({
+      type: "codesesh.worker-log-drain",
+      requestId: "drain-1",
+    });
+    await Promise.resolve();
+
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      type: "codesesh.worker-log-drained",
+      requestId: "drain-1",
+    });
+    expect(mocks.createRegisteredAgents).not.toHaveBeenCalled();
+  });
+
   it("reuses module initialization while isolating agents between batches", async () => {
     mocks.createRegisteredAgents.mockReturnValue([]);
+    mocks.workerData.logContext = { operation_id: "first-operation" };
 
     await runWorker();
     mocks.messageHandler?.({
       type: "run",
       pricingGenerationId: 17,
       context: "second-refresh",
+      logContext: { operation_id: "second-operation" },
       jobs: [],
       agentNames: [],
       sessionsByAgent: {},
@@ -121,6 +144,16 @@ describe("search index worker", () => {
 
     expect(mocks.synchronizePricingGeneration).toHaveBeenCalledOnce();
     expect(mocks.createRegisteredAgents).toHaveBeenCalledTimes(2);
+    expect(mocks.restoreContext).toHaveBeenNthCalledWith(
+      1,
+      { operation_id: "first-operation" },
+      expect.any(Function),
+    );
+    expect(mocks.restoreContext).toHaveBeenNthCalledWith(
+      2,
+      { operation_id: "second-operation" },
+      expect.any(Function),
+    );
     expect(mocks.postMessage).toHaveBeenLastCalledWith(
       expect.objectContaining({ type: "done", context: "second-refresh" }),
     );

--- a/packages/cli/src/search-index-worker.ts
+++ b/packages/cli/src/search-index-worker.ts
@@ -17,7 +17,8 @@ import {
 } from "@codesesh/core/runtime/discovery";
 import { createRegisteredAgents, type SessionCacheMeta } from "@codesesh/core/runtime/agents";
 import { synchronizePricingGeneration } from "@codesesh/core/runtime/pricing";
-import { appLogger } from "./logging.js";
+import { appLogger, type LogContext } from "./logging.js";
+import { acknowledgeWorkerLogDrain } from "./worker-log-drain.js";
 
 export type SearchIndexPersistStage = DurableSessionPublicationFailureStage;
 
@@ -89,6 +90,7 @@ export type SearchIndexWorkerJob =
 export interface SearchIndexWorkerRunRequest {
   type: "run";
   pricingGenerationId: number;
+  logContext?: LogContext;
   jobs?: SearchIndexWorkerJob[];
   context: string;
   agentNames?: string[];
@@ -305,7 +307,12 @@ function runBatch(request: SearchIndexWorkerRunRequest): void {
   } satisfies SearchIndexWorkerMessage);
 }
 
-parentPort?.on("message", (message: SearchIndexWorkerRunRequest) => {
-  if (message.type === "run") runBatch(message);
+const workerPort = parentPort;
+workerPort?.on("message", (message: SearchIndexWorkerRunRequest) => {
+  if (acknowledgeWorkerLogDrain(workerPort, message)) return;
+  if (message.type === "run") {
+    appLogger.restoreContext(message.logContext ?? {}, () => runBatch(message));
+  }
 });
-runBatch(workerData as SearchIndexWorkerRunRequest);
+const initialRequest = workerData as SearchIndexWorkerRunRequest;
+appLogger.restoreContext(initialRequest.logContext ?? {}, () => runBatch(initialRequest));

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -6,6 +6,7 @@ import { createServer as createNodeServer, type Server as NodeServer } from "nod
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { CODESESH_OPERATION_ID_HEADER, CODESESH_REQUEST_ID_HEADER } from "@codesesh/core/contract";
 import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/test-fixtures";
 import { appLogger } from "./logging.js";
 import type { ProjectIdentityResolver } from "./project-identity-resolver.js";
@@ -248,6 +249,99 @@ describe("createServer", () => {
     }
   });
 
+  it("correlates a request without logging its concrete session route", async () => {
+    const observed: Array<{
+      event: string;
+      data: Record<string, unknown>;
+      context: ReturnType<typeof appLogger.captureContext>;
+    }> = [];
+    const originalInfo = appLogger.info.bind(appLogger);
+    const logSpy = vi.spyOn(appLogger, "info").mockImplementation((event, data = {}) => {
+      observed.push({ event, data, context: appLogger.captureContext() });
+      originalInfo(event, data);
+    });
+    const app = await createServer(0, createStore());
+    const access = getServerAccess(app.url);
+    const operationId = "11111111-1111-4111-8111-111111111111";
+
+    try {
+      const response = await fetch(
+        `${access.origin}/api/sessions/codex/private-session-identifier?messageCursor=private-cursor&private-key=private-query`,
+        {
+          headers: {
+            ...access.authorization,
+            [CODESESH_OPERATION_ID_HEADER]: operationId,
+          },
+        },
+      );
+      const requestId = response.headers.get(CODESESH_REQUEST_ID_HEADER);
+      const requestLog = observed.findLast(({ event }) => event === "http.request");
+
+      expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(requestLog).toMatchObject({
+        data: {
+          route: "/api/sessions/:agent/:id",
+          query_keys: ["messageCursor"],
+        },
+        context: { request_id: requestId, operation_id: operationId },
+      });
+      expect(JSON.stringify(requestLog)).not.toContain("private-session-identifier");
+      expect(JSON.stringify(requestLog)).not.toContain("private-query");
+
+      const invalidOperation = await fetch(`${access.origin}/api/agents`, {
+        headers: {
+          ...access.authorization,
+          [CODESESH_OPERATION_ID_HEADER]: "private-operation-secret",
+        },
+      });
+      const invalidRequestId = invalidOperation.headers.get(CODESESH_REQUEST_ID_HEADER);
+      const invalidRequestLog = observed.findLast(({ event }) => event === "http.request");
+      expect(invalidRequestLog?.context).toEqual({ request_id: invalidRequestId });
+      expect(JSON.stringify(invalidRequestLog)).not.toContain("private-operation-secret");
+    } finally {
+      await app.shutdown();
+      logSpy.mockRestore();
+    }
+  });
+
+  it("records handler failures caught by Hono without exposing request details", async () => {
+    const handlerError = new Error("handler failed");
+    const store = {
+      ...createStore(),
+      getSnapshot: () => {
+        throw handlerError;
+      },
+    };
+    const observed: Array<{ event: string; data: Record<string, unknown> }> = [];
+    const logSpy = vi.spyOn(appLogger, "info").mockImplementation((event, data = {}) => {
+      observed.push({ event, data });
+    });
+    const app = await createServer(0, store);
+    const access = getServerAccess(app.url);
+
+    try {
+      const response = await fetch(`${access.origin}/api/agents?private-key=private-query`, {
+        headers: access.authorization,
+      });
+      const requestLog = observed.findLast(({ event }) => event === "http.request");
+
+      expect(response.status).toBe(500);
+      expect(requestLog?.data).toMatchObject({
+        method: "GET",
+        route: "/api/agents",
+        query_keys: [],
+        status: 500,
+        error: handlerError,
+      });
+      expect(requestLog?.data).not.toHaveProperty("path");
+      expect(requestLog?.data).not.toHaveProperty("body");
+      expect(JSON.stringify(requestLog?.data)).not.toContain("private-query");
+    } finally {
+      await app.shutdown();
+      logSpy.mockRestore();
+    }
+  });
+
   it("CS-160: enforces loopback authority before API, SSE, and static routes", async () => {
     const webDist = mkdtempSync(join(tmpdir(), "codesesh-authority-web-"));
     writeFileSync(join(webDist, "index.html"), "<html>app shell</html>");
@@ -295,7 +389,7 @@ describe("createServer", () => {
   it("CS-193: rejects unsafe loopback writes without breaking same-origin JSON", async () => {
     const app = await createServer(0, createStore());
     const access = getServerAccess(app.url);
-    const body = JSON.stringify({ event: "csrf-probe" });
+    const body = JSON.stringify({ event: "app.load.start" });
 
     try {
       const textPlain = await fetch(`${access.origin}/api/logs`, {
@@ -479,7 +573,7 @@ describe("createServer", () => {
               "Content-Type": "application/json",
               Origin: requestOrigin,
             },
-            body: JSON.stringify({ event: "same-origin-probe" }),
+            body: JSON.stringify({ event: "app.load.start" }),
           })
         ).status,
       ).toBe(200);

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -1,4 +1,5 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
+import { matchedRoutes } from "hono/route";
 import { bodyLimit } from "hono/body-limit";
 import { compress } from "hono/compress";
 import { secureHeaders } from "hono/secure-headers";
@@ -6,6 +7,7 @@ import { serve } from "@hono/node-server";
 import type { HttpBindings, ServerType } from "@hono/node-server";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { createServer as createHttpsServer } from "node:https";
 import type { AddressInfo } from "node:net";
 import { resolve, dirname } from "node:path";
@@ -31,9 +33,33 @@ import {
   type RemoteTransport,
 } from "./remote-access.js";
 import type { ScanEventSource } from "./scan-source.js";
+import { CODESESH_OPERATION_ID_HEADER, CODESESH_REQUEST_ID_HEADER } from "@codesesh/core/contract";
 
 const MAX_API_REQUEST_BYTES = 1024 * 1024;
 const SERVER_CLOSE_GRACE_MS = 1_000;
+const OPERATION_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const OBSERVABLE_QUERY_KEYS = new Set([
+  "agent",
+  "costMax",
+  "costMin",
+  "cursor",
+  "cwd",
+  "days",
+  "fileActivity",
+  "from",
+  "kind",
+  "limit",
+  "messageCursor",
+  "path",
+  "project",
+  "projectKey",
+  "projectKind",
+  "q",
+  "sessionId",
+  "tag",
+  "to",
+  "tool",
+]);
 
 export interface CreateServerOptions {
   defaultSessionFrom?: number;
@@ -107,6 +133,42 @@ function isAddressInUse(error: unknown): boolean {
 function getListeningPort(server: ServerType, fallback: number): number {
   const address = server.address();
   return typeof address === "object" && address !== null ? (address as AddressInfo).port : fallback;
+}
+
+function optionalOperationId(value: string | undefined): string | undefined {
+  return value && OPERATION_ID_PATTERN.test(value) ? value : undefined;
+}
+
+function errorStatus(error: unknown): number {
+  try {
+    if (typeof error !== "object" || error === null) return 500;
+    const status = Reflect.get(error, "status");
+    if (typeof status === "number" && status >= 400 && status <= 599) return status;
+  } catch {}
+  return 500;
+}
+
+function matchedRoute(context: Context): string {
+  try {
+    return (
+      matchedRoutes(context)
+        .map((route) => route.path)
+        .filter((path) => !path.includes("*"))
+        .at(-1) ?? "<unmatched>"
+    );
+  } catch {
+    return "<unmatched>";
+  }
+}
+
+function queryKeys(url: string): string[] {
+  try {
+    return [...new Set(new URL(url).searchParams.keys())]
+      .filter((key) => OBSERVABLE_QUERY_KEYS.has(key))
+      .toSorted();
+  } catch {
+    return [];
+  }
 }
 
 async function closeHttpServer(server: ServerType | null, port: number | null): Promise<void> {
@@ -194,43 +256,53 @@ export async function createServer(
     }),
   );
 
+  app.use("*", async (c, next) => {
+    const startedAt = performance.now();
+    const requestId = randomUUID();
+    const actualPath = c.req.path;
+    const operationId = optionalOperationId(c.req.header(CODESESH_OPERATION_ID_HEADER));
+    const context =
+      actualPath === "/api/events"
+        ? {}
+        : { request_id: requestId, ...(operationId ? { operation_id: operationId } : {}) };
+    c.header(CODESESH_REQUEST_ID_HEADER, requestId);
+
+    return appLogger.restoreContext(context, async () => {
+      let thrown: unknown;
+      try {
+        await next();
+      } catch (error) {
+        thrown = error;
+        throw error;
+      } finally {
+        const requestError = thrown ?? c.error;
+        appLogger.info("http.request", {
+          method: c.req.method,
+          route: matchedRoute(c),
+          query_keys: queryKeys(c.req.url),
+          status: requestError == null ? c.res.status : errorStatus(requestError),
+          duration_ms: Math.round(performance.now() - startedAt),
+          ...(requestError == null ? {} : { error: requestError }),
+        });
+      }
+    });
+  });
+
   if (loopbackAuthorityEnabled) {
     app.use("*", async (c, next) => {
       const decision = validateLoopbackAuthority(c.env.incoming.rawHeaders, hostname, actualPort);
       if (!decision.allowed) {
         appLogger.warn("http.loopback_authority.rejected", {
           method: c.req.method,
-          path: new URL(c.req.url).pathname,
+          route: "<rejected>",
           reason: decision.reason,
-          authority: decision.authority,
+          authority_present: Boolean(decision.authority),
         });
         return c.json({ error: "Loopback request authority rejected" }, 403);
       }
       await next();
     });
   }
-
-  app.use("*", async (c, next) => {
-    const startedAt = performance.now();
-    let thrown: unknown;
-
-    try {
-      await next();
-    } catch (error) {
-      thrown = error;
-      throw error;
-    } finally {
-      const url = new URL(c.req.url);
-      appLogger.info("http.request", {
-        method: c.req.method,
-        path: url.pathname,
-        query_keys: [...url.searchParams.keys()].toSorted(),
-        status: c.res.status,
-        duration_ms: Math.round(performance.now() - startedAt),
-        error: thrown instanceof Error ? thrown.message : undefined,
-      });
-    }
-  });
 
   // Ordered before authentication: a request that bypassed the proxy must be
   // refused outright, not given a chance to present a token in the clear.

--- a/packages/cli/src/session-detail-loader.test.ts
+++ b/packages/cli/src/session-detail-loader.test.ts
@@ -8,10 +8,23 @@ vi.mock("@codesesh/core/runtime/discovery", () => ({
   materializeCachedSessionDetailResponse: mocks.cached,
 }));
 vi.mock("./logging.js", () => ({
-  appLogger: { info: vi.fn(), consumeWorkerMessage: vi.fn(() => false) },
+  appLogger: {
+    info: vi.fn(),
+    consumeWorkerMessage: vi.fn(() => false),
+    captureContext: vi.fn(() => ({})),
+  },
 }));
 vi.mock("node:worker_threads", () => ({
   Worker: class extends EventEmitter {
+    postMessage = vi.fn((message: { type?: string; requestId?: string }) => {
+      if (message.type !== "codesesh.worker-log-drain") return;
+      queueMicrotask(() => {
+        this.emit("message", {
+          type: "codesesh.worker-log-drained",
+          requestId: message.requestId,
+        });
+      });
+    });
     terminate = vi.fn(async () => {
       this.emit("exit", 0);
       return 0;
@@ -55,6 +68,9 @@ it("returns serialized worker results and retires the worker", async () => {
   const pending = loader.load(snapshot, reference);
   mocks.workers[0].emit("message", { type: "result", result: { status: "not-ready" } });
   await expect(pending).resolves.toEqual({ status: "not-ready" });
+  expect(mocks.workers[0].postMessage).toHaveBeenCalledWith(
+    expect.objectContaining({ type: "codesesh.worker-log-drain" }),
+  );
   expect(mocks.workers[0].terminate).toHaveBeenCalledOnce();
 });
 
@@ -78,6 +94,33 @@ it("bounds concurrent parsing and cancels outstanding work on shutdown", async (
   await loader.shutdown();
   await Promise.all([first, second]);
   await expect(loader.load(snapshot, reference)).rejects.toThrow();
+});
+
+it("waits for every worker retirement when one termination fails", async () => {
+  const first = expect(loader.load(snapshot, reference)).rejects.toThrow();
+  const second = expect(loader.load(snapshot, reference)).rejects.toThrow();
+  mocks.workers[0].terminate.mockRejectedValueOnce(new Error("termination failed"));
+  let finishSecond = () => {};
+  mocks.workers[1].terminate.mockImplementationOnce(
+    () =>
+      new Promise<number>((resolve) => {
+        finishSecond = () => {
+          mocks.workers[1].emit("exit", 0);
+          resolve(0);
+        };
+      }),
+  );
+  let shutdownCompleted = false;
+
+  const shutdown = loader.shutdown().then(() => {
+    shutdownCompleted = true;
+  });
+  await vi.waitFor(() => expect(mocks.workers[1].terminate).toHaveBeenCalledOnce());
+  expect(shutdownCompleted).toBe(false);
+
+  finishSecond();
+  await shutdown;
+  await Promise.all([first, second]);
 });
 
 it("cancels a worker when the client aborts", async () => {

--- a/packages/cli/src/session-detail-loader.ts
+++ b/packages/cli/src/session-detail-loader.ts
@@ -11,6 +11,7 @@ import type {
   SessionDetailWorkerMessage,
   SessionDetailWorkerRequest,
 } from "./session-detail-worker.js";
+import { terminateWorkerAfterLogDrain } from "./worker-log-drain.js";
 
 export type SessionDetailLoader = (
   snapshot: LiveSnapshot,
@@ -55,6 +56,7 @@ export class ThreadSessionDetailLoader {
       meta: meta ? { [reference.sessionId]: meta } : {},
       messageCursor: options.messageCursor,
       pricingGenerationId: getPricingGeneration().id,
+      logContext: appLogger.captureContext(),
     };
     appLogger.info("session_detail.worker.started", {
       agent: reference.agentName,
@@ -92,13 +94,15 @@ export class ThreadSessionDetailLoader {
     } finally {
       clearTimeout(timeout);
       requestSignal.removeEventListener("abort", abort);
-      await worker.terminate();
+      await terminateWorkerAfterLogDrain(worker);
       await exited;
     }
   };
 
   async shutdown(): Promise<void> {
     this.shutdownController.abort();
-    await Promise.all([...this.workers].map((worker) => worker.terminate()));
+    await Promise.allSettled(
+      [...this.workers].map((worker) => terminateWorkerAfterLogDrain(worker)),
+    );
   }
 }

--- a/packages/cli/src/session-detail-worker.test.ts
+++ b/packages/cli/src/session-detail-worker.test.ts
@@ -46,6 +46,9 @@ it("serializes source messages inside the worker", async () => {
     }),
   });
   expect(mocks.close).toHaveBeenCalledOnce();
+  expect(mocks.close.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.post.mock.invocationCallOrder[0]!,
+  );
 });
 
 it("materializes cached message iterators before crossing threads", async () => {
@@ -76,4 +79,7 @@ it("reports parsing errors and closes storage", async () => {
   await import("./session-detail-worker.js");
   expect(mocks.post).toHaveBeenCalledWith({ type: "error", error: "parse failed" });
   expect(mocks.close).toHaveBeenCalledOnce();
+  expect(mocks.close.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.post.mock.invocationCallOrder[0]!,
+  );
 });

--- a/packages/cli/src/session-detail-worker.test.ts
+++ b/packages/cli/src/session-detail-worker.test.ts
@@ -5,10 +5,12 @@ const mocks = vi.hoisted(() => ({
   post: vi.fn(),
   restore: vi.fn(),
   close: vi.fn(),
+  on: vi.fn(),
 }));
 vi.mock("./diagnostics-bridge.js", () => ({}));
-vi.mock("node:worker_threads", () => ({
-  parentPort: { postMessage: mocks.post },
+vi.mock("node:worker_threads", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:worker_threads")>()),
+  parentPort: { postMessage: mocks.post, on: mocks.on },
   workerData: {
     reference: { agentName: "codex", sessionId: "s1" },
     meta: {},

--- a/packages/cli/src/session-detail-worker.ts
+++ b/packages/cli/src/session-detail-worker.ts
@@ -9,6 +9,8 @@ import {
   type SessionReference,
 } from "@codesesh/core/runtime/discovery";
 import { synchronizePricingGeneration } from "@codesesh/core/runtime/pricing";
+import { appLogger, type LogContext } from "./logging.js";
+import { acknowledgeWorkerLogDrain } from "./worker-log-drain.js";
 
 export interface SessionDetailWorkerRequest {
   reference: SessionReference;
@@ -16,51 +18,68 @@ export interface SessionDetailWorkerRequest {
   meta: Record<string, SessionCacheMeta>;
   messageCursor?: string;
   pricingGenerationId: number;
+  logContext?: LogContext;
 }
 
 export type SessionDetailWorkerMessage =
   | { type: "result"; result: SessionDetailResponseResult }
   | { type: "error"; error: string };
 
+const workerPort = parentPort;
+workerPort?.on("message", (message: unknown) => {
+  acknowledgeWorkerLogDrain(workerPort, message);
+});
+
 const request = workerData as SessionDetailWorkerRequest;
-try {
-  synchronizePricingGeneration(request.pricingGenerationId);
-  const agent = createRegisteredAgents().find((item) => item.name === request.reference.agentName);
-  const sessions = request.head ? [request.head] : [];
-  agent?.restoreSessionCacheMeta(request.meta);
-  const result = materializeSessionDetailResponse(
-    {
-      agents: agent ? [agent] : [],
-      sessions,
-      byAgent: { [request.reference.agentName]: sessions },
-    },
-    request.reference,
-    { messageCursor: request.messageCursor },
-  );
-  if (result.status === "found") {
-    const { messages, ...data } = result.data;
-    parentPort?.postMessage({
-      type: "result",
-      result: {
-        status: "found-json",
-        data,
-        messages: messages.map((message) => JSON.stringify(message)),
-        messageCount: messages.length,
-        sentMessageCount: messages.length,
-      },
-    } satisfies SessionDetailWorkerMessage);
-  } else {
-    parentPort?.postMessage({
-      type: "result",
-      result:
-        result.status === "found-json" ? { ...result, messages: [...result.messages] } : result,
-    } satisfies SessionDetailWorkerMessage);
-  }
-} catch (error) {
-  parentPort?.postMessage({
-    type: "error",
-    error: error instanceof Error ? error.message : String(error),
-  } satisfies SessionDetailWorkerMessage);
-} finally {
-  closeCacheStorage();
-}
+const terminalMessage = appLogger.restoreContext(
+  request.logContext ?? {},
+  (): SessionDetailWorkerMessage => {
+    try {
+      synchronizePricingGeneration(request.pricingGenerationId);
+      const agent = createRegisteredAgents().find(
+        (item) => item.name === request.reference.agentName,
+      );
+      const sessions = request.head ? [request.head] : [];
+      agent?.restoreSessionCacheMeta(request.meta);
+      const result = materializeSessionDetailResponse(
+        {
+          agents: agent ? [agent] : [],
+          sessions,
+          byAgent: { [request.reference.agentName]: sessions },
+        },
+        request.reference,
+        { messageCursor: request.messageCursor },
+      );
+      if (result.status === "found") {
+        const { messages, ...data } = result.data;
+        return {
+          type: "result",
+          result: {
+            status: "found-json",
+            data,
+            messages: messages.map((message) => JSON.stringify(message)),
+            messageCount: messages.length,
+            sentMessageCount: messages.length,
+          },
+        };
+      }
+      return {
+        type: "result",
+        result:
+          result.status === "found-json" ? { ...result, messages: [...result.messages] } : result,
+      };
+    } catch (error) {
+      return {
+        type: "error",
+        error: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      try {
+        closeCacheStorage();
+      } catch (error) {
+        appLogger.error("session_detail.worker.close_failed", { error });
+      }
+    }
+  },
+);
+parentPort?.postMessage(terminalMessage);

--- a/packages/cli/src/worker-log-drain.test.ts
+++ b/packages/cli/src/worker-log-drain.test.ts
@@ -1,0 +1,135 @@
+import { EventEmitter } from "node:events";
+import { MessageChannel, type MessagePort, type Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { appLogger } from "./logging.js";
+import { acknowledgeWorkerLogDrain, terminateWorkerAfterLogDrain } from "./worker-log-drain.js";
+
+function workerFromPort(port: MessagePort, terminate: () => Promise<number>): Worker {
+  return {
+    on: port.on.bind(port),
+    once: port.once.bind(port),
+    off: port.off.bind(port),
+    postMessage: port.postMessage.bind(port),
+    terminate,
+  } as unknown as Worker;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("worker log drain", () => {
+  it("delivers queued messages before one shared termination", async () => {
+    const { port1: workerPort, port2: parentPort } = new MessageChannel();
+    const order: string[] = [];
+    workerPort.on("message", (message: unknown) => {
+      acknowledgeWorkerLogDrain(workerPort, message);
+    });
+    parentPort.on("message", (message: { type?: string }) => {
+      if (message.type === "queued-log") order.push("log");
+    });
+    const terminate = vi.fn(async () => {
+      order.push("terminate");
+      workerPort.close();
+      parentPort.close();
+      return 0;
+    });
+    const worker = workerFromPort(parentPort, terminate);
+
+    workerPort.postMessage({ type: "queued-log" });
+    await Promise.all([terminateWorkerAfterLogDrain(worker), terminateWorkerAfterLogDrain(worker)]);
+
+    expect(order).toEqual(["log", "terminate"]);
+    expect(terminate).toHaveBeenCalledOnce();
+  });
+
+  it("terminates after a short timeout when the worker cannot acknowledge", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(appLogger, "warn").mockImplementation(() => undefined);
+    const worker = new EventEmitter() as EventEmitter & {
+      postMessage: ReturnType<typeof vi.fn>;
+      terminate: ReturnType<typeof vi.fn>;
+      threadId: number;
+    };
+    worker.threadId = 42;
+    worker.postMessage = vi.fn();
+    worker.terminate = vi.fn(async () => 0);
+
+    const termination = terminateWorkerAfterLogDrain(worker as unknown as Worker);
+    await vi.advanceTimersByTimeAsync(99);
+    expect(worker.terminate).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await termination;
+
+    expect(worker.terminate).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith("worker.log_drain_timeout", {
+      timeout_ms: 100,
+      worker_thread_id: 42,
+    });
+    expect(worker.listenerCount("message")).toBe(0);
+    expect(worker.listenerCount("error")).toBe(0);
+    expect(worker.listenerCount("exit")).toBe(0);
+  });
+
+  it("does not terminate a worker that exits while draining", async () => {
+    const worker = new EventEmitter() as EventEmitter & {
+      postMessage: ReturnType<typeof vi.fn>;
+      terminate: ReturnType<typeof vi.fn>;
+    };
+    worker.postMessage = vi.fn();
+    worker.terminate = vi.fn(async () => 0);
+
+    const termination = terminateWorkerAfterLogDrain(worker as unknown as Worker);
+    worker.emit("exit", 7);
+
+    await expect(termination).resolves.toBe(7);
+    expect(worker.terminate).not.toHaveBeenCalled();
+  });
+
+  it("waits for exit after an error instead of terminating immediately", async () => {
+    const worker = new EventEmitter() as EventEmitter & {
+      postMessage: ReturnType<typeof vi.fn>;
+      terminate: ReturnType<typeof vi.fn>;
+    };
+    worker.postMessage = vi.fn();
+    worker.terminate = vi.fn(async () => 0);
+    worker.on("error", () => undefined);
+
+    const termination = terminateWorkerAfterLogDrain(worker as unknown as Worker);
+    worker.emit("error", new Error("failed"));
+    await Promise.resolve();
+    expect(worker.terminate).not.toHaveBeenCalled();
+
+    worker.emit("exit", 1);
+    await expect(termination).resolves.toBe(1);
+    expect(worker.terminate).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges only after the worker barrier settles", async () => {
+    const { port1: workerPort, port2: parentPort } = new MessageChannel();
+    let release = () => {};
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    workerPort.on("message", (message: unknown) => {
+      acknowledgeWorkerLogDrain(workerPort, message, barrier);
+    });
+    const acknowledged = vi.fn();
+    parentPort.on("message", acknowledged);
+
+    parentPort.postMessage({ type: "codesesh.worker-log-drain", requestId: "queued" });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(acknowledged).not.toHaveBeenCalled();
+
+    release();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(acknowledged).toHaveBeenCalledWith({
+      type: "codesesh.worker-log-drained",
+      requestId: "queued",
+    });
+
+    workerPort.close();
+    parentPort.close();
+  });
+});

--- a/packages/cli/src/worker-log-drain.ts
+++ b/packages/cli/src/worker-log-drain.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+import type { MessagePort, Worker } from "node:worker_threads";
+import { appLogger } from "./logging.js";
+
+const WORKER_LOG_DRAIN_REQUEST_TYPE = "codesesh.worker-log-drain";
+const WORKER_LOG_DRAIN_ACK_TYPE = "codesesh.worker-log-drained";
+const WORKER_LOG_DRAIN_TIMEOUT_MS = 100;
+
+interface WorkerLogDrainRequest {
+  type: typeof WORKER_LOG_DRAIN_REQUEST_TYPE;
+  requestId: string;
+}
+
+interface WorkerLogDrainAck {
+  type: typeof WORKER_LOG_DRAIN_ACK_TYPE;
+  requestId: string;
+}
+
+const terminations = new WeakMap<Worker, Promise<number>>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isWorkerLogDrainRequest(message: unknown): boolean {
+  return (
+    isRecord(message) &&
+    message.type === WORKER_LOG_DRAIN_REQUEST_TYPE &&
+    typeof message.requestId === "string"
+  );
+}
+
+function isWorkerLogDrainAck(message: unknown, requestId: string): boolean {
+  return (
+    isRecord(message) &&
+    message.type === WORKER_LOG_DRAIN_ACK_TYPE &&
+    message.requestId === requestId
+  );
+}
+
+export function acknowledgeWorkerLogDrain(
+  port: MessagePort,
+  message: unknown,
+  after: PromiseLike<unknown> = Promise.resolve(),
+): boolean {
+  if (!isWorkerLogDrainRequest(message)) return false;
+  const acknowledge = () => {
+    try {
+      port.postMessage({
+        type: WORKER_LOG_DRAIN_ACK_TYPE,
+        requestId: (message as WorkerLogDrainRequest).requestId,
+      } satisfies WorkerLogDrainAck);
+    } catch {
+      return;
+    }
+  };
+  void Promise.resolve(after).then(acknowledge, acknowledge);
+  return true;
+}
+
+function reportDrainTimeout(worker: Worker): void {
+  try {
+    appLogger.warn("worker.log_drain_timeout", {
+      timeout_ms: WORKER_LOG_DRAIN_TIMEOUT_MS,
+      worker_thread_id: worker.threadId,
+    });
+  } catch {
+    return;
+  }
+}
+
+function requestWorkerLogDrain(worker: Worker): Promise<number | undefined> {
+  return new Promise((resolve) => {
+    const requestId = randomUUID();
+    let settled = false;
+    const finish = (exitCode?: number) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      worker.off("message", onMessage);
+      worker.off("exit", onExit);
+      resolve(exitCode);
+    };
+    const onMessage = (message: unknown) => {
+      if (isWorkerLogDrainAck(message, requestId)) finish();
+    };
+    const onExit = (code: number) => finish(code);
+    const timeout = setTimeout(() => {
+      reportDrainTimeout(worker);
+      finish();
+    }, WORKER_LOG_DRAIN_TIMEOUT_MS);
+
+    worker.on("message", onMessage);
+    worker.once("exit", onExit);
+    try {
+      worker.postMessage({ type: WORKER_LOG_DRAIN_REQUEST_TYPE, requestId });
+    } catch {
+      finish(worker.threadId === -1 ? 0 : undefined);
+    }
+  });
+}
+
+export function terminateWorkerAfterLogDrain(worker: Worker): Promise<number> {
+  const existing = terminations.get(worker);
+  if (existing) return existing;
+
+  const termination = requestWorkerLogDrain(worker).then((exitCode) =>
+    exitCode === undefined ? worker.terminate() : exitCode,
+  );
+  terminations.set(worker, termination);
+  return termination;
+}

--- a/packages/cli/src/worker-runner.ts
+++ b/packages/cli/src/worker-runner.ts
@@ -11,7 +11,7 @@ import {
   type PersistedSessionHeadChange,
   type SessionSnapshotCompleteness,
 } from "@codesesh/core/runtime/discovery";
-import { appLogger } from "./logging.js";
+import { appLogger, type LogContext } from "./logging.js";
 import type {
   ScanRefreshWorkerCommitRequest,
   ScanRefreshWorkerCheckpoint,
@@ -24,6 +24,7 @@ import {
   AgentUnavailableDuringScanError,
 } from "./scan-refresh-error.js";
 import { toError } from "./errors.js";
+import { terminateWorkerAfterLogDrain } from "./worker-log-drain.js";
 
 export interface WorkerPayload {
   previousSessions: SessionHead[];
@@ -61,6 +62,7 @@ interface PendingRequest {
   reject: (error: Error) => void;
   payload: WorkerPayload;
   generation: number;
+  logContext: LogContext;
   onProgress?: (progress: AgentScanProgress) => void;
   onCheckpoint?: (checkpoint: ScanRefreshWorkerCheckpoint) => void;
 }
@@ -70,7 +72,7 @@ interface WorkerSlot {
   worker: Worker;
   pending: Map<number, PendingRequest>;
   generation: number;
-  awaitingCommit: { requestId: number; generation: number } | null;
+  awaitingCommit: { requestId: number; generation: number; logContext: LogContext } | null;
   closed: boolean;
 }
 
@@ -122,6 +124,7 @@ function applyMetaChanges(
 
 export class ThreadWorkerRunner implements WorkerRunner {
   private workers = new Map<string, WorkerSlot>();
+  private retirements = new Set<Promise<number>>();
   private nextRequestId = 1;
   private isShuttingDown = false;
 
@@ -151,6 +154,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       pricingGenerationId: getPricingGeneration().id,
       operation: payload.operation,
       scanOptions: payload.scanOptions,
+      logContext: appLogger.captureContext(),
       ...(existingSlot ? {} : { previousSessions: payload.previousSessions, meta: payload.meta }),
     };
 
@@ -171,6 +175,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
         reject,
         payload,
         generation,
+        logContext: request.logContext ?? {},
         onProgress: payload.onProgress,
         onCheckpoint: payload.onCheckpoint,
       });
@@ -202,7 +207,8 @@ export class ThreadWorkerRunner implements WorkerRunner {
       for (const pending of slot.pending.values()) pending.reject(shutdownError);
       slot.pending.clear();
     }
-    await Promise.allSettled(slots.map((slot) => slot.worker.terminate()));
+    for (const slot of slots) this.retireWorker(slot.worker);
+    await Promise.allSettled(this.retirements);
   }
 
   private createWorker(agentName: string, request: ScanRefreshWorkerRunRequest): WorkerSlot {
@@ -221,15 +227,20 @@ export class ThreadWorkerRunner implements WorkerRunner {
       this.handleMessage(slot, message as ScanRefreshWorkerMessage);
     });
     worker.on("error", (error) => {
-      this.closeWorker(agentName, slot, toError(error));
+      appLogger.restoreContext(this.slotLogContext(slot), () => {
+        this.closeWorker(agentName, slot, toError(error));
+        void this.retireWorker(worker);
+      });
     });
     worker.on("exit", (code) => {
-      if (slot.closed) return;
-      const error = new Error(`Scan refresh worker exited before completing (code ${code})`);
-      if (slot.pending.size > 0) {
-        appLogger.warn("scan.refresh_worker.exit_before_done", { agent: agentName, code });
-      }
-      this.closeWorker(agentName, slot, error);
+      appLogger.restoreContext(this.slotLogContext(slot), () => {
+        if (slot.closed) return;
+        const error = new Error(`Scan refresh worker exited before completing (code ${code})`);
+        if (slot.pending.size > 0) {
+          appLogger.warn("scan.refresh_worker.exit_before_done", { agent: agentName, code });
+        }
+        this.closeWorker(agentName, slot, error);
+      });
     });
     return slot;
   }
@@ -237,6 +248,16 @@ export class ThreadWorkerRunner implements WorkerRunner {
   private handleMessage(slot: WorkerSlot, message: ScanRefreshWorkerMessage): void {
     const pending = slot.pending.get(message.requestId);
     if (!pending) return;
+    appLogger.restoreContext(pending.logContext, () => {
+      this.handlePendingMessage(slot, message, pending);
+    });
+  }
+
+  private handlePendingMessage(
+    slot: WorkerSlot,
+    message: ScanRefreshWorkerMessage,
+    pending: PendingRequest,
+  ): void {
     if (message.generation !== pending.generation) {
       const error = new Error(
         `Scan refresh generation mismatch: expected ${pending.generation}, received ${message.generation}`,
@@ -290,6 +311,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       slot.awaitingCommit = {
         requestId: message.requestId,
         generation: message.generation,
+        logContext: pending.logContext,
       };
       pending.resolve(this.createStagedRun(slot, message.requestId, message.generation, result));
     } catch (error) {
@@ -333,6 +355,7 @@ export class ThreadWorkerRunner implements WorkerRunner {
       type: "commit",
       requestId,
       generation,
+      logContext: awaiting.logContext,
     };
     try {
       slot.worker.postMessage(request);
@@ -363,12 +386,24 @@ export class ThreadWorkerRunner implements WorkerRunner {
     slot.awaitingCommit = null;
   }
 
+  private slotLogContext(slot: WorkerSlot): LogContext {
+    for (const pending of slot.pending.values()) return pending.logContext;
+    return slot.awaitingCommit?.logContext ?? {};
+  }
+
   private invalidateWorker(agentName: string, slot: WorkerSlot): void {
     this.closeWorker(
       agentName,
       slot,
       new Error(`Scan refresh worker state discarded for ${agentName}`),
     );
-    void slot.worker.terminate().catch(() => undefined);
+    void this.retireWorker(slot.worker);
+  }
+
+  private retireWorker(worker: Worker): Promise<number> {
+    const retirement = terminateWorkerAfterLogDrain(worker);
+    this.retirements.add(retirement);
+    void retirement.finally(() => this.retirements.delete(retirement)).catch(() => undefined);
+    return retirement;
   }
 }

--- a/packages/core/src/contract/__tests__/browser-safe.test.ts
+++ b/packages/core/src/contract/__tests__/browser-safe.test.ts
@@ -29,6 +29,8 @@ describe("contract browser-safety", () => {
     expect(Object.keys(contract).sort()).toEqual(
       [
         "AGENT_CATALOG",
+        "CODESESH_OPERATION_ID_HEADER",
+        "CODESESH_REQUEST_ID_HEADER",
         "PROJECT_IDENTITY_KINDS",
         "SMART_TAGS",
         "UNKNOWN_AGENT_NAME",

--- a/packages/core/src/contract/api.ts
+++ b/packages/core/src/contract/api.ts
@@ -1,5 +1,8 @@
 import type { CostSource, ProjectGroup } from "./session.js";
 
+export const CODESESH_REQUEST_ID_HEADER = "X-CodeSesh-Request-ID";
+export const CODESESH_OPERATION_ID_HEADER = "X-CodeSesh-Operation-ID";
+
 export interface AppConfig {
   window: {
     from?: number;

--- a/packages/core/src/contract/index.ts
+++ b/packages/core/src/contract/index.ts
@@ -21,3 +21,4 @@ export * from "./session-reference.js";
 export * from "./session-index.js";
 export * from "./session-tree.js";
 export type * from "./api.js";
+export { CODESESH_OPERATION_ID_HEADER, CODESESH_REQUEST_ID_HEADER } from "./api.js";

--- a/packages/core/src/runtime/diagnostics.ts
+++ b/packages/core/src/runtime/diagnostics.ts
@@ -3,6 +3,8 @@ export {
   ensurePrivateDirectory,
   getSmartTagSourceTimestamp,
   isWorkerLogMessage,
+  PRIVATE_DIR_MODE,
+  PRIVATE_FILE_MODE,
   perf,
   restrictExistingPrivateFiles,
   restrictPrivateFile,
@@ -10,5 +12,6 @@ export {
   SMART_TAG_CLASSIFIER_REVISION,
   WORKER_LOG_MESSAGE_TYPE,
   type WorkerLogLevel,
+  type WorkerLogContext,
   type WorkerLogMessage,
 } from "../utils/index.js";

--- a/packages/core/src/utils/__tests__/worker-log.test.ts
+++ b/packages/core/src/utils/__tests__/worker-log.test.ts
@@ -12,6 +12,7 @@ const message: WorkerLogMessage = {
   event: "worker.ready",
   pid: 42,
   threadId: 3,
+  context: { operation_id: "scan:codex:1" },
   data: { sessions: 2 },
 };
 
@@ -28,6 +29,8 @@ describe("worker log protocol", () => {
     { ...message, event: "" },
     { ...message, pid: 0 },
     { ...message, threadId: -1 },
+    { ...message, context: { operation_id: "x".repeat(161) } },
+    { ...message, context: { unexpected: "value" } },
     { ...message, data: [] },
   ])("rejects an invalid worker message %#", (candidate) => {
     expect(isWorkerLogMessage(candidate)).toBe(false);

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -22,6 +22,7 @@ export { estimateTokenCost } from "./cost.js";
 export {
   WORKER_LOG_MESSAGE_TYPE,
   isWorkerLogMessage,
+  type WorkerLogContext,
   type WorkerLogLevel,
   type WorkerLogMessage,
 } from "./worker-log.js";

--- a/packages/core/src/utils/worker-log.ts
+++ b/packages/core/src/utils/worker-log.ts
@@ -2,6 +2,12 @@ export const WORKER_LOG_MESSAGE_TYPE = "codesesh.worker-log";
 
 export type WorkerLogLevel = "debug" | "info" | "warn" | "error";
 
+export interface WorkerLogContext {
+  request_id?: string;
+  operation_id?: string;
+  publication_id?: string;
+}
+
 export interface WorkerLogMessage {
   type: typeof WORKER_LOG_MESSAGE_TYPE;
   ts: string;
@@ -9,11 +15,22 @@ export interface WorkerLogMessage {
   event: string;
   pid: number;
   threadId: number;
+  context?: WorkerLogContext;
   data: Record<string, unknown>;
 }
 
+const WORKER_LOG_CONTEXT_KEYS = new Set(["request_id", "operation_id", "publication_id"]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isLogContext(value: unknown): value is WorkerLogContext {
+  if (!isRecord(value)) return false;
+  return Object.entries(value).every(
+    ([key, item]) =>
+      WORKER_LOG_CONTEXT_KEYS.has(key) && typeof item === "string" && item.length <= 160,
+  );
 }
 
 export function isWorkerLogMessage(value: unknown): value is WorkerLogMessage {
@@ -31,6 +48,7 @@ export function isWorkerLogMessage(value: unknown): value is WorkerLogMessage {
     Number(value.pid) > 0 &&
     Number.isSafeInteger(value.threadId) &&
     Number(value.threadId) >= 0 &&
+    (value.context === undefined || isLogContext(value.context)) &&
     isRecord(value.data)
   );
 }

--- a/tests/e2e/json-index-exit.spec.ts
+++ b/tests/e2e/json-index-exit.spec.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +8,49 @@ import { expect, test } from "playwright/test";
 
 const CLI_ENTRY = fileURLToPath(new URL("../../packages/cli/dist/index.js", import.meta.url));
 const EXIT_TIMEOUT_MS = 60_000;
+
+async function runJsonCli(home: string, args: string[]) {
+  const child = spawn(process.execPath, [CLI_ENTRY, "--json", ...args], {
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      XDG_DATA_HOME: join(home, ".local", "share"),
+      XDG_CONFIG_HOME: join(home, ".config"),
+      APPDATA: join(home, "AppData", "Roaming"),
+      LOCALAPPDATA: join(home, "AppData", "Local"),
+      CODESESH_LOG_DIR: join(home, "logs"),
+      CODESESH_STATE_STORE: "memory",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: EXIT_TIMEOUT_MS,
+  });
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const [code, signal] = (await once(child, "exit")) as [number | null, NodeJS.Signals | null];
+  return { code, signal, stderr, stdout };
+}
+
+function readLogEvents(home: string): string[] {
+  const logDir = join(home, "logs");
+  return readdirSync(logDir)
+    .filter((name) => name.endsWith(".log"))
+    .flatMap((name) =>
+      readFileSync(join(logDir, name), "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => (JSON.parse(line) as { event: string }).event),
+    );
+}
 
 /**
  * `--json` is one-shot: it prints the session index and must hand the shell
@@ -20,39 +63,27 @@ test("exits after printing the session index as JSON", async () => {
   test.setTimeout(EXIT_TIMEOUT_MS * 2);
   const home = mkdtempSync(join(tmpdir(), "codesesh-json-exit-"));
   try {
-    const child = spawn(process.execPath, [CLI_ENTRY, "--json", "--days", "7"], {
-      env: {
-        ...process.env,
-        HOME: home,
-        USERPROFILE: home,
-        XDG_DATA_HOME: join(home, ".local", "share"),
-        XDG_CONFIG_HOME: join(home, ".config"),
-        APPDATA: join(home, "AppData", "Roaming"),
-        LOCALAPPDATA: join(home, "AppData", "Local"),
-        CODESESH_LOG_DIR: join(home, "logs"),
-        CODESESH_STATE_STORE: "memory",
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: EXIT_TIMEOUT_MS,
-    });
-    let stdout = "";
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
-    let stderr = "";
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-    });
-
-    const [code, signal] = (await once(child, "exit")) as [number | null, NodeJS.Signals | null];
+    const { code, signal, stderr, stdout } = await runJsonCli(home, ["--days", "7"]);
     expect(
       signal,
       `--json never exited on its own; it had to be killed. stderr: ${stderr}`,
     ).toBeNull();
     expect(code, `--json exited non-zero. stderr: ${stderr}`).toBe(0);
     expect(JSON.parse(stdout)).toMatchObject({ sessions: expect.any(Array) });
+    expect(readLogEvents(home)).toContain("cli.json_output");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("flushes the fatal event when startup fails", async () => {
+  const home = mkdtempSync(join(tmpdir(), "codesesh-json-failure-"));
+  try {
+    const result = await runJsonCli(home, ["--from", "2026-01-02", "--to", "2026-01-01"]);
+
+    expect(result.signal).toBeNull();
+    expect(result.code).not.toBe(0);
+    expect(readLogEvents(home)).toContain("cli.fatal");
   } finally {
     rmSync(home, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Keep diagnostics in the repository without adding Evlog, and replace synchronous writes with a bounded asynchronous queue, versioned privacy-safe records, private file permissions, rotation, and retention.
- Correlate browser, HTTP, SSE, and background work through allowlisted metadata and request or operation identifiers while excluding concrete routes, session content, credentials, user paths, and arbitrary client payloads.
- Propagate diagnostic context through workers, drain queued records before worker and process termination, and cap shutdown waits so logging cannot keep the CLI alive.

## Testing

- `pnpm format`
- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm test:migration`
- `pnpm test:e2e`
- `pnpm test:coverage`
