### PR TITLE
perf: Speed up all-time analytics reads

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -157,3 +157,51 @@ reports five fresh-snapshot timings. It prints a response digest without session
 content, excluding the per-request pagination cursor. Before/after responses on
 the measured cache matched exactly after excluding that cursor. OS cache warmth,
 background indexing, and concurrent workloads affect timings.
+
+## Cover message usage reads with the time index
+
+Schema 33 extends the existing usage-time index with `message_index`, `model`,
+`tokens_json`, `cost`, and `cost_source`. The cost-fact query can read these values
+from the index instead of revisiting transcript-bearing message rows. Including
+`message_index` also covers the complete requested ordering. No cost attribution,
+time-window, or response contract changes are needed.
+
+On an isolated copy of a local cache (4,553 sessions, 270,342 timed messages),
+three cost-fact reads gave these median timings:
+
+| Phase | Before | After |
+| --- | ---: | ---: |
+| Message SQL read | 822.22 ms | 424.35 ms |
+| Full cost-fact load | 881.61 ms | 478.02 ms |
+
+All three before/after cost-fact response digests matched. The copied cache's
+migration took 982 ms including opening the cache and reading cached heads.
+The usage index grew from 16,683,008 bytes to 36,913,152 bytes (about 19.3 MiB
+additional storage). Writes must maintain the larger index; this is a read/write
+tradeoff, not an asymptotic complexity change.
+
+A production-build browser comparison used Chromium 151, a 1440×1000 viewport,
+no throttling, and the same copied cache with background scanning enabled. Each
+run waited for startup scanning to become inactive, then performed five 7-day
+to All time switches. Completion required client data loading to finish, the
+Dashboard skeleton and session-loading notice to disappear, and two additional
+animation frames. This approximates presentation completion rather than measuring
+physical display output.
+
+| Browser measurement | Before | After |
+| --- | ---: | ---: |
+| First switch in this run | 7.22 s | 1.30 s |
+| Median of subsequent four switches | 1.86 s | 1.28 s |
+| Range of subsequent four switches | 1.79–2.58 s | 1.23–1.38 s |
+
+Repeated-switch median improved about 31% over the shared-cost-facts change.
+Neither run recorded a frontend task longer than 50 ms during the switches.
+The index was migrated and profiled before the second browser run, so its first
+switch is **not** a matched cold-cache comparison; the first-switch numbers do
+not establish a guaranteed cold-start speedup. Migration timing is separate.
+The original local cache remained at schema 32 throughout this experiment.
+
+To measure the current handlers with `scripts/benchmark-all-time-aggregation.mjs`,
+first start the current CLI against the intended cache so its schema migration
+has completed. Compare unchanged data and the same timestamp; do not compare an
+old index against a new build without checking the actual cache schema.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -121,3 +121,39 @@ node scripts/benchmark-session-window.mjs
 有边界调用返回新数组的行为。需要实际筛选时继续使用原有树规则，保留命中父节点的全部
 子会话；调用方显式提供树时，也继续使用该树。All time 优化主要减少分配和计算常数，
 其渐进复杂度仍为 O(N)。上述数据仅衡量过滤函数，不代表页面或扫描整体耗时。
