### PR TITLE
refactor: Remove unused Codex text helpers

### DIFF
--- a/apps/web/src/components/session-detail/codex-tool.ts
+++ b/apps/web/src/components/session-detail/codex-tool.ts
@@ -72,38 +72,6 @@ function buildQuestionSummary(headers: string[], questionCount: number) {
   return truncateText(parts.join(" · "), 96);
 }
 
-function extractTextSegments(value: unknown): string[] {
-  if (typeof value === "string") {
-    return [value];
-  }
-
-  if (Array.isArray(value)) {
-    return value.flatMap((item) => extractTextSegments(item));
-  }
-
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const textValue = record.text;
-    if (typeof textValue === "string") {
-      return [textValue];
-    }
-    const contentValue = record.content;
-    if (contentValue !== undefined) {
-      return extractTextSegments(contentValue);
-    }
-  }
-
-  return [];
-}
-
-function joinToolText(value: unknown) {
-  const segments = extractTextSegments(value)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
-
-  return segments.join("\n");
-}
-
 function parseJsonText<T>(value: string): T | null {
   try {
     return JSON.parse(value) as T;
@@ -553,8 +521,4 @@ export function buildCodexViewImageDisplay(
   appendDetail(details, t("Detail"), detail);
 
   return { secondaryText: displayPath || undefined, details };
-}
-
-export function extractCodexToolText(value: unknown) {
-  return joinToolText(value);
 }

--- a/apps/web/src/components/session-detail/tool-strategy-characterization.test.ts
+++ b/apps/web/src/components/session-detail/tool-strategy-characterization.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { PlanPart, ToolPart } from "../../lib/api";
 import { buildCodexPlanDisplay } from "./codex-plan";
-import { extractCodexToolText } from "./codex-tool";
 import { getToolDisplayStrategy, normalizeToolState } from "./tool-strategy";
 import {
   BookOpenText,
@@ -853,11 +852,5 @@ describe("Codex plan and text displays", () => {
       contentLabel: fixture.contentLabel,
       contentMarkdown: fixture.contentMarkdown,
     });
-  });
-
-  it("joins nested Codex text segments", () => {
-    expect(extractCodexToolText([{ text: "first" }, { content: [{ text: "second" }] }])).toBe(
-      "first\nsecond",
-    );
   });
 });


### PR DESCRIPTION
Remove the test-only Codex text extraction wrapper and its private recursive implementation, together with the single test that kept this unused path alive. Active text normalization remains covered by its existing tests.

Validation: tool strategy and normalization tests (63 passed), web typecheck, lint, and format check.
