### PR TITLE
fix: Retain snapshots across pagination requests

### DIFF
--- a/packages/cli/src/api/__tests__/catalog-handlers.test.ts
+++ b/packages/cli/src/api/__tests__/catalog-handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AGENT_CATALOG } from "@codesesh/core/contract";
 import type { ScanResultSource } from "../scan-sources.js";
 import {
@@ -140,7 +140,8 @@ describe("handleGetProjects", () => {
     });
   });
 
-  it("rejects a project cursor after the scan snapshot changes", () => {
+  it("keeps project pages and totals on their original snapshot", () => {
+    vi.useFakeTimers();
     const initialSessions = [
       makeSession("one", {
         project_identity: { kind: "path", key: "/workspace/one", displayName: "one" },
@@ -172,8 +173,20 @@ describe("handleGetProjects", () => {
 
     handleGetProjects(nextContext, source);
 
-    expect(nextContext.json).toHaveBeenCalledWith(
-      { error: "project snapshot changed; restart pagination" },
+    expect(nextContext.json).toHaveBeenCalledWith({
+      projects: [expect.objectContaining({ identityKey: "/workspace/two" })],
+      summary: expect.objectContaining({ projects: 2, sessions: 2 }),
+    });
+
+    const freshContext = makeMockContext({ query: { limit: "1" } });
+    handleGetProjects(freshContext, source);
+    expect(freshContext.json.mock.calls[0]![0].summary).toMatchObject({ projects: 3, sessions: 3 });
+
+    vi.advanceTimersByTime(60_000);
+    const expired = makeMockContext({ query: { limit: "1", cursor } });
+    handleGetProjects(expired, source);
+    expect(expired.json).toHaveBeenCalledWith(
+      { error: "project snapshot expired; restart pagination" },
       409,
     );
   });

--- a/packages/cli/src/api/__tests__/session-handlers.test.ts
+++ b/packages/cli/src/api/__tests__/session-handlers.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./handler-test-fixtures.js";
 
 const { handleGetSessionData, handleGetSessions } = await import("../session-handlers.js");
+const { invalidateAliasView } = await import("../session-aliases-view.js");
 
 describe("handleGetSessions", () => {
   it("returns all sessions without filters", () => {
@@ -77,7 +78,8 @@ describe("handleGetSessions", () => {
     expect(legacyContext.json.mock.calls[0]![0].sessions).toHaveLength(3);
   });
 
-  it("rejects a cursor after the scan snapshot changes", () => {
+  it("finishes the original session snapshot while new scans are published", () => {
+    vi.useFakeTimers();
     const initialSessions = [makeSession("first"), makeSession("second")];
     let snapshot = makeScanResult({
       sessions: initialSessions,
@@ -96,10 +98,43 @@ describe("handleGetSessions", () => {
     const nextContext = makeMockContext({ query: { limit: "1", cursor } });
     handleGetSessions(nextContext, source);
 
-    expect(nextContext.json).toHaveBeenCalledWith(
-      { error: "session snapshot changed; restart pagination" },
+    expect(nextContext.json).toHaveBeenCalledWith({ sessions: [initialSessions[1]] });
+
+    const freshContext = makeMockContext({ query: { limit: "1" } });
+    handleGetSessions(freshContext, source);
+    expect(freshContext.json.mock.calls[0]![0].sessions).toEqual([updatedSessions[0]]);
+
+    vi.advanceTimersByTime(60_000);
+    const expired = makeMockContext({ query: { limit: "1", cursor } });
+    handleGetSessions(expired, source);
+    expect(expired.json).toHaveBeenCalledWith(
+      { error: "session snapshot expired; restart pagination" },
       409,
     );
+  });
+
+  it("keeps alias-filtered pages on their original alias view", () => {
+    const sessions = [makeSession("first"), makeSession("second")];
+    const source = makeScanSource({ sessions, byAgent: { claudecode: sessions } });
+    coreMocks.listSessionAliases.mockReturnValue(
+      sessions.map((session) => ({ reference: session.reference, alias: "Saved", updatedAt: 1 })),
+    );
+    const first = makeMockContext({ query: { limit: "1", q: "saved" } });
+    handleGetSessions(first, source);
+
+    coreMocks.listSessionAliases.mockReturnValue([]);
+    invalidateAliasView();
+    const next = makeMockContext({
+      query: { limit: "1", q: "saved", cursor: first.json.mock.calls[0]![0].nextCursor },
+    });
+    handleGetSessions(next, source);
+
+    expect(next.json).toHaveBeenCalledWith({
+      sessions: [{ ...sessions[1], display_title: "Saved" }],
+    });
+    const fresh = makeMockContext({ query: { limit: "1", q: "saved" } });
+    handleGetSessions(fresh, source);
+    expect(fresh.json).toHaveBeenCalledWith({ sessions: [] });
   });
 
   it("rejects invalid pagination parameters", () => {

--- a/packages/cli/src/api/__tests__/snapshot-pagination.test.ts
+++ b/packages/cli/src/api/__tests__/snapshot-pagination.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSnapshotPaginator } from "../snapshot-pagination.js";
+
+const request = { limit: 1, query: new URLSearchParams("agent=codex&from=100") };
+
+function startPagination() {
+  const paginate = createSnapshotPaginator<number, string>();
+  const source = {};
+  const load = vi.fn(() => ({ items: [1, 2, 3], view: "original" }));
+  const first = paginate(source, request, load);
+  if (first.kind !== "page" || !first.nextCursor) throw new Error("Expected a paginated snapshot");
+  return { paginate, source, load, cursor: first.nextCursor };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe("snapshot pagination", () => {
+  it("retains the original items and view without reloading later pages", () => {
+    const { paginate, source, load, cursor } = startPagination();
+    load.mockReturnValue({ items: [4], view: "updated" });
+    const nextRequest = {
+      limit: 2,
+      query: new URLSearchParams("from=100&agent=codex&limit=2&cursor=ignored"),
+      cursor,
+    };
+
+    expect(paginate(source, nextRequest, load)).toEqual({
+      kind: "page",
+      items: [2, 3],
+      view: "original",
+    });
+    expect(paginate(source, nextRequest, load)).toEqual({
+      kind: "page",
+      items: [2, 3],
+      view: "original",
+    });
+    expect(load).toHaveBeenCalledOnce();
+    expect(paginate(source, request, load)).toEqual({
+      kind: "page",
+      items: [4],
+      view: "updated",
+    });
+  });
+
+  it("expires a snapshot after one minute even if its pages were recently read", () => {
+    vi.useFakeTimers();
+    const { paginate, source, load, cursor } = startPagination();
+    vi.advanceTimersByTime(59_999);
+    expect(paginate(source, { ...request, cursor }, load).kind).toBe("page");
+
+    vi.advanceTimersByTime(1);
+    expect(paginate(source, { ...request, cursor }, load)).toEqual({ kind: "stale_snapshot" });
+    expect(load).toHaveBeenCalledOnce();
+    expect(paginate(source, request, load).kind).toBe("page");
+  });
+
+  it("evicts the oldest snapshot when more than 32 reads need retained pages", () => {
+    const { paginate, source, load, cursor } = startPagination();
+    for (let index = 0; index < 31; index++) paginate(source, request, load);
+    expect(paginate(source, { ...request, cursor }, load).kind).toBe("page");
+
+    const newest = paginate(source, request, load);
+    expect(paginate(source, { ...request, cursor }, load)).toEqual({ kind: "stale_snapshot" });
+    if (newest.kind !== "page") throw new Error("Expected newest page");
+    expect(paginate(source, { ...request, cursor: newest.nextCursor }, load).kind).toBe("page");
+  });
+
+  it("does not spend retention capacity on single-page responses", () => {
+    const { paginate, source, load, cursor } = startPagination();
+    load.mockReturnValue({ items: [], view: "empty" });
+    for (let index = 0; index < 33; index++) {
+      expect(paginate(source, request, load)).toEqual({ kind: "page", items: [], view: "empty" });
+    }
+    expect(paginate(source, { ...request, cursor }, load).kind).toBe("page");
+  });
+
+  it("rejects a cursor reused for another query, source, or collection", () => {
+    const { paginate, source, load, cursor } = startPagination();
+    expect(
+      paginate(
+        source,
+        { ...request, cursor, query: new URLSearchParams("agent=claudecode") },
+        load,
+      ),
+    ).toEqual({ kind: "invalid_cursor" });
+    expect(paginate({}, { ...request, cursor }, load)).toEqual({ kind: "stale_snapshot" });
+    const otherCollection = createSnapshotPaginator<number, string>();
+    expect(otherCollection(source, { ...request, cursor }, load)).toEqual({
+      kind: "stale_snapshot",
+    });
+    expect(load).toHaveBeenCalledOnce();
+  });
+
+  it("rejects malformed cursors and offsets outside their retained snapshot", () => {
+    const { paginate, source, load, cursor } = startPagination();
+    const payload = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+    const malformed = ["!", "x".repeat(513), Buffer.from("{").toString("base64url")];
+    for (const value of [
+      null,
+      {},
+      { ...payload, version: 2 },
+      { ...payload, offset: 0 },
+      { ...payload, offset: 3 },
+    ]) {
+      malformed.push(Buffer.from(JSON.stringify(value)).toString("base64url"));
+    }
+    for (const invalid of malformed) {
+      expect(paginate(source, { ...request, cursor: invalid }, load)).toEqual({
+        kind: "invalid_cursor",
+      });
+    }
+    expect(load).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/api/catalog-handlers.ts
+++ b/packages/cli/src/api/catalog-handlers.ts
@@ -1,4 +1,4 @@
-import type { AppConfig } from "@codesesh/core/contract";
+import type { AppConfig, ApiProjectGroup, ApiProjectPage } from "@codesesh/core/contract";
 import { getAgentInfoMap } from "@codesesh/core/runtime/agents";
 import {
   getAnalyticsRevision,
@@ -17,8 +17,10 @@ import {
   type SessionListDefaults,
 } from "./query-params.js";
 import type { ScanResultSource, ScanStatusSource } from "./scan-sources.js";
-import { paginateSnapshot } from "./snapshot-pagination.js";
+import { createSnapshotPaginator } from "./snapshot-pagination.js";
 import { getSnapshotAggregation, getSnapshotSessionTree } from "./snapshot-aggregation.js";
+
+const paginateProjects = createSnapshotPaginator<ApiProjectGroup, ApiProjectPage["summary"]>();
 
 export function handleGetConfig(c: Context, defaults: SessionListDefaults) {
   const payload: AppConfig = {
@@ -83,54 +85,62 @@ export function handleGetProjects(
   const window = parseDateWindowRequest(c, "projects", defaults);
   if (window.kind === "rejected") return window.response;
   const { from, to } = window;
-  const analyticsRevision = getAnalyticsRevision();
-  const catalog = getSnapshotAggregation(
+  const loadSnapshot = () => {
+    const analyticsRevision = getAnalyticsRevision();
+    const catalog = getSnapshotAggregation(
+      scanSource,
+      scanResult.sessions,
+      ["projects", from, to, analyticsRevision],
+      () => {
+        const tree = getSnapshotSessionTree(scanSource, scanResult.sessions);
+        const costFacts = listDashboardCostFacts({ from, to, includeModelCosts: false });
+        const projects = attachProjectMetricsFromTree(
+          listCachedProjectGroups(scanResult.sessions),
+          tree,
+          from,
+          to,
+          costFacts,
+        ).filter(
+          (project) =>
+            project.sessionCount > 0 ||
+            project.messages > 0 ||
+            project.tokens > 0 ||
+            project.cost > 0,
+        );
+        return { projects, summary: summarizeProjects(projects) };
+      },
+    );
+    const projects = projectIdentity
+      ? catalog.projects.filter(
+          (project) =>
+            project.identityKind === projectIdentity.kind &&
+            project.identityKey === projectIdentity.key,
+        )
+      : catalog.projects;
+    return {
+      items: projects,
+      view: projectIdentity ? summarizeProjects(projects) : catalog.summary,
+    };
+  };
+  const page = paginateProjects(
     scanSource,
-    scanResult.sessions,
-    ["projects", from, to, analyticsRevision],
-    () => {
-      const tree = getSnapshotSessionTree(scanSource, scanResult.sessions);
-      const costFacts = listDashboardCostFacts({ from, to, includeModelCosts: false });
-      const projects = attachProjectMetricsFromTree(
-        listCachedProjectGroups(scanResult.sessions),
-        tree,
-        from,
-        to,
-        costFacts,
-      ).filter(
-        (project) =>
-          project.sessionCount > 0 ||
-          project.messages > 0 ||
-          project.tokens > 0 ||
-          project.cost > 0,
-      );
-      return { projects, summary: summarizeProjects(projects) };
+    {
+      cursor: params.get("cursor") ?? undefined,
+      limit: limit.value,
+      query: params,
     },
+    loadSnapshot,
   );
-  const projects = projectIdentity
-    ? catalog.projects.filter(
-        (project) =>
-          project.identityKind === projectIdentity.kind &&
-          project.identityKey === projectIdentity.key,
-      )
-    : catalog.projects;
-  const page = paginateSnapshot(projects, {
-    cursor: params.get("cursor") ?? undefined,
-    limit: limit.value,
-    query: params,
-    snapshotIdentity: scanResult.sessions,
-    viewIdentity: catalog.projects,
-  });
   if (page.kind === "invalid_cursor") {
     reportInvalidQueryParameter("projects", "cursor", "rejected");
     return c.json({ error: "cursor is invalid for this request" }, 400);
   }
   if (page.kind === "stale_snapshot") {
-    return c.json({ error: "project snapshot changed; restart pagination" }, 409);
+    return c.json({ error: "project snapshot expired; restart pagination" }, 409);
   }
   return c.json({
     projects: page.items,
-    summary: projectIdentity ? summarizeProjects(projects) : catalog.summary,
+    summary: page.view,
     ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
   });
 }

--- a/packages/cli/src/api/session-handlers.ts
+++ b/packages/cli/src/api/session-handlers.ts
@@ -31,9 +31,11 @@ import {
 } from "./query-params.js";
 import type { ScanResultSource } from "./scan-sources.js";
 import { createSessionDetailJsonResponse } from "./session-detail-stream.js";
-import { loadAliasView } from "./session-aliases-view.js";
-import { paginateSnapshot } from "./snapshot-pagination.js";
+import { loadAliasView, type AliasView } from "./session-aliases-view.js";
+import { createSnapshotPaginator } from "./snapshot-pagination.js";
 import { getSnapshotAggregation } from "./snapshot-aggregation.js";
+
+const paginateSessions = createSnapshotPaginator<SessionHead, AliasView>();
 
 function getSessionHeadReference(session: SessionHead): SessionReference {
   return session.reference;
@@ -85,76 +87,84 @@ export async function handleGetSessions(
     reportInvalidQueryParameter("sessions", "agent", "empty_result");
   }
 
-  const agentFilter =
-    sessionQuery.agent.kind === "known" ? sessionQuery.agent.agentName : sessionQuery.agent.kind;
-  let sessions = getSnapshotAggregation(
-    scanSource,
-    scanResult.sessions,
-    [
-      "sessions",
-      agentFilter,
-      projectIdentity?.kind,
-      projectIdentity?.key,
-      projectScope?.identity.kind,
-      projectScope?.identity.key,
-      projectScope?.path,
-      tag,
-      from,
-      to,
-    ],
-    () => {
-      let filtered =
-        sessionQuery.agent.kind === "all"
-          ? scanResult.sessions
-          : sessionQuery.agent.kind === "known"
-            ? (scanResult.byAgent[sessionQuery.agent.agentName] ?? [])
-            : [];
+  const loadSnapshot = () => {
+    const agentFilter =
+      sessionQuery.agent.kind === "known" ? sessionQuery.agent.agentName : sessionQuery.agent.kind;
+    let sessions = getSnapshotAggregation(
+      scanSource,
+      scanResult.sessions,
+      [
+        "sessions",
+        agentFilter,
+        projectIdentity?.kind,
+        projectIdentity?.key,
+        projectScope?.identity.kind,
+        projectScope?.identity.key,
+        projectScope?.path,
+        tag,
+        from,
+        to,
+      ],
+      () => {
+        let filtered =
+          sessionQuery.agent.kind === "all"
+            ? scanResult.sessions
+            : sessionQuery.agent.kind === "known"
+              ? (scanResult.byAgent[sessionQuery.agent.agentName] ?? [])
+              : [];
 
-      if (projectIdentity) {
-        filtered = filtered.filter((session) =>
-          matchesProjectIdentity(session.project_identity, projectIdentity),
-        );
-      } else if (projectScope) {
-        filtered = filtered.filter((session) => sessionMatchesProjectScope(session, projectScope));
-      }
-      filtered = filterSessionsByActivityWindow(filtered, from, to);
-      return tag
-        ? filtered.filter((session) => session.smart_tags?.includes(tag as SmartTag))
-        : filtered;
-    },
-  );
+        if (projectIdentity) {
+          filtered = filtered.filter((session) =>
+            matchesProjectIdentity(session.project_identity, projectIdentity),
+          );
+        } else if (projectScope) {
+          filtered = filtered.filter((session) =>
+            sessionMatchesProjectScope(session, projectScope),
+          );
+        }
+        filtered = filterSessionsByActivityWindow(filtered, from, to);
+        return tag
+          ? filtered.filter((session) => session.smart_tags?.includes(tag as SmartTag))
+          : filtered;
+      },
+    );
 
-  const aliases = loadAliasView();
-  if (q) {
-    sessions = sessions.filter((session) => {
-      const alias = aliases.get(getSessionHeadReference(session));
-      return session.title.toLowerCase().includes(q) || alias?.toLowerCase().includes(q);
-    });
-  }
+    const aliases = loadAliasView();
+    if (q) {
+      sessions = sessions.filter((session) => {
+        const alias = aliases.get(getSessionHeadReference(session));
+        return session.title.toLowerCase().includes(q) || alias?.toLowerCase().includes(q);
+      });
+    }
+    return { items: sessions, view: aliases };
+  };
 
   if (paginationRequested) {
-    const page = paginateSnapshot(sessions, {
-      cursor: params.get("cursor") ?? undefined,
-      limit: sessionQuery.limit.value,
-      query: params,
-      snapshotIdentity: scanResult.sessions,
-      viewIdentity: aliases,
-    });
+    const page = paginateSessions(
+      scanSource,
+      {
+        cursor: params.get("cursor") ?? undefined,
+        limit: sessionQuery.limit.value,
+        query: params,
+      },
+      loadSnapshot,
+    );
     if (page.kind === "invalid_cursor") {
       reportInvalidQueryParameter("sessions", "cursor", "rejected");
       return c.json({ error: "cursor is invalid for this request" }, 400);
     }
     if (page.kind === "stale_snapshot") {
-      return c.json({ error: "session snapshot changed; restart pagination" }, 409);
+      return c.json({ error: "session snapshot expired; restart pagination" }, 409);
     }
     return c.json({
       sessions: page.items.map((session) =>
-        toPublicSessionHead(aliases.decorate(session, getSessionHeadReference(session))),
+        toPublicSessionHead(page.view.decorate(session, getSessionHeadReference(session))),
       ),
       ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
     });
   }
 
+  const { items: sessions, view: aliases } = loadSnapshot();
   return c.json({
     sessions: sessions.map((session) =>
       toPublicSessionHead(aliases.decorate(session, getSessionHeadReference(session))),

--- a/packages/cli/src/api/snapshot-pagination.ts
+++ b/packages/cli/src/api/snapshot-pagination.ts
@@ -3,8 +3,6 @@ import { createHash, randomUUID } from "node:crypto";
 interface CursorPayload {
   version: 1;
   snapshot: string;
-  view: string;
-  query: string;
   offset: number;
 }
 
@@ -12,24 +10,25 @@ interface PaginationRequest {
   cursor?: string;
   limit: number;
   query: URLSearchParams;
-  snapshotIdentity: object;
-  viewIdentity: object;
 }
 
-export type PaginationResult<T> =
-  | { kind: "page"; items: T[]; nextCursor?: string }
+interface PaginationSnapshot<T, View> {
+  items: readonly T[];
+  view: View;
+}
+
+interface RetainedSnapshot<T, View> extends PaginationSnapshot<T, View> {
+  query: string;
+  expiresAt: number;
+}
+
+type PaginationResult<T, View> =
+  | { kind: "page"; items: T[]; view: View; nextCursor?: string }
   | { kind: "invalid_cursor" }
   | { kind: "stale_snapshot" };
 
-const identityVersions = new WeakMap<object, string>();
-
-function identityVersion(identity: object): string {
-  const existing = identityVersions.get(identity);
-  if (existing) return existing;
-  const version = randomUUID();
-  identityVersions.set(identity, version);
-  return version;
-}
+const SNAPSHOT_TTL_MS = 60_000;
+const SNAPSHOT_LIMIT = 32;
 
 function queryFingerprint(params: URLSearchParams): string {
   const canonical = new URLSearchParams(params);
@@ -53,8 +52,6 @@ function decodeCursor(cursor: string): CursorPayload | null {
     if (
       value.version !== 1 ||
       typeof value.snapshot !== "string" ||
-      typeof value.view !== "string" ||
-      typeof value.query !== "string" ||
       !Number.isSafeInteger(value.offset) ||
       value.offset! <= 0
     ) {
@@ -66,31 +63,56 @@ function decodeCursor(cursor: string): CursorPayload | null {
   }
 }
 
-/** Keeps every page on the same immutable scan and derived-view versions. */
-export function paginateSnapshot<T>(items: T[], request: PaginationRequest): PaginationResult<T> {
-  const snapshot = identityVersion(request.snapshotIdentity);
-  const view = identityVersion(request.viewIdentity);
-  const query = queryFingerprint(request.query);
-  let offset = 0;
+export function createSnapshotPaginator<T, View>() {
+  const snapshotsBySource = new WeakMap<object, Map<string, RetainedSnapshot<T, View>>>();
 
-  if (request.cursor) {
-    const cursor = decodeCursor(request.cursor);
-    if (!cursor || cursor.query !== query) return { kind: "invalid_cursor" };
-    if (cursor.snapshot !== snapshot || cursor.view !== view) {
-      return { kind: "stale_snapshot" };
+  return function paginateSnapshot(
+    source: object,
+    request: PaginationRequest,
+    load: () => PaginationSnapshot<T, View>,
+  ): PaginationResult<T, View> {
+    const snapshots = snapshotsBySource.get(source) ?? new Map<string, RetainedSnapshot<T, View>>();
+    const now = Date.now();
+    for (const [id, snapshot] of snapshots) {
+      if (snapshot.expiresAt <= now) snapshots.delete(id);
     }
-    if (cursor.offset >= items.length) return { kind: "invalid_cursor" };
-    offset = cursor.offset;
-  }
+    const query = queryFingerprint(request.query);
+    let snapshot: RetainedSnapshot<T, View>;
+    let snapshotId: string;
+    let offset = 0;
 
-  const end = Math.min(offset + request.limit, items.length);
-  const nextCursor =
-    end < items.length
-      ? encodeCursor({ version: 1, snapshot, view, query, offset: end })
-      : undefined;
-  return {
-    kind: "page",
-    items: items.slice(offset, end),
-    ...(nextCursor ? { nextCursor } : {}),
+    if (request.cursor) {
+      const cursor = decodeCursor(request.cursor);
+      if (!cursor) return { kind: "invalid_cursor" };
+      const retained = snapshots.get(cursor.snapshot);
+      if (!retained) return { kind: "stale_snapshot" };
+      if (retained.query !== query || cursor.offset >= retained.items.length) {
+        return { kind: "invalid_cursor" };
+      }
+      snapshot = retained;
+      snapshotId = cursor.snapshot;
+      offset = cursor.offset;
+    } else {
+      const loaded = load();
+      snapshot = { ...loaded, items: [...loaded.items], query, expiresAt: now + SNAPSHOT_TTL_MS };
+      snapshotId = randomUUID();
+    }
+
+    const end = Math.min(offset + request.limit, snapshot.items.length);
+    const nextCursor =
+      end < snapshot.items.length
+        ? encodeCursor({ version: 1, snapshot: snapshotId, offset: end })
+        : undefined;
+    if (!request.cursor && nextCursor) {
+      if (snapshots.size >= SNAPSHOT_LIMIT) snapshots.delete(snapshots.keys().next().value!);
+      snapshots.set(snapshotId, snapshot);
+      snapshotsBySource.set(source, snapshots);
+    }
+    return {
+      kind: "page",
+      items: snapshot.items.slice(offset, end),
+      view: snapshot.view,
+      ...(nextCursor ? { nextCursor } : {}),
+    };
   };
 }


### PR DESCRIPTION
Session and project pagination used to restart whenever the global scan or derived view changed. Continuous background updates could exhaust the client's retries before it finished loading a large list.

Retain each paginated read's items and associated alias view or project summary. Later pages read that snapshot without rebuilding the current view, while new first-page requests see current data. Retention is isolated by collection and scan source, limited to 32 snapshots per source per collection, and expires after 60 seconds. Expired or evicted snapshots return HTTP 409 for the existing client recovery path. Cursors remain bound to their original query and source.

Validation:
- Regression coverage for scan updates, alias-filtered pages, stable project totals, expiry, capacity eviction, cursor validation, and source/collection isolation.
- All 637 CLI tests and 72 related web tests pass.
- CLI lint, typecheck, and format checks pass.
- Full workspace build passes.
