### PR TITLE
fix: Recover from failed live session updates

### DIFF
--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -141,37 +141,47 @@ describe("useLiveSync", () => {
     expect(deps.resyncLiveState).toHaveBeenCalledOnce();
     expect(deps.applyLiveEvent).not.toHaveBeenCalled();
   });
-  it("keeps the recovery notice until a failed resync is retried successfully", async () => {
-    vi.useFakeTimers();
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    const deps = makeDeps();
-    let finishRecovery!: () => void;
-    deps.resyncLiveState
-      .mockRejectedValueOnce(new Error("HTTP unavailable"))
-      .mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            finishRecovery = resolve;
-          }),
-      );
-    const { result } = renderHook(() => useLiveSync(deps));
+  it.each(["reconnect", "event-failure"])(
+    "retries a failed resync after %s until recovery succeeds",
+    async (trigger) => {
+      vi.useFakeTimers();
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const deps = makeDeps();
+      let finishRecovery!: () => void;
+      deps.resyncLiveState
+        .mockRejectedValueOnce(new Error("HTTP unavailable"))
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((resolve) => {
+              finishRecovery = resolve;
+            }),
+        );
+      const { result } = renderHook(() => useLiveSync(deps));
 
-    await act(async () => reconnectCallback?.());
-    expect(result.current.liveNotice).toBe("Live data may be out of date; synchronizing…");
+      await act(async () => {
+        if (trigger === "reconnect") reconnectCallback?.();
+        else {
+          deps.applyLiveEvent.mockRejectedValueOnce(new Error("Event apply failed"));
+          sessionsCallback?.(SAMPLE_SESSIONS_UPDATED_EVENT);
+          await vi.advanceTimersByTimeAsync(500);
+        }
+      });
+      expect(result.current.liveNotice).toBe("Live data may be out of date; synchronizing…");
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_000);
-    });
-    expect(deps.resyncLiveState).toHaveBeenCalledTimes(2);
-    expect(result.current.liveNotice).toBe("Live data may be out of date; synchronizing…");
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      expect(deps.resyncLiveState).toHaveBeenCalledTimes(2);
+      expect(result.current.liveNotice).toBe("Live data may be out of date; synchronizing…");
 
-    await act(async () => finishRecovery());
-    expect(result.current.liveNotice).toBeNull();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(15_000);
-    });
-    expect(deps.resyncLiveState).toHaveBeenCalledTimes(2);
-  });
+      await act(async () => finishRecovery());
+      expect(result.current.liveNotice).toBeNull();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+      expect(deps.resyncLiveState).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it.each(["disconnect", "unmount"] as const)(
     "cancels scheduled recovery on %s",
@@ -207,4 +217,37 @@ describe("useLiveSync", () => {
     await act(async () => finishRecovery());
     expect(result.current.liveNotice).toBe("Live updates disconnected; reconnecting…");
   });
+  it.each(["disconnect", "unmount"] as const)(
+    "does not start recovery when an in-flight event fails after %s",
+    async (reason) => {
+      vi.useFakeTimers();
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      const deps = makeDeps();
+      let failEvent!: (error: Error) => void;
+      deps.applyLiveEvent.mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            failEvent = reject;
+          }),
+      );
+      const { result, unmount } = renderHook(() => useLiveSync(deps));
+      await act(async () => {
+        sessionsCallback?.(SAMPLE_SESSIONS_UPDATED_EVENT);
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      if (reason === "unmount") unmount();
+      else act(() => disconnectCallback?.());
+      await act(async () => {
+        failEvent(new Error("Event apply failed"));
+        await vi.advanceTimersByTimeAsync(15_000);
+      });
+      expect(deps.resyncLiveState).not.toHaveBeenCalled();
+      if (reason === "disconnect") {
+        expect(result.current.liveNotice).toBe("Live updates disconnected; reconnecting…");
+        await act(async () => reconnectCallback?.());
+        expect(deps.resyncLiveState).toHaveBeenCalledOnce();
+        expect(result.current.liveNotice).toBeNull();
+      }
+    },
+  );
 });

--- a/apps/web/src/hooks/useLiveSync.ts
+++ b/apps/web/src/hooks/useLiveSync.ts
@@ -25,6 +25,7 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
   const pendingEventRef = useRef<SessionsUpdatedEvent | null>(null);
   const pendingTimerRef = useRef<number | null>(null);
   const updateChainRef = useRef(Promise.resolve());
+  const startRecoveryRef = useRef(() => {});
 
   const syncLiveUpdate = useEffectEvent(async (event: SessionsUpdatedEvent) => {
     try {
@@ -34,6 +35,7 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
       }
     } catch (error) {
       console.error("Failed to sync live session update:", error);
+      startRecoveryRef.current();
     }
   });
 
@@ -59,6 +61,29 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
 
   useEffect(() => {
     let cancelRecovery = () => {};
+    const startRecovery = () => {
+      cancelRecovery();
+      clearPendingLiveUpdate();
+      setConnectionState("recovering");
+      let cancelled = false;
+      let retryTimer: ReturnType<typeof setTimeout> | undefined;
+      cancelRecovery = () => {
+        cancelled = true;
+        clearTimeout(retryTimer);
+      };
+      const recover = async () => {
+        try {
+          await resync();
+          if (!cancelled) setConnectionState("connected");
+        } catch (error) {
+          if (cancelled) return;
+          console.error("Failed to resync live session state:", error);
+          retryTimer = setTimeout(() => void recover(), LIVE_RECOVERY_RETRY_MS);
+        }
+      };
+      void recover();
+    };
+    startRecoveryRef.current = startRecovery;
     const unsubscribe = subscribeSessionUpdates(
       (event) => {
         pendingEventRef.current = pendingEventRef.current
@@ -71,33 +96,17 @@ export function useLiveSync({ applyLiveEvent, resyncLiveState, setScanStatus }: 
       },
       setScanStatus,
       () => {
-        cancelRecovery();
-        clearPendingLiveUpdate();
-        setConnectionState("recovering");
-        let cancelled = false;
-        let retryTimer: ReturnType<typeof setTimeout> | undefined;
-        cancelRecovery = () => {
-          cancelled = true;
-          clearTimeout(retryTimer);
-        };
-        const recover = async () => {
-          try {
-            await resync();
-            if (!cancelled) setConnectionState("connected");
-          } catch (error) {
-            if (cancelled) return;
-            console.error("Failed to resync live session state:", error);
-            retryTimer = setTimeout(() => void recover(), LIVE_RECOVERY_RETRY_MS);
-          }
-        };
-        void recover();
+        startRecoveryRef.current = startRecovery;
+        startRecovery();
       },
       () => {
+        startRecoveryRef.current = () => {};
         cancelRecovery();
         setConnectionState("disconnected");
       },
     );
     return () => {
+      startRecoveryRef.current = () => {};
       cancelRecovery();
       unsubscribe();
     };


### PR DESCRIPTION
A failed live event application was logged and discarded while the UI remained connected. Start the existing full-resync recovery loop on application failure, keep the recovery notice until synchronization succeeds, and retain the existing retry delay. Disable this trigger on disconnect and unmount so late failures cannot restart recovery.

Validation: web lint, format check, and typecheck passed; all 883 web tests passed. Regression coverage checks successful retry without an SSE reconnect and late event failures after disconnect or unmount.
