### PR TITLE
fix: Preserve pricing snapshot identity

### DIFF
--- a/packages/core/src/pricing/__tests__/refresh-generation.test.ts
+++ b/packages/core/src/pricing/__tests__/refresh-generation.test.ts
@@ -108,6 +108,61 @@ describe("CS-148: pricing generations", () => {
     expect(workerPricing.getPricingGeneration()).toEqual(publishedGeneration);
   });
 
+  it.each([
+    [
+      "zero input or output prices",
+      {
+        "input-only": { input_cost_per_token: 0.000001, output_cost_per_token: 0 },
+        "output-only": { input_cost_per_token: 0, output_cost_per_token: 0.000002 },
+        free: { input_cost_per_token: 0, output_cost_per_token: 0 },
+      },
+    ],
+    [
+      "nested provider prefixes",
+      {
+        "provider/vendor/chat-model": {
+          input_cost_per_token: 0.000001,
+          output_cost_per_token: 0.000002,
+        },
+      },
+    ],
+    [
+      "invalid optional prices",
+      {
+        "fallback-prices": {
+          input_cost_per_token: 0.000001,
+          output_cost_per_token: 0.000002,
+          cache_creation_input_token_cost: Infinity,
+          cache_read_input_token_cost: NaN,
+          output_reasoning_cost_per_token: -1,
+          web_search_cost_per_request: Infinity,
+        },
+      },
+    ],
+  ])("preserves the complete published generation with %s", async (_name, data) => {
+    vi.resetModules();
+    const parentPricing = await import("../fetcher.js");
+    vi.resetModules();
+    const existingWorkerPricing = await import("../fetcher.js");
+    stubFetch(async () => ({ ok: true, json: async () => data }));
+
+    expect(await parentPricing.refreshPricingCache()).toBe(true);
+    expect(parentPricing.publishPendingPricing()).toBe(true);
+    const publishedGeneration = parentPricing.getPricingGeneration();
+    for (const [name, entry] of Object.entries(data)) {
+      expect(publishedGeneration.pricing.get(name)).toMatchObject({
+        inputCostPerToken: entry.input_cost_per_token,
+        outputCostPerToken: entry.output_cost_per_token,
+      });
+    }
+    existingWorkerPricing.synchronizePricingGeneration(publishedGeneration.id);
+    expect(existingWorkerPricing.getPricingGeneration()).toEqual(publishedGeneration);
+
+    vi.resetModules();
+    const newWorkerPricing = await import("../fetcher.js");
+    expect(newWorkerPricing.getPricingGeneration()).toEqual(publishedGeneration);
+  });
+
   it("does not change live prices until the refresh is published", async () => {
     const before = estimateTokenCost(MODEL, MILLION_INPUT);
     const generationBefore = getPricingGeneration().id;

--- a/packages/core/src/pricing/fetcher.ts
+++ b/packages/core/src/pricing/fetcher.ts
@@ -70,8 +70,8 @@ function createPricingGeneration(pricing: Map<string, ModelPricing>): PricingGen
   };
 }
 
-function costNumber(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+function costNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 function getCacheDir() {
@@ -100,35 +100,29 @@ function loadSnapshot(): Map<string, ModelPricing> {
 }
 
 function parseLiteLLMEntry(entry: LiteLLMEntry): ModelPricing | null {
-  const input = entry.input_cost_per_token;
-  const output = entry.output_cost_per_token;
-  if (typeof input !== "number" || typeof output !== "number") return null;
-
-  return {
-    inputCostPerToken: input,
-    outputCostPerToken: output,
-    cacheCreateCostPerToken: entry.cache_creation_input_token_cost ?? input * 1.25,
-    cacheReadCostPerToken: entry.cache_read_input_token_cost ?? input * 0.1,
-    reasoningCostPerToken: entry.output_reasoning_cost_per_token ?? output,
-    webSearchCostPerRequest: costNumber(
+  return normalizePricing({
+    inputCostPerToken: entry.input_cost_per_token,
+    outputCostPerToken: entry.output_cost_per_token,
+    cacheCreateCostPerToken: entry.cache_creation_input_token_cost,
+    cacheReadCostPerToken: entry.cache_read_input_token_cost,
+    reasoningCostPerToken: entry.output_reasoning_cost_per_token,
+    webSearchCostPerRequest:
       entry.web_search_cost_per_request ?? entry.search_context_cost_per_query,
-      WEB_SEARCH_COST,
-    ),
-  };
+  });
 }
 
-function normalizeCachedPricing(raw: Record<string, unknown>): ModelPricing | null {
-  const input = costNumber(raw["inputCostPerToken"], 0);
-  const output = costNumber(raw["outputCostPerToken"], 0);
-  if (input <= 0 || output <= 0) return null;
+function normalizePricing(raw: Record<string, unknown>): ModelPricing | null {
+  const input = costNumber(raw["inputCostPerToken"]);
+  const output = costNumber(raw["outputCostPerToken"]);
+  if (input === undefined || output === undefined) return null;
 
   return {
     inputCostPerToken: input,
     outputCostPerToken: output,
-    cacheCreateCostPerToken: costNumber(raw["cacheCreateCostPerToken"], input * 1.25),
-    cacheReadCostPerToken: costNumber(raw["cacheReadCostPerToken"], input * 0.1),
-    reasoningCostPerToken: costNumber(raw["reasoningCostPerToken"], output),
-    webSearchCostPerRequest: costNumber(raw["webSearchCostPerRequest"], WEB_SEARCH_COST),
+    cacheCreateCostPerToken: costNumber(raw["cacheCreateCostPerToken"]) ?? input * 1.25,
+    cacheReadCostPerToken: costNumber(raw["cacheReadCostPerToken"]) ?? input * 0.1,
+    reasoningCostPerToken: costNumber(raw["reasoningCostPerToken"]) ?? output,
+    webSearchCostPerRequest: costNumber(raw["webSearchCostPerRequest"]) ?? WEB_SEARCH_COST,
   };
 }
 
@@ -170,9 +164,9 @@ function readDiskCache(): PricingGeneration | null {
 
     const next = loadSnapshot();
     for (const [name, rawPricing] of Object.entries(cached.data)) {
-      const pricing = normalizeCachedPricing(rawPricing);
+      const pricing = normalizePricing(rawPricing);
       if (!pricing) continue;
-      indexPricing(next, name, pricing);
+      next.set(normalizeModelKey(name), pricing);
     }
     return createPricingGeneration(next);
   } catch {


### PR DESCRIPTION
Published pricing generations could change when workers loaded the disk cache: zero-priced entries were dropped and provider aliases were expanded again. Workers then rejected the parent generation and could not complete scans, indexing, or uncached detail requests.

This change applies one price normalization policy to remote and cached data, and restores the cached registry without rebuilding aliases. The cache format remains unchanged.

Validation:
- Added round-trip regressions for zero prices, nested provider names, and invalid optional prices, covering existing and newly started workers.
- Passed `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm test`.
- Passed formatting and repository quality, documentation, and version checks.
