### PR TITLE
refactor: Remove unused scan progress formatter

### DIFF
--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  formatAgentScanProgress,
   formatIsoDate,
   formatScanStatusLabel,
   formatSearchSubtitle,
@@ -78,7 +77,6 @@ describe("formatScanStatusLabel", () => {
     expect(formatScanStatusLabel(status)).toBe(
       "Session refresh failed · codex · cache is read-only",
     );
-    expect(formatAgentScanProgress(status, "codex")).toBe("Failed");
   });
 
   it("shows full-history backfill progress after the main scan finishes", () => {
@@ -274,29 +272,5 @@ describe("formatScanStatusLabel", () => {
         },
       } as unknown as ScanStatusEvent),
     ).toBeNull();
-  });
-});
-
-describe("formatAgentScanProgress", () => {
-  it("returns null for complete or missing agent", () => {
-    expect(formatAgentScanProgress(null, "codex")).toBeNull();
-  });
-
-  it("distinguishes publishing from scanning and pending", () => {
-    const status = {
-      agentStatuses: {
-        codex: { status: "publishing", total: 119, processed: 119 },
-        zcode: { status: "publish-queued", total: 84, processed: 84 },
-        claudecode: { status: "indexing", total: 141, processed: 141 },
-        claude: { status: "scanning" },
-        kimi: { status: "pending" },
-      },
-    } as unknown as ScanStatusEvent;
-
-    expect(formatAgentScanProgress(status, "codex")).toBe("Publishing");
-    expect(formatAgentScanProgress(status, "zcode")).toBe("Queued to publish");
-    expect(formatAgentScanProgress(status, "claudecode")).toBe("Publishing");
-    expect(formatAgentScanProgress(status, "claude")).toBe("Scanning");
-    expect(formatAgentScanProgress(status, "kimi")).toBe("Pending");
   });
 });

--- a/apps/web/src/lib/scan-format.ts
+++ b/apps/web/src/lib/scan-format.ts
@@ -127,26 +127,3 @@ export function formatScanStatusLabel(status: ScanStatusEvent | null): string | 
   }
   return null;
 }
-
-export function formatAgentScanProgress(
-  status: ScanStatusEvent | null,
-  agentName: string,
-): string | null {
-  const agentStatus = status?.agentStatuses[agentName];
-  if (!agentStatus || agentStatus.status === "complete") return null;
-  if (agentStatus.status === "failed") return t("Failed");
-  if (agentStatus.status === "finalizing") {
-    if (agentStatus.total && agentStatus.processed != null) {
-      return `${agentStatus.processed}/${agentStatus.total}`;
-    }
-    return t("Finalizing");
-  }
-  if (agentStatus.status === "publishing" || agentStatus.status === "indexing") {
-    return t("Publishing");
-  }
-  if (agentStatus.status === "publish-queued") return t("Queued to publish");
-  if (agentStatus.total && agentStatus.processed != null) {
-    return `${agentStatus.processed}/${agentStatus.total}`;
-  }
-  return agentStatus.status === "scanning" ? t("Scanning") : t("Pending");
-}


### PR DESCRIPTION
Remove formatAgentScanProgress, which has no production callers, and its dedicated tests and assertion. Keep the active scan status label behavior and failure coverage.

Validation: scan formatting tests (25 passed), web typecheck, lint, and format check.
