### PR TITLE
fix: Retry live state recovery after reconnect

### DIFF
--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -38,6 +38,7 @@ function makeDeps(visibleNewSessions = 0) {
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
   sessionsCallback = undefined;
   reconnectCallback = undefined;
@@ -139,5 +140,71 @@ describe("useLiveSync", () => {
     expect(result.current.liveNotice).toBeNull();
     expect(deps.resyncLiveState).toHaveBeenCalledOnce();
     expect(deps.applyLiveEvent).not.toHaveBeenCalled();
+  });
+  it("keeps the recovery notice until a failed resync is retried successfully", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const deps = makeDeps();
+    let finishRecovery!: () => void;
+    deps.resyncLiveState
+      .mockRejectedValueOnce(new Error("HTTP unavailable"))
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishRecovery = resolve;
+          }),
+      );
+    const { result } = renderHook(() => useLiveSync(deps));
+
+    await act(async () => reconnectCallback?.());
+    expect(result.current.liveNotice).toBe("Live data may be out of date; synchronizing…");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(deps.resyncLiveState).toHaveBeenCalledTimes(2);
+    expect(result.current.liveNotice).toBe("Live data may be out of date; synchronizing…");
+
+    await act(async () => finishRecovery());
+    expect(result.current.liveNotice).toBeNull();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(deps.resyncLiveState).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["disconnect", "unmount"] as const)(
+    "cancels scheduled recovery on %s",
+    async (reason) => {
+      vi.useFakeTimers();
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const deps = makeDeps();
+      deps.resyncLiveState.mockRejectedValue(new Error("HTTP unavailable"));
+      const { unmount } = renderHook(() => useLiveSync(deps));
+      await act(async () => reconnectCallback?.());
+
+      if (reason === "unmount") unmount();
+      else act(() => disconnectCallback?.());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+      expect(deps.resyncLiveState).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not let an older recovery clear a later disconnect", async () => {
+    const deps = makeDeps();
+    let finishRecovery!: () => void;
+    deps.resyncLiveState.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRecovery = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useLiveSync(deps));
+    await act(async () => reconnectCallback?.());
+    act(() => disconnectCallback?.());
+    await act(async () => finishRecovery());
+    expect(result.current.liveNotice).toBe("Live updates disconnected; reconnecting…");
   });
 });

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -15,10 +15,13 @@ interface LiveSyncDeps {
 }
 
 const LIVE_UPDATE_WINDOW_MS = 500;
+const LIVE_RECOVERY_RETRY_MS = 5_000;
 
 export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: LiveSyncDeps) {
   const [newSessionCount, setNewSessionCount] = useState<number | null>(null);
-  const [disconnected, setDisconnected] = useState(false);
+  const [connectionState, setConnectionState] = useState<
+    "connected" | "disconnected" | "recovering"
+  >("connected");
   const pendingEventRef = useRef<SessionsUpdatedEvent | null>(null);
   const pendingTimerRef = useRef<number | null>(null);
   const updateChainRef = useRef(Promise.resolve());
@@ -49,19 +52,14 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
     pendingTimerRef.current = null;
   });
 
-  const handleReconnect = useEffectEvent(async () => {
-    clearPendingLiveUpdate();
-    setDisconnected(false);
-    try {
-      await updateChainRef.current;
-      await resyncLiveState();
-    } catch (error) {
-      console.error("Failed to resync live session state:", error);
-    }
+  const resync = useEffectEvent(async () => {
+    await updateChainRef.current;
+    await resyncLiveState();
   });
 
   useEffect(() => {
-    return subscribeSessionUpdates(
+    let cancelRecovery = () => {};
+    const unsubscribe = subscribeSessionUpdates(
       (event) => {
         pendingEventRef.current = pendingEventRef.current
           ? mergeSessionsUpdatedEvents(pendingEventRef.current, event)
@@ -72,11 +70,37 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
         );
       },
       setScanStatus,
-      () => void handleReconnect(),
       () => {
-        setDisconnected(true);
+        cancelRecovery();
+        clearPendingLiveUpdate();
+        setConnectionState("recovering");
+        let cancelled = false;
+        let retryTimer: ReturnType<typeof setTimeout> | undefined;
+        cancelRecovery = () => {
+          cancelled = true;
+          clearTimeout(retryTimer);
+        };
+        const recover = async () => {
+          try {
+            await resync();
+            if (!cancelled) setConnectionState("connected");
+          } catch (error) {
+            if (cancelled) return;
+            console.error("Failed to resync live session state:", error);
+            retryTimer = setTimeout(() => void recover(), LIVE_RECOVERY_RETRY_MS);
+          }
+        };
+        void recover();
+      },
+      () => {
+        cancelRecovery();
+        setConnectionState("disconnected");
       },
     );
+    return () => {
+      cancelRecovery();
+      unsubscribe();
+    };
   }, [setScanStatus]);
 
   useEffect(() => () => clearPendingLiveUpdate(), []);
@@ -88,10 +112,13 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
   }, [newSessionCount]);
 
   return {
-    liveNotice: disconnected
-      ? t("Live updates disconnected; reconnecting…")
-      : newSessionCount == null
-        ? null
-        : t("{0} new sessions found; the list refreshed automatically", [newSessionCount]),
+    liveNotice:
+      connectionState === "disconnected"
+        ? t("Live updates disconnected; reconnecting…")
+        : connectionState === "recovering"
+          ? t("Live data may be out of date; synchronizing…")
+          : newSessionCount == null
+            ? null
+            : t("{0} new sessions found; the list refreshed automatically", [newSessionCount]),
   };
 }

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -506,6 +506,10 @@ export const messages = {
     "发现 {0} 个新会话，列表已自动刷新",
     "新しいセッションを {0} 件検出し、一覧を自動更新しました",
   ],
+  "Live data may be out of date; synchronizing…": [
+    "实时数据可能已过时，正在同步…",
+    "即時資料可能已過時，正在同步…",
+  ],
   "Live updates disconnected; reconnecting…": [
     "实时连接已断开，正在重连…",
     "ライブ更新が切断されました。再接続中…",


### PR DESCRIPTION
A successful SSE reconnect cleared the disconnect notice before the HTTP snapshot resync completed. If that resync failed, missed changes could remain absent indefinitely with no recovery notice.

Keep a distinct recovery notice until the full resync succeeds and retry failed resyncs every five seconds. Cancel scheduled retries on disconnect, another reconnect, or unmount, and prevent obsolete completions from clearing a newer disconnect. Include Simplified and Traditional Chinese translations.

Validation: Web lint and typecheck passed; all 77 live-sync, session-store, and API tests passed, as did the locale tests. Regressions cover failure followed by successful retry, cancellation, and stale recovery completion.