+
+## Share All time cost facts between API handlers
+
+Dashboard and Projects previously loaded the same message cost facts independently
+when the UI switched to All time. They now share the snapshot's unbounded cost
+facts. Dashboard still applies its current-time upper bound during aggregation;
+explicit date ranges retain their bounded reads. Snapshot replacement and analytics
+revision changes invalidate the shared facts.
+
+On a local cache with 4,553 sessions and 270,155 timed messages, three warmed
+iterations with fresh snapshot caches gave these median handler times:
+
+| Measurement | Before | After |
+| --- | ---: | ---: |
+| Dashboard | 1,213.65 ms | 1,226.99 ms |
+| Projects | 1,120.63 ms | 239.83 ms |
+| Combined | 2,306.59 ms | 1,456.90 ms |
+
+The combined time decreased about 37%. Both routes still perform their own
+aggregation. This removes one O(M) database read and conversion per snapshot,
+where M is the number of timed messages; total complexity remains O(M). The
+existing snapshot cache bounds retention. This is a backend measurement, not a
+browser load or rendering measurement.
+
+Reproduce against an existing local CodeSesh cache after building Core:
+
+```bash
+node scripts/benchmark-all-time-aggregation.mjs 1788571200000
+```
+
+Use the same timestamp and unchanged cache when comparing revisions. The script
+builds the two current API handlers together, reads local cached sessions, and
+reports five fresh-snapshot timings. It prints a response digest without session
+content, excluding the per-request pagination cursor. Before/after responses on
+the measured cache matched exactly after excluding that cursor. OS cache warmth,
+background indexing, and concurrent workloads affect timings.

