### PR TITLE
web: Drop unused PostCSS dependencies

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "@codesesh/core": "workspace:*",
-    "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/vite": "catalog:",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
@@ -48,7 +47,6 @@
     "@typescript/native": "catalog:",
     "@vitejs/plugin-react": "^6.1.0",
     "happy-dom": "^20.11.6",
-    "postcss": "^8.5.26",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,9 +142,6 @@ importers:
       '@codesesh/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@tailwindcss/postcss':
-        specifier: ^4.3.3
-        version: 4.3.3
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.3.3(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -172,9 +169,6 @@ importers:
       happy-dom:
         specifier: ^20.11.6
         version: 20.11.6
-      postcss:
-        specifier: ^8.5.26
-        version: 8.5.26
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.3
@@ -309,10 +303,6 @@ importers:
         version: '@typescript/typescript6@6.0.2'
 
 packages:
-
-  '@alloc/quick-lru@5.2.0':
-    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
-    engines: {node: '>=10'}
 
   '@astrojs/check@0.9.10':
     resolution: {integrity: sha512-zgx/UQMozdjOa3bOxjgeCFdtpE3c9rRX6xHwa+2QXvy8z8Akifu2AtubHyv/zzC2znO8dl8fFWL4K+Ba9kS8HQ==}
@@ -1800,9 +1790,6 @@ packages:
   '@tailwindcss/oxide@4.3.3':
     resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
     engines: {node: '>= 20'}
-
-  '@tailwindcss/postcss@4.3.3':
-    resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
 
   '@tailwindcss/vite@4.3.3':
     resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
@@ -4752,8 +4739,6 @@ packages:
 
 snapshots:
 
-  '@alloc/quick-lru@5.2.0': {}
-
   '@astrojs/check@0.9.10(@typescript/typescript6@6.0.2)(prettier-plugin-astro@0.14.1)(prettier@3.9.6)':
     dependencies:
       '@astrojs/language-server': 2.16.13(@typescript/typescript6@6.0.2)(prettier-plugin-astro@0.14.1)(prettier@3.9.6)
@@ -5781,14 +5766,6 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.3.3
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
-
-  '@tailwindcss/postcss@4.3.3':
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      '@tailwindcss/node': 4.3.3
-      '@tailwindcss/oxide': 4.3.3
-      postcss: 8.5.26
-      tailwindcss: 4.3.3
 
   '@tailwindcss/vite@4.3.3(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:


### PR DESCRIPTION
## Summary

- remove `@tailwindcss/postcss` and `postcss` from `apps/web`, which no configuration or module referenced
- keep `@tailwindcss/vite` as the single Tailwind host: `apps/web/vite.config.ts` and `apps/www/astro.config.ts` already register the plugin, and `apps/web/src/index.css` uses the Tailwind 4 `@import`/`@theme`/`@plugin` syntax

Both entries were leftovers from the PostCSS-based setup. The repository has no `postcss.config.*` file and no source import of either package, so they shipped a second styling pipeline that never ran — and `@tailwindcss/postcss` was additionally pinned outside the catalog, letting it drift from the catalogued `tailwindcss` version.

Verified that the compiled stylesheets are unchanged in shape: `apps/web/dist` still emits its Tailwind bundle and `apps/www/dist` still inlines the generated theme tokens.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `node scripts/check-quality-task-coverage.mjs`
- `node scripts/check-docs-paths.mjs`
- `node scripts/check-docs-facts.mjs`
- `node scripts/release-preflight.mjs`
- `pnpm perf:check`
- `pnpm --filter @codesesh/web test:bundle`
- `pnpm test:migration`