### PR TITLE
chore(lint): Enforce reviewed anti-slop policy

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -4,6 +4,22 @@
     "**/dist/**",
     "**/node_modules/**",
     "**/.turbo/**",
-    "**/docs/**"
+    "**/docs/**",
+    ".agent/**",
+    ".agents/**",
+    ".claude/**",
+    ".codex/**",
+    ".continue/**",
+    ".cursor/**",
+    ".gemini/**",
+    ".opencode/**",
+    ".pi/**",
+    ".roo/**",
+    ".windsurf/**",
+    ".delta/**",
+    ".design/**",
+    ".issues/**",
+    ".worktree/**",
+    "tools/oxlint/anti-slop/**"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,10 +1,46 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc", "react", "import"],
+  "jsPlugins": [
+    {
+      "name": "anti-slop",
+      "specifier": "./tools/oxlint/anti-slop/index.ts"
+    }
+  ],
   "categories": {
     "correctness": "error"
   },
-  "rules": {},
+  "rules": {
+    "oxc/no-accumulating-spread": "error",
+    "anti-slop/no-array-filter-map": "off",
+    "anti-slop/no-reduce-accumulator-copy": "error",
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-conditional-empty-object-spread": "off",
+    "anti-slop/no-known-value-widening": "error",
+    "anti-slop/no-module-mocking": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-runtime-typeof": "off",
+    "anti-slop/no-shape-in-symbol-names": "off",
+    "anti-slop/no-unknown-parameters": "off",
+    "anti-slop/no-unknown-returns": "off",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-unsafe-dictionary-type": [
+      "error",
+      {
+        "allowUnknown": true
+      }
+    ],
+    "anti-slop/no-widen-then-assert": "error",
+    "anti-slop/require-readable-spacing": "error",
+    "anti-slop/require-safety-comment-for-type-assertion": [
+      "error",
+      {
+        "scope": "type-escapes"
+      }
+    ]
+  },
   "env": {
     "builtin": true
   },
@@ -13,6 +49,25 @@
     "**/node_modules/**",
     "**/.turbo/**",
     "**/docs/**",
-    "**/.claude/**"
-  ]
+    "**/.claude/**",
+    ".agent/**",
+    ".agents/**",
+    ".claude/**",
+    ".codex/**",
+    ".continue/**",
+    ".cursor/**",
+    ".gemini/**",
+    ".opencode/**",
+    ".pi/**",
+    ".roo/**",
+    ".windsurf/**",
+    ".delta/**",
+    ".design/**",
+    ".issues/**",
+    ".worktree/**",
+    "tools/oxlint/anti-slop/**"
+  ],
+  "options": {
+    "reportUnusedDisableDirectives": "error"
+  }
 }

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -19,6 +19,7 @@ const clientTelemetry = vi.hoisted(() => ({
   logClientEvent: vi.fn<(event: string, data?: Record<string, unknown>) => void>(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Drive subscription events and observe telemetry without a live SSE server.
 vi.mock("./lib/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./lib/api")>()),
   subscribeSessionUpdates: (onUpdate: (event: SessionsUpdatedEvent) => void) => {
@@ -75,6 +76,7 @@ const workspaceProjectPage = {
   },
 };
 
+// oxlint-disable-next-line anti-slop/no-known-value-widening -- This fetch fixture routes heterogeneous JSON response schemas by endpoint path.
 const responses: Record<string, unknown> = {
   "/api/config": { window: { days: 30 } },
   "/api/agents": [],
@@ -97,7 +99,7 @@ const responses: Record<string, unknown> = {
 };
 
 let requestedUrls: string[] = [];
-let projectDetailResponse: unknown = null;
+let projectDetailResponse: typeof workspaceProjectPage | null = null;
 
 beforeEach(() => {
   requestedUrls = [];

--- a/apps/web/src/components/InteractiveReceipt.test.tsx
+++ b/apps/web/src/components/InteractiveReceipt.test.tsx
@@ -88,6 +88,7 @@ function installFonts(ready: Promise<unknown>) {
 
 function createMediaQueryControl(query: string, matches: boolean): MediaQueryControl {
   const listeners = new Set<EventListenerOrEventListenerObject>();
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The media-query fixture installs controlled listeners below before exposing the list.
   const list = {
     media: query,
     matches,
@@ -116,8 +117,8 @@ function createMediaQueryControl(query: string, matches: boolean): MediaQueryCon
       Object.defineProperty(list, "matches", { configurable: true, value: nextMatches });
       const event = { matches: nextMatches, media: query } as MediaQueryListEvent;
       for (const listener of listeners) {
-        if (typeof listener === "function") listener.call(list, event as unknown as Event);
-        else listener.handleEvent(event as unknown as Event);
+        if (typeof listener === "function") listener.call(list, event as Event);
+        else listener.handleEvent(event as Event);
       }
     },
   };
@@ -169,8 +170,10 @@ function installEnvironment({
   });
 
   const context = createCanvasContext();
+  // SAFETY: The receipt painter only calls the canvas methods recorded by this stub.
   const getContext = vi
     .spyOn(HTMLCanvasElement.prototype, "getContext")
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- The receipt painter only calls the canvas methods recorded by this stub.
     .mockReturnValue(context as unknown as CanvasRenderingContext2D);
   const frames = stubAnimationFrames();
 

--- a/apps/web/src/components/ResourceLoadFailure.tsx
+++ b/apps/web/src/components/ResourceLoadFailure.tsx
@@ -1,5 +1,6 @@
 import { useLocale } from "../hooks/useLocale";
 import { t } from "../i18n/translate";
+
 export function ResourceLoadFailure({
   title,
   message,

--- a/apps/web/src/components/SessionDetail.test.tsx
+++ b/apps/web/src/components/SessionDetail.test.tsx
@@ -7,6 +7,7 @@ const displayModelMocks = vi.hoisted(() => ({
   build: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count display model construction to verify unrelated UI state does not rebuild the transcript.
 vi.mock("./session-detail/display-model", () => ({
   buildSessionDetailDisplayModel: displayModelMocks.build,
 }));

--- a/apps/web/src/components/SessionDetail.tsx
+++ b/apps/web/src/components/SessionDetail.tsx
@@ -1,6 +1,5 @@
 import { useLocale } from "../hooks/useLocale";
 import { t } from "../i18n/translate";
-/* eslint-disable react/no-array-index-key */
 import { ChevronDown, ChevronUp, FileText } from "./ui/icons";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { formatSessionReference } from "@codesesh/core/contract";

--- a/apps/web/src/components/SessionDetailSkeleton.tsx
+++ b/apps/web/src/components/SessionDetailSkeleton.tsx
@@ -1,4 +1,5 @@
 import { useLocale } from "../hooks/useLocale";
+
 /**
  * Mirrors the reader's real two-column grid (288px filter aside + stream) so
  * loading → ready does not shift the page.

--- a/apps/web/src/components/app/AppRouteContent.test.tsx
+++ b/apps/web/src/components/app/AppRouteContent.test.tsx
@@ -9,6 +9,7 @@ import { AppRouteContent, type AppRouteModel } from "./AppRouteContent";
 
 const sessionDetailRender = vi.hoisted(() => vi.fn());
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe route-to-detail props without mounting the full transcript UI.
 vi.mock("../SessionDetail", () => ({
   SessionDetail: (props: { session: SessionDetail; childSessions: SessionDetail[] }) => {
     sessionDetailRender(props);

--- a/apps/web/src/components/app/AppToolbar.tsx
+++ b/apps/web/src/components/app/AppToolbar.tsx
@@ -1,5 +1,6 @@
 import { useLocale } from "../../hooks/useLocale";
 import { t } from "../../i18n/translate";
+
 declare const __APP_VERSION__: string;
 
 import type { Ref } from "react";

--- a/apps/web/src/components/overview/OverviewScreen.test.tsx
+++ b/apps/web/src/components/overview/OverviewScreen.test.tsx
@@ -8,6 +8,7 @@ import * as api from "../../lib/api";
 import { createQueryWrapper } from "../../test/query-wrapper";
 import { OverviewScreen } from "./OverviewScreen";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../../lib/api", () => ({ fetchDashboard: vi.fn() }));
 
 const timeWindow = { from: 1, to: 2, days: 7 } as AppConfig["window"];
@@ -83,7 +84,7 @@ const dashboard = {
   activeHours: null,
   modelCost: [{ model: "sonnet", cost: 6, costRecorded: 1, costEstimated: 5 }],
   window: { from: 1, to: 2, days: 7 },
-} as unknown as DashboardData;
+} as DashboardData;
 
 function renderScreen(props: Partial<ComponentProps<typeof OverviewScreen>> = {}) {
   const { Wrapper } = createQueryWrapper();

--- a/apps/web/src/components/overview/overview-usage-chart.test.tsx
+++ b/apps/web/src/components/overview/overview-usage-chart.test.tsx
@@ -92,6 +92,7 @@ describe("OverviewUsageChart", () => {
       new Proxy(daily[1]!, {
         get(target, property, receiver) {
           if (property === "sessions") unrelatedReads++;
+          // oxlint-disable-next-line anti-slop/no-reflect-get -- This Proxy must preserve receiver semantics while counting reads of the real target.
           return Reflect.get(target, property, receiver);
         },
       }),

--- a/apps/web/src/components/session-detail/hidden-tools-footer.tsx
+++ b/apps/web/src/components/session-detail/hidden-tools-footer.tsx
@@ -1,5 +1,6 @@
 import { useLocale } from "../../hooks/useLocale";
 import { t } from "../../i18n/translate";
+
 /**
  * Closes the stream with an honest account of what the current filter removed,
  * and the single action that undoes it.

--- a/apps/web/src/components/session-detail/message-list.test.tsx
+++ b/apps/web/src/components/session-detail/message-list.test.tsx
@@ -7,6 +7,7 @@ import { createTimelineAnchorRegistry } from "./timeline-anchor-registry";
 
 const anchorRegistry = createTimelineAnchorRegistry();
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Render observable row indices to test virtualized ranges without transcript renderer dependencies.
 vi.mock("./message-rendering", () => ({
   MessageItem: ({ messageIndex }: { messageIndex: number }) => (
     <div data-message-index={messageIndex}>Message {messageIndex}</div>
@@ -42,7 +43,7 @@ class ResizeObserverMock {
 
   trigger(target: Element) {
     if (!this.targets.has(target)) return;
-    this.callback([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver);
+    this.callback([{ target } as ResizeObserverEntry], this as ResizeObserver);
   }
 }
 

--- a/apps/web/src/components/session-detail/message-markdown-memo.test.tsx
+++ b/apps/web/src/components/session-detail/message-markdown-memo.test.tsx
@@ -13,6 +13,7 @@ const { markdownRender } = vi.hoisted(() => ({
 
 // Stubbed so the assertions count parses rather than markdown output; the
 // rendered highlight itself is covered by MarkdownContent.test.tsx.
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count markdown renders and inspect plugin inputs to verify memoization.
 vi.mock("react-markdown", () => ({
   default: ({ children, rehypePlugins }: { children: string; rehypePlugins?: unknown[] }) => {
     markdownRender(children, rehypePlugins);

--- a/apps/web/src/components/session-detail/message-rendering.test.tsx
+++ b/apps/web/src/components/session-detail/message-rendering.test.tsx
@@ -7,6 +7,7 @@ import type { MessageBlock } from "./blocks";
 
 const normalizeToolStateCalls = vi.hoisted(() => vi.fn());
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real tool normalization calls to verify rendering memoization.
 vi.mock("./tool-strategy", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./tool-strategy")>();
   return {

--- a/apps/web/src/components/session-detail/session-message-timeline.test.tsx
+++ b/apps/web/src/components/session-detail/session-message-timeline.test.tsx
@@ -29,7 +29,8 @@ class IntersectionObserverMock {
 
   trigger(changes: Array<{ target: Element; isIntersecting: boolean }>) {
     this.callback(
-      changes as unknown as IntersectionObserverEntry[],
+      changes as IntersectionObserverEntry[],
+      // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: This observer fixture supplies the callback identity; timeline tests drive intersection entries explicitly.
       this as unknown as IntersectionObserver,
     );
   }

--- a/apps/web/src/components/session-detail/timeline.ts
+++ b/apps/web/src/components/session-detail/timeline.ts
@@ -13,6 +13,7 @@ export type SessionTimelineEntryKind =
   | "tool-read"
   | "tool-write"
   | "tool-execute";
+
 export type ToolTimelineEntryKind = Extract<SessionTimelineEntryKind, `tool-${string}`>;
 
 export interface SessionTimelineEntry {

--- a/apps/web/src/components/session-detail/tool-strategy.test.ts
+++ b/apps/web/src/components/session-detail/tool-strategy.test.ts
@@ -732,16 +732,17 @@ describe("getToolDisplayStrategy", () => {
 
 describe("getAssistantDisplayLabel", () => {
   it("returns USER for user role", () => {
-    expect(getAssistantDisplayLabel({ role: "user" } as unknown as Message)).toBe("USER");
+    expect(getAssistantDisplayLabel({ role: "user" } as Message)).toBe("USER");
   });
 
   it("returns AGENT for assistant role", () => {
-    expect(getAssistantDisplayLabel({ role: "assistant" } as unknown as Message)).toBe("AGENT");
+    expect(getAssistantDisplayLabel({ role: "assistant" } as Message)).toBe("AGENT");
   });
 });
 
 describe("normalizeMessagesForDisplay", () => {
   it("returns messages unchanged for non-cursor agents", () => {
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: This deliberately minimal message must pass through untouched for agents without normalization.
     const messages = [{ role: "user", content: "hi" } as unknown as Message];
     expect(normalizeMessagesForDisplay(messages, "claudecode")).toBe(messages);
   });

--- a/apps/web/src/hooks/fluid-hover.test.ts
+++ b/apps/web/src/hooks/fluid-hover.test.ts
@@ -5,6 +5,7 @@ let dispose: (() => void) | undefined;
 
 beforeEach(() => {
   vi.useFakeTimers();
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: This fixture supplies only the media-query state and subscription methods read by fluid hover.
   vi.spyOn(window, "matchMedia").mockReturnValue({
     matches: true,
     addEventListener: vi.fn(),

--- a/apps/web/src/hooks/useAppConfig.test.ts
+++ b/apps/web/src/hooks/useAppConfig.test.ts
@@ -5,6 +5,7 @@ import * as api from "../lib/api";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useAppConfig } from "./useAppConfig";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", () => ({ fetchConfig: vi.fn() }));
 
 const config = {

--- a/apps/web/src/hooks/useBookmarks.test.ts
+++ b/apps/web/src/hooks/useBookmarks.test.ts
@@ -6,6 +6,7 @@ import * as bookmarkUtils from "../lib/bookmarks";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useBookmarks } from "./useBookmarks";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", () => ({
   fetchBookmarks: vi.fn(),
   importBookmarks: vi.fn(),
@@ -14,6 +15,7 @@ vi.mock("../lib/api", () => ({
   logClientEvent: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Exercise legacy bookmark migration without depending on browser storage left by other tests.
 vi.mock("../lib/bookmarks", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/bookmarks")>();
   return {

--- a/apps/web/src/hooks/useCanvasFrameLoop.test.tsx
+++ b/apps/web/src/hooks/useCanvasFrameLoop.test.tsx
@@ -69,6 +69,7 @@ describe("useCanvasFrameLoop", () => {
       class {
         constructor(callback: IntersectionObserverCallback) {
           intersectionCallback = callback;
+          // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The frame-loop hook only uses this observer identity and the entries driven by the test.
           observer = this as unknown as IntersectionObserver;
         }
         observe() {}

--- a/apps/web/src/hooks/useCopySessionAsMarkdown.test.tsx
+++ b/apps/web/src/hooks/useCopySessionAsMarkdown.test.tsx
@@ -12,11 +12,13 @@ const apiMocks = vi.hoisted(() => ({
 }));
 const clipboardMocks = vi.hoisted(() => ({ writeToClipboard: vi.fn() }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/api")>()),
   fetchSessionData: apiMocks.fetchSessionData,
   logClientEvent: apiMocks.logClientEvent,
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control clipboard success and failure while verifying the copy action state.
 vi.mock("../lib/clipboard", () => clipboardMocks);
 
 afterEach(() => {

--- a/apps/web/src/hooks/useDashboard.test.ts
+++ b/apps/web/src/hooks/useDashboard.test.ts
@@ -6,9 +6,11 @@ import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useDashboard } from "./useDashboard";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", () => ({ fetchDashboard: vi.fn() }));
 
 const window = { from: 1, to: 2 } as AppConfig["window"];
+// oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: Only response identity and the session count are observed in these query lifecycle tests.
 const data = { totals: { sessions: 3 }, perAgent: [] } as unknown as DashboardData;
 
 const globalScope: DashboardFilters = {};
@@ -85,6 +87,7 @@ describe("useDashboard", () => {
     const first = new Promise<DashboardData>((resolve) => {
       resolveFirst = resolve;
     });
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: Only response identity and the session count are observed in these query lifecycle tests.
     const latest = { totals: { sessions: 9 }, perAgent: [] } as unknown as DashboardData;
     vi.mocked(api.fetchDashboard).mockReturnValueOnce(first).mockResolvedValueOnce(latest);
     const { Wrapper } = createQueryWrapper();

--- a/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/apps/web/src/hooks/useKeyboardShortcuts.test.tsx
@@ -38,7 +38,7 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
       activeAgentKey: null,
       activeSessionId: null,
     } satisfies ViewState,
-    navigate: vi.fn() as unknown as NavigateFunction,
+    navigate: vi.fn() as NavigateFunction,
     selectedProjectNavigationIdentity: null,
     shortcutHelpOpen: false,
     setShortcutHelpOpen: vi.fn(),

--- a/apps/web/src/hooks/useLiveSync.test.ts
+++ b/apps/web/src/hooks/useLiveSync.test.ts
@@ -9,6 +9,7 @@ let sessionsCallback: ((event: SessionsUpdatedEvent) => void) | undefined;
 let reconnectCallback: (() => void) | undefined;
 let disconnectCallback: (() => void) | undefined;
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Drive subscription events and observe telemetry without a live SSE server.
 vi.mock("../lib/api", () => ({
   subscribeSessionUpdates: vi.fn(
     (

--- a/apps/web/src/hooks/usePrefersReducedMotion.test.ts
+++ b/apps/web/src/hooks/usePrefersReducedMotion.test.ts
@@ -9,6 +9,7 @@ function mockMedia(matches: boolean) {
     addEventListener: (_: string, listener: () => void) => listeners.add(listener),
     removeEventListener: (_: string, listener: () => void) => listeners.delete(listener),
   };
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: This media-query fixture implements the state and listener methods used by the hook.
   vi.spyOn(window, "matchMedia").mockReturnValue(media as unknown as MediaQueryList);
 
   return {

--- a/apps/web/src/hooks/useScanStatus.test.ts
+++ b/apps/web/src/hooks/useScanStatus.test.ts
@@ -5,6 +5,7 @@ import type { ScanStatusEvent } from "../lib/api";
 import * as api from "../lib/api";
 import { ScanStatusProvider, useScanStatus, useScanStatusPublisher } from "./useScanStatus";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", () => ({
   fetchScanStatus: vi.fn(),
 }));

--- a/apps/web/src/hooks/useSessionAliasDialog.test.ts
+++ b/apps/web/src/hooks/useSessionAliasDialog.test.ts
@@ -5,6 +5,7 @@ import type { BookmarkView } from "../lib/api";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionAliasDialog } from "./useSessionAliasDialog";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/api")>()),
   deleteSessionAlias: vi.fn(),

--- a/apps/web/src/hooks/useSessionAliasMutations.test.ts
+++ b/apps/web/src/hooks/useSessionAliasMutations.test.ts
@@ -5,6 +5,7 @@ import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionAliasMutations } from "./useSessionAliasMutations";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", () => ({
   deleteSessionAlias: vi.fn(),
   upsertSessionAlias: vi.fn(),

--- a/apps/web/src/hooks/useSessionDetail.test.ts
+++ b/apps/web/src/hooks/useSessionDetail.test.ts
@@ -7,6 +7,7 @@ import { queryKeys } from "../lib/query-keys";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionDetail } from "./useSessionDetail";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../lib/api")>()),
   fetchSessionData: vi.fn(),
@@ -22,13 +23,17 @@ const sessionView: ViewState = {
 function makeSessionDetail(
   agentName: string,
   sessionId: string,
-  overrides: Record<string, unknown> = {},
+  overrides: Partial<SessionDetail> = {},
 ): SessionDetail {
   return {
     reference: { agentName, sessionId },
+    title: sessionId,
+    directory: "/workspace",
+    time_created: 0,
+    stats: { message_count: 0, total_input_tokens: 0, total_output_tokens: 0, total_cost: 0 },
     messages: [],
     ...overrides,
-  } as unknown as SessionDetail;
+  };
 }
 
 const sample = makeSessionDetail("claudecode", "abc");
@@ -152,7 +157,9 @@ describe("useSessionDetail", () => {
     const { result } = renderSessionDetail();
     await waitFor(() => expect(result.current.session).toEqual(sample));
 
-    const updated = makeSessionDetail("claudecode", "abc", { messages: [1] });
+    const updated = makeSessionDetail("claudecode", "abc", {
+      messages: [{ id: "refreshed", role: "user", time_created: 0, parts: [] }],
+    });
     vi.mocked(api.fetchSessionData).mockResolvedValue(updated);
     await act(async () => {
       await result.current.refresh();
@@ -189,8 +196,8 @@ describe("useSessionDetail", () => {
   });
 
   it("requests and merges only messages appended by a live update", async () => {
-    const firstMessage = { id: "m1" };
-    const nextMessage = { id: "m2" };
+    const firstMessage = { id: "m1", role: "user" as const, time_created: 0, parts: [] };
+    const nextMessage = { id: "m2", role: "user" as const, time_created: 0, parts: [] };
     const initial = makeSessionDetail("claudecode", "abc", {
       messages: [firstMessage],
       message_cursor: "cursor-1",

--- a/apps/web/src/hooks/useSessionSearch.test.ts
+++ b/apps/web/src/hooks/useSessionSearch.test.ts
@@ -1,22 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { SearchResult } from "../lib/api";
-import type { SessionIndexes } from "../lib/session-indexes";
+import { buildSessionIndexes, type SessionIndexes } from "../lib/session-indexes";
 import * as api from "../lib/api";
 import { createQueryWrapper } from "../test/query-wrapper";
 import { useSessionSearch } from "./useSessionSearch";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", () => ({
   fetchSearchResults: vi.fn(),
   logClientEvent: vi.fn(),
 }));
 
-const emptyIndexes = {
-  byAgent: new Map(),
-  byProjectIdentityKey: new Map(),
-  projectOptions: [],
-  sessionsByActivity: [],
-} as unknown as SessionIndexes;
+const emptyIndexes = buildSessionIndexes([], []);
 
 function makeSearchResult(id: string): SearchResult {
   return {

--- a/apps/web/src/hooks/useSessionStore.test.ts
+++ b/apps/web/src/hooks/useSessionStore.test.ts
@@ -27,6 +27,7 @@ import {
 import { useDashboard } from "./useDashboard";
 import { useProjectLookup, useProjectPagination } from "./useProjects";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control API response ordering and failures while testing client state transitions.
 vi.mock("../lib/api", async (importOriginal) => {
   const { ApiRequestError } = await importOriginal<typeof import("../lib/api")>();
   return {
@@ -45,8 +46,8 @@ const config = {
 const agents = [
   { name: "ClaudeCode", displayName: "Claude Code", count: 1 },
   { name: "Codex", displayName: "Codex", count: 0 },
-] as unknown as AgentInfo[];
-const projects = [{ identityKind: "path", identityKey: "p1" }] as unknown as ApiProjectGroup[];
+] as AgentInfo[];
+const projects = [{ identityKind: "path", identityKey: "p1" }] as ApiProjectGroup[];
 const projectPage = {
   projects,
   summary: {
@@ -532,7 +533,7 @@ describe("useSessionStore", () => {
 
   it("keeps the latest snapshot when an earlier request finishes late", async () => {
     const firstAgents = deferred<AgentInfo[]>();
-    const latestAgents = [{ name: "Codex", displayName: "Codex" }] as unknown as AgentInfo[];
+    const latestAgents = [{ name: "Codex", displayName: "Codex" }] as AgentInfo[];
     vi.mocked(api.fetchAgents)
       .mockReturnValueOnce(firstAgents.promise)
       .mockResolvedValueOnce(latestAgents);

--- a/apps/web/src/hooks/useTheme.test.ts
+++ b/apps/web/src/hooks/useTheme.test.ts
@@ -15,6 +15,7 @@ function mockMatchMedia(initialMatches: boolean) {
       changeListener = null;
     }),
   };
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: This media-query fixture implements the state and listener methods used by the hook.
   vi.spyOn(window, "matchMedia").mockReturnValue(mediaQueryList as unknown as MediaQueryList);
   return {
     emitChange(matches: boolean) {

--- a/apps/web/src/hooks/useWindowLoadTelemetry.test.ts
+++ b/apps/web/src/hooks/useWindowLoadTelemetry.test.ts
@@ -4,6 +4,7 @@ import type { AppConfig } from "../lib/api";
 import * as api from "../lib/api";
 import { useWindowLoadTelemetry } from "./useWindowLoadTelemetry";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe client telemetry events without making HTTP requests.
 vi.mock("../lib/api", () => ({ logClientEvent: vi.fn() }));
 
 const window = { from: 1, to: 2 } as AppConfig["window"];

--- a/apps/web/src/i18n/language.ts
+++ b/apps/web/src/i18n/language.ts
@@ -53,6 +53,7 @@ function update(preference: LanguagePreference) {
 }
 
 export function setLanguagePreference(preference: LanguagePreference) {
+  // oxlint-disable-next-line anti-slop/no-known-value-widening -- Validate runtime callers before persisting a preference even when TypeScript callers are typed.
   if (!isLanguagePreference(preference)) return;
   try {
     localStorage.setItem(LANGUAGE_STORAGE_KEY, preference);

--- a/apps/web/src/i18n/language.ts
+++ b/apps/web/src/i18n/language.ts
@@ -1,4 +1,5 @@
 export type Locale = "en" | "zh-CN" | "ja";
+
 export type LanguagePreference = Locale | "system";
 
 export const LANGUAGE_STORAGE_KEY = "codesesh.language";

--- a/apps/web/src/lib/projects.ts
+++ b/apps/web/src/lib/projects.ts
@@ -8,6 +8,7 @@ import type { ApiProjectGroup } from "./api";
 // Identity semantics come from the contract; this module only turns them into
 // URLs and back. A route key is percent-encoded, an identity key is not.
 export { getProjectIdentityKey, isProjectIdentityKind };
+
 export type ProjectRouteIdentity = ProjectIdentityRef;
 
 export function getProjectGroupIdentity(project: ApiProjectGroup): ProjectRouteIdentity {

--- a/apps/web/src/lib/scan-format.test.ts
+++ b/apps/web/src/lib/scan-format.test.ts
@@ -7,6 +7,22 @@ import {
 } from "./scan-format";
 import type { ScanStatusEvent } from "./api";
 
+function scanStatus(overrides: Partial<ScanStatusEvent>): ScanStatusEvent {
+  return {
+    type: "scan-status",
+    active: false,
+    phase: "idle",
+    pendingAgents: [],
+    scanningAgents: [],
+    completedAgents: [],
+    agentStatuses: {},
+    totalAgents: 0,
+    updatedAt: 0,
+    backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
+    ...overrides,
+  };
+}
+
 describe("formatIsoDate", () => {
   it("formats as YYYY-MM-DD", () => {
     expect(formatIsoDate(new Date("2026-06-21T14:30:00").getTime())).toBe("2026-06-21");
@@ -15,6 +31,7 @@ describe("formatIsoDate", () => {
 
 describe("formatWindowLabel", () => {
   it("returns All time when from is null", () => {
+    // SAFETY: Window formatting reads only the supplied window bounds from the public config.
     expect(formatWindowLabel({ window: { from: null, to: 1000 } } as never)).toBe("All time");
   });
 
@@ -36,43 +53,47 @@ describe("formatSearchSubtitle", () => {
 describe("formatScanStatusLabel", () => {
   it("returns null for inactive status", () => {
     expect(formatScanStatusLabel(null)).toBeNull();
-    expect(formatScanStatusLabel({ active: false } as ScanStatusEvent)).toBeNull();
+    expect(formatScanStatusLabel(scanStatus({ active: false }))).toBeNull();
   });
 
   it("keeps routine publication quiet", () => {
     expect(
-      formatScanStatusLabel({
-        active: true,
-        phase: "publishing",
-        completedAgents: [],
-        scanningAgents: [],
-        totalAgents: 0,
-        agentStatuses: {},
-      } as unknown as ScanStatusEvent),
+      formatScanStatusLabel(
+        scanStatus({
+          active: true,
+          phase: "publishing",
+          completedAgents: [],
+          scanningAgents: [],
+          totalAgents: 0,
+          agentStatuses: {},
+        }),
+      ),
     ).toBeNull();
   });
 
   it("keeps legacy indexing quiet", () => {
     expect(
-      formatScanStatusLabel({
-        active: true,
-        phase: "indexing",
-        completedAgents: [],
-        scanningAgents: [],
-        totalAgents: 0,
-        agentStatuses: {},
-      } as unknown as ScanStatusEvent),
+      formatScanStatusLabel(
+        scanStatus({
+          active: true,
+          phase: "indexing",
+          completedAgents: [],
+          scanningAgents: [],
+          totalAgents: 0,
+          agentStatuses: {},
+        }),
+      ),
     ).toBeNull();
   });
 
   it("surfaces an inactive refresh failure", () => {
-    const status = {
+    const status = scanStatus({
       active: false,
       backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
       agentStatuses: {
-        codex: { agentName: "codex", status: "failed", error: "cache is read-only" },
+        codex: { updatedAt: 0, agentName: "codex", status: "failed", error: "cache is read-only" },
       },
-    } as unknown as ScanStatusEvent;
+    });
 
     expect(formatScanStatusLabel(status)).toBe(
       "Session refresh failed · codex · cache is read-only",
@@ -81,35 +102,39 @@ describe("formatScanStatusLabel", () => {
 
   it("shows full-history backfill progress after the main scan finishes", () => {
     expect(
-      formatScanStatusLabel({
-        active: false,
-        backfill: {
-          active: true,
-          currentAgent: "codex",
-          pendingAgents: ["claudecode"],
-          completedAgents: [],
-          failedAgents: [],
-        },
-      } as unknown as ScanStatusEvent),
+      formatScanStatusLabel(
+        scanStatus({
+          active: false,
+          backfill: {
+            active: true,
+            currentAgent: "codex",
+            pendingAgents: ["claudecode"],
+            completedAgents: [],
+            failedAgents: [],
+          },
+        }),
+      ),
     ).toBe("Scanning full session history · codex · 1 history scan queued");
   });
 
   it("shows a partial refresh as completed rather than failed", () => {
     expect(
-      formatScanStatusLabel({
-        active: false,
-        backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
-        agentStatuses: {
-          codex: {
-            agentName: "codex",
-            status: "complete",
-            completeness: "partial",
-            sourceFailureCount: 1,
-            sourceFailureSummary: "SyntaxError: truncated JSON",
-            updatedAt: 1,
+      formatScanStatusLabel(
+        scanStatus({
+          active: false,
+          backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
+          agentStatuses: {
+            codex: {
+              agentName: "codex",
+              status: "complete",
+              completeness: "partial",
+              sourceFailureCount: 1,
+              sourceFailureSummary: "SyntaxError: truncated JSON",
+              updatedAt: 1,
+            },
           },
-        },
-      } as unknown as ScanStatusEvent),
+        }),
+      ),
     ).toBe(
       "Session refresh completed with partial data · codex · 1 source failed · SyntaxError: truncated JSON",
     );
@@ -117,40 +142,44 @@ describe("formatScanStatusLabel", () => {
 
   it("does not warn when a completed refresh is partial only because it is windowed", () => {
     expect(
-      formatScanStatusLabel({
-        active: false,
-        backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
-        agentStatuses: {
-          claudecode: {
-            agentName: "claudecode",
-            status: "complete",
-            completeness: "partial",
-            updatedAt: 1,
+      formatScanStatusLabel(
+        scanStatus({
+          active: false,
+          backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
+          agentStatuses: {
+            claudecode: {
+              agentName: "claudecode",
+              status: "complete",
+              completeness: "partial",
+              updatedAt: 1,
+            },
           },
-        },
-      } as unknown as ScanStatusEvent),
+        }),
+      ),
     ).toBeNull();
   });
 
   it("shows a completed partial full-history refresh", () => {
     expect(
-      formatScanStatusLabel({
-        active: false,
-        backfill: {
+      formatScanStatusLabel(
+        scanStatus({
           active: false,
-          pendingAgents: [],
-          completedAgents: ["codex"],
-          failedAgents: [],
-          partialAgents: {
-            codex: {
-              completeness: "partial",
-              sourceFailureCount: 2,
-              sourceFailureSummary: "SyntaxError: truncated JSON",
+          backfill: {
+            active: false,
+            pendingAgents: [],
+            completedAgents: ["codex"],
+            failedAgents: [],
+            partialAgents: {
+              codex: {
+                completeness: "partial",
+                sourceFailureCount: 2,
+                sourceFailureSummary: "SyntaxError: truncated JSON",
+              },
             },
           },
-        },
-        agentStatuses: {},
-      } as unknown as ScanStatusEvent),
+          agentStatuses: {},
+        }),
+      ),
     ).toBe(
       "Full-history refresh completed with partial data · codex · 2 sources failed · SyntaxError: truncated JSON",
     );
@@ -158,17 +187,19 @@ describe("formatScanStatusLabel", () => {
 
   it("shows backfill finalization progress", () => {
     expect(
-      formatScanStatusLabel({
-        active: false,
-        backfill: {
-          active: true,
-          currentAgent: "codex",
-          pendingAgents: [],
-          progress: { phase: "finalizing", total: 2107, processed: 68 },
-          completedAgents: [],
-          failedAgents: [],
-        },
-      } as unknown as ScanStatusEvent),
+      formatScanStatusLabel(
+        scanStatus({
+          active: false,
+          backfill: {
+            active: true,
+            currentAgent: "codex",
+            pendingAgents: [],
+            progress: { phase: "finalizing", total: 2107, processed: 68 },
+            completedAgents: [],
+            failedAgents: [],
+          },
+        }),
+      ),
     ).toBe("Finalizing full-history metadata · codex · 68/2107");
   });
 
@@ -176,54 +207,62 @@ describe("formatScanStatusLabel", () => {
     "keeps routine %s progress quiet",
     (phase) => {
       expect(
-        formatScanStatusLabel({
-          active: true,
-          phase: phase === "scanning" ? "scanning" : "publishing",
-          completedAgents: [],
-          scanningAgents: ["codex"],
-          totalAgents: 1,
-          agentStatuses: {
-            codex: { agentName: "codex", status: phase, total: 1, processed: 0, updatedAt: 1 },
-          },
-        } as unknown as ScanStatusEvent),
+        formatScanStatusLabel(
+          scanStatus({
+            active: true,
+            phase: phase === "scanning" ? "scanning" : "publishing",
+            completedAgents: [],
+            scanningAgents: ["codex"],
+            totalAgents: 1,
+            agentStatuses: {
+              codex: { agentName: "codex", status: phase, total: 1, processed: 0, updatedAt: 1 },
+            },
+          }),
+        ),
       ).toBeNull();
     },
   );
 
   it("keeps initialization visible", () => {
-    expect(formatScanStatusLabel({ active: true, phase: "initializing" } as ScanStatusEvent)).toBe(
+    expect(formatScanStatusLabel(scanStatus({ active: true, phase: "initializing" }))).toBe(
       "Initializing recent sessions",
     );
   });
 
   it("does not hide failures while another agent refreshes", () => {
     expect(
-      formatScanStatusLabel({
-        active: true,
-        phase: "scanning",
-        agentStatuses: { codex: { agentName: "codex", status: "failed", error: "read failed" } },
-      } as unknown as ScanStatusEvent),
+      formatScanStatusLabel(
+        scanStatus({
+          active: true,
+          phase: "scanning",
+          agentStatuses: {
+            codex: { updatedAt: 0, agentName: "codex", status: "failed", error: "read failed" },
+          },
+        }),
+      ),
     ).toBe("Session refresh failed · codex · read failed");
   });
 
   it("does not reuse full-history scan counts while preparing publication", () => {
     expect(
-      formatScanStatusLabel({
-        active: false,
-        backfill: {
-          active: true,
-          currentAgent: "zcode",
-          pendingAgents: [],
-          progress: { phase: "publishing", total: 84, processed: 84, sessions: 84 },
-          completedAgents: [],
-          failedAgents: [],
-        },
-      } as unknown as ScanStatusEvent),
+      formatScanStatusLabel(
+        scanStatus({
+          active: false,
+          backfill: {
+            active: true,
+            currentAgent: "zcode",
+            pendingAgents: [],
+            progress: { phase: "publishing", total: 84, processed: 84, sessions: 84 },
+            completedAgents: [],
+            failedAgents: [],
+          },
+        }),
+      ),
     ).toBe("Preparing full-history publication · zcode");
   });
 
   it("distinguishes writing and committing a full-history index", () => {
-    const status = {
+    const status = scanStatus({
       active: false,
       backfill: {
         active: true,
@@ -233,7 +272,7 @@ describe("formatScanStatusLabel", () => {
         completedAgents: [],
         failedAgents: [],
       },
-    } as unknown as ScanStatusEvent;
+    });
 
     expect(formatScanStatusLabel(status)).toBe("Writing full-history search index · codex");
     status.backfill.progress = { phase: "committing", total: 119, processed: 119 };
@@ -242,35 +281,39 @@ describe("formatScanStatusLabel", () => {
 
   it("does not describe a queued full-history publication as active", () => {
     expect(
-      formatScanStatusLabel({
-        active: false,
-        backfill: {
-          active: true,
-          currentAgent: "zcode",
-          pendingAgents: [],
-          progress: { phase: "publish-queued", total: 84, processed: 84, sessions: 84 },
-          completedAgents: [],
-          failedAgents: [],
-        },
-      } as unknown as ScanStatusEvent),
+      formatScanStatusLabel(
+        scanStatus({
+          active: false,
+          backfill: {
+            active: true,
+            currentAgent: "zcode",
+            pendingAgents: [],
+            progress: { phase: "publish-queued", total: 84, processed: 84, sessions: 84 },
+            completedAgents: [],
+            failedAgents: [],
+          },
+        }),
+      ),
     ).toBe("Full-history publication queued · zcode");
   });
 
   it("keeps routine search maintenance quiet", () => {
     expect(
-      formatScanStatusLabel({
-        active: false,
-        backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
-        agentStatuses: {},
-        searchIndexMaintenance: {
-          active: true,
-          currentAgent: "codex",
-          pendingAgents: [],
-          remaining: 2199,
-          completedAgents: [],
-          failedAgents: [],
-        },
-      } as unknown as ScanStatusEvent),
+      formatScanStatusLabel(
+        scanStatus({
+          active: false,
+          backfill: { active: false, pendingAgents: [], completedAgents: [], failedAgents: [] },
+          agentStatuses: {},
+          searchIndexMaintenance: {
+            active: true,
+            currentAgent: "codex",
+            pendingAgents: [],
+            remaining: 2199,
+            completedAgents: [],
+            failedAgents: [],
+          },
+        }),
+      ),
     ).toBeNull();
   });
 });

--- a/apps/web/src/lib/search.test.ts
+++ b/apps/web/src/lib/search.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createSessionIdentity } from "@codesesh/core/contract";
 import type { SearchResult, SessionHead } from "./api";
 import type { SearchProjectOption } from "../components/app/types";
-import { getSessionAgentKey, type SessionIndexes } from "./session-indexes";
+import { buildSessionIndexes, getSessionAgentKey, type SessionIndexes } from "./session-indexes";
 import { getProjectIdentityKey } from "./projects";
 import { buildLocalRecentResults, buildSearchProjectOptions, usesServerSearch } from "./search";
 
@@ -62,11 +62,12 @@ describe("buildLocalRecentResults", () => {
       }
     }
     return {
+      ...buildSessionIndexes(sessions, []),
       byAgent,
       byProjectIdentityKey,
       projectOptions: [],
       sessionsByActivity: sessions,
-    } as unknown as SessionIndexes;
+    };
   }
 
   const sBugfixApp = makeSession("s-bugfix-app", {

--- a/apps/web/src/lib/session-detail-cache.test.ts
+++ b/apps/web/src/lib/session-detail-cache.test.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { afterEach, describe, expect, it } from "vitest";
 import { queryKeys } from "./query-keys";
 import {
@@ -66,9 +66,9 @@ describe("CS-147: session detail cache is bounded", () => {
     const observed = active
       .getQueryCache()
       .find({ queryKey: queryKeys.sessionDetail("codex", "watched") })!;
-    const observer = { onQueryUpdate: () => {} };
+    const observer = new QueryObserver(active, { queryKey: observed.queryKey });
     // Simulate a mounted component holding this query.
-    observed.addObserver(observer as never);
+    observed.addObserver(observer);
 
     for (let index = 0; index < 5; index += 1) {
       await openDetail(active, `other-${index}`);
@@ -76,7 +76,7 @@ describe("CS-147: session detail cache is bounded", () => {
     pruneSessionDetailCache(active);
 
     expect(cachedDetailIds(active)).toContain("watched");
-    observed.removeObserver(observer as never);
+    observed.removeObserver(observer);
   });
 
   it("keeps a newly created detail during observer handoff", async () => {
@@ -87,8 +87,8 @@ describe("CS-147: session detail cache is bounded", () => {
     const previous = active
       .getQueryCache()
       .find({ queryKey: queryKeys.sessionDetail("codex", "previous-2") })!;
-    const observer = { onQueryUpdate: () => {} };
-    previous.addObserver(observer as never);
+    const observer = new QueryObserver(active, { queryKey: previous.queryKey });
+    previous.addObserver(observer);
 
     const pendingKey = queryKeys.sessionDetail("codex", "pending");
     const pending = active.getQueryCache().build(active, {
@@ -96,7 +96,7 @@ describe("CS-147: session detail cache is bounded", () => {
       queryFn: async () => transcript("pending"),
     });
 
-    previous.removeObserver(observer as never);
+    previous.removeObserver(observer);
 
     expect(active.getQueryCache().find({ queryKey: pendingKey })).toBe(pending);
   });
@@ -129,9 +129,9 @@ describe("CS-147: session detail cache is bounded", () => {
       const query = active
         .getQueryCache()
         .find({ queryKey: queryKeys.sessionDetail("codex", `s${index}`) })!;
-      const observer = { onQueryUpdate: () => {} };
-      query.addObserver(observer as never);
-      query.removeObserver(observer as never);
+      const observer = new QueryObserver(active, { queryKey: query.queryKey });
+      query.addObserver(observer);
+      query.removeObserver(observer);
     }
 
     expect(cachedDetailIds(active)).toHaveLength(RETAINED_INACTIVE_SESSION_DETAILS);

--- a/apps/web/src/lib/time-window.ts
+++ b/apps/web/src/lib/time-window.ts
@@ -8,6 +8,7 @@ import {
 import type { AppConfig } from "./api";
 
 export type TimeWindow = AppConfig["window"];
+
 export type TimeWindowPreset = "7d" | "14d" | "30d" | "90d" | "all" | "custom";
 
 export interface ResolvedTimeWindow {

--- a/apps/web/src/router.test.tsx
+++ b/apps/web/src/router.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Force a render failure to exercise the router error boundary.
 vi.mock("./App", () => ({
   default: () => {
     throw new Error("render failed");

--- a/apps/web/src/test/canvas-stub.ts
+++ b/apps/web/src/test/canvas-stub.ts
@@ -61,7 +61,7 @@ export function stubAnimationFrames() {
 }
 
 function defineSize(size: { width: number; height: number }): () => void {
-  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  const proto = HTMLElement.prototype;
   const previous = {
     clientWidth: Object.getOwnPropertyDescriptor(proto, "clientWidth"),
     clientHeight: Object.getOwnPropertyDescriptor(proto, "clientHeight"),
@@ -72,7 +72,7 @@ function defineSize(size: { width: number; height: number }): () => void {
   return () => {
     for (const [name, descriptor] of Object.entries(previous)) {
       if (descriptor) Object.defineProperty(proto, name, descriptor);
-      else delete proto[name];
+      else Reflect.deleteProperty(proto, name);
     }
   };
 }
@@ -82,8 +82,10 @@ export function stubCanvas(size: { width: number; height: number }): StubbedCanv
     CONTEXT_METHODS.map((name) => [name, vi.fn()]),
   ) as StubbedCanvas["context"];
 
+  // SAFETY: The chart painters only call the drawing methods recorded in CONTEXT_METHODS.
   const getContext = vi
     .spyOn(HTMLCanvasElement.prototype, "getContext")
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- The chart painters only call the drawing methods recorded in CONTEXT_METHODS.
     .mockReturnValue(context as unknown as CanvasRenderingContext2D);
   const rect = vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
     left: 0,
@@ -104,12 +106,12 @@ export function stubCanvas(size: { width: number; height: number }): StubbedCanv
   globalThis.ResizeObserver = class {
     constructor(callback: ResizeObserverCallback) {
       resizeCallback = callback;
-      resizeObserver = this as unknown as ResizeObserver;
+      resizeObserver = this as ResizeObserver;
     }
     observe() {}
     disconnect() {}
     unobserve() {}
-  } as unknown as typeof ResizeObserver;
+  } as typeof ResizeObserver;
 
   return {
     context,

--- a/apps/web/src/types/react-syntax-highlighter.d.ts
+++ b/apps/web/src/types/react-syntax-highlighter.d.ts
@@ -1,5 +1,6 @@
 declare module "react-syntax-highlighter" {
   import type { ComponentType, CSSProperties } from "react";
+
   interface SyntaxHighlighterProps {
     language?: string;
     style?: Record<string, unknown>;
@@ -23,6 +24,7 @@ declare module "react-syntax-highlighter/dist/esm/styles/prism" {
 
 declare module "react-syntax-highlighter/dist/esm/prism-light" {
   import type { ComponentType, CSSProperties } from "react";
+
   interface SyntaxHighlighterProps {
     language?: string;
     style?: Record<string, unknown>;

--- a/apps/www/src/components/Header.astro
+++ b/apps/www/src/components/Header.astro
@@ -152,11 +152,14 @@ const themes = [
       { once: true },
     );
   }
+
   setupFluidHover();
   document.addEventListener("astro:after-swap", setupFluidHover);
 
   const THEMES = ["light", "dark", "system"] as const;
+
   type Theme = (typeof THEMES)[number];
+
   const NEXT_THEME: Record<Theme, Theme> = {
     light: "dark",
     dark: "system",

--- a/apps/www/src/components/InstallCommand.astro
+++ b/apps/www/src/components/InstallCommand.astro
@@ -63,7 +63,8 @@ const t = copy[locale].hero;
         textarea.style.top = "-9999px";
         document.body.append(textarea);
         textarea.select();
-        const execCommand = Reflect.get(document, "execCommand");
+        const execCommand =
+          "execCommand" in document ? document.execCommand : undefined;
         const copied =
           typeof execCommand === "function" &&
           execCommand.call(document, "copy") === true;

--- a/apps/www/src/components/SessionOrbit.astro
+++ b/apps/www/src/components/SessionOrbit.astro
@@ -147,6 +147,7 @@ const earthTextures = [
   import { loadBodyTextures } from "./session-orbit/body-textures";
   import { earthSurfaceShader } from "./session-orbit/earth-surface";
   import { loadEarthTextures } from "./session-orbit/earth-textures";
+
   type Mesh = {
     position: WebGLBuffer;
     normal: WebGLBuffer;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@codesesh/core": "workspace:*",
+    "@oxlint/plugins": "1.81.0",
     "@types/node": "catalog:",
     "@typescript/native": "catalog:",
     "@vitest/coverage-v8": "^5.0.0",

--- a/packages/cli/src/agent-backfill-scheduler.test.ts
+++ b/packages/cli/src/agent-backfill-scheduler.test.ts
@@ -19,6 +19,7 @@ const core = vi.hoisted(() => ({
   })),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control the persisted last-sync timestamp to exercise backfill scheduling.
 vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime/discovery")>()),
   readAgentLastFullSyncAt: core.readAgentLastFullSyncAt,
@@ -41,6 +42,7 @@ class FakeSyncAgent extends FileSystemSessionSource {
   }
 
   getSessionData() {
+    // SAFETY: This orchestration fixture provides empty message content; adapter parsing is covered separately.
     return { messages: [] } as never;
   }
 

--- a/packages/cli/src/agent-operation-scheduler.ts
+++ b/packages/cli/src/agent-operation-scheduler.ts
@@ -1,6 +1,7 @@
 import { appLogger } from "./logging.js";
 
 export type AgentOperationKind = "backfill" | "refresh";
+
 export type AgentOperationResult = "committed" | "failed" | "skipped" | "unchanged";
 
 interface AgentScheduleState {

--- a/packages/cli/src/agent-sync-engine.test.ts
+++ b/packages/cli/src/agent-sync-engine.test.ts
@@ -19,7 +19,6 @@ import type { ScanStatusEvent } from "@codesesh/core/contract";
 import type { StagedWorkerRun, WorkerResult, WorkerRunner } from "./worker-runner.js";
 import { appLogger } from "./logging.js";
 import { AgentUnavailableDuringScanError } from "./scan-refresh-error.js";
-import type { ScanStatusModel } from "./scan-status-model.js";
 
 const core = vi.hoisted(() => {
   const getAgentLastFullSyncAt = vi.fn(() => Date.now());
@@ -72,6 +71,7 @@ const searchIndex = vi.hoisted(() => ({
   snapshot: vi.fn(() => ({ activeBatchId: undefined, pendingBatches: 0 })),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control cache publication, revisions and failures at the scan orchestration boundary.
 vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   const original = await importOriginal<typeof import("@codesesh/core/runtime/discovery")>();
   // Spy that still delegates to the real implementation, so diff behavior is unchanged.
@@ -92,11 +92,13 @@ vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix the classifier revision to exercise stale-tag reconciliation deterministically.
 vi.mock("@codesesh/core/runtime/diagnostics", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime/diagnostics")>()),
   SMART_TAG_CLASSIFIER_REVISION: "smart-tags-v1",
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe enqueued index jobs while testing scan commits independently of index worker scheduling.
 vi.mock("./search-index-job-runner.js", () => ({
   SearchIndexJobRunner: class {
     enqueue = searchIndex.enqueue;
@@ -144,6 +146,7 @@ function makeAgent(overrides: TestAgentOverrides = {}): TestAggregateAgent {
     checkForChanges: () => ({ hasChanges: false, timestamp: Date.now() }),
     commitChangeCheck: () => undefined,
     incrementalScan: (sessions: SessionHead[]) => sessions,
+    // SAFETY: This orchestration fixture provides empty message content; adapter parsing is covered separately.
     getSessionData: () => ({ messages: [] }) as never,
     getSessionWatchPlan: () => ({ status: "not-needed" as const, reason: "test adapter" }),
     getSessionCacheMeta: (sessionId: string) => meta[sessionId],
@@ -155,7 +158,7 @@ function makeAgent(overrides: TestAgentOverrides = {}): TestAggregateAgent {
       for (const sessionId of sessionIds) delete meta[sessionId];
     },
     ...overrides,
-  } as unknown as TestAggregateAgent;
+  } as TestAggregateAgent;
   return Object.assign(agent, {
     sessionSourceAccess: {
       kind: "aggregate" as const,
@@ -185,6 +188,7 @@ class FakeSyncAgent extends FileSystemSessionSource {
   }
 
   getSessionData() {
+    // SAFETY: This orchestration fixture provides empty message content; adapter parsing is covered separately.
     return { messages: [] } as never;
   }
 
@@ -418,12 +422,12 @@ describe("AgentSyncEngine", () => {
     const workerRunner = makeWorkerRunner();
     const warn = vi.spyOn(appLogger, "warn");
     const { engine } = makeEngine(agent, [previous], workerRunner);
-    const refreshState = engine as unknown as { lastRefreshAtByAgent: Map<string, number> };
-    const baseline = refreshState.lastRefreshAtByAgent.get("codex");
+    const refreshTimes = engine["lastRefreshAtByAgent"];
+    const baseline = refreshTimes.get("codex");
 
     await engine.refresh("codex");
 
-    expect(refreshState.lastRefreshAtByAgent.get("codex")).toBe(baseline);
+    expect(refreshTimes.get("codex")).toBe(baseline);
     expect(engine.snapshot().sessions).toEqual([previous]);
     expect(workerRunner.run).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith("scan.refresh.change_check_failed", {
@@ -1489,8 +1493,7 @@ describe("AgentSyncEngine", () => {
     engine.subscribeSessionsChanged(() => {
       throw new Error("session event broadcast failed");
     });
-    const scanStatus = (engine as unknown as { statusReporter: { scanStatus: ScanStatusModel } })
-      .statusReporter.scanStatus;
+    const scanStatus = engine["statusReporter"]["scanStatus"];
     const finishAgent = vi.spyOn(scanStatus, "finishAgent").mockImplementationOnce(() => {
       throw new Error("terminal status publication failed");
     });
@@ -1599,15 +1602,15 @@ describe("AgentSyncEngine", () => {
       [previous],
       workerRunner,
     );
-    const refreshState = engine as unknown as { lastRefreshAtByAgent: Map<string, number> };
-    const baselineTimestamp = refreshState.lastRefreshAtByAgent.get("codex");
+    const refreshTimes = engine["lastRefreshAtByAgent"];
+    const baselineTimestamp = refreshTimes.get("codex");
     const sessionChanges = vi.fn();
     engine.subscribeSessionsChanged(sessionChanges);
 
     await engine.refresh("codex");
 
     expect(engine.snapshot().byAgent.codex).toEqual([previous]);
-    expect(refreshState.lastRefreshAtByAgent.get("codex")).toBe(baselineTimestamp);
+    expect(refreshTimes.get("codex")).toBe(baselineTimestamp);
     expect(sessionChanges).not.toHaveBeenCalled();
     expect(searchIndex.enqueue).not.toHaveBeenCalled();
     expect(workerLifecycle.commit).not.toHaveBeenCalled();

--- a/packages/cli/src/agent-sync-engine.ts
+++ b/packages/cli/src/agent-sync-engine.ts
@@ -67,7 +67,9 @@ export interface AgentSyncEngineInitializationOptions extends LiveSessionIndexOp
 }
 
 type SessionsChangedListener = (change: AgentSessionsChanged) => void;
+
 type StatusChangedListener = (event: ScanStatusEvent) => void;
+
 type CachedSessions = CachedResult;
 
 interface RefreshResult {

--- a/packages/cli/src/api/__tests__/bookmark-handlers.test.ts
+++ b/packages/cli/src/api/__tests__/bookmark-handlers.test.ts
@@ -41,7 +41,7 @@ describe("bookmark handlers", () => {
     ]);
     const c = makeContext();
 
-    handleGetBookmarks(c as never, bookmarkScanSource);
+    handleGetBookmarks(c, bookmarkScanSource);
 
     expect(c.json).toHaveBeenCalledWith({
       bookmarks: [
@@ -76,7 +76,7 @@ describe("bookmark handlers", () => {
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
     const c = makeContext();
 
-    handleGetBookmarks(c as never, source);
+    handleGetBookmarks(c, source);
 
     const bookmark = getResponsePayload<{ bookmarks: BookmarkView[] }>(c).bookmarks[0];
     const responseSession = bookmark?.availability === "available" ? bookmark.session : undefined;
@@ -93,13 +93,13 @@ describe("bookmark handlers", () => {
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw new StateStorageUnavailableError();
     });
-    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
+    handleGetBookmarks(makeContext(), bookmarkScanSource);
     expect(loggerMocks.warn).not.toHaveBeenCalled();
 
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw new Error("corrupt aliases");
     });
-    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
+    handleGetBookmarks(makeContext(), bookmarkScanSource);
     expect(loggerMocks.warn).toHaveBeenLastCalledWith("api.session_aliases.load_failed", {
       error: "corrupt aliases",
     });
@@ -107,7 +107,7 @@ describe("bookmark handlers", () => {
     coreMocks.listSessionAliases.mockImplementationOnce(() => {
       throw "invalid aliases";
     });
-    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
+    handleGetBookmarks(makeContext(), bookmarkScanSource);
     expect(loggerMocks.warn).toHaveBeenLastCalledWith("api.session_aliases.load_failed", {
       error: "invalid aliases",
     });
@@ -118,7 +118,7 @@ describe("bookmark handlers", () => {
       throw new BookmarkStorageUnavailableError();
     });
     const unavailable = makeContext();
-    handleGetBookmarks(unavailable as never, bookmarkScanSource);
+    handleGetBookmarks(unavailable, bookmarkScanSource);
     expect(unavailable.json).toHaveBeenCalledWith(
       { error: "Bookmark storage is unavailable" },
       503,
@@ -127,9 +127,7 @@ describe("bookmark handlers", () => {
     coreMocks.listBookmarks.mockImplementationOnce(() => {
       throw new Error("unexpected");
     });
-    expect(() => handleGetBookmarks(makeContext() as never, bookmarkScanSource)).toThrow(
-      "unexpected",
-    );
+    expect(() => handleGetBookmarks(makeContext(), bookmarkScanSource)).toThrow("unexpected");
   });
 
   it.each([
@@ -143,7 +141,7 @@ describe("bookmark handlers", () => {
   ])("rejects invalid bookmark identity payload %#", async (body) => {
     const c = makeContext({ body });
 
-    await handlePutBookmark(c as never);
+    await handlePutBookmark(c);
 
     expect(c.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
     expect(coreMocks.upsertBookmark).not.toHaveBeenCalled();
@@ -151,12 +149,12 @@ describe("bookmark handlers", () => {
 
   it("rejects writes referencing agents that do not exist", async () => {
     const put = makeContext({ body: { reference: { agentName: "ghost", sessionId: "s1" } } });
-    await handlePutBookmark(put as never);
+    await handlePutBookmark(put);
     expect(put.json).toHaveBeenCalledWith({ error: "Unknown agent: ghost" }, 400);
     expect(coreMocks.upsertBookmark).not.toHaveBeenCalled();
 
     const del = makeContext({ param: { agent: "ghost", id: "s1" } });
-    await handleDeleteBookmark(del as never);
+    await handleDeleteBookmark(del);
     expect(del.json).toHaveBeenCalledWith({ error: "Unknown agent: ghost" }, 400);
     expect(coreMocks.deleteBookmark).not.toHaveBeenCalled();
 
@@ -164,12 +162,12 @@ describe("bookmark handlers", () => {
       param: { agent: "ghost", id: "s1" },
       body: { alias: "renamed" },
     });
-    await handlePutSessionAlias(putAlias as never);
+    await handlePutSessionAlias(putAlias);
     expect(putAlias.json).toHaveBeenCalledWith({ error: "Unknown agent: ghost" }, 400);
     expect(coreMocks.upsertSessionAlias).not.toHaveBeenCalled();
 
     const delAlias = makeContext({ param: { agent: "ghost", id: "s1" } });
-    await handleDeleteSessionAlias(delAlias as never);
+    await handleDeleteSessionAlias(delAlias);
     expect(delAlias.json).toHaveBeenCalledWith({ error: "Unknown agent: ghost" }, 400);
     expect(coreMocks.deleteSessionAlias).not.toHaveBeenCalled();
   });
@@ -179,7 +177,7 @@ describe("bookmark handlers", () => {
       body: [storedBookmark, { reference: { agentName: "ghost", sessionId: "s9" } }],
     });
 
-    await handleImportBookmarks(mixed as never, bookmarkScanSource);
+    await handleImportBookmarks(mixed, bookmarkScanSource);
 
     expect(coreMocks.importBookmarks).toHaveBeenCalledWith([storedBookmark]);
     expect(mixed.json).toHaveBeenCalledWith({
@@ -193,10 +191,10 @@ describe("bookmark handlers", () => {
     const current = makeContext({
       body: { reference: validReference, session: { stale: true }, bookmarkedAt: 99 },
     });
-    await handlePutBookmark(current as never);
+    await handlePutBookmark(current);
 
     const legacy = makeContext({ body: legacyBookmark });
-    await handlePutBookmark(legacy as never);
+    await handlePutBookmark(legacy);
 
     expect(coreMocks.upsertBookmark).toHaveBeenNthCalledWith(1, validReference);
     expect(coreMocks.upsertBookmark).toHaveBeenNthCalledWith(2, validReference);
@@ -211,7 +209,7 @@ describe("bookmark handlers", () => {
       throw new BookmarkStorageUnavailableError();
     });
     const unavailable = makeContext({ body: { reference: validReference } });
-    await handlePutBookmark(unavailable as never);
+    await handlePutBookmark(unavailable);
     expect(unavailable.json).toHaveBeenCalledWith(
       { error: "Bookmark storage is unavailable" },
       503,
@@ -221,21 +219,21 @@ describe("bookmark handlers", () => {
       throw new Error("unexpected");
     });
     await expect(
-      handlePutBookmark(makeContext({ body: { reference: validReference } }) as never),
+      handlePutBookmark(makeContext({ body: { reference: validReference } })),
     ).rejects.toThrow("unexpected");
   });
 
   it("validates, imports, and materializes bookmark fact batches", async () => {
     const nonArray = makeContext({ body: storedBookmark });
-    await handleImportBookmarks(nonArray as never, bookmarkScanSource);
+    await handleImportBookmarks(nonArray, bookmarkScanSource);
     expect(nonArray.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
 
     const mixed = makeContext({ body: [storedBookmark, { invalid: true }] });
-    await handleImportBookmarks(mixed as never, bookmarkScanSource);
+    await handleImportBookmarks(mixed, bookmarkScanSource);
     expect(mixed.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
 
     const valid = makeContext({ body: [storedBookmark] });
-    await handleImportBookmarks(valid as never, bookmarkScanSource);
+    await handleImportBookmarks(valid, bookmarkScanSource);
     expect(coreMocks.importBookmarks).toHaveBeenCalledWith([storedBookmark]);
     expect(valid.json).toHaveBeenCalledWith({
       bookmarks: [availableBookmark],
@@ -243,7 +241,7 @@ describe("bookmark handlers", () => {
     });
 
     const legacy = makeContext({ body: [legacyBookmark] });
-    await handleImportBookmarks(legacy as never, bookmarkScanSource);
+    await handleImportBookmarks(legacy, bookmarkScanSource);
     expect(coreMocks.importBookmarks).toHaveBeenLastCalledWith([storedBookmark]);
   });
 
@@ -252,7 +250,7 @@ describe("bookmark handlers", () => {
       body: [{ reference: validReference, bookmarkedAt: "3" }],
     });
 
-    await handleImportBookmarks(context as never, bookmarkScanSource);
+    await handleImportBookmarks(context, bookmarkScanSource);
 
     expect(context.json).toHaveBeenCalledWith({ error: "Invalid bookmark payload" }, 400);
     expect(coreMocks.importBookmarks).not.toHaveBeenCalled();
@@ -263,7 +261,7 @@ describe("bookmark handlers", () => {
       throw new BookmarkStorageUnavailableError();
     });
     const unavailable = makeContext({ body: [storedBookmark] });
-    await handleImportBookmarks(unavailable as never, bookmarkScanSource);
+    await handleImportBookmarks(unavailable, bookmarkScanSource);
     expect(unavailable.json).toHaveBeenCalledWith(
       { error: "Bookmark storage is unavailable" },
       503,
@@ -273,24 +271,24 @@ describe("bookmark handlers", () => {
       throw new Error("unexpected");
     });
     await expect(
-      handleImportBookmarks(makeContext({ body: [storedBookmark] }) as never, bookmarkScanSource),
+      handleImportBookmarks(makeContext({ body: [storedBookmark] }), bookmarkScanSource),
     ).rejects.toThrow("unexpected");
   });
 
   it("validates bookmark identifiers before deleting", () => {
     const missingAgent = makeContext({ param: { id: "s1" } });
-    handleDeleteBookmark(missingAgent as never);
+    handleDeleteBookmark(missingAgent);
     expect(missingAgent.json).toHaveBeenCalledWith({ error: "Missing bookmark identifier" }, 400);
 
     const missingSession = makeContext({ param: { agent: "codex" } });
-    handleDeleteBookmark(missingSession as never);
+    handleDeleteBookmark(missingSession);
     expect(missingSession.json).toHaveBeenCalledWith({ error: "Missing bookmark identifier" }, 400);
     expect(coreMocks.deleteBookmark).not.toHaveBeenCalled();
   });
 
   it("deletes bookmarks and handles storage failures", () => {
     const valid = makeContext({ param: { agent: "codex", id: "s1" } });
-    handleDeleteBookmark(valid as never);
+    handleDeleteBookmark(valid);
     expect(coreMocks.deleteBookmark).toHaveBeenCalledWith({
       agentName: "codex",
       sessionId: "s1",
@@ -301,7 +299,7 @@ describe("bookmark handlers", () => {
       throw new BookmarkStorageUnavailableError();
     });
     const unavailable = makeContext({ param: { agent: "codex", id: "s1" } });
-    handleDeleteBookmark(unavailable as never);
+    handleDeleteBookmark(unavailable);
     expect(unavailable.json).toHaveBeenCalledWith(
       { error: "Bookmark storage is unavailable" },
       503,
@@ -311,7 +309,7 @@ describe("bookmark handlers", () => {
       throw new Error("unexpected");
     });
     expect(() =>
-      handleDeleteBookmark(makeContext({ param: { agent: "codex", id: "s1" } }) as never),
+      handleDeleteBookmark(makeContext({ param: { agent: "codex", id: "s1" } })),
     ).toThrow("unexpected");
   });
 });
@@ -319,14 +317,14 @@ describe("bookmark handlers", () => {
 describe("session alias handlers", () => {
   it("validates alias payloads and identifiers", async () => {
     const missingAgent = makeContext({ body: { alias: "Renamed" }, param: { id: "s1" } });
-    await handlePutSessionAlias(missingAgent as never);
+    await handlePutSessionAlias(missingAgent);
     expect(missingAgent.json).toHaveBeenCalledWith({ error: "Invalid session alias payload" }, 400);
 
     const missingSession = makeContext({
       body: { alias: "Renamed" },
       param: { agent: "codex" },
     });
-    await handlePutSessionAlias(missingSession as never);
+    await handlePutSessionAlias(missingSession);
     expect(missingSession.json).toHaveBeenCalledWith(
       { error: "Invalid session alias payload" },
       400,
@@ -336,7 +334,7 @@ describe("session alias handlers", () => {
       body: { alias: 42 },
       param: { agent: "codex", id: "s1" },
     });
-    await handlePutSessionAlias(invalidAlias as never);
+    await handlePutSessionAlias(invalidAlias);
     expect(invalidAlias.json).toHaveBeenCalledWith({ error: "Invalid session alias payload" }, 400);
   });
 
@@ -345,7 +343,7 @@ describe("session alias handlers", () => {
       body: { alias: "Renamed" },
       param: { agent: "codex", id: "s1" },
     });
-    await handlePutSessionAlias(valid as never);
+    await handlePutSessionAlias(valid);
     expect(coreMocks.upsertSessionAlias).toHaveBeenCalledWith(
       { agentName: "codex", sessionId: "s1" },
       "Renamed",
@@ -358,7 +356,7 @@ describe("session alias handlers", () => {
       body: { alias: " " },
       param: { agent: "codex", id: "s1" },
     });
-    await handlePutSessionAlias(invalid as never);
+    await handlePutSessionAlias(invalid);
     expect(invalid.json).toHaveBeenCalledWith(
       { error: "Session alias must be non-empty and at most 160 characters" },
       400,
@@ -394,7 +392,7 @@ describe("session alias handlers", () => {
       body: { alias: "Renamed" },
       param: { agent: "codex", id: "s1" },
     });
-    await handlePutSessionAlias(unavailable as never);
+    await handlePutSessionAlias(unavailable);
     expect(unavailable.json).toHaveBeenCalledWith(
       { error: "Session alias storage is unavailable" },
       503,
@@ -408,21 +406,21 @@ describe("session alias handlers", () => {
         makeContext({
           body: { alias: "Renamed" },
           param: { agent: "codex", id: "s1" },
-        }) as never,
+        }),
       ),
     ).rejects.toThrow("unexpected");
   });
 
   it("validates alias identifiers before deleting", () => {
     const missingAgent = makeContext({ param: { id: "s1" } });
-    handleDeleteSessionAlias(missingAgent as never);
+    handleDeleteSessionAlias(missingAgent);
     expect(missingAgent.json).toHaveBeenCalledWith(
       { error: "Missing session alias identifier" },
       400,
     );
 
     const missingSession = makeContext({ param: { agent: "codex" } });
-    handleDeleteSessionAlias(missingSession as never);
+    handleDeleteSessionAlias(missingSession);
     expect(missingSession.json).toHaveBeenCalledWith(
       { error: "Missing session alias identifier" },
       400,
@@ -431,7 +429,7 @@ describe("session alias handlers", () => {
 
   it("deletes aliases and handles storage failures", () => {
     const valid = makeContext({ param: { agent: "codex", id: "s1" } });
-    handleDeleteSessionAlias(valid as never);
+    handleDeleteSessionAlias(valid);
     expect(coreMocks.deleteSessionAlias).toHaveBeenCalledWith({
       agentName: "codex",
       sessionId: "s1",
@@ -442,7 +440,7 @@ describe("session alias handlers", () => {
       throw new StateStorageUnavailableError();
     });
     const unavailable = makeContext({ param: { agent: "codex", id: "s1" } });
-    handleDeleteSessionAlias(unavailable as never);
+    handleDeleteSessionAlias(unavailable);
     expect(unavailable.json).toHaveBeenCalledWith(
       { error: "Session alias storage is unavailable" },
       503,
@@ -452,7 +450,7 @@ describe("session alias handlers", () => {
       throw new Error("unexpected");
     });
     expect(() =>
-      handleDeleteSessionAlias(makeContext({ param: { agent: "codex", id: "s1" } }) as never),
+      handleDeleteSessionAlias(makeContext({ param: { agent: "codex", id: "s1" } })),
     ).toThrow("unexpected");
   });
 });

--- a/packages/cli/src/api/__tests__/client-log-handler.test.ts
+++ b/packages/cli/src/api/__tests__/client-log-handler.test.ts
@@ -6,15 +6,15 @@ const { handlePostClientLog } = await import("../client-log-handler.js");
 describe("client logging handler", () => {
   it("rejects malformed, blank, and unknown log events", async () => {
     const malformed = makeContext({ rejectBody: true });
-    await handlePostClientLog(malformed as never);
+    await handlePostClientLog(malformed);
     expect(malformed.json).toHaveBeenCalledWith({ ok: false }, 400);
 
     const blank = makeContext({ body: { event: "   " } });
-    await handlePostClientLog(blank as never);
+    await handlePostClientLog(blank);
     expect(blank.json).toHaveBeenCalledWith({ ok: false }, 400);
 
     const unknown = makeContext({ body: { event: "private arbitrary text" } });
-    await handlePostClientLog(unknown as never);
+    await handlePostClientLog(unknown);
     expect(unknown.json).toHaveBeenCalledWith({ ok: false }, 400);
     expect(loggerMocks.info).not.toHaveBeenCalled();
   });
@@ -38,7 +38,7 @@ describe("client logging handler", () => {
       body: { event: " session.open.error ", data },
     });
 
-    await handlePostClientLog(c as never);
+    await handlePostClientLog(c);
 
     const [event, loggedData] = loggerMocks.info.mock.calls[0]!;
     expect(event).toBe("client.session.open.error");
@@ -69,7 +69,7 @@ describe("client logging handler", () => {
       },
     });
 
-    await handlePostClientLog(c as never);
+    await handlePostClientLog(c);
 
     expect(loggerMocks.info).toHaveBeenCalledWith("client.app.load.done", {});
   });
@@ -77,7 +77,7 @@ describe("client logging handler", () => {
   it("drops non-record log data", async () => {
     const c = makeContext({ body: { event: "app.load.start", data: "not-an-object" } });
 
-    await handlePostClientLog(c as never);
+    await handlePostClientLog(c);
 
     expect(loggerMocks.info).toHaveBeenCalledWith("client.app.load.start", {});
   });

--- a/packages/cli/src/api/__tests__/handler-test-fixtures.ts
+++ b/packages/cli/src/api/__tests__/handler-test-fixtures.ts
@@ -1,3 +1,4 @@
+import type { Context } from "hono";
 import { afterEach, vi, type Mock } from "vitest";
 import { createSessionIdentity } from "@codesesh/core/contract";
 
@@ -48,6 +49,7 @@ const coreMocks: Record<CoreMockName, Mock> = vi.hoisted(() => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real project projection calls to verify handler work is bounded.
 vi.mock("@codesesh/core/runtime/projects", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/projects")>();
   return {
@@ -69,6 +71,7 @@ vi.mock("@codesesh/core/runtime/projects", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real dashboard builds to verify the handler reuses cached results.
 vi.mock("@codesesh/core/runtime/analytics", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/analytics")>();
   return {
@@ -80,6 +83,7 @@ vi.mock("@codesesh/core/runtime/analytics", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real search filtering calls and control the index query result at the handler boundary.
 vi.mock("@codesesh/core/runtime/search", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/search")>();
   return {
@@ -94,6 +98,7 @@ vi.mock("@codesesh/core/runtime/search", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control cached analytics revisions and search results at the HTTP boundary.
 vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime/discovery")>()),
   getAnalyticsRevision: coreMocks.getAnalyticsRevision,
@@ -103,11 +108,13 @@ vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => ({
   listFileActivity: coreMocks.listFileActivity,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control persistence results and failures at the HTTP handler boundary without modifying user state.
 vi.mock("@codesesh/core/runtime/state", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime/state")>()),
   listSessionAliases: coreMocks.listSessionAliases,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real session-tree builds to verify aggregation reuses the existing tree.
 vi.mock("@codesesh/core/contract", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/contract")>();
   return {
@@ -179,10 +186,11 @@ function makeMockContext(
     param?: Record<string, string>;
     signal?: AbortSignal;
   } = {},
-) {
+): Context & { json: Mock } {
   const jsonFn = vi.fn().mockReturnValue({ status: 200 });
   const params = new URLSearchParams(overrides.query ?? {});
   const url = `http://localhost/${params.size ? `?${params.toString()}` : ""}`;
+  // SAFETY: The fixture implements the req/json surface used by these handlers and retains the JSON spy.
   return {
     req: {
       query: (key: string) => overrides.query?.[key] ?? "",
@@ -191,7 +199,7 @@ function makeMockContext(
       raw: new Request(url, { signal: overrides.signal }),
     },
     json: jsonFn,
-  } as any;
+  } as Context & { json: Mock };
 }
 
 class MockAgent extends BaseAgent {

--- a/packages/cli/src/api/__tests__/query-boundary-handlers.test.ts
+++ b/packages/cli/src/api/__tests__/query-boundary-handlers.test.ts
@@ -19,17 +19,17 @@ describe("query boundary handlers", () => {
     endpoint: string;
     invoke: (context: ReturnType<typeof makeContext>) => unknown;
   }> = [
-    { endpoint: "agents", invoke: (context) => handleGetAgents(context as never, scanSource) },
-    { endpoint: "projects", invoke: (context) => handleGetProjects(context as never, scanSource) },
-    { endpoint: "sessions", invoke: (context) => handleGetSessions(context as never, scanSource) },
-    { endpoint: "search", invoke: (context) => handleSearchSessions(context as never, scanSource) },
+    { endpoint: "agents", invoke: (context) => handleGetAgents(context, scanSource) },
+    { endpoint: "projects", invoke: (context) => handleGetProjects(context, scanSource) },
+    { endpoint: "sessions", invoke: (context) => handleGetSessions(context, scanSource) },
+    { endpoint: "search", invoke: (context) => handleSearchSessions(context, scanSource) },
     {
       endpoint: "file-activity",
-      invoke: (context) => handleGetFileActivity(context as never, scanSource),
+      invoke: (context) => handleGetFileActivity(context, scanSource),
     },
     {
       endpoint: "dashboard",
-      invoke: (context) => handleGetDashboard(context as never, scanSource),
+      invoke: (context) => handleGetDashboard(context, scanSource),
     },
   ];
 
@@ -55,9 +55,9 @@ describe("query boundary handlers", () => {
 
   it("reports rejected and empty-result parameter outcomes", () => {
     const sessions = makeContext({ query: { agent: "nonexistent" } });
-    handleGetSessions(sessions as never, scanSource);
+    handleGetSessions(sessions, scanSource);
     const files = makeContext({ query: { limit: "1.5" } });
-    handleGetFileActivity(files as never, scanSource);
+    handleGetFileActivity(files, scanSource);
 
     expect(loggerMocks.warn).toHaveBeenCalledWith("api.query_parameter.invalid", {
       endpoint: "sessions",
@@ -75,21 +75,21 @@ describe("query boundary handlers", () => {
 
   it("rejects invalid project identities consistently", () => {
     const sessions = makeContext({ query: { projectKind: "path" } });
-    handleGetSessions(sessions as never, scanSource);
+    handleGetSessions(sessions, scanSource);
     expect(sessions.json).toHaveBeenCalledWith(
       { error: "projectKind and projectKey must form a valid project identity" },
       400,
     );
 
     const files = makeContext({ query: { projectKind: "invalid", projectKey: "/repo" } });
-    handleGetFileActivity(files as never, scanSource);
+    handleGetFileActivity(files, scanSource);
     expect(files.json).toHaveBeenCalledWith(
       { error: "projectKind and projectKey must form a valid project identity" },
       400,
     );
 
     const dashboard = makeContext({ query: { projectKey: "/repo" } });
-    handleGetDashboard(dashboard as never, scanSource);
+    handleGetDashboard(dashboard, scanSource);
     expect(dashboard.json).toHaveBeenCalledWith(
       { error: "projectKind and projectKey must form a valid project identity" },
       400,
@@ -114,7 +114,7 @@ describe("query boundary handlers", () => {
     });
 
     const resolver = makeProjectIdentityResolver();
-    await handleGetFileActivity(c as never, scanSource, {}, resolver);
+    await handleGetFileActivity(c, scanSource, {}, resolver);
 
     expect(coreMocks.listFileActivity).toHaveBeenCalledWith(
       {
@@ -143,7 +143,7 @@ describe("query boundary handlers", () => {
     (limit) => {
       const c = makeContext({ query: { kind: "execute", limit } });
 
-      handleGetFileActivity(c as never, scanSource);
+      handleGetFileActivity(c, scanSource);
 
       expect(c.json).toHaveBeenCalledWith({ error: "limit must be a positive integer" }, 400);
       expect(coreMocks.listFileActivity).not.toHaveBeenCalled();
@@ -153,7 +153,7 @@ describe("query boundary handlers", () => {
   it("returns an empty file activity result for an unknown agent without querying storage", () => {
     const c = makeContext({ query: { agent: "nonexistent" } });
 
-    handleGetFileActivity(c as never, scanSource);
+    handleGetFileActivity(c, scanSource);
 
     expect(c.json).toHaveBeenCalledWith({ activity: [] });
     expect(coreMocks.listFileActivity).not.toHaveBeenCalled();
@@ -168,7 +168,7 @@ describe("query boundary handlers", () => {
         days: "1",
       },
     });
-    handleGetDashboard(custom as never, scanSource);
+    handleGetDashboard(custom, scanSource);
     const customFrom = new Date("2026-01-01T00:00:00.000Z").getTime();
     expect(getResponsePayload<{ window: unknown }>(custom).window).toEqual({
       from: customFrom,
@@ -179,7 +179,7 @@ describe("query boundary handlers", () => {
     });
 
     const fallback = makeContext({ query: { to: "2026-01-04T00:00:00.000Z" } });
-    handleGetDashboard(fallback as never, scanSource, {
+    handleGetDashboard(fallback, scanSource, {
       from: new Date("2026-01-01T00:00:00.000Z").getTime(),
     });
     expect(getResponsePayload<{ window: { days: number } }>(fallback).window.days).toBe(4);
@@ -190,7 +190,7 @@ describe("query boundary handlers", () => {
     vi.setSystemTime(new Date("2026-01-03T00:00:00.000Z"));
     const c = makeContext({ query: { days: "0" } });
 
-    handleGetDashboard(c as never, scanSource);
+    handleGetDashboard(c, scanSource);
 
     expect(getResponsePayload<{ window: unknown }>(c).window).toEqual({
       from: undefined,

--- a/packages/cli/src/api/__tests__/query-scope-integration.test.ts
+++ b/packages/cli/src/api/__tests__/query-scope-integration.test.ts
@@ -7,6 +7,7 @@ import type { ScanResultSource } from "../scan-sources.js";
 
 const testHome = mkdtempSync(join(tmpdir(), "codesesh-query-scope-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:os")>()),
   homedir: () => testHome,

--- a/packages/cli/src/api/__tests__/routes.test.ts
+++ b/packages/cli/src/api/__tests__/routes.test.ts
@@ -5,6 +5,7 @@ import type { SessionAlias } from "@codesesh/core/runtime/state";
 const stateMocks = vi.hoisted(() => ({
   listSessionAliases: vi.fn<() => SessionAlias[]>(() => []),
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control persistence results and failures at the HTTP handler boundary without modifying user state.
 vi.mock("@codesesh/core/runtime/state", async (importOriginal) => ({
   ...(await importOriginal<object>()),
   listSessionAliases: stateMocks.listSessionAliases,
@@ -12,6 +13,7 @@ vi.mock("@codesesh/core/runtime/state", async (importOriginal) => ({
 
 const loggerMocks = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn() }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("../../logging.js", () => ({ appLogger: loggerMocks }));
 import {
   SAMPLE_SCAN_STATUS_EVENT,
@@ -251,7 +253,7 @@ describe("createApiRoutes", () => {
           sessions: [],
           byAgent: {},
           agents: [],
-        } as unknown as LiveSnapshot;
+        } as LiveSnapshot;
       },
     };
     const app = createApiRoutes(scanSource);

--- a/packages/cli/src/api/__tests__/search-transport.test.ts
+++ b/packages/cli/src/api/__tests__/search-transport.test.ts
@@ -18,6 +18,7 @@ import type { ScanResultSource } from "../scan-sources.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-search-transport-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {

--- a/packages/cli/src/api/__tests__/session-alias-cache.test.ts
+++ b/packages/cli/src/api/__tests__/session-alias-cache.test.ts
@@ -24,9 +24,9 @@ describe("session alias caching", () => {
   it("queries alias storage once across repeated reads", () => {
     coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
 
-    handleGetSessions(makeContext() as never, scanSource);
-    handleGetSessions(makeContext() as never, scanSource);
-    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
+    handleGetSessions(makeContext(), scanSource);
+    handleGetSessions(makeContext(), scanSource);
+    handleGetBookmarks(makeContext(), bookmarkScanSource);
 
     expect(coreMocks.listSessionAliases).toHaveBeenCalledTimes(1);
   });
@@ -37,7 +37,7 @@ describe("session alias caching", () => {
     coreMocks.listSessionAliases.mockReturnValue([]);
     const readTitle = () => {
       const context = makeContext();
-      handleGetBookmarks(context as never, bookmarkScanSource);
+      handleGetBookmarks(context, bookmarkScanSource);
       const bookmark = getResponsePayload<{ bookmarks: BookmarkView[] }>(context).bookmarks[0];
       return bookmark?.availability === "available" ? bookmark.session.display_title : undefined;
     };
@@ -59,17 +59,17 @@ describe("session alias caching", () => {
 
   it("picks up a stored alias on the next read", async () => {
     coreMocks.listSessionAliases.mockReturnValue([]);
-    handleGetSessions(makeContext() as never, scanSource);
+    handleGetSessions(makeContext(), scanSource);
 
     coreMocks.upsertSessionAlias.mockReturnValue(aliasRecord);
     coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
     await handlePutSessionAlias(
-      makeContext({ body: { alias: "Renamed" }, param: { agent: "codex", id: "s1" } }) as never,
+      makeContext({ body: { alias: "Renamed" }, param: { agent: "codex", id: "s1" } }),
     );
 
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
     const after = makeContext();
-    handleGetBookmarks(after as never, bookmarkScanSource);
+    handleGetBookmarks(after, bookmarkScanSource);
 
     expect(getResponsePayload<{ bookmarks: BookmarkView[] }>(after).bookmarks[0]).toMatchObject({
       session: { display_title: "Renamed" },
@@ -79,13 +79,13 @@ describe("session alias caching", () => {
   it("drops a removed alias on the next read", () => {
     coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
-    handleGetBookmarks(makeContext() as never, bookmarkScanSource);
+    handleGetBookmarks(makeContext(), bookmarkScanSource);
 
     coreMocks.listSessionAliases.mockReturnValue([]);
-    handleDeleteSessionAlias(makeContext({ param: { agent: "codex", id: "s1" } }) as never);
+    handleDeleteSessionAlias(makeContext({ param: { agent: "codex", id: "s1" } }));
 
     const after = makeContext();
-    handleGetBookmarks(after as never, bookmarkScanSource);
+    handleGetBookmarks(after, bookmarkScanSource);
 
     const bookmark = getResponsePayload<{ bookmarks: BookmarkView[] }>(after).bookmarks[0];
     expect(bookmark).toMatchObject({ availability: "available" });
@@ -100,11 +100,11 @@ describe("session alias caching", () => {
     });
     coreMocks.listSessionAliases.mockReturnValue([aliasRecord]);
 
-    handleGetSessions(makeContext() as never, scanSource);
+    handleGetSessions(makeContext(), scanSource);
     coreMocks.listBookmarks.mockReturnValue([storedBookmark]);
     const recovered = makeContext();
-    handleGetBookmarks(recovered as never, bookmarkScanSource);
-    handleGetSessions(makeContext() as never, scanSource);
+    handleGetBookmarks(recovered, bookmarkScanSource);
+    handleGetSessions(makeContext(), scanSource);
 
     expect(getResponsePayload<{ bookmarks: BookmarkView[] }>(recovered).bookmarks[0]).toMatchObject(
       { session: { display_title: "Renamed" } },

--- a/packages/cli/src/api/__tests__/session-reference-transport.test.ts
+++ b/packages/cli/src/api/__tests__/session-reference-transport.test.ts
@@ -9,6 +9,7 @@ const received = vi.hoisted(() => ({
   deleteAlias: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Capture decoded session references at the HTTP-to-core boundary.
 vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/discovery")>();
   return {
@@ -20,6 +21,7 @@ vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control persistence results and failures at the HTTP handler boundary without modifying user state.
 vi.mock("@codesesh/core/runtime/state", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/state")>();
   return {
@@ -47,7 +49,7 @@ const OPAQUE_IDS = [
 
 function makeApp() {
   return createApiRoutes({
-    getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }) as unknown as LiveSnapshot,
+    getSnapshot: () => ({ sessions: [], byAgent: {}, agents: [] }) as LiveSnapshot,
   });
 }
 

--- a/packages/cli/src/api/__tests__/state-handler-test-fixtures.ts
+++ b/packages/cli/src/api/__tests__/state-handler-test-fixtures.ts
@@ -1,3 +1,4 @@
+import type { Context } from "hono";
 import { afterEach, beforeEach, vi, type Mock } from "vitest";
 
 type StateMockName =
@@ -32,6 +33,7 @@ const loggerMocks: Record<LoggerMockName, Mock> = vi.hoisted(() => ({
   warn: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control persistence results and failures at the HTTP handler boundary without modifying user state.
 vi.mock("@codesesh/core/runtime/state", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/state")>();
   return {
@@ -46,12 +48,14 @@ vi.mock("@codesesh/core/runtime/state", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Supply cached analytics reads to exercise handler responses independently of SQLite.
 vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime/discovery")>()),
   listDashboardCostFacts: coreMocks.listDashboardCostFacts,
   listFileActivity: coreMocks.listFileActivity,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("../../logging.js", () => ({ appLogger: loggerMocks }));
 import type { BookmarkRecord, BookmarkView } from "@codesesh/core/runtime/state";
 import type { LiveSnapshot, SessionHead } from "@codesesh/core/runtime/discovery";
@@ -85,9 +89,11 @@ interface TestContext {
   >;
 }
 
-function makeContext(options: ContextOptions = {}): TestContext {
+function makeContext(options: ContextOptions = {}): TestContext & Context {
   const params = new URLSearchParams(options.query ?? {});
   const url = `http://localhost/${params.size > 0 ? `?${params.toString()}` : ""}`;
+  // SAFETY: These handler tests exercise req/json only; route integration tests cover Hono middleware.
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- This partial Hono context is confined to direct handler tests.
   return {
     req: {
       json: () =>
@@ -100,7 +106,7 @@ function makeContext(options: ContextOptions = {}): TestContext {
       raw: new Request(url),
     },
     json: vi.fn((payload: unknown, status = 200) => ({ payload, status })),
-  };
+  } as unknown as TestContext & Context;
 }
 
 function makeProjectIdentityResolver(): ProjectIdentityResolver {

--- a/packages/cli/src/api/request-payloads.ts
+++ b/packages/cli/src/api/request-payloads.ts
@@ -56,10 +56,10 @@ export function parseBookmarkImport(value: unknown): BookmarkRecord | null {
   };
 }
 
-export function sanitizeClientLogData(value: unknown): Record<string, unknown> {
+export function sanitizeClientLogData(value: unknown): Record<string, string | number | null> {
   if (!isRecord(value)) return {};
 
-  const sanitized: Record<string, unknown> = {};
+  const sanitized: Record<string, string | number | null> = {};
   for (const [key, item] of Object.entries(value)) {
     if (CLIENT_LOG_STRING_FIELDS.has(key) && typeof item === "string") {
       if (key === "operation_id" && !UUID_PATTERN.test(item)) continue;

--- a/packages/cli/src/api/snapshot-aggregation.ts
+++ b/packages/cli/src/api/snapshot-aggregation.ts
@@ -21,6 +21,7 @@ interface SnapshotAggregationCache {
 
 const SNAPSHOT_AGGREGATION_CACHE_LIMIT = 64;
 const snapshotAggregationCaches = new WeakMap<ScanResultSource, SnapshotAggregationCache>();
+
 type SnapshotAggregationCacheState = "hit" | "miss";
 
 function getSnapshotAggregationCache(

--- a/packages/cli/src/api/snapshot-pagination.ts
+++ b/packages/cli/src/api/snapshot-pagination.ts
@@ -67,6 +67,7 @@ export function createSnapshotPaginator<T, View>() {
   const snapshotsBySource = new WeakMap<object, Map<string, RetainedSnapshot<T, View>>>();
 
   return function paginateSnapshot(
+    // oxlint-disable-next-line anti-slop/no-object-parameters -- The source is a WeakMap identity token; pagination never reads its fields.
     source: object,
     request: PaginationRequest,
     load: () => PaginationSnapshot<T, View>,

--- a/packages/cli/src/live-scan-store.test.ts
+++ b/packages/cli/src/live-scan-store.test.ts
@@ -78,6 +78,7 @@ const workerThreads = vi.hoisted(() => ({
   acknowledgeLogDrain: true,
   deferSearchIndexWorkers: false,
   deferScanRefreshWorkers: false,
+  // SAFETY: This in-process Worker fixture accepts both scan and index message payloads; each branch reads its own protocol fields.
   workers: [] as Array<{
     url: URL;
     workerData: any;
@@ -92,6 +93,7 @@ const workerThreads = vi.hoisted(() => ({
     emitExit: (code: number) => void;
   }>,
   Worker: vi.fn(function (this: unknown, url: URL, options?: { workerData?: unknown }) {
+    // SAFETY: This in-process Worker fixture accepts both scan and index message payloads; each branch reads its own protocol fields.
     const workerData = (options?.workerData ?? {}) as any;
     const isSearchWorker = Boolean(workerData.jobs);
     const isScanWorker = Boolean(workerData.agentName);
@@ -263,7 +265,7 @@ const workerThreads = vi.hoisted(() => ({
       off: vi.fn((event: string, handler: (message: unknown) => void) => {
         const handlers =
           event === "message" ? messageHandlers : event === "exit" ? exitHandlers : errorHandlers;
-        const index = handlers.indexOf(handler as never);
+        const index = handlers.findIndex((registered) => registered === handler);
         if (index >= 0) handlers.splice(index, 1);
         return worker;
       }),
@@ -318,6 +320,7 @@ const workerThreads = vi.hoisted(() => ({
   }),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control watcher registration and worker bundle discovery while retaining real file operations.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   fsWatch.existsSync.mockImplementation((path: Parameters<typeof actual.existsSync>[0]) =>
@@ -330,11 +333,13 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Register only the fixture agents so orchestration cannot discover host agent data.
 vi.mock("@codesesh/core/runtime/agents", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime/agents")>()),
   createRegisteredAgents: core.createRegisteredAgents,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control cache publication, revisions and failures at the scan orchestration boundary.
 vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/discovery")>();
   return {
@@ -356,6 +361,7 @@ vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control worker messages, failures and shutdown without timing real threads.
 vi.mock("node:worker_threads", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:worker_threads")>()),
   Worker: workerThreads.Worker,
@@ -448,6 +454,7 @@ function watchPlanFor(name: string) {
 }
 
 function makeAgent(name: string, overrides: Record<string, unknown> = {}) {
+  // oxlint-disable-next-line anti-slop/no-known-value-widening -- The fixture composes different registered agent capabilities from per-test overrides.
   const agent: Record<string, unknown> = {
     name,
     displayName: name,

--- a/packages/cli/src/live-scan.ts
+++ b/packages/cli/src/live-scan.ts
@@ -31,6 +31,7 @@ export type {
 };
 
 type StoreListener = (event: SessionsUpdatedEvent) => void;
+
 type ScanStatusListener = (event: ScanStatusEvent) => void;
 
 export interface LiveScanStoreOptions {

--- a/packages/cli/src/live-session-index.test.ts
+++ b/packages/cli/src/live-session-index.test.ts
@@ -42,6 +42,7 @@ function snapshot(
 describe("LiveSessionIndex", () => {
   it("rejects unresolved project identities at snapshot boundaries", () => {
     const codex = makeAgent("codex");
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The missing identity is intentional invalid input; this test verifies rejection at the snapshot boundary.
     const unresolved = {
       ...makeSession("unresolved", 1),
       project_identity: undefined,

--- a/packages/cli/src/log-record.ts
+++ b/packages/cli/src/log-record.ts
@@ -4,6 +4,15 @@ import { types } from "node:util";
 import { AGENT_CATALOG } from "@codesesh/core/contract";
 import type { WorkerLogContext, WorkerLogLevel } from "@codesesh/core/runtime/diagnostics";
 
+type SanitizedLogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | SanitizedLogValue[]
+  | { [key: string]: SanitizedLogValue };
+
 export const LOG_SCHEMA_VERSION = 1;
 export const MIN_LOG_RECORD_BYTES = 512;
 
@@ -355,7 +364,7 @@ export class LogRecordEncoder {
     ancestors: WeakSet<object>,
     trustedCorrelationIds: boolean,
     budget: SanitizationBudget,
-  ): unknown {
+  ): SanitizedLogValue {
     if (budget.remainingValues <= 0 || budget.remainingCharacters <= 0) return TRUNCATED_VALUE;
     budget.remainingValues -= 1;
 
@@ -421,7 +430,7 @@ export class LogRecordEncoder {
         return this.sanitizeArray(value, key, depth, ancestors, trustedCorrelationIds, budget);
       }
       if (types.isMap(value)) {
-        const result: unknown[] = [];
+        const result: SanitizedLogValue[] = [];
         for (const [mapKey, item] of Map.prototype.entries.call(value)) {
           result.push([
             this.sanitizeValue(mapKey, "key", depth + 1, ancestors, trustedCorrelationIds, budget),
@@ -438,7 +447,7 @@ export class LogRecordEncoder {
         return result;
       }
       if (types.isSet(value)) {
-        const result: unknown[] = [];
+        const result: SanitizedLogValue[] = [];
         for (const item of Set.prototype.values.call(value)) {
           result.push(
             this.sanitizeValue(item, key, depth + 1, ancestors, trustedCorrelationIds, budget),
@@ -462,12 +471,13 @@ export class LogRecordEncoder {
   }
 
   private sanitizeObject(
+    // oxlint-disable-next-line anti-slop/no-object-parameters -- Sanitization must inspect arbitrary runtime objects after excluding null and primitives.
     value: object,
     depth: number,
     ancestors: WeakSet<object>,
     trustedCorrelationIds: boolean,
     budget: SanitizationBudget,
-  ): Record<string, unknown> | string {
+  ): { [key: string]: SanitizedLogValue } | string {
     let keys: string[];
     try {
       keys = Object.getOwnPropertyNames(value).slice(0, MAX_OBJECT_FIELDS);
@@ -475,7 +485,7 @@ export class LogRecordEncoder {
       return UNSERIALIZABLE_VALUE;
     }
 
-    const result: Record<string, unknown> = {};
+    const result: { [key: string]: SanitizedLogValue } = {};
     for (const key of keys) {
       let descriptor: PropertyDescriptor | undefined;
       try {
@@ -510,13 +520,13 @@ export class LogRecordEncoder {
     ancestors: WeakSet<object>,
     trustedCorrelationIds: boolean,
     budget: SanitizationBudget,
-  ): unknown[] {
+  ): SanitizedLogValue[] {
     const lengthDescriptor = Object.getOwnPropertyDescriptor(value, "length");
     const length =
       lengthDescriptor && "value" in lengthDescriptor && typeof lengthDescriptor.value === "number"
         ? Math.min(lengthDescriptor.value, MAX_ARRAY_ITEMS)
         : 0;
-    const result: unknown[] = [];
+    const result: SanitizedLogValue[] = [];
     for (let index = 0; index < length; index += 1) {
       const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
       result.push(
@@ -544,7 +554,7 @@ export class LogRecordEncoder {
     ancestors: WeakSet<object>,
     trustedCorrelationIds: boolean,
     budget: SanitizationBudget,
-  ): Record<string, unknown> {
+  ): { [key: string]: SanitizedLogValue } {
     const code = this.errorProperty(error, "code");
     const cause = this.errorProperty(error, "cause");
     const message = this.errorStringProperty(error, "message", "");
@@ -591,6 +601,7 @@ export class LogRecordEncoder {
       if (!descriptor) return undefined;
       return "value" in descriptor ? descriptor.value : ACCESSOR_VALUE;
     } catch {
+      // oxlint-disable-next-line anti-slop/no-known-value-widening -- The error-property boundary returns arbitrary user fields or this unreadable-property sentinel.
       return UNSERIALIZABLE_VALUE;
     }
   }
@@ -600,6 +611,7 @@ export class LogRecordEncoder {
     return value == null ? fallback : typeof value === "string" ? value : UNSERIALIZABLE_VALUE;
   }
 
+  // oxlint-disable-next-line anti-slop/no-object-parameters -- Calling the native URL method tests the brand without trusting user-defined getters.
   private urlString(value: object): string | undefined {
     try {
       return URL.prototype.toString.call(value);

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -15,6 +15,7 @@ import { AsyncLogFileWriter, type DroppedLogCounts } from "./log-file-writer.js"
 import { LogRecordEncoder, type EncodedLogLine } from "./log-record.js";
 
 export type LogContext = WorkerLogContext;
+
 type LogLevel = WorkerLogLevel;
 
 interface WorkerLogPort {

--- a/packages/cli/src/pending-search-index-jobs.ts
+++ b/packages/cli/src/pending-search-index-jobs.ts
@@ -11,8 +11,11 @@ import type {
 import type { LogContext } from "./logging.js";
 
 type FullSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "full" }>;
+
 type ChangesSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "changes" }>;
+
 type MaintenanceSearchIndexJob = Extract<SearchIndexWorkerJob, { kind: "maintenance" }>;
+
 type IncrementalSearchIndexJob = ChangesSearchIndexJob | MaintenanceSearchIndexJob;
 
 const LOG_CONTEXT_KEYS = ["request_id", "operation_id", "publication_id"] as const;

--- a/packages/cli/src/pricing-refresh.test.ts
+++ b/packages/cli/src/pricing-refresh.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({ refresh: vi.fn(), publish: vi.fn() }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control pricing generation publication and synchronization independently of network refresh.
 vi.mock("@codesesh/core/runtime/pricing", () => ({
   refreshPricingCache: mocks.refresh,
   publishPendingPricing: mocks.publish,
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({ appLogger: { info: vi.fn(), warn: vi.fn() } }));
 const { startPricingRefresh } = await import("./pricing-refresh.js");
 

--- a/packages/cli/src/project-identity-resolver.test.ts
+++ b/packages/cli/src/project-identity-resolver.test.ts
@@ -40,7 +40,9 @@ const workerMocks = vi.hoisted(() => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control worker messages, failures and shutdown without timing real threads.
 vi.mock("node:worker_threads", () => ({ Worker: workerMocks.FakeWorker }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({
   appLogger: {
     consumeWorkerMessage: workerMocks.consumeWorkerMessage,

--- a/packages/cli/src/project-identity-worker.test.ts
+++ b/packages/cli/src/project-identity-worker.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   postMessage: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Drive this worker entry point with controlled messages and observe its replies in-process.
 vi.mock("node:worker_threads", () => ({
   parentPort: {
     on: (
@@ -21,14 +22,17 @@ vi.mock("node:worker_threads", () => ({
   threadId: 17,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Inject identity projection failures to verify worker error replies.
 vi.mock("@codesesh/core/runtime/projects", () => ({
   computeIdentityProjection: mocks.computeIdentityProjection,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Keep worker entry point tests from changing process-wide diagnostic callbacks.
 vi.mock("@codesesh/core/runtime/diagnostics", () => ({
   setCoreDiagnostics: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({
   appLogger: { forwardToParent: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));

--- a/packages/cli/src/scan-refresh-worker-integration.test.ts
+++ b/packages/cli/src/scan-refresh-worker-integration.test.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => {
         return { sessions };
       },
     ),
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The hoisted mock factory assigns the real constructor before any agent fixture is created.
     FileSystemSessionSource: undefined as unknown as FileSystemSourceConstructor,
     appLogger: {
       debug: vi.fn(),
@@ -43,6 +44,7 @@ const mocks = vi.hoisted(() => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Drive this worker entry point with controlled messages and observe its replies in-process.
 vi.mock("node:worker_threads", () => ({
   parentPort: {
     postMessage: mocks.postMessage,
@@ -56,8 +58,10 @@ vi.mock("node:worker_threads", () => ({
   },
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({ appLogger: mocks.appLogger }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Register only the fixture agents so orchestration cannot discover host agent data.
 vi.mock("@codesesh/core/runtime/agents", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/agents")>();
   mocks.FileSystemSessionSource = actual.FileSystemSessionSource as FileSystemSourceConstructor;
@@ -67,6 +71,7 @@ vi.mock("@codesesh/core/runtime/agents", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control cache publication, revisions and failures at the scan orchestration boundary.
 vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@codesesh/core/runtime/discovery")>();
   return {
@@ -85,6 +90,7 @@ vi.mock("@codesesh/core/runtime/discovery", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control pricing generation publication and synchronization independently of network refresh.
 vi.mock("@codesesh/core/runtime/pricing", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@codesesh/core/runtime/pricing")>()),
   synchronizePricingGeneration: mocks.synchronizePricingGeneration,
@@ -364,7 +370,7 @@ describe("scan refresh worker entry", () => {
 
   it("coalesces a synchronous progress burst and flushes its latest value", async () => {
     const nowSpy = vi.spyOn(performance, "now").mockReturnValue(0);
-    const scan = vi.fn((options: { onProgress: (progress: object) => void }) => {
+    const scan = vi.fn((options: { onProgress: NonNullable<AgentScanOptions["onProgress"]> }) => {
       for (let processed = 1; processed <= 10_000; processed += 1) {
         options.onProgress({ phase: "scanning", total: 10_000, processed });
       }

--- a/packages/cli/src/scan-refresh-worker.test.ts
+++ b/packages/cli/src/scan-refresh-worker.test.ts
@@ -28,6 +28,7 @@ function makeSession(id: string, overrides: Partial<SessionHead> = {}): SessionH
 }
 
 function makeAgent(getSessionData: BaseAgent["getSessionData"]): BaseAgent {
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: Finalization exercises only the explicit scan, metadata and detail methods of this agent fixture.
   return {
     name: "codex",
     displayName: "Codex",
@@ -44,6 +45,7 @@ function makeAgent(getSessionData: BaseAgent["getSessionData"]): BaseAgent {
 
 describe("finalizeSessions", () => {
   it("attaches project identity to sessions missing one", () => {
+    // SAFETY: Tag finalization reads only message parts and source timestamps from this partial detail fixture.
     const agent = makeAgent(() => ({ messages: [] }) as never);
     const [result] = finalizeSessions(agent, [makeSession("s1")]);
 
@@ -55,6 +57,7 @@ describe("finalizeSessions", () => {
   });
 
   it("computes smart tags for a session whose content changed", () => {
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: Tag finalization reads only message parts and source timestamps from this partial detail fixture.
     const getSessionData = vi.fn(() => ({
       time_created: 1000,
       time_updated: 1000,
@@ -72,6 +75,7 @@ describe("finalizeSessions", () => {
   it("reports source-read and tag-classification timing separately", () => {
     const agent = makeAgent(
       () =>
+        // SAFETY: Tag finalization reads only message parts and source timestamps from this partial detail fixture.
         ({
           time_created: 1000,
           time_updated: 1000,
@@ -94,6 +98,7 @@ describe("finalizeSessions", () => {
   });
 
   it("reports progress while finalizing settled sessions", () => {
+    // SAFETY: Tag finalization reads only message parts and source timestamps from this partial detail fixture.
     const agent = makeAgent(() => ({ messages: [] }) as never);
     const progress: AgentScanProgress[] = [];
 
@@ -106,6 +111,7 @@ describe("finalizeSessions", () => {
   });
 
   it("limits finalization to the selected session ids", () => {
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: Tag finalization reads only message parts and source timestamps from this partial detail fixture.
     const getSessionData = vi.fn(() => ({
       messages: [],
     })) as unknown as BaseAgent["getSessionData"];
@@ -126,6 +132,7 @@ describe("finalizeSessions", () => {
   });
 
   it("checkpoints settled sessions from newest to oldest", () => {
+    // SAFETY: Tag finalization reads only message parts and source timestamps from this partial detail fixture.
     const agent = makeAgent(() => ({ messages: [] }) as never);
     const newest = makeSession("newest", { time_updated: 3_000 });
     const oldest = makeSession("oldest", { time_updated: 2_000 });
@@ -142,7 +149,7 @@ describe("finalizeSessions", () => {
 
   it("does not recompute tags for a session whose tags are already current", () => {
     const getSessionData = vi.fn();
-    const agent = makeAgent(getSessionData as unknown as BaseAgent["getSessionData"]);
+    const agent = makeAgent(getSessionData as BaseAgent["getSessionData"]);
 
     const session = makeSession("s1", {
       smart_tags: ["bugfix"],
@@ -158,7 +165,7 @@ describe("finalizeSessions", () => {
 
   it("skips tag computation for a session still within the settle window", () => {
     const getSessionData = vi.fn();
-    const agent = makeAgent(getSessionData as unknown as BaseAgent["getSessionData"]);
+    const agent = makeAgent(getSessionData as BaseAgent["getSessionData"]);
 
     const hotSession = makeSession("hot", { time_updated: Date.now() - 10_000 });
     const settledSession = makeSession("settled");

--- a/packages/cli/src/search-index-job-runner.test.ts
+++ b/packages/cli/src/search-index-job-runner.test.ts
@@ -86,11 +86,15 @@ const workerMocks = vi.hoisted(() => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control worker messages, failures and shutdown without timing real threads.
 vi.mock("node:worker_threads", () => ({ Worker: workerMocks.FakeWorker }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Exercise the missing worker bundle branch without altering build output.
 vi.mock("node:fs", () => ({ existsSync: () => workerMocks.workerExists }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control pricing generation publication and synchronization independently of network refresh.
 vi.mock("@codesesh/core/runtime/pricing", () => ({
   getPricingGeneration: () => ({ id: 17 }),
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({
   appLogger: {
     debug: vi.fn(),

--- a/packages/cli/src/search-index-maintenance-scheduler.test.ts
+++ b/packages/cli/src/search-index-maintenance-scheduler.test.ts
@@ -8,7 +8,9 @@ const core = vi.hoisted(() => ({
   readPendingSearchIndexMaintenance: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control durable maintenance markers and cache read failures for scheduler recovery tests.
 vi.mock("@codesesh/core/runtime/discovery", () => core);
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({
   appLogger: {
     info: vi.fn(),
@@ -88,7 +90,7 @@ describe("SearchIndexMaintenanceScheduler", () => {
       const job = jobs[0];
       if (job?.kind === "maintenance") processed += job.changes.length;
     });
-    const scheduler = new SearchIndexMaintenanceScheduler(runner as never, () => undefined);
+    const scheduler = new SearchIndexMaintenanceScheduler(runner, () => undefined);
 
     scheduler.enqueue("codex");
     await scheduler.waitForIdle();
@@ -105,7 +107,7 @@ describe("SearchIndexMaintenanceScheduler", () => {
       .mockReturnValueOnce({ sessionIds: [], total: 0 });
     const runner = makeRunner();
     const statuses: SearchIndexMaintenanceStatus[] = [];
-    const scheduler = new SearchIndexMaintenanceScheduler(runner as never, (status) =>
+    const scheduler = new SearchIndexMaintenanceScheduler(runner, (status) =>
       statuses.push(status),
     );
 
@@ -155,7 +157,7 @@ describe("SearchIndexMaintenanceScheduler", () => {
     });
     const runner = makeRunner();
     runner.enqueueMaintenance.mockReturnValueOnce(firstBatch);
-    const scheduler = new SearchIndexMaintenanceScheduler(runner as never, () => undefined);
+    const scheduler = new SearchIndexMaintenanceScheduler(runner, () => undefined);
 
     scheduler.enqueue("codex");
     const updated = { ...makeSession("three"), title: "Updated session" };
@@ -183,7 +185,7 @@ describe("SearchIndexMaintenanceScheduler", () => {
     });
     const runner = makeRunner();
     const statuses: SearchIndexMaintenanceStatus[] = [];
-    const scheduler = new SearchIndexMaintenanceScheduler(runner as never, (status) =>
+    const scheduler = new SearchIndexMaintenanceScheduler(runner, (status) =>
       statuses.push(status),
     );
 
@@ -207,7 +209,7 @@ describe("SearchIndexMaintenanceScheduler", () => {
     core.readCachedSessions.mockReturnValue({ status: "failed" });
     const runner = makeRunner();
     const statuses: SearchIndexMaintenanceStatus[] = [];
-    const scheduler = new SearchIndexMaintenanceScheduler(runner as never, (status) =>
+    const scheduler = new SearchIndexMaintenanceScheduler(runner, (status) =>
       statuses.push(status),
     );
 

--- a/packages/cli/src/search-index-maintenance-scheduler.ts
+++ b/packages/cli/src/search-index-maintenance-scheduler.ts
@@ -31,7 +31,7 @@ export class SearchIndexMaintenanceScheduler {
   private stopped = false;
 
   constructor(
-    private readonly runner: SearchIndexJobRunner,
+    private readonly runner: Pick<SearchIndexJobRunner, "enqueueMaintenance">,
     private readonly onStatus: StatusListener,
   ) {}
 

--- a/packages/cli/src/search-index-worker.test.ts
+++ b/packages/cli/src/search-index-worker.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   messageHandler: undefined as ((message: Record<string, unknown>) => void) | undefined,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Drive this worker entry point with controlled messages and observe its replies in-process.
 vi.mock("node:worker_threads", () => ({
   parentPort: {
     postMessage: mocks.postMessage,
@@ -29,10 +30,12 @@ vi.mock("node:worker_threads", () => ({
   },
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Register only the fixture agents so orchestration cannot discover host agent data.
 vi.mock("@codesesh/core/runtime/agents", () => ({
   createRegisteredAgents: mocks.createRegisteredAgents,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control cache publication, revisions and failures at the scan orchestration boundary.
 vi.mock("@codesesh/core/runtime/discovery", () => ({
   commitDurableSessionPublication: mocks.commitDurableSessionPublication,
   markAgentCacheInitialized: mocks.markAgentCacheInitialized,
@@ -41,14 +44,17 @@ vi.mock("@codesesh/core/runtime/discovery", () => ({
   syncSessionSearchIndexChanges: mocks.syncSessionSearchIndexChanges,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control pricing generation publication and synchronization independently of network refresh.
 vi.mock("@codesesh/core/runtime/pricing", () => ({
   synchronizePricingGeneration: mocks.synchronizePricingGeneration,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Keep worker entry point tests from changing process-wide diagnostic callbacks.
 vi.mock("@codesesh/core/runtime/diagnostics", () => ({
   setCoreDiagnostics: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({
   appLogger: {
     forwardToParent: vi.fn(),

--- a/packages/cli/src/server.test.ts
+++ b/packages/cli/src/server.test.ts
@@ -47,6 +47,7 @@ function getServerAccess(startupUrl: string) {
   };
 }
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe bind options while delegating to the real HTTP server.
 vi.mock("@hono/node-server", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@hono/node-server")>();
   return {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -141,8 +141,8 @@ function optionalOperationId(value: string | undefined): string | undefined {
 
 function errorStatus(error: unknown): number {
   try {
-    if (typeof error !== "object" || error === null) return 500;
-    const status = Reflect.get(error, "status");
+    if (typeof error !== "object" || error === null || !("status" in error)) return 500;
+    const status = error.status;
     if (typeof status === "number" && status >= 400 && status <= 599) return status;
   } catch {}
   return 500;

--- a/packages/cli/src/session-detail-loader.test.ts
+++ b/packages/cli/src/session-detail-loader.test.ts
@@ -1,12 +1,17 @@
 import { EventEmitter } from "node:events";
-import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi, type Mock } from "vitest";
 import type { LiveSnapshot } from "@codesesh/core/runtime/discovery";
 import { SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
 
-const mocks = vi.hoisted(() => ({ cached: vi.fn(), workers: [] as any[] }));
+const mocks = vi.hoisted(() => ({
+  cached: vi.fn(),
+  workers: [] as (EventEmitter & { postMessage: Mock; terminate: Mock<() => Promise<number>> })[],
+}));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Select cache hits or worker fallback without depending on an on-disk cache.
 vi.mock("@codesesh/core/runtime/discovery", () => ({
   materializeCachedSessionDetailResponse: mocks.cached,
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({
   appLogger: {
     info: vi.fn(),
@@ -14,6 +19,7 @@ vi.mock("./logging.js", () => ({
     captureContext: vi.fn(() => ({})),
   },
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control worker messages, failures and shutdown without timing real threads.
 vi.mock("node:worker_threads", () => ({
   Worker: class extends EventEmitter {
     postMessage = vi.fn((message: { type?: string; requestId?: string }) => {
@@ -44,7 +50,7 @@ const snapshot = {
   agents: [],
   sessions: [SAMPLE_SESSION_HEAD],
   byAgent: { claudecode: [SAMPLE_SESSION_HEAD] },
-} as unknown as LiveSnapshot;
+} as LiveSnapshot;
 const reference = SAMPLE_SESSION_HEAD.reference;
 let loader: ThreadSessionDetailLoader;
 beforeEach(() => {
@@ -66,12 +72,12 @@ it("serves a cached result without creating a worker", async () => {
 
 it("returns serialized worker results and retires the worker", async () => {
   const pending = loader.load(snapshot, reference);
-  mocks.workers[0].emit("message", { type: "result", result: { status: "not-ready" } });
+  mocks.workers[0]!.emit("message", { type: "result", result: { status: "not-ready" } });
   await expect(pending).resolves.toEqual({ status: "not-ready" });
-  expect(mocks.workers[0].postMessage).toHaveBeenCalledWith(
+  expect(mocks.workers[0]!.postMessage).toHaveBeenCalledWith(
     expect.objectContaining({ type: "codesesh.worker-log-drain" }),
   );
-  expect(mocks.workers[0].terminate).toHaveBeenCalledOnce();
+  expect(mocks.workers[0]!.terminate).toHaveBeenCalledOnce();
 });
 
 it.each(["error", "exit", "reported-error"])(
@@ -79,11 +85,11 @@ it.each(["error", "exit", "reported-error"])(
   async (failure) => {
     const pending = loader.load(snapshot, reference);
     const rejection = expect(pending).rejects.toThrow();
-    if (failure === "error") mocks.workers[0].emit("error", new Error("failed"));
-    else if (failure === "exit") mocks.workers[0].emit("exit", 1);
-    else mocks.workers[0].emit("message", { type: "error", error: "source failed" });
+    if (failure === "error") mocks.workers[0]!.emit("error", new Error("failed"));
+    else if (failure === "exit") mocks.workers[0]!.emit("exit", 1);
+    else mocks.workers[0]!.emit("message", { type: "error", error: "source failed" });
     await rejection;
-    expect(mocks.workers[0].terminate).toHaveBeenCalledOnce();
+    expect(mocks.workers[0]!.terminate).toHaveBeenCalledOnce();
   },
 );
 
@@ -99,13 +105,13 @@ it("bounds concurrent parsing and cancels outstanding work on shutdown", async (
 it("waits for every worker retirement when one termination fails", async () => {
   const first = expect(loader.load(snapshot, reference)).rejects.toThrow();
   const second = expect(loader.load(snapshot, reference)).rejects.toThrow();
-  mocks.workers[0].terminate.mockRejectedValueOnce(new Error("termination failed"));
+  mocks.workers[0]!.terminate.mockRejectedValueOnce(new Error("termination failed"));
   let finishSecond = () => {};
-  mocks.workers[1].terminate.mockImplementationOnce(
+  mocks.workers[1]!.terminate.mockImplementationOnce(
     () =>
       new Promise<number>((resolve) => {
         finishSecond = () => {
-          mocks.workers[1].emit("exit", 0);
+          mocks.workers[1]!.emit("exit", 0);
           resolve(0);
         };
       }),
@@ -115,7 +121,7 @@ it("waits for every worker retirement when one termination fails", async () => {
   const shutdown = loader.shutdown().then(() => {
     shutdownCompleted = true;
   });
-  await vi.waitFor(() => expect(mocks.workers[1].terminate).toHaveBeenCalledOnce());
+  await vi.waitFor(() => expect(mocks.workers[1]!.terminate).toHaveBeenCalledOnce());
   expect(shutdownCompleted).toBe(false);
 
   finishSecond();
@@ -128,7 +134,7 @@ it("cancels a worker when the client aborts", async () => {
   const pending = expect(loader.load(snapshot, reference, {}, controller.signal)).rejects.toThrow();
   controller.abort();
   await pending;
-  expect(mocks.workers[0].terminate).toHaveBeenCalledOnce();
+  expect(mocks.workers[0]!.terminate).toHaveBeenCalledOnce();
 });
 
 it("terminates a worker that never returns", async () => {

--- a/packages/cli/src/session-detail-worker.test.ts
+++ b/packages/cli/src/session-detail-worker.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, it, vi } from "vitest";
 import { SAMPLE_SESSION_HEAD } from "@codesesh/core/test-fixtures";
+
 const mocks = vi.hoisted(() => ({
   materialize: vi.fn(),
   post: vi.fn(),

--- a/packages/cli/src/session-detail-worker.test.ts
+++ b/packages/cli/src/session-detail-worker.test.ts
@@ -7,7 +7,9 @@ const mocks = vi.hoisted(() => ({
   close: vi.fn(),
   on: vi.fn(),
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Keep worker import tests from installing process-wide diagnostic forwarding.
 vi.mock("./diagnostics-bridge.js", () => ({}));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Drive this worker entry point with controlled messages and observe its replies in-process.
 vi.mock("node:worker_threads", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:worker_threads")>()),
   parentPort: { postMessage: mocks.post, on: mocks.on },
@@ -17,10 +19,13 @@ vi.mock("node:worker_threads", async (importOriginal) => ({
     pricingGenerationId: 0,
   },
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Register only the fixture agents so orchestration cannot discover host agent data.
 vi.mock("@codesesh/core/runtime/agents", () => ({
   createRegisteredAgents: () => [{ name: "codex", restoreSessionCacheMeta: mocks.restore }],
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control pricing generation publication and synchronization independently of network refresh.
 vi.mock("@codesesh/core/runtime/pricing", () => ({ synchronizePricingGeneration: vi.fn() }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control cache publication, revisions and failures at the scan orchestration boundary.
 vi.mock("@codesesh/core/runtime/discovery", () => ({
   materializeSessionDetailResponse: mocks.materialize,
   closeCacheStorage: mocks.close,

--- a/packages/cli/src/session-watcher.test.ts
+++ b/packages/cli/src/session-watcher.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type BaseAgent, type SessionWatchPlan } from "@codesesh/core/runtime/agents";
+import { type SessionWatchPlan } from "@codesesh/core/runtime/agents";
 
 const fsWatch = vi.hoisted(() => ({
   watchers: [] as Array<{
@@ -15,6 +15,7 @@ const fsWatch = vi.hoisted(() => ({
   watch: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Deliver deterministic watch events without relying on OS notification timing.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
@@ -23,6 +24,7 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({
   appLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
@@ -254,7 +256,7 @@ describe("SessionWatcher", () => {
             count: () => 0,
           },
         },
-      ) as unknown as BaseAgent;
+      );
       const watcher = new SessionWatcher();
 
       watcher.start([adapter]);

--- a/packages/cli/src/smart-tag-worker.test.ts
+++ b/packages/cli/src/smart-tag-worker.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   getSmartTagSourceTimestamp: vi.fn(() => 42),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Drive this worker entry point with controlled messages and observe its replies in-process.
 vi.mock("node:worker_threads", () => ({
   parentPort: { postMessage: mocks.postMessage },
   threadId: 17,
@@ -17,6 +18,7 @@ vi.mock("node:worker_threads", () => ({
   },
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Observe logging and worker log forwarding without emitting to the process log sink.
 vi.mock("./logging.js", () => ({
   appLogger: {
     forwardToParent: vi.fn(),
@@ -25,16 +27,19 @@ vi.mock("./logging.js", () => ({
   },
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Register only the fixture agents so orchestration cannot discover host agent data.
 vi.mock("@codesesh/core/runtime/agents", () => ({
   createRegisteredAgents: mocks.createRegisteredAgents,
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control classifier results and failures at the worker message boundary.
 vi.mock("@codesesh/core/runtime/diagnostics", () => ({
   classifySessionTags: mocks.classifySessionTags,
   getSmartTagSourceTimestamp: mocks.getSmartTagSourceTimestamp,
   setCoreDiagnostics: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control pricing generation publication and synchronization independently of network refresh.
 vi.mock("@codesesh/core/runtime/pricing", () => ({
   synchronizePricingGeneration: mocks.synchronizePricingGeneration,
 }));

--- a/packages/cli/src/worker-log-drain.test.ts
+++ b/packages/cli/src/worker-log-drain.test.ts
@@ -5,6 +5,7 @@ import { appLogger } from "./logging.js";
 import { acknowledgeWorkerLogDrain, terminateWorkerAfterLogDrain } from "./worker-log-drain.js";
 
 function workerFromPort(port: MessagePort, terminate: () => Promise<number>): Worker {
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The drain protocol uses only events, postMessage and terminate, which this controllable worker fixture implements.
   return {
     on: port.on.bind(port),
     once: port.once.bind(port),
@@ -56,6 +57,7 @@ describe("worker log drain", () => {
     worker.postMessage = vi.fn();
     worker.terminate = vi.fn(async () => 0);
 
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The drain protocol uses only events, postMessage and terminate, which this controllable worker fixture implements.
     const termination = terminateWorkerAfterLogDrain(worker as unknown as Worker);
     await vi.advanceTimersByTimeAsync(99);
     expect(worker.terminate).not.toHaveBeenCalled();
@@ -80,6 +82,7 @@ describe("worker log drain", () => {
     worker.postMessage = vi.fn();
     worker.terminate = vi.fn(async () => 0);
 
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The drain protocol uses only events, postMessage and terminate, which this controllable worker fixture implements.
     const termination = terminateWorkerAfterLogDrain(worker as unknown as Worker);
     worker.emit("exit", 7);
 
@@ -96,6 +99,7 @@ describe("worker log drain", () => {
     worker.terminate = vi.fn(async () => 0);
     worker.on("error", () => undefined);
 
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The drain protocol uses only events, postMessage and terminate, which this controllable worker fixture implements.
     const termination = terminateWorkerAfterLogDrain(worker as unknown as Worker);
     worker.emit("error", new Error("failed"));
     await Promise.resolve();

--- a/packages/core/src/agents/__tests__/claudecode.test.ts
+++ b/packages/core/src/agents/__tests__/claudecode.test.ts
@@ -18,6 +18,7 @@ import { sessionDetailVersion } from "../../discovery/cache/detail-version.js";
 
 // Spies on statSync while delegating to the real implementation, so the
 // single-stat regression test can count per-file calls during a live scan.
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real filesystem reads and inject read failures without replacing agent parsing.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
@@ -131,7 +132,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     );
     writeFileSync(indexFile, JSON.stringify({ entries: [{ sessionId: "session-1" }] }));
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     // Seed baseline: a full scan populates metaMap with the source fingerprint.
     agent.scan();
@@ -171,7 +172,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     utimesSync(oldFile, oldTime, oldTime);
     utimesSync(newFile, newTime, newTime);
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     expect(
       agent
@@ -207,7 +208,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     utimesSync(parentFile, parentTime, parentTime);
     utimesSync(childFile, childTime, childTime);
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     expect(
       agent
@@ -246,7 +247,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       writeFileSync(metaPath, JSON.stringify({ name: childId }));
     }
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
     const readSpy = vi.mocked(readFileSync);
     const statSpy = vi.mocked(statSync);
 
@@ -299,16 +300,16 @@ describe("ClaudeCodeAgent cache refresh", () => {
       JSON.stringify({ agentId: childId, toolUseId: "tool-child" }),
     );
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
     agent.scan();
     const restoredMeta = agent.snapshotSessionCacheMeta();
     const walkSpy = vi.spyOn(agent, "walkFiles");
 
     agent.restoreSessionCacheMeta(restoredMeta);
-    agent.ensureChildIndex();
+    agent["ensureChildIndex"]();
 
     expect(walkSpy).not.toHaveBeenCalled();
-    expect(agent.childSessionIdByToolUseId.get("tool-child")).toBe(childId);
+    expect(agent["childSessionIdByToolUseId"].get("tool-child")).toBe(childId);
   });
 
   it("rebuilds the child index when restored session sources change", () => {
@@ -321,7 +322,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     mkdirSync(projectDir, { recursive: true });
     writeMinimalClaudeSession(join(projectDir, parentId + ".jsonl"));
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
     agent.scan();
 
     mkdirSync(childDir, { recursive: true });
@@ -330,15 +331,15 @@ describe("ClaudeCodeAgent cache refresh", () => {
       join(childDir, "agent-" + childId + ".meta.json"),
       JSON.stringify({ agentId: childId, toolUseId: "tool-added-child" }),
     );
-    const refreshedAgent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const refreshedAgent = new ClaudeCodeAgent({ sourceRoot: basePath });
     refreshedAgent.scan();
     const walkSpy = vi.spyOn(agent, "walkFiles");
 
     agent.restoreSessionCacheMeta(refreshedAgent.snapshotSessionCacheMeta());
-    agent.ensureChildIndex();
+    agent["ensureChildIndex"]();
 
     expect(walkSpy).toHaveBeenCalledOnce();
-    expect(agent.childSessionIdByToolUseId.get("tool-added-child")).toBe(childId);
+    expect(agent["childSessionIdByToolUseId"].get("tool-added-child")).toBe(childId);
   });
 
   it("drops a window-only child when its parent is outside the window", () => {
@@ -361,7 +362,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     utimesSync(parentFile, parentTime, parentTime);
     utimesSync(childFile, childTime, childTime);
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     expect(
       agent
@@ -426,7 +427,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const indexFile = join(projectDir, "sessions-index.json");
     writeFileSync(indexFile, JSON.stringify({ entries: [] }));
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     const statSpy = vi.mocked(statSync);
     statSpy.mockClear();
@@ -453,7 +454,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     utimesSync(sessionFile, sessionTime, sessionTime);
     utimesSync(indexFile, indexTime, indexTime);
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     expect(agent.listSessionSources()).toEqual([
       {
@@ -553,7 +554,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -729,7 +730,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     const heads = agent.scan();
     const parent = heads.find((head: SessionHead) => head.reference.sessionId === parentId);
@@ -826,7 +827,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -971,7 +972,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     expect(agent.scan()).toEqual([]);
   });
@@ -1015,7 +1016,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -1069,7 +1070,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     expect(agent.scan()).toEqual([]);
   });
@@ -1117,7 +1118,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
     setCoreDiagnostics(sink);
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     const [head] = agent.scan();
 
@@ -1161,7 +1162,7 @@ describe("ClaudeCodeAgent cache refresh", () => {
     const sink: CoreDiagnostics = { warn: (event, detail) => calls.push({ event, detail }) };
     setCoreDiagnostics(sink);
 
-    const agent = new ClaudeCodeAgent({ sourceRoot: basePath }) as any;
+    const agent = new ClaudeCodeAgent({ sourceRoot: basePath });
 
     // No visible messages were extracted, so the session is filtered out entirely.
     expect(agent.scan()).toEqual([]);

--- a/packages/core/src/agents/__tests__/codex-token-usage.test.ts
+++ b/packages/core/src/agents/__tests__/codex-token-usage.test.ts
@@ -4,7 +4,7 @@ import { CodexTokenUsageAccumulator } from "../codex-token-usage.js";
 function tokenPayload(
   lastUsage: Record<string, number> | undefined,
   totalUsage?: Record<string, number>,
-): Record<string, unknown> {
+) {
   return {
     info: {
       last_token_usage: lastUsage,

--- a/packages/core/src/agents/__tests__/codex.test.ts
+++ b/packages/core/src/agents/__tests__/codex.test.ts
@@ -20,6 +20,7 @@ import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostic
 
 // Spies while delegating to the real implementation so regression tests can
 // count filesystem calls during a live scan.
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real filesystem reads and inject read failures without replacing agent parsing.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
@@ -80,8 +81,9 @@ describe("CodexAgent cache refresh", () => {
     writeFileSync(oldA, '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n');
     writeFileSync(newC, '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:05:00Z"}}\n');
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionMetaMap = new Map([
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    // SAFETY: This fixture deliberately models an incomplete legacy cache entry during refresh.
+    agent["sessionMetaMap"] = new Map([
       [
         "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
         { id: "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa", sourcePath: oldA },
@@ -93,8 +95,8 @@ describe("CodexAgent cache refresh", () => {
           sourcePath: join(tempDir, "missing.jsonl"),
         },
       ],
-    ]);
-    agent.listRolloutFiles = () => [
+    ]) as (typeof agent)["sessionMetaMap"];
+    agent["listRolloutFiles"] = () => [
       { file: oldA, stat: statSync(oldA) },
       { file: newC, stat: statSync(newC) },
     ];
@@ -135,8 +137,8 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
     const cached = agent.scan({ from: 0 }) as SessionHead[];
     expect(cached[0]?.stats.total_cost).toBe(0);
     expect(agent.getSessionCacheMeta(sessionId)?.unpricedModels).toEqual([model]);
@@ -169,7 +171,7 @@ describe("CodexAgent cache refresh", () => {
     );
     writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"Old title"}\n`);
 
-    const agent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: sessionsDir });
     // Seed baseline meta with the live fingerprint.
     agent.scan();
     const baselineFingerprint = agent.listSessionSources()[0]?.fingerprint;
@@ -218,7 +220,7 @@ describe("CodexAgent cache refresh", () => {
     utimesSync(oldFile, oldTime, oldTime);
     utimesSync(newFile, newTime, newTime);
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
 
     expect(
       agent
@@ -263,7 +265,7 @@ describe("CodexAgent cache refresh", () => {
       );
     }
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
 
     const statSpy = vi.mocked(statSync);
     statSpy.mockClear();
@@ -295,12 +297,12 @@ describe("CodexAgent cache refresh", () => {
       meta({ id: childId, thread_source: "subagent", parent_thread_id: parentId }),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
     const window = { from: Date.now() - 24 * 60 * 60 * 1000 };
     const openSpy = vi.mocked(openSync);
 
     openSpy.mockClear();
-    let sources = agent.listScanSources(window);
+    let sources = agent["listScanSources"](window);
     expect(sources.map((ref: { file: string }) => ref.file).sort()).toEqual(
       [parentFile, otherParentFile, childFile].sort(),
     );
@@ -309,7 +311,7 @@ describe("CodexAgent cache refresh", () => {
     // A new scan cycle drops the index but must rebuild it from cached meta.
     agent.restoreSessionCacheMeta({});
     openSpy.mockClear();
-    sources = agent.listScanSources(window);
+    sources = agent["listScanSources"](window);
     expect(sources).toHaveLength(3);
     expect(openSpy.mock.calls.length).toBe(0);
 
@@ -320,9 +322,11 @@ describe("CodexAgent cache refresh", () => {
     );
     agent.restoreSessionCacheMeta({});
     openSpy.mockClear();
-    agent.listScanSources(window);
+    agent["listScanSources"](window);
     expect(openSpy.mock.calls.length).toBe(1);
-    expect(agent.ensureSubagentIndex().childFilesByParent.get(otherParentId)).toEqual([childFile]);
+    expect(agent["ensureSubagentIndex"]().childFilesByParent.get(otherParentId)).toEqual([
+      childFile,
+    ]);
   });
 
   it("rebuilds the subagent index from persisted session metadata", () => {
@@ -344,25 +348,25 @@ describe("CodexAgent cache refresh", () => {
       })}\n`,
     );
 
-    const firstAgent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const firstAgent = new CodexAgent({ sourceRoot: tempDir });
     firstAgent.scan();
     const cachedMeta = firstAgent.snapshotSessionCacheMeta();
     expect(cachedMeta[childId]).toMatchObject({ isSubagent: true, parentThreadId: parentId });
 
-    const restoredAgent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const restoredAgent = new CodexAgent({ sourceRoot: tempDir });
     restoredAgent.restoreSessionCacheMeta(cachedMeta);
     const openSpy = vi.mocked(openSync);
     openSpy.mockClear();
     const readDirectorySpy = vi.spyOn(restoredAgent, "readSessionSourceDirectory");
 
-    const sources = restoredAgent.listScanSources({ from: 0 });
+    const sources = restoredAgent["listScanSources"]({ from: 0 });
 
     expect(sources.map((source: { file: string }) => source.file).sort()).toEqual(
       [parentFile, childFile].sort(),
     );
     expect(openSpy).not.toHaveBeenCalled();
     expect(readDirectorySpy).toHaveBeenCalledOnce();
-    expect(restoredAgent.ensureSubagentIndex().childFilesByParent.get(parentId)).toEqual([
+    expect(restoredAgent["ensureSubagentIndex"]().childFilesByParent.get(parentId)).toEqual([
       childFile,
     ]);
   });
@@ -381,15 +385,15 @@ describe("CodexAgent cache refresh", () => {
       })}\n`,
     );
 
-    const firstAgent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const firstAgent = new CodexAgent({ sourceRoot: tempDir });
     firstAgent.scan();
     const cachedMeta = firstAgent.snapshotSessionCacheMeta();
-    delete cachedMeta[childId].isSubagent;
-    delete cachedMeta[childId].parentThreadId;
+    delete cachedMeta[childId]!.isSubagent;
+    delete cachedMeta[childId]!.parentThreadId;
 
-    const restoredAgent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const restoredAgent = new CodexAgent({ sourceRoot: tempDir });
     restoredAgent.restoreSessionCacheMeta(cachedMeta);
-    restoredAgent.listScanSources({ from: 0 });
+    restoredAgent["listScanSources"]({ from: 0 });
 
     expect(restoredAgent.snapshotSessionCacheMeta()[childId]).toMatchObject({
       isSubagent: true,
@@ -415,7 +419,7 @@ describe("CodexAgent cache refresh", () => {
     const sessionTime = new Date(1_700_000_000_000);
     utimesSync(sessionFile, sessionTime, sessionTime);
 
-    const agent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: sessionsDir });
 
     expect(agent.listSessionSources()).toEqual([
       {
@@ -453,7 +457,7 @@ describe("CodexAgent cache refresh", () => {
       );
     }
 
-    const agent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: sessionsDir });
     const readSpy = vi.mocked(readFileSync);
     const statSpy = vi.mocked(statSync);
     readSpy.mockClear();
@@ -491,7 +495,7 @@ describe("CodexAgent cache refresh", () => {
     );
     writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"Old title"}\n`);
 
-    const firstAgent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
+    const firstAgent = new CodexAgent({ sourceRoot: sessionsDir });
     const firstFingerprint = firstAgent.listSessionSources()[0]?.fingerprint;
 
     writeFileSync(
@@ -502,11 +506,11 @@ describe("CodexAgent cache refresh", () => {
         "",
       ].join("\n"),
     );
-    const unrelatedAgent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
+    const unrelatedAgent = new CodexAgent({ sourceRoot: sessionsDir });
     const unrelatedFingerprint = unrelatedAgent.listSessionSources()[0]?.fingerprint;
 
     writeFileSync(indexFile, `{"id":"${sessionId}","thread_name":"New title"}\n`);
-    const renamedAgent = new CodexAgent({ sourceRoot: sessionsDir }) as any;
+    const renamedAgent = new CodexAgent({ sourceRoot: sessionsDir });
     const renamedFingerprint = renamedAgent.listSessionSources()[0]?.fingerprint;
 
     expect(unrelatedFingerprint).toBe(firstFingerprint);
@@ -526,8 +530,9 @@ describe("CodexAgent cache refresh", () => {
       '{"type":"session_meta","payload":{"timestamp":"2026-04-20T10:00:00Z"}}\n',
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionMetaMap = new Map([
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    // SAFETY: This fixture deliberately models an incomplete legacy cache entry during refresh.
+    agent["sessionMetaMap"] = new Map([
       [
         "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
         {
@@ -540,8 +545,8 @@ describe("CodexAgent cache refresh", () => {
           parserVersion: "codex-parser-v2",
         },
       ],
-    ]);
-    agent.listRolloutFiles = () => [{ file: sessionFile, stat: statSync(sessionFile) }];
+    ]) as (typeof agent)["sessionMetaMap"];
+    agent["listRolloutFiles"] = () => [{ file: sessionFile, stat: statSync(sessionFile) }];
 
     const result = refresh(agent, [makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa")]);
 
@@ -563,9 +568,9 @@ describe("CodexAgent cache refresh", () => {
     writeFileSync(oldA, "");
     writeFileSync(newC, "");
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
     // Replace the single-file parser while keeping the shared scan lifecycle intact.
-    agent.parseFileSessionHeadResult = (file: string) => {
+    agent["parseFileSessionHeadResult"] = (file: string) => {
       if (file === oldA) {
         return { status: "parsed", data: makeSession("019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa") };
       }
@@ -584,7 +589,7 @@ describe("CodexAgent cache refresh", () => {
       "019daaaa-aaaa-7aaa-aaaa-aaaaaaaaaaaa",
       "019dcccc-cccc-7ccc-cccc-cccccccccccc",
     ]);
-    expect(agent.sessionMetaMap.has("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb")).toBe(false);
+    expect(agent["sessionMetaMap"].has("019dbbbb-bbbb-7bbb-bbbb-bbbbbbbbbbbb")).toBe(false);
   });
 
   it("uses the latest record timestamp as time_updated", () => {
@@ -604,8 +609,8 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent();
+    agent["sessionIndexCache"] = new Map();
 
     const head = agent.scanSessionSource(sessionFile);
 
@@ -629,8 +634,8 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent();
+    agent["sessionIndexCache"] = new Map();
     const head = agent.scanSessionSource(sessionFile);
 
     expect(head?.time_created).toBe(Date.parse("2026-04-20T10:00:00+08:00"));
@@ -653,8 +658,8 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent();
+    agent["sessionIndexCache"] = new Map();
 
     const head = agent.scanSessionSource(sessionFile);
 
@@ -681,7 +686,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
     const [head] = agent.scan();
     const detail = agent.getSessionData(sessionId);
 
@@ -706,7 +711,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
     const [head] = agent.scan();
     const detail = agent.getSessionData(sessionId);
 
@@ -734,8 +739,8 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent();
+    agent["sessionIndexCache"] = new Map();
 
     const head = agent.scanSessionSource(sessionFile);
 
@@ -764,8 +769,8 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent();
+    agent["sessionIndexCache"] = new Map();
 
     const head = agent.scanSessionSource(sessionFile);
 
@@ -788,8 +793,8 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent();
+    agent["sessionIndexCache"] = new Map();
 
     const head = agent.scanSessionSource(sessionFile);
 
@@ -812,7 +817,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
 
     expect(agent.scan()).toEqual([]);
   });
@@ -889,7 +894,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -959,7 +964,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
 
     agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -1008,7 +1013,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
 
     agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -1186,7 +1191,7 @@ describe("CodexAgent cache refresh", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
 
     const [head] = agent.scan();
     const data = agent.getSessionData(sessionId);
@@ -1289,7 +1294,7 @@ describe("CodexAgent code-mode exec decoding", () => {
     ];
     writeFileSync(sessionFile, lines.join("\n"));
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
     agent.scan();
     return { agent, sessionId };
   }
@@ -1502,8 +1507,8 @@ describe("CodexAgent field shape mismatches", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent() as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent();
+    agent["sessionIndexCache"] = new Map();
 
     const head = agent.scanSessionSource(sessionFile);
 
@@ -1533,7 +1538,7 @@ describe("CodexAgent field shape mismatches", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
+    const agent = new CodexAgent({ sourceRoot: tempDir });
     agent.scan();
 
     const data = agent.getSessionData(sessionId);
@@ -1623,15 +1628,15 @@ describe("CodexAgent subagent folding", () => {
       extra: [tokenCountLine(40, 60, 100)],
     });
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
 
     const heads = agent.scan({ from: 0 });
     expect(heads.map((h: SessionHead) => h.reference.sessionId)).toEqual([PARENT_ID, CHILD_ID]);
-    expect(heads[0].stats.total_input_tokens).toBe(100);
-    expect(heads[0].stats.total_output_tokens).toBe(20);
-    expect(heads[1].parent_reference).toEqual({ agentName: "codex", sessionId: PARENT_ID });
-    expect(heads[1].stats.total_input_tokens).toBe(40);
+    expect(heads[0]!.stats.total_input_tokens).toBe(100);
+    expect(heads[0]!.stats.total_output_tokens).toBe(20);
+    expect(heads[1]!.parent_reference).toEqual({ agentName: "codex", sessionId: PARENT_ID });
+    expect(heads[1]!.stats.total_input_tokens).toBe(40);
     expect(buildSessionTree(heads).roots[0]?.inclusiveStats).toMatchObject({
       inputTokens: 140,
       outputTokens: 80,
@@ -1655,8 +1660,8 @@ describe("CodexAgent subagent folding", () => {
       extra: [tokenCountLine(40, 60, 100)],
     });
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
     agent.scan({ from: 0 });
 
     const data = agent.getSessionData(PARENT_ID);
@@ -1685,8 +1690,8 @@ describe("CodexAgent subagent folding", () => {
       ],
     });
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
     agent.scan({ from: 0 });
 
     const data = agent.getSessionData(PARENT_ID);
@@ -1708,13 +1713,13 @@ describe("CodexAgent subagent folding", () => {
   });
 
   it("merges child messages with exact id and nickname/text visibility rules", () => {
-    const agent = new CodexAgent() as any;
+    const agent = new CodexAgent();
     const visibleMessages = [
       makeMessage({ subagentId: "known-child", nickname: "worker", texts: ["id match"] }),
       makeMessage({ nickname: "worker", texts: ["prefix", "shared text"] }),
     ];
 
-    agent.mergeChildMessages(visibleMessages, [
+    agent["mergeChildMessages"](visibleMessages, [
       makeMessage({ subagentId: "known-child", nickname: "other", texts: ["different"] }),
       makeMessage({ nickname: "worker", texts: ["shared text"] }),
       makeMessage({ subagentId: "different-child", nickname: "worker", texts: ["shared text"] }),
@@ -1731,13 +1736,13 @@ describe("CodexAgent subagent folding", () => {
     const identifiedVisible = [
       makeMessage({ subagentId: "identified", nickname: "worker", texts: ["shared text"] }),
     ];
-    agent.mergeChildMessages(identifiedVisible, [
+    agent["mergeChildMessages"](identifiedVisible, [
       makeMessage({ nickname: "worker", texts: ["shared text"] }),
     ]);
     expect(identifiedVisible).toHaveLength(2);
 
     const newlyVisible: Message[] = [];
-    agent.mergeChildMessages(newlyVisible, [
+    agent["mergeChildMessages"](newlyVisible, [
       makeMessage({ nickname: "worker", texts: ["new text"] }),
       makeMessage({ nickname: "worker", texts: ["new text"] }),
     ]);
@@ -1745,7 +1750,7 @@ describe("CodexAgent subagent folding", () => {
   });
 
   it("merges large child batches without pairwise array scans", () => {
-    const agent = new CodexAgent() as any;
+    const agent = new CodexAgent();
     const visibleMessages = Array.from({ length: 200 }, (_, index) =>
       makeMessage({ nickname: `worker-${index}`, texts: [`visible-${index}`] }),
     );
@@ -1755,7 +1760,7 @@ describe("CodexAgent subagent folding", () => {
     const someSpy = vi.spyOn(Array.prototype, "some");
 
     someSpy.mockClear();
-    agent.mergeChildMessages(visibleMessages, childMessages);
+    agent["mergeChildMessages"](visibleMessages, childMessages);
     const someCallCount = someSpy.mock.calls.length;
     someSpy.mockRestore();
 
@@ -1781,8 +1786,8 @@ describe("CodexAgent subagent folding", () => {
     });
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
     agent.scan({ from: 0 });
     const openSpy = vi.mocked(openSync);
     openSpy.mockClear();
@@ -1794,9 +1799,9 @@ describe("CodexAgent subagent folding", () => {
     agent.getSessionData(PARENT_ID);
     expect(childOpenCount(childFile)).toBe(0);
 
-    const cacheEntry = agent.childSessionSummariesByParent.get(PARENT_ID)?.get(childFile);
+    const cacheEntry = agent["childSessionSummariesByParent"].get(PARENT_ID)?.get(childFile);
     expect(cacheEntry).toBeDefined();
-    cacheEntry.parserVersion = "codex-parser-old";
+    cacheEntry!.parserVersion = "codex-parser-old";
     openSpy.mockClear();
     agent.getSessionData(PARENT_ID);
     expect(childOpenCount(childFile)).toBeGreaterThan(0);
@@ -1830,8 +1835,8 @@ describe("CodexAgent subagent folding", () => {
     });
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
     agent.scan({ from: 0 });
     expect(agent.getSessionData(PARENT_ID).messages).toEqual([]);
 
@@ -1853,16 +1858,16 @@ describe("CodexAgent subagent folding", () => {
     });
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
     agent.scan({ from: 0 });
     agent.getSessionData(PARENT_ID);
-    expect(agent.childSessionSummariesByParent.get(PARENT_ID)?.has(childFile)).toBe(true);
+    expect(agent["childSessionSummariesByParent"].get(PARENT_ID)?.has(childFile)).toBe(true);
 
     rmSync(childFile);
-    agent.subagentIndex = null;
+    agent["subagentIndex"] = null;
     agent.getSessionData(PARENT_ID);
-    expect(agent.childSessionSummariesByParent.has(PARENT_ID)).toBe(false);
+    expect(agent["childSessionSummariesByParent"].has(PARENT_ID)).toBe(false);
   });
 
   it("finds child rollouts when detail parsing starts from cached metadata", () => {
@@ -1879,12 +1884,12 @@ describe("CodexAgent subagent folding", () => {
       ],
     });
 
-    const scanned = new CodexAgent({ sourceRoot: tempDir }) as any;
-    scanned.sessionIndexCache = new Map();
+    const scanned = new CodexAgent({ sourceRoot: tempDir });
+    scanned["sessionIndexCache"] = new Map();
     scanned.scan({ from: 0 });
 
-    const fresh = new CodexAgent() as any;
-    fresh.findBasePath = () => tempDir;
+    const fresh = new CodexAgent();
+    fresh["findBasePath"] = () => tempDir;
     fresh.restoreSessionCacheMeta(scanned.snapshotSessionCacheMeta());
 
     const data = fresh.getSessionData(PARENT_ID);
@@ -1908,13 +1913,13 @@ describe("CodexAgent subagent folding", () => {
       ],
     });
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
 
     const [head] = agent.scan({ from: 0 });
-    expect(head.reference.sessionId).toBe(PARENT_ID);
-    expect(head.stats.total_input_tokens).toBe(100);
-    expect(head.stats.total_output_tokens).toBe(20);
+    expect(head?.reference.sessionId).toBe(PARENT_ID);
+    expect(head?.stats.total_input_tokens).toBe(100);
+    expect(head?.stats.total_output_tokens).toBe(20);
   });
 
   it("expands a changed child to include its parent, leaving roots alone", () => {
@@ -1927,8 +1932,8 @@ describe("CodexAgent subagent folding", () => {
       parentThreadId: PARENT_ID,
     });
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
 
     const refs = [
       {
@@ -1962,10 +1967,10 @@ describe("CodexAgent subagent folding", () => {
       extra: [tokenCountLine(40, 60, 100)],
     });
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
     const [parentHead] = agent.scan({ from: 0 });
-    expect(parentHead.stats.total_input_tokens).toBe(100);
+    expect(parentHead?.stats.total_input_tokens).toBe(100);
 
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
     rmSync(childFile);
@@ -1987,8 +1992,8 @@ describe("CodexAgent subagent folding", () => {
       extra: [tokenCountLine(40, 60, 100)],
     });
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
 
     const childFile = join(tempDir, `rollout-2026-04-20T10-00-00-${CHILD_ID}.jsonl`);
     expect(agent.scanSessionSource(childFile)).toMatchObject({
@@ -2021,8 +2026,8 @@ describe("CodexAgent subagent folding", () => {
       ].join("\n"),
     );
 
-    const agent = new CodexAgent({ sourceRoot: tempDir }) as any;
-    agent.sessionIndexCache = new Map();
+    const agent = new CodexAgent({ sourceRoot: tempDir });
+    agent["sessionIndexCache"] = new Map();
 
     const heads = agent.scan({ from: 0, fast: true });
     expect(heads.find((head: SessionHead) => head.reference.sessionId === CHILD_ID)).toMatchObject({

--- a/packages/core/src/agents/__tests__/cursor-opencode.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-opencode.test.ts
@@ -58,8 +58,8 @@ describe("SQLite-backed agent parse contracts", () => {
       db.close();
     }
 
-    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
-    agent.buildWorkspacePathMap = () => new Map([["composer-1", "/tmp/project"]]);
+    const agent = new CursorAgent({ sourceRoot: tempDir });
+    agent["buildWorkspacePathMap"] = () => new Map([["composer-1", "/tmp/project"]]);
 
     const [head] = agent.scan({ from: 0 });
     const data = agent.getSessionData("composer-1");

--- a/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
+++ b/packages/core/src/agents/__tests__/cursor-scan-shape.test.ts
@@ -164,11 +164,11 @@ describe("CS-142: Cursor scan shape", () => {
     const agent = makeAgent(dbPath);
 
     agent.scan({ from: 0 });
-    expect((agent as any).composerCache.has("stale")).toBe(true);
+    expect(agent["composerCache"].has("stale")).toBe(true);
 
     agent.scan({ from: 3_000 });
 
-    expect((agent as any).composerCache.has("stale")).toBe(false);
+    expect(agent["composerCache"].has("stale")).toBe(false);
     expect(textOf(agent, "stale")).toEqual(["old"]);
   });
 

--- a/packages/core/src/agents/__tests__/cursor.test.ts
+++ b/packages/core/src/agents/__tests__/cursor.test.ts
@@ -66,7 +66,7 @@ describe("CursorAgent parsing", () => {
     symlinkSync(outsideWorkspace, join(workspaceStorage, "linked-workspace"));
     vi.stubEnv("CURSOR_DATA_PATH", dataRoot);
 
-    const map = (new CursorAgent() as any).buildWorkspacePathMap();
+    const map = new CursorAgent()["buildWorkspacePathMap"]();
 
     expect(map).toEqual(new Map());
   });
@@ -93,8 +93,8 @@ describe("CursorAgent parsing", () => {
       },
     });
 
-    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
-    agent.composerCache.set("composer-1", {
+    const agent = new CursorAgent({ sourceRoot: tempDir });
+    agent["composerCache"].set("composer-1", {
       id: "composer-1",
       text: "Fallback title",
       createdAt: 1_000,
@@ -136,8 +136,8 @@ describe("CursorAgent parsing", () => {
       },
     });
 
-    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
-    agent.composerCache.set("composer-1", { id: "composer-1", createdAt: 1_000 });
+    const agent = new CursorAgent({ sourceRoot: tempDir });
+    agent["composerCache"].set("composer-1", { id: "composer-1", createdAt: 1_000 });
 
     const tool = agent
       .getSessionData("composer-1")
@@ -162,8 +162,8 @@ describe("CursorAgent parsing", () => {
     );
     insertKv(dbPath, "bubble:sub-1", fixture);
 
-    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
-    agent.composerCache.set("composer-1", {
+    const agent = new CursorAgent({ sourceRoot: tempDir });
+    agent["composerCache"].set("composer-1", {
       id: "composer-1",
       createdAt: 1_000,
       updatedAt: 2_000,
@@ -200,8 +200,8 @@ describe("CursorAgent parsing", () => {
       createdAt: 1_000,
     });
 
-    const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
-    agent.composerCache.set("composer-1", {
+    const agent = new CursorAgent({ sourceRoot: tempDir });
+    agent["composerCache"].set("composer-1", {
       id: "composer-1",
       createdAt: 1_000,
       updatedAt: 1_000,
@@ -230,8 +230,8 @@ describe("CursorAgent parsing", () => {
     setCoreDiagnostics(sink);
 
     try {
-      const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
-      agent.composerCache.set("composer-1", {
+      const agent = new CursorAgent({ sourceRoot: tempDir });
+      agent["composerCache"].set("composer-1", {
         id: "composer-1",
         createdAt: 1_000,
         updatedAt: 1_000,
@@ -268,8 +268,8 @@ describe("CursorAgent parsing", () => {
     setCoreDiagnostics(sink);
 
     try {
-      const agent = new CursorAgent({ sourceRoot: tempDir }) as any;
-      agent.composerCache.set("composer-1", {
+      const agent = new CursorAgent({ sourceRoot: tempDir });
+      agent["composerCache"].set("composer-1", {
         id: "composer-1",
         createdAt: 1_000,
         updatedAt: 1_000,
@@ -314,6 +314,7 @@ describe("CursorAgent scan outcomes", () => {
   });
 
   it("CS-273: throws instead of returning empty messages when the bubble query fails", () => {
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The injected database throws on prepare before any other database method or message data is used.
     const agent = new CursorAgent() as unknown as {
       loadMessagesFromBubbles(db: unknown, composerId: string, model: string | null): unknown;
     };

--- a/packages/core/src/agents/__tests__/dsh-runtime.test.ts
+++ b/packages/core/src/agents/__tests__/dsh-runtime.test.ts
@@ -8,6 +8,7 @@ import { DshAgent } from "../dsh.js";
 // engine floor at 22 so every other agent still works there. Removing the
 // decoder proves a DSH compressed artifact fails with an actionable runtime
 // diagnostic rather than a bare "not a function".
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Exercise the unsupported Node zstd capability branch on every test runtime.
 vi.mock("node:zlib", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:zlib")>();
   return { ...actual, zstdDecompressSync: undefined };

--- a/packages/core/src/agents/__tests__/dsh.test.ts
+++ b/packages/core/src/agents/__tests__/dsh.test.ts
@@ -11,6 +11,7 @@ import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostic
 
 // Delegates to the real implementation; only the stable-snapshot test replaces
 // it, so a file that keeps changing under the reader can be simulated.
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Simulate file identity changes while retaining real filesystem reads.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return { ...actual, statSync: vi.fn(actual.statSync) };
@@ -432,12 +433,12 @@ describe("DSH Zstandard container", () => {
 
     const real = (await vi.importActual<typeof import("node:fs")>("node:fs")).statSync;
     let identity = 0;
-    vi.mocked(statSync).mockImplementation(((path: string, options?: { bigint?: boolean }) => {
-      const stats = real(path, options as never) as unknown as Record<string, unknown>;
-      // A fresh identity on every bigint stat: the two stats bracketing a read
-      // can never agree, which is exactly what an active append looks like.
-      return options?.bigint ? { ...stats, size: BigInt(identity++) } : stats;
-    }) as unknown as typeof statSync);
+    // SAFETY: This stub preserves both stat return shapes; the reader only requests the bigint option.
+    vi.mocked(statSync).mockImplementation(((path, options?: { bigint?: boolean }) => {
+      if (!options?.bigint) return real(path);
+      // Changing identity makes the stats bracketing every read disagree.
+      return { ...real(path, { bigint: true }), size: BigInt(identity++) };
+    }) as typeof statSync);
 
     expectSourceFailure(/changed during every read attempt/);
   });

--- a/packages/core/src/agents/__tests__/grok.test.ts
+++ b/packages/core/src/agents/__tests__/grok.test.ts
@@ -99,11 +99,7 @@ function writeGrokSession(options: SessionFixtureOptions) {
   return { agent, updatesPath };
 }
 
-function turnUsage(
-  inputTokens: number,
-  outputTokens: number,
-  costUsdTicks: number,
-): Record<string, unknown> {
+function turnUsage(inputTokens: number, outputTokens: number, costUsdTicks: number) {
   return {
     stop_reason: "end_turn",
     usage: {

--- a/packages/core/src/agents/__tests__/kimi-code.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-code.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real filesystem reads and inject read failures without replacing agent parsing.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {

--- a/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
+++ b/packages/core/src/agents/__tests__/kimi-enumeration.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // Both file-read entry points are wrapped (call-through) so the suite can assert
 // *which* files a code path opens: readFileSync for whole-file loads, openSync for
 // the streaming reader. Everything else stays real — the fixtures are real dirs.
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real filesystem reads and inject read failures without replacing agent parsing.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {

--- a/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
+++ b/packages/core/src/agents/__tests__/opencode-sqlite.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { OpenCodeSqliteAgent } from "../opencode-sqlite.js";
 import { SessionScanError } from "../base.js";
+import type { SQLiteDatabase } from "../../utils/sqlite.js";
 import type { ModelPricing } from "../../pricing/fetcher.js";
 import { pricingResolver } from "../../pricing/resolver.js";
 import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostics.js";
@@ -573,14 +574,7 @@ describe("CS-180: related session reads stay inside the selected roots", () => {
     const db = new Database(dbPath, { readonly: true });
 
     try {
-      const rows = (
-        agent as unknown as {
-          readRelatedSessionRows(
-            database: Database.Database,
-            rootIds: string[],
-          ): Record<string, unknown>[];
-        }
-      ).readRelatedSessionRows(db, ["cycle-a"]);
+      const rows = agent["readRelatedSessionRows"](db as SQLiteDatabase, ["cycle-a"]);
 
       expect(rows.map((row) => row.id)).toEqual(["cycle-a", "cycle-b"]);
     } finally {

--- a/packages/core/src/agents/__tests__/pi.test.ts
+++ b/packages/core/src/agents/__tests__/pi.test.ts
@@ -8,6 +8,7 @@ import { setCoreDiagnostics, type CoreDiagnostics } from "../../utils/diagnostic
 
 // Spies on statSync while delegating to the real implementation, so the
 // single-stat regression test can count per-file calls during a live scan.
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real filesystem reads and inject read failures without replacing agent parsing.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return { ...actual, statSync: vi.fn(actual.statSync) };

--- a/packages/core/src/agents/claudecode.ts
+++ b/packages/core/src/agents/claudecode.ts
@@ -64,8 +64,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
   readonly displayName = AGENT_METADATA.displayName;
 
   private basePath: string | null = this.configuredSourceRoot;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private sessionsIndexCache: Record<string, any> = {};
+  private sessionsIndexCache = new Map<string, Map<string, Record<string, unknown>>>();
   private sessionsIndexMtime: Record<string, number | null> = {};
   private childContextsBySource = new Map<string, ClaudeChildContext>();
   private childContextCache = new Map<string, ClaudeChildContextCacheEntry>();
@@ -439,8 +438,9 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
 
     // Invalidate when the index file mtime advances so long-running processes
     // pick up title changes without relying on callers to evict manually.
-    if (cacheKey in this.sessionsIndexCache && this.sessionsIndexMtime[cacheKey] === mtime) {
-      return this.sessionsIndexCache[cacheKey];
+    const cached = this.sessionsIndexCache.get(cacheKey);
+    if (cached && this.sessionsIndexMtime[cacheKey] === mtime) {
+      return cached;
     }
 
     const map = new Map<string, Record<string, unknown>>();
@@ -460,7 +460,7 @@ export class ClaudeCodeAgent extends SingleFileSessionSource<SessionMeta> {
       }
     }
 
-    this.sessionsIndexCache[cacheKey] = map;
+    this.sessionsIndexCache.set(cacheKey, map);
     this.sessionsIndexMtime[cacheKey] = mtime;
     return map;
   }

--- a/packages/core/src/agents/codex-exec-decode.ts
+++ b/packages/core/src/agents/codex-exec-decode.ts
@@ -85,8 +85,8 @@ export function decodeExecCalls(input: unknown): ExecInnerCall[] {
 }
 
 /** Pre-scan `const/let/var NAME = "..."` so shorthand args can resolve them. */
-function collectStringVars(input: string): Map<string, unknown> {
-  const scope = new Map<string, unknown>();
+function collectStringVars(input: string): Map<string, string> {
+  const scope = new Map<string, string>();
   const assignRe = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*/g;
   let match: RegExpExecArray | null;
   while ((match = assignRe.exec(input)) !== null) {
@@ -107,9 +107,9 @@ const IDENT_PART_RE = /[\w$]/;
 class JsValueReader {
   pos: number;
   private readonly src: string;
-  private readonly scope: Map<string, unknown>;
+  private readonly scope: Map<string, string>;
 
-  constructor(src: string, start: number, scope: Map<string, unknown>) {
+  constructor(src: string, start: number, scope: Map<string, string>) {
     this.src = src;
     this.pos = start;
     this.scope = scope;
@@ -272,7 +272,7 @@ class JsValueReader {
     return Number(match[0]);
   }
 
-  private parseIdentifierValue(): unknown {
+  private parseIdentifierValue(): string | boolean | null | undefined {
     const name = this.readIdentifier();
     if (name === "true") return true;
     if (name === "false") return false;
@@ -281,7 +281,7 @@ class JsValueReader {
     return this.resolveIdentifier(name);
   }
 
-  private resolveIdentifier(name: string): unknown {
+  private resolveIdentifier(name: string): string | undefined {
     return this.scope.has(name) ? this.scope.get(name) : undefined;
   }
 

--- a/packages/core/src/agents/dsh-session-log.ts
+++ b/packages/core/src/agents/dsh-session-log.ts
@@ -690,6 +690,8 @@ function decodeStorageRecord(line: string, sourcePath: string): DshEvent[] {
       `corrupt DSH session log ${JSON.stringify(sourcePath)}: event ${JSON.stringify(tag)} has an invalid seq/time`,
     );
   }
+  // SAFETY: The tag and seq/time guards validate the envelope; materialization checks event-specific payloads.
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- Preserve the decoded JSON object after validating its envelope.
   return [parsed as unknown as DshEvent];
 }
 

--- a/packages/core/src/analytics/__tests__/dashboard-tree-reuse.test.ts
+++ b/packages/core/src/analytics/__tests__/dashboard-tree-reuse.test.ts
@@ -3,6 +3,7 @@ import type { SessionHead } from "../../types/session.js";
 
 const treeMocks = vi.hoisted(() => ({ buildSessionTree: vi.fn() }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real session-tree builds to verify aggregation reuses the existing tree.
 vi.mock("../../contract/index.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../contract/index.js")>();
   treeMocks.buildSessionTree.mockImplementation(actual.buildSessionTree);

--- a/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
+++ b/packages/core/src/discovery/__tests__/agent-scan-plan.test.ts
@@ -18,6 +18,7 @@ import type { SessionHead } from "../../types/index.js";
 
 const enumerated: EnumeratedSessionSourceCapability = {
   kind: "enumerated",
+  // SAFETY: Plan selection inspects the capability kind without calling this synchronization placeholder.
   synchronize: () => ({}) as never,
   count: () => 0,
 };
@@ -43,6 +44,7 @@ function agent(
   source: AggregateSessionSourceCapability | EnumeratedSessionSourceCapability,
   sessions: SessionHead[] = [],
 ): BaseAgent {
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: These planning tests only exercise the supplied availability, scan and source capability methods.
   return {
     sessionSourceAccess: source,
     isAvailable: () => true,

--- a/packages/core/src/discovery/__tests__/cache.test.ts
+++ b/packages/core/src/discovery/__tests__/cache.test.ts
@@ -23,6 +23,7 @@ function readCachedValue(agentName: string): CachedResult | null {
   return outcome.status === "success" ? outcome.value : null;
 }
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };

--- a/packages/core/src/discovery/__tests__/migration-smoke.test.ts
+++ b/packages/core/src/discovery/__tests__/migration-smoke.test.ts
@@ -40,6 +40,7 @@ function readCachedValue(agentName: string): CachedResult | null {
   return outcome.status === "success" ? outcome.value : null;
 }
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix home and platform to exercise portable storage paths without touching user data.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {
@@ -217,7 +218,7 @@ function getBookmarkColumns(): string[] {
   }
 }
 
-function readMigratedFacts(): Record<string, unknown> {
+function readMigratedFacts() {
   const db = new Database(getCachePath(), { readonly: true });
   try {
     const scalar = (sql: string): number => {

--- a/packages/core/src/discovery/__tests__/orchestrate.test.ts
+++ b/packages/core/src/discovery/__tests__/orchestrate.test.ts
@@ -156,6 +156,7 @@ describe("buildAgentCacheMeta", () => {
       return [];
     }
     getSessionData() {
+      // SAFETY: This orchestration fixture never loads details; it exercises scan state and watch capabilities.
       return {} as never;
     }
     getSessionWatchPlan() {

--- a/packages/core/src/discovery/__tests__/paths.test.ts
+++ b/packages/core/src/discovery/__tests__/paths.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix home and platform to exercise portable storage paths without touching user data.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {
@@ -9,6 +10,7 @@ vi.mock("node:os", async (importOriginal) => {
   };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Exercise missing default source paths independently of the host filesystem.
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {

--- a/packages/core/src/discovery/__tests__/scanner.test.ts
+++ b/packages/core/src/discovery/__tests__/scanner.test.ts
@@ -48,8 +48,12 @@ function withCurrentIdentity(session: SessionHead): IdentifiedSessionHead {
 
 class TestAgent extends BaseAgent {
   private meta: Record<string, SessionCacheMeta> = {};
-  readonly name = "test";
-  readonly displayName = "test";
+  constructor(
+    readonly name = "test",
+    readonly displayName = name,
+  ) {
+    super();
+  }
   readonly sessionSourceAccess = {
     kind: "aggregate" as const,
     checkForChanges: (sinceTimestamp: number, cachedSessions: SessionHead[]) =>
@@ -225,6 +229,7 @@ describe("filterSessions", () => {
   });
 
   it("returns empty for null directory with cwd filter", () => {
+    // SAFETY: The null directory is intentional malformed adapter data used to test cwd filtering.
     const sessions = [makeSession("a", { directory: null as any })];
     const result = filterSessions(sessions, { cwd: "/home/user/project" });
     expect(result).toHaveLength(0);
@@ -234,6 +239,7 @@ describe("filterSessions", () => {
 // --- scanSessions integration tests ---
 // Mock cache and perf to isolate scanner logic
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control cache restoration and writes while exercising scanner reconciliation.
 vi.mock("../cache/sessions.js", () => ({
   readCachedSessions: vi.fn(() => ({ status: "success", value: null })),
   markAgentCacheInitialized: vi.fn(),
@@ -242,6 +248,7 @@ vi.mock("../cache/sessions.js", () => ({
   saveCachedSessions: vi.fn(),
 }));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix tag classification and timing results while testing scanner orchestration.
 vi.mock("../../utils/index.js", () => ({
   classifySessionTags: vi.fn(() => []),
   getSmartTagSourceTimestamp: vi.fn(() => 1000),
@@ -253,6 +260,7 @@ vi.mock("../../utils/index.js", () => ({
 }));
 
 // Mock createRegisteredAgents to return controlled agents
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Register only the fixture agents so orchestration cannot discover host agent data.
 vi.mock("../../agents/index.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../agents/index.js")>();
   return { ...actual, createRegisteredAgents: vi.fn(() => []) };
@@ -293,17 +301,15 @@ function createTestAgent(overrides: {
   incrementalScanResult?: SessionHead[];
   metaMap?: Map<string, SessionCacheMeta>;
 }) {
-  const agent = new TestAgent() as any;
-  agent.name = overrides.name;
-  agent.displayName = overrides.name;
+  const agent = new TestAgent(overrides.name);
   agent.isAvailable = () => overrides.available;
   agent.scan = () => {
     if (overrides.shouldThrow) throw new Error("scan failed");
-    if (overrides.metaMap) agent._metaMap = overrides.metaMap;
+    if (overrides.metaMap) agent.restoreSessionCacheMeta(Object.fromEntries(overrides.metaMap));
     return overrides.sessions;
   };
   agent.getSessionData = () => ({
-    id: "s1",
+    reference: { agentName: overrides.name, sessionId: "s1" },
     title: "Session",
     directory: "/repo",
     time_created: 1000,
@@ -324,7 +330,7 @@ function createTestAgent(overrides: {
   if (overrides.incrementalScanResult) {
     agent.incrementalScan = () => overrides.incrementalScanResult!;
   }
-  return agent as TestAgent;
+  return agent;
 }
 
 describe("ensureSessionTagsSync", () => {

--- a/packages/core/src/discovery/__tests__/session-detail.test.ts
+++ b/packages/core/src/discovery/__tests__/session-detail.test.ts
@@ -33,6 +33,7 @@ const projectIdentity = {
   displayName: "project",
 };
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };
@@ -335,6 +336,7 @@ describe("materializeSessionDetail", () => {
 
   it("rejects an invalid snapshot instead of resolving identity during a detail request", () => {
     const detail = { ...makeDetail(), project_identity: undefined };
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: The missing identity is intentional invalid input; this test verifies rejection at the snapshot boundary.
     const head = {
       ...makeHead(),
       project_identity: undefined,

--- a/packages/core/src/discovery/__tests__/session-scope.test.ts
+++ b/packages/core/src/discovery/__tests__/session-scope.test.ts
@@ -16,6 +16,7 @@ import { matchesSessionQueryScope, type SessionQueryScope } from "../session-sco
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-query-scope-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:os")>()),
   homedir: () => testHomeDir,

--- a/packages/core/src/discovery/__tests__/smart-tag-worker-lifecycle.test.ts
+++ b/packages/core/src/discovery/__tests__/smart-tag-worker-lifecycle.test.ts
@@ -53,10 +53,12 @@ const workers = vi.hoisted(() => {
   return { FakeWorker, state };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix the worker pool size so lifecycle assertions do not depend on the host CPU count.
 vi.mock("node:os", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:os")>()),
   availableParallelism: vi.fn(() => 3),
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control worker messages, failures and shutdown without timing real threads.
 vi.mock("node:worker_threads", () => ({ Worker: workers.FakeWorker }));
 
 import { finalizeAgentScan } from "../scanner.js";
@@ -80,11 +82,12 @@ function makeSession(index: number): IdentifiedSessionHead {
 
 function makeAgent(): BaseAgent {
   const meta = new Map<string, SessionCacheMeta>();
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: These worker lifecycle tests use only agent identity, metadata and the explicit detail mock.
   return {
     name: "test",
     snapshotSessionCacheMeta: () => Object.fromEntries(meta),
     getSessionData: vi.fn(
-      (): SessionDetail => ({ ...makeSession(0), messages: [] }) as unknown as SessionDetail,
+      (): SessionDetail => ({ ...makeSession(0), messages: [] }) as SessionDetail,
     ),
   } as unknown as BaseAgent;
 }

--- a/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
+++ b/packages/core/src/discovery/__tests__/worker-log-relay.test.ts
@@ -42,10 +42,12 @@ const workers = vi.hoisted(() => {
   return { FakeWorker };
 });
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix the worker pool size so lifecycle assertions do not depend on the host CPU count.
 vi.mock("node:os", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:os")>()),
   availableParallelism: vi.fn(() => 3),
 }));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control worker messages, failures and shutdown without timing real threads.
 vi.mock("node:worker_threads", () => ({ Worker: workers.FakeWorker }));
 
 import { finalizeAgentScan } from "../scanner.js";
@@ -81,6 +83,7 @@ describe("smart tag worker logging", () => {
     });
     const sessions = Array.from({ length: 50 }, (_, index) => makeSession(index));
     const meta = new Map<string, SessionCacheMeta>();
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- SAFETY: This relay test needs only agent identity and metadata; content work is supplied by the controlled worker.
     const agent = {
       name: "test",
       snapshotSessionCacheMeta: () => Object.fromEntries(meta),

--- a/packages/core/src/discovery/agent-scan-plan.ts
+++ b/packages/core/src/discovery/agent-scan-plan.ts
@@ -26,8 +26,11 @@ export type AgentScanPlan =
   | { kind: "reuse-baseline" };
 
 type SourceScanPlan = Extract<AgentScanPlan, { kind: "scan" | "synchronize" }>;
+
 type RefreshScanPlan = Extract<AgentScanPlan, { kind: "synchronize" | "check-for-changes" }>;
+
 type RecomputeScanPlan = Extract<AgentScanPlan, { kind: "reuse-baseline" }>;
+
 export type ExecutableAgentScanPlan = Exclude<AgentScanPlan, { kind: "check-for-changes" }>;
 
 export interface AgentScanPlanExecution {

--- a/packages/core/src/discovery/cache/__tests__/active-hours.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/active-hours.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const home = mkdtempSync(join(tmpdir(), "codesesh-active-hours-"));
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (original) => ({
   ...(await original<typeof import("node:os")>()),
   homedir: () => home,

--- a/packages/core/src/discovery/cache/__tests__/active-hours.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/active-hours.test.ts
@@ -22,6 +22,7 @@ import type { Message } from "../../../types/index.js";
 const from = Date.parse("2026-09-06T00:00:00Z");
 const to = Date.parse("2026-09-07T23:59:59.999Z");
 const options = { from, to, timeZone: "UTC" };
+
 function message(id: string, time: number, extra: Partial<Message> = {}): Message {
   return { id, role: "user", time_created: time, parts: [{ type: "text", text: id }], ...extra };
 }

--- a/packages/core/src/discovery/cache/__tests__/analytics-revision.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/analytics-revision.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-analytics-revision-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };

--- a/packages/core/src/discovery/cache/__tests__/content-migrations.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/content-migrations.test.ts
@@ -26,7 +26,7 @@ function createDatabase(): TestDatabase {
       agent_name TEXT PRIMARY KEY
     );
   `);
-  return db as unknown as TestDatabase;
+  return db as TestDatabase;
 }
 
 function seedAgentCache(db: TestDatabase): void {

--- a/packages/core/src/discovery/cache/__tests__/cost-facts.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/cost-facts.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cost-facts-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };

--- a/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/diagnostics.test.ts
@@ -14,6 +14,7 @@ import {
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-diag-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };

--- a/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/model-cost.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-model-cost-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {

--- a/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/project-groups.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-project-groups-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {
@@ -15,6 +16,7 @@ vi.mock("node:os", async (importOriginal) => {
 
 // Wrap (not replace) withCacheDb so the writable-fallback path is still
 // exercised for real, while letting the test assert whether it ran.
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Count real database access to verify project grouping uses bounded queries.
 vi.mock("../connection.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../connection.js")>();
   return { ...actual, withCacheDb: vi.fn(actual.withCacheDb) };

--- a/packages/core/src/discovery/cache/__tests__/schema.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/schema.test.ts
@@ -25,6 +25,7 @@ function readCachedValue(agentName: string) {
   return outcome.status === "success" ? outcome.value : null;
 }
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };
@@ -203,7 +204,7 @@ describe("cache schema boundary", () => {
         PRAGMA user_version = ${newerVersion};
       `);
 
-      expect(() => ensureCacheSchema(db as unknown as SQLiteDatabase, getCachePath())).toThrow(
+      expect(() => ensureCacheSchema(db as SQLiteDatabase, getCachePath())).toThrow(
         new UnsupportedCacheSchemaVersionError(newerVersion, CACHE_SCHEMA_VERSION),
       );
       expect(Number(db.pragma("user_version", { simple: true }))).toBe(newerVersion);

--- a/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-index-writer.test.ts
@@ -23,6 +23,7 @@ import { makeSessionData, makeSessionHead } from "./fixtures.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-search-writer-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };

--- a/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/search-integration.test.ts
@@ -35,6 +35,7 @@ function readCachedValue(agentName: string): CachedResult | null {
   return outcome.status === "success" ? outcome.value : null;
 }
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {

--- a/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions-lifecycle.test.ts
@@ -40,6 +40,7 @@ import type { SessionHead } from "../../../types/index.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-cache-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {
@@ -645,6 +646,7 @@ describe("saveCachedSessions", () => {
   it("skips a malformed legacy session without aborting migration", () => {
     createLegacyCachedSessionDb(3, {
       ...makeSession("legacy-null-directory"),
+      // SAFETY: The null directory deliberately models corrupt legacy storage so migration recovery is exercised.
       directory: null as never,
       project_identity: undefined,
     });

--- a/packages/core/src/discovery/cache/__tests__/sessions.test.ts
+++ b/packages/core/src/discovery/cache/__tests__/sessions.test.ts
@@ -24,6 +24,7 @@ function readCachedValue(agentName: string): CachedResult | null {
   return outcome.status === "success" ? outcome.value : null;
 }
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(() => testHomeDir) };

--- a/packages/core/src/discovery/cache/schema-version.ts
+++ b/packages/core/src/discovery/cache/schema-version.ts
@@ -16,6 +16,7 @@ export interface ProjectBackfillSessionRow extends DatabaseRow {
   meta_json?: string | null;
   sort_index?: number;
 }
+
 export type LegacyProjectIdentityResolver = (directory: string) => ProjectIdentity;
 
 // Schema migrations hold an immediate SQLite transaction, so identity discovery

--- a/packages/core/src/discovery/cache/sessions.ts
+++ b/packages/core/src/discovery/cache/sessions.ts
@@ -82,6 +82,7 @@ const SESSION_HEAD_SELECT_COLUMNS = `
   s.smart_tags_classifier_revision,
   s.meta_json
 `;
+
 export interface CachedResult {
   sessions: IdentifiedSessionHead[];
   meta: Record<string, SessionCacheMeta>;

--- a/packages/core/src/discovery/session-detail.ts
+++ b/packages/core/src/discovery/session-detail.ts
@@ -207,6 +207,7 @@ function getSessionDetailContext(
 }
 
 type CachedDetailState = "fresh" | "stale" | "missing";
+
 type CachedSessionDetailEntry = Pick<
   CachedSessionRawEntry,
   "data" | "detailVersion" | "pendingReindex"

--- a/packages/core/src/pricing/__tests__/refresh-generation.test.ts
+++ b/packages/core/src/pricing/__tests__/refresh-generation.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const testHome = mkdtempSync(join(tmpdir(), "codesesh-pricing-refresh-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: () => testHome };
@@ -270,7 +271,7 @@ describe("CS-148: pricing generations", () => {
   ])("leaves the current generation alone after %s", async (_name, handler) => {
     const before = estimateTokenCost(MODEL, MILLION_INPUT);
     const generationBefore = getPricingGeneration().id;
-    stubFetch(handler as never);
+    stubFetch(handler);
 
     expect(await refreshPricingCache()).toBe(false);
 

--- a/packages/core/src/pricing/fetcher.ts
+++ b/packages/core/src/pricing/fetcher.ts
@@ -6,6 +6,7 @@ import { ensurePrivateDirectory, restrictPrivateFile } from "../utils/private-st
 import { getCoreDiagnostics } from "../utils/diagnostics.js";
 import { MODELS_DEV_URL, parseModelsDevPricing } from "./models-dev.js";
 import { normalizeModelKey, type ModelPricing } from "./model-pricing.js";
+
 export { normalizeModelKey, type ModelPricing } from "./model-pricing.js";
 import snapshotData from "./data/snapshot.json";
 

--- a/packages/core/src/pricing/fetcher.ts
+++ b/packages/core/src/pricing/fetcher.ts
@@ -63,6 +63,8 @@ function getCachePath() {
 
 function loadSnapshot(): Map<string, ModelPricing> {
   const map = new Map<string, ModelPricing>();
+  // SAFETY: The bundled pricing snapshot stores fixed-position price tuples; JSON imports infer arrays.
+  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- Preserve the documented tuple schema of the bundled JSON asset.
   const snapshot = snapshotData as unknown as Record<string, SnapshotEntry>;
   for (const [name, entry] of Object.entries(snapshot)) {
     const [input, output, cacheCreate, cacheRead, reasoning, webSearch] = entry;

--- a/packages/core/src/projects/identity.test.ts
+++ b/packages/core/src/projects/identity.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./identity.js";
 import { realFs } from "./fs.js";
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Control home expansion while resolving real temporary Git repositories.
 vi.mock("node:os", async () => {
   const actual = await vi.importActual<typeof import("node:os")>("node:os");
   return {

--- a/packages/core/src/projects/identity.ts
+++ b/packages/core/src/projects/identity.ts
@@ -29,6 +29,7 @@ const PARSEABLE_MANIFESTS = ["package.json", "Cargo.toml", "pyproject.toml"] as 
 
 const LOOSE_DIRS = new Set(["/tmp", "/private/tmp"]);
 const LOOSE_HOME_DIRS = ["Desktop", "Downloads", "Documents"];
+
 type PathOps = Pick<
   typeof path.posix,
   "dirname" | "isAbsolute" | "join" | "relative" | "resolve" | "sep"

--- a/packages/core/src/search/__tests__/session-search.test.ts
+++ b/packages/core/src/search/__tests__/session-search.test.ts
@@ -38,6 +38,7 @@ import {
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-session-search-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Route persistent test data to an isolated home directory.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {
@@ -441,6 +442,7 @@ function trackedSessions(sessions: SessionHead[]) {
     sessions: new Proxy(sessions, {
       get(target, property, receiver) {
         if (typeof property === "string" && /^\d+$/.test(property)) reads += 1;
+        // oxlint-disable-next-line anti-slop/no-reflect-get -- This Proxy must preserve receiver semantics while counting reads of the real target.
         return Reflect.get(target, property, receiver);
       },
     }),

--- a/packages/core/src/state/__tests__/bookmarks.test.ts
+++ b/packages/core/src/state/__tests__/bookmarks.test.ts
@@ -14,6 +14,7 @@ import { setStateSchemaEnsuredPath } from "../database.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-bookmarks-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix home and platform to exercise portable storage paths without touching user data.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {

--- a/packages/core/src/state/__tests__/database.test.ts
+++ b/packages/core/src/state/__tests__/database.test.ts
@@ -12,6 +12,7 @@ import {
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-state-database-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix home and platform to exercise portable storage paths without touching user data.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {

--- a/packages/core/src/state/__tests__/session-aliases.test.ts
+++ b/packages/core/src/state/__tests__/session-aliases.test.ts
@@ -12,6 +12,7 @@ import { setStateSchemaEnsuredPath } from "../database.js";
 
 const testHomeDir = mkdtempSync(join(tmpdir(), "codesesh-aliases-test-"));
 
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Fix home and platform to exercise portable storage paths without touching user data.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return {

--- a/packages/core/src/utils/__tests__/private-storage.test.ts
+++ b/packages/core/src/utils/__tests__/private-storage.test.ts
@@ -91,7 +91,11 @@ describe("CS-141: private storage", () => {
     source.exec("CREATE TABLE t (id INTEGER PRIMARY KEY)");
     source.prepare("INSERT INTO t (id) VALUES (1)").run();
 
-    const backupPath = backupDatabase(source as never, dbPath, "test");
+    const backupPath = backupDatabase(
+      source as import("../sqlite.js").SQLiteDatabase,
+      dbPath,
+      "test",
+    );
     source.close();
 
     expect(backupPath).not.toBeNull();

--- a/packages/core/src/utils/__tests__/sqlite-unavailable.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite-unavailable.test.ts
@@ -5,6 +5,7 @@ import { setCoreDiagnostics, type CoreDiagnostics } from "../diagnostics.js";
 // before any host has a chance to call setCoreDiagnostics — so simulating an
 // unavailable native module requires faking createRequire itself rather than
 // vi.mock("better-sqlite3"), which only intercepts the ESM graph.
+// oxlint-disable-next-line anti-slop/no-module-mocking -- Simulate the optional SQLite native binding being unavailable without changing installed dependencies.
 vi.mock("node:module", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:module")>();
   return {

--- a/packages/core/src/utils/__tests__/sqlite.test.ts
+++ b/packages/core/src/utils/__tests__/sqlite.test.ts
@@ -37,7 +37,7 @@ describe("sqlite migration helpers", () => {
   }
 
   it("skips backups for in-memory databases", () => {
-    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    const db = new Database(":memory:") as SQLiteDatabase;
     try {
       db.exec(`
         CREATE TABLE rows (
@@ -53,7 +53,7 @@ describe("sqlite migration helpers", () => {
   });
 
   it("reports migration start and completion", () => {
-    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    const db = new Database(":memory:") as SQLiteDatabase;
     const events = collectMigrationDiagnostics();
     try {
       runSchemaMigrations(db, {
@@ -95,7 +95,7 @@ describe("sqlite migration helpers", () => {
   });
 
   it("rejects an incomplete plan before applying migrations", () => {
-    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    const db = new Database(":memory:") as SQLiteDatabase;
     let migrationRan = false;
     try {
       expect(() =>
@@ -124,7 +124,7 @@ describe("sqlite migration helpers", () => {
   });
 
   it("rejects unordered migration plans", () => {
-    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    const db = new Database(":memory:") as SQLiteDatabase;
     try {
       expect(() =>
         runSchemaMigrations(db, {
@@ -146,7 +146,7 @@ describe("sqlite migration helpers", () => {
   });
 
   it("reports migration failures before rethrowing", () => {
-    const db = new Database(":memory:") as unknown as SQLiteDatabase;
+    const db = new Database(":memory:") as SQLiteDatabase;
     const events = collectMigrationDiagnostics();
     try {
       expect(() =>
@@ -187,7 +187,7 @@ describe("sqlite migration helpers", () => {
   it("keeps the source and backup recoverable when a destructive migration fails", () => {
     const dir = mkdtempSync(join(tmpdir(), "codesesh-migration-recovery-"));
     const dbPath = join(dir, "cache.db");
-    const db = new Database(dbPath) as unknown as SQLiteDatabase;
+    const db = new Database(dbPath) as SQLiteDatabase;
     try {
       db.exec("CREATE TABLE rows(id INTEGER PRIMARY KEY, value TEXT NOT NULL)");
       db.prepare("INSERT INTO rows(id, value) VALUES (1, 'before')").run();
@@ -276,8 +276,7 @@ describe("openDb pragmas", () => {
     const db = openDb(dbPath);
     expect(db).not.toBeNull();
     try {
-      const pragmaCapable = db as unknown as { pragma(sql: string): unknown };
-      expect(pragmaCapable.pragma("busy_timeout")).toEqual([{ timeout: 5000 }]);
+      expect(db?.prepare("PRAGMA busy_timeout").all()).toEqual([{ timeout: 5000 }]);
     } finally {
       db?.close();
     }
@@ -292,8 +291,7 @@ describe("openDb pragmas", () => {
     const db = openDbReadOnly(dbPath);
     expect(db).not.toBeNull();
     try {
-      const pragmaCapable = db as unknown as { pragma(sql: string): unknown };
-      expect(pragmaCapable.pragma("busy_timeout")).toEqual([{ timeout: 5000 }]);
+      expect(db?.prepare("PRAGMA busy_timeout").all()).toEqual([{ timeout: 5000 }]);
     } finally {
       db?.close();
     }

--- a/packages/core/src/utils/session-normalization.ts
+++ b/packages/core/src/utils/session-normalization.ts
@@ -22,6 +22,7 @@ function cleanUnknown(value: unknown): unknown {
   for (const [key, child] of Object.entries(value)) {
     cleaned[key] = cleanUnknown(child);
   }
+  // oxlint-disable-next-line anti-slop/no-known-value-widening -- Recursive cleanup preserves arbitrary tool payload fields while removing empty values.
   return cleaned;
 }
 

--- a/packages/core/src/utils/sqlite.ts
+++ b/packages/core/src/utils/sqlite.ts
@@ -50,7 +50,6 @@ let loadErrorMessage: string | null = null;
 
 try {
   const require = createRequire(import.meta.url);
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mod = require("better-sqlite3");
   DatabaseConstructor = (
     typeof mod === "function" ? mod : (mod as { default?: unknown }).default

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@codesesh/core':
         specifier: workspace:*
         version: link:packages/core
+      '@oxlint/plugins':
+        specifier: 1.81.0
+        version: 1.81.0
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -1350,6 +1353,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxlint/plugins@1.81.0':
+    resolution: {integrity: sha512-HhD8kd3r6XpelZkhxhRty/po8V6yK1VV63Eq4kSsOS2IoHUywG3DV2EX+z/ZHw46aLI74Y6aA604NRiAqLKW9w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@pierre/theming@1.0.0':
     resolution: {integrity: sha512-WsdrnhKfjeyXGDikZmN9pkpeZ5S/cl6EE72feiSc0tlynT1tMYqXqouhuv/foK+PY9OEnebOAVRQn3+rAstR8g==}
@@ -5278,6 +5285,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.81.0':
     optional: true
+
+  '@oxlint/plugins@1.81.0': {}
 
   '@pierre/theming@1.0.0(@shikijs/themes@4.4.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(shiki@4.4.3)':
     optionalDependencies:

--- a/scripts/anti-slop.test.mjs
+++ b/scripts/anti-slop.test.mjs
@@ -1,0 +1,216 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { getPnpmInvocation } from "./lib/pnpm-process.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const policy = JSON.parse(readFileSync(join(repoRoot, ".oxlintrc.json"), "utf8"));
+const directories = [];
+
+function runTool(args) {
+  const { executable, shell } = getPnpmInvocation();
+  const result = spawnSync(executable, ["exec", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    shell,
+    timeout: 20_000,
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.signal).toBeNull();
+  return result;
+}
+
+function fixture(code, ruleNames, overrides = {}) {
+  const directory = mkdtempSync(join(tmpdir(), "codesesh-anti-slop-"));
+  directories.push(directory);
+  const path = join(directory, "fixture.ts");
+  const config = join(directory, ".oxlintrc.json");
+  writeFileSync(path, code);
+  writeFileSync(
+    config,
+    JSON.stringify({
+      categories: { correctness: "off" },
+      jsPlugins: [
+        { name: "anti-slop", specifier: join(repoRoot, "tools/oxlint/anti-slop/index.ts") },
+      ],
+      options: policy.options,
+      rules: {
+        ...Object.fromEntries(
+          ruleNames.map((name) => [`anti-slop/${name}`, policy.rules[`anti-slop/${name}`]]),
+        ),
+        ...overrides,
+      },
+    }),
+  );
+  const lint = (fix = false) => {
+    const result = runTool([
+      "oxlint",
+      "--config",
+      config,
+      "--no-ignore",
+      "--format",
+      "json",
+      ...(fix ? ["--fix"] : []),
+      path,
+    ]);
+    const report = JSON.parse(result.stdout);
+    expect(report.number_of_files).toBe(1);
+    expect(result.status).toBe(
+      report.diagnostics.some((diagnostic) => diagnostic.severity === "error") ? 1 : 0,
+    );
+    return report.diagnostics;
+  };
+  return { path, lint };
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0))
+    rmSync(directory, { recursive: true, force: true });
+});
+
+describe("vendored anti-slop policy", { timeout: 30_000 }, () => {
+  it("permits raw unknown dictionaries but rejects other erased value contracts and aliases", () => {
+    const allowed = fixture(
+      `
+      type Raw = Record<string, unknown>;
+      type Domain = Record<string, { name: string }>;
+      type Mixed = { [key: string]: unknown | string };
+    `,
+      ["no-unsafe-dictionary-type"],
+    );
+    expect(allowed.lint()).toEqual([]);
+    const rejected = fixture(
+      `
+      type Escape = any;
+      type Aliased = Record<string, Escape>;
+      type ObjectValues = { [key: string]: object };
+      type EmptyValues = Record<string, {} | string>;
+    `,
+      ["no-unsafe-dictionary-type"],
+    );
+    expect(rejected.lint().map((diagnostic) => diagnostic.code)).toEqual(
+      Array(3).fill("anti-slop(no-unsafe-dictionary-type)"),
+    );
+    const upstreamDefault = fixture(
+      "type Raw = Record<string, unknown>;",
+      ["no-unsafe-dictionary-type"],
+      { "anti-slop/no-unsafe-dictionary-type": "error" },
+    );
+    expect(upstreamDefault.lint()).toHaveLength(1);
+  });
+
+  it("preserves concrete object and dictionary contracts while rejecting known value erasure", () => {
+    const checked = fixture(
+      `
+      const named: { name: string } = { name: "one" };
+      const indexed: Record<string, { name: string }> = { one: { name: "one" } };
+      type Erased = unknown;
+      type Dictionary<T> = Record<string, T>;
+      const precise: Dictionary<{ name: string }> = { one: { name: "one" } };
+      const broad: Dictionary<unknown> = { name: "one" };
+      const alias: Erased = { name: "one" };
+      const erased: unknown = { name: "one" };
+      const raw: Record<string, unknown> = { name: "one" };
+    `,
+      ["no-known-value-widening"],
+    );
+    expect(checked.lint().map((diagnostic) => diagnostic.code)).toEqual(
+      Array(4).fill("anti-slop(no-known-value-widening)"),
+    );
+  });
+
+  it("requires justifications for any, never, nested escapes and chains without requiring ordinary casts", () => {
+    const checked = fixture(
+      `
+      declare const value: unknown;
+      const ordinary = value as { name: string };
+      const constant = "one" as const;
+      const anyValue = value as any;
+      const neverValue = value as never;
+      const nested = value as { items: any[] };
+      const chained = (value as unknown) as string;
+      const angle = <never>value;
+    `,
+      ["require-safety-comment-for-type-assertion"],
+    );
+    expect(checked.lint()).toHaveLength(5);
+    const upstreamDefault = fixture(
+      "declare const value: unknown; const ordinary = value as string;",
+      ["require-safety-comment-for-type-assertion"],
+      { "anti-slop/require-safety-comment-for-type-assertion": "error" },
+    );
+    expect(upstreamDefault.lint()).toHaveLength(1);
+  });
+
+  it("keeps justified exceptions local and reports stale suppressions", () => {
+    const checked = fixture(
+      `
+      declare const value: unknown;
+      // SAFETY: The fixture supplies the only field read by this boundary.
+      // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- Partial boundary fixture.
+      const fixture = value as unknown as string;
+      const next = value as any;
+      // oxlint-disable-next-line anti-slop/no-module-mocking -- Control worker lifecycle events.
+      vi.mock("node:worker_threads", () => ({}));
+      vi.mock("./owned-module", () => ({}));
+      // oxlint-disable-next-line anti-slop/no-module-mocking -- No mock remains here.
+      const stale = 1;
+    `,
+      [
+        "require-safety-comment-for-type-assertion",
+        "no-chained-type-assertions",
+        "no-module-mocking",
+      ],
+    );
+    const diagnostics = checked.lint();
+    expect(diagnostics).toHaveLength(3);
+    expect(
+      diagnostics.some(
+        (diagnostic) => diagnostic.code === "anti-slop(require-safety-comment-for-type-assertion)",
+      ),
+    ).toBe(true);
+    expect(
+      diagnostics.some((diagnostic) => diagnostic.code === "anti-slop(no-module-mocking)"),
+    ).toBe(true);
+    expect(diagnostics.some((diagnostic) => diagnostic.message.includes("Unused"))).toBe(true);
+  });
+
+  it("separates module declarations, retains JSDoc and overloads, and stabilizes with oxfmt", () => {
+    const checked = fixture(
+      `import type { A } from "a";
+import type { B } from "b";
+/** Attached to Value. */
+export interface Value { name: string; }
+export function parse(value: string): string;
+export function parse(value: number): number;
+export function parse(value: string | number) {
+  const current = value;
+  if (current) return current;
+  return value;
+}
+export type Result = Value;
+`,
+      ["require-readable-spacing"],
+    );
+    expect(checked.lint().length).toBeGreaterThan(0);
+    checked.lint(true);
+    expect(runTool(["oxfmt", "--write", checked.path]).status).toBe(0);
+    const first = readFileSync(checked.path, "utf8");
+    expect(first).toContain(
+      'import type { B } from "b";\n\n/** Attached to Value. */\nexport interface Value',
+    );
+    expect(first).toContain(
+      "export function parse(value: string): string;\nexport function parse(value: number): number;\nexport function parse(value: string | number)",
+    );
+    expect(first).toContain(
+      "  const current = value;\n  if (current) return current;\n  return value;",
+    );
+    expect(checked.lint()).toEqual([]);
+    checked.lint(true);
+    expect(runTool(["oxfmt", "--write", checked.path]).status).toBe(0);
+    expect(readFileSync(checked.path, "utf8")).toBe(first);
+  });
+});

--- a/tests/e2e/www.spec.ts
+++ b/tests/e2e/www.spec.ts
@@ -132,7 +132,9 @@ test("copies the install command with the clipboard API", async ({ page }) => {
 
   await expect(copy).toContainText("Copied");
   await expect
-    .poll(() => page.evaluate(() => Reflect.get(window, "__copiedCommand")))
+    .poll(() =>
+      page.evaluate(() => ("__copiedCommand" in window ? window.__copiedCommand : undefined)),
+    )
     .toBe("npx codesesh");
 });
 

--- a/tools/oxlint/anti-slop/LICENSE
+++ b/tools/oxlint/anti-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dillon Mulroy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/oxlint/anti-slop/POLICY.md
+++ b/tools/oxlint/anti-slop/POLICY.md
@@ -1,0 +1,79 @@
+# CodeSesh anti-slop policy
+
+Judge a rule by the maintenance problems it prevents. Judge each diagnostic
+separately: fix an avoidable loss of information, document a justified exception
+at its exact location, or change a rule that cannot express a useful distinction.
+The number of existing violations is not a reason to disable a valuable rule.
+
+## Enabled rules
+
+All enabled rules use `error`, including in tests. There is no historical
+baseline, directory-wide test exemption, or warning-only adoption period.
+
+| Rule | Maintenance purpose and local decision |
+| --- | --- |
+| `oxc/no-accumulating-spread`, `no-reduce-accumulator-copy` | Prevent repeatedly copying a growing accumulator. Keep both: they catch different copy forms. |
+| `no-chained-type-assertions`, `no-widen-then-assert` | Expose type erasure used to bypass incompatible contracts. Remove redundant casts and complete ordinary fixtures. Allow a local exception for a validated external envelope, bundled tuple data, or a deliberately partial boundary fixture. |
+| `no-known-value-widening` | Preserve information already known at the value's owner. Concrete object contracts and dictionaries with concrete value types are accepted. Erasure to `unknown`, `object`, or unsafe dictionary values remains checked, including supported local aliases. Recursive payload cleanup and heterogeneous endpoint fixtures have local exceptions. |
+| `no-unsafe-dictionary-type` | Reject dictionary values typed as `any`, `object`, or `{}`, including supported aliases/unions. `allowUnknown: true` accepts raw external JSON dictionaries: values must still be narrowed before use. This option does not exempt known-value erasure under the preceding rule. |
+| `no-module-mocking` | Make module replacement a reviewed test design decision. Existing OS home/path fixtures, worker protocol harnesses, injected persistence failures, HTTP client state tests, and call-through performance spies have per-call explanations. A new call still fails lint. Do not add production service layers merely to remove these exceptions. |
+| `no-object-parameters` | Require an actual parameter contract for internal operations. Keep three localized exceptions: a WeakMap identity token, arbitrary object sanitization, and native URL brand probing. |
+| `no-reflect-get`, `no-reflect-apply` | Prefer visible property/call contracts. Guarded property reads replace ordinary reflective reads. Two read-counting Proxy traps retain `Reflect.get` to preserve receiver semantics. |
+| `no-unknown-type-aliases` | Prevent naming an erased contract as though it were a domain type. |
+| `require-safety-comment-for-type-assertion` | With `scope: "type-escapes"`, require a nearby `SAFETY:` reason for assertions containing `any`/`never` and for consecutive assertions. Ordinary single domain casts and `as const` do not need repetitive commentary. Upstream's `scope: "all"` remains available. |
+| `require-readable-spacing` | Separate imports and top-level function, class, interface and type declarations. Keep local statement groups and adjacent overload signatures together. Check compatibility with oxfmt rather than introducing a second formatting preset. |
+
+## Disabled rules
+
+These six rules are explicitly `off` because their current checks do not express
+the project's desired invariant. They are not disabled because cleanup is large.
+
+| Rule | Reason |
+| --- | --- |
+| `no-array-filter-map` | An extra linear traversal is not itself a maintenance defect. Blanket fusion can obscure intent and change callback order, indexes or sparse-array behavior. Accumulator-copy rules and existing growth-rate checks cover concrete performance risks. |
+| `no-conditional-empty-object-spread` | Conditional omission is meaningful for API payloads, options and JSX props. A blanket ban does not distinguish this from accidental structure. |
+| `no-shape-in-symbol-names` | Vocabulary restrictions do not establish whether a domain name is accurate; `Map`, `Set`, counts and references can be useful names. |
+| `no-unknown-parameters` | JSON, SQLite, worker messages and error boundaries need honest unknown inputs. The AST rule cannot reliably distinguish those from erased internal contracts. |
+| `no-unknown-returns` | Boundary readers and recursive tool payload preservation legitimately return unknown values. Renaming or wrapping them to evade the rule would add concepts without strengthening validation. |
+| `no-runtime-typeof` | Runtime validation is required for untrusted history files, network payloads and browser capabilities. The rule cannot identify where such validation belongs. |
+
+## Findings addressed during adoption
+
+The initial scan of 736 files produced 10,705 diagnostics, including 8,544
+spacing reports. These were rule matches, not independent defects.
+
+- The Claude Code index cache erased its nested map type with `any`. It now
+  stores typed maps.
+- The Codex expression reader and log sanitizers returned broader types than
+  their implementations produced. Their contracts now preserve those values.
+- Many tests erased entire Agent instances to reach private caches. Typed field
+  access now retains method and cache checks; incomplete legacy cache fixtures
+  explain their intentional missing fields locally.
+- HTTP handler fixtures repeated `as never` at call sites. The partial Hono
+  context adaptation now lives at the fixture boundary and retains typed spies.
+- Scan status and session detail fixtures omitted required fields. Ordinary
+  fixtures now supply those fields; malformed-input tests explicitly retain
+  their invalid values.
+- Query cache tests now use a real QueryObserver, and the maintenance scheduler
+  accepts the single runner operation it actually uses.
+- Existing module mocks and the remaining partial browser/worker fixtures have
+  narrow explanations, with no exemption for new neighboring code.
+
+## Exceptions and upgrades
+
+Use `oxlint-disable-next-line anti-slop/<rule> -- <specific reason>` at the
+smallest relevant site. For unsafe assertions, also explain the invariant in a
+nearby `SAFETY:` comment. An exception must describe the boundary, required
+methods, invalid test input, or runtime invariant; “legacy” alone is not enough.
+`reportUnusedDisableDirectives: "error"` rejects stale suppressions.
+
+`pnpm exec vitest run scripts/anti-slop.test.mjs` exercises the vendored plugin
+through the installed Oxlint CLI. It checks accepted and rejected contracts,
+local exception boundaries, stale suppressions, JSDoc/overload attachment, and
+fix/format stability. These tests also run in the existing coverage CI job.
+The normal workspace lint commands load the same root plugin configuration.
+
+Keep `@oxlint/plugins` aligned with the installed Oxlint version. On upgrade,
+compare against the source revision in `UPSTREAM.md`, preserve the decisions
+above, rerun rule tests, and reassess diagnostics without adding a baseline.
+These AST rules are guardrails, not proof of complete type or complexity safety.

--- a/tools/oxlint/anti-slop/UPSTREAM.md
+++ b/tools/oxlint/anti-slop/UPSTREAM.md
@@ -1,0 +1,33 @@
+# Anti-slop provenance
+
+- Source repository: https://github.com/dmmulroy/anti-slop
+- Source commit: `c44ef22ca116d0ba62a3ff663a0bd13a3f3fa40b`
+- Source directory: `skills/install-anti-slop/assets/anti-slop/`
+- Installed directory: `tools/oxlint/anti-slop/`
+- Installed on: 2026-09-11
+
+The files were copied by the bundled `install-anti-slop/scripts/install.mjs`.
+Before adding this record, a recursive byte comparison confirmed that every
+bundled file matched the source directory at the commit above. The installed
+skill's metadata identifies `dmmulroy/anti-slop` as its source; the commit was
+verified against the actual assets, not inferred from that metadata.
+
+## Installed entry points
+
+- `index.ts`: generic rules, registered as `anti-slop` in `.oxlintrc.json`.
+- `effect/index.ts`: bundled but not registered; this repository has no direct
+  `effect` dependency.
+- `vendor/eslint-stylistic/`: retained with its original `LICENSE` and
+  `UPSTREAM.md`, which document the nested vendor's source and adaptations.
+
+## Local configuration and deviations
+
+There are no changes to the copied plugin source. This provenance file is the
+only local documentation addition to the upstream asset tree. The upstream root LICENSE is also retained verbatim. The skill's asset bundle does not include the upstream rule tests.
+
+All 18 generic rules and the native `oxc/no-accumulating-spread` companion rule
+are enabled at `error`. `@oxlint/plugins` is pinned to `1.81.0`, matching the
+installed and locked Oxlint version. Keep these versions aligned on upgrades.
+Lint and format ignore agent assets, local worktrees, and this vendored tree.
+Existing application diagnostics are retained for review without suppression
+or automatic cleanup.

--- a/tools/oxlint/anti-slop/UPSTREAM.md
+++ b/tools/oxlint/anti-slop/UPSTREAM.md
@@ -22,12 +22,25 @@ verified against the actual assets, not inferred from that metadata.
 
 ## Local configuration and deviations
 
-There are no changes to the copied plugin source. This provenance file is the
-only local documentation addition to the upstream asset tree. The upstream root LICENSE is also retained verbatim. The skill's asset bundle does not include the upstream rule tests.
+The upstream root `LICENSE` is retained verbatim; it is not included in the
+skill asset bundle. The bundled rule tests are not part of those assets.
 
-All 18 generic rules and the native `oxc/no-accumulating-spread` companion rule
-are enabled at `error`. `@oxlint/plugins` is pinned to `1.81.0`, matching the
-installed and locked Oxlint version. Keep these versions aligned on upgrades.
-Lint and format ignore agent assets, local worktrees, and this vendored tree.
-Existing application diagnostics are retained for review without suppression
-or automatic cleanup.
+Local source changes are limited to:
+
+- `shared/dictionary-types.ts`: recognize concrete object and dictionary value
+  contracts; retain broad-value detection through supported aliases; support
+  the dictionary rule's `allowUnknown` option.
+- `rules/no-unsafe-dictionary-type.ts`: add opt-in `allowUnknown` (default false).
+- `rules/require-safety-comment-for-type-assertion.ts`: add opt-in
+  `scope: "type-escapes"`; upstream's all-assertions behavior remains the default.
+- `rules/require-readable-spacing.ts`: separate imports and module declarations
+  without forcing blank lines throughout function bodies; preserve overloads.
+
+`POLICY.md` records the 12 enabled generic rules, six intentionally disabled
+rules, the native accumulating-spread companion, and justified local exceptions.
+Regression tests live in `scripts/anti-slop.test.mjs` and run the actual CLI.
+
+`@oxlint/plugins` is pinned to `1.81.0`, matching the installed and locked Oxlint
+version. Keep these versions aligned on upgrades. Lint and format ignore agent
+assets, local worktrees, and this vendored tree. Existing ignore entries are
+preserved. No application or test directory was excluded to hide diagnostics.

--- a/tools/oxlint/anti-slop/effect/index.ts
+++ b/tools/oxlint/anti-slop/effect/index.ts
@@ -1,0 +1,21 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noManualEffectErrorTagRule } from "./rules/no-manual-effect-error-tag.ts";
+import { noManualTagComparisonRule } from "./rules/no-manual-tag-comparison.ts";
+import { noManualTaggedConstructionRule } from "./rules/no-manual-tagged-construction.ts";
+import { noServiceConstructorImportsRule } from "./rules/no-service-constructor-imports.ts";
+import { preferEffectMatchRule } from "./rules/prefer-effect-match.ts";
+
+/** Opt-in Oxlint rules for Effect service and Layer architecture. */
+const antiSlopEffectPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop-effect" },
+	rules: {
+		"no-manual-effect-error-tag": noManualEffectErrorTagRule,
+		"no-manual-tag-comparison": noManualTagComparisonRule,
+		"no-manual-tagged-construction": noManualTaggedConstructionRule,
+		"no-service-constructor-imports": noServiceConstructorImportsRule,
+		"prefer-effect-match": preferEffectMatchRule,
+	},
+});
+
+export default antiSlopEffectPlugin;

--- a/tools/oxlint/anti-slop/effect/rules/no-manual-effect-error-tag.ts
+++ b/tools/oxlint/anti-slop/effect/rules/no-manual-effect-error-tag.ts
@@ -1,0 +1,52 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	isInsideBroadEffectHandler,
+	isReasonTagMember,
+	isTagMember,
+	tagMemberFromComparison,
+} from "../shared/tagged-values.ts";
+
+export const noManualEffectErrorTagRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Use Effect tagged error handlers instead of manually branching on `_tag` in a catch handler.",
+		},
+		messages: {
+			tag: "Use Effect.catchTag or Effect.catchTags instead of manually discriminating a tagged error in a broad Effect catch handler.",
+			reason:
+				"Use Effect.catchReason or Effect.catchReasons instead of manually discriminating a tagged `reason` in a broad Effect catch handler.",
+		},
+	},
+	createOnce(context) {
+		return {
+			BinaryExpression(node) {
+				const tagMember = tagMemberFromComparison(node);
+				if (
+					tagMember === undefined ||
+					!isInsideBroadEffectHandler(node)
+				) {
+					return;
+				}
+				context.report({
+					node,
+					messageId: isReasonTagMember(tagMember) ? "reason" : "tag",
+				});
+			},
+			SwitchStatement(node) {
+				if (
+					!isTagMember(node.discriminant) ||
+					!isInsideBroadEffectHandler(node)
+				) {
+					return;
+				}
+				context.report({
+					node,
+					messageId: isReasonTagMember(node.discriminant) ? "reason" : "tag",
+				});
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/effect/rules/no-manual-tag-comparison.ts
+++ b/tools/oxlint/anti-slop/effect/rules/no-manual-tag-comparison.ts
@@ -1,0 +1,45 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	isInsideBroadEffectHandler,
+	isTagMember,
+	tagMemberFromComparison,
+} from "../shared/tagged-values.ts";
+
+export const noManualTagComparisonRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Use Effect Match or Predicate helpers instead of manually branching on `_tag`.",
+		},
+		messages: {
+			manualComparison:
+				"Use Match.tag/Match.tags for tagged-value branching, or Predicate.isTagged for a simple reusable predicate.",
+			manualSwitch:
+				"Use Match.value(value).pipe(Match.tag/Match.tags/Match.tagsExhaustive) or the tagged enum `$match` helper instead of switching on `_tag`.",
+		},
+	},
+	createOnce(context) {
+		return {
+			BinaryExpression(node) {
+				if (
+					tagMemberFromComparison(node) === undefined ||
+					isInsideBroadEffectHandler(node)
+				) {
+					return;
+				}
+				context.report({ node, messageId: "manualComparison" });
+			},
+			SwitchStatement(node) {
+				if (
+					!isTagMember(node.discriminant) ||
+					isInsideBroadEffectHandler(node)
+				) {
+					return;
+				}
+				context.report({ node, messageId: "manualSwitch" });
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/effect/rules/no-manual-tagged-construction.ts
+++ b/tools/oxlint/anti-slop/effect/rules/no-manual-tagged-construction.ts
@@ -1,0 +1,37 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	isMatchPatternObject,
+	isStringLiteral,
+	propertyName,
+} from "../shared/tagged-values.ts";
+
+export const noManualTaggedConstructionRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Construct tagged values with their existing Effect constructor instead of writing `_tag` manually.",
+		},
+		messages: {
+			manualConstruction:
+				"Use the existing Schema tagged `.make`, tagged class/error constructor, or Data.taggedEnum variant constructor instead of writing a literal `_tag` object.",
+		},
+	},
+	createOnce(context) {
+		return {
+			ObjectExpression(node) {
+				if (isMatchPatternObject(node)) return;
+				const tag = node.properties.find(
+					(property) =>
+						property.type === "Property" &&
+						propertyName(property) === "_tag" &&
+						isStringLiteral(property.value),
+				);
+				if (tag !== undefined) {
+					context.report({ node: tag, messageId: "manualConstruction" });
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/effect/rules/no-service-constructor-imports.ts
+++ b/tools/oxlint/anti-slop/effect/rules/no-service-constructor-imports.ts
@@ -1,0 +1,52 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const SERVICE_CONSTRUCTOR_NAME = /^make[A-Z]/u;
+const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/u;
+
+function isProjectLocalImport(source: string): boolean {
+	return source.startsWith("./") || source.startsWith("../");
+}
+
+function getImportedName(specifier: ESTree.ImportSpecifier): string {
+	if (specifier.imported.type === "Identifier") return specifier.imported.name;
+	return specifier.imported.value;
+}
+
+/** Keep dependency-bearing Effect service constructors local to their owning capability modules. */
+export const noServiceConstructorImportsRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow project-local make<CapabilityName> imports outside test and spec files.",
+		},
+		messages: {
+			serviceConstructorImport:
+				'Do not import Effect service constructor "{{name}}" into runtime code. Import the owning Layer, yield the contextual service, and allow its requirements to propagate to the composition root.',
+		},
+	},
+	create(context) {
+		const isTestFile = TEST_FILE.test(context.filename.replaceAll("\\", "/"));
+
+		return {
+			ImportDeclaration(node) {
+				if (isTestFile || !isProjectLocalImport(node.source.value)) return;
+
+				for (const specifier of node.specifiers) {
+					if (specifier.type !== "ImportSpecifier") continue;
+
+					const importedName = getImportedName(specifier);
+					if (!SERVICE_CONSTRUCTOR_NAME.test(importedName)) continue;
+
+					context.report({
+						node: specifier,
+						messageId: "serviceConstructorImport",
+						data: { name: importedName },
+					});
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/effect/rules/prefer-effect-match.ts
+++ b/tools/oxlint/anti-slop/effect/rules/prefer-effect-match.ts
@@ -1,0 +1,54 @@
+import { defineRule, type ESTree } from "@oxlint/plugins";
+
+const equalityOperators = new Set(["==", "===", "!=", "!=="]);
+
+export const preferEffectMatchRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Use Match from Effect for chained literal ternaries over the same value.",
+		},
+		messages: {
+			preferMatch:
+				"Use Match from Effect instead of a chained literal ternary.",
+		},
+	},
+	createOnce(context) {
+		const isLiteral = (node: ESTree.Node): boolean =>
+			node.type === "Literal" ||
+			(node.type === "TemplateLiteral" && node.expressions.length === 0);
+
+		const comparedValue = (node: ESTree.Expression): string | undefined => {
+			if (
+				node.type !== "BinaryExpression" ||
+				!equalityOperators.has(node.operator)
+			) {
+				return undefined;
+			}
+			if (isLiteral(node.left)) return context.sourceCode.getText(node.right);
+			if (isLiteral(node.right)) return context.sourceCode.getText(node.left);
+			return undefined;
+		};
+
+		return {
+			ConditionalExpression(node) {
+				if (node.parent?.type === "ConditionalExpression") return;
+				const value = comparedValue(node.test);
+				if (value === undefined) return;
+
+				let alternate = node.alternate;
+				let literalChecks = 1;
+				while (alternate.type === "ConditionalExpression") {
+					if (comparedValue(alternate.test) !== value) return;
+					literalChecks += 1;
+					alternate = alternate.alternate;
+				}
+
+				if (literalChecks > 1) {
+					context.report({ node, messageId: "preferMatch" });
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/effect/shared/tagged-values.ts
+++ b/tools/oxlint/anti-slop/effect/shared/tagged-values.ts
@@ -1,0 +1,97 @@
+import type { ESTree } from "@oxlint/plugins";
+
+const equalityOperators = new Set(["==", "===", "!=", "!=="]);
+const broadEffectCatchMethods = new Set(["catch", "catchAll", "catchIf"]);
+
+export const isStringLiteral = (
+	node: ESTree.Node | null | undefined,
+): node is ESTree.StringLiteral =>
+	node?.type === "Literal" && typeof node.value === "string";
+
+export const isTagMember = (
+	node: ESTree.Node | null | undefined,
+): node is ESTree.MemberExpression =>
+	node?.type === "MemberExpression" &&
+	((!node.computed &&
+		node.property.type === "Identifier" &&
+		node.property.name === "_tag") ||
+		(node.computed &&
+			isStringLiteral(node.property) &&
+			node.property.value === "_tag"));
+
+export const tagMemberFromComparison = (
+	node: ESTree.BinaryExpression,
+): ESTree.MemberExpression | undefined => {
+	if (!equalityOperators.has(node.operator)) return undefined;
+	if (isTagMember(node.left) && isStringLiteral(node.right)) return node.left;
+	if (isTagMember(node.right) && isStringLiteral(node.left)) return node.right;
+	return undefined;
+};
+
+const isBroadEffectCatchCall = (
+	node: ESTree.Node | null | undefined,
+): node is ESTree.CallExpression =>
+	node?.type === "CallExpression" &&
+	node.callee.type === "MemberExpression" &&
+	node.callee.object.type === "Identifier" &&
+	node.callee.object.name === "Effect" &&
+	!node.callee.computed &&
+	node.callee.property.type === "Identifier" &&
+	broadEffectCatchMethods.has(node.callee.property.name);
+
+export const isInsideBroadEffectHandler = (node: ESTree.Node): boolean => {
+	let current: ESTree.Node | null | undefined = node.parent;
+	while (current !== null && current !== undefined) {
+		if (
+			current.type === "ArrowFunctionExpression" ||
+			current.type === "FunctionExpression"
+		) {
+			return (
+				isBroadEffectCatchCall(current.parent) &&
+				current.parent.arguments.includes(current)
+			);
+		}
+		current = current.parent;
+	}
+	return false;
+};
+
+export const isReasonTagMember = (node: ESTree.MemberExpression): boolean =>
+	node.object.type === "MemberExpression" &&
+	((!node.object.computed &&
+		node.object.property.type === "Identifier" &&
+		node.object.property.name === "reason") ||
+		(node.object.computed &&
+			isStringLiteral(node.object.property) &&
+			node.object.property.value === "reason"));
+
+export const propertyName = (
+	property: ESTree.ObjectProperty,
+): string | undefined => {
+	if (!property.computed && property.key.type === "Identifier") {
+		return property.key.name;
+	}
+	if (
+		property.key.type === "Literal" &&
+		typeof property.key.value === "string"
+	) {
+		return property.key.value;
+	}
+	return undefined;
+};
+
+export const isMatchPatternObject = (node: ESTree.ObjectExpression): boolean => {
+	const call = node.parent;
+	if (call?.type !== "CallExpression" || !call.arguments.includes(node)) {
+		return false;
+	}
+	const callee = call.callee;
+	return (
+		callee.type === "MemberExpression" &&
+		callee.object.type === "Identifier" &&
+		callee.object.name === "Match" &&
+		!callee.computed &&
+		callee.property.type === "Identifier" &&
+		(callee.property.name === "when" || callee.property.name === "not")
+	);
+};

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,47 @@
+import { eslintCompatPlugin } from "@oxlint/plugins";
+
+import { noArrayFilterMapRule } from "./rules/no-array-filter-map.ts";
+import { noReduceAccumulatorCopyRule } from "./rules/no-reduce-accumulator-copy.ts";
+import { noChainedTypeAssertionsRule } from "./rules/no-chained-type-assertions.ts";
+import { noConditionalEmptyObjectSpreadRule } from "./rules/no-conditional-empty-object-spread.ts";
+import { noKnownValueWideningRule } from "./rules/no-known-value-widening.ts";
+import { noModuleMockingRule } from "./rules/no-module-mocking.ts";
+import { noObjectParametersRule } from "./rules/no-object-parameters.ts";
+import { noReflectApplyRule } from "./rules/no-reflect-apply.ts";
+import { noReflectGetRule } from "./rules/no-reflect-get.ts";
+import { noRuntimeTypeofRule } from "./rules/no-runtime-typeof.ts";
+import { noForbiddenTermInSymbolNamesRule } from "./rules/no-shape-in-symbol-names.ts";
+import { noUnknownParametersRule } from "./rules/no-unknown-parameters.ts";
+import { noUnknownReturnsRule } from "./rules/no-unknown-returns.ts";
+import { noUnknownTypeAliasesRule } from "./rules/no-unknown-type-aliases.ts";
+import { noUnsafeDictionaryTypeRule } from "./rules/no-unsafe-dictionary-type.ts";
+import { noWidenThenAssertRule } from "./rules/no-widen-then-assert.ts";
+import { requireReadableSpacingRule } from "./rules/require-readable-spacing.ts";
+import { requireSafetyCommentForTypeAssertionRule } from "./rules/require-safety-comment-for-type-assertion.ts";
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+	meta: { name: "anti-slop" },
+	rules: {
+		"no-array-filter-map": noArrayFilterMapRule,
+		"no-reduce-accumulator-copy": noReduceAccumulatorCopyRule,
+		"no-chained-type-assertions": noChainedTypeAssertionsRule,
+		"no-conditional-empty-object-spread": noConditionalEmptyObjectSpreadRule,
+		"no-known-value-widening": noKnownValueWideningRule,
+		"no-module-mocking": noModuleMockingRule,
+		"no-object-parameters": noObjectParametersRule,
+		"no-reflect-apply": noReflectApplyRule,
+		"no-reflect-get": noReflectGetRule,
+		"no-runtime-typeof": noRuntimeTypeofRule,
+		"no-unsafe-dictionary-type": noUnsafeDictionaryTypeRule,
+		"no-shape-in-symbol-names": noForbiddenTermInSymbolNamesRule,
+		"no-unknown-parameters": noUnknownParametersRule,
+		"no-unknown-returns": noUnknownReturnsRule,
+		"no-unknown-type-aliases": noUnknownTypeAliasesRule,
+		"no-widen-then-assert": noWidenThenAssertRule,
+		"require-readable-spacing": requireReadableSpacingRule,
+		"require-safety-comment-for-type-assertion": requireSafetyCommentForTypeAssertionRule,
+	},
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-array-filter-map.ts
+++ b/tools/oxlint/anti-slop/rules/no-array-filter-map.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { arrayMethodTarget, isKnownArrayExpression, unwrapArrayExpression } from "../shared/array-method.ts";
+
+/** Reject eager array filter/map pipelines; lazy iterator helpers remain allowed. */
+export const noArrayFilterMapRule = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: { description: "Disallow adjacent array filter/map passes in favor of lazy iterator helpers or a single transformation." },
+    messages: {
+      arrayFilterMap: "Avoid consecutive array `{{first}}` and `{{second}}` passes. Prefer `.values().{{first}}(...).{{second}}(...).toArray()` where iterator helpers are supported, or a single `flatMap`/mutating reducer. Preserve callback ordering, indexes, and filtering semantics.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        const outer = arrayMethodTarget(node.callee);
+        if (outer === null || (outer.name !== "map" && outer.name !== "filter")) return;
+        const innerCall = unwrapArrayExpression(outer.object);
+        if (innerCall.type !== "CallExpression") return;
+        const inner = arrayMethodTarget(innerCall.callee);
+        if (inner === null || inner.name !== (outer.name === "map" ? "filter" : "map")) return;
+        if (!isKnownArrayExpression(context.sourceCode, inner.object)) return;
+        context.report({ node, messageId: "arrayFilterMap", data: { first: inner.name, second: outer.name } });
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === "TSAsExpression" || node.type === "TSTypeAssertion";
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === "TSTypeReference" &&
+    typeAnnotation.typeName.type === "Identifier" &&
+    typeAnnotation.typeName.name === "const"
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === "ParenthesizedExpression" && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.",
+    },
+    messages: {
+      chained:
+        "This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.",
+    },
+  },
+  createOnce(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: "chained" });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,49 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === "ParenthesizedExpression") {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === "ObjectExpression" && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === "ConditionalExpression" &&
+    (isEmptyObjectExpression(conditional.consequent) ||
+      isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow object spreads that conditionally spread an empty object to omit fields.",
+    },
+    messages: {
+      avoid:
+        "This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.",
+    },
+  },
+  createOnce(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== "ObjectExpression") return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: "avoid" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,415 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionaryValue,
+	classifyWideningTarget,
+	createTypeEnvironment,
+	isKnownEvidenceExpression,
+	type TypeEnvironment,
+	type WideningTarget,
+} from "../shared/dictionary-types.ts";
+import {
+	containsUnknownType,
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+import { resolveVariable } from "../shared/scope.ts";
+
+import type { ESTree, SourceCode, Variable } from "@oxlint/plugins";
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSSatisfiesExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	return definition?.type === "Variable" && definition.node.type === "VariableDeclarator"
+		? definition.node
+		: null;
+}
+
+function isStableConstVariable(variable: Variable, declarator: ESTree.VariableDeclarator): boolean {
+	return (
+		declarator.parent.type === "VariableDeclaration" &&
+		declarator.parent.kind === "const" &&
+		variable.references.every((reference) => reference.init || !reference.isWrite())
+	);
+}
+
+function hasKnownEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (isKnownEvidenceExpression(expression)) return true;
+	const unwrapped = unwrapExpression(expression);
+	if (unwrapped.type !== "Identifier") return false;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function isFunctionExpression(node: ESTree.Node): node is FunctionExpression {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression" ||
+		node.type === "TSDeclareFunction" ||
+		node.type === "TSEmptyBodyFunctionExpression"
+	);
+}
+
+function localFunctionForCall(
+	sourceCode: SourceCode,
+	callee: ESTree.Expression,
+): FunctionExpression | null {
+	const unwrapped = unwrapExpression(callee);
+	if (isFunctionExpression(unwrapped)) return unwrapped;
+	if (unwrapped.type !== "Identifier") return null;
+	const variable = resolveVariable(sourceCode, unwrapped);
+	if (variable === null || variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (definition.type === "FunctionName" && isFunctionExpression(definition.node)) {
+		return definition.node;
+	}
+	if (definition.type !== "Variable" || definition.node.type !== "VariableDeclarator") {
+		return null;
+	}
+	const initializer = definition.node.init;
+	if (initializer === null) return null;
+	const unwrappedInitializer = unwrapExpression(initializer);
+	return isFunctionExpression(unwrappedInitializer) ? unwrappedInitializer : null;
+}
+
+function variableTypeAnnotation(
+	sourceCode: SourceCode,
+	variable: Variable,
+): ESTree.TSTypeAnnotation | null {
+	if (variable.defs.length !== 1) return null;
+	const [definition] = variable.defs;
+	if (definition === undefined) return null;
+	if (
+		definition.type === "Variable" &&
+		definition.node.type === "VariableDeclarator" &&
+		definition.node.id.type === "Identifier"
+	) {
+		return definition.node.id.typeAnnotation ?? null;
+	}
+	if (definition.type !== "Parameter" || !isFunctionExpression(definition.node)) {
+		return null;
+	}
+	const parameter = definition.node.params.find(
+		(candidate) =>
+			functionParameterBindingName(candidate, sourceCode) === variable.name,
+	);
+	return parameter === undefined ? null : (functionParameterTypeAnnotation(parameter) ?? null);
+}
+
+function hasInformativeType(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): boolean {
+	return classifyUnsafeDictionaryValue(type, environment) === null;
+}
+
+function hasKnownCallArgumentEvidence(
+	sourceCode: SourceCode,
+	expression: ESTree.Expression,
+	environment: TypeEnvironment,
+	visitedVariables = new Set<Variable>(),
+): boolean {
+	if (expression.type === "ParenthesizedExpression" || expression.type === "TSNonNullExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion") {
+		return hasInformativeType(expression.typeAnnotation, environment);
+	}
+	if (expression.type === "TSSatisfiesExpression") {
+		return hasKnownCallArgumentEvidence(
+			sourceCode,
+			expression.expression,
+			environment,
+			visitedVariables,
+		);
+	}
+	if (expression.type === "CallExpression") {
+		const owner = localFunctionForCall(sourceCode, expression.callee);
+		const returnType = owner?.returnType?.typeAnnotation;
+		return returnType !== undefined && hasInformativeType(returnType, environment);
+	}
+	if (expression.type !== "Identifier") return isKnownEvidenceExpression(expression);
+	const variable = resolveVariable(sourceCode, expression);
+	if (variable === null || visitedVariables.has(variable)) return false;
+	const annotation = variableTypeAnnotation(sourceCode, variable);
+	if (annotation !== null) {
+		return hasInformativeType(annotation.typeAnnotation, environment);
+	}
+	const declarator = variableDeclarator(variable);
+	if (
+		declarator === null ||
+		declarator.init === null ||
+		!isStableConstVariable(variable, declarator)
+	) {
+		return false;
+	}
+	visitedVariables.add(variable);
+	return hasKnownCallArgumentEvidence(
+		sourceCode,
+		declarator.init,
+		environment,
+		visitedVariables,
+	);
+}
+
+function typePredicateSubjectIndex(
+	sourceCode: SourceCode,
+	owner: FunctionExpression,
+): number | null {
+	const predicate = owner.returnType?.typeAnnotation;
+	if (predicate?.type !== "TSTypePredicate" || predicate.parameterName.type !== "Identifier") {
+		return null;
+	}
+	const predicateParameterName = predicate.parameterName.name;
+	const index = owner.params.findIndex(
+		(parameter) =>
+			functionParameterBindingName(parameter, sourceCode) === predicateParameterName,
+	);
+	return index === -1 ? null : index;
+}
+
+function annotationTarget(
+	annotation: ESTree.TSTypeAnnotation | null | undefined,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	return annotation === null || annotation === undefined
+		? null
+		: classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (
+			current.type === "ArrowFunctionExpression" ||
+			current.type === "FunctionDeclaration" ||
+			current.type === "FunctionExpression"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+	if (key.type === "Identifier" || key.type === "PrivateIdentifier") return key.name;
+	if (key.type === "Literal") return String(key.value);
+	return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+	if (owner === null) return "anonymous function";
+	if (owner.id !== null) return owner.id.name;
+	const parent = owner.parent;
+	if (parent.type === "VariableDeclarator" && parent.id.type === "Identifier")
+		return parent.id.name;
+	if (parent.type === "MethodDefinition") return sourceKeyName(sourceCode, parent.key);
+	return "anonymous function";
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+	const unwrapped = unwrapExpression(expression);
+	return unwrapped.type === "ObjectExpression" && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+	return destination.kind === "open dictionary" || destination.kind === "generic container";
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+	return node.parent?.type === "TSAsExpression" || node.parent?.type === "TSTypeAssertion";
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.",
+		},
+		messages: {
+			widening:
+				"The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+
+		const reportFlow = (
+			expression: ESTree.Expression,
+			destination: WideningTarget | null,
+			subject: string,
+		) => {
+			if (destination === null) return;
+			if (
+				isDictionaryAccumulatorTarget(destination) &&
+				isEmptyObjectExpression(expression)
+			) {
+				return;
+			}
+			if (!hasKnownEvidence(context.sourceCode, expression)) return;
+			context.report({
+				node: expression,
+				messageId: "widening",
+				data: { subject, target: destination.kind },
+			});
+		};
+
+		const targetFromAnnotation = (annotation: ESTree.TSTypeAnnotation | null | undefined) =>
+			environment === null ? null : annotationTarget(annotation, environment);
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			VariableDeclarator(node) {
+				if (node.init === null || node.id.type !== "Identifier") return;
+				reportFlow(
+					node.init,
+					targetFromAnnotation(node.id.typeAnnotation),
+					`binding \`${node.id.name}\``,
+				);
+			},
+			PropertyDefinition(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AccessorProperty(node) {
+				if (node.value === null) return;
+				reportFlow(
+					node.value,
+					targetFromAnnotation(node.typeAnnotation),
+					`property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+				);
+			},
+			AssignmentExpression(node) {
+				if (node.operator !== "=" || node.left.type !== "Identifier") return;
+				const variable = resolveVariable(context.sourceCode, node.left);
+				if (variable === null) return;
+				const declarator = variableDeclarator(variable);
+				if (declarator === null || declarator.id.type !== "Identifier") return;
+				reportFlow(
+					node.right,
+					targetFromAnnotation(declarator.id.typeAnnotation),
+					`binding \`${declarator.id.name}\``,
+				);
+			},
+			CallExpression(node) {
+				if (environment === null) return;
+				const owner = localFunctionForCall(context.sourceCode, node.callee);
+				if (owner === null) return;
+				const parameterIndex = typePredicateSubjectIndex(context.sourceCode, owner);
+				if (parameterIndex === null) return;
+				const parameter = owner.params[parameterIndex];
+				const argument = node.arguments[parameterIndex];
+				if (parameter === undefined || argument === undefined || argument.type === "SpreadElement") {
+					return;
+				}
+				const parameterAnnotation = functionParameterTypeAnnotation(parameter);
+				if (
+					parameterAnnotation === null ||
+					parameterAnnotation === undefined ||
+					!containsUnknownType(parameterAnnotation.typeAnnotation)
+				) {
+					return;
+				}
+				if (
+					!hasKnownCallArgumentEvidence(
+						context.sourceCode,
+						argument,
+						environment,
+					)
+				) {
+					return;
+				}
+				context.report({
+					node: argument,
+					messageId: "widening",
+					data: {
+						subject: `argument for parameter \`${functionParameterBindingName(parameter, context.sourceCode)}\` of \`${functionName(context.sourceCode, owner)}\``,
+						target: "unknown",
+					},
+				});
+			},
+			ReturnStatement(node) {
+				if (node.argument === null) return;
+				const owner = enclosingFunction(node);
+				reportFlow(
+					node.argument,
+					targetFromAnnotation(owner?.returnType),
+					`return value of \`${functionName(context.sourceCode, owner)}\``,
+				);
+			},
+			ArrowFunctionExpression(node) {
+				if (node.body.type === "BlockStatement") return;
+				reportFlow(
+					node.body,
+					targetFromAnnotation(node.returnType),
+					`return value of \`${functionName(context.sourceCode, node)}\``,
+				);
+			},
+			TSAsExpression(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+			TSTypeAssertion(node) {
+				if (environment === null || hasParentAssertion(node)) return;
+				reportFlow(
+					node.expression,
+					classifyWideningTarget(node.typeAnnotation, environment),
+					"assertion",
+				);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,80 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { resolveVariable } from "../shared/scope.ts";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+const moduleMockMethods = new Set(["doMock", "mock", "unstable_mockModule"]);
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== "ImportSpecifier") return null;
+  return node.imported.type === "Identifier" ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== "Identifier") return false;
+  if (
+    (expression.name === "vi" || expression.name === "jest") &&
+    sourceCode.isGlobalReference(expression)
+  ) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === "vi" || expression.name === "jest";
+  }
+  return variable.defs.some((definition) => {
+    if (definition.type !== "ImportBinding" || definition.parent?.type !== "ImportDeclaration") {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (source === "vitest" && name === "vi") || (source === "@jest/globals" && name === "jest");
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === "Literal" &&
+      (property.value === "doMock" ||
+        property.value === "mock" ||
+        property.value === "unstable_mockModule")
+      ? property.value
+      : null
+    : property.type === "Identifier"
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.",
+    },
+    messages: {
+      moduleMock:
+        "Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: "moduleMock" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,83 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	functionParameterBindingName,
+	functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+type ParameterOwner =
+	| ESTree.ArrowFunctionExpression
+	| ESTree.Function
+	| ESTree.TSCallSignatureDeclaration
+	| ESTree.TSConstructSignatureDeclaration
+	| ESTree.TSConstructorType
+	| ESTree.TSFunctionType
+	| ESTree.TSMethodSignature;
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.",
+		},
+		messages: {
+			objectParameter:
+				"Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToObject = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSObjectKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return (
+					resolved.type === "TSUnionType" && resolved.types.some(matches)
+				);
+			});
+
+		const checkParameters = (node: ParameterOwner) => {
+			for (const parameter of node.params) {
+				const annotation = functionParameterTypeAnnotation(parameter);
+				if (annotation === null || annotation === undefined) continue;
+				if (!resolvesToObject(annotation.typeAnnotation)) continue;
+				context.report({
+					node: annotation.typeAnnotation,
+					messageId: "objectParameter",
+					data: { parameter: functionParameterBindingName(parameter, context.sourceCode) },
+				});
+			}
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			ArrowFunctionExpression: checkParameters,
+			FunctionDeclaration: checkParameters,
+			FunctionExpression: checkParameters,
+			TSCallSignatureDeclaration: checkParameters,
+			TSConstructSignatureDeclaration: checkParameters,
+			TSConstructorType: checkParameters,
+			TSDeclareFunction: checkParameters,
+			TSEmptyBodyFunctionExpression: checkParameters,
+			TSFunctionType: checkParameters,
+			TSMethodSignature: checkParameters,
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.ts
+++ b/tools/oxlint/anti-slop/rules/no-reduce-accumulator-copy.ts
@@ -1,0 +1,109 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, SourceCode, Variable } from "@oxlint/plugins";
+
+import {
+  arrayMethodTarget,
+  isKnownArrayExpression,
+  resolveArrayBinding,
+  unwrapArrayExpression,
+} from "../shared/array-method.ts";
+
+function enclosingReducer(node: ESTree.Node) {
+  let parent = node.parent;
+  while (parent !== null) {
+    if (parent.type === "FunctionDeclaration") return null;
+    if (parent.type === "ArrowFunctionExpression" || parent.type === "FunctionExpression") {
+      const callback = parent;
+      let owner: ESTree.Node | null = callback.parent;
+      while (owner !== null && unwrapArrayExpression(owner) === callback) owner = owner.parent;
+      if (owner?.type !== "CallExpression") return null;
+      const method = arrayMethodTarget(owner.callee);
+      const firstArgument = owner.arguments[0];
+      if (
+        method === null || (method.name !== "reduce" && method.name !== "reduceRight") ||
+        owner.arguments.length > 2 || firstArgument === undefined ||
+        unwrapArrayExpression(firstArgument) !== callback
+      ) return null;
+      const firstParameter = callback.params[0];
+      const accumulator = firstParameter?.type === "AssignmentPattern" ? firstParameter.left : firstParameter;
+      if (accumulator?.type !== "Identifier") return null;
+      return { callback, accumulator, initialValue: owner.arguments[1] };
+    }
+    parent = parent.parent;
+  }
+  return null;
+}
+
+function referencesAccumulator(
+  sourceCode: SourceCode,
+  node: ESTree.Node,
+  accumulator: Variable,
+  visited = new Set<Variable>(),
+): boolean {
+  const variable = resolveArrayBinding(sourceCode, node);
+  if (variable === null || visited.has(variable)) return false;
+  if (variable === accumulator) return true;
+  visited.add(variable);
+  if (variable.references.some(reference => reference.isWrite() && !reference.init)) return false;
+  for (const definition of variable.defs) {
+    if (
+      definition.type === "Variable" && definition.node.type === "VariableDeclarator" &&
+      definition.node.id.type === "Identifier" && definition.node.init !== null &&
+      definition.node.parent.type === "VariableDeclaration" && definition.node.parent.kind === "const"
+    ) {
+      return referencesAccumulator(sourceCode, definition.node.init, accumulator, visited);
+    }
+  }
+  return false;
+}
+
+function isGlobalCopyOwner(sourceCode: SourceCode, node: ESTree.Node, name: string): boolean {
+  node = unwrapArrayExpression(node);
+  if (node.type !== "Identifier" || node.name !== name) return false;
+  const variable = resolveArrayBinding(sourceCode, node);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reject non-spread copies of reducer accumulators; pair with oxc/no-accumulating-spread. */
+export const noReduceAccumulatorCopyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: { description: "Disallow copying growing reducer accumulators with Object.assign, Array.from, or array copy methods." },
+    messages: {
+      accumulatorCopy: "Do not copy the reducer accumulator on every iteration; growing copies can cause quadratic work. Mutate a fresh, locally owned accumulator and return it, or use an iterator pipeline/flatMap.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        const method = arrayMethodTarget(node.callee);
+        if (method === null) return;
+        const reducer = enclosingReducer(node);
+        if (reducer === null) return;
+        const accumulator = context.sourceCode.getDeclaredVariables(reducer.callback).find(variable =>
+          variable.identifiers.some(identifier => identifier.start === reducer.accumulator.start),
+        );
+        if (accumulator === undefined) return;
+        const isAccumulator = (expression: ESTree.Node) =>
+          referencesAccumulator(context.sourceCode, expression, accumulator);
+        let copiesAccumulator = false;
+        if (method.name === "assign" && isGlobalCopyOwner(context.sourceCode, method.object, "Object")) {
+          const target = node.arguments[0];
+          copiesAccumulator = (
+            target !== undefined && unwrapArrayExpression(target).type === "ObjectExpression" &&
+            node.arguments.slice(1).some(isAccumulator)
+          );
+        } else if (method.name === "from" && isGlobalCopyOwner(context.sourceCode, method.object, "Array")) {
+          const source = node.arguments[0];
+          copiesAccumulator = source !== undefined && isAccumulator(source);
+        } else if (["concat", "slice", "toSpliced", "toSorted", "toReversed", "with"].includes(method.name)) {
+          const initialValue = reducer.initialValue;
+          const arrayAccumulator = initialValue !== undefined &&
+            isKnownArrayExpression(context.sourceCode, initialValue);
+          copiesAccumulator = arrayAccumulator && isAccumulator(method.object);
+        }
+        if (copiesAccumulator) context.report({ node, messageId: "accumulatorCopy" });
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.",
+    },
+    messages: {
+      reflectApply:
+        "Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "apply")) {
+          context.report({ node, messageId: "reflectApply" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,28 @@
+import { defineRule } from "@oxlint/plugins";
+
+import { isGlobalReflectMethodCall } from "../shared/reflect-method.ts";
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.",
+    },
+    messages: {
+      reflectGet:
+        "Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === "Super" || node.callee.type === "V8IntrinsicExpression") return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, "get")) {
+          context.report({ node, messageId: "reflectGet" });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,77 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+type RuntimeFunction = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function isRuntimeFunction(node: ESTree.Node): node is RuntimeFunction {
+	return (
+		node.type === "ArrowFunctionExpression" ||
+		node.type === "FunctionDeclaration" ||
+		node.type === "FunctionExpression"
+	);
+}
+
+function isInsideTypeGuard(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isRuntimeFunction(current)) {
+			return current.returnType?.typeAnnotation.type === "TSTypePredicate";
+		}
+		current = current.parent;
+	}
+	return false;
+}
+
+/** Return whether typeof safely probes for the existence of a possibly absent binding. */
+function isExistenceProbe(node: ESTree.UnaryExpression): boolean {
+	const parent = node.parent;
+	if (parent.type !== "BinaryExpression") return false;
+	if (!["===", "!==", "==", "!="].includes(parent.operator)) return false;
+	const other = parent.left === node ? parent.right : parent.left;
+	return other.type === "Literal" && other.value === "undefined";
+}
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.",
+		},
+		messages: {
+			runtimeTypeof:
+				"A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.",
+		},
+		schema: [
+			{
+				type: "object",
+				properties: {
+					allowInTypeGuards: { type: "boolean" },
+				},
+				additionalProperties: false,
+			},
+		],
+		defaultOptions: [{ allowInTypeGuards: false }],
+	},
+	createOnce(context) {
+		return {
+			UnaryExpression(node) {
+				const option = context.options?.[0];
+				const allowInTypeGuards =
+					typeof option === "object" &&
+					option !== null &&
+					!Array.isArray(option) &&
+					option.allowInTypeGuards === true;
+				if (
+					node.operator === "typeof" &&
+					!isExistenceProbe(node) &&
+					(!allowInTypeGuards || !isInsideTypeGuard(node))
+				) {
+					context.report({ node, messageId: "runtimeTypeof" });
+				}
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,46 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+const FORBIDDEN_SYMBOL_NAME = "shape";
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Return whether an identifier names a statically accessed member owned by another value. */
+function isBorrowedMemberName(node: ESTree.Node): boolean {
+  const parent = node.parent;
+  if (parent === null || parent.type !== "MemberExpression") return false;
+  return parent.property === node && parent.computed === false;
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  createOnce(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name) || isBorrowedMemberName(node)) return;
+      context.report({
+        node,
+        messageId: "forbiddenSymbolName",
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,69 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  containsUnknownType,
+  functionParameterBindingName,
+  functionParameterTypeAnnotation,
+} from "../shared/function-parameters.ts";
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function isTypePredicateSubject(owner: ParameterOwner, parameterName: string): boolean {
+  const predicate = owner.returnType?.typeAnnotation;
+  return (
+    predicate?.type === "TSTypePredicate" &&
+    predicate.parameterName.type === "Identifier" &&
+    predicate.parameterName.name === parameterName
+  );
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow explicitly unknown function parameters except `cause` and type-predicate subjects; decode unknown input at its I/O boundary instead.",
+    },
+    messages: {
+      unknownParameter:
+        "Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.",
+    },
+  },
+  createOnce(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = functionParameterTypeAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!containsUnknownType(annotation.typeAnnotation)) continue;
+        const name = functionParameterBindingName(parameter, context.sourceCode);
+        if (name === "cause" || isTypePredicateSubject(node, name)) continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: "unknownParameter",
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,82 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+  createTypeAliasEnvironment,
+  resolvedTypeMatches,
+  type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow functions whose explicit return contract is unknown or Promise<unknown>.",
+    },
+    messages: {
+      unknownReturn:
+        "This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeAliasEnvironment | null = null;
+
+    const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+      environment !== null &&
+      resolvedTypeMatches(type, environment, (resolved, matches) => {
+        if (resolved.type === "TSUnknownKeyword") return true;
+        if (resolved.type === "TSParenthesizedType") {
+          return matches(resolved.typeAnnotation);
+        }
+        if (resolved.type === "TSUnionType") return resolved.types.some(matches);
+        if (
+          resolved.type !== "TSTypeReference" ||
+          resolved.typeName.type !== "Identifier" ||
+          (resolved.typeName.name !== "Promise" &&
+            resolved.typeName.name !== "PromiseLike")
+        ) {
+          return false;
+        }
+        const value = resolved.typeArguments?.params[0];
+        return value !== undefined && matches(value);
+      });
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (!resolvesToUnknown(annotation.typeAnnotation)) return;
+      context.report({ node: annotation.typeAnnotation, messageId: "unknownReturn" });
+    };
+
+    return {
+      Program(node) {
+        environment = createTypeAliasEnvironment(
+          node,
+          context.sourceCode.visitorKeys,
+        );
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,54 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	resolvedTypeMatches,
+	type TypeAliasEnvironment,
+} from "../shared/type-alias-resolution.ts";
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.",
+		},
+		messages: {
+			unknownAlias:
+				"Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeAliasEnvironment | null = null;
+
+		const resolvesToUnknown = (type: ESTree.TSType): boolean =>
+			environment !== null &&
+			resolvedTypeMatches(type, environment, (resolved, matches) => {
+				if (resolved.type === "TSUnknownKeyword") return true;
+				if (resolved.type === "TSParenthesizedType") {
+					return matches(resolved.typeAnnotation);
+				}
+				return resolved.type === "TSUnionType" && resolved.types.some(matches);
+			});
+
+		return {
+			Program(node) {
+				environment = createTypeAliasEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeAliasDeclaration(node) {
+				if (!resolvesToUnknown(node.typeAnnotation)) return;
+				context.report({
+					node: node.id,
+					messageId: "unknownAlias",
+					data: { alias: node.id.name },
+				});
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,154 @@
+import { defineRule } from "@oxlint/plugins";
+
+import {
+	classifyUnsafeDictionary,
+	classifyUnsafeDictionaryValue,
+	createTypeEnvironment,
+	type TypeEnvironment,
+} from "../shared/dictionary-types.ts";
+import { visibleTypeAlias } from "../shared/type-alias-resolution.ts";
+
+import type { ESTree } from "@oxlint/plugins";
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+	"JSDocNonNullableType",
+	"JSDocNullableType",
+	"JSDocUnknownType",
+	"TSAnyKeyword",
+	"TSArrayType",
+	"TSBigIntKeyword",
+	"TSBooleanKeyword",
+	"TSConditionalType",
+	"TSConstructorType",
+	"TSFunctionType",
+	"TSImportType",
+	"TSIndexedAccessType",
+	"TSInferType",
+	"TSIntersectionType",
+	"TSIntrinsicKeyword",
+	"TSLiteralType",
+	"TSMappedType",
+	"TSNamedTupleMember",
+	"TSNeverKeyword",
+	"TSNullKeyword",
+	"TSNumberKeyword",
+	"TSObjectKeyword",
+	"TSParenthesizedType",
+	"TSStringKeyword",
+	"TSSymbolKeyword",
+	"TSTemplateLiteralType",
+	"TSThisType",
+	"TSTupleType",
+	"TSTypeLiteral",
+	"TSTypeOperator",
+	"TSTypePredicate",
+	"TSTypeQuery",
+	"TSTypeReference",
+	"TSUndefinedKeyword",
+	"TSUnionType",
+	"TSUnknownKeyword",
+	"TSVoidKeyword",
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+	return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (current.type === "TSTypeAliasDeclaration") return true;
+		current = current.parent;
+	}
+	return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (node.type !== "TSTypeReference" || node.typeArguments?.params.length) return false;
+	const name = typeReferenceName(node);
+	return (
+		name !== null &&
+		visibleTypeAlias(name, node, environment.typeAliases) !== null &&
+		!isInsideTypeAliasDeclaration(node)
+	);
+}
+
+function isInsideTypeParameterConstraint(node: ESTree.TSType): boolean {
+	let child: ESTree.Node = node;
+	let parent: ESTree.Node | null = child.parent;
+	while (parent !== null && parent.type !== "Program") {
+		if (parent.type === "TSTypeParameter" && parent.constraint === child) return true;
+		child = parent;
+		parent = child.parent;
+	}
+	return false;
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+	if (isInsideTypeParameterConstraint(node)) return false;
+	if (isPlainAliasConsumerUse(node, environment)) return false;
+	if (classifyUnsafeDictionary(node, environment) === null) return false;
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null && current.type !== "Program") {
+		if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null)
+			return false;
+		current = current.parent;
+	}
+	return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+	meta: {
+		type: "problem",
+		docs: {
+			description:
+				"Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
+		},
+		messages: {
+			unsafeDictionary:
+				"This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+		},
+	},
+	createOnce(context) {
+		let environment: TypeEnvironment | null = null;
+		const report = (node: ESTree.Node, value: string) => {
+			context.report({ node, messageId: "unsafeDictionary", data: { value } });
+		};
+		const reportIfUnsafe = (node: ESTree.TSType) => {
+			if (environment === null || !shouldReportType(node, environment)) return;
+			const unsafe = classifyUnsafeDictionary(node, environment);
+			if (unsafe === null) return;
+			report(node, unsafe.unsafeValue);
+		};
+
+		return {
+			Program(node) {
+				environment = createTypeEnvironment(
+					node,
+					context.sourceCode.visitorKeys,
+				);
+			},
+			TSTypeReference: reportIfUnsafe,
+			TSTypeLiteral: reportIfUnsafe,
+			TSMappedType: reportIfUnsafe,
+			TSIndexSignature(node) {
+				if (
+					environment === null ||
+					node.typeAnnotation === null ||
+					node.parent.type === "TSTypeLiteral"
+				)
+					return;
+				const unsafe = classifyUnsafeDictionaryValue(
+					node.typeAnnotation.typeAnnotation,
+					environment,
+				);
+				if (unsafe !== null) report(node, unsafe.unsafeValue);
+			},
+		};
+	},
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -109,6 +109,8 @@ export const noUnsafeDictionaryTypeRule = defineRule({
 			description:
 				"Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.",
 		},
+		schema: [{ type: "object", properties: { allowUnknown: { type: "boolean" } }, additionalProperties: false }],
+		defaultOptions: [{ allowUnknown: false }],
 		messages: {
 			unsafeDictionary:
 				"This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
@@ -128,10 +130,11 @@ export const noUnsafeDictionaryTypeRule = defineRule({
 
 		return {
 			Program(node) {
-				environment = createTypeEnvironment(
-					node,
-					context.sourceCode.visitorKeys,
-				);
+				const option = context.options?.[0];
+				environment = {
+					...createTypeEnvironment(node, context.sourceCode.visitorKeys),
+					allowUnknown: typeof option === "object" && option !== null && !Array.isArray(option) && option.allowUnknown === true,
+				};
 			},
 			TSTypeReference: reportIfUnsafe,
 			TSTypeLiteral: reportIfUnsafe,

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,366 @@
+import { defineRule } from "@oxlint/plugins";
+import type { ESTree, Variable } from "@oxlint/plugins";
+
+type BroadTypeKind = "top" | "object" | "record";
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "TSDeclareFunction",
+  "TSEmptyBodyFunctionExpression",
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === "ParenthesizedExpression") current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === "TSParenthesizedType") current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword";
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === "TSStringKeyword" ||
+    unwrapped.type === "TSNumberKeyword" ||
+    unwrapped.type === "TSSymbolKeyword"
+  ) {
+    return true;
+  }
+  if (unwrapped.type === "TSUnionType") return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === "TSTypeReference" && typeReferenceName(unwrapped) === "PropertyKey";
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === "TSTypeReference") {
+    if (typeReferenceName(unwrapped) === "Readonly") {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== "Record") return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== "TSTypeLiteral" || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === "TSIndexSignature" ? member.parameters : [];
+  return (
+    member?.type === "TSIndexSignature" &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSUnknownKeyword" || unwrapped.type === "TSAnyKeyword") return "top";
+  if (unwrapped.type === "TSObjectKeyword") return "object";
+  return isBroadRecordType(unwrapped) ? "record" : null;
+}
+
+function assertedExpression(
+  node: ESTree.TSAsExpression | ESTree.TSTypeAssertion,
+): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(
+  expression: ESTree.Expression,
+): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion"
+    ? unwrapped
+    : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, "");
+}
+
+function typesHaveSameSyntax(
+  sourceText: string,
+  left: ESTree.TSType | null,
+  right: ESTree.TSType,
+): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case "TSArrayType":
+    case "TSConstructorType":
+    case "TSFunctionType":
+    case "TSMappedType":
+    case "TSObjectKeyword":
+    case "TSTupleType":
+      return true;
+    case "TSTypeLiteral":
+      return unwrapped.members.length > 0;
+    case "TSIntersectionType":
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case "TSTypeOperator":
+      return unwrapped.operator === "readonly" && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === "TSTypeLiteral") {
+    return unwrapped.members.some((member) => member.type !== "TSIndexSignature");
+  }
+
+  if (unwrapped.type !== "TSTypeReference") return false;
+  if (typeReferenceName(unwrapped) === "Readonly") {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== "Record") return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return (
+    parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1])
+  );
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== "Program") {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) =>
+        candidate.identifier.start === identifier.start &&
+        candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === "Variable" && definition.node.type === "VariableDeclarator") {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === "TSAsExpression" || unwrapped.type === "TSTypeAssertion") {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === "Literal" || unwrapped.type === "TemplateLiteral") {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === "ArrayExpression" ||
+    unwrapped.type === "ArrowFunctionExpression" ||
+    unwrapped.type === "ClassExpression" ||
+    unwrapped.type === "FunctionExpression" ||
+    unwrapped.type === "NewExpression" ||
+    unwrapped.type === "ObjectExpression"
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== "Identifier") return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(
+    declarator.init,
+    scopes,
+    boundary,
+    new Set([...visitedVariables, variable]),
+  );
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== "VariableDeclaration" ||
+    declarator.parent.kind !== "const" ||
+    declarator.id.type !== "Identifier" ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === "top") return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === "object") return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.",
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  createOnce(context) {
+    let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== "Identifier") return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(
+          context.sourceCode.text,
+          widened.broadKind,
+          widened.evidence,
+          node.typeAnnotation,
+        )
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "widenThenAssert",
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      Program() {
+        scopes = context.sourceCode.scopeManager.scopes;
+      },
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-readable-spacing.ts
+++ b/tools/oxlint/anti-slop/rules/require-readable-spacing.ts
@@ -1,0 +1,47 @@
+import type { CreateRule } from "@oxlint/plugins";
+
+import createPaddingLineRule from "../vendor/eslint-stylistic/padding-line-between-statements.ts";
+
+const paddingRule = createPaddingLineRule([
+  { blankLine: "always", prev: "import", next: "*" },
+  { blankLine: "always", prev: "*", next: { selector: "Program > :not(ImportDeclaration)" } },
+  { blankLine: "always", prev: { selector: "Program > :not(ImportDeclaration)" }, next: "*" },
+  { blankLine: "always", prev: "*", next: ["function", "class", "interface", "type"] },
+  { blankLine: "always", prev: ["function", "class", "interface", "type"], next: "*" },
+  {
+    blankLine: "always",
+    prev: "*",
+    next: ["multiline-const", "multiline-let", "multiline-var", "multiline-using"],
+  },
+  {
+    blankLine: "always",
+    prev: ["multiline-const", "multiline-let", "multiline-var", "multiline-using"],
+    next: "*",
+  },
+  { blankLine: "always", prev: "*", next: ["return", "if", "switch", "try", "for", "while", "do"] },
+  { blankLine: "always", prev: "block-like", next: "*" },
+  { blankLine: "any", prev: "import", next: "import" },
+  {
+    blankLine: "any",
+    prev: {
+      selector:
+        ':matches(TSDeclareFunction, ExportNamedDeclaration[declaration.type="TSDeclareFunction"])',
+    },
+    next: {
+      selector:
+        ':matches(TSDeclareFunction, FunctionDeclaration, ExportNamedDeclaration[declaration.type="TSDeclareFunction"], ExportNamedDeclaration[declaration.type="FunctionDeclaration"])',
+    },
+  },
+]);
+
+/** Restore structural blank lines with whitespace-only fixes; keep local short bindings and overloads grouped. */
+export const requireReadableSpacingRule: CreateRule = {
+  ...paddingRule,
+  meta: {
+    ...paddingRule.meta,
+    docs: {
+      description: "Require readable spacing between declarations and logical statement groups.",
+    },
+    schema: [],
+  },
+};

--- a/tools/oxlint/anti-slop/rules/require-readable-spacing.ts
+++ b/tools/oxlint/anti-slop/rules/require-readable-spacing.ts
@@ -2,24 +2,14 @@ import type { CreateRule } from "@oxlint/plugins";
 
 import createPaddingLineRule from "../vendor/eslint-stylistic/padding-line-between-statements.ts";
 
+const declarations = {
+  selector: "Program > :matches(FunctionDeclaration, ClassDeclaration, TSInterfaceDeclaration, TSTypeAliasDeclaration, ExportNamedDeclaration[declaration.type=/^(FunctionDeclaration|ClassDeclaration|TSInterfaceDeclaration|TSTypeAliasDeclaration)$/], ExportDefaultDeclaration[declaration.type=/^(FunctionDeclaration|ClassDeclaration)$/])",
+};
+
 const paddingRule = createPaddingLineRule([
   { blankLine: "always", prev: "import", next: "*" },
-  { blankLine: "always", prev: "*", next: { selector: "Program > :not(ImportDeclaration)" } },
-  { blankLine: "always", prev: { selector: "Program > :not(ImportDeclaration)" }, next: "*" },
-  { blankLine: "always", prev: "*", next: ["function", "class", "interface", "type"] },
-  { blankLine: "always", prev: ["function", "class", "interface", "type"], next: "*" },
-  {
-    blankLine: "always",
-    prev: "*",
-    next: ["multiline-const", "multiline-let", "multiline-var", "multiline-using"],
-  },
-  {
-    blankLine: "always",
-    prev: ["multiline-const", "multiline-let", "multiline-var", "multiline-using"],
-    next: "*",
-  },
-  { blankLine: "always", prev: "*", next: ["return", "if", "switch", "try", "for", "while", "do"] },
-  { blankLine: "always", prev: "block-like", next: "*" },
+  { blankLine: "always", prev: "*", next: declarations },
+  { blankLine: "always", prev: declarations, next: "*" },
   { blankLine: "any", prev: "import", next: "import" },
   {
     blankLine: "any",
@@ -34,13 +24,13 @@ const paddingRule = createPaddingLineRule([
   },
 ]);
 
-/** Restore structural blank lines with whitespace-only fixes; keep local short bindings and overloads grouped. */
+/** Separate module declarations without splitting function-local statement groups. */
 export const requireReadableSpacingRule: CreateRule = {
   ...paddingRule,
   meta: {
     ...paddingRule.meta,
     docs: {
-      description: "Require readable spacing between declarations and logical statement groups.",
+      description: "Separate imports and module declarations while preserving local statement groups.",
     },
     schema: [],
   },

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,131 @@
+import { defineRule } from "@oxlint/plugins";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const DEFAULT_SAFETY_MARKERS = ["SAFETY"] as const;
+
+const commentOwnerKinds = new Set([
+  "ExpressionStatement",
+  "PropertyDefinition",
+  "ReturnStatement",
+  "ThrowStatement",
+  "VariableDeclaration",
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === "TSTypeReference" &&
+    node.typeAnnotation.typeName.type === "Identifier" &&
+    node.typeAnnotation.typeName.name === "const"
+  );
+}
+
+function configuredSafetyMarkers(option: unknown): readonly string[] {
+  if (typeof option !== "object" || option === null || !("markers" in option)) {
+    return DEFAULT_SAFETY_MARKERS;
+  }
+  const configured = option.markers;
+  if (!Array.isArray(configured)) return DEFAULT_SAFETY_MARKERS;
+  const markers = configured.flatMap((marker) =>
+    typeof marker === "string" && marker.trim().length > 0 ? [marker.trim()] : [],
+  );
+  return markers.length > 0 ? markers : DEFAULT_SAFETY_MARKERS;
+}
+
+function markerPattern(markers: readonly string[]): RegExp {
+  const alternation = markers
+    .map((marker) => marker.replaceAll(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`))
+    .join("|");
+  return new RegExp(
+    String.raw`(?:^|[^\p{L}\p{N}_])(?:${alternation})\s*:\s*\S`,
+    "u",
+  );
+}
+
+function hasSafetyJustificationBefore(
+  sourceCode: SourceCode,
+  owner: ESTree.Node,
+  assertion: TypeAssertion,
+  pattern: RegExp,
+): boolean {
+  return sourceCode
+    .getCommentsBefore(owner)
+    .some(
+      (comment) => comment.end <= assertion.start && pattern.test(comment.value),
+    );
+}
+
+function hasSafetyComment(
+  sourceCode: SourceCode,
+  node: TypeAssertion,
+  pattern: RegExp,
+): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (hasSafetyJustificationBefore(sourceCode, current, node, pattern)) return true;
+    if (commentOwnerKinds.has(current.type)) {
+      const exportDeclaration = current.parent;
+      return (
+        exportDeclaration.type === "ExportNamedDeclaration" &&
+        exportDeclaration.declaration === current &&
+        hasSafetyJustificationBefore(sourceCode, exportDeclaration, node, pattern)
+      );
+    }
+    if (current.parent.type === "Program") return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.",
+    },
+    messages: {
+      missingSafetyComment:
+        "This type assertion has no `{{marker}}:` justification. State the checked invariant immediately before the assertion or its containing statement.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          markers: {
+            type: "array",
+            items: { type: "string", minLength: 1 },
+            minItems: 1,
+            uniqueItems: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{ markers: ["SAFETY"] }],
+  },
+  createOnce(context) {
+    const patterns = new Map<string, RegExp>();
+
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node)) return;
+      const markers = configuredSafetyMarkers(context.options?.[0]);
+      const patternKey = markers.join("\u0000");
+      const pattern = patterns.get(patternKey) ?? markerPattern(markers);
+      patterns.set(patternKey, pattern);
+      if (hasSafetyComment(context.sourceCode, node, pattern)) return;
+      context.report({
+        node,
+        messageId: "missingSafetyComment",
+        data: { marker: markers[0] ?? DEFAULT_SAFETY_MARKERS[0] },
+      });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -78,13 +78,13 @@ function hasSafetyComment(
   }
 }
 
-/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+/** Require configured type assertions to state the invariant TypeScript cannot express. */
 export const requireSafetyCommentForTypeAssertionRule = defineRule({
   meta: {
     type: "problem",
     docs: {
       description:
-        "Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.",
+        "Require a nearby SAFETY comment for configured TypeScript assertions; const assertions are exempt.",
     },
     messages: {
       missingSafetyComment:
@@ -94,6 +94,7 @@ export const requireSafetyCommentForTypeAssertionRule = defineRule({
       {
         type: "object",
         properties: {
+          scope: { enum: ["all", "type-escapes"] },
           markers: {
             type: "array",
             items: { type: "string", minLength: 1 },
@@ -109,9 +110,26 @@ export const requireSafetyCommentForTypeAssertionRule = defineRule({
   createOnce(context) {
     const patterns = new Map<string, RegExp>();
 
+    const containsTypeEscape = (node: ESTree.Node): boolean => {
+      if (node.type === "TSAnyKeyword" || node.type === "TSNeverKeyword") return true;
+      for (const key of context.sourceCode.visitorKeys[node.type] ?? []) {
+        // SAFETY: Oxlint visitor keys enumerate AST child properties, never metadata or parent links.
+        const child = (node as unknown as Record<string, ESTree.Node | ESTree.Node[] | null>)[key];
+        if (Array.isArray(child) ? child.some(containsTypeEscape) : child && containsTypeEscape(child)) return true;
+      }
+      return false;
+    };
+
     const checkAssertion = (node: TypeAssertion) => {
       if (isConstAssertion(node)) return;
-      const markers = configuredSafetyMarkers(context.options?.[0]);
+      const option = context.options?.[0];
+      if (typeof option === "object" && option !== null && !Array.isArray(option) && option.scope === "type-escapes") {
+        let expression = node.expression;
+        while (expression.type === "ParenthesizedExpression") expression = expression.expression;
+        const chain = expression.type === "TSAsExpression" || expression.type === "TSTypeAssertion";
+        if (!chain && !containsTypeEscape(node.typeAnnotation)) return;
+      }
+      const markers = configuredSafetyMarkers(option);
       const patternKey = markers.join("\u0000");
       const pattern = patterns.get(patternKey) ?? markerPattern(markers);
       patterns.set(patternKey, pattern);

--- a/tools/oxlint/anti-slop/shared/array-method.ts
+++ b/tools/oxlint/anti-slop/shared/array-method.ts
@@ -1,0 +1,94 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+/** Unwrap syntax-only wrappers when inspecting array methods and accumulator references. */
+export function unwrapArrayExpression(node: ESTree.Node): ESTree.Node {
+  while (
+    node.type === "ParenthesizedExpression" ||
+    node.type === "ChainExpression" ||
+    node.type === "TSAsExpression" ||
+    node.type === "TSTypeAssertion" ||
+    node.type === "TSNonNullExpression" ||
+    node.type === "TSSatisfiesExpression"
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+/** Resolve a local binding by scope, not by identifier spelling. */
+export function resolveArrayBinding(sourceCode: SourceCode, node: ESTree.Node): Variable | null {
+  node = unwrapArrayExpression(node);
+  if (node.type !== "Identifier") return null;
+  let scope: Scope | null = sourceCode.getScope(node);
+  while (scope !== null) {
+    const variable = scope.set.get(node.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+/** Read static method names, including computed string literals, without evaluating expressions. */
+export function arrayMethodTarget(
+  node: ESTree.Node,
+): { readonly name: string; readonly object: ESTree.Node } | null {
+  node = unwrapArrayExpression(node);
+  if (node.type !== "MemberExpression") return null;
+  const property = node.property;
+  if (!node.computed && property.type === "Identifier") {
+    return { name: property.name, object: node.object };
+  }
+  if (node.computed && property.type === "Literal" && typeof property.value === "string") {
+    return { name: property.value, object: node.object };
+  }
+  return null;
+}
+
+function isArrayAnnotation(type: ESTree.TSType): boolean {
+  if (type.type === "TSArrayType" || type.type === "TSTupleType") return true;
+  if (type.type === "TSParenthesizedType") return isArrayAnnotation(type.typeAnnotation);
+  if (type.type === "TSTypeOperator" && type.operator === "readonly") {
+    return isArrayAnnotation(type.typeAnnotation);
+  }
+  return (
+    type.type === "TSTypeReference" && type.typeName.type === "Identifier" &&
+    (type.typeName.name === "Array" || type.typeName.name === "ReadonlyArray")
+  );
+}
+
+/** Recognize local array evidence; unknown receivers and iterator pipelines are deliberately excluded. */
+export function isKnownArrayExpression(
+  sourceCode: SourceCode,
+  node: ESTree.Node,
+  visited = new Set<Variable>(),
+): boolean {
+  node = unwrapArrayExpression(node);
+  if (node.type === "ArrayExpression") return true;
+  if (node.type === "CallExpression") {
+    const method = arrayMethodTarget(node.callee);
+    return (
+      method !== null &&
+      ["map", "filter", "flatMap", "slice", "concat", "toSorted", "toReversed", "toSpliced"].includes(method.name) &&
+      isKnownArrayExpression(sourceCode, method.object, visited)
+    );
+  }
+  if (node.type !== "Identifier") return false;
+  const variable = resolveArrayBinding(sourceCode, node);
+  if (variable === null || visited.has(variable)) return false;
+  visited.add(variable);
+  if (variable.references.some(reference => reference.isWrite() && !reference.init)) return false;
+  for (const identifier of variable.identifiers) {
+    const annotation = identifier.typeAnnotation?.typeAnnotation;
+    if (annotation !== undefined) return isArrayAnnotation(annotation);
+  }
+  for (const definition of variable.defs) {
+    if (
+      definition.type === "Variable" && definition.node.type === "VariableDeclarator" &&
+      definition.node.id.type === "Identifier" && definition.node.init !== null &&
+      definition.node.parent.type === "VariableDeclaration" && definition.node.parent.kind === "const"
+    ) {
+      return isKnownArrayExpression(sourceCode, definition.node.init, visited);
+    }
+  }
+  return false;
+}

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,515 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import {
+	createTypeAliasEnvironment,
+	hasVisibleTypeBinding,
+	visibleTypeAlias,
+	type TypeAliasEnvironment as LexicalTypeAliasEnvironment,
+} from "./type-alias-resolution.ts";
+
+const BUILT_INS = new Set([
+	"Record",
+	"Readonly",
+	"Partial",
+	"Required",
+	"Pick",
+	"Omit",
+	"PropertyKey",
+	"NonNullable",
+]);
+const TRANSPARENT_WRAPPERS = new Set(["Readonly", "Partial", "Required", "NonNullable"]);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+	readonly type: ESTree.TSType;
+	readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+	readonly kind: "unsafe-dictionary";
+	readonly unsafeValue: "any" | "empty-object" | "object" | "union" | "unknown";
+};
+
+export type WideningTargetKind =
+	| "anonymous object"
+	| "generic container"
+	| "object"
+	| "open dictionary"
+	| "unknown";
+
+export type WideningTarget = {
+	readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+	readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+	readonly typeAliases: LexicalTypeAliasEnvironment;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+	return statement.type === "ExportNamedDeclaration" ||
+		statement.type === "ExportDefaultDeclaration"
+		? (statement.declaration ?? null)
+		: statement;
+}
+
+export function createTypeEnvironment(
+	program: ESTree.Program,
+	visitorKeys: Readonly<Record<string, readonly string[]>>,
+): TypeEnvironment {
+	const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+
+	for (const statement of program.body) {
+		const declaration = declaredStatement(statement);
+		if (declaration?.type !== "TSInterfaceDeclaration") continue;
+		const declarations = interfaces.get(declaration.id.name) ?? [];
+		declarations.push(declaration);
+		interfaces.set(declaration.id.name, declarations);
+	}
+
+	return {
+		interfaces,
+		typeAliases: createTypeAliasEnvironment(program, visitorKeys),
+	};
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function isBuiltIn(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeEnvironment,
+): boolean {
+	return (
+		BUILT_INS.has(name) &&
+		!hasVisibleTypeBinding(name, use, environment.typeAliases)
+	);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	return (
+		unwrapped.type === "TSTypeReference" &&
+		typeReferenceName(unwrapped) === name &&
+		(unwrapped.typeArguments === null ||
+			unwrapped.typeArguments === undefined ||
+			unwrapped.typeArguments.params.length === 0)
+	);
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+	let current = type;
+	while (
+		current.type === "TSParenthesizedType" ||
+		(current.type === "TSTypeOperator" && current.operator === "readonly")
+	) {
+		current = current.typeAnnotation;
+	}
+	return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+	return unwrapTransparentType(type).type === "TSNeverKeyword";
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+	return (
+		member.type === "TSPropertySignature" &&
+		member.optional === true &&
+		member.typeAnnotation !== null &&
+		member.typeAnnotation !== undefined &&
+		isNeverType(member.typeAnnotation.typeAnnotation)
+	);
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+	return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(
+	declarations: readonly ESTree.TSInterfaceDeclaration[],
+): boolean {
+	if (declarations.length !== 1) return false;
+	const [type] = declarations;
+	return (
+		type !== undefined &&
+		type.extends.length === 0 &&
+		(type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+	);
+}
+
+function resolvedSubstitutionArgument(
+	type: ESTree.TSType,
+	base: TypeAliasEnvironment,
+	resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type !== "TSTypeReference") return type;
+	const name = typeReferenceName(unwrapped);
+	if (name === null || resolving.has(name)) return type;
+	const substitution = base.get(name);
+	if (substitution === undefined) return type;
+	const nextResolving = new Set(resolving);
+	nextResolving.add(name);
+	return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+	alias: ESTree.TSTypeAliasDeclaration,
+	type: ESTree.TSTypeReference,
+	base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = type.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const argument = arguments_[index] ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+	}
+	return next;
+}
+
+function unsafeDirectValue(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary["unsafeValue"] | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+	if (unwrapped.type === "TSAnyKeyword") return "any";
+	if (unwrapped.type === "TSObjectKeyword") return "object";
+	if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
+		return "empty-object";
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some(
+			(member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+		)
+			? "union"
+			: null;
+	}
+	if (unwrapped.type === "TSIntersectionType") {
+		const unsafeMembers = unwrapped.types.map((member) =>
+			unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+		);
+		if (unsafeMembers.includes("any")) return "any";
+		return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null)
+			? unsafeMembers[0]
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+	}
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+	}
+	const interfaceDeclarations = environment.interfaces.get(name);
+	if (interfaceDeclarations !== undefined) {
+		return isEffectivelyEmptyInterface(interfaceDeclarations) ? "empty-object" : null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+	const unwrapped = unwrapTransparentType(type);
+
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+			member.type === "TSIndexSignature" && member.typeAnnotation !== null
+				? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+				: [],
+		);
+	}
+
+	if (unwrapped.type === "TSMappedType") {
+		return unwrapped.typeAnnotation === null
+			? []
+			: [{ type: unwrapped.typeAnnotation, substitutions }];
+	}
+
+	if (unwrapped.type !== "TSTypeReference") return [];
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return [];
+
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? []
+			: dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+	}
+
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? []
+			: dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+	}
+
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		const value = unwrapped.typeArguments?.params[1] ?? null;
+		return value === null ? [] : [{ type: value, substitutions }];
+	}
+
+	if (
+		(name === "Pick" || name === "Omit") &&
+		isBuiltIn(name, unwrapped, environment)
+	) {
+		const source = unwrapped.typeArguments?.params[0];
+		return source === undefined
+			? []
+			: dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+	}
+
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return [];
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return [];
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+	valueType: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+	return unsafeValue === null ? null : { kind: "unsafe-dictionary", unsafeValue };
+}
+
+export function classifyUnsafeDictionary(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): UnsafeDictionary | null {
+	for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+		const unsafeValue = unsafeDirectValue(
+			valueType.type,
+			environment,
+			valueType.substitutions,
+			new Set(),
+		);
+		if (unsafeValue !== null) return { kind: "unsafe-dictionary", unsafeValue };
+	}
+	return null;
+}
+
+export function classifyWideningTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: unwrapped.members.length > 0
+				? { kind: "anonymous object" }
+				: null;
+	}
+	if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, new Map())
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null) return null;
+	if ((alias.typeParameters?.params.length ?? 0) > 0) {
+		const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+		const resolved =
+			substitutions === null
+				? null
+				: classifyAliasBroadTarget(
+						alias.typeAnnotation,
+						environment,
+						substitutions,
+						new Set([name]),
+					);
+		return resolved?.kind === "open dictionary" ? { kind: "generic container" } : null;
+	}
+	const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+	if (substitutions === null) return null;
+	const resolved = classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		substitutions,
+		new Set([name]),
+	);
+	return resolved;
+}
+
+function hasBroadRecordKey(
+	type: ESTree.TSTypeReference,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+): boolean {
+	const key = type.typeArguments?.params[0];
+	return key === undefined || isBroadMappedKey(key, environment, substitutions);
+}
+
+function isBroadMappedKey(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	visitedAliases: ReadonlySet<string> = new Set(),
+): boolean {
+	const unwrapped = unwrapTransparentType(type);
+	if (
+		unwrapped.type === "TSStringKeyword" ||
+		unwrapped.type === "TSNumberKeyword" ||
+		unwrapped.type === "TSSymbolKeyword"
+	) {
+		return true;
+	}
+	if (unwrapped.type === "TSUnionType") {
+		return unwrapped.types.some((member) =>
+			isBroadMappedKey(member, environment, substitutions, visitedAliases),
+		);
+	}
+	if (unwrapped.type !== "TSTypeReference") return false;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return false;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+		return isBroadMappedKey(substitution, environment, substitutions, visitedAliases);
+	}
+	if (name === "PropertyKey" && isBuiltIn(name, unwrapped, environment)) return true;
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (
+		alias === null ||
+		(alias.typeParameters?.params.length ?? 0) > 0 ||
+		visitedAliases.has(name)
+	) {
+		return false;
+	}
+	const nextVisited = new Set(visitedAliases);
+	nextVisited.add(name);
+	return isBroadMappedKey(alias.typeAnnotation, environment, substitutions, nextVisited);
+}
+
+function classifyAliasBroadTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+	substitutions: TypeAliasEnvironment,
+	resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+	const unwrapped = unwrapTransparentType(type);
+	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
+	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
+	if (unwrapped.type === "TSTypeLiteral") {
+		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type === "TSMappedType") {
+		return isBroadMappedKey(unwrapped.constraint, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	if (unwrapped.type !== "TSTypeReference") return null;
+	const name = typeReferenceName(unwrapped);
+	if (name === null) return null;
+	const substitution = substitutions.get(name);
+	if (substitution !== undefined) {
+		return isUnappliedReferenceTo(substitution, name)
+			? null
+			: classifyAliasBroadTarget(
+					substitution,
+					environment,
+					substitutions,
+					resolvingAliases,
+				);
+	}
+	if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, unwrapped, environment)) {
+		const wrapped = unwrapped.typeArguments?.params[0];
+		return wrapped === undefined
+			? null
+			: classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+	}
+	if (name === "Record" && isBuiltIn(name, unwrapped, environment)) {
+		return hasBroadRecordKey(unwrapped, environment, substitutions)
+			? { kind: "open dictionary" }
+			: null;
+	}
+	const alias = visibleTypeAlias(name, unwrapped, environment.typeAliases);
+	if (alias === null || resolvingAliases.has(name)) return null;
+	const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+	if (nextSubstitutions === null) return null;
+	const nextResolving = new Set(resolvingAliases);
+	nextResolving.add(name);
+	return classifyAliasBroadTarget(
+		alias.typeAnnotation,
+		environment,
+		nextSubstitutions,
+		nextResolving,
+	);
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression"
+	) {
+		current = current.expression;
+	}
+	return current.type === "ObjectExpression" && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+	let current = expression;
+	while (
+		current.type === "ParenthesizedExpression" ||
+		current.type === "TSAsExpression" ||
+		current.type === "TSTypeAssertion" ||
+		current.type === "TSNonNullExpression" ||
+		current.type === "TSSatisfiesExpression"
+	) {
+		current = current.expression;
+	}
+	if (current.type === "ObjectExpression") return true;
+	return (
+		current.type === "ArrayExpression" ||
+		current.type === "ArrowFunctionExpression" ||
+		current.type === "ClassExpression" ||
+		current.type === "FunctionExpression" ||
+		current.type === "NewExpression" ||
+		current.type === "Literal" ||
+		current.type === "TemplateLiteral" ||
+		current.type === "UnaryExpression"
+	);
+}

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -32,7 +32,6 @@ export type UnsafeDictionary = {
 };
 
 export type WideningTargetKind =
-	| "anonymous object"
 	| "generic container"
 	| "object"
 	| "open dictionary"
@@ -43,6 +42,7 @@ export type WideningTarget = {
 };
 
 export type TypeEnvironment = {
+	readonly allowUnknown?: boolean;
 	readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
 	readonly typeAliases: LexicalTypeAliasEnvironment;
 };
@@ -180,7 +180,7 @@ function unsafeDirectValue(
 	resolvingAliases: ReadonlySet<string>,
 ): UnsafeDictionary["unsafeValue"] | null {
 	const unwrapped = unwrapTransparentType(type);
-	if (unwrapped.type === "TSUnknownKeyword") return "unknown";
+	if (unwrapped.type === "TSUnknownKeyword") return environment.allowUnknown ? null : "unknown";
 	if (unwrapped.type === "TSAnyKeyword") return "any";
 	if (unwrapped.type === "TSObjectKeyword") return "object";
 	if (unwrapped.type === "TSTypeLiteral" && isEffectivelyEmptyTypeLiteral(unwrapped))
@@ -321,15 +321,24 @@ export function classifyWideningTarget(
 	type: ESTree.TSType,
 	environment: TypeEnvironment,
 ): WideningTarget | null {
+	const target = classifyBroadTarget(type, environment);
+	if (target?.kind === "open dictionary" || target?.kind === "generic container") {
+		return classifyUnsafeDictionary(type, environment) === null ? null : target;
+	}
+	return target;
+}
+
+function classifyBroadTarget(
+	type: ESTree.TSType,
+	environment: TypeEnvironment,
+): WideningTarget | null {
 	const unwrapped = unwrapTransparentType(type);
 	if (unwrapped.type === "TSUnknownKeyword") return { kind: "unknown" };
 	if (unwrapped.type === "TSObjectKeyword") return { kind: "object" };
 	if (unwrapped.type === "TSTypeLiteral") {
 		return unwrapped.members.some((member) => member.type === "TSIndexSignature")
 			? { kind: "open dictionary" }
-			: unwrapped.members.length > 0
-				? { kind: "anonymous object" }
-				: null;
+			: null;
 	}
 	if (unwrapped.type === "TSMappedType") return { kind: "open dictionary" };
 	if (unwrapped.type !== "TSTypeReference") return null;

--- a/tools/oxlint/anti-slop/shared/function-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/function-parameters.ts
@@ -1,0 +1,49 @@
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+export type FunctionParameter = ESTree.ParamPattern;
+
+/** Return whether a type is or contains TypeScript's absorbing unknown top type. */
+export function containsUnknownType(type: ESTree.TSType): boolean {
+	if (type.type === "TSUnknownKeyword") return true;
+	if (type.type === "TSParenthesizedType") return containsUnknownType(type.typeAnnotation);
+	return type.type === "TSUnionType" && type.types.some(containsUnknownType);
+}
+
+/** Return the TypeScript annotation attached to a function parameter or its wrapped binding. */
+export function functionParameterTypeAnnotation(
+	parameter: FunctionParameter,
+): ESTree.TSTypeAnnotation | null | undefined {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterTypeAnnotation(parameter.parameter);
+	}
+	if (parameter.type === "RestElement") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.argument);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return parameter.typeAnnotation ?? functionParameterTypeAnnotation(parameter.left);
+	}
+	return parameter.typeAnnotation;
+}
+
+/** Return only a function parameter's local binding, excluding its annotation and default value. */
+export function functionParameterBindingName(
+	parameter: FunctionParameter,
+	sourceCode: SourceCode,
+): string {
+	if (parameter.type === "TSParameterProperty") {
+		return functionParameterBindingName(parameter.parameter, sourceCode);
+	}
+	if (parameter.type === "AssignmentPattern") {
+		return functionParameterBindingName(parameter.left, sourceCode);
+	}
+	if (parameter.type === "RestElement") {
+		return functionParameterBindingName(parameter.argument, sourceCode);
+	}
+	if (parameter.type === "Identifier") return parameter.name;
+
+	const sourceText = sourceCode.getText(parameter);
+	const annotationStart = parameter.typeAnnotation?.start;
+	return annotationStart === undefined
+		? sourceText
+		: sourceText.slice(0, annotationStart - parameter.start).trimEnd();
+}

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -1,0 +1,61 @@
+import type { ESTree } from "@oxlint/plugins";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function collectInferTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	names: Set<string>,
+): void {
+	if (node.type === "TSInferType") names.add(node.typeParameter.name.name);
+	const record = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = record[key];
+		if (isNode(value)) {
+			collectInferTypeParameterNames(value, visitorKeys, names);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) collectInferTypeParameterNames(child, visitorKeys, names);
+		}
+	}
+}
+
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+): ReadonlySet<string> {
+	const names = new Set<string>();
+	let descendant: ESTree.Node = node;
+	let current: ESTree.Node | null = node;
+	while (current !== null && current.type !== "Program") {
+		if ("typeParameters" in current) {
+			for (const parameter of current.typeParameters?.params ?? []) {
+				names.add(parameter.name.name);
+			}
+		}
+		if (
+			current.type === "TSMappedType" &&
+			(descendant === current.nameType || descendant === current.typeAnnotation)
+		) {
+			names.add(current.key.name);
+		}
+		if (current.type === "TSConditionalType" && descendant === current.trueType) {
+			collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+		}
+		descendant = current;
+		current = current.parent;
+	}
+	return names;
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,24 @@
+import { resolveVariable } from "./scope.ts";
+
+import type { ESTree, SourceCode } from "@oxlint/plugins";
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== "Identifier" || expression.name !== "Reflect") return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!("property" in callee) || !("object" in callee) || !("computed" in callee)) return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === "Literal" && property.value === methodName
+    : property.type === "Identifier" && property.name === methodName;
+}

--- a/tools/oxlint/anti-slop/shared/scope.ts
+++ b/tools/oxlint/anti-slop/shared/scope.ts
@@ -1,0 +1,15 @@
+import type { ESTree, Scope, SourceCode, Variable } from "@oxlint/plugins";
+
+/** Resolve an identifier to its binding by walking lexical scopes upward. */
+export function resolveVariable(
+	sourceCode: SourceCode,
+	identifier: ESTree.IdentifierReference,
+): Variable | null {
+	let scope: Scope | null = sourceCode.getScope(identifier);
+	while (scope !== null) {
+		const variable = scope.set.get(identifier.name);
+		if (variable !== undefined) return variable;
+		scope = scope.upper;
+	}
+	return null;
+}

--- a/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
+++ b/tools/oxlint/anti-slop/shared/type-alias-resolution.ts
@@ -1,0 +1,250 @@
+import type { ESTree } from "@oxlint/plugins";
+
+import { lexicalTypeParameterNames } from "./lexical-type-parameters.ts";
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+type TypeScope = ESTree.Node;
+
+type TypeBinding = {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+	readonly scope: TypeScope;
+};
+
+type Substitution = {
+	readonly substitutions: Substitutions;
+	readonly type: ESTree.TSType;
+};
+
+type Substitutions = ReadonlyMap<string, Substitution>;
+
+export type TypeAliasEnvironment = {
+	readonly aliases: readonly ESTree.TSTypeAliasDeclaration[];
+	readonly bindingsByName: ReadonlyMap<string, readonly TypeBinding[]>;
+	readonly visitorKeys: VisitorKeys;
+};
+
+export type ResolvedTypeMatcher = (
+	type: ESTree.TSType,
+	matches: (child: ESTree.TSType) => boolean,
+) => boolean;
+
+const environmentsByProgram = new WeakMap<ESTree.Program, TypeAliasEnvironment>();
+
+function isNode(value: unknown): value is ESTree.Node {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		typeof value.type === "string"
+	);
+}
+
+function enclosingTypeScope(node: ESTree.Node): TypeScope {
+	let current: ESTree.Node | null = node.parent;
+	while (current !== null) {
+		if (
+			current.type === "Program" ||
+			current.type === "BlockStatement" ||
+			current.type === "TSModuleBlock" ||
+			current.type === "StaticBlock" ||
+			current.type === "SwitchStatement"
+		) {
+			return current;
+		}
+		current = current.parent;
+	}
+	return node;
+}
+
+function declaredTypeBinding(node: ESTree.Node): {
+	readonly alias: ESTree.TSTypeAliasDeclaration | null;
+	readonly name: string;
+} | null {
+	if (node.type === "TSTypeAliasDeclaration") {
+		return { alias: node, name: node.id.name };
+	}
+	if (
+		node.type === "TSInterfaceDeclaration" ||
+		node.type === "TSEnumDeclaration" ||
+		node.type === "ClassDeclaration" ||
+		node.type === "ClassExpression"
+	) {
+		return node.id === null ? null : { alias: null, name: node.id.name };
+	}
+	if (
+		node.type === "ImportSpecifier" ||
+		node.type === "ImportDefaultSpecifier" ||
+		node.type === "ImportNamespaceSpecifier"
+	) {
+		return { alias: null, name: node.local.name };
+	}
+	return null;
+}
+
+function collectTypeBindings(
+	node: ESTree.Node,
+	visitorKeys: VisitorKeys,
+	bindingsByName: Map<string, TypeBinding[]>,
+	aliases: ESTree.TSTypeAliasDeclaration[],
+): void {
+	const declared = declaredTypeBinding(node);
+	if (declared !== null) {
+		const bindings = bindingsByName.get(declared.name) ?? [];
+		bindings.push({ ...declared, scope: enclosingTypeScope(node) });
+		bindingsByName.set(declared.name, bindings);
+		if (declared.alias !== null) aliases.push(declared.alias);
+	}
+
+	// SAFETY: Oxlint's visitor keys identify only ESTree child-node properties.
+	const fields = node as unknown as Readonly<Record<string, unknown>>;
+	for (const key of visitorKeys[node.type] ?? []) {
+		const value = fields[key];
+		if (isNode(value)) {
+			collectTypeBindings(value, visitorKeys, bindingsByName, aliases);
+			continue;
+		}
+		if (!Array.isArray(value)) continue;
+		for (const child of value) {
+			if (isNode(child)) {
+				collectTypeBindings(child, visitorKeys, bindingsByName, aliases);
+			}
+		}
+	}
+}
+
+/** Collect every lexical type alias and competing type binding in a program. */
+export function createTypeAliasEnvironment(
+	program: ESTree.Program,
+	visitorKeys: VisitorKeys,
+): TypeAliasEnvironment {
+	const cached = environmentsByProgram.get(program);
+	if (cached !== undefined) return cached;
+	const bindingsByName = new Map<string, TypeBinding[]>();
+	const aliases: ESTree.TSTypeAliasDeclaration[] = [];
+	collectTypeBindings(program, visitorKeys, bindingsByName, aliases);
+	const environment = { aliases, bindingsByName, visitorKeys };
+	environmentsByProgram.set(program, environment);
+	return environment;
+}
+
+function ancestorDistance(ancestor: ESTree.Node, node: ESTree.Node): number | null {
+	let current: ESTree.Node | null = node;
+	let distance = 0;
+	while (current !== null) {
+		if (current === ancestor) return distance;
+		current = current.parent;
+		distance += 1;
+	}
+	return null;
+}
+
+function nearestTypeBindings(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): readonly TypeBinding[] {
+	const candidates = environment.bindingsByName.get(name) ?? [];
+	let nearestDistance = Number.POSITIVE_INFINITY;
+	let nearest: TypeBinding[] = [];
+	for (const candidate of candidates) {
+		const distance = ancestorDistance(candidate.scope, use);
+		if (distance === null || distance > nearestDistance) continue;
+		if (distance === nearestDistance) {
+			nearest.push(candidate);
+			continue;
+		}
+		nearestDistance = distance;
+		nearest = [candidate];
+	}
+	return nearest;
+}
+
+/** Resolve the nearest visible alias with this name, respecting lexical shadowing. */
+export function visibleTypeAlias(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): ESTree.TSTypeAliasDeclaration | null {
+	if (lexicalTypeParameterNames(use, environment.visitorKeys).has(name)) return null;
+	const bindings = nearestTypeBindings(name, use, environment);
+	return bindings.length === 1 ? (bindings[0]?.alias ?? null) : null;
+}
+
+/** Return whether a local declaration shadows a built-in type at this use. */
+export function hasVisibleTypeBinding(
+	name: string,
+	use: ESTree.Node,
+	environment: TypeAliasEnvironment,
+): boolean {
+	return (
+		lexicalTypeParameterNames(use, environment.visitorKeys).has(name) ||
+		nearestTypeBindings(name, use, environment).length > 0
+	);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+	return type.typeName.type === "Identifier" ? type.typeName.name : null;
+}
+
+function aliasSubstitutions(
+	alias: ESTree.TSTypeAliasDeclaration,
+	reference: ESTree.TSTypeReference,
+	base: Substitutions,
+): Substitutions | null {
+	const parameters = alias.typeParameters?.params ?? [];
+	const arguments_ = reference.typeArguments?.params ?? [];
+	const next = new Map(base);
+	for (const [index, parameter] of parameters.entries()) {
+		const explicitArgument = arguments_[index];
+		const argument = explicitArgument ?? parameter.default;
+		if (argument === null || argument === undefined) return null;
+		const argumentSubstitutions = explicitArgument === undefined ? next : base;
+		next.set(parameter.name.name, {
+			type: argument,
+			substitutions: new Map(argumentSubstitutions),
+		});
+	}
+	return next;
+}
+
+/** Match a type after resolving visible aliases and substituting their type parameters. */
+export function resolvedTypeMatches(
+	type: ESTree.TSType,
+	environment: TypeAliasEnvironment,
+	matcher: ResolvedTypeMatcher,
+): boolean {
+	const evaluate = (
+		current: ESTree.TSType,
+		substitutions: Substitutions,
+		resolvingAliases: ReadonlySet<ESTree.TSTypeAliasDeclaration>,
+	): boolean => {
+		if (current.type === "TSTypeReference") {
+			const name = typeReferenceName(current);
+			if (name !== null) {
+				const substitution = substitutions.get(name);
+				if (substitution !== undefined && !current.typeArguments?.params.length) {
+					return evaluate(
+						substitution.type,
+						substitution.substitutions,
+						resolvingAliases,
+					);
+				}
+				const alias = visibleTypeAlias(name, current, environment);
+				if (alias !== null && !resolvingAliases.has(alias)) {
+					const nextSubstitutions = aliasSubstitutions(alias, current, substitutions);
+					if (nextSubstitutions !== null) {
+						const nextResolving = new Set(resolvingAliases);
+						nextResolving.add(alias);
+						return evaluate(alias.typeAnnotation, nextSubstitutions, nextResolving);
+					}
+				}
+			}
+		}
+		return matcher(current, (child) =>
+			evaluate(child, substitutions, resolvingAliases),
+		);
+	};
+
+	return evaluate(type, new Map(), new Set());
+}

--- a/tools/oxlint/anti-slop/vendor/eslint-stylistic/LICENSE
+++ b/tools/oxlint/anti-slop/vendor/eslint-stylistic/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
+Copyright (c) 2023-PRESENT ESLint Stylistic contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/oxlint/anti-slop/vendor/eslint-stylistic/UPSTREAM.md
+++ b/tools/oxlint/anti-slop/vendor/eslint-stylistic/UPSTREAM.md
@@ -1,0 +1,28 @@
+# Vendored padding-line-between-statements
+
+Source: [ESLint Stylistic](https://github.com/eslint-stylistic/eslint-stylistic), commit `435c3ea0fd26a5fef9042c4b36b6e165fbbf8d08`.
+
+Copied files:
+
+- `packages/eslint-plugin/rules/padding-line-between-statements/padding-line-between-statements.ts`
+- `packages/eslint-plugin/rules/padding-line-between-statements/types.d.ts` → `padding-line-options.d.ts`
+- Root `LICENSE`, retained verbatim. Both OpenJS Foundation and ESLint Stylistic notices apply.
+
+The rule is MIT-licensed. Keep `LICENSE` with every redistributed copy, including skill assets. No Stylistic, ESLint, TypeScript-ESLint, or additional parser runtime dependency is required.
+
+## Local adaptations
+
+- Replace upstream type aliases with Oxlint's ESTree, context, token/comment, and rule types. Upstream's token type includes comments; Oxlint exposes those separately.
+- Replace `AST_NODE_TYPES` enum members with identical string literals.
+- Guard indexed reads for consuming repositories with `noUncheckedIndexedAccess`. Impossible missing AST/configuration entries raise explicit invariant errors rather than introducing new non-null assertions.
+- Replace the repository-specific `createRule` factory with `createPaddingLineRule(options)`. The anti-slop wrapper supplies typed options directly; it exposes no user configuration options.
+- Implement the small required AST helper surface in `padding-line-ast.ts` using Oxlint's public source-code/token API. `isParenthesized` only needs the one-pair check used to exclude parenthesized directive strings, not the upstream general-purpose overloads.
+- Retain the upstream statement matchers, scope tracking, comment-aware insertion/removal, selector support, and diagnostic text. Upstream naming and non-null assumptions remain localized here to keep future diffs reviewable; the file is not a model for new application code.
+
+The opinionated policy lives outside this directory in `../../rules/require-readable-spacing.ts`. It adds spacing without collapsing existing blank lines. Short local bindings, consecutive imports, and adjacent overload signatures/implementation remain grouped. Spacing is syntactic, not an inference of business-logic boundaries.
+
+## Updating and verification
+
+Fetch an explicit upstream revision, compare the original rule and types against this revision, and port relevant fixes while retaining the adapters above. Update this record and preserve the license. Run `pnpm check` and `pnpm sync:skill-assets` as required by repository guidance.
+
+Focused Oxlint RuleTester cases live in `../../rules/require-readable-spacing.test.ts`; they test exact fixes, JSDoc/trailing comments, same-line statements, semicolon-free code, TypeScript exports/overloads, Effect-style generators, and upstream removal behavior. `../../rules/require-readable-spacing-cli.test.ts` verifies the exported plugin through the native Oxlint CLI on multiple files, including rejection, autofix, and repeated-fix stability. The complete upstream JS/TS test suites have not been ported; this is focused compatibility evidence, not a claim of full upstream conformance.

--- a/tools/oxlint/anti-slop/vendor/eslint-stylistic/padding-line-ast.ts
+++ b/tools/oxlint/anti-slop/vendor/eslint-stylistic/padding-line-ast.ts
@@ -1,0 +1,51 @@
+// Local replacements for the upstream helper imports. See UPSTREAM.md.
+import type { ESTree, SourceCode, Token as SyntaxToken, Comment, Location } from "@oxlint/plugins";
+
+type Token = SyntaxToken | Comment;
+
+/** Line terminators recognized by the upstream padding matcher. */
+export const LINEBREAKS = new Set(["\r\n", "\r", "\n", "\u2028", "\u2029"]);
+
+/** Test a closing brace without treating comment text as punctuation. */
+export const isClosingBraceToken = (token: Token): boolean =>
+  token.type === "Punctuator" && token.value === "}";
+
+/** Test a semicolon without treating comment text as punctuation. */
+export const isSemicolonToken = (token: Token): boolean =>
+  token.type === "Punctuator" && token.value === ";";
+
+/** Filter the optional final semicolon when identifying block-like statements. */
+export const isNotSemicolonToken = (token: Token): boolean => !isSemicolonToken(token);
+
+/** Compare token/node boundaries, including attached comments. */
+export const isTokenOnSameLine = (left: { loc: Location }, right: { loc: Location }): boolean =>
+  left.loc.end.line === right.loc.start.line;
+
+/** Recognize declarations and expressions used by the upstream IIFE matcher. */
+export const isFunction = (node: ESTree.Node): boolean =>
+  node.type === "FunctionDeclaration" ||
+  node.type === "FunctionExpression" ||
+  node.type === "ArrowFunctionExpression";
+
+/** Preserve the upstream multiline statement heuristic. */
+export const isSingleLine = (node: ESTree.Node): boolean =>
+  node.loc.start.line === node.loc.end.line;
+
+/** Unwrap optional chaining before checking IIFE syntax. */
+export const skipChainExpression = (node: ESTree.Node): ESTree.Node =>
+  node.type === "ChainExpression" ? node.expression : node;
+
+/** Only a program or function-body expression can begin a directive prologue. */
+export const isTopLevelExpressionStatement = (
+  node: ESTree.Node,
+): node is ESTree.ExpressionStatement =>
+  node.type === "ExpressionStatement" &&
+  (node.parent.type === "Program" ||
+    (node.parent.type === "BlockStatement" && isFunction(node.parent.parent)));
+
+/** A single wrapping pair suffices to exclude a string from directive syntax. */
+export function isParenthesized(node: ESTree.Node, sourceCode: SourceCode): boolean {
+  const before = sourceCode.getTokenBefore(node);
+  const after = sourceCode.getTokenAfter(node);
+  return before?.value === "(" && after?.value === ")";
+}

--- a/tools/oxlint/anti-slop/vendor/eslint-stylistic/padding-line-between-statements.ts
+++ b/tools/oxlint/anti-slop/vendor/eslint-stylistic/padding-line-between-statements.ts
@@ -1,0 +1,906 @@
+// Vendored from ESLint Stylistic; see UPSTREAM.md and LICENSE in this directory.
+import type { ESTree, Context as RuleContext, SourceCode, Token as SyntaxToken, Comment, CreateRule, Location } from '@oxlint/plugins'
+type ASTNode = ESTree.Node
+type Token = SyntaxToken | Comment
+import type {
+  RuleOptions,
+  SelectorOption,
+  StatementOption,
+} from './padding-line-options.d.ts'
+import {
+  isClosingBraceToken,
+  isFunction,
+  isNotSemicolonToken,
+  isParenthesized,
+  isSemicolonToken,
+  isSingleLine,
+  isTokenOnSameLine,
+  isTopLevelExpressionStatement,
+  LINEBREAKS,
+  skipChainExpression,
+} from './padding-line-ast.ts'
+
+const CJS_EXPORT = /^(?:module\s*\.\s*)?exports(?:\s*\.|\s*\[|$)/u
+const CJS_IMPORT = /^require\(/u
+
+/**
+ * This rule is a replica of padding-line-between-statements.
+ *
+ * Ideally we would want to extend the rule support typescript specific support.
+ * But since not all the state is exposed by the eslint and eslint has frozen stylistic rules,
+ * (see - https://eslint.org/blog/2020/05/changes-to-rules-policies for details.)
+ * we are forced to re-implement the rule here.
+ *
+ * We have tried to keep the implementation as close as possible to the eslint implementation, to make
+ * patching easier for future contributors.
+ *
+ * Reference rule - https://github.com/eslint/eslint/blob/main/lib/rules/padding-line-between-statements.js
+ */
+
+type NodeTest = (
+  node: ASTNode,
+  sourceCode: SourceCode,
+) => boolean
+
+interface NodeTestObject {
+  test: NodeTest
+}
+
+const LT = `[${Array.from(LINEBREAKS).join('')}]`
+const PADDING_LINE_SEQUENCE = new RegExp(
+  String.raw`^(\s*?${LT})\s*${LT}(\s*;?)$`,
+  'u',
+)
+
+function isSelectorOption(option: StatementOption): option is SelectorOption {
+  return typeof option === 'object' && !Array.isArray(option)
+}
+
+/**
+ * Creates tester which check if a node starts with specific keyword with the
+ * appropriate AST_NODE_TYPES.
+ * @param keyword The keyword to test.
+ * @returns the created tester.
+ * @private
+ */
+function newKeywordTester(
+  type: string | string[],
+  keyword: string,
+): NodeTestObject {
+  return {
+    test(node, sourceCode): boolean {
+      const isSameKeyword = sourceCode.getFirstToken(node)?.value === keyword
+      const isSameType = Array.isArray(type)
+        ? type.includes(node.type)
+        : type === node.type
+
+      return isSameKeyword && isSameType
+    },
+  }
+}
+
+/**
+ * Creates tester which check if a node is specific type.
+ * @param type The node type to test.
+ * @returns the created tester.
+ * @private
+ */
+function newNodeTypeTester(type: string): NodeTestObject {
+  return {
+    test: (node): boolean => node.type === type,
+  }
+}
+
+/**
+ * Checks the given node is an expression statement of IIFE.
+ * @param node The node to check.
+ * @returns `true` if the node is an expression statement of IIFE.
+ * @private
+ */
+function isIIFEStatement(node: ASTNode): boolean {
+  if (node.type === 'ExpressionStatement') {
+    let expression = skipChainExpression(node.expression)
+    if (expression.type === 'UnaryExpression')
+      expression = skipChainExpression(expression.argument)
+
+    if (expression.type === 'CallExpression') {
+      let node: ASTNode = expression.callee
+      while (node.type === 'SequenceExpression') {
+        const lastExpression = node.expressions.at(-1)
+        if (lastExpression === undefined)
+          throw new Error('Padding rule invariant: sequence expression is empty')
+        node = lastExpression
+      }
+
+      return isFunction(node)
+    }
+  }
+  return false
+}
+
+/**
+ * Checks the given node is a CommonJS require statement
+ * @param node The node to check.
+ * @returns `true` if the node is a CommonJS require statement.
+ * @private
+ */
+function isCJSRequire(node: ASTNode): boolean {
+  if (node.type === 'VariableDeclaration') {
+    const declaration = node.declarations[0]
+    if (declaration?.init) {
+      let call = declaration?.init
+      while (call.type === 'MemberExpression')
+        call = call.object
+
+      if (
+        call.type === 'CallExpression'
+        && call.callee.type === 'Identifier'
+      ) {
+        return call.callee.name === 'require'
+      }
+    }
+  }
+  return false
+}
+
+/**
+ * Checks whether the given node is a block-like statement.
+ * This checks the last token of the node is the closing brace of a block.
+ * @param sourceCode The source code to get tokens.
+ * @param node The node to check.
+ * @returns `true` if the node is a block-like statement.
+ * @private
+ */
+function isBlockLikeStatement(
+  node: ASTNode,
+  sourceCode: SourceCode,
+): boolean {
+  // do-while with a block is a block-like statement.
+  if (
+    node.type === 'DoWhileStatement'
+    && node.body.type === 'BlockStatement'
+  ) {
+    return true
+  }
+
+  /**
+   * IIFE is a block-like statement specially from
+   * JSCS#disallowPaddingNewLinesAfterBlocks.
+   */
+  if (isIIFEStatement(node))
+    return true
+
+  // Checks the last token is a closing brace of blocks.
+  const lastToken = sourceCode.getLastToken(node, isNotSemicolonToken)
+  const belongingNode
+    = lastToken && isClosingBraceToken(lastToken)
+      ? sourceCode.getNodeByRangeIndex(lastToken.range[0])
+      : null
+
+  return (
+    !!belongingNode
+    && (belongingNode.type === 'BlockStatement'
+      || belongingNode.type === 'SwitchStatement')
+  )
+}
+
+/**
+ * Check whether the given node is a directive or not.
+ * @param node The node to check.
+ * @param sourceCode The source code object to get tokens.
+ * @returns `true` if the node is a directive.
+ */
+function isDirective(
+  node: ASTNode,
+  sourceCode: SourceCode,
+): boolean {
+  return (
+    isTopLevelExpressionStatement(node)
+    && node.expression.type === 'Literal'
+    && typeof node.expression.value === 'string'
+    && !isParenthesized(node.expression, sourceCode)
+  )
+}
+
+/**
+ * Check whether the given node is a part of directive prologue or not.
+ * @param node The node to check.
+ * @param sourceCode The source code object to get tokens.
+ * @returns `true` if the node is a part of directive prologue.
+ */
+function isDirectivePrologue(
+  node: ASTNode,
+  sourceCode: SourceCode,
+): boolean {
+  if (
+    isDirective(node, sourceCode)
+    && node.parent
+    && 'body' in node.parent
+    && Array.isArray(node.parent.body)
+  ) {
+    for (const sibling of node.parent.body) {
+      if (sibling === node)
+        break
+
+      if (!isDirective(sibling, sourceCode))
+        return false
+    }
+    return true
+  }
+  return false
+}
+
+/**
+ * Checks the given node is a CommonJS export statement
+ * @param node The node to check.
+ * @returns `true` if the node is a CommonJS export statement.
+ * @private
+ */
+function isCJSExport(node: ASTNode): boolean {
+  if (node.type === 'ExpressionStatement') {
+    const expression = node.expression
+    if (expression.type === 'AssignmentExpression') {
+      let left = expression.left
+      if (left.type === 'MemberExpression') {
+        while (left.object.type === 'MemberExpression')
+          left = left.object
+
+        return (
+          left.object.type === 'Identifier'
+          && (left.object.name === 'exports'
+            || (left.object.name === 'module'
+              && left.property.type === 'Identifier'
+              && left.property.name === 'exports'))
+        )
+      }
+    }
+  }
+  return false
+}
+
+/**
+ * Check whether the given node is an expression
+ * @param node The node to check.
+ * @param sourceCode The source code object to get tokens.
+ * @returns `true` if the node is an expression
+ */
+function isExpression(
+  node: ASTNode,
+  sourceCode: SourceCode,
+): boolean {
+  return (
+    node.type === 'ExpressionStatement'
+    && !isDirectivePrologue(node, sourceCode)
+  )
+}
+
+/**
+ * Gets the actual last token.
+ *
+ * If a semicolon is semicolon-less style's semicolon, this ignores it.
+ * For example:
+ *
+ *     foo()
+ *     ;[1, 2, 3].forEach(bar)
+ * @param sourceCode The source code to get tokens.
+ * @param node The node to get.
+ * @returns The actual last token.
+ * @private
+ */
+function getActualLastToken(
+  node: ASTNode,
+  sourceCode: SourceCode,
+): Token | null {
+  const semiToken = sourceCode.getLastToken(node)!
+  const prevToken = sourceCode.getTokenBefore(semiToken)
+  const nextToken = sourceCode.getTokenAfter(semiToken)
+  const isSemicolonLessStyle
+    = prevToken
+      && nextToken
+      && prevToken.range[0] >= node.range[0]
+      && isSemicolonToken(semiToken)
+      && !isTokenOnSameLine(prevToken, semiToken)
+      && isTokenOnSameLine(semiToken, nextToken)
+
+  return isSemicolonLessStyle ? prevToken : semiToken
+}
+
+/**
+ * This returns the concatenation of the first 2 captured strings.
+ * @param _ Unused. Whole matched string.
+ * @param trailingSpaces The trailing spaces of the first line.
+ * @param indentSpaces The indentation spaces of the last line.
+ * @returns The concatenation of trailingSpaces and indentSpaces.
+ * @private
+ */
+function replacerToRemovePaddingLines(
+  _: string,
+  trailingSpaces: string,
+  indentSpaces: string,
+): string {
+  return trailingSpaces + indentSpaces
+}
+
+function getReportLoc(node: ASTNode, sourceCode: SourceCode): Location {
+  if (isSingleLine(node))
+    return node.loc
+
+  const line = node.loc.start.line
+  const sourceLine = sourceCode.lines[line - 1]
+  if (sourceLine === undefined)
+    throw new Error('Padding rule invariant: statement source line is missing')
+
+  return {
+    start: node.loc.start,
+    end: {
+      line,
+      column: sourceLine.length,
+    },
+  }
+}
+
+/**
+ * Check and report statements for `any` configuration.
+ * It does nothing.
+ *
+ * @private
+ */
+function verifyForAny(): void {
+  // Empty
+}
+
+/**
+ * Check and report statements for `never` configuration.
+ * This autofix removes blank lines between the given 2 statements.
+ * However, if comments exist between 2 blank lines, it does not remove those
+ * blank lines automatically.
+ * @param context The rule context to report.
+ * @param _ Unused. The previous node to check.
+ * @param nextNode The next node to check.
+ * @param paddingLines The array of token pairs that blank
+ * lines exist between the pair.
+ *
+ * @private
+ */
+function verifyForNever(
+  context: RuleContext,
+  _: ASTNode,
+  nextNode: ASTNode,
+  paddingLines: [Token, Token][],
+): void {
+  if (paddingLines.length === 0)
+    return
+
+  context.report({
+    node: nextNode,
+    messageId: 'unexpectedBlankLine',
+    loc: getReportLoc(nextNode, context.sourceCode),
+    fix(fixer) {
+      if (paddingLines.length >= 2)
+        return null
+
+      const paddingPair = paddingLines[0]
+      if (paddingPair === undefined)
+        throw new Error('Padding rule invariant: reported padding pair is missing')
+      const [prevToken, nextToken] = paddingPair
+      const start = prevToken.range[1]
+      const end = nextToken.range[0]
+      const text = context
+        .sourceCode
+        .text
+        .slice(start, end)
+        .replace(PADDING_LINE_SEQUENCE, replacerToRemovePaddingLines)
+
+      return fixer.replaceTextRange([start, end], text)
+    },
+  })
+}
+
+/**
+ * Check and report statements for `always` configuration.
+ * This autofix inserts a blank line between the given 2 statements.
+ * If the `prevNode` has trailing comments, it inserts a blank line after the
+ * trailing comments.
+ * @param context The rule context to report.
+ * @param prevNode The previous node to check.
+ * @param nextNode The next node to check.
+ * @param paddingLines The array of token pairs that blank
+ * lines exist between the pair.
+ *
+ * @private
+ */
+function verifyForAlways(
+  context: RuleContext,
+  prevNode: ASTNode,
+  nextNode: ASTNode,
+  paddingLines: [Token, Token][],
+): void {
+  if (paddingLines.length > 0)
+    return
+
+  context.report({
+    node: nextNode,
+    messageId: 'expectedBlankLine',
+    loc: getReportLoc(nextNode, context.sourceCode),
+    fix(fixer) {
+      const sourceCode = context.sourceCode
+      let prevToken = getActualLastToken(prevNode, sourceCode)!
+      const nextToken
+        = sourceCode.getFirstTokenBetween(prevToken, nextNode, {
+          includeComments: true,
+
+          /**
+           * Skip the trailing comments of the previous node.
+           * This inserts a blank line after the last trailing comment.
+           *
+           * For example:
+           *
+           *     foo(); // trailing comment.
+           *     // comment.
+           *     bar();
+           *
+           * Get fixed to:
+           *
+           *     foo(); // trailing comment.
+           *
+           *     // comment.
+           *     bar();
+           * @param token The token to check.
+           * @returns `true` if the token is not a trailing comment.
+           * @private
+           */
+          filter(token) {
+            if (isTokenOnSameLine(prevToken, token)) {
+              prevToken = token
+              return false
+            }
+            return true
+          },
+        })! || nextNode
+      const insertText = isTokenOnSameLine(prevToken, nextToken)
+        ? '\n\n'
+        : '\n'
+
+      return fixer.insertTextAfter(prevToken, insertText)
+    },
+  })
+}
+
+/**
+ * Types of blank lines.
+ * `any`, `never`, and `always` are defined.
+ * Those have `verify` method to check and report statements.
+ * @private
+ */
+const PaddingTypes = {
+  any: { verify: verifyForAny },
+  never: { verify: verifyForNever },
+  always: { verify: verifyForAlways },
+}
+
+const MaybeMultilineStatementType: Record<string, NodeTestObject> = {
+  'block-like': { test: isBlockLikeStatement },
+  'expression': { test: isExpression },
+  'return': newKeywordTester('ReturnStatement', 'return'),
+  'export': newKeywordTester(
+    [
+      'ExportAllDeclaration',
+      'ExportDefaultDeclaration',
+      'ExportNamedDeclaration',
+    ],
+    'export',
+  ),
+  'var': newKeywordTester('VariableDeclaration', 'var'),
+  'let': newKeywordTester('VariableDeclaration', 'let'),
+  'const': newKeywordTester('VariableDeclaration', 'const'),
+  'using': {
+    test: node => node.type === 'VariableDeclaration'
+      && (node.kind === 'using' || node.kind === 'await using'),
+  },
+  'type': newKeywordTester('TSTypeAliasDeclaration', 'type'),
+}
+
+/**
+ * Types of statements.
+ * Those have `test` method to check it matches to the given statement.
+ * @private
+ */
+const StatementTypes: Record<string, NodeTestObject> = {
+  '*': { test: (): boolean => true },
+  'exports': { test: isCJSExport },
+  'require': { test: isCJSRequire },
+  'directive': { test: isDirectivePrologue },
+  'iife': { test: isIIFEStatement },
+
+  'block': newNodeTypeTester('BlockStatement'),
+  'empty': newNodeTypeTester('EmptyStatement'),
+  'function': newNodeTypeTester('FunctionDeclaration'),
+  'ts-method': newNodeTypeTester('TSMethodSignature'),
+
+  'break': newKeywordTester('BreakStatement', 'break'),
+  'case': newKeywordTester('SwitchCase', 'case'),
+  'class': newKeywordTester('ClassDeclaration', 'class'),
+  'continue': newKeywordTester('ContinueStatement', 'continue'),
+  'debugger': newKeywordTester('DebuggerStatement', 'debugger'),
+  'default': newKeywordTester(
+    ['SwitchCase', 'ExportDefaultDeclaration'],
+    'default',
+  ),
+  'do': newKeywordTester('DoWhileStatement', 'do'),
+  'for': newKeywordTester(
+    [
+      'ForStatement',
+      'ForInStatement',
+      'ForOfStatement',
+    ],
+    'for',
+  ),
+  'if': newKeywordTester('IfStatement', 'if'),
+  'import': newKeywordTester('ImportDeclaration', 'import'),
+  'switch': newKeywordTester('SwitchStatement', 'switch'),
+  'throw': newKeywordTester('ThrowStatement', 'throw'),
+  'try': newKeywordTester('TryStatement', 'try'),
+  'while': newKeywordTester(
+    ['WhileStatement', 'DoWhileStatement'],
+    'while',
+  ),
+  'with': newKeywordTester('WithStatement', 'with'),
+
+  'cjs-export': {
+    test: (node, sourceCode) => node.type === 'ExpressionStatement'
+      && node.expression.type === 'AssignmentExpression'
+      && CJS_EXPORT.test(sourceCode.getText(node.expression.left)),
+  },
+  'cjs-import': {
+    test: (node, sourceCode) => node.type === 'VariableDeclaration'
+      && node.declarations.length > 0
+      && node.declarations[0]?.init != null
+      && CJS_IMPORT.test(sourceCode.getText(node.declarations[0].init)),
+  },
+
+  'enum': newKeywordTester(
+    'TSEnumDeclaration',
+    'enum',
+  ),
+  'interface': newKeywordTester(
+    'TSInterfaceDeclaration',
+    'interface',
+  ),
+  'function-overload': newNodeTypeTester('TSDeclareFunction'),
+  ...Object.fromEntries(
+    Object.entries(MaybeMultilineStatementType)
+      .flatMap(([key, value]) => [
+        [key, value],
+        [
+          `singleline-${key}`,
+          {
+            ...value,
+            test: (node, sourceCode) => value.test(node, sourceCode) && isSingleLine(node),
+          },
+        ],
+        [
+          `multiline-${key}`,
+          {
+            ...value,
+            test: (node, sourceCode) => value.test(node, sourceCode) && !isSingleLine(node),
+          },
+        ],
+      ]),
+  ),
+}
+
+/** Build the vendored padding rule with caller-owned, typed policy options. */
+export default function createPaddingLineRule(options: RuleOptions): CreateRule {
+return {
+  meta: {
+    type: 'layout',
+    docs: {
+      description: 'Require or disallow padding lines between statements',
+    },
+    fixable: 'whitespace',
+    hasSuggestions: false,
+    // This is intentionally an array schema as you can pass 0..n config objects
+    schema: {
+      $defs: {
+        paddingType: {
+          type: 'string',
+          enum: Object.keys(PaddingTypes),
+        },
+        statementType: {
+          type: 'string',
+          enum: Object.keys(StatementTypes),
+        },
+        selectorOption: {
+          type: 'object',
+          properties: {
+            selector: {
+              type: 'string',
+            },
+            lineMode: {
+              type: 'string',
+              enum: ['any', 'singleline', 'multiline'],
+            },
+          },
+          required: ['selector'],
+          additionalProperties: false,
+        },
+        statementMatcher: {
+          anyOf: [
+            { $ref: '#/$defs/statementType' },
+            { $ref: '#/$defs/selectorOption' },
+          ],
+        },
+        statementOption: {
+          anyOf: [
+            { $ref: '#/$defs/statementMatcher' },
+            {
+              type: 'array',
+              items: { $ref: '#/$defs/statementMatcher' },
+              minItems: 1,
+              uniqueItems: true,
+              additionalItems: false,
+            },
+          ],
+        },
+      },
+      type: 'array',
+      additionalItems: false,
+      items: {
+        type: 'object',
+        properties: {
+          blankLine: { $ref: '#/$defs/paddingType' },
+          prev: { $ref: '#/$defs/statementOption' },
+          next: { $ref: '#/$defs/statementOption' },
+        },
+        additionalProperties: false,
+        required: ['blankLine', 'prev', 'next'],
+      },
+    },
+    messages: {
+      unexpectedBlankLine: 'Unexpected blank line before this statement.',
+      expectedBlankLine: 'Expected blank line before this statement.',
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode
+
+    const selectorMatchedNodes = new Map<string, Set<ASTNode>>()
+    const pendingPairs: { prevNode: ASTNode, nextNode: ASTNode }[] = []
+
+    function collectSelectorOption(option: StatementOption): void {
+      if (Array.isArray(option)) {
+        for (const item of option)
+          collectSelectorOption(item)
+        return
+      }
+
+      if (!isSelectorOption(option))
+        return
+
+      selectorMatchedNodes.set(option.selector, new Set())
+    }
+
+    for (const configure of options) {
+      collectSelectorOption(configure.prev)
+      collectSelectorOption(configure.next)
+    }
+
+    type Scope = {
+      upper: Scope
+      prevNode: ASTNode | null
+    } | null
+
+    let scopeInfo: Scope = null
+
+    /**
+     * Processes to enter to new scope.
+     * This manages the current previous statement.
+     *
+     * @private
+     */
+    function enterScope(): void {
+      scopeInfo = {
+        upper: scopeInfo,
+        prevNode: null,
+      }
+    }
+
+    /**
+     * Processes to exit from the current scope.
+     *
+     * @private
+     */
+    function exitScope(): void {
+      if (scopeInfo)
+        scopeInfo = scopeInfo.upper
+    }
+
+    /**
+     * Checks whether the given node matches the given type.
+     * @param node The statement node to check.
+     * @param type The statement type to check.
+     * @returns `true` if the statement node matched the type.
+     * @private
+     */
+    function match(node: ASTNode, type: StatementOption): boolean {
+      let innerStatementNode = node
+
+      while (innerStatementNode.type === 'LabeledStatement')
+        innerStatementNode = innerStatementNode.body
+
+      if (Array.isArray(type))
+        return type.some(match.bind(null, innerStatementNode))
+
+      if (isSelectorOption(type)) {
+        const matchedNodes = selectorMatchedNodes.get(type.selector)
+        if (!matchedNodes?.has(innerStatementNode))
+          return false
+
+        const lineMode = type.lineMode
+
+        if (lineMode === 'singleline')
+          return isSingleLine(innerStatementNode)
+        else if (lineMode === 'multiline')
+          return !isSingleLine(innerStatementNode)
+
+        return true
+      }
+      else {
+        const statementType = StatementTypes[type]
+        if (statementType === undefined)
+          throw new Error(`Padding rule invariant: unsupported statement type ${type}`)
+        return statementType.test(innerStatementNode, sourceCode)
+      }
+    }
+
+    /**
+     * Finds the last matched configure from options.
+     * @param prevNode The previous statement to match.
+     * @param nextNode The current statement to match.
+     * @returns The tester of the last matched configure.
+     * @private
+     */
+    function getPaddingType(
+      prevNode: ASTNode,
+      nextNode: ASTNode,
+    ): (typeof PaddingTypes)[keyof typeof PaddingTypes] {
+      for (let i = options.length - 1; i >= 0; --i) {
+        const configure = options[i]
+        if (configure === undefined)
+          throw new Error('Padding rule invariant: configuration entry is missing')
+        if (
+          match(prevNode, configure.prev)
+          && match(nextNode, configure.next)
+        ) {
+          return PaddingTypes[configure.blankLine]
+        }
+      }
+      return PaddingTypes.any
+    }
+
+    /**
+     * Gets padding line sequences between the given 2 statements.
+     * Comments are separators of the padding line sequences.
+     * @param prevNode The previous statement to count.
+     * @param nextNode The current statement to count.
+     * @returns The array of token pairs.
+     * @private
+     */
+    function getPaddingLineSequences(
+      prevNode: ASTNode,
+      nextNode: ASTNode,
+    ): [Token, Token][] {
+      const pairs: [Token, Token][] = []
+      let prevToken: Token = getActualLastToken(prevNode, sourceCode)!
+
+      if (nextNode.loc.start.line - prevToken.loc.end.line >= 2) {
+        do {
+          const token: Token = sourceCode.getTokenAfter(prevToken, {
+            includeComments: true,
+          })!
+
+          if (token.loc.start.line - prevToken.loc.end.line >= 2)
+            pairs.push([prevToken, token])
+
+          prevToken = token
+        } while (prevToken.range[0] < nextNode.range[0])
+      }
+
+      return pairs
+    }
+
+    /**
+     * Verify padding lines between the given node and the previous node.
+     * @param node The node to verify.
+     *
+     * @private
+     */
+    function verify(node: ASTNode): void {
+      if (
+        !node.parent
+        || ![
+          'BlockStatement',
+          'Program',
+          'StaticBlock',
+          'SwitchCase',
+          'SwitchStatement',
+          'TSInterfaceBody',
+          'TSModuleBlock',
+          'TSTypeLiteral',
+        ].includes(node.parent.type)
+      ) {
+        return
+      }
+
+      // Save this node as the current previous statement.
+      const prevNode = scopeInfo!.prevNode
+
+      // Verify.
+      if (prevNode)
+        pendingPairs.push({ prevNode, nextNode: node })
+
+      scopeInfo!.prevNode = node
+    }
+
+    function verifyPendingPairs(): void {
+      for (const { prevNode, nextNode } of pendingPairs) {
+        const type = getPaddingType(prevNode, nextNode)
+        const paddingLines = getPaddingLineSequences(prevNode, nextNode)
+
+        type.verify(context, prevNode, nextNode, paddingLines)
+      }
+    }
+
+    /**
+     * Verify padding lines between the given node and the previous node.
+     * Then process to enter to new scope.
+     * @param node The node to verify.
+     *
+     * @private
+     */
+    function verifyThenEnterScope(node: ASTNode): void {
+      verify(node)
+      enterScope()
+    }
+
+    const selectorMatchListeners = Object.fromEntries(
+      Array.from(selectorMatchedNodes.keys(), selector => [
+        selector,
+        (node: ASTNode): void => {
+          selectorMatchedNodes.get(selector)?.add(node)
+        },
+      ]),
+    )
+
+    return {
+      'Program': enterScope,
+      'Program:exit': () => {
+        verifyPendingPairs()
+        exitScope()
+      },
+      'BlockStatement': enterScope,
+      'BlockStatement:exit': exitScope,
+      'SwitchStatement': enterScope,
+      'SwitchStatement:exit': exitScope,
+      'SwitchCase': verifyThenEnterScope,
+      'SwitchCase:exit': exitScope,
+      'StaticBlock': enterScope,
+      'StaticBlock:exit': exitScope,
+
+      'TSInterfaceBody': enterScope,
+      'TSInterfaceBody:exit': exitScope,
+      'TSModuleBlock': enterScope,
+      'TSModuleBlock:exit': exitScope,
+      'TSTypeLiteral': enterScope,
+      'TSTypeLiteral:exit': exitScope,
+      'TSDeclareFunction': verifyThenEnterScope,
+      'TSDeclareFunction:exit': exitScope,
+      'TSMethodSignature': verifyThenEnterScope,
+      'TSMethodSignature:exit': exitScope,
+
+      ':statement': verify,
+      ...selectorMatchListeners,
+    }
+  },
+}
+}

--- a/tools/oxlint/anti-slop/vendor/eslint-stylistic/padding-line-options.d.ts
+++ b/tools/oxlint/anti-slop/vendor/eslint-stylistic/padding-line-options.d.ts
@@ -1,0 +1,87 @@
+/* GENERATED, DO NOT EDIT DIRECTLY */
+
+/* @checksum: 3QCTtOH6rJM5_AGJ58rGpeEaBEfaJz17MSCxWB4X_PU */
+
+export type PaddingType = 'any' | 'never' | 'always'
+export type StatementOption =
+  | StatementMatcher
+  | [StatementMatcher, ...StatementMatcher[]]
+export type StatementMatcher =
+  | StatementType
+  | SelectorOption
+export type StatementType =
+  | '*'
+  | 'exports'
+  | 'require'
+  | 'directive'
+  | 'iife'
+  | 'block'
+  | 'empty'
+  | 'function'
+  | 'ts-method'
+  | 'break'
+  | 'case'
+  | 'class'
+  | 'continue'
+  | 'debugger'
+  | 'default'
+  | 'do'
+  | 'for'
+  | 'if'
+  | 'import'
+  | 'switch'
+  | 'throw'
+  | 'try'
+  | 'while'
+  | 'with'
+  | 'cjs-export'
+  | 'cjs-import'
+  | 'enum'
+  | 'interface'
+  | 'function-overload'
+  | 'block-like'
+  | 'singleline-block-like'
+  | 'multiline-block-like'
+  | 'expression'
+  | 'singleline-expression'
+  | 'multiline-expression'
+  | 'return'
+  | 'singleline-return'
+  | 'multiline-return'
+  | 'export'
+  | 'singleline-export'
+  | 'multiline-export'
+  | 'var'
+  | 'singleline-var'
+  | 'multiline-var'
+  | 'let'
+  | 'singleline-let'
+  | 'multiline-let'
+  | 'const'
+  | 'singleline-const'
+  | 'multiline-const'
+  | 'using'
+  | 'singleline-using'
+  | 'multiline-using'
+  | 'type'
+  | 'singleline-type'
+  | 'multiline-type'
+export type PaddingLineBetweenStatementsSchema0 = {
+  blankLine: PaddingType
+  prev: StatementOption
+  next: StatementOption
+}[]
+
+export interface SelectorOption {
+  selector: string
+  lineMode?: 'any' | 'singleline' | 'multiline'
+}
+
+export type PaddingLineBetweenStatementsRuleOptions
+  = PaddingLineBetweenStatementsSchema0
+
+export type RuleOptions
+  = PaddingLineBetweenStatementsRuleOptions
+export type MessageIds =
+  | 'unexpectedBlankLine'
+  | 'expectedBlankLine'


### PR DESCRIPTION
## Summary

Add vendored anti-slop checks to the existing Oxlint setup. Enable 12 generic rules plus the native accumulating-spread rule, and document why six blanket rules do not fit this project. Narrow dictionary, assertion and spacing checks to useful maintenance invariants; retain justified exceptions at specific call sites with unused-suppression detection.

Preserve concrete cache, parser and logging contracts, remove redundant test casts, complete ordinary fixtures, and document intentional module mocks and partial boundary fixtures. Keep the 33 whitespace-only fixes in a separate commit. Plugin provenance, MIT licenses and the full rule policy are recorded under `tools/oxlint/anti-slop/`.

## Validation

- Lint, format, workspace and e2e typechecks, and build pass.
- 2,717 tests pass, including five real-CLI anti-slop regression tests; coverage thresholds pass.
- All 40 Playwright end-to-end tests pass.
- Migration (13 tests), bundle checks (5 tests), growth-rate checks, quality-task coverage, documented paths/facts and release preflight pass.
- A second lint-fix/format cycle produces no changes; regression fixtures preserve JSDoc and overload groups and reject new neighboring violations and stale suppressions.

## Commit structure

1. Vendor upstream sources, licenses and matching plugin dependency.
2. Preserve runtime contracts and document runtime boundary exceptions.
3. Type test fixtures and document reviewed boundary mocks.
4. Enable the reviewed policy with CLI regression tests and rationale.
5. Apply only module declaration spacing fixes.
