### PR TITLE
feat(web): Add model token share to dashboards

### DIFF
--- a/apps/web/src/components/overview/OverviewScreen.test.tsx
+++ b/apps/web/src/components/overview/OverviewScreen.test.tsx
@@ -141,6 +141,7 @@ describe("OverviewScreen", () => {
     await screen.findByRole("heading", { name: "Agents" });
     expect(screen.getByTestId("dashboard")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Daily usage" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Tokens by Model" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Cost by Model" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Active hours" })).toBeTruthy();
     expect(screen.getByText("1 projects · 2 agents in scope")).toBeTruthy();

--- a/apps/web/src/components/overview/OverviewScreen.tsx
+++ b/apps/web/src/components/overview/OverviewScreen.tsx
@@ -24,6 +24,7 @@ import { OverviewAgentDistribution } from "./overview-agent-distribution";
 import { OverviewCostBreakdown } from "./overview-cost-breakdown";
 import { OverviewFilterBar } from "./overview-filter-bar";
 import { OverviewKpiGrid } from "./overview-kpi-grid";
+import { OverviewModelTokens } from "./overview-model-tokens";
 import { OverviewSkeleton } from "./overview-skeleton";
 import { OverviewActiveHours } from "./overview-active-hours";
 import { OverviewUsageChart } from "./overview-usage-chart";
