### PR TITLE
feat(dashboard): Show user activity by time

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -47,6 +47,7 @@ const emptyDashboard: DashboardData = {
   projectRollup: { projects: 0, sessions: 0, tokens: 0, cost: 0 },
   recentSessions: [],
   recentFileActivities: [],
+  activeHours: null,
   window: { to: 1_700_000_000_000 },
 };
 

--- a/apps/web/src/components/overview/OverviewScreen.test.tsx
+++ b/apps/web/src/components/overview/OverviewScreen.test.tsx
@@ -80,6 +80,7 @@ const dashboard = {
   projectRollup: { projects: 0, sessions: 0, tokens: 0, cost: 0 },
   recentSessions: [],
   recentFileActivities: [],
+  activeHours: null,
   modelCost: [{ model: "sonnet", cost: 6, costRecorded: 1, costEstimated: 5 }],
   window: { from: 1, to: 2, days: 7 },
 } as unknown as DashboardData;
@@ -140,6 +141,7 @@ describe("OverviewScreen", () => {
     expect(screen.getByTestId("dashboard")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Daily usage" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Cost by Model" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Active hours" })).toBeTruthy();
     expect(screen.getByText("1 projects · 2 agents in scope")).toBeTruthy();
     expect(screen.getAllByTestId("overview-agent-row")).toHaveLength(1);
   });
@@ -176,6 +178,7 @@ describe("OverviewScreen", () => {
 
     await screen.findByRole("heading", { name: "Agents" });
     expect(screen.getByRole("heading", { name: "Cost by Model" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Active hours" })).toBeTruthy();
     expect(api.fetchDashboard).toHaveBeenLastCalledWith(
       timeWindow,
       { project: { kind: "path", key: "/repo/codesesh" }, agent: undefined },

--- a/apps/web/src/components/overview/OverviewScreen.tsx
+++ b/apps/web/src/components/overview/OverviewScreen.tsx
@@ -25,6 +25,7 @@ import { OverviewCostBreakdown } from "./overview-cost-breakdown";
 import { OverviewFilterBar } from "./overview-filter-bar";
 import { OverviewKpiGrid } from "./overview-kpi-grid";
 import { OverviewSkeleton } from "./overview-skeleton";
+import { OverviewActiveHours } from "./overview-active-hours";
 import { OverviewUsageChart } from "./overview-usage-chart";
 
 export function OverviewScreen({
@@ -78,6 +79,7 @@ export function OverviewScreen({
         <>
           <OverviewKpiGrid totals={dashboard.totals} rangeDays={dashboard.window.days} />
           <OverviewUsageChart daily={dashboard.dailyActivity} />
+          <OverviewActiveHours activity={dashboard.activeHours} />
           <div className="grid gap-4 lg:grid-cols-2">
             <OverviewAgentDistribution perAgent={dashboard.perAgent} />
             <OverviewCostBreakdown

--- a/apps/web/src/components/overview/overview-active-hours.test.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.test.tsx
@@ -1,0 +1,58 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { setLanguagePreference } from "../../i18n/language";
+import { OverviewActiveHours } from "./overview-active-hours";
+
+const counts = Array<number>(84).fill(0);
+counts[0] = 4;
+counts[12] = 1;
+const activity = { timeZone: "Asia/Shanghai", counts };
+afterEach(() => {
+  cleanup();
+  setLanguagePreference("en");
+});
+
+describe("active hours chart", () => {
+  it("reorders weekdays when language changes without moving message counts", () => {
+    render(<OverviewActiveHours activity={activity} />);
+    expect(screen.getAllByRole("columnheader")[1]!.textContent).toBe("Sun");
+    act(() => setLanguagePreference("zh-CN"));
+    expect(screen.getAllByRole("columnheader")[1]!.textContent).toBe("周一");
+    expect(screen.getByRole("button", { name: "周日 · 00:00–02:00 · 4 条用户消息" })).toBeTruthy();
+    act(() => setLanguagePreference("ja"));
+    expect(screen.getAllByRole("columnheader")[1]!.textContent).toBe("日");
+    expect(screen.getByText("タイムゾーン：Asia/Shanghai")).toBeTruthy();
+  });
+
+  it("scales circle area and exposes counts with hover, keyboard and touch", () => {
+    render(<OverviewActiveHours activity={activity} />);
+    const sunday = screen.getByRole("button", { name: "Sun · 00:00–02:00 · 4 user messages" });
+    const monday = screen.getByRole("button", { name: "Mon · 00:00–02:00 · 1 user messages" });
+    const radius = (button: HTMLElement) =>
+      Number(button.querySelector("circle")!.getAttribute("r"));
+    expect(radius(sunday) ** 2 / radius(monday) ** 2).toBe(4);
+    fireEvent.mouseEnter(sunday);
+    expect(screen.getByRole("tooltip").textContent).toBe(sunday.getAttribute("aria-label"));
+    fireEvent.mouseLeave(sunday);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    fireEvent.focus(monday);
+    expect(screen.getByRole("tooltip").textContent).toBe(monday.getAttribute("aria-label"));
+    fireEvent.keyDown(monday, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    fireEvent.click(sunday);
+    expect(screen.getByRole("tooltip")).toBeTruthy();
+    fireEvent.blur(sunday);
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("distinguishes an empty range from unavailable data", () => {
+    const { rerender } = render(
+      <OverviewActiveHours activity={{ ...activity, counts: Array<number>(84).fill(0) }} />,
+    );
+    expect(screen.getByText("No user messages in this range.")).toBeTruthy();
+    expect(screen.getByRole("table").querySelector("circle")).toBeNull();
+    rerender(<OverviewActiveHours activity={null} />);
+    expect(screen.getByText("Activity data is unavailable.")).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+});

--- a/apps/web/src/components/overview/overview-active-hours.test.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.test.tsx
@@ -45,6 +45,16 @@ describe("active hours chart", () => {
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 
+  it.each([
+    [2342, ["500", "1,000", "2,000"]],
+    [7, ["1", "2", "5"]],
+    [1, ["1"]],
+  ] as const)("uses rounded reference counts for a peak of %i", (peak, expected) => {
+    render(<OverviewActiveHours activity={{ ...activity, counts: [peak] }} />);
+    const legend = screen.getByText("Size reference (messages)").nextElementSibling!;
+    expect(Array.from(legend.children, (element) => element.textContent)).toEqual(expected);
+  });
+
   it("distinguishes an empty range from unavailable data", () => {
     const { rerender } = render(
       <OverviewActiveHours activity={{ ...activity, counts: Array<number>(84).fill(0) }} />,

--- a/apps/web/src/components/overview/overview-active-hours.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import type { DashboardActiveHours } from "@codesesh/core/contract";
+import { useLocale } from "../../hooks/useLocale";
+import { t } from "../../i18n/translate";
+import { formatInt } from "../../lib/format";
+import { Panel, PanelHeader } from "../ui/panel";
+
+function hourRange(slot: number): string {
+  return `${String(slot * 2).padStart(2, "0")}:00–${String(slot * 2 + 2).padStart(2, "0")}:00`;
+}
+
+export function OverviewActiveHours({ activity }: { activity: DashboardActiveHours | null }) {
+  const locale = useLocale();
+  const [active, setActive] = useState<number | null>(null);
+  const weekdays = locale === "zh-CN" ? [1, 2, 3, 4, 5, 6, 0] : [0, 1, 2, 3, 4, 5, 6];
+  const formatter = new Intl.DateTimeFormat(locale, { weekday: "short", timeZone: "UTC" });
+  const labels = weekdays.map((day) => formatter.format(Date.UTC(2026, 8, 6 + day)));
+  const peak = Math.max(0, ...(activity?.counts ?? []));
+  const total = activity?.counts.reduce((sum, count) => sum + count, 0) ?? 0;
+
+  return (
+    <Panel className="p-4" aria-label={t("Active hours")}>
+      <PanelHeader title={t("Active hours")} />
+      <p className="mt-1 text-xs text-[var(--console-muted)]">
+        {t(
+          "User messages by weekday and two-hour period. Counts are cumulative within the selected range.",
+        )}
+      </p>
+      {!activity ? (
+        <p className="py-8 text-center text-sm text-[var(--console-muted)]">
+          {t("Activity data is unavailable.")}
+        </p>
+      ) : (
+        <>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-2 console-mono text-[10.5px] text-[var(--console-muted)]">
+            <span>{t("Time zone: {0}", [activity.timeZone])}</span>
+            <span>{t("{0} user messages", [formatInt(total)])}</span>
+          </div>
+          <table className="mt-3 w-full table-fixed border-collapse console-mono text-[10.5px] text-[var(--console-muted)]">
+            <caption className="sr-only">{t("Active hours")}</caption>
+            <thead>
+              <tr>
+                <th scope="col" className="w-[90px] pb-2 text-left font-normal">
+                  {t("Time")}
+                </th>
+                {labels.map((label) => (
+                  <th key={label} scope="col" className="pb-2 font-normal">
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {Array.from({ length: 12 }, (_, slot) => (
+                <tr key={slot} className="border-t border-dashed border-[var(--console-border)]">
+                  <th scope="row" className="h-8 text-left font-normal tabular-nums">
+                    {hourRange(slot)}
+                  </th>
+                  {weekdays.map((day, column) => {
+                    const index = day * 12 + slot;
+                    const count = activity.counts[index] ?? 0;
+                    const summary = `${labels[column]} · ${hourRange(slot)} · ${t("{0} user messages", [formatInt(count)])}`;
+                    return (
+                      <td key={day} className="relative p-0 text-center">
+                        <button
+                          type="button"
+                          aria-label={summary}
+                          className="flex h-8 w-full items-center justify-center rounded-sm outline-none hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--console-text)]"
+                          onMouseEnter={() => setActive(index)}
+                          onMouseLeave={() => setActive(null)}
+                          onFocus={() => setActive(index)}
+                          onBlur={() => setActive(null)}
+                          onClick={() => setActive(index)}
+                          onKeyDown={(event) => {
+                            if (event.key === "Escape") setActive(null);
+                          }}
+                        >
+                          <svg
+                            width="28"
+                            height="28"
+                            viewBox="0 0 28 28"
+                            aria-hidden="true"
+                            className="text-[var(--console-text)]"
+                          >
+                            {count > 0 ? (
+                              <circle
+                                cx="14"
+                                cy="14"
+                                r={12 * Math.sqrt(count / peak)}
+                                fill="currentColor"
+                                opacity="0.75"
+                              />
+                            ) : null}
+                          </svg>
+                        </button>
+                        {active === index ? (
+                          <span
+                            role="tooltip"
+                            className={`pointer-events-none absolute bottom-full z-10 w-max max-w-[180px] rounded-md border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-2 text-left text-[var(--console-text)] shadow-[var(--shadow-overlay)] ${column < 3 ? "left-0" : "right-0"}`}
+                          >
+                            {summary}
+                          </span>
+                        ) : null}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="mt-3 flex min-h-7 flex-wrap items-center justify-end gap-4 console-mono text-[10.5px] text-[var(--console-muted)]">
+            {peak === 0 ? (
+              <span>{t("No user messages in this range.")}</span>
+            ) : (
+              <>
+                <span>{t("Circle area represents message count")}</span>
+                <span className="flex items-center gap-4">
+                  {[
+                    ...new Set([
+                      Math.max(1, Math.round(peak / 4)),
+                      Math.max(1, Math.round(peak / 2)),
+                      peak,
+                    ]),
+                  ].map((count) => (
+                    <span key={count} className="flex items-center gap-1.5">
+                      <svg
+                        width="28"
+                        height="28"
+                        viewBox="0 0 28 28"
+                        aria-hidden="true"
+                        className="text-[var(--console-text)]"
+                      >
+                        <circle
+                          cx="14"
+                          cy="14"
+                          r={12 * Math.sqrt(count / peak)}
+                          fill="currentColor"
+                          opacity="0.75"
+                        />
+                      </svg>
+                      {formatInt(count)}
+                    </span>
+                  ))}
+                </span>
+              </>
+            )}
+          </div>
+        </>
+      )}
+    </Panel>
+  );
+}

--- a/apps/web/src/components/overview/overview-active-hours.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import type { DashboardActiveHours } from "@codesesh/core/contract";
 import { useLocale } from "../../hooks/useLocale";
 import { t } from "../../i18n/translate";
@@ -9,8 +9,37 @@ function hourRange(slot: number): string {
   return `${String(slot * 2).padStart(2, "0")}:00–${String(slot * 2 + 2).padStart(2, "0")}:00`;
 }
 
+function ActivityBubble({
+  count,
+  peak,
+  pattern,
+}: {
+  count: number;
+  peak: number;
+  pattern: string;
+}) {
+  const radius = peak > 0 ? 12 * Math.sqrt(count / peak) : 0;
+  return (
+    <svg
+      width="28"
+      height="28"
+      viewBox="0 0 28 28"
+      aria-hidden="true"
+      className="text-[var(--brand)]"
+    >
+      {count > 0 ? (
+        <>
+          <circle cx="14" cy="14" r={radius} fill="currentColor" opacity="0.2" />
+          <circle cx="14" cy="14" r={radius} fill={`url(#${pattern})`} />
+        </>
+      ) : null}
+    </svg>
+  );
+}
+
 export function OverviewActiveHours({ activity }: { activity: DashboardActiveHours | null }) {
   const locale = useLocale();
+  const pattern = useId();
   const [active, setActive] = useState<number | null>(null);
   const weekdays = locale === "zh-CN" ? [1, 2, 3, 4, 5, 6, 0] : [0, 1, 2, 3, 4, 5, 6];
   const formatter = new Intl.DateTimeFormat(locale, { weekday: "short", timeZone: "UTC" });
@@ -20,6 +49,13 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
 
   return (
     <Panel className="p-4" aria-label={t("Active hours")}>
+      <svg width="0" height="0" aria-hidden="true" className="absolute text-[var(--brand)]">
+        <defs>
+          <pattern id={pattern} width="3" height="3" patternUnits="userSpaceOnUse">
+            <rect width="2" height="2" fill="currentColor" />
+          </pattern>
+        </defs>
+      </svg>
       <PanelHeader title={t("Active hours")} />
       <p className="mt-1 text-xs text-[var(--console-muted)]">
         {t(
@@ -36,7 +72,7 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
             <span>{t("Time zone: {0}", [activity.timeZone])}</span>
             <span>{t("{0} user messages", [formatInt(total)])}</span>
           </div>
-          <table className="mt-3 w-full table-fixed border-collapse console-mono text-[10.5px] text-[var(--console-muted)]">
+          <table className="mt-[14px] w-full table-fixed border-collapse console-mono text-[10.5px] text-[var(--console-muted)]">
             <caption className="sr-only">{t("Active hours")}</caption>
             <thead>
               <tr>
@@ -50,10 +86,13 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
                 ))}
               </tr>
             </thead>
-            <tbody>
+            <tbody className="chart-hatch">
               {Array.from({ length: 12 }, (_, slot) => (
                 <tr key={slot} className="border-t border-dashed border-[var(--console-border)]">
-                  <th scope="row" className="h-8 text-left font-normal tabular-nums">
+                  <th
+                    scope="row"
+                    className="h-8 bg-[var(--console-surface)] text-left font-normal tabular-nums"
+                  >
                     {hourRange(slot)}
                   </th>
                   {weekdays.map((day, column) => {
@@ -65,7 +104,7 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
                         <button
                           type="button"
                           aria-label={summary}
-                          className="flex h-8 w-full items-center justify-center rounded-sm outline-none hover:bg-[var(--console-surface-muted)] focus-visible:ring-2 focus-visible:ring-[var(--console-text)]"
+                          className="flex h-8 w-full items-center justify-center rounded-sm outline-none hover:bg-[var(--brand-soft)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
                           onMouseEnter={() => setActive(index)}
                           onMouseLeave={() => setActive(null)}
                           onFocus={() => setActive(index)}
@@ -75,30 +114,17 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
                             if (event.key === "Escape") setActive(null);
                           }}
                         >
-                          <svg
-                            width="28"
-                            height="28"
-                            viewBox="0 0 28 28"
-                            aria-hidden="true"
-                            className="text-[var(--console-text)]"
-                          >
-                            {count > 0 ? (
-                              <circle
-                                cx="14"
-                                cy="14"
-                                r={12 * Math.sqrt(count / peak)}
-                                fill="currentColor"
-                                opacity="0.75"
-                              />
-                            ) : null}
-                          </svg>
+                          <ActivityBubble count={count} peak={peak} pattern={pattern} />
                         </button>
                         {active === index ? (
                           <span
                             role="tooltip"
                             className={`pointer-events-none absolute bottom-full z-10 w-max max-w-[180px] rounded-md border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-2 text-left text-[var(--console-text)] shadow-[var(--shadow-overlay)] ${column < 3 ? "left-0" : "right-0"}`}
                           >
-                            {summary}
+                            {`${labels[column]} · ${hourRange(slot)} · `}
+                            <span className="font-semibold text-[var(--brand)]">
+                              {t("{0} user messages", [formatInt(count)])}
+                            </span>
                           </span>
                         ) : null}
                       </td>
@@ -113,7 +139,9 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
               <span>{t("No user messages in this range.")}</span>
             ) : (
               <>
-                <span>{t("Circle area represents message count")}</span>
+                <span title={t("Reference sizes; these counts may not occur in the chart.")}>
+                  {t("Size reference (messages)")}
+                </span>
                 <span className="flex items-center gap-4">
                   {[
                     ...new Set([
@@ -123,21 +151,7 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
                     ]),
                   ].map((count) => (
                     <span key={count} className="flex items-center gap-1.5">
-                      <svg
-                        width="28"
-                        height="28"
-                        viewBox="0 0 28 28"
-                        aria-hidden="true"
-                        className="text-[var(--console-text)]"
-                      >
-                        <circle
-                          cx="14"
-                          cy="14"
-                          r={12 * Math.sqrt(count / peak)}
-                          fill="currentColor"
-                          opacity="0.75"
-                        />
-                      </svg>
+                      <ActivityBubble count={count} peak={peak} pattern={pattern} />
                       {formatInt(count)}
                     </span>
                   ))}

--- a/apps/web/src/components/overview/overview-active-hours.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.tsx
@@ -9,26 +9,40 @@ function hourRange(slot: number): string {
   return `${String(slot * 2).padStart(2, "0")}:00–${String(slot * 2 + 2).padStart(2, "0")}:00`;
 }
 
-function ActivityBubble({
-  count,
-  peak,
-  pattern,
-}: {
-  count: number;
-  peak: number;
-  pattern: string;
-}) {
-  const radius = peak > 0 ? 12 * Math.sqrt(count / peak) : 0;
+function referenceCounts(peak: number): number[] {
+  if (peak < 1) return [];
+  return [
+    ...new Set(
+      [peak / 4, peak / 2, peak].map((value) => {
+        const power = 10 ** Math.floor(Math.log10(Math.max(1, value)));
+        const step = value / power;
+        return (step >= 5 ? 5 : step >= 2 ? 2 : 1) * power;
+      }),
+    ),
+  ];
+}
+
+function ActivityBubble({ count, peak }: { count: number; peak: number }) {
+  const pattern = useId();
+  const scale = peak > 0 ? Math.sqrt(count / peak) : 0;
+  const radius = 12 * scale;
   return (
     <svg
       width="28"
       height="28"
       viewBox="0 0 28 28"
       aria-hidden="true"
-      className="text-[var(--brand)]"
+      style={{
+        color: `color-mix(in oklab, var(--activity-high) ${scale * 100}%, var(--activity-low))`,
+      }}
     >
       {count > 0 ? (
         <>
+          <defs>
+            <pattern id={pattern} width="3" height="3" patternUnits="userSpaceOnUse">
+              <rect width="2" height="2" fill="currentColor" />
+            </pattern>
+          </defs>
           <circle cx="14" cy="14" r={radius} fill="currentColor" opacity="0.2" />
           <circle cx="14" cy="14" r={radius} fill={`url(#${pattern})`} />
         </>
@@ -39,7 +53,6 @@ function ActivityBubble({
 
 export function OverviewActiveHours({ activity }: { activity: DashboardActiveHours | null }) {
   const locale = useLocale();
-  const pattern = useId();
   const [active, setActive] = useState<number | null>(null);
   const weekdays = locale === "zh-CN" ? [1, 2, 3, 4, 5, 6, 0] : [0, 1, 2, 3, 4, 5, 6];
   const formatter = new Intl.DateTimeFormat(locale, { weekday: "short", timeZone: "UTC" });
@@ -49,13 +62,6 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
 
   return (
     <Panel className="p-4" aria-label={t("Active hours")}>
-      <svg width="0" height="0" aria-hidden="true" className="absolute text-[var(--brand)]">
-        <defs>
-          <pattern id={pattern} width="3" height="3" patternUnits="userSpaceOnUse">
-            <rect width="2" height="2" fill="currentColor" />
-          </pattern>
-        </defs>
-      </svg>
       <PanelHeader title={t("Active hours")} />
       <p className="mt-1 text-xs text-[var(--console-muted)]">
         {t(
@@ -114,7 +120,7 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
                             if (event.key === "Escape") setActive(null);
                           }}
                         >
-                          <ActivityBubble count={count} peak={peak} pattern={pattern} />
+                          <ActivityBubble count={count} peak={peak} />
                         </button>
                         {active === index ? (
                           <span
@@ -143,15 +149,9 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
                   {t("Size reference (messages)")}
                 </span>
                 <span className="flex items-center gap-4">
-                  {[
-                    ...new Set([
-                      Math.max(1, Math.round(peak / 4)),
-                      Math.max(1, Math.round(peak / 2)),
-                      peak,
-                    ]),
-                  ].map((count) => (
+                  {referenceCounts(peak).map((count) => (
                     <span key={count} className="flex items-center gap-1.5">
-                      <ActivityBubble count={count} peak={peak} pattern={pattern} />
+                      <ActivityBubble count={count} peak={peak} />
                       {formatInt(count)}
                     </span>
                   ))}

--- a/apps/web/src/components/overview/overview-skeleton.tsx
+++ b/apps/web/src/components/overview/overview-skeleton.tsx
@@ -44,6 +44,8 @@ export function OverviewSkeleton() {
         <Bar className="mt-[14px] h-[168px] w-full" />
       </Panel>
 
+      <CardSkeleton bodyClassName="h-[428px] w-full" />
+
       <div className="grid gap-4 lg:grid-cols-[1.45fr_1fr]">
         <CardSkeleton bodyClassName="h-[248px] w-full" />
         <div className="grid content-start gap-4">

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -17,9 +17,10 @@ export const messages = {
     "此范围内暂无用户消息。",
     "この期間のユーザーメッセージはありません。",
   ],
-  "Circle area represents message count": [
-    "圆点面积表示消息数量",
-    "円の面積はメッセージ数を表します",
+  "Size reference (messages)": ["大小参考（消息数）", "サイズの目安（メッセージ数）"],
+  "Reference sizes; these counts may not occur in the chart.": [
+    "圆点面积的参考刻度，不代表图中一定存在对应计数。",
+    "円の面積の目安です。グラフ内に同じ件数が存在するとは限りません。",
   ],
   COST: ["费用", "費用"],
   plan: ["计划", "計画"],

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -1,5 +1,26 @@
 // English source messages map to [Simplified Chinese, Japanese].
 export const messages = {
+  Time: ["时段", "時間帯"],
+  "Active hours": ["活跃时段", "アクティブな時間帯"],
+  "User messages by weekday and two-hour period. Counts are cumulative within the selected range.":
+    [
+      "按星期和两小时时段汇总用户消息，数量为所选统计范围内的累计值。",
+      "曜日と2時間ごとのユーザーメッセージ数。選択した期間内の累計です。",
+    ],
+  "Activity data is unavailable.": [
+    "暂时无法获取活跃时段数据。",
+    "アクティビティデータを取得できません。",
+  ],
+  "Time zone: {0}": ["时区：{0}", "タイムゾーン：{0}"],
+  "{0} user messages": ["{0} 条用户消息", "ユーザーメッセージ {0} 件"],
+  "No user messages in this range.": [
+    "此范围内暂无用户消息。",
+    "この期間のユーザーメッセージはありません。",
+  ],
+  "Circle area represents message count": [
+    "圆点面积表示消息数量",
+    "円の面積はメッセージ数を表します",
+  ],
   COST: ["费用", "費用"],
   plan: ["计划", "計画"],
   USER: ["用户", "ユーザー"],

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -194,6 +194,8 @@
     --console-accent-fg: #ffffff;
 
     /* Brand */
+    --activity-low: #d27845;
+    --activity-high: #b13e16;
     --brand: #e8622e;
     --brand-hover: #c94e1f;
     --brand-soft: #fdede5;
@@ -360,6 +362,8 @@
     --console-accent-strong: #ffffff;
     --console-accent-fg: #101012;
 
+    --activity-low: #ffb38e;
+    --activity-high: #ff7a45;
     --brand: #ff7a45;
     --brand-hover: #ff9166;
     --brand-soft: #2a1710;

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -184,6 +184,7 @@ export function createApiClient(access: RemoteAccess) {
       params.set("projectKey", filters.project.key);
     }
     if (filters.agent) params.set("agent", filters.agent);
+    params.set("timeZone", filters.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone);
     const suffix = params.toString();
     return fetchJson(suffix ? `/api/dashboard?${suffix}` : "/api/dashboard", options);
   }

--- a/apps/web/src/lib/api-contract.ts
+++ b/apps/web/src/lib/api-contract.ts
@@ -89,6 +89,7 @@ export interface SessionFetchProgress {
 }
 
 export interface DashboardFilters {
+  timeZone?: string;
   project?: { kind: ProjectIdentityKind; key: string };
   agent?: string;
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -182,6 +182,7 @@ describe("remote access", () => {
 });
 
 describe("fetchDashboard", () => {
+  const timeZoneQuery = `&timeZone=${encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone)}`;
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -207,7 +208,7 @@ describe("fetchDashboard", () => {
 
     await fetchDashboard({ from: 0, days: 0 }, {});
 
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/dashboard?days=0");
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/dashboard?days=0" + timeZoneQuery);
   });
 
   it("sends exact bounds without a redundant days value", async () => {
@@ -220,7 +221,8 @@ describe("fetchDashboard", () => {
     await fetchDashboard({ from: 10, to: 20, days: 7 }, {});
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      "/api/dashboard?from=1970-01-01T00%3A00%3A00.010Z&to=1970-01-01T00%3A00%3A00.020Z",
+      "/api/dashboard?from=1970-01-01T00%3A00%3A00.010Z&to=1970-01-01T00%3A00%3A00.020Z" +
+        timeZoneQuery,
     );
   });
 
@@ -246,7 +248,7 @@ describe("fetchDashboard", () => {
 
     await fetchDashboard({ days: 7 }, filters);
 
-    expect(fetchMock.mock.calls[0]?.[0]).toBe(expected);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(expected + timeZoneQuery);
   });
 });
 

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -14,6 +14,7 @@ function normalizeDashboardFilters(filters: DashboardFilters): DashboardFilters 
   return {
     ...(filters.project ? { project: filters.project } : {}),
     ...(filters.agent ? { agent: filters.agent } : {}),
+    timeZone: filters.timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
   };
 }
 

--- a/docs/sqlite-storage.md
+++ b/docs/sqlite-storage.md
@@ -6,7 +6,7 @@ CodeSesh 将会话列表、详情快照、搜索索引和增量同步状态存�
 
 - 路径：`~/.cache/codesesh/codesesh.db`
 <!-- repo-fact:cache-schema-version:start -->
-- 当前 schema：`CACHE_SCHEMA_VERSION = 33`
+- 当前 schema：`CACHE_SCHEMA_VERSION = 34`
 <!-- repo-fact:cache-schema-version:end -->
 - 稳定导出入口：`packages/core/src/discovery/index.ts`
 - 实现目录：`packages/core/src/discovery/cache/`
@@ -204,3 +204,7 @@ materializeSessionDetailResponse()
 Schema 33 扩展消息用量时间索引，覆盖消息顺序、模型、tokens 和成本字段。
 Dashboard 的统计查询无需回读含消息正文的大表，也不再为同时间消息额外排序。
 升级时重建该派生索引，不修改消息、会话或成本数据；索引会占用额外空间并增加写入维护开销。
+
+Schema 34 为消息保存 `automated` 来源标记，并增加用户消息发送时间的部分索引。
+Dashboard 活跃时段只统计有发送时间的非自动用户消息，排除子 Agent 会话，按浏览器时区聚合。
+Pi 扩展注入消息通过一次性重新索引补齐来源标记。

--- a/packages/cli/src/api/__tests__/dashboard-handler.test.ts
+++ b/packages/cli/src/api/__tests__/dashboard-handler.test.ts
@@ -16,6 +16,25 @@ const { handleGetDashboard } = await import("../dashboard-handler.js");
 const { handleGetProjects } = await import("../catalog-handlers.js");
 
 describe("handleGetDashboard", () => {
+  it("validates activity time zones and caches each zone independently", () => {
+    const source = makeScanSource();
+    const invalid = makeMockContext({ query: { timeZone: "invalid" } });
+    handleGetDashboard(invalid, source);
+    expect(invalid.json).toHaveBeenCalledWith(
+      { error: "timeZone must be a valid IANA time zone" },
+      400,
+    );
+    expect(coreMocks.listDashboardActiveHours).not.toHaveBeenCalled();
+    for (const timeZone of ["UTC", "UTC", "Asia/Tokyo"]) {
+      handleGetDashboard(makeMockContext({ query: { timeZone } }), source);
+    }
+    expect(coreMocks.listDashboardActiveHours).toHaveBeenCalledTimes(2);
+    expect(coreMocks.listDashboardActiveHours).toHaveBeenLastCalledWith(
+      expect.objectContaining({ timeZone: "Asia/Tokyo" }),
+      undefined,
+    );
+  });
+
   it("rejects invalid dates instead of silently using defaults", () => {
     const c = makeMockContext({ query: { from: "invalid", to: "invalid" } });
 

--- a/packages/cli/src/api/__tests__/handler-test-fixtures.ts
+++ b/packages/cli/src/api/__tests__/handler-test-fixtures.ts
@@ -9,6 +9,7 @@ type CoreMockName =
   | "getAnalyticsRevision"
   | "materializeSessionDetailResponse"
   | "listDashboardCostFacts"
+  | "listDashboardActiveHours"
   | "listFileActivity"
   | "matchesProjectIdentity"
   | "listSessionAliases"
@@ -22,6 +23,7 @@ const coreMocks: Record<CoreMockName, Mock> = vi.hoisted(() => {
     filterSessionSearchCandidates: vi.fn(),
     getAnalyticsRevision: vi.fn(() => "0"),
     materializeSessionDetailResponse: vi.fn(),
+    listDashboardActiveHours: vi.fn(() => null),
     listDashboardCostFacts: vi.fn((): DashboardCostFacts | null => null),
     listFileActivity: vi.fn((): FileActivityResult[] => []),
     matchesProjectIdentity: vi.fn(),
@@ -96,6 +98,7 @@ vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime/discovery")>()),
   getAnalyticsRevision: coreMocks.getAnalyticsRevision,
   listDashboardCostFacts: coreMocks.listDashboardCostFacts,
+  listDashboardActiveHours: coreMocks.listDashboardActiveHours,
   materializeSessionDetailResponse: coreMocks.materializeSessionDetailResponse,
   listFileActivity: coreMocks.listFileActivity,
 }));
@@ -302,6 +305,8 @@ afterEach(() => {
   coreMocks.filterSessionSearchCandidates.mockClear();
   coreMocks.getAnalyticsRevision.mockReset();
   coreMocks.getAnalyticsRevision.mockReturnValue("0");
+  coreMocks.listDashboardActiveHours.mockReset();
+  coreMocks.listDashboardActiveHours.mockReturnValue(null);
   coreMocks.listDashboardCostFacts.mockReset();
   coreMocks.listDashboardCostFacts.mockReturnValue(null);
   coreMocks.materializeSessionDetailResponse.mockReset();

--- a/packages/cli/src/api/dashboard-handler.ts
+++ b/packages/cli/src/api/dashboard-handler.ts
@@ -31,6 +31,16 @@ export function handleGetDashboard(
   scanSource: ScanResultSource,
   defaults: SessionListDefaults = {},
 ) {
+  let timeZone: string;
+  try {
+    timeZone = new Intl.DateTimeFormat("en", {
+      timeZone:
+        optionalQueryValue(c.req.query("timeZone")) ??
+        Intl.DateTimeFormat().resolvedOptions().timeZone,
+    }).resolvedOptions().timeZone;
+  } catch {
+    return c.json({ error: "timeZone must be a valid IANA time zone" }, 400);
+  }
   const scanResult = scanSource.getSnapshot();
   const projectIdentity = parseProjectIdentityFilter(
     c.req.query("projectKind"),
@@ -103,6 +113,7 @@ export function handleGetDashboard(
     to,
     cacheTo,
     analyticsRevision,
+    timeZone,
   );
   const data: DashboardData = {
     ...aggregate,

--- a/packages/cli/src/api/snapshot-aggregation.ts
+++ b/packages/cli/src/api/snapshot-aggregation.ts
@@ -1,5 +1,6 @@
 import {
   listFileActivity,
+  listDashboardActiveHours,
   listDashboardCostFacts,
   type SessionHead,
 } from "@codesesh/core/runtime/discovery";
@@ -74,7 +75,7 @@ export function getSnapshotSessionTree(
   return (cache.sessionTree ??= buildSessionTree(sessions));
 }
 
-type DashboardStorageAggregation = Pick<DashboardData, "recentFileActivities">;
+type DashboardStorageAggregation = Pick<DashboardData, "recentFileActivities" | "activeHours">;
 
 export function getSnapshotCostFacts(
   source: ScanResultSource,
@@ -105,8 +106,10 @@ export function getDashboardStorageAggregation(
   to: number,
   cacheTo: number,
   analyticsRevision: string | null,
+  timeZone: string,
 ): DashboardStorageAggregation {
   const build = (): DashboardStorageAggregation => ({
+    activeHours: listDashboardActiveHours({ ...scope, from, to, timeZone }, source.queryScope),
     recentFileActivities: listFileActivity(
       {
         agent: scope.agent,
@@ -139,6 +142,7 @@ export function getDashboardStorageAggregation(
     sessions,
     [
       "dashboard-storage",
+      timeZone,
       scope.agent,
       scope.projectKind,
       scope.projectKey,

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -55,6 +55,42 @@ function captureDiagnostics(): Array<{ event: string; detail?: Record<string, un
 }
 
 describe("PiAgent", () => {
+  it("marks extension messages as automated while preserving their display", () => {
+    const id = "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa";
+    const { agent } = writePiSession(id, [
+      { type: "session", version: 3, id, timestamp: TS, cwd: "/tmp/project" },
+      {
+        type: "message",
+        id: "a",
+        parentId: null,
+        timestamp: TS,
+        message: { role: "user", content: "Human prompt" },
+      },
+      {
+        type: "message",
+        id: "b",
+        parentId: "a",
+        timestamp: TS,
+        message: { role: "custom", display: true, content: "Extension context" },
+      },
+      {
+        type: "custom_message",
+        id: "c",
+        parentId: "b",
+        timestamp: TS,
+        display: true,
+        content: "Extension notice",
+      },
+    ]);
+    agent.scan();
+    const messages = agent.getSessionData(id)!.messages;
+    expect(messages.map((m) => [m.role, m.automated === true])).toEqual([
+      ["user", false],
+      ["user", true],
+      ["user", true],
+    ]);
+  });
+
   it("parses only the current branch path", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "codesesh-pi-test-"));
     tempDirs.push(tempDir);

--- a/packages/core/src/agents/pi.ts
+++ b/packages/core/src/agents/pi.ts
@@ -424,7 +424,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
     if (role === "custom" && message["display"] === true) {
       const parts = normalizeTextParts(message["content"], timestampMs);
       if (parts.length === 0) return null;
-      return this.emptyUsageResult({ id, role: "user", timestampMs, parts });
+      return this.emptyUsageResult({ id, role: "user", timestampMs, parts, automated: true });
     }
 
     if (role === "branchSummary" || role === "compactionSummary") {
@@ -552,6 +552,7 @@ export class PiAgent extends SingleFileSessionSource<SessionMeta> {
     return {
       id: narrowPiField("summary.id", entry["id"], asString) ?? "",
       role: type === "custom_message" ? "user" : "assistant",
+      automated: type === "custom_message",
       agent: type === "custom_message" ? undefined : "pi",
       timestampMs,
       parts: [{ type: "text", text, time_created: timestampMs }],

--- a/packages/core/src/agents/transcript-builder.ts
+++ b/packages/core/src/agents/transcript-builder.ts
@@ -21,6 +21,7 @@ export interface TranscriptMessageInput {
   costSource?: Message["cost_source"];
   subagentId?: string;
   nickname?: string;
+  automated?: boolean;
 }
 
 export type AssistantMessageInput = Omit<TranscriptMessageInput, "role" | "parts">;
@@ -259,6 +260,7 @@ export class TranscriptBuilder {
       parts: (input.parts ?? []).map((part) => this.retainPart(part)),
       subagent_id: input.subagentId,
       nickname: input.nickname,
+      ...(input.automated ? { automated: true } : {}),
     };
   }
 

--- a/packages/core/src/contract/dashboard.ts
+++ b/packages/core/src/contract/dashboard.ts
@@ -93,7 +93,14 @@ export interface DashboardAggregate {
   recentSessions: DashboardRecentSession[];
 }
 
+export interface DashboardActiveHours {
+  timeZone: string;
+  /** Sunday first; each weekday has twelve consecutive two-hour slots. */
+  counts: number[];
+}
+
 export interface DashboardData extends DashboardAggregate {
+  activeHours: DashboardActiveHours | null;
   recentFileActivities: FileActivityResult[];
   window: { from?: number; to: number; days?: number; compareFrom?: number; compareTo?: number };
 }

--- a/packages/core/src/contract/session.ts
+++ b/packages/core/src/contract/session.ts
@@ -150,6 +150,8 @@ export interface Message {
   parts: MessagePart[];
   subagent_id?: string;
   nickname?: string;
+  /** Source-generated content displayed as a user message, rather than human input. */
+  automated?: boolean;
 }
 
 /** Lightweight metadata for session listing */

--- a/packages/core/src/discovery/__tests__/migration-fixtures.ts
+++ b/packages/core/src/discovery/__tests__/migration-fixtures.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { formatSessionReference } from "../../contract/index.js";
 import type { SessionHead } from "../../types/index.js";
 
-export const EXPECTED_CACHE_SCHEMA_VERSION = 33;
+export const EXPECTED_CACHE_SCHEMA_VERSION = 34;
 
 export const RELEASE_CACHE_FIXTURES = [
   { version: 3, sourceTag: "v0.3.0" },

--- a/packages/core/src/discovery/cache/__tests__/active-hours.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/active-hours.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const home = mkdtempSync(join(tmpdir(), "codesesh-active-hours-"));
+vi.mock("node:os", async (original) => ({
+  ...(await original<typeof import("node:os")>()),
+  homedir: () => home,
+}));
+
+import { listDashboardActiveHours } from "../active-hours.js";
+import { closeCacheStorage } from "../db.js";
+import { syncSessionSearchIndex } from "../search.js";
+import { saveCachedSessions } from "../sessions.js";
+import { loadCachedSessionRawEntry } from "../sessions.js";
+import { makeSessionHead } from "./fixtures.js";
+import type { Message } from "../../../types/index.js";
+
+const from = Date.parse("2026-09-06T00:00:00Z");
+const to = Date.parse("2026-09-07T23:59:59.999Z");
+const options = { from, to, timeZone: "UTC" };
+function message(id: string, time: number, extra: Partial<Message> = {}): Message {
+  return { id, role: "user", time_created: time, parts: [{ type: "text", text: id }], ...extra };
+}
+
+function seed() {
+  const parent = makeSessionHead("parent", { time_updated: to + 86400000 });
+  const child = makeSessionHead("child", { parent_reference: parent.reference });
+  const orphan = makeSessionHead("orphan", {
+    parent_reference: { agentName: "codex", sessionId: "missing" },
+  });
+  const other = makeSessionHead("other", {
+    project_identity: { kind: "path", key: "/other", displayName: "other" },
+  });
+  const sessions = [parent, child, orphan, other];
+  const contents: Record<string, Message[]> = {
+    parent: [
+      message("before", from - 1),
+      message("midnight", from),
+      message("before-two", from + 7200000 - 1),
+      message("two", from + 7200000),
+      message("next-day", from + 86400000),
+      message("end", to),
+      message("after", to + 1),
+      message("untimed", 0),
+      message("assistant", from, { role: "assistant" }),
+      message("tool", from, { role: "tool" }),
+      message("injected", from, { automated: true }),
+    ],
+    child: [message("delegated", from)],
+    orphan: [message("orphan-delegated", from)],
+    other: [message("other-project", from)],
+  };
+  saveCachedSessions("codex", sessions);
+  syncSessionSearchIndex("codex", sessions, (id) => ({
+    ...sessions.find((s) => s.reference.sessionId === id)!,
+    messages: contents[id]!,
+  }));
+}
+
+afterEach(() => {
+  closeCacheStorage();
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("user active hours", () => {
+  it("counts human messages by send time with scope and interval boundaries", () => {
+    seed();
+    const result = listDashboardActiveHours(options)!;
+    expect(result.counts).toHaveLength(84);
+    expect(result.counts.reduce((a, b) => a + b)).toBe(6);
+    expect(result.counts[0]).toBe(3);
+    expect(result.counts[1]).toBe(1);
+    expect(result.counts[12]).toBe(1);
+    expect(result.counts[23]).toBe(1);
+    const project = listDashboardActiveHours({
+      ...options,
+      projectKind: "path",
+      projectKey: "/workspace/project",
+    })!;
+    expect(project.counts.reduce((a, b) => a + b)).toBe(5);
+    expect(
+      listDashboardActiveHours(options, { agents: ["pi"] })!.counts.every((n) => n === 0),
+    ).toBe(true);
+    expect(
+      listDashboardActiveHours({ ...options, agent: "pi" })!.counts.every((n) => n === 0),
+    ).toBe(true);
+    expect(
+      loadCachedSessionRawEntry("codex", "parent")?.messageRows.find(
+        (m) => m.message_id === "injected",
+      )?.automated,
+    ).toBe(1);
+  });
+
+  it("uses the requested time zone across midnight and repeated DST hours", () => {
+    const session = makeSessionHead("dst");
+    saveCachedSessions("codex", [session]);
+    syncSessionSearchIndex("codex", [session], () => ({
+      ...session,
+      messages: [
+        message("first", Date.parse("2026-11-01T05:30:00Z")),
+        message("second", Date.parse("2026-11-01T06:30:00Z")),
+      ],
+    }));
+    const window = {
+      from: Date.parse("2026-11-01T00:00:00Z"),
+      to: Date.parse("2026-11-02T00:00:00Z"),
+    };
+    expect(listDashboardActiveHours({ ...window, timeZone: "America/New_York" })!.counts[0]).toBe(
+      2,
+    );
+    expect(listDashboardActiveHours({ ...window, timeZone: "Asia/Tokyo" })!.counts[7]).toBe(2);
+    expect(
+      listDashboardActiveHours({ ...window, timeZone: "Pacific/Honolulu" })!.counts[6 * 12 + 9],
+    ).toBe(1);
+  });
+
+  it("distinguishes unavailable storage from an empty activity window", () => {
+    expect(listDashboardActiveHours(options)).toBeNull();
+    seed();
+    expect(listDashboardActiveHours({ ...options, from: to, to })!.counts[23]).toBe(1);
+  });
+});

--- a/packages/core/src/discovery/cache/__tests__/content-migrations.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/content-migrations.test.ts
@@ -41,13 +41,15 @@ describe("cache content migrations", () => {
       db.exec(`
         INSERT INTO sessions(agent_name, session_id) VALUES ('codex', 'codex-session');
         INSERT INTO sessions(agent_name, session_id) VALUES ('cursor', 'cursor-session');
+        INSERT INTO sessions(agent_name, session_id) VALUES ('pi', 'pi-session');
       `);
       seedAgentCache(db);
 
       runCacheContentMigrations(db);
 
-      expect(db.prepare("SELECT * FROM pending_reindex").all()).toEqual([
+      expect(db.prepare("SELECT * FROM pending_reindex ORDER BY agent_name").all()).toEqual([
         { agent_name: "codex", session_id: "codex-session" },
+        { agent_name: "pi", session_id: "pi-session" },
       ]);
       expect(db.prepare("SELECT agent_name FROM agent_cache ORDER BY agent_name").all()).toEqual([
         { agent_name: "cursor" },
@@ -55,6 +57,7 @@ describe("cache content migrations", () => {
       expect(db.prepare("SELECT key, value FROM cache_meta ORDER BY key").all()).toEqual([
         { key: "codex_exec_decode_migrated_v3", value: "1" },
         { key: "opencode_subagent_fold_v1", value: "1" },
+        { key: "pi_automated_messages_v1", value: "1" },
         { key: "subagent_tree_v1", value: "1" },
       ]);
 

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -54,6 +54,29 @@ afterEach(() => {
 });
 
 describe("cache schema boundary", () => {
+  it("adds user activity indexing to schema 33 without losing transcripts", () => {
+    const session = makeSessionHead("user-activity");
+    saveCachedSessions("codex", [session]);
+    syncSessionSearchIndex("codex", [session], () => makeSessionData("user-activity"));
+    setSchemaEnsuredPath(null);
+    const db = new Database(getCachePath());
+    db.exec(`DROP INDEX idx_messages_user_activity;
+      ALTER TABLE messages DROP COLUMN automated;
+      PRAGMA user_version = 33;`);
+    db.close();
+    expect(
+      schema.withCacheDb((db) => db.prepare("SELECT message_id, automated FROM messages").all()),
+    ).toEqual([{ message_id: "user-activity-message", automated: 0 }]);
+    expect(
+      schema.withCacheDb((db) =>
+        db
+          .prepare("PRAGMA index_info(idx_messages_user_activity)")
+          .all()
+          .map((row) => row.name),
+      ),
+    ).toEqual(["time_created", "agent_name", "session_id"]);
+  });
+
   it("upgrades the version 32 usage index without changing cost facts", () => {
     const session = makeSessionHead("usage-index");
     saveCachedSessions("codex", [session]);

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -886,6 +886,7 @@ describe("clearCache", () => {
       { key: "analytics_revision", value: "2" },
       { key: "codex_exec_decode_migrated_v3", value: "1" },
       { key: "opencode_subagent_fold_v1", value: "1" },
+      { key: "pi_automated_messages_v1", value: "1" },
       { key: "subagent_tree_v1", value: "1" },
       { key: "version", value: String(CACHE_SCHEMA_VERSION) },
     ]);

--- a/packages/core/src/discovery/cache/active-hours.ts
+++ b/packages/core/src/discovery/cache/active-hours.ts
@@ -1,0 +1,66 @@
+import type { DashboardActiveHours } from "../../contract/dashboard.js";
+import type { DashboardScope } from "../../analytics/dashboard.js";
+import type { SessionQueryScope } from "../session-scope.js";
+import { hasCacheStorage } from "./db.js";
+import { withCacheDbReadOnly } from "./connection.js";
+import { buildSessionQueryScopeFilters } from "./session-scope.js";
+
+export interface ActiveHoursOptions extends DashboardScope {
+  from?: number;
+  to: number;
+  timeZone: string;
+}
+
+export function listDashboardActiveHours(
+  options: ActiveHoursOptions,
+  queryScope?: SessionQueryScope,
+): DashboardActiveHours | null {
+  if (!hasCacheStorage()) return null;
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: options.timeZone,
+    weekday: "short",
+    hour: "2-digit",
+    hourCycle: "h23",
+  });
+  const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const { clauses, params } = buildSessionQueryScopeFilters(queryScope);
+  clauses.push(
+    "s.publication_id IS NULL",
+    "s.parent_agent_name IS NULL AND s.parent_session_id IS NULL",
+    "m.role = 'user' AND m.automated = 0 AND m.time_created > 0",
+    "m.time_created <= ?",
+  );
+  params.push(options.to);
+  if (options.from != null) {
+    clauses.push("m.time_created >= ?");
+    params.push(options.from);
+  }
+  if (options.agent) {
+    clauses.push("s.agent_name = ?");
+    params.push(options.agent);
+  }
+  if (options.projectKind != null || options.projectKey != null) {
+    clauses.push("s.project_identity_kind = ? AND s.project_identity_key = ?");
+    params.push(options.projectKind ?? null, options.projectKey ?? null);
+  }
+  const read = withCacheDbReadOnly((db) => {
+    const counts = Array<number>(84).fill(0);
+    const rows = db
+      .prepare(`
+      SELECT m.time_created FROM messages m
+      JOIN sessions s ON s.agent_name = m.agent_name AND s.session_id = m.session_id
+      WHERE ${clauses.join(" AND ")}
+    `)
+      .iterate(...params);
+    for (const row of rows) {
+      const time = Number(row.time_created);
+      if (Number.isNaN(new Date(time).getTime())) continue;
+      const parts = formatter.formatToParts(time);
+      const weekday = weekdays.indexOf(parts.find((part) => part.type === "weekday")!.value);
+      const hour = Number(parts.find((part) => part.type === "hour")!.value);
+      counts[weekday * 12 + Math.floor(hour / 2)]! += 1;
+    }
+    return { timeZone: options.timeZone, counts };
+  });
+  return read.status === "success" ? read.value : null;
+}

--- a/packages/core/src/discovery/cache/content-migrations.ts
+++ b/packages/core/src/discovery/cache/content-migrations.ts
@@ -7,6 +7,15 @@ interface CacheContentMigration {
 
 const CACHE_CONTENT_MIGRATIONS: readonly CacheContentMigration[] = [
   {
+    key: "pi_automated_messages_v1",
+    apply(db) {
+      if (!tableExists(db, "sessions") || !tableExists(db, "pending_reindex")) return;
+      db.exec(
+        "INSERT OR IGNORE INTO pending_reindex(agent_name, session_id) SELECT agent_name, session_id FROM sessions WHERE agent_name = 'pi'",
+      );
+    },
+  },
+  {
     key: "codex_exec_decode_migrated_v3",
     apply(db) {
       if (!tableExists(db, "sessions") || !tableExists(db, "pending_reindex")) return;

--- a/packages/core/src/discovery/cache/message-cursor.ts
+++ b/packages/core/src/discovery/cache/message-cursor.ts
@@ -19,6 +19,7 @@ export interface MessageCursorContent {
   partsFormatVersion: number | string | null | undefined;
   subagentId: string | null | undefined;
   nickname: string | null | undefined;
+  automated?: number;
 }
 
 function updateField(hash: Hash, value: string | number | null | undefined): void {
@@ -46,6 +47,8 @@ function updateMessageContent(hash: Hash, content: MessageCursorContent): void {
   updateField(hash, content.partsFormatVersion);
   updateField(hash, content.subagentId);
   updateField(hash, content.nickname);
+  // Keep existing cursors valid for messages whose origin has not changed.
+  if (content.automated) updateField(hash, "automated");
 }
 
 export function initialMessageCursorDigest(reference: SessionReference): string {

--- a/packages/core/src/discovery/cache/messages.ts
+++ b/packages/core/src/discovery/cache/messages.ts
@@ -68,6 +68,7 @@ export interface MessageBackfillRow extends DatabaseRow {
   parts_json?: string;
   subagent_id?: string | null;
   nickname?: string | null;
+  automated?: number;
 }
 
 export interface CachedMessageRow extends MessageBackfillRow {
@@ -94,6 +95,7 @@ export interface StructuredMessageRecord {
   partsJson: string;
   subagentId?: string | null;
   nickname?: string | null;
+  automated?: number;
   contentText: string;
   toolMetadataJson?: string | null;
   toolNames: string[];
@@ -116,6 +118,7 @@ export function messageCursorContentFromCachedRow(row: CachedMessageRow): Messag
     partsFormatVersion: row.parts_format_version,
     subagentId: row.subagent_id,
     nickname: row.nickname,
+    automated: row.automated,
   };
 }
 
@@ -138,6 +141,7 @@ export function messageCursorContentFromStructuredRecord(
     partsFormatVersion: MESSAGE_PARTS_FORMAT_VERSION,
     subagentId: record.subagentId,
     nickname: record.nickname,
+    automated: record.automated,
   };
 }
 
@@ -435,6 +439,7 @@ function messageMetadataFromBackfillRow(row: MessageBackfillRow): Omit<Message, 
     provider: row.provider ?? null,
     subagent_id: row.subagent_id ?? undefined,
     nickname: row.nickname ?? undefined,
+    ...(row.automated ? { automated: true } : {}),
   };
 }
 
@@ -625,6 +630,7 @@ export function normalizeMessages(session: SessionDetail): StructuredMessageReco
       partsJson: JSON.stringify(message.parts),
       subagentId: message.subagent_id ?? null,
       nickname: message.nickname ?? null,
+      automated: message.automated ? 1 : 0,
       contentText: buildMessageText(message),
       toolMetadataJson: toolMetadata.length > 0 ? JSON.stringify(toolMetadata) : null,
       toolNames: toolNamesFromMessage(message),

--- a/packages/core/src/discovery/cache/schema-definitions.ts
+++ b/packages/core/src/discovery/cache/schema-definitions.ts
@@ -108,6 +108,7 @@ export function createSessionTables(db: SQLiteDatabase): void {
       content_chain_digest TEXT,
       subagent_id TEXT,
       nickname TEXT,
+      automated INTEGER NOT NULL DEFAULT 0,
       content_text TEXT NOT NULL,
       tool_metadata_json TEXT,
       PRIMARY KEY (agent_name, session_id, message_index),
@@ -520,4 +521,10 @@ function createProjectGroupsView(db: SQLiteDatabase): void {
 export function recreateProjectGroupsView(db: SQLiteDatabase): void {
   db.exec("DROP VIEW IF EXISTS project_groups_v");
   createProjectGroupsView(db);
+}
+
+export function createUserActivityIndex(db: SQLiteDatabase): void {
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_messages_user_activity
+    ON messages(time_created, agent_name, session_id)
+    WHERE role = 'user' AND automated = 0 AND time_created > 0`);
 }

--- a/packages/core/src/discovery/cache/schema.ts
+++ b/packages/core/src/discovery/cache/schema.ts
@@ -37,6 +37,7 @@ import {
   createFileActivityTables,
   createMessageToolTables,
   createMessageUsageIndex,
+  createUserActivityIndex,
   createLegacyProjectTables,
   createSearchStateIndex,
   createSearchTables,
@@ -817,6 +818,7 @@ export function ensureCacheSchema(db: SQLiteDatabase, dbPath: string): void {
   }
   if (currentVersion === 0 && !hasAnyCacheSchema(db)) {
     createLatestCacheSchema(db);
+    createUserActivityIndex(db);
     createSearchStateIndex(db);
     setCacheSchemaVersion(db);
     runCacheContentMigrations(db);
@@ -910,10 +912,20 @@ export function ensureCacheSchema(db: SQLiteDatabase, dbPath: string): void {
           createMessageUsageIndex(db);
         },
       },
+      {
+        version: 34,
+        migrate(db) {
+          if (!columnExists(db, "messages", "automated")) {
+            db.exec("ALTER TABLE messages ADD COLUMN automated INTEGER NOT NULL DEFAULT 0");
+          }
+          createUserActivityIndex(db);
+        },
+      },
     ],
   });
 
   createLatestCacheSchema(db);
+  createUserActivityIndex(db);
   createSearchStateIndex(db);
 
   // Only stamp when behind: every thread's first connection runs ensureSchema,

--- a/packages/core/src/discovery/cache/session-materialization-writer.ts
+++ b/packages/core/src/discovery/cache/session-materialization-writer.ts
@@ -139,9 +139,10 @@ export function prepareSessionMaterializationWriter(
       content_chain_digest,
       subagent_id,
       nickname,
+      automated,
       content_text,
       tool_metadata_json
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(agent_name, session_id, message_index) DO UPDATE SET
       message_id = excluded.message_id,
       role = excluded.role,
@@ -159,6 +160,7 @@ export function prepareSessionMaterializationWriter(
       content_chain_digest = excluded.content_chain_digest,
       subagent_id = excluded.subagent_id,
       nickname = excluded.nickname,
+      automated = excluded.automated,
       content_text = excluded.content_text,
       tool_metadata_json = excluded.tool_metadata_json
   `);
@@ -215,6 +217,7 @@ export function prepareSessionMaterializationWriter(
           contentChainDigest,
           message.subagentId ?? null,
           message.nickname ?? null,
+          message.automated ?? 0,
           message.contentText,
           message.toolMetadataJson ?? null,
         );

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -478,7 +478,8 @@ function readCachedSessionMessageRows(
           parts_format_version,
           content_chain_digest,
           subagent_id,
-          nickname
+          nickname,
+          automated
         FROM messages
         WHERE agent_name = ? AND session_id = ? AND message_index >= ?
         ORDER BY message_index

--- a/packages/core/src/discovery/cache/version.ts
+++ b/packages/core/src/discovery/cache/version.ts
@@ -1,1 +1,1 @@
-export const CACHE_SCHEMA_VERSION = 33;
+export const CACHE_SCHEMA_VERSION = 34;

--- a/packages/core/src/discovery/index.ts
+++ b/packages/core/src/discovery/index.ts
@@ -115,3 +115,5 @@ export type {
 } from "./cache/search.js";
 export { perf } from "../utils/index.js";
 export type { PerfMarker } from "../utils/index.js";
+
+export { listDashboardActiveHours } from "./cache/active-hours.js";

--- a/packages/core/src/runtime/discovery.ts
+++ b/packages/core/src/runtime/discovery.ts
@@ -27,6 +27,7 @@ export {
   inspectAgentRefresh,
   listCachedProjectGroups,
   listDashboardCostFacts,
+  listDashboardActiveHours,
   listFileActivity,
   listModelCostDistribution,
   loadCachedSessionHeads,

--- a/packages/core/src/test-fixtures.ts
+++ b/packages/core/src/test-fixtures.ts
@@ -145,6 +145,7 @@ export const SAMPLE_DASHBOARD_DATA = {
     },
   ],
   recentFileActivities: [],
+  activeHours: null,
   modelCost: null,
   window: { from: 1_699_900_000_000, to: 1_700_003_600_000, days: 1 },
 } satisfies DashboardData;

--- a/tests/e2e/active-hours.spec.ts
+++ b/tests/e2e/active-hours.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "./test-fixtures.js";
+
+test.use({ timezoneId: "Asia/Tokyo" });
+
+for (const width of [1280, 375]) {
+  test(`shows scoped active hours in the browser time zone at ${width}px`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto("/?range=all");
+    const chart = page.getByRole("region", { name: "Active hours", exact: true });
+    await expect(
+      chart.getByRole("button", { name: "Mon · 18:00–20:00 · 3 user messages" }),
+    ).toBeVisible();
+    await expect(chart.getByText("Time zone: Asia/Tokyo")).toBeVisible();
+    await expect(chart.getByRole("button")).toHaveCount(84);
+    await chart.getByRole("button", { name: "Mon · 18:00–20:00 · 3 user messages" }).click();
+    await expect(chart.getByRole("tooltip")).toBeVisible();
+    const bounds = await chart.getByRole("tooltip").boundingBox();
+    expect(bounds!.x).toBeGreaterThanOrEqual(0);
+    expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(width);
+    await page.keyboard.press("Escape");
+    await chart.getByRole("heading").click();
+    await chart.evaluate((element) => element.scrollIntoView({ block: "center" }));
+    await page.mouse.move(0, 0);
+    await chart.screenshot({ path: testInfo.outputPath(`active-hours-${width}.png`) });
+    await page.goto("/projects?range=all");
+    await page
+      .locator("main")
+      .getByRole("link", { name: /codesesh-e2e/ })
+      .click();
+    await expect(
+      chart.getByRole("button", { name: "Mon · 18:00–20:00 · 3 user messages" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Claude Code · 1" }).click();
+    await expect(
+      chart.getByRole("button", { name: "Mon · 18:00–20:00 · 2 user messages" }),
+    ).toBeVisible();
+  });
+}


### PR DESCRIPTION
Adds an **Active hours** chart to both the global and project dashboards, following the selected date range and agent filter. The seven weekday columns and twelve two-hour rows show cumulative user message counts, with circle area proportional to count and details available on hover, focus, or click. Brand-colored tiled circles and the shared hatched background match the existing charts; the legend uses rounded reference counts. Orange tones deepen with message count, with theme-specific colors preserving contrast.

Messages are bucketed by send time in the browser's time zone. Simplified Chinese starts on Monday; Japanese and English start on Sunday. Missing timestamps, child-agent sessions, tool/assistant messages, and known automated Pi messages are excluded. Empty ranges and unavailable storage have separate states.

Schema 34 preserves automated-message provenance and adds a partial index for activity queries. Existing Pi transcripts are queued for reindexing. The query reads indexed timestamps without loading transcript content, returns 84 counts, and shares the existing dashboard cache with time-zone isolation.

Validation:
- Lint, formatting, workspace and e2e type checks, build, documentation checks, and algorithmic growth checks passed.
- 2,641 workspace unit tests passed; coverage thresholds passed.
- All 40 Playwright tests passed, including desktop/mobile activity counts, browser time zone, project scope, and agent filtering.
- Cache migration smoke tests and initial bundle budget passed.
