### PR TITLE
fix: Refresh live project queries together

### DIFF
--- a/apps/web/src/hooks/useProjects.test.tsx
+++ b/apps/web/src/hooks/useProjects.test.tsx
@@ -183,4 +183,89 @@ describe("useProjectPagination", () => {
     expect(result.current.pageNumber).toBe(2);
     expect(requestCursors).toEqual(["old-cursor", "old-cursor"]);
   });
+
+  it("does not let an older window's recovery reset the current window's page", async () => {
+    const firstWindow = { from: 1, to: 2 };
+    const secondWindow = { from: 3, to: 4 };
+    const secondWindowFirstPage = { ...firstPage, nextCursor: "second-window-cursor" };
+    const secondWindowSecondPage = {
+      ...firstPage,
+      projects: [{ ...project, identityKey: "/second-window-page-two", displayName: "second" }],
+      nextCursor: undefined,
+    };
+    let finishRecovery!: (response: Response) => void;
+    const recoveryResponse = new Promise<Response>((resolve) => {
+      finishRecovery = resolve;
+    });
+    let expired = false;
+    let recoveryStarted = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        const params = new URL(url, "http://localhost").searchParams;
+        const cursor = params.get("cursor");
+        if (cursor === "old-cursor") {
+          return Promise.resolve(
+            expired
+              ? jsonResponse({ error: "snapshot changed" }, 409)
+              : jsonResponse({ ...firstPage, nextCursor: undefined }),
+          );
+        }
+        if (cursor === "second-window-cursor") {
+          return Promise.resolve(jsonResponse(secondWindowSecondPage));
+        }
+        if (params.get("from") === new Date(firstWindow.from).toISOString()) {
+          recoveryStarted = true;
+          return recoveryResponse;
+        }
+        return Promise.resolve(jsonResponse(secondWindowFirstPage));
+      }),
+    );
+    const { client, Wrapper } = createQueryWrapper();
+    const { result, rerender } = renderHook(
+      ({ window }) => {
+        useQuery({
+          queryKey: queryKeys.projectPage(firstWindow),
+          queryFn: ({ signal }) => fetchProjects(firstWindow, { signal }),
+          initialData: firstPage,
+          staleTime: Infinity,
+        });
+        return useProjectPagination(
+          window,
+          window === firstWindow ? firstPage : secondWindowFirstPage,
+        );
+      },
+      { initialProps: { window: firstWindow }, wrapper: Wrapper },
+    );
+
+    act(() => result.current.next());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.pageNumber).toBe(2);
+    expired = true;
+    await act(() =>
+      client.invalidateQueries({
+        queryKey: queryKeys.projectPage(firstWindow, "old-cursor"),
+        exact: true,
+      }),
+    );
+    await waitFor(() => expect(recoveryStarted).toBe(true));
+
+    rerender({ window: secondWindow });
+    act(() => result.current.next());
+    await waitFor(() =>
+      expect(result.current.page?.projects).toEqual(secondWindowSecondPage.projects),
+    );
+    expect(result.current.pageNumber).toBe(2);
+
+    await act(async () =>
+      finishRecovery(jsonResponse({ ...firstPage, nextCursor: "fresh-cursor" })),
+    );
+    await waitFor(() =>
+      expect(
+        client.getQueryData<ApiProjectPage>(queryKeys.projectPage(firstWindow))?.nextCursor,
+      ).toBe("fresh-cursor"),
+    );
+    expect(result.current.pageNumber).toBe(2);
+    expect(result.current.page?.projects).toEqual(secondWindowSecondPage.projects);
+  });
 });