@@ -78,6 +79,10 @@ export function OverviewScreen({
       {dashboard ? (
         <>
           <OverviewKpiGrid totals={dashboard.totals} rangeDays={dashboard.window.days} />
+          <OverviewModelTokens
+            models={dashboard.modelDistribution}
+            totalTokens={dashboard.totals.tokens}
+          />
           <OverviewUsageChart daily={dashboard.dailyActivity} />
           <OverviewActiveHours activity={dashboard.activeHours} />
           <div className="grid gap-4 lg:grid-cols-2">

--- a/apps/web/src/components/overview/overview-cost-breakdown.test.tsx
+++ b/apps/web/src/components/overview/overview-cost-breakdown.test.tsx
@@ -123,7 +123,13 @@ describe("OverviewCostBreakdown", () => {
   });
 
   it("says so when there is nothing to break down", () => {
-    render(<OverviewCostBreakdown modelCost={null} modelDistribution={[]} totals={totals()} />);
+    render(
+      <OverviewCostBreakdown
+        modelCost={null}
+        modelDistribution={[]}
+        totals={totals({ tokens: 0 })}
+      />,
+    );
 
     expect(screen.getByText("No model data")).toBeTruthy();
   });

--- a/apps/web/src/components/overview/overview-cost-breakdown.tsx
+++ b/apps/web/src/components/overview/overview-cost-breakdown.tsx
@@ -10,6 +10,7 @@ import { useMemo, useState } from "react";
 
 import type { DashboardTotals, ModelCostEntry, ModelDistributionEntry } from "../../lib/api";
 import { formatCompact, formatPercent, formatUsd, formatUsdCompact } from "../../lib/format";
+import { modelColor, tokenBreakdown, type ModelBreakdownEntry } from "../../lib/model-breakdown";
 import { cn } from "../../lib/utils";
 import { Panel, PanelHeader } from "../ui/panel";
 import { TileDonut } from "../ui/tile-donut";
@@ -19,25 +20,17 @@ const DONUT_SIZE = 142;
 /** Below this share of the total the cache lag is noise, not a missing slice. */
 const REMAINDER_THRESHOLD = 0.01;
 
-interface BreakdownEntry {
-  key: string;
-  label: string;
-  value: number;
-  color: string;
-  display: string;
-}
-
 function hasCost(modelCost: ModelCostEntry[] | null): modelCost is ModelCostEntry[] {
   return modelCost !== null && modelCost.some((entry) => entry.cost > 0);
 }
 
-function costEntries(modelCost: ModelCostEntry[], totalCost: number): BreakdownEntry[] {
+function costEntries(modelCost: ModelCostEntry[], totalCost: number): ModelBreakdownEntry[] {
   const top = [...modelCost].sort((a, b) => b.cost - a.cost).slice(0, LEGEND_LIMIT);
-  const entries = top.map((entry, index) => ({
+  const entries = top.map((entry) => ({
     key: entry.model,
     label: entry.model,
     value: entry.cost,
-    color: `var(--chart-${index + 1})`,
+    color: modelColor(entry.model),
     display: formatUsdCompact(entry.cost),
   }));
 
@@ -52,19 +45,6 @@ function costEntries(modelCost: ModelCostEntry[], totalCost: number): BreakdownE
     });
   }
   return entries;
-}
-
-function tokenEntries(modelDistribution: ModelDistributionEntry[]): BreakdownEntry[] {
-  return [...modelDistribution]
-    .sort((a, b) => b.tokens - a.tokens)
-    .slice(0, LEGEND_LIMIT)
-    .map((entry, index) => ({
-      key: entry.model,
-      label: entry.model,
-      value: entry.tokens,
-      color: `var(--chart-${index + 1})`,
-      display: formatCompact(entry.tokens),
-    }));
 }
 
 export function OverviewCostBreakdown({
@@ -85,11 +65,13 @@ export function OverviewCostBreakdown({
       const byCost = hasCost(modelCost);
       return {
         byCost,
-        entries: byCost ? costEntries(modelCost, totals.cost) : tokenEntries(modelDistribution),
+        entries: byCost
+          ? costEntries(modelCost, totals.cost)
+          : tokenBreakdown(modelDistribution, totals.tokens),
       };
     },
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- Display formatters read the active locale.
-    [locale, modelCost, modelDistribution, totals.cost],
+    [locale, modelCost, modelDistribution, totals.cost, totals.tokens],
   );
   // Shares are of the ring, so they always add up to it; the centre reports the
   // scope total the KPI row already shows, which the ring covers in full once

--- a/apps/web/src/components/overview/overview-model-tokens.test.tsx
+++ b/apps/web/src/components/overview/overview-model-tokens.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { OverviewModelTokens } from "./overview-model-tokens";
+
+afterEach(cleanup);
+
+describe("OverviewModelTokens", () => {
+  it("shows exact token values through keyboard and legend tooltips", () => {
+    render(
+      <OverviewModelTokens
+        models={[
+          { model: "sonnet", tokens: 9999, sessions: 1 },
+          { model: "haiku", tokens: 1, sessions: 1 },
+        ]}
+        totalTokens={10000}
+      />,
+    );
+    const chart = screen.getByRole("listbox", { name: "Model token distribution chart" });
+    const options = within(chart).getAllByRole("option");
+
+    fireEvent.focus(options[0]!);
+    expect(screen.getByRole("tooltip").textContent).toContain("9,999 tokens");
+    fireEvent.keyDown(options[0]!, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(options[1]);
+    expect(screen.getByRole("tooltip").textContent).toContain("haiku");
+    expect(screen.getByRole("tooltip").textContent).toContain("1 tokens · <0.1%");
+    fireEvent.keyDown(options[1]!, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).toBeNull();
+
+    fireEvent.pointerEnter(screen.getByRole("button", { name: /sonnet:/ }));
+    expect(screen.getByRole("tooltip").textContent).toContain("sonnet");
+    fireEvent.pointerLeave(screen.getByRole("button", { name: /sonnet:/ }));
+    expect(screen.queryByRole("tooltip")).toBeNull();
+  });
+
+  it("keeps the long tail and unknown usage in the full token total", () => {
+    render(
+      <OverviewModelTokens
+        models={[60, 20, 10, 5, 3, 1].map((tokens, index) => ({
+          model: `model-${index}`,
+          tokens,
+          sessions: 1,
+        }))}
+        totalTokens={100}
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: "Other: 1 tokens, 1%" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Unknown model: 1 tokens, 1%" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "model-0: 60 tokens, 60%" })).toBeTruthy();
+    expect(screen.getAllByRole("option")).toHaveLength(7);
+  });
+
+  it("shows an empty state for a range with no tokens", () => {
+    render(<OverviewModelTokens models={[]} totalTokens={0} />);
+    expect(screen.getByText("No usage data")).toBeTruthy();
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+});

--- a/apps/web/src/components/overview/overview-model-tokens.tsx
+++ b/apps/web/src/components/overview/overview-model-tokens.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import type { ModelDistributionEntry } from "../../lib/api";
+import { useLocale } from "../../hooks/useLocale";
+import { t } from "../../i18n/translate";
+import { formatCompact, formatInt } from "../../lib/format";
+import { tokenBreakdown } from "../../lib/model-breakdown";
+import { cn } from "../../lib/utils";
+import { ChartTooltip } from "../ui/chart-tooltip";
+import { Panel, PanelHeader } from "../ui/panel";
+import { TileShareBar } from "../ui/tile-share-bar";
+
+export function OverviewModelTokens({
+  models,
+  totalTokens,
+}: {
+  models: ModelDistributionEntry[];
+  totalTokens: number;
+}) {
+  const locale = useLocale();
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const entries = useMemo(
+    () => tokenBreakdown(models, totalTokens),
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- Labels and formatters read the active locale.
+    [locale, models, totalTokens],
+  );
+  const shares = entries.map((entry) => entry.value / totalTokens);
+  const percentages = shares.map((share) =>
+    share > 0 && share < 0.001
+      ? "<0.1%"
+      : share.toLocaleString(locale, { style: "percent", maximumFractionDigits: 1 }),
+  );
+  const itemLabels = entries.map(
+    (entry, index) =>
+      `${entry.label}: ${formatInt(entry.value)} ${t("tokens")}, ${percentages[index]}`,
+  );
+  const activeIndex = entries.findIndex((entry) => entry.key === activeKey);
+  const active = entries[activeIndex];
+  const tooltipPosition =
+    (shares.slice(0, activeIndex).reduce((sum, share) => sum + share, 0) +
+      (shares[activeIndex] ?? 0) / 2) *
+    100;
+  const onHover = (index: number | null) =>
+    setActiveKey(index === null ? null : (entries[index]?.key ?? null));
+
+  return (
+    <Panel role="region" aria-label={t("Tokens by Model")} className="p-4">
+      <PanelHeader
+        title={t("Tokens by Model")}
+        meta={`${formatCompact(totalTokens)} ${t("total tokens")}`}
+      />
+      <p className="console-mono mt-1 text-[10.5px] text-[var(--console-muted)]">
+        {t("Token share in the selected range, including cache tokens.")}
+      </p>
+      {totalTokens <= 0 ? (
+        <p className="console-mono mt-3 text-[11px] text-[var(--console-muted)]">
+          {t("No usage data")}
+        </p>
+      ) : (
+        <>
+          <div className="relative mt-3">
+            <TileShareBar
+              shares={shares}
+              colors={entries.map((entry) => entry.color)}
+              hovered={activeIndex < 0 ? null : activeIndex}
+              onHover={onHover}
+              ariaLabel={t("Model token distribution chart")}
+              itemLabels={itemLabels}
+            />
+            {active ? (
+              <ChartTooltip index={activeIndex} count={entries.length} position={tooltipPosition}>
+                <div className="font-semibold">{active.label}</div>
+                <div>
+                  {formatInt(active.value)} {t("tokens")} · {percentages[activeIndex]}
+                </div>
+              </ChartTooltip>
+            ) : null}
+          </div>
+          <ul className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+            {entries.map((entry, index) => (
+              <li key={entry.key} className="min-w-0 max-w-full">
+                <button
+                  type="button"
+                  aria-label={itemLabels[index]}
+                  className={cn(
+                    "console-mono flex max-w-full items-center gap-1.5 rounded-sm text-[10.5px] text-[var(--console-text)] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--brand)]",
+                    active && active.key !== entry.key ? "opacity-45" : null,
+                  )}
+                  onPointerEnter={() => setActiveKey(entry.key)}
+                  onPointerLeave={() => setActiveKey(null)}
+                  onFocus={() => setActiveKey(entry.key)}
+                  onBlur={() => setActiveKey(null)}
+                  onClick={() => setActiveKey(entry.key)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape") setActiveKey(null);
+                  }}
+                >
+                  <span
+                    aria-hidden
+                    className="size-2 shrink-0 rounded-[2px]"
+                    style={{ background: entry.color }}
+                  />
+                  <span className="truncate">{entry.label}</span>
+                  <span className="shrink-0 text-[var(--console-muted)]">
+                    {entry.display} · {percentages[index]}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </Panel>
+  );
+}

--- a/apps/web/src/components/overview/overview-skeleton.tsx
+++ b/apps/web/src/components/overview/overview-skeleton.tsx
@@ -39,6 +39,8 @@ export function OverviewSkeleton() {
         ))}
       </div>
 
+      <CardSkeleton bodyClassName="h-[68px] w-full" />
+
       <Panel className="p-4">
         <Bar className="h-[15px] w-28" />
         <Bar className="mt-[14px] h-[168px] w-full" />

--- a/apps/web/src/components/ui/chart-tooltip.tsx
+++ b/apps/web/src/components/ui/chart-tooltip.tsx
@@ -3,14 +3,14 @@ import type { ReactNode } from "react";
 export function ChartTooltip({
   index,
   count,
+  position = ((index + 0.5) / count) * 100,
   children,
 }: {
   index: number;
   count: number;
+  position?: number;
   children: ReactNode;
 }) {
-  const position = ((index + 0.5) / count) * 100;
-
   return (
     <div
       role="tooltip"

--- a/apps/web/src/components/ui/tile-share-bar.tsx
+++ b/apps/web/src/components/ui/tile-share-bar.tsx
@@ -1,0 +1,140 @@
+import { useContext, useEffect, useRef } from "react";
+import { useCanvasFrameLoop } from "../../hooks/useCanvasFrameLoop";
+import { usePrefersReducedMotion } from "../../hooks/usePrefersReducedMotion";
+import { ResolvedThemeContext } from "../../hooks/useTheme";
+import { hashUnit, resolveColor, smoothstep, tileWave } from "../../lib/chart-shading";
+import { ChartKeyboardList } from "./chart-keyboard-list";
+
+const HEIGHT = 32;
+const CELL = 4;
+
+export function TileShareBar({
+  shares,
+  colors,
+  hovered,
+  onHover,
+  ariaLabel,
+  itemLabels,
+}: {
+  shares: readonly number[];
+  colors: readonly string[];
+  hovered: number | null;
+  onHover: (index: number | null) => void;
+  ariaLabel: string;
+  itemLabels: readonly string[];
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reducedMotion = usePrefersReducedMotion();
+  const theme = useContext(ResolvedThemeContext);
+  const frameLoop = useCanvasFrameLoop(canvasRef, reducedMotion);
+  const hoveredRef = useRef(hovered);
+  const redraw = useRef(() => {});
+  const sharesKey = shares.join(",");
+  const colorsKey = colors.join("\0");
+
+  useEffect(() => {
+    hoveredRef.current = hovered;
+    if (reducedMotion) redraw.current();
+    else frameLoop.requestFrame();
+  }, [frameLoop, hovered, reducedMotion]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const host = canvas?.parentElement;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !host || !ctx) return;
+    const style = getComputedStyle(canvas);
+    const palette = colorsKey.split("\0").map((color) => resolveColor(style, color));
+    const fractions = sharesKey.split(",").map(Number);
+    let width = 0;
+
+    const layout = () => {
+      width = host.clientWidth;
+      const dpr = Math.min(2, window.devicePixelRatio || 1);
+      canvas.width = Math.round(width * dpr);
+      canvas.height = HEIGHT * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    const draw = (now: number) => {
+      ctx.clearRect(0, 0, width, HEIGHT);
+      let cursor = 0;
+      fractions.forEach((share, index) => {
+        const segmentWidth = share * width;
+        const gap = Math.min(1, segmentWidth / 6);
+        const x = cursor + gap;
+        const w = segmentWidth - gap * 2;
+        cursor += segmentWidth;
+        if (w <= 0) return;
+        const hot = hoveredRef.current === index;
+        ctx.save();
+        ctx.beginPath();
+        ctx.roundRect(x, 0, w, HEIGHT, Math.min(4, w / 2));
+        ctx.clip();
+        ctx.fillStyle = palette[index] ?? "";
+        ctx.globalAlpha = hoveredRef.current === null ? 0.72 : hot ? 1 : 0.3;
+        ctx.beginPath();
+        for (let tx = x + Math.min(CELL, w) / 2; tx < x + w; tx += CELL) {
+          for (let ty = CELL / 2; ty < HEIGHT; ty += CELL) {
+            const fullness = smoothstep(1 - ty / HEIGHT);
+            const wave = tileWave(tx, ty, now * 0.0018);
+            const size =
+              CELL *
+              ((hot ? 0.46 : 0.34) + 0.36 * fullness + 0.26 * wave) *
+              (0.78 + 0.42 * hashUnit(tx, ty));
+            ctx.rect(tx - size / 2, ty - size / 2, size, size);
+          }
+        }
+        ctx.fill();
+        ctx.restore();
+      });
+    };
+
+    redraw.current = () => draw(performance.now());
+    const resize = () => {
+      layout();
+      if (reducedMotion) redraw.current();
+      else frameLoop.requestFrame();
+    };
+    frameLoop.setFrameHandler((now) => {
+      draw(now);
+      return hoveredRef.current === null ? "stop" : "idle";
+    });
+    const observer = new ResizeObserver(resize);
+    observer.observe(host);
+    resize();
+    return () => {
+      observer.disconnect();
+      frameLoop.setFrameHandler(null);
+    };
+  }, [colorsKey, frameLoop, reducedMotion, sharesKey, theme]);
+
+  return (
+    <div
+      className="chart-hatch relative rounded-sm"
+      style={{ height: HEIGHT }}
+      onPointerMove={(event) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        const position = (event.clientX - rect.left) / rect.width;
+        let boundary = 0;
+        const index = shares.findIndex((share) => {
+          boundary += share;
+          return position < boundary;
+        });
+        onHover(index < 0 ? null : index);
+      }}
+      onPointerLeave={(event) => {
+        if (event.pointerType !== "touch") onHover(null);
+      }}
+    >
+      <canvas ref={canvasRef} aria-hidden className="block size-full" />
+      <ChartKeyboardList
+        label={ariaLabel}
+        itemLabels={itemLabels}
+        activeIndex={hovered}
+        onActiveIndexChange={onHover}
+        layout="surface"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/i18n/messages.ts
+++ b/apps/web/src/i18n/messages.ts
@@ -215,6 +215,13 @@ export const messages = {
   more: ["更多", "その他"],
   Other: ["其他", "その他"],
   "Cost by Model": ["模型费用", "モデル別費用"],
+  "Tokens by Model": ["模型 Token 分布", "モデル別トークン"],
+  "Model token distribution chart": ["模型 Token 分布图", "モデル別トークン分布図"],
+  "Token share in the selected range, including cache tokens.": [
+    "当前统计范围内的 Token 占比，包含缓存 Token。",
+    "選択した期間内のトークン割合。キャッシュトークンを含みます。",
+  ],
+  "Unknown model": ["未知模型", "不明なモデル"],
   Models: ["模型", "モデル"],
   "No model data": ["暂无模型数据", "モデルのデータがありません"],
   "{0} chart": ["{0}图表", "{0}グラフ"],

--- a/apps/web/src/lib/model-breakdown.ts
+++ b/apps/web/src/lib/model-breakdown.ts
@@ -1,0 +1,53 @@
+import type { ModelDistributionEntry } from "./api";
+import { t } from "../i18n/translate";
+import { formatCompact } from "./format";
+
+export interface ModelBreakdownEntry {
+  key: string;
+  label: string;
+  value: number;
+  color: string;
+  display: string;
+}
+
+export function modelColor(model: string): string {
+  // FNV-1a binds color to the model ID, independent of rankings and filters.
+  let hash = 2166136261;
+  for (const character of model) hash = Math.imul(hash ^ character.charCodeAt(0), 16777619);
+  return `oklch(0.65 0.16 ${(hash >>> 0) % 360})`;
+}
+
+export function tokenBreakdown(
+  models: ModelDistributionEntry[],
+  totalTokens: number,
+): ModelBreakdownEntry[] {
+  const ranked = models.filter((entry) => entry.tokens > 0).toSorted((a, b) => b.tokens - a.tokens);
+  const entries = ranked.slice(0, 5).map((entry) => ({
+    key: entry.model,
+    label: entry.model,
+    value: entry.tokens,
+    color: modelColor(entry.model),
+    display: formatCompact(entry.tokens),
+  }));
+  const otherTokens = ranked.slice(5).reduce((sum, entry) => sum + entry.tokens, 0);
+  if (otherTokens > 0) {
+    entries.push({
+      key: "__other",
+      label: t("Other"),
+      value: otherTokens,
+      color: "var(--console-border-strong)",
+      display: formatCompact(otherTokens),
+    });
+  }
+  const unknownTokens = totalTokens - ranked.reduce((sum, entry) => sum + entry.tokens, 0);
+  if (unknownTokens > 0) {
+    entries.push({
+      key: "__unknown",
+      label: t("Unknown model"),
+      value: unknownTokens,
+      color: "var(--console-muted)",
+      display: formatCompact(unknownTokens),
+    });
+  }
+  return entries;
+}

--- a/packages/core/src/analytics/__tests__/dashboard.test.ts
+++ b/packages/core/src/analytics/__tests__/dashboard.test.ts
@@ -312,6 +312,7 @@ describe("buildDashboard", () => {
     const session = makeSession("usage-diagnostic", {
       time_created: day1,
       time_updated: day2,
+      model_usage: { sonnet: 120, haiku: 60 },
       stats: {
         message_count: 2,
         total_input_tokens: 150,
@@ -341,6 +342,7 @@ describe("buildDashboard", () => {
           reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day1 + 1_000,
           inputTokens: 100,
+          model: "sonnet",
           outputTokens: 20,
           cacheReadTokens: 80,
           cost: 1,
@@ -351,6 +353,7 @@ describe("buildDashboard", () => {
           reference: { agentName: "claudecode", sessionId: session.reference.sessionId },
           time: day2 + 1_000,
           inputTokens: 50,
+          model: "haiku",
           outputTokens: 10,
           cacheReadTokens: 20,
           cost: 2,
@@ -377,6 +380,14 @@ describe("buildDashboard", () => {
       { sessions: 1, messages: 1, input: 30, output: 10, cache_read: 20, cost: 2 },
     ]);
     expect(result.totals).toMatchObject({ messages: 2, tokens: 180 });
+    expect(result.modelDistribution).toEqual([
+      { model: "sonnet", tokens: 120, sessions: 1 },
+      { model: "haiku", tokens: 60, sessions: 1 },
+    ]);
+
+    const firstDay = buildDashboard([session], opts({ from: day1, to: day2 - 1, costFacts }));
+    expect(firstDay.totals.tokens).toBe(120);
+    expect(firstDay.modelDistribution).toEqual([{ model: "sonnet", tokens: 120, sessions: 1 }]);
   });
 
   it("keeps unreconciled or untimed usage on the session activity day", () => {
@@ -710,8 +721,24 @@ describe("buildDashboard", () => {
   it("aggregates model distribution sorted by tokens desc", () => {
     const result = buildDashboard(
       [
-        makeSession("a", { model_usage: { "gpt-4": 100, "gpt-3.5": 50 } }),
-        makeSession("b", { model_usage: { "gpt-4": 200 } }),
+        makeSession("a", {
+          model_usage: { "gpt-4": 100, "gpt-3.5": 50 },
+          stats: {
+            message_count: 1,
+            total_input_tokens: 150,
+            total_output_tokens: 0,
+            total_cost: 0,
+          },
+        }),
+        makeSession("b", {
+          model_usage: { "gpt-4": 200 },
+          stats: {
+            message_count: 1,
+            total_input_tokens: 200,
+            total_output_tokens: 0,
+            total_cost: 0,
+          },
+        }),
       ],
       opts(),
     );
@@ -721,6 +748,17 @@ describe("buildDashboard", () => {
       tokens: 50,
       sessions: 1,
     });
+  });
+
+  it("leaves tokens unassigned when model totals exceed the session total", () => {
+    const session = makeSession("inconsistent-models", {
+      model_usage: { sonnet: 200 },
+      stats: { message_count: 1, total_input_tokens: 100, total_output_tokens: 0, total_cost: 0 },
+    });
+    const result = buildDashboard([session], opts());
+
+    expect(result.totals.tokens).toBe(100);
+    expect(result.modelDistribution).toEqual([]);
   });
 
   it("keeps the ten most recent sessions", () => {

--- a/packages/core/src/analytics/cost-attribution.ts
+++ b/packages/core/src/analytics/cost-attribution.ts
@@ -43,6 +43,7 @@ export interface AttributedUsage {
   outputTokens: number;
   cacheReadTokens: number;
   cacheCreateTokens: number;
+  modelUsage?: Readonly<Record<string, number>>;
 }
 
 export type UsageAttributionOptions = CostAttributionOptions;
@@ -251,6 +252,10 @@ export function visitAttributedUsage(
             outputTokens,
             cacheReadTokens: detailedTokens ? message.cacheReadTokens : 0,
             cacheCreateTokens: detailedTokens ? message.cacheCreateTokens : 0,
+            modelUsage:
+              detailedTokens && message.model
+                ? { [message.model]: message.inputTokens + outputTokens }
+                : undefined,
           });
         }
       }
@@ -271,15 +276,22 @@ export function visitAttributedUsage(
       if (!detailedTokens) {
         const inputTokens = nonNegative(session.stats.total_input_tokens);
         const outputTokens = nonNegative(session.stats.total_output_tokens);
+        const totalTokens = nonNegative(session.stats.total_tokens ?? inputTokens + outputTokens);
+        const modelTotal = Object.values(session.model_usage ?? {}).reduce(
+          (sum, tokens) => sum + tokens,
+          0,
+        );
         visit({
           entry,
           time: fallbackTime,
           messages: 0,
-          totalTokens: nonNegative(session.stats.total_tokens ?? inputTokens + outputTokens),
+          totalTokens,
           inputTokens,
           outputTokens,
           cacheReadTokens: nonNegative(session.stats.total_cache_read_tokens),
           cacheCreateTokens: nonNegative(session.stats.total_cache_create_tokens),
+          // Unreconciled model totals stay unassigned rather than inflating their shares.
+          modelUsage: modelTotal <= totalTokens ? session.model_usage : undefined,
         });
       }
     }

--- a/packages/core/src/analytics/dashboard.ts
+++ b/packages/core/src/analytics/dashboard.ts
@@ -34,7 +34,11 @@ import {
   toCalendarDayKey,
 } from "../contract/index.js";
 import type { DashboardCostFacts } from "./cost-facts.js";
-import { visitAttributedCosts, visitAttributedUsage } from "./cost-attribution.js";
+import {
+  visitAttributedCosts,
+  visitAttributedUsage,
+  type AttributedUsage,
+} from "./cost-attribution.js";
 
 export type {
   DashboardAgentStat,
@@ -98,7 +102,7 @@ interface DashboardAccumulator {
   agents: Map<string, DashboardAgentAggregate>;
   agentKeys: Set<string>;
   daily: Map<string, DashboardDailyBucket>;
-  models: Map<string, { tokens: number; sessions: number }>;
+  models: Map<string, { tokens: number; sessions: Set<SessionTreeNode> }>;
   modelCosts: Map<string, ModelCostEntry>;
   projects: Map<string, DashboardProjectAggregate>;
   projectKeys: Set<string>;
@@ -208,15 +212,6 @@ function createAccumulator(
   };
 }
 
-function foldModelUsage(node: SessionTreeNode, into: Map<string, number>): void {
-  if (node.session.model_usage) {
-    for (const [model, tokens] of Object.entries(node.session.model_usage)) {
-      into.set(model, (into.get(model) ?? 0) + tokens);
-    }
-  }
-  for (const child of node.children) foldModelUsage(child, into);
-}
-
 function getOrCreateProject(
   session: SessionHead,
   acc: DashboardAccumulator,
@@ -280,18 +275,6 @@ function accumulateActivity(node: SessionTreeNode, acc: DashboardAccumulator): v
   }
   bucket.sessions += 1;
 
-  const usage = new Map<string, number>();
-  foldModelUsage(node, usage);
-  for (const [model, tokens] of usage) {
-    const entry = acc.models.get(model);
-    if (entry) {
-      entry.tokens += tokens;
-      entry.sessions += 1;
-    } else {
-      acc.models.set(model, { tokens, sessions: 1 });
-    }
-  }
-
   trackProjectActivity(node, acc, agentKey);
 
   let recentIndex = acc.recent.length;
@@ -311,14 +294,7 @@ function addUsage(
   acc: DashboardAccumulator,
   entry: SessionTreeNode,
   time: number,
-  usage: {
-    messages: number;
-    totalTokens: number;
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    cacheCreateTokens: number;
-  },
+  usage: Omit<AttributedUsage, "entry" | "time">,
 ): void {
   const { messages, totalTokens, inputTokens, outputTokens, cacheReadTokens, cacheCreateTokens } =
     usage;
@@ -336,6 +312,16 @@ function addUsage(
   acc.messages += messages;
   acc.tokens += totalTokens;
   acc.cacheReadTokens += cacheReadTokens;
+  for (const [model, tokens] of Object.entries(usage.modelUsage ?? {})) {
+    if (tokens <= 0) continue;
+    const current = acc.models.get(model);
+    if (current) {
+      current.tokens += tokens;
+      current.sessions.add(entry);
+    } else {
+      acc.models.set(model, { tokens, sessions: new Set([entry]) });
+    }
+  }
 
   const agentKey = getSessionAgentName(entry.session);
   let metric = acc.agents.get(agentKey);
@@ -537,7 +523,7 @@ export function buildDashboard(
 
   const dailyActivity = [...acc.daily.values()].sort((a, b) => a.date.localeCompare(b.date));
   const modelDistribution: ModelDistributionEntry[] = [...acc.models.entries()]
-    .map(([model, { tokens, sessions: count }]) => ({ model, tokens, sessions: count }))
+    .map(([model, { tokens, sessions }]) => ({ model, tokens, sessions: sessions.size }))
     .sort((a, b) => b.tokens - a.tokens);
   const modelCost = costFactsAvailable
     ? [...acc.modelCosts.values()].sort((a, b) => b.cost - a.cost).slice(0, MODEL_COST_LIMIT)

--- a/tests/e2e/aggregation.spec.ts
+++ b/tests/e2e/aggregation.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "./test-fixtures.js";
 import type { Locator } from "playwright/test";
+import type { DashboardData } from "@codesesh/core/contract";
 
 const CODEX_SESSION_ID = "019daaaa-bbbb-7bbb-8bbb-bbbbbbbbbbbb";
 
@@ -8,6 +9,69 @@ const CODEX_SESSION_ID = "019daaaa-bbbb-7bbb-8bbb-bbbbbbbbbbbb";
 function sessionsKpi(dashboard: Locator): Locator {
   return dashboard.locator("section").filter({ hasText: /^Sessions/ });
 }
+
+test("keeps model colors consistent across token and cost rankings and project scopes", async ({
+  page,
+}) => {
+  await page.route("**/api/dashboard?*", async (route) => {
+    const response = await route.fetch();
+    const data = (await response.json()) as DashboardData;
+    const project = new URL(route.request().url()).searchParams.has("projectKey");
+    const models = project
+      ? [{ model: "sonnet", tokens: 80, sessions: 1 }]
+      : [
+          { model: "sonnet", tokens: 80, sessions: 1 },
+          { model: "haiku", tokens: 20, sessions: 1 },
+        ];
+    await route.fulfill({
+      response,
+      json: {
+        ...data,
+        totals: { ...data.totals, tokens: project ? 80 : 100, cost: 10 },
+        modelDistribution: models,
+        modelCost: [
+          { model: "haiku", cost: 9, costRecorded: 9, costEstimated: 0 },
+          { model: "sonnet", cost: 1, costRecorded: 1, costEstimated: 0 },
+        ],
+      },
+    });
+  });
+  await page.goto("/");
+  const tokens = page.getByRole("region", { name: "Tokens by Model", exact: true });
+  const cost = page.getByRole("region", { name: "Cost by Model", exact: true });
+  const tokenSwatch = (model: string) =>
+    tokens.getByRole("button", { name: new RegExp(`^${model}:`) }).locator("[aria-hidden]");
+  const costSwatch = (model: string) =>
+    cost
+      .getByRole("list")
+      .getByRole("listitem")
+      .filter({ hasText: model })
+      .locator("[aria-hidden]");
+  await expect(tokens.getByRole("button", { name: /^sonnet:/ })).toBeVisible();
+  const sonnetColor = await tokenSwatch("sonnet").evaluate(
+    (element) => getComputedStyle(element).backgroundColor,
+  );
+  await expect(costSwatch("sonnet")).toHaveCSS("background-color", sonnetColor);
+  const haikuColor = await tokenSwatch("haiku").evaluate(
+    (element) => getComputedStyle(element).backgroundColor,
+  );
+  await expect(costSwatch("haiku")).toHaveCSS("background-color", haikuColor);
+  expect(sonnetColor).not.toBe(haikuColor);
+  const chart = tokens.getByRole("listbox");
+  await chart.getByRole("option").first().focus();
+  await expect(tokens.getByRole("tooltip")).toContainText("sonnet");
+  await page.keyboard.press("ArrowRight");
+  await expect(tokens.getByRole("tooltip")).toContainText("haiku");
+  await expect(tokens.getByRole("tooltip")).toContainText("20 tokens");
+
+  await page.goto("/projects");
+  await page
+    .locator("main")
+    .getByRole("link", { name: /codesesh-e2e/ })
+    .click();
+  await expect(tokens.getByRole("button", { name: /^sonnet:/ })).toBeVisible();
+  await expect(tokenSwatch("sonnet")).toHaveCSS("background-color", sonnetColor);
+});
 
 test("aggregates Claude and Codex sessions under one project", async ({ page }) => {
   await page.goto("/");


### PR DESCRIPTION
Add a model token share bar between the summary cards and daily usage on both total and project dashboards. It uses the existing tile chart style and provides pointer, touch, and keyboard tooltips with the model name, token count, and percentage.

Use a shared model-to-color mapping for the token bar and model cost donut so colors stay consistent across charts, rankings, and filters. Group smaller models under Other and show unattributed tokens as Unknown model. Attribute model usage through the same selected time range as dashboard totals to keep shares accurate.

Validation:
- Full workspace build, lint, and formatting checks; Core, Web, and E2E type checks.
- Core and Web unit suites: 2,012 passed, 1 skipped.
- Dashboard aggregation E2E suite: 3 passed, including shared colors and keyboard tooltips on total and project dashboards.
- Initial bundle budget checks passed.
- Manually checked desktop and mobile layouts, tooltips, and real dashboard totals.
