### PR TITLE
fix: Preserve Claude child parent references

### DIFF
--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClaudeCodeAgent } from "../claudecode.js";
+import { buildSessionTree } from "../../contract/session-tree.js";
 import type { Message, MessagePart, SessionHead } from "../../types/index.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
 import { sessionDetailVersion } from "../../discovery/cache/detail-version.js";
@@ -73,21 +74,23 @@ afterEach(() => {
 });
 
 describe("ClaudeCodeAgent cache refresh", () => {
-  it("rebuilds heads and invalidates details from the first-usage parser", () => {
+  it("rebuilds heads and invalidates details with outdated parent references", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-parser-"));
     tempDirs.push(basePath);
     const projectDir = join(basePath, "project");
-    mkdirSync(projectDir);
-    writeMinimalClaudeSession(join(projectDir, "session-1.jsonl"));
+    const childDir = join(projectDir, "missing-parent", "subagents");
+    mkdirSync(childDir, { recursive: true });
+    writeMinimalClaudeSession(join(childDir, "agent-child.jsonl"));
     const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
-    const sessions = agent.scan();
+    const sessions = agent.scan().map((session) => ({ ...session, parent_reference: undefined }));
     const meta = agent.snapshotSessionCacheMeta();
-    const oldMeta = meta["session-1"]!;
+    const oldMeta = meta["child"]!;
     oldMeta.sourceFingerprint = String(oldMeta.sourceFingerprint).replace(
+      String(oldMeta.headIndexVersion),
       "claudecode-head-v8",
-      "claudecode-head-v7",
     );
-    oldMeta.headIndexVersion = "claudecode-head-v7";
+    oldMeta.headIndexVersion = "claudecode-head-v8";
+    oldMeta.parentSessionId = null;
     const oldDetailVersion = sessionDetailVersion(oldMeta);
 
     const refreshed = agent.sessionSourceAccess.synchronize(
@@ -95,9 +98,16 @@ describe("ClaudeCodeAgent cache refresh", () => {
       { kind: "refresh" },
     );
 
-    expect(refreshed.detectedSessionIds).toEqual(["session-1"]);
+    expect(refreshed.detectedSessionIds).toEqual(["child"]);
     expect(refreshed.sourceOutcomes[0]?.status).toBe("parsed");
-    expect(sessionDetailVersion(refreshed.meta["session-1"])).not.toBe(oldDetailVersion);
+    expect(refreshed.sessions[0]?.parent_reference).toEqual({
+      agentName: "claudecode",
+      sessionId: "missing-parent",
+    });
+    expect(agent.getSessionData("child").parent_reference).toEqual(
+      refreshed.sessions[0]?.parent_reference,
+    );
+    expect(sessionDetailVersion(refreshed.meta["child"])).not.toBe(oldDetailVersion);
     expect(
       agent.sessionSourceAccess.synchronize(refreshed, { kind: "refresh" }).detectedSessionIds,
     ).toEqual([]);
@@ -360,6 +370,39 @@ describe("ClaudeCodeAgent cache refresh", () => {
     ).toEqual([]);
   });
 
+  it("keeps an in-window orphan and its related child sources", () => {
+    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-orphan-related-"));
+    tempDirs.push(basePath);
+    const childDir = join(basePath, "project", "missing-parent", "subagents");
+    mkdirSync(childDir, { recursive: true });
+    const orphanFile = join(childDir, "agent-orphan.jsonl");
+    const childFile = join(childDir, "agent-child.jsonl");
+    writeMinimalClaudeSession(orphanFile);
+    writeMinimalClaudeSession(childFile);
+    writeFileSync(
+      join(childDir, "agent-child.meta.json"),
+      JSON.stringify({ parentAgentId: "orphan" }),
+    );
+    const orphanTime = new Date(1_700_000_100_000);
+    const childTime = new Date(1_600_000_100_000);
+    utimesSync(orphanFile, orphanTime, orphanTime);
+    utimesSync(childFile, childTime, childTime);
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
+    const from = orphanTime.getTime() - 1;
+
+    expect(
+      agent
+        .listSessionSources({ from })
+        .map(({ sessionId }) => sessionId)
+        .sort(),
+    ).toEqual(["child", "orphan"]);
+    expect(
+      agent
+        .listSessionSources({ from, includeRelatedSessions: false })
+        .map(({ sessionId }) => sessionId),
+    ).toEqual(["orphan"]);
+  });
+
   it("stats each session file once during a scan", () => {
     const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-stat-"));
     tempDirs.push(basePath);
@@ -417,7 +460,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
         sessionId: "session-1",
         sourcePath: sessionFile,
         fingerprint: JSON.stringify([
-          "claudecode-head-v8",
+          "claudecode-head-v9",
           sessionTime.getTime(),
           statSync(sessionFile).size,
           indexTime.getTime(),
@@ -1155,33 +1198,48 @@ describe("ClaudeCodeAgent head parsing", () => {
     expect(writeSession(["", "   ", ""]).agent.scan()).toEqual([]);
   });
 
-  it("treats a child with missing metadata and parent as a root", () => {
-    const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-orphan-"));
-    tempDirs.push(basePath);
-    const projectDir = join(basePath, "project");
-    const childDir = join(projectDir, "missing-parent", "subagents");
-    const childId = "orphan-child";
-    mkdirSync(childDir, { recursive: true });
-    writeFileSync(
-      join(childDir, "agent-" + childId + ".jsonl"),
-      JSON.stringify({
-        type: "user",
-        timestamp: "2026-04-20T10:00:00Z",
-        cwd: "/tmp/project",
-        message: { role: "user", content: "Orphan child" },
-      }),
-    );
+  it.each([undefined, "declared-parent"])(
+    "preserves parent references before and after a parent appears (%s)",
+    (parentAgentId) => {
+      const basePath = mkdtempSync(join(tmpdir(), "codesesh-claude-orphan-"));
+      tempDirs.push(basePath);
+      const projectDir = join(basePath, "project");
+      const childDir = join(projectDir, "missing-parent", "subagents");
+      const childId = "orphan-child";
+      const parentId = parentAgentId ?? "missing-parent";
+      mkdirSync(childDir, { recursive: true });
+      writeMinimalClaudeSession(join(childDir, "agent-" + childId + ".jsonl"));
+      if (parentAgentId) {
+        writeFileSync(
+          join(childDir, "agent-" + childId + ".meta.json"),
+          JSON.stringify({ parentAgentId }),
+        );
+      }
+      const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
+      const initial = agent.scan();
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+      expect(initial).toMatchObject([
+        {
+          reference: { agentName: "claudecode", sessionId: childId },
+          parent_reference: { agentName: "claudecode", sessionId: parentId },
+        },
+      ]);
+      expect(buildSessionTree(initial).mountStateOf(initial[0]!)).toBe("orphan");
 
-    expect(agent.scan()).toMatchObject([
-      {
-        reference: { agentName: "claudecode", sessionId: childId },
-        title: "Orphan child",
-        parent_reference: undefined,
-      },
-    ]);
-  });
+      const parentFile = join(projectDir, parentId + ".jsonl");
+      writeMinimalClaudeSession(parentFile);
+      const added = refresh(agent, initial);
+      const child = added.sessions.find((session) => session.reference.sessionId === childId)!;
+      expect(added.detectedSessionIds).toEqual([parentId]);
+      expect(buildSessionTree(added.sessions).mountStateOf(child)).toBe("mounted-child");
+      expect(agent.getSessionData(childId).parent_reference).toEqual(child.parent_reference);
+
+      rmSync(parentFile);
+      const removed = refresh(agent, added.sessions);
+      expect(buildSessionTree(removed.sessions).mountStateOf(child)).toBe("orphan");
+      expect(removed.sessions[0]?.parent_reference).toEqual(child.parent_reference);
+    },
+  );
 
   it("skips a file whose first record is malformed", () => {
     expect(writeSession(["not json", userLine("Visible")]).agent.scan()).toEqual([]);

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -26,8 +26,7 @@ import {
 } from "./claudecode-record-converter.js";
 import { TranscriptBuilder } from "./transcript-builder.js";
 
-// v8: request usage uses the final snapshot, shared by heads and message costs.
-const HEAD_INDEX_VERSION = "claudecode-head-v8";
+const HEAD_INDEX_VERSION = "claudecode-head-v9";
 
 export function resolveClaudeCodeDataRoot(): string {
   return resolveHomePath("CLAUDE_CONFIG_DIR", ".claude");
@@ -124,7 +123,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     const allSources = this.walkFiles(projectDirs, (entry) => entry.name.endsWith(".jsonl"), {
       recursive: true,
     });
-    this.indexChildContexts(allSources, projectDirs);
+    this.indexChildContexts(allSources);
     const indexedSources = allSources.flatMap((source) => {
       const child = this.childContextsBySource.get(source.file);
       if (!child && !projectDirSet.has(dirname(source.file))) return [];
@@ -142,6 +141,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
 
     if (options?.from != null || options?.to != null) {
       type IndexedSource = (typeof indexedSources)[number];
+      const knownSessionIds = new Set(indexedSources.map(({ sessionId }) => sessionId));
       const childrenByParent = new Map<string, IndexedSource[]>();
       for (const indexed of indexedSources) {
         const parentId = indexed.child?.parentSessionId;
@@ -164,7 +164,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
         const indexed = windowSelectedById.get(sessionId);
         if (!indexed) return false;
         const parentId = indexed.child?.parentSessionId;
-        if (!parentId) {
+        if (!parentId || !knownSessionIds.has(parentId)) {
           acceptedIds.add(sessionId);
           return true;
         }
@@ -184,7 +184,9 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
 
       if (options?.includeRelatedSessions !== false) {
         const pending = [...connectedSelected.values()]
-          .filter(({ child }) => !child?.parentSessionId)
+          .filter(
+            ({ child }) => !child?.parentSessionId || !knownSessionIds.has(child.parentSessionId),
+          )
           .map(({ sessionId }) => sessionId);
         while (pending.length > 0) {
           const parentId = pending.pop()!;
@@ -321,42 +323,19 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       this.walkFiles(projectDirs, (entry) => entry.name.endsWith(".jsonl"), {
         recursive: true,
       }),
-      projectDirs,
     );
   }
 
-  private indexChildContexts(
-    sources: readonly SessionSourceFile[],
-    projectDirs: readonly string[],
-  ): void {
+  private indexChildContexts(sources: readonly SessionSourceFile[]): void {
     this.childContextsBySource.clear();
     this.childSessionIdByToolUseId.clear();
-    const projectDirSet = new Set(projectDirs);
-    const contexts = new Map<string, ClaudeChildContext>();
-    const knownSessionIds = new Set<string>();
 
     for (const source of sources) {
       const child = this.readChildContext(source.file);
-      if (!child) {
-        if (projectDirSet.has(dirname(source.file))) {
-          knownSessionIds.add(basename(source.file, ".jsonl"));
-        }
-        continue;
-      }
-      contexts.set(source.file, child);
-      knownSessionIds.add(child.sessionId);
-    }
-
-    for (const [sourcePath, child] of contexts) {
-      const parentSessionId =
-        child.parentSessionId && knownSessionIds.has(child.parentSessionId)
-          ? child.parentSessionId
-          : null;
-      const normalized =
-        parentSessionId === child.parentSessionId ? child : { ...child, parentSessionId };
-      this.childContextsBySource.set(sourcePath, normalized);
+      if (!child) continue;
+      this.childContextsBySource.set(source.file, child);
       if (child.toolUseId) {
-        this.childSessionIdByToolUseId.set(child.toolUseId, normalized.sessionId);
+        this.childSessionIdByToolUseId.set(child.toolUseId, child.sessionId);
       }
     }
 
@@ -402,11 +381,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     if (!sessionId) return null;
 
     const parentAgentId = asString(metadata?.["parentAgentId"])?.trim();
-    const candidateParentId = parentAgentId || basename(parentDir) || null;
-    const parentSessionId =
-      candidateParentId && this.hasChildParent(sourcePath, projectDir, candidateParentId)
-        ? candidateParentId
-        : null;
+    const parentSessionId = parentAgentId || basename(parentDir) || null;
     const name = asString(metadata?.["name"])?.trim();
     const description = asString(metadata?.["description"])?.trim();
 
@@ -420,15 +395,6 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
     };
     this.childContextCache.set(sourcePath, { metaMtimeMs, context });
     return context;
-  }
-
-  private hasChildParent(sourcePath: string, projectDir: string, parentSessionId: string): boolean {
-    const subagentsDir = dirname(sourcePath);
-    return [
-      join(projectDir, parentSessionId + ".jsonl"),
-      join(subagentsDir, "agent-" + parentSessionId + ".jsonl"),
-      join(subagentsDir, parentSessionId + ".jsonl"),
-    ].some((path) => existsSync(path));
   }
 
   protected createFileSessionMeta(head: SessionHead, source: SessionSourceFile): SessionMeta {


### PR DESCRIPTION
Claude child metadata was cached after discarding parent references whose transcripts had not appeared yet. Because the cache only tracked the child's metadata timestamp, a later parent file did not reconnect the child in a running instance.

Preserve the parent identity from Claude metadata or the transcript directory and let the session tree determine whether it can be mounted. Remove the duplicate parent-existence filtering and bump the head parser version so existing cached heads are rebuilt. Windowed scans still include true orphans and exclude children whose known parents are outside the selected window.

Validation:
- Reproduced a child remaining detached after its parent appeared in the same agent instance.
- Added coverage for delayed parents, retained parent references, windowed orphan selection, and old parser-cache invalidation.
- Passed local lint, formatting, typecheck, build, and tests.
