### PR TITLE
feat(web): Clarify active hours periods and legend

### DIFF
--- a/apps/web/src/components/overview/overview-active-hours.test.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.test.tsx
@@ -26,6 +26,20 @@ describe("active hours chart", () => {
 
   it("scales circle area and exposes counts with hover, keyboard and touch", () => {
     render(<OverviewActiveHours activity={activity} />);
+    expect(screen.getAllByRole("rowheader").map((header) => header.textContent)).toEqual([
+      "00:00",
+      "02:00",
+      "04:00",
+      "06:00",
+      "08:00",
+      "10:00",
+      "12:00",
+      "14:00",
+      "16:00",
+      "18:00",
+      "20:00",
+      "22:00",
+    ]);
     const sunday = screen.getByRole("button", { name: "Sun · 00:00–02:00 · 4 user messages" });
     const monday = screen.getByRole("button", { name: "Mon · 00:00–02:00 · 1 user messages" });
     const radius = (button: HTMLElement) =>
@@ -45,14 +59,15 @@ describe("active hours chart", () => {
     expect(screen.queryByRole("tooltip")).toBeNull();
   });
 
-  it.each([
-    [2342, ["500", "1,000", "2,000"]],
-    [7, ["1", "2", "5"]],
-    [1, ["1"]],
-  ] as const)("uses rounded reference counts for a peak of %i", (peak, expected) => {
+  it.each([2342, 7, 1])("shows a relative area legend and the exact peak of %i", (peak) => {
     render(<OverviewActiveHours activity={{ ...activity, counts: [peak] }} />);
-    const legend = screen.getByText("Size reference (messages)").nextElementSibling!;
-    expect(Array.from(legend.children, (element) => element.textContent)).toEqual(expected);
+    const legend = screen.getByLabelText("Size reference (messages)");
+    expect(legend.textContent).toBe("LessMore");
+    const radii = Array.from(legend.querySelectorAll("svg"), (svg) =>
+      Number(svg.querySelector("circle")!.getAttribute("r")),
+    );
+    expect(radii).toEqual([4, 8, 12]);
+    expect(screen.getByText(`Peak: ${peak.toLocaleString("en-US")}`)).toBeTruthy();
   });
 
   it("distinguishes an empty range from unavailable data", () => {

--- a/apps/web/src/components/overview/overview-active-hours.test.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.test.tsx
@@ -15,18 +15,23 @@ afterEach(() => {
 describe("active hours chart", () => {
   it("reorders weekdays when language changes without moving message counts", () => {
     render(<OverviewActiveHours activity={activity} />);
-    expect(screen.getAllByRole("columnheader")[1]!.textContent).toBe("Sun");
+    expect(screen.getAllByRole("columnheader")[2]!.textContent).toBe("Sun");
     act(() => setLanguagePreference("zh-CN"));
-    expect(screen.getAllByRole("columnheader")[1]!.textContent).toBe("周一");
+    expect(screen.getAllByRole("columnheader")[2]!.textContent).toBe("周一");
     expect(screen.getByRole("button", { name: "周日 · 00:00–02:00 · 4 条用户消息" })).toBeTruthy();
     act(() => setLanguagePreference("ja"));
-    expect(screen.getAllByRole("columnheader")[1]!.textContent).toBe("日");
+    expect(screen.getAllByRole("columnheader")[2]!.textContent).toBe("日");
     expect(screen.getByText("タイムゾーン：Asia/Shanghai")).toBeTruthy();
   });
 
   it("scales circle area and exposes counts with hover, keyboard and touch", () => {
     render(<OverviewActiveHours activity={activity} />);
-    expect(screen.getAllByRole("rowheader").map((header) => header.textContent)).toEqual([
+    expect(
+      screen
+        .getAllByRole("rowheader")
+        .filter((header) => header.getAttribute("scope") === "row")
+        .map((header) => header.textContent),
+    ).toEqual([
       "00:00",
       "02:00",
       "04:00",
@@ -40,6 +45,14 @@ describe("active hours chart", () => {
       "20:00",
       "22:00",
     ]);
+    const groups = screen.getAllByRole("rowgroup").slice(1);
+    expect(groups.map((group) => group.querySelector('[scope="rowgroup"]')?.textContent)).toEqual([
+      "Overnight",
+      "Morning",
+      "Afternoon",
+      "Evening",
+    ]);
+    expect(groups.map((group) => group.querySelectorAll("tr").length)).toEqual([3, 3, 3, 3]);
     const sunday = screen.getByRole("button", { name: "Sun · 00:00–02:00 · 4 user messages" });
     const monday = screen.getByRole("button", { name: "Mon · 00:00–02:00 · 1 user messages" });
     const radius = (button: HTMLElement) =>

--- a/apps/web/src/components/overview/overview-active-hours.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.tsx
@@ -40,6 +40,7 @@ function ActivityBubble({ count, peak }: { count: number; peak: number }) {
 
 export function OverviewActiveHours({ activity }: { activity: DashboardActiveHours | null }) {
   const locale = useLocale();
+  const periods = [t("Overnight"), t("Morning"), t("Afternoon"), t("Evening")];
   const [active, setActive] = useState<number | null>(null);
   const weekdays = locale === "zh-CN" ? [1, 2, 3, 4, 5, 6, 0] : [0, 1, 2, 3, 4, 5, 6];
   const formatter = new Intl.DateTimeFormat(locale, { weekday: "short", timeZone: "UTC" });
@@ -69,7 +70,10 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
             <caption className="sr-only">{t("Active hours")}</caption>
             <thead>
               <tr>
-                <th scope="col" className="w-[48px] pb-2 text-left font-normal">
+                <th scope="col" className={locale === "en" ? "w-16" : "w-9"}>
+                  <span className="sr-only">{t("Day period")}</span>
+                </th>
+                <th scope="col" className="w-11 pb-2 text-left font-normal">
                   {t("Time")}
                 </th>
                 {labels.map((label) => (
@@ -79,53 +83,74 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
                 ))}
               </tr>
             </thead>
-            <tbody className="chart-hatch">
-              {Array.from({ length: 12 }, (_, slot) => (
-                <tr key={slot} className="border-t border-dashed border-[var(--console-border)]">
-                  <th
-                    scope="row"
-                    className="h-8 bg-[var(--console-surface)] text-left font-normal tabular-nums"
-                  >
-                    {`${String(slot * 2).padStart(2, "0")}:00`}
-                  </th>
-                  {weekdays.map((day, column) => {
-                    const index = day * 12 + slot;
-                    const count = activity.counts[index] ?? 0;
-                    const summary = `${labels[column]} · ${hourRange(slot)} · ${t("{0} user messages", [formatInt(count)])}`;
-                    return (
-                      <td key={day} className="relative p-0 text-center">
-                        <button
-                          type="button"
-                          aria-label={summary}
-                          className="flex h-8 w-full items-center justify-center rounded-sm outline-none hover:bg-[var(--brand-soft)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
-                          onMouseEnter={() => setActive(index)}
-                          onMouseLeave={() => setActive(null)}
-                          onFocus={() => setActive(index)}
-                          onBlur={() => setActive(null)}
-                          onClick={() => setActive(index)}
-                          onKeyDown={(event) => {
-                            if (event.key === "Escape") setActive(null);
-                          }}
+            {periods.map((period, group) => (
+              <tbody key={period} className="chart-hatch">
+                {Array.from({ length: 3 }, (_, row) => {
+                  const slot = group * 3 + row;
+                  return (
+                    <tr
+                      key={slot}
+                      className={
+                        row === 0 && group > 0
+                          ? "border-t border-solid border-[var(--console-border-strong)]"
+                          : "border-t border-dashed border-[var(--console-border)]"
+                      }
+                    >
+                      {row === 0 ? (
+                        <th
+                          scope="rowgroup"
+                          rowSpan={3}
+                          className="bg-[var(--console-surface)] pr-2 text-left align-middle font-normal"
                         >
-                          <ActivityBubble count={count} peak={peak} />
-                        </button>
-                        {active === index ? (
-                          <span
-                            role="tooltip"
-                            className={`pointer-events-none absolute bottom-full z-10 w-max max-w-[180px] rounded-md border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-2 text-left text-[var(--console-text)] shadow-[var(--shadow-overlay)] ${column < 3 ? "left-0" : "right-0"}`}
-                          >
-                            {`${labels[column]} · ${hourRange(slot)} · `}
-                            <span className="font-semibold text-[var(--brand)]">
-                              {t("{0} user messages", [formatInt(count)])}
-                            </span>
-                          </span>
-                        ) : null}
-                      </td>
-                    );
-                  })}
-                </tr>
-              ))}
-            </tbody>
+                          {period}
+                        </th>
+                      ) : null}
+                      <th
+                        scope="row"
+                        className="h-8 bg-[var(--console-surface)] text-left font-normal tabular-nums"
+                      >
+                        {`${String(slot * 2).padStart(2, "0")}:00`}
+                      </th>
+                      {weekdays.map((day, column) => {
+                        const index = day * 12 + slot;
+                        const count = activity.counts[index] ?? 0;
+                        const summary = `${labels[column]} · ${hourRange(slot)} · ${t("{0} user messages", [formatInt(count)])}`;
+                        return (
+                          <td key={day} className="relative p-0 text-center">
+                            <button
+                              type="button"
+                              aria-label={summary}
+                              className="flex h-8 w-full items-center justify-center rounded-sm outline-none hover:bg-[var(--brand-soft)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]"
+                              onMouseEnter={() => setActive(index)}
+                              onMouseLeave={() => setActive(null)}
+                              onFocus={() => setActive(index)}
+                              onBlur={() => setActive(null)}
+                              onClick={() => setActive(index)}
+                              onKeyDown={(event) => {
+                                if (event.key === "Escape") setActive(null);
+                              }}
+                            >
+                              <ActivityBubble count={count} peak={peak} />
+                            </button>
+                            {active === index ? (
+                              <span
+                                role="tooltip"
+                                className={`pointer-events-none absolute bottom-full z-10 w-max max-w-[180px] rounded-md border border-[var(--console-border)] bg-[var(--console-surface)] px-2.5 py-2 text-left text-[var(--console-text)] shadow-[var(--shadow-overlay)] ${column < 3 ? "left-0" : "right-0"}`}
+                              >
+                                {`${labels[column]} · ${hourRange(slot)} · `}
+                                <span className="font-semibold text-[var(--brand)]">
+                                  {t("{0} user messages", [formatInt(count)])}
+                                </span>
+                              </span>
+                            ) : null}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            ))}
           </table>
           <div className="mt-3 flex min-h-7 flex-wrap items-center justify-end gap-4 console-mono text-[10.5px] text-[var(--console-muted)]">
             {peak === 0 ? (

--- a/apps/web/src/components/overview/overview-active-hours.tsx
+++ b/apps/web/src/components/overview/overview-active-hours.tsx
@@ -9,19 +9,6 @@ function hourRange(slot: number): string {
   return `${String(slot * 2).padStart(2, "0")}:00–${String(slot * 2 + 2).padStart(2, "0")}:00`;
 }
 
-function referenceCounts(peak: number): number[] {
-  if (peak < 1) return [];
-  return [
-    ...new Set(
-      [peak / 4, peak / 2, peak].map((value) => {
-        const power = 10 ** Math.floor(Math.log10(Math.max(1, value)));
-        const step = value / power;
-        return (step >= 5 ? 5 : step >= 2 ? 2 : 1) * power;
-      }),
-    ),
-  ];
-}
-
 function ActivityBubble({ count, peak }: { count: number; peak: number }) {
   const pattern = useId();
   const scale = peak > 0 ? Math.sqrt(count / peak) : 0;
@@ -82,7 +69,7 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
             <caption className="sr-only">{t("Active hours")}</caption>
             <thead>
               <tr>
-                <th scope="col" className="w-[90px] pb-2 text-left font-normal">
+                <th scope="col" className="w-[48px] pb-2 text-left font-normal">
                   {t("Time")}
                 </th>
                 {labels.map((label) => (
@@ -99,7 +86,7 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
                     scope="row"
                     className="h-8 bg-[var(--console-surface)] text-left font-normal tabular-nums"
                   >
-                    {hourRange(slot)}
+                    {`${String(slot * 2).padStart(2, "0")}:00`}
                   </th>
                   {weekdays.map((day, column) => {
                     const index = day * 12 + slot;
@@ -145,17 +132,17 @@ export function OverviewActiveHours({ activity }: { activity: DashboardActiveHou
               <span>{t("No user messages in this range.")}</span>
             ) : (
               <>
-                <span title={t("Reference sizes; these counts may not occur in the chart.")}>
-                  {t("Size reference (messages)")}
-                </span>
-                <span className="flex items-center gap-4">
-                  {referenceCounts(peak).map((count) => (
-                    <span key={count} className="flex items-center gap-1.5">
-                      <ActivityBubble count={count} peak={peak} />
-                      {formatInt(count)}
-                    </span>
+                <span
+                  className="flex items-center gap-1.5"
+                  aria-label={t("Size reference (messages)")}
+                >
+                  {t("Less")}
+                  {[1, 4, 9].map((count) => (
+                    <ActivityBubble key={count} count={count} peak={9} />
                   ))}
+                  {t("More")}
                 </span>
+                <span>{t("Peak: {0}", [formatInt(peak)])}</span>
               </>
             )}
           </div>

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -18,10 +18,9 @@ export const messages = {
     "この期間のユーザーメッセージはありません。",
   ],
   "Size reference (messages)": ["大小参考（消息数）", "サイズの目安（メッセージ数）"],
-  "Reference sizes; these counts may not occur in the chart.": [
-    "圆点面积的参考刻度，不代表图中一定存在对应计数。",
-    "円の面積の目安です。グラフ内に同じ件数が存在するとは限りません。",
-  ],
+  Less: ["少", "少ない"],
+  More: ["多", "多い"],
+  "Peak: {0}": ["峰值：{0}", "最大：{0}"],
   COST: ["费用", "費用"],
   plan: ["计划", "計画"],
   USER: ["用户", "ユーザー"],

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -1,5 +1,10 @@
 // English source messages map to [Simplified Chinese, Japanese].
 export const messages = {
+  "Day period": ["时段分组", "時間帯の区分"],
+  Overnight: ["凌晨", "未明"],
+  Morning: ["上午", "午前"],
+  Afternoon: ["下午", "午後"],
+  Evening: ["晚上", "夜間"],
   Time: ["时段", "時間帯"],
   "Active hours": ["活跃时段", "アクティブな時間帯"],
   "User messages by weekday and two-hour period. Counts are cumulative within the selected range.":


### PR DESCRIPTION
Make the Active hours bubble chart easier to scan by grouping its rows into Overnight (00:00–06:00), Morning (06:00–12:00), Afternoon (12:00–18:00), and Evening (18:00–24:00). Each group has a label spanning three rows and a solid separator at its boundary. Group labels are localized in English, Chinese, and Japanese.

Two-hour rows show only their starting time, with a narrower time-label column. Tooltips and accessible button labels retain the full interval and exact message count. The legend shows three progressively larger bubbles between Less and More, plus the exact peak count. Bubble area scaling, texture, weekday columns, and interactions retain their original behavior.

Validation:
- 14 related tests passed, covering grouping, area scaling, full-range tooltips, short row labels, and the relative legend.
- Web typecheck, lint, format check, and production build passed.
- Browser checks of desktop and 375px layouts, including Chinese and English group labels.
