### PR TITLE
fix: Preserve instance query scope

### DIFF
--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -180,6 +180,7 @@ export class AgentSyncEngine {
     this.indexPublisher = new SearchIndexPublisher({
       jobs: this.searchIndexJobs,
       snapshot: () => this.sessionIndex.snapshot(),
+      agentSessions: (agentName) => this.sessionIndex.agentSessions(agentName),
       readCachedSessions: (agentName) => this.readCachedSessionsOrWarn("search.index", agentName),
     });
     this.sessionPublication = new SessionPublicationCoordinator(
@@ -409,7 +410,7 @@ export class AgentSyncEngine {
       appLogger.warn("scan.refresh.missing_agent", { agent: agentName });
       return { result: "skipped", completion: { completeness: "complete" } };
     }
-    const previousSessions = this.sessionIndex.snapshot().byAgent[agentName] ?? [];
+    const previousSessions = this.sessionIndex.agentSessions(agentName);
     const refreshBaseline = cached?.sessions ?? previousSessions;
     const cacheTimestamp = cached?.timestamp ?? this.lastRefreshAtByAgent.get(agentName) ?? 0;
     if (cached) agent.restoreSessionCacheMeta(cached.meta);
@@ -596,7 +597,7 @@ export class AgentSyncEngine {
    * empty database.
    */
   private refreshUnavailableAgent(agentName: string): RefreshStrategyResult {
-    const previousSessions = this.sessionIndex.snapshot().byAgent[agentName] ?? [];
+    const previousSessions = this.sessionIndex.agentSessions(agentName);
     if (previousSessions.length > 0) {
       appLogger.warn("scan.refresh.agent_unavailable", {
         agent: agentName,
@@ -945,9 +946,8 @@ export class AgentSyncEngine {
     const startedAt = performance.now();
     const agent = this.findAgent(agentName);
     if (!agent || !agent.isAvailable()) return "skipped";
-    const snapshot = this.sessionIndex.snapshot();
     const cached = this.readCachedSessionsOrWarn("scan.backfill", agentName);
-    const baseline = cached?.sessions ?? snapshot.byAgent[agentName] ?? [];
+    const baseline = cached?.sessions ?? this.sessionIndex.agentSessions(agentName);
     const meta = cached?.meta ?? buildAgentCacheMeta(agent);
     const backfillCursor = getAgentFullSyncCursor(agentName);
     if (cached) agent.restoreSessionCacheMeta(cached.meta);

--- a/packages/cli/src/api/__tests__/query-boundary-handlers.test.ts
+++ b/packages/cli/src/api/__tests__/query-boundary-handlers.test.ts
@@ -23,7 +23,10 @@ describe("query boundary handlers", () => {
     { endpoint: "projects", invoke: (context) => handleGetProjects(context as never, scanSource) },
     { endpoint: "sessions", invoke: (context) => handleGetSessions(context as never, scanSource) },
     { endpoint: "search", invoke: (context) => handleSearchSessions(context as never, scanSource) },
-    { endpoint: "file-activity", invoke: (context) => handleGetFileActivity(context as never) },
+    {
+      endpoint: "file-activity",
+      invoke: (context) => handleGetFileActivity(context as never, scanSource),
+    },
     {
       endpoint: "dashboard",
       invoke: (context) => handleGetDashboard(context as never, scanSource),
@@ -54,7 +57,7 @@ describe("query boundary handlers", () => {
     const sessions = makeContext({ query: { agent: "nonexistent" } });
     handleGetSessions(sessions as never, scanSource);
     const files = makeContext({ query: { limit: "1.5" } });
-    handleGetFileActivity(files as never);
+    handleGetFileActivity(files as never, scanSource);
 
     expect(loggerMocks.warn).toHaveBeenCalledWith("api.query_parameter.invalid", {
       endpoint: "sessions",
@@ -79,7 +82,7 @@ describe("query boundary handlers", () => {
     );
 
     const files = makeContext({ query: { projectKind: "invalid", projectKey: "/repo" } });
-    handleGetFileActivity(files as never);
+    handleGetFileActivity(files as never, scanSource);
     expect(files.json).toHaveBeenCalledWith(
       { error: "projectKind and projectKey must form a valid project identity" },
       400,
@@ -111,24 +114,27 @@ describe("query boundary handlers", () => {
     });
 
     const resolver = makeProjectIdentityResolver();
-    await handleGetFileActivity(c as never, {}, resolver);
+    await handleGetFileActivity(c as never, scanSource, {}, resolver);
 
-    expect(coreMocks.listFileActivity).toHaveBeenCalledWith({
-      agent: "codex",
-      sessionId: "s1",
-      projectKind: "path",
-      projectKey: "/repo",
-      project: "repo",
-      projectScope: {
-        identity: { kind: "path", key: "/repo" },
-        path: "/repo",
+    expect(coreMocks.listFileActivity).toHaveBeenCalledWith(
+      {
+        agent: "codex",
+        sessionId: "s1",
+        projectKind: "path",
+        projectKey: "/repo",
+        project: "repo",
+        projectScope: {
+          identity: { kind: "path", key: "/repo" },
+          path: "/repo",
+        },
+        path: "src/index.ts",
+        kind: "edit",
+        from: new Date("2026-01-01T00:00:00.000Z").getTime(),
+        to: new Date("2026-01-02T00:00:00.000Z").getTime(),
+        limit: 200,
       },
-      path: "src/index.ts",
-      kind: "edit",
-      from: new Date("2026-01-01T00:00:00.000Z").getTime(),
-      to: new Date("2026-01-02T00:00:00.000Z").getTime(),
-      limit: 200,
-    });
+      undefined,
+    );
     expect(resolver.resolve).toHaveBeenCalledWith("/repo", expect.any(AbortSignal));
   });
 
@@ -137,7 +143,7 @@ describe("query boundary handlers", () => {
     (limit) => {
       const c = makeContext({ query: { kind: "execute", limit } });
 
-      handleGetFileActivity(c as never);
+      handleGetFileActivity(c as never, scanSource);
 
       expect(c.json).toHaveBeenCalledWith({ error: "limit must be a positive integer" }, 400);
       expect(coreMocks.listFileActivity).not.toHaveBeenCalled();
@@ -147,7 +153,7 @@ describe("query boundary handlers", () => {
   it("returns an empty file activity result for an unknown agent without querying storage", () => {
     const c = makeContext({ query: { agent: "nonexistent" } });
 
-    handleGetFileActivity(c as never);
+    handleGetFileActivity(c as never, scanSource);
 
     expect(c.json).toHaveBeenCalledWith({ activity: [] });
     expect(coreMocks.listFileActivity).not.toHaveBeenCalled();

--- a/packages/cli/src/api/__tests__/query-scope-integration.test.ts
+++ b/packages/cli/src/api/__tests__/query-scope-integration.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { IdentifiedSessionDetail, SessionReference } from "@codesesh/core/contract";
+import type { ScanResultSource } from "../scan-sources.js";
+
+const testHome = mkdtempSync(join(tmpdir(), "codesesh-query-scope-"));
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  homedir: () => testHome,
+}));
+
+vi.stubEnv("CODESESH_STATE_DIR", join(testHome, "state"));
+vi.stubEnv("CODESESH_LOG_DIR", join(testHome, "logs"));
+
+const { closeCacheStorage, syncSessionSearchIndex } =
+  await import("@codesesh/core/runtime/discovery");
+const { appLogger } = await import("../../logging.js");
+const { createApiRoutes } = await import("../routes.js");
+
+const directory = "/fixtures/scoped-project";
+const now = Date.now() - 60_000;
+
+function makeDetail(
+  agentName: string,
+  sessionId: string,
+  project: string,
+  time: number,
+): IdentifiedSessionDetail {
+  return {
+    reference: { agentName, sessionId },
+    title: "scopeneedle",
+    directory: project,
+    project_identity: { kind: "path", key: project, displayName: project },
+    time_created: time,
+    time_updated: time,
+    stats: { message_count: 1, total_input_tokens: 0, total_output_tokens: 0, total_cost: 0 },
+    messages: [
+      {
+        id: `${sessionId}-message`,
+        role: "assistant",
+        time_created: time,
+        parts: [
+          { type: "text", text: "scopeneedle" },
+          {
+            type: "tool",
+            tool: "Read",
+            state: { status: "completed", input: { file_path: "src/scoped.ts" } },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const visible = makeDetail("codex", "visible", directory, now);
+const otherProject = makeDetail("codex", "other-project", "/fixtures/other-project", now + 1_000);
+const otherAgent = makeDetail("claudecode", "other-agent", directory, now + 2_000);
+const source: ScanResultSource = {
+  queryScope: {
+    agents: ["codex"],
+    projectScope: { identity: { kind: "path", key: directory }, path: directory },
+  },
+  getSnapshot: () => ({ sessions: [], byAgent: { codex: [] }, agents: [] }),
+};
+
+const app = createApiRoutes(source);
+
+async function references(path: string, collection: string): Promise<SessionReference[]> {
+  const response = await app.request(path);
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as Record<string, Array<{ reference: SessionReference }>>;
+  return body[collection]!.map((item) => item.reference);
+}
+
+beforeAll(() => {
+  for (const [agent, details] of [
+    ["codex", [visible, otherProject]],
+    ["claudecode", [otherAgent]],
+  ] as const) {
+    syncSessionSearchIndex(agent, [...details], (sessionId) =>
+      details.find((detail) => detail.reference.sessionId === sessionId)!,
+    );
+  }
+});
+
+afterAll(async () => {
+  await appLogger.flush();
+  closeCacheStorage();
+  vi.unstubAllEnvs();
+  rmSync(testHome, { recursive: true, force: true });
+});
+
+describe("instance query scope across indexed API reads", () => {
+  it.each([
+    ["/search?days=0&q=scopeneedle&limit=1", "results"],
+    ["/file-activity?days=0&limit=1", "activity"],
+    ["/dashboard?days=0", "recentFileActivities"],
+  ])("limits %s before pagination even while the live snapshot is empty", async (path, field) => {
+    expect(await references(path, field)).toEqual([visible.reference]);
+  });
+
+  it.each([
+    ["/search?days=0&q=scopeneedle%20agent:claudecode", "results"],
+    ["/file-activity?days=0&agent=claudecode", "activity"],
+    [
+      "/dashboard?days=0&projectKind=path&projectKey=/fixtures/other-project",
+      "recentFileActivities",
+    ],
+  ])("does not let request filters widen the instance scope: %s", async (path, field) => {
+    expect(await references(path, field)).toEqual([]);
+  });
+});

--- a/packages/cli/src/api/__tests__/search-handlers.test.ts
+++ b/packages/cli/src/api/__tests__/search-handlers.test.ts
@@ -46,6 +46,7 @@ describe("handleSearchSessions", () => {
         projectKey: "github.com/acme/app",
       }),
       scanSource.getSnapshot(),
+      { queryScope: undefined },
     );
     expect(c.json).toHaveBeenCalledWith({ results: sentinelResults });
   });
@@ -67,6 +68,7 @@ describe("handleSearchSessions", () => {
         },
       }),
       scanSource.getSnapshot(),
+      { queryScope: undefined },
     );
   });
 
@@ -175,6 +177,7 @@ describe("handleSearchSessions", () => {
       "needle",
       expect.objectContaining({ limit: 100 }),
       expect.anything(),
+      { queryScope: undefined },
     );
   });
 
@@ -223,6 +226,7 @@ describe("handleSearchSessions", () => {
       "agent:claudecode custom cache",
       expect.anything(),
       expect.anything(),
+      { queryScope: undefined },
     );
     const results = c.json.mock.calls[0]![0].results;
     expect(results).toHaveLength(1);
@@ -249,6 +253,7 @@ describe("handleSearchSessions", () => {
       "old alias",
       expect.objectContaining({ limit: 50 }),
       expect.anything(),
+      { queryScope: undefined },
     );
     expect(c.json.mock.calls[0]![0].results[0].session.reference.sessionId).toBe("s1000");
   });
@@ -455,7 +460,7 @@ describe("handleGetFileActivity", () => {
     ]);
     const c = makeMockContext();
 
-    handleGetFileActivity(c);
+    handleGetFileActivity(c, makeScanSource());
 
     const responseSession = c.json.mock.calls[0]![0].activity[0].session;
     expect(responseSession.display_title).toBe("Activity alias");

--- a/packages/cli/src/api/routes.ts
+++ b/packages/cli/src/api/routes.ts
@@ -181,7 +181,7 @@ export function createApiRoutes(
     handleSearchSessions(c, scanSource, listDefaults, options.projectIdentityResolver),
   );
   api.get("/file-activity", (c) =>
-    handleGetFileActivity(c, listDefaults, options.projectIdentityResolver),
+    handleGetFileActivity(c, scanSource, listDefaults, options.projectIdentityResolver),
   );
   api.get("/sessions/:agent/:id", (c) =>
     handleGetSessionData(c, scanSource, options.loadSessionDetail),

--- a/packages/cli/src/api/scan-sources.ts
+++ b/packages/cli/src/api/scan-sources.ts
@@ -1,7 +1,8 @@
-import type { LiveSnapshot } from "@codesesh/core/runtime/discovery";
+import type { LiveSnapshot, SessionQueryScope } from "@codesesh/core/runtime/discovery";
 import type { ScanStatusEvent } from "@codesesh/core/contract";
 
 export interface ScanResultSource {
+  readonly queryScope?: SessionQueryScope;
   getSnapshot(): LiveSnapshot;
 }
 

--- a/packages/cli/src/api/search-handlers.ts
+++ b/packages/cli/src/api/search-handlers.ts
@@ -91,13 +91,18 @@ export async function handleSearchSessions(
   const getSessionTree = () =>
     (sessionTree ??= getSnapshotSessionTree(scanSource, scanResult.sessions));
   const effectiveSearchOptions = mergeSearchQueryOptions(query, resolvedSearchOptions).options;
-  const searchContext =
-    effectiveSearchOptions.costMin != null || effectiveSearchOptions.costMax != null
+  const searchContext = {
+    queryScope: scanSource.queryScope,
+    ...(effectiveSearchOptions.costMin != null || effectiveSearchOptions.costMax != null
       ? { sessionTree: getSessionTree() }
-      : undefined;
-  const searchResults = searchContext
-    ? executeSessionSearch(query, resolvedSearchOptions, scanResult, searchContext)
-    : executeSessionSearch(query, resolvedSearchOptions, scanResult);
+      : {}),
+  };
+  const searchResults = executeSessionSearch(
+    query,
+    resolvedSearchOptions,
+    scanResult,
+    searchContext,
+  );
   const results = searchResults.map((result) => ({
     ...result,
     session: aliases.decorate(result.session, result.reference),
@@ -123,6 +128,7 @@ export async function handleSearchSessions(
 
 export async function handleGetFileActivity(
   c: Context,
+  scanSource: ScanResultSource,
   defaults: SessionListDefaults = {},
   resolver?: ProjectIdentityResolver,
 ) {
@@ -161,18 +167,21 @@ export async function handleGetFileActivity(
 
   const aliases = loadAliasView();
   return c.json({
-    activity: listFileActivity({
-      agent: sessionQuery.agent.kind === "known" ? sessionQuery.agent.agentName : undefined,
-      sessionId: optionalQueryValue(c.req.query("sessionId")),
-      projectKind: projectIdentity?.kind,
-      projectKey: projectIdentity?.key,
-      project: optionalQueryValue(c.req.query("project")),
-      projectScope,
-      path: optionalQueryValue(c.req.query("path")),
-      kind: parseFileActivityKind(optionalQueryValue(c.req.query("kind"))),
-      from: window.from,
-      to: window.to,
-      limit: sessionQuery.limit.value,
-    }).map((activity) => toPublicReferencedSessionHead(decorateFileActivity(activity, aliases))),
+    activity: listFileActivity(
+      {
+        agent: sessionQuery.agent.kind === "known" ? sessionQuery.agent.agentName : undefined,
+        sessionId: optionalQueryValue(c.req.query("sessionId")),
+        projectKind: projectIdentity?.kind,
+        projectKey: projectIdentity?.key,
+        project: optionalQueryValue(c.req.query("project")),
+        projectScope,
+        path: optionalQueryValue(c.req.query("path")),
+        kind: parseFileActivityKind(optionalQueryValue(c.req.query("kind"))),
+        from: window.from,
+        to: window.to,
+        limit: sessionQuery.limit.value,
+      },
+      scanSource.queryScope,
+    ).map((activity) => toPublicReferencedSessionHead(decorateFileActivity(activity, aliases))),
   });
 }

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -153,5 +153,6 @@ export function findAliasSearchResults(
   return filterSessionSearchCandidates(results, search.options, {
     sessionSnapshot: scanResult.sessions,
     sessionTree: context.sessionTree,
+    queryScope: context.queryScope,
   }).sort((a, b) => getSessionActivityTime(b.session) - getSessionActivityTime(a.session));
 }

--- a/packages/cli/src/api/snapshot-aggregation.ts
+++ b/packages/cli/src/api/snapshot-aggregation.ts
@@ -105,14 +105,17 @@ export function getDashboardStorageAggregation(
   analyticsRevision: string | null,
 ): DashboardStorageAggregation {
   const build = (): DashboardStorageAggregation => ({
-    recentFileActivities: listFileActivity({
-      agent: scope.agent,
-      projectKind: scope.projectKind,
-      projectKey: scope.projectKey,
-      from,
-      to,
-      limit: 12,
-    }),
+    recentFileActivities: listFileActivity(
+      {
+        agent: scope.agent,
+        projectKind: scope.projectKind,
+        projectKey: scope.projectKey,
+        from,
+        to,
+        limit: 12,
+      },
+      source.queryScope,
+    ),
   });
   const startedAt = performance.now();
   const log = (cache: SnapshotAggregationCacheState | "unavailable") => {

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -364,7 +364,7 @@ vi.mock("node:worker_threads", async (importOriginal) => ({
 import { LiveScanStore, type SessionsUpdatedEvent } from "./live-scan.js";
 import { appLogger } from "./logging.js";
 import { SearchIndexJobRunner } from "./search-index-job-runner.js";
-import { ThreadWorkerRunner } from "./worker-runner.js";
+import { ThreadWorkerRunner, type WorkerRunner } from "./worker-runner.js";
 
 let restoreRuntime: (() => void) | null = null;
 
@@ -579,6 +579,55 @@ describe("LiveScanStore", () => {
     restoreRuntime = null;
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("preserves a project scope through refresh and backfill without narrowing uncached index inputs", async () => {
+    const inside = makeSession("inside");
+    const outside = makeSession("outside", {
+      directory: `${FIXTURE_DIR}-outside`,
+      project_identity: { kind: "path", key: `${FIXTURE_DIR}-outside`, displayName: "outside" },
+    });
+    const sessions = [inside, outside];
+    const codex = makeAgent("codex");
+    core.createRegisteredAgents.mockReturnValue([codex]);
+    core.scanSessions.mockResolvedValue({
+      agents: [codex],
+      byAgent: { codex: sessions },
+      sessions,
+    });
+    core.isAgentCacheInitialized.mockReturnValue(false);
+    core.getAgentLastFullSyncAt.mockReturnValue(0);
+    const run = vi.fn<WorkerRunner["run"]>(async () => ({
+      result: { sessions, meta: {}, completeness: "complete", explicitRemovedSessionIds: [] },
+      commit: () => {},
+      discard: () => {},
+    }));
+    const store = new LiveScanStore({
+      watchEnabled: false,
+      scanOptions: { cwd: FIXTURE_DIR, writeCache: false },
+      startupScanOptions: { from: 1 },
+      workerRunner: { activeCount: 0, run, reset: () => {}, shutdown: async () => {} },
+    });
+
+    await store.initialize();
+    expect(core.scanSessions.mock.calls[0]![0]).not.toHaveProperty("cwd");
+    expect(core.scanSessions.mock.calls[0]![0].writeCache).toBe(false);
+    expect(store.getSnapshot().sessions).toEqual([inside]);
+    expect(workerThreads.workers[0]?.workerData.jobs[0].sessions).toEqual(sessions);
+
+    store.startBackgroundRefresh();
+    await vi.waitFor(() =>
+      expect(store.getScanStatus().backfill.completedAgents).toEqual(["codex"]),
+    );
+
+    expect(run.mock.calls.map(([, payload]) => payload.operation.kind)).toEqual([
+      "full-scan",
+      "backfill",
+    ]);
+    for (const [, payload] of run.mock.calls) expect(payload.previousSessions).toEqual(sessions);
+    expect(store.getSnapshot().sessions).toEqual([inside]);
+    expect(store.getSnapshot().sessions).toBe(store.getSnapshot().sessions);
+    await store.shutdown();
   });
 
   it("initializes a sorted snapshot for allowed registered agents", async () => {

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -5,8 +5,10 @@ import {
   scanSessions,
   type LiveSnapshot,
   type ScanOptions,
+  type SessionQueryScope,
 } from "@codesesh/core/runtime/discovery";
 import { createRegisteredAgents } from "@codesesh/core/runtime/agents";
+import { createProjectScopeMatcher } from "@codesesh/core/runtime/projects";
 import type {
   AgentScanStatus,
   BackfillStatus,
@@ -42,6 +44,7 @@ export interface LiveScanStoreOptions {
 const NEW_SESSION_EVENT_WINDOW_MS = 250;
 
 export class LiveScanStore {
+  readonly queryScope: SessionQueryScope;
   private readonly watchEnabled: boolean;
   private readonly scanOptions: ScanOptions;
   private readonly startupScanOptions: Pick<ScanOptions, "from" | "to">;
@@ -57,6 +60,14 @@ export class LiveScanStore {
   constructor(options: LiveScanStoreOptions = {}) {
     this.watchEnabled = options.watchEnabled ?? true;
     this.scanOptions = options.scanOptions ?? {};
+    this.queryScope = {
+      ...(this.scanOptions.agents?.length
+        ? { agents: this.scanOptions.agents.map((agent) => agent.toLowerCase()) }
+        : {}),
+      ...(this.scanOptions.cwd
+        ? { projectScope: createProjectScopeMatcher(this.scanOptions.cwd) }
+        : {}),
+    };
     this.startupScanOptions = options.startupScanOptions ?? {};
     this.deferInitialRefresh = options.deferInitialRefresh === true;
     const workerRunner =
@@ -81,8 +92,9 @@ export class LiveScanStore {
       startup_to: this.startupScanOptions.to,
       deferred: this.deferInitialRefresh || undefined,
     });
+    const { cwd: _cwd, ...scanOptions } = this.scanOptions;
     const initialResult = await scanSessions({
-      ...this.scanOptions,
+      ...scanOptions,
       useCache: this.scanOptions.useCache ?? true,
       cacheOnly: this.deferInitialRefresh,
       writeCache: this.deferInitialRefresh ? false : this.scanOptions.writeCache,
@@ -92,7 +104,7 @@ export class LiveScanStore {
     this.syncEngine.initialize(initialResult, {
       cacheTimestamps: initialResult.cacheTimestamps,
       registeredAgents: createRegisteredAgents(),
-      allowedAgents: this.getAllowedAgents(),
+      queryScope: this.queryScope,
     });
     const snapshot = this.getSnapshot();
     const indexStartedAt = performance.now();
@@ -226,10 +238,5 @@ export class LiveScanStore {
     const workerUrl = new URL("./smart-tag-worker.js", import.meta.url);
     if (workerUrl.protocol === "file:" && !existsSync(fileURLToPath(workerUrl))) return null;
     return workerUrl;
-  }
-
-  private getAllowedAgents(): Set<string> | null {
-    if (!this.scanOptions.agents?.length) return null;
-    return new Set(this.scanOptions.agents.map((agent) => agent.toLowerCase()));
   }
 }

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -133,7 +133,7 @@ describe("LiveSessionIndex", () => {
 
     index.initialize(snapshot([codex], { codex: [older, newer] }), {
       registeredAgents: [codex, kimi, cursor],
-      allowedAgents: new Set(["codex", "kimi"]),
+      queryScope: { agents: ["codex", "kimi"] },
     });
 
     expect(index.snapshot()).toEqual({
@@ -186,6 +186,48 @@ describe("LiveSessionIndex", () => {
       ],
       removedSessionRefs: [],
     });
+  });
+
+  it("keeps the complete baseline while publishing sessions that enter or leave the project scope", () => {
+    const codex = makeAgent("codex");
+    const inside = {
+      ...makeSession("moving", 1),
+      directory: "/projects/inside",
+      project_identity: { kind: "path" as const, key: "/projects/inside", displayName: "inside" },
+    };
+    const outside = {
+      ...inside,
+      directory: "/projects/outside",
+      project_identity: { kind: "path" as const, key: "/projects/outside", displayName: "outside" },
+    };
+    const index = new LiveSessionIndex();
+    index.initialize(snapshot([codex], { codex: [inside] }), {
+      queryScope: {
+        projectScope: {
+          identity: { kind: "path", key: "/projects/inside" },
+          path: "/projects/inside",
+        },
+      },
+    });
+    const initialSessions = index.snapshot().sessions;
+    expect(index.snapshot().sessions).toBe(initialSessions);
+
+    const removed = index.commitAgentSessions("codex", [outside]);
+    expect(removed?.removedSessionRefs).toEqual([inside.reference]);
+    expect(index.snapshot().sessions).toEqual([]);
+    expect(index.agentSessions("codex")).toEqual([outside]);
+
+    const added = index.commitAgentSessions("codex", [inside]);
+    expect(added?.newSessionRefs).toEqual([inside.reference]);
+    expect(index.snapshot().sessions).toEqual([inside]);
+    const visibleSessions = index.snapshot().sessions;
+    const visibleAgentSessions = index.snapshot().byAgent.codex;
+    const outsideOnly = { ...outside, reference: { agentName: "codex", sessionId: "outside" } };
+
+    expect(index.commitAgentSessions("codex", [inside, outsideOnly])).toBeNull();
+    expect(index.agentSessions("codex")).toEqual([inside, outsideOnly]);
+    expect(index.snapshot().sessions).toBe(visibleSessions);
+    expect(index.snapshot().byAgent.codex).toBe(visibleAgentSessions);
   });
 
   it("omits internal metadata from published session heads", () => {
@@ -252,7 +294,7 @@ describe("LiveSessionIndex", () => {
     ]);
   });
 
-  it("updates the snapshot even when no event is needed", () => {
+  it("updates the canonical baseline without replacing an unchanged query projection", () => {
     const codex = makeAgent("codex");
     const original = makeSession("session", 1);
     const equivalent = { ...original };
@@ -260,7 +302,8 @@ describe("LiveSessionIndex", () => {
     index.initialize(snapshot([codex], { codex: [original] }));
 
     expect(index.commitAgentSessions("codex", [equivalent])).toBeNull();
-    expect(index.snapshot().sessions[0]).toBe(equivalent);
+    expect(index.snapshot().sessions[0]).toBe(original);
+    expect(index.agentSessions("codex")[0]).toBe(equivalent);
   });
 
   it("resets signature lineage when a new snapshot is initialized", () => {

--- a/packages/cli/src/live-session-index.ts
+++ b/packages/cli/src/live-session-index.ts
@@ -1,11 +1,13 @@
 import {
   computeSessionDiff,
   mergeSortedSessions,
+  matchesSessionQueryScope,
   sessionSignature,
   type AgentCacheFailure,
   sortSessions,
   type IdentifiedSessionHead,
   type LiveSnapshot,
+  type SessionQueryScope,
 } from "@codesesh/core/runtime/discovery";
 import { type AgentScanFailure, type BaseAgent } from "@codesesh/core/runtime/agents";
 import {
@@ -18,12 +20,14 @@ import {
 
 export interface LiveSessionIndexOptions {
   registeredAgents?: BaseAgent[];
-  allowedAgents?: ReadonlySet<string> | null;
+  queryScope?: SessionQueryScope;
 }
 
 export class LiveSessionIndex {
   private agents: BaseAgent[] = [];
   private agentsByName = new Map<string, BaseAgent>();
+  private queryScope?: SessionQueryScope;
+  private allByAgent: Record<string, IdentifiedSessionHead[]> = {};
   private byAgent: Record<string, IdentifiedSessionHead[]> = {};
   private sessions: IdentifiedSessionHead[] = [];
   private cacheFailures: Record<string, AgentCacheFailure> = {};
@@ -31,6 +35,7 @@ export class LiveSessionIndex {
   private signatureCaches = new Map<string, Map<string, string>>();
 
   initialize(snapshot: LiveSnapshot, options: LiveSessionIndexOptions = {}): void {
+    this.queryScope = options.queryScope;
     const agentMap = new Map<string, BaseAgent>();
     for (const agent of snapshot.agents) agentMap.set(agent.name, agent);
     for (const agent of options.registeredAgents ?? []) {
@@ -38,11 +43,14 @@ export class LiveSessionIndex {
     }
 
     this.agents = [...agentMap.values()].filter(
-      (agent) => !options.allowedAgents || options.allowedAgents.has(agent.name.toLowerCase()),
+      (agent) =>
+        !this.queryScope?.agents?.length ||
+        this.queryScope.agents.includes(agent.name.toLowerCase()),
     );
     this.agentsByName = new Map(this.agents.map((agent) => [agent.name, agent]));
     this.cacheFailures = { ...snapshot.cacheFailures };
     this.scanFailures = { ...snapshot.scanFailures };
+    this.allByAgent = {};
     this.byAgent = Object.fromEntries(
       this.agents.flatMap((agent) => {
         if (this.scanFailures[agent.name] && !(agent.name in snapshot.byAgent)) return [];
@@ -51,7 +59,8 @@ export class LiveSessionIndex {
           assertSessionIdentity(session, agent.name);
           assertIdentifiedSessionHead(session);
         }
-        return [[agent.name, sortSessions(sessions)]];
+        this.allByAgent[agent.name] = sortSessions(sessions);
+        return [[agent.name, this.visibleSessions(this.allByAgent[agent.name]!)]];
       }),
     );
     this.sessions = mergeSortedSessions(Object.values(this.byAgent));
@@ -72,6 +81,10 @@ export class LiveSessionIndex {
     return this.agentsByName.get(agentName);
   }
 
+  agentSessions(agentName: string): IdentifiedSessionHead[] {
+    return this.allByAgent[agentName] ?? [];
+  }
+
   commitAgentSessions(
     agentName: string,
     nextSessions: IdentifiedSessionHead[],
@@ -81,6 +94,7 @@ export class LiveSessionIndex {
       assertSessionIdentity(session, agentName);
       assertIdentifiedSessionHead(session);
     }
+    const visibleSessions = this.visibleSessions(nextSessions);
     delete this.cacheFailures[agentName];
     delete this.scanFailures[agentName];
     const previousSessions = this.byAgent[agentName] ?? [];
@@ -88,16 +102,19 @@ export class LiveSessionIndex {
     const signatureCache = this.signatureCache(agentName);
     const { changes, removedSessionIds, counts } = computeSessionDiff(
       previousSessions,
-      nextSessions,
+      visibleSessions,
       candidateChangedIds,
       sessionSignature,
       signatureCache,
     );
     for (const removedId of removedSessionIds) signatureCache.delete(removedId);
 
-    this.byAgent[agentName] = sortSessions(nextSessions);
+    this.allByAgent[agentName] = sortSessions(nextSessions);
+    const hasChanges = counts.new > 0 || counts.updated > 0 || counts.removed > 0;
+    if (!hasChanges && agentName in this.byAgent) return null;
+    this.byAgent[agentName] = this.visibleSessions(this.allByAgent[agentName]!);
     this.sessions = mergeSortedSessions(Object.values(this.byAgent));
-    if (counts.new === 0 && counts.updated === 0 && counts.removed === 0) return null;
+    if (!hasChanges) return null;
 
     const changedSessionHeads = changes.map(({ session }) => ({
       reference: session.reference,
@@ -137,5 +154,10 @@ export class LiveSessionIndex {
     const cache = new Map<string, string>();
     this.signatureCaches.set(agentName, cache);
     return cache;
+  }
+
+  private visibleSessions(sessions: IdentifiedSessionHead[]): IdentifiedSessionHead[] {
+    if (!this.queryScope?.projectScope) return sessions;
+    return sessions.filter((session) => matchesSessionQueryScope(session, this.queryScope));
   }
 }

--- a/packages/cli/src/search-index-publisher.ts
+++ b/packages/cli/src/search-index-publisher.ts
@@ -2,6 +2,7 @@ import {
   buildAgentCacheMeta,
   type CachedResult,
   type LiveSnapshot,
+  type IdentifiedSessionHead,
 } from "@codesesh/core/runtime/discovery";
 import { appLogger } from "./logging.js";
 import type { SearchIndexJobRunner } from "./search-index-job-runner.js";
@@ -13,6 +14,7 @@ import type {
 export interface SearchIndexPublisherOptions {
   jobs: SearchIndexJobRunner;
   snapshot(): LiveSnapshot;
+  agentSessions(agentName: string): IdentifiedSessionHead[];
   readCachedSessions(agentName: string): CachedResult | null;
 }
 
@@ -46,7 +48,7 @@ export class SearchIndexPublisher {
               kind: "full",
               context,
               agentName: agent.name,
-              sessions: snapshot.byAgent[agent.name] ?? [],
+              sessions: this.options.agentSessions(agent.name),
               meta: buildAgentCacheMeta(agent),
               completeness: "partial",
               removedSessionIds: [],

--- a/packages/core/src/discovery/__tests__/session-scope.test.ts
+++ b/packages/core/src/discovery/__tests__/session-scope.test.ts
@@ -1,0 +1,153 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { SessionDetail, SessionHead } from "../../types/index.js";
+import {
+  executeSessionSearch,
+  filterSessionSearchCandidates,
+} from "../../search/session-search.js";
+import { closeCacheStorage } from "../cache/db.js";
+import { listFileActivity } from "../cache/file-activity.js";
+import { syncSessionSearchIndex } from "../cache/search.js";
+import { saveCachedSessions } from "../cache/sessions.js";
+import { makeSessionHead } from "../cache/__tests__/fixtures.js";
+import { matchesSessionQueryScope, type SessionQueryScope } from "../session-scope.js";
+
+const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-query-scope-"));
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  homedir: () => testHomeDir,
+}));
+
+const queryScope: SessionQueryScope = {
+  agents: ["codex"],
+  projectScope: {
+    identity: { kind: "path", key: "/workspace/allowed" },
+    path: "/workspace/allowed",
+  },
+};
+
+function makeDetail(id: string, agentName: string, directory: string, time: number): SessionDetail {
+  return {
+    ...makeSessionHead(id, {
+      reference: { agentName, sessionId: id },
+      title: "needle",
+      directory,
+      project_identity: { kind: "path", key: directory, displayName: id },
+      time_created: time,
+      time_updated: time,
+    }),
+    messages: [
+      {
+        id: `${id}-message`,
+        role: "assistant",
+        time_created: time,
+        parts: [
+          { type: "text", text: "needle" },
+          {
+            type: "tool",
+            tool: "Read",
+            state: { status: "completed", input: { file_path: "src/shared.ts" } },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const details = [
+  {
+    ...makeDetail("dot-escape", "codex", "/workspace/other", 700),
+    directory: "/workspace/allowed/../other",
+  },
+  { ...makeDetail("empty-directory", "codex", "/workspace/unrelated", 600), directory: "" },
+  makeDetail("different-case", "codex", "/workspace/ALLOWED", 500),
+  makeDetail("other-agent", "claudecode", "/workspace/allowed", 400),
+  makeDetail("other-project", "codex", "/outside/project", 300),
+  makeDetail("visible", "codex", "/workspace/allowed", 200),
+  makeDetail("trailing-parent", "codex", "/workspace/", 150),
+  {
+    ...makeDetail("historical", "codex", "/worktrees/allowed", 100),
+    project_identity: { kind: "path" as const, key: "/workspace/allowed", displayName: "allowed" },
+  },
+];
+const heads = details.map(({ messages: _messages, ...head }) => head);
+const byAgent: Record<string, SessionHead[]> = {};
+for (const head of heads) (byAgent[head.reference.agentName] ??= []).push(head);
+const fullSnapshot = { sessions: heads, byAgent };
+const visible = heads.find((head) => head.reference.sessionId === "visible")!;
+const partialSnapshot = { sessions: [visible], byAgent: { codex: [visible] } };
+const allowedIds = ["visible", "trailing-parent", "historical"];
+
+beforeAll(() => {
+  for (const [agentName, sessions] of Object.entries(byAgent)) {
+    saveCachedSessions(agentName, sessions);
+    syncSessionSearchIndex(agentName, sessions, (id) =>
+      details.find((detail) => detail.reference.sessionId === id)!,
+    );
+  }
+});
+
+afterAll(() => {
+  closeCacheStorage();
+  rmSync(testHomeDir, { recursive: true, force: true });
+});
+
+describe("instance session query scope", () => {
+  it("applies the same scope before limits across recent, text, and file queries", () => {
+    const context = { queryScope };
+    for (const query of ["", "needle", "file:shared.ts"]) {
+      const results = executeSessionSearch(query, { limit: 1 }, fullSnapshot, context);
+      expect(results.map((result) => result.reference.sessionId)).toEqual(["visible"]);
+    }
+    expect(
+      listFileActivity({ limit: 1 }, queryScope).map((row) => row.reference.sessionId),
+    ).toEqual(["visible"]);
+  });
+
+  it("keeps indexed history in the instance scope when the live snapshot is incomplete", () => {
+    const results = executeSessionSearch("needle", { limit: 3 }, partialSnapshot, { queryScope });
+    expect(results.map((result) => result.reference.sessionId)).toEqual(allowedIds);
+    expect(results.every((result) => matchesSessionQueryScope(result.session, queryScope))).toBe(
+      true,
+    );
+  });
+
+  it("matches memory and SQL rules for empty paths, casing, dot segments, and trailing slashes", () => {
+    closeCacheStorage();
+    for (const query of ["", "needle"]) {
+      const results = executeSessionSearch(query, {}, fullSnapshot, { queryScope });
+      expect(results.map((result) => result.reference.sessionId)).toEqual(allowedIds);
+    }
+    expect(listFileActivity({}, queryScope).map((row) => row.reference.sessionId)).toEqual(
+      allowedIds,
+    );
+  });
+
+  it("intersects user agent and project filters with the instance scope", () => {
+    const context = { queryScope };
+    expect(executeSessionSearch("agent:claudecode needle", {}, fullSnapshot, context)).toEqual([]);
+    expect(executeSessionSearch("", { agent: "claudecode" }, fullSnapshot, context)).toEqual([]);
+    const outsideProject = {
+      identity: { kind: "path" as const, key: "/outside/project" },
+      path: "/outside/project",
+    };
+    expect(
+      executeSessionSearch("needle", { projectScope: outsideProject }, fullSnapshot, context),
+    ).toEqual([]);
+    expect(listFileActivity({ agent: "claudecode" }, queryScope)).toEqual([]);
+    expect(listFileActivity({ projectScope: outsideProject }, queryScope)).toEqual([]);
+  });
+
+  it("keeps alias candidates inside the same scope", () => {
+    const candidates = executeSessionSearch("", {}, fullSnapshot);
+    const results = filterSessionSearchCandidates(
+      candidates,
+      { file: "shared.ts" },
+      { queryScope },
+    );
+    expect(results.map((result) => result.reference.sessionId)).toEqual(allowedIds);
+  });
+});

--- a/packages/core/src/discovery/cache/__tests__/file-activity.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/file-activity.test.ts
@@ -41,8 +41,8 @@ describe("cached file activity", () => {
     });
 
     expect(result.where).toContain("s.project_identity_kind = ? AND s.project_identity_key = ?");
-    expect(result.where).toContain("REPLACE(LOWER(s.directory), char(92), '/')");
-    expect(result.where).toContain("instr(?, REPLACE(LOWER(s.directory), char(92), '/') || '/')");
+    expect(result.where).toContain("codesesh_project_scope_path(s.directory)");
+    expect(result.where).toContain("instr(?, codesesh_project_scope_path(s.directory) || '/')");
     expect(result.params).toEqual([
       "git_remote",
       "github.com/acme/app",
@@ -63,9 +63,9 @@ describe("cached file activity", () => {
     expect(result.params).toEqual([
       "path",
       "C:/workspace/app",
-      "c:/workspace/app",
-      "c:/workspace/app",
-      "c:/workspace/app",
+      "C:/workspace/app",
+      "C:/workspace/app",
+      "C:/workspace/app",
     ]);
   });
 

--- a/packages/core/src/discovery/cache/__tests__/search.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search.test.ts
@@ -20,9 +20,9 @@ describe("cache search", () => {
     expect(result.params).toEqual([
       "path",
       "C:/workspace/app",
-      "c:/workspace/app",
-      "c:/workspace/app",
-      "c:/workspace/app",
+      "C:/workspace/app",
+      "C:/workspace/app",
+      "C:/workspace/app",
     ]);
   });
 

--- a/packages/core/src/discovery/cache/db.ts
+++ b/packages/core/src/discovery/cache/db.ts
@@ -5,6 +5,7 @@ import { homedir } from "node:os";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import { openDb, type DatabaseRow, type SQLiteDatabase } from "../../utils/sqlite.js";
 import type { SessionHead } from "../../types/index.js";
+import { normalizeProjectScopePath } from "../../projects/scope.js";
 
 const CACHE_FILENAME = "codesesh.db";
 const LEGACY_CACHE_FILENAME = "scan-cache.json";
@@ -44,6 +45,9 @@ export function getCacheConnection(path: string): CacheConnection | null {
 
   const db = openDb(path);
   if (!db) return null;
+  db.function("codesesh_project_scope_path", { deterministic: true }, (directory) =>
+    normalizeProjectScopePath(String(directory ?? "")),
+  );
 
   const connection = { db, ftsReady: false, publicationStagingCleaned: false };
   cacheConnections.set(path, connection);

--- a/packages/core/src/discovery/cache/file-activity.ts
+++ b/packages/core/src/discovery/cache/file-activity.ts
@@ -8,10 +8,12 @@ import type {
   SessionFileActivity,
 } from "../../types/index.js";
 import type { FileActivityResult, SearchHighlightRange } from "../../contract/index.js";
-import { normalizeProjectScopePath, type ProjectScopeMatcher } from "../../projects/scope.js";
+import type { ProjectScopeMatcher } from "../../projects/scope.js";
+import type { SessionQueryScope } from "../session-scope.js";
 import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import { filePathFtsQuery, hasCacheStorage, likePattern, normalizeFilePathSearch } from "./db.js";
 import { withCacheDb, withCacheDbReadOnly } from "./connection.js";
+import { buildSessionQueryScopeFilters } from "./session-scope.js";
 import {
   buildSessionSearchFilters,
   mergeSearchQueryOptions,
@@ -49,21 +51,14 @@ export function fileActivityFilters(options: FileActivityOptions): {
   projectKind: ProjectIdentityKind | null;
   projectKey: string | null;
   projectLike: string | null;
-  scopeKind: ProjectIdentityKind | null;
-  scopeKey: string | null;
-  scopePath: string | null;
   path: string;
   pathLike: string | null;
 } {
   const path = options.path ? normalizeFilePathSearch(options.path) : "";
-  const scope = options.projectScope;
   return {
     projectKind: options.projectKind ?? null,
     projectKey: options.projectKey ?? null,
     projectLike: options.project ? likePattern(options.project) : null,
-    scopeKind: scope?.identity.kind ?? null,
-    scopeKey: scope?.identity.key ?? null,
-    scopePath: scope ? normalizeProjectScopePath(scope.path).toLowerCase() : null,
     path,
     pathLike: path ? likePattern(path) : null,
   };
@@ -83,13 +78,15 @@ export function fileActivityFromRow(row: FileActivityRow): SessionFileActivity {
   };
 }
 
-export function buildFileActivityWhere(options: FileActivityOptions): {
+export function buildFileActivityWhere(
+  options: FileActivityOptions,
+  queryScope?: SessionQueryScope,
+): {
   where: string;
   params: unknown[];
 } {
   const filters = fileActivityFilters(options);
-  const clauses: string[] = [];
-  const params: unknown[] = [];
+  const { clauses, params } = buildSessionQueryScopeFilters(queryScope);
 
   if (options.agent != null) {
     clauses.push("fa.agent_name = ?");
@@ -113,18 +110,10 @@ export function buildFileActivityWhere(options: FileActivityOptions): {
     );
     params.push(filters.projectLike, filters.projectLike, filters.projectLike);
   }
-  if (filters.scopeKey != null && filters.scopePath != null) {
-    const normalizedDirectory = "REPLACE(LOWER(s.directory), char(92), '/')";
-    clauses.push(
-      `((s.project_identity_kind = ? AND s.project_identity_key = ?) OR ${normalizedDirectory} = ? OR instr(${normalizedDirectory}, ? || '/') = 1 OR instr(?, ${normalizedDirectory} || '/') = 1)`,
-    );
-    params.push(
-      filters.scopeKind,
-      filters.scopeKey,
-      filters.scopePath,
-      filters.scopePath,
-      filters.scopePath,
-    );
+  if (options.projectScope) {
+    const project = buildSessionQueryScopeFilters({ projectScope: options.projectScope });
+    clauses.push(...project.clauses);
+    params.push(...project.params);
   }
   if (filters.pathLike != null) {
     const pathQuery = filePathFtsQuery(filters.path);
@@ -195,19 +184,23 @@ const FILE_ACTIVITY_JOIN = `
 /** Most recent first, then busiest, then path — the tie-break every caller relies on. */
 const FILE_ACTIVITY_ORDER = "fa.latest_time DESC, fa.count DESC, fa.path";
 
-export function listFileActivity(options: FileActivityOptions = {}): FileActivityResult[] {
-  return queryFileActivity(options);
+export function listFileActivity(
+  options: FileActivityOptions = {},
+  queryScope?: SessionQueryScope,
+): FileActivityResult[] {
+  return queryFileActivity({ options, queryScope });
 }
 
 interface FileActivityQuery {
   options: FileActivityOptions;
+  queryScope?: SessionQueryScope;
   sessionSearchOptions?: SearchOptions;
   /** Keep only each session's top-ranked row, so the limit counts sessions. */
   onePerSession?: boolean;
 }
 
 function fileActivityWhere(query: FileActivityQuery): { where: string; params: unknown[] } {
-  const filters = buildFileActivityWhere(query.options);
+  const filters = buildFileActivityWhere(query.options, query.queryScope);
   const sessionFilters = query.sessionSearchOptions
     ? buildSessionSearchFilters(query.sessionSearchOptions)
     : { where: "", params: [] };
@@ -255,16 +248,12 @@ function fileActivitySql(query: FileActivityQuery, where: string): string {
   `;
 }
 
-function queryFileActivity(
-  options: FileActivityOptions,
-  sessionSearchOptions?: SearchOptions,
-  onePerSession = false,
-): FileActivityResult[] {
+function queryFileActivity(query: FileActivityQuery): FileActivityResult[] {
   if (!hasCacheStorage()) {
     return [];
   }
 
-  const query: FileActivityQuery = { options, sessionSearchOptions, onePerSession };
+  const { options } = query;
   const { where, params } = fileActivityWhere(query);
   const sql = fileActivitySql(query, where);
   const queryRows = (db: SQLiteDatabase) =>
@@ -301,20 +290,22 @@ export function findFilePathHighlightRanges(path: string, query: string): Search
 export function searchFileActivitySessions(
   query: string,
   options: SearchOptions = {},
+  queryScope?: SessionQueryScope,
 ): SearchResult[] {
   const search = mergeSearchQueryOptions(query, options);
   const path = normalizeFilePathSearch(search.options.file ?? search.text);
   if (!path) return [];
 
-  const rows = queryFileActivity(
-    {
+  const rows = queryFileActivity({
+    options: {
       path,
       kind: search.options.fileKind,
       limit: search.options.limit ?? 50,
     },
-    search.options,
-    true,
-  );
+    sessionSearchOptions: search.options,
+    onePerSession: true,
+    queryScope,
+  });
 
   return rows.map((row) => {
     const prefix = `${row.kind} `;

--- a/packages/core/src/discovery/cache/search.ts
+++ b/packages/core/src/discovery/cache/search.ts
@@ -15,12 +15,14 @@ import {
   type SearchMatchType,
   type SearchResult,
 } from "../../contract/index.js";
-import { normalizeProjectScopePath, type ProjectScopeMatcher } from "../../projects/scope.js";
+import type { ProjectScopeMatcher } from "../../projects/scope.js";
+import type { SessionQueryScope } from "../session-scope.js";
 import { getCoreDiagnostics } from "../../utils/diagnostics.js";
 import type { DatabaseRow, SQLiteDatabase } from "../../utils/sqlite.js";
 import { escapeRegExp, filePathFtsQuery, hasCacheStorage, likePattern } from "./db.js";
 import { normalizeToolName, sessionFromRow, type SessionRow } from "./messages.js";
 import { withSearchDb } from "./connection.js";
+import { buildSessionQueryScopeFilters } from "./session-scope.js";
 import {
   parseSearchQuery,
   splitSearchTokens,
@@ -190,12 +192,14 @@ export function sessionMatchesSearchCost(
   return true;
 }
 
-export function buildSessionSearchFilters(options: SearchOptions): {
+export function buildSessionSearchFilters(
+  options: SearchOptions,
+  queryScope?: SessionQueryScope,
+): {
   where: string;
   params: unknown[];
 } {
-  const clauses: string[] = [];
-  const params: unknown[] = [];
+  const { clauses, params } = buildSessionQueryScopeFilters(queryScope);
 
   if (options.agent) {
     clauses.push("s.agent_name = ?");
@@ -210,18 +214,9 @@ export function buildSessionSearchFilters(options: SearchOptions): {
     }
   }
   if (options.projectScope) {
-    const scopePath = normalizeProjectScopePath(options.projectScope.path).toLowerCase();
-    const normalizedDirectory = "REPLACE(LOWER(s.directory), char(92), '/')";
-    clauses.push(
-      `((s.project_identity_kind = ? AND s.project_identity_key = ?) OR ${normalizedDirectory} = ? OR instr(${normalizedDirectory}, ? || '/') = 1 OR instr(?, ${normalizedDirectory} || '/') = 1)`,
-    );
-    params.push(
-      options.projectScope.identity.kind,
-      options.projectScope.identity.key,
-      scopePath,
-      scopePath,
-      scopePath,
-    );
+    const project = buildSessionQueryScopeFilters({ projectScope: options.projectScope });
+    clauses.push(...project.clauses);
+    params.push(...project.params);
   }
   if (options.project) {
     clauses.push(
@@ -599,7 +594,11 @@ function rowsToSearchResults(
   });
 }
 
-export function searchSessions(query: string, options: SearchOptions = {}): SearchResult[] {
+export function searchSessions(
+  query: string,
+  options: SearchOptions = {},
+  queryScope?: SessionQueryScope,
+): SearchResult[] {
   const search = mergeSearchQueryOptions(query, options);
   const normalizedQuery = search.text.trim();
   if (!hasCacheStorage()) {
@@ -607,7 +606,7 @@ export function searchSessions(query: string, options: SearchOptions = {}): Sear
   }
 
   const results = withSearchDb((db) => {
-    const filters = buildSessionSearchFilters(search.options);
+    const filters = buildSessionSearchFilters(search.options, queryScope);
 
     if (!normalizedQuery) {
       const rows = db

--- a/packages/core/src/discovery/cache/session-scope.ts
+++ b/packages/core/src/discovery/cache/session-scope.ts
@@ -1,0 +1,24 @@
+import { normalizeProjectScopePath } from "../../projects/scope.js";
+import type { SessionQueryScope } from "../session-scope.js";
+
+export function buildSessionQueryScopeFilters(scope?: SessionQueryScope): {
+  clauses: string[];
+  params: unknown[];
+} {
+  const clauses: string[] = [];
+  const params: unknown[] = [];
+  if (scope?.agents?.length) {
+    clauses.push(`s.agent_name IN (${scope.agents.map(() => "?").join(", ")})`);
+    params.push(...scope.agents);
+  }
+  if (scope?.projectScope) {
+    const project = scope.projectScope;
+    const path = normalizeProjectScopePath(project.path);
+    const directory = "codesesh_project_scope_path(s.directory)";
+    clauses.push(
+      `((s.project_identity_kind = ? AND s.project_identity_key = ?) OR (s.directory <> '' AND (${directory} = ? OR instr(${directory}, ? || '/') = 1 OR instr(?, ${directory} || '/') = 1)))`,
+    );
+    params.push(project.identity.kind, project.identity.key, path, path, path);
+  }
+  return { clauses, params };
+}

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -7,6 +7,7 @@ export {
   inheritSessionTags,
 } from "./session-tags.js";
 export type { AgentCacheFailure, LiveSnapshot, ScanOptions } from "./scanner.js";
+export { matchesSessionQueryScope, type SessionQueryScope } from "./session-scope.js";
 export type { SessionTagTiming } from "./session-tags.js";
 export {
   beginAgentRefresh,

--- a/packages/core/src/discovery/session-scope.ts
+++ b/packages/core/src/discovery/session-scope.ts
@@ -1,0 +1,12 @@
+import type { SessionHead } from "../types/index.js";
+import { matchesProjectScope, type ProjectScopeMatcher } from "../projects/scope.js";
+
+export interface SessionQueryScope {
+  agents?: readonly string[];
+  projectScope?: ProjectScopeMatcher;
+}
+
+export function matchesSessionQueryScope(session: SessionHead, scope?: SessionQueryScope): boolean {
+  if (scope?.agents?.length && !scope.agents.includes(session.reference.agentName)) return false;
+  return !scope?.projectScope || matchesProjectScope(session, scope.projectScope);
+}

--- a/packages/core/src/runtime/discovery.ts
+++ b/packages/core/src/runtime/discovery.ts
@@ -34,6 +34,7 @@ export {
   markAgentFullSyncCompleted,
   markAgentFullSyncProgress,
   markAgentFullSyncStarted,
+  matchesSessionQueryScope,
   materializeCachedSessionDetailResponse,
   materializeSessionDetailResponse,
   mergeSearchQueryOptions,
@@ -81,6 +82,7 @@ export type {
   SessionDetailResponseResult,
   SessionPersistenceDiff,
   SessionPersistenceDiffOptions,
+  SessionQueryScope,
   SessionSnapshotCompleteness,
   SessionTagTiming,
 } from "../discovery/index.js";

--- a/packages/core/src/runtime/projects.ts
+++ b/packages/core/src/runtime/projects.ts
@@ -1,6 +1,7 @@
 export type { ProjectIdentityRef } from "../types/index.js";
 export {
   computeIdentityProjection,
+  createProjectScopeMatcher,
   createProjectScopeMatcherFromIdentity,
   isProjectIdentityKind,
   matchesProjectIdentity,

--- a/packages/core/src/search/session-search.ts
+++ b/packages/core/src/search/session-search.ts
@@ -23,6 +23,7 @@ import { searchFileActivitySessions } from "../discovery/cache/file-activity.js"
 import { matchesProjectScope, type ProjectScopeMatcher } from "../projects/scope.js";
 import { matchesProjectIdentity } from "../projects/identity.js";
 import { getSessionActivityTime } from "../analytics/dashboard.js";
+import { matchesSessionQueryScope, type SessionQueryScope } from "../discovery/session-scope.js";
 
 export interface SessionSearchSnapshot {
   /** Globally sorted by activity descending; ties preserve the canonical live-index order. */
@@ -33,6 +34,7 @@ export interface SessionSearchSnapshot {
 
 export interface SessionSearchContext {
   sessionTree?: SessionTree;
+  queryScope?: SessionQueryScope;
 }
 
 export interface SessionSearchFilterContext extends SessionSearchContext {
@@ -51,7 +53,13 @@ export function executeSessionSearch(
     return searchRecentSessions(snapshot, merged.options, context);
   }
 
-  return searchIndexedSessions(query, merged.text, merged.parsed, merged.options);
+  return searchIndexedSessions(
+    query,
+    merged.text,
+    merged.parsed,
+    merged.options,
+    context.queryScope,
+  );
 }
 
 // Qualifiers alone (tag:/cost:/agent:/project:) do not force the indexed
@@ -124,14 +132,16 @@ export function filterSessionSearchCandidates(
   const sessionSnapshot =
     context.sessionSnapshot ?? candidates.map((candidate) => candidate.session);
   const inclusiveCosts = buildInclusiveCostLookup(sessionSnapshot, options, context.sessionTree);
-  const headMatches = candidates.filter((candidate) =>
-    matchesSessionSearchFilters(
-      candidate.reference.agentName,
-      candidate.session,
-      options,
-      projectScope,
-      inclusiveCostFor(candidate.reference.agentName, candidate.session, inclusiveCosts),
-    ),
+  const headMatches = candidates.filter(
+    (candidate) =>
+      matchesSessionQueryScope(candidate.session, context.queryScope) &&
+      matchesSessionSearchFilters(
+        candidate.reference.agentName,
+        candidate.session,
+        options,
+        projectScope,
+        inclusiveCostFor(candidate.reference.agentName, candidate.session, inclusiveCosts),
+      ),
   );
   if (!options.file && !options.fileKind && !options.tools?.length) return headMatches;
 
@@ -167,6 +177,7 @@ function searchRecentSessions(
   for (const session of sessions) {
     const agentName = options.agent ?? session.reference.agentName;
     if (
+      !matchesSessionQueryScope(session, context.queryScope) ||
       !matchesSessionSearchFilters(
         agentName,
         session,
@@ -248,12 +259,13 @@ function searchIndexedSessions(
   textQuery: string,
   parsed: ParsedSearchQuery,
   options: SearchOptions,
+  queryScope?: SessionQueryScope,
 ): SearchResult[] {
   const fileQuery = deriveFileQuery(query, parsed, options);
-  const fileResults = fileQuery ? searchFileActivitySessions(fileQuery, options) : [];
+  const fileResults = fileQuery ? searchFileActivitySessions(fileQuery, options, queryScope) : [];
   const sessionResults = canSkipSessionsSearch(fileQuery, textQuery)
     ? []
-    : searchSessions(query, options);
+    : searchSessions(query, options, queryScope);
   const textMatchReferences =
     textQuery && options.file
       ? new Set(sessionResults.map((result) => getSessionReferenceKey(result.reference)))


### PR DESCRIPTION
CLI agent and project filters only constrained the initial snapshot. Background refresh could publish unrelated projects, while indexed search and file activity queried the global cache without the instance scope.

This change keeps one fixed query scope for the instance and applies it to live projections and indexed reads before limits. Request filters intersect with that scope. Scanning and persistence retain complete session inputs, including when no cache exists. Updates outside the visible scope preserve the current snapshot identity.

Project path matching now shares the same normalization between in-memory and SQLite queries, including empty paths, case, and dot segments.

Validation:
- Added refresh/backfill and scope entry/exit regressions, including complete uncached index inputs and stable visible snapshots.
- Added real SQLite/API coverage for scoped search, file activity, Dashboard activity, request-filter intersection, and incomplete live snapshots.
- Passed local lint, formatting, typecheck, build, and tests.
