### PR TITLE
fix: Keep background refresh notices quiet

### DIFF
--- a/apps/web/src/components/app/ScanStatusNotice.tsx
+++ b/apps/web/src/components/app/ScanStatusNotice.tsx
@@ -19,9 +19,12 @@ export function ScanStatusNotice({ visible }: { visible: boolean }) {
     : null;
   return (
     <>
-      <div>
+      <div className={visible ? "flow-root h-9" : undefined}>
         {visible && label ? (
-          <p className="console-mono mt-2 inline-flex max-w-4xl rounded-sm border border-[var(--console-warning-border)] bg-[var(--console-warning-bg)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-warning)]">
+          <p
+            title={label}
+            className="console-mono mt-2 w-fit max-w-full truncate rounded-sm border border-[var(--console-warning-border)] bg-[var(--console-warning-bg)] px-2 py-1 text-[11px] leading-relaxed text-[var(--console-warning)]"
+          >
             {label}
           </p>
         ) : null}

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -40,7 +40,7 @@ describe("formatScanStatusLabel", () => {
     expect(formatScanStatusLabel({ active: false } as ScanStatusEvent)).toBeNull();
   });
 
-  it("returns a publishing message for the publishing phase", () => {
+  it("keeps routine publication quiet", () => {
     expect(
       formatScanStatusLabel({
         active: true,
@@ -50,10 +50,10 @@ describe("formatScanStatusLabel", () => {
         totalAgents: 0,
         agentStatuses: {},
       } as unknown as ScanStatusEvent),
-    ).toBe("Publishing session updates");
+    ).toBeNull();
   });
 
-  it("maps the legacy indexing phase to publishing", () => {
+  it("keeps legacy indexing quiet", () => {
     expect(
       formatScanStatusLabel({
         active: true,
@@ -63,7 +63,7 @@ describe("formatScanStatusLabel", () => {
         totalAgents: 0,
         agentStatuses: {},
       } as unknown as ScanStatusEvent),
-    ).toBe("Publishing session updates");
+    ).toBeNull();
   });
 
   it("surfaces an inactive refresh failure", () => {
@@ -174,53 +174,38 @@ describe("formatScanStatusLabel", () => {
     ).toBe("Finalizing full-history metadata · codex · 68/2107");
   });
 
-  it.each([
-    ["scanning", "Checking for new or changed sessions"],
-    ["finalizing", "Finalizing session metadata"],
-  ] as const)("shows current item counts while %s", (phase, label) => {
-    expect(
-      formatScanStatusLabel({
-        active: true,
-        phase: phase === "scanning" ? "scanning" : "publishing",
-        completedAgents: ["claudecode"],
-        scanningAgents: ["codex"],
-        totalAgents: 2,
-        agentStatuses: {
-          codex: {
-            agentName: "codex",
-            status: phase,
-            total: 2108,
-            processed: 17,
-            updatedAt: 1,
+  it.each(["scanning", "finalizing", "publish-queued", "publishing", "indexing"] as const)(
+    "keeps routine %s progress quiet",
+    (phase) => {
+      expect(
+        formatScanStatusLabel({
+          active: true,
+          phase: phase === "scanning" ? "scanning" : "publishing",
+          completedAgents: [],
+          scanningAgents: ["codex"],
+          totalAgents: 1,
+          agentStatuses: {
+            codex: { agentName: "codex", status: phase, total: 1, processed: 0, updatedAt: 1 },
           },
-        },
-      } as unknown as ScanStatusEvent),
-    ).toBe(`${label} · codex · 17/2108 · 1/2 agents ready`);
+        } as unknown as ScanStatusEvent),
+      ).toBeNull();
+    },
+  );
+
+  it("keeps initialization visible", () => {
+    expect(formatScanStatusLabel({ active: true, phase: "initializing" } as ScanStatusEvent)).toBe(
+      "Initializing recent sessions",
+    );
   });
 
-  it.each([
-    ["publish-queued", "Session publication queued"],
-    ["publishing", "Publishing session updates"],
-    ["indexing", "Publishing session updates"],
-  ] as const)("does not reuse completed scan counts while %s", (phase, label) => {
+  it("does not hide failures while another agent refreshes", () => {
     expect(
       formatScanStatusLabel({
         active: true,
-        phase: "publishing",
-        completedAgents: ["claudecode"],
-        scanningAgents: ["codex"],
-        totalAgents: 2,
-        agentStatuses: {
-          codex: {
-            agentName: "codex",
-            status: phase,
-            total: 119,
-            processed: 119,
-            updatedAt: 1,
-          },
-        },
+        phase: "scanning",
+        agentStatuses: { codex: { agentName: "codex", status: "failed", error: "read failed" } },
       } as unknown as ScanStatusEvent),
-    ).toBe(`${label} · codex · 1/2 agents ready`);
+    ).toBe("Session refresh failed · codex · read failed");
   });
 
   it("does not reuse full-history scan counts while preparing publication", () => {
@@ -273,7 +258,7 @@ describe("formatScanStatusLabel", () => {
     ).toBe("Full-history publication queued · zcode");
   });
 
-  it("labels search maintenance as non-blocking background work", () => {
+  it("keeps routine search maintenance quiet", () => {
     expect(
       formatScanStatusLabel({
         active: false,
@@ -288,7 +273,7 @@ describe("formatScanStatusLabel", () => {
           failedAgents: [],
         },
       } as unknown as ScanStatusEvent),
-    ).toBe("Updating search index in background · codex · 2199 remaining");
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -86,48 +86,8 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
   if (failedAgent) {
     return `Session refresh failed · ${failedAgent.agentName}${failedAgent.error ? ` · ${failedAgent.error}` : ""}`;
   }
-  if (status.active) {
-    const completed = status.completedAgents.length;
-    const total = status.totalAgents;
-    const current = status.scanningAgents[0];
-    const currentStatus = current ? status.agentStatuses[current] : null;
-    const itemProgress =
-      (currentStatus?.status === "scanning" || currentStatus?.status === "finalizing") &&
-      currentStatus.total &&
-      currentStatus.processed != null
-        ? ` · ${currentStatus.processed}/${currentStatus.total}`
-        : "";
-    const agentProgress =
-      total > 0
-        ? current
-          ? ` · ${current}${itemProgress} · ${completed}/${total} agents ready`
-          : ` · ${completed}/${total} agents ready`
-        : "";
-    const stageLabel =
-      currentStatus?.status === "publish-queued"
-        ? "Session publication queued"
-        : currentStatus?.status === "finalizing"
-          ? "Finalizing session metadata"
-          : currentStatus?.status === "publishing" ||
-              currentStatus?.status === "indexing" ||
-              status.phase === "publishing" ||
-              status.phase === "indexing"
-            ? "Publishing session updates"
-            : "Checking for new or changed sessions";
-
-    if (status.phase === "initializing") {
-      return `Initializing recent sessions${agentProgress}`;
-    }
-    if (status.phase === "publishing" || status.phase === "indexing") {
-      return `${stageLabel}${agentProgress}`;
-    }
-
-    if (total > 0) {
-      return current
-        ? `${stageLabel} · ${current}${itemProgress} · ${completed}/${total} agents ready`
-        : `Checking for new or changed sessions · ${completed}/${total} agents ready`;
-    }
-    return "Checking for new or changed sessions";
+  if (status.active && status.phase === "initializing") {
+    return "Initializing recent sessions";
   }
 
   const partialBackfill = Object.entries(status.backfill?.partialAgents ?? {}).find(
@@ -149,11 +109,6 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
     return `Session refresh completed with partial data · ${partialAgent.agentName}${detail ? ` · ${detail}` : ""}`;
   }
 
-  if (status.searchIndexMaintenance?.active) {
-    const current = status.searchIndexMaintenance.currentAgent;
-    const remaining = status.searchIndexMaintenance.remaining;
-    return `Updating search index in background${current ? ` · ${current}` : ""}${remaining != null ? ` · ${remaining} remaining` : ""}`;
-  }
   if (status.searchIndexMaintenance?.failedAgents.length) {
     return `Background search index maintenance paused · ${status.searchIndexMaintenance.failedAgents.join(", ")}`;
   }

--- a/tests/e2e/dashboard-refresh.spec.ts
+++ b/tests/e2e/dashboard-refresh.spec.ts
@@ -1,0 +1,89 @@
+import { SAMPLE_SCAN_STATUS_EVENT } from "@codesesh/core/test-fixtures";
+import { expect, test } from "./test-fixtures.js";
+
+for (const width of [1280, 375]) {
+  test(`keeps background refresh quiet and layout stable at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.route("**/api/status*", (route) =>
+      route.fulfill({ json: SAMPLE_SCAN_STATUS_EVENT }),
+    );
+    await page.addInitScript(() => {
+      class TestEventSource extends EventTarget {
+        private readonly onStatus = (event: Event) => {
+          this.dispatchEvent(
+            new MessageEvent("scan-status", {
+              data: JSON.stringify((event as CustomEvent).detail),
+            }),
+          );
+        };
+        constructor() {
+          super();
+          window.addEventListener("test-scan-status", this.onStatus);
+        }
+        close() {
+          window.removeEventListener("test-scan-status", this.onStatus);
+        }
+      }
+      Object.defineProperty(window, "EventSource", { value: TestEventSource });
+    });
+    await page.goto("/");
+    const dashboard = page.getByTestId("dashboard");
+    await expect(dashboard.locator("section").first()).toBeVisible();
+    await page.evaluate(() => document.fonts.ready);
+    const initialTop = await dashboard.evaluate((element) => element.getBoundingClientRect().top);
+    const notice = page.locator("p[title]").filter({ hasText: /session|history|index/i });
+    for (const active of [true, false, true, false]) {
+      await page.evaluate(
+        (status) => {
+          window.dispatchEvent(new CustomEvent("test-scan-status", { detail: status }));
+        },
+        {
+          ...SAMPLE_SCAN_STATUS_EVENT,
+          active,
+          phase: active ? "scanning" : "idle",
+          updatedAt: Date.now(),
+        },
+      );
+      await page.evaluate(() => new Promise(requestAnimationFrame));
+      await expect(notice).toHaveCount(0);
+      await expect(
+        page.getByText("Checking for new or changed sessions", { exact: false }),
+      ).toHaveCount(0);
+      await expect
+        .poll(() => dashboard.evaluate((element) => element.getBoundingClientRect().top))
+        .toBe(initialTop);
+    }
+    for (const [phase, label] of [
+      ["initializing", "Initializing recent sessions"],
+      ["failed", "Session refresh failed"],
+    ] as const) {
+      await page.evaluate(
+        (status) => {
+          window.dispatchEvent(new CustomEvent("test-scan-status", { detail: status }));
+        },
+        {
+          ...SAMPLE_SCAN_STATUS_EVENT,
+          active: phase === "initializing",
+          phase: phase === "initializing" ? "initializing" : "idle",
+          updatedAt: Date.now(),
+          agentStatuses:
+            phase === "failed"
+              ? {
+                  codex: {
+                    agentName: "codex",
+                    status: "failed",
+                    error: "read failed",
+                    updatedAt: Date.now(),
+                  },
+                }
+              : {},
+        },
+      );
+      await expect(notice).toContainText(label);
+      await expect(notice).toBeVisible();
+      expect(await dashboard.evaluate((element) => element.getBoundingClientRect().top)).toBe(
+        initialTop,
+      );
+    }
+  });
+}


### PR DESCRIPTION
Routine background scans repeatedly showed and removed a notice above the Dashboard, causing distracting flashes and roughly 36px of layout movement.

Keep routine scanning, publication, and search-index maintenance quiet. Preserve initialization, full-history progress, failures, and partial-data warnings. Reserve a fixed-height notice area and truncate long labels so meaningful notices do not shift the Dashboard on desktop or narrow screens.

Validation: 27 scan-format tests, browser regression tests at 1280px and 375px, Web lint and typecheck, e2e typecheck, formatting, and the build required by Playwright. Browser tests verify silent background updates, visible initialization/failure notices, and stable content positions.
