### PR TITLE
fix: Repair dashboard chart tooltips

### DIFF
--- a/apps/web/src/components/overview/overview-agent-distribution.test.tsx
+++ b/apps/web/src/components/overview/overview-agent-distribution.test.tsx
@@ -37,9 +37,18 @@ describe("OverviewAgentDistribution", () => {
 
     fireEvent.focus(options[0]!);
     expect(liveSummary.textContent).toBe("Codex: $4.00, 3 sessions");
+    expect(screen.getByRole("tooltip").textContent).toBe(
+      "Codex3.0k tok · $4.003 sessions · 30 messages",
+    );
 
     fireEvent.keyDown(options[0]!, { key: "ArrowRight" });
     expect(document.activeElement).toBe(options[1]);
     expect(liveSummary.textContent).toBe("Claude Code: $2.00, 2 sessions");
+    expect(screen.getByRole("tooltip").textContent).toBe(
+      "Claude Code2.0k tok · $2.002 sessions · 20 messages",
+    );
+
+    fireEvent.keyDown(options[1]!, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/apps/web/src/components/overview/overview-agent-distribution.tsx
+++ b/apps/web/src/components/overview/overview-agent-distribution.tsx
@@ -9,9 +9,10 @@ import { useMemo, useState } from "react";
 
 import type { BarHover } from "../../hooks/useBarField";
 import type { DashboardAgentStat } from "../../lib/api";
-import { formatInt, formatUsd } from "../../lib/format";
+import { formatCompact, formatInt, formatUsd } from "../../lib/format";
 import { cn } from "../../lib/utils";
 import { AgentIcon } from "../AgentIcon";
+import { ChartTooltip } from "../ui/chart-tooltip";
 import { Panel, PanelHeader } from "../ui/panel";
 import { TileBarPlot } from "../ui/tile-bar-plot";
 
@@ -48,6 +49,8 @@ export function OverviewAgentDistribution({ perAgent }: { perAgent: DashboardAge
     [locale, perAgent],
   );
 
+  const hovered = hover === null ? undefined : visible[hover.column];
+
   return (
     <Panel role="region" aria-label={t("Agents")} className="p-4">
       <PanelHeader
@@ -58,7 +61,7 @@ export function OverviewAgentDistribution({ perAgent }: { perAgent: DashboardAge
       {visible.length === 0 ? (
         <p className="console-mono mt-3 text-[11px] text-[var(--console-muted)]">{t("No data")}</p>
       ) : (
-        <div className="mt-[14px]">
+        <div className="relative mt-[14px]">
           <TileBarPlot
             values={values}
             axisMax={axisMax}
@@ -70,6 +73,19 @@ export function OverviewAgentDistribution({ perAgent }: { perAgent: DashboardAge
             ariaLabel={t("Agent distribution chart")}
             itemLabels={itemLabels}
           />
+          {hovered && hover ? (
+            <ChartTooltip index={hover.column} count={visible.length}>
+              <div>{hovered.displayName}</div>
+              <div>
+                {formatCompact(hovered.tokens)} {t("tok ·")}{" "}
+                <span className="text-[var(--brand)]">{formatUsd(hovered.cost)}</span>
+              </div>
+              <div>
+                {formatInt(hovered.sessions)} {t("sessions ·")} {formatInt(hovered.messages)}{" "}
+                {t("messages")}
+              </div>
+            </ChartTooltip>
+          ) : null}
           <div
             className="mt-2 grid"
             style={{ gridTemplateColumns: `repeat(${visible.length}, minmax(0, 1fr))` }}

--- a/apps/web/src/components/overview/overview-usage-chart.tsx
+++ b/apps/web/src/components/overview/overview-usage-chart.tsx
@@ -12,7 +12,7 @@ import type { BarHover } from "../../hooks/useBarField";
 import type { DashboardDailyBucket } from "../../lib/api";
 import { niceMax } from "../../lib/chart-shading";
 import { formatCompact, formatInt, formatMonthDay, formatUsd } from "../../lib/format";
-import { cn } from "../../lib/utils";
+import { ChartTooltip } from "../ui/chart-tooltip";
 import { Panel, PanelHeader } from "../ui/panel";
 import { TileAreaPlot } from "../ui/tile-area-plot";
 import { TILE_AXIS_WIDTH, TileBarPlot } from "../ui/tile-bar-plot";
@@ -108,13 +108,7 @@ function DayTooltip({
   useLocale();
 
   return (
-    <div
-      className={cn(
-        "console-mono pointer-events-none absolute top-2 z-10 rounded-md border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-2 text-[10.5px] whitespace-nowrap text-[var(--console-text)] shadow-[var(--shadow-overlay)]",
-        index >= count * 0.75 ? "-translate-x-full" : "-translate-x-1/2",
-      )}
-      style={{ left: `${((index + 0.5) / count) * 100}%` }}
-    >
+    <ChartTooltip index={index} count={count}>
       <div>{formatMonthDay(bucket.date)}</div>
       <div>
         {formatCompact(bucketTokens(bucket))} {t("tok ·")}{" "}
@@ -128,7 +122,7 @@ function DayTooltip({
         {t("· Read")} {formatCompact(bucket.cache_read)} {t("· Write")}{" "}
         {formatCompact(bucket.cache_create)}
       </div>
-    </div>
+    </ChartTooltip>
   );
 }
 

--- a/apps/web/src/components/ui/chart-tooltip.tsx
+++ b/apps/web/src/components/ui/chart-tooltip.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+export function ChartTooltip({
+  index,
+  count,
+  children,
+}: {
+  index: number;
+  count: number;
+  children: ReactNode;
+}) {
+  const position = ((index + 0.5) / count) * 100;
+
+  return (
+    <div
+      role="tooltip"
+      className="console-mono pointer-events-none absolute top-2 z-10 w-max max-w-full rounded-md border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-2 text-[10.5px] break-words text-[var(--console-text)] shadow-[var(--shadow-overlay)]"
+      style={{ left: `${position}%`, transform: `translateX(-${position}%)` }}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Fix dashboard bar-chart tooltips: Daily usage tooltips now stay within the plot bounds, preventing the sidebar from covering the leftmost tooltip. Agent distribution bars now show the agent name, token usage, cost, sessions, and messages on hover or keyboard focus.

Both charts share a width-constrained tooltip layout that adjusts horizontal alignment with the selected column.

Validation:
- Web lint, formatting, typecheck, and production build passed.
- Both chart test files passed (7 tests), including agent tooltip navigation and dismissal.
- Verified the leftmost Daily usage tooltip bounds and visible Agent tooltip in the local browser.
