### PR TITLE
fix: Read cached details from one snapshot

### DIFF
--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -4,8 +4,13 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BaseAgent, type ChangeCheckResult, type SessionCacheMeta } from "../../agents/base.js";
 import type { IdentifiedSessionHead, SessionDetail, SessionHead } from "../../types/index.js";
-import { readCachedSessionCursor, saveCachedSessions } from "../cache/sessions.js";
+import {
+  loadCachedSessionRawEntry,
+  readCachedSessionCursor,
+  saveCachedSessions,
+} from "../cache/sessions.js";
 import { withCacheDb } from "../cache/connection.js";
+import { sessionDetailVersion } from "../cache/detail-version.js";
 import { MESSAGE_CURSOR_VERSION } from "../cache/message-cursor.js";
 import { syncSessionSearchIndex } from "../cache/search.js";
 import {
@@ -708,6 +713,63 @@ describe("materializeSessionDetail", () => {
       messageCount: 0,
       sentMessageCount: 0,
     });
+  });
+
+  it("reads structured metadata and messages from one committed cache snapshot", () => {
+    const head = makeHead();
+    persistDetail(head, makeDetail("Cached Session"), "before");
+    const before = loadCachedSessionRawEntry("test", "s1");
+    expect(before).not.toBeNull();
+
+    const nextMeta = makeMeta("after");
+    const nextVersion = sessionDetailVersion(nextMeta);
+    const nextPartsJson = JSON.stringify([{ type: "text", text: "Updated body" }]);
+    const nextPath = "/workspace/project/src/updated.ts";
+    const writer = new Database(getCachePath());
+    const originalPrepare = Database.prototype.prepare;
+    let published = false;
+    const prepareSpy = vi.spyOn(Database.prototype, "prepare").mockImplementation(function (
+      this: Database.Database,
+      source: string,
+    ) {
+      if (this !== writer && !published && source.includes("SELECT 1 FROM pending_reindex")) {
+        published = true;
+        writer.transaction(() => {
+          writer
+            .prepare(
+              "UPDATE sessions SET title = ?, meta_json = ? WHERE agent_name = ? AND session_id = ?",
+            )
+            .run("Updated Session", JSON.stringify(nextMeta), "test", "s1");
+          writer
+            .prepare(
+              "UPDATE session_documents SET detail_version = ? WHERE agent_name = ? AND session_id = ?",
+            )
+            .run(nextVersion, "test", "s1");
+          writer
+            .prepare(
+              "UPDATE session_file_activity SET path = ? WHERE agent_name = ? AND session_id = ?",
+            )
+            .run(nextPath, "test", "s1");
+          writer
+            .prepare("UPDATE messages SET parts_json = ? WHERE agent_name = ? AND session_id = ?")
+            .run(nextPartsJson, "test", "s1");
+        })();
+      }
+      return originalPrepare.call(this, source);
+    });
+
+    try {
+      expect(loadCachedSessionRawEntry("test", "s1")).toEqual(before);
+      expect(loadCachedSessionRawEntry("test", "s1")).toMatchObject({
+        data: { title: "Updated Session", file_activity: [{ path: nextPath }] },
+        meta: nextMeta,
+        detailVersion: nextVersion,
+        messageRows: [{ parts_json: nextPartsJson }],
+      });
+    } finally {
+      prepareSpy.mockRestore();
+      writer.close();
+    }
   });
 
   it("reads cursor metadata and message ranges from one cache snapshot", () => {

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -493,12 +493,14 @@ export function loadCachedSessionRawEntry(
 ): CachedSessionRawEntry | null {
   if (!hasCacheStorage()) return null;
 
-  const outcome = withCacheDbReadOnly((db) => {
-    const entry = loadCachedSessionEntryBase(db, agentName, sessionId);
-    return entry
-      ? { ...entry, messageRows: readCachedSessionMessageRows(db, agentName, sessionId, 0) }
-      : null;
-  });
+  const outcome = withCacheDbReadOnly((db) =>
+    db.transaction(() => {
+      const entry = loadCachedSessionEntryBase(db, agentName, sessionId);
+      return entry
+        ? { ...entry, messageRows: readCachedSessionMessageRows(db, agentName, sessionId, 0) }
+        : null;
+    })(),
+  );
   return outcome.status === "success" ? outcome.value : null;
 }
 


### PR DESCRIPTION
Structured cache reads fetched session metadata and messages with separate SQLite snapshots. A background publication between those reads could return an old title with new messages while reporting the detail as fresh.

Read the existing metadata and message queries in one deferred transaction, matching the cursor reader's consistency guarantee without adding queries or stored state.

Validation:
- Reproduced the mixed-generation response through the detail materializer before the change and verified a consistent response afterward.
- Added a real second-connection regression that publishes during a read, checks the complete old snapshot, and verifies the next read sees the new generation.
- Passed local lint, formatting, typecheck, build, and tests.
