### PR TITLE
refactor: Remove unused path extraction

### DIFF
--- a/apps/web/src/components/session-detail/path-extract.test.ts
+++ b/apps/web/src/components/session-detail/path-extract.test.ts
@@ -1,70 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  collectPathsFromValue,
-  extractPathsFromToolInput,
   formatTrackedPath,
   getDisplayPath,
   getDisplayTextWithRelativePaths,
   getFilePathFromInput,
-  looksLikeFilePath,
-  shouldTreatAsPathKey,
 } from "./path-extract";
-
-describe("looksLikeFilePath", () => {
-  it("accepts absolute paths", () => {
-    expect(looksLikeFilePath("/home/user/file.ts")).toBe(true);
-  });
-
-  it("accepts relative paths", () => {
-    expect(looksLikeFilePath("./src/index.ts")).toBe(true);
-    expect(looksLikeFilePath("../parent/dir")).toBe(true);
-  });
-
-  it("rejects URLs", () => {
-    expect(looksLikeFilePath("https://example.com")).toBe(false);
-  });
-
-  it("rejects multiline text", () => {
-    expect(looksLikeFilePath("line1\nline2")).toBe(false);
-  });
-
-  it("rejects excessively long strings", () => {
-    expect(looksLikeFilePath(`${"/path".repeat(100)}`)).toBe(false);
-  });
-});
-
-describe("shouldTreatAsPathKey", () => {
-  it("treats path/file keys as path keys", () => {
-    expect(shouldTreatAsPathKey("path")).toBe(true);
-    expect(shouldTreatAsPathKey("filePath")).toBe(true);
-    expect(shouldTreatAsPathKey("file_path")).toBe(true);
-  });
-
-  it("rejects content/command keys", () => {
-    expect(shouldTreatAsPathKey("command")).toBe(false);
-    expect(shouldTreatAsPathKey("content")).toBe(false);
-    expect(shouldTreatAsPathKey("cwd")).toBe(false);
-  });
-});
-
-describe("collectPathsFromValue / extractPathsFromToolInput", () => {
-  it("collects paths from nested objects under path keys", () => {
-    const paths = new Set<string>();
-    collectPathsFromValue({ filePath: "/abs/file.ts" }, "", paths);
-    expect([...paths]).toEqual(["/abs/file.ts"]);
-  });
-
-  it("extractPathsFromToolInput returns array", () => {
-    expect(extractPathsFromToolInput({ path: "/a.ts", other: { filePath: "/b.ts" } })).toEqual([
-      "/a.ts",
-      "/b.ts",
-    ]);
-  });
-
-  it("ignores non-path values under path keys", () => {
-    expect(extractPathsFromToolInput({ path: "not a path" })).toEqual([]);
-  });
-});
 
 describe("getFilePathFromInput", () => {
   it("reads from common file fields", () => {

--- a/apps/web/src/components/session-detail/path-extract.ts
+++ b/apps/web/src/components/session-detail/path-extract.ts
@@ -2,86 +2,8 @@
  * File-path extraction and display-path formatting.
  * Consumed by file-change summary and tool display strategies.
  */
-import type { ToolPart } from "../../lib/api";
 import { escapeRegExp, parseJsonText } from "./utils";
 import { toPlainText, toRecord } from "./tool-normalize";
-
-export function looksLikeFilePath(value: string) {
-  const text = value.trim();
-  if (!text || text.length > 300) return false;
-  if (text.includes("\n")) return false;
-  if (/^[a-z]+:\/\//i.test(text)) return false;
-  if (/[<>{}]/.test(text)) return false;
-  if (text.startsWith("/")) return true;
-  if (text.startsWith("./") || text.startsWith("../") || text.startsWith("~/")) return true;
-  if (text.includes("/") || text.includes("\\")) return true;
-  return /^[A-Za-z0-9_.@-]+\.[A-Za-z0-9_-]+$/.test(text);
-}
-
-export function shouldTreatAsPathKey(key: string) {
-  const normalized = key.trim().toLowerCase();
-  if (!normalized) return false;
-  if (
-    normalized.includes("command") ||
-    normalized.includes("content") ||
-    normalized.includes("text") ||
-    normalized.includes("prompt") ||
-    normalized.includes("url") ||
-    normalized.includes("body") ||
-    normalized.includes("title") ||
-    normalized.includes("description") ||
-    normalized === "cwd" ||
-    normalized === "workdir" ||
-    normalized === "directory"
-  ) {
-    return false;
-  }
-  return (
-    normalized === "path" ||
-    normalized === "paths" ||
-    normalized.includes("file") ||
-    normalized.includes("path")
-  );
-}
-
-export function collectPathsFromValue(
-  value: unknown,
-  keyHint: string,
-  paths: Set<string>,
-  depth = 0,
-): void {
-  if (value == null || depth > 4) return;
-
-  if (typeof value === "string") {
-    if (shouldTreatAsPathKey(keyHint) && looksLikeFilePath(value)) {
-      paths.add(value.trim());
-    }
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectPathsFromValue(item, keyHint, paths, depth + 1);
-    }
-    return;
-  }
-
-  if (typeof value === "object") {
-    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
-      collectPathsFromValue(nested, key, paths, depth + 1);
-    }
-  }
-}
-
-export function extractPathsFromToolInput(inputValue: unknown) {
-  const paths = new Set<string>();
-  collectPathsFromValue(inputValue, "", paths);
-  return [...paths];
-}
-
-export function getToolInputValue(part: ToolPart) {
-  return part.state.input ?? null;
-}
 
 export function getFilePathFromInput(inputValue: unknown) {
   const input = toRecord(inputValue);


### PR DESCRIPTION
Remove the unused recursive path extraction helpers and their ten tests. Keep the path display helpers and their seven behavior tests.

Validation: focused tests (7 passed), web typecheck, lint, and format check.
