### PR TITLE
fix: Keep unavailable session details retryable

### DIFF
--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -121,9 +121,9 @@ describe("useSessionDetail", () => {
     expect(result.current.session).toBeNull();
   });
 
-  it("recovers from a failed detail request with a local retry", async () => {
+  it.each([500, 503])("recovers from a %i detail response with a local retry", async (status) => {
     vi.mocked(api.fetchSessionData)
-      .mockRejectedValueOnce(new api.ApiRequestError("server unavailable", 500))
+      .mockRejectedValueOnce(new api.ApiRequestError("server unavailable", status))
       .mockResolvedValueOnce(sample);
     const { result } = renderSessionDetail();
 

--- a/packages/cli/src/api/__tests__/session-handlers.test.ts
+++ b/packages/cli/src/api/__tests__/session-handlers.test.ts
@@ -599,13 +599,15 @@ describe("handleGetSessionData", () => {
     expect(c.json).toHaveBeenCalledWith({ error: "Unknown agent: unknown" }, 404);
   });
 
-  it("maps unavailable detail to 404", async () => {
+  it("maps unavailable detail to a retryable 503", async () => {
     coreMocks.materializeSessionDetailResponse.mockReturnValue({ status: "not-ready" });
     const c = makeMockContext({ param: { agent: "claudecode", id: "s1" } });
+    c.header = vi.fn();
 
     await handleGetSessionData(c, makeScanSource());
 
-    expect(c.json).toHaveBeenCalledWith({ error: "Session cache not ready" }, 404);
+    expect(c.header).toHaveBeenCalledWith("Retry-After", "1");
+    expect(c.json).toHaveBeenCalledWith({ error: "Session detail not ready; retry later" }, 503);
   });
 
   it("maps materialization errors to 500", async () => {

--- a/packages/cli/src/api/session-handlers.ts
+++ b/packages/cli/src/api/session-handlers.ts
@@ -202,7 +202,8 @@ export async function handleGetSessionData(
         session_id: sessionId,
         duration_ms: Math.round(performance.now() - startedAt),
       });
-      return c.json({ error: "Session cache not ready" }, 404);
+      c.header("Retry-After", "1");
+      return c.json({ error: "Session detail not ready; retry later" }, 503);
     }
 
     appLogger.info("api.session_data", {


### PR DESCRIPTION
An unavailable session detail returned 404, so the UI showed a missing-session page without a retry action. Return 503 with Retry-After for the existing not-ready outcome, allowing the existing load-failure page to offer a retry. Unknown agents continue to return 404; absence from a partial snapshot is not treated as proof that a source session does not exist.

Validation: repository lint and format checks, CLI and web typechecks, 32 session-handler tests, and 17 session-detail hook tests passed. Tests cover the retry header and recovery from a 503 response.
