### PR TITLE
fix: Refresh bookmark views during live sync

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -228,10 +228,7 @@ export default function App() {
     setScanStatus,
   });
 
-  const refreshAliasViews = useCallback(async () => {
-    await Promise.all([reload(), refreshBookmarks()]);
-  }, [refreshBookmarks, reload]);
-  const sessionAliases = useSessionAliasDialog(refreshAliasViews);
+  const sessionAliases = useSessionAliasDialog(reload);
 
   const searchSubtitle =
     searchState.status === "failed"

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -4,6 +4,7 @@ import {
   SAMPLE_SESSIONS_UPDATED_EVENT,
 } from "@codesesh/core/test-fixtures";
 import { createSessionIdentity } from "@codesesh/core/contract";
+import { useQuery } from "@tanstack/react-query";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -13,6 +14,7 @@ import type {
   ApiProjectGroup,
   ApiProjectPage,
   SessionHead,
+  BookmarkView,
 } from "../lib/api";
 import * as api from "../lib/api";
 import { queryKeys } from "../lib/query-keys";
@@ -90,6 +92,41 @@ async function renderStore(window: AppConfig["window"] = config.window) {
 }
 
 describe("useSessionStore", () => {
+  it.each(["live", "resync"] as const)(
+    "refreshes materialized bookmark views on %s",
+    async (refresh) => {
+      const initial: BookmarkView = {
+        reference: SAMPLE_SESSION_HEAD.reference,
+        bookmarkedAt: 1,
+        availability: "session-unavailable",
+      };
+      const updated: BookmarkView = {
+        ...initial,
+        availability: "available",
+        session: { ...SAMPLE_SESSION_HEAD, title: "Updated title" },
+      };
+      const fetchBookmarks = vi.fn().mockResolvedValue({ bookmarks: [initial] });
+      const { Wrapper } = createQueryWrapper();
+      const { result } = renderHook(
+        () => ({
+          store: useSessionStore(config.window),
+          bookmarks: useQuery({ queryKey: queryKeys.bookmarks, queryFn: fetchBookmarks }),
+        }),
+        { wrapper: Wrapper },
+      );
+      await waitFor(() => expect(result.current.store.loading).toBe(false));
+      await waitFor(() => expect(result.current.bookmarks.data?.bookmarks).toEqual([initial]));
+      fetchBookmarks.mockResolvedValue({ bookmarks: [updated] });
+
+      await act(async () => {
+        if (refresh === "resync") await result.current.store.resyncLiveState();
+        else await result.current.store.applyLiveEvent(SAMPLE_SESSIONS_UPDATED_EVENT);
+      });
+
+      await waitFor(() => expect(result.current.bookmarks.data?.bookmarks).toEqual([updated]));
+    },
+  );
+
   it("resynchronizes when an active project page rejects its old cursor", async () => {
     const firstPage = { ...projectPage, nextCursor: "old-cursor" };
     const nextFirstPage = { ...projectPage, nextCursor: "new-cursor" };

--- a/apps/web/src/lib/session-query-consistency.test.ts
+++ b/apps/web/src/lib/session-query-consistency.test.ts
@@ -32,7 +32,7 @@ function changedHead(
 }
 
 describe("live session detail invalidation", () => {
-  it("invalidates every changed detail with one cache scan request", async () => {
+  it("invalidates changed details and bookmark views with one cache scan request", async () => {
     const active = makeClient();
     const changedKey = queryKeys.sessionDetail("codex", "changed");
     const removedKey = queryKeys.sessionDetail("codex", "removed");
@@ -42,6 +42,7 @@ describe("live session detail invalidation", () => {
     active.setQueryData(removedKey, { id: "removed" });
     active.setQueryData(unchangedKey, { id: "unchanged" });
     active.setQueryData(descendantKey, { id: "changed-messages" });
+    active.setQueryData(queryKeys.bookmarks, { bookmarks: [] });
     const invalidateQueries = vi.spyOn(active, "invalidateQueries");
     const event = {
       ...SAMPLE_SESSIONS_UPDATED_EVENT,
@@ -62,6 +63,7 @@ describe("live session detail invalidation", () => {
     expect(active.getQueryState(removedKey)?.isInvalidated).toBe(true);
     expect(active.getQueryState(unchangedKey)?.isInvalidated).toBe(false);
     expect(active.getQueryState(descendantKey)?.isInvalidated).toBe(false);
+    expect(active.getQueryState(queryKeys.bookmarks)?.isInvalidated).toBe(true);
   });
 
   it("does not scan the cache when no detail changed", async () => {

--- a/apps/web/src/lib/session-query-consistency.ts
+++ b/apps/web/src/lib/session-query-consistency.ts
@@ -53,6 +53,7 @@ export async function invalidateSessionDerivedQueries(queryClient: QueryClient):
   await Promise.all([
     ...invalidateSessionCollections(queryClient),
     queryClient.invalidateQueries({ queryKey: queryKeys.sessionDetails }),
+    queryClient.invalidateQueries({ queryKey: queryKeys.bookmarks }),
   ]);
 }
 
@@ -79,6 +80,7 @@ export async function invalidateLiveSessionDerivedQueries(
 
   await queryClient.invalidateQueries({
     predicate: ({ queryKey }) => {
+      if (queryKey.length === 1 && queryKey[0] === queryKeys.bookmarks[0]) return true;
       if (
         queryKey.length !== 3 ||
         queryKey[0] !== queryKeys.sessionDetails[0] ||


### PR DESCRIPTION
Refresh materialized bookmark views when sessions change and when live state reconnects. Titles, statistics, and availability now update through the shared session query invalidation path.

Alias updates use that same path, removing the separate bookmark refresh callback from App.

Validation: both live-update and reconnect regressions failed before the fix and now pass. All 61 related tests, web lint, typecheck, and format checks pass.
