### PR TITLE
feat: Cache model pricing from models.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ listener directly. The printed and automatically opened startup URL uses `--publ
 Using `--remote-access` without either TLS option still starts on a non-loopback address and prints
 a warning that the transport is unencrypted.
 
+Model estimates use [models.dev](https://models.dev/api.json), cached in `~/.cache/codesesh/models-dev-pricing.json` for one hour. Startup reuses valid cached prices; missing or expired prices are refreshed before scanning, with a 10-second timeout. Network failures fall back to stale cached or bundled prices. Subsequent scans recalculate previously unpriced sessions when their model prices become available.
+
 ---
 
 ## Web UI Walkthrough

--- a/README_CN.md
+++ b/README_CN.md
@@ -206,6 +206,8 @@ npx codesesh -j
 生成新的访问 token，并将其包含在输出 URL 中。请将该 URL 视为密码，不要公开或保存到
 共享的 shell 历史记录中。
 
+模型估算价格来自 [models.dev](https://models.dev/api.json)，缓存在 `~/.cache/codesesh/models-dev-pricing.json`，有效期为 1 小时。启动时复用有效缓存；缓存过期或缺失时，在扫描前刷新，最多等待 10 秒。网络失败时继续使用旧缓存或内置价格。新模型定价可用后，后续扫描会重新计算此前缺少定价的会话。
+
 ---
 
 ## Web UI 说明

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -245,6 +245,8 @@ const main = defineCommand({
     );
     const { from: listDefaultFrom, to: listDefaultTo, days: listDefaultDays } = listWindow;
 
+    await pricingRefresh.ready();
+
     const store = new LiveScanStore({
       watchEnabled: !jsonOnly,
       scanOptions,
@@ -268,7 +270,6 @@ const main = defineCommand({
     }
 
     if (jsonOnly) {
-      // Nothing will consume a later generation, so stop waiting for it.
       await pricingRefresh.cancel();
       const scanFailureDiagnostics = formatScanFailureDiagnostics(result);
       if (scanFailureDiagnostics.length > 0) {
@@ -318,8 +319,6 @@ const main = defineCommand({
 
     const { url } = app;
     if (!jsonOnly) {
-      // The startup scan has finished and background scans have not begun.
-      pricingRefresh.publish();
       store.startBackgroundRefresh();
     }
     let shuttingDown = false;

--- a/packages/cli/src/pricing-refresh.test.ts
+++ b/packages/cli/src/pricing-refresh.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ refresh: vi.fn(), publish: vi.fn() }));
+vi.mock("@codesesh/core/runtime/pricing", () => ({
+  refreshPricingCache: mocks.refresh,
+  publishPendingPricing: mocks.publish,
+}));
+vi.mock("./logging.js", () => ({ appLogger: { info: vi.fn(), warn: vi.fn() } }));
+const { startPricingRefresh } = await import("./pricing-refresh.js");
+
+beforeEach(() => vi.resetAllMocks());
+
+describe("startup pricing", () => {
+  it("waits for prices before publishing the generation used by the first scan", async () => {
+    let finish!: (value: boolean) => void;
+    mocks.refresh.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        finish = resolve;
+      }),
+    );
+    const refresh = startPricingRefresh();
+    const ready = refresh.ready();
+    expect(mocks.publish).not.toHaveBeenCalled();
+    finish(true);
+    await ready;
+    expect(mocks.publish).toHaveBeenCalledOnce();
+    expect(mocks.refresh).toHaveBeenCalledWith({
+      signal: expect.any(AbortSignal),
+      timeoutMs: 10_000,
+    });
+  });
+
+  it("allows scanning with fallback prices when the refresh fails", async () => {
+    mocks.refresh.mockRejectedValue(new Error("offline"));
+    await expect(startPricingRefresh().ready()).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/pricing-refresh.ts
+++ b/packages/cli/src/pricing-refresh.ts
@@ -1,11 +1,3 @@
-/**
- * Lifecycle owner for the background price refresh.
- *
- * The refresh used to be fired and forgotten: no timeout, no cancellation, and
- * it replaced the live prices the moment it returned — so one scan could price
- * its first sessions differently from its last. Here it is bounded, cancellable
- * on shutdown, and published only at a point where no scan is running.
- */
 import { publishPendingPricing, refreshPricingCache } from "@codesesh/core/runtime/pricing";
 import { appLogger } from "./logging.js";
 
@@ -13,8 +5,8 @@ import { appLogger } from "./logging.js";
 const REFRESH_TIMEOUT_MS = 10_000;
 
 export interface PricingRefresh {
-  /** Makes a completed refresh current. Safe to call more than once. */
-  publish(): void;
+  /** Waits for the bounded refresh and publishes prices before scanning. */
+  ready(): Promise<void>;
   /** Cancels an in-flight refresh and waits for it to settle. */
   cancel(): Promise<void>;
 }
@@ -29,7 +21,8 @@ export function startPricingRefresh(timeoutMs = REFRESH_TIMEOUT_MS): PricingRefr
   );
 
   return {
-    publish() {
+    async ready() {
+      await completion;
       if (publishPendingPricing()) appLogger.info("pricing.refresh.published", {});
     },
     async cancel() {

--- a/packages/core/src/pricing/__tests__/models-dev.test.ts
+++ b/packages/core/src/pricing/__tests__/models-dev.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { parseModelsDevPricing } from "../models-dev.js";
+
+const model = (input: number, output = 15) => ({ cost: { input, output } });
+
+describe("models.dev pricing", () => {
+  it("converts dollars per million tokens and cache prices into per-token prices", () => {
+    const prices = parseModelsDevPricing({
+      anthropic: {
+        models: {
+          "claude-new": {
+            cost: {
+              input: 3,
+              output: 15,
+              cache_write: 3.75,
+              cache_read: 0.3,
+            },
+          },
+        },
+      },
+    });
+    expect(prices.get("claude-new")).toEqual({
+      inputCostPerToken: 0.000003,
+      outputCostPerToken: 0.000015,
+      cacheCreateCostPerToken: 0.00000375,
+      cacheReadCostPerToken: 0.0000003,
+      reasoningCostPerToken: 0.000015,
+      webSearchCostPerRequest: 0.01,
+    });
+  });
+
+  it("prefers original providers for bare names and preserves explicit provider prices", () => {
+    const data = {
+      "aaa-reseller": { models: { "gpt-new": model(9), "openai/gpt-new": model(8) } },
+      openai: { models: { "gpt-new": model(2) } },
+      openrouter: { models: { "openai/gpt-new": model(4) } },
+    };
+    const prices = parseModelsDevPricing(data);
+    expect(prices.get("gpt-new")?.inputCostPerToken).toBe(0.000002);
+    expect(prices.get("openai/gpt-new")?.inputCostPerToken).toBe(0.000002);
+    expect(prices.get("openrouter/openai/gpt-new")?.inputCostPerToken).toBe(0.000004);
+    expect(parseModelsDevPricing(Object.fromEntries(Object.entries(data).reverse()))).toEqual(
+      prices,
+    );
+  });
+
+  it("ignores malformed entries while preserving zero and missing cache prices", () => {
+    const prices = parseModelsDevPricing({
+      broken: null,
+      test: {
+        models: {
+          broken: null,
+          missing: {},
+          invalid: model(-1),
+          infinite: model(Infinity),
+          free: model(0, 0),
+          normal: model(2),
+        },
+      },
+    });
+    expect([...prices.keys()].sort()).toEqual(["free", "normal", "test/free", "test/normal"]);
+    expect(prices.get("free")?.inputCostPerToken).toBe(0);
+    expect(prices.get("normal")?.cacheReadCostPerToken).toBe(0.000002);
+    expect(parseModelsDevPricing(null).size).toBe(0);
+  });
+});

--- a/packages/core/src/pricing/__tests__/refresh-generation.test.ts
+++ b/packages/core/src/pricing/__tests__/refresh-generation.test.ts
@@ -12,22 +12,21 @@ vi.mock("node:os", async (importOriginal) => {
 
 const { setCoreDiagnostics } = await import("../../utils/diagnostics.js");
 const { estimateTokenCost } = await import("../../utils/cost.js");
-const {
-  getPricingGeneration,
-  getPricingRegistry,
-  hasPendingPricing,
-  publishPendingPricing,
-  refreshPricingCache,
-} = await import("../fetcher.js");
+const { getPricingGeneration, hasPendingPricing, publishPendingPricing, refreshPricingCache } =
+  await import("../fetcher.js");
 
 const MODEL = "claude-sonnet-4-5";
 const MILLION_INPUT = { input: 1_000_000, output: 0 };
-const cachePath = join(testHome, ".cache", "codesesh", "litellm-pricing.json");
+const cachePath = join(testHome, ".cache", "codesesh", "models-dev-pricing.json");
 
 /** A remote payload that moves this model's price to an unmistakable value. */
 function remotePricing(inputCost: number) {
   return {
-    [MODEL]: { input_cost_per_token: inputCost, output_cost_per_token: inputCost },
+    anthropic: {
+      models: {
+        [MODEL]: { cost: { input: inputCost * 1_000_000, output: inputCost * 1_000_000 } },
+      },
+    },
   };
 }
 
@@ -45,6 +44,62 @@ afterEach(() => {
 });
 
 describe("CS-148: pricing generations", () => {
+  it("reuses fresh prices across process restarts without fetching", async () => {
+    stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000123) }));
+    await refreshPricingCache();
+    publishPendingPricing();
+    vi.resetModules();
+    const restarted = await import("../fetcher.js");
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    expect(await restarted.refreshPricingCache()).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(restarted.getPricingRegistry().get(MODEL)?.inputCostPerToken).toBe(0.000123);
+  });
+
+  it("refreshes an expired cache and makes a previously missing model priceable", async () => {
+    stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000123) }));
+    await refreshPricingCache();
+    publishPendingPricing();
+    const cache = JSON.parse(readFileSync(cachePath, "utf8"));
+    cache.timestamp = Date.now() - 60 * 60 * 1000;
+    writeFileSync(cachePath, JSON.stringify(cache));
+    vi.resetModules();
+    const restarted = await import("../fetcher.js");
+    const { pricingBecameAvailable } = await import("../cost.js");
+    const missing = ["brand-new-model"];
+    expect(pricingBecameAvailable(missing)).toBe(false);
+    const fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        openai: { models: { "brand-new-model": { cost: { input: 2, output: 8 } } } },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetch);
+    expect(await restarted.refreshPricingCache()).toBe(true);
+    expect(fetch).toHaveBeenCalledWith("https://models.dev/api.json", expect.any(Object));
+    expect(pricingBecameAvailable(missing)).toBe(false);
+    restarted.publishPendingPricing();
+    expect(pricingBecameAvailable(missing)).toBe(true);
+  });
+
+  it.each([{}, { bad: null }, { bad: { inputCostPerToken: -1 } }])(
+    "refreshes a fresh but unusable cache: %j",
+    async (data) => {
+      mkdirSync(join(testHome, ".cache", "codesesh"), { recursive: true });
+      writeFileSync(cachePath, JSON.stringify({ timestamp: Date.now(), data }));
+      stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000123) }));
+      expect(await refreshPricingCache()).toBe(true);
+    },
+  );
+
+  it("shares concurrent refresh requests", async () => {
+    const fetch = vi.fn(async () => ({ ok: true, json: async () => remotePricing(0.000123) }));
+    vi.stubGlobal("fetch", fetch);
+    expect(await Promise.all([refreshPricingCache(), refreshPricingCache()])).toEqual([true, true]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
   it("loads stale cache data and derives generation identity from its content", async () => {
     mkdirSync(join(testHome, ".cache", "codesesh"), { recursive: true });
     writeFileSync(
@@ -88,6 +143,9 @@ describe("CS-148: pricing generations", () => {
   });
 
   it("CS-194: keeps parent and isolated worker pricing on one generation", async () => {
+    vi.resetModules();
+    const { getPricingGeneration, getPricingRegistry, refreshPricingCache, publishPendingPricing } =
+      await import("../fetcher.js");
     const generationBefore = getPricingGeneration().id;
     const pricingBefore = getPricingRegistry().get(MODEL);
     stubFetch(async () => ({ ok: true, json: async () => remotePricing(0.000777) }));
@@ -112,17 +170,17 @@ describe("CS-148: pricing generations", () => {
     [
       "zero input or output prices",
       {
-        "input-only": { input_cost_per_token: 0.000001, output_cost_per_token: 0 },
-        "output-only": { input_cost_per_token: 0, output_cost_per_token: 0.000002 },
-        free: { input_cost_per_token: 0, output_cost_per_token: 0 },
+        "input-only": { input: 0.000001, output: 0 },
+        "output-only": { input: 0, output: 0.000002 },
+        free: { input: 0, output: 0 },
       },
     ],
     [
       "nested provider prefixes",
       {
         "provider/vendor/chat-model": {
-          input_cost_per_token: 0.000001,
-          output_cost_per_token: 0.000002,
+          input: 0.000001,
+          output: 0.000002,
         },
       },
     ],
@@ -130,12 +188,10 @@ describe("CS-148: pricing generations", () => {
       "invalid optional prices",
       {
         "fallback-prices": {
-          input_cost_per_token: 0.000001,
-          output_cost_per_token: 0.000002,
-          cache_creation_input_token_cost: Infinity,
-          cache_read_input_token_cost: NaN,
-          output_reasoning_cost_per_token: -1,
-          web_search_cost_per_request: Infinity,
+          input: 0.000001,
+          output: 0.000002,
+          cache_write: Infinity,
+          cache_read: NaN,
         },
       },
     ],
@@ -144,15 +200,22 @@ describe("CS-148: pricing generations", () => {
     const parentPricing = await import("../fetcher.js");
     vi.resetModules();
     const existingWorkerPricing = await import("../fetcher.js");
-    stubFetch(async () => ({ ok: true, json: async () => data }));
+    stubFetch(async () => ({
+      ok: true,
+      json: async () => ({
+        test: {
+          models: Object.fromEntries(Object.entries(data).map(([name, cost]) => [name, { cost }])),
+        },
+      }),
+    }));
 
     expect(await parentPricing.refreshPricingCache()).toBe(true);
     expect(parentPricing.publishPendingPricing()).toBe(true);
     const publishedGeneration = parentPricing.getPricingGeneration();
     for (const [name, entry] of Object.entries(data)) {
       expect(publishedGeneration.pricing.get(name)).toMatchObject({
-        inputCostPerToken: entry.input_cost_per_token,
-        outputCostPerToken: entry.output_cost_per_token,
+        inputCostPerToken: entry.input / 1_000_000,
+        outputCostPerToken: entry.output / 1_000_000,
       });
     }
     existingWorkerPricing.synchronizePricingGeneration(publishedGeneration.id);

--- a/packages/core/src/pricing/__tests__/resolver.test.ts
+++ b/packages/core/src/pricing/__tests__/resolver.test.ts
@@ -15,6 +15,22 @@ describe("pricing resolver", () => {
     expect(pricingResolver.resolve("claude-opus-4-6-thinking")).toEqual(expected);
   });
 
+  it("prefers exact model prices over legacy aliases and stripped dates", () => {
+    const registry = getPricingRegistry();
+    const names = ["gpt-5-codex", "claude-sonnet-4-6-20260905"];
+    const pricing = { ...registry.get("claude-sonnet-4-6")!, inputCostPerToken: 0.000123 };
+    for (const name of names) {
+      const previous = registry.get(name);
+      try {
+        registry.set(name, pricing);
+        expect(pricingResolver.resolve(name)).toEqual(pricing);
+      } finally {
+        if (previous) registry.set(name, previous);
+        else registry.delete(name);
+      }
+    }
+  });
+
   it("rejects unknown model names", () => {
     expect(pricingResolver.resolve("vendor/nonexistent-model")).toBeNull();
   });

--- a/packages/core/src/pricing/__tests__/resolver.test.ts
+++ b/packages/core/src/pricing/__tests__/resolver.test.ts
@@ -10,9 +10,16 @@ describe("pricing resolver", () => {
   });
 
   it("uses the longest billable model prefix for fuzzy variants", () => {
-    const expected = getPricingRegistry().get("claude-opus-4-6");
-
-    expect(pricingResolver.resolve("claude-opus-4-6-thinking")).toEqual(expected);
+    const registry = getPricingRegistry();
+    const expected = registry.get("claude-opus-4-6")!;
+    registry.set("test-fuzzy-model", { ...expected, inputCostPerToken: 1 });
+    registry.set("test-fuzzy-model-extended", expected);
+    try {
+      expect(pricingResolver.resolve("test-fuzzy-model-extended-thinking")).toEqual(expected);
+    } finally {
+      registry.delete("test-fuzzy-model");
+      registry.delete("test-fuzzy-model-extended");
+    }
   });
 
   it("prefers exact model prices over legacy aliases and stripped dates", () => {

--- a/packages/core/src/pricing/fetcher.ts
+++ b/packages/core/src/pricing/fetcher.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { ensurePrivateDirectory, restrictPrivateFile } from "../utils/private-storage.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
+import { MODELS_DEV_URL, parseModelsDevPricing } from "./models-dev.js";
 import snapshotData from "./data/snapshot.json";
 
 export interface ModelPricing {
@@ -17,19 +18,7 @@ export interface ModelPricing {
 
 type SnapshotEntry = [number, number, number | null, number | null, number?, number?];
 
-interface LiteLLMEntry {
-  input_cost_per_token?: number;
-  output_cost_per_token?: number;
-  cache_creation_input_token_cost?: number;
-  cache_read_input_token_cost?: number;
-  output_reasoning_cost_per_token?: number;
-  web_search_cost_per_request?: unknown;
-  search_context_cost_per_query?: unknown;
-}
-
-const LITELLM_URL =
-  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const CACHE_TTL_MS = 60 * 60 * 1000;
 const WEB_SEARCH_COST = 0.01;
 const REFRESH_TIMEOUT_MS = 10_000;
 
@@ -46,6 +35,7 @@ export interface PricingGeneration {
 let published = createPricingGeneration(loadSnapshot());
 /** A completed refresh waiting for a safe point to become current. */
 let pending: Map<string, ModelPricing> | null = null;
+let refreshInFlight: Promise<boolean> | null = null;
 published = readDiskCache() ?? published;
 
 export function normalizeModelKey(key: string): string {
@@ -79,7 +69,7 @@ function getCacheDir() {
 }
 
 function getCachePath() {
-  return join(getCacheDir(), "litellm-pricing.json");
+  return join(getCacheDir(), "models-dev-pricing.json");
 }
 
 function loadSnapshot(): Map<string, ModelPricing> {
@@ -99,30 +89,20 @@ function loadSnapshot(): Map<string, ModelPricing> {
   return map;
 }
 
-function parseLiteLLMEntry(entry: LiteLLMEntry): ModelPricing | null {
-  return normalizePricing({
-    inputCostPerToken: entry.input_cost_per_token,
-    outputCostPerToken: entry.output_cost_per_token,
-    cacheCreateCostPerToken: entry.cache_creation_input_token_cost,
-    cacheReadCostPerToken: entry.cache_read_input_token_cost,
-    reasoningCostPerToken: entry.output_reasoning_cost_per_token,
-    webSearchCostPerRequest:
-      entry.web_search_cost_per_request ?? entry.search_context_cost_per_query,
-  });
-}
-
-function normalizePricing(raw: Record<string, unknown>): ModelPricing | null {
-  const input = costNumber(raw["inputCostPerToken"]);
-  const output = costNumber(raw["outputCostPerToken"]);
+function normalizePricing(raw: unknown): ModelPricing | null {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const values = raw as Record<string, unknown>;
+  const input = costNumber(values["inputCostPerToken"]);
+  const output = costNumber(values["outputCostPerToken"]);
   if (input === undefined || output === undefined) return null;
 
   return {
     inputCostPerToken: input,
     outputCostPerToken: output,
-    cacheCreateCostPerToken: costNumber(raw["cacheCreateCostPerToken"]) ?? input * 1.25,
-    cacheReadCostPerToken: costNumber(raw["cacheReadCostPerToken"]) ?? input * 0.1,
-    reasoningCostPerToken: costNumber(raw["reasoningCostPerToken"]) ?? output,
-    webSearchCostPerRequest: costNumber(raw["webSearchCostPerRequest"]) ?? WEB_SEARCH_COST,
+    cacheCreateCostPerToken: costNumber(values["cacheCreateCostPerToken"]) ?? input * 1.25,
+    cacheReadCostPerToken: costNumber(values["cacheReadCostPerToken"]) ?? input * 0.1,
+    reasoningCostPerToken: costNumber(values["reasoningCostPerToken"]) ?? output,
+    webSearchCostPerRequest: costNumber(values["webSearchCostPerRequest"]) ?? WEB_SEARCH_COST,
   };
 }
 
@@ -137,38 +117,32 @@ function indexPricing(map: Map<string, ModelPricing>, name: string, pricing: Mod
   }
 }
 
-function parseLiteLLMData(data: Record<string, LiteLLMEntry>): Map<string, ModelPricing> {
-  const map = new Map<string, ModelPricing>();
-  for (const [name, entry] of Object.entries(data)) {
-    const pricing = parseLiteLLMEntry(entry);
-    if (pricing) indexPricing(map, name, pricing);
-  }
-  return map;
-}
-
 interface PricingCache {
   timestamp: number;
   data: Record<string, Record<string, unknown>>;
 }
 
-function readDiskCache(): PricingGeneration | null {
+function readDiskCache(requireFresh = false): PricingGeneration | null {
   const path = getCachePath();
   if (!existsSync(path)) return null;
 
   try {
     const cached = JSON.parse(readFileSync(path, "utf-8")) as PricingCache;
-    if (!Number.isFinite(cached.timestamp)) return null;
+    if (!Number.isFinite(cached.timestamp) || cached.timestamp > Date.now()) return null;
+    if (requireFresh && Date.now() - cached.timestamp >= CACHE_TTL_MS) return null;
     if (cached.data == null || typeof cached.data !== "object" || Array.isArray(cached.data)) {
       return null;
     }
 
     const next = loadSnapshot();
+    let validEntries = 0;
     for (const [name, rawPricing] of Object.entries(cached.data)) {
       const pricing = normalizePricing(rawPricing);
       if (!pricing) continue;
       next.set(normalizeModelKey(name), pricing);
+      validEntries++;
     }
-    return createPricingGeneration(next);
+    return validEntries > 0 ? createPricingGeneration(next) : null;
   } catch {
     return null;
   }
@@ -270,28 +244,24 @@ export interface RefreshPricingOptions {
  * {@link publishPendingPricing}, so an in-flight scan keeps the prices it
  * started with.
  */
-export async function refreshPricingCache(options: RefreshPricingOptions = {}): Promise<boolean> {
-  const path = getCachePath();
-  if (existsSync(path)) {
-    try {
-      const cached = JSON.parse(readFileSync(path, "utf-8")) as { timestamp?: number };
-      if (typeof cached.timestamp === "number" && Date.now() - cached.timestamp <= CACHE_TTL_MS) {
-        return false;
-      }
-    } catch {
-      // refresh malformed cache
-    }
-  }
+export function refreshPricingCache(options: RefreshPricingOptions = {}): Promise<boolean> {
+  refreshInFlight ??= fetchPricing(options).finally(() => {
+    refreshInFlight = null;
+  });
+  return refreshInFlight;
+}
+
+async function fetchPricing(options: RefreshPricingOptions): Promise<boolean> {
+  if (pending || readDiskCache(true)) return false;
 
   const timeout = AbortSignal.timeout(options.timeoutMs ?? REFRESH_TIMEOUT_MS);
   const signal = options.signal ? AbortSignal.any([options.signal, timeout]) : timeout;
 
   getCoreDiagnostics()?.info?.("pricing.refresh.started", { generation: published.id });
   try {
-    const response = await fetch(LITELLM_URL, { signal });
+    const response = await fetch(MODELS_DEV_URL, { signal });
     if (!response.ok) return false;
-    const data = (await response.json()) as Record<string, LiteLLMEntry>;
-    const remote = parseLiteLLMData(data);
+    const remote = parseModelsDevPricing(await response.json());
     if (remote.size === 0) return false;
 
     const next = loadSnapshot();

--- a/packages/core/src/pricing/fetcher.ts
+++ b/packages/core/src/pricing/fetcher.ts
@@ -5,16 +5,9 @@ import { join } from "node:path";
 import { ensurePrivateDirectory, restrictPrivateFile } from "../utils/private-storage.js";
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import { MODELS_DEV_URL, parseModelsDevPricing } from "./models-dev.js";
+import { normalizeModelKey, type ModelPricing } from "./model-pricing.js";
+export { normalizeModelKey, type ModelPricing } from "./model-pricing.js";
 import snapshotData from "./data/snapshot.json";
-
-export interface ModelPricing {
-  inputCostPerToken: number;
-  outputCostPerToken: number;
-  cacheCreateCostPerToken: number;
-  cacheReadCostPerToken: number;
-  reasoningCostPerToken: number;
-  webSearchCostPerRequest: number;
-}
 
 type SnapshotEntry = [number, number, number | null, number | null, number?, number?];
 
@@ -37,10 +30,6 @@ let published = createPricingGeneration(loadSnapshot());
 let pending: Map<string, ModelPricing> | null = null;
 let refreshInFlight: Promise<boolean> | null = null;
 published = readDiskCache() ?? published;
-
-export function normalizeModelKey(key: string): string {
-  return key.trim().toLowerCase().replaceAll("_", "-");
-}
 
 function createPricingGeneration(pricing: Map<string, ModelPricing>): PricingGeneration {
   const hash = createHash("sha256");

--- a/packages/core/src/pricing/model-pricing.ts
+++ b/packages/core/src/pricing/model-pricing.ts
@@ -1,0 +1,12 @@
+export interface ModelPricing {
+  inputCostPerToken: number;
+  outputCostPerToken: number;
+  cacheCreateCostPerToken: number;
+  cacheReadCostPerToken: number;
+  reasoningCostPerToken: number;
+  webSearchCostPerRequest: number;
+}
+
+export function normalizeModelKey(key: string): string {
+  return key.trim().toLowerCase().replaceAll("_", "-");
+}

--- a/packages/core/src/pricing/models-dev.ts
+++ b/packages/core/src/pricing/models-dev.ts
@@ -1,0 +1,64 @@
+import type { ModelPricing } from "./fetcher.js";
+import { normalizeModelKey } from "./fetcher.js";
+
+export const MODELS_DEV_URL = "https://models.dev/api.json";
+
+const ORIGINAL_PROVIDERS = new Set([
+  "anthropic",
+  "openai",
+  "google",
+  "deepseek",
+  "moonshotai",
+  "minimax",
+  "mistral",
+  "xai",
+  "cohere",
+  "zai",
+  "zhipuai",
+  "alibaba",
+  "meta",
+  "stepfun",
+]);
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function perToken(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value / 1_000_000
+    : undefined;
+}
+
+export function parseModelsDevPricing(data: unknown): Map<string, ModelPricing> {
+  const providers = Object.entries(record(data) ?? {}).sort(
+    ([a], [b]) =>
+      Number(ORIGINAL_PROVIDERS.has(b)) - Number(ORIGINAL_PROVIDERS.has(a)) || a.localeCompare(b),
+  );
+  const qualified = new Map<string, ModelPricing>();
+  const aliases = new Map<string, ModelPricing>();
+  for (const [provider, rawProvider] of providers) {
+    const models = record(record(rawProvider)?.["models"]);
+    for (const [model, rawModel] of Object.entries(models ?? {})) {
+      const cost = record(record(rawModel)?.["cost"]);
+      if (!cost) continue;
+      const input = perToken(cost["input"]);
+      const output = perToken(cost["output"]);
+      if (input === undefined || output === undefined) continue;
+      const pricing: ModelPricing = {
+        inputCostPerToken: input,
+        outputCostPerToken: output,
+        cacheCreateCostPerToken: perToken(cost["cache_write"]) ?? input,
+        cacheReadCostPerToken: perToken(cost["cache_read"]) ?? input,
+        reasoningCostPerToken: output,
+        webSearchCostPerRequest: 0.01,
+      };
+      qualified.set(normalizeModelKey(`${provider}/${model}`), pricing);
+      const name = normalizeModelKey(model);
+      if (!aliases.has(name)) aliases.set(name, pricing);
+    }
+  }
+  return new Map([...aliases, ...qualified]);
+}

--- a/packages/core/src/pricing/models-dev.ts
+++ b/packages/core/src/pricing/models-dev.ts
@@ -1,5 +1,4 @@
-import type { ModelPricing } from "./fetcher.js";
-import { normalizeModelKey } from "./fetcher.js";
+import { normalizeModelKey, type ModelPricing } from "./model-pricing.js";
 
 export const MODELS_DEV_URL = "https://models.dev/api.json";
 

--- a/packages/core/src/pricing/resolver.ts
+++ b/packages/core/src/pricing/resolver.ts
@@ -77,6 +77,8 @@ export interface PricingResolver {
 export const pricingResolver: PricingResolver = {
   resolve(rawModelName: string): ModelPricing | null {
     const registry = getPricingRegistry();
+    const exact = registry.get(normalizeModelKey(rawModelName));
+    if (exact && hasBillablePricing(exact)) return exact;
     const candidates = getCandidates(rawModelName);
 
     for (const candidate of candidates) {


### PR DESCRIPTION
Use models.dev for model pricing, with a one-hour disk cache and a bounded refresh before the first scan. Repeated CLI runs reuse cached prices; failed refreshes retain stale or bundled prices. Newly available model prices can reprice previously unpriced sessions, including in JSON mode.

Preserve provider-specific prices, prefer original providers for bare model names, and resolve exact models before legacy aliases. Validate cached data and coalesce concurrent refreshes.

Validation: Core and CLI tests (1,745 passed), lint, formatting, typechecks, Core build, and a live models.dev fetch/cache smoke test.
