### PR TITLE
fix: Refresh aggregates after overlapping updates

### DIFF
--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -820,15 +820,16 @@ describe("useSessionStore", () => {
     expect(result.current.version).toBeGreaterThan(0);
   });
 
-  it("keeps overlapping live events on the incremental path", async () => {
+  it("refreshes aggregates again after an event arrives during an in-flight refresh", async () => {
     const { result } = await renderStore();
     await act(() => result.current.reload());
     vi.mocked(api.fetchSessions).mockClear();
     const firstAgents = deferred<AgentInfo[]>();
+    const updatedAgents = agents.map((agent) => ({ ...agent, count: agent.count + 1 }));
     vi.mocked(api.fetchAgents)
       .mockClear()
       .mockReturnValueOnce(firstAgents.promise)
-      .mockResolvedValue(agents);
+      .mockResolvedValue(updatedAgents);
 
     let firstUpdate!: ReturnType<typeof result.current.applyLiveEvent>;
     let secondUpdate!: ReturnType<typeof result.current.applyLiveEvent>;
@@ -841,6 +842,8 @@ describe("useSessionStore", () => {
     firstAgents.resolve(agents);
     await act(async () => firstAgents.promise);
 
+    await waitFor(() => expect(result.current.agents).toEqual(updatedAgents));
+    expect(api.fetchAgents).toHaveBeenCalledTimes(2);
     expect(api.fetchSessions).not.toHaveBeenCalled();
     expect(result.current.version).toBeGreaterThan(0);
   });

--- a/apps/web/src/hooks/useSessionStore.ts
+++ b/apps/web/src/hooks/useSessionStore.ts
@@ -219,6 +219,7 @@ function sameWindow(
 export function useSessionStore(window: AppConfig["window"] | null) {
   const queryClient = useQueryClient();
   const pendingProjectionLoads = useRef(new PendingSessionProjectionLoads()).current;
+  const liveAggregateRefreshRef = useRef<{ dirty: boolean } | null>(null);
   const liveAggregateWindowRef = useRef<AppConfig["window"] | null>(null);
   const liveAggregateRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const projectionQuery = useQuery<SessionProjection>({
@@ -259,6 +260,7 @@ export function useSessionStore(window: AppConfig["window"] | null) {
 
   useEffect(
     () => () => {
+      liveAggregateRefreshRef.current = null;
       if (liveAggregateRefreshTimerRef.current) {
         clearTimeout(liveAggregateRefreshTimerRef.current);
         liveAggregateRefreshTimerRef.current = null;
@@ -328,16 +330,30 @@ export function useSessionStore(window: AppConfig["window"] | null) {
       const forceAggregateRefresh = !sameWindow(liveAggregateWindowRef.current, activeWindow);
       const refreshAggregates = () => {
         liveAggregateRefreshTimerRef.current = null;
-        void Promise.all([
-          refreshLiveSnapshotAggregates(queryClient, activeWindow),
-          refreshProjectQueries(queryClient, activeWindow),
-        ])
-          .then(() => {
-            liveAggregateWindowRef.current = activeWindow;
-          })
-          .catch(() => undefined);
+        if (liveAggregateRefreshRef.current) {
+          liveAggregateRefreshRef.current.dirty = true;
+          return;
+        }
+        const refresh = { dirty: false };
+        liveAggregateRefreshRef.current = refresh;
+        const run = async () => {
+          try {
+            do {
+              refresh.dirty = false;
+              await Promise.all([
+                refreshLiveSnapshotAggregates(queryClient, activeWindow),
+                refreshProjectQueries(queryClient, activeWindow),
+              ]);
+              if (liveAggregateRefreshRef.current !== refresh) return;
+              liveAggregateWindowRef.current = activeWindow;
+            } while (refresh.dirty);
+          } finally {
+            if (liveAggregateRefreshRef.current === refresh) liveAggregateRefreshRef.current = null;
+          }
+        };
+        void run().catch(() => undefined);
       };
-      if (forceAggregateRefresh) {
+      if (forceAggregateRefresh || liveAggregateRefreshRef.current) {
         refreshAggregates();
       } else if (!liveAggregateRefreshTimerRef.current) {
         const delay = liveAggregateRefreshDelay(queryClient, activeWindow);


### PR DESCRIPTION
Live events arriving during an aggregate request could reuse its older response without scheduling another refresh, leaving dashboard and project statistics behind the session list. Coalesce these events into a trailing refresh owned by the active window, and discard pending work when the window changes.

Validation: web lint and typecheck passed; all 35 useSessionStore tests passed, including an overlapping-request regression that checks the final agent counts.
