### PR TITLE
fix: Reconcile final Claude request usage

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClaudeCodeAgent } from "../claudecode.js";
 import type { Message, MessagePart, SessionHead } from "../../types/index.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
+import { sessionDetailVersion } from "../../discovery/cache/detail-version.js";
 
 // Spies on statSync while delegating to the real implementation, so the
 // single-stat regression test can count per-file calls during a live scan.
@@ -72,6 +73,36 @@ afterEach(() => {
 });
 
 describe("ClaudeCodeAgent cache refresh", () => {
+  it("rebuilds heads and invalidates details from the first-usage parser", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-parser-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    mkdirSync(projectDir);
+    writeMinimalClaudeSession(join(projectDir, "session-1.jsonl"));
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
+    const sessions = agent.scan();
+    const meta = agent.snapshotSessionCacheMeta();
+    const oldMeta = meta["session-1"]!;
+    oldMeta.sourceFingerprint = String(oldMeta.sourceFingerprint).replace(
+      "claudecode-head-v8",
+      "claudecode-head-v7",
+    );
+    oldMeta.headIndexVersion = "claudecode-head-v7";
+    const oldDetailVersion = sessionDetailVersion(oldMeta);
+
+    const refreshed = agent.sessionSourceAccess.synchronize(
+      { sessions, meta },
+      { kind: "refresh" },
+    );
+
+    expect(refreshed.detectedSessionIds).toEqual(["session-1"]);
+    expect(refreshed.sourceOutcomes[0]?.status).toBe("parsed");
+    expect(sessionDetailVersion(refreshed.meta["session-1"])).not.toBe(oldDetailVersion);
+    expect(
+      agent.sessionSourceAccess.synchronize(refreshed, { kind: "refresh" }).detectedSessionIds,
+    ).toEqual([]);
+  });
+
   it("detects sessions-index changes via fingerprint comparison", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-cache-"));
     tempDirs.push(basePath);
@@ -386,7 +417,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
         sessionId: "session-1",
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "claudecode-head-v7",
+          "claudecode-head-v8",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           indexTime.getTime(),
@@ -773,6 +804,110 @@ describe("ClaudeCodeAgent cache refresh", () => {
       total_cost: 0.00062175,
     });
     expect(data.messages.filter((message: Message) => (message.cost ?? 0) > 0)).toHaveLength(1);
+  });
+
+  it.each(["Visible reasoning", ""])("uses final request usage with reasoning %j", (thinking) => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-final-usage-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    mkdirSync(projectDir);
+    const sessionId = "streamed";
+    const record = (uuid: string, output: number, content: unknown[], timestamp: string) => ({
+      type: "assistant",
+      uuid,
+      requestId: "request-1",
+      timestamp,
+      message: {
+        role: "assistant",
+        model: "claude-sonnet-4-5-20250929",
+        usage: {
+          input_tokens: 100,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 5,
+          output_tokens: output,
+        },
+        content,
+      },
+    });
+    writeFileSync(
+      join(projectDir, `${sessionId}.jsonl`),
+      [
+        record("thinking", 3, [{ type: "thinking", thinking }], "2026-04-20T10:00:00Z"),
+        record(
+          "tool",
+          20,
+          [{ type: "tool_use", id: "read-1", name: "Read", input: {} }],
+          "2026-04-20T10:00:01Z",
+        ),
+        record("text", 30, [{ type: "text", text: "Done" }], "2026-04-20T10:00:02Z"),
+        record("final", 40, [], "2026-04-20T10:00:03Z"),
+        record("repeated", 40, [], "2026-04-20T10:00:03Z"),
+      ]
+        .map((value) => JSON.stringify(value))
+        .join("\n"),
+    );
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
+    const [head] = agent.scan();
+    const detail = agent.getSessionData(sessionId);
+
+    const expected = {
+      total_input_tokens: 115,
+      total_output_tokens: 40,
+      total_cache_read_tokens: 10,
+      total_cache_create_tokens: 5,
+      total_cost: 0.00092175,
+    };
+    expect(head?.stats).toMatchObject(expected);
+    expect(detail.stats).toMatchObject(expected);
+    expect(head?.model_usage).toEqual({ "claude-sonnet-4-5-20250929": 155 });
+    const charged = detail.messages.filter((message) => (message.cost ?? 0) > 0);
+    expect(charged).toHaveLength(1);
+    expect(charged[0]?.time_completed).toBe(Date.parse("2026-04-20T10:00:03Z"));
+  });
+
+  it("keeps consecutive requests and content-free usage attributed to their own models", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-requests-"));
+    tempDirs.push(basePath);
+    const projectDir = join(basePath, "project");
+    mkdirSync(projectDir);
+    const models = [
+      "claude-sonnet-4-5-20250929",
+      "claude-sonnet-4-5-20250929",
+      "claude-opus-4-6",
+      "claude-opus-4-6",
+    ];
+    writeFileSync(
+      join(projectDir, "requests.jsonl"),
+      models
+        .map((model, index) =>
+          JSON.stringify({
+            type: "assistant",
+            uuid: `message-${index}`,
+            requestId: `request-${index}`,
+            timestamp: "2026-04-20T10:00:00Z",
+            message: {
+              role: "assistant",
+              model,
+              usage: { input_tokens: 100, output_tokens: 20 },
+              content:
+                index === 3
+                  ? [{ type: "thinking", thinking: "" }]
+                  : [{ type: "text", text: "Response" }],
+            },
+          }),
+        )
+        .join("\n"),
+    );
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
+    const [head] = agent.scan();
+    const detail = agent.getSessionData("requests");
+
+    expect(detail.messages.map((message) => message.model)).toEqual(models);
+    expect(detail.messages.map((message) => message.cost)).toEqual([0.0006, 0.0006, 0.001, 0.001]);
+    expect(detail.messages[3]?.parts).toEqual([]);
+    expect(detail.stats.total_cost).toBeCloseTo(head!.stats.total_cost, 10);
+    expect(detail.stats.total_input_tokens).toBe(400);
+    expect(detail.stats.total_output_tokens).toBe(80);
   });
 
   it("filters internal-only sessions", () => {

--- a/packages/core/src/agents/claudecode-record-converter.ts
+++ b/packages/core/src/agents/claudecode-record-converter.ts
@@ -6,8 +6,9 @@ import { cleanInternalText } from "../utils/session-normalization.js";
 import { parseAgentTimestamp } from "../utils/timestamp.js";
 import { TranscriptBuilder, type TranscriptMessageInput } from "./transcript-builder.js";
 
-interface ClaudeUsage {
+export interface ClaudeUsage {
   key: string;
+  model: string | undefined;
   input: number;
   output: number;
   cacheRead: number;
@@ -50,6 +51,7 @@ export function extractClaudeUsage(
 
   return {
     key,
+    model: asString(msg["model"])?.trim() || undefined,
     input: readUsageNumber(usage, "input_tokens"),
     output: readUsageNumber(usage, "output_tokens"),
     cacheRead: readUsageNumber(usage, "cache_read_input_tokens"),
@@ -64,7 +66,7 @@ export class ClaudeRecordConverter {
     data: Record<string, unknown>,
     builder: TranscriptBuilder,
     assistantUuidToToolCalls: Map<string, string[]>,
-    countedUsageKeys: Set<string>,
+    requestMessages: Map<string, Message>,
     childSessionIdByToolUseId: ReadonlyMap<string, string>,
   ): void {
     if (data["isMeta"] === true) return;
@@ -77,7 +79,7 @@ export class ClaudeRecordConverter {
         data,
         builder,
         assistantUuidToToolCalls,
-        countedUsageKeys,
+        requestMessages,
         childSessionIdByToolUseId,
       );
     } else if (msgType === "user") {
@@ -91,13 +93,18 @@ export class ClaudeRecordConverter {
     data: Record<string, unknown>,
     builder: TranscriptBuilder,
     assistantUuidToToolCalls: Map<string, string[]>,
-    countedUsageKeys: Set<string>,
+    requestMessages: Map<string, Message>,
     childSessionIdByToolUseId: ReadonlyMap<string, string>,
   ): void {
     const msg = asRecord(data["message"]) ?? {};
     const timestampMs = parseClaudeTimestampMs(data);
+    const model = asString(msg["model"])?.trim();
     const rawContent = asArray(msg["content"]) ?? [];
     const uuid = String(data["uuid"] ?? "");
+    const usage = extractClaudeUsage(data, msg);
+    let usageMessage = usage ? requestMessages.get(usage.key) : undefined;
+    // A distinct request must not inherit another request's model or usage.
+    if (usage && !usageMessage) builder.beginTurn();
 
     const toolCallIds: string[] = [];
     for (const item of rawContent) {
@@ -110,10 +117,10 @@ export class ClaudeRecordConverter {
         if (text) {
           const message = builder.appendAssistantPart(
             this.buildReasoningPart(text, timestampMs),
-            { id: uuid, timestampMs, agent: "claude" },
+            { id: uuid, timestampMs, agent: "claude", model },
             { deduplicateTail: true },
           );
-          this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
+          usageMessage ??= message;
         }
         continue;
       }
@@ -127,10 +134,11 @@ export class ClaudeRecordConverter {
               id: uuid,
               timestampMs,
               agent: "claude",
+              model,
             },
             { deduplicateTail: true },
           );
-          this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
+          usageMessage ??= message;
         }
         continue;
       }
@@ -143,11 +151,11 @@ export class ClaudeRecordConverter {
       const toolPart = this.buildToolPart(part, timestampMs);
       const message = builder.appendToolCall(
         toolPart,
-        { id: uuid, timestampMs, agent: "claude", subagentId },
+        { id: uuid, timestampMs, agent: "claude", subagentId, model },
         { modeOnCreate: "tool" },
       );
       if (subagentId) message.subagent_id = subagentId;
-      this.applyAssistantMetadata(message, data, msg, countedUsageKeys);
+      usageMessage ??= message;
       if (toolCallId) {
         toolCallIds.push(toolCallId);
       }
@@ -155,6 +163,26 @@ export class ClaudeRecordConverter {
 
     if (toolCallIds.length > 0) {
       assistantUuidToToolCalls.set(uuid, toolCallIds);
+    }
+    if (usage) {
+      usageMessage ??= builder.appendMessage({
+        id: uuid,
+        role: "assistant",
+        timestampMs,
+        agent: "claude",
+        model,
+      });
+      requestMessages.set(usage.key, usageMessage);
+      usageMessage.model = usage.model;
+      usageMessage.tokens = {
+        input: usage.input + usage.cacheCreate + usage.cacheRead,
+        output: usage.output,
+        cache_read: usage.cacheRead,
+        cache_create: usage.cacheCreate,
+      };
+      usageMessage.time_completed = timestampMs;
+      usageMessage.cost = estimateTokenCost(usage.model, usageMessage.tokens) ?? 0;
+      usageMessage.cost_source = usageMessage.cost > 0 ? "estimated" : undefined;
     }
   }
 
@@ -252,33 +280,6 @@ export class ClaudeRecordConverter {
       },
       time_created: timestampMs,
     };
-  }
-
-  private applyAssistantMetadata(
-    message: Message,
-    data: Record<string, unknown>,
-    msg: Record<string, unknown>,
-    countedUsageKeys: Set<string>,
-  ): void {
-    const model = msg["model"];
-    if (model && typeof model === "string" && !message.model) {
-      message.model = model;
-    }
-    const usage = extractClaudeUsage(data, msg);
-    if (usage && !message.tokens && !countedUsageKeys.has(usage.key)) {
-      countedUsageKeys.add(usage.key);
-      message.tokens = {
-        input: usage.input + usage.cacheCreate + usage.cacheRead,
-        output: usage.output,
-        cache_read: usage.cacheRead,
-        cache_create: usage.cacheCreate,
-      };
-      const cost = estimateTokenCost(message.model, message.tokens);
-      if (cost !== null) {
-        message.cost = cost;
-        message.cost_source = "estimated";
-      }
-    }
   }
 
   // --- User content normalization ---

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -3,7 +3,7 @@ import { join, basename, dirname } from "node:path";
 import { getAgentCatalogEntry } from "../contract/agent-catalog.js";
 import { SingleFileSessionSource, filteredSession, parsedSession, skippedSession } from "./base.js";
 import type { ParseSessionResult } from "./base.js";
-import type { SessionHead, SessionDetail } from "../types/index.js";
+import type { Message, SessionHead, SessionDetail } from "../types/index.js";
 import { firstExisting, resolveHomePath } from "../discovery/paths.js";
 import { readJsonlFile, readJsonlFileLines } from "../utils/jsonl.js";
 import { basenameTitle, normalizeTitleText, resolveSessionTitle } from "../utils/title-fallback.js";
@@ -22,11 +22,12 @@ import {
   ClaudeRecordConverter,
   extractClaudeUsage,
   parseClaudeTimestampMs,
+  type ClaudeUsage,
 } from "./claudecode-record-converter.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
 
-// v7: unified timestamp parsing changes head times for numeric timestamps.
-const HEAD_INDEX_VERSION = "claudecode-head-v7";
+// v8: request usage uses the final snapshot, shared by heads and message costs.
+const HEAD_INDEX_VERSION = "claudecode-head-v8";
 
 export function resolveClaudeCodeDataRoot(): string {
   return resolveHomePath("CLAUDE_CONFIG_DIR", ".claude");
@@ -241,14 +242,14 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     this.ensureChildIndex();
     const builder = new TranscriptBuilder();
     const assistantUuidToToolCalls = new Map<string, string[]>();
-    const countedUsageKeys = new Set<string>();
+    const requestMessages = new Map<string, Message>();
     for (const record of readJsonlFile(meta.sourcePath)) {
       try {
         CLAUDE_RECORD_CONVERTER.convertRecord(
           record,
           builder,
           assistantUuidToToolCalls,
-          countedUsageKeys,
+          requestMessages,
           this.childSessionIdByToolUseId,
         );
       } catch {
@@ -524,7 +525,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     let totalCacheCreateTokens = 0;
     let totalCost = 0;
     const modelUsageMap: Record<string, number> = {};
-    const countedUsageKeys = new Set<string>();
+    const usageByRequest = new Map<string, ClaudeUsage>();
     let messageTitle: string | null = null;
 
     for (const line of readJsonlFileLines(filePath)) {
@@ -580,32 +581,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
           }
           if (role === "assistant") {
             const usage = extractClaudeUsage(data, msg);
-            if (usage && !countedUsageKeys.has(usage.key)) {
-              countedUsageKeys.add(usage.key);
-              const inputTokens = usage.input;
-              const cacheRead = usage.cacheRead;
-              const cacheCreate = usage.cacheCreate;
-              const outputTokens = usage.output;
-
-              totalInputTokens += inputTokens + cacheRead + cacheCreate;
-              totalOutputTokens += outputTokens;
-              totalCacheReadTokens += cacheRead;
-              totalCacheCreateTokens += cacheCreate;
-
-              const m = asString(msg["model"]);
-              if (m?.trim()) {
-                const name = m.trim();
-                const msgTotal = inputTokens + cacheRead + cacheCreate + outputTokens;
-                modelUsageMap[name] = (modelUsageMap[name] ?? 0) + msgTotal;
-                const cost = estimateTokenCost(name, {
-                  input: inputTokens + cacheRead + cacheCreate,
-                  output: outputTokens,
-                  cache_read: cacheRead,
-                  cache_create: cacheCreate,
-                });
-                if (cost !== null) totalCost += cost;
-              }
-            }
+            if (usage) usageByRequest.set(usage.key, usage);
           }
         }
       } catch {
@@ -614,6 +590,23 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     }
 
     if (lineIndex === 0) return skippedSession("empty file");
+
+    for (const usage of usageByRequest.values()) {
+      const input = usage.input + usage.cacheRead + usage.cacheCreate;
+      totalInputTokens += input;
+      totalOutputTokens += usage.output;
+      totalCacheReadTokens += usage.cacheRead;
+      totalCacheCreateTokens += usage.cacheCreate;
+      if (!usage.model) continue;
+      modelUsageMap[usage.model] = (modelUsageMap[usage.model] ?? 0) + input + usage.output;
+      totalCost +=
+        estimateTokenCost(usage.model, {
+          input,
+          output: usage.output,
+          cache_read: usage.cacheRead,
+          cache_create: usage.cacheCreate,
+        }) ?? 0;
+    }
 
     const directory = cwd ?? projectDir;
     const directoryTitle = basenameTitle(directory) || basenameTitle(projectDir);

--- a/packages/core/src/discovery/cache/__tests__/cost-facts.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/cost-facts.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,6 +16,7 @@ import { syncSessionSearchIndex } from "../search.js";
 import { saveCachedSessions } from "../sessions.js";
 import { makeSessionHead, TEST_NOW } from "./fixtures.js";
 import type { Message } from "../../../types/index.js";
+import { buildDashboard } from "../../../analytics/dashboard.js";
 
 function cacheDir(): string {
   return join(testHomeDir, ".cache", "codesesh");
@@ -32,6 +33,86 @@ afterEach(() => {
 });
 
 describe("listDashboardCostFacts", () => {
+  it("reconciles seven-day Claude model costs from final parent and child request usage", async () => {
+    const { ClaudeCodeAgent } = await import("../../../agents/claudecode.js");
+    const sourceRoot = join(cacheDir(), "claude");
+    const projectDir = join(sourceRoot, "project");
+    const childDir = join(projectDir, "parent", "subagents");
+    mkdirSync(childDir, { recursive: true });
+    const record = (
+      requestId: string,
+      model: string,
+      timestamp: string,
+      output: number,
+      content: unknown[],
+    ) => ({
+      type: "assistant",
+      uuid: `${requestId}-${output}`,
+      requestId,
+      timestamp,
+      message: {
+        role: "assistant",
+        model,
+        usage: { input_tokens: 100, output_tokens: output },
+        content,
+      },
+    });
+    const sonnet = "claude-sonnet-4-5";
+    const opus = "claude-opus-4-6";
+    writeFileSync(
+      join(projectDir, "parent.jsonl"),
+      [
+        record("outside", sonnet, "2026-04-18T12:00:00Z", 20, [
+          { type: "text", text: "Earlier request" },
+        ]),
+        record("streamed", opus, "2026-04-19T23:59:59Z", 3, [{ type: "thinking", thinking: "" }]),
+        record("streamed", opus, "2026-04-20T00:00:01Z", 40, [
+          { type: "text", text: "Final response" },
+        ]),
+      ]
+        .map((value) => JSON.stringify(value))
+        .join("\n"),
+    );
+    writeFileSync(
+      join(childDir, "agent-child.jsonl"),
+      JSON.stringify(
+        record("child", sonnet, "2026-04-21T12:00:00Z", 20, [{ type: "thinking", thinking: "" }]),
+      ),
+    );
+    const agent = new ClaudeCodeAgent({ sourceRoot });
+    const sessions = agent.scan().map((head) => makeSessionHead(head.reference.sessionId, head));
+    expect(sessions).toHaveLength(2);
+    saveCachedSessions("claudecode", sessions);
+    syncSessionSearchIndex("claudecode", sessions, (id) => agent.getSessionData(id));
+    const from = Date.parse("2026-04-20T00:00:00Z");
+    const to = Date.parse("2026-04-26T23:59:59Z");
+    const facts = listDashboardCostFacts({ from, to });
+    const dashboard = buildDashboard(sessions, {
+      byAgentNames: ["claudecode"],
+      scope: {},
+      from,
+      to,
+      costFacts: facts,
+    });
+
+    for (const head of sessions) {
+      expect(
+        facts?.sessions.find((summary) => summary.reference.sessionId === head.reference.sessionId)
+          ?.messageCost,
+      ).toBeCloseTo(head.stats.total_cost, 10);
+    }
+    expect(dashboard.totals.cost).toBeCloseTo(0.0021, 10);
+    expect(dashboard.perAgent[0]?.cost).toBeCloseTo(dashboard.totals.cost, 10);
+    expect(dashboard.modelCost).toEqual([
+      { model: opus, cost: 0.0015, costRecorded: 0, costEstimated: 0.0015 },
+      { model: sonnet, cost: 0.0006, costRecorded: 0, costEstimated: 0.0006 },
+    ]);
+    expect(dashboard.modelCost!.reduce((sum, model) => sum + model.cost, 0)).toBeCloseTo(
+      dashboard.totals.cost,
+      10,
+    );
+  });
+
   it("returns timed messages while retaining all-session reconciliation totals", () => {
     const session = makeSessionHead("costed", {
       stats: {

--- a/packages/core/src/utils/__tests__/session-normalization.test.ts
+++ b/packages/core/src/utils/__tests__/session-normalization.test.ts
@@ -3,6 +3,19 @@ import { cleanParsedMessages, firstUserMessageTitle } from "../session-normaliza
 import type { Message } from "../../types/index.js";
 
 describe("session normalization", () => {
+  it("retains usage facts when the provider omits visible content", () => {
+    const message: Message = {
+      id: "usage",
+      role: "assistant",
+      time_created: 1,
+      tokens: { input: 100, output: 20 },
+      parts: [{ type: "reasoning", text: "" }],
+    };
+    expect(cleanParsedMessages([message])).toEqual([{ ...message, parts: [] }]);
+    expect(cleanParsedMessages([{ ...message, tokens: undefined, cost: 0.01 }])).toHaveLength(1);
+    expect(cleanParsedMessages([{ ...message, tokens: { input: 0, output: 0 } }])).toEqual([]);
+  });
+
   it("removes internal-only parts and deeply cleans tool payloads", () => {
     const messages: Message[] = [
       {

--- a/packages/core/src/utils/session-normalization.ts
+++ b/packages/core/src/utils/session-normalization.ts
@@ -57,7 +57,9 @@ export function cleanMessageParts(parts: MessagePart[]): MessagePart[] {
 
 export function cleanParsedMessage(message: Message): Message | null {
   const parts = cleanMessageParts(message.parts);
-  if (parts.length === 0) return null;
+  const hasUsage =
+    (message.cost ?? 0) > 0 || Object.values(message.tokens ?? {}).some((value) => value > 0);
+  if (parts.length === 0 && !hasUsage) return null;
   return { ...message, parts };
 }
 


### PR DESCRIPTION
## Summary

- Use the final cumulative usage snapshot once per Claude request for both session heads and message costs.
- Keep separate requests attributed to their own models, including requests with no visible content.
- Refresh existing Claude head and detail caches through the parser fingerprint version.

## Root cause

Claude streaming fragments can repeat a request ID with increasing output-token counts. Session heads previously retained the first fragment, while message costs retained the first visible fragment. When these totals disagreed, dashboard attribution fell back to the full session cost and could discard its model breakdown, hiding known Claude costs in Other and including costs outside the selected date window. Empty reasoning-only responses also lost their usage during content cleanup.

## Validation

- Reproduced the discrepancy with temporary diagnostic logging against a read-only local cache; re-parsed 630 Claude sessions with zero head/message cost mismatches after the fix.
- Added regressions for cumulative fragments, repeated snapshots, consecutive requests and model changes, content-free usage, cache invalidation, and a seven-day parent/subagent dashboard through SQLite.
- Passed lint, formatting, typecheck, build, unit tests, coverage gates, migration tests, repository-fact checks, algorithmic growth checks, bundle-budget checks, and all 32 end-to-end tests (rerun after isolating a concurrent local rebuild).
- No private transcripts or diagnostic files are included in this PR.