### PR TITLE
fix: Avoid full index rebuilds during refresh

### DIFF
--- a/apps/web/src/hooks/useScanStatus.test.ts
+++ b/apps/web/src/hooks/useScanStatus.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, render, renderHook, waitFor } from "@testing-library/react";
 import { createElement, createRef, Profiler, useImperativeHandle, type ReactNode } from "react";
-import { flushSync } from "react-dom";
 import type { ScanStatusEvent } from "../lib/api";
 import * as api from "../lib/api";
 import { ScanStatusProvider, useScanStatus, useScanStatusPublisher } from "./useScanStatus";
@@ -144,7 +143,7 @@ describe("useScanStatus", () => {
     const publish = publisherRef.current?.publish;
     if (!publish) throw new Error("Scan status publisher is not mounted");
     for (let index = 1; index <= 10_000; index += 1) {
-      flushSync(() => publish({ ...sample, updatedAt: sample.updatedAt + index }));
+      act(() => publish({ ...sample, updatedAt: sample.updatedAt + index }));
     }
 
     expect(statusRender).toHaveBeenCalledTimes(10_001);

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -174,7 +174,35 @@ describe("formatScanStatusLabel", () => {
     ).toBe("Finalizing full-history metadata · codex · 68/2107");
   });
 
-  it("shows finalization progress instead of a stalled scan label", () => {
+  it.each([
+    ["scanning", "Checking for new or changed sessions"],
+    ["finalizing", "Finalizing session metadata"],
+  ] as const)("shows current item counts while %s", (phase, label) => {
+    expect(
+      formatScanStatusLabel({
+        active: true,
+        phase: phase === "scanning" ? "scanning" : "publishing",
+        completedAgents: ["claudecode"],
+        scanningAgents: ["codex"],
+        totalAgents: 2,
+        agentStatuses: {
+          codex: {
+            agentName: "codex",
+            status: phase,
+            total: 2108,
+            processed: 17,
+            updatedAt: 1,
+          },
+        },
+      } as unknown as ScanStatusEvent),
+    ).toBe(`${label} · codex · 17/2108 · 1/2 agents ready`);
+  });
+
+  it.each([
+    ["publish-queued", "Session publication queued"],
+    ["publishing", "Publishing session updates"],
+    ["indexing", "Publishing session updates"],
+  ] as const)("does not reuse completed scan counts while %s", (phase, label) => {
     expect(
       formatScanStatusLabel({
         active: true,
@@ -185,17 +213,17 @@ describe("formatScanStatusLabel", () => {
         agentStatuses: {
           codex: {
             agentName: "codex",
-            status: "finalizing",
-            total: 2108,
-            processed: 17,
+            status: phase,
+            total: 119,
+            processed: 119,
             updatedAt: 1,
           },
         },
       } as unknown as ScanStatusEvent),
-    ).toBe("Finalizing session metadata · codex · 17/2108 · 1/2 agents ready");
+    ).toBe(`${label} · codex · 1/2 agents ready`);
   });
 
-  it("does not claim published progress can resume", () => {
+  it("does not reuse full-history scan counts while preparing publication", () => {
     expect(
       formatScanStatusLabel({
         active: false,
@@ -203,7 +231,7 @@ describe("formatScanStatusLabel", () => {
           active: true,
           currentAgent: "zcode",
           pendingAgents: [],
-          progress: { phase: "publishing", sessions: 84 },
+          progress: { phase: "publishing", total: 84, processed: 84, sessions: 84 },
           completedAgents: [],
           failedAgents: [],
         },
@@ -218,14 +246,14 @@ describe("formatScanStatusLabel", () => {
         active: true,
         currentAgent: "codex",
         pendingAgents: [],
-        progress: { phase: "indexing" },
+        progress: { phase: "indexing", total: 119, processed: 119 },
         completedAgents: [],
         failedAgents: [],
       },
     } as unknown as ScanStatusEvent;
 
     expect(formatScanStatusLabel(status)).toBe("Writing full-history search index · codex");
-    status.backfill.progress = { phase: "committing" };
+    status.backfill.progress = { phase: "committing", total: 119, processed: 119 };
     expect(formatScanStatusLabel(status)).toBe("Committing full-history publication · codex");
   });
 
@@ -242,7 +270,7 @@ describe("formatScanStatusLabel", () => {
           failedAgents: [],
         },
       } as unknown as ScanStatusEvent),
-    ).toBe("Full-history publication queued · zcode · 84/84");
+    ).toBe("Full-history publication queued · zcode");
   });
 
   it("labels search maintenance as non-blocking background work", () => {
@@ -272,8 +300,9 @@ describe("formatAgentScanProgress", () => {
   it("distinguishes publishing from scanning and pending", () => {
     const status = {
       agentStatuses: {
-        codex: { status: "publishing" },
-        zcode: { status: "publish-queued" },
+        codex: { status: "publishing", total: 119, processed: 119 },
+        zcode: { status: "publish-queued", total: 84, processed: 84 },
+        claudecode: { status: "indexing", total: 141, processed: 141 },
         claude: { status: "scanning" },
         kimi: { status: "pending" },
       },
@@ -281,6 +310,7 @@ describe("formatAgentScanProgress", () => {
 
     expect(formatAgentScanProgress(status, "codex")).toBe("Publishing");
     expect(formatAgentScanProgress(status, "zcode")).toBe("Queued to publish");
+    expect(formatAgentScanProgress(status, "claudecode")).toBe("Publishing");
     expect(formatAgentScanProgress(status, "claude")).toBe("Scanning");
     expect(formatAgentScanProgress(status, "kimi")).toBe("Pending");
   });

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -54,7 +54,11 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
     const pending = status.backfill.pendingAgents.length;
     const progress = status.backfill.progress;
     const progressLabel =
-      progress?.total && progress.processed != null
+      (progress?.phase == null ||
+        progress.phase === "scanning" ||
+        progress.phase === "finalizing") &&
+      progress?.total &&
+      progress.processed != null
         ? ` · ${progress.processed}/${progress.total}`
         : "";
     const stageLabel =
@@ -88,7 +92,9 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
     const current = status.scanningAgents[0];
     const currentStatus = current ? status.agentStatuses[current] : null;
     const itemProgress =
-      currentStatus?.total && currentStatus.processed != null
+      (currentStatus?.status === "scanning" || currentStatus?.status === "finalizing") &&
+      currentStatus.total &&
+      currentStatus.processed != null
         ? ` · ${currentStatus.processed}/${currentStatus.total}`
         : "";
     const agentProgress =

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -14,6 +14,7 @@
 | 文件活动搜索的 limit 作用于 Session | `packages/core/src/discovery/cache/__tests__/search-integration.test.ts` |
 | 关键查询走预期索引（`EXPLAIN QUERY PLAN`） | 同上两处 |
 | 仅会话头元数据变化时复用已物化消息 | `packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts` |
+| 已有索引的批量会话更新不重建无关历史全文 | 同上 |
 | 首屏 JS gzip 预算与延迟依赖 | `apps/web/tests/initial-bundle.test.ts` |
 | Session Detail 缓存基数上界 | `apps/web/src/lib/session-detail-cache.test.ts` |
 | 一帧测量只产生一次 commit | `apps/web/src/components/session-detail/message-list.test.tsx` |

--- a/docs/scanning-and-caching.md
+++ b/docs/scanning-and-caching.md
@@ -166,8 +166,10 @@ saveCachedSessionChanges()
 完整初始化/backfill 使用 `saveCachedSessions()` 和 `syncSessionSearchIndex()`。增量路径
 只加载需要重新索引的会话详情；未变化会话不会再次调用 `getSessionData()`。
 
-当变化量达到 `SEARCH_INDEX_BULK_SYNC_THRESHOLD` 时，FTS 使用批量重建；小批量变化由
-触发器增量维护。
+已有会话索引时，FTS 默认由触发器增量维护；只有全局索引为空且变化量达到
+`SEARCH_INDEX_BULK_SYNC_THRESHOLD` 时才自动批量重建。会话全文索引由所有 Agent 共用，
+不能仅凭单个 Agent 的变化量或文件事件数量触发全局重建。程序化调用仍可通过
+`isBulk` 或 `bulkThreshold` 显式指定重建策略。
 
 ## 详情一致性
 

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -636,7 +636,7 @@ describe("AgentSyncEngine", () => {
     expect(checkForChanges).toHaveBeenCalledTimes(1);
   });
 
-  it("marks search index work as bulk after many pending signals", async () => {
+  it("does not force a search index rebuild after many pending signals", async () => {
     vi.useFakeTimers();
     const previous = makeSession("session", "before");
     const updated = makeSession("session", "after");
@@ -658,11 +658,12 @@ describe("AgentSyncEngine", () => {
       [
         expect.objectContaining({
           kind: "changes",
-          searchIndexOptions: { isBulk: true },
         }),
       ],
       expect.any(Function),
     );
+    const jobs = searchIndex.enqueue.mock.calls[0]?.[1] as Array<Record<string, unknown>>;
+    expect(jobs[0]).not.toHaveProperty("searchIndexOptions");
     await engine.shutdown();
   });
 

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -123,7 +123,6 @@ type RefreshStrategyResult =
 
 const REFRESH_DEBOUNCE_MS = 200;
 const EMPTY_AGENT_REFRESH_DEBOUNCE_MS = 30_000;
-const SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD = 100;
 // SSE carries one compact summary; logs retain the complete failure list.
 const SOURCE_FAILURE_SUMMARY_MAX_LENGTH = 160;
 
@@ -469,8 +468,6 @@ export class AgentSyncEngine {
     }
 
     const nextSessions = attachMissingProjectIdentities(strategyResult.nextSessions);
-    const searchIndexOptions =
-      pendingPathCount >= SEARCH_INDEX_BULK_PENDING_PATH_THRESHOLD ? { isBulk: true } : undefined;
     const persistenceDiff =
       strategyResult.publication.kind === "changes" ? strategyResult.publication.diff : null;
     const publicationSessions =
@@ -515,7 +512,6 @@ export class AgentSyncEngine {
           changes: persistenceDiff.changedSessions,
           removedSessionIds: persistenceDiff.removedSessionIds,
           meta: selectCacheMeta(pendingMeta, changedSessionIds),
-          ...(searchIndexOptions ? { searchIndexOptions } : {}),
         }
       : {
           kind: "full",
@@ -526,7 +522,6 @@ export class AgentSyncEngine {
           completeness: strategyResult.completeness,
           removedSessionIds: explicitRemovedSessionIds,
           saveCache: true,
-          ...(searchIndexOptions ? { searchIndexOptions } : {}),
         };
     const completion = buildScanCompletion(
       strategyResult.completeness,

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -8,6 +8,7 @@ import {
   readPendingSearchIndexMaintenance,
   syncSessionSearchIndex,
   syncSessionSearchIndexChanges,
+  type SearchIndexSyncOptions,
 } from "../search-index-writer.js";
 import { setSchemaEnsuredPath } from "../db.js";
 import { commitDurableSessionPublication } from "../publication.js";
@@ -465,6 +466,129 @@ describe("search index writer", () => {
       syncSessionSearchIndexChanges("codex", [], ["one", "one"], () => makeSessionData("one")),
     ).toMatchObject({ deleted: 1, indexed: 0 });
     expect(searchSessions("visible")).toEqual([]);
+  });
+
+  it.each([null, "codex", "claudecode"])(
+    "only automatically rebuilds an empty global index (existing agent: %s)",
+    (existingAgent) => {
+      if (existingAgent) {
+        const existing = makeSessionHead("existing", {
+          reference: { agentName: existingAgent, sessionId: "existing" },
+        });
+        syncSessionSearchIndex(existingAgent, [existing], () => ({
+          ...makeSessionData("existing", "preserved content"),
+          ...existing,
+        }));
+      }
+      const sessions = Array.from({ length: 100 }, (_, index) =>
+        makeSessionHead(`initial-${index}`),
+      );
+
+      const publication = commitDurableSessionPublication(
+        {
+          kind: "snapshot",
+          agentName: "codex",
+          sessions,
+          meta: {},
+          completeness: "partial",
+          removedSessionIds: [],
+        },
+        (sessionId) => makeSessionData(sessionId, `published ${sessionId}`),
+      );
+
+      expect(publication).toMatchObject({
+        status: "committed",
+        searchIndex: {
+          mode: existingAgent ? "incremental" : "bulk",
+          changed: 100,
+          indexed: 100,
+          rebuildDurationMs: existingAgent ? undefined : expect.any(Number),
+        },
+      });
+      expect(searchSessions("published initial-42")).toHaveLength(1);
+      if (existingAgent) expect(searchSessions("preserved content")).toHaveLength(1);
+    },
+  );
+
+  it("incrementally publishes large updates and deletions without retaining old content", () => {
+    const sessions = Array.from({ length: 101 }, (_, index) => makeSessionHead(`updated-${index}`));
+    syncSessionSearchIndex("codex", sessions, (sessionId) =>
+      makeSessionData(sessionId, `outdated ${sessionId}`),
+    );
+    const changes = sessions.slice(0, 100).map((session, sortIndex) => ({
+      session: { ...session, title: `Published ${sortIndex}` },
+      sortIndex,
+    }));
+
+    const publication = commitDurableSessionPublication(
+      {
+        kind: "changes",
+        agentName: "codex",
+        changes,
+        removedSessionIds: ["updated-100"],
+        meta: {},
+      },
+      (sessionId) => makeSessionData(sessionId, `current ${sessionId}`),
+    );
+
+    expect(publication).toMatchObject({
+      status: "committed",
+      searchIndex: {
+        mode: "incremental",
+        changed: 100,
+        deleted: 1,
+        indexed: 100,
+        rebuildDurationMs: undefined,
+      },
+    });
+    expect(searchSessions("outdated")).toEqual([]);
+    expect(searchSessions("current updated-42")).toHaveLength(1);
+    expect(searchSessions("updated-100")).toEqual([]);
+
+    expect(
+      syncSessionSearchIndexChanges(
+        "codex",
+        [],
+        changes.map(({ session }) => session.reference.sessionId),
+        () => {
+          throw new Error("deletions must not load session details");
+        },
+      ),
+    ).toMatchObject({
+      mode: "incremental",
+      deleted: 100,
+      indexed: 0,
+      rebuildDurationMs: undefined,
+    });
+    expect(searchSessions("current")).toEqual([]);
+  });
+
+  it.each<{ options: SearchIndexSyncOptions; mode: "bulk" | "incremental" }>([
+    { options: { isBulk: true, bulkThreshold: 0 }, mode: "bulk" },
+    { options: { isBulk: false, bulkThreshold: 1 }, mode: "incremental" },
+    { options: { bulkThreshold: 1 }, mode: "bulk" },
+    { options: { bulkThreshold: 2 }, mode: "incremental" },
+    { options: { bulkThreshold: 0 }, mode: "incremental" },
+  ])("preserves explicit bulk options: $options", ({ options, mode }) => {
+    const session = makeSessionHead("one");
+    syncSessionSearchIndex("codex", [session], () => makeSessionData("one", "outdated content"));
+    const updated = { ...session, title: "Updated head" };
+
+    const result = syncSessionSearchIndexChanges(
+      "codex",
+      [{ session: updated, sortIndex: 0 }],
+      [],
+      () => makeSessionData("one", "current content"),
+      options,
+    );
+
+    expect(result).toMatchObject({
+      mode,
+      indexed: 1,
+      rebuildDurationMs: mode === "bulk" ? expect.any(Number) : undefined,
+    });
+    expect(searchSessions("outdated")).toEqual([]);
+    expect(searchSessions("current")).toHaveLength(1);
   });
 
   it("plans direct and durable changes with the same rules", () => {

--- a/packages/core/src/discovery/cache/schema-fts.ts
+++ b/packages/core/src/discovery/cache/schema-fts.ts
@@ -28,8 +28,12 @@ export function runSearchIndexWrite<T>(
 
     if (rebuild) {
       const rebuildStartedAt = performance.now();
+      getCoreDiagnostics()?.info?.("search_index.fts_rebuild.started");
       rebuildSearchIndex(db);
       rebuildDurationMs = performance.now() - rebuildStartedAt;
+      getCoreDiagnostics()?.info?.("search_index.fts_rebuild.completed", {
+        duration_ms: Math.round(rebuildDurationMs),
+      });
       createSearchTriggers(db);
     }
 

--- a/packages/core/src/discovery/cache/search-index-writer.ts
+++ b/packages/core/src/discovery/cache/search-index-writer.ts
@@ -157,13 +157,23 @@ function createSearchIndexLoadTiming(): SearchIndexLoadTiming {
   return { calls: 0, reused: 0, getSessionDataMs: 0, materializationMs: 0 };
 }
 
-function shouldBulkSyncSearchIndex(options: SearchIndexSyncOptions, changedCount: number): boolean {
+function shouldBulkSyncSearchIndex(
+  db: SQLiteDatabase,
+  options: SearchIndexSyncOptions,
+  changedCount: number,
+): boolean {
   if (options.isBulk != null) {
     return options.isBulk;
   }
 
   const threshold = options.bulkThreshold ?? SEARCH_INDEX_BULK_SYNC_THRESHOLD;
-  return threshold > 0 && changedCount >= threshold;
+  if (!(threshold > 0 && changedCount >= threshold)) return false;
+
+  // Automatic rebuilds must not retokenize previously indexed sessions from any agent.
+  return (
+    options.bulkThreshold != null ||
+    db.prepare("SELECT 1 FROM session_documents LIMIT 1").get() === undefined
+  );
 }
 
 function loadSearchIndexEntry(
@@ -507,7 +517,13 @@ function readSearchIndexPlanInput(
   };
 }
 
-function createSearchIndexPlan(input: SearchIndexPlanInput): SearchIndexPlan {
+function planSearchIndexWrite(
+  db: SQLiteDatabase,
+  agentName: string,
+  request: SearchIndexPlanRequest,
+  options: SearchIndexSyncOptions,
+): SearchIndexPlan {
+  const input = readSearchIndexPlanInput(db, agentName, request, options);
   const changes = input.candidates.filter(({ session }) =>
     searchIndexEntryNeedsUpdate(input.state, session, input.options),
   );
@@ -538,7 +554,7 @@ function createSearchIndexPlan(input: SearchIndexPlanInput): SearchIndexPlan {
     }),
   );
   const changedCount = input.removedSessionIds.length + changes.length;
-  const isBulk = shouldBulkSyncSearchIndex(input.options, changedCount);
+  const isBulk = shouldBulkSyncSearchIndex(db, input.options, changedCount);
 
   return {
     agentName: input.agentName,
@@ -551,15 +567,6 @@ function createSearchIndexPlan(input: SearchIndexPlanInput): SearchIndexPlan {
     needsRebuild: isBulk && changedCount > 0,
     startedAt: input.startedAt,
   };
-}
-
-function planSearchIndexWrite(
-  db: SQLiteDatabase,
-  agentName: string,
-  request: SearchIndexPlanRequest,
-  options: SearchIndexSyncOptions,
-): SearchIndexPlan {
-  return createSearchIndexPlan(readSearchIndexPlanInput(db, agentName, request, options));
 }
 
 function detailVersionForPlan(plan: SearchIndexPlan, sessionId: string): string {


### PR DESCRIPTION
Session publication rebuilt the shared full-text index whenever one agent had at least 100 changes. File-event bursts could also force a rebuild even when few sessions changed. In the reported run, Claude and Codex spent about 55s and 40s rebuilding the entire index, while the UI continued to show completed counts from the preceding scan phase.

This PR:

- Keeps existing indexes incremental by default. Automatic bulk rebuilds are limited to an empty global index; explicit `isBulk` and `bulkThreshold` options remain compatible.
- Removes the CLI override based on file-event counts and adds rebuild timing diagnostics.
- Hides stale scan counts during publication and publication queuing, while preserving counts during scanning and metadata finalization.
- Adds regression coverage and updates the scanning and performance documentation.
- Flushes each update in the existing scan-status stress test with `act`, so React callbacks cannot outlive the test environment. This resolves the asynchronous teardown failure found by the first CI run without changing production behavior or weakening the render-count assertion.

Atomic publication, rollback behavior, and the existing 64-entry staging limit are unchanged.

A single-run publication benchmark used independent copies of the same 9.4GB cache containing 4,164 indexed sessions, with 141 Claude and 122 Codex changes. It ran on an Apple M1 Pro with 32 GiB RAM, macOS 27.0, and Node 24.20.0, against base commit `9232ffa` and this change.

| Measurement | Before | After |
| --- | ---: | ---: |
| Combined publication time | 134.744s | 14.500s |
| Observed WAL peak | 901.4 MiB | 239.4 MiB |
| Process peak RSS | 800.6 MiB | 755.0 MiB |

Both strategies indexed all 263 changes, returned all 263 search probes, and had no indexed-message-count mismatches. The benchmark reconstructs messages from cached data and measures materialization, staging, writes, and transaction commit; it excludes source-file scanning, queueing, and browser rendering. It is not an end-to-end startup claim or a CI timing threshold.

Validation completed locally:

- `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `pnpm test` (2,592 passed, 1 skipped)
- `pnpm perf:check`
- Formatting checks for changed source files
- Documentation path/fact checks, quality-task coverage, and release preflight
- Full `pnpm format:check`
- `pnpm test:coverage` (all coverage thresholds passed), `pnpm test:migration`, and `pnpm --filter @codesesh/web test:bundle`
- `pnpm exec tsc --noEmit -p tsconfig.e2e.json`
