### PR TITLE
refactor: Remove route decoding wrapper

### DIFF
--- a/apps/web/src/lib/projects.test.ts
+++ b/apps/web/src/lib/projects.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { decodeProjectRouteKey, getProjectPath, type ProjectRouteIdentity } from "./projects";
+import { getProjectPath, type ProjectRouteIdentity } from "./projects";
 
 function getRouteKey(project: ProjectRouteIdentity): string {
   const segments = getProjectPath(project)
     .replace(/^\/+|\/+$/g, "")
     .split("/");
 
-  return decodeProjectRouteKey(segments[2]!);
+  return decodeURIComponent(segments[2]!);
 }
 
 describe("project routes", () => {

--- a/apps/web/src/lib/projects.ts
+++ b/apps/web/src/lib/projects.ts
@@ -14,10 +14,6 @@ export function getProjectGroupIdentity(project: ApiProjectGroup): ProjectRouteI
   return { kind: project.identityKind, key: project.identityKey };
 }
 
-export function decodeProjectRouteKey(value: string): string {
-  return decodeURIComponent(value);
-}
-
 export function getProjectPath(project: ProjectRouteIdentity): string {
   return `/projects/${encodeURIComponent(project.kind)}/${encodeURIComponent(project.key)}`;
 }


### PR DESCRIPTION
Remove the test-only decodeProjectRouteKey wrapper. Use decodeURIComponent directly in the route round-trip tests while preserving coverage for absolute paths and reserved characters.

Validation: project route tests (2 passed), web typecheck, lint, and format check.
