### PR TITLE
fix: Report bookmark storage read failures

### DIFF
--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -373,5 +373,10 @@ describe("useBookmarks", () => {
     await act(() => result.current.refresh());
     await waitFor(() => expect(result.current.error).toBeNull());
     expect(result.current.isSessionBookmarked("cc", "recovered")).toBe(true);
+
+    vi.mocked(api.fetchBookmarks).mockRejectedValueOnce(error);
+    await act(() => result.current.refresh());
+    await waitFor(() => expect(result.current.error).toBe("offline"));
+    expect(result.current.bookmarkedSessions).toEqual([available("recovered")]);
   });
 });

--- a/packages/cli/src/api/__tests__/bookmark-handlers.test.ts
+++ b/packages/cli/src/api/__tests__/bookmark-handlers.test.ts
@@ -119,7 +119,10 @@ describe("bookmark handlers", () => {
     });
     const unavailable = makeContext();
     handleGetBookmarks(unavailable as never, bookmarkScanSource);
-    expect(unavailable.json).toHaveBeenCalledWith({ bookmarks: [], storageAvailable: false });
+    expect(unavailable.json).toHaveBeenCalledWith(
+      { error: "Bookmark storage is unavailable" },
+      503,
+    );
 
     coreMocks.listBookmarks.mockImplementationOnce(() => {
       throw new Error("unexpected");

--- a/packages/cli/src/api/bookmark-handlers.ts
+++ b/packages/cli/src/api/bookmark-handlers.ts
@@ -76,7 +76,7 @@ export function handleGetBookmarks(c: Context, scanSource: ScanResultSource) {
         storageAvailable: true,
       });
     },
-    () => c.json({ bookmarks: [], storageAvailable: false }),
+    () => c.json({ error: "Bookmark storage is unavailable" }, 503),
   );
 }
 


### PR DESCRIPTION
Return HTTP 503 when bookmark storage cannot be read, instead of reporting a successful empty bookmark list. The existing client query error path now reports the failure and retains previously loaded bookmarks.

Validation: the updated handler regression failed before the fix; all 39 bookmark handler and hook tests pass, including retaining cached bookmarks after a failed refresh. CLI and web lint, typecheck, and format checks pass.
