### PR TITLE
fix: Preserve confirmed bookmark writes

### DIFF
--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -252,6 +252,51 @@ describe("useBookmarks", () => {
     expect(result.current.isSessionBookmarked("cc", "racy")).toBe(false);
   });
 
+  it("keeps successful bookmarks confirmed while another write is pending", async () => {
+    const firstRequest = deferred<void>();
+    const secondRequest = deferred<void>();
+    let serverBookmarks: BookmarkView[] = [];
+    vi.mocked(api.fetchBookmarks).mockImplementation(async () => ({ bookmarks: serverBookmarks }));
+    vi.mocked(api.upsertBookmark)
+      .mockImplementationOnce(async () => {
+        await firstRequest.promise;
+        serverBookmarks = [available("first")];
+        return { bookmark: fact("first") };
+      })
+      .mockImplementationOnce(async () => {
+        await secondRequest.promise;
+        serverBookmarks = [available("second"), ...serverBookmarks];
+        return { bookmark: fact("second") };
+      });
+    vi.mocked(api.deleteBookmark).mockImplementationOnce(async () => {
+      serverBookmarks = serverBookmarks.filter(({ reference }) => reference.sessionId !== "first");
+    });
+    const { result } = renderBookmarks();
+    await waitFor(() => expect(api.fetchBookmarks).toHaveBeenCalledOnce());
+
+    act(() => result.current.toggleBookmark(available("first")));
+    act(() => result.current.toggleBookmark(available("second")));
+    await waitFor(() => expect(api.upsertBookmark).toHaveBeenCalledTimes(1));
+
+    firstRequest.resolve();
+    await waitFor(() => expect(api.upsertBookmark).toHaveBeenCalledTimes(2));
+    expect(result.current.isSessionBookmarked("cc", "first")).toBe(true);
+    expect(result.current.isSessionBookmarked("cc", "second")).toBe(true);
+
+    act(() => result.current.toggleBookmark(available("first")));
+    await waitFor(() => expect(result.current.isSessionBookmarked("cc", "first")).toBe(false));
+    secondRequest.resolve();
+
+    await waitFor(() =>
+      expect(api.deleteBookmark).toHaveBeenCalledWith({
+        agentName: "cc",
+        sessionId: "first",
+      }),
+    );
+    await waitFor(() => expect(result.current.bookmarkedSessions).toEqual([available("second")]));
+    expect(api.upsertBookmark).toHaveBeenCalledTimes(2);
+  });
+
   it("rolls back only the failed bookmark while another toggle is pending", async () => {
     const failedRequest = deferred<void>();
     const successfulRequest = deferred<void>();

--- a/apps/web/src/hooks/useBookmarks.ts
+++ b/apps/web/src/hooks/useBookmarks.ts
@@ -107,13 +107,23 @@ export function useBookmarks() {
         await deleteBookmark(bookmark.reference);
         return;
       }
-      await upsertBookmark(bookmark.reference);
+      return upsertBookmark(bookmark.reference);
     },
     onMutate: ({ bookmark, isBookmarked }) => {
       logClientEvent(isBookmarked ? "bookmark.delete" : "bookmark.add", {
         agent: bookmark.reference.agentName,
         session: bookmark.reference.sessionId,
       });
+    },
+    onSuccess: async (data, { bookmark, isBookmarked }) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.bookmarks });
+      queryClient.setQueryData<{ bookmarks: BookmarkView[] }>(queryKeys.bookmarks, (previous) => ({
+        bookmarks: toggledBookmarks(
+          previous?.bookmarks ?? EMPTY_BOOKMARKS,
+          data ? { ...bookmark, ...data.bookmark } : bookmark,
+          isBookmarked,
+        ),
+      }));
     },
     onError: (error) => {
       console.error("Failed to toggle bookmark:", error);


### PR DESCRIPTION
When multiple bookmark writes overlap, a successful write used to disappear from the optimistic view until the last write refetched the list. Clicking that bookmark again could submit the wrong action.

Merge each successful write into the confirmed query cache before its pending mutation completes, and cancel stale reads before updating that cache. Remaining optimistic toggles continue to apply in order.

Validation: the new regression failed before the fix and now passes; all 13 bookmark hook tests, web lint, typecheck, and format checks pass.