--- a/apps/web/src/hooks/useProjects.test.tsx
+++ b/apps/web/src/hooks/useProjects.test.tsx
@@ -1,8 +1,10 @@
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ApiProjectGroup } from "../lib/api";
+import { fetchProjects, type ApiProjectGroup, type ApiProjectPage } from "../lib/api";
+import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
-import { useProjectLookup } from "./useProjects";
+import { useProjectLookup, useProjectPagination } from "./useProjects";
 
 const project = {
   identityKind: "path",
@@ -16,6 +18,19 @@ const project = {
   cost: 0,
   agentStats: [],
 } satisfies ApiProjectGroup;
+
+const firstPage: ApiProjectPage = {
+  projects: [project],
+  summary: { projects: 101, sessions: 101, tokens: 101, cost: 0, latestActivity: 1 },
+  nextCursor: "old-cursor",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
 
 afterEach(() => {
   cleanup();
@@ -67,5 +82,105 @@ describe("useProjectLookup", () => {
 
     expect(result.current.project).toBe(project);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("useProjectPagination", () => {
+  it.each([true, false])(
+    "recovers a stale live page with an active first page: %s",
+    async (firstPageActive) => {
+      const window = { from: 1, to: 2 };
+      const secondPage = {
+        ...firstPage,
+        projects: [{ ...project, identityKey: "/workspace/second", displayName: "second" }],
+        nextCursor: undefined,
+      };
+      let snapshotChanged = false;
+      const requestCursors: Array<string | null> = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((url: string) => {
+          const cursor = new URL(url, "http://localhost").searchParams.get("cursor");
+          requestCursors.push(cursor);
+          if (cursor === "old-cursor" && snapshotChanged) {
+            return Promise.resolve(jsonResponse({ error: "snapshot changed" }, 409));
+          }
+          return Promise.resolve(
+            jsonResponse(
+              cursor
+                ? secondPage
+                : { ...firstPage, nextCursor: snapshotChanged ? "new-cursor" : "old-cursor" },
+            ),
+          );
+        }),
+      );
+      const { client, Wrapper } = createQueryWrapper();
+      const { result } = renderHook(
+        () => {
+          const initial = useQuery({
+            queryKey: queryKeys.projectPage(window),
+            queryFn: ({ signal }) => fetchProjects(window, { signal }),
+            initialData: firstPage,
+            enabled: firstPageActive,
+            staleTime: Infinity,
+          });
+          return useProjectPagination(window, initial.data);
+        },
+        { wrapper: Wrapper },
+      );
+
+      act(() => result.current.next());
+      await waitFor(() => expect(result.current.page?.projects).toEqual(secondPage.projects));
+      expect(result.current.pageNumber).toBe(2);
+
+      snapshotChanged = true;
+      await act(() =>
+        client.invalidateQueries({
+          queryKey: queryKeys.projectWindow(window),
+          refetchType: "active",
+        }),
+      );
+
+      await waitFor(() => expect(result.current.page?.nextCursor).toBe("new-cursor"));
+      expect(result.current.pageNumber).toBe(1);
+      expect(result.current.error).toBeNull();
+
+      act(() => result.current.next());
+      await waitFor(() => expect(result.current.pageNumber).toBe(2));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(requestCursors.at(-1)).toBe("new-cursor");
+      expect(result.current.page?.projects).toEqual(secondPage.projects);
+    },
+  );
+
+  it("keeps non-stale failures on their page for retry", async () => {
+    const requestCursors: Array<string | null> = [];
+    let failing = true;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        requestCursors.push(new URL(url, "http://localhost").searchParams.get("cursor"));
+        return Promise.resolve(
+          failing
+            ? jsonResponse({ error: "unavailable" }, 503)
+            : jsonResponse({ ...firstPage, nextCursor: undefined }),
+        );
+      }),
+    );
+    const { Wrapper } = createQueryWrapper();
+    const { result } = renderHook(() => useProjectPagination({ from: 1, to: 2 }, firstPage), {
+      wrapper: Wrapper,
+    });
+
+    act(() => result.current.next());
+    await waitFor(() => expect(result.current.error).toContain("503"));
+    expect(result.current.pageNumber).toBe(2);
+    expect(result.current.canPrevious).toBe(true);
+
+    failing = false;
+    await act(() => result.current.retry());
+    await waitFor(() => expect(result.current.error).toBeNull());
+    expect(result.current.pageNumber).toBe(2);
+    expect(requestCursors).toEqual(["old-cursor", "old-cursor"]);
   });
 });

--- a/apps/web/src/hooks/useProjects.ts
+++ b/apps/web/src/hooks/useProjects.ts
@@ -45,8 +45,12 @@ export function useProjectPagination(
         { queryKey: queryKeys.projectPage(window ?? {}), exact: true },
         { cancelRefetch: true },
       )
-      .then(() => setNavigation({ key, cursors: [] }));
-  }, [key, queryClient, staleCursor, window]);
+      .then(() =>
+        setNavigation((current) =>
+          current.key === key && current.cursors.at(-1) === cursor ? { key, cursors: [] } : current,
+        ),
+      );
+  }, [cursor, key, queryClient, staleCursor, window]);
 
   const next = useCallback(() => {
     const nextCursor = query.data?.nextCursor;

--- a/apps/web/src/hooks/useProjects.ts
+++ b/apps/web/src/hooks/useProjects.ts
@@ -1,5 +1,5 @@
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ApiProjectGroup, ApiProjectPage, AppConfig } from "../lib/api";
 import { ApiRequestError, fetchProject, fetchProjects } from "../lib/api";
 import { getProjectIdentityKey, type ProjectRouteIdentity } from "../lib/projects";
@@ -35,6 +35,18 @@ export function useProjectPagination(
     retry: false,
   });
   const page = query.data ?? (cursor ? null : initialPage);