--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 32`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 33`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`
@@ -200,3 +200,7 @@ materializeSessionDetailResponse()
 - `packages/core/src/discovery/scanner.ts`
 - `packages/cli/src/agent-sync-engine.ts`
 - `packages/cli/src/search-index-worker.ts`
+
+Schema 33 扩展消息用量时间索引，覆盖消息顺序、模型、tokens 和成本字段。
+Dashboard 的统计查询无需回读含消息正文的大表，也不再为同时间消息额外排序。
+升级时重建该派生索引，不修改消息、会话或成本数据；索引会占用额外空间并增加写入维护开销。

--- a/packages/cli/src/api/__tests__/dashboard-handler.test.ts
+++ b/packages/cli/src/api/__tests__/dashboard-handler.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./handler-test-fixtures.js";
 
 const { handleGetDashboard } = await import("../dashboard-handler.js");
+const { handleGetProjects } = await import("../catalog-handlers.js");
 
 describe("handleGetDashboard", () => {
   it("rejects invalid dates instead of silently using defaults", () => {
@@ -579,5 +580,104 @@ describe("handleGetDashboard", () => {
       expect.objectContaining({ costFacts }),
     );
     expect(response.modelCost).toEqual([]);
+  });
+});
+
+describe("shared all-time cost facts", () => {
+  it.each([true, false])("reads once with dashboard first: %s", (dashboardFirst) => {
+    const source = makeScanSource();
+    const dashboard = () => handleGetDashboard(makeMockContext({ query: { days: "0" } }), source);
+    const projects = () =>
+      handleGetProjects(makeMockContext({ query: { from: new Date(0).toISOString() } }), source);
+    const requests = dashboardFirst ? [dashboard, projects] : [projects, dashboard];
+    for (const request of requests) request();
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenCalledTimes(1);
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenCalledWith({
+      from: undefined,
+      to: undefined,
+    });
+
+    coreMocks.getAnalyticsRevision.mockReturnValue("updated");
+    for (const request of requests) request();
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenCalledTimes(2);
+
+    const snapshot = source.getSnapshot();
+    snapshot.sessions = [...snapshot.sessions];
+    for (const request of requests) request();
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps explicit upper bounds separate from the all-time project query", () => {
+    const source = makeScanSource();
+    const to = "2026-07-26T12:00:00.000Z";
+    handleGetDashboard(makeMockContext({ query: { days: "0", to } }), source);
+    handleGetProjects(makeMockContext({ query: { from: new Date(0).toISOString() } }), source);
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenCalledTimes(2);
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenNthCalledWith(1, {
+      from: undefined,
+      to: Date.parse(to),
+    });
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenNthCalledWith(2, {
+      from: undefined,
+      to: undefined,
+    });
+  });
+
+  it("does not reuse facts when the analytics revision is unavailable", () => {
+    coreMocks.getAnalyticsRevision.mockReturnValue(null);
+    const source = makeScanSource();
+    handleGetDashboard(makeMockContext({ query: { days: "0" } }), source);
+    handleGetProjects(makeMockContext({ query: { from: new Date(0).toISOString() } }), source);
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenCalledTimes(2);
+  });
+
+  it("excludes future messages from dashboard totals while retaining them for unbounded projects", () => {
+    const now = Date.now();
+    const session = makeSession("timed", {
+      time_created: now - 100,
+      time_updated: now - 100,
+      stats: { message_count: 2, total_input_tokens: 0, total_output_tokens: 0, total_cost: 2 },
+    });
+    coreMocks.listDashboardCostFacts.mockReturnValue({
+      sessions: [
+        {
+          reference: session.reference,
+          messageCount: 2,
+          untimedMessageCount: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          reasoningTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          untimedInputTokens: 0,
+          untimedOutputTokens: 0,
+          untimedReasoningTokens: 0,
+          untimedCacheReadTokens: 0,
+          untimedCacheCreateTokens: 0,
+          messageCost: 2,
+          untimedMessageCost: 0,
+          modelCosts: [],
+        },
+      ],
+      messages: [now - 100, now + 86400000].map((time) => ({
+        reference: session.reference,
+        time,
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreateTokens: 0,
+        cost: 1,
+      })),
+    });
+    const source = makeScanSource({ sessions: [session], byAgent: { agent: [session] } });
+    const dashboard = makeMockContext({ query: { days: "0" } });
+    const projects = makeMockContext({ query: { from: new Date(0).toISOString() } });
+    handleGetDashboard(dashboard, source);
+    handleGetProjects(projects, source);
+    expect(dashboard.json.mock.calls[0]![0].totals.cost).toBe(1);
+    expect(dashboard.json.mock.calls[0]![0].totals.messages).toBe(1);
+    expect(projects.json.mock.calls[0]![0].summary.cost).toBe(2);
+    expect(coreMocks.listDashboardCostFacts).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/api/catalog-handlers.ts
+++ b/packages/cli/src/api/catalog-handlers.ts
@@ -18,7 +18,11 @@ import {
 } from "./query-params.js";
 import type { ScanResultSource, ScanStatusSource } from "./scan-sources.js";
 import { createSnapshotPaginator } from "./snapshot-pagination.js";
-import { getSnapshotAggregation, getSnapshotSessionTree } from "./snapshot-aggregation.js";
+import {
+  getSnapshotAggregation,
+  getSnapshotCostFacts,
+  getSnapshotSessionTree,
+} from "./snapshot-aggregation.js";
 
 const paginateProjects = createSnapshotPaginator<ApiProjectGroup, ApiProjectPage["summary"]>();
 
@@ -93,7 +97,10 @@ export function handleGetProjects(
       ["projects", from, to, analyticsRevision],
       () => {
         const tree = getSnapshotSessionTree(scanSource, scanResult.sessions);
-        const costFacts = listDashboardCostFacts({ from, to, includeModelCosts: false });
+        const costFacts =
+          (from == null || from === 0) && to == null
+            ? getSnapshotCostFacts(scanSource, scanResult.sessions, from, to, to, analyticsRevision)
+            : listDashboardCostFacts({ from, to, includeModelCosts: false });
         const projects = attachProjectMetricsFromTree(
           listCachedProjectGroups(scanResult.sessions),
           tree,

--- a/packages/cli/src/api/dashboard-handler.ts
+++ b/packages/cli/src/api/dashboard-handler.ts
@@ -21,7 +21,7 @@ import {
 import type { ScanResultSource } from "./scan-sources.js";
 import { decorateFileActivity, loadAliasView } from "./session-aliases-view.js";
 import {
-  getDashboardCostFacts,
+  getSnapshotCostFacts,
   getDashboardStorageAggregation,
   getSnapshotAggregation,
 } from "./snapshot-aggregation.js";
@@ -57,12 +57,13 @@ export function handleGetDashboard(
   const fixedTo = dateWindow.to;
   const cacheTo = fixedTo ?? startOfCalendarDay(to);
   const analyticsRevision = getAnalyticsRevision();
-  const costFacts = getDashboardCostFacts(
+  // Keep all-time facts reusable by Projects; buildDashboard applies the current-time bound.
+  const costFacts = getSnapshotCostFacts(
     scanSource,
     scanResult.sessions,
     compare?.from ?? from,
-    to,
-    cacheTo,
+    from == null && fixedTo == null ? undefined : to,
+    from == null && fixedTo == null ? undefined : cacheTo,
     analyticsRevision,
   );
   const aggregate = getSnapshotAggregation(

--- a/packages/cli/src/api/snapshot-aggregation.ts
+++ b/packages/cli/src/api/snapshot-aggregation.ts
@@ -76,7 +76,7 @@ export function getSnapshotSessionTree(
 
 type DashboardStorageAggregation = Pick<DashboardData, "recentFileActivities">;
 
-export function getDashboardCostFacts(
+export function getSnapshotCostFacts(
   source: ScanResultSource,
   sessions: SessionHead[],
   from: number | undefined,
@@ -84,13 +84,15 @@ export function getDashboardCostFacts(
   cacheTo: number | undefined,
   analyticsRevision: string | null,
 ): DashboardCostFacts | null {
-  const build = () => listDashboardCostFacts({ from, to });
+  // Effective message timestamps are positive; the UI uses epoch zero for All time.
+  const costFrom = from === 0 ? undefined : from;
+  const build = () => listDashboardCostFacts({ from: costFrom, to });
   if (analyticsRevision === null) return build();
 
   return getSnapshotAggregation(
     source,
     sessions,
-    ["dashboard-cost-facts", from, cacheTo, analyticsRevision],
+    ["cost-facts", costFrom, cacheTo, analyticsRevision],
     build,
   );
 }

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { formatSessionReference } from "../../contract/index.js";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 32;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 33;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -11,6 +11,7 @@ import { syncSessionSearchIndex } from "../search-index-writer.js";
 import { makeSessionData, makeSessionHead } from "./fixtures.js";
 import { setCoreDiagnostics } from "../../../utils/diagnostics.js";
 import { ensureCacheSchema } from "../schema.js";
+import { listDashboardCostFacts } from "../cost-facts.js";
 import { CACHE_SCHEMA_VERSION } from "../version.js";
 import { UnsupportedCacheSchemaVersionError } from "../errors.js";
 
@@ -53,6 +54,59 @@ afterEach(() => {
 });
 
 describe("cache schema boundary", () => {
+  it("upgrades the version 32 usage index without changing cost facts", () => {
+    const session = makeSessionHead("usage-index");
+    saveCachedSessions("codex", [session]);
+    syncSessionSearchIndex("codex", [session], () => ({
+      ...makeSessionData(session.reference.sessionId),
+      ...session,
+      messages: [
+        {
+          id: "usage",
+          role: "assistant",
+          time_created: 100,
+          time_completed: 200,
+          model: "model",
+          tokens: { input: 20, output: 5 },
+          cost: 2,
+          cost_source: "recorded",
+          parts: [],
+        },
+      ],
+    }));
+    const before = listDashboardCostFacts();
+    setSchemaEnsuredPath(null);
+    const legacyDb = new Database(getCachePath());
+    legacyDb.exec(`
+      DROP INDEX idx_messages_usage_time;
+      CREATE INDEX idx_messages_usage_time ON messages(
+        CASE WHEN time_completed > 0 THEN time_completed WHEN time_created > 0 THEN time_created END,
+        agent_name, session_id
+      );
+      PRAGMA user_version = 32;
+      UPDATE cache_meta SET value = '32' WHERE key = 'schema_version';
+    `);
+    legacyDb.close();
+    const columns = schema.withCacheDb((db) =>
+      db
+        .prepare("PRAGMA index_info(idx_messages_usage_time)")
+        .all()
+        .map((row) => row.name),
+    );
+    expect(columns).toEqual([
+      null,
+      "agent_name",
+      "session_id",
+      "message_index",
+      "model",
+      "tokens_json",
+      "cost",
+      "cost_source",
+    ]);
+    expect(listDashboardCostFacts()).toEqual(before);
+    expect(readCachedValue("codex")?.sessions).toHaveLength(1);
+  });
+
   it("opens an empty cache with the complete current schema", () => {
     const state = schema.withCacheDb((db) => {
       const objects = db

--- a/packages/core/src/discovery/cache/schema-definitions.ts
+++ b/packages/core/src/discovery/cache/schema-definitions.ts
@@ -118,7 +118,17 @@ export function createSessionTables(db: SQLiteDatabase): void {
 
     CREATE INDEX IF NOT EXISTS idx_messages_session
       ON messages(agent_name, session_id, message_index);
+  `);
 
