### PR TITLE
fix(core): Use the user activity index on startup

### DIFF
--- a/packages/core/src/discovery/cache/__tests__/active-hours.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/active-hours.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const home = mkdtempSync(join(tmpdir(), "codesesh-active-hours-"));
@@ -10,7 +11,7 @@ vi.mock("node:os", async (original) => ({
 }));
 
 import { listDashboardActiveHours } from "../active-hours.js";
-import { closeCacheStorage } from "../db.js";
+import { closeCacheStorage, getCachePath } from "../db.js";
 import { syncSessionSearchIndex } from "../search.js";
 import { saveCachedSessions } from "../sessions.js";
 import { loadCachedSessionRawEntry } from "../sessions.js";
@@ -91,6 +92,27 @@ describe("user active hours", () => {
         (m) => m.message_id === "injected",
       )?.automated,
     ).toBe(1);
+  });
+
+  it.each([undefined, from])("reads the user activity index with lower bound %s", (lowerBound) => {
+    seed();
+    const prepare = vi.spyOn(Database.prototype, "prepare");
+    let sql: string;
+    try {
+      expect(listDashboardActiveHours({ ...options, from: lowerBound })!.counts).toHaveLength(84);
+      sql = prepare.mock.calls.find(([source]) => source.includes("SELECT m.time_created"))![0];
+    } finally {
+      prepare.mockRestore();
+    }
+    const db = new Database(getCachePath(), { readonly: true });
+    try {
+      const params = lowerBound === undefined ? [to] : [to, lowerBound];
+      const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(...params) as { detail: string }[];
+      expect(plan[0]!.detail).toContain("idx_messages_user_activity");
+      expect(plan.map(({ detail }) => detail).join("\n")).not.toContain("idx_messages_session");
+    } finally {
+      db.close();
+    }
   });
 
   it("uses the requested time zone across midnight and repeated DST hours", () => {

--- a/packages/core/src/discovery/cache/active-hours.ts
+++ b/packages/core/src/discovery/cache/active-hours.ts
@@ -45,9 +45,10 @@ export function listDashboardActiveHours(
   }
   const read = withCacheDbReadOnly((db) => {
     const counts = Array<number>(84).fill(0);
+    // Avoid the session-first plan, which reads every message before filtering user activity.
     const rows = db
       .prepare(`
-      SELECT m.time_created FROM messages m
+      SELECT m.time_created FROM messages m INDEXED BY idx_messages_user_activity
       JOIN sessions s ON s.agent_name = m.agent_name AND s.session_id = m.session_id
       WHERE ${clauses.join(" AND ")}
     `)


### PR DESCRIPTION
The first dashboard request can block the local HTTP server for several seconds. SQLite chooses the parent-session index followed by per-session message lookups for Active hours, reading unrelated message rows before applying the user-message and date predicates.

Pin this query to the existing partial idx_messages_user_activity index. It contains only timed, non-automated user messages and supports the date range before joining session metadata. Counting, scope filters, and time-zone handling remain unchanged; no schema migration is required.

Evidence from a local cache:
- Recent startup logs: CLI ready in about 0.2s, first dashboard request 8.2–8.9s, storage aggregation 7.6–8.2s.
- All-time SQL read: about 9,000ms before versus 59ms with the index, both returning 62,578 timestamps.
- Complete Active hours aggregation after the change: 203ms standalone and 125ms during a browser startup run.
- End-to-end browser runs after the change: default 7-day overview visible in 3.2s; all-time overview in 4.6s. Other aggregation and startup work still contributes to these totals. These are local measurements, not universal latency guarantees.

Validation:
- Core: 1,122 tests passed, 1 skipped.
- New query-plan checks cover bounded and all-time windows and fail with the old query.
- Existing tests preserve counts, filters, boundary timestamps, and DST behavior.
- Core lint, format check, typecheck/build, and CLI build passed.
- Real CLI + Chromium startup checks against the local cache.