+  const staleCursor =
+    Boolean(cursor) && query.error instanceof ApiRequestError && query.error.status === 409;
+
+  useEffect(() => {
+    if (!staleCursor) return;
+    void queryClient
+      .invalidateQueries(
+        { queryKey: queryKeys.projectPage(window ?? {}), exact: true },
+        { cancelRefetch: true },
+      )
+      .then(() => setNavigation({ key, cursors: [] }));
+  }, [key, queryClient, staleCursor, window]);
 
   const next = useCallback(() => {
     const nextCursor = query.data?.nextCursor;
@@ -47,29 +59,22 @@ export function useProjectPagination(
   }, [cursors, key]);
 
   const retry = useCallback(async () => {
-    if (cursor && query.error instanceof ApiRequestError && query.error.status === 409) {
-      setNavigation({ key, cursors: [] });
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.projectPage(window ?? {}),
-        exact: true,
-      });
-      return;
-    }
     await query.refetch();
-  }, [cursor, key, query, queryClient, window]);
+  }, [query]);
 
   return {
     page,
     pageNumber: cursors.length + 1,
-    loading: query.isPending || query.isPlaceholderData,
-    error:
-      query.isError && query.error instanceof Error
+    loading: staleCursor || query.isPending || query.isPlaceholderData,
+    error: staleCursor
+      ? null
+      : query.isError && query.error instanceof Error
         ? query.error.message
         : query.isError
           ? "Unable to load projects."
           : null,
-    canPrevious: cursors.length > 0 && !query.isPlaceholderData,
-    canNext: Boolean(query.data?.nextCursor) && !query.isPlaceholderData,
+    canPrevious: cursors.length > 0 && !staleCursor && !query.isPlaceholderData,
+    canNext: Boolean(query.data?.nextCursor) && !staleCursor && !query.isPlaceholderData,
     next,
     previous,
     retry,

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -23,13 +23,19 @@ import {
   type SessionProjection,
 } from "./useSessionStore";
 import { useDashboard } from "./useDashboard";
+import { useProjectLookup, useProjectPagination } from "./useProjects";
 
-vi.mock("../lib/api", () => ({
-  fetchAgents: vi.fn(),
-  fetchDashboard: vi.fn(),
-  fetchProjects: vi.fn(),
-  fetchSessions: vi.fn(),
-}));
+vi.mock("../lib/api", async (importOriginal) => {
+  const { ApiRequestError } = await importOriginal<typeof import("../lib/api")>();
+  return {
+    ApiRequestError,
+    fetchAgents: vi.fn(),
+    fetchDashboard: vi.fn(),
+    fetchProjects: vi.fn(),
+    fetchProject: vi.fn(),
+    fetchSessions: vi.fn(),
+  };
+});
 
 const config = {
   window: { from: 1_700_000_000_000, to: 1_700_004_000_000, days: 7 },
@@ -84,6 +90,95 @@ async function renderStore(window: AppConfig["window"] = config.window) {
 }
 
 describe("useSessionStore", () => {
+  it("resynchronizes when an active project page rejects its old cursor", async () => {
+    const firstPage = { ...projectPage, nextCursor: "old-cursor" };
+    const nextFirstPage = { ...projectPage, nextCursor: "new-cursor" };
+    let expired = false;
+    vi.mocked(api.fetchProjects).mockImplementation(async (_window, options) => {
+      if (options?.cursor) {
+        if (expired) throw new api.ApiRequestError("Project cursor expired", 409);
+        return projectPage;
+      }
+      return expired ? nextFirstPage : firstPage;
+    });
+    const { client, Wrapper } = createQueryWrapper();
+    client.setQueryData(queryKeys.projectPage(config.window), firstPage);
+    const { result } = renderHook(
+      () => ({
+        store: useSessionStore(config.window),
+        pagination: useProjectPagination(config.window, firstPage),
+      }),
+      { wrapper: Wrapper },
+    );
+    await waitFor(() => expect(result.current.store.loading).toBe(false));
+    act(() => result.current.pagination.next());
+    await waitFor(() => expect(result.current.pagination.pageNumber).toBe(2));
+    await waitFor(() => expect(result.current.pagination.loading).toBe(false));
+
+    expired = true;
+    await act(async () => {
+      await expect(result.current.store.resyncLiveState()).resolves.toBeUndefined();
+    });
+
+    await waitFor(() => expect(result.current.pagination.pageNumber).toBe(1));
+    await waitFor(() => expect(result.current.pagination.page?.nextCursor).toBe("new-cursor"));
+    expect(result.current.pagination.error).toBeNull();
+  });
+
+  it.each(["live", "resync"] as const)(
+    "refreshes project details and invalidates inactive pages in the current window on %s",
+    async (refresh) => {
+      const outsideProject: ApiProjectGroup = {
+        identityKind: "path",
+        identityKey: "/outside-first-page",
+        displayName: "Outside",
+        sources: ["codex"],
+        sessionCount: 2,
+        lastActivity: 1,
+        messages: 2,
+        tokens: 2,
+        cost: 0,
+        agentStats: [],
+      };
+      const identity = { kind: "path", key: outsideProject.identityKey } as const;
+      vi.mocked(api.fetchProject).mockResolvedValue(outsideProject);
+      const { client, Wrapper } = createQueryWrapper();
+      const inactivePageKey = queryKeys.projectPage(config.window, "inactive-cursor");
+      const otherWindowKey = queryKeys.projectDetail({ from: 1, to: 2 }, identity);
+      client.setQueryData(inactivePageKey, projectPage);
+      client.setQueryData(otherWindowKey, outsideProject);
+      const { result } = renderHook(
+        () => {
+          const store = useSessionStore(config.window);
+          const lookup = useProjectLookup(config.window, identity, store.projects);
+          return { store, lookup };
+        },
+        { wrapper: Wrapper },
+      );
+      await waitFor(() => expect(result.current.store.loading).toBe(false));
+      await waitFor(() => expect(result.current.lookup.project?.sessionCount).toBe(2));
+      vi.mocked(api.fetchProject).mockResolvedValue({ ...outsideProject, sessionCount: 1 });
+
+      await act(async () => {
+        if (refresh === "resync") await result.current.store.resyncLiveState();
+        else
+          await result.current.store.applyLiveEvent({
+            ...SAMPLE_SESSIONS_UPDATED_EVENT,
+            newSessionRefs: [],
+            changedSessionHeads: [],
+            removedSessionRefs: [SAMPLE_SESSION_HEAD.reference],
+            projectionSessionOrder: [],
+          });
+      });
+
+      await waitFor(() => expect(result.current.lookup.project?.sessionCount).toBe(1));
+      expect(api.fetchProject).toHaveBeenCalledTimes(2);
+      expect(api.fetchProjects).toHaveBeenCalledTimes(2);
+      expect(client.getQueryState(inactivePageKey)?.isInvalidated).toBe(true);
+      expect(client.getQueryState(otherWindowKey)?.isInvalidated).toBe(false);
+    },
+  );
+
   it("makes sessions ready before the initial dashboard request completes", async () => {
     const dashboard = deferred<DashboardData>();
     vi.mocked(api.fetchDashboard).mockReturnValueOnce(dashboard.promise);

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -179,17 +179,16 @@ async function refreshLiveSnapshotAggregates(
   ]);
 }
 
-async function refreshLiveProjects(
+async function refreshProjectQueries(
   queryClient: QueryClient,
   window: AppConfig["window"],
 ): Promise<void> {
-  const options = projectsOptions(window);
-  await queryClient.invalidateQueries({
-    queryKey: options.queryKey,
-    exact: true,
-    refetchType: "none",
-  });
-  await queryClient.fetchQuery(options);
+  await queryClient.invalidateQueries(
+    { queryKey: queryKeys.projectWindow(window), refetchType: "active" },
+    { cancelRefetch: false },
+  );
+  const error = queryClient.getQueryState(queryKeys.projectPage(window))?.error;
+  if (error) throw error;
 }
 
 function liveAggregateRefreshDelay(queryClient: QueryClient, window: AppConfig["window"]): number {
@@ -269,16 +268,15 @@ export function useSessionStore(window: AppConfig["window"] | null) {
 
   const reload = useCallback(async (): Promise<void> => {
     if (!window) return;
-    const [agentsResult, projectionResult, dashboardResult, projectsResult] = await Promise.all([
+    const [agentsResult, projectionResult, dashboardResult] = await Promise.all([
       refetchAgents({ cancelRefetch: true }),
       refetchProjection({ cancelRefetch: true }),
       refetchDashboard({ cancelRefetch: true }),
-      refetchProjects({ cancelRefetch: true }),
+      refreshProjectQueries(queryClient, window),
     ]);
-    const failure =
-      agentsResult.error ?? projectionResult.error ?? dashboardResult.error ?? projectsResult.error;
+    const failure = agentsResult.error ?? projectionResult.error ?? dashboardResult.error;
     if (failure) throw failure;
-  }, [refetchAgents, refetchDashboard, refetchProjection, refetchProjects, window]);
+  }, [queryClient, refetchAgents, refetchDashboard, refetchProjection, window]);
 
   const applyLiveEvent = useCallback(
     async (event: SessionsUpdatedEvent): Promise<LiveSessionApplyResult | null> => {
@@ -331,7 +329,7 @@ export function useSessionStore(window: AppConfig["window"] | null) {
         liveAggregateRefreshTimerRef.current = null;
         void Promise.all([
           refreshLiveSnapshotAggregates(queryClient, activeWindow),
-          refreshLiveProjects(queryClient, activeWindow),
+          refreshProjectQueries(queryClient, activeWindow),
         ])
           .then(() => {
             liveAggregateWindowRef.current = activeWindow;

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -26,10 +26,11 @@ export const queryKeys = {
   agentCatalogs: ["agent-catalog"] as const,
   agentCatalog: (window: TimeWindow) => ["agent-catalog", normalizeWindow(window)] as const,
   projects: ["projects"] as const,
+  projectWindow: (window: TimeWindow) => ["projects", normalizeWindow(window)] as const,
   projectPage: (window: TimeWindow, cursor?: string) =>
-    ["projects", "page", normalizeWindow(window), cursor ?? null] as const,
+    ["projects", normalizeWindow(window), "page", cursor ?? null] as const,
   projectDetail: (window: TimeWindow, project: ProjectIdentityRef) =>
-    ["projects", "detail", normalizeWindow(window), project] as const,
+    ["projects", normalizeWindow(window), "detail", project] as const,
   search: (query: string, options: SearchRequestOptions) => ["search", query, options] as const,
   searches: ["search"] as const,
   sessionDetails: ["session-detail"] as const,


### PR DESCRIPTION
Project live refresh only updated the first catalog page. Details fetched for projects outside that page and later pagination queries retained outdated statistics after session changes.

Group project page and detail queries under their time window and refresh that family for live updates and resynchronization. Active queries refetch, inactive pages become stale, and other windows remain untouched. When the server rejects a stale pagination cursor, navigation returns to a refreshed first page; ordinary request failures remain retryable on the current page. Recovery only resets the window and cursor that requested it, so a delayed response cannot overwrite newer navigation.

Validation:
- Reproduced stale project counts through the live store and project lookup before the change.
- Added regressions for live/resync detail refresh, inactive pages, window isolation, stale cursor recovery, cross-window recovery races, and ordinary request failures.
- Passed local lint, formatting, typecheck, build, and tests.