+  createMessageUsageIndex(db);
+  createSessionModelCostTable(db);
+  createSessionCostSummaryTable(db);
+  createMessageToolTables(db);
+}
+
+export function createMessageUsageIndex(db: SQLiteDatabase): void {
+  // Keep analytics reads off message rows containing large transcript payloads.
+  db.exec(`
     CREATE INDEX IF NOT EXISTS idx_messages_usage_time
       ON messages(
         CASE
@@ -126,13 +136,14 @@ export function createSessionTables(db: SQLiteDatabase): void {
           WHEN time_created > 0 THEN time_created
         END,
         agent_name,
-        session_id
+        session_id,
+        message_index,
+        model,
+        tokens_json,
+        cost,
+        cost_source
       );
   `);
-
-  createSessionModelCostTable(db);
-  createSessionCostSummaryTable(db);
-  createMessageToolTables(db);
 }
 
 /**

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -36,6 +36,7 @@ import {
   createFileActivityPathSearchTables,
   createFileActivityTables,
   createMessageToolTables,
+  createMessageUsageIndex,
   createLegacyProjectTables,
   createSearchStateIndex,
   createSearchTables,
@@ -902,6 +903,13 @@ export function ensureCacheSchema(db: SQLiteDatabase, dbPath: string): void {
       { version: 30, destructive: true, migrate: dropDerivedSessionSlug },
       { version: 31, migrate: dropDurablePublicationStaging },
       { version: 32, migrate: dropLegacyCacheTables },
+      {
+        version: 33,
+        migrate(db) {
+          db.exec("DROP INDEX IF EXISTS idx_messages_usage_time");
+          createMessageUsageIndex(db);
+        },
+      },
     ],
   });
 

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 32;
+export const CACHE_SCHEMA_VERSION = 33;

--- a/scripts/benchmark-all-time-aggregation.mjs
+++ b/scripts/benchmark-all-time-aggregation.mjs
@@ -1,0 +1,92 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { loadCachedSessionHeads } from "@codesesh/core/runtime/discovery";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const cache = join(root, "node_modules", ".cache");
+mkdirSync(cache, { recursive: true });
+const work = mkdtempSync(join(cache, "all-time-benchmark-"));
+const now = process.argv[2] === undefined ? Date.now() : Number(process.argv[2]);
+if (!Number.isFinite(now)) throw new Error("Expected an optional epoch timestamp in milliseconds");
+
+try {
+  const entry = join(work, "handlers.ts");
+  writeFileSync(
+    entry,
+    ["dashboard-handler", "catalog-handlers"]
+      .map(
+        (name) =>
+          `export * from ${JSON.stringify(join(root, "packages/cli/src/api", `${name}.js`))};`,
+      )
+      .join("\n"),
+  );
+  const build = spawnSync(
+    "pnpm",
+    [
+      "--filter",
+      "codesesh",
+      "exec",
+      "tsup",
+      entry,
+      "--format",
+      "esm",
+      "--out-dir",
+      join(work, "dist"),
+      "--silent",
+    ],
+    { cwd: root, stdio: "inherit", shell: process.platform === "win32" },
+  );
+  if (build.status !== 0) throw new Error("Could not build API benchmark entry");
+  const { handleGetDashboard, handleGetProjects } = await import(
+    pathToFileURL(join(work, "dist", "handlers.js")).href
+  );
+  const require = createRequire(join(root, "packages/core/package.json"));
+  const Database = require("better-sqlite3");
+  const db = new Database(join(homedir(), ".cache/codesesh/codesesh.db"), { readonly: true });
+  const references = db
+    .prepare(
+      "SELECT agent_name AS agentName, session_id AS sessionId FROM sessions WHERE publication_id IS NULL",
+    )
+    .all();
+  db.close();
+  const heads = loadCachedSessionHeads(references).map(({ session }) => session);
+  Date.now = () => now;
+  const context = (query) => ({
+    req: { query: (key) => query[key], url: `http://localhost/api?${new URLSearchParams(query)}` },
+    json: (value) => value,
+  });
+  for (let iteration = 0; iteration < 5; iteration++) {
+    const sessions = [...heads];
+    const byAgent = Object.groupBy(sessions, (session) => session.reference.agentName);
+    const source = { getSnapshot: () => ({ sessions, byAgent }) };
+    const started = performance.now();
+    const dashboard = handleGetDashboard(context({ days: "0" }), source);
+    const middle = performance.now();
+    const { nextCursor: _cursor, ...projects } = handleGetProjects(
+      context({ from: new Date(0).toISOString(), limit: "100" }),
+      source,
+    );
+    const finished = performance.now();
+    const digest = createHash("sha256")
+      .update(JSON.stringify({ dashboard, projects }))
+      .digest("hex");
+    console.log(
+      JSON.stringify({
+        iteration,
+        now,
+        sessions: sessions.length,
+        dashboard_ms: middle - started,
+        projects_ms: finished - middle,
+        total_ms: finished - started,
+        digest,
+      }),
+    );
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
Switching Dashboard to All time repeatedly read hundreds of thousands of message cost facts. Share those facts between Dashboard and Projects, and extend the existing usage-time index to cover the analytics query so it avoids rereading transcript-bearing message rows and sorting tied timestamps.

Schema 33 rebuilds only the derived index. Snapshot/revision invalidation, cost attribution, explicit date ranges, and future-message exclusion are preserved.

## Browser validation
Production builds, Chromium 151, 1440×1000, no throttling, and 4,553 local sessions. Completion is measured from selecting All time until client loading finishes, skeletons disappear, and two further animation frames complete.

- Sharing cost facts reduced repeated-switch median from 2.67 s to 1.96 s in the initial browser comparison.
- A subsequent isolated-cache comparison of the covering index reduced repeated-switch median from 1.86 s to 1.28 s (about 31% further improvement); ranges were 1.79–2.58 s and 1.23–1.38 s.
- First-switch observations were 7.22 s and 1.30 s, but the new index was migrated and profiled before the second run. This is not a matched cold-cache comparison or a guaranteed cold-start speedup.
- No frontend tasks longer than 50 ms were recorded during these switches.

## Storage validation and tradeoffs
With 270,342 timed messages, median message SQL read decreased from 822 ms to 424 ms. Complete cost-fact digests matched before and after migration. The schema migration plus opening/reading cached heads took 982 ms on the database copy. Index storage increased by about 19.3 MiB; writes must maintain the larger index. The original local cache was not migrated during this experiment.

See docs/performance.md for methods and limits. The API benchmark reports response digests without session content.

## Validation
- Core: 1,115 tests passed, 1 skipped
- CLI: 644 tests passed
- Migration regression and release migration smoke tests
- Core and CLI typechecks/builds
- Repository lint and formatting
- Documentation fact/path checks and performance scaling checks
