### PR TITLE
perf: Avoid redundant session refresh work

### DIFF
--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -1235,6 +1235,102 @@ describe("AgentSyncEngine", () => {
     );
   });
 
+  it.each(["complete", "partial"] as const)(
+    "skips publication for repeated unchanged %s full scans",
+    async (completeness) => {
+      const steady = makeSession("steady");
+      const meta = { steady: { id: "steady", sourcePath: "/database" } };
+      const commitChangeCheck = vi.fn();
+      const workerRunner: WorkerRunner = {
+        activeCount: 0,
+        run: vi.fn(async () =>
+          workerResult(
+            {
+              sessions: [steady],
+              meta,
+              changedIds: [],
+            },
+            completeness,
+          ),
+        ),
+        reset: vi.fn(),
+        shutdown: vi.fn(async () => undefined),
+      };
+      const agent = makeAgent({
+        checkForChanges: () => ({ hasChanges: true, timestamp: 2 }),
+        commitChangeCheck,
+      });
+      const { engine } = makeEngine(agent, [steady], workerRunner);
+      const sessionChanges = vi.fn();
+      engine.subscribeSessionsChanged(sessionChanges);
+
+      for (let i = 0; i < 21; i++) await engine.refresh("codex");
+
+      expect(workerRunner.run).toHaveBeenCalledTimes(21);
+      expect(workerRunner.run).toHaveBeenCalledWith(
+        "codex",
+        expect.objectContaining({
+          operation: { kind: "full-scan" },
+        }),
+      );
+      expect(searchIndex.enqueue).not.toHaveBeenCalled();
+      expect(sessionChanges).not.toHaveBeenCalled();
+      expect(workerLifecycle.commit).toHaveBeenCalledTimes(21);
+      expect(workerLifecycle.discard).not.toHaveBeenCalled();
+      expect(commitChangeCheck).toHaveBeenCalledTimes(21);
+      expect(agent.snapshotSessionCacheMeta()).toEqual(meta);
+      expect(engine.snapshot().sessions).toEqual([steady]);
+      await engine.shutdown();
+    },
+  );
+
+  it("preserves failure reporting for a full scan with unchanged sessions", async () => {
+    const steady = makeSession("steady");
+    const workerRunner: WorkerRunner = {
+      activeCount: 0,
+      run: vi.fn(async () =>
+        workerResult(
+          {
+            sessions: [steady],
+            meta: {},
+            changedIds: [],
+            sourceFailures: [
+              {
+                sessionId: "steady",
+                sourcePath: "/database",
+                stage: "parsing",
+                errorClass: "SyntaxError",
+                message: "Invalid session",
+              },
+            ],
+          },
+          "partial",
+        ),
+      ),
+      reset: vi.fn(),
+      shutdown: vi.fn(async () => undefined),
+    };
+    const { engine } = makeEngine(
+      makeAgent({
+        checkForChanges: () => ({ hasChanges: true, timestamp: 2 }),
+      }),
+      [steady],
+      workerRunner,
+    );
+
+    await engine.refresh("codex");
+
+    expect(searchIndex.enqueue).toHaveBeenCalledOnce();
+    expect(engine.status().agentStatuses.codex).toEqual(
+      expect.objectContaining({
+        completeness: "partial",
+        sourceFailureCount: 1,
+        sourceFailureSummary: "SyntaxError: Invalid session",
+      }),
+    );
+    await engine.shutdown();
+  });
+
   it("persists meta-only changes reported by a full rescan", async () => {
     // Regression test for the zcode/opencode startup loop: checkForChanges kept
     // reporting stale cache meta (missing pricingCaptureEpoch), the full rescan

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -788,31 +788,35 @@ export class AgentSyncEngine {
       try {
         const { result } = workerRun;
         const sessions = attachMissingProjectIdentities(result.sessions);
-        return {
-          ...this.refreshStrategyBase(sessions, result.completeness, scope, {
-            checkDuration,
-            scanDuration: performance.now() - scanStartedAt,
-            sourceFailures: result.sourceFailures ?? [],
-            workerRun,
-            pendingAgentState: {
-              meta: result.meta,
-              refreshedAt: checkResult.timestamp,
-              refreshTransaction,
-            },
-          }),
-          status: "continue",
-          publication: {
-            kind: "changes",
-            // Meta-only changes (e.g. a pricing capture epoch bump) leave the head
-            // signature intact; without the worker-reported ids they would never
-            // persist and checkForChanges would rescan on every startup.
-            diff: buildSessionPersistenceDiff(baseline, sessions, {
-              candidateChangedIds: result.changedIds ?? [],
-              completeness: result.completeness,
-              explicitRemovedSessionIds: result.explicitRemovedSessionIds,
-            }),
-            candidateChangedIds: [],
+        const persistenceDiff = buildSessionPersistenceDiff(baseline, sessions, {
+          // Worker-reported IDs also preserve metadata-only pricing repairs.
+          candidateChangedIds: result.changedIds ?? [],
+          completeness: result.completeness,
+          explicitRemovedSessionIds: result.explicitRemovedSessionIds,
+        });
+        const strategy = this.refreshStrategyBase(sessions, result.completeness, scope, {
+          checkDuration,
+          scanDuration: performance.now() - scanStartedAt,
+          sourceFailures: result.sourceFailures ?? [],
+          workerRun,
+          pendingAgentState: {
+            meta: result.meta,
+            refreshedAt: checkResult.timestamp,
+            refreshTransaction,
           },
+        });
+        if (
+          persistenceDiff.changedSessions.length === 0 &&
+          persistenceDiff.removedSessionIds.length === 0 &&
+          (result.sourceFailures?.length ?? 0) === 0
+        ) {
+          this.logUnchangedRefresh(agent.name, refreshStartedAt);
+          return { ...strategy, status: "unchanged" };
+        }
+        return {
+          ...strategy,
+          status: "continue",
+          publication: { kind: "changes", diff: persistenceDiff, candidateChangedIds: [] },
         };
       } catch (error) {
         workerRun.discard();

--- a/packages/cli/src/session-watcher.test.ts
+++ b/packages/cli/src/session-watcher.test.ts
@@ -350,6 +350,65 @@ describe("SessionWatcher", () => {
     }
   });
 
+  it("ignores declared shared-memory files while watching workspace changes", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "watcher-workspaces-"));
+    const watcher = new SessionWatcher();
+    try {
+      const workspaceRoot = join(tempDir, "workspaceStorage");
+      mkdirSync(join(workspaceRoot, "entry"), { recursive: true });
+      const changed = vi.fn();
+      watcher.onAgentsChanged(changed);
+      watcher.start([
+        source("cursor", {
+          status: "supported",
+          targets: [
+            {
+              root: tempDir,
+              path: workspaceRoot,
+              ignoredFileNames: ["state.vscdb-shm"],
+            },
+          ],
+        }),
+      ]);
+      const emit = async (event: string, filename: string | null) => {
+        fsWatch.watchers[0]!.listener(event, filename);
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(1_000);
+      };
+      const shmPath = join("workspaceStorage", "entry", "state.vscdb-shm");
+      writeFileSync(join(tempDir, shmPath), "shared memory");
+      for (let i = 0; i < 21; i++) await emit("change", shmPath);
+      rmSync(join(tempDir, shmPath));
+      await emit("rename", shmPath);
+      expect(changed).not.toHaveBeenCalled();
+
+      for (const filename of [
+        "state.vscdb",
+        "state.vscdb-wal",
+        "state.vscdb-journal",
+        "workspace.json",
+      ]) {
+        const path = join("workspaceStorage", "entry", filename);
+        writeFileSync(join(tempDir, path), "data");
+        await emit("change", path);
+        expect(changed).toHaveBeenCalledExactlyOnceWith(new Set(["cursor"]));
+        changed.mockClear();
+        rmSync(join(tempDir, path));
+        await emit("rename", path);
+        expect(changed).toHaveBeenCalledExactlyOnceWith(new Set(["cursor"]));
+        changed.mockClear();
+      }
+      for (const filename of [join("workspaceStorage", "entry"), "workspaceStorage", null]) {
+        await emit("rename", filename);
+        expect(changed).toHaveBeenCalledExactlyOnceWith(new Set(["cursor"]));
+        changed.mockClear();
+      }
+    } finally {
+      await watcher.dispose();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("CS-139: emits a database agent change for its WAL sidecar", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "watcher-db-wal-"));
     try {

--- a/packages/cli/src/session-watcher.ts
+++ b/packages/cli/src/session-watcher.ts
@@ -9,7 +9,7 @@
  * are all internal details.
  */
 import { existsSync, readdirSync, statSync, watch, type FSWatcher } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { SessionWatchPlan } from "@codesesh/core/runtime/agents";
 import { appLogger } from "./logging.js";
 
@@ -24,6 +24,7 @@ export interface SessionWatchSource {
 interface WatchScope {
   agentName: string;
   targetPath: string;
+  ignoredFileNames?: readonly string[];
 }
 
 interface WatchRegistration {
@@ -189,7 +190,11 @@ export class SessionWatcher {
         if (
           !scopes.some((scope) => scope.agentName === agent.name && scope.targetPath === targetPath)
         ) {
-          scopes.push({ agentName: agent.name, targetPath });
+          scopes.push({
+            agentName: agent.name,
+            targetPath,
+            ignoredFileNames: target.ignoredFileNames,
+          });
         }
         scopesByRoot.set(rootPath, scopes);
       }
@@ -337,7 +342,15 @@ export class SessionWatcher {
     const changedPath = resolveWatchEventPath(watchPath, filename);
     const agentNames = new Set(
       scopes
-        .filter((scope) => isRelatedPath(changedPath, scope.targetPath))
+        .filter(
+          (scope) =>
+            isRelatedPath(changedPath, scope.targetPath) &&
+            !(
+              scope.ignoredFileNames?.includes(basename(changedPath)) &&
+              changedPath !== scope.targetPath &&
+              isSameOrChildPath(scope.targetPath, changedPath)
+            ),
+        )
         .map((scope) => scope.agentName),
     );
 

--- a/packages/core/src/agents/__tests__/watch-plan.test.ts
+++ b/packages/core/src/agents/__tests__/watch-plan.test.ts
@@ -134,6 +134,7 @@ describe("registered agent session watch plans", () => {
         {
           root: roots.cursor,
           path: join("/tmp/cursor-home", "workspaceStorage"),
+          ignoredFileNames: ["state.vscdb-shm"],
         },
       ],
     });

--- a/packages/core/src/agents/base.ts
+++ b/packages/core/src/agents/base.ts
@@ -145,6 +145,8 @@ export interface SessionWatchTarget {
   path: string;
   /** Stable ancestor to watch when the source path can be created or replaced. */
   root?: string;
+  /** Exact descendant file names that do not represent session changes. */
+  ignoredFileNames?: readonly string[];
 }
 
 /** `supported` may have no targets when the provider has no location in the current environment. */

--- a/packages/core/src/agents/cursor.ts
+++ b/packages/core/src/agents/cursor.ts
@@ -117,7 +117,12 @@ export class CursorAgent extends DatabaseSessionSource {
               root: dataPath,
               path: join(dataPath, "globalStorage", "state.vscdb"),
             },
-            { root: dataPath, path: join(dataPath, "workspaceStorage") },
+            {
+              root: dataPath,
+              path: join(dataPath, "workspaceStorage"),
+              // Read-only SQLite opens can rewrite shared memory without changing sessions.
+              ignoredFileNames: ["state.vscdb-shm"],
+            },
           ]
         : [],
     };


### PR DESCRIPTION
Cursor workspace directory watches treated SQLite shared-memory changes as session changes, and unchanged full scans still queued persistence and search-index publication. A local trace contained 21 Cursor refreshes with no session additions, updates, or removals.

This change lets the Cursor adapter exclude `state.vscdb-shm` from workspace notifications and stops full scans before publication when their persistence diff is empty and no source failures occurred. Worker state and change-check transactions still commit. Database, WAL, journal, workspace metadata, and directory notifications remain enabled; worker-reported metadata-only pricing repairs still persist.

Validation:
- Regression replay against the previous code: 22 shared-memory notifications triggered 22 refresh callbacks; 21 unchanged full scans queued 21 publications. Both counts are now zero in controlled tests.
- Core: 1,115 tests passed, 1 skipped. CLI: 648 tests passed.
- Core and CLI lint, formatting, typechecks, and builds passed.
- Existing update, deletion, bounded-scan, and metadata-repair coverage passes; added coverage preserves failure reporting and staged worker commits.

The replay measures avoided work, not end-to-end startup speed. It does not establish that every Cursor notification in the local trace came from shared memory.
