### PR TITLE
perf(www): Improve Cloudflare Pages delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,18 @@ Package-level baselines prevent coverage regressions, while stricter targeted
 thresholds protect the scanning, API, live runtime, hook, and interaction paths.
 The Astro landing page is covered by Playwright rather than Vitest.
 
+The Pages deployment uses `apps/www/public/_headers` to cache fingerprinted
+`/_astro/` assets for one year. Keep HTML and unversioned public files on the
+Pages defaults so deployments remain visible. Landing pages preload their hero
+image, which Pages can use for Early Hints. These optimizations use the existing
+Pages service. `apps/www/public/404.html` disables Pages' SPA fallback so missing
+assets return an uncached 404 instead of a cacheable copy of the homepage.
+
+Use one Cloudflare Web Analytics injection source for the landing page. When
+Pages injects the beacon, leave `PUBLIC_ANALYTICS_TOKEN` unset; it is only a
+fallback for deployments without automatic injection. Check both Pages and zone
+settings if the production HTML contains multiple CF beacons. Umami is separate.
+
 ### Reproduce Required CI Checks
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) is the source of truth. CI runs the main

--- a/README_CN.md
+++ b/README_CN.md
@@ -262,6 +262,16 @@ pnpm --filter @codesesh/www deploy:cf
 扫描、API、实时运行时、Hook 和交互路径继续使用更严格的定向门槛。
 Astro 落地页由 Playwright 覆盖，不计入 Vitest 覆盖率。
 
+Pages 部署通过 `apps/www/public/_headers` 为文件名带内容哈希的 `/_astro/` 资源
+设置一年缓存。HTML 和未版本化的公共文件沿用 Pages 默认策略，保证部署更新及时可见。
+落地页预加载首屏主图，Pages 可据此生成 Early Hints。这些优化使用现有 Pages 服务。
+`apps/www/public/404.html` 关闭 Pages 的 SPA 回退，让缺失资源返回不可缓存的 404，
+避免把首页 HTML 当作静态资源长期缓存。
+
+落地页的 Cloudflare Web Analytics 应只保留一个注入入口。Pages 已注入 beacon 时，
+不要设置 `PUBLIC_ANALYTICS_TOKEN`；该变量仅供没有自动注入的部署作为回退。
+若生产 HTML 出现多个 CF beacon，需同时检查 Pages 和域名级配置。Umami 独立运行。
+
 ### 复现 CI 必需检查
 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml) 是事实源。CI 会在 Linux、macOS、Windows

--- a/apps/www/.env.example
+++ b/apps/www/.env.example
@@ -1,3 +1,4 @@
-# Client-side web-analytics site token (public-by-design identifier).
-# Set in the deploy environment; when absent, analytics stays disabled.
+# Optional Cloudflare Web Analytics fallback token (public site identifier).
+# Leave empty when Pages injects the beacon. The fallback skips existing beacons.
+# This does not control Pages/zone injection or Umami.
 PUBLIC_ANALYTICS_TOKEN=

--- a/apps/www/public/404.html
+++ b/apps/www/public/404.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Page not found | CodeSesh</title>
+  </head>
+  <body>
+    <main>
+      <h1>Page not found</h1>
+      <p><a href="/">Return to CodeSesh</a></p>
+    </main>
+  </body>
+</html>

--- a/apps/www/public/_headers
+++ b/apps/www/public/_headers
@@ -1,0 +1,2 @@
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -2,6 +2,7 @@
 import "@fontsource-variable/ibm-plex-sans";
 import "@fontsource-variable/jetbrains-mono";
 import "@fontsource-variable/space-grotesk";
+import heroArtwork from "../assets/backgrounds/session-orbit.webp";
 import {
   copy,
   localeConfig,
@@ -167,6 +168,7 @@ const jsonLd = {
 <html lang={currentLocale.language}>
   <head>
     <meta charset="UTF-8" />
+    {!page && <link rel="preload" href={heroArtwork.src} as="image" />}
     <script is:inline>
       // Applies the persisted theme before first paint to avoid a light->dark
       // flash. Key ("www-theme") is independent from apps/web's

--- a/apps/www/src/layouts/LandingLayout.astro
+++ b/apps/www/src/layouts/LandingLayout.astro
@@ -50,9 +50,8 @@ const defaultLocaleUrl = new URL(
 const ogLocaleAlternates = alternateLocales.filter(
   (alternate) => alternate.ogLocale !== currentLocale.ogLocale,
 );
-// The token is a public-by-design client-side site ID, but it belongs in
-// deploy configuration, not source: rotating or re-pointing analytics must
-// not require a code change. A missing token disables analytics.
+// Pages can inject its own beacon; this public site ID enables the fallback
+// for deployments without automatic injection.
 const analyticsToken = import.meta.env.PUBLIC_ANALYTICS_TOKEN as
   string | undefined;
 const analyticsEnabled = import.meta.env.PROD && Boolean(analyticsToken);

--- a/apps/www/src/scripts/analytics-loader.js
+++ b/apps/www/src/scripts/analytics-loader.js
@@ -9,6 +9,8 @@
   window.addEventListener(
     "load",
     function () {
+      if (document.querySelector("script[data-cf-beacon]")) return;
+
       var beacon = document.createElement("script");
       beacon.async = true;
       beacon.src = "https://static.cloudflareinsights.com/beacon.min.js";


### PR DESCRIPTION
The landing page currently gives fingerprinted assets a short browser cache lifetime and discovers the hero image in the body. This change caches `/_astro/` assets for one year and preloads the existing hero image on landing routes, using Cloudflare Pages without adding services or paid features.

- Add a static 404 page so missing assets return an uncached 404 instead of Pages' SPA fallback serving homepage HTML under the immutable asset rule.
- Keep HTML and unversioned public files on Pages' default cache policy; changelog pages do not preload the hero.
- Skip the optional manual Cloudflare beacon when a beacon is already present, and document Pages/zone injection ownership and the fallback environment variable.

Validation:
- `pnpm --filter @codesesh/www build` (includes Astro type checking)
- `pnpm --filter @codesesh/www lint`
- `pnpm --filter @codesesh/www format:check`
- `pnpm test:e2e --project=www-chromium` — 11 passed
- Documentation path/fact checks and `git diff --check`
- Local Wrangler Pages checks: immutable hashed assets, revalidated HTML/public files, and `404` + `no-store` for missing assets.
- Manual analytics checks: existing beacon, absent beacon, preview domain, and localhost.
- Local browser comparison with caching disabled and a 2 Mbps download throttle: hero requests began about 90 ms earlier and completed about 250 ms earlier, with similar first-contentful-paint times. These are local samples, not field measurements.

Deployment notes: the hero preload is eligible for Pages' automatic Early Hints generation; edge `103` responses require verification after deployment. The manual guard does not remove duplicate beacons injected by separate Cloudflare configurations. No production deployment or Cloudflare setting changes are included.
