### PR TITLE
refactor: Remove file classification wrapper

### DIFF
--- a/apps/web/src/components/session-detail/file-change.test.ts
+++ b/apps/web/src/components/session-detail/file-change.test.ts
@@ -4,7 +4,6 @@ import {
   buildFileChangeSummary,
   buildFileChangeSummaryFromActivity,
   buildToolAnchorId,
-  classifyToolKind,
   classifyToolOperation,
   summarizeFileChangeItems,
   type FileChangeRecord,
@@ -24,30 +23,6 @@ function part(overrides?: Partial<ToolPart>): ToolPart {
 describe("buildToolAnchorId", () => {
   it("formats as tool-{msg}-{tool}", () => {
     expect(buildToolAnchorId(3, 7)).toBe("tool-3-7");
-  });
-});
-
-describe("classifyToolKind", () => {
-  it("classifies read tools", () => {
-    expect(classifyToolKind(part({ tool: "read", title: "read" }))).toBe("read");
-  });
-
-  it("classifies edit tools", () => {
-    expect(classifyToolKind(part({ tool: "edit", title: "edit" }))).toBe("edit");
-    expect(classifyToolKind(part({ tool: "apply_patch", title: "apply_patch" }))).toBe("edit");
-  });
-
-  it("classifies write tools", () => {
-    expect(classifyToolKind(part({ tool: "write", title: "write" }))).toBe("write");
-    expect(classifyToolKind(part({ tool: "create_file", title: "create_file" }))).toBe("write");
-  });
-
-  it("classifies delete tools", () => {
-    expect(classifyToolKind(part({ tool: "delete", title: "delete" }))).toBe("delete");
-  });
-
-  it("returns null for unknown tools", () => {
-    expect(classifyToolKind(part({ tool: "bash", title: "bash" }))).toBeNull();
   });
 });
 

--- a/apps/web/src/components/session-detail/file-change.ts
+++ b/apps/web/src/components/session-detail/file-change.ts
@@ -45,12 +45,8 @@ export function buildToolAnchorId(messageIndex: number, toolIndex: number) {
   return `tool-${messageIndex}-${toolIndex}`;
 }
 
-export function classifyToolKind(part: ToolPart): FileChangeKind | null {
-  return classifyFileTool(part);
-}
-
 export function classifyToolOperation(part: ToolPart): ToolOperationKind {
-  const fileKind = classifyToolKind(part);
+  const fileKind = classifyFileTool(part);
   if (fileKind === "read") return "read";
   if (fileKind) return "write";
   return "execute";


### PR DESCRIPTION
Call the canonical Core file classifier directly from classifyToolOperation. Remove the pass-through classifyToolKind wrapper and its five tests; retain operation classification and file summary behavior coverage.

Validation: file change tests (7 passed), web typecheck, lint, and format check.
