### PR TITLE
fix: Expire shared session alias views

### DIFF
--- a/packages/cli/src/api/__tests__/session-alias-cache.test.ts
+++ b/packages/cli/src/api/__tests__/session-alias-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { BookmarkView } from "./state-handler-test-fixtures.js";
 import {
   bookmarkScanSource,
@@ -29,6 +29,32 @@ describe("session alias caching", () => {
     handleGetBookmarks(makeContext() as never, bookmarkScanSource);
 
     expect(coreMocks.listSessionAliases).toHaveBeenCalledTimes(1);
+  });
+
+  it("observes another instance's alias writes after the cache expires", () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
+    coreMocks.listSessionAliases.mockReturnValue([]);
+    const readTitle = () => {
+      const context = makeContext();
+      handleGetBookmarks(context as never, bookmarkScanSource);
+      const bookmark = getResponsePayload<{ bookmarks: BookmarkView[] }>(context).bookmarks[0];
+      return bookmark?.availability === "available" ? bookmark.session.display_title : undefined;
+    };
+    try {
+      expect(readTitle()).toBeUndefined();
+      coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
+      expect(readTitle()).toBeUndefined();
+
+      now.mockReturnValue(2_000);
+      expect(readTitle()).toBe("Renamed");
+
+      coreMocks.listSessionAliases.mockReturnValue([]);
+      now.mockReturnValue(3_000);
+      expect(readTitle()).toBeUndefined();
+    } finally {
+      now.mockRestore();
+    }
   });
 
   it("picks up a stored alias on the next read", async () => {

--- a/packages/cli/src/api/session-aliases-view.ts
+++ b/packages/cli/src/api/session-aliases-view.ts
@@ -63,20 +63,15 @@ function readAliasView(): AliasView | null {
 
 const EMPTY_ALIAS_VIEW = buildAliasView(new Map());
 
-/**
- * Aliases change only through this process's own PUT/DELETE handlers, so the
- * read model is built once and reused until one of them invalidates it. Six read
- * handlers call this per request; without the cache each one re-queries the whole
- * table. Failed reads return an empty view for that request but are not published,
- * so a recovered store is retried on the next request.
- */
-let cachedView: AliasView | null = null;
+// Other CLI instances share state.db but cannot invalidate this process's view.
+const ALIAS_VIEW_TTL_MS = 1_000;
+let cachedView: { view: AliasView; expiresAt: number } | null = null;
 
 export function loadAliasView(): AliasView {
-  if (cachedView) return cachedView;
+  if (cachedView && Date.now() < cachedView.expiresAt) return cachedView.view;
   const loaded = readAliasView();
   if (!loaded) return EMPTY_ALIAS_VIEW;
-  cachedView = loaded;
+  cachedView = { view: loaded, expiresAt: Date.now() + ALIAS_VIEW_TTL_MS };
   return loaded;
 }
 


### PR DESCRIPTION
Multiple CLI instances share state.db, but the permanent alias cache only observed writes made through the current process. Reloading another instance could therefore keep showing an old title indefinitely.

Expire alias views after one second while retaining immediate invalidation for local writes and retrying failed storage reads. A regression covers external alias additions and deletions without a local write.

Validation: CLI lint and typecheck passed. The API suite initially passed 224 of 225 tests; an existing dashboard window test timed out. The targeted rerun passed all 39 tests, including that dashboard test and the alias/SSE regressions.
