### PR TITLE
fix: Keep new session content visible

### DIFF
--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -13,7 +13,11 @@ import {
 import { buildSessionDetailDisplayModel } from "./session-detail/display-model";
 import { SessionFilterAside } from "./session-detail/filter-panel";
 import { SessionFilterChips } from "./session-detail/filter-chips";
-import { deriveHiddenCount, deriveHiddenTools } from "./session-detail/filter-state";
+import {
+  deriveHiddenCount,
+  deriveHiddenTools,
+  deriveSelectedFilters,
+} from "./session-detail/filter-state";
 import { HiddenToolsFooter } from "./session-detail/hidden-tools-footer";
 import { useSessionFilters } from "./session-detail/use-session-filters";
 import {
@@ -138,9 +142,9 @@ export function SessionDetail({
   const selection = useMemo(
     () =>
       measureSessionDetailWork("SessionDetail:selectDisplayModel", () =>
-        displayModel.select(filterState.selected),
+        displayModel.select(deriveSelectedFilters(toc, filterState.excluded)),
       ),
-    [displayModel, filterState.selected],
+    [displayModel, toc, filterState.excluded],
   );
   const { messages: filteredMessages, timelineEntries, visibleUnitCount } = selection;
   const childSessionById = useMemo(

--- a/apps/web/src/components/session-detail/filter-chips.tsx
+++ b/apps/web/src/components/session-detail/filter-chips.tsx
@@ -31,7 +31,7 @@ export function SessionFilterChips({
   if (chips.length === 0) return null;
 
   const contentSummary = TOC_CONTENT_FILTER_IDS.filter(
-    (id) => toc.counts[id] > 0 && state.selected.has(id),
+    (id) => toc.counts[id] > 0 && !state.excluded.has(id),
   ).map((id) => CONTENT_SHORT_LABEL[id]);
 
   return (

--- a/apps/web/src/components/session-detail/filter-panel.test.tsx
+++ b/apps/web/src/components/session-detail/filter-panel.test.tsx
@@ -1,8 +1,16 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, renderHook, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
+import type { Message } from "../../lib/api";
+import { buildSessionDetailDisplayModel } from "./display-model";
 import { SessionFilterPanel } from "./filter-panel";
+import { deriveSelectedFilters } from "./filter-state";
 import { useSessionFilters } from "./use-session-filters";
-import type { SessionDetailToc, ToolFilterItem } from "./toc";
+import {
+  buildSessionDetailToc,
+  filterSessionMessages,
+  type SessionDetailToc,
+  type ToolFilterItem,
+} from "./toc";
 
 const TOOLS: ToolFilterItem[] = [
   { id: "tool:bash", toolKey: "bash", label: "Bash", count: 4, kind: "execute" },
@@ -150,5 +158,78 @@ describe("SessionFilterPanel", () => {
 
     rerender(<Harness sessionId="s2" />);
     expect(checkbox("Grep").getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("shows new replies, content kinds and tools as the same session grows", () => {
+    const initial: Message[] = [
+      { id: "question", role: "user", time_created: 1, parts: [{ type: "text", text: "Help" }] },
+    ];
+    const next: Message[] = [
+      ...initial,
+      {
+        id: "reply",
+        role: "assistant",
+        time_created: 2,
+        parts: [
+          { type: "text", text: "Answer" },
+          { type: "reasoning", text: "Thinking" },
+          { type: "plan", text: "Plan", approval_status: "success" },
+          { type: "tool", tool: "Read", state: { status: "completed", input: { path: "a.ts" } } },
+        ],
+      },
+    ];
+    const models = buildSessionDetailDisplayModel({
+      messages: next,
+      agentName: "claudecode",
+    }).messages;
+    const nextToc = buildSessionDetailToc(models);
+    const { result, rerender } = renderHook(
+      ({ messages }) => {
+        const display = buildSessionDetailDisplayModel({ messages, agentName: "claudecode" });
+        return useSessionFilters(buildSessionDetailToc(display.messages), "same-session");
+      },
+      { initialProps: { messages: initial } },
+    );
+
+    rerender({ messages: next });
+
+    const visible = filterSessionMessages(
+      models,
+      deriveSelectedFilters(nextToc, result.current.state.excluded),
+    );
+    expect(visible.messages.map(({ msg }) => msg.id)).toEqual(["question", "reply"]);
+    expect(visible.visibleUnitCount).toBe(nextToc.totalUnitCount);
+    expect(visible.visibleUnitCount).toBe(5);
+  });
+
+  it("preserves explicit exclusions while new categories appear and old ones return", () => {
+    const initialToc: SessionDetailToc = {
+      ...toc,
+      filterIds: new Set(["user", "tool:read"]),
+      counts: { user: 1, agent_message: 0, thinking: 0, plan: 0, tools_all: 1 },
+      tools: TOOLS.filter(({ toolKey }) => toolKey === "read"),
+      totalUnitCount: 2,
+    };
+    const { result, rerender } = renderHook(
+      ({ currentToc }) => useSessionFilters(currentToc, "same-session"),
+      {
+        initialProps: { currentToc: initialToc },
+      },
+    );
+    act(() => {
+      result.current.actions.toggleContentKind("user");
+      result.current.actions.toggleTool("tool:read");
+    });
+
+    rerender({ currentToc: buildSessionDetailToc([]) });
+    rerender({ currentToc: toc });
+
+    const selected = deriveSelectedFilters(toc, result.current.state.excluded);
+    expect(selected.has("user")).toBe(false);
+    expect(selected.has("tool:read")).toBe(false);
+    expect(selected.has("agent_message")).toBe(true);
+    expect(selected.has("tool:write")).toBe(true);
+    act(() => result.current.actions.resetAll());
+    expect(deriveSelectedFilters(toc, result.current.state.excluded)).toEqual(toc.filterIds);
   });
 });

--- a/apps/web/src/components/session-detail/filter-panel.tsx
+++ b/apps/web/src/components/session-detail/filter-panel.tsx
@@ -70,7 +70,7 @@ export function SessionFilterPanel({
               <TriStateCheckbox
                 size={15}
                 label={CONTENT_LABEL[id]}
-                state={state.selected.has(id) ? "checked" : "unchecked"}
+                state={state.excluded.has(id) ? "unchecked" : "checked"}
                 onToggle={() => actions.toggleContentKind(id)}
               />
               <span className="min-w-0 flex-1 truncate text-[13px] text-[var(--console-text)]">
@@ -151,7 +151,7 @@ function ToolGroup({
               <TriStateCheckbox
                 size={14}
                 label={tool.label}
-                state={state.selected.has(tool.id) ? "checked" : "unchecked"}
+                state={state.excluded.has(tool.id) ? "unchecked" : "checked"}
                 onToggle={() => actions.toggleTool(tool.id)}
               />
               <span className="console-mono min-w-0 flex-1 truncate text-xs text-[var(--console-text)]">

--- a/apps/web/src/components/session-detail/filter-state.test.ts
+++ b/apps/web/src/components/session-detail/filter-state.test.ts
@@ -5,6 +5,7 @@ import {
   deriveActiveChips,
   deriveHiddenCount,
   deriveHiddenTools,
+  deriveSelectedFilters,
   deriveToolsParentState,
   deriveVisibleTools,
   resetAll,
@@ -46,14 +47,14 @@ function createToc(): SessionDetailToc {
 const toc = createToc();
 
 function selectedIds(state: SessionFilterState) {
-  return [...state.selected].toSorted();
+  return [...deriveSelectedFilters(toc, state.excluded)].toSorted();
 }
 
 describe("createFilterState", () => {
   it("starts with every filter on, no query and the tool group open", () => {
-    const state = createFilterState(toc);
+    const state = createFilterState();
     expect(selectedIds(state)).toEqual([...toc.filterIds].toSorted());
-    expect(state.selected.has("tools_all")).toBe(false);
+    expect(deriveSelectedFilters(toc, state.excluded).has("tools_all")).toBe(false);
     expect(state.toolQuery).toBe("");
     expect(state.toolsExpanded).toBe(true);
   });
@@ -61,27 +62,27 @@ describe("createFilterState", () => {
 
 describe("reducers", () => {
   it("toggles a content kind off and back on without touching tools", () => {
-    const off = toggleContentKind(createFilterState(toc), "thinking");
-    expect(off.selected.has("thinking")).toBe(false);
+    const off = toggleContentKind(createFilterState(), "thinking");
+    expect(selectedIds(off)).not.toContain("thinking");
     expect(countSelectedTools(toc, off)).toBe(TOOLS.length);
-    expect(toggleContentKind(off, "thinking").selected.has("thinking")).toBe(true);
+    expect(selectedIds(toggleContentKind(off, "thinking"))).toContain("thinking");
   });
 
   it("toggles a single tool", () => {
-    const off = toggleTool(createFilterState(toc), "tool:grep");
-    expect(off.selected.has("tool:grep")).toBe(false);
-    expect(toggleTool(off, "tool:grep").selected.has("tool:grep")).toBe(true);
+    const off = toggleTool(createFilterState(), "tool:grep");
+    expect(selectedIds(off)).not.toContain("tool:grep");
+    expect(selectedIds(toggleTool(off, "tool:grep"))).toContain("tool:grep");
   });
 
   it("scopes select-all / clear-all to the queried tool subset", () => {
-    const none = setAllTools(createFilterState(toc), toc, false);
+    const none = setAllTools(createFilterState(), toc, false);
     expect(countSelectedTools(toc, none)).toBe(0);
 
     const queried = setToolQuery(none, "re");
     expect(deriveVisibleTools(toc, queried).map((tool) => tool.label)).toEqual(["Grep", "Read"]);
 
     const some = setAllTools(queried, toc, true);
-    expect([...some.selected].filter((id) => id.startsWith("tool:")).toSorted()).toEqual([
+    expect(selectedIds(some).filter((id) => id.startsWith("tool:"))).toEqual([
       "tool:grep",
       "tool:read",
     ]);
@@ -91,34 +92,46 @@ describe("reducers", () => {
   });
 
   it("applies select-all to every tool when the query is empty", () => {
-    const none = setAllTools(createFilterState(toc), toc, false);
+    const none = setAllTools(createFilterState(), toc, false);
     expect(countSelectedTools(toc, setAllTools(none, toc, true))).toBe(TOOLS.length);
   });
 
   it("selects exactly the write tools and leaves content kinds alone", () => {
-    const state = selectWriteToolsOnly(toggleContentKind(createFilterState(toc), "user"), toc);
-    expect([...state.selected].filter((id) => id.startsWith("tool:")).toSorted()).toEqual([
+    const state = selectWriteToolsOnly(toggleContentKind(createFilterState(), "user"), toc);
+    expect(selectedIds(state).filter((id) => id.startsWith("tool:"))).toEqual([
       "tool:edit",
       "tool:write",
     ]);
-    expect(state.selected.has("agent_message")).toBe(true);
-    expect(state.selected.has("user")).toBe(false);
+    expect(selectedIds(state)).toContain("agent_message");
+    expect(selectedIds(state)).not.toContain("user");
+  });
+
+  it.each([
+    { action: "clear all", apply: (state: SessionFilterState) => setAllTools(state, toc, false) },
+    {
+      action: "writes only",
+      apply: (state: SessionFilterState) => selectWriteToolsOnly(state, toc),
+    },
+  ])("keeps $action limited to tools present when invoked", ({ apply }) => {
+    const state = apply(createFilterState());
+    const updatedToc = { ...toc, filterIds: new Set([...toc.filterIds, "tool:search"]) };
+    const selected = deriveSelectedFilters(updatedToc, state.excluded);
+
+    expect(selected.has("tool:read")).toBe(false);
+    expect(selected.has("tool:search")).toBe(true);
   });
 
   it("stores the tool query and the group collapse flag", () => {
-    const queried = setToolQuery(createFilterState(toc), "Ba");
+    const queried = setToolQuery(createFilterState(), "Ba");
     expect(queried.toolQuery).toBe("Ba");
     expect(toggleToolsExpanded(queried).toolsExpanded).toBe(false);
   });
 
   it("resets every filter and the query while keeping the group open state", () => {
     const messy = toggleToolsExpanded(
-      setToolQuery(
-        selectWriteToolsOnly(toggleContentKind(createFilterState(toc), "plan"), toc),
-        "x",
-      ),
+      setToolQuery(selectWriteToolsOnly(toggleContentKind(createFilterState(), "plan"), toc), "x"),
     );
-    const reset = resetAll(messy, toc);
+    const reset = resetAll(messy);
     expect(selectedIds(reset)).toEqual([...toc.filterIds].toSorted());
     expect(reset.toolQuery).toBe("");
     expect(reset.toolsExpanded).toBe(false);
@@ -127,7 +140,7 @@ describe("reducers", () => {
 
 describe("deriveToolsParentState", () => {
   it("covers the tri-state truth table", () => {
-    const all = createFilterState(toc);
+    const all = createFilterState();
     expect(deriveToolsParentState(toc, all)).toBe("all");
     expect(deriveToolsParentState(toc, toggleTool(all, "tool:grep"))).toBe("partial");
     expect(deriveToolsParentState(toc, setAllTools(all, toc, false))).toBe("none");
@@ -135,13 +148,13 @@ describe("deriveToolsParentState", () => {
 
   it("reports none when the session used no tools", () => {
     const toolless: SessionDetailToc = { ...toc, tools: [], maxToolCount: 0 };
-    expect(deriveToolsParentState(toolless, createFilterState(toolless))).toBe("none");
+    expect(deriveToolsParentState(toolless, createFilterState())).toBe("none");
   });
 });
 
 describe("deriveVisibleTools", () => {
   it("matches case-insensitively and returns every tool for a blank query", () => {
-    const state = createFilterState(toc);
+    const state = createFilterState();
     expect(deriveVisibleTools(toc, state)).toBe(toc.tools);
     expect(deriveVisibleTools(toc, setToolQuery(state, "  ")).length).toBe(TOOLS.length);
     expect(deriveVisibleTools(toc, setToolQuery(state, "wRi")).map((t) => t.label)).toEqual([
@@ -152,7 +165,7 @@ describe("deriveVisibleTools", () => {
 
 describe("deriveActiveChips", () => {
   it("is empty while every tool is on, and lists the survivors otherwise", () => {
-    const all = createFilterState(toc);
+    const all = createFilterState();
     expect(deriveActiveChips(toc, all)).toEqual([]);
 
     const withoutGrep = toggleTool(all, "tool:grep");
@@ -170,7 +183,7 @@ describe("deriveActiveChips", () => {
 
 describe("hidden derivations", () => {
   it("lists the unselected tools with their counts", () => {
-    const state = toggleTool(toggleTool(createFilterState(toc), "tool:grep"), "tool:bash");
+    const state = toggleTool(toggleTool(createFilterState(), "tool:grep"), "tool:bash");
     expect(deriveHiddenTools(toc, state)).toEqual([
       { label: "Bash", count: 4 },
       { label: "Grep", count: 9 },
@@ -178,7 +191,7 @@ describe("hidden derivations", () => {
   });
 
   it("counts hidden units across content kinds and tools", () => {
-    const all = createFilterState(toc);
+    const all = createFilterState();
     expect(deriveHiddenCount(toc, all)).toBe(0);
     expect(deriveHiddenCount(toc, toggleContentKind(all, "thinking"))).toBe(toc.counts.thinking);
     expect(deriveHiddenCount(toc, toggleTool(all, "tool:grep"))).toBe(9);

--- a/apps/web/src/components/session-detail/filter-state.ts
+++ b/apps/web/src/components/session-detail/filter-state.ts
@@ -2,9 +2,8 @@
  * Pure reducers and derivations behind the reader's two-level content filter.
  * No React: the hook in `use-session-filters.ts` only binds these to state.
  *
- * `selected` holds content-kind ids and `tool:<key>` ids. It NEVER holds
- * `tools_all` — the tool group's tri-state is derived from the tool subset,
- * so the two can no longer drift apart.
+ * Only explicit exclusions are stored. New content kinds and tools remain
+ * visible when a live session grows; selection is derived from its current toc.
  */
 import {
   TOC_CONTENT_FILTER_IDS,
@@ -14,21 +13,28 @@ import {
 } from "./toc";
 
 export interface SessionFilterState {
-  selected: Set<string>;
+  excluded: Set<string>;
   toolQuery: string;
   toolsExpanded: boolean;
 }
 
 export type ToolsParentState = "all" | "none" | "partial";
 
-export function createFilterState(toc: SessionDetailToc): SessionFilterState {
-  return { selected: new Set(toc.filterIds), toolQuery: "", toolsExpanded: true };
+export function createFilterState(): SessionFilterState {
+  return { excluded: new Set(), toolQuery: "", toolsExpanded: true };
+}
+
+export function deriveSelectedFilters(
+  toc: SessionDetailToc,
+  excluded: ReadonlySet<string>,
+): Set<string> {
+  return new Set([...toc.filterIds].filter((id) => !excluded.has(id)));
 }
 
 function toggleId(state: SessionFilterState, id: string): SessionFilterState {
-  const selected = new Set(state.selected);
-  if (!selected.delete(id)) selected.add(id);
-  return { ...state, selected };
+  const excluded = new Set(state.excluded);
+  if (!excluded.delete(id)) excluded.add(id);
+  return { ...state, excluded };
 }
 
 export function toggleContentKind(
@@ -47,24 +53,24 @@ export function setAllTools(
   toc: SessionDetailToc,
   checked: boolean,
 ): SessionFilterState {
-  const selected = new Set(state.selected);
+  const excluded = new Set(state.excluded);
   for (const tool of deriveVisibleTools(toc, state)) {
-    if (checked) selected.add(tool.id);
-    else selected.delete(tool.id);
+    if (checked) excluded.delete(tool.id);
+    else excluded.add(tool.id);
   }
-  return { ...state, selected };
+  return { ...state, excluded };
 }
 
 export function selectWriteToolsOnly(
   state: SessionFilterState,
   toc: SessionDetailToc,
 ): SessionFilterState {
-  const selected = new Set(state.selected);
+  const excluded = new Set(state.excluded);
   for (const tool of toc.tools) {
-    if (tool.kind === "write") selected.add(tool.id);
-    else selected.delete(tool.id);
+    if (tool.kind === "write") excluded.delete(tool.id);
+    else excluded.add(tool.id);
   }
-  return { ...state, selected };
+  return { ...state, excluded };
 }
 
 export function setToolQuery(state: SessionFilterState, toolQuery: string): SessionFilterState {
@@ -75,12 +81,12 @@ export function toggleToolsExpanded(state: SessionFilterState): SessionFilterSta
   return { ...state, toolsExpanded: !state.toolsExpanded };
 }
 
-export function resetAll(state: SessionFilterState, toc: SessionDetailToc): SessionFilterState {
-  return { ...state, selected: new Set(toc.filterIds), toolQuery: "" };
+export function resetAll(state: SessionFilterState): SessionFilterState {
+  return { ...state, excluded: new Set(), toolQuery: "" };
 }
 
 export function countSelectedTools(toc: SessionDetailToc, state: SessionFilterState): number {
-  return toc.tools.reduce((total, tool) => total + (state.selected.has(tool.id) ? 1 : 0), 0);
+  return toc.tools.reduce((total, tool) => total + (state.excluded.has(tool.id) ? 0 : 1), 0);
 }
 
 export function deriveToolsParentState(
@@ -109,7 +115,7 @@ export function deriveActiveChips(
 ): Array<{ id: `tool:${string}`; label: string }> {
   if (deriveToolsParentState(toc, state) === "all") return [];
   return toc.tools
-    .filter((tool) => state.selected.has(tool.id))
+    .filter((tool) => !state.excluded.has(tool.id))
     .map((tool) => ({ id: tool.id, label: tool.label }));
 }
 
@@ -118,17 +124,17 @@ export function deriveHiddenTools(
   state: SessionFilterState,
 ): Array<{ label: string; count: number }> {
   return toc.tools
-    .filter((tool) => !state.selected.has(tool.id))
+    .filter((tool) => state.excluded.has(tool.id))
     .map((tool) => ({ label: tool.label, count: tool.count }));
 }
 
 export function deriveHiddenCount(toc: SessionDetailToc, state: SessionFilterState): number {
   let hidden = 0;
   for (const id of TOC_CONTENT_FILTER_IDS) {
-    if (!state.selected.has(id)) hidden += toc.counts[id];
+    if (state.excluded.has(id)) hidden += toc.counts[id];
   }
   for (const tool of toc.tools) {
-    if (!state.selected.has(tool.id)) hidden += tool.count;
+    if (state.excluded.has(tool.id)) hidden += tool.count;
   }
   return hidden;
 }

--- a/apps/web/src/components/session-detail/use-session-filters.ts
+++ b/apps/web/src/components/session-detail/use-session-filters.ts
@@ -1,9 +1,8 @@
 /**
  * Binds `filter-state.ts` to React state for one session.
  *
- * The filter set is rebuilt on `sessionKey` change only. Keying it on the toc
- * would reset it on every live-sync rebuild (`toc.filterIds` is a fresh Set
- * each time), which silently threw away the reader's filters.
+ * User exclusions reset only when the session changes. Live toc updates do
+ * not change those decisions and provide the current targets for bulk actions.
  */
 import { useMemo, useState } from "react";
 
@@ -34,7 +33,7 @@ export function useSessionFilters(
   toc: SessionDetailToc,
   sessionKey: string,
 ): { state: SessionFilterState; actions: SessionFilterActions } {
-  const [state, setState] = useState(() => createFilterState(toc));
+  const [state, setState] = useState(createFilterState);
   const [renderedSessionKey, setRenderedSessionKey] = useState(sessionKey);
 
   // React's "adjust state during render" pattern: cheaper and flash-free
@@ -42,7 +41,7 @@ export function useSessionFilters(
   // the previous session's filter set.
   if (renderedSessionKey !== sessionKey) {
     setRenderedSessionKey(sessionKey);
-    setState(createFilterState(toc));
+    setState(createFilterState());
   }
 
   const actions = useMemo<SessionFilterActions>(
@@ -53,7 +52,7 @@ export function useSessionFilters(
       selectWriteToolsOnly: () => setState((s) => selectWriteToolsOnly(s, toc)),
       setToolQuery: (query) => setState((s) => setToolQuery(s, query)),
       toggleToolsExpanded: () => setState((s) => toggleToolsExpanded(s)),
-      resetAll: () => setState((s) => resetAll(s, toc)),
+      resetAll: () => setState(resetAll),
     }),
     [toc],
   );


### PR DESCRIPTION
Live session filters stored the categories present at first render as the complete selection. A first assistant reply or newly used tool was therefore hidden even when the reader had not applied a filter.

Store only explicit exclusions and derive visible categories from the current session contents. Existing choices survive live updates, while new categories remain visible. Bulk actions retain their current-category scope, and changing sessions or resetting clears the exclusions. Tool search and expansion do not trigger message filtering again.

Validation:
- Reproduced a live reply disappearing before the change and verified both messages remain visible afterward.
- Added coverage for new replies/content/tools, retained exclusions after categories disappear and return, and bulk-action behavior.
- Passed local lint, formatting, typecheck, build, and tests.
